### PR TITLE
Add degenerate examples to SDP test.

### DIFF
--- a/solvers/test/clarabel_solver_test.cc
+++ b/solvers/test/clarabel_solver_test.cc
@@ -365,6 +365,83 @@ GTEST_TEST(TestL2NormCost, ShortestDistanceFromPlaneToTwoPoints) {
   tester.CheckSolution(solver, std::nullopt, 5E-4);
 }
 
+GTEST_TEST(TestSemidefiniteProgram, TrivialSDP) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    TestTrivialSDP(solver, kTol);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, CommonLyapunov) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    FindCommonLyapunov(solver, {}, kTol);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, OuterEllipsoid) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    FindOuterEllipsoid(solver, {}, kTol);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, EigenvalueProblem) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    SolveEigenvalueProblem(solver, {}, kTol);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, SolveSDPwithSecondOrderConeExample1) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    SolveSDPwithSecondOrderConeExample1(solver, kTol);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, SolveSDPwithSecondOrderConeExample2) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    SolveSDPwithSecondOrderConeExample2(solver, kTol);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, SolveSDPwithOverlappingVariables) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    SolveSDPwithOverlappingVariables(solver, kTol);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, TestTrivial1x1SDP) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    TestTrivial1x1SDP(solver, 1E-5, /*check_dual=*/false, /*dual_tol=*/1E-5);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, TestTrivial2x2SDP) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    TestTrivial2x2SDP(solver, 1E-5, /*check_dual=*/false, /*dual_tol=*/1E-5);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, Test1x1with3x3SDP) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    Test1x1with3x3SDP(solver, 1E-4, /*check_dual=*/false, /*dual_tol=*/1E-4);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, Test2x2with3x3SDP) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    Test2x2with3x3SDP(solver, 1E-3, /*check_dual=*/false, /*dual_tol*/ 1E-2);
+  }
+}
+
 GTEST_TEST(TestExponentialConeProgram, ExponentialConeTrivialExample) {
   ClarabelSolver solver;
   if (solver.available()) {
@@ -389,11 +466,12 @@ GTEST_TEST(TestExponentialConeProgram, MinimalEllipsoidConveringPoints) {
 }
 
 GTEST_TEST(TestExponentialConeProgram, MatrixLogDeterminantLower) {
-  ClarabelSolver scs_solver;
-  if (scs_solver.available()) {
-    MatrixLogDeterminantLower(scs_solver, kTol);
+  ClarabelSolver solver;
+  if (solver.available()) {
+    MatrixLogDeterminantLower(solver, kTol);
   }
 }
+
 GTEST_TEST(TestSos, UnivariateQuarticSos) {
   UnivariateQuarticSos dut;
   ClarabelSolver solver;

--- a/solvers/test/csdp_solver_test.cc
+++ b/solvers/test/csdp_solver_test.cc
@@ -78,6 +78,27 @@ TEST_F(TrivialSDP1, Solve) {
   }
 }
 
+GTEST_TEST(TestSemidefiniteProgram, TestTrivial2x2SDP) {
+  CsdpSolver solver;
+  if (solver.available()) {
+    TestTrivial2x2SDP(solver, 1E-5, /*check_dual=*/false, /*dual_tol=*/1E-5);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, Test1x1with3x3SDP) {
+  CsdpSolver solver;
+  if (solver.available()) {
+    Test1x1with3x3SDP(solver, 1E-4, /*check_dual=*/false, /*dual_tol=*/1E-5);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, Test2x2with3x3SDP) {
+  CsdpSolver solver;
+  if (solver.available()) {
+    Test2x2with3x3SDP(solver, 1E-2, /*check_dual=*/false, /*dual_tol=*/1E-5);
+  }
+}
+
 std::vector<RemoveFreeVariableMethod> GetRemoveFreeVariableMethods() {
   return {RemoveFreeVariableMethod::kNullspace,
           RemoveFreeVariableMethod::kTwoSlackVariables,

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -526,6 +526,34 @@ GTEST_TEST(MosekTest, SolveSDPwithQuadraticCosts) {
   }
 }
 
+GTEST_TEST(MosekTest, TestTrivial1x1SDP) {
+  MosekSolver solver;
+  if (solver.available()) {
+    TestTrivial1x1SDP(solver, 1E-8, /*check_dual=*/true, /*dual_tol=*/1E-8);
+  }
+}
+
+GTEST_TEST(MosekTest, TestTrivial2x2SDP) {
+  MosekSolver solver;
+  if (solver.available()) {
+    TestTrivial2x2SDP(solver, 1E-8, /*check_dual=*/true, /*dual_tol=*/1E-8);
+  }
+}
+
+GTEST_TEST(MosekTest, Test1x1with3x3SDP) {
+  MosekSolver solver;
+  if (solver.available()) {
+    Test1x1with3x3SDP(solver, 1E-4, /*check_dual=*/true, /*dual_tol=*/1E-4);
+  }
+}
+
+GTEST_TEST(MosekTest, Test2x2with3x3SDP) {
+  MosekSolver solver;
+  if (solver.available()) {
+    Test2x2with3x3SDP(solver, 1E-3, /*check_dual=*/true, /*dual_tol=*/1E-3);
+  }
+}
+
 GTEST_TEST(MosekTest, LPDualSolution1) {
   MosekSolver solver;
   if (solver.available()) {

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -411,6 +411,35 @@ GTEST_TEST(TestSemidefiniteProgram, SolveSDPwithOverlappingVariables) {
   }
 }
 
+GTEST_TEST(TestSemidefiniteProgram, TestTrivial1x1SDP) {
+  ScsSolver scs_solver;
+  if (scs_solver.available()) {
+    TestTrivial1x1SDP(scs_solver, 1E-5, /*check_dual=*/false);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, TestTrivial2x2SDP) {
+  ScsSolver scs_solver;
+  if (scs_solver.available()) {
+    TestTrivial2x2SDP(scs_solver, 1E-5, /*check_dual=*/false);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, Test1x1with3x3SDP) {
+  ScsSolver scs_solver;
+  if (scs_solver.available()) {
+    Test1x1with3x3SDP(scs_solver, 1E-5, /*check_dual=*/false);
+  }
+}
+
+GTEST_TEST(TestSemidefiniteProgram, Test2x2with3x3SDP) {
+  ScsSolver scs_solver;
+  if (scs_solver.available()) {
+    Test2x2with3x3SDP(scs_solver, 1E-2, /*check_dual=*/false,
+                      /*dual_tol=*/1E-5);
+  }
+}
+
 GTEST_TEST(TestExponentialConeProgram, ExponentialConeTrivialExample) {
   ScsSolver solver;
   if (solver.available()) {

--- a/solvers/test/semidefinite_program_examples.cc
+++ b/solvers/test/semidefinite_program_examples.cc
@@ -391,6 +391,177 @@ void TestSDPDualSolution1(const SolverInterface& solver, double tol,
   // clang-format on
   EXPECT_TRUE(CompareMatrices(psd_dual, psd_dual_expected, tol));
 }
+
+void TestTrivial1x1SDP(const SolverInterface& solver, double primal_tol,
+                       bool check_dual, double dual_tol) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<1>("x");
+  auto scalar_psd_con =
+      prog.AddPositiveSemidefiniteConstraint(Vector1<symbolic::Variable>(x(0)));
+  prog.AddLinearCost(x(0));
+  MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, std::nullopt, &result);
+  EXPECT_TRUE(result.is_success());
+  EXPECT_NEAR(result.get_optimal_cost(), 0, primal_tol);
+  EXPECT_NEAR(result.GetSolution(x(0)), 0, primal_tol);
+  if (check_dual) {
+    const auto scalar_psd_dual =
+        math::ToSymmetricMatrixFromLowerTriangularColumns(
+            result.GetDualSolution(scalar_psd_con));
+    EXPECT_TRUE(CompareMatrices(scalar_psd_dual, Vector1d(1), dual_tol));
+  }
+}
+
+void TestTrivial2x2SDP(const SolverInterface& solver, double primal_tol,
+                       bool check_dual, double dual_tol) {
+  MathematicalProgram prog;
+  auto S = prog.NewSymmetricContinuousVariables<2>();
+  const auto psd_con = prog.AddPositiveSemidefiniteConstraint(S);
+  prog.AddBoundingBoxConstraint(1, 1, S(1, 0));
+  prog.AddLinearCost(S(0, 0) + S(1, 1));
+  MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, std::nullopt, &result);
+  EXPECT_TRUE(result.is_success());
+  const Eigen::Matrix2d S_expected = Eigen::Matrix2d::Ones();
+  EXPECT_TRUE(CompareMatrices(result.GetSolution(S), S_expected, primal_tol));
+  EXPECT_NEAR(result.get_optimal_cost(), 2, primal_tol);
+  if (check_dual) {
+    Eigen::Matrix2d psd_dual_expected;
+    // clang-format off
+  psd_dual_expected << 1, -1,
+                       -1, 1;
+    // clang-format on
+    const auto psd_dual = math::ToSymmetricMatrixFromLowerTriangularColumns(
+        result.GetDualSolution(psd_con));
+    EXPECT_TRUE(CompareMatrices(psd_dual, psd_dual_expected, dual_tol));
+  }
+}
+
+void Test1x1with3x3SDP(const SolverInterface& solver, double primal_tol,
+                       bool check_dual, double dual_tol) {
+  MathematicalProgram prog;
+  auto x = prog.NewSymmetricContinuousVariables<6>();
+  const auto scalar_psd_con =
+      prog.AddPositiveSemidefiniteConstraint(Vector1<symbolic::Variable>(x(1)));
+  Matrix3<symbolic::Variable> psd_mat;
+  // clang-format off
+  psd_mat << x(0), x(1), x(3),
+             x(1), x(2), x(4),
+             x(3), x(4), x(5);
+  // clang-format on
+  const auto psd_con = prog.AddPositiveSemidefiniteConstraint(psd_mat);
+  prog.AddBoundingBoxConstraint(9, 9, x(0));
+  prog.AddBoundingBoxConstraint(1, 1, x(2));
+  prog.AddBoundingBoxConstraint(4, 4, x(5));
+  prog.AddLinearCost(x(1) + x(3) + x(4));
+  MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, std::nullopt, &result);
+  EXPECT_TRUE(result.is_success());
+  const Eigen::Matrix3d psd_mat_sol = result.GetSolution(psd_mat);
+  Eigen::Matrix3d psd_mat_expected;
+  // The optimal solution occurs when x(1) = 0, and the problem is equivalent to
+  // min x(3) + x(4).
+  // s.t x(3)*x(3)+9*x(4)*x(4)<=36.
+  // We can solve this problem analytically.
+  // clang-format off
+  psd_mat_expected << 9, 0, -18 / std::sqrt(10),
+                      0, 1, -2 / std::sqrt(10),
+                      -18 / std::sqrt(10), -2 / std::sqrt(10), 4;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(psd_mat_sol, psd_mat_expected, primal_tol));
+  EXPECT_NEAR(result.get_optimal_cost(), -20 / std::sqrt(10), primal_tol);
+  if (check_dual) {
+    const auto x_sol = result.GetSolution(x);
+    // The dual problem is
+    // max 9*y(0) + y(1) + 4*y(2)
+    // s.t [-y(0)    0.5-0.5*y(3)   0.5] is psd
+    //     [0.5-0.5*y(3)    -y(1)   0.5]
+    //     [0.5              0.5  -y(2)]
+    //     y(3) >= 0
+    const Eigen::Matrix3d psd_dual =
+        math::ToSymmetricMatrixFromLowerTriangularColumns(
+            result.GetDualSolution(psd_con));
+    const double scalar_psd_dual = result.GetDualSolution(scalar_psd_con)(0);
+    EXPECT_NEAR(psd_dual(0, 1), 0.5 - 0.5 * scalar_psd_dual, dual_tol);
+    // Check the duality gap, should be zero.
+    EXPECT_NEAR(-9 * psd_dual(0, 0) - psd_dual(1, 1) - 4 * psd_dual(2, 2),
+                result.get_optimal_cost(), dual_tol);
+    // Check complementary slackness.
+    EXPECT_NEAR((psd_mat_expected * psd_dual).trace(), 0, dual_tol);
+    EXPECT_NEAR(x_sol(1) * scalar_psd_dual, 0, dual_tol);
+    // Check the dual matrix being psd.
+    EXPECT_GE(scalar_psd_dual, -dual_tol);
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es(psd_dual);
+    EXPECT_TRUE((es.eigenvalues().array() >= -dual_tol).all());
+  }
+}
+
+void Test2x2with3x3SDP(const SolverInterface& solver, double primal_tol,
+                       bool check_dual, double dual_tol) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<5>("x");
+  prog.AddLinearCost(x(1) + x(2) + x(4));
+  Matrix2<symbolic::Variable> psd_mat_2x2;
+  Matrix3<symbolic::Variable> psd_mat_3x3;
+  // clang-format off
+  psd_mat_2x2 << x(0), x(1),
+                 x(1), x(2);
+  psd_mat_3x3 << x(0), x(1), x(2),
+                 x(1), x(3), x(4),
+                 x(2), x(4), x(2);
+  // clang-format on
+  auto psd_2x2_con = prog.AddPositiveSemidefiniteConstraint(psd_mat_2x2);
+  auto psd_3x3_con = prog.AddPositiveSemidefiniteConstraint(psd_mat_3x3);
+  prog.AddBoundingBoxConstraint(1, 1, x(0));
+  prog.AddBoundingBoxConstraint(1, 1, x(3));
+  MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, std::nullopt, &result);
+  EXPECT_TRUE(result.is_success());
+  const Eigen::Matrix2d psd_2x2_sol = result.GetSolution(psd_mat_2x2);
+  const Eigen::Matrix3d psd_3x3_sol = result.GetSolution(psd_mat_3x3);
+  Eigen::Matrix2d psd_2x2_expected;
+  Eigen::Matrix3d psd_3x3_expected;
+  // clang-format off
+  psd_2x2_expected <<  1, -1,
+                      -1,  1;
+  psd_3x3_expected <<  1, -1,  1,
+                      -1,  1, -1,
+                       1, -1,  1;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(psd_2x2_sol, psd_2x2_expected, primal_tol));
+  EXPECT_TRUE(CompareMatrices(psd_3x3_sol, psd_3x3_expected, primal_tol));
+  EXPECT_NEAR(result.get_optimal_cost(), -1, primal_tol);
+  if (check_dual) {
+    // The dual problem is
+    // max y(4) + y(5)
+    // [y(0)-y(4)  0.5 + 0.5*y(1)  0.5 + 0.5*y(2)-0.5*y(3)]
+    // [    *         -y(5)           0.5                 ] is psd
+    // [    *            *             y(3)               ]
+    //
+    // [-y(0) -0.5*y(1)] is psd
+    // [ *      -y(2)  ]
+    // The solution is y = [-0.5, -1, -0.5, 0.5, -0.5, -0.5]
+    const auto psd_2x2_dual = math::ToSymmetricMatrixFromLowerTriangularColumns(
+        result.GetDualSolution(psd_2x2_con));
+    const auto psd_3x3_dual = math::ToSymmetricMatrixFromLowerTriangularColumns(
+        result.GetDualSolution(psd_3x3_con));
+    Eigen::Matrix2d psd_2x2_dual_expected;
+    Eigen::Matrix3d psd_3x3_dual_expected;
+    // clang-format off
+    psd_2x2_dual_expected << 0.5, 0.5,
+                             0.5, 0.5;
+    psd_3x3_dual_expected << 0,   0,   0,
+                             0, 0.5, 0.5,
+                             0, 0.5, 0.5;
+    // clang-format on
+    EXPECT_TRUE(CompareMatrices(psd_2x2_dual, psd_2x2_dual_expected, dual_tol));
+    EXPECT_TRUE(CompareMatrices(psd_3x3_dual, psd_3x3_dual_expected, dual_tol));
+    // Check complementarity slackness.
+    EXPECT_NEAR((psd_2x2_dual * psd_2x2_sol).trace(), 0, dual_tol);
+    EXPECT_NEAR((psd_3x3_dual * psd_3x3_sol).trace(), 0, dual_tol);
+  }
+}
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/semidefinite_program_examples.h
+++ b/solvers/test/semidefinite_program_examples.h
@@ -131,6 +131,50 @@ void SolveSDPwithQuadraticCosts(const SolverInterface& solver, double tol);
  */
 void TestSDPDualSolution1(const SolverInterface& solver, double tol,
                           double complementarity_tol = 5E-7);
+
+// A trivial semidefinite program
+// min S(0, 0)
+// s.t S is psd
+// where S is a 1x1 psd matrix
+// The analytical solution is S = [0]
+void TestTrivial1x1SDP(const SolverInterface& solver, double primal_tol,
+                       bool check_dual = true, double dual_tol = 1E-5);
+
+// A trivial semidefinite program
+// min S(0, 0) + S(1, 1)
+// s.t S(1, 0) = 1
+//     S is psd.
+// The analytical solution is
+// S = [1 1]
+//     [1 1]
+void TestTrivial2x2SDP(const SolverInterface& solver, double primal_tol,
+                       bool check_dual = true, double dual_tol = 1E-5);
+
+// A semidefinite program with both a 1x1 psd matrix and a 3x3 psd matrix
+// min x[1] + x[3] + x[4]
+// s.t [x(1)] is psd
+//     [x(0) x(1) x(3)]  is psd
+//     [x(1) x(2) x(4)]
+//     [x(3) x(4) x(5)]
+//     x[0] = 9
+//     x[2] = 1
+//     x[5] = 4
+void Test1x1with3x3SDP(const SolverInterface& solver, double primal_tol,
+                       bool check_dual = true, double dual_tol = 1E-5);
+
+// A semidefinite program with both a 2x2 psd matrix and a 3x3 psd matrix
+// min x[1] + x[2] + x[4]
+// s.t [x[0] x[1]] is psd
+//     [x[1] x[2]]
+//
+//     [x[0] x[1] x[2]]
+//     [x[1] x[3] x[4]] is psd
+//     [x[2] x[4] x[2]]
+//     x[0] = 1
+//     x[3] = 1
+// Notice that the psd matrices share variables.
+void Test2x2with3x3SDP(const SolverInterface& solver, double primal_tol,
+                       bool check_dual = true, double dual_tol = 1E-5);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Include psd constraints on 1x1 or 2x2 matrices.

Towards #21663

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22114)
<!-- Reviewable:end -->
