### PR TITLE
[math] Remove obsolete compiler workaround

### DIFF
--- a/math/test/jacobian_test.cc
+++ b/math/test/jacobian_test.cc
@@ -31,12 +31,7 @@ TEST_F(AutodiffJacobianTest, QuadraticForm) {
   Matrix3d A;
   FillWithNumbersIncreasingFromZero(A);
 
-  // Work around GCC 5.4 Wshadow bug; the bug is fixed as of GCC 6.1.
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
   auto quadratic_form = [&](const auto& x) {
-#pragma GCC diagnostic pop
     using Scalar = typename std::remove_reference_t<decltype(x)>::Scalar;
     return (x.transpose() * A.cast<Scalar>().eval() * x).eval();
   };
@@ -102,12 +97,7 @@ TEST_F(AutoDiffHessianTest, QuadraticFunction) {
   FillWithNumbersIncreasingFromZero(D);
   FillWithNumbersIncreasingFromZero(e);
 
-  // Work around GCC 5.4 Wshadow bug; the bug is fixed as of GCC 6.1.
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67273.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
   auto quadratic_function = [&](const auto& x) {
-#pragma GCC diagnostic pop
     using Scalar = typename std::remove_reference_t<decltype(x)>::Scalar;
     return ((A.cast<Scalar>() * x + b.cast<Scalar>()).transpose() *
             C.cast<Scalar>() * (D.cast<Scalar>() * x + e.cast<Scalar>()))


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22191)
<!-- Reviewable:end -->
