### PR TITLE
Fix typo: UnwrapToContinous => UnwrapToContinuous

### DIFF
--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -726,11 +726,11 @@ void DefinePlanningTrajectoryOptimization(py::module m) {
             py_rvp::reference_internal, cls_doc.graph_of_convex_sets.doc)
         .def_static("NormalizeSegmentTimes", &Class::NormalizeSegmentTimes,
             py::arg("trajectory"), cls_doc.NormalizeSegmentTimes.doc)
-        .def_static("UnwrapToContinousTrajectory",
-            &Class::UnwrapToContinousTrajectory, py::arg("gcs_trajectory"),
+        .def_static("UnwrapToContinuousTrajectory",
+            &Class::UnwrapToContinuousTrajectory, py::arg("gcs_trajectory"),
             py::arg("continuous_revolute_joints"),
             py::arg("starting_rounds") = std::nullopt, py::arg("tol") = 1e-8,
-            cls_doc.UnwrapToContinousTrajectory.doc);
+            cls_doc.UnwrapToContinuousTrajectory.doc);
   }
 
   m.def("GetContinuousRevoluteJointIndices", &GetContinuousRevoluteJointIndices,

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -773,7 +773,7 @@ class TestTrajectoryOptimization(unittest.TestCase):
         traj, result = gcs_wraparound.SolvePath(g1, g2)
         self.assertTrue(result.is_success())
 
-        new_traj = GcsTrajectoryOptimization.UnwrapToContinousTrajectory(
+        new_traj = GcsTrajectoryOptimization.UnwrapToContinuousTrajectory(
             gcs_trajectory=traj,
             continuous_revolute_joints=[0],
             starting_rounds=[43],

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.cc
@@ -2329,7 +2329,7 @@ double UnwrapAngle(const double angle, const int round) {
 }  // namespace
 
 trajectories::CompositeTrajectory<double>
-GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+GcsTrajectoryOptimization::UnwrapToContinuousTrajectory(
     const trajectories::CompositeTrajectory<double>& gcs_trajectory,
     std::vector<int> continuous_revolute_joints,
     std::optional<std::vector<int>> starting_rounds, double tol) {

--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -1330,7 +1330,7 @@ class GcsTrajectoryOptimization final {
    GcsTrajectoryOptimization::SolvePath() is a CompositeTrajectory of
    BezierCurves.
     */
-  static trajectories::CompositeTrajectory<double> UnwrapToContinousTrajectory(
+  static trajectories::CompositeTrajectory<double> UnwrapToContinuousTrajectory(
       const trajectories::CompositeTrajectory<double>& gcs_trajectory,
       std::vector<int> continuous_revolute_joints,
       std::optional<std::vector<int>> starting_rounds = std::nullopt,

--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -1169,7 +1169,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, InvalidSubspace) {
       "Subspace must be a Point or HPolyhedron.");
 }
 
-GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
+GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinuousTrajectory) {
   std::vector<copyable_unique_ptr<trajectories::Trajectory<double>>> segments;
   Eigen::MatrixXd control_points_1(3, 3), control_points_2(3, 3),
       control_points_3(3, 3);
@@ -1193,7 +1193,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
   const auto traj = trajectories::CompositeTrajectory<double>(segments);
   std::vector<int> continuous_revolute_joints = {1, 2};
   const auto unwrapped_traj =
-      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinuousTrajectory(
           traj, continuous_revolute_joints);
   // Small number to shift time around discontinuity points.
   const double time_eps = 1e-7;
@@ -1214,7 +1214,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
                               pos_eps));
   std::vector<int> starting_rounds = {-1, 0};
   const auto unwrapped_traj_with_start =
-      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinuousTrajectory(
           traj, continuous_revolute_joints, starting_rounds, 1e-8);
   // Check if the start is unwrapped to the correct value.
   EXPECT_TRUE(CompareMatrices(unwrapped_traj_with_start.value(0.0),
@@ -1229,7 +1229,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
   // Check for invalid start_rounds
   const std::vector<int> invalid_start_rounds = {-1, 0, 1};
   EXPECT_THROW(
-      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinuousTrajectory(
           traj, continuous_revolute_joints, invalid_start_rounds, 1e-8),
       std::runtime_error);
   // Check for discontinuity for continuous revolute joints
@@ -1244,14 +1244,14 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, UnwrapToContinousTrajectory) {
   // unwrapping will fail.
   continuous_revolute_joints = {0, 1};
   DRAKE_EXPECT_THROWS_MESSAGE(
-      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinuousTrajectory(
           traj_not_continous_on_revolute_manifold, continuous_revolute_joints),
       ".*is not a multiple of 2π at segment.*");
   // If we set the tolerance to be very large, no error will occur. We use a
   // tolerance of 0.6, which is larger than the 0.5 gap between adjacent
   // segments.
   const double loose_tol = 0.6;
-  EXPECT_NO_THROW(GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+  EXPECT_NO_THROW(GcsTrajectoryOptimization::UnwrapToContinuousTrajectory(
       traj_not_continous_on_revolute_manifold, continuous_revolute_joints,
       std::nullopt, loose_tol));
 }
@@ -1271,7 +1271,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, NotBezierCurveError) {
   const auto traj = trajectories::CompositeTrajectory<double>(segments);
   std::vector<int> continuous_revolute_joints = {0};
   DRAKE_EXPECT_THROWS_MESSAGE(
-      GcsTrajectoryOptimization::UnwrapToContinousTrajectory(
+      GcsTrajectoryOptimization::UnwrapToContinuousTrajectory(
           traj, continuous_revolute_joints),
       ".*BezierCurve<double>.*");
 }


### PR DESCRIPTION
It was spelled incorrectly in an impressive number of places, including the public (experimental) API.

fyi @sadraddini

+@SeanCurtis-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22280)
<!-- Reviewable:end -->
