### PR TITLE
[py perception] Add bindings for PointCloud copy

### DIFF
--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -129,6 +129,7 @@ void init_perception(py::module m) {
             py::arg("num_closest"), py::arg("parallelize") = false,
             py::call_guard<py::gil_scoped_release>(),
             cls_doc.EstimateNormals.doc);
+    DefCopyAndDeepCopy(&cls);
   }
 
   AddValueInstantiation<PointCloud>(m);

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -1,5 +1,6 @@
 import pydrake.perception as mut
 
+import copy
 import unittest
 
 import numpy as np
@@ -45,6 +46,7 @@ class TestPerception(unittest.TestCase):
 
         fields = mut.Fields(mut.BaseField.kXYZs)
         pc = mut.PointCloud(new_size=0, fields=fields)
+        copy.deepcopy(pc)
         self.assertEqual(pc.fields(), fields)
         self.assertEqual(pc.size(), 0)
         pc.resize(new_size=2)


### PR DESCRIPTION
This fixes the problem reported in [SO #79142422](https://stackoverflow.com/questions/79142422/cannot-use-an-abstractvalue-holding-a-list-of-pointclouds-as-an-abstractport-or).

FYI r2 has a test case that attempts to reproduce the user's problem. They did not provide an actual fully-worked repro, so this is my best guess.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22148)
<!-- Reviewable:end -->
