### PR TITLE
[tools] Prepare glob changing default to allow_empty=False

### DIFF
--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -87,8 +87,6 @@ filegroup(
         "**/*.obj",
         "**/*.png",
         "**/*.sdf",
-        "**/*.urdf",
-        "**/*.xml",
     ]),
     visibility = [
         "//:__pkg__",

--- a/multibody/benchmarks/acrobot/BUILD.bazel
+++ b/multibody/benchmarks/acrobot/BUILD.bazel
@@ -30,12 +30,12 @@ drake_cc_library(
 
 filegroup(
     name = "models",
-    srcs = glob([
-        "**/*.obj",
-        "**/*.sdf",
-        "**/*.urdf",
-        "**/*.xml",
-    ]),
+    srcs = [
+        "acrobot.sdf",
+        "acrobot.urdf",
+        "acrobot.xml",
+        "double_pendulum.urdf",
+    ],
 )
 
 drake_cc_library(

--- a/multibody/benchmarks/free_body/BUILD.bazel
+++ b/multibody/benchmarks/free_body/BUILD.bazel
@@ -11,12 +11,9 @@ package(default_visibility = ["//visibility:private"])
 filegroup(
     name = "models",
     testonly = 1,
-    srcs = glob([
-        "**/*.obj",
-        "**/*.sdf",
-        "**/*.urdf",
-        "**/*.xml",
-    ]),
+    srcs = [
+        "uniform_solid_cylinder.urdf",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/lint/bazel_lint.bzl
+++ b/tools/lint/bazel_lint.bzl
@@ -70,13 +70,17 @@ def bazel_lint(
 
     _bazel_lint(
         name = name,
-        files = native.glob([
-            "*.bzl",
-            "*.BUILD",
-            "*.BUILD.bazel",
-            "BUILD",
-            "BUILD.bazel",
-            "WORKSPACE",
-        ], exclude = exclude) + extra_srcs,
+        files = native.glob(
+            [
+                "*.bzl",
+                "*.BUILD",
+                "*.BUILD.bazel",
+                "BUILD",
+                "BUILD.bazel",
+                "WORKSPACE",
+            ],
+            exclude = exclude,
+            allow_empty = True,
+        ) + extra_srcs,
         ignore = ignore,
     )

--- a/tools/lint/cpplint.bzl
+++ b/tools/lint/cpplint.bzl
@@ -61,7 +61,10 @@ def _add_linter_rules(
     # alias Drake's config file into their top-level BUILD.bazel file.)
     cpplint_data = list(data)
     cpplint_cfgs = ["//:CPPLINT.cfg"]
-    for x in native.glob(["CPPLINT.cfg", "test/CPPLINT.cfg"]):
+    for x in native.glob(
+        ["CPPLINT.cfg", "test/CPPLINT.cfg"],
+        allow_empty = True,
+    ):
         cpplint_cfgs.append("//" + native.package_name() + ":" + x)
     for item in cpplint_cfgs:
         if item not in cpplint_data:

--- a/tools/workspace/gurobi/package-darwin.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-darwin.BUILD.bazel.in
@@ -15,12 +15,12 @@ genrule(
 
 GUROBI_C_HDRS = glob([
     "gurobi-distro/include/gurobi_c.h",
-]) or [":error-message.h"]
+], allow_empty = True) or [":error-message.h"]
 
 GUROBI_CXX_HDRS = glob([
     "gurobi-distro/include/gurobi_c.h",
     "gurobi-distro/include/gurobi_c++.h",
-]) or [":error-message.h"]
+], allow_empty = True) or [":error-message.h"]
 
 cc_library(
     name = "gurobi_c",

--- a/tools/workspace/gurobi/package-linux.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-linux.BUILD.bazel.in
@@ -15,12 +15,12 @@ genrule(
 
 GUROBI_C_HDRS = glob([
     "gurobi-distro/include/gurobi_c.h",
-]) or [":error-message.h"]
+], allow_empty = True) or [":error-message.h"]
 
 GUROBI_CXX_HDRS = glob([
     "gurobi-distro/include/gurobi_c.h",
     "gurobi-distro/include/gurobi_c++.h",
-]) or [":error-message.h"]
+], allow_empty = True) or [":error-message.h"]
 
 # In the Gurobi package, libgurobi100.so is a symlink to libgurobi.so.10.0.*.
 # However, if we use libgurobi.so.10.0.* in srcs, executables that link this
@@ -31,21 +31,21 @@ GUROBI_CXX_HDRS = glob([
 
 GUROBI_C_SRCS = glob([
     "gurobi-distro/lib/libgurobi100.so",
-]) or [":error-message.h"]
+], allow_empty = True) or [":error-message.h"]
 
 GUROBI_CXX_SRCS = glob([
     "gurobi-distro/lib/libgurobi100.so",
     "gurobi-distro/lib/libgurobi_g++5.2.a",
-]) or [":error-message.h"]
+], allow_empty = True) or [":error-message.h"]
 
 GUROBI_INSTALL_LIBRARIES = glob([
     "gurobi-distro/lib/libgurobi.so.10.0.*",
     "gurobi-distro/lib/libgurobi100.so",
-]) or [":error-message.h"]
+], allow_empty = True) or [":error-message.h"]
 
 GUROBI_DOCS = glob([
     "gurobi-distro/EULA.pdf",
-]) or [":error-message.h"]
+], allow_empty = True) or [":error-message.h"]
 
 cc_library(
     name = "gurobi_c",

--- a/tools/workspace/mosek/package.BUILD.bazel
+++ b/tools/workspace/mosek/package.BUILD.bazel
@@ -17,7 +17,7 @@ _TBB_MAJMIN_GLOB = glob([
     "bin/libtbb_debug.so.*.*",
     # This is the spelling for osxaarch64 and osx64x86.
     "bin/libtbb.*.*.dylib",
-])
+], allow_empty = True)
 
 len(_TBB_MAJMIN_GLOB) == 1 or fail("Glob failure: " + str(glob(["**"])))
 
@@ -30,7 +30,7 @@ _TBB_MAJ_GLOB = glob([
     "bin/libtbb_debug.so.*",
     # This is the spelling for osxaarch64 and osx64x86.
     "bin/libtbb.*.dylib",
-], exclude = _TBB_MAJMIN_GLOB)
+], exclude = _TBB_MAJMIN_GLOB, allow_empty = True)
 
 len(_TBB_MAJ_GLOB) == 1 or fail("Glob failure: " + str(glob(["**"])))
 
@@ -59,7 +59,7 @@ cc_library(
 _MOSEK_MAJMIN_GLOB = glob([
     "bin/libmosek64.so.*.*",
     "bin/libmosek64.*.*.dylib",
-])
+], allow_empty = True)
 
 len(_MOSEK_MAJMIN_GLOB) == 1 or fail("Glob failure: " + str(glob(["**"])))
 

--- a/tools/workspace/pkg_config.bzl
+++ b/tools/workspace/pkg_config.bzl
@@ -248,7 +248,7 @@ cc_library(
             hdrs_path.get_child(symlink_dest),
         )
         includes += ["include/" + symlink_dest]
-    hdrs_prologue = "glob([\"include/**\"]) + "
+    hdrs_prologue = "glob([\"include/**\"], allow_empty = True) + "
 
     extra_deprecation = getattr(
         repository_ctx.attr,

--- a/tools/workspace/vtk_internal/rules.bzl
+++ b/tools/workspace/vtk_internal/rules.bzl
@@ -89,7 +89,7 @@ def _vtk_cc_module_impl(
         subdir + "/**/*.txx.in",
     ], exclude = [
         "**/test*",
-    ] + hdrs_glob_exclude)
+    ] + hdrs_glob_exclude, allow_empty = True)
     gen_hdrs = [
         # We want to start from, e.g., "Common/Core/vtkDebug.h.in" and generate
         # "gen/Common/Core/vtkDebug.h" with CMake substitutions applied, which


### PR DESCRIPTION
In Bazel 8, glob lines that don't match anything are an error.  (If we have lines that are _expected_ to sometimes not match anything, then we need to mark that with `allow_empty = True` on the glob call.)

Towards #22182.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22185)
<!-- Reviewable:end -->
