### PR TITLE
Remove the 2x2 psd matrix constraint with larger psd matrix.

### DIFF
--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -626,7 +626,7 @@ GTEST_TEST(MosekSolver, SocpDualSolution2) {
 GTEST_TEST(MosekTest, SDPDualSolution1) {
   MosekSolver solver;
   if (solver.available()) {
-    TestSDPDualSolution1(solver, 3E-6);
+    TestSDPDualSolution1(solver, 1E-4);
   }
 }
 

--- a/solvers/test/semidefinite_program_examples.cc
+++ b/solvers/test/semidefinite_program_examples.cc
@@ -23,7 +23,7 @@ const double kInf = std::numeric_limits<double>::infinity();
 void TestTrivialSDP(const SolverInterface& solver, double tol) {
   MathematicalProgram prog;
 
-  auto S = prog.NewSymmetricContinuousVariables<2>("S");
+  auto S = prog.NewSymmetricContinuousVariables<3>("S");
 
   // S is p.s.d
   prog.AddPositiveSemidefiniteConstraint(S);
@@ -38,7 +38,9 @@ void TestTrivialSDP(const SolverInterface& solver, double tol) {
 
   auto S_value = result.GetSolution(S);
 
-  EXPECT_TRUE(CompareMatrices(S_value, Eigen::Matrix2d::Ones(), tol));
+  Eigen::Matrix3d S_expected = Eigen::Matrix3d::Zero();
+  S_expected.topLeftCorner<2, 2>() = Eigen::Matrix2d::Ones();
+  EXPECT_TRUE(CompareMatrices(S_value, S_expected, tol));
   EXPECT_NEAR(result.get_optimal_cost(), 2.0, tol);
 }
 
@@ -265,40 +267,56 @@ void SolveSDPwithSecondOrderConeExample2(const SolverInterface& solver,
 void SolveSDPwithOverlappingVariables(const SolverInterface& solver,
                                       double tol) {
   MathematicalProgram prog;
-  auto x = prog.NewContinuousVariables<3>();
-  prog.AddPositiveSemidefiniteConstraint(
-      (Matrix2<symbolic::Variable>() << x(0), x(1), x(1), x(0)).finished());
-  prog.AddPositiveSemidefiniteConstraint(
-      (Matrix2<symbolic::Variable>() << x(0), x(2), x(2), x(0)).finished());
+  auto x = prog.NewContinuousVariables<6>();
+  Matrix3<symbolic::Variable> psd_mat1;
+  Matrix3<symbolic::Variable> psd_mat2;
+  // clang-format off
+  psd_mat1 << x(0), x(1), x(3),
+              x(1), x(0), x(4),
+              x(3), x(4), x(5);
+  psd_mat2 << x(0), x(2), x(3),
+              x(2), x(0), x(4),
+              x(3), x(4), x(5);
+  // clang-format on
+  prog.AddPositiveSemidefiniteConstraint(psd_mat1);
+  prog.AddPositiveSemidefiniteConstraint(psd_mat2);
   prog.AddBoundingBoxConstraint(1, 1, x(1));
-  prog.AddLinearCost(2 * x(0) + x(2));
+  prog.AddLinearCost(2 * x(0) + x(2) + x(5));
 
   MathematicalProgramResult result;
   solver.Solve(prog, {}, {}, &result);
   EXPECT_TRUE(result.is_success());
-  EXPECT_TRUE(
-      CompareMatrices(result.GetSolution(x), Eigen::Vector3d(1, 1, -1), tol));
+  Vector6<double> x_expected;
+  x_expected << 1, 1, -1, 0, 0, 0;
+  EXPECT_TRUE(CompareMatrices(result.GetSolution(x), x_expected, tol));
   EXPECT_NEAR(result.get_optimal_cost(), 1, tol);
 }
 
 void SolveSDPwithQuadraticCosts(const SolverInterface& solver, double tol) {
   MathematicalProgram prog;
-  auto x = prog.NewContinuousVariables<3>();
-  const Matrix2<symbolic::Variable> X1 =
-      (Matrix2<symbolic::Variable>() << x(0), x(1), x(1), x(0)).finished();
-  auto psd_constraint1 = prog.AddPositiveSemidefiniteConstraint(X1);
-  const Matrix2<symbolic::Variable> X2 =
-      (Matrix2<symbolic::Variable>() << x(0), x(2), x(2), x(0)).finished();
-  auto psd_constraint2 = prog.AddPositiveSemidefiniteConstraint(X2);
+  auto x = prog.NewContinuousVariables<6>();
+  Matrix3<symbolic::Variable> psd_mat1;
+  Matrix3<symbolic::Variable> psd_mat2;
+  // clang-format off
+  psd_mat1 << x(0), x(1), x(3),
+              x(1), x(0), x(4),
+              x(3), x(4), x(5);
+  psd_mat2 << x(0), x(2), x(3),
+              x(2), x(0), x(4),
+              x(3), x(4), x(5);
+  // clang-format on
+  auto psd_constraint1 = prog.AddPositiveSemidefiniteConstraint(psd_mat1);
+  auto psd_constraint2 = prog.AddPositiveSemidefiniteConstraint(psd_mat2);
   prog.AddBoundingBoxConstraint(1, 1, x(1));
   prog.AddQuadraticCost(x(0) * x(0));
-  prog.AddLinearCost(2 * x(0) + x(2));
+  prog.AddLinearCost(2 * x(0) + x(2) + x(5));
 
   MathematicalProgramResult result;
   solver.Solve(prog, {}, {}, &result);
   EXPECT_TRUE(result.is_success());
-  EXPECT_TRUE(
-      CompareMatrices(result.GetSolution(x), Eigen::Vector3d(1, 1, -1), tol));
+  Vector6<double> x_expected;
+  x_expected << 1, 1, -1, 0, 0, 0;
+  EXPECT_TRUE(CompareMatrices(result.GetSolution(x), x_expected, tol));
   EXPECT_NEAR(result.get_optimal_cost(), 2, tol);
 
   // Check the complementarity condition for the PSD constraint.
@@ -306,27 +324,35 @@ void SolveSDPwithQuadraticCosts(const SolverInterface& solver, double tol) {
       result.GetDualSolution(psd_constraint1));
   const auto psd_dual2 = math::ToSymmetricMatrixFromLowerTriangularColumns(
       result.GetDualSolution(psd_constraint2));
-  const auto X1_sol = result.GetSolution(X1);
-  const auto X2_sol = result.GetSolution(X2);
-  EXPECT_NEAR((psd_dual1 * X1_sol).trace(), 0, tol);
-  EXPECT_NEAR((psd_dual2 * X2_sol).trace(), 0, tol);
+  const auto psd_mat1_sol = result.GetSolution(psd_mat1);
+  const auto psd_mat2_sol = result.GetSolution(psd_mat2);
+  EXPECT_NEAR((psd_dual1 * psd_mat1_sol).trace(), 0, tol);
+  EXPECT_NEAR((psd_dual2 * psd_mat2_sol).trace(), 0, tol);
 }
 
-void TestSDPDualSolution1(const SolverInterface& solver, double tol) {
+void TestSDPDualSolution1(const SolverInterface& solver, double tol,
+                          double complementarity_tol) {
   MathematicalProgram prog;
-  auto X = prog.NewSymmetricContinuousVariables<2>();
-  auto psd_con = prog.AddPositiveSemidefiniteConstraint(X);
+  auto x = prog.NewContinuousVariables<6>();
+  Matrix3<symbolic::Variable> psd_mat;
+  // clang-format off
+  psd_mat << x(0), x(1), x(3),
+             x(1), x(2), x(4),
+             x(3), x(4), x(5);
+  // clang-format on
+  auto psd_con = prog.AddPositiveSemidefiniteConstraint(psd_mat);
   auto bb_con = prog.AddBoundingBoxConstraint(
       Eigen::Vector2d(kInf, kInf), Eigen::Vector2d(4, 1),
-      Vector2<symbolic::Variable>(X(0, 0), X(1, 1)));
-  prog.AddLinearCost(X(1, 0));
+      Vector2<symbolic::Variable>(x(0), x(2)));
+  prog.AddLinearCost(x(1) + x(5));
   MathematicalProgramResult result;
   solver.Solve(prog, {}, {}, &result);
   EXPECT_TRUE(result.is_success());
 
-  const auto X_sol = result.GetSolution(X);
+  const Vector6<double> x_sol = result.GetSolution(x);
+  const auto psd_mat_sol = result.GetSolution(psd_mat);
   EXPECT_TRUE(CompareMatrices(
-      X_sol, (Eigen::Matrix2d() << 4, -2, -2, 1).finished(), tol));
+      x_sol, (Vector6d() << 4, -2, 1, 0, 0, 0).finished(), tol));
   // The optimal cost is -sqrt(x0 * x2), hence the sensitivity to the
   // bounding box constraint on x0 is -.25, and the sensitivity to the bounding
   // box constraint on x2 is -1.
@@ -335,27 +361,33 @@ void TestSDPDualSolution1(const SolverInterface& solver, double tol) {
                               bb_con_dual_expected, tol));
   const auto psd_dual = math::ToSymmetricMatrixFromLowerTriangularColumns(
       result.GetDualSolution(psd_con));
-  // Complementarity condition ensures the inner product of X and its dual is 0.
-  EXPECT_NEAR((X_sol * psd_dual).trace(), 0, tol);
+  // Complementarity condition ensures the inner product of psd_mat and its dual
+  // is 0.
+  EXPECT_NEAR((psd_mat_sol * psd_dual).trace(), 0, complementarity_tol);
   // The problem in the primal form is
-  // min [0  0.5] ● X
-  //     [0.5  0]
-  // s.t [1 0] ● X <= 4
-  //     [0 0]
+  // min [0  0.5 0] ● X
+  //     [0.5  0 0]
+  //     [0    0 1]
+  // s.t [1 0 0] ● X <= 4
+  //     [0 0 0]
+  //     [0 0 0]
   //
-  //     [0 0] ● X <= 1
-  //     [0 1]
+  //     [0 0 0] ● X <= 1
+  //     [0 1 0]
+  //     [0 0 0]
   // The problem in the dual form (LMI) is
   // max 4*y1 + y2
-  // s.t [-y1  0.5]  is psd   (1)
-  //     [0.5  -y2]
+  // s.t [-y1  0.5 0]  is psd   (1)
+  //     [0.5  -y2 0]
+  //     [ 0   0   1]
   // The optimal solution is to the dual is y1 = -0.25, y2 = -1. Plug in this
   // dual solution to the left hand side of (1) is what Mosek/SCS returns as the
   // dual solution.
-  Eigen::Matrix2d psd_dual_expected;
   // clang-format off
-  psd_dual_expected << 0.25, 0.5,
-                       0.5, 1;
+  Eigen::Matrix3d psd_dual_expected;
+  psd_dual_expected << 0.25, 0.5, 0,
+                       0.5, 1, 0,
+                       0,  0, 1;
   // clang-format on
   EXPECT_TRUE(CompareMatrices(psd_dual, psd_dual_expected, tol));
 }

--- a/solvers/test/semidefinite_program_examples.h
+++ b/solvers/test/semidefinite_program_examples.h
@@ -9,12 +9,13 @@ namespace drake {
 namespace solvers {
 namespace test {
 /// Test a trivial semidefinite problem.
-/// min S(0, 0) + S(1, 1)
+/// min S(0, 0) + S(1, 1) + S(2, 2)
 /// s.t S(1, 0) = 1
 ///     S is p.s.d
 /// The analytical solution is
-/// S = [1 1]
-///     [1 1]
+/// S = [1 1 0]
+///     [1 1 0]
+///     [0 0 0]
 void TestTrivialSDP(const SolverInterface& solver, double tol);
 
 // Solve a semidefinite programming problem.
@@ -87,13 +88,16 @@ void SolveSDPwithSecondOrderConeExample2(const SolverInterface& solver,
 
 /** Solve an SDP with two PSD constraint, where each PSD constraint has
  * duplicate entries and the two PSD matrix share a common variables.
- * min 2 * x0 + x2
- * s.t [x0 x1] is psd
- *     [x1 x0]
- *     [x0 x2] is psd
- *     [x2 x0]
+ * min 2 * x0 + x2 + x5
+ * s.t [x0 x1 x3] is psd
+ *     [x1 x0 x4]
+ *     [x3 x4 x5]
+ *
+ *     [x0 x2 x3] is psd
+ *     [x2 x0 x4]
+ *     [x3 x4 x5]
  *     x1 == 1
- * The optimal solution will be x = (1, 1, -1).
+ * The optimal solution will be x = (1, 1, -1, 0, 0, 0).
  */
 void SolveSDPwithOverlappingVariables(const SolverInterface& solver,
                                       double tol);
@@ -101,26 +105,32 @@ void SolveSDPwithOverlappingVariables(const SolverInterface& solver,
 /** Solve an SDP with quadratic cost and two PSD constraints, where each PSD
  * constraint has duplicate entries and the two PSD matrix share a common
  * variables.
- * min x0² + 2*x0 + x2
- * s.t ⎡x0 x1⎤ is psd
- *     ⎣x1 x0⎦
- *     ⎡x0 x2⎤ is psd
- *     ⎣x2 x0⎦
+ * min x0² + 2*x0 + x2 + x5
+ * s.t ⎡x0 x1 x3⎤ is psd
+ *     |x1 x0 x4|
+ *     ⎣x3 x4 x5⎦
+ *
+ *     ⎡x0 x2 x3⎤ is psd
+ *     |x2 x0 x4|
+ *     ⎣x3 x4 x5⎦
+ *
  *     x1 == 1
  *
- * The optimal solution will be x = (1, 1, -1).
+ * The optimal solution will be x = (1, 1, -1, 0, 0, 0).
  */
 void SolveSDPwithQuadraticCosts(const SolverInterface& solver, double tol);
 
 /**
  * Test a simple SDP with only PSD constraint and bounding box constraint.
- * min x1
- * s.t ⎡x0 x1⎤ is psd
- *     ⎣x1 x2⎦
+ * min x1 + x5
+ * s.t ⎡x0 x1 x3⎤ is psd
+ *     |x1 x2 x4|
+ *     ⎣x3 x4 x5⎦
  *     x0 <= 4
  *     x2 <= 1
  */
-void TestSDPDualSolution1(const SolverInterface& solver, double tol);
+void TestSDPDualSolution1(const SolverInterface& solver, double tol,
+                          double complementarity_tol = 5E-7);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
The 2x2 psd matrix is in fact a second order cone constraint, which will not be imposed as a psd constraint in the solvers in the future.

towards #21663

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22071)
<!-- Reviewable:end -->
