### PR TITLE
[multibody] Speed up inverse dynamics by exploiting new templatized code

### DIFF
--- a/multibody/tree/body_node.cc
+++ b/multibody/tree/body_node.cc
@@ -86,49 +86,6 @@ void BodyNode<T>::CalcCompositeBodyInertia_TipToBase(
   }
 }
 
-// This method computes the total force Ftot_BBo on body B that must be
-// applied for it to incur in a spatial acceleration A_WB. Mathematically:
-//   Ftot_BBo = M_B_W * A_WB + b_Bo
-// where b_Bo contains the velocity dependent gyroscopic terms (see Eq. 2.26,
-// p. 27, in A. Jain's book). The above balance is performed at the origin
-// Bo of the body frame B, which does not necessarily need to coincide with
-// the body center of mass.
-// Notes:
-//   1. Ftot_BBo = b_Bo when A_WB = 0.
-//   2. b_Bo = 0 when w_WB = 0.
-//   3. b_Bo.translational() = 0 when Bo = Bcm (p_BoBcm = 0).
-//      When Fb_Bo_W_cache is nullptr velocities are considered to be zero.
-//      Therefore, from (2), the bias term is assumed to be zero and is not
-//      computed.
-template <typename T>
-void BodyNode<T>::CalcBodySpatialForceGivenItsSpatialAcceleration(
-    const std::vector<SpatialInertia<T>>& M_B_W_cache,
-    const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
-    const SpatialAcceleration<T>& A_WB, SpatialForce<T>* Ftot_BBo_W_ptr) const {
-  DRAKE_DEMAND(Ftot_BBo_W_ptr != nullptr);
-
-  // Output spatial force applied on mobilized body B, at Bo, measured in W.
-  SpatialForce<T>& Ftot_BBo_W = *Ftot_BBo_W_ptr;
-
-  // RigidBody for this node.
-  const RigidBody<T>& body_B = body();
-
-  // Mobilized body B spatial inertia about Bo expressed in world W.
-  const SpatialInertia<T>& M_B_W = M_B_W_cache[body_B.mobod_index()];
-
-  // Equations of motion for a rigid body written at a generic point Bo not
-  // necessarily coincident with the body's center of mass. This corresponds
-  // to Eq. 2.26 (p. 27) in A. Jain's book.
-  Ftot_BBo_W = M_B_W * A_WB;
-
-  // If velocities are zero, then Fb_Bo_W is zero and does not contribute.
-  if (Fb_Bo_W_cache != nullptr) {
-    // Dynamic bias for body B.
-    const SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_cache)[body_B.mobod_index()];
-    Ftot_BBo_W += Fb_Bo_W;
-  }
-}
-
 template <typename T>
 void BodyNode<T>::CalcArticulatedBodyHingeInertiaMatrixFactorization(
     const MatrixUpTo6<T>& D_B,

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -149,10 +149,8 @@ class BodyNode : public MultibodyElement<T> {
   }
 
   // Returns a constant reference to the mobilizer associated with this node.
-  // Aborts if called on the root node corresponding to the _world_ body, for
-  // which there is no mobilizer.
   const Mobilizer<T>& get_mobilizer() const {
-    DRAKE_DEMAND(mobilizer_ != nullptr);
+    DRAKE_ASSERT(mobilizer_ != nullptr);
     return *mobilizer_;
   }
 
@@ -230,12 +228,11 @@ class BodyNode : public MultibodyElement<T> {
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
   // this node's kinematics that only depend on generalized positions.
-  // This method aborts in Debug builds when:
+  // Don't call this on the World body.
   //
-  // - Called on the _root_ node.
-  // - `pc` is nullptr.
-  //
-  // @param[in] context The context with the state of the MultibodyTree model.
+  // @param[in] frame_body_pose_cache parameterized frame offsets
+  // @param[in] positions
+  //   The current position coordinates q for the full MultibodyTree model.
   // @param[out] pc A pointer to a valid, non nullptr, kinematics cache.
   // @pre CalcPositionKinematicsCache_BaseToTip() must have already been called
   // for the parent node (and, by recursive precondition, all predecessor nodes
@@ -244,54 +241,52 @@ class BodyNode : public MultibodyElement<T> {
       const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
       PositionKinematicsCache<T>* pc) const = 0;
 
-  // Calculates the hinge matrix H_PB_W.
-  // @param[in] context
-  //   The context with the state of the MultibodyTree model.
+  // Calculates the hinge matrix H_PB_W, the `6 x nm` hinge matrix that relates
+  // V_PB_W`(body B's spatial velocity in its parent body P, expressed in world
+  // W) to this node's nm generalized velocities (or mobilities) v_B as
+  // V_PB_W = H_PB_W * v_B.
+  //
+  // @param[in] frame_body_pose_cache parameterized frame offsets
+  // @param[in] positions
+  //   The current position coordinates q for the full MultibodyTree model.
   // @param[in] pc
-  //   An already updated position kinematics cache in sync with `context`.
-  // @param[out] H_PB_W
-  //   The `6 x nm` hinge matrix that relates `V_PB_W` (body B's spatial
-  //   velocity in its parent body P, expressed in world W) to this node's `nm`
-  //   generalized velocities (or mobilities) `v_B` as `V_PB_W = H_PB_W * v_B`.
-  // @note `H_PB_W` is only a function of the model's generalized positions q.
+  //   An already updated position kinematics cache in sync with positions.
+  // @param[out] H_PB_W_cache
+  //   The cache entry being calculated; just this node's H_PB is updated.
+
+  // @note `H_PB_W` is only a function of this node's generalized positions q.
   //
   // @pre The position kinematics cache `pc` was already updated to be in sync
-  // with `context` by MultibodyTree::CalcPositionKinematicsCache().
-
-  // TODO(sherm1) This function should not take a context.
+  // with positions by MultibodyTree::CalcPositionKinematicsCache().
   virtual void CalcAcrossNodeJacobianWrtVExpressedInWorld(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
       const PositionKinematicsCache<T>& pc,
       std::vector<Vector6<T>>* H_PB_W_cache) const = 0;
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
   // this node's kinematics that depend on the generalized velocities.
-  // This method aborts in Debug builds when:
-  // - Called on the _root_ node.
-  // - `vc` is nullptr.
-  // @param[in] context
-  //   The context with the state of the MultibodyTree model.
+  // Don't call this on World.
+  // @param[in] positions
+  //   The current position coordinates q for the full MultibodyTree model.
   // @param[in] pc
-  //   An already updated position kinematics cache in sync with `context`.
-  // @param[in] H_PB_W
-  //   The `6 x nm` hinge matrix that relates `V_PB_W` (body B's spatial
-  //   velocity in its parent body P, expressed in world W) to this node's `nm`
-  //   generalized velocities (or mobilities) `v_B` as `V_PB_W = H_PB_W * v_B`.
+  //   An already updated position kinematics cache in sync with positions.
+  // @param[in] H_PB_W_cache
+  //   Already calculated hinge matrices; for more information see
+  //   CalcAcrossNodeJacobianWrtVExpressedInWorld().
+  // @param[in] velocities
+  //   The current velocity coordinates v for the full MultibodyTree model.
   // @param[out] vc
   //   A pointer to a valid, non nullptr, velocity kinematics cache.
   // @pre The position kinematics cache `pc` was already updated to be in sync
-  // with `context` by MultibodyTree::CalcPositionKinematicsCache().
+  // with positions by MultibodyTree::CalcPositionKinematicsCache().
   // @pre CalcVelocityKinematicsCache_BaseToTip() must have already been called
   // for the parent node (and, by recursive precondition, all predecessor nodes
   // in the tree.)
   // Unit test coverage for this method is provided, among others, in
   // double_pendulum_test.cc, and by any other unit tests making use of
   // MultibodyTree::CalcVelocityKinematicsCache().
-
-  // TODO(sherm1) This function should not take a context.
   virtual void CalcVelocityKinematicsCache_BaseToTip(
-      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const T* positions, const PositionKinematicsCache<T>& pc,
       const std::vector<Vector6<T>>& H_PB_W_cache, const T* velocities,
       VelocityKinematicsCache<T>* vc) const = 0;
 
@@ -331,23 +326,24 @@ class BodyNode : public MultibodyElement<T> {
   // This method is used by MultibodyTree within a base-to-tip loop to compute
   // this node's kinematics that depend on the generalized accelerations, i.e.
   // the generalized velocities' time derivatives.
-  // This method aborts in Debug builds when:
-  // - Called on the _root_ node.
-  // - `ac` is nullptr.
-  // @param[in] context The context with the state of the MultibodyTree model.
+  // Don't call this on World.
+  //
+  // @param[in] frame_body_pose_cache parameterized frame offsets
+  // @param[in] positions
+  //   The current position coordinates q for the full MultibodyTree model.
   // @param[in] pc
-  //   An already updated position kinematics cache in sync with `context`.
+  //   An already updated position kinematics cache in sync with positions.
+  // @param[in] velocities
+  //   The current velocity coordinates v for the full MultibodyTree model.
   // @param[in] vc
-  //   An already updated velocity kinematics cache in sync with `context`.
+  //   An already updated velocity kinematics cache in sync with velocities.
   //   If vc is nullptr, velocities are assumed to be zero and velocity
   //   dependent terms are not computed.
-  // @param[in] mbt_vdot
+  // @param[in] accelerations
   //   The entire vector of generalized accelerations for the full
   //   MultibodyTree model. It must have a size equal to the number of
-  //   generalized velocities in the model. This method assumes the caller,
-  //   MultibodyTree<T>::CalcAccelerationKinematicsCache(), provides a vector
-  //   of the right size.
-  // @param[in,out] A_WB_array_ptr
+  //   generalized velocities in the model.
+  // @param[in,out] A_WB_array
   //   A pointer to a valid, non nullptr, vector of spatial accelerations
   //   containing the spatial acceleration `A_WB` for each body. On input, it
   //   must contain already pre-computed spatial accelerations for the inboard
@@ -355,30 +351,27 @@ class BodyNode : public MultibodyElement<T> {
   //   size equal to the number of bodies in the MultibodyTree and ordered by
   //   MobodIndex. The calling MultibodyTree method must guarantee these
   //   conditions are satisfied. This method will abort if the pointer is
-  //   null. There is no mechanism to assert that `A_WB_array_ptr` is ordered
+  //   null. There is no mechanism to assert that `A_WB_array` is ordered
   //   by MobodIndex and the correctness of MultibodyTree methods, properly
   //   unit tested, should guarantee this condition.
   //
   // @pre The position kinematics cache `pc` was already updated to be in sync
-  // with `context` by MultibodyTree::CalcPositionKinematicsCache().
+  // with positions by MultibodyTree::CalcPositionKinematicsCache().
   // @pre The velocity kinematics cache `vc` was already updated to be in sync
-  // with `context` by MultibodyTree::CalcVelocityKinematicsCache().
+  // with velocities by MultibodyTree::CalcVelocityKinematicsCache().
   // @pre CalcAccelerationKinematicsCache_BaseToTip() must have already been
   // called for the parent node (and, by recursive precondition, all
   // predecessor nodes in the tree). Therefore, on input, the argument array
-  // `A_WB_array_ptr` must contain already pre-computed spatial accelerations
+  // `A_WB_array` must contain already pre-computed spatial accelerations
   // for the inboard bodies to this node's body B.
   // Unit test coverage for this method is provided, among others, in
   // double_pendulum_test.cc, and by any other unit tests making use of
   // MultibodyTree::CalcAccelerationKinematicsCache().
-
-  // TODO(sherm1) This function should not take a context.
   virtual void CalcSpatialAcceleration_BaseToTip(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_poses_cache,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>* vc, const VectorX<T>& mbt_vdot,
-      std::vector<SpatialAcceleration<T>>* A_WB_array_ptr) const = 0;
+      const FrameBodyPoseCache<T>& frame_body_poses_cache, const T* positions,
+      const PositionKinematicsCache<T>& pc, const T* velocities,
+      const VelocityKinematicsCache<T>* vc, const T* accelerations,
+      std::vector<SpatialAcceleration<T>>* A_WB_array) const = 0;
 
   // Computes the generalized forces `tau` for a single BodyNode.
   // This method is used by MultibodyTree within a tip-to-base loop to compute
@@ -387,79 +380,56 @@ class BodyNode : public MultibodyElement<T> {
   //
   // This method aborts in Debug builds when `F_BMo_W_array` is nullptr.
   //
-  // @param[in] context The context with the state of the MultibodyTree model.
+  // @param[in] frame_body_pose_cache parameterized frame offsets
+  // @param[in] positions
+  //   The current position coordinates q for the full MultibodyTree model.
   // @param[in] pc
-  //   An already updated position kinematics cache in sync with `context`.
-  // @param[in] M_B_W_cache
-  //   An already updated cache storing the spatial inertia M_Bo_W(q) for each
-  //   body in the model, in sync with `context`.
-  // @param[in] Fb_Bo_W_cache
-  //   An already updated cache storing the bias term Fb_Bo_W(q, v) for each
-  //   body in the model, in sync with `context`.
-  //   If Fb_Bo_W_cache is nullptr, velocities are assumed to be zero (thus
-  //   Fb_Bo_W is zero) and velocity dependent terms are not computed.
+  //   An already updated position kinematics cache in sync with positions.
+  // @param[in] M_B_W_cache precalculated spatial inertias in World
+  //   Already up to date cache entries
+  // @param[in] Fb_Bo_W_cache velocity-dependent bias terms
+  //   Null if we're ignoring velocity, otherwise must be up to date.
   // @param[in] A_WB_array
   //   A vector of known spatial accelerations containing the spatial
-  //   acceleration `A_WB` for each body in the MultibodyTree model. It must be
+  //   acceleration A_WB for each body in the MultibodyTree model. It must be
   //   of size equal to the number of bodies in the MultibodyTree and ordered
   //   by MobodIndex. The calling MultibodyTree method must guarantee these
   //   conditions are satisfied.
-  // @param[in] Fapplied_Bo_W
-  //   Externally applied spatial force on this node's body B at the body's
-  //   frame origin `Bo`, expressed in the world frame.
-  //   `Fapplied_Bo_W` **must** not be an entry into `F_BMo_W_array_ptr`, which
-  //   would result in undefined results.
-  // @param[in] tau_applied
-  //   Externally applied generalized force at this node's mobilizer. It can
-  //   have zero size, implying no generalized forces are applied. Otherwise it
-  //   must have a size equal to the number of generalized velocities for this
-  //   node's mobilizer, see get_num_mobilizer_velocities().
-  //   `tau_applied` **must** not be an entry into `tau_array`, which would
-  //   result in undefined results.
-  // @param[out] F_BMo_W_array_ptr
-  //   A pointer to a valid, non nullptr, vector of spatial forces containing,
+  // @param[in] Fapplied_Bo_W_array
+  //   Either zero length or num_mobods. All applied spatial forces. May be the
+  //   same object as the output F_BMo_W_array in which case the body B entry
+  //   will be overwritten on return.
+  // @param[in] tau_applied_array
+  //   Either zero length or num_velocities. All applied generalized forces. May
+  //   be the same object as the output tau_array in which case the entries
+  //   for body B's mobilizer will be overwritten on return.
+  // @param[out] F_BMo_W_array
+  //   A non-null pointer to a vector of spatial forces containing,
   //   for each body B, the spatial force `F_BMo_W` corresponding to its
   //   inboard mobilizer reaction forces on body B applied at the origin `Mo`
-  //   of the inboard mobilizer, expressed in the world frame W.  It must be of
-  //   size equal to the number of bodies in the MultibodyTree and ordered by
-  //   MobodIndex. The calling MultibodyTree method must guarantee these
-  //   conditions are satisfied. This method will abort if the pointer is null.
-  //   To access a mobilizer's reaction force on a given body B, access this
-  //   array with the index returned by RigidBody::mobod_index().
+  //   of the inboard mobilizer, expressed in the world frame W. Note that
+  //   everything outboard of body B must already have been computed!
+  //   This can be the same object as Fapplied_Bo_W_array.
   // @param[out] tau_array
   //   A non-null pointer to the output vector of generalized forces that would
-  //   result in body B having spatial acceleration `A_WB`. This method will
-  //   abort if the pointer is null. The calling MultibodyTree method must
-  //   guarantee the size of the array is the number of generalized velocities
-  //   in the model.
+  //   result in body B having spatial acceleration `A_WB`. This can be the same
+  //   object as tau_applied_array.
   //
-  // @note There is no mechanism to assert that either `A_WB_array` nor
-  //   `F_BMo_W_array_ptr` are ordered by MobodIndex and the correctness of
-  //   MultibodyTree methods, properly unit tested, should guarantee this
-  //   condition.
-  //
-  // @pre The position kinematics cache `pc` was already updated to be in sync
-  // with `context` by MultibodyTree::CalcPositionKinematicsCache().
-  // @pre The velocity kinematics cache `vc` was already updated to be in sync
-  // with `context` by MultibodyTree::CalcVelocityKinematicsCache().
   // @pre CalcInverseDynamics_TipToBase() must have already been
   // called for all the child nodes of `this` node (and, by recursive
   // precondition, all successor nodes in the tree.)
   // Unit test coverage for this method is provided, among others, in
   // double_pendulum_test.cc, and by any other unit tests making use of
   // MultibodyTree::CalcInverseDynamics().
-
-  // TODO(sherm1) This function should not take a context.
   virtual void CalcInverseDynamics_TipToBase(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
       const PositionKinematicsCache<T>& pc,
       const std::vector<SpatialInertia<T>>& M_B_W_cache,
       const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
       const std::vector<SpatialAcceleration<T>>& A_WB_array,
-      const SpatialForce<T>& Fapplied_Bo_W,
-      const Eigen::Ref<const VectorX<T>>& tau_applied,
-      std::vector<SpatialForce<T>>* F_BMo_W_array_ptr,
+      const std::vector<SpatialForce<T>>& Fapplied_Bo_W_array,
+      const Eigen::Ref<const VectorX<T>>& tau_applied_array,
+      std::vector<SpatialForce<T>>* F_BMo_W_array,
       EigenPtr<VectorX<T>> tau_array) const = 0;
 
   // This method is used by MultibodyTree within a tip-to-base loop to compute
@@ -606,25 +576,26 @@ class BodyNode : public MultibodyElement<T> {
   // `A_WB = Aplus_WB + Ab_WB + H_PB_W * vdot_B`. Refer to
   // @ref abi_computing_accelerations for a detailed description and
   // derivation.
-  // @param[in] context The context with the state of the MultibodyTree model.
-  // @param[in] pc An already updated position kinematics cache in sync with
-  //   `context`.
+  //
+  // @param[in] frame_body_pose_cache parameterized frame offsets
+  // @param[in] positions
+  //   The current position coordinates q for the full MultibodyTree model.
+  // @param[in] pc
+  //   An already updated position kinematics cache in sync with positions.
+  // @param[in] velocities
+  //   The current velocity coordinates v for the full MultibodyTree model.
   // @param[in] vc An already updated velocity kinematics cache in sync with
-  //   `context`.
-  // @param[out] Ab_WB The spatial acceleration bias for this node, measured
-  //   and expressed in the world frame W. Must be non nullptr.
+  //   velocities.
+  // @param[out] Ab_WB_array The spatial acceleration bias for all nodes,
+  //   measured and expressed in the world frame W. Must be non nullptr.
   //
-  // @pre pc and vc previously computed to be in sync with `context.
-  //
-  // @throws when `Ab_WB` is nullptr.
-
-  // TODO(sherm1) This function should not take a context.
+  // @pre pc & vc previously computed to be in sync with positions & velocities.
+  // @pre Ab_WB_array is not null.
   virtual void CalcSpatialAccelerationBias(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      const PositionKinematicsCache<T>& pc,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
+      const PositionKinematicsCache<T>& pc, const T* velocities,
       const VelocityKinematicsCache<T>& vc,
-      SpatialAcceleration<T>* Ab_WB) const = 0;
+      std::vector<SpatialAcceleration<T>>* Ab_WB_array) const = 0;
 
   // Helper method to be called within a base-to-tip recursion that computes
   // into the PositionKinematicsCache:
@@ -659,17 +630,6 @@ class BodyNode : public MultibodyElement<T> {
       const PositionKinematicsCache<T>& pc,
       const std::vector<SpatialInertia<T>>& M_B_W_all,
       std::vector<SpatialInertia<T>>* Mc_B_W_all) const;
-
-  // Computes the total force Ftot_BBo on body B that must be applied for it to
-  // incur in a spatial acceleration A_WB.
-  // This function doesn't depend on the particular Mobilizer type so we
-  // implement once here in the base class rather than in the templatized
-  // derived class.
-  void CalcBodySpatialForceGivenItsSpatialAcceleration(
-      const std::vector<SpatialInertia<T>>& M_B_W_cache,
-      const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
-      const SpatialAcceleration<T>& A_WB,
-      SpatialForce<T>* Ftot_BBo_W_ptr) const;
 
   // Forms LLT factorization of articulated rigid body's hinge inertia matrix.
   // @param[in] D_B Articulated rigid body hinge matrix.

--- a/multibody/tree/body_node_impl.h
+++ b/multibody/tree/body_node_impl.h
@@ -64,21 +64,17 @@ class BodyNodeImpl final : public BodyNode<T> {
 
   ~BodyNodeImpl() final;
 
-  // TODO(sherm1) Just a warm up -- move the rest of the kernel computations
-  //  here also.
-
   void CalcPositionKinematicsCache_BaseToTip(
       const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
       PositionKinematicsCache<T>* pc) const final;
 
   void CalcAcrossNodeJacobianWrtVExpressedInWorld(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
       const PositionKinematicsCache<T>& pc,
       std::vector<Vector6<T>>* H_PB_W_cache) const final;
 
   void CalcVelocityKinematicsCache_BaseToTip(
-      const systems::Context<T>& context, const PositionKinematicsCache<T>& pc,
+      const T* positions, const PositionKinematicsCache<T>& pc,
       const std::vector<Vector6<T>>& H_PB_W_cache, const T* velocities,
       VelocityKinematicsCache<T>* vc) const final;
 
@@ -106,22 +102,20 @@ class BodyNodeImpl final : public BodyNode<T> {
 #undef DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK
 
   void CalcSpatialAcceleration_BaseToTip(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_poses_cache,
-      const PositionKinematicsCache<T>& pc,
-      const VelocityKinematicsCache<T>* vc, const VectorX<T>& mbt_vdot,
-      std::vector<SpatialAcceleration<T>>* A_WB_array_ptr) const final;
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
+      const PositionKinematicsCache<T>& pc, const T* velocities,
+      const VelocityKinematicsCache<T>* vc, const T* accelerations,
+      std::vector<SpatialAcceleration<T>>* A_WB_array) const final;
 
   void CalcInverseDynamics_TipToBase(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
       const PositionKinematicsCache<T>& pc,
       const std::vector<SpatialInertia<T>>& M_B_W_cache,
       const std::vector<SpatialForce<T>>* Fb_Bo_W_cache,
       const std::vector<SpatialAcceleration<T>>& A_WB_array,
-      const SpatialForce<T>& Fapplied_Bo_W,
+      const std::vector<SpatialForce<T>>& Fapplied_Bo_W,
       const Eigen::Ref<const VectorX<T>>& tau_applied,
-      std::vector<SpatialForce<T>>* F_BMo_W_array_ptr,
+      std::vector<SpatialForce<T>>* F_BMo_W_array,
       EigenPtr<VectorX<T>> tau_array) const final;
 
   void CalcArticulatedBodyInertiaCache_TipToBase(
@@ -148,11 +142,10 @@ class BodyNodeImpl final : public BodyNode<T> {
       AccelerationKinematicsCache<T>* ac) const final;
 
   void CalcSpatialAccelerationBias(
-      const systems::Context<T>& context,
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      const PositionKinematicsCache<T>& pc,
+      const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,
+      const PositionKinematicsCache<T>& pc, const T* velocities,
       const VelocityKinematicsCache<T>& vc,
-      SpatialAcceleration<T>* Ab_WB) const final;
+      std::vector<SpatialAcceleration<T>>* Ab_WB_array) const final;
 
  private:
   // Given a pointer to the contiguous array of all q's in this system, returns
@@ -171,6 +164,10 @@ class BodyNodeImpl final : public BodyNode<T> {
   // a pointer to the ones for this mobilizer.
   // @pre `velocities` is the full set of v's for this system
   const T* get_v(const T* velocities) const {
+    return &velocities[mobilizer().velocity_start_in_v()];
+  }
+
+  T* get_mutable_v(T* velocities) const {
     return &velocities[mobilizer().velocity_start_in_v()];
   }
 

--- a/multibody/tree/body_node_world.h
+++ b/multibody/tree/body_node_world.h
@@ -32,13 +32,13 @@ class BodyNodeWorld final : public BodyNode<T> {
   }
 
   void CalcAcrossNodeJacobianWrtVExpressedInWorld(
-      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
-      const PositionKinematicsCache<T>&, std::vector<Vector6<T>>*) const final {
+      const FrameBodyPoseCache<T>&, const T*, const PositionKinematicsCache<T>&,
+      std::vector<Vector6<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 
   void CalcVelocityKinematicsCache_BaseToTip(
-      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const T*, const PositionKinematicsCache<T>&,
       const std::vector<Vector6<T>>&, const T*,
       VelocityKinematicsCache<T>*) const final {
     DRAKE_UNREACHABLE();
@@ -67,19 +67,21 @@ class BodyNodeWorld final : public BodyNode<T> {
 #undef DEFINE_DUMMY_OFF_DIAGONAL_BLOCK
 
   void CalcSpatialAcceleration_BaseToTip(
-      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
-      const PositionKinematicsCache<T>&, const VelocityKinematicsCache<T>*,
-      const VectorX<T>&, std::vector<SpatialAcceleration<T>>*) const final {
+      const FrameBodyPoseCache<T>&, const T*, const PositionKinematicsCache<T>&,
+      const T*, const VelocityKinematicsCache<T>*, const T*,
+      std::vector<SpatialAcceleration<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcInverseDynamics_TipToBase(
-      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
-      const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
-      const std::vector<SpatialForce<T>>*,
-      const std::vector<SpatialAcceleration<T>>&, const SpatialForce<T>&,
-      const Eigen::Ref<const VectorX<T>>&, std::vector<SpatialForce<T>>*,
-      EigenPtr<VectorX<T>>) const final {
+  void CalcInverseDynamics_TipToBase(const FrameBodyPoseCache<T>&, const T*,
+                                     const PositionKinematicsCache<T>&,
+                                     const std::vector<SpatialInertia<T>>&,
+                                     const std::vector<SpatialForce<T>>*,
+                                     const std::vector<SpatialAcceleration<T>>&,
+                                     const std::vector<SpatialForce<T>>&,
+                                     const Eigen::Ref<const VectorX<T>>&,
+                                     std::vector<SpatialForce<T>>*,
+                                     EigenPtr<VectorX<T>>) const final {
     DRAKE_UNREACHABLE();
   }
 
@@ -115,11 +117,10 @@ class BodyNodeWorld final : public BodyNode<T> {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcSpatialAccelerationBias(const systems::Context<T>&,
-                                   const FrameBodyPoseCache<T>&,
-                                   const PositionKinematicsCache<T>&,
-                                   const VelocityKinematicsCache<T>&,
-                                   SpatialAcceleration<T>*) const final {
+  void CalcSpatialAccelerationBias(
+      const FrameBodyPoseCache<T>&, const T*, const PositionKinematicsCache<T>&,
+      const T*, const VelocityKinematicsCache<T>&,
+      std::vector<SpatialAcceleration<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 };

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -29,23 +29,28 @@ of dynamic-sized Eigen matrices that would otherwise lead to run-time
 dynamic memory allocations.
 
 Every concrete Mobilizer derived from MobilizerImpl must implement the
-following (ideally inline) methods:
+following (ideally inline) methods.
 
+  // Returns X_FM(q)
   math::RigidTransform<T> calc_X_FM(const T* q) const;
 
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&,
+  // Returns H_FM(q)⋅v
+  SpatialVelocity<T> calc_V_FM(const T* q,
                                const T* v) const;
+
+  // Returns H_FM(q)⋅vdot + Hdot_FM(q,v)⋅v
+  SpatialAcceleration<T> calc_A_FM(const T* q,
+                                   const T* v,
+                                   const T* vdot) const;
+
+  // Returns tau = H_FMᵀ(q)⋅F_BMo_F
+  void calc_tau(const T* q, const SpatialForce<T>& F_BMo_F, T* tau) const;
 
 The coordinate pointers are guaranteed to point to the kNq or kNv state
 variables for the particular mobilizer. They are only 8-byte aligned so
 be careful when interpreting them as Eigen vectors for computation purposes.
 
-TODO(sherm1) The above signatures should _not_ include a Context; all the
- low-level methods should be purely numerical. Anything needed from the
- Context should be extracted once prior to the tree recursion and passed
- directly to the low-level methods.
-
-%MobilizerImpl also provides a number of size specific methods to retrieve
+MobilizerImpl also provides a number of size specific methods to retrieve
 multibody quantities of interest from caching structures. These are common
 to all mobilizer implementations and therefore they live in this class.
 Users should not need to interact with this class directly unless they need

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1284,8 +1284,8 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
   const std::vector<Vector6<T>>& H_PB_W_cache =
       EvalAcrossNodeJacobianWrtVExpressedInWorld(context);
 
-  const Eigen::VectorBlock<const VectorX<T>> v_block = get_velocities(context);
-  const T* v = v_block.data();
+  const T* positions = get_positions(context).data();
+  const T* velocities = get_velocities(context).data();
 
   // Performs a base-to-tip recursion computing body velocities.
   // This skips the world, level = 0.
@@ -1297,8 +1297,8 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
       DRAKE_ASSERT(node.mobod_index() == mobod_index);
 
       // Update per-mobod kinematics.
-      node.CalcVelocityKinematicsCache_BaseToTip(context, pc, H_PB_W_cache, v,
-                                                 vc);
+      node.CalcVelocityKinematicsCache_BaseToTip(positions, pc, H_PB_W_cache,
+                                                 velocities, vc);
     }
   }
 }
@@ -1417,6 +1417,9 @@ void MultibodyTree<T>::CalcSpatialAccelerationBias(
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 
+  const T* const positions = get_positions(context).data();
+  const T* const velocities = get_velocities(context).data();
+
   // This skips the world mobilized body, mobod_index 0.
   // For world we opted for leaving Ab_WB initialized to NaN so that
   // an accidental usage (most likely indicating unnecessary math) in code would
@@ -1427,9 +1430,8 @@ void MultibodyTree<T>::CalcSpatialAccelerationBias(
   for (MobodIndex mobod_index(1); mobod_index < topology_.num_mobods();
        ++mobod_index) {
     const BodyNode<T>& node = *body_nodes_[mobod_index];
-    SpatialAcceleration<T>& Ab_WB = (*Ab_WB_all)[mobod_index];
-    node.CalcSpatialAccelerationBias(context, frame_body_pose_cache, pc, vc,
-                                     &Ab_WB);
+    node.CalcSpatialAccelerationBias(frame_body_pose_cache, positions, pc,
+                                     velocities, vc, &*Ab_WB_all);
   }
 }
 
@@ -1516,7 +1518,7 @@ void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
     std::vector<SpatialAcceleration<T>>* A_WB_array) const {
   const bool ignore_velocities = false;
   CalcSpatialAccelerationsFromVdot(context, known_vdot, ignore_velocities,
-                                   A_WB_array);
+                                   &*A_WB_array);
 }
 
 template <typename T>
@@ -1537,19 +1539,21 @@ void MultibodyTree<T>::CalcSpatialAccelerationsFromVdot(
   // The world's spatial acceleration is always zero.
   A_WB_array->at(world_mobod_index()) = SpatialAcceleration<T>::Zero();
 
-  // Performs a base-to-tip recursion computing body accelerations.
-  // This skips the world, depth = 0.
-  for (int level = 1; level < forest_height(); ++level) {
-    for (MobodIndex mobod_index : body_node_levels_[level]) {
-      const BodyNode<T>& node = *body_nodes_[mobod_index];
+  const T* const positions = get_positions(context).data();
+  const T* const velocities =
+      ignore_velocities ? nullptr : get_velocities(context).data();
+  const T* const accelerations = known_vdot.data();
 
-      DRAKE_ASSERT(node.get_topology().level == level);
-      DRAKE_ASSERT(node.mobod_index() == mobod_index);
+  // Performs a base-to-tip recursion computing body accelerations. World was
+  // handled above so is skipped here.
+  for (MobodIndex mobod_index{1}; mobod_index < num_mobods(); ++mobod_index) {
+    const BodyNode<T>& node = *body_nodes_[mobod_index];
+    DRAKE_ASSERT(node.mobod_index() == mobod_index);
 
-      // Update per-node kinematics.
-      node.CalcSpatialAcceleration_BaseToTip(context, frame_body_pose_cache, pc,
-                                             vc, known_vdot, A_WB_array);
-    }
+    // Update per-node kinematics.
+    node.CalcSpatialAcceleration_BaseToTip(frame_body_pose_cache, positions, pc,
+                                           velocities, vc, accelerations,
+                                           &*A_WB_array);
   }
 }
 
@@ -1595,7 +1599,10 @@ void MultibodyTree<T>::CalcInverseDynamics(
                       F_BMo_W_array, tau_array);
 }
 
-// All argument vectors are indexed by MobodIndex.
+// All argument vectors are indexed by MobodIndex. Note that we permit (perhaps
+// unwisely) the output arguments F_BMo_W_array and tau_array to use the same
+// memory as the input arguments Fapplied_Bo_W_array & tau_applied_array.
+// (There are internal usages that take advantage of that.)
 template <typename T>
 void MultibodyTree<T>::CalcInverseDynamics(
     const systems::Context<T>& context, const VectorX<T>& known_vdot,
@@ -1605,39 +1612,23 @@ void MultibodyTree<T>::CalcInverseDynamics(
     std::vector<SpatialForce<T>>* F_BMo_W_array,
     EigenPtr<VectorX<T>> tau_array) const {
   DRAKE_DEMAND(known_vdot.size() == num_velocities());
-  const int Fapplied_size = static_cast<int>(Fapplied_Bo_W_array.size());
-  DRAKE_DEMAND(Fapplied_size == topology_.num_mobods() || Fapplied_size == 0);
-  const int tau_applied_size = tau_applied_array.size();
-  DRAKE_DEMAND(tau_applied_size == num_velocities() || tau_applied_size == 0);
-
-  DRAKE_DEMAND(A_WB_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(A_WB_array->size()) == topology_.num_mobods());
-
-  DRAKE_DEMAND(F_BMo_W_array != nullptr);
-  DRAKE_DEMAND(static_cast<int>(F_BMo_W_array->size()) ==
-               topology_.num_mobods());
-
-  DRAKE_DEMAND(tau_array->size() == num_velocities());
+  DRAKE_DEMAND(ssize(Fapplied_Bo_W_array) == 0 ||
+               ssize(Fapplied_Bo_W_array) == num_mobods());
+  DRAKE_DEMAND(ssize(tau_applied_array) == 0 ||
+               ssize(tau_applied_array) == num_velocities());
+  DRAKE_DEMAND(A_WB_array != nullptr && ssize(*A_WB_array) == num_mobods());
+  DRAKE_DEMAND(F_BMo_W_array != nullptr &&
+               ssize(*F_BMo_W_array) == num_mobods());
+  DRAKE_DEMAND(tau_array != nullptr && ssize(*tau_array) == num_velocities());
 
   // Compute body spatial accelerations given the generalized accelerations are
   // known.
   CalcSpatialAccelerationsFromVdot(context, known_vdot, ignore_velocities,
-                                   A_WB_array);
-
-  // Vector of generalized forces per mobilizer.
-  // It has zero size if no forces are applied.
-  VectorUpTo6<T> tau_applied_mobilizer(0);
-
-  // Spatial force applied on B at Bo.
-  // It is left initialized to zero if no forces are applied.
-  SpatialForce<T> Fapplied_Bo_W = SpatialForce<T>::Zero();
+                                   &*A_WB_array);
 
   const FrameBodyPoseCache<T>& frame_body_pose_cache =
       EvalFrameBodyPoses(context);
-
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-
-  const VectorX<T>& reflected_inertia = EvalReflectedInertiaCache(context);
 
   // Eval M_Bo_W(q).
   const std::vector<SpatialInertia<T>>& spatial_inertia_in_world_cache =
@@ -1646,6 +1637,8 @@ void MultibodyTree<T>::CalcInverseDynamics(
   // Eval Fb_Bo_W(q, v). Fb_Bo_W = 0 if v = 0.
   const std::vector<SpatialForce<T>>* dynamic_bias_cache =
       ignore_velocities ? nullptr : &EvalDynamicBiasCache(context);
+
+  const T* const positions = get_positions(context).data();
 
   // Performs a tip-to-base recursion computing the total spatial force F_BMo_W
   // acting on body B, about point Mo, expressed in the world frame W.
@@ -1659,33 +1652,21 @@ void MultibodyTree<T>::CalcInverseDynamics(
       DRAKE_ASSERT(node.get_topology().level == level);
       DRAKE_ASSERT(node.mobod_index() == mobod_index);
 
-      // Make a copy to the total applied forces since the call to
-      // CalcInverseDynamics_TipToBase() below could overwrite the entry for the
-      // current body node if the input applied forces arrays are the same
-      // in-memory object as the output arrays.
-      // This allows users to specify the same input and output arrays if
-      // desired to minimize memory footprint.
-      // Leave them initialized to zero if no applied forces were provided.
-      if (tau_applied_size != 0) {
-        tau_applied_mobilizer =
-            node.get_mobilizer().get_generalized_forces_from_array(
-                tau_applied_array);
-      }
-      if (Fapplied_size != 0) {
-        Fapplied_Bo_W = Fapplied_Bo_W_array[mobod_index];
-      }
-
       // Compute F_BMo_W for the body associated with this node and project it
-      // onto the space of generalized forces for the associated mobilizer.
+      // onto the space of generalized forces tau for the associated mobilizer.
       node.CalcInverseDynamics_TipToBase(
-          context, frame_body_pose_cache, pc, spatial_inertia_in_world_cache,
-          dynamic_bias_cache, *A_WB_array, Fapplied_Bo_W, tau_applied_mobilizer,
-          F_BMo_W_array, tau_array);
+          frame_body_pose_cache, positions, pc, spatial_inertia_in_world_cache,
+          dynamic_bias_cache,  // null if ignoring velocities
+          *A_WB_array,
+          Fapplied_Bo_W_array,        // null if no applied spatial forces
+          tau_applied_array,          // null if no applied generalized forces
+          F_BMo_W_array, tau_array);  // outputs
     }
   }
 
   // Add the effect of reflected inertias.
   // See JointActuator::reflected_inertia().
+  const VectorX<T>& reflected_inertia = EvalReflectedInertiaCache(context);
   for (int i = 0; i < num_velocities(); ++i) {
     (*tau_array)(i) += reflected_inertia(i) * known_vdot(i);
   }
@@ -2515,6 +2496,8 @@ void MultibodyTree<T>::CalcAcrossNodeJacobianWrtVExpressedInWorld(
   // Quick return on nv = 0. Nothing to compute.
   if (num_velocities() == 0) return;
 
+  const T* positions = get_positions(context).data();
+
   const FrameBodyPoseCache<T>& frame_body_pose_cache =
       EvalFrameBodyPoses(context);
 
@@ -2525,7 +2508,7 @@ void MultibodyTree<T>::CalcAcrossNodeJacobianWrtVExpressedInWorld(
     const BodyNode<T>& node = *body_nodes_[mobod_index];
 
     node.CalcAcrossNodeJacobianWrtVExpressedInWorld(
-        context, frame_body_pose_cache, pc, H_PB_W_cache);
+        frame_body_pose_cache, positions, pc, H_PB_W_cache);
   }
 }
 

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -131,10 +131,9 @@ math::RigidTransform<T> PlanarMobilizer<T>::CalcAcrossMobilizerTransform(
 
 template <typename T>
 SpatialVelocity<T> PlanarMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v) const {
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return calc_V_FM(context, v.data());
+  return calc_V_FM(nullptr, v.data());
 }
 
 template <typename T>
@@ -143,18 +142,15 @@ PlanarMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
-  Vector6<T> A_FM_vector;
-  A_FM_vector << 0.0, 0.0, vdot[2], vdot[0], vdot[1], 0.0;
-  return SpatialAcceleration<T>(A_FM_vector);
+  return calc_A_FM(nullptr, nullptr, vdot.data());
 }
 
 template <typename T>
 void PlanarMobilizer<T>::ProjectSpatialForce(const systems::Context<T>&,
-                                             const SpatialForce<T>& F_Mo_F,
+                                             const SpatialForce<T>& F_BMo_F,
                                              Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
-  tau.head(2) = F_Mo_F.translational().head(2);
-  tau[2] = F_Mo_F.rotational()[2];
+  calc_tau(nullptr, F_BMo_F, tau.data());
 }
 
 template <typename T>

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -31,6 +31,13 @@ namespace internal {
  The generalized velocities for this mobilizer are the rate of change of the
  coordinates, v = q̇.
 
+ H_FM₆ₓ₃=[0 0 0]    Hdot_FM = 0₆ₓ₃
+         [0 0 0]
+         [0 0 1]
+         [1 0 0]
+         [0 1 0]
+         [0 0 0]
+
  @tparam_default_scalar */
 template <typename T>
 class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
@@ -144,9 +151,24 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   /* Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame
    M measured and expressed in frame F as a function of the input velocity v. */
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
     return SpatialVelocity<T>(Vector3<T>(0.0, 0.0, v[2]),
                               Vector3<T>(v[0], v[1], 0.0));
+  }
+  /* Returns H_FM⋅vdot + Hdot_FM⋅v. See class description for definitions. */
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    return SpatialAcceleration<T>(Vector3<T>(0.0, 0.0, vdot[2]),
+                                  Vector3<T>(vdot[0], vdot[1], 0.0));
+  }
+
+  /* Returns tau = H_FMᵀ⋅F */
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    const Vector3<T>& t_B_F = F_BMo_F.rotational();       // torque
+    const Vector3<T>& f_BMo_F = F_BMo_F.translational();  // force
+    tau[0] = f_BMo_F[0];                                  // force along x
+    tau[1] = f_BMo_F[1];                                  // force along y
+    tau[2] = t_B_F[2];                                    // torque about z
   }
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -84,10 +84,9 @@ math::RigidTransform<T> PrismaticMobilizer<T>::CalcAcrossMobilizerTransform(
 
 template <typename T>
 SpatialVelocity<T> PrismaticMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v) const {
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return calc_V_FM(context, v.data());
+  return calc_V_FM(nullptr, v.data());
 }
 
 template <typename T>
@@ -96,19 +95,15 @@ PrismaticMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
-  return SpatialAcceleration<T>(Vector3<T>::Zero(),
-                                vdot[0] * translation_axis());
+  return calc_A_FM(nullptr, nullptr, vdot.data());
 }
 
 template <typename T>
 void PrismaticMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>&, const SpatialForce<T>& F_BMo_F,
     Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
-  // Computes tau = H_FMᵀ * F_Mo_F where H_FM ∈ ℝ⁶ is:
-  // H_FM = [0ᵀ; axis_Fᵀ]ᵀ (see CalcAcrossMobilizerSpatialVelocity().)
-  // Therefore H_FMᵀ * F_Mo_F = axis_F.dot(F_Mo_F.translational()):
-  tau[0] = axis_F_.dot(F_Mo_F.translational());
+  calc_tau(nullptr, F_BMo_F, tau.data());
 }
 
 template <typename T>

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -30,6 +30,8 @@ namespace internal {
 // are coincident. The translation distance is defined to be positive in the
 // direction of `axis_F`.
 //
+// H_FM₆ₓ₁=[0₃, axis_F]ᵀ     Hdot_FM₆ₓ₁ = 0
+//
 // @tparam_default_scalar
 template <typename T>
 class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
@@ -127,8 +129,20 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   // M measured and expressed in frame F as a function of the input
   // translational velocity v along this mobilizer's axis (see
   // translation_axis()).
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
     return SpatialVelocity<T>(Vector3<T>::Zero(), v[0] * translation_axis());
+  }
+
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    return SpatialAcceleration<T>(Vector3<T>::Zero(),
+                                  vdot[0] * translation_axis());
+  }
+
+  // Returns tau = H_FMᵀ⋅F, where H_FMᵀ = [0₃ᵀ axis_Fᵀ].
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    const Vector3<T>& f_BMo_F = F_BMo_F.translational();
+    tau[0] = axis_F_.dot(f_BMo_F);
   }
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -243,10 +243,9 @@ QuaternionFloatingMobilizer<T>::CalcAcrossMobilizerTransform(
 template <typename T>
 SpatialVelocity<T>
 QuaternionFloatingMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v) const {
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return calc_V_FM(context, v.data());
+  return calc_V_FM(nullptr, v.data());
 }
 
 template <typename T>
@@ -255,17 +254,14 @@ QuaternionFloatingMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
-  const auto& alpha_FM = vdot.template head<3>();
-  const auto& a_FM = vdot.template tail<3>();
-  return SpatialAcceleration<T>(alpha_FM, a_FM);
+  return calc_A_FM(nullptr, nullptr, vdot.data());
 }
 
 template <typename T>
 void QuaternionFloatingMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>&, const SpatialForce<T>& F_BMo_F,
     Eigen::Ref<VectorX<T>> tau) const {
-  DRAKE_ASSERT(tau.size() == kNv);
-  tau = F_Mo_F.get_coeffs();
+  calc_tau(nullptr, F_BMo_F, tau.data());
 }
 
 template <typename T>

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -83,10 +83,9 @@ math::RigidTransform<T> RevoluteMobilizer<T>::CalcAcrossMobilizerTransform(
 
 template <typename T>
 SpatialVelocity<T> RevoluteMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v) const {
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return calc_V_FM(context, v.data());
+  return calc_V_FM(nullptr, v.data());
 }
 
 template <typename T>
@@ -95,18 +94,15 @@ RevoluteMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
-  return SpatialAcceleration<T>(vdot[0] * axis_F_, Vector3<T>::Zero());
+  return calc_A_FM(nullptr, nullptr, vdot.data());
 }
 
 template <typename T>
 void RevoluteMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>&, const SpatialForce<T>& F_BMo_F,
     Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
-  // Computes tau = H_FMᵀ * F_Mo_F where H_FM ∈ ℝ⁶ is:
-  // H_FM = [axis_Fᵀ; 0ᵀ]ᵀ (see CalcAcrossMobilizerSpatialVelocity().)
-  // Therefore H_FMᵀ * F_Mo_F = axis_F.dot(F_Mo_F.translational()):
-  tau[0] = axis_F_.dot(F_Mo_F.rotational());
+  calc_tau(nullptr, F_BMo_F, tau.data());
 }
 
 template <typename T>

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -32,6 +32,8 @@ namespace internal {
 // either frame F or M are constant. That is, `axis_F` and `axis_M` remain
 // unchanged w.r.t. both frames by this mobilizer's motion.
 //
+// H_FM₆ₓ₁=[axis_F 0₃]ᵀ     Hdot_FM₆ₓ₁ = 0₆
+//
 // @tparam_default_scalar
 template <typename T>
 class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
@@ -128,8 +130,21 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Computes the across-mobilizer spatial velocity V_FM(q, v) of the outboard
   // frame M measured and expressed in frame F as a function of the input
   // angular velocity `v` about this mobilizer's axis (@see revolute_axis()).
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
     return SpatialVelocity<T>(v[0] * axis_F_, Vector3<T>::Zero());
+  }
+
+  // Here H₆ₓ₁=[axis, 0₃]ᵀ so Hdot = 0 and
+  // A_FM = H⋅vdot + Hdot⋅v = [axis⋅vdot, 0₃]ᵀ
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    return SpatialAcceleration<T>(vdot[0] * axis_F_, Vector3<T>::Zero());
+  }
+
+  // Returns tau = H_FMᵀ⋅F, where H_FMᵀ = [axis_Fᵀ 0₃ᵀ].
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    const Vector3<T>& t_BMo_F = F_BMo_F.rotational();
+    tau[0] = axis_F_.dot(t_BMo_F);
   }
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -109,10 +109,9 @@ math::RigidTransform<T> RpyBallMobilizer<T>::CalcAcrossMobilizerTransform(
 
 template <typename T>
 SpatialVelocity<T> RpyBallMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v) const {
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return calc_V_FM(context, v.data());
+  return calc_V_FM(nullptr, v.data());
 }
 
 template <typename T>
@@ -121,15 +120,15 @@ RpyBallMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
-  return SpatialAcceleration<T>(vdot, Vector3<T>::Zero());
+  return calc_A_FM(nullptr, nullptr, vdot.data());
 }
 
 template <typename T>
 void RpyBallMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>&, const SpatialForce<T>& F_BMo_F,
     Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
-  tau = F_Mo_F.rotational();
+  calc_tau(nullptr, F_BMo_F, tau.data());
 }
 
 template <typename T>

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -57,6 +57,9 @@ namespace internal {
 // @note The roll-pitch-yaw (space x-y-z) Euler sequence is also known as the
 // Tait-Bryan angles or Cardan angles.
 //
+//    H_FM₆ₓ₃=[ I₃ₓ₃ ]    Hdot_FM = 0₆ₓ₃
+//            [ 0₃ₓ₃ ]
+//
 // @tparam_default_scalar
 template <typename T>
 class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
@@ -182,9 +185,25 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // M measured and expressed in frame F as a function of the input generalized
   // velocity v which contains the components of the angular velocity w_FM
   // expressed in frame F. The translational velocity is always zero.
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
     const Eigen::Map<const Vector3<T>> w_FM(v);
     return SpatialVelocity<T>(w_FM, Vector3<T>::Zero());
+  }
+
+  // Here H₆ₓ₃=[I₃ₓ₃ 0₃ₓ₃]ᵀ so Hdot=0 and
+  // A_FM = H⋅vdot + Hdot⋅v = [vdot, 0₃]ᵀ
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    const Eigen::Map<const Vector3<T>> alpha_FM(vdot);
+    return SpatialAcceleration<T>(alpha_FM, Vector3<T>::Zero());
+  }
+
+  // Returns tau = H_FMᵀ⋅F. The rotational part of H is identity here and
+  // the rest is zero.
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    Eigen::Map<VVector> tau_as_vector(tau);
+    const Vector3<T>& t_BMo_F = F_BMo_F.rotational();
+    tau_as_vector = t_BMo_F;
   }
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(

--- a/multibody/tree/rpy_floating_mobilizer.cc
+++ b/multibody/tree/rpy_floating_mobilizer.cc
@@ -180,10 +180,9 @@ math::RigidTransform<T> RpyFloatingMobilizer<T>::CalcAcrossMobilizerTransform(
 
 template <typename T>
 SpatialVelocity<T> RpyFloatingMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v) const {
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return calc_V_FM(context, v.data());
+  return calc_V_FM(nullptr, v.data());
 }
 
 template <typename T>
@@ -192,15 +191,15 @@ RpyFloatingMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
-  return SpatialAcceleration<T>(vdot);
+  return calc_A_FM(nullptr, nullptr, vdot.data());
 }
 
 template <typename T>
 void RpyFloatingMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>&, const SpatialForce<T>& F_BMo_F,
     Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
-  tau = F_Mo_F.get_coeffs();
+  calc_tau(nullptr, F_BMo_F, tau.data());
 }
 
 template <typename T>

--- a/multibody/tree/rpy_floating_mobilizer.h
+++ b/multibody/tree/rpy_floating_mobilizer.h
@@ -58,6 +58,8 @@ namespace internal {
 // @note The roll-pitch-yaw (space x-y-z) Euler sequence is also known as the
 // Tait-Bryan angles or Cardan angles.
 //
+//   H_FM₆ₓ₆ = I₆ₓ₆     Hdot_FM₆ₓ₆ = 0₆ₓ₆
+//
 // @tparam_default_scalar
 template <typename T>
 class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
@@ -233,9 +235,23 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   // measured and expressed in frame F as a function of the input generalized
   // velocity v, packed as documented in get_generalized_velocities(). (That's
   // conveniently just V_FM already.)
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
     const Eigen::Map<const VVector> V_FM(v);
     return SpatialVelocity<T>(V_FM);  // w_FM, v_FM
+  }
+
+  // We chose the generalized velocities for this mobilizer so that H=I, Hdot=0.
+  // Therefore A_FM = H⋅vdot + Hdot⋅v = vdot.
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    const Eigen::Map<const VVector> A_FM(vdot);
+    return SpatialAcceleration<T>(A_FM);
+  }
+
+  // Returns tau = H_FMᵀ⋅F. H is identity for this mobilizer.
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    Eigen::Map<VVector> tau_as_vector(tau);
+    tau_as_vector = F_BMo_F.get_coeffs();
   }
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -128,10 +128,9 @@ math::RigidTransform<T> ScrewMobilizer<T>::CalcAcrossMobilizerTransform(
 
 template <typename T>
 SpatialVelocity<T> ScrewMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
-    const systems::Context<T>& context,
-    const Eigen::Ref<const VectorX<T>>& v) const {
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return calc_V_FM(context, v.data());
+  return calc_V_FM(nullptr, v.data());
 }
 
 template <typename T>
@@ -140,19 +139,15 @@ ScrewMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
-  Vector6<T> A_FM_vector;
-  A_FM_vector << (axis_ * vdot[0]),
-      (axis_ * GetScrewTranslationFromRotation(vdot[0], screw_pitch_));
-  return SpatialAcceleration<T>(A_FM_vector);
+  return calc_A_FM(nullptr, nullptr, vdot.data());
 }
 
 template <typename T>
 void ScrewMobilizer<T>::ProjectSpatialForce(const systems::Context<T>&,
-                                            const SpatialForce<T>& F_Mo_F,
+                                            const SpatialForce<T>& F_BMo_F,
                                             Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
-  tau[0] = F_Mo_F.rotational().dot(axis_) +
-           F_Mo_F.translational().dot(axis_) / (2 * M_PI) * screw_pitch_;
+  calc_tau(nullptr, F_BMo_F, tau.data());
 }
 
 template <typename T>

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -52,6 +52,9 @@ T GetScrewRotationFromTranslation(const T& z, double screw_pitch) {
  at all times for this mobilizer. The generalized velocity for this mobilizer
  is the rate of change of the coordinate, ω =˙θ (θ_dot).
 
+ H_FM₆ₓ₁ = [axisᵀ f⋅axisᵀ]ᵀ where f=pitch/2π
+ Hdot_FM = 0₆ₓ₁
+
  @tparam_default_scalar */
 template <typename T>
 class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
@@ -189,6 +192,7 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    frame F and the outboard frame M as a function of the configuration q stored
    in `context`. */
   math::RigidTransform<T> calc_X_FM(const T* q) const {
+    DRAKE_ASSERT(q != nullptr);
     const Vector3<T> p_FM(axis_ *
                           GetScrewTranslationFromRotation(q[0], screw_pitch_));
     return math::RigidTransform<T>(Eigen::AngleAxis<T>(q[0], axis_), p_FM);
@@ -198,11 +202,28 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
    M measured and expressed in frame F as a function of the input velocity v,
    which is the angular velocity. We scale that by the pitch to find the
    related translational velocity. */
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T* v) const {
-    const SpatialVelocity<T> V_FM(
-        axis_ * v[0],
-        axis_ * GetScrewTranslationFromRotation(v[0], screw_pitch_));
-    return V_FM;
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
+    DRAKE_ASSERT(v != nullptr);
+    const T f_v = GetScrewTranslationFromRotation(v[0], screw_pitch_);
+    return SpatialVelocity<T>(v[0] * axis_, f_v * axis_);
+  }
+
+  /* Our lone generalized acceleration is the angular acceleration θdotdot about
+  the screw axis. Therefore we have H₆ₓ₁=[axis f⋅axis] where f=pitch/2π, and
+  Hdot=0, so A_FM = H⋅vdot + Hdot⋅v = [axis⋅vdot, f⋅axis⋅vdot]ᵀ */
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    DRAKE_ASSERT(vdot != nullptr);
+    const T f_vdot = GetScrewTranslationFromRotation(vdot[0], screw_pitch_);
+    return SpatialAcceleration<T>(vdot[0] * axis_, f_vdot * axis_);
+  }
+
+  /* Returns tau = H_FMᵀ⋅F. See above for H. */
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    const T f = screw_pitch_ / (2 * M_PI);
+    const Vector3<T>& t_B_F = F_BMo_F.rotational();       // torque
+    const Vector3<T>& f_BMo_F = F_BMo_F.translational();  // force
+    tau[0] = axis_.dot(t_B_F) + f * axis_.dot(f_BMo_F);
   }
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -74,13 +74,13 @@ class DummyBodyNode : public BodyNode<double> {
   }
 
   void CalcAcrossNodeJacobianWrtVExpressedInWorld(
-      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
-      const PositionKinematicsCache<T>&, std::vector<Vector6<T>>*) const final {
+      const FrameBodyPoseCache<T>&, const T*, const PositionKinematicsCache<T>&,
+      std::vector<Vector6<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 
   void CalcVelocityKinematicsCache_BaseToTip(
-      const systems::Context<T>&, const PositionKinematicsCache<T>&,
+      const T*, const PositionKinematicsCache<T>&,
       const std::vector<Vector6<T>>&, const T*,
       VelocityKinematicsCache<T>*) const final {
     DRAKE_UNREACHABLE();
@@ -109,19 +109,21 @@ class DummyBodyNode : public BodyNode<double> {
 #undef DEFINE_DUMMY_OFF_DIAGONAL_BLOCK
 
   void CalcSpatialAcceleration_BaseToTip(
-      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
-      const PositionKinematicsCache<T>&, const VelocityKinematicsCache<T>*,
-      const VectorX<T>&, std::vector<SpatialAcceleration<T>>*) const final {
+      const FrameBodyPoseCache<T>&, const T*, const PositionKinematicsCache<T>&,
+      const T*, const VelocityKinematicsCache<T>*, const T*,
+      std::vector<SpatialAcceleration<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcInverseDynamics_TipToBase(
-      const systems::Context<T>&, const FrameBodyPoseCache<T>&,
-      const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
-      const std::vector<SpatialForce<T>>*,
-      const std::vector<SpatialAcceleration<T>>&, const SpatialForce<T>&,
-      const Eigen::Ref<const VectorX<T>>&, std::vector<SpatialForce<T>>*,
-      EigenPtr<VectorX<T>>) const final {
+  void CalcInverseDynamics_TipToBase(const FrameBodyPoseCache<T>&, const T*,
+                                     const PositionKinematicsCache<T>&,
+                                     const std::vector<SpatialInertia<T>>&,
+                                     const std::vector<SpatialForce<T>>*,
+                                     const std::vector<SpatialAcceleration<T>>&,
+                                     const std::vector<SpatialForce<T>>&,
+                                     const Eigen::Ref<const VectorX<T>>&,
+                                     std::vector<SpatialForce<T>>*,
+                                     EigenPtr<VectorX<T>>) const final {
     DRAKE_UNREACHABLE();
   }
 
@@ -157,11 +159,10 @@ class DummyBodyNode : public BodyNode<double> {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcSpatialAccelerationBias(const systems::Context<T>&,
-                                   const FrameBodyPoseCache<T>&,
-                                   const PositionKinematicsCache<T>&,
-                                   const VelocityKinematicsCache<T>&,
-                                   SpatialAcceleration<T>*) const final {
+  void CalcSpatialAccelerationBias(
+      const FrameBodyPoseCache<T>&, const T*, const PositionKinematicsCache<T>&,
+      const T*, const VelocityKinematicsCache<T>&,
+      std::vector<SpatialAcceleration<T>>*) const final {
     DRAKE_UNREACHABLE();
   }
 };

--- a/multibody/tree/universal_mobilizer.cc
+++ b/multibody/tree/universal_mobilizer.cc
@@ -7,7 +7,6 @@
 #include "drake/common/eigen_types.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/body_node_impl.h"
-// #include "drake/multibody/tree/multibody_tree.h"
 
 namespace drake {
 namespace multibody {
@@ -87,21 +86,20 @@ const UniversalMobilizer<T>& UniversalMobilizer<T>::SetAngularRates(
 
 template <typename T>
 Eigen::Matrix<T, 3, 2> UniversalMobilizer<T>::CalcHwMatrix(
-    const systems::Context<T>& context, Vector3<T>* Hw_dot) const {
-  const Vector2<T>& q = this->get_positions(context);
+    const T* q, const T* v, Vector3<T>* Hw_dot) const {
+  DRAKE_ASSERT(q != nullptr);
   const T s = sin(q[0]);
   const T c = cos(q[0]);
   // The Hw matrix is defined as Hw = [Fx_F, My_F] where Fx_F is the unit x
-  // vector and My_F simply picks off the middle column of R_FI(θ₁) because My_M
+  // vector and My_F simply picks off the middle column of R_FI(θ₀) because My_M
   // is the unit y vector.
-  const Vector3<T> Fx_F = Vector3<T>::UnitX();
-  const Vector3<T> My_F(0.0, c, s);
   Eigen::Matrix<T, 3, 2> H;
-  H << Fx_F, My_F;
-  if (Hw_dot) {
+  H.col(0) = Vector3<T>::UnitX();    // Fx_F
+  H.col(1) = Vector3<T>(0.0, c, s);  // My_F
+  if (Hw_dot != nullptr) {
+    DRAKE_ASSERT(v != nullptr);
     // Since only the second column of Hw evolves with time, we only return that
     // column as a vector. The vector is the time derivative of My_F.
-    const Vector2<T>& v = this->get_velocities(context);
     *Hw_dot = Vector3<T>(0, -s * v[0], c * v[0]);
   }
   return H;
@@ -120,7 +118,9 @@ SpatialVelocity<T> UniversalMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& v) const {
   DRAKE_ASSERT(v.size() == kNv);
-  return calc_V_FM(context, v.data());
+  const auto& q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  return calc_V_FM(q.data(), v.data());
 }
 
 template <typename T>
@@ -128,25 +128,21 @@ SpatialAcceleration<T>
 UniversalMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
-  const Vector2<T>& v = this->get_velocities(context);
-  DRAKE_ASSERT(vdot.size() == kNv);
-  Vector3<T> Hw_dot_col1;
-  const Eigen::Matrix<T, 3, 2> Hw = this->CalcHwMatrix(context, &Hw_dot_col1);
-  // Calculated using alpha_FM = Hw_FM⋅v̇ + Hwdot_FM⋅v. See Mobilizer class
-  // documentation for derivation.
-  return SpatialAcceleration<T>(Hw * vdot + Hw_dot_col1 * v[1],
-                                Vector3<T>::Zero());
+  const auto& q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  const auto& v = this->get_velocities(context);
+  DRAKE_ASSERT(v.size() == kNv && vdot.size() == kNv);
+  return calc_A_FM(q.data(), v.data(), vdot.data());
 }
 
 template <typename T>
 void UniversalMobilizer<T>::ProjectSpatialForce(
-    const systems::Context<T>& context, const SpatialForce<T>& F_Mo_F,
+    const systems::Context<T>& context, const SpatialForce<T>& F_BMo_F,
     Eigen::Ref<VectorX<T>> tau) const {
   DRAKE_ASSERT(tau.size() == kNv);
-  const Eigen::Matrix<T, 3, 2> Hw = this->CalcHwMatrix(context);
-  // Computes tau = H_FMᵀ * F_Mo_F where H_FM ∈ ℝ³ˣ² is calculated as described
-  // in CalcHwMatrix().
-  tau = Hw.transpose() * F_Mo_F.rotational();
+  const auto& q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  calc_tau(q.data(), F_BMo_F, tau.data());
 }
 
 template <typename T>

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -34,9 +34,7 @@ SpatialVelocity<T> WeldMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
 
 template <typename T>
 SpatialAcceleration<T> WeldMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
-    const systems::Context<T>&,
-    const Eigen::Ref<const VectorX<T>>& vdot) const {
-  DRAKE_ASSERT(vdot.size() == kNv);
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>&) const {
   return SpatialAcceleration<T>::Zero();
 }
 

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -54,9 +54,16 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
 
   // Computes the across-mobilizer velocity V_FM which for this mobilizer is
   // always zero since the outboard frame M is fixed to the inboard frame F.
-  SpatialVelocity<T> calc_V_FM(const systems::Context<T>&, const T*) const {
+  SpatialVelocity<T> calc_V_FM(const T*, const T*) const {
     return SpatialVelocity<T>::Zero();
   }
+
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T*) const {
+    return SpatialAcceleration<T>::Zero();
+  }
+
+  // Does nothing since there are no taus.
+  void calc_tau(const T*, const SpatialForce<T>&, T*) const {}
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(
       const systems::Context<T>&) const final;


### PR DESCRIPTION
### What's here
- Removes passed-in context from some calls in favor of passing in positions and velocities. (This is moving in the direction of standardizing the parameter lists so they can be replaced with preloaded structs.)
- Added inlines calc_A_FM() and calc_tau() to all mobilizers and replaces calls to the equivalent virtuals.
- Reimplements the virtuals using the inlines.
- Updates both CalcSpatialAcceleration and CalcInverseDynamics because the latter depends on the former.
- Profiled with valgrind, improved inlining

With gcc, this PR is a 12% speedup of inverse dynamics, 29% since start of this PR sequence begining with #21853. (Likely more gain with clang but I didn't measure it this time.)

### What's not here
- Any algorithmic changes 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22014)
<!-- Reviewable:end -->
