### PR TITLE
Use yaml's !!binary string for strings as necessary

### DIFF
--- a/bindings/pydrake/common/test/yaml_typed_test.py
+++ b/bindings/pydrake/common/test/yaml_typed_test.py
@@ -38,11 +38,17 @@ class StringStruct:
 
 
 @dc.dataclass
+class PathStruct:
+    value: Path = "/path/to/nowhere"
+
+
+@dc.dataclass
 class AllScalarsStruct:
     some_bool: bool = False
     some_float: float = nan
     some_int: int = 11
     some_str: str = "nominal_string"
+    some_path: Path = "/path/to/nowhere"
 
 
 @dc.dataclass
@@ -231,17 +237,57 @@ class TestYamlTypedRead(unittest.TestCase,
                                 **options)
 
     @run_with_multiple_values(_all_typed_read_options())
+    def test_read_path(self, *, options):
+        cases = [
+            ("no_directory.txt", None),
+            ("/absolute/path/file.txt", None),
+            ("\"\"", "."),
+            ("!!str", "."),
+            (".", "."),
+            ("/non_lexical//path", "/non_lexical/path"),
+            ("/quoted\"/path", None),
+            ("\"1234\"", "1234"),
+            ("'1234'", "1234"),
+            ("!!str 1234", "1234"),
+            ("\"1234.5\"", "1234.5"),
+            ("'1234.5'", "1234.5"),
+            ("!!str 1234.5", "1234.5"),
+            ("\"true\"", "true"),
+            ("'true'", "true"),
+            ("!!str true", "true"),
+        ]
+        for value, maybe_expected in cases:
+            data = f"value: {value}"
+            x = yaml_load_typed(schema=PathStruct, data=data, **options)
+            expected = value if maybe_expected is None else maybe_expected
+            self.assertEqual(x.value, Path(expected))
+
+    @run_with_multiple_values(_all_typed_read_options())
+    def test_read_path_missing(self, *, options):
+        if options["allow_schema_with_no_yaml"]:
+            default_value = PathStruct()
+            x = yaml_load_typed(schema=PathStruct, data="{}",
+                                **options)
+            self.assertEqual(x.value, default_value.value, msg=repr(x.value))
+        else:
+            with self.assertRaisesRegex(RuntimeError, ".*missing.*"):
+                yaml_load_typed(schema=PathStruct, data="{}",
+                                **options)
+
+    @run_with_multiple_values(_all_typed_read_options())
     def test_read_all_scalars(self, *, options):
         data = dedent("""
         some_bool: true
         some_float: 101.0
         some_int: 102
+        some_path: /alternative/path
         some_str: foo
         """)
         x = yaml_load_typed(schema=AllScalarsStruct, data=data, **options)
         self.assertEqual(x.some_bool, True)
         self.assertEqual(x.some_float, 101.0)
         self.assertEqual(x.some_int, 102)
+        self.assertEqual(x.some_path, Path("/alternative/path"))
         self.assertEqual(x.some_str, "foo")
 
     @run_with_multiple_values(_all_typed_read_options())
@@ -734,6 +780,20 @@ class TestYamlTypedWrite(unittest.TestCase):
         ]
         for value, expected_str in cases:
             actual_doc = yaml_dump_typed(StringStruct(value=value))
+            expected_doc = f"value: {expected_str}\n"
+            self.assertEqual(actual_doc, expected_doc)
+
+    def test_write_path(self):
+        cases = [
+            (Path(""), "."),
+            (Path("/absolute/path"), "/absolute/path"),
+            (Path("relative/path"), "relative/path"),
+            (Path("1234"), "'1234'"),
+            (Path("1234.5"), "'1234.5'"),
+            (Path("true"), "'true'"),
+        ]
+        for value, expected_str in cases:
+            actual_doc = yaml_dump_typed(PathStruct(value=value))
             expected_doc = f"value: {expected_str}\n"
             self.assertEqual(actual_doc, expected_doc)
 

--- a/bindings/pydrake/common/yaml.py
+++ b/bindings/pydrake/common/yaml.py
@@ -5,6 +5,7 @@ import math
 import functools
 import types
 import typing
+from pathlib import Path
 
 import numpy as np
 import yaml
@@ -313,6 +314,12 @@ def _merge_yaml_dict_item_into_target(*, options, name, yaml_value,
         _merge_yaml_dict_item_into_target(
             options=options, name=name, yaml_value=yaml_value, target=target,
             value_schema=nested_optional_type)
+        return
+
+    # Handle pathlib.Path.
+    if value_schema == Path:
+        new_value = Path(yaml_value)
+        setter(new_value)
         return
 
     # Handle NumPy types.
@@ -664,6 +671,10 @@ def _yaml_dump_typed_item(*, obj, schema):
                 class_name = class_name_with_args.split("[", 1)[0]
                 result["_tag"] = "!" + class_name
         return result
+
+    # Handle pathlib.Path types.
+    if schema == Path:
+        return str(obj)
 
     # Handle NumPy types.
     if schema == np.ndarray:

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -979,6 +979,8 @@ drake_cc_googletest(
     name = "file_source_test",
     deps = [
         ":file_source",
+        "//common/test_utilities:expect_throws_message",
+        "//common/yaml:yaml_io",
     ],
 )
 
@@ -1099,6 +1101,8 @@ drake_cc_googletest(
         ":find_resource",
         ":memory_file",
         ":temp_directory",
+        "//common/test_utilities:expect_throws_message",
+        "//common/yaml:yaml_io",
     ],
 )
 

--- a/common/memory_file.h
+++ b/common/memory_file.h
@@ -67,6 +67,16 @@ class MemoryFile final {
    any number less than or equal to zero. */
   std::string to_string(int contents_limit = 100) const;
 
+  /** Serialization stub.
+
+   %MemoryFile cannot actually be serialized yet. Attempting to do will throw.
+   This stub merely permits FileSource to be serialized (when it contains a
+   `std::filesystem::path`). */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    throw std::runtime_error("Serialization for MemoryFile not yet supported.");
+  }
+
  private:
   reset_after_move<std::string> contents_;
 

--- a/common/test/file_source_test.cc
+++ b/common/test/file_source_test.cc
@@ -1,9 +1,24 @@
 #include "drake/common/file_source.h"
 
+#include <filesystem>
+
 #include <gtest/gtest.h>
+
+#include "drake/common/memory_file.h"
+#include "drake/common/name_value.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/yaml_io.h"
 
 namespace drake {
 namespace {
+
+namespace fs = std::filesystem;
+
+/* We want to lock down the idea that the default value is an empty path. */
+GTEST_TEST(FileSourceTest, DefaultPath) {
+  FileSource dut;
+  EXPECT_TRUE(std::holds_alternative<std::filesystem::path>(dut));
+}
 
 GTEST_TEST(FileSourceTest, ToString) {
   EXPECT_EQ(to_string(FileSource("a/b/c")), "\"a/b/c\"");
@@ -13,5 +28,32 @@ GTEST_TEST(FileSourceTest, ToString) {
   EXPECT_EQ(to_string(FileSource(file)), file.to_string());
   EXPECT_EQ(fmt::to_string(FileSource(file)), file.to_string());
 }
+
+/* Quick and dirty struct that has a FileSource and can be serialized. */
+struct HasFileSource {
+  template <typename Archive>
+  void Serialize(Archive* archive) {
+    archive->Visit(DRAKE_NVP(source));
+  }
+  FileSource source;
+};
+
+/* The path value gets (de)serialized. */
+GTEST_TEST(FileSourceTest, SerializePath) {
+  const HasFileSource dut{.source = fs::path("/some/path")};
+  const std::string y = yaml::SaveYamlString(dut);
+  const auto decoded = yaml::LoadYamlString<HasFileSource>(y);
+  ASSERT_TRUE(std::holds_alternative<fs::path>(decoded.source));
+  EXPECT_EQ(std::get<fs::path>(dut.source), std::get<fs::path>(decoded.source));
+}
+
+/* The MemoryFile value simply throws (see MemoryFile implementation). */
+GTEST_TEST(FileSourceTest, SerializeMemoryFile) {
+  const HasFileSource dut{.source = MemoryFile("stuff", ".ext", "hint")};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      yaml::SaveYamlString(dut),
+      "Serialization for MemoryFile not yet supported.");
+}
+
 }  // namespace
 }  // namespace drake

--- a/common/test/memory_file_test.cc
+++ b/common/test/memory_file_test.cc
@@ -7,6 +7,8 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/yaml_io.h"
 
 namespace drake {
 namespace {
@@ -107,6 +109,14 @@ GTEST_TEST(MemoryFileTest, ToString) {
   EXPECT_THAT(file.to_string(5), testing::HasSubstr("\"<01234...>\""));
 
   EXPECT_THAT(fmt::to_string(file), testing::HasSubstr("\"0123456789\""));
+}
+
+/* Serialization compiles but throws. */
+GTEST_TEST(MemoryFileTest, SerializationThrows) {
+  const MemoryFile dut("stuff", ".ext", "hint");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      yaml::SaveYamlString(dut),
+      "Serialization for MemoryFile not yet supported.");
 }
 
 }  // namespace

--- a/common/yaml/test/example_structs.h
+++ b/common/yaml/test/example_structs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <filesystem>
 #include <map>
 #include <optional>
 #include <ostream>
@@ -60,6 +61,20 @@ bool operator==(const StringStruct& a, const StringStruct& b) {
   return a.value == b.value;
 }
 
+struct PathStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  std::filesystem::path value{"/path/to/nowhere"};
+};
+
+// This is used only for EXPECT_EQ, not by any YAML operations.
+bool operator==(const PathStruct& a, const PathStruct& b) {
+  return a.value == b.value;
+}
+
 struct AllScalarsStruct {
   template <typename Archive>
   void Serialize(Archive* a) {
@@ -71,6 +86,7 @@ struct AllScalarsStruct {
     a->Visit(DRAKE_NVP(some_int64));
     a->Visit(DRAKE_NVP(some_uint64));
     a->Visit(DRAKE_NVP(some_string));
+    a->Visit(DRAKE_NVP(some_path));
   }
 
   bool some_bool = false;
@@ -81,6 +97,7 @@ struct AllScalarsStruct {
   int64_t some_int64 = 14;
   uint64_t some_uint64 = 15;
   std::string some_string = "kNominalString";
+  std::filesystem::path some_path{"/path/to/nowhere"};
 };
 
 struct ArrayStruct {

--- a/common/yaml/test/json_test.cc
+++ b/common/yaml/test/json_test.cc
@@ -19,6 +19,7 @@ GTEST_TEST(YamlJsonTest, WriteScalars) {
                                   R"""("some_float":1.2345,)"""
                                   R"""("some_int32":12,)"""
                                   R"""("some_int64":14,)"""
+                                  R"""("some_path":"/path/to/nowhere",)"""
                                   R"""("some_string":"kNominalString",)"""
                                   R"""("some_uint32":12,)"""
                                   R"""("some_uint64":15})""");

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -199,6 +199,19 @@ TEST_P(YamlReadArchiveTest, Path) {
   test("true");
 }
 
+// Decode base64 strings automatically.
+TEST_P(YamlReadArchiveTest, String) {
+  const auto test = [](const std::string& value, const std::string& expected) {
+    const auto& x = AcceptNoThrow<StringStruct>(LoadSingleValue(value));
+    EXPECT_EQ(x.value, expected);
+  };
+
+  test("all printable", "all printable");
+  test("\"\\tall\\nprintable\\r  char\"", "\tall\nprintable\r  char");
+  test("!!binary Tm9uUHJpbnRhYmxlAw==", "NonPrintable\x03");
+  test("!!binary |\n    Tm9uUHJpbnRhYmxlAw==", "NonPrintable\x03");
+}
+
 TEST_P(YamlReadArchiveTest, PathMissing) {
   const PathStruct default_path;
   const auto& x = AcceptEmptyDoc<PathStruct>();

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -76,6 +76,12 @@ TEST_F(YamlWriteArchiveTest, String) {
 
   test("a", "a");
   test("1", "1");
+  test("\twith\nnew\r  line", "\"\\twith\\nnew\\r  line\"");
+  test(
+      R"""(multi
+  lines)""",
+      "\"multi\\n  lines\"");
+  test("NonPrintable\x03", "!!binary Tm9uUHJpbnRhYmxlAw==");
 }
 
 TEST_F(YamlWriteArchiveTest, Path) {

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/yaml/yaml_write_archive.h"
 
+#include <filesystem>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -75,6 +76,21 @@ TEST_F(YamlWriteArchiveTest, String) {
 
   test("a", "a");
   test("1", "1");
+}
+
+TEST_F(YamlWriteArchiveTest, Path) {
+  const auto test = [](const std::filesystem::path& value,
+                       const std::string& expected) {
+    const PathStruct x{value};
+    EXPECT_EQ(Save(x), WrapDoc(expected));
+  };
+
+  test("", ".");
+  test("/absolute/path", "/absolute/path");
+  test("relative/path", "relative/path");
+  test("1234", "!!str 1234");
+  test("1234.5", "!!str 1234.5");
+  test("true", "!!str true");
 }
 
 TEST_F(YamlWriteArchiveTest, StdArray) {

--- a/common/yaml/yaml_node.cc
+++ b/common/yaml/yaml_node.cc
@@ -147,6 +147,8 @@ std::string_view Node::GetTag() const {
                 return kTagFloat;
               case JsonSchemaTag::kStr:
                 return kTagStr;
+              case JsonSchemaTag::kBinary:
+                return kTagBinary;
             }
             DRAKE_UNREACHABLE();
           },

--- a/common/yaml/yaml_node.h
+++ b/common/yaml/yaml_node.h
@@ -71,6 +71,11 @@ enum class JsonSchemaTag {
   kFloat,
   // https://yaml.org/spec/1.2.2/#generic-string
   kStr,
+  // Note: this isn't one of the json schema tags, properly. It is a valid
+  // yaml tag which is treated the same as the json tags when reading/writing
+  // data.
+  // https://yaml.org/type/binary.html
+  kBinary,
 };
 
 /* Data type that represents a YAML node.  A Node can hold one of three
@@ -170,6 +175,9 @@ class Node final {
 
   // https://yaml.org/spec/1.2.2/#generic-string
   static constexpr std::string_view kTagStr{"tag:yaml.org,2002:str"};
+
+  // https://yaml.org/type/binary.html
+  static constexpr std::string_view kTagBinary{"tag:yaml.org,2002:binary"};
 
   /* Sets the filename where this Node was read from. A nullopt indicates that
   the filename is not known. */

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -265,6 +265,12 @@ void YamlReadArchive::ParseScalar(const std::string& value,
   *result = value;
 }
 
+void YamlReadArchive::ParseScalar(const std::string& value,
+                                  std::filesystem::path* result) {
+  DRAKE_DEMAND(result != nullptr);
+  *result = value;
+}
+
 const internal::Node* YamlReadArchive::MaybeGetSubNode(const char* name) const {
   DRAKE_DEMAND(name != nullptr);
   if (mapish_item_key_ != nullptr) {

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -124,10 +124,18 @@ internal::Node ConvertJbederYamlNodeToDrakeYamlNode(const YAML::Node& parent,
       return internal::Node::MakeNull();
     }
     case YAML::NodeType::Scalar: {
-      auto result = internal::Node::MakeScalar(node.Scalar());
-      result.SetTag(node.Tag());
-      result.SetMark(mark);
-      return result;
+      if (node.Tag() == Node::kTagBinary) {
+        std::vector<unsigned char> decoded = YAML::DecodeBase64(node.Scalar());
+        auto result = internal::Node::MakeScalar(
+            std::string(decoded.begin(), decoded.end()));
+        result.SetMark(mark);
+        return result;
+      } else {
+        auto result = internal::Node::MakeScalar(node.Scalar());
+        result.SetTag(node.Tag());
+        result.SetMark(mark);
+        return result;
+      }
     }
     case YAML::NodeType::Sequence: {
       auto result = internal::Node::MakeSequence();

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <filesystem>
 #include <map>
 #include <optional>
 #include <ostream>
@@ -516,6 +517,7 @@ class YamlReadArchive final {
   void ParseScalar(const std::string& value, int64_t* result);
   void ParseScalar(const std::string& value, uint64_t* result);
   void ParseScalar(const std::string& value, std::string* result);
+  void ParseScalar(const std::string& value, std::filesystem::path* result);
 
   template <typename T>
   void ParseScalarImpl(const std::string& value, T* result);

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -223,6 +223,10 @@ class YamlWriteArchive final {
   // be conditioned so it doesn't get misinterpreted when read.
   void VisitPathScalar(const char* name, std::filesystem::path value);
 
+  // If the string has non-printable characters, it will be written as binary
+  // data (e.g., with the !!binary tag and encoded in base64).
+  void VisitStringScalar(const char* name, std::string value);
+
   // This is used for simple types that can be converted to a string.
   template <typename NVP>
   void VisitScalar(const NVP& nvp) {
@@ -236,6 +240,11 @@ class YamlWriteArchive final {
       auto scalar = internal::Node::MakeScalar(std::move(value_str));
       scalar.SetTag(internal::JsonSchemaTag::kFloat);
       root_.Add(nvp.name(), std::move(scalar));
+      return;
+    }
+
+    if constexpr (std::is_same_v<T, std::string>) {
+      VisitStringScalar(nvp.name(), std::move(value));
       return;
     }
 


### PR DESCRIPTION
When a string has non-printable characters, the string automatically gets
encoded in YAML's binary encoding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22298)
<!-- Reviewable:end -->
