### PR TITLE
[tools] Fix some skylark deprecations

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -293,7 +293,12 @@ def _gather_transitive_hdrs_impl(ctx):
         )
     ])
 
-    return struct(files = result)
+    return [
+        DefaultInfo(
+            files = result,
+            runfiles = ctx.runfiles(transitive_files = result),
+        ),
+    ]
 
 _gather_transitive_hdrs = rule(
     attrs = {

--- a/tools/workspace/metadata.bzl
+++ b/tools/workspace/metadata.bzl
@@ -7,9 +7,9 @@ def generate_repository_metadata(repository_ctx, **kwargs):
     """
     repository_ctx.file(
         "drake_repository_metadata.json",
-        content = struct(
+        content = json.encode(struct(
             name = repository_ctx.name,
             **kwargs
-        ).to_json(),
+        )),
         executable = False,
     )


### PR DESCRIPTION
In Bazel 8, certain skylark API are deprecated:
- Stop using the deprecated to_json method.
- Fix gather_transitive_hdrs to use a provider; using a bare struct is deprecated.

Towards #22182.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22187)
<!-- Reviewable:end -->
