### PR TITLE
[systems] Add diagram life support

### DIFF
--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1431,6 +1431,10 @@ Diagram<T>::ConvertScalarType() const {
   // Move the new systems into the blueprint.
   blueprint->systems = std::move(new_systems);
 
+  // Do nothing about life_support. Since scalar conversion is effectively a
+  // deep copy, the lifetime extensions provided by life_support are not needed
+  // here.
+
   return blueprint;
 }
 
@@ -1551,6 +1555,7 @@ void Diagram<T>::Initialize(std::unique_ptr<Blueprint> blueprint) {
   connection_map_ = std::move(blueprint->connection_map);
   output_port_ids_ = std::move(blueprint->output_port_ids);
   registered_systems_ = std::move(blueprint->systems);
+  life_support_ = std::move(blueprint->life_support);
 
   // This cache entry just maintains temporary storage. It is only ever used
   // by DoCalcNextUpdateTime(). Since this declaration of the cache entry

--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -681,6 +681,7 @@ std::unique_ptr<typename Diagram<T>::Blueprint> DiagramBuilder<T>::Compile() {
   blueprint->output_port_names = output_port_names_;
   blueprint->connection_map = connection_map_;
   blueprint->systems = std::move(registered_systems_);
+  blueprint->life_support = std::move(life_support_);
 
   already_built_ = true;
 

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -467,6 +467,14 @@ class DiagramBuilder {
   /// as more ports are exported.
   int num_output_ports() const;
 
+  /// (Internal use only). Returns a mutable reference to life support data for
+  /// the diagram. The data will be moved to the diagram at Build() time. Data
+  /// stored here will have a life-cycle that is the union of the builder and
+  /// the diagram.
+  internal::DiagramLifeSupport& get_mutable_life_support() {
+    return life_support_;
+  }
+
  private:
   // Declares a new input to the entire Diagram, using @p model_input to
   // supply the data type. @p name is an optional name for the input port; if
@@ -533,6 +541,8 @@ class DiagramBuilder {
   std::unordered_set<const System<T>*> systems_;
   // The Systems in this DiagramBuilder, in the order they were registered.
   internal::OwnedSystems<T> registered_systems_;
+
+  internal::DiagramLifeSupport life_support_;
 };
 
 }  // namespace systems

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -4084,6 +4084,35 @@ GTEST_TEST(ImplicitTimeDerivatives, DiagramProcessing) {
   EXPECT_EQ(residual, expected_result);
 }
 
+// Life support data has a lifetime that is the union of the builder and the
+// resulting diagram.
+GTEST_TEST(LifeSupport, Lifetime) {
+  std::weak_ptr<int> spy;
+  {
+    auto do_build = [&]() {
+      auto thing = std::make_shared<int>(42);
+      spy = thing;
+      DiagramBuilder<double> builder;
+      builder.get_mutable_life_support().attributes.emplace("thing",
+                                                            std::move(thing));
+      // Thing is living inside builder.
+      EXPECT_FALSE(builder.get_mutable_life_support().attributes.empty());
+      EXPECT_FALSE(spy.expired());
+      builder.AddSystem<EmptySystem<double>>();
+      auto result = builder.Build();
+      // Thing has been transferred to diagram.
+      EXPECT_TRUE(builder.get_mutable_life_support().attributes.empty());
+      EXPECT_FALSE(spy.expired());
+      return result;
+    };
+    auto diagram = do_build();
+    // Builder is gone; thing remains.
+    EXPECT_FALSE(spy.expired());
+  }
+  // Diagram is gone; thing is now also gone.
+  EXPECT_TRUE(spy.expired());
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
This patch adds an internal properties interface that allows arbitrary objects to track the lifetime of systems that get transferred from a diagram builder to a diagram.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22132)
<!-- Reviewable:end -->
