### PR TITLE
Fixes bug in IrisFromCliqueCover edge case

### DIFF
--- a/planning/iris/iris_from_clique_cover.cc
+++ b/planning/iris/iris_from_clique_cover.cc
@@ -169,7 +169,7 @@ void ComputeGreedyTruncatedCliqueCover(
   // to the queue. Removing this line will cause an infinite loop.
   computed_cliques->done_filling();
   log()->info(
-      "Finished adding cliques. Total of {} clique added. Number of cliques "
+      "Finished adding cliques. Total of {} cliques added. Number of cliques "
       "left to process = {}",
       num_cliques, computed_cliques->size());
 }
@@ -229,7 +229,7 @@ std::queue<HPolyhedron> IrisWorker(
           .minCoeff(&nearest_point_col);
       Eigen::VectorXd center = clique_points.col(nearest_point_col);
       iris_options.starting_ellipse =
-          Hyperellipsoid(center, clique_ellipse.A());
+          Hyperellipsoid(clique_ellipse.A(), center);
     }
     checker.UpdatePositions(iris_options.starting_ellipse->center(),
                             builder_id);

--- a/planning/iris/test/iris_from_clique_cover_test.cc
+++ b/planning/iris/test/iris_from_clique_cover_test.cc
@@ -249,6 +249,8 @@ GTEST_TEST(IrisInConfigurationSpaceFromCliqueCover,
       builder.parser().AddModelsFromString(box_in_box, "urdf");
   // Choose ridiculous edge size to get fully connected visibility graph.
   // This will ensure the collision of the ellipsoid center.
+  // TODO(Alexandre.Amice): Clean up this test when the modular version of
+  // IrisInConfigurationSpaceFromCliqueCover lands.
   params.edge_step_size = 10.0;
   params.model = builder.Build();
   auto checker =

--- a/planning/iris/test/iris_from_clique_cover_test.cc
+++ b/planning/iris/test/iris_from_clique_cover_test.cc
@@ -230,16 +230,16 @@ GTEST_TEST(IrisInConfigurationSpaceFromCliqueCover,
   Eigen::Matrix3Xd env_points(3, 5);
   // clang-format off
   env_points << -2, 2,  2, -2, -2,
-                  2, 2, -2, -2,  2,
-                  0, 0,  0,  0,  0;
+                 2, 2, -2, -2,  2,
+                 0, 0,  0,  0,  0;
   // clang-format on
   meshcat->SetLine("Domain", env_points, 8.0, Rgba(0, 0, 0));
 
   Eigen::Matrix3Xd obstacle_points(3, 5);
   // clang-format off
   obstacle_points << -1, 1,  1, -1, -1,
-                  1, 1, -1, -1,  1,
-                  0, 0,  0,  0,  0;
+                      1, 1, -1, -1,  1,
+                      0, 0,  0,  0,  0;
   // clang-format on
   meshcat->SetLine("Obstacle", obstacle_points, 8.0, Rgba(0, 0, 0));
   CollisionCheckerParams params;


### PR DESCRIPTION
We had a bug in how we were selecting the ellipsoid center if the center of the minimum volume circumscribing ellipsoid of a clique was in collision. The center and the A-matrix were flipped. This PR corrects the bug and adds test coverage for it. This issue was brought up in #22233 . 

Thank you @dkreho1 for finding the bug!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22239)
<!-- Reviewable:end -->
