### PR TITLE
[pydrake] Factor out actual_ref_count() for tests

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -402,6 +402,7 @@ drake_py_unittest(
     ],
     deps = [
         ":all_py",
+        "//bindings/pydrake/common/test_utilities",
     ],
 )
 

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -520,6 +520,7 @@ drake_py_unittest(
     deps = [
         ":common",
         ":ref_cycle_test_util_py",
+        "//bindings/pydrake/common/test_utilities",
     ],
 )
 

--- a/bindings/pydrake/common/test/ref_cycle_test.py
+++ b/bindings/pydrake/common/test/ref_cycle_test.py
@@ -2,32 +2,13 @@
 
 See also ref_cycle_test_util_py.cc for the bindings used in the tests.
 """
-import functools
 import gc
-import sys
 import unittest
 import weakref
 
 from pydrake.common.ref_cycle_test_util import (
     NotDynamic, IsDynamic, invalid_arg_index, free_function, ouroboros)
-
-
-def actual_ref_count(o):
-    """Returns the actual ref count of `o`, in the caller's scope."""
-    # sys.getrefcount() always artificially adds 1 to its result, owing to the
-    # machinery of python calling the native-code implementation. Since we wrap
-    # it here, we have to adjust the result to account for the
-    # python-implemented function call. For extra fun, the ref-count cost of a
-    # python function call varies with python interpreter versions, so
-    # wrapped_refcount_cost() actually measures the total (native call plus
-    # python call) cost.
-    @functools.cache
-    def wrapped_refcount_cost():
-        def wrapped(o):
-            return sys.getrefcount(o)
-        return wrapped(object())
-
-    return sys.getrefcount(o) - wrapped_refcount_cost()
+from pydrake.common.test_utilities.memory_test_util import actual_ref_count
 
 
 class TestRefCycle(unittest.TestCase):

--- a/bindings/pydrake/common/test_utilities/BUILD.bazel
+++ b/bindings/pydrake/common/test_utilities/BUILD.bazel
@@ -61,6 +61,15 @@ drake_py_library(
 )
 
 drake_py_library(
+    name = "memory_test_util_py",
+    testonly = True,
+    srcs = ["memory_test_util.py"],
+    deps = [
+        ":module_py",
+    ],
+)
+
+drake_py_library(
     name = "meta_py",
     testonly = 1,
     srcs = ["meta.py"],
@@ -130,6 +139,7 @@ drake_py_library(
     testonly = 1,
     deps = [
         ":deprecation_py",
+        ":memory_test_util_py",
         ":module_py",
         ":numpy_compare_py",
         ":pickle_compare_py",

--- a/bindings/pydrake/common/test_utilities/memory_test_util.py
+++ b/bindings/pydrake/common/test_utilities/memory_test_util.py
@@ -1,0 +1,20 @@
+import functools
+import sys
+
+
+def actual_ref_count(o):
+    """Returns the actual ref count of `o`, in the caller's scope."""
+    # sys.getrefcount() always artificially adds 1 to its result, owing to the
+    # machinery of python calling the native-code implementation. Since we wrap
+    # it here, we have to adjust the result to account for the
+    # python-implemented function call. For extra fun, the ref-count cost of a
+    # python function call varies with python interpreter versions, so
+    # wrapped_refcount_cost() actually measures the total (native call plus
+    # python call) cost.
+    @functools.cache
+    def wrapped_refcount_cost():
+        def wrapped(o):
+            return sys.getrefcount(o)
+        return wrapped(object())
+
+    return sys.getrefcount(o) - wrapped_refcount_cost()

--- a/bindings/pydrake/test/memory_leak_test.py
+++ b/bindings/pydrake/test/memory_leak_test.py
@@ -21,6 +21,7 @@ from pydrake.systems.primitives import ConstantVectorSource
 
 from pydrake.common import RandomGenerator
 from pydrake.common.schema import Rotation, Transform
+from pydrake.common.test_utilities.memory_test_util import actual_ref_count
 from pydrake.lcm import DrakeLcmParams
 from pydrake.geometry import Meshcat
 from pydrake.manipulation import ApplyDriverConfigs, IiwaDriver
@@ -96,6 +97,7 @@ def _report_sentinels(sentinels, message: str):
         finalizer = sentinel.finalizer
         print(f"sentinel alive? {finalizer.alive}")
         if finalizer.alive:
+            print(f"ref_count: {actual_ref_count(finalizer.peek()[0])}")
             o = finalizer.peek()[0]
             is_tracked = gc.is_tracked(o)
             print(f"is_tracked: {is_tracked}")


### PR DESCRIPTION
Move a quirky, but useful piece of memory test code to infrastructure, so it can be more easily reused.

This is progress toward fine-tuning pydrake object lifetimes, so they neither leak, nor get finalized too early.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22126)
<!-- Reviewable:end -->
