### PR TITLE
[pydrake] add value instantiations for vector<PointCloud>

### DIFF
--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -132,6 +132,8 @@ void init_perception(py::module m) {
   }
 
   AddValueInstantiation<PointCloud>(m);
+  // Some ports need `Value<std::vector<PointCloud>>`.
+  AddValueInstantiation<std::vector<PointCloud>>(m);
 
   m.def("Concatenate", &Concatenate, py::arg("clouds"), doc.Concatenate.doc);
 

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pydrake.common.value import AbstractValue, Value
 from pydrake.systems.sensors import CameraInfo, PixelType
-from pydrake.systems.framework import InputPort, OutputPort
+from pydrake.systems.framework import InputPort, LeafSystem, OutputPort
 
 
 class TestPerception(unittest.TestCase):
@@ -143,3 +143,24 @@ class TestPerception(unittest.TestCase):
         dut = mut.PointCloudToLcm(frame_name="world")
         dut.get_input_port()
         dut.get_output_port()
+
+    def test_value_instantiations(self):
+        pc = AbstractValue.Make(mut.PointCloud(0))
+        self.assertIsInstance(pc, Value[mut.PointCloud])
+        pc_list = AbstractValue.Make([mut.PointCloud(0) for _ in range(3)])
+        self.assertIsInstance(pc_list, Value[list[mut.PointCloud]])
+
+        class TestSystem(LeafSystem):
+            def __init__(self):
+                LeafSystem.__init__(self)
+                pc = AbstractValue.Make(mut.PointCloud(0))
+                self.DeclareAbstractInputPort("cloud", pc)
+                pc_list = AbstractValue.Make(
+                    [mut.PointCloud(0) for _ in range(3)])
+                self.DeclareAbstractInputPort("cloud_list", pc_list)
+
+        sys = TestSystem()
+        context = sys.CreateDefaultContext()
+        sys.get_input_port(0).FixValue(context, mut.PointCloud(0))
+        sys.get_input_port(1).FixValue(context,
+                                       [mut.PointCloud(0) for _ in range(3)])


### PR DESCRIPTION
Resolves https://stackoverflow.com/questions/79142422/cannot-use-an-abstractvalue-holding-a-list-of-pointclouds-as-an-abstractport-or

+@seancurtis-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22116)
<!-- Reviewable:end -->
