### PR TITLE
[geometry] Add precomputed values to mesh/field types

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_meshes.cc
+++ b/bindings/pydrake/geometry/geometry_py_meshes.cc
@@ -122,6 +122,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.tetrahedra.doc)
         .def("num_elements", &Class::num_elements, cls_doc.num_elements.doc)
         .def("num_vertices", &Class::num_vertices, cls_doc.num_vertices.doc)
+        .def("inward_normal", &Class::inward_normal, py::arg("e"), py::arg("f"),
+            cls_doc.inward_normal.doc)
+        .def("edge_vector", &Class::edge_vector, py::arg("e"), py::arg("a"),
+            py::arg("b"), cls_doc.edge_vector.doc)
         .def("CalcTetrahedronVolume", &Class::CalcTetrahedronVolume,
             py::arg("e"), cls_doc.CalcTetrahedronVolume.doc)
         .def("CalcVolume", &Class::CalcVolume, cls_doc.CalcVolume.doc)
@@ -177,7 +181,8 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def(py::init<int, int, int, int>(), py::arg("v0"), py::arg("v1"),
             py::arg("v2"), py::arg("v3"), cls_doc.ctor.doc_4args)
         // TODO(SeanCurtis-TRI): Bind constructor that takes array of ints.
-        .def("vertex", &Class::vertex, py::arg("i"), cls_doc.vertex.doc);
+        .def("vertex", &Class::vertex, py::arg("i"), cls_doc.vertex.doc)
+        .def("num_vertices", &Class::num_vertices, cls_doc.num_vertices.doc);
     DefCopyAndDeepCopy(&cls);
   }
 }

--- a/bindings/pydrake/geometry/test/meshes_test.py
+++ b/bindings/pydrake/geometry/test/meshes_test.py
@@ -1,5 +1,6 @@
 import pydrake.geometry as mut
 import pydrake.geometry._testing as mut_testing
+from pydrake.common.test_utilities import numpy_compare
 
 import copy
 import unittest
@@ -141,6 +142,8 @@ class TestGeometryMeshes(unittest.TestCase):
         self.assertIsInstance(dut.vertex(v=0), np.ndarray)
         self.assertIsInstance(dut.num_elements(), int)
         self.assertIsInstance(dut.num_vertices(), int)
+        self.assertIsInstance(dut.inward_normal(e=0, f=0), np.ndarray)
+        self.assertIsInstance(dut.edge_vector(e=0, a=0, b=1), np.ndarray)
 
         # Sanity check some calculations
         self.assertAlmostEqual(dut.CalcTetrahedronVolume(e=1), 1/6.0,
@@ -154,9 +157,19 @@ class TestGeometryMeshes(unittest.TestCase):
         self.assertIsInstance(dut.tetrahedra()[0], mut.VolumeElement)
         self.assertEqual(len(dut.vertices()), 5)
 
+        numpy_compare.assert_float_equal(
+            dut.inward_normal(e=0, f=3), (-1., 0., 0.))
+        numpy_compare.assert_float_equal(
+            dut.inward_normal(e=1, f=3), (1., 0., 0.))
+        numpy_compare.assert_float_equal(
+            dut.edge_vector(e=0, a=1, b=3), (-1., 0., 0.))
+        numpy_compare.assert_float_equal(
+            dut.edge_vector(e=1, a=1, b=3), (1., 0., 0.))
+
         # Now check the VolumeElement bindings.
         tetrahedron0 = dut.element(e=0)
         self.assertEqual(tetrahedron0.vertex(i=0), 2)
+        self.assertEqual(tetrahedron0.num_vertices(), 4)
 
     def test_convert_volume_to_surface_mesh(self):
         # Use the volume mesh from `test_volume_mesh()`.

--- a/geometry/proximity/mesh_field_linear.h
+++ b/geometry/proximity/mesh_field_linear.h
@@ -198,6 +198,7 @@ class MeshFieldLinear {
                      static_cast<int>(values_at_Mo_.size()));
       }
     }
+    CalcMinAndMaxValues();
   }
 
   /** (Advanced) Constructor variant which receives the pre-computed,
@@ -224,6 +225,7 @@ class MeshFieldLinear {
     DRAKE_DEMAND(static_cast<int>(gradients_.size()) == mesh_->num_elements());
 
     CalcValueAtMeshOriginForAllElements();
+    CalcMinAndMaxValues();
   }
 
   /** @returns true iff the gradient field could not be computed, and the mesh
@@ -238,8 +240,38 @@ class MeshFieldLinear {
    @pre v ∈ [0, this->mesh().num_vertices()).
    */
   const T& EvaluateAtVertex(int v) const {
-    DRAKE_ASSERT(v >= 0 && v < mesh_->num_vertices());
+    DRAKE_DEMAND(v >= 0 && v < mesh_->num_vertices());
     return values_[v];
+  }
+
+  /** (Advanced) Evaluates the minimum field value on an element.
+   @param e The index of the element.
+   @pre e ∈ [0, this->mesh().num_elements()).
+   */
+  const T& EvaluateMin(int e) const {
+    DRAKE_DEMAND(e >= 0 && e < mesh_->num_elements());
+    return min_values_[e];
+  }
+
+  /** (Advanced) Evaluates the maximum field value on an element.
+   @param e The index of the element.
+   @pre e ∈ [0, this->mesh().num_elements()).
+   */
+  const T& EvaluateMax(int e) const {
+    DRAKE_DEMAND(e >= 0 && e < mesh_->num_elements());
+    return max_values_[e];
+  }
+
+  /** (Advanced) Evaluates the linear function associated with element e at the
+   mesh origin Mo.
+   @param e The index of the element.
+   @pre e ∈ [0, this->mesh().num_elements()).
+   @pre The field has valid gradients.
+  */
+  const T& EvaluateAtMo(int e) const {
+    DRAKE_DEMAND(e >= 0 && e < mesh_->num_elements());
+    DRAKE_DEMAND(e < ssize(values_at_Mo_));
+    return values_at_Mo_[e];
   }
 
   /** Evaluates the field value at a location on an element.
@@ -361,8 +393,14 @@ class MeshFieldLinear {
     return new_mesh_field;
   }
 
+  /** The mesh M to which this field refers. */
   const MeshType& mesh() const { return *mesh_; }
+  /** The field value at each vertex. */
   const std::vector<T>& values() const { return values_; }
+  /** The minimum field value on each element. */
+  const std::vector<T>& min_values() const { return min_values_; }
+  /** The maximum field value on each element. */
+  const std::vector<T>& max_values() const { return max_values_; }
 
   // TODO(#12173): Consider NaN==NaN to be true in equality tests.
   /** Checks to see whether the given MeshFieldLinear object is equal via deep
@@ -416,6 +454,25 @@ class MeshFieldLinear {
     }
   }
 
+  void CalcMinAndMaxValues() {
+    min_values_.clear();
+    max_values_.clear();
+    min_values_.reserve(this->mesh().num_elements());
+    max_values_.reserve(this->mesh().num_elements());
+    for (int e = 0; e < this->mesh().num_elements(); ++e) {
+      T min, max;
+      min = max = values_[this->mesh().element(e).vertex(0)];
+
+      for (int i = 1; i < mesh().element(e).num_vertices(); ++i) {
+        min = std::min(min, values_[this->mesh().element(e).vertex(i)]);
+        max = std::max(max, values_[this->mesh().element(e).vertex(i)]);
+      }
+
+      min_values_.emplace_back(min);
+      max_values_.emplace_back(max);
+    }
+  }
+
   std::optional<Vector3<T>> MaybeCalcGradientVector(int e) const {
     // In the case of the PolygonSurfaceMesh, where kVertexPerElement is marked
     // as "indeterminate" (aka -1), we'll simply use the first three vertices.
@@ -454,6 +511,12 @@ class MeshFieldLinear {
   // The field values are indexed in the same way as vertices, i.e.,
   // values_[i] is the field value for the mesh vertices_[i].
   std::vector<T> values_;
+  // Stores the minimum value of the field for each element, i.e.,
+  // min_values_[i] is the minimum field value on the domain of elements_[i].
+  std::vector<T> min_values_;
+  // Stores the maximum value of the field for each element, i.e.,
+  // min_values_[i] is the minimum field value on the domain of elements_[i].
+  std::vector<T> max_values_;
   // The gradients are indexed in the same way as elements, i.e.,
   // gradients_[i] is the gradient vector on elements_[i]. The elements could
   // be tetrahedra for VolumeMesh or triangles for TriangleSurfaceMesh.

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -68,6 +68,23 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateAtVertex) {
   EXPECT_EQ(mesh_field->EvaluateAtVertex(3), 3);
 }
 
+GTEST_TEST(MeshFieldLinearTest, EvaluateMinAndMaxAndMo) {
+  auto mesh = GenerateMesh<double>();
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+  // Arbitrary values such that min and max are unique on each element.
+  std::vector<double> e_values = {1., -2., 2., 3.};
+  auto mesh_field =
+      std::make_unique<MeshFieldLinear<double, TriangleSurfaceMesh<double>>>(
+          std::move(e_values), mesh.get());
+  EXPECT_EQ(mesh_field->EvaluateMin(0), -2);
+  EXPECT_EQ(mesh_field->EvaluateMin(1), 1);
+  EXPECT_EQ(mesh_field->EvaluateMax(0), 2);
+  EXPECT_EQ(mesh_field->EvaluateMax(1), 3);
+  EXPECT_NEAR(mesh_field->EvaluateAtMo(0), 1, kEps);
+  EXPECT_NEAR(mesh_field->EvaluateAtMo(1), 1, kEps);
+}
+
 // Tests CloneAndSetMesh(). We use `double` and TriangleSurfaceMesh<double> as
 // representative arguments for type parameters.
 GTEST_TEST(MeshFieldLinearTest, TestDoCloneWithMesh) {

--- a/geometry/proximity/volume_mesh.cc
+++ b/geometry/proximity/volume_mesh.cc
@@ -6,12 +6,34 @@ namespace drake {
 namespace geometry {
 
 template <typename T>
+VolumeMesh<T>::VolumeMesh(std::vector<VolumeElement>&& elements,
+                          std::vector<Vector3<T>>&& vertices)
+    : elements_(std::move(elements)), vertices_M_(std::move(vertices)) {
+  if (elements_.empty()) {
+    throw std::logic_error("A mesh must contain at least one tetrahedron");
+  }
+  ComputePositionDependentQuantities();
+}
+
+template <typename T>
 void VolumeMesh<T>::TransformVertices(
     const math::RigidTransform<T>& transform) {
   const math::RigidTransform<T>& X_NM = transform;
   for (Vector3<T>& vertex : vertices_M_) {
     const Vector3<T> p_MV = vertex;
     vertex = X_NM * p_MV;
+  }
+
+  // Transform all position dependent quantities.
+  const math::RotationMatrix<T>& R_NM = X_NM.rotation();
+  for (int i = 0; i < num_elements(); ++i) {
+    for (int j = 0; j < 4; ++j) {
+      inward_normals_M_[i][j] = R_NM * inward_normals_M_[i][j];
+    }
+
+    for (int j = 0; j < 6; ++j) {
+      edge_vectors_M_[i][j] = R_NM * edge_vectors_M_[i][j];
+    }
   }
 }
 
@@ -26,6 +48,80 @@ void VolumeMesh<T>::SetAllPositions(const Eigen::Ref<const VectorX<T>>& p_MVs) {
   for (int v = 0, i = 0; v < num_vertices(); ++v, i += 3) {
     vertices_M_[v] = Vector3<T>(p_MVs[i], p_MVs[i + 1], p_MVs[i + 2]);
   }
+
+  ComputePositionDependentQuantities();
+}
+
+template <typename T>
+void VolumeMesh<T>::ComputePositionDependentQuantities() {
+  inward_normals_M_.clear();
+  edge_vectors_M_.clear();
+  inward_normals_M_.reserve(num_elements());
+  edge_vectors_M_.reserve(num_elements());
+  for (int e = 0; e < num_elements(); ++e) {
+    const Vector3<T>& a = vertices_M_[elements_[e].vertex(0)];
+    const Vector3<T>& b = vertices_M_[elements_[e].vertex(1)];
+    const Vector3<T>& c = vertices_M_[elements_[e].vertex(2)];
+    const Vector3<T>& d = vertices_M_[elements_[e].vertex(3)];
+
+    const Vector3<T> ab = b - a;
+    const Vector3<T> ac = c - a;
+    const Vector3<T> ad = d - a;
+    const Vector3<T> bc = c - b;
+    const Vector3<T> bd = d - b;
+    const Vector3<T> cd = d - c;
+
+    edge_vectors_M_.push_back(
+        std::array<Vector3<T>, 6>{ab, ac, ad, bc, bd, cd});
+
+    // Assume the first three vertices a, b, c define a triangle with its
+    // right-handed normal pointing towards the inside of the tetrahedra. The
+    // fourth vertex, d, is on the positive side of the plane defined by a,
+    // b, c. The faces that wind CCW from inside the element are:
+    //  {b d c}  Across from vertex a
+    //  {a c d}  Across from vertex b
+    //  {a d b}  Across from vertex c
+    //  {a b c}  Across from vertex d
+    //
+    // For example, a standard tetrahedron looks like this:
+    //
+    //              Mz
+    //              ┆
+    //            d ●
+    //              ┆
+    //              ┆    c
+    //            a ●┄┄┄●┄┄┄ My
+    //             ╱
+    //          b ●
+    //          ╱
+    //
+    inward_normals_M_.push_back(std::array<Vector3<T>, 4>{
+        bd.cross(bc).normalized(), (ac).cross(ad).normalized(),
+        (ad).cross(ab).normalized(), (ab).cross(ac).normalized()});
+  }
+}
+
+template <typename T>
+bool VolumeMesh<T>::Equal(const VolumeMesh<T>& mesh,
+                          double vertex_tolerance) const {
+  if (this == &mesh) return true;
+
+  if (this->num_elements() != mesh.num_elements()) return false;
+  if (this->num_vertices() != mesh.num_vertices()) return false;
+
+  // Check tetrahedral elements.
+  for (int i = 0; i < this->num_elements(); ++i) {
+    if (!this->element(i).Equal(mesh.element(i))) return false;
+  }
+  // Check vertices.
+  for (int i = 0; i < this->num_vertices(); ++i) {
+    if ((this->vertex(i) - mesh.vertex(i)).norm() > vertex_tolerance) {
+      return false;
+    }
+  }
+
+  // All checks passed.
+  return true;
 }
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -50,6 +50,9 @@ class VolumeElement {
   explicit VolumeElement(const int v[4])
       : VolumeElement(v[0], v[1], v[2], v[3]) {}
 
+  /** Returns the number of vertices in this element. */
+  int num_vertices() const { return 4; }
+
   /** Returns the vertex index in VolumeMesh of the i-th vertex of this
    element.
    @param i  The local index of the vertex in this element.
@@ -138,15 +141,10 @@ class VolumeMesh {
    convention documented in the VolumeElement class. This class however does not
    enforce this convention and it is thus the responsibility of the user.  */
   VolumeMesh(std::vector<VolumeElement>&& elements,
-             std::vector<Vector3<T>>&& vertices)
-      : elements_(std::move(elements)), vertices_M_(std::move(vertices)) {
-    if (elements_.empty()) {
-      throw std::logic_error("A mesh must contain at least one tetrahedron");
-    }
-  }
+             std::vector<Vector3<T>>&& vertices);
 
   const VolumeElement& element(int e) const {
-    DRAKE_DEMAND(0 <= e && num_elements());
+    DRAKE_DEMAND(0 <= e && e < num_elements());
     return elements_[e];
   }
 
@@ -157,6 +155,41 @@ class VolumeMesh {
   const Vector3<T>& vertex(int v) const {
     DRAKE_DEMAND(0 <= v && v < num_vertices());
     return vertices_M_[v];
+  }
+
+  /** Returns the inward facing normal of face f of element e.
+   @param e The index of the element.
+   @param f The index of the triangular face of the tetrahedral element e
+            formed by the vertices [(f + 1) % 4, (f + 2) % 4, (f + 3) % 4].
+   @pre e ∈ [0, num_elements())
+   @pre f ∈ [0, 4)
+   */
+  const Vector3<T>& inward_normal(int e, int f) const {
+    DRAKE_DEMAND(0 <= e && e < num_elements());
+    DRAKE_DEMAND(0 <= f && f < kVertexPerElement);
+    return inward_normals_M_[e][f];
+  }
+
+  /** Returns p_AB_M, the position vector from vertex A to vertex B in M, where
+   A and B are specified by the element local indices a and b of element e.
+   @param e The index of the element.
+   @param a The element local index of vertex A.
+   @param b The element local index of vertex B.
+   @pre e ∈ [0, num_elements())
+   @pre a ∈ [0, 4)
+   @pre b ∈ [0, 4)
+   @pre a < b
+  */
+  const Vector3<T>& edge_vector(int e, int a, int b) const {
+    DRAKE_DEMAND(0 <= e && e < num_elements());
+    DRAKE_DEMAND(0 <= a && a < kVertexPerElement);
+    DRAKE_DEMAND(0 <= b && b < kVertexPerElement);
+    DRAKE_DEMAND(a < b);
+    // The following formula gives this table:
+    // {a, b} = {0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}
+    // index  =      0,      1,      2,      3,      4,      5
+    const int index = a + b - !a;
+    return edge_vectors_M_[e][index];
   }
 
   const std::vector<Vector3<T>>& vertices() const { return vertices_M_; }
@@ -174,22 +207,13 @@ class VolumeMesh {
   /** Calculates volume of a tetrahedral element. It is a signed volume, i.e.,
    it can be negative depending on the order of the four vertices of the
    tetrahedron.
-   @pre `f ∈ [0, num_elements())`.
+   @pre `e ∈ [0, num_elements())`.
    */
   T CalcTetrahedronVolume(int e) const {
-    // TODO(DamrongGuoy): Refactor this function out of VolumeMesh when we need
-    //  it. CalcTetrahedronVolume(index) will call
-    //  CalcTetrahedronVolume(Vector3, Vector3, Vector3, Vector3).
-    const Vector3<T>& a = vertices_M_[elements_[e].vertex(0)];
-    const Vector3<T>& b = vertices_M_[elements_[e].vertex(1)];
-    const Vector3<T>& c = vertices_M_[elements_[e].vertex(2)];
-    const Vector3<T>& d = vertices_M_[elements_[e].vertex(3)];
-    // Assume the first three vertices a, b, c define a triangle with its
-    // right-handed normal pointing towards the inside of the tetrahedra. The
-    // fourth vertex, d, is on the positive side of the plane defined by a,
-    // b, c. With this convention, the computed volume will be positive,
-    // otherwise negative.
-    const T volume = (d - a).dot((b - a).cross(c - a)) / T(6.0);
+    const T volume =
+        (this->edge_vector(e, 0, 3).dot(
+            this->edge_vector(e, 0, 1).cross(this->edge_vector(e, 0, 2)))) /
+        T(6.0);
     return volume;
   }
 
@@ -257,26 +281,7 @@ class VolumeMesh {
                             be considered equal.
    @returns `true` if the given mesh is equal.
    */
-  bool Equal(const VolumeMesh<T>& mesh, double vertex_tolerance = 0) const {
-    if (this == &mesh) return true;
-
-    if (this->num_elements() != mesh.num_elements()) return false;
-    if (this->num_vertices() != mesh.num_vertices()) return false;
-
-    // Check tetrahedral elements.
-    for (int i = 0; i < this->num_elements(); ++i) {
-      if (!this->element(i).Equal(mesh.element(i))) return false;
-    }
-    // Check vertices.
-    for (int i = 0; i < this->num_vertices(); ++i) {
-      if ((this->vertex(i) - mesh.vertex(i)).norm() > vertex_tolerance) {
-        return false;
-      }
-    }
-
-    // All checks passed.
-    return true;
-  }
+  bool Equal(const VolumeMesh<T>& mesh, double vertex_tolerance = 0) const;
 
   /** Calculates the gradient ∇u of a linear field u on the tetrahedron `e`.
    Field u is defined by the four field values `field_value[i]` at the i-th
@@ -352,6 +357,9 @@ class VolumeMesh {
     return *result;
   }
 
+  // Calculates the inward facing normals and element edge vectors.
+  void ComputePositionDependentQuantities();
+
   // Like CalcGradBarycentric, but returns std::nullopt instead of throwing on
   // degenerate geometry.
   std::optional<Vector3<T>> MaybeCalcGradBarycentric(int e, int i) const;
@@ -361,6 +369,14 @@ class VolumeMesh {
   // The vertices that are shared between the tetrahedral elements, measured and
   // expressed in the mesh's frame M.
   std::vector<Vector3<T>> vertices_M_;
+  // Stores the inward facing normals of each face of the tetrahedron, measured
+  // and expressed in the mesh's frame M. Index i stores the normal of the face
+  // formed by vertices {0, 1, 2, 3} / {i}.
+  std::vector<std::array<Vector3<T>, 4>> inward_normals_M_;
+  // Stores the edge vectors of each tetrahedron, measured and
+  // expressed in the mesh's frame M, in lexicographical order:
+  // {0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}
+  std::vector<std::array<Vector3<T>, 6>> edge_vectors_M_;
 
   friend class VolumeMeshTester<T>;
 };


### PR DESCRIPTION
Towards #21744.

Adds precomputed face normals and edge vectors to `VolumeMesh`.
Adds precomputed Min/Max/Origin pressure values for `MeshFieldLinear` .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22097)
<!-- Reviewable:end -->
