### PR TITLE
Clarify upgrade advice for bazelisk

### DIFF
--- a/tools/workspace/README.md
+++ b/tools/workspace/README.md
@@ -97,6 +97,9 @@ Once all upgrades are ready, open a Drake pull request and label it
 change the drop-down that says "Combine commits for review" to choose
 "Review each commit separately" instead.
 
+If any packages suggested that additional pre-merge testing is needed,
+launch jobs as specified in the output of ``new_release``.
+
 Once all of the Jenkins builds of the pull request have passed, assign the
 pull request for review. If the pull request contains no especially complicated
 changes, it may be assigned to the on-call platform reviewer and labelled

--- a/tools/workspace/bazelisk/repository.bzl
+++ b/tools/workspace/bazelisk/repository.bzl
@@ -18,6 +18,13 @@ def bazelisk_repository(
         Additionally, you must manually update the version number in
           setup/ubuntu/source_distribution/install_bazelisk.sh
         and adjust the expected checksums accordingly.
+
+        To calculate the checksums, download the deb files specifed in
+        install_bazelisk.sh and use:
+          shasum -a 256 'xxx.deb'
+
+        To fully test, a Linux uprovisioned job must be launched from the
+        pull request.
         """,
         commit = "v1.25.0",
         sha256 = "8ff4c6b9ab6a00fbef351d52fde39afc2b9f047865f219a89ed0b23ad6f8cf06",  # noqa


### PR DESCRIPTION
Towards #22087

When performing upgrades using the semi-automated script, most externals only require the standard pre-merge jobs to test. In the case of bazelisk, however, an unprovisioned Linux job should also be run. Add a reminder to the documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22171)
<!-- Reviewable:end -->
