### PR TITLE
[multibody] Remove dynamic_cast from inline get-downcast functions

### DIFF
--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -77,6 +77,21 @@ BallRpyJoint<T>::MakeImplementationBlueprint(
   return blue_print;
 }
 
+namespace internal {
+
+template <typename T>
+const BallRpyJoint<T>* DynamicCastJoint<BallRpyJoint>::cast(
+    const Joint<T>* element) {
+  return dynamic_cast<const BallRpyJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<BallRpyJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -279,6 +279,16 @@ class BallRpyJoint final : public Joint<T> {
 template <typename T>
 const char BallRpyJoint<T>::kTypeName[] = "ball_rpy";
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<BallRpyJoint> {
+  template <typename T>
+  static const BallRpyJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/door_hinge.cc
+++ b/multibody/tree/door_hinge.cc
@@ -210,6 +210,21 @@ std::unique_ptr<ForceElement<Expression>> DoorHinge<T>::DoCloneToScalar(
   return TemplatedClone(tree_clone);
 }
 
+namespace internal {
+
+template <typename T>
+const DoorHinge<T>* DynamicCastForceElement<DoorHinge>::cast(
+    const ForceElement<T>* element) {
+  return dynamic_cast<const DoorHinge<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastForceElement<DoorHinge>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/door_hinge.h
+++ b/multibody/tree/door_hinge.h
@@ -232,6 +232,16 @@ class DoorHinge final : public ForceElement<T> {
   const DoorHingeConfig config_;
 };
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastForceElement<DoorHinge> {
+  template <typename T>
+  static const DoorHinge<T>* cast(const ForceElement<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/force_element.h
+++ b/multibody/tree/force_element.h
@@ -278,5 +278,21 @@ class ForceElement : public MultibodyElement<T> {
   }
 };
 
+namespace internal {
+
+// This helper exists so that concrete force element types can specialize it
+// with non-inline definitions. MbT code (on behalf of MbP) needs to perform
+// dynamic casting, but we want to avoid doing that inline, so MbT calls this
+// helper, which then (if the ToType is a Drake force element) is non-inline.
+// This is the fallback implementation for non-Drake force element types.
+template <template <typename> class ToType>
+struct DynamicCastForceElement {
+  template <typename T>
+  static const ToType<T>* cast(const ForceElement<T>* element) {
+    return dynamic_cast<const ToType<T>*>(element);
+  }
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -1090,5 +1090,21 @@ class Joint : public MultibodyElement<T> {
   systems::NumericParameterIndex damping_parameter_index_;
 };
 
+namespace internal {
+
+// This helper exists so that concrete joint types can specialize it with
+// non-inline definitions. MbT code (on behalf of MbP) needs to perform
+// dynamic casting, but we want to avoid doing that inline, so MbT calls
+// this helper, which then (if the ToType is a Drake joint) is non-inline.
+// This is the fallback implementation for non-Drake joint types.
+template <template <typename> class ToType>
+struct DynamicCastJoint {
+  template <typename T>
+  static const ToType<T>* cast(const Joint<T>* element) {
+    return dynamic_cast<const ToType<T>*>(element);
+  }
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.cc
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.cc
@@ -375,6 +375,22 @@ LinearBushingRollPitchYaw<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+namespace internal {
+
+template <typename T>
+const LinearBushingRollPitchYaw<T>*
+DynamicCastForceElement<LinearBushingRollPitchYaw>::cast(
+    const ForceElement<T>* element) {
+  return dynamic_cast<const LinearBushingRollPitchYaw<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastForceElement<LinearBushingRollPitchYaw>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.h
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.h
@@ -805,6 +805,17 @@ class LinearBushingRollPitchYaw final : public ForceElement<T> {
   systems::NumericParameterIndex force_damping_parameter_index_;
 };
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastForceElement<LinearBushingRollPitchYaw> {
+  template <typename T>
+  static const LinearBushingRollPitchYaw<T>* cast(
+      const ForceElement<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/linear_spring_damper.cc
+++ b/multibody/tree/linear_spring_damper.cc
@@ -227,6 +227,21 @@ T LinearSpringDamper<T>::CalcLengthTimeDerivative(
   return length_dot;
 }
 
+namespace internal {
+
+template <typename T>
+const LinearSpringDamper<T>* DynamicCastForceElement<LinearSpringDamper>::cast(
+    const ForceElement<T>* element) {
+  return dynamic_cast<const LinearSpringDamper<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastForceElement<LinearSpringDamper>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/linear_spring_damper.h
+++ b/multibody/tree/linear_spring_damper.h
@@ -148,6 +148,16 @@ class LinearSpringDamper final : public ForceElement<T> {
   double damping_;
 };
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastForceElement<LinearSpringDamper> {
+  template <typename T>
+  static const LinearSpringDamper<T>* cast(const ForceElement<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -608,13 +608,22 @@ const Joint<T>& MultibodyTree<T>::GetJointByNameImpl(
 }
 
 template <typename T>
+void MultibodyTree<T>::ThrowForceElementSubtypeMismatch(
+    const ForceElement<T>& force_element,
+    const std::type_info& desired_type) const {
+  throw std::logic_error(fmt::format(
+      "GetForceElement(): ForceElement is not of type '{}' but of type '{}'.",
+      NiceTypeName::Get(desired_type), NiceTypeName::Get(force_element)));
+}
+
+template <typename T>
 void MultibodyTree<T>::ThrowJointSubtypeMismatch(
-    const Joint<T>& joint, std::string_view desired_type) const {
+    const Joint<T>& joint, const std::type_info& desired_type) const {
   throw std::logic_error(fmt::format(
       "GetJointByName(): Joint '{}' in model instance '{}' is not of type {} "
       "but of type {}.",
       joint.name(), model_instances_.get_element(joint.model_instance()).name(),
-      desired_type, NiceTypeName::Get(joint)));
+      NiceTypeName::Get(desired_type), NiceTypeName::Get(joint)));
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -673,24 +673,7 @@ class MultibodyTree {
   // See MultibodyPlant method.
   template <template <typename> class ForceElementType = ForceElement>
   const ForceElementType<T>& GetForceElement(
-      ForceElementIndex force_element_index) const {
-    static_assert(
-        std::is_base_of_v<ForceElement<T>, ForceElementType<T>>,
-        "ForceElementType<T> must be a sub-class of ForceElement<T>.");
-    const ForceElement<T>* force_element =
-        &get_force_element(force_element_index);
-
-    const ForceElementType<T>* typed_force_element =
-        dynamic_cast<const ForceElementType<T>*>(force_element);
-    if (typed_force_element == nullptr) {
-      throw std::logic_error(
-          fmt::format("ForceElement is not of type '{}' but of type '{}'.",
-                      NiceTypeName::Get<ForceElementType<T>>(),
-                      NiceTypeName::Get(*force_element)));
-    }
-
-    return *typed_force_element;
-  }
+      ForceElementIndex force_element_index) const;
 
   const ForceElement<T>& get_force_element(
       ForceElementIndex force_element_index) const {
@@ -826,17 +809,7 @@ class MultibodyTree {
   template <template <typename> class JointType = Joint>
   const JointType<T>& GetJointByName(
       std::string_view name,
-      std::optional<ModelInstanceIndex> model_instance = std::nullopt) const {
-    static_assert(std::is_base_of_v<Joint<T>, JointType<T>>,
-                  "JointType<T> must be a sub-class of Joint<T>.");
-    const Joint<T>& joint = GetJointByNameImpl(name, model_instance);
-    const JointType<T>* const typed_joint =
-        dynamic_cast<const JointType<T>*>(&joint);
-    if (typed_joint == nullptr) {
-      ThrowJointSubtypeMismatch(joint, NiceTypeName::Get<JointType<T>>());
-    }
-    return *typed_joint;
-  }
+      std::optional<ModelInstanceIndex> model_instance = std::nullopt) const;
 
   // See MultibodyPlant method.
   template <template <typename> class JointType = Joint>
@@ -2536,8 +2509,11 @@ class MultibodyTree {
   const Joint<T>& GetJointByNameImpl(std::string_view,
                                      std::optional<ModelInstanceIndex>) const;
 
+  [[noreturn]] void ThrowForceElementSubtypeMismatch(
+      const ForceElement<T>&, const std::type_info&) const;
+
   [[noreturn]] void ThrowJointSubtypeMismatch(const Joint<T>&,
-                                              std::string_view) const;
+                                              const std::type_info&) const;
 
   // If X_BF is nullopt, returns the body frame of `body`. Otherwise, adds a
   // FixedOffsetFrame (named based on the joint_name and frame_suffix) to `body`

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -76,6 +76,21 @@ PlanarJoint<T>::MakeImplementationBlueprint(
   return blue_print;
 }
 
+namespace internal {
+
+template <typename T>
+const PlanarJoint<T>* DynamicCastJoint<PlanarJoint>::cast(
+    const Joint<T>* element) {
+  return dynamic_cast<const PlanarJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<PlanarJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -357,6 +357,16 @@ class PlanarJoint final : public Joint<T> {
       const internal::MultibodyTree<ToScalar>& tree_clone) const;
 };
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<PlanarJoint> {
+  template <typename T>
+  static const PlanarJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -89,6 +89,21 @@ std::unique_ptr<Joint<symbolic::Expression>> PrismaticJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+namespace internal {
+
+template <typename T>
+const PrismaticJoint<T>* DynamicCastJoint<PrismaticJoint>::cast(
+    const Joint<T>* element) {
+  return dynamic_cast<const PrismaticJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<PrismaticJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -353,6 +353,16 @@ class PrismaticJoint final : public Joint<T> {
 template <typename T>
 const char PrismaticJoint<T>::kTypeName[] = "prismatic";
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<PrismaticJoint> {
+  template <typename T>
+  static const PrismaticJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/prismatic_spring.cc
+++ b/multibody/tree/prismatic_spring.cc
@@ -113,6 +113,21 @@ PrismaticSpring<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+namespace internal {
+
+template <typename T>
+const PrismaticSpring<T>* DynamicCastForceElement<PrismaticSpring>::cast(
+    const ForceElement<T>* element) {
+  return dynamic_cast<const PrismaticSpring<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastForceElement<PrismaticSpring>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/prismatic_spring.h
+++ b/multibody/tree/prismatic_spring.h
@@ -98,6 +98,16 @@ class PrismaticSpring final : public ForceElement<T> {
   double stiffness_{0};
 };
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastForceElement<PrismaticSpring> {
+  template <typename T>
+  static const PrismaticSpring<T>* cast(const ForceElement<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/quaternion_floating_joint.cc
+++ b/multibody/tree/quaternion_floating_joint.cc
@@ -98,6 +98,21 @@ void QuaternionFloatingJoint<T>::DoAddInDamping(
   t_BMo_F.template tail<3>() -= translational_damping * v_FM;
 }
 
+namespace internal {
+
+template <typename T>
+const QuaternionFloatingJoint<T>*
+DynamicCastJoint<QuaternionFloatingJoint>::cast(const Joint<T>* element) {
+  return dynamic_cast<const QuaternionFloatingJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<QuaternionFloatingJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -457,6 +457,16 @@ class QuaternionFloatingJoint final : public Joint<T> {
 template <typename T>
 const char QuaternionFloatingJoint<T>::kTypeName[] = "quaternion_floating";
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<QuaternionFloatingJoint> {
+  template <typename T>
+  static const QuaternionFloatingJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -107,6 +107,21 @@ RevoluteJoint<T>::MakeImplementationBlueprint(
   return blue_print;
 }
 
+namespace internal {
+
+template <typename T>
+const RevoluteJoint<T>* DynamicCastJoint<RevoluteJoint>::cast(
+    const Joint<T>* element) {
+  return dynamic_cast<const RevoluteJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<RevoluteJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -375,6 +375,16 @@ class RevoluteJoint final : public Joint<T> {
 template <typename T>
 const char RevoluteJoint<T>::kTypeName[] = "revolute";
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<RevoluteJoint> {
+  template <typename T>
+  static const RevoluteJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/revolute_spring.cc
+++ b/multibody/tree/revolute_spring.cc
@@ -112,6 +112,21 @@ RevoluteSpring<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+namespace internal {
+
+template <typename T>
+const RevoluteSpring<T>* DynamicCastForceElement<RevoluteSpring>::cast(
+    const ForceElement<T>* element) {
+  return dynamic_cast<const RevoluteSpring<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastForceElement<RevoluteSpring>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/revolute_spring.h
+++ b/multibody/tree/revolute_spring.h
@@ -92,6 +92,16 @@ class RevoluteSpring final : public ForceElement<T> {
   double stiffness_;
 };
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastForceElement<RevoluteSpring> {
+  template <typename T>
+  static const RevoluteSpring<T>* cast(const ForceElement<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/rpy_floating_joint.cc
+++ b/multibody/tree/rpy_floating_joint.cc
@@ -79,6 +79,21 @@ RpyFloatingJoint<T>::MakeImplementationBlueprint(
   return blue_print;
 }
 
+namespace internal {
+
+template <typename T>
+const RpyFloatingJoint<T>* DynamicCastJoint<RpyFloatingJoint>::cast(
+    const Joint<T>* element) {
+  return dynamic_cast<const RpyFloatingJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<RpyFloatingJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -465,6 +465,16 @@ class RpyFloatingJoint final : public Joint<T> {
 template <typename T>
 const char RpyFloatingJoint<T>::kTypeName[] = "rpy_floating";
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<RpyFloatingJoint> {
+  template <typename T>
+  static const RpyFloatingJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -107,6 +107,21 @@ ScrewJoint<T>::MakeImplementationBlueprint(
   return blue_print;
 }
 
+namespace internal {
+
+template <typename T>
+const ScrewJoint<T>* DynamicCastJoint<ScrewJoint>::cast(
+    const Joint<T>* element) {
+  return dynamic_cast<const ScrewJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<ScrewJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -391,6 +391,16 @@ class ScrewJoint final : public Joint<T> {
   double screw_pitch_;
 };
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<ScrewJoint> {
+  template <typename T>
+  static const ScrewJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -276,6 +276,11 @@ TEST_F(BallRpyJointTest, DefaultAngles) {
       mutable_joint_->set_default_angles(out_of_bounds_high_angles));
 }
 
+TEST_F(BallRpyJointTest, DynamicCast) {
+  const Joint<double>* base = joint_;
+  EXPECT_EQ(internal::DynamicCastJoint<BallRpyJoint>::cast(base), joint_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/door_hinge_test.cc
+++ b/multibody/tree/test/door_hinge_test.cc
@@ -480,6 +480,12 @@ TEST_F(DoorHingeTest, EnergyTestWithAllTorques) {
   TestEnergyConservation(plant(), init_state);
 }
 
+TEST_F(DoorHingeTest, DynamicCast) {
+  const DoorHinge<double>* dut = &door_hinge();
+  const ForceElement<double>* base = dut;
+  EXPECT_EQ(internal::DynamicCastForceElement<DoorHinge>::cast(base), dut);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -772,6 +772,13 @@ GTEST_TEST(LinearBushingRollPitchYawTest, BushingParameters) {
   EXPECT_TRUE(CompareMatrices(new_force_damping, new_default_force_damping));
 }
 
+TEST_F(LinearBushingRollPitchYawTester, DynamicCast) {
+  const ForceElement<double>* base = bushing_;
+  EXPECT_EQ(
+      internal::DynamicCastForceElement<LinearBushingRollPitchYaw>::cast(base),
+      bushing_);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/linear_spring_damper_test.cc
+++ b/multibody/tree/test/linear_spring_damper_test.cc
@@ -283,6 +283,12 @@ TEST_F(SpringDamperTester, Power) {
   EXPECT_EQ(plant_.EvalNonConservativePower(*context_), non_conservative_power);
 }
 
+TEST_F(SpringDamperTester, DynamicCast) {
+  const ForceElement<double>* base = spring_damper_;
+  EXPECT_EQ(internal::DynamicCastForceElement<LinearSpringDamper>::cast(base),
+            spring_damper_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -322,6 +322,11 @@ TEST_F(PlanarJointTest, RandomState) {
   EXPECT_NE(mutable_joint_->get_rotation(*context_), last_rotation);
 }
 
+TEST_F(PlanarJointTest, DynamicCast) {
+  const Joint<double>* base = joint_;
+  EXPECT_EQ(internal::DynamicCastJoint<PlanarJoint>::cast(base), joint_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -278,6 +278,11 @@ TEST_F(PrismaticJointTest, DefaultTranslation) {
       mutable_joint1_->set_default_translation(out_of_bounds_high_translation));
 }
 
+TEST_F(PrismaticJointTest, DynamicCast) {
+  const Joint<double>* base = joint1_;
+  EXPECT_EQ(internal::DynamicCastJoint<PrismaticJoint>::cast(base), joint1_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/prismatic_spring_test.cc
+++ b/multibody/tree/test/prismatic_spring_test.cc
@@ -179,6 +179,12 @@ TEST_F(SpringTester, Clone) {
   EXPECT_EQ(spring_->nominal_position(), spring_clone->nominal_position());
 }
 
+TEST_F(SpringTester, DynamicCast) {
+  const ForceElement<double>* base = spring_;
+  EXPECT_EQ(internal::DynamicCastForceElement<PrismaticSpring>::cast(base),
+            spring_);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -381,6 +381,12 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
 }
 
+TEST_F(QuaternionFloatingJointTest, DynamicCast) {
+  const Joint<double>* base = joint_;
+  EXPECT_EQ(internal::DynamicCastJoint<QuaternionFloatingJoint>::cast(base),
+            joint_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -297,6 +297,11 @@ TEST_F(RevoluteJointTest, DefaultAngle) {
   EXPECT_NO_THROW(mutable_joint1_->set_default_angle(out_of_bounds_high_angle));
 }
 
+TEST_F(RevoluteJointTest, DynamicCast) {
+  const Joint<double>* base = joint1_;
+  EXPECT_EQ(internal::DynamicCastJoint<RevoluteJoint>::cast(base), joint1_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/revolute_spring_test.cc
+++ b/multibody/tree/test/revolute_spring_test.cc
@@ -166,6 +166,12 @@ TEST_F(SpringTester, Power) {
               kTolerance);
 }
 
+TEST_F(SpringTester, DynamicCast) {
+  const ForceElement<double>* base = spring_;
+  EXPECT_EQ(internal::DynamicCastForceElement<RevoluteSpring>::cast(base),
+            spring_);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/rpy_floating_joint_test.cc
+++ b/multibody/tree/test/rpy_floating_joint_test.cc
@@ -382,6 +382,11 @@ TEST_F(RpyFloatingJointTest, RandomState) {
   EXPECT_TRUE(joint_->GetPose(*context_).IsExactlyIdentity());
 }
 
+TEST_F(RpyFloatingJointTest, DynamicCast) {
+  const Joint<double>* base = joint_;
+  EXPECT_EQ(internal::DynamicCastJoint<RpyFloatingJoint>::cast(base), joint_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -297,6 +297,11 @@ TEST_F(ScrewJointTest, RandomState) {
   EXPECT_NE(joint_->get_rotation(*context_), last_rotation);
 }
 
+TEST_F(ScrewJointTest, DynamicCast) {
+  const Joint<double>* base = joint_;
+  EXPECT_EQ(internal::DynamicCastJoint<ScrewJoint>::cast(base), joint_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -293,6 +293,11 @@ TEST_F(UniversalJointTest, DefaultAngles) {
       mutable_joint_->set_default_angles(out_of_bounds_high_angles));
 }
 
+TEST_F(UniversalJointTest, DynamicCast) {
+  const Joint<double>* base = joint_;
+  EXPECT_EQ(internal::DynamicCastJoint<UniversalJoint>::cast(base), joint_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -102,6 +102,11 @@ TEST_F(WeldJointTest, JointLocking) {
   DRAKE_EXPECT_NO_THROW(joint_->Lock(context.get()));
 }
 
+TEST_F(WeldJointTest, DynamicCast) {
+  const Joint<double>* base = joint_;
+  EXPECT_EQ(internal::DynamicCastJoint<WeldJoint>::cast(base), joint_);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -227,6 +227,22 @@ UniformGravityFieldElement<T>::DoCloneToScalar(
       gravity_vector(), disabled_model_instances_);
 }
 
+namespace internal {
+
+template <typename T>
+const UniformGravityFieldElement<T>*
+DynamicCastForceElement<UniformGravityFieldElement>::cast(
+    const ForceElement<T>* element) {
+  return dynamic_cast<const UniformGravityFieldElement<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastForceElement<UniformGravityFieldElement>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/uniform_gravity_field_element.h
+++ b/multibody/tree/uniform_gravity_field_element.h
@@ -136,6 +136,17 @@ class UniformGravityFieldElement : public ForceElement<T> {
   std::set<ModelInstanceIndex> disabled_model_instances_;
 };
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastForceElement<UniformGravityFieldElement> {
+  template <typename T>
+  static const UniformGravityFieldElement<T>* cast(
+      const ForceElement<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -76,6 +76,21 @@ UniversalJoint<T>::MakeImplementationBlueprint(
   return blue_print;
 }
 
+namespace internal {
+
+template <typename T>
+const UniversalJoint<T>* DynamicCastJoint<UniversalJoint>::cast(
+    const Joint<T>* element) {
+  return dynamic_cast<const UniversalJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<UniversalJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -280,6 +280,16 @@ class UniversalJoint final : public Joint<T> {
 template <typename T>
 const char UniversalJoint<T>::kTypeName[] = "universal";
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<UniversalJoint> {
+  template <typename T>
+  static const UniversalJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -67,6 +67,20 @@ WeldJoint<T>::MakeImplementationBlueprint(
   return blue_print;
 }
 
+namespace internal {
+
+template <typename T>
+const WeldJoint<T>* DynamicCastJoint<WeldJoint>::cast(const Joint<T>* element) {
+  return dynamic_cast<const WeldJoint<T>*>(element);
+}
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &DynamicCastJoint<WeldJoint>::template cast<T>
+));
+// clang-format on
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -132,6 +132,16 @@ class WeldJoint final : public Joint<T> {
 template <typename T>
 const char WeldJoint<T>::kTypeName[] = "weld";
 
+namespace internal {
+
+// Specialized to provide a non-inline definition.
+template <>
+struct DynamicCastJoint<WeldJoint> {
+  template <typename T>
+  static const WeldJoint<T>* cast(const Joint<T>* element);
+};
+
+}  // namespace internal
 }  // namespace multibody
 }  // namespace drake
 


### PR DESCRIPTION
The `dynamic_cast` operation does not meet our styleguide requirements for being inline. We need to move the definitions to the cc files.

This change is tangentially inspired by https://github.com/RobotLocomotion/drake/issues/22204.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22209)
<!-- Reviewable:end -->
