### PR TITLE
[build] Fully retire the non-lcmtypes drake module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@
 
 load("//tools/install:install.bzl", "install", "install_test")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:py.bzl", "py_library")
+load("//tools/skylark:drake_py.bzl", "drake_py_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -17,12 +17,13 @@ exports_files([
     "package.xml",
 ])
 
-# Drake's top-level module; all drake_py_stuff rules add this to deps.
-# (We use py_library here because drake_py_library would be circular.)
-# This file should NOT be installed (see commits in __init__.py).
-py_library(
+# A legacy hack module to disambiguate the 'drake' module when Drake is being
+# used as a non-bzlmod external. We should remove this when we drop support for
+# WORKSPACE (i.e., Bazel >= 9).
+drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
+    visibility = ["//lcmtypes:__pkg__"],
 )
 
 # Expose shared library for (a) installed binaries, (b) Drake Python bindings,

--- a/__init__.py
+++ b/__init__.py
@@ -1,17 +1,13 @@
-# It confusing to have both drake-the-workspace and drake-the-lcmtypes-package
-# on sys.path at the same time via Bazel's py_library(imports = ...).
+# It's brittle to have both drake-the-workspace and drake-the-lcmtypes-package
+# available on the sys.path at the same time in Bazel.
 #
-# To prevent that confusion, and possibly also import errors, in our
-# //lcmtypes:lcmtypes_drake_py rule we use add_current_package_to_imports =
-# False, and then here in drake-the-workspace's package initialization we use
-# __path__ editing to fold the two directories into the same package.
+# To avoid import errors based on which one came first on the path, in our
+# //lcmtypes:lcmtypes_drake_py rule we depend on this file, and here (in
+# drake-the-workspace's package initialization) we use __path__ editing to
+# fold the two directories into the same package.
 #
 # We need to do it on a best-effort basis, because not all of our py_binary
 # rules use lcmtypes -- sometimes the lcmtypes will be absent from runfiles.
-#
-# Note that this file should NOT be installed (`//:install` should not touch
-# it).  The `//lcmtypes`-supplied init file is the correct file to install.
-
 try:
     import drake.lcmtypes
     __path__.append(list(drake.lcmtypes.__path__)[0] + "/drake")

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -35,6 +35,7 @@ exports_files([
 PACKAGE_INFO = get_pybind_package_info(base_package = "//bindings")
 
 # This target provides the following Python modules:
+# - drake (i.e., our lcmtypes)
 # - pydrake
 # - pydrake.autodiffutils
 # - pydrake.common (and all of its sub-modules)
@@ -48,6 +49,7 @@ drake_py_library(
     ],
     deps = [
         "//bindings/pydrake/common:_init_py",
+        "//lcmtypes:lcmtypes_drake_py",
     ],
 )
 
@@ -349,7 +351,6 @@ drake_py_unittest(
     name = "lcm_test",
     deps = [
         ":lcm_py",
-        "//lcmtypes:lcmtypes_drake_py",
     ],
 )
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -227,7 +227,6 @@ drake_pybind_library(
         ":framework_py",
         ":module_py",
         "//bindings/pydrake:lcm_py",
-        "//lcmtypes:lcmtypes_drake_py",
     ],
     py_srcs = ["_lcm_extra.py"],
 )

--- a/bindings/pydrake/visualization/BUILD.bazel
+++ b/bindings/pydrake/visualization/BUILD.bazel
@@ -49,7 +49,6 @@ drake_pybind_library(
         "//bindings/pydrake/systems",
         "//bindings/pydrake/geometry",
         "//bindings/pydrake:lcm_py",
-        "//lcmtypes:lcmtypes_drake_py",
     ],
     py_srcs = [
         "meldis.py",

--- a/common/proto/call_python_client_notebook.ipynb
+++ b/common/proto/call_python_client_notebook.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "# Example Python client.\n",
-    "from drake.common.proto.call_python_client import CallPythonClient"
+    "from common.proto.call_python_client import CallPythonClient"
    ]
   },
   {

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -254,23 +254,12 @@ drake_lcm_cc_library(
     ],
 )
 
-# Generate the *.py sources, but keep __init__.py separate, so that it doesn't
-# get installed.  The install will use this (private) library.  Users should
-# depend on ":lcmtypes_drake_py", immediately below.
 drake_lcm_py_library(
-    name = "_generated_lcmtypes_drake_py",
-    # We'll rely on the //:module_py path munging instead.
-    add_current_package_to_imports = False,
+    name = "lcmtypes_drake_py",
     lcm_package = "drake",
     lcm_srcs = ALL_LCM_SRCS,
-    visibility = ["//visibility:private"],
-)
-
-drake_py_library(
-    name = "lcmtypes_drake_py",
-    srcs = ["__init__.py"],
     deps = [
-        ":_generated_lcmtypes_drake_py",
+        "//:module_py",
     ],
 )
 
@@ -351,7 +340,7 @@ install(
         ],
     }),
     targets = [
-        ":_generated_lcmtypes_drake_py",
+        ":lcmtypes_drake_py",
     ] + select({
         "@lcm//:lcm_install_java_is_off": [],
         "//conditions:default": [

--- a/lcmtypes/__init__.py
+++ b/lcmtypes/__init__.py
@@ -1,1 +1,0 @@
-# Empty Python module `__init__`, required to make this a module.

--- a/multibody/parsing/test/package_downloader_test.py
+++ b/multibody/parsing/test/package_downloader_test.py
@@ -8,7 +8,7 @@ import zipfile
 import unittest
 from urllib.error import HTTPError
 
-import drake.multibody.parsing.package_downloader as mut
+import multibody.parsing.package_downloader as mut
 
 # We'll mock out the internet-touching methods. We don't want our unit test
 # touching the internet. See setUp and tearDown below for details.

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -9,15 +9,10 @@ load("//tools/skylark:py.bzl", "py_binary", "py_library", "py_test")
 
 def drake_py_library(
         name,
-        deps = None,
         **kwargs):
     """A wrapper to insert Drake-specific customizations."""
-
-    # Work around https://github.com/bazelbuild/bazel/issues/1567.
-    deps = (deps or []) + ["//:module_py"]
     py_library(
         name = name,
-        deps = deps,
         srcs_version = "PY3",
         **kwargs
     )
@@ -134,11 +129,6 @@ def drake_py_binary(
         library code. This prevents submodules from leaking in as top-level
         submodules. For more detail, see #8041.
     """
-
-    # Work around https://github.com/bazelbuild/bazel/issues/1567.
-    deps = deps or []
-    if "//:module_py" not in deps:
-        deps += ["//:module_py"]
     if main == None and len(srcs) == 1:
         main = srcs[0]
     _py_target_isolated(
@@ -265,10 +255,7 @@ def drake_py_test(
     kwargs = incorporate_num_threads(kwargs, num_threads = num_threads)
     kwargs = amend(kwargs, "tags", append = ["py"])
 
-    # Work around https://github.com/bazelbuild/bazel/issues/1567.
     deps = deps or []
-    if "//:module_py" not in deps:
-        deps += ["//:module_py"]
     if not allow_import_unittest:
         deps = deps + ["//common/test_utilities:disable_python_unittest"]
     _py_target_isolated(


### PR DESCRIPTION
Towards #20731.  See #21453 for prior art.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22265)
<!-- Reviewable:end -->
