### PR TITLE
Adds a scene_graph() accessor to multibody::Parser.

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -111,8 +111,9 @@ PYBIND11_MODULE(parsing, m) {
         .def(py::init<MultibodyPlant<double>*, std::string_view>(),
             py::arg("plant"), py::arg("model_name_prefix"),
             cls_doc.ctor.doc_2args_plant_model_name_prefix)
-        .def("plant", &Class::plant, py_rvp::reference_internal,
-            cls_doc.plant.doc)
+        .def("plant", &Class::plant, py_rvp::reference, cls_doc.plant.doc)
+        .def("scene_graph", &Class::scene_graph, py_rvp::reference,
+            cls_doc.scene_graph.doc)
         .def("package_map", &Class::package_map, py_rvp::reference_internal,
             cls_doc.package_map.doc)
         .def(

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -179,8 +179,11 @@ class TestParsing(unittest.TestCase):
         # collisions.
         Parser(plant=plant, model_name_prefix="prefix1").AddModelsFromString(
             model, "urdf")
-        Parser(plant=plant, scene_graph=scene_graph,
-               model_name_prefix="prefix2").AddModelsFromString(model, "urdf")
+        parser = Parser(
+            plant=plant, scene_graph=scene_graph, model_name_prefix="prefix2")
+        parser.AddModelsFromString(model, "urdf")
+        self.assertEqual(parser.plant(), plant)
+        self.assertEqual(parser.scene_graph(), scene_graph)
 
     def test_strict(self):
         model = """<robot name='robot' version='0.99'>

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -69,6 +69,14 @@ Parser::Parser(MultibodyPlant<double>* plant,
 
 Parser::~Parser() {}
 
+geometry::SceneGraph<double>* Parser::scene_graph() {
+  if (plant_->geometry_source_is_registered()) {
+    DRAKE_DEMAND(!plant_->is_finalized());
+    return plant_->GetMutableSceneGraphPreFinalize();
+  }
+  return nullptr;
+}
+
 CollisionFilterGroups Parser::GetCollisionFilterGroups() const {
   return CollisionFilterGroups(ConvertInstancedNamesToStrings(
       data_->collision_filter_groups_storage_, *plant_));

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -180,6 +180,10 @@ class Parser final {
   /// parser.
   MultibodyPlant<double>& plant() { return *plant_; }
 
+  /// Gets a mutable pointer to the SceneGraph that will be modified by this
+  /// parser, or nullptr if this parser does not have a SceneGraph.
+  geometry::SceneGraph<double>* scene_graph();
+
   /// Gets a mutable reference to the PackageMap used by this parser.
   PackageMap& package_map() { return package_map_; }
 

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -33,6 +33,7 @@ GTEST_TEST(FileParserTest, BasicTest) {
     MultibodyPlant<double> plant(0.0);
     Parser dut(&plant);
     EXPECT_EQ(&dut.plant(), &plant);
+    EXPECT_EQ(dut.scene_graph(), nullptr);
     EXPECT_EQ(dut.AddModels(sdf_name).size(), 1);
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(sdf_name);
     EXPECT_EQ(prefix_ids.size(), 1);
@@ -43,7 +44,10 @@ GTEST_TEST(FileParserTest, BasicTest) {
   // Load the same model again with a name prefix.
   {
     MultibodyPlant<double> plant(0.0);
-    Parser dut(&plant);
+    geometry::SceneGraph<double> scene_graph;
+    Parser dut(&plant, &scene_graph);
+    EXPECT_EQ(&dut.plant(), &plant);
+    EXPECT_EQ(dut.scene_graph(), &scene_graph);
     EXPECT_EQ(dut.AddModels(urdf_name).size(), 1);
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(urdf_name);
     EXPECT_EQ(prefix_ids.size(), 1);


### PR DESCRIPTION
Currently the Parser uses GetMutableSceneGraphPreFinalize() to access the scene_graph, but per slack, this is not the long-term solution.

Nevertheless, conceptually the Parser _does_ have access to the scene_graph (unless no scene_graph is registered) as well as the plant, so adding this API should be durable even the GetMutableSceneGraphPreFinalize() workflow goes away.

+@jwnimmer-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22317)
<!-- Reviewable:end -->
