### PR TITLE
Remove outdated code from mac temurin install

### DIFF
--- a/setup/mac/binary_distribution/Brewfile
+++ b/setup/mac/binary_distribution/Brewfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-cask 'temurin' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
+cask 'temurin'
 
 brew 'eigen'
 brew 'gcc'


### PR DESCRIPTION
Removes the outdated Ruby code associated with the mac temurin installation as it is no longer necessary for successful builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22242)
<!-- Reviewable:end -->
