### PR TITLE
Move the warning on small-size PSD matrix to each solver backend.

### DIFF
--- a/solvers/aggregate_costs_constraints.cc
+++ b/solvers/aggregate_costs_constraints.cc
@@ -695,6 +695,7 @@ void ParsePositiveSemidefiniteConstraints(
   DRAKE_ASSERT(psd_cone_length->empty());
   const double sqrt2 = std::sqrt(2);
   for (const auto& psd_constraint : prog.positive_semidefinite_constraints()) {
+    psd_constraint.evaluator()->WarnOnSmallMatrixSize();
     // PositiveSemidefiniteConstraint encodes the matrix X being psd.
     // We convert it to SCS/Clarabel form
     // A * x + s = 0
@@ -738,6 +739,7 @@ void ParsePositiveSemidefiniteConstraints(
   }
   for (const auto& lmi_constraint :
        prog.linear_matrix_inequality_constraints()) {
+    lmi_constraint.evaluator()->WarnOnSmallMatrixSize();
     // LinearMatrixInequalityConstraint encodes
     // F₀ + x₁*F₁ + x₂*F₂ + ... + xₙFₙ is p.s.d
     // We convert this to SCS/Clarabel form as

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -768,18 +768,6 @@ PositiveSemidefiniteConstraint::PositiveSemidefiniteConstraint(int rows)
                  Eigen::VectorXd::Constant(
                      rows, std::numeric_limits<double>::infinity())),
       matrix_rows_(rows) {
-  // TODO(hongkai.dai): remove the warning when we change the solver backend.
-  if (matrix_rows_ == 1) {
-    drake::log()->warn(
-        "PositiveSemidefiniteConstraint: rows==1, please consider "
-        "reformulating this as a linear inequality constraint for better "
-        "speed/numerics.");
-  } else if (matrix_rows_ == 2) {
-    drake::log()->warn(
-        "PositiveSemidefiniteConstraint: rows==2, please consider to "
-        "reformulating this as a rotated Lorentz cone constraint for better "
-        "speed/numerics.");
-  }
   set_is_thread_safe(true);
 }
 
@@ -823,6 +811,20 @@ std::string PositiveSemidefiniteConstraint::DoToLatex(
   return fmt::format("{} \\succeq 0", symbolic::ToLatex(S.eval(), precision));
 }
 
+void PositiveSemidefiniteConstraint::WarnOnSmallMatrixSize() const {
+  if (matrix_rows_ == 1) {
+    drake::log()->warn(
+        "PositiveSemidefiniteConstraint: rows==1, please consider "
+        "reformulating this as a linear inequality constraint for better "
+        "speed/numerics.");
+  } else if (matrix_rows_ == 2) {
+    drake::log()->warn(
+        "PositiveSemidefiniteConstraint: rows==2, please consider "
+        "reformulating this as a rotated Lorentz cone constraint for better "
+        "speed/numerics.");
+  }
+}
+
 LinearMatrixInequalityConstraint::~LinearMatrixInequalityConstraint() = default;
 
 void LinearMatrixInequalityConstraint::DoEval(
@@ -858,20 +860,6 @@ LinearMatrixInequalityConstraint::LinearMatrixInequalityConstraint(
       F_{std::move(F)},
       matrix_rows_(F_.empty() ? 0 : F_.front().rows()) {
   DRAKE_THROW_UNLESS(!F_.empty());
-  // TODO(hongkai.dai): remove the warning when we change the solver backend.
-  if (matrix_rows_ == 1) {
-    drake::log()->warn(
-        "LinearMatrixInequalityConstraint: the matrix has size 1. Please "
-        "consider"
-        "reformulating this as a linear inequality constraint for better "
-        "speed/numerics.");
-  } else if (matrix_rows_ == 2) {
-    drake::log()->warn(
-        "LinearMatrixInequalityConstraint: the matrix has size 2. Please "
-        "consider "
-        "reformulating this as a rotated Lorentz cone constraint for better "
-        "speed/numerics.");
-  }
 
   set_bounds(Eigen::VectorXd::Zero(matrix_rows_),
              Eigen::VectorXd::Constant(
@@ -890,6 +878,22 @@ std::string LinearMatrixInequalityConstraint::DoToLatex(
     S += vars(i - 1) * F_[i];
   }
   return fmt::format("{} \\succeq 0", symbolic::ToLatex(S, precision));
+}
+
+void LinearMatrixInequalityConstraint::WarnOnSmallMatrixSize() const {
+  // TODO(hongkai.dai): remove the warning when we change the solver backend.
+  if (matrix_rows_ == 1) {
+    drake::log()->warn(
+        "LinearMatrixInequalityConstraint: the matrix has size 1. Please "
+        "consider"
+        "reformulating this as a linear inequality constraint for better "
+        "speed/numerics.");
+  } else if (matrix_rows_ == 2) {
+    drake::log()->warn(
+        "LinearMatrixInequalityConstraint: the matrix has size 2. Please "
+        "consider reformulating this as a rotated Lorentz cone constraint for "
+        "better speed/numerics.");
+  }
 }
 
 ExpressionConstraint::ExpressionConstraint(

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -997,6 +997,12 @@ class PositiveSemidefiniteConstraint : public Constraint {
 
   int matrix_rows() const { return matrix_rows_; }
 
+  /**
+   * Throw a warning if the matrix size is either 1x1 or 2x2.
+   */
+  // TODO(hongkai.dai): remove the warning when we change the solver backend.
+  void WarnOnSmallMatrixSize() const;
+
  protected:
   /**
    * Evaluate the eigen values of the symmetric matrix.
@@ -1066,6 +1072,12 @@ class LinearMatrixInequalityConstraint : public Constraint {
   /// Gets the number of rows in the matrix inequality constraint. Namely
   /// Fi are all matrix_rows() x matrix_rows() matrices.
   int matrix_rows() const { return matrix_rows_; }
+
+  /**
+   * Warn if the matrix size is 1x1 or 2x2.
+   */
+  // TODO(hongkai.dai): remove the warning when we change the solver backend.
+  void WarnOnSmallMatrixSize() const;
 
  protected:
   /**

--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -839,6 +839,7 @@ MSKrescodee MosekSolverProgram::AddPositiveSemidefiniteConstraints(
   bar_var_dimension.reserve(prog.positive_semidefinite_constraints().size());
   int psd_count = 0;
   for (const auto& binding : prog.positive_semidefinite_constraints()) {
+    binding.evaluator()->WarnOnSmallMatrixSize();
     bar_var_dimension.push_back(binding.evaluator()->matrix_rows());
     psd_barvar_indices->emplace(binding, numbarvar + psd_count);
     psd_count++;
@@ -872,6 +873,7 @@ MSKrescodee MosekSolverProgram::AddLinearMatrixInequalityConstraint(
   // where A is a sparse matrix.
   std::vector<Eigen::Triplet<double>> A_triplets;
   for (const auto& binding : prog.linear_matrix_inequality_constraints()) {
+    binding.evaluator()->WarnOnSmallMatrixSize();
     // Allocate memory for A_triplets. We allocate the maximal memory by
     // assuming that A is dense.
     // TODO(hongkai.dai): change LinearMatrixInequalityConstraint::F() to return


### PR DESCRIPTION
Since I am going to change each solver (Mosek, SCS, Clarabel) such that they handle the special-case small-size PSD matrix constraint, I move the warning to each solver. So in the future when the specific solver (like MosekSolver) can handle these small-size PSD constraint, I will only remove the warning for that single solver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22136)
<!-- Reviewable:end -->
