### PR TITLE
[solvers] Clean up common options doc

### DIFF
--- a/solvers/common_solver_option.h
+++ b/solvers/common_solver_option.h
@@ -16,32 +16,30 @@ namespace solvers {
 /** Some options can be applied to not one solver, but many solvers (for
 example, many solvers support printing out the progress in each iteration).
 CommonSolverOption contain the names of these supported options. The user can
-use these options as "key" in SolverOption::SetOption(). */
+use these options as "key" in SolverOption::SetOption(). If the solver doesn't
+support the option, the option is ignored. */
 enum class CommonSolverOption {
   /** Many solvers support printing the progress of each iteration to a file.
-  The user can call SolverOptions::SetOption(kPrintFileName, file_name) where
-  file_name is a string. If the user doesn't want to print to a file, then use
-  SolverOptions::SetOption(kPrintFileName, ""), where the empty string ""
-  indicates no print. */
+  The user can call SolverOptions::SetOption(kPrintFileName, "filename.log")
+  to enable this. To disable, set the option to the empty string `""`, which
+  indicates that no file should be written. */
   kPrintFileName,
 
   /** Many solvers support printing the progress of each iteration to the
-  console, the user can call SolverOptions::SetOption(kPrintToConsole, 1) to
-  turn on printing to the console, or SolverOptions::SetOption(kPrintToConsole,
-  0) to turn off printing to the console. */
+  console. The user can call `SolverOptions::SetOption(kPrintToConsole, 1)`
+  to enable this, or use `0` to turn off printing to the console. */
   kPrintToConsole,
 
-  /** Some of our solver interfaces support writing a standalone (e.g. it does
-  not depend on Drake) minimal reproduction of the problem to a file. This is
-  especially useful for sending bug reports upstream to the developers of the
-  solver. To enable this, use e.g.
-  SolverOptions::SetOption(kStandaloneReproductionFileName,
-  "reproduction.txt"). To disable, use
-  SolverOptions::SetOption(kStandaloneReproductionFileName, ""), where the empty
-  string "" indicates that no file should be written. */
+  /** Some solvers support writing a standalone (e.g., it does not depend on
+  Drake) minimal reproduction of the problem to a file. This is especially
+  useful for sending bug reports upstream to the developers of the solver.
+  The user can call
+  `SolverOptions::SetOption(kStandaloneReproductionFileName, "filename.txt")`
+  to enable this. To disable, set the option to the empty string `""`, which
+  indicates that no file should be written. */
   kStandaloneReproductionFileName,
 
-  /** Many solvers are multi-threaded. The user can request the maximum number
+  /** Some solvers are multi-threaded. The user can request the maximum number
   of threads used by the solver with this `int` option. When not set, the value
   defaults to Parallelism.Max().num_threads(), which can be controlled via the
   \ref drake::Parallelism "DRAKE_NUM_THREADS" environment variable.


### PR DESCRIPTION
This edits the text to improve the uniformity across the various solver options, and emphasizes the "ignore if unknown" which was already documented in `class SolverOptions` but sometimes users don't see that note.

Towards #22078.

+@hongkai-dai for feature review, please.  Low priority.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22193)
<!-- Reviewable:end -->
