### PR TITLE
Improve ExtractAndAppendVariablesFromExpression.

### DIFF
--- a/common/symbolic/decompose.cc
+++ b/common/symbolic/decompose.cc
@@ -184,6 +184,21 @@ void DecomposeAffineExpressions(
 }
 
 void ExtractAndAppendVariablesFromExpression(
+    const Expression& e, std::vector<Variable>* vars,
+    std::unordered_map<Variable::Id, int>* map_var_to_index) {
+  DRAKE_THROW_UNLESS(vars != nullptr);
+  DRAKE_THROW_UNLESS(map_var_to_index != nullptr);
+  DRAKE_THROW_UNLESS(map_var_to_index->size() == vars->size());
+  for (const Variable& var : e.GetVariables()) {
+    const auto [_, emplace_success] =
+        map_var_to_index->try_emplace(var.get_id(), vars->size());
+    if (emplace_success) {
+      vars->push_back(var);
+    }
+  }
+}
+
+void ExtractAndAppendVariablesFromExpression(
     const Expression& e, VectorX<Variable>* vars,
     std::unordered_map<Variable::Id, int>* map_var_to_index) {
   DRAKE_DEMAND(static_cast<int>(map_var_to_index->size()) == vars->size());

--- a/common/symbolic/decompose.h
+++ b/common/symbolic/decompose.h
@@ -4,7 +4,9 @@
 #include <tuple>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/polynomial.h"
@@ -43,7 +45,7 @@ void DecomposeAffineExpressions(
     const Eigen::Ref<const VectorX<Variable>>& vars,
     EigenPtr<Eigen::MatrixXd> M, EigenPtr<Eigen::VectorXd> v);
 
-/** Given an expression `e`, extract all variables inside `e`, append these
+/** Given an expression `e`, extracts all variables inside `e`, appends these
 variables to `vars` if they are not included in `vars` yet.
 
 @param[in] e  A symbolic expression.
@@ -53,10 +55,14 @@ included in `vars`, will be appended to the end of `vars`.
 @param[in,out] map_var_to_index. map_var_to_index is of the same size as
 `vars`, and map_var_to_index[vars(i).get_id()] = i. This invariance holds for
 map_var_to_index both as the input and as the output.
-@note This function is very slow if you call this function within a loop as it
-involves repeated heap memory allocation. Consider using
-ExtractVariablesFromExpression.
 */
+void ExtractAndAppendVariablesFromExpression(
+    const symbolic::Expression& e, std::vector<Variable>* vars,
+    std::unordered_map<symbolic::Variable::Id, int>* map_var_to_index);
+
+DRAKE_DEPRECATED("2024-05-01",
+                 "Use the overloaded function with std::vector<Variable> "
+                 "instead of VectorX<Variable>")
 void ExtractAndAppendVariablesFromExpression(
     const symbolic::Expression& e, VectorX<Variable>* vars,
     std::unordered_map<symbolic::Variable::Id, int>* map_var_to_index);


### PR DESCRIPTION
Use std::vector<symbolic::Variable> instead of Eigen::VectorX<symbolic::Variable> for faster resizing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22201)
<!-- Reviewable:end -->
