### PR TITLE
Fix a bug in MosekSolver with psd matrix containing repeated entries.

### DIFF
--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -1384,6 +1384,10 @@ MSKrescodee MosekSolverProgram::
         // <A, X̅ᵢ> = 0, where
         // A(m, n) = 1 if m == n else 0.5
         // A(p, q) = -1 if p == q else -0.5
+        // Hence A is the difference between the E matrix (The entry coefficient
+        // matrix) for the (m, n) entry and (p, q) entry.
+        // <E_indices[0], X̅ᵢ> = X̅ᵢ(m, n)
+        // <E_indices[1], X̅ᵢ> = X̅ᵢ(p, q)
         std::array<MSKint64t, 2> E_indices{};
         rescode = AddMatrixVariableEntryCoefficientMatrixIfNonExistent(
             matrix_variable_entries[0], &(E_indices[0]));
@@ -1396,16 +1400,7 @@ MSKrescodee MosekSolverProgram::
           return rescode;
         }
 
-        // weights[0] = A(m, n), weights[1] = A(p, q).
-        std::array<MSKrealt, 2> weights{};
-        weights[0] = matrix_variable_entries[0].row_index() ==
-                             matrix_variable_entries[0].col_index()
-                         ? 1.0
-                         : 0.5;
-        weights[1] = matrix_variable_entries[i].row_index() ==
-                             matrix_variable_entries[i].col_index()
-                         ? -1.0
-                         : -0.5;
+        std::array<MSKrealt, 2> weights{1, -1};
 
         rescode = MSK_putbaraij(task_, linear_constraint_index,
                                 matrix_variable_entries[0].bar_matrix_index(),

--- a/solvers/test/clarabel_solver_test.cc
+++ b/solvers/test/clarabel_solver_test.cc
@@ -470,6 +470,13 @@ GTEST_TEST(TestSemidefiniteProgram, Test2X2LMI) {
   }
 }
 
+GTEST_TEST(TestSemidefiniteProgram, TestHankel) {
+  ClarabelSolver solver;
+  if (solver.available()) {
+    TestHankel(solver, 1E-5, /*check_dual=*/true, /*dual_tol=*/1E-5);
+  }
+}
+
 GTEST_TEST(TestExponentialConeProgram, ExponentialConeTrivialExample) {
   ClarabelSolver solver;
   if (solver.available()) {

--- a/solvers/test/mosek_solver_internal_test.cc
+++ b/solvers/test/mosek_solver_internal_test.cc
@@ -853,6 +853,262 @@ GTEST_TEST(AddLinearMatrixInequalityConstraint, LMIandPSD) {
   }
   MSK_deleteenv(&env);
 }
+
+GTEST_TEST(PositiveSemidefiniteConstraint, Hankel) {
+  // Test the Hankel matrix being PSD. A Hankel matrix has a lot of repeated
+  // entries, so this test emphasize adding equality constraint between repeated
+  // entries in the bar variable.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<5>("x");
+  Matrix3<symbolic::Variable> X;
+  // clang-format off
+  X << x(0), x(1), x(2),
+       x(1), x(2), x(3),
+       x(2), x(3), x(4);
+  // clang-format on
+  auto psd_con = prog.AddPositiveSemidefiniteConstraint(X);
+  MSKenv_t env;
+  MSK_makeenv(&env, nullptr);
+  MosekSolverProgram dut(prog, env);
+
+  EXPECT_TRUE(dut.decision_variable_to_mosek_nonmatrix_variable().empty());
+  EXPECT_EQ(dut.decision_variable_to_mosek_matrix_variable().size(),
+            prog.num_vars());
+  std::unordered_map<Binding<PositiveSemidefiniteConstraint>, MSKint32t>
+      psd_barvar_indices;
+  dut.AddPositiveSemidefiniteConstraints(prog, &psd_barvar_indices);
+  // There is only one bar variable.
+  EXPECT_EQ(psd_barvar_indices.size(), 1);
+  EXPECT_EQ(psd_barvar_indices.at(psd_con), 0);
+
+  // x(2) is repeated in X.
+  dut.AddEqualityConstraintBetweenMatrixVariablesForSameDecisionVariable();
+  MSKint32t numcon;
+  MSK_getnumcon(dut.task(), &numcon);
+  EXPECT_EQ(numcon, 1);
+  // Get the barA matrix info
+  {
+    MSKint64t A_triplet_num;
+    std::array<MSKint32t, 2> A_triplet_subi;
+    std::array<MSKint32t, 2> A_triplet_subj;
+    std::array<MSKint32t, 2> A_triplet_subk;
+    std::array<MSKint32t, 2> A_triplet_subl;
+    std::array<MSKrealt, 2> A_triplet_valijkl;
+    MSK_getbarablocktriplet(dut.task(), 2, &A_triplet_num,
+                            A_triplet_subi.data(), A_triplet_subj.data(),
+                            A_triplet_subk.data(), A_triplet_subl.data(),
+                            A_triplet_valijkl.data());
+    EXPECT_EQ(A_triplet_num, 2);
+    // Only one constraint, so the constraint indices are all 0.
+    EXPECT_EQ(A_triplet_subi[0], 0);
+    EXPECT_EQ(A_triplet_subi[1], 0);
+    // Only one bar variable, so the matrix variable indices are all 0.
+    EXPECT_EQ(A_triplet_subj[0], 0);
+    EXPECT_EQ(A_triplet_subj[1], 0);
+    // The barA matrix is
+    // [0, 0, 0.5]
+    // [0, -1, 0 ]
+    // [0.5, 0, 0]
+    // or the negation of this matrix.
+    Eigen::Matrix3d barA = Eigen::Matrix3d::Zero();
+    for (int i = 0; i < 2; ++i) {
+      barA(A_triplet_subk[i], A_triplet_subl[i]) = A_triplet_valijkl[i];
+    }
+    Eigen::Matrix3d barA_expected;
+    // Mosek only records the lower triangular part of the matrix.
+    // clang-format off
+    barA_expected << 0, 0, 0,
+                     0, -1, 0,
+                     0.5, 0, 0;
+    // clang-format on
+    if (barA(1, 1) >= 0) {
+      barA_expected *= -1;
+    }
+    EXPECT_TRUE(CompareMatrices(barA, barA_expected));
+  }
+
+  MSK_deleteenv(&env);
+}
+
+GTEST_TEST(PositiveSemidefiniteConstraint, OffDiagonalRepeatedEntry) {
+  // Test a PSD constraint on a matrix whose off-diagonal terms contain repeated
+  // variables.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<5>("x");
+  Matrix3<symbolic::Variable> X;
+  // clang-format off
+  X << x(0), x(1), x(2),
+       x(1), x(3), x(1),
+       x(2), x(1), x(4);
+  // clang-format on
+  auto psd_con = prog.AddPositiveSemidefiniteConstraint(X);
+  MSKenv_t env;
+  MSK_makeenv(&env, nullptr);
+  MosekSolverProgram dut(prog, env);
+
+  EXPECT_TRUE(dut.decision_variable_to_mosek_nonmatrix_variable().empty());
+  EXPECT_EQ(dut.decision_variable_to_mosek_matrix_variable().size(),
+            prog.num_vars());
+  std::unordered_map<Binding<PositiveSemidefiniteConstraint>, MSKint32t>
+      psd_barvar_indices;
+  dut.AddPositiveSemidefiniteConstraints(prog, &psd_barvar_indices);
+  // There is only one bar variable.
+  EXPECT_EQ(psd_barvar_indices.size(), 1);
+  EXPECT_EQ(psd_barvar_indices.at(psd_con), 0);
+
+  // x(1) is repeated in X.
+  dut.AddEqualityConstraintBetweenMatrixVariablesForSameDecisionVariable();
+  MSKint32t numcon;
+  MSK_getnumcon(dut.task(), &numcon);
+  EXPECT_EQ(numcon, 1);
+  // Get the barA matrix info
+  {
+    MSKint64t A_triplet_num;
+    std::array<MSKint32t, 2> A_triplet_subi;
+    std::array<MSKint32t, 2> A_triplet_subj;
+    std::array<MSKint32t, 2> A_triplet_subk;
+    std::array<MSKint32t, 2> A_triplet_subl;
+    std::array<MSKrealt, 2> A_triplet_valijkl;
+    MSK_getbarablocktriplet(dut.task(), 2, &A_triplet_num,
+                            A_triplet_subi.data(), A_triplet_subj.data(),
+                            A_triplet_subk.data(), A_triplet_subl.data(),
+                            A_triplet_valijkl.data());
+    EXPECT_EQ(A_triplet_num, 2);
+    // Only one constraint, so the constraint indices are all 0.
+    EXPECT_EQ(A_triplet_subi[0], 0);
+    EXPECT_EQ(A_triplet_subi[1], 0);
+    // Only one bar variable, so the matrix variable indices are all 0.
+    EXPECT_EQ(A_triplet_subj[0], 0);
+    EXPECT_EQ(A_triplet_subj[1], 0);
+    // The barA matrix is
+    // [  0, 0.5,    0]
+    // [0.5,   0, -0.5]
+    // [  0, -0.5,   0]
+    // or the negation of this matrix.
+    Eigen::Matrix3d barA = Eigen::Matrix3d::Zero();
+    for (int i = 0; i < 2; ++i) {
+      barA(A_triplet_subk[i], A_triplet_subl[i]) = A_triplet_valijkl[i];
+    }
+    Eigen::Matrix3d barA_expected;
+    // Mosek only records the lower triangular part of the matrix.
+    // clang-format off
+    barA_expected << 0, 0, 0,
+                     0.5, 0, 0,
+                     0, -0.5, 0;
+    // clang-format on
+    // The constraint Xbar(1, 0) == Xbar(2, 1) can be cast as either Xbar(1, 0)
+    // - Xbar(2, 1) = 0 or Xbar(2, 1) - Xbar(1, 0) = 0, so we consider both
+    // situation here.
+    if (barA(2, 1) >= 0) {
+      barA_expected *= -1;
+    }
+    EXPECT_TRUE(CompareMatrices(barA, barA_expected));
+  }
+
+  MSK_deleteenv(&env);
+}
+
+GTEST_TEST(PositiveSemidefiniteConstraint, RepeatedVariableDifferentMatrices) {
+  // Test PSD constraints on two matrices, these two matrices share a repeated
+  // variable.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<11>("x");
+  Matrix3<symbolic::Variable> X1;
+  Matrix3<symbolic::Variable> X2;
+  // clang-format off
+  X1 << x(0), x(1), x(2),
+        x(1), x(3), x(4),
+        x(2), x(4), x(5);
+  X2 << x(6), x(7), x(8),
+        x(7), x(1), x(9),
+        x(8), x(9), x(10);
+  // clang-format on
+  auto psd_con1 = prog.AddPositiveSemidefiniteConstraint(X1);
+  auto psd_con2 = prog.AddPositiveSemidefiniteConstraint(X2);
+  MSKenv_t env;
+  MSK_makeenv(&env, nullptr);
+  MosekSolverProgram dut(prog, env);
+
+  EXPECT_TRUE(dut.decision_variable_to_mosek_nonmatrix_variable().empty());
+  EXPECT_EQ(dut.decision_variable_to_mosek_matrix_variable().size(),
+            prog.num_vars());
+  std::unordered_map<Binding<PositiveSemidefiniteConstraint>, MSKint32t>
+      psd_barvar_indices;
+  dut.AddPositiveSemidefiniteConstraints(prog, &psd_barvar_indices);
+  // There are two bar variables.
+  EXPECT_EQ(psd_barvar_indices.size(), 2);
+
+  // x(1) is repeated in X1 and X2.
+  dut.AddEqualityConstraintBetweenMatrixVariablesForSameDecisionVariable();
+  MSKint32t numcon;
+  MSK_getnumcon(dut.task(), &numcon);
+  EXPECT_EQ(numcon, 1);
+  // Get the barA matrix info
+  {
+    MSKint64t A_triplet_num;
+    std::array<MSKint32t, 2> A_triplet_subi;
+    std::array<MSKint32t, 2> A_triplet_subj;
+    std::array<MSKint32t, 2> A_triplet_subk;
+    std::array<MSKint32t, 2> A_triplet_subl;
+    std::array<MSKrealt, 2> A_triplet_valijkl;
+    MSK_getbarablocktriplet(dut.task(), 2, &A_triplet_num,
+                            A_triplet_subi.data(), A_triplet_subj.data(),
+                            A_triplet_subk.data(), A_triplet_subl.data(),
+                            A_triplet_valijkl.data());
+    EXPECT_EQ(A_triplet_num, 2);
+    // Only one constraint, so the constraint indices are all 0.
+    EXPECT_EQ(A_triplet_subi[0], 0);
+    EXPECT_EQ(A_triplet_subi[1], 0);
+    // Two bar variable, so the matrix variable indices are {0, 1}.
+    if (A_triplet_subj[0] == 0) {
+      EXPECT_EQ(A_triplet_subj[1], 1);
+    } else {
+      EXPECT_EQ(A_triplet_subj[0], 1);
+      EXPECT_EQ(A_triplet_subj[1], 0);
+    }
+    // The barA matrix for X1 is
+    // [  0, 0.5, 0]
+    // [0.5,   0, 0]
+    // [  0,   0, 0]
+    // The barA matrix for X2 is
+    // [0 0 0]
+    // [0 -1 0]
+    // [0 0 0]
+    // or the negation of this matrix.
+    std::array<Eigen::Matrix3d, 2> barA;
+    for (int i = 0; i < 2; ++i) {
+      barA[i].setZero();
+    }
+    for (int i = 0; i < 2; ++i) {
+      barA[A_triplet_subj[i]](A_triplet_subk[i], A_triplet_subl[i]) =
+          A_triplet_valijkl[i];
+    }
+    Eigen::Matrix3d barA_for_X1 = barA[psd_barvar_indices[psd_con1]];
+    Eigen::Matrix3d barA_for_X2 = barA[psd_barvar_indices[psd_con2]];
+    Eigen::Matrix3d barA_for_X1_expected;
+    Eigen::Matrix3d barA_for_X2_expected;
+    // Mosek only records the lower triangular part of the matrix.
+    // clang-format off
+    barA_for_X1_expected<< 0, 0, 0,
+                           0.5, 0, 0,
+                           0, 0, 0;
+    barA_for_X2_expected << 0, 0, 0,
+                            0, -1, 0,
+                            0, 0, 0;
+    // clang-format on
+    // The constraint X1(0, 1) == X2(1, 1) can be formulated as either X1(0, 1)
+    // - X2(1, 1) = 0 or X2(1, 1) - X1(0, 1) = 0, with a negation sign. We
+    // consider both cases here.
+    if (barA_for_X1(1, 0) < 0) {
+      barA_for_X1_expected *= -1;
+      barA_for_X2_expected *= -1;
+    }
+    EXPECT_TRUE(CompareMatrices(barA_for_X1, barA_for_X1_expected));
+    EXPECT_TRUE(CompareMatrices(barA_for_X2, barA_for_X2_expected));
+  }
+
+  MSK_deleteenv(&env);
+}
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -568,6 +568,13 @@ GTEST_TEST(MosekTest, Test2X2LMI) {
   }
 }
 
+GTEST_TEST(MosekTest, TestHankel) {
+  MosekSolver solver;
+  if (solver.available()) {
+    TestHankel(solver, 1E-5, true, 1E-6);
+  }
+}
+
 GTEST_TEST(MosekTest, LPDualSolution1) {
   MosekSolver solver;
   if (solver.available()) {

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -468,6 +468,13 @@ GTEST_TEST(TestSemidefiniteProgram, Test2X2LMI) {
   }
 }
 
+GTEST_TEST(TestSemidefiniteProgram, TestHankel) {
+  ScsSolver solver;
+  if (solver.available()) {
+    TestHankel(solver, 1E-5, /*check_dual=*/true, /*dual_tol=*/1E-5);
+  }
+}
+
 GTEST_TEST(TestExponentialConeProgram, ExponentialConeTrivialExample) {
   ScsSolver solver;
   if (solver.available()) {

--- a/solvers/test/semidefinite_program_examples.cc
+++ b/solvers/test/semidefinite_program_examples.cc
@@ -630,6 +630,75 @@ void Test2x2LMI(const SolverInterface& solver, double primal_tol,
   }
 }
 
+namespace {
+MatrixX<symbolic::Variable> Hankel(
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& c,
+    const Eigen::Ref<const VectorX<symbolic::Variable>>& r) {
+  MatrixX<symbolic::Variable> ret(c.rows(), r.rows());
+  for (int i = 0; i < ret.rows(); ++i) {
+    for (int j = 0; j < ret.cols(); ++j) {
+      if (i + j < ret.rows()) {
+        ret(i, j) = c(i + j);
+      } else {
+        ret(i, j) = r(i + j - ret.rows() + 1);
+      }
+    }
+  }
+  return ret;
+}
+}  // namespace
+void TestHankel(const SolverInterface& solver, double primal_tol,
+                bool check_dual, double dual_tol) {
+  int n = 3;
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables(2 * n - 1, "x");
+  auto X = Hankel(x.head(n), x.tail(n));
+  auto psd_con = prog.AddPositiveSemidefiniteConstraint(X);
+  prog.AddBoundingBoxConstraint(1, kInf, x(1));
+  prog.AddLinearCost(X.cast<symbolic::Expression>().trace());
+
+  MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, std::nullopt, &result);
+  ASSERT_TRUE(result.is_success());
+
+  const auto X_sol = result.GetSolution(X);
+  // We can compute the optimal solution by hand.
+  const double x2_expected = std::sqrt((std::sqrt(13) - 1) / 6);
+  const double x0_expected = 1 / x2_expected;
+  const double x3_expected = x2_expected * x2_expected;
+  const double x4_expected = x3_expected * x3_expected / x2_expected;
+  Eigen::Matrix<double, 5, 1> x_expected;
+  x_expected << x0_expected, 1, x2_expected, x3_expected, x4_expected;
+  const auto x_sol = result.GetSolution(x);
+  EXPECT_TRUE(CompareMatrices(x_sol, x_expected, primal_tol));
+  Eigen::Matrix3d X_expected;
+  // clang-format off
+  X_expected << x0_expected, 1, x2_expected,
+                1, x2_expected, x3_expected,
+                x2_expected, x3_expected, x4_expected;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(X_sol, X_expected, primal_tol));
+  if (check_dual) {
+    // The dual PSD matrix has the form
+    // [1 -y1/2 -y0/2]
+    // [* 1+y0    0  ]
+    // [*   *     1  ]
+    // with y1 >= 0
+    const Eigen::Matrix3d psd_dual =
+        math::ToSymmetricMatrixFromLowerTriangularColumns(
+            result.GetDualSolution(psd_con));
+    EXPECT_NEAR((psd_dual * X_sol).trace(), 0, dual_tol);
+    EXPECT_NEAR(psd_dual(0, 0), 1, dual_tol);
+    EXPECT_NEAR(psd_dual(1, 2), 0, dual_tol);
+    EXPECT_NEAR(psd_dual(2, 2), 1, dual_tol);
+    EXPECT_LE(psd_dual(0, 1), dual_tol);
+    EXPECT_NEAR(psd_dual(0, 2) * 2 + psd_dual(1, 1), 1, primal_tol);
+
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es(psd_dual);
+    EXPECT_TRUE((es.eigenvalues().array() >= -dual_tol).all());
+  }
+}
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/semidefinite_program_examples.h
+++ b/solvers/test/semidefinite_program_examples.h
@@ -190,6 +190,16 @@ void TestTrivial1x1LMI(const SolverInterface& solver, double primal_tol,
 //     [1, -2]  [2, 8]
 void Test2x2LMI(const SolverInterface& solver, double primal_tol,
                 bool check_dual, double dual_tol);
+
+// min trace(X)
+// s.t X[0, 1] >= 1
+//     X is psd
+//     X is hankel.
+// Since X is hankel, some of its entries contain repeated variables. This test
+// is reported from github issue
+// https://github.com/RobotLocomotion/drake/issues/22158
+void TestHankel(const SolverInterface& solver, double primal_tol,
+                bool check_dual, double dual_tol);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
When the PSD matrix contains repeated entries, the MosekSolver imposed a wrong constraint. This PR fixes the bug.

resolves #22158

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22173)
<!-- Reviewable:end -->
