### PR TITLE
Pin temurin to 22.x

### DIFF
--- a/setup/mac/binary_distribution/Brewfile
+++ b/setup/mac/binary_distribution/Brewfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-cask 'temurin' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
+cask 'temurin@22' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
 
 brew 'eigen'
 brew 'gcc'


### PR DESCRIPTION
Unprovisoned jobs have been consistently causing our MacOS CI to hang for the past few days.  This appears to be caused by the Jenkins agent crashing in the middle of a job, requiring a Jenkins restart to reconnect.

Our provisioned images are running Java 22.x, while our unprovisioned images install Java 23.x.  This PR pins temurin to 22.x in an attempt to resolve the CI failures for unprovisioned images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22073)
<!-- Reviewable:end -->
