### PR TITLE
Allow subclasses of CollisionChecker to return the pair of geometries that's in collision.

### DIFF
--- a/planning/scene_graph_collision_checker.cc
+++ b/planning/scene_graph_collision_checker.cc
@@ -36,7 +36,8 @@ using systems::Context;
 
 SceneGraphCollisionChecker::SceneGraphCollisionChecker(
     CollisionCheckerParams params)
-    : CollisionChecker(std::move(params), true /* supports parallel */) {
+    : CollisionChecker(std::move(params), true /* supports parallel */,
+                       true /* can return the collision pair */) {
   AllocateContexts();
   // Enforce that all filters known to the collision checker are active in
   // SceneGraph, as CollisionChecker introduces additional filters that may not
@@ -118,7 +119,8 @@ void SceneGraphCollisionChecker::UpdateCollisionFilters() {
 }
 
 bool SceneGraphCollisionChecker::DoCheckContextConfigCollisionFree(
-    const CollisionCheckerContext& model_context) const {
+    const CollisionCheckerContext& model_context,
+    geometry::SignedDistancePair<double>* collision_pair) const {
   const QueryObject<double>& query_object = model_context.GetQueryObject();
   const SceneGraphInspector<double>& inspector = query_object.inspector();
 
@@ -154,6 +156,11 @@ bool SceneGraphCollisionChecker::DoCheckContextConfigCollisionFree(
       } else {
         log()->trace("Environment collision between bodies [{}] and [{}]",
                      body_A->scoped_name(), body_B->scoped_name());
+      }
+      if (collision_pair != nullptr) {
+        // If the user has given us an object to store the pair in collision,
+        // keep it.
+        *collision_pair = distance_pair;
       }
       return false;
     }

--- a/planning/scene_graph_collision_checker.h
+++ b/planning/scene_graph_collision_checker.h
@@ -37,7 +37,8 @@ class SceneGraphCollisionChecker final : public CollisionChecker {
   void DoUpdateContextPositions(CollisionCheckerContext*) const final;
 
   bool DoCheckContextConfigCollisionFree(
-      const CollisionCheckerContext& model_context) const final;
+      const CollisionCheckerContext& model_context,
+      geometry::SignedDistancePair<double>* collision_pair) const final;
 
   std::optional<geometry::GeometryId> DoAddCollisionShapeToBody(
       const std::string& group_name, const multibody::RigidBody<double>& bodyA,

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -124,7 +124,8 @@ class CollisionCheckerTester : public UnimplementedCollisionChecker {
   }
 
   bool DoCheckContextConfigCollisionFree(
-      const CollisionCheckerContext& model_context) const override {
+      const CollisionCheckerContext& model_context,
+      geometry::SignedDistancePair<double>* collision_pair) const override {
     // CollisionChecker promises that positions have been updated from public
     // method arguments.
     positions_for_check_ = plant().GetPositions(model_context.plant_context());
@@ -1735,7 +1736,8 @@ class MockEdgeChecker : public UnimplementedCollisionChecker {
 
  protected:
   bool DoCheckContextConfigCollisionFree(
-      const CollisionCheckerContext& model_context) const override {
+      const CollisionCheckerContext& model_context,
+      geometry::SignedDistancePair<double>*) const override {
     // Make this call artificially more expensive so that parallel edge checks
     // will actually perform work in multiple OpenMP threads.
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/planning/unimplemented_collision_checker.cc
+++ b/planning/unimplemented_collision_checker.cc
@@ -17,7 +17,8 @@ namespace {
 
 UnimplementedCollisionChecker::UnimplementedCollisionChecker(
     CollisionCheckerParams params, bool supports_parallel_checking)
-    : CollisionChecker(std::move(params), supports_parallel_checking) {}
+    : CollisionChecker(std::move(params), supports_parallel_checking,
+                       false /* cannot return collision pair */) {}
 
 UnimplementedCollisionChecker::UnimplementedCollisionChecker(
     const UnimplementedCollisionChecker&) = default;
@@ -35,7 +36,8 @@ void UnimplementedCollisionChecker::DoUpdateContextPositions(
 }
 
 bool UnimplementedCollisionChecker::DoCheckContextConfigCollisionFree(
-    const CollisionCheckerContext&) const {
+    const CollisionCheckerContext&,
+    geometry::SignedDistancePair<double>*) const {
   ThrowNotImplemented(__func__);
 }
 

--- a/planning/unimplemented_collision_checker.h
+++ b/planning/unimplemented_collision_checker.h
@@ -45,7 +45,8 @@ class UnimplementedCollisionChecker : public CollisionChecker {
       CollisionCheckerContext* model_context) const override;
 
   bool DoCheckContextConfigCollisionFree(
-      const CollisionCheckerContext&) const override;
+      const CollisionCheckerContext&,
+      geometry::SignedDistancePair<double>* collision_pair) const override;
 
   std::optional<geometry::GeometryId> DoAddCollisionShapeToBody(
       const std::string& group_name, const multibody::RigidBody<double>& bodyA,


### PR DESCRIPTION
Related to #22049.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22054)
<!-- Reviewable:end -->
