### PR TITLE
Use the preprocessing solver options even if a specific preprocessing solver is not specified.

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -120,9 +120,8 @@ struct GraphOfConvexSetsOptions {
   /** Optional solver options to be used by preprocessing_solver in the
   preprocessing stage of GCS, which is used in SolveShortestPath. If
   preprocessing_solver is set but this parameter is not then solver_options is
-  used. If preprocessing_solver is not set, this parameter is ignored. For
-  instance, one might want to print solver logs for the main optimization, but
-  not from the many smaller preprocessing optimizations. */
+  used. For instance, one might want to print solver logs for the main
+  optimization, but not from the many smaller preprocessing optimizations. */
   std::optional<solvers::SolverOptions> preprocessing_solver_options{
       std::nullopt};
 };


### PR DESCRIPTION
Right now the behavior of GraphOfConvexSets is to only use options.preprocessing_solver_options if the user also specifies an options.preprocessing_solver. This PR changes the behavior so these options are used if provided, regardless of whether or not the user specified a solver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22077)
<!-- Reviewable:end -->
