### PR TITLE
[pydrake] Add function to make arbitrary ref cycles

### DIFF
--- a/bindings/pydrake/common/ref_cycle_pybind.h
+++ b/bindings/pydrake/common/ref_cycle_pybind.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 
 namespace drake {
@@ -50,6 +52,13 @@ struct ref_cycle {};
  index. */
 void ref_cycle_impl(size_t peer0, size_t peer1,
     const py::detail::function_call& call, py::handle ret);
+
+/* This function constructs a reference cycle from arbitrary handles. It may be
+ needed in special cases where the ordinary call-policy annotations won't work.
+ The `location_hint` will appear in any exception messages; it should help
+ developers locate where and why this function was called. */
+void make_arbitrary_ref_cycle(
+    py::handle p0, py::handle p1, const std::string& location_hint);
 
 }  // namespace internal
 }  // namespace pydrake

--- a/bindings/pydrake/common/test/ref_cycle_test.py
+++ b/bindings/pydrake/common/test/ref_cycle_test.py
@@ -7,7 +7,8 @@ import unittest
 import weakref
 
 from pydrake.common.ref_cycle_test_util import (
-    NotDynamic, IsDynamic, invalid_arg_index, free_function, ouroboros)
+    arbitrary_bad, arbitrary_ok, free_function,  invalid_arg_index, IsDynamic,
+    NotDynamic, ouroboros)
 from pydrake.common.test_utilities.memory_test_util import actual_ref_count
 
 
@@ -56,11 +57,27 @@ class TestRefCycle(unittest.TestCase):
         self.assertEqual(len(dut._pydrake_internal_ref_cycle_peers), 1)
         self.check_is_collectable_cycle(returned, dut)
 
+    def test_arbitrary_ok(self):
+        got = arbitrary_ok()
+        self.assertTrue(hasattr(got, '_pydrake_internal_ref_cycle_peers'))
+
+    def test_arbitrary_bad(self):
+        with self.assertRaisesRegex(RuntimeError,
+                                    ".*IsDynamic::arbitrary_bad.*"):
+            arbitrary_bad()
+
     def test_free_function(self):
         p0 = IsDynamic()
         p1 = IsDynamic()
         free_function(p0, p1)
         self.check_is_collectable_cycle(p0, p1)
+
+    def test_init_cycle(self):
+        # Cover the case where index 1 refers to the `self` of a py::init<>()
+        # binding.
+        other = IsDynamic()
+        dut = IsDynamic(other)
+        self.check_is_collectable_cycle(dut, other)
 
     def test_not_dynamic_add(self):
         dut = NotDynamic()

--- a/bindings/pydrake/common/test/ref_cycle_test_util_py.cc
+++ b/bindings/pydrake/common/test/ref_cycle_test_util_py.cc
@@ -22,6 +22,7 @@ class TestDummyBase {
   TestDummyBase(const TestDummyBase&) = default;
   ~TestDummyBase() = default;
 
+  explicit TestDummyBase(IsDynamic*) {}
   void AddNot(NotDynamic*) {}
   NotDynamic* ReturnNot() { return new NotDynamic(); }
   NotDynamic* ReturnNullNot() { return nullptr; }
@@ -50,6 +51,7 @@ PYBIND11_MODULE(ref_cycle_test_util, m) {
     using Class = IsDynamic;
     py::class_<Class>(m, "IsDynamic", py::dynamic_attr())
         .def(py::init<>())
+        .def(py::init<IsDynamic*>(), py::arg("thing"), ref_cycle<1, 2>())
         .def("AddNot", &Class::AddNot)
         .def("AddNotCycle", &Class::AddNot, ref_cycle<1, 2>())
         .def("ReturnNot", &Class::ReturnNot)
@@ -71,6 +73,18 @@ PYBIND11_MODULE(ref_cycle_test_util, m) {
   // Returns its argument and creates a self-cycle.
   m.def(
       "ouroboros", [](IsDynamic* x) { return x; }, ref_cycle<0, 1>());
+  m.def("arbitrary_ok", []() {
+    auto d1 = py::cast(new IsDynamic);
+    auto d2 = py::cast(new IsDynamic);
+    internal::make_arbitrary_ref_cycle(d1, d2, "IsDynamic::arbitrary_ok");
+    return d1;
+  });
+  m.def("arbitrary_bad", []() {
+    auto dyn = py::cast(new IsDynamic);
+    auto bad = py::cast(new NotDynamic);
+    internal::make_arbitrary_ref_cycle(dyn, bad, "IsDynamic::arbitrary_bad");
+    return dyn;
+  });
 }
 
 }  // namespace pydrake


### PR DESCRIPTION
This patch adds internal::make_arbitrary_ref_cycle(), which will prove useful for awkward bindings like those involving multiple return values.

While in the neighborhood, it also adds a few previously missing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22146)
<!-- Reviewable:end -->
