### PR TITLE
[multibody] Change resolution hint to speed up joint_locking_test

### DIFF
--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -550,8 +550,8 @@ class FilteredContactResultsTest
         CoulombFriction<double>{1.0, 1.0} /* friction */, &ball_props);
 
     // N.B. these properties go unused if the contact model is kPoint.
-    geometry::AddCompliantHydroelasticProperties(
-        0.1 * radius_, hydroelastic_modulus_, &ball_props);
+    geometry::AddCompliantHydroelasticProperties(radius_, hydroelastic_modulus_,
+                                                 &ball_props);
 
     plant_->RegisterCollisionGeometry(ball, X_BS, geometry::Sphere(radius_),
                                       "collision", std::move(ball_props));


### PR DESCRIPTION
Uses a larger resolution hint in `joint_locking_test` to speed up the test and avoid timeout in debug builds (per CI failure [#199](https://drake-jenkins.csail.mit.edu/view/Nightly/job/linux-noble-gcc-bazel-nightly-everything-debug/199/)).