### PR TITLE
[multibody] Better message for pre-Finalize CreateDefaultContext

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -520,6 +520,8 @@ GTEST_TEST(MultibodyPlant, EmptyWorldElements) {
 GTEST_TEST(MultibodyPlantTest, EmptyWorldDiscrete) {
   const double discrete_update_period = 1.0e-3;
   MultibodyPlant<double> plant(discrete_update_period);
+  DRAKE_EXPECT_THROWS_MESSAGE(plant.CreateDefaultContext(),
+                              ".*CreateDefaultContext.*Finalize.*");
   plant.Finalize();
   EXPECT_EQ(plant.num_velocities(), 0);
   EXPECT_EQ(plant.num_positions(), 0);
@@ -539,6 +541,8 @@ GTEST_TEST(MultibodyPlantTest, EmptyWorldDiscrete) {
 
 GTEST_TEST(MultibodyPlantTest, EmptyWorldContinuous) {
   MultibodyPlant<double> plant(0.0);
+  DRAKE_EXPECT_THROWS_MESSAGE(plant.CreateDefaultContext(),
+                              ".*CreateDefaultContext.*Finalize.*");
   plant.Finalize();
   EXPECT_EQ(plant.num_velocities(), 0);
   EXPECT_EQ(plant.num_positions(), 0);

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -75,6 +75,12 @@ void MultibodyTreeSystem<T>::SetDefaultParameters(
     const Context<T>& context, Parameters<T>* parameters) const {
   LeafSystem<T>::SetDefaultParameters(context, parameters);
 
+  if (!already_finalized_) {
+    throw std::logic_error(
+        "MultibodyPlant cannot SetDefaultParameters or CreateDefaultContext "
+        "until after MultibodyPlant::Finalize() has been called.");
+  }
+
   // Mobilizers.
   for (MobodIndex mobilizer_index(0); mobilizer_index < tree_->num_mobilizers();
        ++mobilizer_index) {


### PR DESCRIPTION
This was inspired by a user's trouble report on slack.  The prior message was: `discrete_values.h:201 in get_mutable_vector(): condition '0 <= index && index < num_groups()' failed.`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22283)
<!-- Reviewable:end -->
