### PR TITLE
RenderEngineVtk can be forced into PBR mode

### DIFF
--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -186,6 +186,12 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtkParams& parameters)
   for (auto& pipeline : pipelines_) {
     pipeline = make_unique<RenderingPipeline>(backend);
   }
+
+  // Requesting PBR on construction should require all materials to be PBR.
+  if (parameters.force_to_pbr) {
+    SetPbrMaterials();
+  }
+
   // Only populate the fallback lights if we haven't specified an environment
   // map.
   // Until we introduce CubeMap, the default texture (NullTexture) should be
@@ -515,7 +521,8 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
            make_unique<RenderingPipeline>(other.pipelines_[2]->backend)}},
       default_diffuse_{other.default_diffuse_},
       default_clear_color_{other.default_clear_color_},
-      fallback_lights_(other.fallback_lights_) {
+      fallback_lights_(other.fallback_lights_),
+      use_pbr_materials_(other.use_pbr_materials_) {
   InitializePipelines();
 
   for (const auto& [id, source_props] : other.props_) {

--- a/geometry/render_vtk/render_engine_vtk_params.h
+++ b/geometry/render_vtk/render_engine_vtk_params.h
@@ -103,6 +103,7 @@ struct RenderEngineVtkParams {
     a->Visit(DRAKE_NVP(exposure));
     a->Visit(DRAKE_NVP(cast_shadows));
     a->Visit(DRAKE_NVP(shadow_map_size));
+    a->Visit(DRAKE_NVP(force_to_pbr));
     a->Visit(DRAKE_NVP(gltf_extensions));
     a->Visit(DRAKE_NVP(backend));
   }
@@ -211,6 +212,20 @@ struct RenderEngineVtkParams {
    See the note on `cast_shadows` for the warning on directional lights and
    shadow maps. */
   int shadow_map_size{256};
+
+  /** RenderEngineVtk can use one of two illumination models: Phong or
+   Physically based rendering (PBR). It defaults to Phong. However, it
+   automatically switches to PBR if:
+
+       - an environment map is added, or
+       - a glTF mesh is added.
+
+   If `force_to_pbr` is set to true, it switches the engine to use PBR
+   regardless of the scene's contents.
+
+   Be aware, switching to PBR will lead to a qualitative change in rendered
+   images even if literally nothing else changes. */
+  bool force_to_pbr{false};
 
   /** Map from the name of a glTF extension (e.g., "KHR_materials_sheen") to
    render engine settings related to that extension. */

--- a/geometry/render_vtk/test/render_engine_vtk_params_test.cc
+++ b/geometry/render_vtk/test/render_engine_vtk_params_test.cc
@@ -34,6 +34,7 @@ environment_map:
 exposure: 1.0
 cast_shadows: true
 shadow_map_size: 512
+force_to_pbr: true
 gltf_extensions:
   KHR_draco_mesh_compression:
     warn_unimplemented: true


### PR DESCRIPTION
Adds a new parameter to RenderEngineVtkParams. Rather than waiting for the engine's lighting model to get promoted based on its content, it can be pushed into that mode upon construction.

This also fixes a bug in which cloned instances forgot whether or not phong materials should be automatically promoted to PBR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22170)
<!-- Reviewable:end -->
