### PR TITLE
Update parsing infrastructure

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -322,24 +322,27 @@ void DefineGeometryPropertiesSubclasses(py::module m) {
   {
     py::class_<IllustrationProperties, GeometryProperties> cls(
         m, "IllustrationProperties", doc.IllustrationProperties.doc);
-    cls.def(py::init(), doc.IllustrationProperties.ctor.doc)
-        .def(py::init<const IllustrationProperties&>(), py::arg("other"),
+    cls  // BR
+        .def(py::init(), doc.IllustrationProperties.ctor.doc)
+        .def(py::init<const GeometryProperties&>(), py::arg("other"),
             "Creates a copy of the properties");
     DefCopyAndDeepCopy(&cls);
   }
   {
     py::class_<PerceptionProperties, GeometryProperties> cls(
         m, "PerceptionProperties", doc.PerceptionProperties.doc);
-    cls.def(py::init(), doc.PerceptionProperties.ctor.doc)
-        .def(py::init<const PerceptionProperties&>(), py::arg("other"),
+    cls  // BR
+        .def(py::init(), doc.PerceptionProperties.ctor.doc)
+        .def(py::init<const GeometryProperties&>(), py::arg("other"),
             "Creates a copy of the properties");
     DefCopyAndDeepCopy(&cls);
   }
   {
     py::class_<ProximityProperties, GeometryProperties> cls(
         m, "ProximityProperties", doc.ProximityProperties.doc);
-    cls.def(py::init(), doc.ProximityProperties.ctor.doc)
-        .def(py::init<const ProximityProperties&>(), py::arg("other"),
+    cls  // BR
+        .def(py::init(), doc.ProximityProperties.ctor.doc)
+        .def(py::init<const GeometryProperties&>(), py::arg("other"),
             "Creates a copy of the properties");
     DefCopyAndDeepCopy(&cls);
   }

--- a/bindings/pydrake/geometry/test/common_test.py
+++ b/bindings/pydrake/geometry/test/common_test.py
@@ -157,6 +157,17 @@ class TestGeometryCore(unittest.TestCase):
             props_copy3 = copy.deepcopy(props)
             self.assertTrue(props_copy3.HasProperty("g", "p"))
 
+        # Cross-property-set copying. We don't do all cross possibilities.
+        # Merely confirm that each set can be copied from another set.
+        source = mut.PerceptionProperties()
+        source.AddProperty("a", "b", 10)
+        illustration = mut.IllustrationProperties(source)
+        self.assertEqual(illustration.GetProperty("a", "b"), 10)
+        proximity = mut.ProximityProperties(illustration)
+        self.assertEqual(proximity.GetProperty("a", "b"), 10)
+        perception = mut.PerceptionProperties(proximity)
+        self.assertEqual(perception.GetProperty("a", "b"), 10)
+
     def test_geometry_properties_cpp_types(self):
         """
         Confirms that types stored in properties in python, resolve to expected

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -977,6 +977,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("diffuse_color"),
             cls_doc.RegisterVisualGeometry
                 .doc_5args_body_X_BG_shape_name_diffuse_color)
+        .def("RegisterVisualGeometry",
+            py::overload_cast<const RigidBody<T>&,
+                std::unique_ptr<geometry::GeometryInstance>>(
+                &Class::RegisterVisualGeometry),
+            py::arg("body"), py::arg("geometry_instance"),
+            cls_doc.RegisterVisualGeometry.doc_2args_body_geometry_instance)
         .def("RegisterCollisionGeometry",
             py::overload_cast<const RigidBody<T>&,
                 const RigidTransform<double>&, const geometry::Shape&,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -232,6 +232,11 @@ class TestPlant(unittest.TestCase):
             plant.RegisterVisualGeometry(
                 body=body, X_BG=body_X_BG, shape=box, name="new_body_visual",
                 diffuse_color=[1., 0.64, 0.0, 0.5])
+            plant.RegisterVisualGeometry(
+                body=body,
+                geometry_instance=GeometryInstance(X_PG=body_X_BG,
+                                                   shape=Sphere(1.0),
+                                                   name="from_instance"))
             plant.RegisterCollisionGeometry(
                 body=body, X_BG=body_X_BG, shape=box,
                 name="new_body_collision", coulomb_friction=body_friction)

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -963,6 +963,13 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "geometry_roles_test",
+    deps = [
+        ":geometry_roles",
+    ],
+)
+
+drake_cc_googletest(
     name = "geometry_version_test",
     deps = [
         ":geometry_version",

--- a/geometry/geometry_roles.cc
+++ b/geometry/geometry_roles.cc
@@ -5,9 +5,18 @@
 namespace drake {
 namespace geometry {
 
+ProximityProperties::ProximityProperties(const GeometryProperties& other)
+    : GeometryProperties(other) {}
+
 ProximityProperties::~ProximityProperties() = default;
 
+PerceptionProperties::PerceptionProperties(const GeometryProperties& other)
+    : GeometryProperties(other) {}
+
 PerceptionProperties::~PerceptionProperties() = default;
+
+IllustrationProperties::IllustrationProperties(const GeometryProperties& other)
+    : GeometryProperties(other) {}
 
 IllustrationProperties::~IllustrationProperties() = default;
 

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -142,6 +142,17 @@ namespace geometry {
  type of role that it depends on, and the properties (if any) associated with
  that role that it requires/prefers.
 
+ There are times where different roles may have common properties (e.g., when
+ visualizing proximity geometries, we can specify their appearance in the
+ visualizer, or the appearance of a geometry should be the same for both
+ perception and illustration roles). To ease the sharing of these property
+ values, one set of properties can be instantiated as a copy of any other
+ set of geometry properties -- regardless of role. Doing so indiscriminately
+ may introduce meaningless properties, so use this power judiciously. A
+ property would be meaningless if there is no consumer that would use it. This
+ isn't an error, but it does mean that property values would be copied and
+ persisted without value.
+
  Next topic: @ref proximity_queries  */
 
 /** The set of properties for geometry used in a _proximity_ role.
@@ -155,8 +166,8 @@ namespace geometry {
 class ProximityProperties final : public GeometryProperties {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ProximityProperties);
-  // TODO(SeanCurtis-TRI): Should this have the physical properties built in?
   ProximityProperties() = default;
+  explicit ProximityProperties(const GeometryProperties& other);
   ~ProximityProperties() final;
 };
 
@@ -168,8 +179,8 @@ class ProximityProperties final : public GeometryProperties {
 class PerceptionProperties final : public GeometryProperties {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PerceptionProperties);
-  // TODO(SeanCurtis-TRI): Should this have a render label built in?
   PerceptionProperties() = default;
+  explicit PerceptionProperties(const GeometryProperties& other);
   ~PerceptionProperties() final;
 };
 
@@ -182,6 +193,7 @@ class IllustrationProperties final : public GeometryProperties {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IllustrationProperties);
   IllustrationProperties() = default;
+  explicit IllustrationProperties(const GeometryProperties& other);
   ~IllustrationProperties() final;
 };
 

--- a/geometry/test/geometry_roles_test.cc
+++ b/geometry/test/geometry_roles_test.cc
@@ -1,0 +1,44 @@
+#include "drake/geometry/geometry_roles.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace {
+
+// An instance of XProperties can be constructed from YProperties (the result is
+// that it simply copies all of the properties). Remember, that the derived
+// FooProperties classes add no functionality to GeometryProperties -- they are
+// merely a type distinction.
+GTEST_TEST(GeometryRoleTest, CopyFromOther) {
+  PerceptionProperties source;
+  source.AddProperty("test", "int", 10);
+  source.AddProperty("test", "string", "value");
+
+  const GeometryProperties& generic = source;
+
+  ProximityProperties proximity(generic);
+  EXPECT_EQ(proximity.GetProperty<int>("test", "int"),
+            source.GetProperty<int>("test", "int"));
+  EXPECT_EQ(proximity.GetProperty<std::string>("test", "string"),
+            source.GetProperty<std::string>("test", "string"));
+
+  IllustrationProperties illustration(generic);
+  EXPECT_EQ(illustration.GetProperty<int>("test", "int"),
+            source.GetProperty<int>("test", "int"));
+  EXPECT_EQ(illustration.GetProperty<std::string>("test", "string"),
+            source.GetProperty<std::string>("test", "string"));
+
+  // Proximity -> Perception.
+  PerceptionProperties perception(generic);
+  EXPECT_EQ(perception.GetProperty<int>("test", "int"),
+            source.GetProperty<int>("test", "int"));
+  EXPECT_EQ(perception.GetProperty<std::string>("test", "string"),
+            source.GetProperty<std::string>("test", "string"));
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/multibody/parsing/detail_sdf_geometry.h
+++ b/multibody/parsing/detail_sdf_geometry.h
@@ -28,23 +28,26 @@ using ResolveFilename = std::function<std::string (
 /* Given an sdf::Geometry object representing a <geometry> element from an SDF
  file, this method makes a new drake::geometry::Shape object from this
  specification.
- If no recognizable geometry is specified, nullptr is returned. If the geometry
- is recognized, but malformed, emits an error. When the error policy is set to
- not throw it returns std::nullopt. */
-std::optional<std::unique_ptr<geometry::Shape>> MakeShapeFromSdfGeometry(
-    const SDFormatDiagnostic& diagnostic,
-    const sdf::Geometry& sdf_geometry,
+ If no recognizable geometry is specified or the geometry is recognized but
+ malformed, nullptr is returned. In the case of a malformed specification, an
+ error is also emitted on `diagnostic`. */
+std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
+    const SDFormatDiagnostic& diagnostic, const sdf::Geometry& sdf_geometry,
     ResolveFilename resolve_filename);
 
 /* Given an sdf::Visual object representing a <visual> element from an SDF
  file, this method makes a new drake::geometry::GeometryInstance object from
- this specification at a pose `X_LG` relatve to its parent link.
- This method returns nullptr when the given SDF specification corresponds
- to an uninterpreted geometry type:
- - `sdf::GeometryType::EMPTY` (`<empty/>` SDF tag.)
- - `sdf::GeometryType::HEIGHTMAP` (`<heightmap/>` SDF tag.)
- If the geometry is malformed, emits an error. When the error policy is not
- set to throw it returns an std::nullopt.
+ this specification at a pose `X_LG` relative to its parent link.
+
+ This method returns null when:
+   1. the given SDF specification corresponds to an uninterpreted geometry type:
+      - `sdf::GeometryType::EMPTY` (`<empty/>` SDF tag.)
+      - `sdf::GeometryType::HEIGHTMAP` (`<heightmap/>` SDF tag.)
+   2. the <visual> has had both of its Drake roles disabled.
+   3. the <visual> specification was in some way malformed.
+
+ In the case of a malformed specification, an error is also emitted to
+ `diagnostic`.
 
  <!-- TODO(SeanCurtis-TRI): Ultimately, a module for what we parse should be
   written outside of this _internal_ namespace. This should go there and
@@ -74,11 +77,10 @@ std::optional<std::unique_ptr<geometry::Shape>> MakeShapeFromSdfGeometry(
 
  This feature is one way to provide multiple visual representations of a body.
  */
-std::optional<std::unique_ptr<geometry::GeometryInstance>>
-    MakeGeometryInstanceFromSdfVisual(
-        const SDFormatDiagnostic& diagnostic,
-        const sdf::Visual& sdf_visual, ResolveFilename resolve_filename,
-        const math::RigidTransformd& X_LG);
+std::unique_ptr<geometry::GeometryInstance> MakeGeometryInstanceFromSdfVisual(
+    const SDFormatDiagnostic& diagnostic, const sdf::Visual& sdf_visual,
+    ResolveFilename resolve_filename, const math::RigidTransformd& X_LG);
+
 
 /* Extracts the material properties from the given sdf::Visual object.
  The sdf::Visual object represents a corresponding <visual> tag from an SDF

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1099,24 +1099,20 @@ std::optional<std::vector<LinkInfo>> AddLinksFromSpecification(
 
         const RigidTransformd X_LG = ResolveRigidTransform(
             diagnostic, sdf_visual.SemanticPose());
-        std::optional<unique_ptr<GeometryInstance>> geometry_instance =
+        unique_ptr<GeometryInstance> geometry_instance =
             MakeGeometryInstanceFromSdfVisual(
                 diagnostic, sdf_visual, resolve_filename, X_LG);
-        if (!geometry_instance.has_value()) return std::nullopt;
-        // We check for nullptr in case someone decided to specify an SDF
-        // <empty/> geometry.
-        if (*geometry_instance) {
-          // The parsing should *always* produce an IllustrationProperties
-          // instance, even if it is empty.
-          DRAKE_DEMAND(
-              (*geometry_instance)->illustration_properties() != nullptr);
+        // No instance may simply mean there was a visual we should skip and we
+        // move on to the next. If there is a _real_ problem, we assume an error
+        // was reported to diagnostic (and it responds appropriately).
+        if (geometry_instance == nullptr) continue;
 
-          plant->RegisterVisualGeometry(
-              body, (*geometry_instance)->pose(),
-              (*geometry_instance)->shape(),
-              (*geometry_instance)->name(),
-              *(*geometry_instance)->illustration_properties());
-        }
+        // The instance should be pre-configured to have both illustration and
+        // perception properties.
+        DRAKE_DEMAND(geometry_instance->illustration_properties() != nullptr &&
+                     geometry_instance->perception_properties() != nullptr);
+
+        plant->RegisterVisualGeometry(body, std::move(geometry_instance));
       }
 
       for (uint64_t collision_index = 0;

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -195,16 +195,8 @@ std::string NoopResolveFilename(const SDFormatDiagnostic&,
 
 class SceneGraphParserDetail : public test::DiagnosticPolicyTestBase {
  public:
-  SceneGraphParserDetail() {
-    // Don't let warnings leak into spdlog; tests should always specifically
-    // handle any warnings that appear.
-    diagnostic_policy_.SetActionForWarnings(
-        &DiagnosticPolicy::ErrorDefaultAction);
-    RecordErrors();
-  }
-
   // Wraps a function under test with helpful defaults.
-  std::optional<std::unique_ptr<geometry::Shape>> MakeShapeFromSdfGeometry(
+  std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
       const sdf::Geometry& sdf_geometry,
       const ResolveFilename& resolve_filename = &NoopResolveFilename) {
     return internal::MakeShapeFromSdfGeometry(
@@ -231,10 +223,8 @@ class SceneGraphParserDetail : public test::DiagnosticPolicyTestBase {
 TEST_F(SceneGraphParserDetail, MakeEmptyFromSdfGeometry) {
   unique_ptr<sdf::Geometry> sdf_geometry =
       MakeSdfGeometryFromString("<empty/>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(shape.has_value());
-  EXPECT_EQ(*shape, nullptr);
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_EQ(shape, nullptr);
 }
 
 // Verify MakeShapeFromSdfGeometry can make a box from an sdf::Geometry.
@@ -243,10 +233,8 @@ TEST_F(SceneGraphParserDetail, MakeBoxFromSdfGeometry) {
       "<box>"
       "  <size>1.0 2.0 3.0</size>"
       "</box>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(shape.has_value());
-  const Box* box = dynamic_cast<const Box*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Box* box = dynamic_cast<const Box*>(shape.get());
   ASSERT_NE(box, nullptr);
   EXPECT_EQ(box->size(), Vector3d(1.0, 2.0, 3.0));
 }
@@ -261,10 +249,8 @@ TEST_F(SceneGraphParserDetail, MakeDrakeCapsuleFromSdfGeometry) {
       "  <radius>0.5</radius>"
       "  <length>1.2</length>"
       "</drake:capsule>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(shape.has_value());
-  const Capsule* capsule = dynamic_cast<const Capsule*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Capsule* capsule = dynamic_cast<const Capsule*>(shape.get());
   ASSERT_NE(capsule, nullptr);
   EXPECT_EQ(capsule->radius(), 0.5);
   EXPECT_EQ(capsule->length(), 1.2);
@@ -278,9 +264,9 @@ TEST_F(SceneGraphParserDetail, CheckInvalidDrakeCapsules) {
       "<drake:capsule>"
       "  <length>1.2</length>"
       "</drake:capsule>");
-  std::optional<unique_ptr<Shape>> shape_no_radius =
+  unique_ptr<Shape> shape_no_radius =
       MakeShapeFromSdfGeometry(*no_radius_geometry);
-  EXPECT_FALSE(shape_no_radius.has_value());
+  EXPECT_EQ(shape_no_radius, nullptr);
   EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
       ".*Element <radius> is required within element <drake:capsule>."));
   ClearDiagnostics();
@@ -289,9 +275,9 @@ TEST_F(SceneGraphParserDetail, CheckInvalidDrakeCapsules) {
       "<drake:capsule>"
       "  <radius>0.5</radius>"
       "</drake:capsule>");
-  std::optional<unique_ptr<Shape>> shape_no_length =
+  unique_ptr<Shape> shape_no_length =
       MakeShapeFromSdfGeometry(*no_length_geometry);
-  EXPECT_FALSE(shape_no_length.has_value());
+  EXPECT_EQ(shape_no_length, nullptr);
   EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
       ".*Element <length> is required within element <drake:capsule>."));
   ClearDiagnostics();
@@ -304,10 +290,8 @@ TEST_F(SceneGraphParserDetail, MakeCapsuleFromSdfGeometry) {
       "  <radius>0.5</radius>"
       "  <length>1.2</length>"
       "</capsule>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(shape.has_value());
-  const Capsule* capsule = dynamic_cast<const Capsule*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Capsule* capsule = dynamic_cast<const Capsule*>(shape.get());
   ASSERT_NE(capsule, nullptr);
   EXPECT_EQ(capsule->radius(), 0.5);
   EXPECT_EQ(capsule->length(), 1.2);
@@ -320,10 +304,8 @@ TEST_F(SceneGraphParserDetail, MakeCylinderFromSdfGeometry) {
       "  <radius>0.5</radius>"
       "  <length>1.2</length>"
       "</cylinder>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(shape.has_value());
-  const Cylinder* cylinder = dynamic_cast<const Cylinder*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Cylinder* cylinder = dynamic_cast<const Cylinder*>(shape.get());
   ASSERT_NE(cylinder, nullptr);
   EXPECT_EQ(cylinder->radius(), 0.5);
   EXPECT_EQ(cylinder->length(), 1.2);
@@ -340,10 +322,8 @@ TEST_F(SceneGraphParserDetail, MakeDrakeEllipsoidFromSdfGeometry) {
       "  <b>1.2</b>"
       "  <c>0.9</c>"
       "</drake:ellipsoid>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(shape.has_value());
-  const Ellipsoid* ellipsoid = dynamic_cast<const Ellipsoid*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Ellipsoid* ellipsoid = dynamic_cast<const Ellipsoid*>(shape.get());
   ASSERT_NE(ellipsoid, nullptr);
   EXPECT_EQ(ellipsoid->a(), 0.5);
   EXPECT_EQ(ellipsoid->b(), 1.2);
@@ -359,7 +339,8 @@ TEST_F(SceneGraphParserDetail, CheckInvalidEllipsoids) {
       "  <b>1.2</b>"
       "  <c>0.9</c>"
       "</drake:ellipsoid>");
-  MakeShapeFromSdfGeometry(*no_a_geometry);
+  unique_ptr<Shape> shape_no_a = MakeShapeFromSdfGeometry(*no_a_geometry);
+  EXPECT_EQ(shape_no_a, nullptr);
   EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
       ".*Element <a> is required within element <drake:ellipsoid>."));
   ClearDiagnostics();
@@ -369,7 +350,8 @@ TEST_F(SceneGraphParserDetail, CheckInvalidEllipsoids) {
       "  <a>0.5</a>"
       "  <c>0.9</c>"
       "</drake:ellipsoid>");
-  MakeShapeFromSdfGeometry(*no_b_geometry);
+  unique_ptr<Shape> shape_no_b = MakeShapeFromSdfGeometry(*no_b_geometry);
+  EXPECT_EQ(shape_no_b, nullptr);
   EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
       ".*Element <b> is required within element <drake:ellipsoid>."));
   ClearDiagnostics();
@@ -379,7 +361,8 @@ TEST_F(SceneGraphParserDetail, CheckInvalidEllipsoids) {
       "  <a>0.5</a>"
       "  <b>1.2</b>"
       "</drake:ellipsoid>");
-  MakeShapeFromSdfGeometry(*no_c_geometry);
+  unique_ptr<Shape> shape_no_c = MakeShapeFromSdfGeometry(*no_c_geometry);
+  EXPECT_EQ(shape_no_c, nullptr);
   EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
       ".*Element <c> is required within element <drake:ellipsoid>."));
   ClearDiagnostics();
@@ -392,9 +375,8 @@ TEST_F(SceneGraphParserDetail, MakeEllipsoidFromSdfGeometry) {
       "<ellipsoid>"
       "  <radii>0.5 1.2 0.9</radii>"
       "</ellipsoid>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Ellipsoid* ellipsoid = dynamic_cast<const Ellipsoid*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Ellipsoid* ellipsoid = dynamic_cast<const Ellipsoid*>(shape.get());
   ASSERT_NE(ellipsoid, nullptr);
   EXPECT_EQ(ellipsoid->a(), 0.5);
   EXPECT_EQ(ellipsoid->b(), 1.2);
@@ -407,9 +389,8 @@ TEST_F(SceneGraphParserDetail, MakeSphereFromSdfGeometry) {
       "<sphere>"
       "  <radius>0.5</radius>"
       "</sphere>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Sphere* sphere = dynamic_cast<const Sphere*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Sphere* sphere = dynamic_cast<const Sphere*>(shape.get());
   ASSERT_NE(sphere, nullptr);
   EXPECT_EQ(sphere->radius(), 0.5);
 }
@@ -423,9 +404,8 @@ TEST_F(SceneGraphParserDetail, MakeHalfSpaceFromSdfGeometry) {
       "</plane>");
   // MakeShapeFromSdfGeometry() ignores <normal> and <size> to create the
   // HalfSpace. Therefore we only verify it created the right object.
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(dynamic_cast<const HalfSpace*>(shape->get()) != nullptr);
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_TRUE(dynamic_cast<const HalfSpace*>(shape.get()) != nullptr);
 }
 
 // Verify MakeShapeFromSdfGeometry can make a mesh from an sdf::Geometry.
@@ -439,9 +419,8 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
       "  <uri>" + absolute_file_path + "</uri>"
       "  <scale> 3 3 3 </scale>"
       "</mesh>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Mesh* mesh = dynamic_cast<const Mesh*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Mesh* mesh = dynamic_cast<const Mesh*>(shape.get());
   ASSERT_NE(mesh, nullptr);
   ASSERT_TRUE(mesh->source().is_path());
   EXPECT_EQ(mesh->source().path(), absolute_file_path);
@@ -459,7 +438,8 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometryIsotropicError) {
       "  <uri>" + absolute_file_path + "</uri>"
       "  <scale> 3 1 2 </scale>"
       "</mesh>");
-  MakeShapeFromSdfGeometry(*sdf_geometry);
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_EQ(shape, nullptr);
   EXPECT_THAT(FormatFirstError(), ::testing::MatchesRegex(
       ".*Drake meshes only support isotropic scaling. Therefore"
       " all three scaling factors must be exactly equal."));
@@ -475,9 +455,8 @@ TEST_F(SceneGraphParserDetail, MakeConvexFromSdfGeometry) {
       "  <uri>" + absolute_file_path + "</uri>"
       "  <scale> 3 3 3 </scale>"
       "</mesh>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  const Convex* convex = dynamic_cast<const Convex*>(shape->get());
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  const Convex* convex = dynamic_cast<const Convex*>(shape.get());
   ASSERT_NE(convex, nullptr);
   EXPECT_TRUE(convex->source().is_path());
   EXPECT_EQ(convex->source().path(), absolute_file_path);
@@ -490,9 +469,8 @@ TEST_F(SceneGraphParserDetail, MakeHeightmapFromSdfGeometry) {
       "<heightmap>"
       "  <uri>/path/to/some/heightmap.png</uri>"
       "</heightmap>");
-  std::optional<unique_ptr<Shape>> shape =
-      MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_EQ(*shape, nullptr);
+  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
+  EXPECT_EQ(shape, nullptr);
 }
 
 // Verify that MakeShapeFromSdfGeometry does nothing with a polyline.
@@ -509,8 +487,7 @@ TEST_F(SceneGraphParserDetail, MakePolylineFromSdfGeometry) {
       "</polyline>");
   std::optional<unique_ptr<Shape>> shape =
       MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_TRUE(shape.has_value());
-  EXPECT_EQ(*shape, nullptr);
+  EXPECT_EQ(shape, nullptr);
 }
 
 // Verify MakeGeometryInstanceFromSdfVisual can make a GeometryInstance from an
@@ -529,12 +506,15 @@ TEST_F(SceneGraphParserDetail, MakeGeometryInstanceFromSdfVisual) {
       "  </geometry>"
       "</visual>");
 
-  std::optional<unique_ptr<GeometryInstance>> geometry_instance =
+  unique_ptr<GeometryInstance> geometry_instance =
       MakeGeometryInstanceFromSdfVisual(
           sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
           ToRigidTransform(sdf_visual->RawPose()));
 
-  const RigidTransformd X_LC((*geometry_instance)->pose());
+  EXPECT_NE(geometry_instance->perception_properties(), nullptr);
+  EXPECT_NE(geometry_instance->illustration_properties(), nullptr);
+
+  const RigidTransformd X_LC(geometry_instance->pose());
 
   // These are the expected values as specified by the string above.
   const RollPitchYaw<double> expected_rpy(3.14, 6.28, 1.57);
@@ -546,6 +526,36 @@ TEST_F(SceneGraphParserDetail, MakeGeometryInstanceFromSdfVisual) {
   EXPECT_TRUE(X_LC.rotation().IsNearlyEqualTo(R_LC_expected, kTolerance));
   EXPECT_TRUE(CompareMatrices(X_LC.translation(), p_LCo_expected,
                               kTolerance, MatrixCompareType::relative));
+}
+
+// Verify MakeGeometryInstanceFromSdfVisual() creates an instance such that only
+// the perception properties have the ("renderer", "accepting") property.
+TEST_F(SceneGraphParserDetail,
+       MakeGeometryInstanceFromSdfVisualAcceptingRenderer) {
+  unique_ptr<sdf::Visual> sdf_visual = MakeSdfVisualFromString(
+      "<visual name = 'some_link_visual'>"
+      "  <pose>1.0 2.0 3.0 3.14 6.28 1.57</pose>"
+      "  <geometry><sphere><radius>1.0</radius></sphere></geometry>"
+      "  <drake:accepting_renderer>renderer1</drake:accepting_renderer>"
+      "</visual>");
+
+  unique_ptr<GeometryInstance> geometry_instance =
+      MakeGeometryInstanceFromSdfVisual(
+          sdf_diagnostic_, *sdf_visual, NoopResolveFilename,
+          ToRigidTransform(sdf_visual->RawPose()));
+
+  ASSERT_NE(geometry_instance->perception_properties(), nullptr);
+  ASSERT_NE(geometry_instance->illustration_properties(), nullptr);
+
+  EXPECT_FALSE(geometry_instance->illustration_properties()->HasProperty(
+      "renderer", "accepting"));
+  EXPECT_TRUE(geometry_instance->perception_properties()->HasProperty(
+      "renderer", "accepting"));
+  const auto& names =
+      geometry_instance->perception_properties()
+          ->GetProperty<std::set<std::string>>("renderer", "accepting");
+  EXPECT_EQ(names.size(), 1);
+  EXPECT_TRUE(names.contains("renderer1"));
 }
 
 // Confirms the failure conditions for SDFormat. SceneGraph requirements on

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -938,45 +938,57 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
     const RigidBody<T>& body, const math::RigidTransform<double>& X_BG,
     const geometry::Shape& shape, const std::string& name,
     const geometry::IllustrationProperties& properties) {
-  // TODO(SeanCurtis-TRI): Consider simply adding an interface that takes a
-  // unique pointer to an already instantiated GeometryInstance. This will
-  // require shuffling around a fair amount of code and should ultimately be
-  // supplanted by providing a cleaner interface between parsing MBP and SG
-  // elements.
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_THROW_UNLESS(geometry_source_is_registered());
 
-  // TODO(amcastro-tri): Consider doing this after finalize so that we can
-  // register geometry that has a fixed path to world to the world body (i.e.,
-  // as anchored geometry).
-  GeometryId id = RegisterGeometry(
-      body, X_BG, shape, GetScopedName(*this, body.model_instance(), name));
-  scene_graph_->AssignRole(*source_id_, id, properties);
+  // Note: the geometry name will be scoped in the subsequent call to
+  // RegisterVisualGeometry().
+  auto instance =
+      std::make_unique<geometry::GeometryInstance>(X_BG, shape, name);
+  instance->set_illustration_properties(properties);
+  instance->set_perception_properties(
+      geometry::PerceptionProperties(properties));
 
-  // TODO(SeanCurtis-TRI): Eliminate the automatic assignment of perception
-  //  and illustration in favor of a protocol that allows definition.
-  geometry::PerceptionProperties perception_props;
-  perception_props.AddProperty("label", "id", RenderLabel(body.index()));
-  if (properties.HasProperty("phong", "diffuse")) {
-    perception_props.AddProperty(
-        "phong", "diffuse",
-        properties.GetProperty<geometry::Rgba>("phong", "diffuse"));
+  const std::optional<geometry::GeometryId> id =
+      RegisterVisualGeometry(body, std::move(instance));
+  // We assigned properties, so this must be defined.
+  DRAKE_DEMAND(id.has_value());
+
+  return *id;
+}
+
+template <typename T>
+geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
+    const RigidBody<T>& body,
+    std::unique_ptr<geometry::GeometryInstance> geometry) {
+  DRAKE_THROW_UNLESS(geometry != nullptr);
+  DRAKE_MBP_THROW_IF_FINALIZED();
+  DRAKE_THROW_UNLESS(geometry_source_is_registered());
+
+  if (geometry->perception_properties() == nullptr &&
+      geometry->illustration_properties() == nullptr) {
+    geometry->set_illustration_properties(geometry::IllustrationProperties());
+    geometry->set_perception_properties(geometry::PerceptionProperties());
   }
-  if (properties.HasProperty("phong", "diffuse_map")) {
-    perception_props.AddProperty(
-        "phong", "diffuse_map",
-        properties.GetProperty<std::string>("phong", "diffuse_map"));
+
+  // Map ("label", "id") to body index as necessary.
+  geometry::PerceptionProperties* percep =
+      geometry->mutable_perception_properties();
+  if (percep != nullptr) {
+    if (!percep->HasProperty("label", "id")) {
+      percep->AddProperty("label", "id", RenderLabel(body.index()));
+    }
   }
-  if (properties.HasProperty("renderer", "accepting")) {
-    perception_props.AddProperty(
-        "renderer", "accepting",
-        properties.GetProperty<std::set<std::string>>("renderer", "accepting"));
-  }
-  scene_graph_->AssignRole(*source_id_, id, perception_props);
+
+  geometry->set_name(
+      GetScopedName(*this, body.model_instance(), geometry->name()));
+
+  const geometry::GeometryId id = RegisterGeometry(body, std::move(geometry));
 
   DRAKE_ASSERT(ssize(visual_geometries_) == num_bodies());
   visual_geometries_[body.index()].push_back(id);
   ++num_visual_geometries_;
+
   return id;
 }
 
@@ -1000,7 +1012,9 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
   // register geometry that has a fixed path to world to the world body (i.e.,
   // as anchored geometry).
   GeometryId id = RegisterGeometry(
-      body, X_BG, shape, GetScopedName(*this, body.model_instance(), name));
+      body,
+      std::make_unique<geometry::GeometryInstance>(
+          X_BG, shape, GetScopedName(*this, body.model_instance(), name)));
 
   scene_graph_->AssignRole(*source_id_, id, std::move(properties));
   DRAKE_ASSERT(ssize(collision_geometries_) == num_bodies());
@@ -1103,18 +1117,16 @@ std::unordered_set<BodyIndex> MultibodyPlant<T>::GetFloatingBaseBodies() const {
 
 template <typename T>
 geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
-    const RigidBody<T>& body, const math::RigidTransform<double>& X_BG,
-    const geometry::Shape& shape, const std::string& name) {
+    const RigidBody<T>& body,
+    std::unique_ptr<geometry::GeometryInstance> instance) {
   DRAKE_ASSERT(!is_finalized());
   DRAKE_ASSERT(geometry_source_is_registered());
   DRAKE_ASSERT(body_has_registered_frame(body));
 
   // Register geometry in the body frame.
-  std::unique_ptr<geometry::GeometryInstance> geometry_instance =
-      std::make_unique<GeometryInstance>(X_BG, shape.Clone(), name);
   GeometryId geometry_id = scene_graph_->RegisterGeometry(
       source_id_.value(), body_index_to_frame_id_[body.index()],
-      std::move(geometry_instance));
+      std::move(instance));
   geometry_id_to_body_index_[geometry_id] = body.index();
   return geometry_id;
 }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1986,7 +1986,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// "roles". The `RegisterCollisionGeometry()` methods register geometry with
   /// SceneGraph and assign it the proximity role. The
   /// `RegisterVisualGeometry()` methods do the same, but assign the
-  /// illustration role.
+  /// illustration and/or perception role, depending on how the API is
+  /// exercised (see below).
   ///
   /// All geometry registration methods return a @ref geometry::GeometryId
   /// GeometryId. This is how SceneGraph refers to the geometries. The
@@ -2021,6 +2022,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// See documentation of geometry::SceneGraphInspector on where to get an
   /// inspector.
   ///
+  /// <h4> %MultibodyPlant names vs. SceneGraph names
+  ///
   /// In %MultibodyPlant, frame names only have to be unique in a single
   /// model instance. However, SceneGraph knows nothing of model instances. So,
   /// to generate unique names for the corresponding frames in SceneGraph,
@@ -2029,6 +2032,23 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// `[model instance name]::[body name]`. Searching for a frame with just the
   /// name `body name` will fail. (See RigidBody::name() and
   /// GetModelInstanceName() for those values.)
+  ///
+  /// Geometry names get scoped in the same way. The name passed to a
+  /// RegisterXXGeometry becomes the scoped name `[model instance name]::[name]`
+  /// in SceneGraph.
+  ///
+  /// <h4>Registering visual roles</h4>
+  ///
+  /// Drake has two visual roles: illustration and perception. Unless otherwise
+  /// indicated, the RegisterVisualGeometry() APIs register the given geometry
+  /// with both roles. One API allows specific control over which roles are
+  /// assigned.
+  /// @note This "assign-all-roles" behavior may change in the future and code
+  /// that directly relies on it will break.
+  ///
+  /// Furthermore, unless the ("label", "id") property has already
+  /// been defined, the PerceptionProperties will be assigned that property
+  /// with a geometry::RenderLabel whose value is equal to the body's index.
   /// @{
 
   /// Registers `this` plant to serve as a source for an instance of
@@ -2053,13 +2073,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       geometry::SceneGraph<T>* scene_graph);
 
   /// Registers geometry in a SceneGraph with a given geometry::Shape to be
-  /// used for visualization of a given `body`.
+  /// used for visualization of a given `body`. The perception properties are a
+  /// copy of the given `properties`. If the resulting perception properties
+  /// do not include ("label", "id"), then it is added as documented above.
   ///
-  /// @note Currently, the visual geometry will _also_ be assigned a perception
-  /// role. Its render label's value will be equal to the body's index and its
-  /// perception color will be the same as its illustration color (defaulting to
-  /// gray if no color is provided). This behavior will change in the near
-  /// future and code that directly relies on this behavior will break.
+  /// See @ref mbp_geometry "the overview" for more details.
   ///
   /// @param[in] body
   ///   The body for which geometry is being registered.
@@ -2074,26 +2092,53 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] properties
   ///   The illustration properties for this geometry.
   /// @throws std::exception if called post-finalize.
-  /// @throws std::exception if `scene_graph` does not correspond to the same
-  /// instance with which RegisterAsSourceForSceneGraph() was called.
   /// @returns the id for the registered geometry.
   geometry::GeometryId RegisterVisualGeometry(
       const RigidBody<T>& body, const math::RigidTransform<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
       const geometry::IllustrationProperties& properties);
 
-  /// Overload for visual geometry registration; it converts the `diffuse_color`
-  /// (RGBA with values in the range [0, 1]) into a
-  /// geometry::DrakeVisualizer-compatible set of
-  /// geometry::IllustrationProperties.
+  /// Registers the given `geometry_instance` in a SceneGraph to be used for
+  /// visualization of a given `body`.
+  ///
+  /// The roles that `geometry_instance` gets assigned (illustration/perception)
+  /// in SceneGraph depend solely on the properties that have _already_ been
+  /// assigned to `geometry_instance`. If _any_ visual roles have been assigned,
+  /// those will be the only roles used. If _no_ visual roles have been
+  /// assigned, then both roles will be assigned using the default set of
+  /// property values.
+  ///
+  /// If the registered geometry has the perception role, it will have the
+  /// ("label", "id") property. Possibly assigned as documented above.
+  ///
+  /// See @ref mbp_geometry "the overview" for more details.
+  ///
+  /// @param[in] body
+  ///   The body for which geometry is being registered.
+  /// @param[in] geometry_instance
+  ///   The geometry to associate with the visual appearance of `body`.
+  /// @throws std::exception if `geometry_instance` is null.
+  /// @throws std::exception if called post-finalize.
+  /// @returns the id for the registered geometry.
+  geometry::GeometryId RegisterVisualGeometry(
+      const RigidBody<T>& body,
+      std::unique_ptr<geometry::GeometryInstance> geometry_instance);
+
+  /// Overload for visual geometry registration. The following properties are
+  /// set:
+  ///   - ("phong", "diffuse") = `diffuse_color` in both sets of properties.
+  ///   - ("label", "id") in perception properties as documented above.
+  ///
+  /// See @ref mbp_geometry "the overview" for more details.
   geometry::GeometryId RegisterVisualGeometry(
       const RigidBody<T>& body, const math::RigidTransform<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
       const Vector4<double>& diffuse_color);
 
-  /// Overload for visual geometry registration; it relies on the downstream
-  /// geometry::IllustrationProperties _consumer_ to provide default parameter
-  /// values (see @ref geometry_roles for details).
+  /// Overload for visual geometry registration. The ("label", "id")  property
+  /// is set in the perception properties (as documented above).
+  ///
+  /// See @ref mbp_geometry "the overview" for more details.
   geometry::GeometryId RegisterVisualGeometry(
       const RigidBody<T>& body, const math::RigidTransform<double>& X_BG,
       const geometry::Shape& shape, const std::string& name);
@@ -5736,8 +5781,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // 3. `scene_graph` points to the same SceneGraph instance previously
   //    passed to RegisterAsSourceForSceneGraph().
   geometry::GeometryId RegisterGeometry(
-      const RigidBody<T>& body, const math::RigidTransform<double>& X_BG,
-      const geometry::Shape& shape, const std::string& name);
+      const RigidBody<T>& body,
+      std::unique_ptr<geometry::GeometryInstance> instance);
 
   // Registers a geometry frame for every body. If the body already has a
   // geometry frame, it is unchanged. This registration is part of finalization.


### PR DESCRIPTION
1. MultibodyPlant::RegisterVisualGeometry() can now take a GeometryInstance.
  - Clean up documentation.
  - Extend tests to include what is *actually* done.
2. SDF parser makes use of new API.
   - Stop returning optional<unique_ptr<>> (simply return the unique ptr).
   - Instead of constructing, deconstructing, and reconstructing geometry instances, we just pass the instance.

Relates #13689

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22102)
<!-- Reviewable:end -->
