### PR TITLE
Restore "Implement SpGrid for MPM (#22163)"

### DIFF
--- a/multibody/mpm/BUILD.bazel
+++ b/multibody/mpm/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_library_linux_only(
         "spgrid.h",
     ],
     deps = [
+        "//common:essential",
         "@spgrid_internal",
     ],
 )

--- a/multibody/mpm/spgrid.h
+++ b/multibody/mpm/spgrid.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <type_traits>
@@ -11,10 +12,17 @@
 #include <SPGrid_Mask.h>
 #include <SPGrid_Page_Map.h>
 
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
 namespace drake {
 namespace multibody {
 namespace mpm {
 namespace internal {
+
+/* A Pad is a 3x3x3 subgrid. */
+template <typename T>
+using Pad = std::array<std::array<std::array<T, 3>, 3>, 3>;
 
 /* SpGrid is a wrapper class around the SPGrid library designed for managing
  sparse grid data in 3D space.
@@ -43,14 +51,35 @@ namespace internal {
  structure applied to adaptive smoke simulation." ACM Transactions on Graphics
  (TOG) 33.6 (2014): 1-12.
 
+ @note The implementation of this class has many triple-nested loops. We write
+ them out explicitly (instead of using a sugar like IterateGrid()) because they
+ are called in performance-critical inner loops and can potentially be inlined.
+
  @tparam GridData The type of data stored in the grid. It must satisfy the
  following requirements:
   - It must have a default constructor.
   - It must have a member function `set_zero()` that sets the data to zero.
-  - Its size must be less than or equal to 4KB. */
-template <typename GridData>
+  - Its size must be less than or equal to 4KB.
+ @tparam log2_max_grid_size
+ SPGrid imposes a limit on the maximum number of grid points per dimension,
+ denoted as N. While N can be quite large (as discussed in Section 3.1 of
+ [Setaluri, 2014]), increasing it excessively may lead to performance
+ degradation due to a known limitation in the SPGrid library. To balance
+ grid coverage and performance, we default N to 1024 (logN = 10). With this
+ number of grid nodes and a typical grid spacing of 1 cm, the grid can
+ span 10.24 meters per dimension. This coverage is sufficient for the
+ majority of stationary manipulation simulations. We make it a template
+ parameter so that in unit tests we can use a smaller max size because
+ the underlying SPGrid library reserves a span of virtual memory space
+ (without actually allocating them) according to the max size, and a large
+ reservation upsets Valgrind. */
+// TODO(xuchenhan-tri): Enumerate all possible GridData so that we can move the
+// implementation to the .cc file.
+template <typename GridData, int log2_max_grid_size = 10>
 class SpGrid {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SpGrid);
+
   static constexpr int kDim = 3;
   static constexpr int kLog2Page = 12;  // 4KB page size.
   static_assert(std::is_default_constructible<GridData>::value,
@@ -73,33 +102,87 @@ class SpGrid {
    and reset the grid data. */
   SpGrid()
       : allocator_(kMaxGridSize, kMaxGridSize, kMaxGridSize),
-        blocks_(allocator_) {}
-
-  /* Clears the contents of this SpGrid and ensures that each block containing
-   the given offsets is allocated and zero-initialized.
-   @note Actual allocation only happens the first time a block containing an
-   offset is used in the lifetime of an SpGrid. Subsequent calls to `Allocate()`
-   touching the same block only zero out the grid data. */
-  void Allocate(const std::vector<Offset>& offsets) {
-    blocks_.Clear();
-    for (const Offset& offset : offsets) {
-      blocks_.Set_Page(offset);
-    }
-    blocks_.Update_Block_Offsets();
-
-    auto [block_offsets, num_blocks] = blocks_.Get_Blocks();
-    const uint64_t page_size = 1 << kLog2Page;
-    const uint64_t data_size = 1 << kDataBits;
-    /* Note that Array is a wrapper around pointer to data memory and can be
-     cheaply copied. */
-    Array data = allocator_.Get_Array();
-    /* Zero out the data in each block. */
-    for (int b = 0; b < static_cast<int>(num_blocks); ++b) {
-      const uint64_t offset = block_offsets[b];
-      for (uint64_t i = 0; i < page_size; i += data_size) {
-        data(offset + i).set_zero();
+        helper_blocks_(allocator_),
+        blocks_(allocator_) {
+    /* Compute the cell offset strides. */
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        for (int k = 0; k < 3; ++k) {
+          cell_offset_strides_[i][j][k] =
+              Mask::Linear_Offset(i - 1, j - 1, k - 1);
+        }
       }
     }
+    /* Compute the block offset strides. */
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        for (int k = 0; k < 3; ++k) {
+          block_offset_strides_[i][j][k] = Mask::Linear_Offset(
+              (i - 1) * kNumNodesInBlockX, (j - 1) * kNumNodesInBlockY,
+              (k - 1) * kNumNodesInBlockZ);
+        }
+      }
+    }
+  }
+
+  /* Makes `this` an exact copy of the `other` SpGrid. */
+  void SetFrom(const SpGrid<GridData, log2_max_grid_size>& other) {
+    /* Copy over the page maps. */
+    helper_blocks_.Clear();
+    auto [block_offsets, num_blocks] = other.helper_blocks_.Get_Blocks();
+    for (int b = 0; b < static_cast<int>(num_blocks); ++b) {
+      helper_blocks_.Set_Page(block_offsets[b]);
+    }
+    helper_blocks_.Update_Block_Offsets();
+
+    blocks_.Clear();
+    std::tie(block_offsets, num_blocks) = other.blocks_.Get_Blocks();
+    for (int b = 0; b < static_cast<int>(num_blocks); ++b) {
+      blocks_.Set_Page(block_offsets[b]);
+    }
+    blocks_.Update_Block_Offsets();
+    /* Copy over the data. */
+    IterateGridWithOffset([&](uint64_t offset, GridData* node_data) {
+      *node_data = other.get_data(offset);
+    });
+
+    block_offset_strides_ = other.block_offset_strides_;
+    cell_offset_strides_ = other.cell_offset_strides_;
+  }
+
+  /* Clears the contents of this SpGrid and ensures that each block in the
+   one-ring of blocks containing the given offsets is allocated and
+   zero-initialized.
+   @note Actual allocation only happens the first time a block is used in the
+   lifetime of an SpGrid. Subsequent calls to `Allocate()` touching the same
+   block only zero out the grid data. */
+  void Allocate(const std::vector<Offset>& offsets) {
+    helper_blocks_.Clear();
+    for (const Offset& offset : offsets) {
+      helper_blocks_.Set_Page(offset);
+    }
+    helper_blocks_.Update_Block_Offsets();
+
+    auto [block_offsets, num_blocks] = helper_blocks_.Get_Blocks();
+    /* Touch all neighboring blocks of each block in `helper_blocks_` to
+     ensure all grid nodes in the one ring of the given offsets have memory
+     allocated. */
+    for (int b = 0; b < static_cast<int>(num_blocks); ++b) {
+      const uint64_t current_offset = block_offsets[b];
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          for (int k = 0; k < 3; ++k) {
+            const uint64_t neighbor_block_offset = Mask::Packed_Add(
+                current_offset, block_offset_strides_[i][j][k]);
+            blocks_.Set_Page(neighbor_block_offset);
+          }
+        }
+      }
+    }
+    blocks_.Update_Block_Offsets();
+    IterateGrid([](GridData* node_data) {
+      node_data->set_zero();
+    });
   }
 
   /* Returns the offset (1D index) of a grid node given its 3D grid
@@ -109,20 +192,144 @@ class SpGrid {
     return Mask::Packed_Add(world_space_offset, origin_offset_);
   }
 
-  /* Returns the number of allocated blocks. */
-  int num_blocks() const { return blocks_.Get_Blocks().second; }
+  /* Returns the 3D grid coordinates in world space given the offset (1D
+   index) of a grid node.
+   @note This function is not particularly efficient. Do not use it in
+   computationally intensive inner loops. Instead, prefer accessing grid data
+   directly using the offsets. */
+  Vector3<int> OffsetToCoordinate(uint64_t offset) const {
+    const std::array<int, 3> reference_space_coordinate =
+        Mask::LinearToCoord(offset);
+    const std::array<int, 3> reference_space_origin =
+        Mask::LinearToCoord(origin_offset_);
+    return Vector3<int>(
+        reference_space_coordinate[0] - reference_space_origin[0],
+        reference_space_coordinate[1] - reference_space_origin[1],
+        reference_space_coordinate[2] - reference_space_origin[2]);
+  }
+
+  /* Returns the number of blocks that contain the offsets passed in the last
+   call to `Allocate()`. This is the quantity that's often useful in MPM
+   transfers, and it is equal to the number of blocks in `helper_blocks_`. */
+  int num_blocks() const { return helper_blocks_.Get_Blocks().second; }
+
+  /* Given the offset of a grid node, returns the grid data in the pad with
+   the given node at the center.
+   @pre All nodes in the requested pad are active. */
+  Pad<GridData> GetPadData(uint64_t center_node_offset) const {
+    Pad<GridData> result;
+    ConstArray data = allocator_.Get_Const_Array();
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        for (int k = 0; k < 3; ++k) {
+          const uint64_t offset = Mask::Packed_Add(
+              center_node_offset, cell_offset_strides_[i][j][k]);
+          result[i][j][k] = data(offset);
+        }
+      }
+    }
+    return result;
+  }
+
+  /* Given the offset of a grid node, writes the grid data in the pad with the
+   given node at the center.
+   @pre All nodes in the requested pad are active. */
+  void SetPadData(uint64_t center_node_offset, const Pad<GridData>& pad_data) {
+    Array grid_data = allocator_.Get_Array();
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        for (int k = 0; k < 3; ++k) {
+          const uint64_t offset = Mask::Packed_Add(
+              center_node_offset, cell_offset_strides_[i][j][k]);
+          grid_data(offset) = pad_data[i][j][k];
+        }
+      }
+    }
+  }
+
+  // TODO(xuchenhan-tri): Add a parallel version of IterateGrid.
+  /* Iterates over all grid nodes in the grid and applies the given function
+   `func` to each grid node. */
+  void IterateGrid(const std::function<void(GridData*)>& func) {
+    const uint64_t data_size = 1 << kDataBits;
+    Array grid_data = allocator_.Get_Array();
+    auto [block_offsets, num_blocks] = blocks_.Get_Blocks();
+    for (int b = 0; b < static_cast<int>(num_blocks); ++b) {
+      const uint64_t block_offset = block_offsets[b];
+      uint64_t node_offset = block_offset;
+      /* The coordinate of the origin of this block. */
+      for (int i = 0; i < kNumNodesInBlockX; ++i) {
+        for (int j = 0; j < kNumNodesInBlockY; ++j) {
+          for (int k = 0; k < kNumNodesInBlockZ; ++k) {
+            GridData& node_data = grid_data(node_offset);
+            func(&node_data);
+            node_offset += data_size;
+          }
+        }
+      }
+    }
+  }
+
+  /* Iterates over all grid nodes in the grid and applies the given function
+   `func` to each grid node's offset and data. */
+  void IterateGridWithOffset(
+      const std::function<void(Offset, GridData*)>& func) {
+    const uint64_t data_size = 1 << kDataBits;
+    Array grid_data = allocator_.Get_Array();
+    auto [block_offsets, num_blocks] = blocks_.Get_Blocks();
+    for (int b = 0; b < static_cast<int>(num_blocks); ++b) {
+      const uint64_t block_offset = block_offsets[b];
+      uint64_t node_offset = block_offset;
+      /* The coordinate of the origin of this block. */
+      for (int i = 0; i < kNumNodesInBlockX; ++i) {
+        for (int j = 0; j < kNumNodesInBlockY; ++j) {
+          for (int k = 0; k < kNumNodesInBlockZ; ++k) {
+            GridData& node_data = grid_data(node_offset);
+            func(node_offset, &node_data);
+            node_offset += data_size;
+          }
+        }
+      }
+    }
+  }
+
+  /* Iterates over all grid nodes in the grid and applies the given function
+   `func` to each grid node's offset and data. */
+  void IterateConstGridWithOffset(
+      const std::function<void(Offset, const GridData&)>& func) const {
+    const uint64_t data_size = 1 << kDataBits;
+    ConstArray grid_data = allocator_.Get_Array();
+    auto [block_offsets, num_blocks] = blocks_.Get_Blocks();
+    for (int b = 0; b < static_cast<int>(num_blocks); ++b) {
+      const uint64_t block_offset = block_offsets[b];
+      uint64_t node_offset = block_offset;
+      /* The coordinate of the origin of this block. */
+      for (int i = 0; i < kNumNodesInBlockX; ++i) {
+        for (int j = 0; j < kNumNodesInBlockY; ++j) {
+          for (int k = 0; k < kNumNodesInBlockZ; ++k) {
+            const GridData& node_data = grid_data(node_offset);
+            func(node_offset, node_data);
+            node_offset += data_size;
+          }
+        }
+      }
+    }
+  }
 
  private:
-  /* SPGrid imposes a limit on the maximum number of grid points per dimension,
-   denoted as N. While N can be quite large (as discussed in Section 3.1 of
-   [Setaluri, 2014]), increasing it excessively may lead to performance
-   degradation due to a known limitation in the SPGrid library. To balance
-   grid coverage and performance, we set N to 1024 (logN = 10). With this
-   number of grid nodes and a typical grid spacing of 1 cm, the grid can
-   span 10.24 meters per dimension. This coverage is sufficient for the
-   majority of stationary manipulation simulations. */
-  static constexpr int kLog2MaxGridSize = 10;
-  static constexpr int kMaxGridSize = 1 << kLog2MaxGridSize;
+  /* Returns reference to the data at the given grid offset.
+   @pre Given `offset` is valid. */
+  const GridData& get_data(uint64_t offset) const {
+    return allocator_.Get_Const_Array()(offset);
+  }
+
+  /* Returns mutable reference to the data at the given grid offset.
+   @pre Given `offset` is valid. */
+  GridData& get_mutable_data(uint64_t offset) {
+    return allocator_.Get_Array()(offset);
+  }
+
+  static constexpr int kMaxGridSize = 1 << log2_max_grid_size;
 
   static constexpr int kDataBits = Mask::data_bits;
   static constexpr int kNumNodesInBlockX = 1 << Mask::block_xbits;
@@ -141,8 +348,28 @@ class SpGrid {
 
   /* SPGrid allocator. */
   Allocator allocator_;
-  /* All active/allocated blocks in the block. */
+  /* PageMap that helps allocate memory for grid data in `Allocate()`. We
+   persist it in the class so that we don't need to construct and destruct it
+   any time `Allocate()` is called. */
+  PageMap helper_blocks_;
+  /* All active/allocated blocks. */
   PageMap blocks_;
+
+  /* Stores the difference in linear offset from a given grid node to the grid
+   node exactly one block away. For example, let
+   `a = block_offset_strides_[i][j][k]`, and `b` be the linear offset of a grid
+   node `n`. Suppose `c = a + b`, then we have
+   LinearToCoord(c) = LinearToCoord(b) + ((i - 1) * kNumNodesInBlockX,
+                                          (j - 1) * kNumNodesInBlockY,
+                                          (k - 1) * kNumNodesInBlockZ). */
+  Pad<uint64_t> block_offset_strides_;
+  /* Similar to block_offset_strides_, but instead of providing strides for
+   nodes a "block" away, provides the strides for nodes a "cell" away (i.e.
+   immediate grid neighbors). For example, let
+   `a = cell_offset_strides_[i][j][k]`, and `b` be the linear offset of a grid
+   node `n`. Suppose `c = a + b`, then we have
+   LinearToCoord(c) = LinearToCoord(b) + (i - 1, j - 1, k - 1). */
+  Pad<uint64_t> cell_offset_strides_;
 };
 
 }  // namespace internal

--- a/multibody/mpm/test/spgrid_test.cc
+++ b/multibody/mpm/test/spgrid_test.cc
@@ -10,21 +10,41 @@ namespace mpm {
 namespace internal {
 namespace {
 
+using Vector4d = Eigen::Vector4d;
+const int kLog2MaxGridSize = 5;
+
 struct GridData {
-  Eigen::Vector4<double> data;
+  Vector4d data;
   void set_zero() { data.setZero(); }
 };
+
+bool operator==(const GridData& lhs, const GridData& rhs) {
+  return lhs.data == rhs.data;
+}
+
+using Offset = SpGrid<GridData, kLog2MaxGridSize>::Offset;
+
+/* Helper function to help cutting down the amount of boilerplates when looping
+ over pads. */
+void TripleLoop(const std::function<void(int, int, int)>& func) {
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < 3; ++k) {
+        func(i, j, k);
+      }
+    }
+  }
+}
 
 GTEST_TEST(SpGridTest, Constructor) {
   /* Constructor itself shouldn't allocate memory; memory is only allocated when
    Allocate() is called. */
   test::LimitMalloc guard;
-  SpGrid<GridData> grid;
+  SpGrid<GridData, kLog2MaxGridSize> grid;
 }
 
 GTEST_TEST(SpGridTest, Allocate) {
-  SpGrid<GridData> grid;
-  using Offset = SpGrid<GridData>::Offset;
+  SpGrid<GridData, kLog2MaxGridSize> grid;
   /* Given the size of GridData (4 * 8 = 32 bytes), each block in SpGrid is of
    size 4 * 4 * 8. We choose offsets such that offset0 and offset1 belong to the
    same block, but offset2 belongs to a separate block. */
@@ -48,6 +68,150 @@ GTEST_TEST(SpGridTest, Allocate) {
     grid.Allocate(offsets);
     EXPECT_EQ(grid.num_blocks(), 2);
   }
+}
+
+GTEST_TEST(SpGridTest, CoordinateOffsetConversion) {
+  SpGrid<GridData, kLog2MaxGridSize> grid;
+
+  /* Test that different coordinates yield different offsets */
+  Offset offset0 = grid.CoordinateToOffset(0, 0, 0);
+  Offset offset1 = grid.CoordinateToOffset(10, 0, 0);
+  Offset offset2 = grid.CoordinateToOffset(0, 10, 0);
+
+  EXPECT_NE(offset0, offset1);
+  EXPECT_NE(offset0, offset2);
+  EXPECT_NE(offset1, offset2);
+
+  /* Test with negative coordinates. */
+  Offset negative_offset = grid.CoordinateToOffset(-1, -1, -1);
+  EXPECT_NE(negative_offset, offset0);
+
+  /* Verify that the conversion is reversible */
+  Vector3<int> coordinate0 = grid.OffsetToCoordinate(offset0);
+  EXPECT_EQ(coordinate0, Vector3<int>(0, 0, 0));
+  Vector3<int> coordinate1 = grid.OffsetToCoordinate(offset1);
+  EXPECT_EQ(coordinate1, Vector3<int>(10, 0, 0));
+  Vector3<int> coordinate2 = grid.OffsetToCoordinate(offset2);
+  EXPECT_EQ(coordinate2, Vector3<int>(0, 10, 0));
+}
+
+GTEST_TEST(SpGridTest, SetPadDataAndGetPadData) {
+  SpGrid<GridData, kLog2MaxGridSize> grid;
+
+  /* Allocate memory for a specific offset to ensure that the pads around it are
+   active. */
+  Offset center_offset = grid.CoordinateToOffset(9, 1, 1);
+  std::vector<Offset> offsets = {center_offset};
+  grid.Allocate(offsets);
+
+  /* Create pad data to set at the center offset. */
+  Pad<GridData> pad_to_set;
+  auto func = [&](int i, int j, int k) {
+    pad_to_set[i][j][k].data = Vector4d(i, j, k, i + j + k);
+  };
+  TripleLoop(func);
+
+  /* Set the pad data at the specified offset. */
+  grid.SetPadData(center_offset, pad_to_set);
+
+  /* Retrieve the pad data at the same offset. */
+  Pad<GridData> pad_retrieved = grid.GetPadData(center_offset);
+
+  /* Check if the retrieved data matches the set data. */
+  auto check_func = [&](int i, int j, int k) {
+    EXPECT_EQ(pad_retrieved[i][j][k].data, pad_to_set[i][j][k].data);
+  };
+  TripleLoop(check_func);
+}
+
+GTEST_TEST(SpGridTest, IterateGrid) {
+  SpGrid<GridData, kLog2MaxGridSize> grid;
+  std::vector<Offset> offsets = {grid.CoordinateToOffset(0, 0, 0),
+                                 grid.CoordinateToOffset(1, 1, 1),
+                                 grid.CoordinateToOffset(2, 2, 2)};
+  grid.Allocate(offsets);
+
+  /* Use IterateGrid to modify all grid nodes. */
+  grid.IterateGrid([](GridData* node_data) {
+    node_data->data = Vector4d(1.0, 2.0, 3.0, 4.0);
+  });
+
+  /* Verify that data has been modified using GetPadData that we tested
+   elsewhere. */
+  for (const auto& offset : offsets) {
+    Pad<GridData> pad = grid.GetPadData(offset);
+    auto check_func = [&](int i, int j, int k) {
+      EXPECT_EQ(pad[i][j][k].data, Vector4d(1.0, 2.0, 3.0, 4.0));
+    };
+    TripleLoop(check_func);
+  }
+}
+
+GTEST_TEST(SpGridTest, IterateGridWithOffset) {
+  SpGrid<GridData, kLog2MaxGridSize> grid;
+  std::vector<Offset> offsets = {grid.CoordinateToOffset(0, 0, 0),
+                                 grid.CoordinateToOffset(1, 1, 1),
+                                 grid.CoordinateToOffset(2, 2, 2)};
+  grid.Allocate(offsets);
+
+  /* Use IterateGridWithOffset to modify all grid nodes. */
+  grid.IterateGridWithOffset([](Offset offset, GridData* node_data) {
+    node_data->data =
+        Vector4d(offset * 1.0, offset * 2.0, offset * 3.0, offset * 4.0);
+  });
+
+  /* Verify data using GetPadData that we tested elsewhere. */
+  for (const auto& offset : offsets) {
+    const Pad<GridData> pad = grid.GetPadData(offset);
+    auto func = [&](int i, int j, int k) {
+      const Vector3<int> coord =
+          grid.OffsetToCoordinate(offset) + Vector3<int>(i - 1, j - 1, k - 1);
+      const Offset adjusted_offset =
+          grid.CoordinateToOffset(coord.x(), coord.y(), coord.z());
+      Vector4d expected_value(adjusted_offset * 1.0, adjusted_offset * 2.0,
+                              adjusted_offset * 3.0, adjusted_offset * 4.0);
+      EXPECT_EQ(pad[i][j][k].data, expected_value);
+    };
+    TripleLoop(func);
+  }
+
+  // Use IterateConstGridWithOffset to ensure const access does not modify data
+  grid.IterateConstGridWithOffset([](Offset offset, const GridData& node_data) {
+    Vector4d expected_value(offset * 1.0, offset * 2.0, offset * 3.0,
+                            offset * 4.0);
+    EXPECT_EQ(node_data.data, expected_value);
+  });
+}
+
+GTEST_TEST(SpGridTest, SetFrom) {
+  SpGrid<GridData, kLog2MaxGridSize> grid1;
+  SpGrid<GridData, kLog2MaxGridSize> grid2;
+
+  /* Allocate memory for grid1 with some offsets and set data */
+  std::vector<Offset> offsets = {grid1.CoordinateToOffset(0, 0, 0),
+                                 grid1.CoordinateToOffset(1, 1, 1),
+                                 grid1.CoordinateToOffset(2, 2, 2)};
+  grid1.Allocate(offsets);
+
+  grid1.IterateGridWithOffset([](Offset offset, GridData* node_data) {
+    node_data->data = Eigen::Vector4<double>(offset * 1.0, offset * 2.0,
+                                             offset * 3.0, offset * 4.0);
+  });
+
+  /* Set grid2 from grid1 and confirm they are the same. */
+  grid2.SetFrom(grid1);
+  EXPECT_EQ(grid1.num_blocks(), grid2.num_blocks());
+
+  /* Verify data consistency using GetPadData for each allocated offset. */
+  for (const auto& offset : offsets) {
+    Pad<GridData> pad1 = grid1.GetPadData(offset);
+    Pad<GridData> pad2 = grid2.GetPadData(offset);
+    EXPECT_EQ(pad1, pad2);
+  }
+
+  /* Offset computations are also the same. */
+  EXPECT_EQ(grid1.CoordinateToOffset(8, 4, 7),
+            grid2.CoordinateToOffset(8, 4, 7));
 }
 
 }  // namespace


### PR DESCRIPTION
Valgrind tests time out with mmap calls that reserve large span of virtual memory. So we add a knob to allow limiting the size of that reservation in unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22198)
<!-- Reviewable:end -->
