### PR TITLE
Adds SparseMatrixGain as a primitive system.

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -494,6 +494,7 @@ drake_py_unittest(
         ":test_util_py",
         "//bindings/pydrake:trajectories_py",
         "//bindings/pydrake/common/test_utilities:numpy_compare_py",
+        "//bindings/pydrake/common/test_utilities:scipy_stub_py",
     ],
 )
 

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -26,6 +26,7 @@
 #include "drake/systems/primitives/saturation.h"
 #include "drake/systems/primitives/shared_pointer_system.h"
 #include "drake/systems/primitives/sine.h"
+#include "drake/systems/primitives/sparse_matrix_gain.h"
 #include "drake/systems/primitives/symbolic_vector_system.h"
 #include "drake/systems/primitives/trajectory_affine_system.h"
 #include "drake/systems/primitives/trajectory_linear_system.h"
@@ -395,6 +396,18 @@ PYBIND11_MODULE(primitives, m) {
         .def(py::init<const VectorX<T>&, const VectorX<T>&>(),
             py::arg("min_value"), py::arg("max_value"),
             doc.Saturation.ctor.doc_2args);
+
+    DefineTemplateClassWithDefault<SparseMatrixGain<T>, LeafSystem<T>>(
+        m, "SparseMatrixGain", GetPyParam<T>(), doc.SparseMatrixGain.doc)
+        .def(py::init([](const Eigen::SparseMatrix<double>& D) {
+          // Our interactions with scipy don't work yet with (0,N) matrices.
+          DRAKE_THROW_UNLESS(D.rows() > 0 || D.cols() == 0);
+          return std::make_unique<SparseMatrixGain<T>>(D);
+        }),
+            py::arg("D"), doc.SparseMatrixGain.ctor.doc)
+        .def("D", &SparseMatrixGain<T>::D, doc.SparseMatrixGain.D.doc)
+        .def("set_D", &SparseMatrixGain<T>::set_D, py::arg("D"),
+            doc.SparseMatrixGain.set_D.doc);
 
     DefineTemplateClassWithDefault<StateInterpolatorWithDiscreteDerivative<T>,
         Diagram<T>>(m, "StateInterpolatorWithDiscreteDerivative",

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -1,4 +1,5 @@
 import gc
+import scipy.sparse
 import unittest
 import numpy as np
 
@@ -52,6 +53,7 @@ from pydrake.systems.primitives import (
     Saturation, Saturation_,
     SharedPointerSystem, SharedPointerSystem_,
     Sine, Sine_,
+    SparseMatrixGain_,
     StateInterpolatorWithDiscreteDerivative,
     StateInterpolatorWithDiscreteDerivative_,
     SymbolicVectorSystem, SymbolicVectorSystem_,
@@ -762,6 +764,38 @@ class TestGeneral(unittest.TestCase):
         discrete_derivative = DiscreteDerivative(
             num_inputs=5, time_step=0.5, suppress_initial_transient=False)
         self.assertFalse(discrete_derivative.suppress_initial_transient())
+
+    @numpy_compare.check_all_types
+    def test_sparse_matrix_gain(self, T):
+        D = scipy.sparse.csc_matrix(
+            (np.array([2, 1., 3]), np.array([0, 1, 0]),
+             np.array([0, 2, 2, 3])), shape=(2, 3))
+        dut = SparseMatrixGain_[T](D=D)
+        context = dut.CreateDefaultContext()
+        u = np.array([1, 2, 3])
+        dut.get_input_port().FixValue(context, u)
+        y = dut.get_output_port().Eval(context)
+        numpy_compare.assert_float_equal(y, D.todense() @ u)
+
+        numpy_compare.assert_float_equal(D.todense(), dut.D().todense())
+        D2 = scipy.sparse.csc_matrix(
+            (np.array([1, 4, 6]), np.array([0, 1, 0]),
+             np.array([0, 2, 2, 3])), shape=(2, 3))
+        dut.set_D(D=D2)
+        numpy_compare.assert_float_equal(D2.todense(), dut.D().todense())
+
+        # Make sure empty matrices work as expected.
+        D00 = scipy.sparse.csc_matrix(([], [], []), shape=(0, 0))
+        # Having zero rows doesn't work yet...
+        # D01 = scipy.sparse.csc_matrix(([], [], [0]), shape=(0, 1))
+        D10 = scipy.sparse.csc_matrix(([1.2], [0], [0]), shape=(1, 0))
+        for D in [D00, D10]:
+            dut = SparseMatrixGain_[T](D=D)
+            context = dut.CreateDefaultContext()
+            u = np.ones((D.shape[1], 1))
+            dut.get_input_port().FixValue(context, u)
+            y = dut.get_output_port().Eval(context)
+            self.assertEqual(y.size, D.shape[0])
 
     def test_state_interpolator_with_discrete_derivative(self):
         state_interpolator = StateInterpolatorWithDiscreteDerivative(

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_package_library(
         ":saturation",
         ":shared_pointer_system",
         ":sine",
+        ":sparse_matrix_gain",
         ":symbolic_vector_system",
         ":trajectory_affine_system",
         ":trajectory_linear_system",
@@ -285,6 +286,15 @@ drake_cc_library(
     deps = [
         "//systems/framework:diagram_builder",
         "//systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_library(
+    name = "sparse_matrix_gain",
+    srcs = ["sparse_matrix_gain.cc"],
+    hdrs = ["sparse_matrix_gain.h"],
+    deps = [
+        "//systems/framework",
     ],
 )
 
@@ -695,6 +705,16 @@ drake_cc_googletest(
     name = "shared_pointer_system_test",
     deps = [
         ":shared_pointer_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sparse_matrix_gain_test",
+    deps = [
+        ":sparse_matrix_gain",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework",
+        "//systems/framework/test_utilities",
     ],
 )
 

--- a/systems/primitives/sparse_matrix_gain.cc
+++ b/systems/primitives/sparse_matrix_gain.cc
@@ -1,0 +1,38 @@
+#include "drake/systems/primitives/sparse_matrix_gain.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+SparseMatrixGain<T>::SparseMatrixGain(const Eigen::SparseMatrix<double>& D)
+    : LeafSystem<T>(SystemTypeTag<SparseMatrixGain>{}), D_(D) {
+  InputPortIndex u_index =
+      this->DeclareVectorInputPort("u", D.cols()).get_index();
+  this->DeclareVectorOutputPort("y", D.rows(), &SparseMatrixGain<T>::CalcOutput,
+                                {this->input_port_ticket(u_index)});
+}
+
+template <typename T>
+SparseMatrixGain<T>::~SparseMatrixGain() = default;
+
+template <typename T>
+template <typename U>
+SparseMatrixGain<T>::SparseMatrixGain(const SparseMatrixGain<U>& other)
+    : SparseMatrixGain<T>(other.D()) {}
+
+template <typename T>
+void SparseMatrixGain<T>::CalcOutput(const Context<T>& context,
+                                     BasicVector<T>* output_vector) const {
+  DRAKE_THROW_UNLESS(this->get_input_port().HasValue(context));
+  const BasicVector<T>* u = this->EvalVectorInput(context, 0);
+  DRAKE_DEMAND(u != nullptr);
+  output_vector->SetFromVector(D_ * u->value());
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::SparseMatrixGain);

--- a/systems/primitives/sparse_matrix_gain.h
+++ b/systems/primitives/sparse_matrix_gain.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <Eigen/SparseCore>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+// TODO(russt): Consider deriving from LinearSystem, but see the draft and
+// discussion at https://github.com/RobotLocomotion/drake/pull/21591 which
+// emphasized that we need to avoid performance degredation for dense matrices
+// in AffineSystem.
+
+/// A variant of MatrixGain which supports multiplication by SparseMatrix, `D`.
+/// Specifically, given an input signal `u` and a state `x`, the output of this
+/// system, `y`, is:
+///
+/// @f[
+///   y = D u
+/// @f]
+///
+/// Note that, unlike MatrixGain, this system is not derived from LinearSystem
+/// (which does not yet support sparse matrices). However, we use `D` as the
+/// name for the gain matrix here to be consistent.
+///
+/// @system
+/// name: SparseMatrixGain
+/// input_ports:
+/// - u
+/// output_ports:
+/// - y
+/// @endsystem
+///
+/// @tparam_default_scalar
+/// @ingroup primitive_systems
+///
+/// @see MatrixGain
+template <typename T>
+class SparseMatrixGain final : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SparseMatrixGain);
+
+  /// A constructor where the gain matrix `D` is @p D.
+  explicit SparseMatrixGain(const Eigen::SparseMatrix<double>& D);
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit SparseMatrixGain(const SparseMatrixGain<U>&);
+
+  ~SparseMatrixGain() final;
+
+  /// Getter for the gain matrix `D`.
+  const Eigen::SparseMatrix<double>& D() const { return D_; }
+
+  // Note: we use a setter instead of returning a mutable D to simplify the
+  // python bindings.
+
+  /// Setter for the gain matrix `D`.
+  void set_D(const Eigen::SparseMatrix<double>& D) { D_ = D; }
+
+ private:
+  void CalcOutput(const Context<T>& context,
+                  BasicVector<T>* output_vector) const;
+
+  Eigen::SparseMatrix<double> D_{};
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/test/sparse_matrix_gain_test.cc
+++ b/systems/primitives/test/sparse_matrix_gain_test.cc
@@ -1,0 +1,73 @@
+#include "drake/systems/primitives/sparse_matrix_gain.h"
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using Eigen::SparseMatrix;
+
+// Tests that the outputs are correctly computed.
+GTEST_TEST(MatrixGainTest, BasicTest) {
+  SparseMatrix<double> D = (Eigen::Matrix<double, 2, 3>() << 0, 1, 2, 3, 4, 0)
+                               .finished()
+                               .sparseView();
+  SparseMatrixGain<double> dut(D);
+
+  EXPECT_EQ(dut.get_input_port().size(), 3);
+  EXPECT_EQ(dut.get_output_port().size(), 2);
+  EXPECT_TRUE(CompareMatrices(dut.D().toDense(), D.toDense()));
+
+  auto context = dut.CreateDefaultContext();
+
+  const Eigen::Vector3d u(2.17, 5.99, 1.32);
+  dut.get_input_port().FixValue(context.get(), u);
+  EXPECT_TRUE(CompareMatrices(dut.get_output_port().Eval(*context), D * u));
+
+  SparseMatrix<double> D2 = (Eigen::Matrix<double, 2, 3>() << 1, 3, 0, 0, 3, 0)
+                                .finished()
+                                .sparseView();
+  dut.set_D(D2);
+  EXPECT_TRUE(CompareMatrices(dut.D().toDense(), D2.toDense()));
+}
+
+GTEST_TEST(MatrixGainTest, EmptyMatrix) {
+  // Intentionally include (0, 0), (0, 1), and (1, 0) matrices to make sure
+  // empty matrices are handled correctly.
+  for (int rows = 0; rows < 2; ++rows) {
+    for (int cols = 0; cols < 2; ++cols) {
+      SparseMatrix<double> D(rows, cols);
+      SparseMatrixGain<double> dut(D);
+
+      EXPECT_EQ(dut.get_input_port().size(), cols);
+      EXPECT_EQ(dut.get_output_port().size(), rows);
+
+      auto context = dut.CreateDefaultContext();
+      const Eigen::VectorXd u = Eigen::VectorXd::Ones(cols);
+      dut.get_input_port().FixValue(context.get(), u);
+      EXPECT_TRUE(CompareMatrices(dut.get_output_port().Eval(*context),
+                                  D.toDense() * u));
+    }
+  }
+}
+
+// Tests converting to different scalar types.
+GTEST_TEST(SparseMatrixGainTest, ConvertScalarType) {
+  SparseMatrix<double> D = (Eigen::Matrix<double, 2, 3>() << 0, 1, 2, 3, 4, 0)
+                               .finished()
+                               .sparseView();
+  SparseMatrixGain<double> dut(D);
+
+  EXPECT_TRUE(is_autodiffxd_convertible(dut, [&](const auto& converted) {
+    EXPECT_EQ(converted.D().toDense(), D.toDense());
+  }));
+  EXPECT_TRUE(is_symbolic_convertible(dut, [&](const auto& converted) {
+    EXPECT_EQ(converted.D().toDense(), D.toDense());
+  }));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
In service of #20971 (to support using a sparse actuation matrix in controllers). This is a follow-up to a previous failed attempt in of LinearSystem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22314)
<!-- Reviewable:end -->
