### PR TITLE
Fixes up InverseDynamicsController to use the actuation matrix

### DIFF
--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -138,6 +138,10 @@ PYBIND11_MODULE(controllers, m) {
             cls_doc.get_input_port_desired_state.doc)
         .def("get_output_port_control", &Class::get_output_port_control,
             py_rvp::reference_internal, cls_doc.get_output_port_control.doc)
+        .def("get_output_port_generalized_force",
+            &Class::get_output_port_generalized_force,
+            py_rvp::reference_internal,
+            cls_doc.get_output_port_generalized_force.doc)
         .def("get_multibody_plant_for_control",
             &Class::get_multibody_plant_for_control, py_rvp::reference_internal,
             cls_doc.get_multibody_plant_for_control.doc);

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -273,6 +273,8 @@ class TestControllers(unittest.TestCase):
             builder.ExportInput(
                 controller.get_input_port_desired_state(), "x_desired")
             builder.ExportOutput(controller.get_output_port_control(), "u")
+            builder.ExportOutput(
+                controller.get_output_port_generalized_force(), "tau")
             diagram = builder.Build()
             return diagram
 

--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -87,7 +87,7 @@ drake_cc_library(
         "//systems/primitives:adder",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:demultiplexer",
-        "//systems/primitives:pass_through",
+        "//systems/primitives:sparse_matrix_gain",
     ],
 )
 

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -28,22 +28,19 @@ class InverseDynamicsControllerTest : public ::testing::Test {
                           const VectorX<double>& kp, const VectorX<double>& ki,
                           const VectorX<double>& kd,
                           const Context<double>* robot_context = nullptr) {
-    EXPECT_EQ(test_sys->get_output_port().get_index(), 0);
-
     auto inverse_dynamics_context = test_sys->CreateDefaultContext();
-    auto output = test_sys->AllocateOutput();
     const MultibodyPlant<double>& robot_plant =
         *test_sys->get_multibody_plant_for_control();
 
     // Sets current state and reference state and acceleration values.
     const int dim = robot_plant.num_positions();
     VectorX<double> q(dim), v(dim), q_r(dim), v_r(dim), vd_r(dim);
-    q << 0.3, 0.2, 0.1, 0, -0.1, -0.2, -0.3;
+    q = Eigen::VectorXd::LinSpaced(dim, 0.3, -0.3);
     v = q * 3;
 
     q_r = (q + VectorX<double>::Constant(dim, 0.1)) * 2.;
     v_r.setZero();
-    vd_r << 1, 2, 3, 4, 5, 6, 7;
+    vd_r = Eigen::VectorXd::LinSpaced(dim, 1, dim);
 
     // Connects inputs.
     VectorX<double> state_input(robot_plant.num_positions() +
@@ -65,12 +62,8 @@ class InverseDynamicsControllerTest : public ::testing::Test {
         inverse_dynamics_context.get(), reference_acceleration_input);
 
     // Sets integrated position error.
-    VectorX<double> q_int(dim);
-    q_int << -1, -2, -3, -4, -5, -6, -7;
+    VectorX<double> q_int = Eigen::VectorXd::LinSpaced(dim, -1, -7);
     test_sys->set_integral_value(inverse_dynamics_context.get(), q_int);
-
-    // Computes output.
-    test_sys->CalcOutput(*inverse_dynamics_context, output.get());
 
     // The results should equal to this.
     VectorX<double> vd_d = (kp.array() * (q_r - q).array()).matrix() +
@@ -80,12 +73,23 @@ class InverseDynamicsControllerTest : public ::testing::Test {
     std::unique_ptr<Context<double>> workspace_context =
         robot_context == nullptr ? robot_plant.CreateDefaultContext()
                                  : robot_context->Clone();
-    VectorX<double> expected_torque = controllers_test::ComputeTorque(
-        robot_plant, q, v, vd_d, workspace_context.get());
+    VectorX<double> expected_generalized_force =
+        controllers_test::ComputeTorque(robot_plant, q, v, vd_d,
+                                        workspace_context.get());
+    Eigen::VectorXd expected_actuation =
+        robot_plant.MakeActuationMatrixPseudoinverse() *
+        expected_generalized_force;
 
     // Checks the expected and computed gravity torque.
-    const BasicVector<double>* output_vector = output->get_vector_data(0);
-    EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->get_value(),
+    const Eigen::VectorXd& actuation =
+        test_sys->get_output_port_control().Eval(*inverse_dynamics_context);
+    EXPECT_TRUE(CompareMatrices(expected_actuation, actuation, 1e-10,
+                                MatrixCompareType::absolute));
+
+    const Eigen::VectorXd& generalized_force =
+        test_sys->get_output_port_generalized_force().Eval(
+            *inverse_dynamics_context);
+    EXPECT_TRUE(CompareMatrices(expected_generalized_force, generalized_force,
                                 1e-10, MatrixCompareType::absolute));
   }
 };
@@ -172,6 +176,48 @@ TEST_F(InverseDynamicsControllerTest,
       std::move(robot), kp, ki, kd, true, custom_context.get());
 
   ConfigTestAndCheck(dut.get(), kp, ki, kd, custom_context.get());
+}
+
+// Tests the case when the actuators are ordered differently than the
+// generalized forces (so B is not the identity matrix).
+TEST_F(InverseDynamicsControllerTest, ActuatorOrder) {
+  std::string xml = R"""(
+<mujoco model="test">
+  <worldbody>
+    <body name="upper_arm" pos="0 0 2">
+      <joint name="shoulder" type="hinge" axis="0 1 0"/>
+      <geom name="upper_arm" fromto="0 0 0 0 0 1" size="0.05" type="capsule" mass="1"/>
+      <body name="lower_arm" pos="0 0 1">
+        <joint name="elbow" type="hinge" axis="0 1 0"/>
+        <geom name="lower_arm" fromto="0 0 0 0 0 1" size="0.049" type="capsule" mass="1"/>
+      </body>
+    </body>
+  </worldbody>
+   <actuator>
+    <!-- intentionally list these in reverse order -->
+    <motor name="elbow" joint="elbow"/>
+    <motor name="shoulder" joint="shoulder"/>
+  </actuator>
+</mujoco>
+)""";
+  auto mbp = std::make_unique<MultibodyPlant<double>>(0.0);
+  multibody::Parser(mbp.get()).AddModelsFromString(xml, ".xml");
+  mbp->Finalize();
+  EXPECT_EQ(mbp->num_positions(), 2);
+  EXPECT_EQ(mbp->num_velocities(), 2);
+  EXPECT_EQ(mbp->num_actuators(), 2);
+  EXPECT_FALSE(mbp->MakeActuationMatrix().isIdentity());
+
+  const int dim = mbp->num_positions();
+  VectorX<double> kp(dim), ki(dim), kd(dim);
+  kp << 1, 2;
+  ki << 0.1, 0.2;
+  kd = kp / 2.;
+
+  auto dut = std::make_unique<InverseDynamicsController<double>>(
+      std::move(mbp), kp, ki, kd, true);
+
+  ConfigTestAndCheck(dut.get(), kp, ki, kd);
 }
 
 GTEST_TEST(AdditionalInverseDynamicsTest, ScalarConversion) {


### PR DESCRIPTION
Clarifies that the control output of the inverse dynamics controller
is actuation, not generalized forces, and uses the actuation matrix to
achieve this. Previously, by connecting the output of the
InverseDynamicsController system to an actuation input port of the
MultibodyPlant, we implicitly assumed that the actuator matrix was the
identity matrix. If the actuators were in a different order than the
joints (generalized forces), then our method produced the wrong
actuator inputs.

The generalized_force output port is still available, partly for
backwards compatibility, and because it's possible that there are
applications that prefer this.

This is a rewrite of PR #20971.
+@sherm1 for feature review, please (as the reviewer of #20971)
cc @EricCousineau-TRI who was involved in the first PR.
cc @siddancha 

Note: I will follow-up with changes to Anzu as needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22315)
<!-- Reviewable:end -->
