### PR TITLE
Fix error spew in sdf parsing

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1045,7 +1045,7 @@ void DrakeVisualToSdfVisual(const SDFormatDiagnostic& diagnostic,
                             const sdf::ParserConfig& parser_config,
                             sdf::Link* link) {
   sdf::ElementPtr link_element = link->Element();
-  sdf::ElementPtr drake_visual = link_element->GetElement("drake:visual");
+  sdf::ElementPtr drake_visual = link_element->FindElement("drake:visual");
   while (drake_visual != nullptr) {
     if (DrakeVisualToSdfVisualRecurse(diagnostic, drake_visual)) {
       // Stash an attribute into the element that we can use later to recognize


### PR DESCRIPTION
ElementPtr::GetElement() adds an element if missing. FindElement() simply returns it. The addition of imaginary elements was causing sdformat to spew errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22301)
<!-- Reviewable:end -->
