### PR TITLE
[common] Add fmt_debug_string polyfill

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -69,6 +69,7 @@ drake_cc_package_library(
 drake_cc_library(
     name = "fmt",
     srcs = [
+        "fmt.cc",
         "fmt_eigen.cc",
     ],
     hdrs = [

--- a/common/fmt.cc
+++ b/common/fmt.cc
@@ -1,0 +1,49 @@
+#include "drake/common/fmt.h"
+
+namespace drake {
+
+// We can simplify this after we drop support for Ubuntu 22.04 Jammy.
+std::string fmt_debug_string(std::string_view x) {
+#if FMT_VERSION >= 90000
+  return fmt::format("{:?}", x);
+#else
+  std::string result;
+  result.reserve(x.size() + 2);
+  result.push_back('"');
+  for (const char ch : x) {
+    // Check for characters with a custom escape sequence.
+    if (ch == '\n') {
+      result.push_back('\\');
+      result.push_back('n');
+      continue;
+    }
+    if (ch == '\r') {
+      result.push_back('\\');
+      result.push_back('r');
+      continue;
+    }
+    if (ch == '\t') {
+      result.push_back('\\');
+      result.push_back('t');
+      continue;
+    }
+    // Check for characters that require a leading backslash.
+    if (ch == '"' || ch == '\\') {
+      result.push_back('\\');
+      result.push_back(ch);
+      continue;
+    }
+    // Check for any other non-printable characters.
+    if (ch < 0x20 || ch >= 0x7F) {
+      result.append(fmt::format("\\x{:02x}", static_cast<int>(ch)));
+      continue;
+    }
+    // Normal character.
+    result.push_back(ch);
+  }
+  result.push_back('"');
+  return result;
+#endif
+}
+
+}  // namespace drake

--- a/common/fmt.h
+++ b/common/fmt.h
@@ -41,6 +41,14 @@ std::string fmt_floating_point(T x) {
   return result;
 }
 
+
+/** Returns `fmt::("{:?}", x)`, i.e, using fmt's "debug string format"; see
+https://fmt.dev docs for the '?' presentation type for details. We provide this
+wrapper because not all of our supported platforms have a new-enough fmt
+to rely on it. On platforms with older fmt, we use a Drake re-implementation
+of the feature that does NOT handle unicode correctly. */
+std::string fmt_debug_string(std::string_view x);
+
 namespace internal::formatter_as {
 
 /* The DRAKE_FORMATTER_AS macro specializes this for it's format_as types.

--- a/common/test/fmt_test.cc
+++ b/common/test/fmt_test.cc
@@ -2,6 +2,7 @@
 
 #include <ostream>
 
+#include <fmt/args.h>
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
@@ -76,6 +77,29 @@ GTEST_TEST(FmtTest, FloatingPoint) {
   EXPECT_EQ(fmt_floating_point(1.11f), "1.11");
   EXPECT_EQ(fmt_floating_point(1.1f), "1.1");
   EXPECT_EQ(fmt_floating_point(1.0f), "1.0");
+}
+
+GTEST_TEST(FmtTest, DebugString) {
+  // We'll use these named fmt args to help make our expected values clear.
+  fmt::dynamic_format_arg_store<fmt::format_context> args;
+  args.push_back(fmt::arg("bs", '\\'));  // backslash
+  args.push_back(fmt::arg("dq", '"'));   // double quote
+
+  // Plain string.
+  EXPECT_EQ(fmt_debug_string("Hello, world!"),
+            fmt::vformat("{dq}Hello, world!{dq}", args));
+
+  // Custom escape sequences.
+  EXPECT_EQ(fmt_debug_string("aa\nbb\rcc\tdd"),
+            fmt::vformat("{dq}aa{bs}nbb{bs}rcc{bs}tdd{dq}", args));
+
+  // Printable characters that require escaping.
+  EXPECT_EQ(fmt_debug_string("aa\"bb'cc\\dd"),
+            fmt::vformat("{dq}aa{bs}{dq}bb'cc{bs}{bs}dd{dq}", args));
+
+  // Non-printable characters.
+  EXPECT_EQ(fmt_debug_string("aa\x0e!\x7f_"),
+            fmt::vformat("{dq}aa{bs}x0e!{bs}x7f_{dq}", args));
 }
 
 }  // namespace


### PR DESCRIPTION
Towards #22078.

---

Sometimes we want to print or log a string.  Imagine this function:

```c++
void DoFoo(const std::string& arg);
```

For logging, we might try:

```c++
void DoFoo(const std::string& arg) {
  if (condition) {
    drake::log()->warn("Suspicious arg = {}", arg);
  }
  ...
}
```

That would print e.g.

```
WARNING Suspicious arg = Hello, world!
````

However, we'll usually want to print the _quoted_ string value, so that the user can see e.g. if they have training whitespace:

```c++
void DoFoo(const std::string& arg) {
  if (condition) {
    drake::log()->warn("Suspicious arg = \"{}\"", arg);
  }
  ...
}
```

That would print e.g.

```
WARNING Suspicious arg = "Hello, world!"
````

That's great!  But what if the string itself has double quotes inside of it?  The output would be confusing.  Or, some strings might contain non-printable characters like 0x08, or awkwardly-printable characters like a tab (`\t`).

Format has a solution for that:

```c++
void DoFoo(const std::string& arg) {
  if (condition) {
    drake::log()->warn("Suspicious arg = {:?}", arg);
  }
  ...
}
```

The `?` presentation type is the "debug string" format, which not only double-quotes the string but also converts non-printable characters into their `\xNN` hex code, so that the output is a string literal that can be pasted back into either C++ or Python.

Unfortunately, our Jammy copy of fmt is just slightly too old to contain this feature, so we need to polyfill it until we drop jammy.

```c++
void DoFoo(const std::string& arg) {
  if (condition) {
    drake::log()->warn("Suspicious arg = {}", fmt_debug_string(arg));
  }
  ...
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22150)
<!-- Reviewable:end -->
