### PR TITLE
Discourage AddPositiveSemidefiniteConstraint() for a matrix of symbolic::Expression.

### DIFF
--- a/geometry/optimization/spectrahedron.cc
+++ b/geometry/optimization/spectrahedron.cc
@@ -279,7 +279,7 @@ Spectrahedron::DoAddPointInNonnegativeScalingConstraints(
     VectorX<Expression> Axplusb = this_A * x + this_b;
     const int num_rows = binding.evaluator()->matrix_rows();
     Map<MatrixX<Expression>> S(Axplusb.data(), num_rows, num_rows);
-    constraints.emplace_back(prog->AddPositiveSemidefiniteConstraint(S));
+    constraints.emplace_back(prog->AddLinearMatrixInequalityConstraint(S));
   }
   return constraints;
 }

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -22,6 +22,7 @@
 #include "drake/common/symbolic/decompose.h"
 #include "drake/common/symbolic/latex.h"
 #include "drake/common/symbolic/monomial_util.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/binding.h"
 #include "drake/solvers/decision_variable.h"
@@ -620,7 +621,7 @@ void CreateLogDetermiant(
   psd_mat << X,             *Z,
              Z->transpose(), diag_Z;
   // clang-format on
-  prog->AddPositiveSemidefiniteConstraint(psd_mat);
+  prog->AddLinearMatrixInequalityConstraint(psd_mat);
   // Now introduce the slack variable t.
   *t = prog->NewContinuousVariables(X_rows);
   // Introduce the constraint log(Z(i, i)) >= t(i).
@@ -1198,13 +1199,13 @@ MathematicalProgram::AddPrincipalSubmatrixIsPsdConstraint(
       math::ExtractPrincipalSubmatrix(symmetric_matrix_var, minor_indices));
 }
 
-Binding<PositiveSemidefiniteConstraint>
+Binding<LinearMatrixInequalityConstraint>
 MathematicalProgram::AddPrincipalSubmatrixIsPsdConstraint(
     const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
     const std::set<int>& minor_indices) {
-  // This function relies on AddPositiveSemidefiniteConstraint to validate the
+  // This function relies on AddLinearMatrixInequalityConstraint to validate the
   // documented symmetry prerequisite.
-  return AddPositiveSemidefiniteConstraint(
+  return AddLinearMatrixInequalityConstraint(
       math::ExtractPrincipalSubmatrix(e, minor_indices));
 }
 

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2618,6 +2618,9 @@ class MathematicalProgram {
    *      x+y,     0,   x;
    * prog.AddPositiveSemidefiniteConstraint(e);
    * @endcode
+   * @note This function will add additional variables and linear equality
+   * constraints. Consider calling AddLinearMatrixInequalityConstraint(e), which
+   * doesn't introduce new variables or linear equality constraints.
    */
   Binding<PositiveSemidefiniteConstraint> AddPositiveSemidefiniteConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& e);
@@ -2630,7 +2633,7 @@ class MathematicalProgram {
    * @pre All values in  `minor_indices` lie in the range [0,
    * symmetric_matrix_var.rows() - 1].
    * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
-   * @see AddPositiveSemidefiniteConstraint.
+   * @see AddPositiveSemidefiniteConstraint
    */
   Binding<PositiveSemidefiniteConstraint> AddPrincipalSubmatrixIsPsdConstraint(
       const Eigen::Ref<const MatrixXDecisionVariable>& symmetric_matrix_var,
@@ -2645,9 +2648,14 @@ class MathematicalProgram {
    * @pre All values in  `minor_indices` lie in the range [0,
    * symmetric_matrix_var.rows() - 1].
    * @param e Imposes constraint "e is positive semidefinite".
-   * @see AddPositiveSemidefiniteConstraint.
+   * @see AddLinearMatrixInequalityConstraint.
+   * @note the return type is Binding<LinearMatrixInequalityConstraint>,
+   * different from the overloaded function above which returns
+   * Binding<PositiveSemidefiniteConstraint>. We impose the constraint as an LMI
+   * so as to add fewer additional variables and constraints.
    */
-  Binding<PositiveSemidefiniteConstraint> AddPrincipalSubmatrixIsPsdConstraint(
+  Binding<LinearMatrixInequalityConstraint>
+  AddPrincipalSubmatrixIsPsdConstraint(
       const Eigen::Ref<const MatrixX<symbolic::Expression>>& e,
       const std::set<int>& minor_indices);
 

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -90,7 +90,7 @@ void AddRotationMatrixSpectrahedralSdpConstraint(
     R(1, 2) + R(2, 1), R(0, 1) + R(1, 0), R(2, 0) - R(0, 2), 1 - R(0, 0) + R(1, 1) - R(2, 2); // #NOLINT
   // clang-format on
 
-  prog->AddPositiveSemidefiniteConstraint(M);
+  prog->AddLinearMatrixInequalityConstraint(M);
 }
 
 namespace {

--- a/solvers/test/clarabel_solver_test.cc
+++ b/solvers/test/clarabel_solver_test.cc
@@ -661,7 +661,7 @@ GTEST_TEST(TestZeroStepSize, ZeroStepSize) {
   const auto y = prog.NewContinuousVariables<2>("y");
   MatrixX<symbolic::Expression> mat(2, 2);
   mat << y(0, 0), 0.5, 0.5, y(1);
-  prog.AddPositiveSemidefiniteConstraint(mat);
+  prog.AddLinearMatrixInequalityConstraint(mat);
   prog.AddLogDeterminantLowerBoundConstraint(mat, 1);
   prog.AddLinearCost(-y(0));
   SolverOptions options;

--- a/solvers/test/exponential_cone_program_examples.cc
+++ b/solvers/test/exponential_cone_program_examples.cc
@@ -94,7 +94,7 @@ void MinimalEllipsoidCoveringPoints(const SolverInterface& solver, double tol) {
   Matrix3<symbolic::Expression> ellipsoid_psd;
   ellipsoid_psd << S, b.cast<symbolic::Expression>() / 2,
       b.cast<symbolic::Expression>().transpose() / 2, c;
-  prog.AddPositiveSemidefiniteConstraint(ellipsoid_psd);
+  prog.AddLinearMatrixInequalityConstraint(ellipsoid_psd);
   const auto [linear_cost, log_det_t, log_det_Z] =
       prog.AddMaximizeLogDeterminantCost(S.cast<symbolic::Expression>());
   for (int i = 0; i < 4; ++i) {

--- a/solvers/test/get_program_type_test.cc
+++ b/solvers/test/get_program_type_test.cc
@@ -60,8 +60,8 @@ GTEST_TEST(GetProgramTypeTest, SOCP) {
   EXPECT_NE(GetProgramType(prog), ProgramType::kSOCP);
   prog.RemoveCost(quadratic_cost);
   EXPECT_EQ(GetProgramType(prog), ProgramType::kSOCP);
-  prog.AddPositiveSemidefiniteConstraint(x[0] * Eigen::Matrix2d::Identity() +
-                                         x[1] * Eigen::Matrix2d::Ones());
+  prog.AddLinearMatrixInequalityConstraint(x[0] * Eigen::Matrix2d::Identity() +
+                                           x[1] * Eigen::Matrix2d::Ones());
   EXPECT_NE(GetProgramType(prog), ProgramType::kSOCP);
 }
 
@@ -190,8 +190,8 @@ GTEST_TEST(GetProgramTypeTest, MISOCP) {
   prog.AddLorentzConeConstraint(x.cast<symbolic::Expression>());
   prog.AddLinearCost(x[0] + x[1]);
   EXPECT_EQ(GetProgramType(prog), ProgramType::kMISOCP);
-  prog.AddPositiveSemidefiniteConstraint(x[0] * Eigen::Matrix2d::Identity() +
-                                         b[0] * Eigen::Matrix2d::Ones());
+  prog.AddLinearMatrixInequalityConstraint(x[0] * Eigen::Matrix2d::Identity() +
+                                           b[0] * Eigen::Matrix2d::Ones());
   EXPECT_NE(GetProgramType(prog), ProgramType::kMISOCP);
 }
 

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3058,41 +3058,35 @@ GTEST_TEST(TestMathematicalProgram,
                   X(3, 0), X(3, 1), X(3, 3);
   // clang-format on
 
-  auto psd_cnstr = prog.AddPrincipalSubmatrixIsPsdConstraint(
+  auto lmi_cnstr = prog.AddPrincipalSubmatrixIsPsdConstraint(
                            2 * Matrix4d::Identity() * X, minor_indices)
                        .evaluator();
 
-  EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1);
-  EXPECT_EQ(prog.GetAllConstraints().size(), 2);
+  EXPECT_EQ(prog.linear_matrix_inequality_constraints().size(), 1);
+  EXPECT_EQ(prog.GetAllConstraints().size(), 1);
 
-  const auto& new_psd_cnstr = prog.positive_semidefinite_constraints().back();
-  EXPECT_EQ(psd_cnstr.get(), new_psd_cnstr.evaluator().get());
+  const auto& new_lmi_cnstr =
+      prog.linear_matrix_inequality_constraints().back();
+  EXPECT_EQ(lmi_cnstr.get(), new_lmi_cnstr.evaluator().get());
 
   MathematicalProgram prog_manual;
   prog_manual.AddDecisionVariables(minor_manual);
-  auto psd_cnstr_manual = prog_manual
-                              .AddPositiveSemidefiniteConstraint(
+  auto lmi_cnstr_manual = prog_manual
+                              .AddLinearMatrixInequalityConstraint(
                                   2 * Matrix3d::Identity() * minor_manual)
                               .evaluator();
-  const auto& new_psd_cnstr_manual =
-      prog.positive_semidefinite_constraints().back();
+  const auto& new_lmi_cnstr_manual =
+      prog.linear_matrix_inequality_constraints().back();
 
-  EXPECT_TRUE(CheckStructuralEquality(new_psd_cnstr_manual.variables(),
-                                      new_psd_cnstr.variables()));
-  EXPECT_EQ(prog.positive_semidefinite_constraints().size(),
-            prog_manual.positive_semidefinite_constraints().size());
+  EXPECT_TRUE(CheckStructuralEquality(new_lmi_cnstr_manual.variables(),
+                                      new_lmi_cnstr.variables()));
+  EXPECT_EQ(prog.linear_matrix_inequality_constraints().size(),
+            prog_manual.linear_matrix_inequality_constraints().size());
   EXPECT_EQ(prog.linear_equality_constraints().size(),
             prog_manual.linear_equality_constraints().size());
-  EXPECT_EQ(prog.linear_equality_constraints().size(), 1);
+  EXPECT_TRUE(prog.linear_equality_constraints().empty());
   EXPECT_EQ(prog.GetAllConstraints().size(),
             prog_manual.GetAllConstraints().size());
-
-  EXPECT_TRUE(CompareMatrices(
-      prog.linear_equality_constraints()[0].evaluator()->upper_bound(),
-      prog_manual.linear_equality_constraints()[0].evaluator()->upper_bound()));
-  EXPECT_TRUE(CompareMatrices(
-      prog.linear_equality_constraints()[0].evaluator()->lower_bound(),
-      prog_manual.linear_equality_constraints()[0].evaluator()->lower_bound()));
 }
 
 GTEST_TEST(TestMathematicalProgram, AddLinearMatrixInequalityConstraint) {
@@ -3678,7 +3672,7 @@ GTEST_TEST(TestMathematicalProgram, TestClone) {
   prog.AddRotatedLorentzConeConstraint(
       Vector4<symbolic::Expression>(x(0) + x(1), x(1) + x(2), +x(0), +x(1)));
   prog.AddPositiveSemidefiniteConstraint(X);
-  prog.AddPositiveSemidefiniteConstraint(X - Eigen::Matrix3d::Ones());
+  prog.AddLinearMatrixInequalityConstraint(X - Eigen::Matrix3d::Ones());
   int num_all_constraints = prog.GetAllConstraints().size();
   prog.AddLinearMatrixInequalityConstraint(
       {Eigen::Matrix2d::Identity(), Eigen::Matrix2d::Ones(),
@@ -4914,7 +4908,7 @@ GTEST_TEST(MathematicalProgramTest, AddLogDeterminantLowerBoundConstraint) {
     EXPECT_TRUE(constraint.variables()(i).equal_to(t(i)));
   }
   EXPECT_EQ(prog.exponential_cone_constraints().size(), 3);
-  EXPECT_EQ(prog.positive_semidefinite_constraints().size(), 1);
+  EXPECT_EQ(prog.linear_matrix_inequality_constraints().size(), 1);
 }
 
 class EmptyCost final : public Cost {


### PR DESCRIPTION
Instead should use AddLinearMatrixInequalityConstraint() which adds a linear matrix inequality constraint. This avoids adding additional PSD matrix variable and linear equality constraints.

This also changes the return type of some functions, including

- AddPrincipalSubmatrixIsPsdConstraint() returns Binding<LinearMatrixInequalityConstraint> instead of Binding<PositiveSemidefiniteConstraint>
- Spechedron::AddPointInNonnegativeScalingConstraints() returns Binding<LinearMatrixInequalityConstraint> instead of Binding<PositiveSemidefiniteConstraint>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22234)
<!-- Reviewable:end -->
