### PR TITLE
[common] Work around linker error with clang 16+

### DIFF
--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -19,6 +19,7 @@ static_assert(EIGEN_VERSION_AT_LEAST(3, 3, 5),
 #include "drake/common/constants.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/fmt_eigen.h"  // Clang-16 workaround; see #22061.
 
 namespace drake {
 


### PR DESCRIPTION
This patch avoids linker errors seen with clang 16 through 18 seen on both macos and ubuntu noble. Somehow, without this patch, the compiler emits undefined symbols containing the Drake-only using-statement type `MatrixX`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22172)
<!-- Reviewable:end -->
