### PR TITLE
Python bindings for methods of GcsTrajectoryOptimization::EdgesBetweenSubgraphs for adding generic costs and constraints.

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -483,7 +483,28 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             overload_cast_explicit<const std::vector<
                 geometry::optimization::GraphOfConvexSets::Edge*>&>(
                 &Class::EdgesBetweenSubgraphs::Edges),
-            py_rvp::reference_internal, subgraph_edges_doc.Edges.doc);
+            py_rvp::reference_internal, subgraph_edges_doc.Edges.doc)
+        .def("edge_constituent_vertex_durations",
+            &Class::EdgesBetweenSubgraphs::edge_constituent_vertex_durations,
+            subgraph_edges_doc.edge_constituent_vertex_durations.doc)
+        // As in trajectory_optimization_py.cc, we use a lambda to *copy*
+        // the decision variables; otherwise we get dtype=object arrays
+        // cannot be referenced.
+        .def(
+            "edge_constituent_vertex_control_points",
+            [](const GcsTrajectoryOptimization::EdgesBetweenSubgraphs& self)
+                -> std::pair<MatrixX<symbolic::Variable>,
+                    MatrixX<symbolic::Variable>> {
+              return self.edge_constituent_vertex_control_points();
+            },
+            subgraph_edges_doc.edge_constituent_vertex_control_points.doc)
+        .def("AddEdgeCost", &Class::EdgesBetweenSubgraphs::AddEdgeCost,
+            py::arg("e"), py::arg("use_in_transcription") = all_transcriptions,
+            subgraph_edges_doc.AddEdgeCost.doc)
+        .def("AddEdgeConstraint",
+            &Class::EdgesBetweenSubgraphs::AddEdgeConstraint, py::arg("e"),
+            py::arg("use_in_transcription") = all_transcriptions,
+            subgraph_edges_doc.AddEdgeConstraint.doc);
 
     gcs_traj_opt  // BR
         .def(py::init<int, const std::vector<int>&>(), py::arg("num_positions"),

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -331,8 +331,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         np.testing.assert_allclose(restricted_traj_start, start, atol=1e-6)
         np.testing.assert_allclose(restricted_traj_end, end, atol=1e-6)
 
-        # We can add additional costs and constraints with the placeholder
-        # variables.
+        # We can add additional costs and constraints to Subgraphs with the
+        # placeholder variables.
         vertex_duration = regions.vertex_duration()
         vertex_control_points = regions.vertex_control_points()
         edge_constituent_vertex_durations = (
@@ -376,6 +376,31 @@ class TestTrajectoryOptimization(unittest.TestCase):
                             use_in_transcription=all_transcriptions)
         regions.AddEdgeConstraint(e=edge_constraint,
                                   use_in_transcription=all_transcriptions)
+
+        # We can add additional costs and constraints to EdgesBetweenSubgraphs
+        # with the placeholder variables.
+        edge_constituent_vertex_durations = (
+            edges.edge_constituent_vertex_durations()
+        )
+        edge_constituent_vertex_control_points = (
+            edges.edge_constituent_vertex_control_points()
+        )
+        edge_cost = sum([
+            edge_constituent_vertex_durations[0],
+            edge_constituent_vertex_durations[1],
+            edge_constituent_vertex_control_points[0][0, 0],
+            edge_constituent_vertex_control_points[1][0, 0],
+            edge_constituent_vertex_control_points[1][0, 1]
+        ])
+        edge_constraint = edge_cost >= 0
+
+        edges.AddEdgeCost(e=edge_cost)
+        edges.AddEdgeConstraint(e=edge_constraint)
+
+        edges.AddEdgeCost(e=edge_cost,
+                          use_in_transcription=all_transcriptions)
+        edges.AddEdgeConstraint(e=edge_constraint,
+                                use_in_transcription=all_transcriptions)
 
         traj, result = gcs.SolvePath(source, target)
         self.assertTrue(result.is_success())


### PR DESCRIPTION
Towards #21981. Adds python bindings to the methods introduced in #22155.

+@rpoyner-tri for review, please! (This PR only adds bindings, so I've tagged it as single reviewer ok.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22177)
<!-- Reviewable:end -->
