### PR TITLE
[render_vtk] Use EGL by default on Ubuntu

### DIFF
--- a/bindings/pydrake/geometry/BUILD.bazel
+++ b/bindings/pydrake/geometry/BUILD.bazel
@@ -145,6 +145,7 @@ drake_py_unittest(
 
 drake_py_unittest(
     name = "render_engine_gl_test",
+    display = True,
     deps = [
         ":geometry",
         "//bindings/pydrake/common/test_utilities",

--- a/bindings/pydrake/visualization/test/multicam_scenario.yaml
+++ b/bindings/pydrake/visualization/test/multicam_scenario.yaml
@@ -68,7 +68,7 @@ Multicam:
     camera_1:
       name: gl_camera_front
       renderer_name: gl
-      renderer_class: !RenderEngineGlParams {}
+      renderer_class: !RenderEngineVtkParams {}
       width: 1000
       height: 1000
       depth: True

--- a/common/test_utilities/BUILD.bazel
+++ b/common/test_utilities/BUILD.bazel
@@ -10,6 +10,7 @@ load(
     "//tools/skylark:drake_py.bzl",
     "drake_py_library",
 )
+load("//tools/skylark:drake_sh.bzl", "drake_sh_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -196,7 +197,7 @@ drake_cc_binary(
 
 # N.B. All sh_tests are excluded from sanitizer builds by default; these death
 # tests are therefore skipped under those configurations.
-sh_test(
+drake_sh_test(
     name = "limit_malloc_death_test",
     srcs = [":limit_malloc_test"],
     args = select({

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -9,6 +9,7 @@ load(
     "//tools/skylark:drake_py.bzl",
     "drake_py_unittest",
 )
+load("//tools/skylark:drake_sh.bzl", "drake_sh_test")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -166,9 +167,8 @@ alias(
 )
 
 # Test that kuka_simulation can load the dual arm urdf
-sh_test(
+drake_sh_test(
     name = "dual_kuka_simulation_test",
-    size = "small",
     srcs = ["kuka_simulation"],
     args = [
         "$(location :kuka_simulation)",

--- a/geometry/benchmarking/BUILD.bazel
+++ b/geometry/benchmarking/BUILD.bazel
@@ -82,6 +82,7 @@ drake_cc_googlebench_binary(
         # To save time, only run the low-resolution tests in CI.
         "--benchmark_filter=.*/1/1/320/240",
     ],
+    test_display = True,
     test_tags = vtk_test_tags(),
     deps = [
         "//common:add_text_logging_gflags",

--- a/geometry/render/render_camera.h
+++ b/geometry/render/render_camera.h
@@ -153,7 +153,9 @@ class ColorRenderCamera {
   /** This camera's core render properties.  */
   const RenderCameraCore& core() const { return core_; }
 
-  /** If true, requests that the RenderEngine display the rendered image.  */
+  /** If true, requests that the RenderEngine display the rendered image.
+  Whether or not the image is able to be displayed depends on the specific
+  render engine and its configuration. */
   bool show_window() const { return show_window_; }
 
  private:

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -210,6 +210,7 @@ drake_cc_googletest_linux_only(
 
 drake_cc_googletest_linux_only(
     name = "internal_opengl_context_test",
+    display = True,
     tags = [
         # GLX functions show up with bad reads, bad writes, possibly lost, and
         # definitely lost.  We will investiate soon but for now we'll omit the
@@ -237,6 +238,7 @@ drake_cc_googletest_linux_only(
         "//examples/scene_graph:models",
         "//geometry/render:test_models",
     ] + glob(["test/*.png"]),
+    display = True,
     tags = vtk_test_tags(),
     deps = [
         ":internal_render_engine_gl",
@@ -285,6 +287,7 @@ drake_cc_googletest_linux_only(
 
 drake_cc_googletest_linux_only(
     name = "internal_shader_program_test",
+    display = True,
     tags = vtk_test_tags(),
     deps = [
         ":internal_opengl_context",
@@ -300,6 +303,7 @@ drake_cc_googletest_linux_only(
     data = [
         "//geometry/render:test_models",
     ],
+    display = True,
     tags = vtk_test_tags() + [
         # We launch up to 3 child tasks.
         "cpu:4",
@@ -320,6 +324,7 @@ drake_cc_googletest_linux_only(
     data = [
         "//geometry/render:test_models",
     ],
+    display = True,
     # TODO(#21420) This test is currently broken on Ubuntu 24.04 ("Noble").
     enable_condition = "//tools:ubuntu_jammy",
     tags = vtk_test_tags() + [

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "drake_cc_library",
     "drake_cc_package_library",
 )
+load("//tools/skylark:drake_sh.bzl", "drake_sh_test")
 load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
 package(default_visibility = ["//visibility:private"])
@@ -180,26 +181,24 @@ drake_cc_googletest(
     ],
 )
 
-# Re-run internal_render_engine_vtk_test, but with the EGL backend.
-sh_test(
-    name = "internal_render_engine_vtk_egl_test",
+# Re-run internal_render_engine_vtk_test, but with the GLX backend.
+drake_sh_test(
+    name = "internal_render_engine_vtk_glx_test",
     timeout = "moderate",
     srcs = ["internal_render_engine_vtk_test"],
     args = select({
         ":osx": [
-            # EGL is a Linux-only feature.
+            # GLX is a Linux-only feature.
             "--gtest_filter=-*",
         ],
         "//conditions:default": [
-            "--backend=EGL",
+            "--backend=GLX",
         ],
     }),
     data = [
         ":internal_render_engine_vtk_test",
     ],
-    env = {
-        "DISPLAY": "should_not_be_used",
-    },
+    display = True,
     tags = vtk_test_tags(),
 )
 

--- a/geometry/render_vtk/factory.h
+++ b/geometry/render_vtk/factory.h
@@ -20,6 +20,10 @@ namespace geometry {
  <a href="https://github.com/RobotLocomotion/drake/issues/20144">#20144</a>
  for further discussion.
 
+ @note On Ubuntu, render::ColorRenderCamera::show_window only shows a window
+ when RenderEngineVtkParams::backend is set to "GLX"; the default backend value
+ of "EGL" cannot show a window.
+
  @anchor render_engine_vtk_properties
  <h2>Geometry perception properties</h2>
 

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -1147,7 +1147,22 @@ void RenderEngineVtk::UpdateWindow(const RenderCameraCore& camera,
   const CameraInfo& intrinsics = camera.intrinsics();
   p.window->SetSize(intrinsics.width(), intrinsics.height());
   p.window->SetOffScreenRendering(!show_window);
-  if (show_window) p.window->SetWindowName(name);
+  if (show_window) {
+    p.window->SetWindowName(name);
+    switch (pipelines_[0]->backend) {
+      case RenderEngineVtkBackend::kCocoa:
+      case RenderEngineVtkBackend::kGlx:
+        // These backends DO support show_window.
+        break;
+      case RenderEngineVtkBackend::kEgl: {
+        // This backend does NOT support show_window.
+        static const logging::Warn log_once(
+            "RenderEngineVtk was called using show_window=True, but that "
+            "feature is not available when RenderEngineVtkParams.backend "
+            "is using \"EGL\"");
+      }
+    }
+  }
 
   vtkCamera* vtk_camera = p.renderer->GetActiveCamera();
   DRAKE_DEMAND(vtk_camera->GetUseExplicitProjectionTransformMatrix());

--- a/geometry/render_vtk/render_engine_vtk_params.cc
+++ b/geometry/render_vtk/render_engine_vtk_params.cc
@@ -18,7 +18,7 @@ constexpr bool kApple = false;
 RenderEngineVtkBackend ParseRenderEngineVtkBackend(
     const RenderEngineVtkParams& parameters) {
   const RenderEngineVtkBackend default_result =
-      kApple ? RenderEngineVtkBackend::kCocoa : RenderEngineVtkBackend::kGlx;
+      kApple ? RenderEngineVtkBackend::kCocoa : RenderEngineVtkBackend::kEgl;
   const std::string_view backend = parameters.backend;
   if (backend.empty()) {
     return default_result;

--- a/geometry/render_vtk/render_engine_vtk_params.h
+++ b/geometry/render_vtk/render_engine_vtk_params.h
@@ -227,8 +227,8 @@ struct RenderEngineVtkParams {
   Any other value will throw an error.
 
   By default (i.e., when set to the empty string) the render engine will choose
-  which library to use. At the moment the default is "Cocoa" on macOS and "GLX"
-  on Linux, but we anticipate changing the default in the future.
+  which library to use. At the moment the default is "Cocoa" on macOS and "EGL"
+  on Linux.
 
   If the option is set to one of the permissible values but the related graphics
   library has not been compiled into current build (e.g., "GLX" on macOS), then

--- a/geometry/render_vtk/test/render_engine_vtk_params_test.cc
+++ b/geometry/render_vtk/test/render_engine_vtk_params_test.cc
@@ -96,12 +96,12 @@ GTEST_TEST(RenderEngineVtkParams, Backend) {
   dut.backend = "";
   EXPECT_EQ(
       ParseRenderEngineVtkBackend(dut),
-      kApple ? RenderEngineVtkBackend::kCocoa : RenderEngineVtkBackend::kGlx);
+      kApple ? RenderEngineVtkBackend::kCocoa : RenderEngineVtkBackend::kEgl);
 
   dut.backend = "Cocoa";
   EXPECT_EQ(
       ParseRenderEngineVtkBackend(dut),
-      kApple ? RenderEngineVtkBackend::kCocoa : RenderEngineVtkBackend::kGlx);
+      kApple ? RenderEngineVtkBackend::kCocoa : RenderEngineVtkBackend::kEgl);
 
   dut.backend = "EGL";
   EXPECT_EQ(

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -422,6 +422,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "camera_config_functions_test",
     allow_network = ["render_gltf_client"],
+    display = True,
     tags = vtk_test_tags(),
     deps = [
         ":camera_config_functions",
@@ -583,6 +584,7 @@ drake_cc_googletest_linux_only(
         ":test/rgbd_sensor_async_gl_test.dmd.yaml",
         "@drake_models//:manipulation_station",
     ],
+    display = True,
     # TODO(#21420) This test is currently broken on Ubuntu 24.04 ("Noble").
     enable_condition = "//tools:ubuntu_jammy",
     tags = vtk_test_tags() + [

--- a/systems/sensors/camera_config.h
+++ b/systems/sensors/camera_config.h
@@ -409,9 +409,10 @@ struct CameraConfig {
 
   /** Controls whether the rendered RGB and/or label images are displayed (in
    separate windows controlled by the thread in which the camera images are
-   rendered). As both image types are rendered from `ColorRenderCamera`, it
-   applies to both of them and depends on whether the RenderEngine instance
-   supports it.
+   rendered). Because both RGB and label images are configured from the same
+   `ColorRenderCamera`, this setting applies to both images. Even when set to
+   true, whether or not the image is able to be displayed depends on the
+   specific render engine and its configuration.
 
    Note: This flag is intended for quick debug use during development instead of
    serving as an image viewer. Currently, there are known issues, e.g.,

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -28,11 +28,6 @@ build --test_summary=terse
 # config_setting rules for proprietary software are provided in //tools.
 build --test_tag_filters=-gurobi,-mosek,-snopt
 
-# Allow user environment variables relating to host graphics configuration to
-# flow through to tests that use X.
-build --test_env=DISPLAY
-build --test_env=XAUTHORITY
-
 # Location of the Gurobi license key file, typically named "gurobi.lic".
 # Setting this --test_env for all configurations is deliberate to improve
 # remote caching performance.

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -10,6 +10,7 @@ load(
     "drake_py_library",
     "drake_py_unittest",
 )
+load("//tools/skylark:drake_sh.bzl", "drake_sh_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -163,9 +164,8 @@ drake_py_unittest(
     deps = [":formatter"],
 )
 
-sh_test(
+drake_sh_test(
     name = "clang_format_includes_test",
-    size = "small",
     srcs = ["test/clang_format_includes_test.sh"],
     data = [
         ":clang-format-includes",

--- a/tools/performance/defs.bzl
+++ b/tools/performance/defs.bzl
@@ -14,6 +14,7 @@ def drake_cc_googlebench_binary(
         test_size = "small",
         test_timeout = None,
         test_args = None,
+        test_display = False,
         test_tags = None):
     """Declares a testonly binary that uses google benchmark.  Automatically
     adds appropriate deps and ensures it either has an automated smoke test
@@ -49,6 +50,7 @@ def drake_cc_googlebench_binary(
             deps = new_deps,
             size = test_size,
             timeout = test_timeout,
+            display = test_display,
             args = [
                 # When running as a unit test, run each function only once to
                 # save time. (Once should be sufficient to prove the lack of

--- a/tools/skylark/README.md
+++ b/tools/skylark/README.md
@@ -30,6 +30,17 @@ Note that this does not affect network sandboxing (i.e., Bazel's block-network
 tag). Code outside of Drake purview can still access the network in tests (e.g.,
 license servers for commercial solvers).
 
+**display**
+
+Can either be True or False (defaults to False).
+
+When True, provides access to the Xorg DISPLAY environment variable so that
+the test can use the X display.  When False, unsets DISPLAY to forbid access.
+
+Note that the X display in Jenkins CI tends to crash frequently, so any tests
+marked with `display = True` are a likely candidate for `flaky = True` so that
+X crashes don't lead to false positives in CI.
+
 **num_threads**
 
 Can either be None, or else an integer.

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -3,6 +3,7 @@ load("//tools/skylark:cc.bzl", "cc_binary", "cc_library", "cc_test")
 load(
     "//tools/skylark:kwargs.bzl",
     "incorporate_allow_network",
+    "incorporate_display",
     "incorporate_num_threads",
 )
 load("//tools/workspace:generate_file.bzl", "generate_file")
@@ -834,6 +835,7 @@ def drake_cc_test(
         gcc_copts = [],
         clang_copts = [],
         allow_network = None,
+        display = False,
         num_threads = None,
         **kwargs):
     """Creates a rule to declare a C++ unit test.  Note that for almost all
@@ -846,6 +848,9 @@ def drake_cc_test(
     @param allow_network (optional, default is ["meshcat"])
         See drake/tools/skylark/README.md for details.
 
+    @param display (optional, default is False)
+        See drake/tools/skylark/README.md for details.
+
     @param num_threads (optional, default is 1)
         See drake/tools/skylark/README.md for details.
     """
@@ -855,6 +860,7 @@ def drake_cc_test(
         srcs = ["test/%s.cc" % name]
     kwargs["testonly"] = 1
     kwargs = incorporate_allow_network(kwargs, allow_network = allow_network)
+    kwargs = incorporate_display(kwargs, display = display)
     kwargs = incorporate_num_threads(kwargs, num_threads = num_threads)
     new_copts = _platform_copts(copts, gcc_copts, clang_copts, cc_test = 1)
     new_srcs, add_deps = _maybe_add_pruned_private_hdrs_dep(
@@ -1003,6 +1009,7 @@ def drake_cc_googletest_linux_only(
         linkopts = [],
         tags = [],
         timeout = None,
+        display = False,
         visibility = ["//visibility:private"],
         enable_condition = "@drake//tools/skylark:linux"):
     """Declares a platform-specific drake_cc_googletest. When not building on
@@ -1053,5 +1060,6 @@ def drake_cc_googletest_linux_only(
             enable_condition: [":_{}_compile".format(name)],
             "//conditions:default": [],
         }),
+        display = display,
         visibility = visibility,
     )

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -2,6 +2,7 @@ load(
     "//tools/skylark:kwargs.bzl",
     "amend",
     "incorporate_allow_network",
+    "incorporate_display",
     "incorporate_num_threads",
 )
 load("//tools/skylark:py.bzl", "py_binary", "py_library", "py_test")
@@ -219,6 +220,7 @@ def drake_py_test(
         isolate = True,
         allow_import_unittest = False,
         allow_network = None,
+        display = False,
         num_threads = None,
         **kwargs):
     """A wrapper to insert Drake-specific customizations.
@@ -239,6 +241,9 @@ def drake_py_test(
     @param allow_network (optional, default is ["meshcat"])
         See drake/tools/skylark/README.md for details.
 
+    @param display (optional, default is False)
+        See drake/tools/skylark/README.md for details.
+
     @param num_threads (optional, default is 1)
         See drake/tools/skylark/README.md for details.
 
@@ -256,6 +261,7 @@ def drake_py_test(
     shard_count = kwargs.pop("_drake_py_unittest_shard_count", None)
 
     kwargs = incorporate_allow_network(kwargs, allow_network = allow_network)
+    kwargs = incorporate_display(kwargs, display = display)
     kwargs = incorporate_num_threads(kwargs, num_threads = num_threads)
     kwargs = amend(kwargs, "tags", append = ["py"])
 

--- a/tools/skylark/drake_sh.bzl
+++ b/tools/skylark/drake_sh.bzl
@@ -1,0 +1,36 @@
+load(
+    "//tools/skylark:kwargs.bzl",
+    "amend",
+    "incorporate_allow_network",
+    "incorporate_display",
+    "incorporate_num_threads",
+)
+
+def drake_sh_test(
+        name,
+        *,
+        allow_network = None,
+        display = False,
+        num_threads = None,
+        **kwargs):
+    """A wrapper to insert Drake-specific customizations.
+
+    @param allow_network (optional, default is ["meshcat"])
+        See drake/tools/skylark/README.md for details.
+
+    @param display (optional, default is False)
+        See drake/tools/skylark/README.md for details.
+
+    @param num_threads (optional, default is 1)
+        See drake/tools/skylark/README.md for details.
+
+    By default, sets test size to "small" to indicate a unit test.
+    """
+    kwargs = incorporate_allow_network(kwargs, allow_network = allow_network)
+    kwargs = incorporate_display(kwargs, display = display)
+    kwargs = incorporate_num_threads(kwargs, num_threads = num_threads)
+    kwargs = amend(kwargs, "size", default = "small")
+    native.sh_test(
+        name = name,
+        **kwargs
+    )

--- a/tools/skylark/kwargs.bzl
+++ b/tools/skylark/kwargs.bzl
@@ -57,6 +57,16 @@ def _bump_cpu_tag(kwargs, *, new_size):
     kwargs["tags"] = tags
     return kwargs
 
+def incorporate_display(kwargs, *, display):
+    if display not in (True, False):
+        fail("The 'display = ...' attribute should be a boolean.")
+    if display:
+        kwargs = amend(kwargs, "env_inherit", append = [
+            "DISPLAY",
+            "XAUTHORITY",
+        ])
+    return kwargs
+
 def incorporate_num_threads(kwargs, *, num_threads):
     """Incorporates multi-threading directives (e.g., for OpenMP) into
     well-known Bazel args (i.e., tags=, env=).


### PR DESCRIPTION
This also fixes RenderEngineGltfClient to not require a DISPLAY.

Closes #21700.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22081)
<!-- Reviewable:end -->
