### PR TITLE
Use consistent epsilon values for testing inertia and reporting errors.

### DIFF
--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -192,9 +192,9 @@ void RotationalInertia<T>::ThrowNotPhysicallyValid(
   // or if moments of inertia do not satisfy the triangle inequality.
   if constexpr (scalar_predicate<T>::is_bool) {
     if (!IsNaN()) {
-      const Vector3<double> p = CalcPrincipalMomentsOfInertia();
       if (!AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
-              p(0), p(1), p(2))) {
+              /* is_test_principal_moments_of_inertia = */ true)) {
+        const Vector3<double> p = CalcPrincipalMomentsOfInertia();
         error_message += fmt::format(
             "\nThe associated principal moments of inertia:"
             "\n{}  {}  {}",

--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -194,7 +194,7 @@ void RotationalInertia<T>::ThrowNotPhysicallyValid(
     if (!IsNaN()) {
       const Vector3<double> p = CalcPrincipalMomentsOfInertia();
       if (!AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
-              p(0), p(1), p(2), /* epsilon = */ 0.0)) {
+              p(0), p(1), p(2))) {
         error_message += fmt::format(
             "\nThe associated principal moments of inertia:"
             "\n{}  {}  {}",

--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -186,7 +186,10 @@ boolean<T> RotationalInertia<T>::
     AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
         bool use_principal_moments) const {
   // We use a tiny multiple of max_possible_inertia_moment to guide the value
-  // of ε. To avoid false negatives when max_possible_inertia_moment ≈ 0,
+  // of ε. We scale ε by max_possible_inertia_moment regardless of whether or
+  // not we are using principle moments of inertia so that ε is similar across
+  // similar inertias and independent of how this function is invoked.
+  // To avoid false negatives when max_possible_inertia_moment ≈ 0,
   // we also use a tiny absolute tolerance.
   // Note: A side effect of ε is that some inertias are incorrectly classified
   // as valid. We prefer to include some ever-so-slightly invalid inertias

--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -185,10 +185,7 @@ template <typename T>
 boolean<T> RotationalInertia<
     T>::AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality() const {
   // We use a tiny multiple of max_possible_inertia_moment to guide the value
-  // of ε. We scale ε by max_possible_inertia_moment regardless of whether or
-  // not we are using principle moments of inertia so that ε is similar across
-  // similar inertias and independent of how this function is invoked.
-  // To avoid false negatives when max_possible_inertia_moment ≈ 0,
+  // of ε. To avoid false negatives when max_possible_inertia_moment ≈ 0,
   // we also use a tiny absolute tolerance.
   // Note: A side effect of ε is that some inertias are incorrectly classified
   // as valid. We prefer to include some ever-so-slightly invalid inertias

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -597,8 +597,7 @@ class RotationalInertia {
     //    Imin ≈ 0.961    Imed ≈ 2   Imax ≈ 3.04
     // violate the triangle inequality since Imin + Imed < Imax.
     return !IsNaN() &&
-           AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
-               /* use_principal_moments = */ true);
+           AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality();
   }
 
   /// Re-expresses `this` rotational inertia `I_BP_E` in place to `I_BP_A`.
@@ -953,11 +952,8 @@ class RotationalInertia {
   // The positive (near-zero) ε accounts for round-off errors, e.g., from
   // re-expressing inertia in another frame, hence very small (equal to -ε)
   // negative moments of inertia are regarded as near-enough positive.
-  // @param use_principal_moments determines whether this test is performed for
-  // `this` rotational inertia's principal moments of inertia or for
-  // `this` rotational inertia's diagonal moments of inertia.
-  boolean<T> AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
-      bool use_principal_moments) const;
+  boolean<T> AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality()
+      const;
 
   // Tests whether each moment of inertia is non-negative (to within epsilon).
   // This test allows for small (equal to -epsilon) negative moments of inertia

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -960,6 +960,10 @@ class RotationalInertia {
     // We use a tiny multiple of max_possible_inertia_moment to guide the value
     // of ε. To avoid false negatives when max_possible_inertia_moment ≈ 0,
     // we also use a tiny absolute tolerance.
+    // Note: A side effect of ε is that some inertias are incorrectly classified
+    // as valid. We prefer to include some ever-so-slightly invalid inertias
+    // rather than exclude ones that were definitely valid but were penalized by
+    // finite precision during valid mathematical operations.
     using std::abs;
     using std::max;
     const double precision = 16 * std::numeric_limits<double>::epsilon();

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -941,29 +941,26 @@ class RotationalInertia {
     return moment_max <= epsilon && product_max <= epsilon;
   }
 
-  // Tests whether each moment of inertia is non-negative (to within `epsilon`)
-  // and tests whether moments of inertia satisfy triangle-inequality.  The
-  // triangle-inequality test requires `epsilon` when the sum of two moments are
-  // nearly equal to the third one. Example: Ixx = Iyy = 50, Izz = 100.00000001,
-  // or Ixx = -0.0001 (negative),  Ixx = 49.9999,  Iyy = 50.
-  // The positive (non-zero) `epsilon` accounts for round-off errors, e.g., from
+  // Tests whether each moment of inertia is non-negative (to within ε) and
+  // tests whether moments of inertia satisfy the triangle-inequality.
+  // The triangle-inequality test requires ε when the sum of two moments are
+  // nearly equal to the third one. Example: Ixx = Iyy = 50, Izz = 100.00000001.
+  // The positive (non-zero) ε accounts for round-off errors, e.g., from
   // re-expressing inertia in another frame and is typically much smaller than
   // the largest possible principal moment of inertia in the rotational inertia.
   // @param Ixx, Iyy, Izz moments of inertia for a generic rotational inertia,
   //        (i.e., not necessarily principal moments of inertia).
-  // @note Denoting Imin and Imax as the smallest and largest possible moments
-  //       of inertia in a valid rotational inertia, denoting Imed as the
-  //       intermediate moment of inertia, and denoting tr as the trace of the
-  //       rotational inertia (e.g., Ixx + Iyy + Izz), one can prove:
-  //       0 <= Imin <= tr/3,   tr/3 <= Imed <= tr/2,   tr/3 <= Imax <= tr/2.
-  //       If Imin == 0, then Imed == Imax == tr / 2.
-  //       Heuristically, `epsilon` is a small multiplier of Trace() / 2.
   static boolean<T> AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
       const T& Ixx, const T& Iyy, const T& Izz) {
-    // To check the validity of `this` rotational inertia, use an epsilon value
-    // related to machine precision multiplied by the largest possible element
-    // that can appear in a valid `this` rotational inertia. Note: The largest
-    // product of inertia is at most half the largest moment of inertia.
+    // Denoting Imin and Imax as the smallest and largest possible moments of
+    // inertia in a rotational inertia, denoting Imed as the intermediate moment
+    // inertia, and denoting tr = Ixx + Iyy + Izz as the trace of the rotational
+    // inertia, one can prove that if Imin == 0, then Imed == Imax == tr / 2 and
+    // in all cases  0 ≤ Imin ≤ tr/3,  tr/3 ≤ Imed ≤ tr/2,  tr/3 ≤ Imax ≤ tr/2.
+    // Hence: to check the validity of `this` rotational inertia, use an ε value
+    // related to machine precision multiplied by Imax = tr/2.
+    // Tangent: The product of inertia Iᵢⱼ with the largest absolute value is at
+    // most half the largest moment of inertia, i.e., |Iᵢⱼ| ≤ Imax/2.
     using std::abs;
     const double precision = 16 * std::numeric_limits<double>::epsilon();
     const T max_possible_inertia_moment = 0.5 * abs(Ixx + Iyy + Izz);

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -598,7 +598,7 @@ class RotationalInertia {
     // violate the triangle inequality since Imin + Imed < Imax.
     return !IsNaN() &&
            AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
-               /* is_test_principal_moments_of_inertia = */ true);
+               /* use_principal_moments = */ true);
   }
 
   /// Re-expresses `this` rotational inertia `I_BP_E` in place to `I_BP_A`.
@@ -951,38 +951,13 @@ class RotationalInertia {
   // The triangle-inequality test requires ε when the sum of two moments are
   // nearly equal to the third one. Example: Ixx = Iyy = 50, Izz = 100.00000001.
   // The positive (near-zero) ε accounts for round-off errors, e.g., from
-  // re-expressing inertia in another frame.
-  // @param is_test_principal_moments_of_inertia determines whether this test is
-  // performed for `this` rotational inertia's principal moments of inertia or
-  // for `this` rotational inertia's diagonal moments of inertia.
+  // re-expressing inertia in another frame, hence very small (equal to -ε)
+  // negative moments of inertia are regarded as near-enough positive.
+  // @param use_principal_moments determines whether this test is performed for
+  // `this` rotational inertia's principal moments of inertia or for
+  // `this` rotational inertia's diagonal moments of inertia.
   boolean<T> AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
-      bool is_test_principal_moments_of_inertia) const {
-    // We use a tiny multiple of max_possible_inertia_moment to guide the value
-    // of ε. To avoid false negatives when max_possible_inertia_moment ≈ 0,
-    // we also use a tiny absolute tolerance.
-    // Note: A side effect of ε is that some inertias are incorrectly classified
-    // as valid. We prefer to include some ever-so-slightly invalid inertias
-    // rather than exclude ones that were definitely valid but were penalized by
-    // finite precision during valid mathematical operations.
-    using std::abs;
-    using std::max;
-    const double precision = 16 * std::numeric_limits<double>::epsilon();
-    const T max_possible_inertia_moment = CalcMaximumPossibleMomentOfInertia();
-    const T epsilon = precision * max(1.0, max_possible_inertia_moment);
-
-    const Vector3<double> moments = is_test_principal_moments_of_inertia
-                                        ? CalcPrincipalMomentsOfInertia()
-                                        : ExtractDoubleOrThrow(get_moments());
-    const double Ixx = moments.x();
-    const double Iyy = moments.y();
-    const double Izz = moments.z();
-    const auto are_moments_near_positive =
-        AreMomentsOfInertiaNearPositive(Ixx, Iyy, Izz, epsilon);
-    const auto is_triangle_inequality_satisfied = Ixx + Iyy + epsilon >= Izz &&
-                                                  Ixx + Iyy + epsilon >= Iyy &&
-                                                  Iyy + Izz + epsilon >= Ixx;
-    return are_moments_near_positive && is_triangle_inequality_satisfied;
-  }
+      bool use_principal_moments) const;
 
   // Tests whether each moment of inertia is non-negative (to within epsilon).
   // This test allows for small (equal to -epsilon) negative moments of inertia

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -587,8 +587,6 @@ class RotationalInertia {
   ///         calculated (eigenvalue solver) or if scalar type T cannot be
   ///         converted to a double.
   boolean<T> CouldBePhysicallyValid() const {
-    // Calculate principal moments of inertia p and then test these principal
-    // moments to be mostly non-negative and also satisfy triangle inequality.
     return !IsNaN() &&
            AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality();
   }

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -589,13 +589,6 @@ class RotationalInertia {
   boolean<T> CouldBePhysicallyValid() const {
     // Calculate principal moments of inertia p and then test these principal
     // moments to be mostly non-negative and also satisfy triangle inequality.
-    // Note: An inertia matrix that passes the triangle inequality test is
-    // InertiaMatrix = ⌈  1    -0.2   0   ⌉    Ixx + Iyy ≥ Izz
-    //                 | -0.2   2    -0.2 |    Ixx + Izz ≥ Iyy
-    //                 ⌊  0    -0.2   3   ⌋    Iyy + Izz ≥ Ixx
-    // However, the principal moments of inertia for this matrix
-    //    Imin ≈ 0.961    Imed ≈ 2   Imax ≈ 3.04
-    // violate the triangle inequality since Imin + Imed < Imax.
     return !IsNaN() &&
            AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality();
   }

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -92,6 +92,8 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
       std::exception);
 
   // Form an arbitrary (but valid) rotational inertia.
+  // Ensure MakeFromMomentsAndProductsOfInertia() and CouldBePhysicallyValid()
+  // lead to the same conclusion for at least one valid rotational inertia.
   const double Ixx = 17, Iyy = 13, Izz = 10;
   const double Ixy = -3, Ixz = -3, Iyz = -6;
   RotationalInertia<double> I =
@@ -100,7 +102,7 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
   EXPECT_TRUE(I.CouldBePhysicallyValid());
 
   // Ensure an invalid rotational inertia always throws an exception if the
-  // 2nd argument of MakeFromMomentsAndProductsOfInertia is false or missing.
+  // 2nd argument of MakeFromMomentsAndProductsOfInertia() is false or missing.
   EXPECT_THROW(
       RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
           2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
@@ -110,7 +112,7 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
                std::exception);
 
   // Ensure an invalid rotational inertia does not throw an exception if the
-  // 2nd argument of MakeFromMomentsAndProductsOfInertia is true.
+  // 2nd argument of MakeFromMomentsAndProductsOfInertia() is true.
   EXPECT_NO_THROW(
       I = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
           2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz,

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -77,7 +77,7 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
           0, 0, 0, 0, 0, 0, /* skip_validity_check = */ false);
   EXPECT_TRUE(I.CouldBePhysicallyValid());
 
-  // Check that a _invalid_ rotational inertia with tiny negative moments of
+  // Check that an _invalid_ rotational inertia with tiny negative moments of
   // inertia does _not_ throw an exception (ensure test is not too fussy).
   constexpr double kTiny = 8 * kEpsilon;
   I = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -72,17 +72,16 @@ GTEST_TEST(RotationalInertia, DiagonalInertiaConstructor) {
 // Test rotational inertia factory method set via a 3x3 matrix.
 GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
   // Ensure a zero rotational inertia is valid.
-  RotationalInertia<double> I =
+  EXPECT_NO_THROW(
       RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-          0, 0, 0, 0, 0, 0, /* skip_validity_check = */ false);
-  EXPECT_TRUE(I.CouldBePhysicallyValid());
+          0, 0, 0, 0, 0, 0, /* skip_validity_check = */ false));
 
   // Check that an _invalid_ rotational inertia with tiny negative moments of
   // inertia does _not_ throw an exception (ensure test is not too fussy).
   constexpr double kTiny = 8 * kEpsilon;
-  I = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-      -kTiny, 0, -kTiny, 0, 0, 0, /* skip_validity_check = */ false);
-  EXPECT_TRUE(I.CouldBePhysicallyValid());
+  EXPECT_NO_THROW(
+      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          -kTiny, 0, -kTiny, 0, 0, 0, /* skip_validity_check = */ false));
 
   // Ensure an _invalid_ rotational inertia with very small negative moments of
   // inertia throws an exception (ensure test is fussy enough for robotics).
@@ -95,8 +94,9 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
   // Form an arbitrary (but valid) rotational inertia.
   const double Ixx = 17, Iyy = 13, Izz = 10;
   const double Ixy = -3, Ixz = -3, Iyz = -6;
-  I = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-      Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false);
+  RotationalInertia<double> I =
+      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false);
   EXPECT_TRUE(I.CouldBePhysicallyValid());
 
   // Ensure an invalid rotational inertia always throws an exception if the

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -117,7 +117,7 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
           1.0, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false),
       expected_message);
 
-  // Ensure no exception is thrown even though the rotational inertia is invalid
+  // Ensure no exception is thrown for this _invalid_ rotational inertia
   // because it is close enough to valid to pass the triangle inequality test.
   constexpr double Jxx = 2, Jyy = 4, Jzz = 6;
   const double trace = Jxx + Jyy + Jzz;

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -69,7 +69,8 @@ GTEST_TEST(RotationalInertia, DiagonalInertiaConstructor) {
   EXPECT_EQ(I.get_products(), products_expected);
 }
 
-// Test rotational inertia factory method set via a 3x3 matrix.
+// Test the factory method for rotational inertia factory that uses moments and
+// products of inertia (similar to construction from a 3x3 symmetric matrix).
 GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
   // Ensure a zero rotational inertia is valid.
   EXPECT_NO_THROW(
@@ -93,13 +94,22 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
 
   // Form an arbitrary (but valid) rotational inertia.
   // Ensure MakeFromMomentsAndProductsOfInertia() and CouldBePhysicallyValid()
-  // lead to the same conclusion for at least one valid rotational inertia.
+  // lead to the same conclusion for at least one _valid_ rotational inertia.
   const double Ixx = 17, Iyy = 13, Izz = 10;
   const double Ixy = -3, Ixz = -3, Iyz = -6;
-  RotationalInertia<double> I =
-      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-          Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false);
+  RotationalInertia<double> I;
+  EXPECT_NO_THROW(
+      I = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ false));
   EXPECT_TRUE(I.CouldBePhysicallyValid());
+
+  // Ensure MakeFromMomentsAndProductsOfInertia() and CouldBePhysicallyValid()
+  // lead to the same conclusion for at least one _invalid_ rotational inertia.
+  RotationalInertia<double> I_bad;
+  EXPECT_NO_THROW(
+      I_bad = RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          2 * Ixx, Iyy, Izz, Ixy, Ixz, Iyz, /* skip_validity_check = */ true));
+  EXPECT_FALSE(I_bad.CouldBePhysicallyValid());
 
   // Ensure an invalid rotational inertia always throws an exception if the
   // 2nd argument of MakeFromMomentsAndProductsOfInertia() is false or missing.


### PR DESCRIPTION
The epsilon used to test for an invalid inertia differs from the epsilon = 0 used to report an error (in the error message).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22217)
<!-- Reviewable:end -->
