### PR TITLE
Correct VTK header generation from binary files

### DIFF
--- a/tools/workspace/vtk_internal/BUILD.bazel
+++ b/tools/workspace/vtk_internal/BUILD.bazel
@@ -1,7 +1,17 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_cc.bzl", "drake_cc_library")
+load(
+    "//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
 
-exports_files(glob(["gen/**"]))
+exports_files(
+    [
+        "data_to_header.py",
+    ] + glob([
+        "gen/**",
+    ]),
+)
 
 drake_cc_library(
     name = "vtk_opengl_init",
@@ -18,4 +28,19 @@ drake_cc_library(
     alwayslink = True,
 )
 
-add_lint_tests()
+drake_cc_googletest(
+    name = "data_to_header_test",
+    data = [
+        "@vtk_internal//:Rendering/OpenGL2/glsl/vtkDepthOfFieldPassFS.glsl",
+        "@vtk_internal//:Rendering/OpenGL2/textures/BlueNoiseTexture64x64.jpg",
+    ],
+    deps = [
+        "//common:find_resource",
+        "//common:find_runfiles",
+        "@vtk_internal//:vtkRenderingOpenGL2",
+    ],
+)
+
+add_lint_tests(
+    python_lint_extra_srcs = ["data_to_header.py"],
+)

--- a/tools/workspace/vtk_internal/data_to_header.py
+++ b/tools/workspace/vtk_internal/data_to_header.py
@@ -1,0 +1,80 @@
+# A re-implementation of upstream's vtkEncodeString.cmake. This is not a *full*
+# implementation. It is sufficient for the files that we actually run through
+# the conversion.
+
+import argparse
+from pathlib import Path
+
+
+def _is_binary(path: Path):
+    """Determines if the file at the indicated path is a binary file or not.
+    The list is a strict list of the file types we know we're converting. If
+    we end up converting other file types, it will require appending the
+    types here; they can't be added by accident.
+    """
+    BINARY_EXT = ['.jpg']
+    ASCII_EXT = ['.glsl']
+    ext = path.suffix.lower()
+    if ext in BINARY_EXT:
+        return True
+    elif ext in ASCII_EXT:
+        return False
+    else:
+        raise ValueError(f"No support for converting {ext} files yet.")
+
+
+def _header(constant_name: str, binary: bool):
+    # Choice of unsigned char/char comes from VTK.
+    byte_type = "unsigned char" if binary else "char"
+    opening = "{" if binary else 'R"vtkdrakeinternal('
+    return f"""
+#pragma once
+VTK_ABI_NAMESPACE_BEGIN
+constexpr {byte_type} {constant_name}[] = {opening}"""
+
+
+def _footer(binary: bool):
+    closing = "};" if binary else ')vtkdrakeinternal";'
+    return f"""{closing}
+VTK_ABI_NAMESPACE_END
+"""
+
+
+def _print_binary_as_hex(in_file):
+    """Converts a binary file to a sequence of comma-separated hexadecimal byte
+    values, suitable for initializing an array of bytes in C++.
+    """
+    all_hex = ', '.join([f'0x{b:02x}' for b in in_file.read()])
+    # Don't write a single line with a billion columns. Each byte takes
+    # six characters (0xAA, ). Chop off chunks to fit 80-column lines.
+    width = 78  # 13 * 6
+    start = 0
+    while start < len(all_hex):
+        print(f"  {all_hex[start:start+width].strip()}")
+        start += width
+
+
+def _print_conversion(source: Path):
+    is_binary = _is_binary(source)
+    constant_name = source.stem
+    print(_header(constant_name, is_binary))
+    file_code = "b" if is_binary else ""
+    with open(source, f"r{file_code}") as in_file:
+        if is_binary:
+            _print_binary_as_hex(in_file)
+        else:
+            print(in_file.read())
+    print(_footer(is_binary))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "in_path", type=Path, help="The source file to convert")
+    args = parser.parse_args()
+
+    _print_conversion(args.in_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/workspace/vtk_internal/package.BUILD.bazel
+++ b/tools/workspace/vtk_internal/package.BUILD.bazel
@@ -3,6 +3,10 @@
 load("@drake//tools/install:install.bzl", "install")
 load("@drake//tools/skylark:cc.bzl", "cc_binary", "cc_library")
 load(
+    "@drake//tools/skylark:py.bzl",
+    "py_binary",
+)
+load(
     "@drake//tools/workspace/vtk_internal:rules.bzl",
     "compile_all_modules",
     "generate_common_core_sources",
@@ -15,6 +19,14 @@ config_setting(
     constraint_values = ["@platforms//os:osx"],
 )
 
+# Necessary for @drake//tools/workspace/vtk_internal:data_to_header_test.
+exports_files(
+    [
+        "Rendering/OpenGL2/textures/BlueNoiseTexture64x64.jpg",
+        "Rendering/OpenGL2/glsl/vtkDepthOfFieldPassFS.glsl",
+    ],
+)
+
 # When the rules.bzl needs to declare an objc_library, it adds this to `deps`
 # to improve the error messages in case of a mis-configured build.
 cc_library(
@@ -22,6 +34,13 @@ cc_library(
     linkstatic = True,
     features = ["-supports_pic"],
     tags = ["manual"],
+)
+
+py_binary(
+    name = "data_to_header",
+    srcs = ["@drake//tools/workspace/vtk_internal:data_to_header.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
 )
 
 # Generate some source files on the fly, using Bazel re-implementations of

--- a/tools/workspace/vtk_internal/test/data_to_header_test.cc
+++ b/tools/workspace/vtk_internal/test/data_to_header_test.cc
@@ -1,0 +1,64 @@
+#include <string>
+
+// clang-format off
+#include <gtest/gtest.h>
+
+// The converted header files require these macros be defined.
+#define VTK_ABI_NAMESPACE_BEGIN
+#define VTK_ABI_NAMESPACE_END
+#include <BlueNoiseTexture64x64.h>  // vtkRenderingOpenGl2
+#include <vtkDepthOfFieldPassFS.h>  // vtkRenderingOpenGl2
+// clang-format on
+
+#include "drake/common/find_resource.h"
+#include "drake/common/find_runfiles.h"
+
+namespace drake {
+namespace {
+
+// Confirm that the in-memory C++-representation of the data files match the
+// data files.
+GTEST_TEST(InternalVtkTest, BinaryFile) {
+  // The C++ data is available and defined.
+  ASSERT_GT(sizeof(BlueNoiseTexture64x64), 0);
+  const std::string memory_contents(
+      std::string_view(reinterpret_cast<const char*>(BlueNoiseTexture64x64),
+                       sizeof(BlueNoiseTexture64x64)));
+  ASSERT_FALSE(memory_contents.empty());
+
+  const std::string path =
+      FindRunfile(
+          "vtk_internal/Rendering/OpenGL2/textures/BlueNoiseTexture64x64.jpg")
+          .abspath;
+  ASSERT_FALSE(path.empty());
+  const std::string disk_contents = ReadFileOrThrow(path);
+
+  EXPECT_EQ(memory_contents, disk_contents);
+}
+
+GTEST_TEST(InternalVtkTest, AsciiFile) {
+  // The C++ data is available and defined.
+  ASSERT_GT(sizeof(vtkDepthOfFieldPassFS), 0);
+  const std::string memory_contents(vtkDepthOfFieldPassFS);
+  ASSERT_FALSE(memory_contents.empty());
+
+  const std::string path =
+      FindRunfile(
+          "vtk_internal/Rendering/OpenGL2/glsl/vtkDepthOfFieldPassFS.glsl")
+          .abspath;
+  ASSERT_FALSE(path.empty());
+  const std::string disk_contents = ReadFileOrThrow(path);
+
+  // The conversion may embed the ascii with some surrounding whitespace; we
+  // don't care. We'll simply trim trailing/leading whitespace and then compare.
+  auto trim = [](const std::string& s) {
+    auto start = s.find_first_not_of(" \n\t");
+    auto last = s.find_last_not_of(" \n\t");
+    return std::string_view(s.data() + start, last - start + 1);
+  };
+
+  EXPECT_EQ(trim(memory_contents), trim(disk_contents));
+}
+
+}  // namespace
+}  // namespace drake


### PR DESCRIPTION
The technique we were using to emulate vtkEncodeString.cmake was insufficient for binary files. Up til now, we were only dependent on ascii files and it was fine.

However, when use SSAO we'll be dependent on a texture. That texture doesn't get converted properly. The solution is to initialize the char array as unsigned char with an array of one-byte hex values.

We don't currently depend on it so we have a smoke test in place to confirm correctness.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22092)
<!-- Reviewable:end -->
