### PR TITLE
[solvers] SolverOptions is serializable

### DIFF
--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -802,10 +802,10 @@ class TestGeometryOptimization(unittest.TestCase):
             ClpSolver.id(), "log_level", 3)
         options.parallelism = True
         self.assertIn("scaling",
-                      options.solver_options.GetOptions(ClpSolver.id()))
+                      options.solver_options.options[ClpSolver().id().name()])
         self.assertIn("log_level",
-                      options.restriction_solver_options.GetOptions(
-                          ClpSolver.id()))
+                      options.restriction_solver_options.options[
+                          ClpSolver().id().name()])
         self.assertIn("convex_relaxation", repr(options))
 
         spp = mut.GraphOfConvexSets()
@@ -1161,8 +1161,9 @@ class TestCspaceFreePolytope(unittest.TestCase):
         self.assertEqual(find_separation_options.solver_id, ScsSolver.id())
         self.assertFalse(find_separation_options.terminate_at_failure)
         self.assertEqual(
-            find_separation_options.solver_options.common_solver_options()[
-                CommonSolverOption.kPrintToConsole], 1)
+            find_separation_options.solver_options.options[
+                "Drake"]["kPrintToConsole"],
+            1)
 
         # FindSeparationCertificateGivenPolytopeOptions
         lagrangian_options = \
@@ -1195,8 +1196,9 @@ class TestCspaceFreePolytope(unittest.TestCase):
         self.assertFalse(
             lagrangian_options.terminate_at_failure)
         self.assertEqual(
-            lagrangian_options.solver_options.common_solver_options()[
-                CommonSolverOption.kPrintToConsole], 1)
+            lagrangian_options.solver_options.options[
+                "Drake"]["kPrintToConsole"],
+            1)
         self.assertTrue(
             lagrangian_options.ignore_redundant_C)
 
@@ -1234,8 +1236,9 @@ class TestCspaceFreePolytope(unittest.TestCase):
             polytope_options.solver_id,
             ScsSolver.id())
         self.assertEqual(
-            polytope_options.solver_options.common_solver_options()[
-                CommonSolverOption.kPrintToConsole], 1)
+            polytope_options.solver_options.options[
+                "Drake"]["kPrintToConsole"],
+            1)
         np.testing.assert_array_almost_equal(
             polytope_options.s_inner_pts, np.zeros(
                 (2, 1)), 1e-5)

--- a/bindings/pydrake/planning/test/graph_algorithms_test.py
+++ b/bindings/pydrake/planning/test/graph_algorithms_test.py
@@ -58,8 +58,7 @@ class TestGraphAlgorithms(unittest.TestCase):
         # Test the default constructor.
         solver_default = mut.MaxCliqueSolverViaMip()
         self.assertIsNone(solver_default.GetInitialGuess())
-        self.assertFalse(
-            solver_default.GetSolverOptions().get_print_to_console())
+        self.assertEqual(len(solver_default.GetSolverOptions().options), 0)
 
         # Test the argument constructor.
         solver_options = SolverOptions()
@@ -68,21 +67,19 @@ class TestGraphAlgorithms(unittest.TestCase):
         solver = mut.MaxCliqueSolverViaMip(solver_options=solver_options,
                                            initial_guess=initial_guess)
         # Test the getters.
-        numpy_compare.assert_equal(
-            solver.GetInitialGuess(), initial_guess
+        numpy_compare.assert_equal(solver.GetInitialGuess(), initial_guess)
+        self.assertTrue(
+            solver.GetSolverOptions().options["Drake"]["kPrintToConsole"],
         )
-        self.assertTrue(solver.GetSolverOptions().get_print_to_console())
 
         # Test the setters.
         new_guess = np.zeros(graph.shape[0])
         solver.SetInitialGuess(initial_guess=new_guess)
-        numpy_compare.assert_equal(
-            solver.GetInitialGuess(), new_guess
-        )
+        numpy_compare.assert_equal(solver.GetInitialGuess(), new_guess)
 
         new_options = SolverOptions()
         solver.SetSolverOptions(solver_options=new_options)
-        self.assertFalse(solver.GetSolverOptions().get_print_to_console())
+        self.assertEqual(len(solver.GetSolverOptions().options), 0)
 
         # Test solve max clique.
         if GurobiOrMosekSolverAvailable():

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -5,6 +5,7 @@
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -1353,27 +1354,36 @@ void BindMathematicalProgram(py::module m) {
           doc.MathematicalProgram.SetSolverOptions.doc)
       .def("solver_options", &MathematicalProgram::solver_options,
           py_rvp::reference_internal,
-          doc.MathematicalProgram.solver_options.doc)
-      // TODO(m-chaturvedi) Add Pybind11 documentation.
+          doc.MathematicalProgram.solver_options.doc);
+// Deprecated 2025-09-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  prog_cls  // BR
       .def("GetSolverOptions",
-          [](MathematicalProgram& prog, SolverId solver_id) {
-            py::dict out;
-            py::object update = out.attr("update");
-            update(prog.GetSolverOptionsDouble(solver_id));
-            update(prog.GetSolverOptionsInt(solver_id));
-            update(prog.GetSolverOptionsStr(solver_id));
-            return out;
-          })
+          WrapDeprecated(
+              doc.MathematicalProgram.GetSolverOptionsDouble.doc_deprecated,
+              [](MathematicalProgram& prog, SolverId solver_id) {
+                py::dict out;
+                py::object update = out.attr("update");
+                update(prog.GetSolverOptionsDouble(solver_id));
+                update(prog.GetSolverOptionsInt(solver_id));
+                update(prog.GetSolverOptionsStr(solver_id));
+                return out;
+              }))
       .def("GetSolverOptions",
-          [](MathematicalProgram& prog, SolverType solver_type) {
-            py::dict out;
-            py::object update = out.attr("update");
-            const SolverId id = SolverTypeConverter::TypeToId(solver_type);
-            update(prog.GetSolverOptionsDouble(id));
-            update(prog.GetSolverOptionsInt(id));
-            update(prog.GetSolverOptionsStr(id));
-            return out;
-          })
+          WrapDeprecated(
+              doc.MathematicalProgram.GetSolverOptionsDouble.doc_deprecated,
+              [](MathematicalProgram& prog, SolverType solver_type) {
+                py::dict out;
+                py::object update = out.attr("update");
+                const SolverId id = SolverTypeConverter::TypeToId(solver_type);
+                update(prog.GetSolverOptionsDouble(id));
+                update(prog.GetSolverOptionsInt(id));
+                update(prog.GetSolverOptionsStr(id));
+                return out;
+              }));
+#pragma GCC diagnostic pop
+  prog_cls  // BR
       .def("generic_costs", &MathematicalProgram::generic_costs,
           doc.MathematicalProgram.generic_costs.doc)
       .def("generic_constraints", &MathematicalProgram::generic_constraints,

--- a/bindings/pydrake/solvers/solvers_py_options.cc
+++ b/bindings/pydrake/solvers/solvers_py_options.cc
@@ -1,4 +1,5 @@
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"
@@ -29,10 +30,15 @@ void DefineSolversOptions(py::module m) {
   }
 
   {
-    // TODO(jwnimmer-tri) Bind the accessors for SolverOptions.
+    using NestedOptionsDict = decltype(SolverOptions{}.options);
     py::class_<SolverOptions> cls(m, "SolverOptions", doc.SolverOptions.doc);
     cls  // BR
-        .def(py::init<>(), doc.SolverOptions.ctor.doc)
+        .def(py::init([](NestedOptionsDict& options) {
+          auto result = std::make_unique<SolverOptions>();
+          result->options = std::move(options);
+          return result;
+        }),
+            py::kw_only(), py::arg("options") = NestedOptionsDict{})
         .def("SetOption",
             py::overload_cast<const SolverId&, std::string,
                 SolverOptions::OptionValue>(&SolverOptions::SetOption),
@@ -43,34 +49,11 @@ void DefineSolversOptions(py::module m) {
                 &SolverOptions::SetOption),
             py::arg("key"), py::arg("value"),
             doc.SolverOptions.SetOption.doc_2args)
-        .def(
-            "GetOptions",
-            [](const SolverOptions& solver_options, SolverId solver_id) {
-              py::dict out;
-              py::object update = out.attr("update");
-              update(solver_options.GetOptionsDouble(solver_id));
-              update(solver_options.GetOptionsInt(solver_id));
-              update(solver_options.GetOptionsStr(solver_id));
-              return out;
-            },
-            py::arg("solver_id"), doc.SolverOptions.GetOptionsDouble.doc)
-        .def("common_solver_options", &SolverOptions::common_solver_options,
-            doc.SolverOptions.common_solver_options.doc)
-        .def("get_print_file_name", &SolverOptions::get_print_file_name,
-            doc.SolverOptions.get_print_file_name.doc)
-        .def("get_print_to_console", &SolverOptions::get_print_to_console,
-            doc.SolverOptions.get_print_to_console.doc)
-        .def("get_standalone_reproduction_file_name",
-            &SolverOptions::get_standalone_reproduction_file_name,
-            doc.SolverOptions.get_standalone_reproduction_file_name.doc)
-        .def("get_max_threads", &SolverOptions::get_max_threads,
-            doc.SolverOptions.get_max_threads.doc)
-        .def("__repr__", [](const SolverOptions&) -> std::string {
-          // This is a minimal implementation that serves to avoid displaying
-          // memory addresses in pydrake docs and help strings. In the future,
-          // we should enhance this to provide more details.
-          return "<SolverOptions>";
-        });
+        .def_readwrite("options", &SolverOptions::options)
+        .def(py::self == py::self)
+        .def(py::self != py::self);
+    DefAttributesUsingSerialize(&cls);
+    DefReprUsingSerialize(&cls);
     DefCopyAndDeepCopy(&cls);
 
     constexpr char kSetOptionKwargNameDeprecation[] =
@@ -105,6 +88,45 @@ void DefineSolversOptions(py::module m) {
                 }),
             py::arg("solver_id"), py::arg("solver_option"),
             py::arg("option_value"), kSetOptionKwargNameDeprecation);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("GetOptions",
+            WrapDeprecated(doc.SolverOptions.GetOptionsDouble.doc_deprecated,
+                [](const SolverOptions& solver_options, SolverId solver_id) {
+                  py::dict out;
+                  py::object update = out.attr("update");
+                  update(solver_options.GetOptionsDouble(solver_id));
+                  update(solver_options.GetOptionsInt(solver_id));
+                  update(solver_options.GetOptionsStr(solver_id));
+                  return out;
+                }),
+            py::arg("solver_id"),
+            doc.SolverOptions.GetOptionsDouble.doc_deprecated)
+        .def("common_solver_options",
+            WrapDeprecated(
+                doc.SolverOptions.common_solver_options.doc_deprecated,
+                &SolverOptions::common_solver_options),
+            doc.SolverOptions.common_solver_options.doc_deprecated)
+        .def("get_print_file_name",
+            WrapDeprecated(doc.SolverOptions.get_print_file_name.doc_deprecated,
+                &SolverOptions::get_print_file_name),
+            doc.SolverOptions.get_print_file_name.doc_deprecated)
+        .def("get_print_to_console",
+            WrapDeprecated(
+                doc.SolverOptions.get_print_to_console.doc_deprecated,
+                &SolverOptions::get_print_to_console),
+            doc.SolverOptions.get_print_to_console.doc_deprecated)
+        .def("get_standalone_reproduction_file_name",
+            WrapDeprecated(
+                doc.SolverOptions.get_standalone_reproduction_file_name
+                    .doc_deprecated,
+                &SolverOptions::get_standalone_reproduction_file_name))
+        .def("get_max_threads",
+            WrapDeprecated(doc.SolverOptions.get_max_threads.doc_deprecated,
+                &SolverOptions::get_max_threads),
+            doc.SolverOptions.get_max_threads.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 }
 

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1,5 +1,6 @@
 import copy
 from functools import partial
+import textwrap
 import unittest
 import warnings
 
@@ -10,6 +11,7 @@ from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import kDrakeAssertIsArmed, Parallelism
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.yaml import yaml_dump_typed, yaml_load_typed
 from pydrake.forwarddiff import jacobian
 from pydrake.math import ge
 from pydrake.solvers import (
@@ -1315,13 +1317,22 @@ class TestMathematicalProgram(unittest.TestCase):
             prog.SetSolverOption(solver, "india", 2)
             prog.SetSolverOption(solver, "sierra", "3")
             expected = {"foxtrot": 1.0, "india": 2, "sierra": "3"}
-            self.assertDictEqual(prog.GetSolverOptions(solver), expected)
+            with catch_drake_warnings(expected_count=1):
+                self.assertDictEqual(prog.GetSolverOptions(solver), expected)
             old_options = prog.solver_options()
+            self.assertEqual(old_options.options, {
+                gurobi_id.name(): expected,
+            })
             new_options = copy.deepcopy(old_options)
             new_options.SetOption(gurobi_id, "india", 4)
+            self.assertNotEqual(new_options, old_options)
             prog.SetSolverOptions(new_options)
             expected["india"] = 4
-            self.assertDictEqual(prog.GetSolverOptions(solver), expected)
+            with catch_drake_warnings(expected_count=1):
+                self.assertDictEqual(prog.GetSolverOptions(solver), expected)
+            self.assertEqual(old_options.options, {
+                gurobi_id.name(): expected,
+            })
 
     def test_solver_options(self):
         CSO = mp.CommonSolverOption
@@ -1353,14 +1364,85 @@ class TestMathematicalProgram(unittest.TestCase):
             CSO.kStandaloneReproductionFileName: "repro.txt",
             CSO.kMaxThreads: 4,
         }
-        self.assertDictEqual(dut.GetOptions(solver_id), expected_dummy)
-        self.assertEqual(dut.common_solver_options(), expected_common)
-        self.assertEqual(dut.get_print_to_console(), True)
-        self.assertEqual(dut.get_print_file_name(), "print.log")
-        self.assertEqual(dut.get_standalone_reproduction_file_name(),
-                         "repro.txt")
-        self.assertEqual(dut.get_max_threads(), 4)
+        self.assertEqual(dut.options, {
+            "dummy": expected_dummy,
+            "Drake": dict(
+                (key.name, value)
+                for key, value in expected_common.items()
+            )
+        })
+        with catch_drake_warnings(expected_count=1):
+            self.assertDictEqual(dut.GetOptions(solver_id), expected_dummy)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.common_solver_options(), expected_common)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.get_print_to_console(), True)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.get_print_file_name(), "print.log")
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.get_standalone_reproduction_file_name(),
+                             "repro.txt")
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.get_max_threads(), 4)
+        self.assertTrue(dut == dut)
+        self.assertFalse(dut != dut)
         copy.deepcopy(dut)
+        roundtrip = eval(repr(dut), dict(SolverOptions=SolverOptions))
+        self.assertEqual(roundtrip, dut)
+
+    def test_solver_options_yaml(self):
+        CSO = mp.CommonSolverOption
+        dut = SolverOptions()
+        id1 = SolverId("id1")
+        id2 = SolverId("id2")
+        dut.SetOption(id1, "some_double", 1.1)
+        dut.SetOption(id1, "some_int", 2)
+        dut.SetOption(id2, "some_string", "foo")
+        dut.SetOption(CSO.kPrintFileName, "foo.txt")
+        dut.SetOption(CSO.kPrintToConsole, 1)
+        dut.SetOption(CSO.kStandaloneReproductionFileName, "bar.py")
+        dut.SetOption(CSO.kMaxThreads, 2)
+
+        # If you change either of these two string constants, then you must
+        # make the same change to the C++ solver_options.cc unit test.
+        py_expected = textwrap.dedent("""\
+        options:
+          Drake:
+            kMaxThreads: !!int '2'
+            kPrintFileName: !!str 'foo.txt'
+            kPrintToConsole: !!int '1'
+            kStandaloneReproductionFileName: !!str 'bar.py'
+          id1:
+            some_double: 1.1
+            some_int: !!int '2'
+          id2:
+            some_string: !!str 'foo'
+        """)
+        cxx_expected = textwrap.dedent("""\
+        options:
+          Drake:
+            kMaxThreads: !!int 2
+            kPrintFileName: !!str foo.txt
+            kPrintToConsole: !!int 1
+            kStandaloneReproductionFileName: !!str bar.py
+          id1:
+            some_double: 1.1
+            some_int: !!int 2
+          id2:
+            some_string: !!str foo
+        """)
+
+        # Check that Python can save and then re-load the options.
+        self.maxDiff = None
+        actual_written = yaml_dump_typed(dut)
+        self.assertMultiLineEqual(py_expected, actual_written)
+        readback = yaml_load_typed(data=actual_written, schema=SolverOptions)
+        self.assertEqual(readback, dut)
+
+        # Cross-check that the output written by the C++ unit test can be
+        # re-loaded in Python.
+        cxx_readback = yaml_load_typed(data=cxx_expected, schema=SolverOptions)
+        self.assertEqual(cxx_readback, dut)
 
     def test_infeasible_constraints(self):
         prog = mp.MathematicalProgram()

--- a/planning/graph_algorithms/test/max_clique_solver_via_mip_test.cc
+++ b/planning/graph_algorithms/test/max_clique_solver_via_mip_test.cc
@@ -67,14 +67,14 @@ GTEST_TEST(MaxCliqueSolverViaMipTest, TestConstructorSettersAndGetters) {
   solvers::SolverOptions options{};
   options.SetOption(solvers::CommonSolverOption::kPrintToConsole, 1);
   solver.SetSolverOptions(options);
-  EXPECT_TRUE(solver.GetSolverOptions().get_print_to_console());
+  EXPECT_EQ(solver.GetSolverOptions(), options);
 
   // Test the constructor with the initial guess and solver options passed.
   MaxCliqueSolverViaMip solver2{initial_guess, options};
   EXPECT_TRUE(solver2.GetInitialGuess().has_value());
   EXPECT_TRUE(
       CompareMatrices(solver2.GetInitialGuess().value(), initial_guess));
-  EXPECT_TRUE(solver2.GetSolverOptions().get_print_to_console());
+  EXPECT_EQ(solver2.GetSolverOptions(), options);
 }
 
 GTEST_TEST(MaxCliqueSolverViaMipTest, TestClone) {
@@ -88,7 +88,7 @@ GTEST_TEST(MaxCliqueSolverViaMipTest, TestClone) {
   ASSERT_FALSE(solver_clone_mip == nullptr);
   EXPECT_TRUE(CompareMatrices(solver.GetInitialGuess().value(),
                               solver_clone_mip->GetInitialGuess().value()));
-  EXPECT_EQ(solver_clone_mip->GetSolverOptions().get_print_to_console(), 1);
+  EXPECT_EQ(solver_clone_mip->GetSolverOptions(), options);
 }
 
 GTEST_TEST(MaxCliqueSolverViaMipTest, CompleteGraph) {

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -313,6 +313,8 @@ drake_cc_library(
     ],
     deps = [
         ":solver_id",
+        "//common:name_value",
+        "//common:string_container",
     ],
     implementation_deps = [
         "//common:overloaded",
@@ -2098,6 +2100,7 @@ drake_cc_googletest(
         ":solver_options",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+        "//common/yaml",
     ],
 )
 

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -23,6 +23,7 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt.h"
 #include "drake/common/polynomial.h"
@@ -3247,19 +3248,31 @@ class MathematicalProgram {
    */
   const SolverOptions& solver_options() const { return solver_options_; }
 
-  const std::unordered_map<std::string, double>& GetSolverOptionsDouble(
+  DRAKE_DEPRECATED("2025-09-01", "Use the solver_options() accessor, instead")
+  std::unordered_map<std::string, double> GetSolverOptionsDouble(
       const SolverId& solver_id) const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return solver_options_.GetOptionsDouble(solver_id);
+#pragma GCC diagnostic pop
   }
 
-  const std::unordered_map<std::string, int>& GetSolverOptionsInt(
+  DRAKE_DEPRECATED("2025-09-01", "Use the solver_options() accessor, instead")
+  std::unordered_map<std::string, int> GetSolverOptionsInt(
       const SolverId& solver_id) const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return solver_options_.GetOptionsInt(solver_id);
+#pragma GCC diagnostic pop
   }
 
-  const std::unordered_map<std::string, std::string>& GetSolverOptionsStr(
+  DRAKE_DEPRECATED("2025-09-01", "Use the solver_options() accessor, instead")
+  std::unordered_map<std::string, std::string> GetSolverOptionsStr(
       const SolverId& solver_id) const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return solver_options_.GetOptionsStr(solver_id);
+#pragma GCC diagnostic pop
   }
 
   /**

--- a/solvers/solver_options.cc
+++ b/solvers/solver_options.cc
@@ -1,209 +1,242 @@
 #include "drake/solvers/solver_options.h"
 
-#include <map>
+#include <algorithm>
 #include <sstream>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
-#include "drake/common/never_destroyed.h"
 #include "drake/common/overloaded.h"
 
 namespace drake {
 namespace solvers {
 
-// A shorthand for our member field type, for options typed as T's, as in
-// MapMap[SolverId][string] => T.
-template <typename T>
-using MapMap = std::unordered_map<SolverId, std::unordered_map<std::string, T>>;
+using OptionValue = SolverOptions::OptionValue;
 
-// A shorthand for our member field type.
-using CommonMap =
-    std::unordered_map<CommonSolverOption, SolverOptions::OptionValue>;
+namespace {
+/* The 'options' map uses this "solver name" for the common options. */
+constexpr const char kCommonKey[] = "Drake";
+}  // namespace
+
+namespace internal {
+
+/* Returns a suitable repr-like string for the given value. */
+std::string OptionValueToString(const OptionValue& option_value) {
+  return std::visit(overloaded{[](const double& unboxed_value) {
+                                 return fmt_floating_point(unboxed_value);
+                               },
+                               [](const int& unboxed_value) {
+                                 return fmt::to_string(unboxed_value);
+                               },
+                               [](const std::string& unboxed_value) {
+                                 return fmt_debug_string(unboxed_value);
+                               }},
+                    option_value);
+}
+
+}  // namespace internal
 
 void SolverOptions::SetOption(const SolverId& solver_id, std::string key,
-                              OptionValue value) {
-  std::visit(
-      overloaded{
-          [&](double unboxed_value) {
-            solver_options_double_[solver_id][std::move(key)] = unboxed_value;
-          },
-          [&](int unboxed_value) {
-            solver_options_int_[solver_id][std::move(key)] = unboxed_value;
-          },
-          [&](std::string&& unboxed_value) {
-            solver_options_str_[solver_id][std::move(key)] =
-                std::move(unboxed_value);
-          },
-      },
-      std::move(value));
+                              OptionValue option_value) {
+  options[solver_id.name()][std::move(key)] = std::move(option_value);
+
+  // Remove on 2025-09-01 upon completion of deprecation.
+  solver_ids.insert(solver_id);
 }
 
 void SolverOptions::SetOption(CommonSolverOption key, OptionValue value) {
   switch (key) {
-    case CommonSolverOption::kPrintToConsole: {
-      if (!std::holds_alternative<int>(value)) {
-        throw std::runtime_error(fmt::format(
-            "SolverOptions::SetOption support {} only with int value.", key));
+    case CommonSolverOption::kPrintFileName: {
+      if (std::holds_alternative<std::string>(value)) {
+        options[kCommonKey][fmt::to_string(key)] = std::move(value);
+        return;
       }
-      const int int_value = std::get<int>(value);
-      if (int_value != 0 && int_value != 1) {
-        throw std::runtime_error(
-            fmt::format("{} expects value either 0 or 1", key));
-      }
-      common_solver_options_[key] = std::move(value);
+      throw std::runtime_error(fmt::format(
+          "SolverOptions::SetOption({}) value must be a string, not {}.", key,
+          internal::OptionValueToString(value)));
       return;
     }
-    case CommonSolverOption::kPrintFileName: {
-      if (!std::holds_alternative<std::string>(value)) {
-        throw std::runtime_error(fmt::format(
-            "SolverOptions::SetOption support {} only with std::string value.",
-            key));
+    case CommonSolverOption::kPrintToConsole: {
+      if (std::holds_alternative<int>(value)) {
+        const int int_value = std::get<int>(value);
+        if (int_value == 0 || int_value == 1) {
+          options[kCommonKey][fmt::to_string(key)] = std::move(value);
+          return;
+        }
       }
-      common_solver_options_[key] = std::move(value);
+      throw std::runtime_error(fmt::format(
+          "SolverOptions::SetOption({}) value must be 0 or 1, not {}.", key,
+          internal::OptionValueToString(value)));
       return;
     }
     case CommonSolverOption::kStandaloneReproductionFileName: {
-      if (!std::holds_alternative<std::string>(value)) {
-        throw std::runtime_error(fmt::format(
-            "SolverOptions::SetOption support {} only with std::string value.",
-            key));
+      if (std::holds_alternative<std::string>(value)) {
+        options[kCommonKey][fmt::to_string(key)] = std::move(value);
+        return;
       }
-      common_solver_options_[key] = std::move(value);
-      return;
+      throw std::runtime_error(fmt::format(
+          "SolverOptions::SetOption({}) value must be a string, not {}.", key,
+          internal::OptionValueToString(value)));
     }
     case CommonSolverOption::kMaxThreads: {
-      if (!std::holds_alternative<int>(value)) {
-        throw std::runtime_error(fmt::format(
-            "SolverOptions::SetOption support {} only with int value.", key));
+      if (std::holds_alternative<int>(value)) {
+        const int int_value = std::get<int>(value);
+        if (int_value > 0) {
+          options[kCommonKey][fmt::to_string(key)] = std::move(value);
+          return;
+        }
       }
-      const int int_value = std::get<int>(value);
-      if (int_value <= 0) {
-        throw std::runtime_error(
-            fmt::format("kMaxThreads must be > 0, got {}", int_value));
-      }
-      common_solver_options_[key] = std::move(value);
-      return;
+      throw std::runtime_error(fmt::format(
+          "SolverOptions::SetOption({}) value must be an int > 0, not {}.", key,
+          internal::OptionValueToString(value)));
     }
   }
   DRAKE_UNREACHABLE();
 }
 
 namespace {
-// If options has an entry for the given solver_id, returns a reference to the
-// mapped value.  Otherwise, returns a long-lived reference to an empty value.
+// If options has an entry for the given solver_id, returns a copy of the mapped
+// value, filered by the requested type `T`. Otherwise, returns an empty map.
+// This function should be removed when the deprecations 2025-09-01 expire.
 template <typename T>
-const std::unordered_map<std::string, T>& GetOptionsHelper(
-    const SolverId& solver_id, const MapMap<T>& options) {
-  static never_destroyed<std::unordered_map<std::string, T>> empty;
-  const auto iter = options.find(solver_id);
-  return (iter != options.end()) ? iter->second : empty.access();
+std::unordered_map<std::string, T> GetOptionsHelper(
+    const SolverId& solver_id, const SolverOptions& solver_options) {
+  std::unordered_map<std::string, T> result;
+  const auto iter = solver_options.options.find(solver_id.name());
+  if (iter != solver_options.options.end()) {
+    const string_unordered_map<OptionValue>& items = iter->second;
+    for (const auto& [key, value] : items) {
+      if (std::holds_alternative<T>(value)) {
+        result[key] = std::get<T>(value);
+      }
+    }
+  }
+  return result;
 }
 }  // namespace
 
-const std::unordered_map<std::string, double>& SolverOptions::GetOptionsDouble(
+// Deprecated 2025-09-01.
+std::unordered_map<std::string, double> SolverOptions::GetOptionsDouble(
     const SolverId& solver_id) const {
-  return GetOptionsHelper(solver_id, solver_options_double_);
+  return GetOptionsHelper<double>(solver_id, *this);
 }
 
-const std::unordered_map<std::string, int>& SolverOptions::GetOptionsInt(
+// Deprecated 2025-09-01.
+std::unordered_map<std::string, int> SolverOptions::GetOptionsInt(
     const SolverId& solver_id) const {
-  return GetOptionsHelper(solver_id, solver_options_int_);
+  return GetOptionsHelper<int>(solver_id, *this);
 }
 
-const std::unordered_map<std::string, std::string>&
-SolverOptions::GetOptionsStr(const SolverId& solver_id) const {
-  return GetOptionsHelper(solver_id, solver_options_str_);
+// Deprecated 2025-09-01.
+std::unordered_map<std::string, std::string> SolverOptions::GetOptionsStr(
+    const SolverId& solver_id) const {
+  return GetOptionsHelper<std::string>(solver_id, *this);
 }
 
+// Deprecated 2025-09-01.
+std::unordered_map<CommonSolverOption, OptionValue>
+SolverOptions::common_solver_options() const {
+  std::unordered_map<CommonSolverOption, OptionValue> result;
+  const auto iter1 = options.find(kCommonKey);
+  if (iter1 != options.end()) {
+    const string_unordered_map<OptionValue>& common = iter1->second;
+    for (auto key : {CommonSolverOption::kPrintFileName,
+                     CommonSolverOption::kPrintToConsole,
+                     CommonSolverOption::kStandaloneReproductionFileName,
+                     CommonSolverOption::kMaxThreads}) {
+      const auto iter2 = common.find(fmt::to_string(key));
+      if (iter2 != common.end()) {
+        const OptionValue& value = iter2->second;
+        result[key] = value;
+      }
+    }
+  }
+  return result;
+}
+
+// Deprecated 2025-09-01.
 std::string SolverOptions::get_print_file_name() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::unordered_map<CommonSolverOption, OptionValue> common =
+      common_solver_options();
+#pragma GCC diagnostic pop
   // N.B. SetOption sanity checks the value; we don't need to re-check here.
   std::string result;
-  auto iter = common_solver_options_.find(CommonSolverOption::kPrintFileName);
-  if (iter != common_solver_options_.end()) {
+  auto iter = common.find(CommonSolverOption::kPrintFileName);
+  if (iter != common.end()) {
     result = std::get<std::string>(iter->second);
   }
   return result;
 }
 
+// Deprecated 2025-09-01.
 bool SolverOptions::get_print_to_console() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::unordered_map<CommonSolverOption, OptionValue> common =
+      common_solver_options();
+#pragma GCC diagnostic pop
   // N.B. SetOption sanity checks the value; we don't need to re-check here.
   bool result = false;
-  auto iter = common_solver_options_.find(CommonSolverOption::kPrintToConsole);
-  if (iter != common_solver_options_.end()) {
+  auto iter = common.find(CommonSolverOption::kPrintToConsole);
+  if (iter != common.end()) {
     const int value = std::get<int>(iter->second);
     result = static_cast<bool>(value);
   }
   return result;
 }
 
+// Deprecated 2025-09-01.
 std::string SolverOptions::get_standalone_reproduction_file_name() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::unordered_map<CommonSolverOption, OptionValue> common =
+      common_solver_options();
+#pragma GCC diagnostic pop
   // N.B. SetOption sanity checks the value; we don't need to re-check here.
   std::string result;
-  auto iter = common_solver_options_.find(
-      CommonSolverOption::kStandaloneReproductionFileName);
-  if (iter != common_solver_options_.end()) {
+  auto iter = common.find(CommonSolverOption::kStandaloneReproductionFileName);
+  if (iter != common.end()) {
     result = std::get<std::string>(iter->second);
   }
   return result;
 }
 
+// Deprecated 2025-09-01.
 std::optional<int> SolverOptions::get_max_threads() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::unordered_map<CommonSolverOption, OptionValue> common =
+      common_solver_options();
+#pragma GCC diagnostic pop
   // N.B. SetOption sanity checks the value; we don't need to re-check here.
-  auto iter = common_solver_options_.find(CommonSolverOption::kMaxThreads);
-  if (iter != common_solver_options_.end()) {
+  auto iter = common.find(CommonSolverOption::kMaxThreads);
+  if (iter != common.end()) {
     return std::get<int>(iter->second);
   }
   return std::nullopt;
 }
 
+// Deprecated 2025-09-01.
 std::unordered_set<SolverId> SolverOptions::GetSolverIds() const {
-  std::unordered_set<SolverId> result;
-  for (const auto& pair : solver_options_double_) {
-    result.insert(pair.first);
-  }
-  for (const auto& pair : solver_options_int_) {
-    result.insert(pair.first);
-  }
-  for (const auto& pair : solver_options_str_) {
-    result.insert(pair.first);
-  }
-  return result;
+  return solver_ids;
 }
 
-namespace {
-template <typename T>
-void MergeHelper(const MapMap<T>& other, MapMap<T>* self) {
-  for (const auto& other_id_keyvals : other) {
-    const SolverId& id = other_id_keyvals.first;
-    std::unordered_map<std::string, T>& self_keyvals = (*self)[id];
-    for (const auto& other_keyval : other_id_keyvals.second) {
+void SolverOptions::Merge(const SolverOptions& other) {
+  for (const auto& [other_solver, other_keyvals] : other.options) {
+    string_unordered_map<OptionValue>& self_keyvals =
+        this->options[other_solver];
+    for (const auto& other_keyval : other_keyvals) {
       // This is a no-op when the key already exists.
       self_keyvals.insert(other_keyval);
     }
   }
 }
 
-void MergeHelper(const CommonMap& other, CommonMap* self) {
-  for (const auto& other_keyval : other) {
-    // This is a no-op when the key already exists.
-    self->insert(other_keyval);
-  }
-}
-}  // namespace
-
-void SolverOptions::Merge(const SolverOptions& other) {
-  MergeHelper(other.solver_options_double_, &solver_options_double_);
-  MergeHelper(other.solver_options_int_, &solver_options_int_);
-  MergeHelper(other.solver_options_str_, &solver_options_str_);
-  MergeHelper(other.common_solver_options_, &common_solver_options_);
-}
-
 bool SolverOptions::operator==(const SolverOptions& other) const {
-  return solver_options_double_ == other.solver_options_double_ &&
-         solver_options_int_ == other.solver_options_int_ &&
-         solver_options_str_ == other.solver_options_str_ &&
-         common_solver_options_ == other.common_solver_options_;
+  return options == other.options;
 }
 
 bool SolverOptions::operator!=(const SolverOptions& other) const {
@@ -211,84 +244,91 @@ bool SolverOptions::operator!=(const SolverOptions& other) const {
 }
 
 namespace {
-template <typename T>
-void Summarize(const SolverId& id,
-               const std::unordered_map<std::string, T>& keyvals,
-               std::map<std::string, std::string>* pairs) {
-  for (const auto& keyval : keyvals) {
-    (*pairs)[fmt::format("{}:{}", id.name(), keyval.first)] =
-        fmt::format("{}", keyval.second);
+/* Returns keys of the given map in sorted order, paired up with a "bool comma"
+marker that is set to false for the last item only. The keys are string_view
+aliases into `map`, so the `map` object must outlive this result. */
+template <typename Map>
+std::vector<std::pair<std::string_view, bool>> SortedKeys(const Map& map) {
+  std::vector<std::pair<std::string_view, bool>> result;
+  if (!map.empty()) {
+    for (const auto& [key, _] : map) {
+      result.push_back({std::string_view{key}, true});
+    }
+    std::sort(result.begin(), result.end());
+    result.back().second = false;
   }
+  return result;
 }
-
 }  // namespace
 
-std::ostream& operator<<(std::ostream& os, const SolverOptions& x) {
-  os << "{SolverOptions";
-  const auto& ids = x.GetSolverIds();
-  if (ids.empty()) {
-    os << " empty";
-  } else {
-    // Map keyed on "solver_name:option_key" so our output is deterministic.
-    std::map<std::string, std::string> pairs;
-    for (const auto& id : ids) {
-      Summarize(id, x.GetOptionsDouble(id), &pairs);
-      Summarize(id, x.GetOptionsInt(id), &pairs);
-      Summarize(id, x.GetOptionsStr(id), &pairs);
+std::string SolverOptions::to_string() const {
+  std::ostringstream result;
+  result << "SolverOptions(options={";
+  for (const auto& [solver_name, comma1] : SortedKeys(options)) {
+    result << fmt::format("\"{}\":{{", solver_name);
+    const auto iter1 = options.find(solver_name);
+    DRAKE_DEMAND(iter1 != options.end());
+    const string_unordered_map<OptionValue>& solver_options = iter1->second;
+    for (const auto& [key, comma2] : SortedKeys(solver_options)) {
+      const auto iter2 = solver_options.find(key);
+      DRAKE_DEMAND(iter2 != solver_options.end());
+      const OptionValue& value = iter2->second;
+      result << fmt_debug_string(key);
+      result << ":";
+      result << internal::OptionValueToString(value);
+      if (comma2) {
+        result << ",";
+      }
     }
-    for (const auto& keyval : x.common_solver_options()) {
-      const CommonSolverOption& key = keyval.first;
-      const auto& val = keyval.second;
-      std::visit(
-          [key, &pairs](auto& val_x) {
-            pairs[fmt::format("CommonSolverOption::{}", key)] =
-                fmt::format("{}", val_x);
-          },
-          val);
-    }
-    for (const auto& pair : pairs) {
-      os << ", " << pair.first << "=" << pair.second;
+    result << "}";
+    if (comma1) {
+      result << ",";
     }
   }
-  os << "}";
-  return os;
-}
-
-std::string to_string(const SolverOptions& x) {
-  std::ostringstream result;
-  result << x;
+  result << "})";
   return result.str();
 }
 
-namespace {
-// Check if all the keys in key_value pair key_vals is a subset of
-// allowable_keys, and throw an invalid argument if not.
-template <typename T>
-void CheckOptionKeysForSolverHelper(
-    const std::unordered_map<std::string, T>& key_vals,
-    const std::unordered_set<std::string>& allowable_keys,
-    const std::string& solver_name) {
-  for (const auto& key_val : key_vals) {
-    if (!allowable_keys.contains(key_val.first)) {
-      throw std::invalid_argument(key_val.first +
-                                  " is not allowed in the SolverOptions for " +
-                                  solver_name + ".");
-    }
-  }
+// Deprecated 2025-09-01.
+std::ostream& operator<<(std::ostream& os, const SolverOptions& x) {
+  os << x.to_string();
+  return os;
 }
-}  // namespace
 
+// Deprecated 2025-09-01.
+std::string to_string(const SolverOptions& x) {
+  return x.to_string();
+}
+
+// Deprecated 2025-09-01.
 void SolverOptions::CheckOptionKeysForSolver(
     const SolverId& solver_id,
     const std::unordered_set<std::string>& double_keys,
     const std::unordered_set<std::string>& int_keys,
     const std::unordered_set<std::string>& str_keys) const {
-  CheckOptionKeysForSolverHelper(GetOptionsDouble(solver_id), double_keys,
-                                 solver_id.name());
-  CheckOptionKeysForSolverHelper(GetOptionsInt(solver_id), int_keys,
-                                 solver_id.name());
-  CheckOptionKeysForSolverHelper(GetOptionsStr(solver_id), str_keys,
-                                 solver_id.name());
+  auto iter = options.find(solver_id.name());
+  if (iter == options.end()) {
+    return;
+  }
+  for (const auto& [key, value] : iter->second) {
+    const std::string& key_str = key;  // Allow lambda capture.
+    const bool allowed =
+        std::visit(overloaded{[&key_str, &double_keys](const double&) {
+                                return double_keys.contains(key_str);
+                              },
+                              [&key_str, &int_keys](const int&) {
+                                return int_keys.contains(key_str);
+                              },
+                              [&key_str, &str_keys](const std::string&) {
+                                return str_keys.contains(key_str);
+                              }},
+                   value);
+    if (!allowed) {
+      throw std::invalid_argument(
+          fmt::format("{} is not allowed in the SolverOptions for {}", key,
+                      solver_id.name()));
+    }
+  }
 }
 
 }  // namespace solvers

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -1,15 +1,18 @@
 #pragma once
 
-#include <optional>
-#include <ostream>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 #include <variant>
 
-#include "drake/common/drake_assert.h"
-#include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+// Remove on 2025-09-01 upon completion of deprecation.
+#include <optional>
+#include <ostream>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
+#include "drake/common/name_value.h"
+#include "drake/common/string_unordered_map.h"
 #include "drake/solvers/common_solver_option.h"
 #include "drake/solvers/solver_id.h"
 
@@ -62,12 +65,8 @@ boolean options should be passed as integers (0 or 1).
 
 "CSDP" -- Parameter name and values as specified at
 https://manpages.ubuntu.com/manpages/focal/en/man1/csdp-randgraph.1.html */
-class SolverOptions {
+struct SolverOptions final {
  public:
-  SolverOptions() = default;
-
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SolverOptions);
-
   /** The values stored in SolverOptions can be double, int, or string.
   In the future, we might re-order or add more allowed types without any
   deprecation period, so be sure to use std::visit or std::get<T> to
@@ -84,41 +83,64 @@ class SolverOptions {
   option, the option is ignored. */
   void SetOption(CommonSolverOption key, OptionValue value);
 
-  const std::unordered_map<std::string, double>& GetOptionsDouble(
-      const SolverId& solver_id) const;
+  /** Merges the other solver options into this. If `other` and `this` option
+  both define the same option for the same solver, we ignore the one from
+  `other` and keep the one from `this`. */
+  void Merge(const SolverOptions& other);
 
-  const std::unordered_map<std::string, int>& GetOptionsInt(
-      const SolverId& solver_id) const;
+  bool operator==(const SolverOptions& other) const;
+  bool operator!=(const SolverOptions& other) const;
+  std::string to_string() const;
 
-  const std::unordered_map<std::string, std::string>& GetOptionsStr(
-      const SolverId& solver_id) const;
-
-  /** Gets the common options for all solvers. Refer to CommonSolverOption for
-  more details. */
-  const std::unordered_map<CommonSolverOption, OptionValue>&
-  common_solver_options() const {
-    return common_solver_options_;
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(options));
   }
 
-  /** Returns the kPrintFileName set via CommonSolverOption, or else an empty
-  string if the option has not been set. */
+  /** The options are indexed first by the solver name and second by the key.
+  In the case of Drake's common options, the solver name is "Drake". */
+  string_unordered_map<string_unordered_map<OptionValue>> options;
+
+  // ==========================================================================
+  // EVERYTHING AFTER THIS POINT IN THIS STRUCT IS DEPRECATION GOOP; IGNORE IT.
+  // ==========================================================================
+
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
+  std::unordered_map<std::string, double> GetOptionsDouble(
+      const SolverId& solver_id) const;
+
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
+  std::unordered_map<std::string, int> GetOptionsInt(
+      const SolverId& solver_id) const;
+
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
+  std::unordered_map<std::string, std::string> GetOptionsStr(
+      const SolverId& solver_id) const;
+
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
+  std::unordered_map<CommonSolverOption, OptionValue> common_solver_options()
+      const;
+
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
   std::string get_print_file_name() const;
 
-  /** Returns the kPrintToConsole set via CommonSolverOption, or else false if
-  the option has not been set. */
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
   bool get_print_to_console() const;
 
-  /** Returns the kStandaloneReproductionFileName set via CommonSolverOption, or
-  else an empty string if the option has not been set. */
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
   std::string get_standalone_reproduction_file_name() const;
 
-  /** Returns the kMaxThreads set via CommonSolverOption. Returns nullopt if
-  kMaxThreads is unset. */
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
   std::optional<int> get_max_threads() const;
 
   template <typename T>
-  const std::unordered_map<std::string, T>& GetOptions(
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
+  std::unordered_map<std::string, T> GetOptions(
       const SolverId& solver_id) const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     if constexpr (std::is_same_v<T, double>) {
       return GetOptionsDouble(solver_id);
     } else if constexpr (std::is_same_v<T, int>) {
@@ -126,33 +148,23 @@ class SolverOptions {
     } else if constexpr (std::is_same_v<T, std::string>) {
       return GetOptionsStr(solver_id);
     }
+#pragma GCC diagnostic pop
     DRAKE_UNREACHABLE();
   }
 
-  /** Returns the IDs that have any option set. */
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
   std::unordered_set<SolverId> GetSolverIds() const;
 
-  /**  Merges the other solver options into this. If `other` and `this` option
-  both define the same option for the same solver, we ignore then one from
-  `other` and keep the one from `this`. */
-  void Merge(const SolverOptions& other);
-
-  /** Returns true if `this` and `other` have exactly the same solvers, with
-  exactly the same keys and values for the options for each solver. */
-  bool operator==(const SolverOptions& other) const;
-
-  /** Negate operator==. */
-  bool operator!=(const SolverOptions& other) const;
-
-  /** Check if for a given solver_id, the option keys are included in
-  double_keys, int_keys and str_keys.
-  @param solver_id If this SolverOptions has set options for this solver_id,
-  then we check if the option keys are a subset of `double_keys`, `int_keys` and
-  `str_keys`.
-  @param double_keys The set of allowable keys for double options.
-  @param int_keys The set of allowable keys for int options.
-  @param str_keys The set of allowable keys for string options.
-  @throws std::exception if the solver contains un-allowed options. */
+  // Check if for a given solver_id, the option keys are included in
+  // double_keys, int_keys and str_keys.
+  // @param solver_id If this SolverOptions has set options for this solver_id,
+  // then we check if the option keys are a subset of `double_keys`, `int_keys`
+  // and `str_keys`.
+  // @param double_keys The set of allowable keys for double options.
+  // @param int_keys The set of allowable keys for int options.
+  // @param str_keys The set of allowable keys for string options.
+  // @throws std::exception if the solver contains un-allowed options.
+  DRAKE_DEPRECATED("2025-09-01", "Access the 'options' directly, instead.")
   void CheckOptionKeysForSolver(
       const SolverId& solver_id,
       const std::unordered_set<std::string>& allowable_double_keys,
@@ -160,24 +172,22 @@ class SolverOptions {
       const std::unordered_set<std::string>& allowable_str_keys) const;
 
  private:
-  std::unordered_map<SolverId, std::unordered_map<std::string, double>>
-      solver_options_double_{};
-  std::unordered_map<SolverId, std::unordered_map<std::string, int>>
-      solver_options_int_{};
-  std::unordered_map<SolverId, std::unordered_map<std::string, std::string>>
-      solver_options_str_{};
-
-  std::unordered_map<CommonSolverOption, OptionValue> common_solver_options_{};
+  // Remove this field on 2025-09-01 upon completion of deprecation.
+  std::unordered_set<SolverId> solver_ids;
 };
 
+DRAKE_DEPRECATED("2025-09-01", "Use options.to_string(), instead.")
 std::string to_string(const SolverOptions&);
+
+DRAKE_DEPRECATED("2025-09-01", "Use options.to_string(), instead.")
 std::ostream& operator<<(std::ostream&, const SolverOptions&);
+
+namespace internal {
+/* Converts the option_value to a string. */
+std::string OptionValueToString(const SolverOptions::OptionValue& option_value);
+}  // namespace internal
 
 }  // namespace solvers
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::solvers::SolverOptions> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::solvers, SolverOptions, x, x.to_string())

--- a/solvers/specific_options.cc
+++ b/solvers/specific_options.cc
@@ -2,11 +2,11 @@
 
 #include <algorithm>
 #include <limits>
-#include <unordered_map>
 #include <vector>
 
 #include <fmt/ranges.h>
 
+#include "drake/common/never_destroyed.h"
 #include "drake/common/overloaded.h"
 
 namespace drake {
@@ -15,12 +15,67 @@ namespace internal {
 
 using OptionValue = SolverOptions::OptionValue;
 
+namespace {
+
+/* Utility function for our constructor. Extracts one common (Drake) option
+from `common`. Does nothing if not set, or if set to the wrong type. */
+template <typename T, typename U>
+void GetOneCommonOption(const string_unordered_map<OptionValue>& common,
+                        CommonSolverOption key, U* out) {
+  if (auto iter = common.find(to_string(key)); iter != common.end()) {
+    const OptionValue& value = iter->second;
+    if (std::holds_alternative<T>(value)) {
+      *out = std::get<T>(value);
+    }
+  }
+}
+
+/* Utility function for our constructor. Extracts and returns common (Drake)
+options from `all_options`. */
+CommonSolverOptionValues GetCommonOptions(const SolverOptions* all_options) {
+  // Check the pointer on behalf of our constructor.
+  DRAKE_THROW_UNLESS(all_options != nullptr);
+  CommonSolverOptionValues result;
+  if (auto iter = all_options->options.find("Drake");
+      iter != all_options->options.end()) {
+    const string_unordered_map<OptionValue>& common = iter->second;
+    GetOneCommonOption<std::string>(common, CommonSolverOption::kPrintFileName,
+                                    &result.print_file_name);
+    GetOneCommonOption<int>(common, CommonSolverOption::kPrintToConsole,
+                            &result.print_to_console);
+    GetOneCommonOption<std::string>(
+        common, CommonSolverOption::kStandaloneReproductionFileName,
+        &result.standalone_reproduction_file_name);
+    GetOneCommonOption<int>(common, CommonSolverOption::kMaxThreads,
+                            &result.max_threads);
+  }
+  return result;
+}
+
+/* Utility function for our constructor. Returns a reference to the solver
+specific options for given solver `id` contained in `all_options`, or an empty
+map in case there are none. */
+const string_unordered_map<SolverOptions::OptionValue>& GetDirectOptions(
+    const SolverId* id, const SolverOptions* all_options) {
+  // Check the pointer on behalf of our constructor.
+  DRAKE_THROW_UNLESS(id != nullptr);
+  DRAKE_DEMAND(all_options != nullptr);  // Already checked by GetCommonOptions.
+  auto iter = all_options->options.find(id->name());
+  if (iter != all_options->options.end()) {
+    return iter->second;
+  }
+  static const never_destroyed<string_unordered_map<SolverOptions::OptionValue>>
+      empty;
+  return empty.access();
+}
+
+}  // namespace
+
 SpecificOptions::SpecificOptions(const SolverId* id,
                                  const SolverOptions* all_options)
-    : id_{id}, all_options_{all_options} {
-  DRAKE_DEMAND(id != nullptr);
-  DRAKE_DEMAND(all_options != nullptr);
-}
+    : common_options_{GetCommonOptions(all_options)},
+      direct_options_{GetDirectOptions(id, all_options)},
+      solver_name_{id->name()} {}
 
 SpecificOptions::~SpecificOptions() = default;
 
@@ -29,41 +84,34 @@ void SpecificOptions::Respell(
                              string_unordered_map<OptionValue>*)>& respell) {
   DRAKE_DEMAND(respell != nullptr);
   DRAKE_DEMAND(respelled_.empty());
-  respell(
-      CommonSolverOptionValues{
-          .print_file_name = all_options_->get_print_file_name(),
-          .print_to_console = all_options_->get_print_to_console(),
-          .standalone_reproduction_file_name =
-              all_options_->get_standalone_reproduction_file_name(),
-          .max_threads = all_options_->get_max_threads(),
-      },
-      &respelled_);
+  respell(common_options_, &respelled_);
 }
 
 template <typename Result>
 std::optional<Result> SpecificOptions::Pop(std::string_view key) {
-  if (popped_.contains(key)) {
+  if (auto iter = direct_options_.find(key); iter != direct_options_.end()) {
+    if (popped_.contains(key)) {
+      return std::nullopt;
+    }
+    const OptionValue& boxed_value = iter->second;
+    if (std::holds_alternative<Result>(boxed_value)) {
+      popped_.emplace(key);
+      return std::get<Result>(boxed_value);
+    }
     return std::nullopt;
   }
-  const auto& typed_options = all_options_->template GetOptions<Result>(*id_);
-  // TODO(jwnimmer-tri) Nix this string copy after we fix SolverOptions to use
-  // sensible representation choices.
-  if (auto iter = typed_options.find(std::string{key});
-      iter != typed_options.end()) {
-    popped_.emplace(key);
-    return iter->second;
-  }
   if (auto iter = respelled_.find(key); iter != respelled_.end()) {
-    const OptionValue& value = iter->second;
-    if (std::holds_alternative<Result>(value)) {
-      popped_.emplace(key);
-      return std::get<Result>(value);
+    OptionValue& boxed_value = iter->second;
+    if (std::holds_alternative<Result>(boxed_value)) {
+      std::optional<Result> result = std::move(std::get<Result>(boxed_value));
+      respelled_.erase(iter);
+      return result;
     }
     throw std::logic_error(fmt::format(
         "{}: internal error: option {} was respelled to the wrong type",
-        id_->name(), key));
+        solver_name_, key));
   }
-  return {};
+  return std::nullopt;
 }
 
 template std::optional<double> SpecificOptions::Pop(std::string_view);
@@ -78,9 +126,6 @@ void SpecificOptions::CopyToCallbacks(
   // Wrap the solver's set_{type} callbacks with error-reporting sugar, and
   // logic to promote integers to doubles.
   auto on_double = [this, &set_double](const std::string& key, double value) {
-    if (popped_.contains(key)) {
-      return;
-    }
     if (set_double != nullptr) {
       set_double(key, value);
       return;
@@ -88,13 +133,10 @@ void SpecificOptions::CopyToCallbacks(
     throw std::logic_error(fmt::format(
         "{}: floating-point options are not supported; the option {}={} is "
         "invalid",
-        id_->name(), key, value));
+        solver_name_, key, value));
   };
   auto on_int = [this, &set_int, &set_double](const std::string& key,
                                               int value) {
-    if (popped_.contains(key)) {
-      return;
-    }
     if (set_int != nullptr) {
       set_int(key, value);
       return;
@@ -106,81 +148,65 @@ void SpecificOptions::CopyToCallbacks(
     throw std::logic_error(fmt::format(
         "{}: integer and floating-point options are not supported; the option "
         "{}={} is invalid",
-        id_->name(), key, value));
+        solver_name_, key, value));
   };
   auto on_string = [this, &set_string](const std::string& key,
                                        const std::string& value) {
-    if (popped_.contains(key)) {
-      return;
-    }
     if (set_string != nullptr) {
       set_string(key, value);
       return;
     }
     throw std::logic_error(fmt::format(
-        "{}: string options are not supported; the option {}='{}' is invalid",
-        id_->name(), key, value));
+        "{}: string options are not supported; the option {}={} is invalid",
+        solver_name_, key, fmt_debug_string(value)));
   };
 
   // Handle solver-specific options.
-  const std::unordered_map<std::string, double>& options_double =
-      all_options_->GetOptionsDouble(*id_);
-  const std::unordered_map<std::string, int>& options_int =
-      all_options_->GetOptionsInt(*id_);
-  const std::unordered_map<std::string, std::string>& options_str =
-      all_options_->GetOptionsStr(*id_);
-  for (const auto& [key, value] : options_double) {
-    on_double(key, value);
-  }
-  for (const auto& [key, value] : options_int) {
-    on_int(key, value);
-  }
-  for (const auto& [key, value] : options_str) {
-    on_string(key, value);
+  for (const auto& [key, boxed_value] : direct_options_) {
+    if (popped_.contains(key)) {
+      continue;
+    }
+    const std::string& key_str = key;  // Allow lambda capture.
+    std::visit(overloaded{[&key_str, &on_double](double value) {
+                            on_double(key_str, value);
+                          },
+                          [&key_str, &on_int](int value) {
+                            on_int(key_str, value);
+                          },
+                          [&key_str, &on_string](const std::string& value) {
+                            on_string(key_str, value);
+                          }},
+               boxed_value);
   }
 
   // Handle any respelled options, being careful not to set anything that has
   // already been set.
-  for (const auto& [respelled_key, boxed_value] : respelled_) {
-    // Pedantically, lambdas cannot capture a structured binding so we need to
-    // make a local variable that we can capture.
-    const auto& key = respelled_key;
-    std::visit(
-        overloaded{[&key, &on_double, &options_double](double value) {
-                     if (!options_double.contains(key)) {
-                       on_double(key, value);
-                     }
-                   },
-                   [&key, &on_int, &options_int](int value) {
-                     if (!options_int.contains(key)) {
-                       on_int(key, value);
-                     }
-                   },
-                   [&key, &on_string, &options_str](const std::string& value) {
-                     if (!options_str.contains(key)) {
-                       on_string(key, value);
-                     }
-                   }},
-        boxed_value);
+  for (const auto& [key, boxed_value] : respelled_) {
+    if (direct_options_.contains(key) && !popped_.contains(key)) {
+      continue;
+    }
+    const std::string& key_str = key;  // Allow lambda capture.
+    std::visit(overloaded{[&key_str, &on_double](double value) {
+                            on_double(key_str, value);
+                          },
+                          [&key_str, &on_int](int value) {
+                            on_int(key_str, value);
+                          },
+                          [&key_str, &on_string](const std::string& value) {
+                            on_string(key_str, value);
+                          }},
+               boxed_value);
   }
 }
 
 void SpecificOptions::InitializePending() {
   pending_keys_.clear();
-  for (const auto& [key, _] : all_options_->GetOptionsDouble(*id_)) {
+  pending_keys_.reserve(direct_options_.size());
+  for (const auto& [key, _] : direct_options_) {
+    if (popped_.contains(key)) {
+      continue;
+    }
     pending_keys_.insert(key);
-  }
-  for (const auto& [key, _] : all_options_->GetOptionsInt(*id_)) {
-    pending_keys_.insert(key);
-  }
-  for (const auto& [key, _] : all_options_->GetOptionsStr(*id_)) {
-    pending_keys_.insert(key);
-  }
-  for (const auto& [key, _] : respelled_) {
-    pending_keys_.insert(key);
-  }
-  for (const auto& key : popped_) {
-    pending_keys_.erase(key);
   }
 }
 
@@ -188,52 +214,38 @@ void SpecificOptions::CheckNoPending() const {
   // Identify any unsupported names (i.e., leftovers in `pending_`).
   if (!pending_keys_.empty()) {
     std::vector<std::string_view> unknown_names;
-    for (const auto& name : pending_keys_) {
+    for (const std::string_view& name : pending_keys_) {
       unknown_names.push_back(name);
     }
     std::sort(unknown_names.begin(), unknown_names.end());
     throw std::logic_error(fmt::format(
         "{}: the following solver option names were not recognized: {}",
-        id_->name(), fmt::join(unknown_names, ", ")));
+        solver_name_, fmt::join(unknown_names, ", ")));
   }
 }
 
-std::optional<OptionValue> SpecificOptions::PrepareToCopy(const char* name) {
+const OptionValue* SpecificOptions::PrepareToCopy(const char* name) {
   DRAKE_DEMAND(name != nullptr);
-  const std::unordered_map<std::string, double>& options_double =
-      all_options_->GetOptionsDouble(*id_);
-  // TODO(jwnimmer-tri) Nix these string copies after we fix SolverOptions to
-  // use sensible representation choices.
-  if (auto iter = options_double.find(std::string{name});
-      iter != options_double.end()) {
-    pending_keys_.erase(iter->first);
-    return iter->second;
+  if (popped_.contains(name)) {
+    return nullptr;
   }
-  const std::unordered_map<std::string, int>& options_int =
-      all_options_->GetOptionsInt(*id_);
-  if (auto iter = options_int.find(std::string{name});
-      iter != options_int.end()) {
+  if (auto iter = direct_options_.find(name); iter != direct_options_.end()) {
     pending_keys_.erase(iter->first);
-    return iter->second;
-  }
-  const std::unordered_map<std::string, std::string>& options_str =
-      all_options_->GetOptionsStr(*id_);
-  if (auto iter = options_str.find(std::string{name});
-      iter != options_str.end()) {
-    pending_keys_.erase(iter->first);
-    return iter->second;
+    const OptionValue& boxed_value = iter->second;
+    return &boxed_value;
   }
   if (auto iter = respelled_.find(name); iter != respelled_.end()) {
     pending_keys_.erase(iter->first);
-    return iter->second;
+    const OptionValue& boxed_value = iter->second;
+    return &boxed_value;
   }
-  return {};
+  return nullptr;
 }
 
 template <typename T>
 void SpecificOptions::CopyFloatingPointOption(const char* name, T* output) {
   DRAKE_DEMAND(output != nullptr);
-  if (auto boxed_value = PrepareToCopy(name)) {
+  if (const OptionValue* boxed_value = PrepareToCopy(name)) {
     if (std::holds_alternative<double>(*boxed_value)) {
       *output = std::get<double>(*boxed_value);
       return;
@@ -242,9 +254,9 @@ void SpecificOptions::CopyFloatingPointOption(const char* name, T* output) {
       *output = std::get<int>(*boxed_value);
       return;
     }
-    throw std::logic_error(
-        fmt::format("{}: Expected a floating-point value for option {}",
-                    id_->name(), name));
+    throw std::logic_error(fmt::format(
+        "{}: Expected a floating-point value for option {}={}", solver_name_,
+        name, internal::OptionValueToString(*boxed_value)));
   }
 }
 template void SpecificOptions::CopyFloatingPointOption(const char*, double*);
@@ -253,7 +265,7 @@ template void SpecificOptions::CopyFloatingPointOption(const char*, float*);
 template <typename T>
 void SpecificOptions::CopyIntegralOption(const char* name, T* output) {
   DRAKE_DEMAND(output != nullptr);
-  if (auto boxed_value = PrepareToCopy(name)) {
+  if (const OptionValue* boxed_value = PrepareToCopy(name)) {
     if (std::holds_alternative<int>(*boxed_value)) {
       const int value = std::get<int>(*boxed_value);
       if constexpr (std::is_same_v<T, int>) {
@@ -262,7 +274,7 @@ void SpecificOptions::CopyIntegralOption(const char* name, T* output) {
         if (!(value == 0 || value == 1)) {
           throw std::logic_error(fmt::format(
               "{}: Expected a boolean value (0 or 1) for int option {}={}",
-              id_->name(), name, value));
+              solver_name_, name, value));
         }
         *output = value;
       } else {
@@ -270,7 +282,7 @@ void SpecificOptions::CopyIntegralOption(const char* name, T* output) {
         if (value < 0) {
           throw std::logic_error(fmt::format(
               "{}: Expected a non-negative value for unsigned int option {}={}",
-              id_->name(), name, value));
+              solver_name_, name, value));
         }
         // In practice it's unlikely that sizeof(int) > 4, but better safe than
         // sorry. This also serves as a reminder to sanity check other casts if
@@ -279,14 +291,15 @@ void SpecificOptions::CopyIntegralOption(const char* name, T* output) {
             static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
           throw std::logic_error(
               fmt::format("{}: Too-large value for uint32 option {}={}",
-                          id_->name(), name, value));
+                          solver_name_, name, value));
         }
         *output = value;
       }
       return;
     }
     throw std::logic_error(fmt::format(
-        "{}: Expected an integer value for option {}", id_->name(), name));
+        "{}: Expected an integer value for option {}={}", solver_name_, name,
+        internal::OptionValueToString(*boxed_value)));
   }
 }
 template void SpecificOptions::CopyIntegralOption(const char*, int*);
@@ -295,13 +308,14 @@ template void SpecificOptions::CopyIntegralOption(const char*, uint32_t*);
 
 void SpecificOptions::CopyStringOption(const char* name, std::string* output) {
   DRAKE_DEMAND(output != nullptr);
-  if (auto boxed_value = PrepareToCopy(name)) {
+  if (const OptionValue* boxed_value = PrepareToCopy(name)) {
     if (std::holds_alternative<std::string>(*boxed_value)) {
       *output = std::get<std::string>(*boxed_value);
       return;
     }
     throw std::logic_error(fmt::format(
-        "{}: Expected a string value for option {}", id_->name(), name));
+        "{}: Expected a string value for option {}={}", solver_name_, name,
+        internal::OptionValueToString(*boxed_value)));
   }
 }
 

--- a/solvers/specific_options.h
+++ b/solvers/specific_options.h
@@ -75,21 +75,22 @@ class SpecificOptions {
           string_unordered_map<SolverOptions::OptionValue>* /* respelled */)>&
           respell);
 
-  /* Returns and effectively removes the value of the option named `key`. (To be
-  specific: the `all_option` object passed to our constructor remains unchanged;
+  /* Returns and effectively removes the value of the option named `key`. (To
+  be specific: the `all_options` object passed to our constructor is unchanged;
   instead, the `key` is memorized and future calls to either of the `CopyTo...`
   functions will skip over it.) If the option was not set or was set to a
-  different type), returns nullopt. When checking if an option was set, this
+  different type, returns nullopt. When checking if an option was set, this
   checks `all_options` for our `id` as well as any options added during a
   Respell().
-  @tparam T must be one of: double, int, std::string. */
+  @tparam Result must be one of: double, int, std::string. */
   template <typename Result>
   std::optional<Result> Pop(std::string_view key);
 
   /* Helper for "Method 1 - dynamic", per our class overview. Converts options
   when the solver offers a generic key-value API where options are passed by
   string name. Any of the `set_...` arguments can be nullptr, which implies
-  that the back-end does not support any options of that type. */
+  that the back-end does not support any options of that type, which implies
+  that any options set to such a type will throw an exception. */
   void CopyToCallbacks(
       const std::function<void(const std::string& key, double value)>&
           set_double,
@@ -137,8 +138,9 @@ class SpecificOptions {
   void CheckNoPending() const;
 
   /* Helper function for CopyToSerializableStruct(). Finds the option with the
-  given name, removes it from pending_keys_, and returns it. */
-  std::optional<SolverOptions::OptionValue> PrepareToCopy(const char* name);
+  given name, removes it from pending_keys_, and returns it. If the option was
+  not set, returns nullptr. */
+  const SolverOptions::OptionValue* PrepareToCopy(const char* name);
 
   /* Output helper functions for CopyToSerializableStruct().
   Each one sets its `output` argument to the option value for the given name,
@@ -152,17 +154,23 @@ class SpecificOptions {
   void CopyStringOption(const char* name, std::string* output);
   //@}
 
-  // The solver we're operating on behalf of (as passed to our constructor).
-  const SolverId* const id_;
+  // The common (Drake) options for all solvers.
+  const CommonSolverOptionValues common_options_;
 
-  // The full options for all solvers (as passed to our constructor).
-  const SolverOptions* const all_options_;
+  // The direct options for the solver we're operating on behalf of.
+  // These take precedence over the common_options_.
+  // @warning When looking up options in this map, you must ALWAYS cross-check
+  // the key against popped_ and pretend it's missing here when listed there.
+  const string_unordered_map<SolverOptions::OptionValue>& direct_options_;
+
+  // The name of the solver we're operating on behalf of.
+  const std::string& solver_name_;
+
+  // Keys of direct_options_ that have already been popped.
+  string_unordered_set popped_;
 
   // The result of the Respell() callback (or empty, if never called).
   string_unordered_map<SolverOptions::OptionValue> respelled_;
-
-  // Items that have already been popped.
-  string_unordered_set popped_;
 
   // Temporary storage during CopyToSerializableStruct() of option names that
   // are set but haven't yet been processed by Visit().

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3958,7 +3958,9 @@ GTEST_TEST(TestMathematicalProgram, TestAddVisualizationCallback) {
   EXPECT_TRUE(was_called);
 }
 
-GTEST_TEST(TestMathematicalProgram, TestSolverOptions) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(TestMathematicalProgram, DeprecatedTestSolverOptions) {
   MathematicalProgram prog;
   const SolverId solver_id("solver_id");
   const SolverId wrong_solver_id("wrong_solver_id");
@@ -3987,6 +3989,44 @@ GTEST_TEST(TestMathematicalProgram, TestSolverOptions) {
   EXPECT_EQ(prog.GetSolverOptionsInt(solver_id).size(), 0);
   EXPECT_EQ(prog.GetSolverOptionsStr(dummy_id).at("string_name"), "30.0");
   EXPECT_EQ(prog.GetSolverOptionsStr(solver_id).size(), 0);
+}
+#pragma GCC diagnostic pop
+
+GTEST_TEST(TestMathematicalProgram, TestSolverOptions) {
+  MathematicalProgram prog;
+  const SolverId solver_id("solver_id");
+
+  // Set each type once, directly on the program.
+  prog.SetSolverOption(solver_id, "double_name", 1.0);
+  EXPECT_THAT(prog.solver_options().options.at("solver_id").at("double_name"),
+              testing::VariantWith<double>(1.0));
+  prog.SetSolverOption(solver_id, "int_name", 2);
+  EXPECT_THAT(prog.solver_options().options.at("solver_id").at("int_name"),
+              testing::VariantWith<int>(2));
+  prog.SetSolverOption(solver_id, "string_name", "3");
+  EXPECT_THAT(prog.solver_options().options.at("solver_id").at("string_name"),
+              testing::VariantWith<std::string>("3"));
+
+  // The only solver with options set is the "solver_id".
+  EXPECT_EQ(prog.solver_options().options.size(), 1);
+
+  // Set each type once on an options struct, then set that onto the program.
+  // It erases all of the prior options.
+  const SolverId dummy_id("dummy_id");
+  SolverOptions dummy_options;
+  dummy_options.SetOption(dummy_id, "double_name", 10.0);
+  dummy_options.SetOption(dummy_id, "int_name", 20);
+  dummy_options.SetOption(dummy_id, "string_name", "30.0");
+  prog.SetSolverOptions(dummy_options);
+  EXPECT_THAT(prog.solver_options().options.at("dummy_id").at("double_name"),
+              testing::VariantWith<double>(10.0));
+  EXPECT_THAT(prog.solver_options().options.at("dummy_id").at("int_name"),
+              testing::VariantWith<int>(20));
+  EXPECT_THAT(prog.solver_options().options.at("dummy_id").at("string_name"),
+              testing::VariantWith<std::string>("30.0"));
+
+  // The only solver with options set is the "dummy_id".
+  EXPECT_EQ(prog.solver_options().options.size(), 1);
 }
 
 void CheckNewSosPolynomial(MathematicalProgram::NonnegativePolynomial type) {

--- a/solvers/test/solver_base_test.cc
+++ b/solvers/test/solver_base_test.cc
@@ -73,12 +73,14 @@ class StubSolverBase1 final : public StubSolverBase {
     result->set_solution_result(kSolutionFound);
     result->set_optimal_cost(1.0);
     Eigen::VectorXd x_val = x_init;
-    const auto& options_double = options.GetOptionsDouble(id());
-    if (options_double.contains("x0_solution")) {
-      x_val[0] = options_double.find("x0_solution")->second;
-    }
-    if (options_double.contains("x1_solution")) {
-      x_val[1] = options_double.find("x1_solution")->second;
+    if (options.options.contains(id().name())) {
+      const auto& my_options = options.options.at(id().name());
+      if (my_options.contains("x0_solution")) {
+        x_val[0] = std::get<double>(my_options.at("x0_solution"));
+      }
+      if (my_options.contains("x1_solution")) {
+        x_val[1] = std::get<double>(my_options.at("x1_solution"));
+      }
     }
     result->set_x_val(x_val);
   }

--- a/solvers/test/solver_options_test.cc
+++ b/solvers/test/solver_options_test.cc
@@ -1,15 +1,44 @@
 #include "drake/solvers/solver_options.h"
 
-// Remove this include on 2025-05-01 upon completion of deprecation.
+#include <limits>
+
+// Remove this include on 2025-09-01 upon completion of deprecation.
 #include <sstream>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/yaml_io.h"
 
 namespace drake {
 namespace solvers {
+
+using testing::Pair;
+using testing::UnorderedElementsAre;
+
+GTEST_TEST(OptionValueTest, ToString) {
+  using OptionValue = SolverOptions::OptionValue;
+  const OptionValue value_double = 22.0;
+  const OptionValue value_int = 10;
+  const OptionValue value_string = "hello";
+  EXPECT_EQ(internal::OptionValueToString(value_double), "22.0");
+  EXPECT_EQ(internal::OptionValueToString(value_int), "10");
+  EXPECT_EQ(internal::OptionValueToString(value_string), "\"hello\"");
+
+  const OptionValue value_nan = std::numeric_limits<double>::quiet_NaN();
+  const OptionValue value_inf = std::numeric_limits<double>::infinity();
+  const OptionValue value_neg_inf = -std::numeric_limits<double>::infinity();
+  EXPECT_EQ(internal::OptionValueToString(value_nan), "nan");
+  EXPECT_EQ(internal::OptionValueToString(value_inf), "inf");
+  EXPECT_EQ(internal::OptionValueToString(value_neg_inf), "-inf");
+
+  const OptionValue value_needs_escaping = "hello, \n\"world\"";
+  EXPECT_EQ(internal::OptionValueToString(value_needs_escaping),
+            fmt::format("{dq}hello, {bs}n{bs}{dq}world{bs}{dq}{dq}",
+                        fmt::arg("bs", '\\'), fmt::arg("dq", '"')));
+}
 
 GTEST_TEST(SolverOptionsTest, CommonToString) {
   const CommonSolverOption dut = CommonSolverOption::kPrintFileName;
@@ -17,6 +46,7 @@ GTEST_TEST(SolverOptionsTest, CommonToString) {
   EXPECT_EQ(fmt::to_string(dut), "kPrintFileName");
 }
 
+// Deprecated 2025-05-01.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(SolverOptionsTest, DeprecatedCommonStream) {
@@ -27,54 +57,111 @@ GTEST_TEST(SolverOptionsTest, DeprecatedCommonStream) {
 }
 #pragma GCC diagnostic pop
 
-GTEST_TEST(SolverOptionsTest, SetGetOption) {
+GTEST_TEST(SolverOptionsTest, Comparison) {
+  SolverOptions foo;
+  SolverOptions bar;
+  EXPECT_TRUE(foo == bar);
+  EXPECT_TRUE(bar == foo);
+  EXPECT_FALSE(foo != bar);
+  EXPECT_FALSE(bar != foo);
+
+  foo.SetOption(CommonSolverOption::kPrintToConsole, 1);
+  EXPECT_FALSE(foo == bar);
+  EXPECT_FALSE(bar == foo);
+  EXPECT_TRUE(foo != bar);
+  EXPECT_TRUE(bar != foo);
+
+  bar.SetOption(CommonSolverOption::kPrintToConsole, 1);
+  EXPECT_TRUE(foo == bar);
+  EXPECT_TRUE(bar == foo);
+  EXPECT_FALSE(foo != bar);
+  EXPECT_FALSE(bar != foo);
+}
+
+// Deprecated 2025-09-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(SolverOptionsTest, SetGetOptionDeprecated) {
   SolverOptions dut;
-  EXPECT_EQ(to_string(dut), "{SolverOptions empty}");
+  EXPECT_EQ(to_string(dut), "SolverOptions(options={})");
   EXPECT_EQ(dut.get_print_file_name(), "");
   EXPECT_EQ(dut.get_print_to_console(), false);
   EXPECT_EQ(dut.get_standalone_reproduction_file_name(), "");
   EXPECT_EQ(dut.get_max_threads(), std::nullopt);  // The value is unset.
 
-  const SolverId id1("id1");
-  const SolverId id2("id2");
-
-  dut.SetOption(id1, "some_double", 1.1);
-  dut.SetOption(id1, "some_before", 1.2);
-  dut.SetOption(id1, "some_int", 2);
-
-  dut.SetOption(id2, "some_int", "3");
-  dut.SetOption(id2, "some_string", "foo");
-
   dut.SetOption(CommonSolverOption::kPrintFileName, "foo.txt");
   dut.SetOption(CommonSolverOption::kPrintToConsole, 1);
   dut.SetOption(CommonSolverOption::kStandaloneReproductionFileName, "bar.py");
   dut.SetOption(CommonSolverOption::kMaxThreads, 2);
-
-  EXPECT_EQ(to_string(dut),
-            "{SolverOptions,"
-            " CommonSolverOption::kMaxThreads=2,"
-            " CommonSolverOption::kPrintFileName=foo.txt,"
-            " CommonSolverOption::kPrintToConsole=1,"
-            " CommonSolverOption::kStandaloneReproductionFileName=bar.py,"
-            " id1:some_before=1.2,"
-            " id1:some_double=1.1,"
-            " id1:some_int=2,"
-            " id2:some_int=3,"
-            " id2:some_string=foo}");
   EXPECT_EQ(dut.get_print_file_name(), "foo.txt");
   EXPECT_EQ(dut.get_print_to_console(), true);
   EXPECT_EQ(dut.get_standalone_reproduction_file_name(), "bar.py");
   EXPECT_EQ(dut.get_max_threads(), 2);
 
-  const std::unordered_map<CommonSolverOption,
-                           std::variant<double, int, std::string>>
-      common_options_expected(
-          {{CommonSolverOption::kPrintToConsole, 0},
-           {CommonSolverOption::kPrintFileName, "foo.txt"}});
-  // TODO(hongkai.dai): Test GetOption<double>() and `GetOptionDouble()` when
-  // a CommonSolverOption takes a double value.
+  const SolverId id1("id1");
+  const SolverId id2("id2");
+  dut.SetOption(id1, "some_double", 1.1);
+  dut.SetOption(id1, "some_int", 2);
+  dut.SetOption(id2, "some_string", "foo");
+  EXPECT_THAT(dut.template GetOptions<double>(id1),
+              UnorderedElementsAre(Pair("some_double", 1.1)));
+  EXPECT_THAT(dut.template GetOptions<int>(id1),
+              UnorderedElementsAre(Pair("some_int", 2)));
+  EXPECT_TRUE(dut.template GetOptions<std::string>(id1).empty());
+  EXPECT_TRUE(dut.template GetOptions<double>(id2).empty());
+  EXPECT_TRUE(dut.template GetOptions<int>(id2).empty());
+  EXPECT_THAT(dut.template GetOptions<std::string>(id2),
+              UnorderedElementsAre(Pair("some_string", "foo")));
+}
+#pragma GCC diagnostic pop
+
+GTEST_TEST(SolverOptionsTest, SetGetOption) {
+  SolverOptions dut;
+  EXPECT_TRUE(dut.options.empty());
+  EXPECT_EQ(dut.to_string(), "SolverOptions(options={})");
+
+  const SolverId id1("id1");
+  const SolverId id2("id2");
+  dut.SetOption(id1, "some_double", 1.1);
+  dut.SetOption(id1, "some_int", 2);
+  dut.SetOption(id2, "some_string", "foo");
+  dut.SetOption(CommonSolverOption::kPrintFileName, "foo.txt");
+  dut.SetOption(CommonSolverOption::kPrintToConsole, 1);
+  dut.SetOption(CommonSolverOption::kStandaloneReproductionFileName, "bar.py");
+  dut.SetOption(CommonSolverOption::kMaxThreads, 2);
+
+  EXPECT_THAT(
+      dut.options,
+      UnorderedElementsAre(
+          Pair("id1", UnorderedElementsAre(Pair("some_double", 1.1),
+                                           Pair("some_int", 2))),
+          Pair("id2", UnorderedElementsAre(Pair("some_string", "foo"))),
+          Pair("Drake", UnorderedElementsAre(
+                            Pair("kPrintFileName", "foo.txt"),
+                            Pair("kPrintToConsole", 1),
+                            Pair("kStandaloneReproductionFileName", "bar.py"),
+                            Pair("kMaxThreads", 2)))));
+  EXPECT_EQ(dut.to_string(),
+            "SolverOptions(options={"
+            "\"Drake\":{"
+            "\"kMaxThreads\":2,"
+            "\"kPrintFileName\":\"foo.txt\","
+            "\"kPrintToConsole\":1,"
+            "\"kStandaloneReproductionFileName\":\"bar.py\""
+            "},"
+            "\"id1\":{"
+            "\"some_double\":1.1,"
+            "\"some_int\":2"
+            "},"
+            "\"id2\":{"
+            "\"some_string\":\"foo\""
+            "}"
+            "})");
 }
 
+// Deprecated 2025-09-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(SolverOptionsTest, Ids) {
   using Set = std::unordered_set<SolverId>;
 
@@ -98,6 +185,7 @@ GTEST_TEST(SolverOptionsTest, Ids) {
   dut.SetOption(id1, "some_double", 1.0);
   EXPECT_EQ(dut.GetSolverIds(), Set({id1, id2, id3}));
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(SolverOptionsTest, Merge) {
   const SolverId id1("foo1");
@@ -139,6 +227,9 @@ GTEST_TEST(SolverOptionsTest, Merge) {
   EXPECT_EQ(dut, dut_expected);
 }
 
+// Deprecated 2025-09-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(SolverOptionsTest, CheckOptionKeysForSolver) {
   const SolverId id1("id1");
   const SolverId id2("id2");
@@ -160,27 +251,86 @@ GTEST_TEST(SolverOptionsTest, CheckOptionKeysForSolver) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       solver_options.CheckOptionKeysForSolver(id1, {"key1"}, {"key2"},
                                               {"key3"}),
-      "key2 is not allowed in the SolverOptions for id1.");
+      "key2 is not allowed in the SolverOptions for id1");
 
   DRAKE_EXPECT_NO_THROW(solver_options.CheckOptionKeysForSolver(
       id1, {"key1", "key2"}, {"key2"}, {"key3"}));
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(SolverOptionsTest, SetOptionError) {
   SolverOptions solver_options;
   DRAKE_EXPECT_THROWS_MESSAGE(
       solver_options.SetOption(CommonSolverOption::kPrintFileName, 1),
-      "SolverOptions::SetOption support kPrintFileName only with std::string "
-      "value.");
+      ".*SetOption.*kPrintFileName.*must be a string, not 1.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       solver_options.SetOption(CommonSolverOption::kPrintToConsole, 2),
-      "kPrintToConsole expects value either 0 or 1");
+      ".*SetOption.*kPrintToConsole.*must be 0 or 1, not 2.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       solver_options.SetOption(CommonSolverOption::kMaxThreads, 2.1),
-      "SolverOptions::SetOption support kMaxThreads only with int value.");
+      ".*SetOption.*kMaxThreads.*must be an int > 0, not 2.1.");
   DRAKE_EXPECT_THROWS_MESSAGE(
       solver_options.SetOption(CommonSolverOption::kMaxThreads, -1),
-      "kMaxThreads must be > 0.*");
+      ".*SetOption.*kMaxThreads.*must be an int > 0, not -1.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      solver_options.SetOption(
+          CommonSolverOption::kStandaloneReproductionFileName, 1),
+      ".*SetOption.*kStandalone.*must be a string, not 1.");
+}
+
+GTEST_TEST(SolverOptionsTest, Serialization) {
+  SolverOptions dut;
+  const SolverId id1("id1");
+  const SolverId id2("id2");
+  dut.SetOption(id1, "some_double", 1.1);
+  dut.SetOption(id1, "some_int", 2);
+  dut.SetOption(id2, "some_string", "foo");
+  dut.SetOption(CommonSolverOption::kPrintFileName, "foo.txt");
+  dut.SetOption(CommonSolverOption::kPrintToConsole, 1);
+  dut.SetOption(CommonSolverOption::kStandaloneReproductionFileName, "bar.py");
+  dut.SetOption(CommonSolverOption::kMaxThreads, 2);
+
+  // If you change either of these two string constants, then you must
+  // make the same change to the Python mathematicalprogram_test.py.
+  const std::string cxx_expected = R"""(options:
+  Drake:
+    kMaxThreads: !!int 2
+    kPrintFileName: !!str foo.txt
+    kPrintToConsole: !!int 1
+    kStandaloneReproductionFileName: !!str bar.py
+  id1:
+    some_double: 1.1
+    some_int: !!int 2
+  id2:
+    some_string: !!str foo
+)""";
+  const std::string py_expected = R"""(options:
+  Drake:
+    kMaxThreads: !!int '2'
+    kPrintFileName: !!str 'foo.txt'
+    kPrintToConsole: !!int '1'
+    kStandaloneReproductionFileName: !!str 'bar.py'
+  id1:
+    some_double: 1.1
+    some_int: !!int '2'
+  id2:
+    some_string: !!str 'foo'
+)""";
+
+  // Check that C++ can save and then re-load the options.
+  const std::string actual_written = yaml::SaveYamlString(dut);
+  EXPECT_EQ(actual_written, cxx_expected);
+  SolverOptions readback;
+  EXPECT_NO_THROW(readback =
+                      yaml::LoadYamlString<SolverOptions>(actual_written));
+  EXPECT_EQ(readback, dut);
+
+  // Cross-check that the output written by the Python unit test can be
+  // re-loaded in C++.
+  SolverOptions py_readback;
+  EXPECT_NO_THROW(py_readback =
+                      yaml::LoadYamlString<SolverOptions>(py_expected));
+  EXPECT_EQ(py_readback, dut);
 }
 
 }  // namespace solvers

--- a/solvers/test/specific_options_test.cc
+++ b/solvers/test/specific_options_test.cc
@@ -21,6 +21,14 @@ const SolverId& GetSolverId() {
   return result.access();
 }
 
+GTEST_TEST(SpecificOptionsTest, NullChecks) {
+  const SolverId& solver_id = GetSolverId();
+  SolverOptions options;
+  EXPECT_NO_THROW(SpecificOptions(&solver_id, &options));
+  DRAKE_EXPECT_THROWS_MESSAGE(SpecificOptions(nullptr, &options), ".*null.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(SpecificOptions(&solver_id, nullptr), ".*null.*");
+}
+
 GTEST_TEST(SpecificOptionsTest, BasicPop) {
   const SolverId& solver_id = GetSolverId();
   SolverOptions solver_options;
@@ -336,28 +344,28 @@ GTEST_TEST(SpecificOptionsTest, StructNoSuchField) {
 GTEST_TEST(SpecificOptionsTest, StructWrongType) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       CopyOneOptionToSerializableStruct("my_double", "foo"),
-      ".*floating.point.*my_double.*");
+      ".*floating.point.*my_double=\"foo\".*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       CopyOneOptionToSerializableStruct("my_int", "foo"),
-      ".*integer.*my_int.*");
+      ".*integer.*my_int=\"foo\".*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       CopyOneOptionToSerializableStruct("my_string", 0.5),
-      ".*string.*my_string.*");
+      ".*string.*my_string=0.5.*");
 }
 
 GTEST_TEST(SpecificOptionsTest, StructBadBool) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       CopyOneOptionToSerializableStruct("print_to_console", -1),
-      ".*(0 or 1).*print_to_console.*");
+      ".*(0 or 1).*print_to_console=-1.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       CopyOneOptionToSerializableStruct("print_to_console", 2),
-      ".*(0 or 1).*print_to_console.*");
+      ".*(0 or 1).*print_to_console=2.*");
 }
 
 GTEST_TEST(SpecificOptionsTest, StructBadUint32) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       CopyOneOptionToSerializableStruct("max_threads", -1),
-      ".*non-negative.*max_threads.*");
+      ".*non-negative.*max_threads=-1.*");
 }
 
 }  // namespace


### PR DESCRIPTION
Closes #20967.

The options are now just plain nested dictionaries, no longer hidden behind an API.

The API to set options remains unchanged. (Setting the dictionary values directly is also fine, now.)

The API to get options is all deprecated now.  Users should access the data directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22078)
<!-- Reviewable:end -->
