### PR TITLE
[tools] Disable cpplint's build/include checks

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -20,6 +20,12 @@ filter=+build/pragma_once
 # Disable cpplint's include order.  We have our own via //tools:drakelint.
 filter=-build/include_order
 
+# Disable cpplint's check to include the h file atop the cc file (along with
+# some other, even less relevant checks). Given the layout of bazel's runfiles
+# during linting and our include path customizations, cpplint yields false
+# positives because it's unable to discern the root of our include path.
+filter=-build/include
+
 # We do not care about the whitespace details of a TODO comment.  It is not
 # relevant for easy grepping, and the GSG does not specify any particular
 # whitespace style.  (We *do* care what the "TODO(username)" itself looks like


### PR DESCRIPTION
Towards #20731.

When using `--enable_bzlmod=true`, the default runfiles layout is not compatible with how `cpplint` expects things to work.  (In particular, the root of our runfiles is named `_main` instead of `drake` now.)  With some major surgery to our skylark lint rules we could probably get it working, but I don't think this feature is important enough to merit that level of surgery and maintenance.  We have `clang-format-includes` which ensures the self-include statement is always first atop the file, and that seems good enough; forgetting the self-include entirely is not a common failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22264)
<!-- Reviewable:end -->
