### PR TITLE
Parallelize the Rounding Stage of GCS

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -207,7 +207,6 @@ drake_cc_library(
     implementation_deps = [
         "//solvers:mosek_solver",
         "//solvers:solve",
-        "@common_robotics_utilities",
     ],
 )
 

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -207,6 +207,7 @@ drake_cc_library(
     implementation_deps = [
         "//solvers:mosek_solver",
         "//solvers:solve",
+        "@common_robotics_utilities",
     ],
 )
 

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -1646,7 +1646,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     // If any costs or constraints aren't thread-safe, we can't parallelize.
     bool is_thread_safe = GcsIsThreadsafe(*this);
     if (!is_thread_safe) {
-      log()->warn(
+      static const logging::Warn log_once(
           "GCS restriction has costs or constraints which are not declared "
           "thread-safe. Any paths being considered in the rounding process "
           "that contain these constraints will be solved sequentially.");

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include <common_robotics_utilities/parallelism.hpp>
 #include <fmt/format.h>
 
 #include "drake/common/parallelism.h"

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -1694,8 +1694,9 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     if (best_cost < kInf) {
       // We found at least one valid result.
       result = rounded_results[best_result_idx];
-      SubstituteAdditionalVariables(*(prog_ptrs[best_result_idx]), &result,
-                                    candidate_paths[best_result_idx]);
+      MakeRestrictionResultLookLikeMixedInteger(
+          *(prog_ptrs[best_result_idx]), &result,
+          candidate_paths[best_result_idx]);
     } else {
       // In the event that all rounded results are infeasible, we still want
       // to propagate the solver id for logging.
@@ -2063,7 +2064,7 @@ GraphOfConvexSets::ConstructRestrictionProgram(
   return prog;
 }
 
-void GraphOfConvexSets::SubstituteAdditionalVariables(
+void GraphOfConvexSets::MakeRestrictionResultLookLikeMixedInteger(
     const MathematicalProgram& prog, MathematicalProgramResult* result,
     const std::vector<const Edge*>& active_edges) const {
   DRAKE_DEMAND(result != nullptr);
@@ -2168,7 +2169,7 @@ MathematicalProgramResult GraphOfConvexSets::SolveConvexRestriction(
 
   MathematicalProgramResult result;
   solver->Solve(*prog, {}, solver_options, &result);
-  SubstituteAdditionalVariables(*prog, &result, active_edges);
+  MakeRestrictionResultLookLikeMixedInteger(*prog, &result, active_edges);
 
   return result;
 }

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -880,7 +880,7 @@ class GraphOfConvexSets {
 
   // Add results for additional variables in `result` to make it comparable with
   // other transcriptions.
-  void SubstituteAdditionalVariables(
+  void MakeRestrictionResultLookLikeMixedInteger(
       const solvers::MathematicalProgram& prog,
       solvers::MathematicalProgramResult* result,
       const std::vector<const Edge*>& active_edges) const;

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -863,14 +863,27 @@ class GraphOfConvexSets {
  private: /* Facilitates testing. */
   friend class PreprocessShortestPathTest;
 
-  // Modify prog so that it contains the variables and constraints of the
+  // Construct a prog so that it contains the variables and constraints of the
   // preprocessing program for a given edge.
   std::unique_ptr<solvers::MathematicalProgram> ConstructPreprocessingProgram(
       EdgeId edge_id,
       const std::map<VertexId, std::vector<int>>& incoming_edges,
-
       const std::map<VertexId, std::vector<int>>& outgoing_edges,
       VertexId source_id, VertexId target_id) const;
+
+  // Construct a prog that can be used to solve the convex restriction for a
+  // given set of active edges (and optionally populate with an initial guess if
+  // one is provided).
+  std::unique_ptr<solvers::MathematicalProgram> ConstructRestrictionProgram(
+      const std::vector<const Edge*>& active_edges,
+      const solvers::MathematicalProgramResult* initial_guess) const;
+
+  // Add results for additional variables in `result` to make it comparable with
+  // other transcriptions.
+  void SubstituteAdditionalVariables(
+      const solvers::MathematicalProgram& prog,
+      solvers::MathematicalProgramResult* result,
+      const std::vector<const Edge*>& active_edges) const;
 
   std::set<EdgeId> PreprocessShortestPath(
       VertexId source_id, VertexId target_id,


### PR DESCRIPTION
This ended up being pretty simple -- solve all the restrictions in a parallel for loop, and override `options.parallelism` to set the number of threads to one if any not-thread-safe costs or constraints are included in the GCS.

Gonna test this with the various debug builds before I send it up for review.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22222)
<!-- Reviewable:end -->
