### PR TITLE
Add math::FourthOrderTensor

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_package_library(
         ":discrete_lyapunov_equation",
         ":eigen_sparse_triplet",
         ":evenly_distributed_pts_on_sphere",
+        ":fourth_order_tensor",
         ":geometric_transform",
         ":gradient",
         ":gray_code",
@@ -131,6 +132,16 @@ drake_cc_library(
     hdrs = ["discrete_lyapunov_equation.h"],
     deps = [
         "//common:is_approx_equal_abstol",
+    ],
+)
+
+drake_cc_library(
+    name = "fourth_order_tensor",
+    srcs = ["fourth_order_tensor.cc"],
+    hdrs = ["fourth_order_tensor.h"],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
     ],
 )
 
@@ -429,6 +440,14 @@ drake_cc_googletest(
     name = "eigen_sparse_triplet_test",
     deps = [
         ":eigen_sparse_triplet",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fourth_order_tensor_test",
+    deps = [
+        ":fourth_order_tensor",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/math/fourth_order_tensor.cc
+++ b/math/fourth_order_tensor.cc
@@ -1,0 +1,83 @@
+#include "drake/math/fourth_order_tensor.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace math {
+namespace internal {
+
+template <typename T>
+FourthOrderTensor<T>::FourthOrderTensor(const MatrixType& data) : data_(data) {}
+
+template <typename T>
+FourthOrderTensor<T>::FourthOrderTensor() = default;
+
+template <typename T>
+void FourthOrderTensor<T>::ContractWithVectors(
+    const Eigen::Ref<const Vector3<T>>& u,
+    const Eigen::Ref<const Vector3<T>>& v, EigenPtr<Matrix3<T>> B) const {
+  B->setZero();
+  for (int l = 0; l < 3; ++l) {
+    for (int j = 0; j < 3; ++j) {
+      *B += data_.template block<3, 3>(3 * j, 3 * l) * u(j) * v(l);
+    }
+  }
+}
+
+template <typename T>
+void FourthOrderTensor<T>::SetAsOuterProduct(
+    const Eigen::Ref<const Matrix3<T>>& M,
+    const Eigen::Ref<const Matrix3<T>>& N) {
+  const auto M_vec = Eigen::Map<const Vector<T, 9>>(M.data());
+  const auto N_vec = Eigen::Map<const Vector<T, 9>>(N.data());
+  data_.noalias() = M_vec * N_vec.transpose();
+}
+
+template <typename T>
+FourthOrderTensor<T> FourthOrderTensor<T>::MakeSymmetricIdentity(T scale) {
+  const T half_scale = 0.5 * scale;
+  FourthOrderTensor<T> result;
+  /* The δᵢₖδⱼₗ term. */
+  result.SetToDiagonal(half_scale);
+  /* Outerloop j(k) and inner loop i(l) to be more memory friendly (the matrix
+   data is column major). */
+  for (int j = 0; j < 3; ++j) {
+    /* The δᵢₗδⱼₖ term. */
+    for (int i = 0; i < 3; ++i) {
+      const int l = i;
+      const int k = j;
+      result.data_(3 * j + i, 3 * l + k) += half_scale;
+    }
+  }
+  return result;
+}
+
+template <typename T>
+FourthOrderTensor<T> FourthOrderTensor<T>::MakeMajorIdentity(T scale) {
+  FourthOrderTensor<T> result;
+  result.SetToDiagonal(scale);
+  return result;
+}
+
+template <typename T>
+FourthOrderTensor<T>& FourthOrderTensor<T>::operator+=(
+    const FourthOrderTensor<T>& other) {
+  data_ += other.data_;
+  return *this;
+}
+
+template <typename T>
+void FourthOrderTensor<T>::SetToDiagonal(T scale) {
+  /* This generates better instructions than calling.
+   data_ = scale*Matrix<T,9,9>::Identity() */
+  data_.setZero();
+  data_.diagonal().array() = scale;
+}
+
+}  // namespace internal
+}  // namespace math
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::math::internal::FourthOrderTensor);
+template class drake::math::internal::FourthOrderTensor<float>;

--- a/math/fourth_order_tensor.h
+++ b/math/fourth_order_tensor.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace math {
+namespace internal {
+
+/* This class provides functionalities related to 4th-order tensors of
+ dimension 3*3*3*3.  @tparam float, double, AutoDiffXd. */
+template <typename T>
+class FourthOrderTensor {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FourthOrderTensor)
+  using MatrixType = Eigen::Matrix<T, 9, 9>;
+
+  /* Constructs a 4th-order tensor represented by the given matrix using the
+   convention layed out in the class documentation. */
+  explicit FourthOrderTensor(const MatrixType& data);
+
+  /* Constructs a zero 4th-order tensor. */
+  FourthOrderTensor();
+
+  /* Performs contraction between this 4th-order tensor A and two vectors u and
+   v and outputs 2nd order tensor B. In Einstein notation, the contraction being
+   done is Bᵢₖ = uⱼ Aᵢⱼₖₗ vₗ. */
+  void ContractWithVectors(const Eigen::Ref<const Vector3<T>>& u,
+                           const Eigen::Ref<const Vector3<T>>& v,
+                           EigenPtr<Matrix3<T>> B) const;
+
+  /* Sets this 4th-order tensor as the outer product of the matrices (2nd-order
+   tensor) M and N. More specifically, in Einstein notion, sets Aᵢⱼₖₗ = MᵢⱼNₖₗ.
+   @warn This function assumes the input matrices are _not_ aliasing the data in
+   this 4th-order tensor. */
+  void SetAsOuterProduct(const Eigen::Ref<const Matrix3<T>>& M,
+                         const Eigen::Ref<const Matrix3<T>>& N);
+
+  /* Returns a a scaled symmetric identity 4th-order tensor. In Einstein
+   notation, the result is scale * 1/2 * (δᵢₖδⱼₗ + δᵢₗδⱼₖ). */
+  static FourthOrderTensor<T> MakeSymmetricIdentity(T scale);
+
+  /* Returns a scaled major identity 4th-order tensor. In Einstein
+   notation, the result is scale * δᵢₖδⱼₗ.  */
+  static FourthOrderTensor<T> MakeMajorIdentity(T scale);
+
+  FourthOrderTensor<T>& operator+=(const FourthOrderTensor<T>& other);
+
+  /* Returns this 4th-order tensor encoded as a 2D matrix.
+   The tensor is represented using a a 9*9 matrix organized as following
+
+                  l = 0       l = 1       l = 2
+              -------------------------------------
+              |           |           |           |
+    j = 0     |   Aᵢ₀ₖ₀   |   Aᵢ₀ₖ₁   |   Aᵢ₀ₖ₂   |
+              |           |           |           |
+              -------------------------------------
+              |           |           |           |
+    j = 1     |   Aᵢ₁ₖ₀   |   Aᵢ₁ₖ₁   |   Aᵢ₁ₖ₂   |
+              |           |           |           |
+              -------------------------------------
+              |           |           |           |
+    j = 2     |   Aᵢ₂ₖ₀   |   Aᵢ₂ₖ₁   |   Aᵢ₂ₖ₂   |
+              |           |           |           |
+              -------------------------------------
+  Namely the ik-th entry in the jl-th block corresponds to the value Aᵢⱼₖₗ. */
+  const MatrixType& data() const { return data_; }
+
+  /* Returns this 4th-order tensor encoded as a mutable 2D matrix.
+   @see data() for the layout of the matrix. */
+  MatrixType& mutable_data() { return data_; }
+
+  /* Sets this 4th-order tensor to be scale * δᵢₖδⱼₗ. */
+  void SetToDiagonal(T scale);
+
+  /* Returns the value of the 4th-order tensor at the given indices.
+   @pre 0 <= i, j, k, l < 3. */
+  const T& operator()(int i, int j, int k, int l) const {
+    DRAKE_ASSERT(0 <= i && i < 3);
+    DRAKE_ASSERT(0 <= j && j < 3);
+    DRAKE_ASSERT(0 <= k && k < 3);
+    DRAKE_ASSERT(0 <= l && l < 3);
+    return data_(3 * j + i, 3 * l + k);
+  }
+
+  /* Returns a mutable reference to the value of the 4th-order tensor at the
+   given indices.
+   @pre 0 <= i, j, k, l < 3. */
+  T& operator()(int i, int j, int k, int l) {
+    DRAKE_ASSERT(0 <= i && i < 3);
+    DRAKE_ASSERT(0 <= j && j < 3);
+    DRAKE_ASSERT(0 <= k && k < 3);
+    DRAKE_ASSERT(0 <= l && l < 3);
+    return data_(3 * j + i, 3 * l + k);
+  }
+
+  /* Sets the data of this 4th-order tensor to the given matrix, using the
+   convention laid out in the function data(). */
+  void set_data(const MatrixType& data) { data_ = data; }
+
+ private:
+  MatrixType data_{MatrixType::Zero()};
+};
+
+template <typename T>
+FourthOrderTensor<T> operator+(const FourthOrderTensor<T>& t1,
+                               const FourthOrderTensor<T>& t2) {
+  return FourthOrderTensor<T>(t1) += t2;
+}
+
+}  // namespace internal
+}  // namespace math
+}  // namespace drake

--- a/math/test/fourth_order_tensor_test.cc
+++ b/math/test/fourth_order_tensor_test.cc
@@ -1,0 +1,146 @@
+#include "drake/math/fourth_order_tensor.h"
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
+
+namespace drake {
+namespace math {
+namespace internal {
+namespace {
+
+Eigen::Matrix<double, 9, 9> MakeArbitraryMatrix() {
+  Eigen::Matrix<double, 9, 9> data;
+  for (int i = 0; i < 9; ++i) {
+    for (int j = 0; j < 9; ++j) {
+      data(i, j) = i + 2 * j;
+    }
+  }
+  return data;
+}
+
+GTEST_TEST(FourthOrderTensorTest, DefaultConstructor) {
+  FourthOrderTensor<double> tensor;
+  EXPECT_TRUE(tensor.data().isZero());
+}
+
+GTEST_TEST(FourthOrderTensorTest, ConstructWithData) {
+  const Eigen::Matrix<double, 9, 9> data = MakeArbitraryMatrix();
+  FourthOrderTensor<double> tensor(data);
+  /* Getter and mutable getter. */
+  EXPECT_EQ(tensor.data(), data);
+  EXPECT_EQ(tensor.data(), tensor.mutable_data());
+  tensor.mutable_data() = data.transpose();
+  EXPECT_EQ(tensor.data(), data.transpose());
+  /* Setter */
+  tensor.set_data(data);
+  EXPECT_EQ(tensor.data(), data);
+  /* Operator with four indices. */
+  EXPECT_EQ(tensor(0, 0, 0, 0), data(0, 0));
+  EXPECT_EQ(tensor(1, 1, 1, 1), data(4, 4));
+  EXPECT_EQ(tensor(0, 1, 2, 2), data(3, 8));
+}
+
+GTEST_TEST(FourthOrderTensorTest, ContractWithVectors) {
+  FourthOrderTensor<double> tensor(MakeArbitraryMatrix());
+
+  /* If any vector input is zero, the contraction is zero. */
+  Vector3d u = Vector3d::Zero();
+  Vector3d v(4.0, 5.0, 6.0);
+  Matrix3d B;
+  tensor.ContractWithVectors(u, v, &B);
+  EXPECT_TRUE(B.isZero());
+  tensor.ContractWithVectors(v, u, &B);
+  EXPECT_TRUE(B.isZero());
+
+  /* If the 9x9 representation of the tensor has a repeating pattern in the
+   blocks, the contraction is a multiple of that block. */
+  Matrix3d block;
+  block << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  Eigen::Matrix<double, 9, 9> data;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      data.block<3, 3>(3 * i, 3 * j) = block;
+    }
+  }
+  tensor = FourthOrderTensor<double>(data);
+  u << 1.0, 2.0, 3.0;
+  v << 4.0, 5.0, 6.0;
+  tensor.ContractWithVectors(u, v, &B);
+  EXPECT_TRUE(CompareMatrices(B, block * (u * v.transpose()).sum()));
+}
+
+GTEST_TEST(FourthOrderTensorTest, SetAsOuterProduct) {
+  FourthOrderTensor<double> t1, t2;
+  Matrix3d M, N;
+  M << 1, 0, 3, 0, 5, 0, 7, 0, 9;
+  N << 0, 2, 0, 4, 0, 6, 0, 8, 0;
+  t1.SetAsOuterProduct(M, N);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < 3; ++k) {
+        for (int l = 0; l < 3; ++l) {
+          EXPECT_EQ(t1(i, j, k, l), M(i, j) * N(k, l));
+        }
+      }
+    }
+  }
+  t2.SetAsOuterProduct(N, M);
+  EXPECT_TRUE(CompareMatrices(t1.data(), t2.data().transpose()));
+}
+
+GTEST_TEST(FourthOrderTensorTest, MakeSymmetricIdentity) {
+  const double scale = 1.23;
+  const FourthOrderTensor<double> tensor =
+      FourthOrderTensor<double>::MakeSymmetricIdentity(scale);
+  /* The expected result is  scale * 1/2 * (δᵢₖδⱼₗ + δᵢₗδⱼₖ).  */
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < 3; ++k) {
+        for (int l = 0; l < 3; ++l) {
+          double expected_entry = 0.0;
+          if (i == k && j == l) expected_entry += 0.5 * scale;
+          if (i == l && j == k) expected_entry += 0.5 * scale;
+          EXPECT_EQ(tensor(i, j, k, l), expected_entry);
+        }
+      }
+    }
+  }
+}
+
+GTEST_TEST(FourthOrderTensorTest, MakeMajorIdentity) {
+  const double scale = 1.23;
+  const FourthOrderTensor<double> tensor =
+      FourthOrderTensor<double>::MakeMajorIdentity(scale);
+  /* The expected result is scale * δᵢₖδⱼₗ.  */
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < 3; ++k) {
+        for (int l = 0; l < 3; ++l) {
+          double expected_entry = 0.0;
+          if (i == k && j == l) expected_entry = scale;
+          EXPECT_EQ(tensor(i, j, k, l), expected_entry);
+        }
+      }
+    }
+  }
+}
+
+GTEST_TEST(FourthOrderTensorTest, Addition) {
+  const Eigen::Matrix<double, 9, 9> data1 = MakeArbitraryMatrix();
+  const Eigen::Matrix<double, 9, 9> data2 = MakeArbitraryMatrix().transpose();
+  FourthOrderTensor<double> tensor1(data1);
+  const FourthOrderTensor<double> tensor2(data2);
+  tensor1 += tensor2;
+  EXPECT_EQ(tensor1.data(), data1 + data2);
+
+  const FourthOrderTensor<double> tensor3 = tensor1 + tensor2;
+  EXPECT_EQ(tensor3.data(), data1 + 2.0 * data2);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace math
+}  // namespace drake

--- a/multibody/fem/BUILD.bazel
+++ b/multibody/fem/BUILD.bazel
@@ -83,6 +83,7 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:nice_type_name",
+        "//math:fourth_order_tensor",
     ],
 )
 
@@ -407,6 +408,7 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//common:essential",
+        "//math:fourth_order_tensor",
     ],
 )
 

--- a/multibody/fem/constitutive_model.h
+++ b/multibody/fem/constitutive_model.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/nice_type_name.h"
+#include "drake/math/fourth_order_tensor.h"
 
 namespace drake {
 namespace multibody {
@@ -92,8 +93,8 @@ class ConstitutiveModel {
                    |           |           |           |
                    -------------------------------------
   @pre `dPdF != nullptr`. */
-  void CalcFirstPiolaStressDerivative(const Data& data,
-                                      Eigen::Matrix<T, 9, 9>* dPdF) const {
+  void CalcFirstPiolaStressDerivative(
+      const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const {
     DRAKE_ASSERT(dPdF != nullptr);
     derived().CalcFirstPiolaStressDerivativeImpl(data, dPdF);
   }
@@ -123,8 +124,8 @@ class ConstitutiveModel {
                     NiceTypeName::Get(derived())));
   }
 
-  void CalcFirstPiolaStressDerivativeImpl(const Data& data,
-                                          Eigen::Matrix<T, 9, 9>* dPdF) const {
+  void CalcFirstPiolaStressDerivativeImpl(
+      const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const {
     throw std::logic_error(
         fmt::format("The derived class {} must provide a shadow definition of "
                     "CalcFirstPiolaStressDerivativeImpl() to be correct.",

--- a/multibody/fem/corotated_model.cc
+++ b/multibody/fem/corotated_model.cc
@@ -44,19 +44,16 @@ void CorotatedModel<T>::CalcFirstPiolaStressImpl(const Data& data,
 
 template <typename T>
 void CorotatedModel<T>::CalcFirstPiolaStressDerivativeImpl(
-    const Data& data, Eigen::Matrix<T, 9, 9>* dPdF) const {
+    const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const {
   const T& Jm1 = data.Jm1();
   const Matrix3<T>& F = data.deformation_gradient();
   const Matrix3<T>& R = data.R();
   const Matrix3<T>& S = data.S();
   const Matrix3<T>& JFinvT = data.JFinvT();
-  const Vector<T, 3 * 3>& flat_JFinvT =
-      Eigen::Map<const Vector<T, 3 * 3>>(JFinvT.data(), 3 * 3);
   auto& local_dPdF = (*dPdF);
-  /* The contribution from derivatives of Jm1. */
-  local_dPdF.noalias() = lambda_ * flat_JFinvT * flat_JFinvT.transpose();
+  local_dPdF.SetAsOuterProduct(lambda_ * JFinvT, JFinvT);
   /* The contribution from derivatives of F. */
-  local_dPdF.diagonal().array() += 2.0 * mu_;
+  local_dPdF.mutable_data().diagonal().array() += 2.0 * mu_;
   /* The contribution from derivatives of R. */
   internal::AddScaledRotationalDerivative<T>(R, S, -2.0 * mu_, &local_dPdF);
   /* The contribution from derivatives of JFinvT. */

--- a/multibody/fem/corotated_model.h
+++ b/multibody/fem/corotated_model.h
@@ -69,8 +69,8 @@ class CorotatedModel final
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressDerivativeImpl() as required
    by the CRTP base class. */
-  void CalcFirstPiolaStressDerivativeImpl(const Data& data,
-                                          Eigen::Matrix<T, 9, 9>* dPdF) const;
+  void CalcFirstPiolaStressDerivativeImpl(
+      const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const;
 
   T E_;       // Young's modulus, N/m².
   T nu_;      // Poisson's ratio.

--- a/multibody/fem/linear_constitutive_model.cc
+++ b/multibody/fem/linear_constitutive_model.cc
@@ -29,21 +29,10 @@ LinearConstitutiveModel<T>::LinearConstitutiveModel(const T& youngs_modulus,
     Keep in mind that the indices are laid out such that the ik-th entry in
     the jl-th block corresponds to the value dPᵢⱼ/dFₖₗ.  */
   /* First term. */
-  dPdF_ = mu_ * Eigen::Matrix<T, 9, 9>::Identity();
-  for (int k = 0; k < 3; ++k) {
-    /* Second term. */
-    for (int l = 0; l < 3; ++l) {
-      const int i = l;
-      const int j = k;
-      dPdF_(3 * j + i, 3 * l + k) += mu_;
-    }
-    /* Third term. */
-    for (int i = 0; i < 3; ++i) {
-      const int l = k;
-      const int j = i;
-      dPdF_(3 * j + i, 3 * l + k) += lambda_;
-    }
-  }
+  dPdF_.SetAsOuterProduct(Matrix3<T>::Identity(),
+                          lambda_ * Matrix3<T>::Identity());
+  dPdF_ +=
+      math::internal::FourthOrderTensor<T>::MakeSymmetricIdentity(2.0 * mu_);
 }
 
 template <typename T>
@@ -65,7 +54,7 @@ void LinearConstitutiveModel<T>::CalcFirstPiolaStressImpl(const Data& data,
 
 template <typename T>
 void LinearConstitutiveModel<T>::CalcFirstPiolaStressDerivativeImpl(
-    const Data&, Eigen::Matrix<T, 9, 9>* dPdF) const {
+    const Data&, math::internal::FourthOrderTensor<T>* dPdF) const {
   *dPdF = dPdF_;
 }
 

--- a/multibody/fem/linear_constitutive_model.h
+++ b/multibody/fem/linear_constitutive_model.h
@@ -71,14 +71,14 @@ class LinearConstitutiveModel final
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressDerivativeImpl() as required
    by the CRTP base class. */
-  void CalcFirstPiolaStressDerivativeImpl(const Data& data,
-                                          Eigen::Matrix<T, 9, 9>* dPdF) const;
+  void CalcFirstPiolaStressDerivativeImpl(
+      const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const;
 
   T E_;       // Young's modulus, N/m².
   T nu_;      // Poisson's ratio.
   T mu_;      // Lamé's second parameter/Shear modulus, N/m².
   T lambda_;  // Lamé's first parameter, N/m².
-  Eigen::Matrix<T, 9, 9>
+  math::internal::FourthOrderTensor<T>
       dPdF_;  // The First Piola stress derivative is constant and precomputed.
 };
 

--- a/multibody/fem/linear_corotated_model.cc
+++ b/multibody/fem/linear_corotated_model.cc
@@ -82,17 +82,17 @@ void LinearCorotatedModel<T>::CalcFirstPiolaStressImpl(const Data& data,
 */
 template <typename T>
 void LinearCorotatedModel<T>::CalcFirstPiolaStressDerivativeImpl(
-    const Data& data, Eigen::Matrix<T, 9, 9>* dPdF) const {
+    const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const {
   const Matrix3<T>& R0 = data.R0();
   auto& local_dPdF = (*dPdF);
   /* Add in μ * δₐᵢδⱼᵦ. */
-  local_dPdF = mu_ * Eigen::Matrix<T, 9, 9>::Identity();
+  local_dPdF = math::internal::FourthOrderTensor<T>::MakeMajorIdentity(mu_);
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
       for (int alpha = 0; alpha < 3; ++alpha) {
         for (int beta = 0; beta < 3; ++beta) {
           /* Add in  μ *  Rᵢᵦ Rₐⱼ +   λ * Rₐᵦ * Rᵢⱼ. */
-          local_dPdF(3 * j + i, 3 * beta + alpha) +=
+          local_dPdF.mutable_data()(3 * j + i, 3 * beta + alpha) +=
               mu_ * R0(i, beta) * R0(alpha, j) +
               lambda_ * R0(alpha, beta) * R0(i, j);
         }

--- a/multibody/fem/linear_corotated_model.h
+++ b/multibody/fem/linear_corotated_model.h
@@ -71,8 +71,8 @@ class LinearCorotatedModel final
 
   /* Shadows ConstitutiveModel::CalcFirstPiolaStressDerivativeImpl() as required
    by the CRTP base class. */
-  void CalcFirstPiolaStressDerivativeImpl(const Data& data,
-                                          Eigen::Matrix<T, 9, 9>* dPdF) const;
+  void CalcFirstPiolaStressDerivativeImpl(
+      const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const;
 
   T E_;       // Young's modulus, N/m².
   T nu_;      // Poisson's ratio.

--- a/multibody/fem/matrix_utilities.cc
+++ b/multibody/fem/matrix_utilities.cc
@@ -52,7 +52,7 @@ void PolarDecompose(const Matrix3<T>& F, EigenPtr<Matrix3<T>> R,
 template <typename T>
 void AddScaledRotationalDerivative(
     const Matrix3<T>& R, const Matrix3<T>& S, const T& scale,
-    EigenPtr<Eigen::Matrix<T, 9, 9>> scaled_dRdF) {
+    math::internal::FourthOrderTensor<T>* scaled_dRdF) {
   /* Some notes on derivation on the derivative of the rotation matrix from
    polar decomposition: we start with the result from section 2 of [McAdams,
    2011] about the differential of the rotation matrix, which states that δR =
@@ -94,7 +94,7 @@ void AddScaledRotationalDerivative(
       for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; ++j) {
           const int row_index = 3 * j + i;
-          (*scaled_dRdF)(row_index, column_index) +=
+          scaled_dRdF->mutable_data()(row_index, column_index) +=
               sRART(i, a) * A(j, b) - sRA(i, b) * RA(a, j);
         }
       }
@@ -118,46 +118,46 @@ void CalcCofactorMatrix(const Matrix3<T>& M, EigenPtr<Matrix3<T>> cofactor) {
 template <typename T>
 void AddScaledCofactorMatrixDerivative(
     const Matrix3<T>& M, const T& scale,
-    EigenPtr<Eigen::Matrix<T, 9, 9>> scaled_dCdM) {
+    math::internal::FourthOrderTensor<T>* scaled_dCdM) {
   /* See the convention for ordering the 9-by-9 derivatives at the top of the
    header file. */
   const Matrix3<T> A = scale * M;
-  (*scaled_dCdM)(4, 0) += A(2, 2);
-  (*scaled_dCdM)(5, 0) += -A(1, 2);
-  (*scaled_dCdM)(7, 0) += -A(2, 1);
-  (*scaled_dCdM)(8, 0) += A(1, 1);
-  (*scaled_dCdM)(3, 1) += -A(2, 2);
-  (*scaled_dCdM)(5, 1) += A(0, 2);
-  (*scaled_dCdM)(6, 1) += A(2, 1);
-  (*scaled_dCdM)(8, 1) += -A(0, 1);
-  (*scaled_dCdM)(3, 2) += A(1, 2);
-  (*scaled_dCdM)(4, 2) += -A(0, 2);
-  (*scaled_dCdM)(6, 2) += -A(1, 1);
-  (*scaled_dCdM)(7, 2) += A(0, 1);
-  (*scaled_dCdM)(1, 3) += -A(2, 2);
-  (*scaled_dCdM)(2, 3) += A(1, 2);
-  (*scaled_dCdM)(7, 3) += A(2, 0);
-  (*scaled_dCdM)(8, 3) += -A(1, 0);
-  (*scaled_dCdM)(0, 4) += A(2, 2);
-  (*scaled_dCdM)(2, 4) += -A(0, 2);
-  (*scaled_dCdM)(6, 4) += -A(2, 0);
-  (*scaled_dCdM)(8, 4) += A(0, 0);
-  (*scaled_dCdM)(0, 5) += -A(1, 2);
-  (*scaled_dCdM)(1, 5) += A(0, 2);
-  (*scaled_dCdM)(6, 5) += A(1, 0);
-  (*scaled_dCdM)(7, 5) += -A(0, 0);
-  (*scaled_dCdM)(1, 6) += A(2, 1);
-  (*scaled_dCdM)(2, 6) += -A(1, 1);
-  (*scaled_dCdM)(4, 6) += -A(2, 0);
-  (*scaled_dCdM)(5, 6) += A(1, 0);
-  (*scaled_dCdM)(0, 7) += -A(2, 1);
-  (*scaled_dCdM)(2, 7) += A(0, 1);
-  (*scaled_dCdM)(3, 7) += A(2, 0);
-  (*scaled_dCdM)(5, 7) += -A(0, 0);
-  (*scaled_dCdM)(0, 8) += A(1, 1);
-  (*scaled_dCdM)(1, 8) += -A(0, 1);
-  (*scaled_dCdM)(3, 8) += -A(1, 0);
-  (*scaled_dCdM)(4, 8) += A(0, 0);
+  scaled_dCdM->mutable_data()(4, 0) += A(2, 2);
+  scaled_dCdM->mutable_data()(5, 0) += -A(1, 2);
+  scaled_dCdM->mutable_data()(7, 0) += -A(2, 1);
+  scaled_dCdM->mutable_data()(8, 0) += A(1, 1);
+  scaled_dCdM->mutable_data()(3, 1) += -A(2, 2);
+  scaled_dCdM->mutable_data()(5, 1) += A(0, 2);
+  scaled_dCdM->mutable_data()(6, 1) += A(2, 1);
+  scaled_dCdM->mutable_data()(8, 1) += -A(0, 1);
+  scaled_dCdM->mutable_data()(3, 2) += A(1, 2);
+  scaled_dCdM->mutable_data()(4, 2) += -A(0, 2);
+  scaled_dCdM->mutable_data()(6, 2) += -A(1, 1);
+  scaled_dCdM->mutable_data()(7, 2) += A(0, 1);
+  scaled_dCdM->mutable_data()(1, 3) += -A(2, 2);
+  scaled_dCdM->mutable_data()(2, 3) += A(1, 2);
+  scaled_dCdM->mutable_data()(7, 3) += A(2, 0);
+  scaled_dCdM->mutable_data()(8, 3) += -A(1, 0);
+  scaled_dCdM->mutable_data()(0, 4) += A(2, 2);
+  scaled_dCdM->mutable_data()(2, 4) += -A(0, 2);
+  scaled_dCdM->mutable_data()(6, 4) += -A(2, 0);
+  scaled_dCdM->mutable_data()(8, 4) += A(0, 0);
+  scaled_dCdM->mutable_data()(0, 5) += -A(1, 2);
+  scaled_dCdM->mutable_data()(1, 5) += A(0, 2);
+  scaled_dCdM->mutable_data()(6, 5) += A(1, 0);
+  scaled_dCdM->mutable_data()(7, 5) += -A(0, 0);
+  scaled_dCdM->mutable_data()(1, 6) += A(2, 1);
+  scaled_dCdM->mutable_data()(2, 6) += -A(1, 1);
+  scaled_dCdM->mutable_data()(4, 6) += -A(2, 0);
+  scaled_dCdM->mutable_data()(5, 6) += A(1, 0);
+  scaled_dCdM->mutable_data()(0, 7) += -A(2, 1);
+  scaled_dCdM->mutable_data()(2, 7) += A(0, 1);
+  scaled_dCdM->mutable_data()(3, 7) += A(2, 0);
+  scaled_dCdM->mutable_data()(5, 7) += -A(0, 0);
+  scaled_dCdM->mutable_data()(0, 8) += A(1, 1);
+  scaled_dCdM->mutable_data()(1, 8) += -A(0, 1);
+  scaled_dCdM->mutable_data()(3, 8) += -A(1, 0);
+  scaled_dCdM->mutable_data()(4, 8) += A(0, 0);
 }
 
 template <typename T>

--- a/multibody/fem/matrix_utilities.h
+++ b/multibody/fem/matrix_utilities.h
@@ -5,31 +5,12 @@
 #include <Eigen/SparseCore>
 
 #include "drake/common/eigen_types.h"
+#include "drake/math/fourth_order_tensor.h"
 
 namespace drake {
 namespace multibody {
 namespace fem {
 namespace internal {
-
-/* Some of the following functions involve calculations about a 4th order tensor
-(call it A) of dimension 3*3*3*3. We follow the following convention to flatten
-the 4th order tensor into 9*9 matrices that are organized as follows:
-
-                  l = 1       l = 2       l = 3
-              -------------------------------------
-              |           |           |           |
-    j = 1     |   Aᵢ₁ₖ₁   |   Aᵢ₁ₖ₂   |   Aᵢ₁ₖ₃   |
-              |           |           |           |
-              -------------------------------------
-              |           |           |           |
-    j = 2     |   Aᵢ₂ₖ₁   |   Aᵢ₂ₖ₂   |   Aᵢ₂ₖ₃   |
-              |           |           |           |
-              -------------------------------------
-              |           |           |           |
-    j = 3     |   Aᵢ₃ₖ₁   |   Aᵢ₃ₖ₂   |   Aᵢ₃ₖ₃   |
-              |           |           |           |
-              -------------------------------------
-Namely the ik-th entry in the jl-th block corresponds to the value Aᵢⱼₖₗ. */
 
 /* Calculates the condition number for the given matrix A.
  The condition number is calculated via
@@ -67,7 +48,7 @@ void PolarDecompose(const Matrix3<T>& F, EigenPtr<Matrix3<T>> R,
 template <typename T>
 void AddScaledRotationalDerivative(
     const Matrix3<T>& R, const Matrix3<T>& S, const T& scale,
-    EigenPtr<Eigen::Matrix<T, 9, 9>> scaled_dRdF);
+    math::internal::FourthOrderTensor<T>* scaled_dRdF);
 
 /* Calculates the cofactor matrix of the given input 3-by-3 matrix M.
  @pre cofactor != nullptr.
@@ -85,7 +66,7 @@ void CalcCofactorMatrix(const Matrix3<T>& M, EigenPtr<Matrix3<T>> cofactor);
 template <typename T>
 void AddScaledCofactorMatrixDerivative(
     const Matrix3<T>& M, const T& scale,
-    EigenPtr<Eigen::Matrix<T, 9, 9>> scaled_dCdM);
+    math::internal::FourthOrderTensor<T>* scaled_dCdM);
 
 /* Given a size 3N vector with block structure with size 3 block entries Bᵢ
  where i ∈ V = {0, ..., N-1} and a permutation P on V, this function builds the

--- a/multibody/fem/test/constitutive_model_test.cc
+++ b/multibody/fem/test/constitutive_model_test.cc
@@ -48,7 +48,7 @@ GTEST_TEST(ConstitutiveModelTest, InvalidModel) {
                   "CalcFirstPiolaStressImpl.. to be correct.",
                   NiceTypeName::Get(model)));
 
-  Eigen::Matrix<double, 9, 9> dPdF;
+  math::internal::FourthOrderTensor<double> dPdF;
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.CalcFirstPiolaStressDerivative(data, &dPdF),
       fmt::format("The derived class {} must provide a shadow definition of "

--- a/multibody/fem/test/constitutive_model_test_utilities.cc
+++ b/multibody/fem/test/constitutive_model_test_utilities.cc
@@ -160,14 +160,14 @@ void TestdPdFIsDerivativeOfP() {
   data.UpdateData(deformation_gradients, previous_step_deformation_gradients);
   Matrix3<AutoDiffXd> P;
   model.CalcFirstPiolaStress(data, &P);
-  Eigen::Matrix<AutoDiffXd, 9, 9> dPdF;
+  math::internal::FourthOrderTensor<AutoDiffXd> dPdF;
   model.CalcFirstPiolaStressDerivative(data, &dPdF);
   for (int i = 0; i < kSpaceDimension; ++i) {
     for (int j = 0; j < kSpaceDimension; ++j) {
       Matrix3d dPijdF;
       for (int k = 0; k < kSpaceDimension; ++k) {
         for (int l = 0; l < kSpaceDimension; ++l) {
-          dPijdF(k, l) = dPdF(3 * j + i, 3 * l + k).value();
+          dPijdF(k, l) = dPdF(i, j, k, l).value();
         }
       }
       EXPECT_TRUE(CompareMatrices(

--- a/multibody/fem/test/matrix_utilities_test.cc
+++ b/multibody/fem/test/matrix_utilities_test.cc
@@ -68,8 +68,7 @@ GTEST_TEST(MatrixUtilitiesTest, AddScaledRotationalDerivative) {
   const Matrix3<AutoDiffXd> F = MakeAutoDiffMatrix(3, 3);
   Matrix3<AutoDiffXd> R, S;
   PolarDecompose<AutoDiffXd>(F, &R, &S);
-  Eigen::Matrix<AutoDiffXd, 9, 9> scaled_dRdF =
-      Eigen::Matrix<AutoDiffXd, 9, 9>::Zero();
+  math::internal::FourthOrderTensor<AutoDiffXd> scaled_dRdF;
   AutoDiffXd scale = 1.23;
   AddScaledRotationalDerivative<AutoDiffXd>(R, S, scale, &scaled_dRdF);
   for (int i = 0; i < 3; ++i) {
@@ -77,7 +76,7 @@ GTEST_TEST(MatrixUtilitiesTest, AddScaledRotationalDerivative) {
       Matrix3<double> scaled_dRijdF;
       for (int k = 0; k < 3; ++k) {
         for (int l = 0; l < 3; ++l) {
-          scaled_dRijdF(k, l) = scaled_dRdF(3 * j + i, 3 * l + k).value();
+          scaled_dRijdF(k, l) = scaled_dRdF(i, j, k, l).value();
         }
       }
       EXPECT_TRUE(
@@ -100,8 +99,7 @@ GTEST_TEST(MatrixUtilitiesTest, AddScaledCofactorMatrixDerivative) {
   const Matrix3<AutoDiffXd> A = MakeAutoDiffMatrix(3, 3);
   Matrix3<AutoDiffXd> C;
   CalcCofactorMatrix<AutoDiffXd>(A, &C);
-  Eigen::Matrix<AutoDiffXd, 9, 9> scaled_dCdA =
-      Eigen::Matrix<AutoDiffXd, 9, 9>::Zero();
+  math::internal::FourthOrderTensor<AutoDiffXd> scaled_dCdA;
   AutoDiffXd scale = 1.23;
   AddScaledCofactorMatrixDerivative<AutoDiffXd>(A, scale, &scaled_dCdA);
   for (int i = 0; i < 3; ++i) {
@@ -109,7 +107,7 @@ GTEST_TEST(MatrixUtilitiesTest, AddScaledCofactorMatrixDerivative) {
       Matrix3<double> scaled_dCijdA;
       for (int k = 0; k < 3; ++k) {
         for (int l = 0; l < 3; ++l) {
-          scaled_dCijdA(k, l) = scaled_dCdA(3 * j + i, 3 * l + k).value();
+          scaled_dCijdA(k, l) = scaled_dCdA(i, j, k, l).value();
         }
       }
       EXPECT_TRUE(


### PR DESCRIPTION
Make the abstraction for 3x3x3x3 fourth-order tensors and move it from fem::internal namespace to math namespace to prepare it to be used for MPM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22190)
<!-- Reviewable:end -->
