### PR TITLE
[math] Fix GeneratePythonCsc to eschew C++ streams

### DIFF
--- a/math/matrix_util.cc
+++ b/math/matrix_util.cc
@@ -1,14 +1,17 @@
 #include "drake/math/matrix_util.h"
 
+#include <sstream>
+
 #include <fmt/format.h>
 
 namespace drake {
 namespace math {
-void GeneratePythonCsc(const Eigen::SparseMatrix<double>& mat,
-                       std::string_view name, std::ostream* python_stream) {
+std::string GeneratePythonCsc(const Eigen::SparseMatrix<double>& mat,
+                              std::string_view name) {
+  std::stringstream python_stream;
   if (mat.nonZeros() == 0) {
-    *python_stream << fmt::format("{} = sparse.csc_matrix(({}, {}))\n", name,
-                                  mat.rows(), mat.cols());
+    python_stream << fmt::format("{} = sparse.csc_matrix(({}, {}))\n", name,
+                                 mat.rows(), mat.cols());
   } else {
     std::vector<double> data;
     std::vector<int> rows;
@@ -24,12 +27,13 @@ void GeneratePythonCsc(const Eigen::SparseMatrix<double>& mat,
       }
     }
 
-    *python_stream << fmt::format(
+    python_stream << fmt::format(
         R"""({} = sparse.csc_matrix((np.array([{}], dtype=np.float64), ([{}], [{}])), shape=({}, {}))
 )""",
         name, fmt::join(data, ", "), fmt::join(rows, ", "),
         fmt::join(cols, ", "), mat.rows(), mat.cols());
   }
+  return python_stream.str();
 }
 }  // namespace math
 }  // namespace drake

--- a/math/matrix_util.h
+++ b/math/matrix_util.h
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <fstream>
 #include <functional>
 #include <set>
 #include <string_view>
@@ -253,15 +252,15 @@ MatrixX<typename Derived::Scalar> ExtractPrincipalSubmatrix(
   return minor;
 }
 
-/// Generate the python code to construct scipy.sparse matrix. The generated
+/// Returns the python statement to construct scipy.sparse matrix. The generated
 /// code will call sparse.csc_matrix() directly (please make sure you have
-/// imported the module through `from scipy import sparse`.
+/// imported the module through `from scipy import sparse`), and will end with a
+/// newline.
 /// @param mat The Eigen matrix to be generated to python code.
 /// @param name The name of the python variable for the sparse matrix.
-/// @param python_stream[in/out] The generated python code will be appended to
-/// `python_stream`
-void GeneratePythonCsc(const Eigen::SparseMatrix<double>& mat,
-                       std::string_view name, std::ostream* python_stream);
+/// @returns the generated python code
+std::string GeneratePythonCsc(const Eigen::SparseMatrix<double>& mat,
+                              std::string_view name);
 
 }  // namespace math
 }  // namespace drake

--- a/math/test/matrix_util_test.cc
+++ b/math/test/matrix_util_test.cc
@@ -1,8 +1,5 @@
 #include "drake/math/matrix_util.h"
 
-#include <fstream>
-#include <sstream>
-
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic/expression.h"
@@ -251,20 +248,18 @@ GTEST_TEST(GeneratePythonCsc, TestNonEmpty) {
         0,  0.5, 0;
   // clang-format on
   const Eigen::SparseMatrix<double> A_sparse = A.sparseView();
-  std::ostringstream python_stream;
-  GeneratePythonCsc(A_sparse, "A", &python_stream);
   EXPECT_EQ(
-      python_stream.str(),
+      GeneratePythonCsc(A_sparse, "A"),
       "A = sparse.csc_matrix((np.array([1.5, 0.5, 0.5, 1], "
       "dtype=np.float64), ([0, 0, 1, 0], [0, 1, 1, 2])), shape=(2, 3))\n");
 }
 
 GTEST_TEST(GeneratePythonCsc, TestEmpty) {
   const Eigen::SparseMatrix<double> A_sparse(2, 3);
-  std::ostringstream python_stream;
-  GeneratePythonCsc(A_sparse, "A", &python_stream);
-  EXPECT_EQ(python_stream.str(), "A = sparse.csc_matrix((2, 3))\n");
+  EXPECT_EQ(GeneratePythonCsc(A_sparse, "A"),
+            "A = sparse.csc_matrix((2, 3))\n");
 }
+
 }  // namespace test
 }  // namespace math
 }  // namespace drake

--- a/solvers/clarabel_solver.cc
+++ b/solvers/clarabel_solver.cc
@@ -226,8 +226,8 @@ b = [{}]
 )""",
       fmt::join(q_vec.data(), q_vec.data() + q_vec.size(), ", "),
       fmt::join(b_vec.data(), b_vec.data() + b_vec.size(), ", "));
-  math::GeneratePythonCsc(P, "P", &out_file);
-  math::GeneratePythonCsc(A, "A", &out_file);
+  out_file << math::GeneratePythonCsc(P, "P");
+  out_file << math::GeneratePythonCsc(A, "A");
   out_file << "cones = [" << std::endl;
 
   for (const clarabel::SupportedConeT<double>& cone : cones) {

--- a/solvers/scs_solver.cc
+++ b/solvers/scs_solver.cc
@@ -329,8 +329,8 @@ b = np.array([{}], dtype=np.float64)
       fmt::join(c_vec.data(), c_vec.data() + c_vec.size(), ", "),
       fmt::join(b_vec.data(), b_vec.data() + b_vec.size(), ", "));
 
-  math::GeneratePythonCsc(P, "P", &out_file);
-  math::GeneratePythonCsc(A, "A", &out_file);
+  out_file << math::GeneratePythonCsc(P, "P");
+  out_file << math::GeneratePythonCsc(A, "A");
 
   out_file << "data=dict(P=P, A=A, b=b, c=c)\n";
 


### PR DESCRIPTION
Even considering this specific change in isolation, it is clearly monotonically better.

Bigger picture, C++ streams are _terrible_ and we should be skeptical during platform review of any new uses of them.  Sometimes inside function bodies a temporary local stream is nice, but we should absolutely never use streams in API, nevermind public-stable API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22268)
<!-- Reviewable:end -->
