### PR TITLE
[solvers] Add CommonSolverOption::to_string

### DIFF
--- a/solvers/common_solver_option.cc
+++ b/solvers/common_solver_option.cc
@@ -4,24 +4,27 @@
 
 namespace drake {
 namespace solvers {
-std::ostream& operator<<(std::ostream& os,
-                         CommonSolverOption common_solver_option) {
+
+std::string_view to_string(CommonSolverOption common_solver_option) {
   switch (common_solver_option) {
     case CommonSolverOption::kPrintFileName:
-      os << "kPrintFileName";
-      return os;
+      return "kPrintFileName";
     case CommonSolverOption::kPrintToConsole:
-      os << "kPrintToConsole";
-      return os;
+      return "kPrintToConsole";
     case CommonSolverOption::kStandaloneReproductionFileName:
-      os << "kStandaloneReproductionFileName";
-      return os;
+      return "kStandaloneReproductionFileName";
     case CommonSolverOption::kMaxThreads:
-      os << "kMaxThreads";
-      return os;
-    default:
-      DRAKE_UNREACHABLE();
+      return "kMaxThreads";
   }
+  DRAKE_UNREACHABLE();
 }
+
+// Deprecated 2025-05-01.
+std::ostream& operator<<(std::ostream& os,
+                         CommonSolverOption common_solver_option) {
+  os << to_string(common_solver_option);
+  return os;
+}
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/common_solver_option.h
+++ b/solvers/common_solver_option.h
@@ -1,10 +1,14 @@
 #pragma once
 
 #include <optional>
-#include <ostream>
 #include <string>
+#include <string_view>
 
-#include "drake/common/fmt_ostream.h"
+// Remove this include on 2025-05-01 upon completion of deprecation.
+#include <ostream>
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 
 namespace drake {
 namespace solvers {
@@ -56,8 +60,11 @@ enum class CommonSolverOption {
   kMaxThreads,
 };
 
-std::ostream& operator<<(std::ostream& os,
-                         CommonSolverOption common_solver_option);
+/** Returns the short, unadorned name of the option, e.g., `kPrintFileName`. */
+std::string_view to_string(CommonSolverOption);
+
+DRAKE_DEPRECATED("2025-05-01", "Use to_string(), instead.")
+std::ostream& operator<<(std::ostream&, CommonSolverOption);
 
 namespace internal {
 
@@ -73,9 +80,5 @@ struct CommonSolverOptionValues {
 }  // namespace solvers
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::solvers::CommonSolverOption>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::solvers, CommonSolverOption, x,
+                   ::drake::solvers::to_string(x))

--- a/solvers/test/solver_options_test.cc
+++ b/solvers/test/solver_options_test.cc
@@ -1,5 +1,8 @@
 #include "drake/solvers/solver_options.h"
 
+// Remove this include on 2025-05-01 upon completion of deprecation.
+#include <sstream>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"
@@ -7,6 +10,23 @@
 
 namespace drake {
 namespace solvers {
+
+GTEST_TEST(SolverOptionsTest, CommonToString) {
+  const CommonSolverOption dut = CommonSolverOption::kPrintFileName;
+  EXPECT_EQ(to_string(dut), "kPrintFileName");
+  EXPECT_EQ(fmt::to_string(dut), "kPrintFileName");
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(SolverOptionsTest, DeprecatedCommonStream) {
+  const CommonSolverOption dut = CommonSolverOption::kPrintFileName;
+  std::stringstream stream;
+  stream << dut;
+  EXPECT_EQ(stream.str(), "kPrintFileName");
+}
+#pragma GCC diagnostic pop
+
 GTEST_TEST(SolverOptionsTest, SetGetOption) {
   SolverOptions dut;
   EXPECT_EQ(to_string(dut), "{SolverOptions empty}");
@@ -162,5 +182,6 @@ GTEST_TEST(SolverOptionsTest, SetOptionError) {
       solver_options.SetOption(CommonSolverOption::kMaxThreads, -1),
       "kMaxThreads must be > 0.*");
 }
+
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Deprecate `operator<<`.  I'm using a 6-month window since the deprecations for #22078 might be intrusive, and it's not that costly to keep around the shims a little extra while.

Towards #22078.  Efficient string look-up of common option names is important for that feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22079)
<!-- Reviewable:end -->
