### PR TITLE
Allow serialization for MemoryFile

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -201,6 +201,7 @@ drake_cc_library(
     hdrs = ["memory_file.h"],
     deps = [
         ":essential",
+        ":name_value",
         ":reset_after_move",
         ":sha256",
     ],

--- a/common/test/file_source_test.cc
+++ b/common/test/file_source_test.cc
@@ -47,12 +47,14 @@ GTEST_TEST(FileSourceTest, SerializePath) {
   EXPECT_EQ(std::get<fs::path>(dut.source), std::get<fs::path>(decoded.source));
 }
 
-/* The MemoryFile value simply throws (see MemoryFile implementation). */
+/* The MemoryFile value gets (de)serialized. */
 GTEST_TEST(FileSourceTest, SerializeMemoryFile) {
   const HasFileSource dut{.source = MemoryFile("stuff", ".ext", "hint")};
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      yaml::SaveYamlString(dut),
-      "Serialization for MemoryFile not yet supported.");
+  const std::string y = yaml::SaveYamlString(dut);
+  const auto decoded = yaml::LoadYamlString<HasFileSource>(y);
+  ASSERT_TRUE(std::holds_alternative<MemoryFile>(decoded.source));
+  EXPECT_EQ(std::get<MemoryFile>(dut.source).contents(),
+            std::get<MemoryFile>(decoded.source).contents());
 }
 
 }  // namespace

--- a/common/test/memory_file_test.cc
+++ b/common/test/memory_file_test.cc
@@ -111,12 +111,28 @@ GTEST_TEST(MemoryFileTest, ToString) {
   EXPECT_THAT(fmt::to_string(file), testing::HasSubstr("\"0123456789\""));
 }
 
-/* Serialization compiles but throws. */
-GTEST_TEST(MemoryFileTest, SerializationThrows) {
-  const MemoryFile dut("stuff", ".ext", "hint");
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      yaml::SaveYamlString(dut),
-      "Serialization for MemoryFile not yet supported.");
+/** Confirm that this can be serialized appropriately. The serialization work
+ (with all of its nuances) get tested elsewhere. Here, we're simply testing
+ that the fields get serialized and deserialized as expected. */
+GTEST_TEST(MemoryFileTest, Serialization) {
+    // This content is the text shown in the serialization documentation. Same
+    // for the extension and filename hint as well.
+  const std::string content("This is an example of memory file test contents.");
+  const std::string content_b64(
+      "VGhpcyBpcyBhbiBleGFtcGxlIG9mIG1lbW9yeSBmaWxlIHRlc3QgY29udGVudHMu");
+  const MemoryFile dut(content, ".txt", "payload.txt");
+
+  // Serialization.
+  const std::string y = yaml::SaveYamlString(dut);
+  EXPECT_EQ(y, fmt::format("contents: !!binary {}\nextension: "
+                           ".txt\nfilename_hint: payload.txt\n",
+                           content_b64));
+
+  // Deserialization.
+  const auto from_yaml = yaml::LoadYamlString<MemoryFile>(y);
+  EXPECT_EQ(from_yaml.contents(), dut.contents());
+  EXPECT_EQ(from_yaml.extension(), dut.extension());
+  EXPECT_EQ(from_yaml.filename_hint(), dut.filename_hint());
 }
 
 }  // namespace


### PR DESCRIPTION
Path member can now be serialized like other basic member types.

Serializing something of type vector<uint8_t> is interpreted as a byte string. If all bytes are printable, it is equivalent to a string. If there are any non-printable characters, it is converted to base64 and prefixed with YAML's !!binary tag.

MemoryFile makes use of this to serialize its file contents (it creates a temporary vector<uint8_t> for serialization to trigger the potential binary yaml encoding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22277)
<!-- Reviewable:end -->
