### PR TITLE
Fix exception message when center of mass is NAN.

### DIFF
--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -975,6 +975,23 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithBadInertia) {
       expected_message);
 }
 
+// Ensure IsPhysicallyValid() fails if the center of mass position is NAN.
+// Note: This tests that the old exception message was improved from:
+// "CalcPrincipalMomentsAndMaybeAxesOfInertia(): Unable to calculate eigenvalues
+// or eigenvectors of the 3x3 matrix associated with a RotationalInertia." to
+// a message that clearly communicates a problem with center of mass position.
+GTEST_TEST(SpatialInertia, IsPhysicallyValidWithCMPositionAsNAN) {
+  const std::string expected_message =
+      "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
+      " Center of mass = \\[7  nan  9\\] is not finite.\n";
+  const Vector3<double> p_BoBcm_B(7, NAN, 9);
+  const UnitInertia<double> G_BBo_B =
+      UnitInertia<double>::SolidSphere(/* radius = */ 1.0);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SpatialInertia<double>(/* mass = */ 1.0, p_BoBcm_B, G_BBo_B),
+      expected_message);
+}
+
 // Tests IsPhysicallyValid() fails within the constructor since the COM given is
 // inconsistently too far out for the unit inertia provided.
 GTEST_TEST(SpatialInertia, IsPhysicallyValidWithCOMTooFarOut) {


### PR DESCRIPTION
Resolves issue #22017

When an invalid center of mass (e.g., containing NAN or INF) is used in an SpatialInertia() constructor, a confusing exception message is issued, namely:

"CalcPrincipalMomentsAndMaybeAxesOfInertia(): Unable to calculate eigenvalues or eigenvectors of the 3x3 matrix associated with a RotationalInertia."

This PR creates a better message that more clearly communicate that the problem is with the center of mass position vector.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22016)
<!-- Reviewable:end -->
