### PR TITLE
[pydrake] Shorten memory_leak_test to mitigate timeouts

### DIFF
--- a/bindings/pydrake/test/memory_leak_test.py
+++ b/bindings/pydrake/test/memory_leak_test.py
@@ -331,4 +331,4 @@ class TestMemoryLeaks(unittest.TestCase):
 
     def test_full_example(self):
         # Note: this test doesn't invoke the #14355 deliberate cycle.
-        self.do_test(dut=_dut_full_example, count=2)
+        self.do_test(dut=_dut_full_example, count=1)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22313)
<!-- Reviewable:end -->
