### PR TITLE
[workspace] Use built-in rules_python for Bazel >= 8

### DIFF
--- a/tools/workspace/rules_python/BUILD.bazel
+++ b/tools/workspace/rules_python/BUILD.bazel
@@ -1,6 +1,8 @@
+load("@rules_python_drake_constants//:defs.bzl", "CONSTANTS")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
 
+# This test is only relevant when @rules_python is using Drake's pinned copy.
 drake_py_unittest(
     name = "rules_python_internal_test",
     data = [
@@ -11,6 +13,6 @@ drake_py_unittest(
     deps = [
         "@rules_python//python/runfiles",
     ],
-)
+) if CONSTANTS["USE_DRAKE_PIN"] else None
 
 add_lint_tests()

--- a/tools/workspace/rules_python/repository.bzl
+++ b/tools/workspace/rules_python/repository.bzl
@@ -4,6 +4,21 @@ load(
 )
 load("//tools/workspace:github.bzl", "github_archive")
 
+# (Internal use only) Creates a @rules_python_drake_constants repository that
+# communicates whether @rules_python is using Drake's pinned version or Bazel's
+# vendored copy.
+def _rules_python_drake_constants_repository_impl(repo_ctx):
+    constants_json = repo_ctx.attr.constants_json
+    repo_ctx.file("BUILD.bazel", "")
+    repo_ctx.file("defs.bzl", "CONSTANTS = {}".format(constants_json))
+
+_rules_python_drake_constants_repository = repository_rule(
+    implementation = _rules_python_drake_constants_repository_impl,
+    attrs = {
+        "constants_json": attr.string(),
+    },
+)
+
 # Note that we do NOT install a LICENSE file as part of the Drake install
 # because this repository is required only when building and testing with
 # Bazel.
@@ -11,6 +26,18 @@ load("//tools/workspace:github.bzl", "github_archive")
 def rules_python_repository(
         name,
         mirrors = None):
+    # For Bazel versions < 8, we pin our own particular copy of rules_python.
+    # For Bazel versions >= 8, we'll use Bazel's vendored copy of rules_python.
+    # Our minimum version (per WORKSPACE) is 7.1 so we can use a string match.
+    use_drake_rules_python_pin = native.bazel_version[0:2] == "7."
+    _rules_python_drake_constants_repository(
+        name = name + "_drake_constants",
+        constants_json = json.encode({
+            "USE_DRAKE_PIN": 1 if use_drake_rules_python_pin else 0,
+        }),
+    )
+    if not use_drake_rules_python_pin:
+        return
     github_archive(
         name = name,
         repository = "bazelbuild/rules_python",  # License: Apache-2.0,


### PR DESCRIPTION
Towards #22182.

Between `8.0.0rc2` and `8.0.0rc3` (and still in `8.0.0rc4`), Bazel has started rejecting our `rules_python` pin with this error:

```console
env USE_BAZEL_VERSION=8.0.0rc3 bazel test //...
Computing main repo mapping: 
...
ERROR: external/rules_python/python/py_cc_link_params_info.bzl:6:84: name 'PyCcLinkParamsProvider' is not defined
ERROR: external/rules_python/python/private/reexports.bzl:37:17: name 'PyInfo' is not defined (did you mean 'CcInfo'?)
ERROR: external/rules_python/python/private/reexports.bzl:40:24: name 'PyRuntimeInfo' is not defined
```

That is fixed in newer releases of rules_python, but we are having trouble upgrading to that (see #22129).

Thus, for bazel 8 we will rely on Bazel's own vendored copy of `@rules_python`.  This means that our version pinning of the ruleset is indirect -- we pin Bazel (in `.bazeliskrc`) and Bazel pins `@rules_python`.  While not ideal, this still provides for reproducible builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22237)
<!-- Reviewable:end -->
