### PR TITLE
Bug fixes for holonomic and weld constraints

### DIFF
--- a/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_holonomic_constraint.cc
@@ -23,15 +23,15 @@ SapHolonomicConstraint<T>::Parameters::Parameters(
       relaxation_times_(std::move(relaxation_times)),
       beta_(beta) {
   constexpr double kInf = std::numeric_limits<double>::infinity();
-  DRAKE_DEMAND(impulse_lower_limits.size() == impulse_upper_limits.size());
-  DRAKE_DEMAND(impulse_lower_limits.size() == stiffnesses.size());
-  DRAKE_DEMAND(impulse_lower_limits.size() == relaxation_times.size());
-  DRAKE_DEMAND((impulse_lower_limits.array() <= kInf).all());
-  DRAKE_DEMAND((impulse_upper_limits.array() >= -kInf).all());
+  DRAKE_DEMAND(impulse_lower_limits_.size() == impulse_upper_limits_.size());
+  DRAKE_DEMAND(impulse_lower_limits_.size() == stiffnesses_.size());
+  DRAKE_DEMAND(impulse_lower_limits_.size() == relaxation_times_.size());
+  DRAKE_DEMAND((impulse_lower_limits_.array() <= kInf).all());
+  DRAKE_DEMAND((impulse_upper_limits_.array() >= -kInf).all());
   DRAKE_DEMAND(
-      (impulse_lower_limits.array() <= impulse_upper_limits.array()).all());
-  DRAKE_DEMAND((stiffnesses.array() > 0).all());
-  DRAKE_DEMAND((relaxation_times.array() >= 0).all());
+      (impulse_lower_limits_.array() <= impulse_upper_limits_.array()).all());
+  DRAKE_DEMAND((stiffnesses_.array() > 0).all());
+  DRAKE_DEMAND((relaxation_times_.array() >= 0).all());
 }
 
 template <typename T>

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -640,6 +640,9 @@ void SapDriver<T>::AddWeldConstraints(
     const math::RigidTransform<T>& X_WB = body_B.EvalPoseInWorld(context);
     const math::RigidTransform<T> X_WP = X_WA * spec.X_AP.template cast<T>();
     const math::RigidTransform<T> X_WQ = X_WB * spec.X_BQ.template cast<T>();
+    const math::RotationMatrix<T> R_AW = X_WA.rotation().transpose();
+    const math::RotationMatrix<T> R_BW = X_WB.rotation().transpose();
+
     const Vector3<T> p_AP_W =
         X_WA.rotation() * spec.X_AP.translation().template cast<T>();
     const Vector3<T> p_BQ_W =
@@ -647,8 +650,8 @@ void SapDriver<T>::AddWeldConstraints(
 
     // Let M be the midpoint of P and Q.
     const Vector3<T> p_WM = 0.5 * (X_WP.translation() + X_WQ.translation());
-    const Vector3<T> p_AM = p_WM - X_WA.translation();
-    const Vector3<T> p_BM = p_WM - X_WB.translation();
+    const Vector3<T> p_AM = R_AW * (p_WM - X_WA.translation());
+    const Vector3<T> p_BM = R_BW * (p_WM - X_WB.translation());
 
     // Dense Jacobian.
     manager().internal_tree().CalcJacobianSpatialVelocity(

--- a/multibody/plant/test/sap_driver_weld_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_weld_constraints_test.cc
@@ -23,6 +23,7 @@
   MultibodyPlant used for testing, before constraints are added. */
 
 using drake::math::RigidTransformd;
+using drake::math::RollPitchYawd;
 using drake::math::RotationMatrixd;
 using drake::multibody::contact_solvers::internal::SapContactProblem;
 using drake::multibody::contact_solvers::internal::SapHolonomicConstraint;
@@ -120,6 +121,8 @@ class TwoBodiesTest : public ::testing::TestWithParam<TestConfig> {
   const RigidTransformd X_AP_{RotationMatrixd::MakeZRotation(theta), p_AP_};
   const RigidTransformd X_BQ_{RotationMatrixd::MakeZRotation(-theta), p_BQ_};
   const Vector3d kOffset_{0.1, 0.2, 0.3};
+  const RotationMatrixd kRotationOffset_{
+      RollPitchYawd(Vector3d(1.0, 2.0, 3.0))};
 };
 
 // This test configures a single weld constraint in variety of ways (causing
@@ -137,8 +140,14 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
   // Place Bo at known offset from Ao; this does *not* satisfy the
   // constraint. We'll observe a non-zero value when evaluating the constraint
   // function.
-  plant_.SetFreeBodyPoseInWorldFrame(context_.get(), *bodyB_,
-                                     RigidTransformd(kOffset_));
+  // Moreover, rotate both bodies A and B an arbitrary non-identity amount.
+  if (!config.bodyA_anchored) {
+    plant_.SetFreeBodyPoseInWorldFrame(
+        context_.get(), *bodyA_,
+        RigidTransformd(kRotationOffset_, Vector3d::Zero()));
+  }
+  plant_.SetFreeBodyPoseInWorldFrame(
+      context_.get(), *bodyB_, RigidTransformd(kRotationOffset_, kOffset_));
   const ContactProblemCache<double>& problem_cache =
       SapDriverTest::EvalContactProblemCache(sap_driver(), *context_);
   const SapContactProblem<double>& problem = *problem_cache.sap_problem;
@@ -242,7 +251,7 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
                             -p_BBm_Wx,               I3).finished();
     // clang-format on
     EXPECT_TRUE(
-        CompareMatrices(J, J_expected, kEps, MatrixCompareType::relative));
+        CompareMatrices(J, J_expected, 8 * kEps, MatrixCompareType::relative));
   } else {
     const MatrixXd& Ja = constraint->first_clique_jacobian().MakeDenseMatrix();
     // clang-format off
@@ -250,8 +259,8 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
       -(MatrixXd(6, 6) <<         I3, Matrix3d::Zero(),
                            -p_AAm_Wx,               I3).finished();
     // clang-format on
-    EXPECT_TRUE(
-        CompareMatrices(Ja, Ja_expected, kEps, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(Ja, Ja_expected, 8 * kEps,
+                                MatrixCompareType::relative));
 
     const MatrixXd& Jb = constraint->second_clique_jacobian().MakeDenseMatrix();
     // clang-format off
@@ -259,8 +268,8 @@ TEST_P(TwoBodiesTest, ConfirmConstraintProperties) {
         (MatrixXd(6, 6) <<        I3, Matrix3d::Zero(),
                            -p_BBm_Wx,               I3).finished();
     // clang-format on
-    EXPECT_TRUE(
-        CompareMatrices(Jb, Jb_expected, kEps, MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(Jb, Jb_expected, 8 * kEps,
+                                MatrixCompareType::relative));
   }
 }
 


### PR DESCRIPTION
A separate comits for each fix:
 - Fixes math in the computation of the weld constraint Jacobian
 - Fixes DEMAND of already moved variables in holonomic constraints

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22057)
<!-- Reviewable:end -->
