### PR TITLE
[pydrake] Make controllers test harder to pass

### DIFF
--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -1,3 +1,4 @@
+import gc
 import math
 import unittest
 
@@ -276,6 +277,7 @@ class TestControllers(unittest.TestCase):
             return diagram
 
         diagram = make_diagram()
+        gc.collect()
         # N.B. Without the workaround for #14355, we get a segfault when
         # creating the context.
         context = diagram.CreateDefaultContext()


### PR DESCRIPTION
In anticipation of removing the object immortality workaround, add explicit garbage collection to a test that is likely to fail if subsequent fixes don't have adequate object lifetimes.

In the current regime, the objects in question are still immortal, so the test will still succeed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22127)
<!-- Reviewable:end -->
