### PR TITLE
Revert "Parallelize the generic method for checking boundedness of a convex set."

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -109,9 +109,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module m) {
             cls_doc.ambient_dimension.doc)
         .def("IntersectsWith", &ConvexSet::IntersectsWith, py::arg("other"),
             cls_doc.IntersectsWith.doc)
-        .def("IsBounded", &ConvexSet::IsBounded,
-            py::arg("parallelism") = Parallelism::None(),
-            py::call_guard<py::gil_scoped_release>(), cls_doc.IsBounded.doc)
+        .def("IsBounded", &ConvexSet::IsBounded, cls_doc.IsBounded.doc)
         .def("IsEmpty", &ConvexSet::IsEmpty, cls_doc.IsEmpty.doc)
         .def("MaybeGetPoint", &ConvexSet::MaybeGetPoint,
             cls_doc.MaybeGetPoint.doc)

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -6,7 +6,7 @@ import copy
 
 import numpy as np
 
-from pydrake.common import RandomGenerator, temp_directory, Parallelism
+from pydrake.common import RandomGenerator, temp_directory
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.geometry import (
@@ -456,7 +456,6 @@ class TestGeometryOptimization(unittest.TestCase):
         self.assertFalse(s.IsEmpty())
         self.assertFalse(s.MaybeGetFeasiblePoint() is None)
         self.assertTrue(s.PointInSet(s.MaybeGetFeasiblePoint()))
-        self.assertTrue(s.IsBounded(Parallelism.Max()))
 
     def test_v_polytope(self):
         mut.VPolytope()

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -95,7 +95,6 @@ drake_cc_library(
         "//solvers:mosek_solver",
         "//solvers:scs_solver",
         "//solvers:solve",
-        "@common_robotics_utilities",
         "@qhull_internal//:qhull",
     ],
 )
@@ -537,7 +536,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "intersection_test",
-    num_threads = 2,
     deps = [
         ":convex_set",
         ":test_utilities",
@@ -614,7 +612,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "spectrahedron_test",
-    num_threads = 2,
     deps = [
         ":convex_set",
         "//common/test_utilities:eigen_matrix_compare",

--- a/geometry/optimization/affine_ball.cc
+++ b/geometry/optimization/affine_ball.cc
@@ -94,10 +94,6 @@ double AffineBall::DoCalcVolume() const {
          std::abs(B_.determinant());
 }
 
-std::optional<bool> AffineBall::DoIsBoundedShortcut() const {
-  return true;
-}
-
 AffineBall AffineBall::MakeAxisAligned(
     const Eigen::Ref<const VectorXd>& radius,
     const Eigen::Ref<const VectorXd>& center) {

--- a/geometry/optimization/affine_ball.h
+++ b/geometry/optimization/affine_ball.h
@@ -118,17 +118,11 @@ class AffineBall final : public ConvexSet {
     CheckInvariants();
   }
 
-  /** Every AffineBall is bounded by construction.
-  @param parallelism Ignored -- no parallelization is used.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
   /* AffineBall can only represent bounded sets. */
-  std::optional<bool> DoIsBoundedShortcut() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final { return true; };
 
   /* AffineBall can only represent nonempty sets. */
   bool DoIsEmpty() const final { return false; };

--- a/geometry/optimization/affine_subspace.h
+++ b/geometry/optimization/affine_subspace.h
@@ -144,13 +144,6 @@ class AffineSubspace final : public ConvexSet {
   to this AffineSubspace.*/
   Eigen::MatrixXd OrthogonalComplementBasis() const;
 
-  /** An AffineSubspace is bounded if and only if it is zero-dimensional (i.e.,
-  a point).
-  @param parallelism Ignored -- no parallelization is used.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 

--- a/geometry/optimization/cartesian_product.cc
+++ b/geometry/optimization/cartesian_product.cc
@@ -132,11 +132,10 @@ std::unique_ptr<ConvexSet> CartesianProduct::DoClone() const {
   return std::make_unique<CartesianProduct>(*this);
 }
 
-std::optional<bool> CartesianProduct::DoIsBoundedShortcutParallel(
-    Parallelism parallelism) const {
+std::optional<bool> CartesianProduct::DoIsBoundedShortcut() const {
   // Note: The constructor enforces that A_ is full column rank.
   for (const auto& s : sets_) {
-    if (!s->IsBounded(parallelism)) {
+    if (!s->IsBounded()) {
       return false;
     }
   }

--- a/geometry/optimization/cartesian_product.h
+++ b/geometry/optimization/cartesian_product.h
@@ -90,19 +90,10 @@ class CartesianProduct final : public ConvexSet {
   product. */
   using ConvexSet::CalcVolume;
 
-  /** A CartesianProduct is bounded if and only if each constituent set is
-  bounded. This class honors requests for parallelism only so far as its
-  constituent sets do.
-  @param parallelism The maximum number of threads to use.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  std::optional<bool> DoIsBoundedShortcutParallel(
-      Parallelism parallelism) const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/convex_hull.cc
+++ b/geometry/optimization/convex_hull.cc
@@ -82,14 +82,8 @@ std::unique_ptr<ConvexSet> ConvexHull::DoClone() const {
   return std::make_unique<ConvexHull>(*this);
 }
 
-std::optional<bool> ConvexHull::DoIsBoundedShortcutParallel(
-    Parallelism parallelism) const {
-  for (const auto& s : sets_) {
-    if (!s->IsBounded(parallelism)) {
-      return false;
-    }
-  }
-  return true;
+std::optional<bool> ConvexHull::DoIsBoundedShortcut() const {
+  return std::nullopt;
 }
 
 bool ConvexHull::DoIsEmpty() const {

--- a/geometry/optimization/convex_hull.h
+++ b/geometry/optimization/convex_hull.h
@@ -64,19 +64,10 @@ class ConvexHull final : public ConvexSet, private ShapeReifier {
   /** @throws  Not implemented. */
   using ConvexSet::CalcVolume;
 
-  /** A ConvexHull is bounded if and only if each constituent set is bounded.
-  This class honors requests for parallelism only so far as its constituent sets
-  do.
-  @param parallelism The maximum number of threads to use.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  std::optional<bool> DoIsBoundedShortcutParallel(
-      Parallelism parallelism) const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -1,19 +1,14 @@
 #include "drake/geometry/optimization/convex_set.h"
 
 #include <algorithm>
-#include <atomic>
 #include <limits>
 #include <memory>
-
-#include <common_robotics_utilities/parallelism.hpp>
 
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/geometry/optimization/hyperrectangle.h"
 #include "drake/math/matrix_util.h"
-#include "drake/solvers/choose_best_solver.h"
 #include "drake/solvers/solution_result.h"
 #include "drake/solvers/solve.h"
-#include "drake/solvers/solver_interface.h"
 
 namespace drake {
 namespace geometry {
@@ -24,14 +19,14 @@ using solvers::Binding;
 using solvers::Constraint;
 using solvers::LinearCost;
 using solvers::MathematicalProgram;
-using solvers::MathematicalProgramResult;
 using solvers::SolutionResult;
 using solvers::VariableRefList;
 using solvers::VectorXDecisionVariable;
 
 namespace {
 
-bool SolverReturnedWithoutError(const MathematicalProgramResult& result) {
+bool SolverReturnedWithoutError(
+    const solvers::MathematicalProgramResult& result) {
   const SolutionResult status = result.get_solution_result();
   return status == SolutionResult::kSolutionFound ||
          status == SolutionResult::kInfeasibleConstraints ||
@@ -55,142 +50,15 @@ bool ConvexSet::IntersectsWith(const ConvexSet& other) const {
   if (ambient_dimension() == 0) {
     return !other.IsEmpty() && !this->IsEmpty();
   }
-  MathematicalProgram prog{};
+  solvers::MathematicalProgram prog{};
   const auto& x = prog.NewContinuousVariables(this->ambient_dimension(), "x");
   this->AddPointInSetConstraints(&prog, x);
   other.AddPointInSetConstraints(&prog, x);
-  MathematicalProgramResult result = solvers::Solve(prog);
+  solvers::MathematicalProgramResult result = solvers::Solve(prog);
   return result.is_success();
 }
 
-namespace {
-using common_robotics_utilities::parallelism::DegreeOfParallelism;
-using common_robotics_utilities::parallelism::ParallelForBackend;
-using common_robotics_utilities::parallelism::StaticParallelForIndexLoop;
-
-void ConstructEmptyBoundednessProgram(MathematicalProgram* prog,
-                                      const ConvexSet& s) {
-  // Creates a MathematicalProgram that can be used to check if a ConvexSet is
-  // bounded along a certain direction. The direction should be specified after
-  // the program has been constructed, by modifying the coefficients of the
-  // (only) LinearCost in the program.
-  const int n = s.ambient_dimension();
-
-  DRAKE_DEMAND(prog != nullptr);
-  DRAKE_DEMAND(prog->num_vars() == 0);
-
-  VectorXDecisionVariable x = prog->NewContinuousVariables(n, "x");
-  s.AddPointInSetConstraints(prog, x);
-  VectorXd objective_vector = VectorXd::Zero(n);
-  prog->AddLinearCost(objective_vector, x);
-}
-
-bool ProgramResultImpliesUnbounded(const MathematicalProgramResult& result) {
-  return result.get_solution_result() == solvers::SolutionResult::kUnbounded ||
-         result.get_solution_result() ==
-             solvers::SolutionResult::kInfeasibleOrUnbounded ||
-         result.get_solution_result() ==
-             solvers::SolutionResult::kDualInfeasible;
-}
-
-bool IsBoundedSequential(const ConvexSet& s) {
-  // Let a variable x be contained in the convex set. Iteratively try to
-  // minimize or maximize x[i] for each dimension i. If any solves are
-  // unbounded, the set is not bounded.
-  MathematicalProgram prog;
-  ConstructEmptyBoundednessProgram(&prog, s);
-
-  VectorXd objective_vector = VectorXd::Zero(s.ambient_dimension());
-  for (int i = 0; i < s.ambient_dimension(); ++i) {
-    for (bool maximize : {true, false}) {
-      objective_vector[i] = maximize ? -1 : 1;
-      prog.linear_costs()[0].evaluator()->UpdateCoefficients(objective_vector);
-      // TODO(cohnt): Directly modify the cost's internally held coefficients,
-      // once that functionality is available. (#22131)
-      const auto result = solvers::Solve(prog);
-      if (ProgramResultImpliesUnbounded(result)) {
-        return false;
-      }
-      objective_vector[i] = 0;
-    }
-  }
-  return true;
-}
-
-bool IsBoundedParallel(const ConvexSet& s, Parallelism parallelism) {
-  // Pre-allocate programs (which will be updated and solved within the parallel
-  // loop).
-  std::vector<MathematicalProgram> progs(parallelism.num_threads());
-  for (int i = 0; i < ssize(progs); ++i) {
-    ConstructEmptyBoundednessProgram(&(progs[i]), s);
-  }
-
-  // Pre-allocate empty MathematicalProgramResults for each thread.
-  std::vector<MathematicalProgramResult> results(parallelism.num_threads());
-
-  // Pre-allocate solver instances.
-  const solvers::SolverId solver_id = solvers::ChooseBestSolver(progs[0]);
-  std::vector<std::unique_ptr<solvers::SolverInterface>> solver_interfaces(
-      parallelism.num_threads());
-
-  // Pre-allocate the solver options.
-  std::vector<solvers::SolverOptions> options(parallelism.num_threads());
-
-  // Pre-allocate the objective vectors, initially filling them with all zeros.
-  std::vector<VectorXd> objective_vectors(
-      parallelism.num_threads(), VectorXd::Zero(s.ambient_dimension()));
-
-  for (int i = 0; i < parallelism.num_threads(); ++i) {
-    solver_interfaces[i] = solvers::MakeSolver(solver_id);
-    options[i].SetOption(solvers::CommonSolverOption::kMaxThreads, 1);
-  }
-
-  std::atomic<bool> certified_unbounded = false;
-
-  // This worker lambda maps the index i to a dimension and direction to check
-  // boundedness. If unboundedness has already been verified, it just exits
-  // early. If unboundedness is verified in this iteration, certified_unbounded
-  // will be updated to reflect that fact. For a given index i, the dimension is
-  // int(i / 2), and if i % 2 == 0, then we maximize, otherwise, we minimize.
-  auto solve_ith = [&](const int thread_num, const int64_t i) {
-    if (certified_unbounded.load()) {
-      return;
-    }
-
-    const int dimension = i / 2;
-    bool maximize = i % 2 == 0;
-
-    // Update the objective vector.
-    objective_vectors[thread_num][dimension] = maximize ? -1 : 1;
-
-    // By construction, each MathematicalProgram has one cost (the linear cost).
-    progs[thread_num].linear_costs()[0].evaluator()->UpdateCoefficients(
-        objective_vectors[thread_num]);
-    // TODO(cohnt): Directly modify the cost's internally held coefficients,
-    // once that functionality is available. (#22131)
-    solver_interfaces[thread_num]->Solve(progs[thread_num], std::nullopt,
-                                         options[thread_num],
-                                         &(results[thread_num]));
-    if (ProgramResultImpliesUnbounded(results[thread_num])) {
-      certified_unbounded.store(true);
-    }
-
-    // Reset the objective vector.
-    objective_vectors[thread_num][dimension] = 0;
-  };
-
-  // We run the loop from 0 to 2 * s.ambient_dimension(), since two programs are
-  // solved for each dimension (maximizing and minimizing). All programs are the
-  // same size, so static scheduling is appropriate.
-  StaticParallelForIndexLoop(DegreeOfParallelism(parallelism.num_threads()), 0,
-                             2 * s.ambient_dimension(), solve_ith,
-                             ParallelForBackend::BEST_AVAILABLE);
-
-  return !certified_unbounded.load();
-}
-}  // namespace
-
-bool ConvexSet::GenericDoIsBounded(Parallelism parallelism) const {
+bool ConvexSet::GenericDoIsBounded() const {
   // The empty set is bounded. We check it first, to ensure that the program
   // is feasible, so SolutionResult::kInfeasibleOrUnbounded or
   // SolutionResult::kDualInfeasible indicates unbounded, as solvers may not
@@ -198,12 +66,42 @@ bool ConvexSet::GenericDoIsBounded(Parallelism parallelism) const {
   if (IsEmpty()) {
     return true;
   }
+  // Let a variable x be contained in the convex set. Iteratively try to
+  // minimize or maximize x[i] for each dimension i. If any solves are
+  // unbounded, the set is not bounded.
+  MathematicalProgram prog;
+  VectorXDecisionVariable x =
+      prog.NewContinuousVariables(ambient_dimension(), "x");
+  AddPointInSetConstraints(&prog, x);
+  Binding<LinearCost> objective =
+      prog.AddLinearCost(VectorXd::Zero(ambient_dimension()), x);
 
-  if (parallelism.num_threads() == 1) {
-    return IsBoundedSequential(*this);
-  } else {
-    return IsBoundedParallel(*this, parallelism);
+  VectorXd objective_vector(ambient_dimension());
+  for (int i = 0; i < ambient_dimension(); ++i) {
+    objective_vector.setZero();
+    objective_vector[i] = 1;
+    objective.evaluator()->UpdateCoefficients(objective_vector);
+    const auto result = solvers::Solve(prog);
+    if (result.get_solution_result() == solvers::SolutionResult::kUnbounded ||
+        result.get_solution_result() ==
+            solvers::SolutionResult::kInfeasibleOrUnbounded ||
+        result.get_solution_result() ==
+            solvers::SolutionResult::kDualInfeasible) {
+      return false;
+    }
+
+    objective_vector[i] = -1;
+    objective.evaluator()->UpdateCoefficients(objective_vector);
+    const auto result2 = solvers::Solve(prog);
+    if (result2.get_solution_result() == solvers::SolutionResult::kUnbounded ||
+        result2.get_solution_result() ==
+            solvers::SolutionResult::kInfeasibleOrUnbounded ||
+        result2.get_solution_result() ==
+            solvers::SolutionResult::kDualInfeasible) {
+      return false;
+    }
   }
+  return true;
 }
 
 std::optional<std::pair<std::vector<double>, Eigen::MatrixXd>>
@@ -336,7 +234,7 @@ bool ConvexSet::DoIsEmpty() const {
     // required, to ensure AddPointInSetConstraints is not called for a zero
     // dimensional set -- this would throw an error.
   }
-  MathematicalProgram prog;
+  solvers::MathematicalProgram prog;
   auto point = prog.NewContinuousVariables(ambient_dimension());
   AddPointInSetConstraints(&prog, point);
   auto result = solvers::Solve(prog);
@@ -362,7 +260,7 @@ std::optional<Eigen::VectorXd> ConvexSet::DoMaybeGetPoint() const {
 
 std::optional<Eigen::VectorXd> ConvexSet::DoMaybeGetFeasiblePoint() const {
   DRAKE_DEMAND(ambient_dimension() > 0);
-  MathematicalProgram prog;
+  solvers::MathematicalProgram prog;
   auto point = prog.NewContinuousVariables(ambient_dimension());
   AddPointInSetConstraints(&prog, point);
   auto result = solvers::Solve(prog);
@@ -402,7 +300,7 @@ bool ConvexSet::GenericDoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
 std::pair<VectorX<symbolic::Variable>,
           std::vector<solvers::Binding<solvers::Constraint>>>
 ConvexSet::AddPointInSetConstraints(
-    MathematicalProgram* prog,
+    solvers::MathematicalProgram* prog,
     const Eigen::Ref<const solvers::VectorXDecisionVariable>& vars) const {
   DRAKE_THROW_UNLESS(vars.size() == ambient_dimension());
   DRAKE_THROW_UNLESS(ambient_dimension() > 0);
@@ -411,7 +309,7 @@ ConvexSet::AddPointInSetConstraints(
 
 std::vector<solvers::Binding<solvers::Constraint>>
 ConvexSet::AddPointInNonnegativeScalingConstraints(
-    MathematicalProgram* prog,
+    solvers::MathematicalProgram* prog,
     const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
     const symbolic::Variable& t) const {
   DRAKE_THROW_UNLESS(ambient_dimension() > 0);
@@ -425,7 +323,8 @@ ConvexSet::AddPointInNonnegativeScalingConstraints(
 
 std::vector<solvers::Binding<solvers::Constraint>>
 ConvexSet::AddPointInNonnegativeScalingConstraints(
-    MathematicalProgram* prog, const Eigen::Ref<const Eigen::MatrixXd>& A,
+    solvers::MathematicalProgram* prog,
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
     const Eigen::Ref<const Eigen::VectorXd>& b,
     const Eigen::Ref<const Eigen::VectorXd>& c, double d,
     const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
@@ -444,7 +343,7 @@ ConvexSet::AddPointInNonnegativeScalingConstraints(
 
 std::optional<symbolic::Variable>
 ConvexSet::HandleZeroAmbientDimensionConstraints(
-    MathematicalProgram* prog, const ConvexSet& set,
+    solvers::MathematicalProgram* prog, const ConvexSet& set,
     std::vector<solvers::Binding<solvers::Constraint>>* constraints) const {
   if (set.IsEmpty()) {
     drake::log()->warn(

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -8,7 +8,6 @@
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/parallelism.h"
 #include "drake/common/reset_after_move.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/query_object.h"
@@ -91,30 +90,18 @@ class ConvexSet {
 
   /** Returns true iff the set is bounded, e.g., there exists an element-wise
   finite lower and upper bound for the set.  Note: for some derived classes,
-  this check is trivial, but for others it can require solving a number of
-  (typically small) optimization problems. Each derived class documents the cost
-  of its boundedness test and whether it honors the request for parallelism.
-  (Derived classes which do not have a specialized check will, by default, honor
-  parallelism requests.) Note that the overhead of multithreading may lead to
-  slower runtimes for simple, low-dimensional sets, but can enable major
-  speedups for more challenging problems.
-
-  @param parallelism requests the number of cores to use when solving
-  mathematical programs to check boundedness, subject to whether a particular
-  derived class honors parallelism. */
-  bool IsBounded(Parallelism parallelism = Parallelism::None()) const {
+  this check is trivial, but for others it can require solving an (typically
+  small) optimization problem. Check the derived class documentation for any
+  notes. */
+  bool IsBounded() const {
     if (ambient_dimension() == 0) {
       return true;
     }
-    auto shortcut_result = DoIsBoundedShortcutParallel(parallelism);
+    const auto shortcut_result = DoIsBoundedShortcut();
     if (shortcut_result.has_value()) {
       return shortcut_result.value();
     }
-    shortcut_result = DoIsBoundedShortcut();
-    if (shortcut_result.has_value()) {
-      return shortcut_result.value();
-    }
-    return GenericDoIsBounded(parallelism);
+    return GenericDoIsBounded();
   }
 
   /** Returns true iff the set is empty. Note: for some derived classes, this
@@ -331,15 +318,6 @@ class ConvexSet {
     return std::nullopt;
   }
 
-  /** Non-virtual interface implementation for DoIsBoundedShortcutParallel().
-  Trivially returns std::nullopt. This allows a derived class to implement its
-  own boundedness checks that leverage parallelization, to potentially avoid the
-  more expensive base class checks.
-  @pre ambient_dimension() >= 0 */
-  virtual std::optional<bool> DoIsBoundedShortcutParallel(Parallelism) const {
-    return std::nullopt;
-  }
-
   /** Non-virtual interface implementation for DoProjectionShortcut().
 
   This allows a derived class to implement a method which computes the
@@ -494,7 +472,7 @@ class ConvexSet {
  private:
   /** Generic implementation for IsBounded() -- applicable for all convex sets.
   @pre ambient_dimension() >= 0 */
-  bool GenericDoIsBounded(Parallelism parallelism) const;
+  bool GenericDoIsBounded() const;
 
   /** Generic implementation for PointInSet() -- applicable for all convex sets.
   @pre ambient_dimension() >= 0 */

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -75,11 +75,7 @@ class HPolyhedron final : public ConvexSet {
   finite lower and upper bound for the set.  For HPolyhedron, while there are
   some fast checks to confirm a set is unbounded, confirming boundedness
   requires solving a linear program (based on Stiemke’s theorem of
-  alternatives).
-  @param parallelism Ignored -- the linear program solver will determine the
-  number of threads to use.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
+  alternatives). */
   using ConvexSet::IsBounded;
 
   /** Returns true iff this HPolyhedron is entirely contained in the HPolyhedron

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -145,12 +145,6 @@ class Hyperellipsoid final : public ConvexSet {
   /** Computes the volume for the hyperellipsoid set.*/
   double Volume() const { return CalcVolume(); }
 
-  /** A Hyperellipsoid is bounded if the kernel of A is rank-zero.
-  @param parallelism Ignored -- no parallelization is used.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 

--- a/geometry/optimization/hyperrectangle.cc
+++ b/geometry/optimization/hyperrectangle.cc
@@ -98,10 +98,6 @@ std::optional<Eigen::VectorXd> Hyperrectangle::DoMaybeGetFeasiblePoint() const {
   return (ub_ + lb_) / 2.0;
 }
 
-std::optional<bool> Hyperrectangle::DoIsBoundedShortcut() const {
-  return true;
-}
-
 std::optional<bool> Hyperrectangle::DoPointInSetShortcut(
     const Eigen::Ref<const Eigen::VectorXd>& x, double tol) const {
   return (x.array() >= lb_.array() - tol).all() &&

--- a/geometry/optimization/hyperrectangle.h
+++ b/geometry/optimization/hyperrectangle.h
@@ -71,13 +71,6 @@ class Hyperrectangle final : public ConvexSet {
     CheckInvariants();
   }
 
-  /** A Hyperrectangle is always bounded, since infinite lower and upper bounds
-  are prohibited.
-  @param parallelism Ignored -- no parallelization is used.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
@@ -86,7 +79,7 @@ class Hyperrectangle final : public ConvexSet {
   bool DoIsEmpty() const final { return false; }
 
   /** We only support finite hyperrectangles */
-  std::optional<bool> DoIsBoundedShortcut() const final;
+  std::optional<bool> DoIsBoundedShortcut() const final { return true; }
 
   std::optional<Eigen::VectorXd> DoMaybeGetPoint() const final;
 

--- a/geometry/optimization/intersection.cc
+++ b/geometry/optimization/intersection.cc
@@ -55,10 +55,9 @@ std::unique_ptr<ConvexSet> Intersection::DoClone() const {
   return std::make_unique<Intersection>(*this);
 }
 
-std::optional<bool> Intersection::DoIsBoundedShortcutParallel(
-    Parallelism parallelism) const {
+std::optional<bool> Intersection::DoIsBoundedShortcut() const {
   for (const auto& s : sets_) {
-    if (s->IsBounded(parallelism)) {
+    if (s->IsBounded()) {
       return true;
     }
   }

--- a/geometry/optimization/intersection.h
+++ b/geometry/optimization/intersection.h
@@ -45,19 +45,10 @@ class Intersection final : public ConvexSet {
   /** @throws  Not implemented. */
   using ConvexSet::CalcVolume;
 
-  /** An Intersection is bounded if all its constituent sets are bounded. If any
-  are unbounded, the generic method for checking boundedness is used. This class
-  honors requests for parallelism only so far as its constituent sets do.
-  @param parallelism The maximum number of threads to use.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  std::optional<bool> DoIsBoundedShortcutParallel(
-      Parallelism parallelism) const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -99,13 +99,9 @@ std::unique_ptr<ConvexSet> MinkowskiSum::DoClone() const {
   return std::make_unique<MinkowskiSum>(*this);
 }
 
-std::optional<bool> MinkowskiSum::DoIsBoundedShortcutParallel(
-    Parallelism parallelism) const {
-  if (IsEmpty()) {
-    return true;
-  }
+std::optional<bool> MinkowskiSum::DoIsBoundedShortcut() const {
   for (const auto& s : sets_) {
-    if (!s->IsBounded(parallelism)) {
+    if (!s->IsBounded()) {
       return false;
     }
   }

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -63,19 +63,10 @@ class MinkowskiSum final : public ConvexSet {
   */
   using ConvexSet::PointInSet;
 
-  /** A MinkowskiSum is bounded if all its constituent sets are bounded or if
-  any are empty. This class honors requests for parallelism only so far as its
-  constituent sets do.
-  @param parallelism The maximum number of threads to use.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  std::optional<bool> DoIsBoundedShortcutParallel(
-      Parallelism parallelism) const final;
+  std::optional<bool> DoIsBoundedShortcut() const final;
 
   bool DoIsEmpty() const final;
 

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -48,12 +48,6 @@ class Point final : public ConvexSet {
   @pre x must be of size ambient_dimension(). */
   void set_x(const Eigen::Ref<const Eigen::VectorXd>& x);
 
-  /** Every Point is bounded by construction.
-  @param parallelism Ignored -- no parallelization is used.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 

--- a/geometry/optimization/spectrahedron.h
+++ b/geometry/optimization/spectrahedron.h
@@ -43,18 +43,9 @@ class Spectrahedron final : public ConvexSet {
   /** @throws  Not implemented. */
   using ConvexSet::CalcVolume;
 
-  /** Spectrahedron uses the generic method for boundedness checking, which uses
-  `parallelism`.
-  @param parallelism The maximum number of threads to use.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 
-  /* We only use DoIsBoundedShortcut here to avoid an edge case that causes an
-  error with the CSDP solver (#19927). */
   std::optional<bool> DoIsBoundedShortcut() const final;
 
   // N.B. No need to override DoMaybeGetPoint here.

--- a/geometry/optimization/test/convex_hull_test.cc
+++ b/geometry/optimization/test/convex_hull_test.cc
@@ -217,36 +217,6 @@ GTEST_TEST(ConvexHullTest, AddPointInNonnegativeScalingConstraints2) {
   EXPECT_TRUE(CompareMatrices(t_sol, 0.2 / 3 * Eigen::Vector3d::Ones(), 1e-6));
 }
 
-GTEST_TEST(ConvexHullTest, BoundedTest) {
-  HPolyhedron H1 = HPolyhedron::MakeL1Ball(3);
-  HPolyhedron H2 =
-      HPolyhedron(-Eigen::Matrix3d::Identity(), Eigen::Vector3d{1, 1, 1});
-  ConvexHull C1(MakeConvexSets(H1, H2));
-
-  EXPECT_FALSE(C1.IsBounded(Parallelism::None()));
-  EXPECT_FALSE(C1.IsBounded(Parallelism::Max()));
-
-  ConvexHull C2(MakeConvexSets(H1, H1));
-  EXPECT_TRUE(C2.IsBounded(Parallelism::None()));
-  EXPECT_TRUE(C2.IsBounded(Parallelism::Max()));
-
-  // Check a high dimensional example.
-  HPolyhedron H3 = HPolyhedron::MakeUnitBox(100);
-  Eigen::MatrixXd A = H3.A();
-  Eigen::VectorXd b = H3.b();
-
-  ASSERT_EQ(A.rows(), 200);
-  HPolyhedron H4(A.topRows(199), b.head(199));
-
-  ConvexHull C3(MakeConvexSets(H3, H3));  // bounded
-  ConvexHull C4(MakeConvexSets(H3, H4));  // unbounded
-
-  EXPECT_TRUE(C3.IsBounded(Parallelism::Max()));
-  EXPECT_FALSE(C4.IsBounded(Parallelism::Max()));
-
-  // See also intersection_test.cc for more extensive testing.
-}
-
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/test/intersection_test.cc
+++ b/geometry/optimization/test/intersection_test.cc
@@ -57,8 +57,7 @@ GTEST_TEST(IntersectionTest, BasicTest) {
   }
 
   // Test IsBounded.
-  EXPECT_TRUE(S.IsBounded(Parallelism::None()));
-  EXPECT_TRUE(S.IsBounded(Parallelism::Max()));
+  EXPECT_TRUE(S.IsBounded());
 
   // Test IsEmpty
   EXPECT_FALSE(S.IsEmpty());
@@ -96,8 +95,7 @@ GTEST_TEST(IntersectionTest, DefaultCtor) {
   EXPECT_NO_THROW(dut.Clone());
   EXPECT_EQ(dut.ambient_dimension(), 0);
   EXPECT_TRUE(dut.IntersectsWith(dut));
-  EXPECT_TRUE(dut.IsBounded(Parallelism::None()));
-  EXPECT_TRUE(dut.IsBounded(Parallelism::Max()));
+  EXPECT_TRUE(dut.IsBounded());
   EXPECT_FALSE(dut.IsEmpty());
   EXPECT_TRUE(dut.MaybeGetPoint().has_value());
   EXPECT_TRUE(dut.PointInSet(Eigen::VectorXd::Zero(0)));
@@ -143,12 +141,10 @@ GTEST_TEST(IntersectionTest, BoundedTest) {
 
   EXPECT_FALSE(H1.IsBounded());
   EXPECT_FALSE(H2.IsBounded());
-  EXPECT_TRUE(S1.IsBounded(Parallelism::None()));
-  EXPECT_TRUE(S1.IsBounded(Parallelism::Max()));
+  EXPECT_TRUE(S1.IsBounded());
 
   Intersection S2(H1, H1);
-  EXPECT_FALSE(S2.IsBounded(Parallelism::None()));
-  EXPECT_FALSE(S2.IsBounded(Parallelism::Max()));
+  EXPECT_FALSE(S2.IsBounded());
 }
 
 GTEST_TEST(IntersectionTest, CloneTest) {
@@ -285,36 +281,6 @@ GTEST_TEST(IntersectionTest, EmptyInput) {
   const VPolytope V = VPolytope(vertices);
   Intersection S(P, V);
   EXPECT_TRUE(S.IsEmpty());
-}
-
-GTEST_TEST(IntersectionTest, BoundedTest2) {
-  // A higher-dimensional, more complicated boundedness check that can't use the
-  // shortcut, since both constituent sets are unbounded. Note that this is
-  // implicitly testing ConvexSet::GenericDoIsBounded, since we can't easily
-  // test that functionality in convex_set_test.cc.
-  HPolyhedron l1 = HPolyhedron::MakeUnitBox(100);
-  Eigen::MatrixXd A = l1.A();
-  Eigen::VectorXd b = l1.b();
-
-  // Put half of the rows in one HPolyhedron, and the other half in another.
-  // Also make a variant where one row is skipped, to make it unbounded. Because
-  // each of these three sets are unbounded, the shortcut boundedness check
-  // cannot be called, so the generic check has to be performed. Note: we cannot
-  // guarantee that we've fallen back to the GenericDoIsBounded method, or that
-  // multiple threads are actually being used by that method.
-  ASSERT_EQ(A.rows(), 200);
-  HPolyhedron half1(A.topRows(100), b.head(100));
-  HPolyhedron half2(A.bottomRows(100), b.tail(100));
-  HPolyhedron half2_unbounded(A.bottomRows(99), b.tail(99));
-
-  // Cross-check that our BUILD file allows parallelism.
-  DRAKE_DEMAND(Parallelism::Max().num_threads() > 1);
-
-  Intersection bounded(half1, half2);
-  Intersection unbounded(half1, half2_unbounded);
-
-  EXPECT_TRUE(bounded.IsBounded(Parallelism::Max()));
-  EXPECT_FALSE(unbounded.IsBounded(Parallelism::Max()));
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/minkowski_sum_test.cc
+++ b/geometry/optimization/test/minkowski_sum_test.cc
@@ -301,26 +301,6 @@ GTEST_TEST(MinkowskiSumTest, EmptyInput) {
   EXPECT_FALSE(S.MaybeGetFeasiblePoint().has_value());
 }
 
-GTEST_TEST(MinkowskiSumTest, EmptyAndUnboundedSets) {
-  // If a MinkowskiSum has a constituent set which is empty and another which is
-  // unbounded, the whole set is empty.
-
-  // Create a HPolyhedron in ℝ^1 with no inequalities (so it's unbounded).
-  Eigen::Matrix<double, 0, 1> A1;
-  Eigen::Vector<double, 0> b1;
-  HPolyhedron h1(A1, b1);
-
-  // Create an HPolyhedron in ℝ^1 with x1 <= -1 and -x1 <= 0 (so it's empty).
-  Eigen::Matrix<double, 2, 1> A2;
-  A2 << 1, -1;
-  Eigen::Vector2d b2(-1, 0);
-  HPolyhedron h2(A2, b2);
-
-  MinkowskiSum m(h1, h2);
-  EXPECT_TRUE(m.IsEmpty());
-  EXPECT_TRUE(m.IsBounded());
-}
-
 }  // namespace optimization
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/optimization/test/spectrahedron_test.cc
+++ b/geometry/optimization/test/spectrahedron_test.cc
@@ -64,13 +64,8 @@ GTEST_TEST(SpectrahedronTest, TrivialSdp1) {
 
   Spectrahedron spect(prog);
   EXPECT_EQ(spect.ambient_dimension(), 3 * (3 + 1) / 2);
+  EXPECT_TRUE(spect.IsBounded());
   EXPECT_FALSE(spect.IsEmpty());
-
-  // Cross-check that our BUILD file allows parallelism.
-  DRAKE_DEMAND(Parallelism::Max().num_threads() > 1);
-
-  EXPECT_TRUE(spect.IsBounded(Parallelism::None()));
-  EXPECT_TRUE(spect.IsBounded(Parallelism::Max()));
 
   const double kTol{1e-6};
   EXPECT_TRUE(spect.PointInSet(x_star, kTol));
@@ -332,36 +327,31 @@ GTEST_TEST(SpectrahedronTest, UnboundedTest) {
   auto X1 = prog.NewSymmetricContinuousVariables<2>();
   prog.AddPositiveSemidefiniteConstraint(X1);
   Spectrahedron spect(prog);
-  EXPECT_FALSE(spect.IsBounded(Parallelism::None()));
-  EXPECT_FALSE(spect.IsBounded(Parallelism::Max()));
+  EXPECT_FALSE(spect.IsBounded());
 
   // Construct an unbounded but constrained SDP, and check that IsBounded
   // notices.
   prog.AddLinearConstraint(X1(0, 0) >= 0);
   Spectrahedron spect2(prog);
-  EXPECT_FALSE(spect2.IsBounded(Parallelism::None()));
-  EXPECT_FALSE(spect2.IsBounded(Parallelism::Max()));
+  EXPECT_FALSE(spect2.IsBounded());
 
   // Add more constraints that keep the program unbounded
   prog.AddLinearConstraint(X1(0, 0) == X1(1, 1));
   prog.AddLinearConstraint(X1(0, 1) >= 1);
   Spectrahedron spect3(prog);
-  EXPECT_FALSE(spect3.IsBounded(Parallelism::None()));
-  EXPECT_FALSE(spect3.IsBounded(Parallelism::Max()));
+  EXPECT_FALSE(spect3.IsBounded());
 
   // Add a constraint that makes the program bounded
   prog.AddLinearConstraint(X1(0, 0) + X1(0, 1) + X1(1, 1) <= 43);
   Spectrahedron spect4(prog);
-  EXPECT_TRUE(spect4.IsBounded(Parallelism::None()));
-  EXPECT_TRUE(spect4.IsBounded(Parallelism::Max()));
+  EXPECT_TRUE(spect4.IsBounded());
 
   // Add a constraint that makes the program infeasible (the empty
   // set is bounded)
   prog.AddLinearConstraint(X1(0, 0) >= 50);
   Spectrahedron spect5(prog);
   EXPECT_TRUE(spect5.IsEmpty());
-  EXPECT_TRUE(spect5.IsBounded(Parallelism::None()));
-  EXPECT_TRUE(spect5.IsBounded(Parallelism::Max()));
+  EXPECT_TRUE(spect5.IsBounded());
 }
 
 }  // namespace

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -468,12 +468,12 @@ std::unique_ptr<ConvexSet> VPolytope::DoClone() const {
   return std::make_unique<VPolytope>(*this);
 }
 
-bool VPolytope::DoIsEmpty() const {
-  return vertices_.cols() == 0;
-}
-
 std::optional<bool> VPolytope::DoIsBoundedShortcut() const {
   return true;
+}
+
+bool VPolytope::DoIsEmpty() const {
+  return vertices_.cols() == 0;
 }
 
 std::optional<VectorXd> VPolytope::DoMaybeGetPoint() const {

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -99,12 +99,6 @@ class VPolytope final : public ConvexSet {
   @note this function calls qhull to compute the volume. */
   using ConvexSet::CalcVolume;
 
-  /** Every VPolytope is bounded by construction.
-  @param parallelism Ignored -- no parallelization is used.
-  @note See @ref ConvexSet::IsBounded "parent class's documentation" for more
-  details. */
-  using ConvexSet::IsBounded;
-
  private:
   std::unique_ptr<ConvexSet> DoClone() const final;
 


### PR DESCRIPTION
Reverts RobotLocomotion/drake#22084

Dear Thomas,

 The on-call build cop, Nicole C., believes that your PR 22084 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failure under investigation is:
https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-nightly-everything-valgrind-memcheck/367/

 This is testing to see which change PR 22084 or 22117 caused the failure.
 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22135)
<!-- Reviewable:end -->
