### PR TITLE
[workspace] Force-disable CoinUtils debugging hooks

### DIFF
--- a/tools/workspace/coinutils_internal/defs.bzl
+++ b/tools/workspace/coinutils_internal/defs.bzl
@@ -123,6 +123,11 @@ def coin_cc_library(
             "-w",
             # On Clang 12, "-w" doesn't suppress this for some reason.
             "-Wno-register",
+            # The Coin family of software uses NDEBUG for gross things, not
+            # just controlling <cassert> but actually inserting huge swaths
+            # of debugging code, some of which is not thread-safe. Even in
+            # Drake's debug builds, we still don't want any of that stuff.
+            "-DNDEBUG",
         ],
         deps = deps + [":_config_private"],
     )


### PR DESCRIPTION
Towards #21957.

One example: https://github.com/coin-or/CoinUtils/blob/b6ed55a0/src/CoinFactorization2.cpp#L158-L190.  If you grep for `NDEBUG` in CoinUtils and Clp, there is a lot more.  In Ipopt there is almost nothing, but there are calls to `assert(...)` to we might as well nerf those here, too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22063)
<!-- Reviewable:end -->
