### PR TITLE
[tools] Add single point of control for rules_java

### DIFF
--- a/tools/skylark/drake_java.bzl
+++ b/tools/skylark/drake_java.bzl
@@ -1,3 +1,5 @@
+load("//tools/skylark:java.bzl", "java_binary")
+
 MainClassInfo = provider()
 
 # Generate a launcher file to run installed java binaries
@@ -48,7 +50,7 @@ def drake_java_binary(
         for key, value in kwargs.items()
         if key == "visibility" or key == "jvm_flags"
     }
-    native.java_binary(
+    java_binary(
         name = name,
         main_class = main_class,
         **kwargs

--- a/tools/skylark/java.bzl
+++ b/tools/skylark/java.bzl
@@ -1,0 +1,26 @@
+"""Provides a single point of control for rules_java inside Drake."""
+
+load(
+    "@rules_java//java:defs.bzl",
+    _java_binary = "java_binary",
+    _java_import = "java_import",
+    _java_library = "java_library",
+)
+
+def java_binary(name, **kwargs):
+    _java_binary(
+        name = name,
+        **kwargs
+    )
+
+def java_import(name, **kwargs):
+    _java_import(
+        name = name,
+        **kwargs
+    )
+
+def java_library(name, **kwargs):
+    _java_library(
+        name = name,
+        **kwargs
+    )

--- a/tools/workspace/java.bzl
+++ b/tools/workspace/java.bzl
@@ -11,6 +11,7 @@ def _impl(repo_ctx):
 
     # Create the /jar/BUILD.bazel file.
     build_content = """\
+load("@drake//tools/skylark:java.bzl", "java_import")
 package(default_visibility = ["//visibility:public"])
 """
     if os_name in repo_ctx.attr.local_os_targets:

--- a/tools/workspace/lcm/lcm.bzl
+++ b/tools/workspace/lcm/lcm.bzl
@@ -1,4 +1,5 @@
 load("//tools/skylark:cc.bzl", "cc_library")
+load("//tools/skylark:java.bzl", "java_library")
 load("//tools/skylark:pathutils.bzl", "basename", "dirname", "join_paths")
 load("//tools/skylark:py.bzl", "py_library")
 load(
@@ -320,7 +321,7 @@ def lcm_java_library(
     if "@lcm//:lcm-java" not in deps:
         deps = deps + ["@lcm//:lcm-java"]
 
-    native.java_library(
+    java_library(
         name = name,
         srcs = outs,
         deps = deps,

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -4,6 +4,7 @@ load("@drake//tools/install:install.bzl", "install", "install_files")
 load("@drake//tools/lint:python_lint.bzl", "python_lint")
 load("@drake//tools/skylark:cc.bzl", "cc_binary", "cc_library")
 load("@drake//tools/skylark:drake_java.bzl", "drake_java_binary")
+load("@drake//tools/skylark:java.bzl", "java_library")
 load("@drake//tools/skylark:py.bzl", "py_library")
 load(
     "@drake//tools/workspace:generate_export_header.bzl",


### PR DESCRIPTION
In Bazel 8, most rules not loaded via a 'load' statement are deprecated.

Towards #22182.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22184)
<!-- Reviewable:end -->
