### PR TITLE
[solvers] IpoptSolver doesn't hard-code the linear solver

### DIFF
--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -57,7 +57,9 @@ void SetAppOptions(const std::string& default_linear_solver,
   // Turn off the banner.
   set_string_option("sb", "yes");
 
-  set_string_option("linear_solver", default_linear_solver);
+  if (!default_linear_solver.empty()) {
+    set_string_option("linear_solver", default_linear_solver);
+  }
 
   // The default tolerance.
   const double tol = 1.05e-10;  // Note: SNOPT is only 1e-6, but in #3712 we
@@ -145,6 +147,16 @@ const char* IpoptSolverDetails::ConvertStatusToString() const {
     }
   }
   return "Unknown enumerated SolverReturn value.";
+}
+
+IpoptSolver::IpoptSolver()
+    : SolverBase(id(), &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {
+  const std::vector<std::string_view> linear_solvers =
+      internal::GetSupportedIpoptLinearSolvers();
+  if (!linear_solvers.empty()) {
+    default_linear_solver_ = linear_solvers.at(0);
+  }
 }
 
 bool IpoptSolver::is_available() {

--- a/solvers/ipopt_solver_common.cc
+++ b/solvers/ipopt_solver_common.cc
@@ -8,17 +8,6 @@
 namespace drake {
 namespace solvers {
 
-IpoptSolver::IpoptSolver()
-    : SolverBase(id(), &is_available, &is_enabled, &ProgramAttributesSatisfied),
-      // The default linear solver is MA27, but it is not freely redistributable
-      // so we cannot use it. MUMPS is the only compatible linear solver
-      // guaranteed to be available on both macOS and Ubuntu. In versions of
-      // IPOPT prior to 3.13, it would correctly determine that MUMPS was the
-      // only available solver, but its behavior changed to instead error having
-      // unsuccessfully tried to dlopen a nonexistent hsl library that would
-      // contain MA27.
-      default_linear_solver_("mumps") {}
-
 IpoptSolver::~IpoptSolver() = default;
 
 void IpoptSolver::SetDefaultLinearSolver(std::string linear_solver) {

--- a/solvers/ipopt_solver_internal.h
+++ b/solvers/ipopt_solver_internal.h
@@ -4,6 +4,7 @@
 // that we can expose the internals to ipopt_solver_internal_test.
 
 #include <memory>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -143,6 +144,12 @@ class DRAKE_NO_EXPORT IpoptSolver_NLP : public Ipopt::TNLP {
   // corresponding dual variables.
   std::unordered_map<Binding<Constraint>, int> constraint_dual_start_index_;
 };
+
+// Returns Drake's supported values for the "linear_solver" IpoptSolver option.
+// This will be affected by which options the IPOPT library was compiled with.
+// The first item in the result is Drake's default value.
+std::vector<std::string_view> GetSupportedIpoptLinearSolvers();
+
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/no_ipopt.cc
+++ b/solvers/no_ipopt.cc
@@ -13,6 +13,10 @@ const char* IpoptSolverDetails::ConvertStatusToString() const {
       "solver.");
 }
 
+IpoptSolver::IpoptSolver()
+    : SolverBase(id(), &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
+
 bool IpoptSolver::is_available() {
   return false;
 }

--- a/solvers/test/ipopt_solver_internal_test.cc
+++ b/solvers/test/ipopt_solver_internal_test.cc
@@ -270,6 +270,27 @@ GTEST_TEST(TestIpoptSolverNlp, NonlinearConstraintDuplicatedVariables) {
     EXPECT_TRUE(CompareMatrices(jac.toDense(), jac_expected));
   }
 }
+
+#if defined(__APPLE__)
+constexpr bool kApple = true;
+#else
+constexpr bool kApple = false;
+#endif
+
+// This provides a cross-check of our build system choices for @ipopt.
+GTEST_TEST(TestIpoptSolver, SupportedLinearSolvers) {
+  const std::vector<std::string_view> actual = GetSupportedIpoptLinearSolvers();
+  std::vector<std::string_view> expected;
+  if (kApple) {
+    // Homebrew doesn't provide SPRAL.
+    expected.emplace_back("mumps");
+  } else {
+    expected.emplace_back("mumps");
+    expected.emplace_back("spral");
+  }
+  EXPECT_EQ(actual, expected);
+}
+
 }  // namespace internal
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Towards #21476.  This will simplify the work of changing which linear solver(s) the build system provides.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22275)
<!-- Reviewable:end -->
