### PR TITLE
Unify RotationalInertia validity tests and exception messages.

### DIFF
--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -239,17 +239,17 @@ std::string RotationalInertia<T>::GetInvalidityReport() const {
 }
 
 template <typename T>
-void RotationalInertia<T>::ThrowNotPhysicallyValid(
+void RotationalInertia<T>::ThrowIfNotPhysicallyValidImpl(
     const char* func_name) const {
-  std::string error_message = fmt::format(
-      "{}(): The rotational inertia\n"
-      "{}did not pass the test CouldBePhysicallyValid().",
-      func_name, *this);
-
-  // Provide additional information if a moment of inertia is non-negative
-  // or if moments of inertia do not satisfy the triangle inequality.
-  error_message += GetInvalidityReport();
-  throw std::logic_error(error_message);
+  DRAKE_DEMAND(func_name != nullptr);
+  const std::string reason_for_invalidity = GetInvalidityReport();
+  if (!reason_for_invalidity.empty()) {
+    const std::string error_message = fmt::format(
+        "{}(): The rotational inertia\n"
+        "{}did not pass the test CouldBePhysicallyValid().{}",
+        func_name, *this, reason_for_invalidity);
+    throw std::logic_error(error_message);
+  }
 }
 
 // TODO(Mitiguy) Consider using this code (or code similar to this) to write

--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -216,7 +216,8 @@ boolean<T> RotationalInertia<
 }
 
 template <typename T>
-std::string RotationalInertia<T>::GetInvalidityReport() const {
+std::optional<std::string> RotationalInertia<T>::CreateInvalidityReport()
+    const {
   // Default return value is an empty string (this RotationalInertia is valid).
   std::string error_message;
   if (IsNaN()) {
@@ -235,6 +236,7 @@ std::string RotationalInertia<T>::GetInvalidityReport() const {
       }
     }
   }
+  if (error_message.empty()) return std::nullopt;
   return error_message;
 }
 
@@ -242,12 +244,12 @@ template <typename T>
 void RotationalInertia<T>::ThrowIfNotPhysicallyValidImpl(
     const char* func_name) const {
   DRAKE_DEMAND(func_name != nullptr);
-  const std::string reason_for_invalidity = GetInvalidityReport();
-  if (!reason_for_invalidity.empty()) {
+  const std::optional<std::string> invalidity_report = CreateInvalidityReport();
+  if (invalidity_report.has_value()) {
     const std::string error_message = fmt::format(
         "{}(): The rotational inertia\n"
         "{}did not pass the test CouldBePhysicallyValid().{}",
-        func_name, *this, reason_for_invalidity);
+        func_name, *this, *invalidity_report);
     throw std::logic_error(error_message);
   }
 }

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -605,8 +605,7 @@ class RotationalInertia {
   ///         calculated (eigenvalue solver) or if scalar type T cannot be
   ///         converted to a double.
   boolean<T> CouldBePhysicallyValid() const {
-    return !IsNaN() &&
-           AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality();
+    return boolean<T>(GetInvalidityReport().empty() == true);
   }
 
   /// Re-expresses `this` rotational inertia `I_BP_E` in place to `I_BP_A`.
@@ -953,6 +952,11 @@ class RotationalInertia {
     const T product_max = product_difference.template lpNorm<Eigen::Infinity>();
     return moment_max <= epsilon && product_max <= epsilon;
   }
+
+  // Returns an error string if `this` RotationalInertia is verifiably invalid
+  // or else returns an empty string (e.g., if unable to test validity because
+  // the type T underlying this method is symbolic).
+  std::string GetInvalidityReport() const;
 
   // Tests whether each moment of inertia is non-negative (to within ε) and
   // tests whether moments of inertia satisfy the triangle-inequality.

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -980,10 +980,6 @@ class RotationalInertia {
 
   // Returns an error string if `this` RotationalInertia is verifiably invalid.
   // Note: Not returning an error string does not _guarantee_ validity.
-  // For numerical type T, validity includes tests that principal moments of
-  // inertia (eigenvalues) are positive and satisfy the triangle inequality.
-  // For symbolic type T, tests are rudimentary (e.g., test for NaN moments or
-  // products of inertia.
   std::optional<std::string> CreateInvalidityReport() const;
 
   // No exception is thrown if type T is Symbolic.

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -605,7 +606,7 @@ class RotationalInertia {
   ///         calculated (eigenvalue solver) or if scalar type T cannot be
   ///         converted to a double.
   boolean<T> CouldBePhysicallyValid() const {
-    return boolean<T>(GetInvalidityReport().empty());
+    return boolean<T>(!CreateInvalidityReport().has_value());
   }
 
   /// Re-expresses `this` rotational inertia `I_BP_E` in place to `I_BP_A`.
@@ -977,15 +978,15 @@ class RotationalInertia {
     return Ixx + epsilon >= 0 && Iyy + epsilon >= 0 && Izz + epsilon >= 0;
   }
 
-  // Returns an error string if `this` RotationalInertia is verifiably invalid
-  // or else returns an empty string (an empty string does not _guarantee_
-  // validity). For numerical type T, validity includes tests that principal
-  // moments of inertia (eigenvalues) are positive and satisfy the triangle
-  // inequality. For symbolic type T, tests are rudimentary (e.g., test for NaN
-  // moments or products of inertia).
-  std::string GetInvalidityReport() const;
+  // Returns an error string if `this` RotationalInertia is verifiably invalid.
+  // Note: Not returning an error string does not _guarantee_ validity.
+  // For numerical type T, validity includes tests that principal moments of
+  // inertia (eigenvalues) are positive and satisfy the triangle inequality.
+  // For symbolic type T, tests are rudimentary (e.g., test for NaN moments or
+  // products of inertia.
+  std::optional<std::string> CreateInvalidityReport() const;
 
-  // Throw an exception if GetInvalidityReport() returns an error string.
+  // Throw an exception if CreateInvalidityReport() returns an error string.
   void ThrowIfNotPhysicallyValidImpl(const char* func_name) const;
 
   // ==========================================================================

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -986,6 +986,13 @@ class RotationalInertia {
   // products of inertia.
   std::optional<std::string> CreateInvalidityReport() const;
 
+  // No exception is thrown if type T is Symbolic.
+  void ThrowIfNotPhysicallyValid(const char* func_name) {
+    if constexpr (scalar_predicate<T>::is_bool) {
+      ThrowIfNotPhysicallyValidImpl(func_name);
+    }
+  }
+
   // Throw an exception if CreateInvalidityReport() returns an error string.
   void ThrowIfNotPhysicallyValidImpl(const char* func_name) const;
 
@@ -994,18 +1001,6 @@ class RotationalInertia {
   // assertions or demands. We do not try to attempt a smart way throw based on
   // a given symbolic::Formula but instead we make these methods a no-throw
   // for non-numeric types.
-
-  // SFINAE for numeric types. See ThrowIfNotPhysicallyValidImpl().
-  template <typename T1 = T>
-  typename std::enable_if_t<scalar_predicate<T1>::is_bool>
-  ThrowIfNotPhysicallyValid(const char* func_name) {
-    ThrowIfNotPhysicallyValidImpl(func_name);
-  }
-
-  // SFINAE for non-numeric types -- does nothing;
-  template <typename T1 = T>
-  typename std::enable_if_t<!scalar_predicate<T1>::is_bool>
-  ThrowIfNotPhysicallyValid(const char*) {}
 
   // Throws an exception if a rotational inertia is multiplied by a negative
   // number - which implies that the resulting rotational inertia is invalid.

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -988,7 +988,13 @@ class RotationalInertia {
   // Throw an exception if GetInvalidityReport() returns an error string.
   void ThrowIfNotPhysicallyValidImpl(const char* func_name) const;
 
-  // SFINAE for numeric types.
+  // ==========================================================================
+  // The following set of methods, ThrowIfSomeCondition(), are used within
+  // assertions or demands. We do not try to attempt a smart way throw based on
+  // a given symbolic::Formula but instead we make these methods a no-throw
+  // for non-numeric types.
+
+  // SFINAE for numeric types. See ThrowIfNotPhysicallyValidImpl().
   template <typename T1 = T>
   typename std::enable_if_t<scalar_predicate<T1>::is_bool>
   ThrowIfNotPhysicallyValid(const char* func_name) {
@@ -999,12 +1005,6 @@ class RotationalInertia {
   template <typename T1 = T>
   typename std::enable_if_t<!scalar_predicate<T1>::is_bool>
   ThrowIfNotPhysicallyValid(const char*) {}
-
-  // ==========================================================================
-  // The following set of methods, ThrowIfSomeCondition(), are used within
-  // assertions or demands. We do not try to attempt a smart way throw based on
-  // a given symbolic::Formula but instead we make these methods a no-throw
-  // for non-numeric types.
 
   // Throws an exception if a rotational inertia is multiplied by a negative
   // number - which implies that the resulting rotational inertia is invalid.

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -131,13 +131,7 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
 
   // Check for a thrown exception with proper error message when creating a
   // rotational inertia with NaN moments/products of inertia.
-  std::string expected_message =
-      "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
-      "\\[nan    0    0\\]\n"
-      "\\[  0   13    0\\]\n"
-      "\\[  0    0   10\\]\n"
-      "did not pass the test CouldBePhysicallyValid\\(\\)\\.\n"
-      "NaN detected in RotationalInertia\\.";
+  std::string expected_message = "[^]*NaN detected in RotationalInertia\\.";
   constexpr double nan = std::numeric_limits<double>::quiet_NaN();
   DRAKE_EXPECT_THROWS_MESSAGE(
       RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -129,9 +129,25 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
           /* skip_validity_check = */ true));
   EXPECT_FALSE(I.CouldBePhysicallyValid());
 
+  // Check for a thrown exception with proper error message when creating a
+  // rotational inertia with NaN moments/products of inertia.
+  std::string expected_message =
+      "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
+      "\\[nan    0    0\\]\n"
+      "\\[  0   13    0\\]\n"
+      "\\[  0    0   10\\]\n"
+      "did not pass the test CouldBePhysicallyValid\\(\\)\\.\n"
+      "NaN detected in RotationalInertia\\.";
+  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          nan, Iyy, Izz, /* Ixy = */ 0, /* Ixz = */ 0, /* Iyz = */ 0,
+          /* skip_validity_check = */ false),
+      expected_message);
+
   // Check for a thrown exception with proper error message when creating an
   // invalid rotational inertia (a principal moment of inertia is negative).
-  std::string expected_message =
+  expected_message =
       "MakeFromMomentsAndProductsOfInertia\\(\\): The rotational inertia\n"
       "\\[ 1  -3  -3\\]\n"
       "\\[-3  13  -6\\]\n"


### PR DESCRIPTION
This PR is work towards a unified and logical sequence for inertia validity checks.
This PR is specifically for RotationalInertia().  
A subsequent one will follow for SpatialInertia() and its cousin in the Geometry class.

All of the testing for validity is delegated to one function, namely GetInvalidityReport().
It reports an empty string if all seems well, otherwise it returns a string with why the inertia is invalid.
This process will be repeated for each of the three classes (RotationalInertia, SpatialInertia, and its cousin in the Geometry class) and provide a better mechanism for error handling and for ensuring that inertia validity checks provide consistently sensible messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22278)
<!-- Reviewable:end -->
