### PR TITLE
[geometry] Fix refine_mesh for cwd-relative paths

### DIFF
--- a/geometry/proximity/refine_mesh.cc
+++ b/geometry/proximity/refine_mesh.cc
@@ -1,3 +1,6 @@
+#include <unistd.h>
+
+#include <cstdlib>
 #include <filesystem>
 
 #include <gflags/gflags.h>
@@ -37,6 +40,14 @@ int do_main(int argc, char* argv[]) {
   if (argc < 3) {
     drake::log()->error("missing output filename");
     return 1;
+  }
+
+  // Make cwd be what the user expected, not the runfiles tree.
+  if (const char* path = std::getenv("BUILD_WORKING_DIRECTORY")) {
+    const int error = ::chdir(path);
+    if (error != 0) {
+      log()->warn("Could not chdir to '{}'", path);
+    }
   }
 
   VolumeMesh<double> mesh =


### PR DESCRIPTION
When the user does 'bazel run :refine_mesh' we should still allow a relative path for input or output. We call chdir here to undo the chdir performed by 'bazel run' into the runfiles tree.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22106)
<!-- Reviewable:end -->
