### PR TITLE
[visualization] Fix meshcat control deletion paths

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -372,7 +372,7 @@ void DefineMeshcat(py::module m) {
         .def("GetButtonClicks", &Class::GetButtonClicks, py::arg("name"),
             cls_doc.GetButtonClicks.doc)
         .def("DeleteButton", &Class::DeleteButton, py::arg("name"),
-            cls_doc.DeleteButton.doc)
+            py::arg("strict") = true, cls_doc.DeleteButton.doc)
         .def("AddSlider", &Class::AddSlider, py::arg("name"), py::arg("min"),
             py::arg("max"), py::arg("step"), py::arg("value"),
             py::arg("decrement_keycode") = "",
@@ -384,7 +384,7 @@ void DefineMeshcat(py::module m) {
         .def("GetSliderNames", &Class::GetSliderNames,
             cls_doc.GetSliderNames.doc)
         .def("DeleteSlider", &Class::DeleteSlider, py::arg("name"),
-            cls_doc.DeleteSlider.doc)
+            py::arg("strict") = true, cls_doc.DeleteSlider.doc)
         .def("DeleteAddedControls", &Class::DeleteAddedControls,
             cls_doc.DeleteAddedControls.doc)
         .def("GetGamepad", &Class::GetGamepad, cls_doc.GetGamepad.doc)

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -217,7 +217,8 @@ class TestGeometryVisualizers(unittest.TestCase):
             "name": "alice",
         }))
         self.assertEqual(meshcat.GetButtonClicks(name="alice"), 1)
-        meshcat.DeleteButton(name="alice")
+        self.assertTrue(meshcat.DeleteButton(name="alice"))
+        self.assertFalse(meshcat.DeleteButton(name="alice", strict=False))
         meshcat.AddSlider(name="slider",
                           min=0,
                           max=1,
@@ -230,6 +231,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         self.assertAlmostEqual(meshcat.GetSliderValue(
             name="slider"), 0.7, delta=1e-14)
         meshcat.DeleteSlider(name="slider")
+        meshcat.DeleteSlider(name="slider", strict=False)
         meshcat.DeleteAddedControls()
         self.assertIn("data:application/octet-binary;base64",
                       meshcat.StaticHtml())

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -59,14 +59,15 @@ using math::RotationMatrixd;
 
 template <typename Mapping>
 [[noreturn]] void ThrowThingNotFound(std::string_view thing,
-                                     std::string_view name, Mapping thing_map) {
+                                     std::string_view name,
+                                     const Mapping& thing_map) {
   std::vector<std::string> keys;
   for (const auto& map_pair : thing_map) {
     keys.push_back(map_pair.first);
   }
   throw std::logic_error(
-      fmt::format("Meshcat does not have any {} named {}.  The "
-                  "registered {} names are ({}).",
+      fmt::format("Meshcat does not have any {} named {}."
+                  " The registered {} names are ({}).",
                   thing, name, thing, fmt::join(keys, ", ")));
 }
 
@@ -1601,7 +1602,7 @@ class Meshcat::Impl {
   }
 
   // This function is public via the PIMPL.
-  void DeleteButton(std::string name) {
+  bool DeleteButton(std::string name, bool strict) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     internal::DeleteControl data;
@@ -1609,7 +1610,11 @@ class Meshcat::Impl {
       std::lock_guard<std::mutex> lock(controls_mutex_);
       auto iter = buttons_.find(name);
       if (iter == buttons_.end()) {
-        ThrowThingNotFound("button", name, buttons_);
+        if (strict) {
+          ThrowThingNotFound("button", name, buttons_);
+        } else {
+          return false;
+        }
       }
       buttons_.erase(iter);
       auto c_iter = std::find(controls_.begin(), controls_.end(), name);
@@ -1626,6 +1631,7 @@ class Meshcat::Impl {
       msgpack::pack(message_stream, data);
       app_->publish("all", message_stream.str(), uWS::OpCode::BINARY, false);
     });
+    return true;
   }
 
   // This function is public via the PIMPL.
@@ -1735,7 +1741,7 @@ class Meshcat::Impl {
   }
 
   // This function is public via the PIMPL.
-  void DeleteSlider(std::string name) {
+  bool DeleteSlider(std::string name, bool strict) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     internal::DeleteControl data;
@@ -1743,7 +1749,11 @@ class Meshcat::Impl {
       std::lock_guard<std::mutex> lock(controls_mutex_);
       auto iter = sliders_.find(name);
       if (iter == sliders_.end()) {
-        ThrowThingNotFound("slider", name, sliders_);
+        if (strict) {
+          ThrowThingNotFound("slider", name, sliders_);
+        } else {
+          return false;
+        }
       }
       sliders_.erase(iter);
       auto c_iter = std::find(controls_.begin(), controls_.end(), name);
@@ -1760,6 +1770,7 @@ class Meshcat::Impl {
       msgpack::pack(message_stream, data);
       app_->publish("all", message_stream.str(), uWS::OpCode::BINARY, false);
     });
+    return true;
   }
 
   // This function is public via the PIMPL.
@@ -1775,10 +1786,10 @@ class Meshcat::Impl {
       sliders = sliders_;
     }
     for (auto iter = buttons.begin(); iter != buttons.end(); ++iter) {
-      DeleteButton(iter->first);
+      DeleteButton(iter->first, /* strict = */ true);
     }
     for (auto iter = sliders.begin(); iter != sliders.end(); ++iter) {
-      DeleteSlider(iter->first);
+      DeleteSlider(iter->first, /* strict = */ true);
     }
   }
 
@@ -2768,8 +2779,8 @@ int Meshcat::GetButtonClicks(std::string_view name) const {
   return impl().GetButtonClicks(name);
 }
 
-void Meshcat::DeleteButton(std::string name) {
-  impl().DeleteButton(std::move(name));
+bool Meshcat::DeleteButton(std::string name, bool strict) {
+  return impl().DeleteButton(std::move(name), strict);
 }
 
 void Meshcat::AddSlider(std::string name, double min, double max, double step,
@@ -2791,8 +2802,8 @@ std::vector<std::string> Meshcat::GetSliderNames() const {
   return impl().GetSliderNames();
 }
 
-void Meshcat::DeleteSlider(std::string name) {
-  impl().DeleteSlider(std::move(name));
+bool Meshcat::DeleteSlider(std::string name, bool strict) {
+  return impl().DeleteSlider(std::move(name), strict);
 }
 
 void Meshcat::DeleteAddedControls() {

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -767,8 +767,10 @@ class Meshcat {
   int GetButtonClicks(std::string_view name) const;
 
   /** Removes the button `name` from the GUI.
-   @throws std::exception if `name` is not a registered button. */
-  void DeleteButton(std::string name);
+   @returns true iff the button was removed.
+   @throws std::exception if `strict` is true and `name` is not a registered
+           button. */
+  bool DeleteButton(std::string name, bool strict = true);
 
   /** Adds a slider with the label `name` to the meshcat browser controls GUI.
    The slider range is given by [`min`, `max`]. `step` is the smallest
@@ -802,8 +804,10 @@ class Meshcat {
   std::vector<std::string> GetSliderNames() const;
 
   /** Removes the slider `name` from the GUI.
-   @throws std::exception if `name` is not a registered slider. */
-  void DeleteSlider(std::string name);
+   @returns true iff the slider was removed.
+   @throws std::exception if `strict` is true and `name` is not a registered
+           slider. */
+  bool DeleteSlider(std::string name, bool strict = true);
 
   /** Removes all buttons and sliders from the GUI that have been registered by
    this Meshcat instance. It does *not* clear the default GUI elements set in

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -859,13 +859,14 @@ GTEST_TEST(MeshcatTest, Buttons) {
   EXPECT_EQ(meshcat.GetButtonClicks("alice"), 1);
 
   // Removing the button then asking for clicks is an error.
-  meshcat.DeleteButton("alice");
+  EXPECT_TRUE(meshcat.DeleteButton("alice"));
   DRAKE_EXPECT_THROWS_MESSAGE(meshcat.GetButtonClicks("alice"),
                               "Meshcat does not have any button named alice.*");
 
-  // Removing a non-existent button is an error.
+  // Strictly (the default) removing a missing button throws.
   DRAKE_EXPECT_THROWS_MESSAGE(meshcat.DeleteButton("alice"),
                               "Meshcat does not have any button named alice.*");
+  EXPECT_FALSE(meshcat.DeleteButton("alice", /*strict = */ false));
 
   // Adding the button anew starts with a zero count again.
   meshcat.AddButton("alice");
@@ -919,7 +920,7 @@ GTEST_TEST(MeshcatTest, Sliders) {
   DRAKE_EXPECT_THROWS_MESSAGE(meshcat.AddSlider("slider", 0.2, 1.5, 0.1, 0.5),
                               "Meshcat already has a slider named slider.");
 
-  meshcat.DeleteSlider("slider");
+  EXPECT_TRUE(meshcat.DeleteSlider("slider"));
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       meshcat.GetSliderValue("slider"),
@@ -938,6 +939,12 @@ GTEST_TEST(MeshcatTest, Sliders) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       meshcat.GetSliderValue("slider2"),
       "Meshcat does not have any slider named slider2.*");
+
+  // Strictly (the default) removing a missing slider throws.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.DeleteSlider("slider1"),
+      "Meshcat does not have any slider named slider1.*");
+  EXPECT_FALSE(meshcat.DeleteSlider("slider1", /*strict = */false));
 
   slider_names = meshcat.GetSliderNames();
   EXPECT_EQ(slider_names.size(), 0);

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -217,14 +217,20 @@ void JointSliders<T>::Delete() {
   if (was_registered) {
     for (const auto& [position_index, slider_name] : position_names_) {
       unused(position_index);
-      meshcat_->DeleteSlider(slider_name);
+      meshcat_->DeleteSlider(slider_name, /*strict = */ false);
     }
   }
 }
 
 template <typename T>
 JointSliders<T>::~JointSliders() {
-  Delete();
+  // Destructors are not allowed to throw. Ensure this by catching any
+  // exceptions and failing fast.
+  try {
+    Delete();
+  } catch (...) {
+    DRAKE_UNREACHABLE();
+  }
 }
 
 template <typename T>

--- a/visualization/meshcat_pose_sliders.cc
+++ b/visualization/meshcat_pose_sliders.cc
@@ -146,7 +146,7 @@ void MeshcatPoseSliders<T>::Delete() {
   if (was_registered) {
     for (int i = 0; i < 6; ++i) {
       if (visible_[i]) {
-        meshcat_->DeleteSlider(slider_names_[i]);
+        meshcat_->DeleteSlider(slider_names_[i], /*strict = */ false);
       }
     }
   }
@@ -154,7 +154,13 @@ void MeshcatPoseSliders<T>::Delete() {
 
 template <typename T>
 MeshcatPoseSliders<T>::~MeshcatPoseSliders() {
-  Delete();
+  // Destructors are not allowed to throw. Ensure this by catching any
+  // exceptions and failing fast.
+  try {
+    Delete();
+  } catch (...) {
+    DRAKE_UNREACHABLE();
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
Fix a footgun that has been hiding in plain sight for some time: the mismatch among the meshcat controls API, its (mis-)uses, and the fact that Python bindings make destructor ordering unpredictable.

Why hasn't it fired? Largely because pybind memory management was configured to leak diagrams and leaf systems forever, so destructors would never run. In order to open the way to a fix for memory leaks, the destructor hazard(s) must be addressed first.

* Introduce a non-strict deletion mode, that warns instead of throws.
* Use non-strict deletion when called from destructors.
* In addition, catch all exceptions in destructors, and abort if any are raised.
* Update bindings, doc, and tests.

Note that this patch does *not* solve any of the inherent hazards of the meshcat controls API: the delusion of control ownership, problems with overlapping client lifetimes, etc. It merely stops the destructor-operated deletion paths from throwing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22028)
<!-- Reviewable:end -->
