### PR TITLE
Deprecate SemidefiniteRelaxationOptions flag `preserve_convex_quadratic_constraints`

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -1,7 +1,11 @@
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include "drake/solvers/semidefinite_relaxation.h"
+#pragma GCC diagnostic pop
 
 namespace drake {
 namespace pydrake {
@@ -13,14 +17,12 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.solvers;
 
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     const auto& cls_doc = doc.SemidefiniteRelaxationOptions;
     py::class_<SemidefiniteRelaxationOptions> options(
         m, "SemidefiniteRelaxationOptions", cls_doc.doc);
-    options
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-        .def(ParamInit<SemidefiniteRelaxationOptions>())
-#pragma GCC diagnostic pop
+    options.def(ParamInit<SemidefiniteRelaxationOptions>())
         .def_readwrite("add_implied_linear_equality_constraints",
             &SemidefiniteRelaxationOptions::
                 add_implied_linear_equality_constraints,
@@ -28,20 +30,15 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
         .def_readwrite("add_implied_linear_constraints",
             &SemidefiniteRelaxationOptions::add_implied_linear_constraints,
             cls_doc.add_implied_linear_constraints.doc)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         .def_readwrite("preserve_convex_quadratic_constraints",
             &SemidefiniteRelaxationOptions::
                 preserve_convex_quadratic_constraints,
             cls_doc.preserve_convex_quadratic_constraints.doc_deprecated)
-#pragma GCC diagnostic pop
         .def("set_to_strongest",
             &SemidefiniteRelaxationOptions::set_to_strongest,
             cls_doc.set_to_strongest.doc)
         .def("set_to_weakest", &SemidefiniteRelaxationOptions::set_to_weakest,
             cls_doc.set_to_weakest.doc)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         .def("__repr__", [](const SemidefiniteRelaxationOptions& self) {
           return py::str(
               "SemidefiniteRelaxationOptions("
@@ -53,17 +50,17 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
                   self.preserve_convex_quadratic_constraints);
         });
 #pragma GCC diagnostic pop
+    DeprecateAttribute(options, "preserve_convex_quadratic_constraints",
+        cls_doc.preserve_convex_quadratic_constraints.doc_deprecated);
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("MakeSemidefiniteRelaxation",
       py::overload_cast<const MathematicalProgram&,
           const SemidefiniteRelaxationOptions&>(
           &solvers::MakeSemidefiniteRelaxation),
-      py::arg("prog"),
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-      py::arg("options") = SemidefiniteRelaxationOptions(),
-#pragma GCC diagnostic pop
+      py::arg("prog"), py::arg("options") = SemidefiniteRelaxationOptions(),
       doc.MakeSemidefiniteRelaxation.doc_2args);
   m.def("MakeSemidefiniteRelaxation",
       py::overload_cast<const MathematicalProgram&,
@@ -71,11 +68,9 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
           const SemidefiniteRelaxationOptions&>(
           &solvers::MakeSemidefiniteRelaxation),
       py::arg("prog"), py::arg("variable_groups"),
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       py::arg("options") = SemidefiniteRelaxationOptions(),
-#pragma GCC diagnostic pop
       doc.MakeSemidefiniteRelaxation.doc_3args);
+#pragma GCC diagnostic pop
 }
 
 }  // namespace internal

--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -25,9 +25,6 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
         .def_readwrite("add_implied_linear_constraints",
             &SemidefiniteRelaxationOptions::add_implied_linear_constraints,
             cls_doc.add_implied_linear_constraints.doc);
-    options.def_readwrite("preserve_convex_quadratic_constraints",
-        &SemidefiniteRelaxationOptions::preserve_convex_quadratic_constraints,
-        cls_doc.preserve_convex_quadratic_constraints.doc);
     options
         .def("set_to_strongest",
             &SemidefiniteRelaxationOptions::set_to_strongest,
@@ -42,6 +39,9 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
               .format(self.add_implied_linear_equality_constraints,
                   self.add_implied_linear_constraints);
         });
+    options.def_readwrite("preserve_convex_quadratic_constraints",
+        &SemidefiniteRelaxationOptions::preserve_convex_quadratic_constraints,
+        cls_doc.preserve_convex_quadratic_constraints.doc);
     DeprecateAttribute(options, "preserve_convex_quadratic_constraints",
         cls_doc.preserve_convex_quadratic_constraints.doc);
   }

--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -25,12 +25,9 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
         .def_readwrite("add_implied_linear_constraints",
             &SemidefiniteRelaxationOptions::add_implied_linear_constraints,
             cls_doc.add_implied_linear_constraints.doc);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     options.def_readwrite("preserve_convex_quadratic_constraints",
         &SemidefiniteRelaxationOptions::preserve_convex_quadratic_constraints,
-        cls_doc.preserve_convex_quadratic_constraints.doc_deprecated);
-#pragma GCC diagnostic pop
+        cls_doc.preserve_convex_quadratic_constraints.doc);
     options
         .def("set_to_strongest",
             &SemidefiniteRelaxationOptions::set_to_strongest,
@@ -46,7 +43,7 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
                   self.add_implied_linear_constraints);
         });
     DeprecateAttribute(options, "preserve_convex_quadratic_constraints",
-        cls_doc.preserve_convex_quadratic_constraints.doc_deprecated);
+        cls_doc.preserve_convex_quadratic_constraints.doc);
   }
 
   m.def("MakeSemidefiniteRelaxation",

--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -2,10 +2,7 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include "drake/solvers/semidefinite_relaxation.h"
-#pragma GCC diagnostic pop
 
 namespace drake {
 namespace pydrake {
@@ -17,8 +14,6 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.solvers;
 
   {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     const auto& cls_doc = doc.SemidefiniteRelaxationOptions;
     py::class_<SemidefiniteRelaxationOptions> options(
         m, "SemidefiniteRelaxationOptions", cls_doc.doc);
@@ -29,11 +24,14 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
             cls_doc.add_implied_linear_equality_constraints.doc)
         .def_readwrite("add_implied_linear_constraints",
             &SemidefiniteRelaxationOptions::add_implied_linear_constraints,
-            cls_doc.add_implied_linear_constraints.doc)
-        .def_readwrite("preserve_convex_quadratic_constraints",
-            &SemidefiniteRelaxationOptions::
-                preserve_convex_quadratic_constraints,
-            cls_doc.preserve_convex_quadratic_constraints.doc_deprecated)
+            cls_doc.add_implied_linear_constraints.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    options.def_readwrite("preserve_convex_quadratic_constraints",
+        &SemidefiniteRelaxationOptions::preserve_convex_quadratic_constraints,
+        cls_doc.preserve_convex_quadratic_constraints.doc_deprecated);
+#pragma GCC diagnostic pop
+    options
         .def("set_to_strongest",
             &SemidefiniteRelaxationOptions::set_to_strongest,
             cls_doc.set_to_strongest.doc)
@@ -43,24 +41,19 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
           return py::str(
               "SemidefiniteRelaxationOptions("
               "add_implied_linear_equality_constraints={}, "
-              "add_implied_linear_constraints={}, "
-              "preserve_convex_quadratic_constraints={})")
+              "add_implied_linear_constraints={})")
               .format(self.add_implied_linear_equality_constraints,
-                  self.add_implied_linear_constraints,
-                  self.preserve_convex_quadratic_constraints);
+                  self.add_implied_linear_constraints);
         });
-#pragma GCC diagnostic pop
     DeprecateAttribute(options, "preserve_convex_quadratic_constraints",
         cls_doc.preserve_convex_quadratic_constraints.doc_deprecated);
   }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("MakeSemidefiniteRelaxation",
       py::overload_cast<const MathematicalProgram&,
           const SemidefiniteRelaxationOptions&>(
           &solvers::MakeSemidefiniteRelaxation),
-      py::arg("prog"), py::arg("options") = SemidefiniteRelaxationOptions(),
+      py::arg("prog"), py::arg("options") = SemidefiniteRelaxationOptions{},
       doc.MakeSemidefiniteRelaxation.doc_2args);
   m.def("MakeSemidefiniteRelaxation",
       py::overload_cast<const MathematicalProgram&,
@@ -68,9 +61,8 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
           const SemidefiniteRelaxationOptions&>(
           &solvers::MakeSemidefiniteRelaxation),
       py::arg("prog"), py::arg("variable_groups"),
-      py::arg("options") = SemidefiniteRelaxationOptions(),
+      py::arg("options") = SemidefiniteRelaxationOptions{},
       doc.MakeSemidefiniteRelaxation.doc_3args);
-#pragma GCC diagnostic pop
 }
 
 }  // namespace internal

--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -16,7 +16,11 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
     const auto& cls_doc = doc.SemidefiniteRelaxationOptions;
     py::class_<SemidefiniteRelaxationOptions> options(
         m, "SemidefiniteRelaxationOptions", cls_doc.doc);
-    options.def(ParamInit<SemidefiniteRelaxationOptions>())
+    options
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        .def(ParamInit<SemidefiniteRelaxationOptions>())
+#pragma GCC diagnostic pop
         .def_readwrite("add_implied_linear_equality_constraints",
             &SemidefiniteRelaxationOptions::
                 add_implied_linear_equality_constraints,
@@ -24,15 +28,20 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
         .def_readwrite("add_implied_linear_constraints",
             &SemidefiniteRelaxationOptions::add_implied_linear_constraints,
             cls_doc.add_implied_linear_constraints.doc)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         .def_readwrite("preserve_convex_quadratic_constraints",
             &SemidefiniteRelaxationOptions::
                 preserve_convex_quadratic_constraints,
-            cls_doc.preserve_convex_quadratic_constraints.doc)
+            cls_doc.preserve_convex_quadratic_constraints.doc_deprecated)
+#pragma GCC diagnostic pop
         .def("set_to_strongest",
             &SemidefiniteRelaxationOptions::set_to_strongest,
             cls_doc.set_to_strongest.doc)
         .def("set_to_weakest", &SemidefiniteRelaxationOptions::set_to_weakest,
             cls_doc.set_to_weakest.doc)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         .def("__repr__", [](const SemidefiniteRelaxationOptions& self) {
           return py::str(
               "SemidefiniteRelaxationOptions("
@@ -43,13 +52,18 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
                   self.add_implied_linear_constraints,
                   self.preserve_convex_quadratic_constraints);
         });
+#pragma GCC diagnostic pop
   }
 
   m.def("MakeSemidefiniteRelaxation",
       py::overload_cast<const MathematicalProgram&,
           const SemidefiniteRelaxationOptions&>(
           &solvers::MakeSemidefiniteRelaxation),
-      py::arg("prog"), py::arg("options") = SemidefiniteRelaxationOptions(),
+      py::arg("prog"),
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      py::arg("options") = SemidefiniteRelaxationOptions(),
+#pragma GCC diagnostic pop
       doc.MakeSemidefiniteRelaxation.doc_2args);
   m.def("MakeSemidefiniteRelaxation",
       py::overload_cast<const MathematicalProgram&,
@@ -57,7 +71,10 @@ void DefineSolversSemidefiniteRelaxation(py::module m) {
           const SemidefiniteRelaxationOptions&>(
           &solvers::MakeSemidefiniteRelaxation),
       py::arg("prog"), py::arg("variable_groups"),
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       py::arg("options") = SemidefiniteRelaxationOptions(),
+#pragma GCC diagnostic pop
       doc.MakeSemidefiniteRelaxation.doc_3args);
 }
 

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -58,15 +58,12 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         options = SemidefiniteRelaxationOptions()
         options.add_implied_linear_equality_constraints = True
         options.add_implied_linear_constraints = True
-        options.preserve_convex_quadratic_constraints = True
         self.assertTrue(options.add_implied_linear_equality_constraints)
         self.assertTrue(options.add_implied_linear_constraints)
-        self.assertTrue(options.preserve_convex_quadratic_constraints)
 
         options.set_to_weakest()
         self.assertFalse(options.add_implied_linear_equality_constraints)
         self.assertFalse(options.add_implied_linear_constraints)
-        self.assertFalse(options.preserve_convex_quadratic_constraints)
 
         options.set_to_strongest()
         self.assertTrue(options.add_implied_linear_constraints)

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -22,7 +22,9 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         relaxation = MakeSemidefiniteRelaxation(prog=prog, options=options)
 
         self.assertEqual(relaxation.num_vars(), 6)
-        self.assertEqual(len(relaxation.positive_semidefinite_constraints()), 1)
+        self.assertEqual(
+            len(relaxation.positive_semidefinite_constraints()), 1
+        )
         self.assertEqual(len(relaxation.linear_equality_constraints()), 1)
         self.assertEqual(len(relaxation.linear_constraints()), 2)
 
@@ -48,7 +50,9 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         # with the "1" variable double counted. Therefore, there are
         # 5 choose 2 + 4 choose 2 - 1 variables.
         self.assertEqual(relaxation.num_vars(), 10 + 6 - 1)
-        self.assertEqual(len(relaxation.positive_semidefinite_constraints()), 2)
+        self.assertEqual(
+            len(relaxation.positive_semidefinite_constraints()), 2
+        )
         self.assertEqual(len(relaxation.linear_equality_constraints()), 1)
         self.assertEqual(len(relaxation.linear_constraints()), 2 + 1)
 

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import unittest
 
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.solvers import (
     MakeSemidefiniteRelaxation,
     SemidefiniteRelaxationOptions,
@@ -60,6 +61,9 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         options.add_implied_linear_constraints = True
         self.assertTrue(options.add_implied_linear_equality_constraints)
         self.assertTrue(options.add_implied_linear_constraints)
+        with catch_drake_warnings(expected_count=2) as w:
+            options.preserve_convex_quadratic_constraints = True
+            self.assertTrue(options.preserve_convex_quadratic_constraints)
 
         options.set_to_weakest()
         self.assertFalse(options.add_implied_linear_equality_constraints)

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -14,16 +14,15 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
     def test_MakeSemidefiniteRelaxation(self):
         prog = MathematicalProgram()
         y = prog.NewContinuousVariables(2, "y")
-        A = np.array([[0.5, 0.7], [-.2, 0.4], [-2.3, -4.5]])
-        lb = np.array([1.3, -.24, 0.25])
+        A = np.array([[0.5, 0.7], [-0.2, 0.4], [-2.3, -4.5]])
+        lb = np.array([1.3, -0.24, 0.25])
         ub = np.array([5.6, 0.1, 1.4])
         prog.AddLinearConstraint(A, lb, ub, y)
         options = SemidefiniteRelaxationOptions()
         relaxation = MakeSemidefiniteRelaxation(prog=prog, options=options)
 
         self.assertEqual(relaxation.num_vars(), 6)
-        self.assertEqual(len(relaxation.positive_semidefinite_constraints()),
-                         1)
+        self.assertEqual(len(relaxation.positive_semidefinite_constraints()), 1)
         self.assertEqual(len(relaxation.linear_equality_constraints()), 1)
         self.assertEqual(len(relaxation.linear_constraints()), 2)
 
@@ -35,25 +34,23 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         x_vars = Variables(x)
         y_vars = Variables(y)
 
-        A = np.array([[0.5, 0.7],
-                      [-.2, 0.4],
-                      [-2.3, -4.5]])
-        lb = np.array([1.3, -.24, 0.25])
+        A = np.array([[0.5, 0.7], [-0.2, 0.4], [-2.3, -4.5]])
+        lb = np.array([1.3, -0.24, 0.25])
         ub = np.array([5.6, 0.1, 1.4])
         prog.AddLinearConstraint(A, lb, ub, x)
-        prog.AddQuadraticConstraint(A@A.T, lb, 0, 5, y)
+        prog.AddQuadraticConstraint(A @ A.T, lb, 0, 5, y)
         options = SemidefiniteRelaxationOptions()
         relaxation = MakeSemidefiniteRelaxation(
-            prog=prog, variable_groups=[x_vars, y_vars], options=options)
+            prog=prog, variable_groups=[x_vars, y_vars], options=options
+        )
 
         # The semidefinite variables have 4 and 3 rows respectively,
         # with the "1" variable double counted. Therefore, there are
         # 5 choose 2 + 4 choose 2 - 1 variables.
         self.assertEqual(relaxation.num_vars(), 10 + 6 - 1)
-        self.assertEqual(len(relaxation.positive_semidefinite_constraints()),
-                         2)
+        self.assertEqual(len(relaxation.positive_semidefinite_constraints()), 2)
         self.assertEqual(len(relaxation.linear_equality_constraints()), 1)
-        self.assertEqual(len(relaxation.linear_constraints()), 2+1)
+        self.assertEqual(len(relaxation.linear_constraints()), 2 + 1)
 
     def test_MakeSemidefiniteRelaxationOptions(self):
         options = SemidefiniteRelaxationOptions()

--- a/solvers/semidefinite_relaxation.cc
+++ b/solvers/semidefinite_relaxation.cc
@@ -58,8 +58,7 @@ MatrixXDecisionVariable DoMakeSemidefiniteRelaxation(
       group_number);
 
   internal::DoLinearizeQuadraticCostsAndConstraints(
-      sub_prog, X, variables_to_sorted_indices, relaxation,
-      options.preserve_convex_quadratic_constraints);
+      sub_prog, X, variables_to_sorted_indices, relaxation);
 
   if (options.add_implied_linear_constraints) {
     internal::DoAddImpliedLinearConstraints(

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -30,13 +30,16 @@ struct SemidefiniteRelaxationOptions {
    * relaxation.*/
   bool add_implied_linear_constraints = true;
 
-  // TODO(Alexandre.Amice): change this to true by default.
-
-  /** Given a program with convex quadratic constraints, sets whether
-   * equivalent rotated second order cone constraints are enforced on the last
-   * column of X in the semidefinite relaxation. This ensures that the last
-   * column of X, which are a relaxation of the original program's variables
-   * satisfy the original progam's quadratic constraints.*/
+  /** No longer in use, hence this parameter does nothing. Given a convex
+   * quadratic constraint xᵀP x + xᵀq + r <= 0 it is always stronger to add the
+   * linearized constraint Tr(PX) + xᵀq + r <= 0 (as is already done for all
+   * convex and nonconvex quadratic constraints), rendering the original convex
+   * quadratic constraints unnecessary.
+   * */
+  DRAKE_DEPRECATED("2025-04-01",
+                   "Preserving convex quadratic constraints is looser than "
+                   "adding their linearized counterparts, and this "
+                   "functionality will therefore be removed.")
   bool preserve_convex_quadratic_constraints = false;
 
   /** Configure the semidefinite relaxation options to provide the strongest
@@ -46,7 +49,6 @@ struct SemidefiniteRelaxationOptions {
   void set_to_strongest() {
     add_implied_linear_equality_constraints = true;
     add_implied_linear_constraints = true;
-    preserve_convex_quadratic_constraints = true;
   }
 
   /** Configure the semidefinite relaxation options to provide the weakest
@@ -58,7 +60,6 @@ struct SemidefiniteRelaxationOptions {
   void set_to_weakest() {
     add_implied_linear_equality_constraints = false;
     add_implied_linear_constraints = false;
-    preserve_convex_quadratic_constraints = false;
   }
 };
 

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -37,9 +37,10 @@ struct SemidefiniteRelaxationOptions {
    * quadratic constraints unnecessary.
    * */
   DRAKE_DEPRECATED("2025-04-01",
-                   "Preserving convex quadratic constraints is looser than "
-                   "adding their linearized counterparts, and this "
-                   "functionality will therefore be removed.")
+                   "The convex quadratics constraints are already implied by a "
+                   "linear constraint that is always added to the semidefinite "
+                   "relaxation. Therefore, this flag has no effect on the "
+                   "solution to the overall program and so will be removed.")
   bool preserve_convex_quadratic_constraints = false;
 
   /** Configure the semidefinite relaxation options to provide the strongest

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -30,17 +30,16 @@ struct SemidefiniteRelaxationOptions {
    * relaxation.*/
   bool add_implied_linear_constraints{true};
 
-  /** No longer in use, hence this parameter does nothing. Given a convex
-   * quadratic constraint xᵀP x + xᵀq + r <= 0 it is always stronger to add the
-   * linearized constraint Tr(PX) + xᵀq + r <= 0 (as is already done for all
-   * convex and nonconvex quadratic constraints), rendering the original convex
-   * quadratic constraints unnecessary.
+  /** 2025-04-01 DEPRECATION NOTICE: The convex quadratic constraints are
+   * already implied by a linear constraint that is always added to the
+   * semidefinite relaxation. Therefore, this flag has no effect on the solution
+   * to the overall program and will be deprecated on April 1st, 2025.
+   *
+   * Given a convex quadratic constraint xᵀP x + xᵀq + r <= 0 it is always
+   * stronger to add the linearized constraint Tr(PX) + xᵀq + r <= 0 (as is
+   * already done for all convex and nonconvex quadratic constraints), rendering
+   * the original convex quadratic constraints unnecessary.
    * */
-  DRAKE_DEPRECATED("2025-04-01",
-                   "The convex quadratics constraints are already implied by a "
-                   "linear constraint that is always added to the semidefinite "
-                   "relaxation. Therefore, this flag has no effect on the "
-                   "solution to the overall program and so will be removed.")
   bool preserve_convex_quadratic_constraints{false};
 
   /** Configure the semidefinite relaxation options to provide the strongest

--- a/solvers/semidefinite_relaxation.h
+++ b/solvers/semidefinite_relaxation.h
@@ -23,12 +23,12 @@ struct SemidefiniteRelaxationOptions {
   /** Given a program with the linear constraints Ay ≤ b, sets whether to add
    * the implied linear constraints [A,-b]X[A,-b]ᵀ ≤ 0 to the semidefinite
    * relaxation.*/
-  bool add_implied_linear_equality_constraints = true;
+  bool add_implied_linear_equality_constraints{true};
 
   /** Given a program with the linear equality constraints Ay = b, sets whether
    * to add the implied linear constraints [A, -b]X = 0 to the semidefinite
    * relaxation.*/
-  bool add_implied_linear_constraints = true;
+  bool add_implied_linear_constraints{true};
 
   /** No longer in use, hence this parameter does nothing. Given a convex
    * quadratic constraint xᵀP x + xᵀq + r <= 0 it is always stronger to add the
@@ -41,7 +41,7 @@ struct SemidefiniteRelaxationOptions {
                    "linear constraint that is always added to the semidefinite "
                    "relaxation. Therefore, this flag has no effect on the "
                    "solution to the overall program and so will be removed.")
-  bool preserve_convex_quadratic_constraints = false;
+  bool preserve_convex_quadratic_constraints{false};
 
   /** Configure the semidefinite relaxation options to provide the strongest
    * possible semidefinite relaxation that we currently support. This in general

--- a/solvers/semidefinite_relaxation_internal.h
+++ b/solvers/semidefinite_relaxation_internal.h
@@ -41,17 +41,14 @@ void InitializeSemidefiniteRelaxationForProg(
 
 // Iterates over the quadratic costs and constraints in prog, remove them if
 // present in the relaxation, and add an equivalent linear cost or constraint on
-// the semidefinite variable X. If the cost or constraint is convex, and
-// preserve_convex_quadratic_constraints is true, then the cost/constraint is
-// not removed. The map variables_to_sorted_indices maps the decision variables
-// in prog to their index in the last column of X.
-// [in/out] relaxation A pointer to a mathematical program to which the
-// linearized costs and constraints are added. It cannot be null.
+// the semidefinite variable X. The map variables_to_sorted_indices maps the
+// decision variables in prog to their index in the last column of X. [in/out]
+// relaxation A pointer to a mathematical program to which the linearized costs
+// and constraints are added. It cannot be null.
 void DoLinearizeQuadraticCostsAndConstraints(
     const MathematicalProgram& prog, const MatrixXDecisionVariable& X,
     const std::map<symbolic::Variable, int>& variables_to_sorted_indices,
-    MathematicalProgram* relaxation,
-    bool preserve_convex_quadratic_constraints = false);
+    MathematicalProgram* relaxation);
 
 // Aggregates all the finite linear constraints in the program into a single
 // expression Ay ≤ b, which can be expressed as [A, -b][y; 1] ≤ 0.

--- a/solvers/test/semidefinite_relaxation_internal_test.cc
+++ b/solvers/test/semidefinite_relaxation_internal_test.cc
@@ -186,18 +186,14 @@ TEST_F(MakeSemidefiniteRelaxationTestFixture,
   // A non-convex quadratic cost
   prog_.AddQuadraticCost(y(0) * y(1), false);
 
-  // The preserve convex argument has no effect on the quadratic costs.
-  for (const auto& preserve_convex : {false, true}) {
-    ReinitializeRelaxation();
-    DoLinearizeQuadraticCostsAndConstraints(prog_, X_,
-                                            variables_to_sorted_indices_,
-                                            relaxation_.get(), preserve_convex);
-    EXPECT_EQ(relaxation_->linear_costs().size(), 2);
-    SetRelaxationInitialGuess(yd, relaxation_.get());
-    EXPECT_NEAR(relaxation_->EvalBindingAtInitialGuess(
-                    relaxation_->linear_costs()[0])[0],
-                0, 1e-12);
-  }
+  ReinitializeRelaxation();
+  DoLinearizeQuadraticCostsAndConstraints(
+      prog_, X_, variables_to_sorted_indices_, relaxation_.get());
+  EXPECT_EQ(relaxation_->linear_costs().size(), 2);
+  SetRelaxationInitialGuess(yd, relaxation_.get());
+  EXPECT_NEAR(
+      relaxation_->EvalBindingAtInitialGuess(relaxation_->linear_costs()[0])[0],
+      0, 1e-12);
 }
 
 TEST_F(MakeSemidefiniteRelaxationTestFixture,
@@ -209,33 +205,28 @@ TEST_F(MakeSemidefiniteRelaxationTestFixture,
   const double lb = -0.4, ub = 0.5;
   prog_.AddQuadraticConstraint(Q, b, lb, ub, y);
 
-  // The preserve convex argument has no effect on non-convex quadratic
-  // constraints.
-  for (const auto& preserve_convex : {false, true}) {
-    ReinitializeRelaxation();
-    DoLinearizeQuadraticCostsAndConstraints(prog_, X_,
-                                            variables_to_sorted_indices_,
-                                            relaxation_.get(), preserve_convex);
+  ReinitializeRelaxation();
+  DoLinearizeQuadraticCostsAndConstraints(
+      prog_, X_, variables_to_sorted_indices_, relaxation_.get());
 
-    EXPECT_EQ(relaxation_->positive_semidefinite_constraints().size(), 1);
-    // The constraint the "one" variable is equal to one.
-    EXPECT_EQ(relaxation_->linear_equality_constraints().size(), 1);
-    EXPECT_EQ(relaxation_->linear_constraints().size(), 1);
-    EXPECT_EQ(relaxation_->GetAllConstraints().size(), 3);
+  EXPECT_EQ(relaxation_->positive_semidefinite_constraints().size(), 1);
+  // The constraint the "one" variable is equal to one.
+  EXPECT_EQ(relaxation_->linear_equality_constraints().size(), 1);
+  EXPECT_EQ(relaxation_->linear_constraints().size(), 1);
+  EXPECT_EQ(relaxation_->GetAllConstraints().size(), 3);
 
-    const Vector2d y_test(1.3, 0.24);
-    SetRelaxationInitialGuess(y_test, relaxation_.get());
-    EXPECT_NEAR(
-        relaxation_->EvalBindingAtInitialGuess(
-            relaxation_->linear_constraints()[0])[0],
-        (0.5 * y_test.transpose() * Q * y_test + b.transpose() * y_test)[0],
-        1e-12);
+  const Vector2d y_test(1.3, 0.24);
+  SetRelaxationInitialGuess(y_test, relaxation_.get());
+  EXPECT_NEAR(
+      relaxation_->EvalBindingAtInitialGuess(
+          relaxation_->linear_constraints()[0])[0],
+      (0.5 * y_test.transpose() * Q * y_test + b.transpose() * y_test)[0],
+      1e-12);
 
-    EXPECT_EQ(
-        relaxation_->linear_constraints()[0].evaluator()->lower_bound()[0], lb);
-    EXPECT_EQ(
-        relaxation_->linear_constraints()[0].evaluator()->upper_bound()[0], ub);
-  }
+  EXPECT_EQ(relaxation_->linear_constraints()[0].evaluator()->lower_bound()[0],
+            lb);
+  EXPECT_EQ(relaxation_->linear_constraints()[0].evaluator()->upper_bound()[0],
+            ub);
 }
 
 // This test checks that repeated variables in a quadratic constraint are

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -66,20 +66,24 @@ GTEST_TEST(SemidefiniteRelaxationOptions, DefaultOptionsTest) {
   // the solve time and tightness of semidefinite relaxations. If the default
   // options are changed, please ensure that the commit message specifically
   // highlights this change for downstream developers.
-  SemidefiniteRelaxationOptions options;
+  SemidefiniteRelaxationOptions options{};
   EXPECT_TRUE(options.add_implied_linear_equality_constraints);
   EXPECT_TRUE(options.add_implied_linear_constraints);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_FALSE(options.preserve_convex_quadratic_constraints);
+#pragma GCC diagnostic pop
 }
 
 GTEST_TEST(SemidefiniteRelaxationOptions, SetWeakestTest) {
-  SemidefiniteRelaxationOptions options;
+  SemidefiniteRelaxationOptions options{};
   options.set_to_weakest();
   EXPECT_FALSE(options.add_implied_linear_equality_constraints);
   EXPECT_FALSE(options.add_implied_linear_constraints);
 }
 
 GTEST_TEST(SemidefiniteRelaxationOptions, SetStrongestTest) {
-  SemidefiniteRelaxationOptions options;
+  SemidefiniteRelaxationOptions options{};
   options.set_to_strongest();
   EXPECT_TRUE(options.add_implied_linear_equality_constraints);
   EXPECT_TRUE(options.add_implied_linear_constraints);
@@ -163,7 +167,7 @@ class MakeSemidefiniteRelaxationTest : public ::testing::Test {
 };
 
 TEST_F(MakeSemidefiniteRelaxationTest, EnsureProgramsAreValidated) {
-  SemidefiniteRelaxationOptions options;
+  SemidefiniteRelaxationOptions options{};
   prog_.AddCost(sin(y_[0]));
   DRAKE_EXPECT_THROWS_MESSAGE(
       MakeSemidefiniteRelaxation(prog_, options),
@@ -185,7 +189,7 @@ TEST_F(MakeSemidefiniteRelaxationTest, VerifyLinearCostsAndConstraintsCloned) {
     prog_.RemoveConstraint(constraint);
   }
 
-  SemidefiniteRelaxationOptions options;
+  SemidefiniteRelaxationOptions options{};
   // Don't add any implied constraints.
   options.set_to_weakest();
   auto relaxation = MakeSemidefiniteRelaxation(prog_, options);
@@ -263,9 +267,36 @@ TEST_F(MakeSemidefiniteRelaxationTest, VerifyLinearCostsAndConstraintsCloned) {
   EXPECT_EQ(indices.size(), y_.size());
 }
 
+TEST_F(MakeSemidefiniteRelaxationTest, LinearizeQuadraticCostsAndConstraints) {
+  SemidefiniteRelaxationOptions options{};
+  options.set_to_weakest();
+  auto relaxation = MakeSemidefiniteRelaxation(prog_, options);
+
+  // The semidefinite program is initialized.
+  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
+
+  // All the quadratic costs are linearized.
+  EXPECT_EQ(relaxation->quadratic_costs().size(), 0);
+  EXPECT_EQ(relaxation->linear_costs().size(),
+            prog_.linear_costs().size() + prog_.quadratic_costs().size());
+
+  // All the quadratic constraints are linearized.
+  EXPECT_EQ(relaxation->quadratic_constraints().size(), 0);
+  EXPECT_EQ(
+      relaxation->linear_constraints().size(),
+      prog_.linear_constraints().size() + prog_.quadratic_constraints().size());
+
+  // One extra constraint from "one" equals 1, one from the semidefinite
+  // constraint.
+  EXPECT_EQ(relaxation->GetAllConstraints().size(),
+            prog_.GetAllConstraints().size() + 1 + 1);
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(MakeSemidefiniteRelaxationTest,
        LinearizeQuadraticCostsAndConstraintsPreserveFalse) {
-  SemidefiniteRelaxationOptions options;
+  SemidefiniteRelaxationOptions options{};
   // Don't add any implied constraints.
   options.set_to_weakest();
   options.preserve_convex_quadratic_constraints = false;
@@ -292,16 +323,16 @@ TEST_F(MakeSemidefiniteRelaxationTest,
   EXPECT_EQ(relaxation->GetAllConstraints().size(),
             prog_.GetAllConstraints().size() + 1 + 1);
 }
-
-TEST_F(MakeSemidefiniteRelaxationTest,
-       LinearizeQuadraticCostsAndConstraintsPreserveTrue) {
-  SemidefiniteRelaxationOptions options;
-  options.set_to_weakest();
+#pragma GCC diagnostic pop
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+TEST_F(MakeSemidefiniteRelaxationTest,
+       LinearizeQuadraticCostsAndConstraintsPreserveTrue) {
+  SemidefiniteRelaxationOptions options{};
+  options.set_to_weakest();
+
   options.preserve_convex_quadratic_constraints = true;
-#pragma GCC diagnostic pop
   auto relaxation = MakeSemidefiniteRelaxation(prog_, options);
 
   // The semidefinite program is initialized.
@@ -324,13 +355,14 @@ TEST_F(MakeSemidefiniteRelaxationTest,
   EXPECT_EQ(relaxation->rotated_lorentz_cone_constraints().size(), 0);
 
   // One extra constraint from "one" equals 1, one from the semidefinite
-  // constraint, one from preserving the convex quadratic.
+  // constraint.
   EXPECT_EQ(relaxation->GetAllConstraints().size(),
-            prog_.GetAllConstraints().size() + 1 + 1 + 1);
+            prog_.GetAllConstraints().size() + 1 + 1);
 }
+#pragma GCC diagnostic pop
 
 TEST_F(MakeSemidefiniteRelaxationTest, AddImpliedLinearConstraint) {
-  SemidefiniteRelaxationOptions options;
+  SemidefiniteRelaxationOptions options{};
   options.set_to_weakest();
   options.add_implied_linear_constraints = true;
   auto relaxation = MakeSemidefiniteRelaxation(prog_, options);
@@ -351,7 +383,7 @@ TEST_F(MakeSemidefiniteRelaxationTest, AddImpliedLinearConstraint) {
 }
 
 TEST_F(MakeSemidefiniteRelaxationTest, AddImpliedLinearEqualityConstraint) {
-  SemidefiniteRelaxationOptions options;
+  SemidefiniteRelaxationOptions options{};
   options.set_to_weakest();
   options.add_implied_linear_equality_constraints = true;
   auto relaxation = MakeSemidefiniteRelaxation(prog_, options);

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -69,7 +69,6 @@ GTEST_TEST(SemidefiniteRelaxationOptions, DefaultOptionsTest) {
   SemidefiniteRelaxationOptions options;
   EXPECT_TRUE(options.add_implied_linear_equality_constraints);
   EXPECT_TRUE(options.add_implied_linear_constraints);
-  EXPECT_FALSE(options.preserve_convex_quadratic_constraints);
 }
 
 GTEST_TEST(SemidefiniteRelaxationOptions, SetWeakestTest) {
@@ -77,7 +76,6 @@ GTEST_TEST(SemidefiniteRelaxationOptions, SetWeakestTest) {
   options.set_to_weakest();
   EXPECT_FALSE(options.add_implied_linear_equality_constraints);
   EXPECT_FALSE(options.add_implied_linear_constraints);
-  EXPECT_FALSE(options.preserve_convex_quadratic_constraints);
 }
 
 GTEST_TEST(SemidefiniteRelaxationOptions, SetStrongestTest) {
@@ -85,7 +83,6 @@ GTEST_TEST(SemidefiniteRelaxationOptions, SetStrongestTest) {
   options.set_to_strongest();
   EXPECT_TRUE(options.add_implied_linear_equality_constraints);
   EXPECT_TRUE(options.add_implied_linear_constraints);
-  EXPECT_TRUE(options.preserve_convex_quadratic_constraints);
 }
 
 class MakeSemidefiniteRelaxationTest : public ::testing::Test {
@@ -266,11 +263,9 @@ TEST_F(MakeSemidefiniteRelaxationTest, VerifyLinearCostsAndConstraintsCloned) {
   EXPECT_EQ(indices.size(), y_.size());
 }
 
-TEST_F(MakeSemidefiniteRelaxationTest,
-       LinearizeQuadraticCostsAndConstraintsPreserveFalse) {
+TEST_F(MakeSemidefiniteRelaxationTest, LinearizeQuadraticCostsAndConstraints) {
   SemidefiniteRelaxationOptions options;
-  // Don't add any implied constraints. This also sets
-  // preserve_convex_quadratic_constraints to false.
+  // Don't add any implied constraints.
   options.set_to_weakest();
   auto relaxation = MakeSemidefiniteRelaxation(prog_, options);
 
@@ -294,35 +289,6 @@ TEST_F(MakeSemidefiniteRelaxationTest,
   // One extra constraint from "one" equals 1 and the semidefinite constraint.
   EXPECT_EQ(relaxation->GetAllConstraints().size(),
             prog_.GetAllConstraints().size() + 1 + 1);
-}
-
-TEST_F(MakeSemidefiniteRelaxationTest,
-       LinearizeQuadraticCostsAndConstraintsPreserveTrue) {
-  SemidefiniteRelaxationOptions options;
-  options.set_to_weakest();
-  options.preserve_convex_quadratic_constraints = true;
-  auto relaxation = MakeSemidefiniteRelaxation(prog_, options);
-
-  // The semidefinite program is initialized.
-  EXPECT_EQ(relaxation->positive_semidefinite_constraints().size(), 1);
-
-  // All the quadratic costs are linearized.
-  EXPECT_EQ(relaxation->quadratic_costs().size(), 0);
-  EXPECT_EQ(relaxation->linear_costs().size(),
-            prog_.linear_costs().size() + prog_.quadratic_costs().size());
-
-  // All the quadratic constraints are linearized.
-  EXPECT_EQ(relaxation->quadratic_constraints().size(), 0);
-  EXPECT_EQ(
-      relaxation->linear_constraints().size(),
-      prog_.linear_constraints().size() + prog_.quadratic_constraints().size());
-  // The convex quadratic is rewritten as a lorentz cone constraint.
-  EXPECT_EQ(relaxation->rotated_lorentz_cone_constraints().size(), 1);
-
-  // One extra constraint from "one" equals 1, one from the semidefinite
-  // constraint, one from preserving the convex quadratic.
-  EXPECT_EQ(relaxation->GetAllConstraints().size(),
-            prog_.GetAllConstraints().size() + 1 + 1 + 1);
 }
 
 TEST_F(MakeSemidefiniteRelaxationTest, AddImpliedLinearConstraint) {

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -69,10 +69,7 @@ GTEST_TEST(SemidefiniteRelaxationOptions, DefaultOptionsTest) {
   SemidefiniteRelaxationOptions options{};
   EXPECT_TRUE(options.add_implied_linear_equality_constraints);
   EXPECT_TRUE(options.add_implied_linear_constraints);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_FALSE(options.preserve_convex_quadratic_constraints);
-#pragma GCC diagnostic pop
 }
 
 GTEST_TEST(SemidefiniteRelaxationOptions, SetWeakestTest) {
@@ -292,8 +289,6 @@ TEST_F(MakeSemidefiniteRelaxationTest, LinearizeQuadraticCostsAndConstraints) {
             prog_.GetAllConstraints().size() + 1 + 1);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(MakeSemidefiniteRelaxationTest,
        LinearizeQuadraticCostsAndConstraintsPreserveFalse) {
   SemidefiniteRelaxationOptions options{};
@@ -323,10 +318,6 @@ TEST_F(MakeSemidefiniteRelaxationTest,
   EXPECT_EQ(relaxation->GetAllConstraints().size(),
             prog_.GetAllConstraints().size() + 1 + 1);
 }
-#pragma GCC diagnostic pop
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(MakeSemidefiniteRelaxationTest,
        LinearizeQuadraticCostsAndConstraintsPreserveTrue) {
   SemidefiniteRelaxationOptions options{};
@@ -359,7 +350,6 @@ TEST_F(MakeSemidefiniteRelaxationTest,
   EXPECT_EQ(relaxation->GetAllConstraints().size(),
             prog_.GetAllConstraints().size() + 1 + 1);
 }
-#pragma GCC diagnostic pop
 
 TEST_F(MakeSemidefiniteRelaxationTest, AddImpliedLinearConstraint) {
   SemidefiniteRelaxationOptions options{};

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -340,11 +340,6 @@ TEST_F(MakeSemidefiniteRelaxationTest,
       relaxation->linear_constraints().size(),
       prog_.linear_constraints().size() + prog_.quadratic_constraints().size());
 
-  // The convex quadratic should NOT be rewritten as a lorentz cone constraint
-  // (given that the SemidefiniteRelaxationOptions attribute
-  // `preserve_convex_quadratic_constraints` will soon be deprecated.
-  EXPECT_EQ(relaxation->rotated_lorentz_cone_constraints().size(), 0);
-
   // One extra constraint from "one" equals 1, one from the semidefinite
   // constraint.
   EXPECT_EQ(relaxation->GetAllConstraints().size(),


### PR DESCRIPTION
Addressing #20777 .

As discussed, given a convex quadratic constraint xᵀP x + xᵀq + r <= 0, it is always stronger to add the linearized constraint Tr(PX) + xᵀq + r <= 0 (as is already done for all convex and nonconvex quadratic constraints in `MakeSemidefiniteRelaxation), rendering the original convex quadratic constraints unnecessary. Hence, we want to remove the code that we currently have implemented in Drake that supports keeping these constraints around in their conic form.

Removing the flag `preserve_convex_quadratic_constraints` in the struct `SemidefiniteRelaxationOptions` would be a breaking change, hence I have added the `DRAKE_DEPRECATED` flag to the attribute, and removed all the code where the flag is used so the flag does nothing (mathematically, it already does nothing, but adding/not adding the constraints could in principle affect the numerics of the optimization and hence the solver performance).

I am not sure what is the correct way to add the corresponding deprecation warning in the python bindings. @jwnimmer-tri  Could you provide some pointers here, as well as on my use of the C++ macro?

FYI @RussTedrake @AlexandreAmice

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22123)
<!-- Reviewable:end -->
