### PR TITLE
Fix Bug Where Infeasible HPolyhedron with Few Constraints is Tagged as Unbounded

### DIFF
--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -681,12 +681,15 @@ HPolyhedron HPolyhedron::MakeL1Ball(const int dim) {
 std::optional<bool> HPolyhedron::DoIsBoundedShortcut() const {
   if (A_.rows() < A_.cols()) {
     // If A_ has fewer rows than columns, then either the HPolyhedron is
-    // unbounded, or it's empty (and therefore bounded).
+    // unbounded, or it's empty due to a subset of the inequalities being
+    // mutually exclusive (and therefore bounded).
     return IsEmpty();
   }
   Eigen::ColPivHouseholderQR<MatrixXd> qr(A_);
   if (qr.dimensionOfKernel() > 0) {
-    return false;
+    // A similar edge case to the above is possible, so once again, the
+    // HPolyhedron is bounded if and only if it is empty.
+    return IsEmpty();
   }
   // Stiemke's theorem of alternatives says that, given A with ker(A) = {0}, we
   // either have existence of x ≠ 0 such that Ax ≥ 0 or we have existence of y

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -679,17 +679,25 @@ HPolyhedron HPolyhedron::MakeL1Ball(const int dim) {
 }
 
 std::optional<bool> HPolyhedron::DoIsBoundedShortcut() const {
+  if (IsEmpty()) {
+    // We must always test if an HPolyhedron is empty, as all subsequent tests
+    // depend on the HPolyhedron being nonempty. See
+    // BoundednessCheckEmptyEdgeCases in hpolyhedron_test.cc for examples.
+    return true;
+  }
   if (A_.rows() < A_.cols()) {
     // If A_ has fewer rows than columns, then either the HPolyhedron is
     // unbounded, or it's empty due to a subset of the inequalities being
-    // mutually exclusive (and therefore bounded).
-    return IsEmpty();
+    // mutually exclusive (and therefore bounded). Emptiness has already
+    // been checked above, so it's unbounded.
+    return false;
   }
   Eigen::ColPivHouseholderQR<MatrixXd> qr(A_);
   if (qr.dimensionOfKernel() > 0) {
     // A similar edge case to the above is possible, so once again, the
-    // HPolyhedron is bounded if and only if it is empty.
-    return IsEmpty();
+    // HPolyhedron is bounded if and only if it is empty; because we already
+    // checked for emptiness, it's unbounded.
+    return false;
   }
   // Stiemke's theorem of alternatives says that, given A with ker(A) = {0}, we
   // either have existence of x ≠ 0 such that Ax ≥ 0 or we have existence of y

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -680,7 +680,9 @@ HPolyhedron HPolyhedron::MakeL1Ball(const int dim) {
 
 std::optional<bool> HPolyhedron::DoIsBoundedShortcut() const {
   if (A_.rows() < A_.cols()) {
-    return false;
+    // If A_ has fewer rows than columns, then either the HPolyhedron is
+    // unbounded, or it's empty (and therefore bounded).
+    return IsEmpty();
   }
   Eigen::ColPivHouseholderQR<MatrixXd> qr(A_);
   if (qr.dimensionOfKernel() > 0) {

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1756,15 +1756,23 @@ GTEST_TEST(HPolyhedronTest, MaximumVolumeInscribedAffineTransformationTest2) {
             VPolytope(initial_polytope).CalcVolume());
 }
 
-GTEST_TEST(HPolyhedronTest, EmptyWithFewConstraints) {
-  // An empty HPolyhedron in R^5, defined by x1 <= -1 and x1 >= 0
+GTEST_TEST(HPolyhedronTest, BoundednessCheckEmptyEdgeCases) {
+  // An empty HPolyhedron in R^3, defined by x1 <= -1 and x1 >= 0. This checks
+  // the special case when there are fewer rows than columns.
   MatrixXd A = MatrixXd::Zero(2, 3);
   VectorXd b = VectorXd::Zero(2);
   A(0, 0) = 1;
   A(1, 0) = -1;
   b(0) = -1;
   HPolyhedron h(A, b);
-  ASSERT_TRUE(h.IsEmpty());
+  EXPECT_TRUE(h.IsEmpty());
+  EXPECT_TRUE(h.IsBounded());
+
+  // An empty polyhedron in R^1, defined by the constraint 0x <= -1 and 0x <= 0.
+  // This checks the special case where the kernel has positive dimension.
+  A = MatrixXd::Zero(2, 1);
+  h = HPolyhedron{A, b};
+  EXPECT_TRUE(h.IsEmpty());
   EXPECT_TRUE(h.IsBounded());
 }
 

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1774,6 +1774,18 @@ GTEST_TEST(HPolyhedronTest, BoundednessCheckEmptyEdgeCases) {
   h = HPolyhedron{A, b};
   EXPECT_TRUE(h.IsEmpty());
   EXPECT_TRUE(h.IsBounded());
+
+  // An empty polyheron in R^2, defined by the constraints x1 <= -1, x1 >= 0,
+  // and x2 >= 0. This checks the special case where Stiemke's theorem of
+  // alternatives would otherwise suggest it to be unbounded.
+  A = MatrixXd::Zero(3, 2);
+  A(0, 0) = 1;
+  A(1, 0) = -1;
+  A(2, 1) = -1;
+  b = Vector3d(-1, 0, 0);
+  h = HPolyhedron(A, b);
+  EXPECT_TRUE(h.IsEmpty());
+  EXPECT_TRUE(h.IsBounded());
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1755,6 +1755,19 @@ GTEST_TEST(HPolyhedronTest, MaximumVolumeInscribedAffineTransformationTest2) {
   EXPECT_GE(VPolytope(inbody).CalcVolume(),
             VPolytope(initial_polytope).CalcVolume());
 }
+
+GTEST_TEST(HPolyhedronTest, EmptyWithFewConstraints) {
+  // An empty HPolyhedron in R^5, defined by x1 <= -1 and x1 >= 0
+  MatrixXd A = MatrixXd::Zero(2, 3);
+  VectorXd b = VectorXd::Zero(2);
+  A(0,0) = 1;
+  A(1,0) = -1;
+  b(0) = -1;
+  HPolyhedron h(A, b);
+  ASSERT_TRUE(h.IsEmpty());
+  EXPECT_TRUE(h.IsBounded());
+}
+
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1757,7 +1757,7 @@ GTEST_TEST(HPolyhedronTest, MaximumVolumeInscribedAffineTransformationTest2) {
 }
 
 GTEST_TEST(HPolyhedronTest, BoundednessCheckEmptyEdgeCases) {
-  // An empty HPolyhedron in R^3, defined by x1 <= -1 and x1 >= 0. This checks
+  // An empty HPolyhedron in ℝ^3, defined by x1 <= -1 and x1 >= 0. This checks
   // the special case when there are fewer rows than columns.
   MatrixXd A = MatrixXd::Zero(2, 3);
   VectorXd b = VectorXd::Zero(2);
@@ -1768,14 +1768,15 @@ GTEST_TEST(HPolyhedronTest, BoundednessCheckEmptyEdgeCases) {
   EXPECT_TRUE(h.IsEmpty());
   EXPECT_TRUE(h.IsBounded());
 
-  // An empty polyhedron in R^1, defined by the constraint 0x <= -1 and 0x <= 0.
-  // This checks the special case where the kernel has positive dimension.
+  // An empty HPolyhedron in ℝ^1, defined by the constraint 0x <= -1 and
+  // 0x <= 0. This checks the special case where the kernel has positive
+  // dimension.
   A = MatrixXd::Zero(2, 1);
   h = HPolyhedron{A, b};
   EXPECT_TRUE(h.IsEmpty());
   EXPECT_TRUE(h.IsBounded());
 
-  // An empty polyheron in R^2, defined by the constraints x1 <= -1, x1 >= 0,
+  // An empty HPolyhedron in ℝ^2, defined by the constraints x1 <= -1, x1 >= 0,
   // and x2 >= 0. This checks the special case where Stiemke's theorem of
   // alternatives would otherwise suggest it to be unbounded.
   A = MatrixXd::Zero(3, 2);

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1760,8 +1760,8 @@ GTEST_TEST(HPolyhedronTest, EmptyWithFewConstraints) {
   // An empty HPolyhedron in R^5, defined by x1 <= -1 and x1 >= 0
   MatrixXd A = MatrixXd::Zero(2, 3);
   VectorXd b = VectorXd::Zero(2);
-  A(0,0) = 1;
-  A(1,0) = -1;
+  A(0, 0) = 1;
+  A(1, 0) = -1;
   b(0) = -1;
   HPolyhedron h(A, b);
   ASSERT_TRUE(h.IsEmpty());


### PR DESCRIPTION
If an HPolyhedron has fewer inequalities than the dimension of the ambient space, it's generally unbounded. The only exception to this case is when a subset of the inequalities are mutually exclusive; then the HPolyhedron is empty, and hence, bounded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22117)
<!-- Reviewable:end -->
