### PR TITLE
Allow PartialPermutation to accept empty vector

### DIFF
--- a/multibody/contact_solvers/sap/partial_permutation.cc
+++ b/multibody/contact_solvers/sap/partial_permutation.cc
@@ -15,6 +15,7 @@ namespace internal {
 PartialPermutation::PartialPermutation(std::vector<int> permutation)
     : permutation_(std::move(permutation)) {
   const int domain_size = permutation_.size();
+  if (domain_size == 0) return;
   // Determine size of the permuted domain.
   const int permuted_domain_size =
       *std::max_element(permutation_.begin(), permutation_.end()) + 1;

--- a/multibody/contact_solvers/sap/test/partial_permutation_test.cc
+++ b/multibody/contact_solvers/sap/test/partial_permutation_test.cc
@@ -19,6 +19,13 @@ GTEST_TEST(PartialPermutation, EmptyPermutation) {
   EXPECT_EQ(p.permuted_domain_size(), 0);
 }
 
+GTEST_TEST(PartialPermutation, EmptyPermutationFromStdVector) {
+  std::vector<int> permutation;
+  PartialPermutation p(std::move(permutation));
+  EXPECT_EQ(p.domain_size(), 0);
+  EXPECT_EQ(p.permuted_domain_size(), 0);
+}
+
 // Creates a permutation of size 6 where none of the indexes participates and
 // adds permuted indexes one at a time with push().
 GTEST_TEST(PartialPermutation, PushElements) {


### PR DESCRIPTION
Prevents segfaulting when constructing `PartialPermutation` with an empty `std::vector`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22229)
<!-- Reviewable:end -->
