### PR TITLE
[bindings] Re-enable some gym test cases on macOS

### DIFF
--- a/bindings/pydrake/examples/gym/envs/cart_pole.py
+++ b/bindings/pydrake/examples/gym/envs/cart_pole.py
@@ -1,5 +1,4 @@
 import gymnasium as gym
-import matplotlib.pyplot as plt
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
@@ -125,6 +124,7 @@ def make_sim(meshcat=None,
         print("Actuation view: ", actuation_view(np.ones(na)), '\n')
 
         # Visualize the plant.
+        import matplotlib.pyplot as plt
         plt.figure()
         plot_graphviz(plant.GetTopologyGraphvizString())
         plt.plot(1)

--- a/bindings/pydrake/examples/gym/play_cart_pole.py
+++ b/bindings/pydrake/examples/gym/play_cart_pole.py
@@ -2,7 +2,6 @@
 Play a policy for //bindings/pydrake/examples/gym/envs:cart_pole.
 """
 import argparse
-import sys
 import warnings
 
 import gymnasium as gym
@@ -70,12 +69,6 @@ def _main():
     parser.add_argument('--model_path', help="path to the policy zip file.")
     parser.add_argument('--log_path', help="path to the logs directory.")
     args = parser.parse_args()
-
-    if args.test and (sys.platform == "darwin"):
-        # TODO(#21577) Importing Gym on macOS Homebrew goes up in flames.
-        # We need to skip this test in Drake CI.
-        print("Testing is disabled when on macOS")
-        return
 
     if not args.debug:
         warnings.filterwarnings("ignore")

--- a/bindings/pydrake/gym/test/drake_gym_test.py
+++ b/bindings/pydrake/gym/test/drake_gym_test.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 import gymnasium as gym
@@ -26,13 +25,9 @@ class DrakeGymTest(unittest.TestCase):
     def make_env(self):
         return gym.make("DrakeCartPole-v0")
 
-    # TODO(#21577) Importing Gym on macOS Homebrew goes up in flames.
-    @unittest.skipIf(sys.platform == "darwin", "Disabled macOS")
     def test_make_env(self):
         self.make_env()
 
-    # TODO(#21577) Importing Gym on macOS Homebrew goes up in flames.
-    @unittest.skipIf(sys.platform == "darwin", "Disabled macOS")
     def test_sb3_check_env(self):
         """Run stable-baselines's built-in test suite for our env."""
         dut = self.make_env()
@@ -45,8 +40,6 @@ class DrakeGymTest(unittest.TestCase):
     # supported versions of `gymnasium` and `stable_baselines3`, stable
     # baselines vector envs do not pass stable baselines' `check_env` tests.
 
-    # TODO(#21577) Importing Gym on macOS Homebrew goes up in flames.
-    @unittest.skipIf(sys.platform == "darwin", "Disabled macOS")
     def test_reset(self):
         # reset(int) sets a deterministic seed.
         dut = self.make_env()
@@ -68,8 +61,6 @@ class DrakeGymTest(unittest.TestCase):
         self.assertIsInstance(opts, dict)
         self.assertTrue(dut.observation_space.contains(observation))
 
-    # TODO(#21577) Importing Gym on macOS Homebrew goes up in flames.
-    @unittest.skipIf(sys.platform == "darwin", "Disabled macOS")
     def test_step(self):
         dut = self.make_env()
         dut.reset()


### PR DESCRIPTION
This involves deferring the import of the non-hermetic dumpster fire known as `matplotlib.pyplot` until it is needed, so that unit tests are not exposed to it.

Closes #21577.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22112)
<!-- Reviewable:end -->
