### PR TITLE
Do not convert an int to a bool in Python binding of Meshcat::SetProperty

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -347,7 +347,7 @@ void DefineMeshcat(py::module m) {
         .def("SetProperty",
             py::overload_cast<std::string_view, std::string, bool,
                 std::optional<double>>(&Class::SetProperty),
-            py::arg("path"), py::arg("property"), py::arg("value"),
+            py::arg("path"), py::arg("property"), py::arg("value").noconvert(),
             py::arg("time_in_recording") = std::nullopt,
             cls_doc.SetProperty.doc_bool)
         .def("SetProperty",


### PR DESCRIPTION
Previously, this lead to unintuitive behavior. For example, if you call `meshcat.SetProperty("/Lights/AmbientLight/<object>", "intensity", 2)`, then the light intensity is set to 1.

Closes #21982.

Since we don't have any sort of `meshcat::GetProperty` method, I don't think we have a way of testing this change?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22021)
<!-- Reviewable:end -->
