### PR TITLE
Remove bad merge error

### DIFF
--- a/multibody/tree/geometry_spatial_inertia.h
+++ b/multibody/tree/geometry_spatial_inertia.h
@@ -73,13 +73,6 @@ SpatialInertia<double> CalcSpatialInertia(const geometry::Shape& shape,
 SpatialInertia<double> CalcSpatialInertia(
     const geometry::TriangleSurfaceMesh<double>& mesh, double density);
 
-DRAKE_DEPRECATED(
-    "2024-11-01",
-    "In the function CalcSpatialInertia(), the density argument's default "
-    "value of 1.0 was removed. Provide a sensible density value.")
-SpatialInertia<double> CalcSpatialInertia(
-    const geometry::TriangleSurfaceMesh<double>& mesh);
-
 // TODO(SeanCurtis-TRI): Add CalcSpatialinertia(VolumeMesh).
 
 }  // namespace multibody


### PR DESCRIPTION
A deprecated declaration was leaked back into pr 21929. This removes it again.

Note: there is no implementation.