### PR TITLE
[math] Add requires clause to RigidTransform and RotationMatrix cast

### DIFF
--- a/common/default_scalars.h
+++ b/common/default_scalars.h
@@ -73,6 +73,14 @@
 /// See also @ref system_scalar_conversion.
 /// @{
 
+namespace drake {
+// A constant that is true iff T is a default scalar type.
+template <typename T>
+constexpr bool is_default_scalar =
+    std::is_same_v<T, double> || std::is_same_v<T, drake::AutoDiffXd> ||
+    std::is_same_v<T, drake::symbolic::Expression>;
+}  // namespace drake
+
 // In support of the macros below, we define a struct template that provides
 // the per-phase typedef `scalar_phase_t<DRAKE_ONCE_PER_SCALAR_PHASE>::type`.
 // If more scalar types are added, also fix drake/tools/skylark/drake_cc.bzl

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -983,10 +983,12 @@ bool RenderEngineGl::DoRegisterDeformableVisual(
 
 void RenderEngineGl::DoUpdateVisualPose(GeometryId id,
                                         const RigidTransformd& X_WG) {
-  const auto X_WG_f = X_WG.cast<float>();
+  const Eigen::Matrix4f X_WG_f = X_WG.GetAsMatrix4().template cast<float>();
+  const Eigen::Matrix3f R_WG_f =
+      X_WG.rotation().matrix().template cast<float>();
   for (auto& instance : visuals_.at(id).instances) {
-    instance.T_WN = X_WG_f.GetAsMatrix4() * instance.T_GN;
-    instance.N_WN = X_WG_f.rotation().matrix() * instance.N_GN;
+    instance.T_WN = X_WG_f * instance.T_GN;
+    instance.N_WN = R_WG_f * instance.N_GN;
   }
 }
 

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -306,7 +306,9 @@ class RigidTransform {
   /// %RigidTransform.  For example, Eigen currently allows cast from type
   /// double to AutoDiffXd, but not vice-versa.
   template <typename U>
-  RigidTransform<U> cast() const {
+  RigidTransform<U> cast() const
+    requires is_default_scalar<U>
+  {  // NOLINT(whitespace/braces)
     const RotationMatrix<U> R = R_AB_.template cast<U>();
     const Vector3<U> p = p_AoBo_A_.template cast<U>();
     return RigidTransform<U>(R, p);

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -345,7 +345,9 @@ class RotationMatrix {
   /// %Matrix3 that underlies this %RotationMatrix.  For example, Eigen
   /// currently allows cast from type double to AutoDiffXd, but not vice-versa.
   template <typename U>
-  RotationMatrix<U> cast() const {
+  RotationMatrix<U> cast() const
+    requires is_default_scalar<U>
+  {  // NOLINT(whitespace/braces)
     // TODO(Mitiguy) Make the RotationMatrix::cast() method more robust.  It is
     // currently limited by Eigen's cast() for the matrix underlying this class.
     // Consider the following logic to improve casts (and address issue #11785).


### PR DESCRIPTION
In slack, a user reported trying to use `RigidTransform<float>` in their own code (inspired by one of these examples) and got a linker error.  This fixes both the bad examples, and now the compiler will also bark about invalid casts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22094)
<!-- Reviewable:end -->
