### PR TITLE
Silence erroneous VTK warning

### DIFF
--- a/tools/workspace/vtk_internal/patches/fix_illumination_bugs.patch
+++ b/tools/workspace/vtk_internal/patches/fix_illumination_bugs.patch
@@ -150,7 +150,7 @@ index e557044f37..5d218b7a9c 100644
        lights->InitTraversal();
        l = lights->GetNextItem();
        this->CurrentLightIndex = 0;
-@@ -464,6 +484,17 @@ void vtkShadowMapBakerPass::Render(const vtkRenderState* s)
+@@ -464,6 +484,18 @@ void vtkShadowMapBakerPass::Render(const vtkRenderState* s)
        {
          if (l->GetSwitch() && this->LightCreatesShadow(l))
          {
@@ -158,7 +158,8 @@ index e557044f37..5d218b7a9c 100644
 +            // Restore the light's original matrix.
 +            vtkMatrix4x4* cachedTransform = cachedLightTransforms.at(l);
 +            if (cachedTransform != nullptr) {
-+              l->GetTransformMatrix()->DeepCopy(cachedTransform);
++              // Restore values without tweaking modified time.
++              vtkMatrix4x4::DeepCopy(*l->GetTransformMatrix()->Element, *cachedTransform->Element);
 +            } else {
 +              // This may be redundant; it is unlikely if the light didn't
 +              // originally have a transform that it would pick one up.


### PR DESCRIPTION
The patch stored and restored light matrix values to correct handling multiple shadow-casting lights. However, it did so in a way that advanced the light matrix's modified time out of the expected code path.

This uses a different technique for restoring the light matrix values that doesn't advance the matrix's modified time.

To see the effect run:

```bash
bazel test geometry/render_vtk:internal_render_engine_vtk_test \
    --test_filter="*WholeImageCustomParams" --test_output=all
```

At the end of the blob of warnings you'll see:

```bash
Warning: In vtkTransform.cxx, line 180
vtkTransform (0x5b4ba1d22810): InternalUpdate: doing hack to support legacy code.  This is deprecated in VTK 4.2.  May be removed in a future version.
```

This commit removes that message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22047)
<!-- Reviewable:end -->
