### PR TITLE
[multibody] Remove dynamic_cast from snake_case inline functions

### DIFF
--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -117,7 +117,7 @@ class BallRpyJoint final : public Joint<T> {
   /// @returns The angle coordinates of `this` joint stored in the `context`
   ///          ordered as θr, θp, θy.
   Vector3<T> get_angles(const Context<T>& context) const {
-    return get_mobilizer()->get_angles(context);
+    return get_mobilizer().get_angles(context);
   }
 
   /// Sets the `context` so that the generalized coordinates corresponding to
@@ -130,7 +130,7 @@ class BallRpyJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const BallRpyJoint<T>& set_angles(Context<T>* context,
                                     const Vector3<T>& angles) const {
-    get_mobilizer()->SetAngles(context, angles);
+    get_mobilizer().SetAngles(context, angles);
     return *this;
   }
 
@@ -138,7 +138,7 @@ class BallRpyJoint final : public Joint<T> {
   /// sampled from. See get_angles() for details on the angle representation.
   void set_random_angles_distribution(
       const Vector3<symbolic::Expression>& angles) {
-    get_mutable_mobilizer()->set_random_position_distribution(
+    get_mutable_mobilizer().set_random_position_distribution(
         Vector3<symbolic::Expression>{angles});
   }
 
@@ -152,7 +152,7 @@ class BallRpyJoint final : public Joint<T> {
   ///   parent frame F, expressed in F. Refer to this class's documentation for
   ///   further details and definitions of these frames.
   Vector3<T> get_angular_velocity(const systems::Context<T>& context) const {
-    return get_mobilizer()->get_angular_velocity(context);
+    return get_mobilizer().get_angular_velocity(context);
   }
 
   /// Sets in `context` the state for `this` joint so that the angular velocity
@@ -166,7 +166,7 @@ class BallRpyJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const BallRpyJoint<T>& set_angular_velocity(systems::Context<T>* context,
                                               const Vector3<T>& w_FM) const {
-    get_mobilizer()->SetAngularVelocity(context, w_FM);
+    get_mobilizer().SetAngularVelocity(context, w_FM);
     return *this;
   }
 
@@ -205,7 +205,7 @@ class BallRpyJoint final : public Joint<T> {
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const override {
     Eigen::Ref<VectorX<T>> t_BMo_F =
-        get_mobilizer()->get_mutable_generalized_forces_from_array(
+        get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     const Vector3<T>& w_FM = get_angular_velocity(context);
     t_BMo_F = -this->GetDampingVector(context)[0] * w_FM;
@@ -213,29 +213,29 @@ class BallRpyJoint final : public Joint<T> {
 
  private:
   int do_get_velocity_start() const override {
-    return get_mobilizer()->velocity_start_in_v();
+    return get_mobilizer().velocity_start_in_v();
   }
 
   int do_get_num_velocities() const override { return 3; }
 
   int do_get_position_start() const override {
-    return get_mobilizer()->position_start_in_q();
+    return get_mobilizer().position_start_in_q();
   }
 
   int do_get_num_positions() const override { return 3; }
 
   std::string do_get_position_suffix(int index) const override {
-    return get_mobilizer()->position_suffix(index);
+    return get_mobilizer().position_suffix(index);
   }
 
   std::string do_get_velocity_suffix(int index) const override {
-    return get_mobilizer()->velocity_suffix(index);
+    return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
       const VectorX<double>& default_positions) override {
     if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(default_positions);
+      get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
@@ -261,21 +261,13 @@ class BallRpyJoint final : public Joint<T> {
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
-  const internal::RpyBallMobilizer<T>* get_mobilizer() const {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    const internal::RpyBallMobilizer<T>* mobilizer =
-        dynamic_cast<const internal::RpyBallMobilizer<T>*>(
-            this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  const internal::RpyBallMobilizer<T>& get_mobilizer() const {
+    return this->template get_mobilizer_downcast<internal::RpyBallMobilizer>();
   }
 
-  internal::RpyBallMobilizer<T>* get_mutable_mobilizer() {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    auto* mobilizer = dynamic_cast<internal::RpyBallMobilizer<T>*>(
-        this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  internal::RpyBallMobilizer<T>& get_mutable_mobilizer() {
+    return this
+        ->template get_mutable_mobilizer_downcast<internal::RpyBallMobilizer>();
   }
 
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -995,6 +995,30 @@ class Joint : public MultibodyElement<T> {
                : std::make_pair(&frame_on_parent(), &frame_on_child());
   }
 
+  /// (Internal use only) Returns the mobilizer implementing this joint,
+  /// downcast to its specific type.
+  ///
+  /// @pre get_implementation().has_mobilizer() is true
+  /// @pre ConcreteMobilizer must exactly match the dynamic type of the
+  /// mobilizer associated with this Joint. This requirement is (only) checked
+  /// in Debug builds.
+  template <template <typename> class ConcreteMobilizer>
+  const ConcreteMobilizer<T>& get_mobilizer_downcast() const {
+    const internal::Mobilizer<T>* result = this->get_implementation().mobilizer;
+    DRAKE_DEMAND(result != nullptr);
+    DRAKE_ASSERT(typeid(*result) == typeid(ConcreteMobilizer<T>));
+    return static_cast<const ConcreteMobilizer<T>&>(*result);
+  }
+
+  /// (Internal use only) Mutable flavor of get_mobilizer_downcast().
+  template <template <typename> class ConcreteMobilizer>
+  ConcreteMobilizer<T>& get_mutable_mobilizer_downcast() {
+    internal::Mobilizer<T>* result = this->get_implementation().mobilizer;
+    DRAKE_DEMAND(result != nullptr);
+    DRAKE_ASSERT(typeid(*result) == typeid(ConcreteMobilizer<T>));
+    return static_cast<ConcreteMobilizer<T>&>(*result);
+  }
+
  private:
   // Make all other Joint<U> objects a friend of Joint<T> so they can make
   // Joint<ToScalar>::JointImplementation from CloneToScalar<ToScalar>().

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -101,7 +101,7 @@ class PlanarJoint final : public Joint<T> {
   /// @retval p_FoMo_F The position of `this` joint stored in the `context`
   ///                  ordered as (x, y). See class documentation for details.
   Vector2<T> get_translation(const Context<T>& context) const {
-    return get_mobilizer()->get_translations(context);
+    return get_mobilizer().get_translations(context);
   }
 
   /// Sets the `context` so that the position of `this` joint equals `p_FoMo_F`.
@@ -113,7 +113,7 @@ class PlanarJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const PlanarJoint<T>& set_translation(Context<T>* context,
                                         const Vector2<T>& p_FoMo_F) const {
-    get_mobilizer()->set_translations(context, p_FoMo_F);
+    get_mobilizer().set_translations(context, p_FoMo_F);
     return *this;
   }
 
@@ -123,7 +123,7 @@ class PlanarJoint final : public Joint<T> {
   /// @retval theta The angle of `this` joint stored in the `context`. See class
   ///               documentation for details.
   const T& get_rotation(const systems::Context<T>& context) const {
-    return get_mobilizer()->get_angle(context);
+    return get_mobilizer().get_angle(context);
   }
 
   /// Sets the `context` so that the angle θ of `this` joint equals `theta`.
@@ -134,7 +134,7 @@ class PlanarJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const PlanarJoint<T>& set_rotation(systems::Context<T>* context,
                                      const T& theta) const {
-    get_mobilizer()->SetAngle(context, theta);
+    get_mobilizer().SetAngle(context, theta);
     return *this;
   }
 
@@ -151,8 +151,8 @@ class PlanarJoint final : public Joint<T> {
   const PlanarJoint<T>& set_pose(systems::Context<T>* context,
                                  const Vector2<T>& p_FoMo_F,
                                  const T& theta) const {
-    get_mobilizer()->set_translations(context, p_FoMo_F);
-    get_mobilizer()->SetAngle(context, theta);
+    get_mobilizer().set_translations(context, p_FoMo_F);
+    get_mobilizer().SetAngle(context, theta);
     return *this;
   }
 
@@ -163,7 +163,7 @@ class PlanarJoint final : public Joint<T> {
   ///                  the `context`.
   Vector2<T> get_translational_velocity(
       const systems::Context<T>& context) const {
-    return get_mobilizer()->get_translation_rates(context);
+    return get_mobilizer().get_translation_rates(context);
   }
 
   /// Sets the translational velocity, in meters per second, of this `this`
@@ -175,7 +175,7 @@ class PlanarJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const PlanarJoint<T>& set_translational_velocity(
       systems::Context<T>* context, const Vector2<T>& v_FoMo_F) const {
-    get_mobilizer()->SetTranslationRates(context, v_FoMo_F);
+    get_mobilizer().SetTranslationRates(context, v_FoMo_F);
     return *this;
   }
 
@@ -187,7 +187,7 @@ class PlanarJoint final : public Joint<T> {
   /// @retval theta_dot The rate of change of `this` joint's angle θ as
   ///                   stored in the `context`.
   const T& get_angular_velocity(const systems::Context<T>& context) const {
-    return get_mobilizer()->get_angular_rate(context);
+    return get_mobilizer().get_angular_rate(context);
   }
 
   /// Sets the rate of change, in radians per second, of `this` joint's angle
@@ -200,7 +200,7 @@ class PlanarJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const PlanarJoint<T>& set_angular_velocity(systems::Context<T>* context,
                                              const T& theta_dot) const {
-    get_mobilizer()->SetAngularRate(context, theta_dot);
+    get_mobilizer().SetAngularRate(context, theta_dot);
     return *this;
   }
 
@@ -247,7 +247,7 @@ class PlanarJoint final : public Joint<T> {
       const Vector2<symbolic::Expression>& p_FoMo_F,
       const symbolic::Expression& theta) {
     Vector3<symbolic::Expression> state(p_FoMo_F[0], p_FoMo_F[1], theta);
-    get_mutable_mobilizer()->set_random_position_distribution(state);
+    get_mutable_mobilizer().set_random_position_distribution(state);
   }
 
  private:
@@ -270,7 +270,7 @@ class PlanarJoint final : public Joint<T> {
                        MultibodyForces<T>* forces) const final {
     DRAKE_DEMAND(joint_dof < 3);
     Eigen::Ref<VectorX<T>> tau_mob =
-        get_mobilizer()->get_mutable_generalized_forces_from_array(
+        get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     tau_mob(joint_dof) += joint_tau;
   }
@@ -283,7 +283,7 @@ class PlanarJoint final : public Joint<T> {
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const final {
     Eigen::Ref<VectorX<T>> tau =
-        get_mobilizer()->get_mutable_generalized_forces_from_array(
+        get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     const Vector2<T>& v_translation = get_translational_velocity(context);
     const T& v_angular = get_angular_velocity(context);
@@ -294,29 +294,29 @@ class PlanarJoint final : public Joint<T> {
   }
 
   int do_get_velocity_start() const final {
-    return get_mobilizer()->velocity_start_in_v();
+    return get_mobilizer().velocity_start_in_v();
   }
 
   int do_get_num_velocities() const final { return 3; }
 
   int do_get_position_start() const final {
-    return get_mobilizer()->position_start_in_q();
+    return get_mobilizer().position_start_in_q();
   }
 
   int do_get_num_positions() const final { return 3; }
 
   std::string do_get_position_suffix(int index) const override {
-    return get_mobilizer()->position_suffix(index);
+    return get_mobilizer().position_suffix(index);
   }
 
   std::string do_get_velocity_suffix(int index) const override {
-    return get_mobilizer()->velocity_suffix(index);
+    return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
       const VectorX<double>& default_positions) final {
     if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(default_positions);
+      get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
@@ -342,21 +342,13 @@ class PlanarJoint final : public Joint<T> {
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
-  const internal::PlanarMobilizer<T>* get_mobilizer() const {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    const internal::PlanarMobilizer<T>* mobilizer =
-        dynamic_cast<const internal::PlanarMobilizer<T>*>(
-            this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  const internal::PlanarMobilizer<T>& get_mobilizer() const {
+    return this->template get_mobilizer_downcast<internal::PlanarMobilizer>();
   }
 
-  internal::PlanarMobilizer<T>* get_mutable_mobilizer() {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    auto* mobilizer = dynamic_cast<internal::PlanarMobilizer<T>*>(
-        this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  internal::PlanarMobilizer<T>& get_mutable_mobilizer() {
+    return this
+        ->template get_mutable_mobilizer_downcast<internal::PlanarMobilizer>();
   }
 
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -133,7 +133,7 @@ class PrismaticJoint final : public Joint<T> {
   ///   The context of the MultibodyTree this joint belongs to.
   /// @returns The translation coordinate of `this` joint read from `context`.
   const T& get_translation(const Context<T>& context) const {
-    return get_mobilizer()->get_translation(context);
+    return get_mobilizer().get_translation(context);
   }
 
   /// Sets `context` so that the generalized coordinate corresponding to the
@@ -145,7 +145,7 @@ class PrismaticJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const PrismaticJoint<T>& set_translation(Context<T>* context,
                                            const T& translation) const {
-    get_mobilizer()->SetTranslation(context, translation);
+    get_mobilizer().SetTranslation(context, translation);
     return *this;
   }
 
@@ -156,7 +156,7 @@ class PrismaticJoint final : public Joint<T> {
   /// @returns The rate of change of `this` joint's translation read from
   /// `context`.
   const T& get_translation_rate(const Context<T>& context) const {
-    return get_mobilizer()->get_translation_rate(context);
+    return get_mobilizer().get_translation_rate(context);
   }
 
   /// Sets the rate of change, in meters per second, of `this` joint's
@@ -170,7 +170,7 @@ class PrismaticJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const PrismaticJoint<T>& set_translation_rate(
       Context<T>* context, const T& translation_dot) const {
-    get_mobilizer()->SetTranslationRate(context, translation_dot);
+    get_mobilizer().SetTranslationRate(context, translation_dot);
     return *this;
   }
 
@@ -212,7 +212,7 @@ class PrismaticJoint final : public Joint<T> {
 
   void set_random_translation_distribution(
       const symbolic::Expression& translation) {
-    get_mutable_mobilizer()->set_random_position_distribution(
+    get_mutable_mobilizer().set_random_position_distribution(
         Vector1<symbolic::Expression>{translation});
   }
 
@@ -244,7 +244,7 @@ class PrismaticJoint final : public Joint<T> {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
     Eigen::Ref<VectorX<T>> tau_mob =
-        get_mobilizer()->get_mutable_generalized_forces_from_array(
+        get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     tau_mob(joint_dof) += joint_tau;
   }
@@ -263,29 +263,29 @@ class PrismaticJoint final : public Joint<T> {
 
  private:
   int do_get_velocity_start() const override {
-    return get_mobilizer()->velocity_start_in_v();
+    return get_mobilizer().velocity_start_in_v();
   }
 
   int do_get_num_velocities() const override { return 1; }
 
   int do_get_position_start() const override {
-    return get_mobilizer()->position_start_in_q();
+    return get_mobilizer().position_start_in_q();
   }
 
   int do_get_num_positions() const override { return 1; }
 
   std::string do_get_position_suffix(int index) const override {
-    return get_mobilizer()->position_suffix(index);
+    return get_mobilizer().position_suffix(index);
   }
 
   std::string do_get_velocity_suffix(int index) const override {
-    return get_mobilizer()->velocity_suffix(index);
+    return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
       const VectorX<double>& default_positions) override {
     if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(default_positions);
+      get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
@@ -330,23 +330,14 @@ class PrismaticJoint final : public Joint<T> {
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
-  const internal::PrismaticMobilizer<T>* get_mobilizer() const {
-    // This implementation should always use a mobilizer.
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    const internal::PrismaticMobilizer<T>* mobilizer =
-        dynamic_cast<const internal::PrismaticMobilizer<T>*>(
-            this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  const internal::PrismaticMobilizer<T>& get_mobilizer() const {
+    return this
+        ->template get_mobilizer_downcast<internal::PrismaticMobilizer>();
   }
 
-  internal::PrismaticMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should always use a mobilizer.
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    auto* mobilizer = dynamic_cast<internal::PrismaticMobilizer<T>*>(
-        this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  internal::PrismaticMobilizer<T>& get_mutable_mobilizer() {
+    return this->template get_mutable_mobilizer_downcast<
+        internal::PrismaticMobilizer>();
   }
 
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -282,7 +282,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// See get_translation() for details on the translation representation.
   void set_random_translation_distribution(
       const Vector3<symbolic::Expression>& p_FM) {
-    get_mutable_mobilizer()->set_random_translation_distribution(p_FM);
+    get_mutable_mobilizer().set_random_translation_distribution(p_FM);
   }
 
   /// (Advanced) Sets the random distribution that the orientation of this joint
@@ -296,7 +296,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// common case of uniformly sampling rotations.
   void set_random_quaternion_distribution(
       const Eigen::Quaternion<symbolic::Expression>& q_FM) {
-    get_mutable_mobilizer()->set_random_quaternion_distribution(q_FM);
+    get_mutable_mobilizer().set_random_quaternion_distribution(q_FM);
   }
 
   /// Sets the random distribution such that the orientation of this joint will
@@ -305,7 +305,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
     RandomGenerator generator;
     auto q_FM =
         math::UniformlyRandomQuaternion<symbolic::Expression>(&generator);
-    get_mutable_mobilizer()->set_random_quaternion_distribution(q_FM);
+    get_mutable_mobilizer().set_random_quaternion_distribution(q_FM);
   }
 
   /// @}
@@ -398,7 +398,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   void do_set_default_positions(
       const VectorX<double>& default_positions) override {
     if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(default_positions);
+      get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
@@ -439,20 +439,13 @@ class QuaternionFloatingJoint final : public Joint<T> {
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
   const internal::QuaternionFloatingMobilizer<T>& get_mobilizer() const {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    const internal::QuaternionFloatingMobilizer<T>* mobilizer =
-        dynamic_cast<const internal::QuaternionFloatingMobilizer<T>*>(
-            this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return *mobilizer;
+    return this->template get_mobilizer_downcast<
+        internal::QuaternionFloatingMobilizer>();
   }
 
-  internal::QuaternionFloatingMobilizer<T>* get_mutable_mobilizer() {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    auto* mobilizer = dynamic_cast<internal::QuaternionFloatingMobilizer<T>*>(
-        this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  internal::QuaternionFloatingMobilizer<T>& get_mutable_mobilizer() {
+    return this->template get_mutable_mobilizer_downcast<
+        internal::QuaternionFloatingMobilizer>();
   }
 
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -164,7 +164,7 @@ class RevoluteJoint final : public Joint<T> {
   ///   The context of the MultibodyTree this joint belongs to.
   /// @returns The angle coordinate of `this` joint stored in the `context`.
   const T& get_angle(const Context<T>& context) const {
-    return get_mobilizer()->get_angle(context);
+    return get_mobilizer().get_angle(context);
   }
 
   /// Sets the `context` so that the generalized coordinate corresponding to the
@@ -175,12 +175,12 @@ class RevoluteJoint final : public Joint<T> {
   ///   The desired angle in radians to be stored in `context`.
   /// @returns a constant reference to `this` joint.
   const RevoluteJoint<T>& set_angle(Context<T>* context, const T& angle) const {
-    get_mobilizer()->SetAngle(context, angle);
+    get_mobilizer().SetAngle(context, angle);
     return *this;
   }
 
   void set_random_angle_distribution(const symbolic::Expression& angle) {
-    get_mutable_mobilizer()->set_random_position_distribution(
+    get_mutable_mobilizer().set_random_position_distribution(
         Vector1<symbolic::Expression>{angle});
   }
 
@@ -191,7 +191,7 @@ class RevoluteJoint final : public Joint<T> {
   /// @returns The rate of change of `this` joint's angle as stored in the
   /// `context`.
   const T& get_angular_rate(const Context<T>& context) const {
-    return get_mobilizer()->get_angular_rate(context);
+    return get_mobilizer().get_angular_rate(context);
   }
 
   /// Sets the rate of change, in radians per second, of this `this` joint's
@@ -205,7 +205,7 @@ class RevoluteJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const RevoluteJoint<T>& set_angular_rate(Context<T>* context,
                                            const T& angle) const {
-    get_mobilizer()->SetAngularRate(context, angle);
+    get_mobilizer().SetAngularRate(context, angle);
     return *this;
   }
 
@@ -276,7 +276,7 @@ class RevoluteJoint final : public Joint<T> {
     // mobilizer.
     DRAKE_DEMAND(joint_dof == 0);
     Eigen::Ref<VectorX<T>> tau_mob =
-        get_mobilizer()->get_mutable_generalized_forces_from_array(
+        get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     tau_mob(joint_dof) += joint_tau;
   }
@@ -295,29 +295,29 @@ class RevoluteJoint final : public Joint<T> {
 
  private:
   int do_get_velocity_start() const override {
-    return get_mobilizer()->velocity_start_in_v();
+    return get_mobilizer().velocity_start_in_v();
   }
 
   int do_get_num_velocities() const override { return 1; }
 
   int do_get_position_start() const override {
-    return get_mobilizer()->position_start_in_q();
+    return get_mobilizer().position_start_in_q();
   }
 
   int do_get_num_positions() const override { return 1; }
 
   std::string do_get_position_suffix(int index) const override {
-    return get_mobilizer()->position_suffix(index);
+    return get_mobilizer().position_suffix(index);
   }
 
   std::string do_get_velocity_suffix(int index) const override {
-    return get_mobilizer()->velocity_suffix(index);
+    return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
       const VectorX<double>& default_positions) override {
     if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(default_positions);
+      get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
@@ -354,23 +354,13 @@ class RevoluteJoint final : public Joint<T> {
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
-  const internal::RevoluteMobilizer<T>* get_mobilizer() const {
-    // This implementation should always use a mobilizer.
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    const internal::RevoluteMobilizer<T>* mobilizer =
-        dynamic_cast<const internal::RevoluteMobilizer<T>*>(
-            this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  const internal::RevoluteMobilizer<T>& get_mobilizer() const {
+    return this->template get_mobilizer_downcast<internal::RevoluteMobilizer>();
   }
 
-  internal::RevoluteMobilizer<T>* get_mutable_mobilizer() {
-    // This implementation should always use a mobilizer.
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    auto* mobilizer = dynamic_cast<internal::RevoluteMobilizer<T>*>(
-        this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  internal::RevoluteMobilizer<T>& get_mutable_mobilizer() {
+    return this->template get_mutable_mobilizer_downcast<
+        internal::RevoluteMobilizer>();
   }
 
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -447,20 +447,13 @@ class RpyFloatingJoint final : public Joint<T> {
 
   // Returns the mobilizer implementing this joint.
   const internal::RpyFloatingMobilizer<T>& get_mobilizer() const {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    const auto* mobilizer =
-        dynamic_cast<const internal::RpyFloatingMobilizer<T>*>(
-            this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return *mobilizer;
+    return this
+        ->template get_mobilizer_downcast<internal::RpyFloatingMobilizer>();
   }
 
   internal::RpyFloatingMobilizer<T>& get_mutable_mobilizer() {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    auto* mobilizer = dynamic_cast<internal::RpyFloatingMobilizer<T>*>(
-        this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return *mobilizer;
+    return this->template get_mutable_mobilizer_downcast<
+        internal::RpyFloatingMobilizer>();
   }
 
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -136,7 +136,7 @@ class ScrewJoint final : public Joint<T> {
   /// @retval z The translation of `this` joint stored in the `context` as (z).
   ///           See class documentation for details.
   T get_translation(const Context<T>& context) const {
-    return get_mobilizer()->get_translation(context);
+    return get_mobilizer().get_translation(context);
   }
 
   /// Sets the `context` so that the translation of `this` joint equals to (z).
@@ -146,7 +146,7 @@ class ScrewJoint final : public Joint<T> {
   ///              as (z). See class documentation for details.
   /// @returns a constant reference to `this` joint.
   const ScrewJoint<T>& set_translation(Context<T>* context, const T& z) const {
-    get_mobilizer()->SetTranslation(context, z);
+    get_mobilizer().SetTranslation(context, z);
     return *this;
   }
 
@@ -156,7 +156,7 @@ class ScrewJoint final : public Joint<T> {
   /// @retval theta The angle of `this` joint stored in the `context`. See class
   ///               documentation for details.
   const T& get_rotation(const systems::Context<T>& context) const {
-    return get_mobilizer()->get_angle(context);
+    return get_mobilizer().get_angle(context);
   }
 
   /// Sets the `context` so that the angle θ of `this` joint equals `theta`.
@@ -167,7 +167,7 @@ class ScrewJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const ScrewJoint<T>& set_rotation(systems::Context<T>* context,
                                     const T& theta) const {
-    get_mobilizer()->SetAngle(context, theta);
+    get_mobilizer().SetAngle(context, theta);
     return *this;
   }
 
@@ -177,7 +177,7 @@ class ScrewJoint final : public Joint<T> {
   /// @retval vz The translational velocity of `this` joint as stored in the
   ///            `context`.
   T get_translational_velocity(const systems::Context<T>& context) const {
-    return get_mobilizer()->get_translation_rate(context);
+    return get_mobilizer().get_translation_rate(context);
   }
 
   /// Sets the translational velocity, in meters per second, of this `this`
@@ -189,7 +189,7 @@ class ScrewJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const ScrewJoint<T>& set_translational_velocity(systems::Context<T>* context,
                                                   const T& vz) const {
-    get_mobilizer()->SetTranslationRate(context, vz);
+    get_mobilizer().SetTranslationRate(context, vz);
     return *this;
   }
 
@@ -201,7 +201,7 @@ class ScrewJoint final : public Joint<T> {
   /// @retval theta_dot The rate of change of `this` joint's angle θ as
   ///                   stored in the `context`.
   const T& get_angular_velocity(const systems::Context<T>& context) const {
-    return get_mobilizer()->get_angular_rate(context);
+    return get_mobilizer().get_angular_rate(context);
   }
 
   /// Sets the rate of change, in radians per second, of `this` joint's angle
@@ -214,7 +214,7 @@ class ScrewJoint final : public Joint<T> {
   /// @returns a constant reference to `this` joint.
   const ScrewJoint<T>& set_angular_velocity(systems::Context<T>* context,
                                             const T& theta_dot) const {
-    get_mobilizer()->SetAngularRate(context, theta_dot);
+    get_mobilizer().SetAngularRate(context, theta_dot);
     return *this;
   }
 
@@ -273,7 +273,7 @@ class ScrewJoint final : public Joint<T> {
   /// on the definition of the position and angle.
   void set_random_pose_distribution(
       const Vector1<symbolic::Expression>& theta) {
-    get_mutable_mobilizer()->set_random_position_distribution(theta);
+    get_mutable_mobilizer().set_random_position_distribution(theta);
   }
 
  private:
@@ -294,7 +294,7 @@ class ScrewJoint final : public Joint<T> {
                        MultibodyForces<T>* forces) const final {
     DRAKE_DEMAND(joint_dof < 1);
     Eigen::Ref<VectorX<T>> tau_mob =
-        get_mobilizer()->get_mutable_generalized_forces_from_array(
+        get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     tau_mob(joint_dof) += joint_tau;
   }
@@ -307,36 +307,36 @@ class ScrewJoint final : public Joint<T> {
   void DoAddInDamping(const systems::Context<T>& context,
                       MultibodyForces<T>* forces) const final {
     Eigen::Ref<VectorX<T>> tau =
-        get_mobilizer()->get_mutable_generalized_forces_from_array(
+        get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
     const T& v_angular = get_angular_velocity(context);
     tau[0] -= this->GetDamping(context) * v_angular;
   }
 
   int do_get_velocity_start() const final {
-    return get_mobilizer()->velocity_start_in_v();
+    return get_mobilizer().velocity_start_in_v();
   }
 
   int do_get_num_velocities() const final { return 1; }
 
   int do_get_position_start() const final {
-    return get_mobilizer()->position_start_in_q();
+    return get_mobilizer().position_start_in_q();
   }
 
   int do_get_num_positions() const final { return 1; }
 
   std::string do_get_position_suffix(int index) const override {
-    return get_mobilizer()->position_suffix(index);
+    return get_mobilizer().position_suffix(index);
   }
 
   std::string do_get_velocity_suffix(int index) const override {
-    return get_mobilizer()->velocity_suffix(index);
+    return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
       const VectorX<double>& default_positions) final {
     if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(default_positions);
+      get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
@@ -370,21 +370,13 @@ class ScrewJoint final : public Joint<T> {
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
-  const internal::ScrewMobilizer<T>* get_mobilizer() const {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    const internal::ScrewMobilizer<T>* mobilizer =
-        dynamic_cast<const internal::ScrewMobilizer<T>*>(
-            this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  const internal::ScrewMobilizer<T>& get_mobilizer() const {
+    return this->template get_mobilizer_downcast<internal::ScrewMobilizer>();
   }
 
-  internal::ScrewMobilizer<T>* get_mutable_mobilizer() {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    auto* mobilizer = dynamic_cast<internal::ScrewMobilizer<T>*>(
-        this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  internal::ScrewMobilizer<T>& get_mutable_mobilizer() {
+    return this
+        ->template get_mutable_mobilizer_downcast<internal::ScrewMobilizer>();
   }
 
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -45,7 +45,7 @@ class JointTester {
   JointTester() = delete;
   static const internal::RevoluteMobilizer<double>* get_mobilizer(
       const RevoluteJoint<double>& joint) {
-    return joint.get_mobilizer();
+    return &joint.get_mobilizer();
   }
 };
 

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -35,7 +35,7 @@ class JointTester {
   // RevoluteMobilizer.
   static const internal::RevoluteMobilizer<double>* get_mobilizer(
       const RevoluteJoint<double>& joint) {
-    return joint.get_mobilizer();
+    return &joint.get_mobilizer();
   }
 };
 

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -65,7 +65,7 @@ class WeldJoint final : public Joint<T> {
     // Since WeldJoint has no state, the start index has no meaning. However,
     // we let its decide the return value for this case (this has to do with
     // allowing zero sized Eigen blocks).
-    return get_mobilizer()->velocity_start_in_v();
+    return get_mobilizer().velocity_start_in_v();
   }
 
   int do_get_num_velocities() const override { return 0; }
@@ -74,17 +74,17 @@ class WeldJoint final : public Joint<T> {
     // Since WeldJoint has no state, the start index has no meaning. However,
     // we let it decide the return value for this case (this has to do with
     // allowing zero sized Eigen blocks).
-    return get_mobilizer()->position_start_in_q();
+    return get_mobilizer().position_start_in_q();
   }
 
   int do_get_num_positions() const override { return 0; }
 
   std::string do_get_position_suffix(int index) const override {
-    return get_mobilizer()->position_suffix(index);
+    return get_mobilizer().position_suffix(index);
   }
 
   std::string do_get_velocity_suffix(int index) const override {
-    return get_mobilizer()->velocity_suffix(index);
+    return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(const VectorX<double>&) override { return; }
@@ -111,21 +111,13 @@ class WeldJoint final : public Joint<T> {
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.
-  const internal::WeldMobilizer<T>* get_mobilizer() const {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    const internal::WeldMobilizer<T>* mobilizer =
-        dynamic_cast<const internal::WeldMobilizer<T>*>(
-            this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  const internal::WeldMobilizer<T>& get_mobilizer() const {
+    return this->template get_mobilizer_downcast<internal::WeldMobilizer>();
   }
 
-  internal::WeldMobilizer<T>* get_mutable_mobilizer() {
-    DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-    auto* mobilizer = dynamic_cast<internal::WeldMobilizer<T>*>(
-        this->get_implementation().mobilizer);
-    DRAKE_DEMAND(mobilizer != nullptr);
-    return mobilizer;
+  internal::WeldMobilizer<T>& get_mutable_mobilizer() {
+    return this
+        ->template get_mutable_mobilizer_downcast<internal::WeldMobilizer>();
   }
 
   // Helper method to make a clone templated on ToScalar.


### PR DESCRIPTION
Using `dynamic_cast` in an inline function is verboten per our style guide.  This commit replaces it with a `static_cast`.  This change is tangentially inspired by #22204.

We could move the existing implementation to the cc file instead, but fixing the cast seems to me like the better approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22205)
<!-- Reviewable:end -->
