### PR TITLE
[solvers] Throw when IpoptSolver options are invalid

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1485,6 +1485,7 @@ drake_cc_googletest(
         ":second_order_cone_program_examples",
         "//common:temp_directory",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ] + select({
         "//conditions:default": [
             "@ipopt",


### PR DESCRIPTION
Noticed during #21957.  When we set the linear_solver to "ma27", IPOPT was just ignoring us.

Across the board, our policy for solver options is:
- If a "common solver option" cannot be set, then ignore it.
- If a solver-specific option cannot be set, then that's an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22062)
<!-- Reviewable:end -->
