### PR TITLE
[render] Hotfix missing glob in "Differentiate visual roles ..."

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -133,12 +133,11 @@ filegroup(
     name = "test_models",
     testonly = 1,
     srcs = [
+        "test/box.sdf",
         ":box_checkered",
         ":box_no_mtl",
     ] + glob([
         "test/meshes/*",
-        "test/box.sdf",
-        "test/configure_visual_roles.sdf",
         "test/*.png",
     ]),
 )


### PR DESCRIPTION
Amends #22013.

TANSTA `test/configure_visual_roles.sdf`, which is an error in Bazel >= 8.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22236)
<!-- Reviewable:end -->
