### PR TITLE
Parallelize the Pairwise Set Intersection Checking for GCS (with or without Continuous Revolute Joints)

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -1474,7 +1474,8 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("continuous_revolute_joints"), py::arg("preprocess_bbox") = true,
       py::arg("parallelism") = Parallelism::Max(),
       doc.ComputePairwiseIntersections
-          .doc_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox_parallelism);
+          .doc_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox_parallelism,
+      py::call_guard<py::gil_scoped_release>());
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("CalcPairwiseIntersections",
@@ -1492,7 +1493,8 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("convex_sets_A"), py::arg("convex_sets_B"),
       py::arg("continuous_revolute_joints"), py::arg("preprocess_bbox") = true,
       doc.CalcPairwiseIntersections
-          .doc_deprecated_deprecated_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox);
+          .doc_deprecated_deprecated_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox,
+      py::call_guard<py::gil_scoped_release>());
 #pragma GCC diagnostic pop
   m.def(
       "ComputePairwiseIntersections",
@@ -1510,7 +1512,8 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("continuous_revolute_joints"), py::arg("bboxes_A"),
       py::arg("bboxes_B"), py::arg("parallelism") = Parallelism::Max(),
       doc.ComputePairwiseIntersections
-          .doc_6args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B_parallelism);
+          .doc_6args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B_parallelism,
+      py::call_guard<py::gil_scoped_release>());
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("CalcPairwiseIntersections",
@@ -1530,7 +1533,8 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("continuous_revolute_joints"), py::arg("bboxes_A"),
       py::arg("bboxes_B"),
       doc.CalcPairwiseIntersections
-          .doc_deprecated_deprecated_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B);
+          .doc_deprecated_deprecated_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B,
+      py::call_guard<py::gil_scoped_release>());
 #pragma GCC diagnostic pop
   m.def(
       "ComputePairwiseIntersections",
@@ -1544,7 +1548,8 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("preprocess_bbox") = true,
       py::arg("parallelism") = Parallelism::Max(),
       doc.ComputePairwiseIntersections
-          .doc_4args_convex_sets_continuous_revolute_joints_preprocess_bbox_parallelism);
+          .doc_4args_convex_sets_continuous_revolute_joints_preprocess_bbox_parallelism,
+      py::call_guard<py::gil_scoped_release>());
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("CalcPairwiseIntersections",
@@ -1560,7 +1565,8 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("preprocess_bbox") = true,
       doc.CalcPairwiseIntersections
-          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_preprocess_bbox);
+          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_preprocess_bbox,
+      py::call_guard<py::gil_scoped_release>());
 #pragma GCC diagnostic pop
   m.def(
       "ComputePairwiseIntersections",
@@ -1574,7 +1580,8 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("bboxes") = std::vector<Hyperrectangle>{},
       py::arg("parallelism") = Parallelism::Max(),
       doc.ComputePairwiseIntersections
-          .doc_4args_convex_sets_continuous_revolute_joints_bboxes_parallelism);
+          .doc_4args_convex_sets_continuous_revolute_joints_bboxes_parallelism,
+      py::call_guard<py::gil_scoped_release>());
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("CalcPairwiseIntersections",
@@ -1590,7 +1597,8 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("bboxes") = std::vector<Hyperrectangle>{},
       doc.CalcPairwiseIntersections
-          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_bboxes);
+          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_bboxes,
+      py::call_guard<py::gil_scoped_release>());
 #pragma GCC diagnostic pop
 }
 

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -1493,8 +1493,7 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("convex_sets_A"), py::arg("convex_sets_B"),
       py::arg("continuous_revolute_joints"), py::arg("preprocess_bbox") = true,
       doc.CalcPairwiseIntersections
-          .doc_deprecated_deprecated_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox,
-      py::call_guard<py::gil_scoped_release>());
+          .doc_deprecated_deprecated_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox);
 #pragma GCC diagnostic pop
   m.def(
       "ComputePairwiseIntersections",
@@ -1533,8 +1532,7 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("continuous_revolute_joints"), py::arg("bboxes_A"),
       py::arg("bboxes_B"),
       doc.CalcPairwiseIntersections
-          .doc_deprecated_deprecated_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B,
-      py::call_guard<py::gil_scoped_release>());
+          .doc_deprecated_deprecated_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B);
 #pragma GCC diagnostic pop
   m.def(
       "ComputePairwiseIntersections",
@@ -1565,8 +1563,7 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("preprocess_bbox") = true,
       doc.CalcPairwiseIntersections
-          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_preprocess_bbox,
-      py::call_guard<py::gil_scoped_release>());
+          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_preprocess_bbox);
 #pragma GCC diagnostic pop
   m.def(
       "ComputePairwiseIntersections",
@@ -1597,8 +1594,7 @@ void DefineGeodesicConvexity(py::module m) {
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("bboxes") = std::vector<Hyperrectangle>{},
       doc.CalcPairwiseIntersections
-          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_bboxes,
-      py::call_guard<py::gil_scoped_release>());
+          .doc_deprecated_deprecated_3args_convex_sets_continuous_revolute_joints_bboxes);
 #pragma GCC diagnostic pop
 }
 

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -1465,15 +1465,16 @@ void DefineGeodesicConvexity(py::module m) {
       [](const std::vector<ConvexSet*>& convex_sets_A,
           const std::vector<ConvexSet*>& convex_sets_B,
           const std::vector<int>& continuous_revolute_joints,
-          bool preprocess_bbox) {
+          bool preprocess_bbox, Parallelism parallelism) {
         return ComputePairwiseIntersections(CloneConvexSets(convex_sets_A),
             CloneConvexSets(convex_sets_B), continuous_revolute_joints,
-            preprocess_bbox);
+            preprocess_bbox, parallelism);
       },
       py::arg("convex_sets_A"), py::arg("convex_sets_B"),
       py::arg("continuous_revolute_joints"), py::arg("preprocess_bbox") = true,
+      py::arg("parallelism") = Parallelism::Max(),
       doc.ComputePairwiseIntersections
-          .doc_4args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox);
+          .doc_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_preprocess_bbox_parallelism);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("CalcPairwiseIntersections",
@@ -1499,16 +1500,17 @@ void DefineGeodesicConvexity(py::module m) {
           const std::vector<ConvexSet*>& convex_sets_B,
           const std::vector<int>& continuous_revolute_joints,
           const std::vector<Hyperrectangle>& bboxes_A,
-          const std::vector<Hyperrectangle>& bboxes_B) {
+          const std::vector<Hyperrectangle>& bboxes_B,
+          Parallelism parallelism) {
         return ComputePairwiseIntersections(CloneConvexSets(convex_sets_A),
             CloneConvexSets(convex_sets_B), continuous_revolute_joints,
-            bboxes_A, bboxes_B);
+            bboxes_A, bboxes_B, parallelism);
       },
       py::arg("convex_sets_A"), py::arg("convex_sets_B"),
       py::arg("continuous_revolute_joints"), py::arg("bboxes_A"),
-      py::arg("bboxes_B"),
+      py::arg("bboxes_B"), py::arg("parallelism") = Parallelism::Max(),
       doc.ComputePairwiseIntersections
-          .doc_5args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B);
+          .doc_6args_convex_sets_A_convex_sets_B_continuous_revolute_joints_bboxes_A_bboxes_B_parallelism);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("CalcPairwiseIntersections",
@@ -1534,14 +1536,15 @@ void DefineGeodesicConvexity(py::module m) {
       "ComputePairwiseIntersections",
       [](const std::vector<ConvexSet*>& convex_sets,
           const std::vector<int>& continuous_revolute_joints,
-          bool preprocess_bbox) {
+          bool preprocess_bbox, Parallelism parallelism) {
         return ComputePairwiseIntersections(CloneConvexSets(convex_sets),
-            continuous_revolute_joints, preprocess_bbox);
+            continuous_revolute_joints, preprocess_bbox, parallelism);
       },
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("preprocess_bbox") = true,
+      py::arg("parallelism") = Parallelism::Max(),
       doc.ComputePairwiseIntersections
-          .doc_3args_convex_sets_continuous_revolute_joints_preprocess_bbox);
+          .doc_4args_convex_sets_continuous_revolute_joints_preprocess_bbox_parallelism);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("CalcPairwiseIntersections",
@@ -1563,14 +1566,15 @@ void DefineGeodesicConvexity(py::module m) {
       "ComputePairwiseIntersections",
       [](const std::vector<ConvexSet*>& convex_sets,
           const std::vector<int>& continuous_revolute_joints,
-          const std::vector<Hyperrectangle>& bboxes) {
-        return ComputePairwiseIntersections(
-            CloneConvexSets(convex_sets), continuous_revolute_joints, bboxes);
+          const std::vector<Hyperrectangle>& bboxes, Parallelism parallelism) {
+        return ComputePairwiseIntersections(CloneConvexSets(convex_sets),
+            continuous_revolute_joints, bboxes, parallelism);
       },
       py::arg("convex_sets"), py::arg("continuous_revolute_joints"),
       py::arg("bboxes") = std::vector<Hyperrectangle>{},
+      py::arg("parallelism") = Parallelism::Max(),
       doc.ComputePairwiseIntersections
-          .doc_3args_convex_sets_continuous_revolute_joints_bboxes);
+          .doc_4args_convex_sets_continuous_revolute_joints_bboxes_parallelism);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   m.def("CalcPairwiseIntersections",

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -1501,24 +1501,28 @@ class TestCspaceFreePolytope(unittest.TestCase):
                         convex_sets_A=sets_A,
                         convex_sets_B=sets_B,
                         continuous_revolute_joints=[0],
-                        preprocess_bbox=True))
+                        preprocess_bbox=True,
+                        parallelism=Parallelism.Max()))
         outputs.append(
                 mut.ComputePairwiseIntersections(
                         convex_sets_A=sets_A,
                         convex_sets_B=sets_B,
                         continuous_revolute_joints=[0],
                         bboxes_A=bboxes_A,
-                        bboxes_B=bboxes_B))
+                        bboxes_B=bboxes_B,
+                        parallelism=Parallelism.Max()))
         outputs.append(
                 mut.ComputePairwiseIntersections(
                         convex_sets=sets_A,
                         continuous_revolute_joints=[0],
-                        preprocess_bbox=True))
+                        preprocess_bbox=True,
+                        parallelism=Parallelism.Max()))
         outputs.append(
                 mut.ComputePairwiseIntersections(
                         convex_sets=sets_A,
                         continuous_revolute_joints=[0],
-                        bboxes=bboxes_A))
+                        bboxes=bboxes_A,
+                        parallelism=Parallelism.Max()))
         for out in outputs:
             self.assertIsInstance(out, tuple)
             self.assertIsInstance(out[0], list)

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -495,7 +495,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py::arg("edges_between_regions"), py::arg("order"),
             py::arg("h_min") = 1e-6, py::arg("h_max") = 20,
             py::arg("name") = "", py::arg("edge_offsets") = py::none(),
-            cls_doc.AddRegions.doc_7args)
+            cls_doc.AddRegions.doc_7args,
+            py::call_guard<py::gil_scoped_release>())
         .def(
             "AddRegions",
             [](Class& self,
@@ -507,7 +508,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             },
             py_rvp::reference_internal, py::arg("regions"), py::arg("order"),
             py::arg("h_min") = 1e-6, py::arg("h_max") = 20,
-            py::arg("name") = "", cls_doc.AddRegions.doc_5args)
+            py::arg("name") = "", cls_doc.AddRegions.doc_5args,
+            py::call_guard<py::gil_scoped_release>())
         .def("RemoveSubgraph", &Class::RemoveSubgraph, py::arg("subgraph"),
             cls_doc.RemoveSubgraph.doc)
         .def(
@@ -532,7 +534,8 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py_rvp::reference_internal, py::arg("from_subgraph"),
             py::arg("to_subgraph"), py::arg("subspace") = py::none(),
             py::arg("edges_between_regions") = py::none(),
-            py::arg("edge_offsets") = py::none(), cls_doc.AddEdges.doc)
+            py::arg("edge_offsets") = py::none(), cls_doc.AddEdges.doc,
+            py::call_guard<py::gil_scoped_release>())
         .def("AddTimeCost", &Class::AddTimeCost, py::arg("weight") = 1.0,
             cls_doc.AddTimeCost.doc)
         .def("AddPathLengthCost",

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -458,6 +458,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "geodesic_convexity_test",
+    num_threads = 2,
     deps = [
         ":convex_set",
         ":geodesic_convexity",

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -43,6 +43,7 @@ drake_cc_library(
     implementation_deps = [
         "//geometry/optimization:convex_set",
         "//solvers:solve",
+        "@common_robotics_utilities",
     ],
 )
 

--- a/geometry/optimization/geodesic_convexity.cc
+++ b/geometry/optimization/geodesic_convexity.cc
@@ -317,9 +317,9 @@ std::vector<std::tuple<int, int, Eigen::VectorXd>> ReorganizeEdgesAndOffsets(
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets_A, const ConvexSets& convex_sets_B,
     const std::vector<int>& continuous_revolute_joints, bool preprocess_bbox) {
-  auto [edges, edge_offsets] =
-      ComputePairwiseIntersections(convex_sets_A, convex_sets_B,
-                                   continuous_revolute_joints, preprocess_bbox);
+  auto [edges, edge_offsets] = ComputePairwiseIntersections(
+      convex_sets_A, convex_sets_B, continuous_revolute_joints, preprocess_bbox,
+      Parallelism::None());
   return ReorganizeEdgesAndOffsets(edges, edge_offsets);
 }
 
@@ -379,7 +379,7 @@ std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const std::vector<Hyperrectangle>& bboxes_B) {
   auto [edges, edge_offsets] = ComputePairwiseIntersections(
       convex_sets_A, convex_sets_B, continuous_revolute_joints, bboxes_A,
-      bboxes_B);
+      bboxes_B, Parallelism::None());
   return ReorganizeEdgesAndOffsets(edges, edge_offsets);
 }
 
@@ -535,8 +535,9 @@ ComputePairwiseIntersections(const ConvexSets& convex_sets_A,
 std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const ConvexSets& convex_sets,
     const std::vector<int>& continuous_revolute_joints, bool preprocess_bbox) {
-  auto [edges, edge_offsets] = ComputePairwiseIntersections(
-      convex_sets, continuous_revolute_joints, preprocess_bbox);
+  auto [edges, edge_offsets] =
+      ComputePairwiseIntersections(convex_sets, continuous_revolute_joints,
+                                   preprocess_bbox, Parallelism::None());
   return ReorganizeEdgesAndOffsets(edges, edge_offsets);
 }
 
@@ -554,7 +555,7 @@ std::vector<std::tuple<int, int, Eigen::VectorXd>> CalcPairwiseIntersections(
     const std::vector<int>& continuous_revolute_joints,
     const std::vector<Hyperrectangle>& bboxes) {
   auto [edges, edge_offsets] = ComputePairwiseIntersections(
-      convex_sets, continuous_revolute_joints, bboxes);
+      convex_sets, continuous_revolute_joints, bboxes, Parallelism::None());
   return ReorganizeEdgesAndOffsets(edges, edge_offsets);
 }
 

--- a/geometry/optimization/geodesic_convexity.h
+++ b/geometry/optimization/geodesic_convexity.h
@@ -153,6 +153,7 @@ axis-aligned bounding boxes (AABBs) for every set. This can speed up the
 pairwise intersection checks, by determining some sets to be disjoint without
 needing to solve an optimization problem. However, it does require some overhead
 to compute those bounding boxes.
+@param parallelism specifies the number of threads to use.
 
 @throws if `continuous_revolute_joints` has repeated entries, or if any entry
 is outside the interval [0, ambient_dimension), where ambient_dimension is the
@@ -163,7 +164,8 @@ std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
 ComputePairwiseIntersections(const ConvexSets& convex_sets_A,
                              const ConvexSets& convex_sets_B,
                              const std::vector<int>& continuous_revolute_joints,
-                             bool preprocess_bbox = true);
+                             bool preprocess_bbox = true,
+                             Parallelism parallelism = Parallelism::Max());
 
 /** Computes the pairwise intersections between two lists of convex sets,
 returning a list of edges. Each edge is a tuple in the form [index_A, index_B,
@@ -220,7 +222,8 @@ ComputePairwiseIntersections(
     const ConvexSets& convex_sets_A, const ConvexSets& convex_sets_B,
     const std::vector<int>& continuous_revolute_joints,
     const std::vector<geometry::optimization::Hyperrectangle>& bboxes_A,
-    const std::vector<geometry::optimization::Hyperrectangle>& bboxes_B);
+    const std::vector<geometry::optimization::Hyperrectangle>& bboxes_B,
+    Parallelism parallelism = Parallelism::Max());
 
 /** Overload of `CalcPairwiseIntersections` allowing the user to supply axis-
 aligned bounding boxes if they're known a priori, to save on computation time.
@@ -259,6 +262,7 @@ continuous revolute joints.
 axis-aligned bounding boxes for every set. This can speed up the pairwise
 intersection checks, by determining some sets to be disjoint without needing
 to solve an optimization problem.
+@param parallelism specifies the number of threads to use.
 
 @throws if `continuous_revolute_joints` has repeated entries, or if any entry
 is outside the interval [0, ambient_dimension), where ambient_dimension is the
@@ -268,7 +272,8 @@ ambient dimension of the convex sets in `convex_sets`.
 std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
 ComputePairwiseIntersections(const ConvexSets& convex_sets,
                              const std::vector<int>& continuous_revolute_joints,
-                             bool preprocess_bbox = true);
+                             bool preprocess_bbox = true,
+                             Parallelism parallelism = Parallelism::Max());
 
 /** Convenience overload to compute pairwise intersections within a list of
 convex sets. Equivalent to calling CalcPairwiseIntersections(convex_sets,
@@ -312,7 +317,8 @@ std::pair<std::vector<std::pair<int, int>>, std::vector<Eigen::VectorXd>>
 ComputePairwiseIntersections(
     const ConvexSets& convex_sets,
     const std::vector<int>& continuous_revolute_joints,
-    const std::vector<geometry::optimization::Hyperrectangle>& bboxes);
+    const std::vector<geometry::optimization::Hyperrectangle>& bboxes,
+    Parallelism parallelism = Parallelism::Max());
 
 /** Overload of `CalcPairwiseIntersections` allowing the user to supply axis-
 aligned bounding boxes if they're known a priori, to save on computation time.

--- a/geometry/optimization/test/geodesic_convexity_test.cc
+++ b/geometry/optimization/test/geodesic_convexity_test.cc
@@ -340,109 +340,119 @@ GTEST_TEST(GeodesicConvexityTest, ComputePairwiseIntersections1) {
   // h2 <--> h3: would intersect if h2 is translated by (4, -1) * 2π
   // h2 <--> h4: would intersect if h2 is translated by (1, -5) * 2π
 
-  auto [edges_none, offsets_none] =
-      ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{});
-  auto [edges_zero, offsets_zero] =
-      ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{0});
-  auto [edges_one, offsets_one] =
-      ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{1});
-  auto [edges_both, offsets_both] =
-      ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{0, 1});
+  // Cross-check that our BUILD file allows parallelism.
+  DRAKE_DEMAND(Parallelism::Max().num_threads() > 1);
 
-  EXPECT_EQ(edges_none.size(), offsets_none.size());
-  EXPECT_EQ(edges_zero.size(), offsets_zero.size());
-  EXPECT_EQ(edges_one.size(), offsets_one.size());
-  EXPECT_EQ(edges_both.size(), offsets_both.size());
+  for (auto parallelism : {Parallelism::None(), Parallelism::Max()}) {
+    auto [edges_none, offsets_none] =
+        ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{},
+                                     true /* preprocess_bbox */, parallelism);
+    auto [edges_zero, offsets_zero] =
+        ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{0},
+                                     true /* preprocess_bbox */, parallelism);
+    auto [edges_one, offsets_one] =
+        ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{1},
+                                     true /* preprocess_bbox */, parallelism);
+    auto [edges_both, offsets_both] =
+        ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{0, 1},
+                                     true /* preprocess_bbox */, parallelism);
 
-  // Without continuous revolute joints, the intersection is empty.
-  EXPECT_EQ(edges_none.size(), 0);
-  // With only first joint continuous, the only intersection is h1 <--> h3.
-  EXPECT_EQ(edges_zero.size(), 1);
-  // With only second joint continuous, the intersection is empty.
-  EXPECT_EQ(edges_one.size(), 0);
-  // With all joints continuous, all possible pairs exist.
-  EXPECT_EQ(edges_both.size(), 4);
+    EXPECT_EQ(edges_none.size(), offsets_none.size());
+    EXPECT_EQ(edges_zero.size(), offsets_zero.size());
+    EXPECT_EQ(edges_one.size(), offsets_one.size());
+    EXPECT_EQ(edges_both.size(), offsets_both.size());
 
-  // All results should be the same if the bounding boxes are provided.
-  std::vector<Hyperrectangle> bboxes_A = {h1, h2};
-  std::vector<Hyperrectangle> bboxes_B = {h3, h4};
-  EXPECT_EQ(ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{},
-                                         bboxes_A, bboxes_B)
-                .first.size(),
-            0);
-  EXPECT_EQ(ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{0},
-                                         bboxes_A, bboxes_B)
-                .first.size(),
-            1);
-  EXPECT_EQ(ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{1},
-                                         bboxes_A, bboxes_B)
-                .first.size(),
-            0);
-  const auto [other_intersection_edges, other_intersection_edge_offsets] =
-      ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{0, 1},
-                                   bboxes_A, bboxes_B);
-  ASSERT_EQ(other_intersection_edges.size(),
-            other_intersection_edge_offsets.size());
-  ASSERT_EQ(other_intersection_edges.size(), 4);
-  const auto& intersection_edges = edges_both;
-  const auto& intersection_edge_offsets = offsets_both;
-  // We use assert because we need the lengths of intersection_edges and
-  // other_intersection_edges to be the same for this next check.
-  for (int i = 0; i < ssize(intersection_edges); ++i) {
-    // Check that each entry is the same. The first two elements of the tuple
-    // are integers, so we can compare directly. The last entry is an
-    // Eigen::VectorXd, so we have to use CompareMatrices.
-    EXPECT_EQ(intersection_edges[i].first, other_intersection_edges[i].first);
-    EXPECT_EQ(intersection_edges[i].second, other_intersection_edges[i].second);
-    EXPECT_TRUE(CompareMatrices(intersection_edge_offsets[i],
-                                other_intersection_edge_offsets[i], 1e-15));
-  }
+    // Without continuous revolute joints, the intersection is empty.
+    EXPECT_EQ(edges_none.size(), 0);
+    // With only first joint continuous, the only intersection is h1 <--> h3.
+    EXPECT_EQ(edges_zero.size(), 1);
+    // With only second joint continuous, the intersection is empty.
+    EXPECT_EQ(edges_one.size(), 0);
+    // With all joints continuous, all possible pairs exist.
+    EXPECT_EQ(edges_both.size(), 4);
 
-  for (int i = 0; i < ssize(intersection_edges); ++i) {
-    const int index_a = intersection_edges[i].first;
-    const int index_b = intersection_edges[i].second;
-    const Eigen::VectorXd& offset = intersection_edge_offsets[i];
-
-    // Verify all centers are integer multiples of 2π apart.
-    const auto offset_mod_2π = offset.array() / (2 * M_PI);
-    for (int j = 0; j < offset_mod_2π.size(); ++j) {
-      EXPECT_NEAR(offset_mod_2π[j], std::round(offset_mod_2π[j]), 1e-9);
+    // All results should be the same if the bounding boxes are provided.
+    std::vector<Hyperrectangle> bboxes_A = {h1, h2};
+    std::vector<Hyperrectangle> bboxes_B = {h3, h4};
+    EXPECT_EQ(ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{},
+                                           bboxes_A, bboxes_B, parallelism)
+                  .first.size(),
+              0);
+    EXPECT_EQ(ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{0},
+                                           bboxes_A, bboxes_B, parallelism)
+                  .first.size(),
+              1);
+    EXPECT_EQ(ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{1},
+                                           bboxes_A, bboxes_B, parallelism)
+                  .first.size(),
+              0);
+    const auto [other_intersection_edges, other_intersection_edge_offsets] =
+        ComputePairwiseIntersections(sets_A, sets_B, std::vector<int>{0, 1},
+                                     bboxes_A, bboxes_B);
+    ASSERT_EQ(other_intersection_edges.size(),
+              other_intersection_edge_offsets.size());
+    ASSERT_EQ(other_intersection_edges.size(), 4);
+    const auto& intersection_edges = edges_both;
+    const auto& intersection_edge_offsets = offsets_both;
+    // We use assert because we need the lengths of intersection_edges and
+    // other_intersection_edges to be the same for this next check.
+    for (int i = 0; i < ssize(intersection_edges); ++i) {
+      // Check that each entry is the same. The first two elements of the tuple
+      // are integers, so we can compare directly. The last entry is an
+      // Eigen::VectorXd, so we have to use CompareMatrices.
+      EXPECT_EQ(intersection_edges[i].first, other_intersection_edges[i].first);
+      EXPECT_EQ(intersection_edges[i].second,
+                other_intersection_edges[i].second);
+      EXPECT_TRUE(CompareMatrices(intersection_edge_offsets[i],
+                                  other_intersection_edge_offsets[i], 1e-15));
     }
-    // The center of the first rectangle + offset should be inside the second
-    // rectangle.
-    const auto* h_a =
-        dynamic_cast<const Hyperrectangle*>(sets_A[index_a].get());
-    DRAKE_DEMAND(h_a != nullptr);
-    EXPECT_TRUE(sets_B[index_b]->PointInSet(h_a->Center() + offset, 1e-6));
-  }
 
-  // Deprecation tests.
+    for (int i = 0; i < ssize(intersection_edges); ++i) {
+      const int index_a = intersection_edges[i].first;
+      const int index_b = intersection_edges[i].second;
+      const Eigen::VectorXd& offset = intersection_edge_offsets[i];
+
+      // Verify all centers are integer multiples of 2π apart.
+      const auto offset_mod_2π = offset.array() / (2 * M_PI);
+      for (int j = 0; j < offset_mod_2π.size(); ++j) {
+        EXPECT_NEAR(offset_mod_2π[j], std::round(offset_mod_2π[j]), 1e-9);
+      }
+      // The center of the first rectangle + offset should be inside the second
+      // rectangle.
+      const auto* h_a =
+          dynamic_cast<const Hyperrectangle*>(sets_A[index_a].get());
+      DRAKE_DEMAND(h_a != nullptr);
+      EXPECT_TRUE(sets_B[index_b]->PointInSet(h_a->Center() + offset, 1e-6));
+    }
+
+    // Deprecation tests.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  ASSERT_NO_THROW(CalcPairwiseIntersections(
-      sets_A, sets_B, std::vector<int>{0, 1}, bboxes_A, bboxes_B));
-  auto edges_both_old = CalcPairwiseIntersections(
-      sets_A, sets_B, std::vector<int>{0, 1}, bboxes_A, bboxes_B);
-  ASSERT_EQ(edges_both_old.size(), edges_both.size());
-  for (int i = 0; i < ssize(edges_both); ++i) {
-    EXPECT_EQ(std::get<0>(edges_both_old[i]), edges_both[i].first);
-    EXPECT_EQ(std::get<1>(edges_both_old[i]), edges_both[i].second);
-    EXPECT_TRUE(CompareMatrices(std::get<2>(edges_both_old[i]), offsets_both[i],
-                                1e-15));
-  }
+    ASSERT_NO_THROW(CalcPairwiseIntersections(
+        sets_A, sets_B, std::vector<int>{0, 1}, bboxes_A, bboxes_B));
+    auto edges_both_old = CalcPairwiseIntersections(
+        sets_A, sets_B, std::vector<int>{0, 1}, bboxes_A, bboxes_B);
+    ASSERT_EQ(edges_both_old.size(), edges_both.size());
+    for (int i = 0; i < ssize(edges_both); ++i) {
+      EXPECT_EQ(std::get<0>(edges_both_old[i]), edges_both[i].first);
+      EXPECT_EQ(std::get<1>(edges_both_old[i]), edges_both[i].second);
+      EXPECT_TRUE(CompareMatrices(std::get<2>(edges_both_old[i]),
+                                  offsets_both[i], 1e-15));
+    }
 
-  ASSERT_NO_THROW(
-      CalcPairwiseIntersections(sets_A, sets_B, std::vector<int>{0, 1}, true));
-  edges_both_old =
-      CalcPairwiseIntersections(sets_A, sets_B, std::vector<int>{0, 1}, true);
-  ASSERT_EQ(edges_both_old.size(), edges_both.size());
-  for (int i = 0; i < ssize(edges_both); ++i) {
-    EXPECT_EQ(std::get<0>(edges_both_old[i]), edges_both[i].first);
-    EXPECT_EQ(std::get<1>(edges_both_old[i]), edges_both[i].second);
-    EXPECT_TRUE(CompareMatrices(std::get<2>(edges_both_old[i]), offsets_both[i],
-                                1e-15));
-  }
+    ASSERT_NO_THROW(CalcPairwiseIntersections(sets_A, sets_B,
+                                              std::vector<int>{0, 1}, true));
+    edges_both_old =
+        CalcPairwiseIntersections(sets_A, sets_B, std::vector<int>{0, 1}, true);
+    ASSERT_EQ(edges_both_old.size(), edges_both.size());
+    for (int i = 0; i < ssize(edges_both); ++i) {
+      EXPECT_EQ(std::get<0>(edges_both_old[i]), edges_both[i].first);
+      EXPECT_EQ(std::get<1>(edges_both_old[i]), edges_both[i].second);
+      EXPECT_TRUE(CompareMatrices(std::get<2>(edges_both_old[i]),
+                                  offsets_both[i], 1e-15));
+    }
 #pragma GCC diagnostic pop
+  }
 }
 
 GTEST_TEST(GeodesicConvexityTest, ComputePairwiseIntersections2) {
@@ -453,82 +463,88 @@ GTEST_TEST(GeodesicConvexityTest, ComputePairwiseIntersections2) {
   Hyperrectangle h3(Eigen::Vector2d(8 * M_PI, 0.0),
                     Eigen::Vector2d(1.0 + 8 * M_PI, 1.0));
   ConvexSets sets = MakeConvexSets(h1, h2, h3);
-  // Let's check the expected value of each pair of intersections.
-  // h1 <--> h2: would intersect if h1 is translated by (0, 1) * 2π
-  // h1 <--> h3: would intersect if h1 is translated by (4, 0) * 2π
-  // h2 <--> h3: would intersect if h2 is translated by (4, -1) * 2π
-  // Without continuous revolute joints, the intersection is empty.
-  auto [intersections_none, offsets_none] =
-      ComputePairwiseIntersections(sets, std::vector<int>{});
-  EXPECT_EQ(intersections_none.size(), offsets_none.size());
-  EXPECT_EQ(intersections_none.size(), 0);
-  // With only first joint continuous, the only intersection is h1 <--> h3.
-  auto [intersections_zero, offsets_zero] =
-      ComputePairwiseIntersections(sets, std::vector<int>{0});
-  EXPECT_EQ(intersections_zero.size(), offsets_zero.size());
-  EXPECT_EQ(intersections_zero.size(), 2);
-  EXPECT_EQ(intersections_zero[0].first, 0);
-  EXPECT_EQ(intersections_zero[0].second, 2);
-  EXPECT_TRUE(
-      CompareMatrices(offsets_zero[0], Eigen::Vector2d(8 * M_PI, 0.0), 1e-9));
-  // With all joints continuous, all pairs of intersections are non-empty.
-  auto [intersections_both, offsets_both] =
-      ComputePairwiseIntersections(sets, std::vector<int>{0, 1});
-  EXPECT_EQ(intersections_both.size(), offsets_both.size());
-  EXPECT_EQ(intersections_both.size(), 6);
-  for (int i = 0; i < ssize(intersections_both); ++i) {
-    const int index_a = intersections_both[i].first;
-    const int index_b = intersections_both[i].second;
-    const Eigen::VectorXd& offset = offsets_both[i];
-    // Verify all centers are integer multiples of 2π apart.
-    const auto offset_mod_2π = offset.array() / (2 * M_PI);
-    for (int j = 0; j < offset_mod_2π.size(); ++j) {
-      EXPECT_NEAR(offset_mod_2π[j], std::round(offset_mod_2π[j]), 1e-9);
-    }
-    // The center of the first rectangle + offset should be inside the second
-    // rectangle.
-    const auto* h_first =
-        dynamic_cast<const Hyperrectangle*>(sets[index_a].get());
-    DRAKE_DEMAND(h_first != nullptr);
-    EXPECT_TRUE(sets[index_b]->PointInSet(h_first->Center() + offset, 1e-6));
-  }
 
-// Deprecation tests.
+  // Cross-check that our BUILD file allows parallelism.
+  DRAKE_DEMAND(Parallelism::Max().num_threads() > 1);
+
+  for (auto parallelism : {Parallelism::None(), Parallelism::Max()}) {
+    // Let's check the expected value of each pair of intersections.
+    // h1 <--> h2: would intersect if h1 is translated by (0, 1) * 2π
+    // h1 <--> h3: would intersect if h1 is translated by (4, 0) * 2π
+    // h2 <--> h3: would intersect if h2 is translated by (4, -1) * 2π
+    // Without continuous revolute joints, the intersection is empty.
+    auto [intersections_none, offsets_none] = ComputePairwiseIntersections(
+        sets, std::vector<int>{}, true /* preprocess_bbox */, parallelism);
+    EXPECT_EQ(intersections_none.size(), offsets_none.size());
+    EXPECT_EQ(intersections_none.size(), 0);
+    // With only first joint continuous, the only intersection is h1 <--> h3.
+    auto [intersections_zero, offsets_zero] = ComputePairwiseIntersections(
+        sets, std::vector<int>{0}, true /* preprocess_bbox */, parallelism);
+    EXPECT_EQ(intersections_zero.size(), offsets_zero.size());
+    EXPECT_EQ(intersections_zero.size(), 2);
+    EXPECT_EQ(intersections_zero[0].first, 0);
+    EXPECT_EQ(intersections_zero[0].second, 2);
+    EXPECT_TRUE(
+        CompareMatrices(offsets_zero[0], Eigen::Vector2d(8 * M_PI, 0.0), 1e-9));
+    // With all joints continuous, all pairs of intersections are non-empty.
+    auto [intersections_both, offsets_both] = ComputePairwiseIntersections(
+        sets, std::vector<int>{0, 1}, true /* preprocess_bbox */, parallelism);
+    EXPECT_EQ(intersections_both.size(), offsets_both.size());
+    EXPECT_EQ(intersections_both.size(), 6);
+    for (int i = 0; i < ssize(intersections_both); ++i) {
+      const int index_a = intersections_both[i].first;
+      const int index_b = intersections_both[i].second;
+      const Eigen::VectorXd& offset = offsets_both[i];
+      // Verify all centers are integer multiples of 2π apart.
+      const auto offset_mod_2π = offset.array() / (2 * M_PI);
+      for (int j = 0; j < offset_mod_2π.size(); ++j) {
+        EXPECT_NEAR(offset_mod_2π[j], std::round(offset_mod_2π[j]), 1e-9);
+      }
+      // The center of the first rectangle + offset should be inside the second
+      // rectangle.
+      const auto* h_first =
+          dynamic_cast<const Hyperrectangle*>(sets[index_a].get());
+      DRAKE_DEMAND(h_first != nullptr);
+      EXPECT_TRUE(sets[index_b]->PointInSet(h_first->Center() + offset, 1e-6));
+    }
+
+    // Deprecation tests.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  std::vector<Hyperrectangle> bboxes;
-  bboxes.emplace_back(h1);
-  bboxes.emplace_back(h2);
-  bboxes.emplace_back(h3);
+    std::vector<Hyperrectangle> bboxes;
+    bboxes.emplace_back(h1);
+    bboxes.emplace_back(h2);
+    bboxes.emplace_back(h3);
 
-  ASSERT_NO_THROW(
-      CalcPairwiseIntersections(sets, std::vector<int>{0, 1}, bboxes));
-  auto intersections_both_old =
-      CalcPairwiseIntersections(sets, std::vector<int>{0, 1}, bboxes);
-  ASSERT_EQ(intersections_both_old.size(), intersections_both.size());
-  for (int i = 0; i < ssize(intersections_both); ++i) {
-    EXPECT_EQ(std::get<0>(intersections_both_old[i]),
-              intersections_both[i].first);
-    EXPECT_EQ(std::get<1>(intersections_both_old[i]),
-              intersections_both[i].second);
-    EXPECT_TRUE(CompareMatrices(std::get<2>(intersections_both_old[i]),
-                                offsets_both[i], 1e-15));
-  }
+    ASSERT_NO_THROW(
+        CalcPairwiseIntersections(sets, std::vector<int>{0, 1}, bboxes));
+    auto intersections_both_old =
+        CalcPairwiseIntersections(sets, std::vector<int>{0, 1}, bboxes);
+    ASSERT_EQ(intersections_both_old.size(), intersections_both.size());
+    for (int i = 0; i < ssize(intersections_both); ++i) {
+      EXPECT_EQ(std::get<0>(intersections_both_old[i]),
+                intersections_both[i].first);
+      EXPECT_EQ(std::get<1>(intersections_both_old[i]),
+                intersections_both[i].second);
+      EXPECT_TRUE(CompareMatrices(std::get<2>(intersections_both_old[i]),
+                                  offsets_both[i], 1e-15));
+    }
 
-  ASSERT_NO_THROW(
-      CalcPairwiseIntersections(sets, std::vector<int>{0, 1}, true));
-  intersections_both_old =
-      CalcPairwiseIntersections(sets, std::vector<int>{0, 1}, true);
-  ASSERT_EQ(intersections_both_old.size(), intersections_both.size());
-  for (int i = 0; i < ssize(intersections_both); ++i) {
-    EXPECT_EQ(std::get<0>(intersections_both_old[i]),
-              intersections_both[i].first);
-    EXPECT_EQ(std::get<1>(intersections_both_old[i]),
-              intersections_both[i].second);
-    EXPECT_TRUE(CompareMatrices(std::get<2>(intersections_both_old[i]),
-                                offsets_both[i], 1e-15));
-  }
+    ASSERT_NO_THROW(
+        CalcPairwiseIntersections(sets, std::vector<int>{0, 1}, true));
+    intersections_both_old =
+        CalcPairwiseIntersections(sets, std::vector<int>{0, 1}, true);
+    ASSERT_EQ(intersections_both_old.size(), intersections_both.size());
+    for (int i = 0; i < ssize(intersections_both); ++i) {
+      EXPECT_EQ(std::get<0>(intersections_both_old[i]),
+                intersections_both[i].first);
+      EXPECT_EQ(std::get<1>(intersections_both_old[i]),
+                intersections_both[i].second);
+      EXPECT_TRUE(CompareMatrices(std::get<2>(intersections_both_old[i]),
+                                  offsets_both[i], 1e-15));
+    }
 #pragma GCC diagnostic pop
+  }
 }
 
 }  // namespace optimization


### PR DESCRIPTION
Closes #21351. (Although once we have a `parallelism` option added to GCS, as is being discussed in #21965, we should make sure that gets plumbed through.)

Note that the parallelism here is used in two ways -- the computation of AABBs of the constituent sets is handled with a parallel for loop, and then the pairwise intersections themselves are checked with `SolveInParallel`.

This leads to significant speedups, especially on faster graphs. With 224 sets (resulting in 5928 edges), we have the following computation times:
```
Parallel? No AABB Preprocessing? No 	Runtime: 1.174356460571289
Parallel? No AABB Preprocessing? Yes 	Runtime: 1.1098930835723877
Parallel? Yes AABB Preprocessing? No 	Runtime: 0.2572915554046631
Parallel? Yes AABB Preprocessing? Yes 	Runtime: 0.2135148048400879
```
With 1120 sets (resulting in 152680 edges), we have the following computation times:
```
Parallel? No AABB Preprocessing? No 	Runtime: 26.704376697540283
Parallel? No AABB Preprocessing? Yes 	Runtime: 19.698741912841797
Parallel? Yes AABB Preprocessing? No 	Runtime: 4.901020050048828
Parallel? Yes AABB Preprocessing? Yes 	Runtime: 3.577193021774292
```
(This is on my personal computer, with 20 threads.)

+@sadraddini for feature review, if you have the time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22142)
<!-- Reviewable:end -->
