### PR TITLE
Drake application yaml logic handles !!binary tag

### DIFF
--- a/bindings/pydrake/common/test/yaml_typed_test.py
+++ b/bindings/pydrake/common/test/yaml_typed_test.py
@@ -1,3 +1,4 @@
+import base64
 import copy
 import dataclasses as dc
 import functools
@@ -8,6 +9,7 @@ from pathlib import Path
 from textwrap import dedent
 import typing
 import unittest
+import yaml
 
 import numpy as np
 
@@ -33,8 +35,18 @@ class FloatStruct:
 
 
 @dc.dataclass
+class IntStruct:
+    value: int = -1
+
+
+@dc.dataclass
 class StringStruct:
     value: str = "nominal_string"
+
+
+@dc.dataclass
+class BytesStruct:
+    value: bytes = b"\x00\x01\x02"
 
 
 @dc.dataclass
@@ -45,6 +57,7 @@ class PathStruct:
 @dc.dataclass
 class AllScalarsStruct:
     some_bool: bool = False
+    some_bytes: bytes = b"\x00\x01\x02"
     some_float: float = nan
     some_int: int = 11
     some_path: Path = "/path/to/nowhere"
@@ -66,6 +79,11 @@ class MapStruct:
 @dc.dataclass
 class InnerStruct:
     inner_value: float = nan
+
+
+@dc.dataclass
+class OptionalByteStruct:
+    value: bytes | None = b"\x02\x03\x04"
 
 
 @dc.dataclass
@@ -127,7 +145,7 @@ class NullableVariantStruct:
 
 @dc.dataclass
 class PrimitiveVariantStruct:
-    value: typing.Union[typing.List[float], bool, int, float, str] = nan
+    value: typing.Union[typing.List[float], bool, int, float, str, bytes] = nan
 
 
 @dc.dataclass
@@ -270,7 +288,7 @@ class TestYamlTypedRead(unittest.TestCase,
         ]
         for value in cases:
             data = f"value: {value}"
-            with self.assertRaises(TypeError):
+            with self.assertRaises(Exception):
                 yaml_load_typed(schema=PathStruct, data=data, **options)
 
     @run_with_multiple_values(_all_typed_read_options())
@@ -286,9 +304,82 @@ class TestYamlTypedRead(unittest.TestCase,
                                 **options)
 
     @run_with_multiple_values(_all_typed_read_options())
+    def test_read_bytes(self, *, options):
+        # Using !!binary on a schema whose type is bytes.
+        cases = [
+            ("!!binary A3Rlc3Rfc3RyAw==", b"\x03test_str\x03"),
+            ("!!binary |\n  A3Rlc3Rfc3RyAw==", b"\x03test_str\x03"),
+            ("!!binary |\n  A3Rlc3Rf\n  c3RyAw====", b"\x03test_str\x03"),
+            ("!!binary", b""),
+        ]
+        for value, expected in cases:
+            data = f"value: {value}"
+            x = yaml_load_typed(schema=BytesStruct, data=data, **options)
+            self.assertEqual(x.value, expected)
+
+        # Malformed base64 encoding.
+        cases = [
+            ("A3Rfc3RyAw=", "Incorrect padding"),
+            ("A3Rfc*RyAw==", "Invalid base64-encoded string")]
+        for value, error_regex in cases:
+            data = f"value: !!binary {value}"
+            with self.assertRaisesRegex(Exception, error_regex):
+                yaml_load_typed(schema=BytesStruct, data=data, **options)
+
+        # Assigning any other type to bytes is rejected.
+        cases = [
+            # String.
+            ("test string", "Expected.*bytes.*str"),
+            ("!!str 1234", "Expected.*bytes.*str"),
+            # Int.
+            ("12", "Expected.*bytes.*int"),
+            ("!!int 12", "Expected.*bytes.*int"),
+            ("0x3", "Expected.*bytes.*int"),
+            # Pyyaml defect: 0o3 should be an int.
+            ("0o3", "Expected.*bytes.*str"),
+            # Pyyaml defect: 00:03 should be an int (value of 3).
+            ("00:03", "Expected.*bytes.*str"),
+            # Float.
+            ("1234.5", "Expected.*bytes.*float"),
+            ("!!float 1234.5", "Expected.*bytes.*float"),
+            (".inf", "Expected.*bytes.*float"),
+            ("00:03.3", "Expected.*bytes.*float"),
+            # Null
+            ("null", "Expected.*bytes.*NoneType"),
+            ("", "Expected.*bytes.*NoneType"),
+            # Bool
+            ("true", "Expected.*bytes.*bool"),
+            ("!!bool true", "Expected.*bytes.*bool"),
+        ]
+        for value, error_regex in cases:
+            data = f"value: {value}"
+            with self.assertRaisesRegex(RuntimeError, error_regex,
+                                        msg=f"For value '{value}'"):
+                yaml_load_typed(schema=BytesStruct, data=data, **options)
+
+        # Using !!binary and assigning it to non-bytes should throw.
+        cases = [
+            (b".inf", FloatStruct),
+            (b"inf", FloatStruct),
+            (b"1234.5", FloatStruct),
+            (b"1234", IntStruct),
+            (b"test/path", PathStruct),
+            (b"a string", StringStruct)
+        ]
+        for byte_value, schema in cases:
+            encoded = base64.b64encode(byte_value)
+            data = f"value: !!binary {encoded.decode('utf-8')}"
+            with self.assertRaisesRegex(RuntimeError,
+                                        "Expected a .* value .* instead got "
+                                        "yaml data of type <class 'bytes'>",
+                                        msg=f"value: {byte_value}"):
+                yaml_load_typed(schema=schema, data=data, **options)
+
+    @run_with_multiple_values(_all_typed_read_options())
     def test_read_all_scalars(self, *, options):
         data = dedent("""
         some_bool: true
+        some_bytes: !!binary BQYH
         some_float: 101.0
         some_int: 102
         some_path: /alternative/path
@@ -296,6 +387,7 @@ class TestYamlTypedRead(unittest.TestCase,
         """)
         x = yaml_load_typed(schema=AllScalarsStruct, data=data, **options)
         self.assertEqual(x.some_bool, True)
+        self.assertEqual(x.some_bytes, b'\x05\x06\x07')
         self.assertEqual(x.some_float, 101.0)
         self.assertEqual(x.some_int, 102)
         self.assertEqual(x.some_path, Path("/alternative/path"))
@@ -445,6 +537,18 @@ class TestYamlTypedRead(unittest.TestCase,
                         schema=schema, data=amended_data, **options)
                     self.assertEqual(actual, schema(expected))
 
+    def test_read_optional_bytes(self):
+        """Smoke test for compatibility for the non-json scalar: binary. This
+        is trivial in python, but awkward in C++. To maintain parity with the
+        C++ tests, we simply mirror the C++ test.
+
+        This skips the nuance of parsing configuration, assuming that is
+        handled by the more general test_read_optional.
+        """
+        data = "value: !!binary b3RoZXID/3N0dWZm"
+        actual = yaml_load_typed(schema=OptionalByteStruct, data=data)
+        self.assertEqual(actual, OptionalByteStruct(b"other\x03\xffstuff"))
+
     @run_with_multiple_values(_all_typed_read_options())
     def test_read_variant(self, *, options):
         data = "value: foo"
@@ -527,6 +631,10 @@ class TestYamlTypedRead(unittest.TestCase,
         data = "value: !!str 'foo'"
         x = yaml_load_typed(schema=schema, data=data, **options)
         self.assertEqual(x.value, "foo")
+
+        data = "value: !!binary A3Rlc3Rfc3RyAw=="
+        x = yaml_load_typed(schema=schema, data=data, **options)
+        self.assertEqual(x.value, b"\x03test_str\x03")
 
     @run_with_multiple_values(_all_typed_read_options())
     def test_read_variant_missing(self, *, options):
@@ -813,6 +921,37 @@ class TestYamlTypedWrite(unittest.TestCase):
             expected_doc = f"value: {expected_str}\n"
             self.assertEqual(actual_doc, expected_doc)
 
+    def test_write_all_scalars(self):
+        x = AllScalarsStruct()
+        x.some_bool = True
+        x.some_float = 100.0
+        x.some_int = 102
+        x.some_str = "foo"
+        x.some_path = Path("/test/path")
+        x.some_bytes = b'\x05\x06\x07'
+        actual_doc = yaml_dump_typed(x)
+        expected_doc = dedent("""\
+        some_bool: true
+        some_bytes: !!binary |
+          BQYH
+        some_float: 100.0
+        some_int: 102
+        some_path: /test/path
+        some_str: foo
+        """)
+        self.assertEqual(actual_doc, expected_doc)
+
+    def test_write_bytes(self):
+        cases = [
+            (b"", "!!binary \"\""),
+            (b"all ascii", "!!binary |\n  YWxsIGFzY2lp"),
+            (b"other\x03\xffstuff", "!!binary |\n  b3RoZXID/3N0dWZm")
+        ]
+        for value, expected_str in cases:
+            actual_doc = yaml_dump_typed(BytesStruct(value=value))
+            expected_doc = f"value: {expected_str}\n"
+            self.assertEqual(actual_doc, expected_doc)
+
     def test_write_path(self):
         cases = [
             # In contrast to C++, there is no "empty" Path; it defaults to '.'.
@@ -937,6 +1076,15 @@ class TestYamlTypedWrite(unittest.TestCase):
             actual_doc = yaml_dump_typed(LegacyOptionalStruct(value=value))
             self.assertEqual(actual_doc, expected_doc)
 
+    def test_write_optional_bytes(self):
+        """Smoke test for compatibility for the non-json scalar: binary. This
+        is trivial in python, but awkward in C++. To maintain parity with the
+        C++ tests, we simply mirror the C++ test."""
+        actual_doc = yaml_dump_typed(OptionalByteStruct(None))
+        self.assertEqual(actual_doc, "{}\n")
+        actual_doc = yaml_dump_typed(OptionalByteStruct(b"other\x03\xffstuff"))
+        self.assertEqual(actual_doc, "value: !!binary |\n  b3RoZXID/3N0dWZm\n")
+
     def test_write_variant(self):
         cases = [
             (
@@ -1028,6 +1176,10 @@ class TestYamlTypedWrite(unittest.TestCase):
                 "foo",
                 # TODO(jwnimmer-tri) Ditto the above (re: quoting).
                 "value: !!str 'foo'\n",
+            ),
+            (
+                b"other\x03\xffstuff",
+                "value: !!binary |\n  b3RoZXID/3N0dWZm\n",
             ),
         ]
         for value, expected_doc in cases:

--- a/bindings/pydrake/common/yaml.py
+++ b/bindings/pydrake/common/yaml.py
@@ -279,7 +279,27 @@ def _create_from_schema(*, schema, forthcoming_value):
 # For details, see:
 #  https://yaml.org/spec/1.2.2/#scalars
 #  https://yaml.org/spec/1.2.2/#json-schema
-_PRIMITIVE_YAML_TYPES = (bool, int, float, str)
+_PRIMITIVE_JSON_TYPES = (bool, int, float, str)
+_PRIMITIVE_YAML_TYPES = _PRIMITIVE_JSON_TYPES + (bytes,)
+
+
+def _convert_yaml_primitive_to_schema_type(*, yaml_value, value_schema):
+    """Given a primitive yaml value parsed from a document and the declared
+    schema type we are reading it into, converts the value to the requested
+    schema type or else returns None when the types are not compatible.
+    """
+    yaml_value_type = type(yaml_value)
+    # Allow exact matches.
+    if yaml_value_type is value_schema:
+        return yaml_value
+    # All implicit promotion from int -> float.
+    if yaml_value_type is int and value_schema is float:
+        return float(yaml_value)
+    # Allow parsing strings to numbers.
+    if yaml_value_type is str and value_schema in (float, int):
+        return value_schema(yaml_value)
+    # Don't allow any other primitive conversions.
+    return None
 
 
 def _merge_yaml_dict_item_into_target(*, options, name, yaml_value,
@@ -299,12 +319,20 @@ def _merge_yaml_dict_item_into_target(*, options, name, yaml_value,
     # Handle all of the plain YAML scalars:
     #  https://yaml.org/spec/1.2.2/#scalars
     #  https://yaml.org/spec/1.2.2/#json-schema
+    #  https://yaml.org/type/binary.html
     if value_schema in _PRIMITIVE_YAML_TYPES:
         if type(yaml_value) in (list, dict):
             raise RuntimeError(
                 f"Expected a {value_schema} value for '{name}' but instead got"
                 f" non-scalar yaml data of type {type(yaml_value)}")
-        new_value = value_schema(yaml_value)
+        new_value = _convert_yaml_primitive_to_schema_type(
+            yaml_value=yaml_value,
+            value_schema=value_schema,
+        )
+        if new_value is None:
+            raise RuntimeError(
+                f"Expected a {value_schema} value for '{name}' but instead got"
+                f" yaml data of type {type(yaml_value)} ({yaml_value!r})")
         setter(new_value)
         return
 
@@ -329,6 +357,10 @@ def _merge_yaml_dict_item_into_target(*, options, name, yaml_value,
 
     # Handle pathlib.Path.
     if value_schema == Path:
+        if not isinstance(yaml_value, str):
+            raise RuntimeError(
+                f"Expected a !!str value for '{name}: Path' but instead got"
+                f" yaml data of type {type(yaml_value)}")
         new_value = Path(yaml_value)
         setter(new_value)
         return
@@ -675,9 +707,13 @@ def _yaml_dump_typed_item(*, obj, schema):
         union_schema = generic_args[i]
         result = _yaml_dump_typed_item(obj=obj, schema=union_schema)
         if i != 0:
-            if union_schema in _PRIMITIVE_YAML_TYPES:
+            if union_schema in _PRIMITIVE_JSON_TYPES:
                 result = _SchemaDumper.ExplicitScalar(
                     value=result, schema=union_schema)
+            elif union_schema in _PRIMITIVE_YAML_TYPES:
+                # The correct tag will be automatically applied by pyyaml with
+                # no special effort on our part.
+                pass
             else:
                 class_name_with_args = pretty_class_name(union_schema)
                 class_name = class_name_with_args.split("[", 1)[0]
@@ -773,7 +809,7 @@ def yaml_dump_typed(data,
     # Sanity checks.
     assert data is not None
     if child_name is not None:
-        if type(child_name) not in _PRIMITIVE_YAML_TYPES:
+        if type(child_name) not in _PRIMITIVE_JSON_TYPES:
             raise RuntimeError("The child_name must be a primitive type, "
                                f"not a {type(child_name)}")
 

--- a/common/yaml/test/example_structs.h
+++ b/common/yaml/test/example_structs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <filesystem>
 #include <map>
 #include <optional>
@@ -47,6 +48,24 @@ bool operator==(const DoubleStruct& a, const DoubleStruct& b) {
   return a.value == b.value;
 }
 
+// A value used in the test data below to include a default (placeholder) value
+// when initializing struct data members.
+constexpr int kNominalInt = -1;
+
+struct IntStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  int value = kNominalInt;
+};
+
+// This is used only for EXPECT_EQ, not by any YAML operations.
+bool operator==(const IntStruct& a, const IntStruct& b) {
+  return a.value == b.value;
+}
+
 struct StringStruct {
   template <typename Archive>
   void Serialize(Archive* a) {
@@ -59,6 +78,29 @@ struct StringStruct {
 // This is used only for EXPECT_EQ, not by any YAML operations.
 bool operator==(const StringStruct& a, const StringStruct& b) {
   return a.value == b.value;
+}
+
+struct BytesStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  std::vector<std::byte> value{std::byte(0), std::byte(1), std::byte(2)};
+};
+
+// This is used only for EXPECT_EQ, not by any YAML operations.
+bool operator==(const BytesStruct& a, const BytesStruct& b) {
+  return a.value == b.value;
+}
+
+// Sugar that copies a std::string to a std::vector<std::byte>, to make it
+// easier to set or check a BytesStruct::value.
+// NOTE: The input _may_ include internal null characters, and the
+// returned vector includes those but _does not_ include any null terminator.
+std::vector<std::byte> StringToByteVector(std::string_view str) {
+  const auto* data = reinterpret_cast<const std::byte*>(str.data());
+  return std::vector<std::byte>(data, data + str.size());
 }
 
 struct PathStruct {
@@ -75,6 +117,9 @@ bool operator==(const PathStruct& a, const PathStruct& b) {
   return a.value == b.value;
 }
 
+// Note: We can't currently write the vector of bytes to the equivalent json
+// representation. Setting `include_bytes` to `false` will omit the bytes from
+// serialization.
 struct AllScalarsStruct {
   template <typename Archive>
   void Serialize(Archive* a) {
@@ -87,6 +132,9 @@ struct AllScalarsStruct {
     a->Visit(DRAKE_NVP(some_uint64));
     a->Visit(DRAKE_NVP(some_string));
     a->Visit(DRAKE_NVP(some_path));
+    if (include_bytes) {
+      a->Visit(DRAKE_NVP(some_bytes));
+    }
   }
 
   bool some_bool = false;
@@ -98,6 +146,8 @@ struct AllScalarsStruct {
   uint64_t some_uint64 = 15;
   std::string some_string = "kNominalString";
   std::filesystem::path some_path{"/path/to/nowhere"};
+  std::vector<std::byte> some_bytes{std::byte(0), std::byte(1), std::byte(2)};
+  bool include_bytes = true;
 };
 
 struct ArrayStruct {
@@ -166,6 +216,22 @@ struct UnorderedMapStruct {
       : value(value_in.begin(), value_in.end()) {}
 
   string_unordered_map<double> value;
+};
+
+struct OptionalBytesStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  OptionalBytesStruct() { value = StringToByteVector("\x02\x03\x04"); }
+
+  explicit OptionalBytesStruct(
+      const std::optional<std::vector<std::byte>>& value_in) {
+    value = value_in;
+  }
+
+  std::optional<std::vector<std::byte>> value;
 };
 
 struct OptionalStruct {
@@ -283,8 +349,8 @@ struct VariantWrappingStruct {
   VariantStruct inner;
 };
 
-using PrimitiveVariant =
-    std::variant<std::vector<double>, bool, int, double, std::string>;
+using PrimitiveVariant = std::variant<std::vector<double>, bool, int, double,
+                                      std::string, std::vector<std::byte>>;
 
 struct PrimitiveVariantStruct {
   template <typename Archive>

--- a/common/yaml/test/json_test.cc
+++ b/common/yaml/test/json_test.cc
@@ -13,7 +13,7 @@ namespace test {
 namespace {
 
 GTEST_TEST(YamlJsonTest, WriteScalars) {
-  AllScalarsStruct data;
+  AllScalarsStruct data{.include_bytes = false};
   EXPECT_EQ(SaveJsonString(data), R"""({"some_bool":false,)"""
                                   R"""("some_double":1.2345,)"""
                                   R"""("some_float":1.2345,)"""
@@ -23,6 +23,12 @@ GTEST_TEST(YamlJsonTest, WriteScalars) {
                                   R"""("some_string":"kNominalString",)"""
                                   R"""("some_uint32":12,)"""
                                   R"""("some_uint64":15})""");
+}
+
+GTEST_TEST(YamlJsonTest, BinaryScalarThrows) {
+  BytesStruct data;
+  DRAKE_EXPECT_THROWS_MESSAGE(SaveJsonString(data),
+                              ".*Cannot save.*scalar.*with.*binary.*");
 }
 
 GTEST_TEST(YamlJsonTest, StringEscaping) {

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -64,7 +64,19 @@ class YamlReadArchiveTest : public ::testing::TestWithParam<LoadYamlOptions> {
   // empty string, the result is a map from "value" to Null (not an empty map,
   // nor Null itself, etc.)
   static internal::Node LoadSingleValue(const std::string& value) {
-    return Load("doc:\n  value: " + value + "\n");
+    // The corresponding test in python lacks the `doc:` context. Therefore, the
+    // python-generated yaml has two fewer indenting spaces than the
+    // C++-generated yaml. So, that the test call sites can look the same, we
+    // account for the disparity in indentation here by replacing "\n" in
+    // `value` with "\n  ".
+    std::string indented = value;
+    std::string::size_type n = 0;
+    while ((n = indented.find("\n", n)) != std::string::npos) {
+      indented.replace(n, 1, "\n  ");
+      n += 3;
+    }
+
+    return Load("doc:\n  value: " + indented + "\n");
   }
 
   // Parses root into a Serializable and returns the result of the parse.
@@ -169,6 +181,84 @@ TEST_P(YamlReadArchiveTest, DoubleMissing) {
   EXPECT_EQ(x.value, kNominalDouble);
 }
 
+TEST_P(YamlReadArchiveTest, Bytes) {
+  const auto test = [](const std::string& value, const std::string& expected) {
+    const auto& x = AcceptNoThrow<BytesStruct>(LoadSingleValue(value));
+    EXPECT_EQ(x.value, StringToByteVector(expected))
+        << "Expected string: '" << expected << "'";
+  };
+
+  // Using !!binary on a schema whose type is bytes.
+  test("!!binary A3Rlc3Rfc3RyAw==", "\x03test_str\x03");
+  test("!!binary |\n  A3Rlc3Rfc3RyAw==", "\x03test_str\x03");
+  test("!!binary |\n  A3Rlc3R\n  fc3RyAw==", "\x03test_str\x03");
+  test("!!binary ", "");
+
+  // Malformed base64 value.
+  {
+    // Proper encoding of "\x03t_str\x03" is 'A3Rfc3RyAw=='.
+
+    // Missing character.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        AcceptIntoDummy<BytesStruct>(LoadSingleValue("!!binary A3Rfc3RyAw=")),
+        ".*invalid base64.*");
+
+    // Invalid character.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        AcceptIntoDummy<BytesStruct>(LoadSingleValue("!!binary A3Rfc*RyAw==")),
+        ".*invalid base64.*");
+  }
+
+  // Assigning any other type to bytes is rejected.
+  // Note: these various value strings should be converted to various primitive
+  // types (string, int, etc.) before we process the scalar value. However,
+  // this doesn't currently happen so the error message can't complain that the
+  // wrong *type* has been passed to value. When we aggressively convert and
+  // check for mismatch, these error matches will shift to match what is done
+  // in yaml.py.
+  const auto reject = [](const std::string& value,
+                         const std::string& error_regex =
+                             ".*must be base64.*") {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        AcceptIntoDummy<BytesStruct>(LoadSingleValue(value)), error_regex);
+  };
+  // String.
+  reject("test string");
+  reject("!!str 1234");
+  // Int.
+  reject("12");
+  reject("!!int 12");
+  reject("0x3");
+  reject("0o3");
+  reject("00:03");
+  // Float.
+  reject("1234.5");
+  reject("!!float 1234.5");
+  reject(".inf");
+  reject("00:03.3");
+  // Null. Null triggers the more general exception of assigning null to scalar.
+  reject("null", ".*has non-Scalar .Null.*");
+  reject("", ".*has non-Scalar .Null.*");
+  // Bool.
+  reject("true");
+  reject("!!bool true");
+
+  // Using !!binary for non-binary types is bad.
+  const auto reject_bad_target = []<class T>(const std::string& value,
+                                             const T&) {
+    DRAKE_EXPECT_THROWS_MESSAGE(AcceptIntoDummy<T>(LoadSingleValue(value)),
+                                ".*incompatible !!binary tag.*");
+  };  // NOLINT  -- templated lambda confuses cpplint about the semicolon.
+  // These all use valid base64 encoding of what would otherwise be valid string
+  // values for the serializable type.
+  reject_bad_target("!!binary LmluZg==", DoubleStruct{});      // .inf
+  reject_bad_target("!!binary aW5m", DoubleStruct{});          // inf
+  reject_bad_target("!!binary MTIzNC41", DoubleStruct{});      // 1234.5
+  reject_bad_target("!!binary MTIzNA==", IntStruct{});         // 1234
+  reject_bad_target("!!binary dGVzdC9wYXRo", PathStruct{});    // test/path
+  reject_bad_target("!!binary YSBzdHJpbmc=", StringStruct{});  // "a string"
+}
+
 TEST_P(YamlReadArchiveTest, Path) {
   const auto test_valid = [](const std::string& value,
                              const std::string& expected) {
@@ -231,6 +321,7 @@ doc:
   some_uint64: 105
   some_string: foo
   some_path: /alternative/path
+  some_bytes: !!binary BQYH
 )""";
   const auto& x = AcceptNoThrow<AllScalarsStruct>(Load(doc));
   EXPECT_EQ(x.some_bool, true);
@@ -242,6 +333,7 @@ doc:
   EXPECT_EQ(x.some_uint64, 105);
   EXPECT_EQ(x.some_string, "foo");
   EXPECT_EQ(x.some_path, "/alternative/path");
+  EXPECT_EQ(x.some_bytes, StringToByteVector("\x05\x06\x07"));
 }
 
 TEST_P(YamlReadArchiveTest, StdArray) {
@@ -588,6 +680,14 @@ TEST_P(YamlReadArchiveTest, Optional) {
   }
 }
 
+/* Smoke test for compatibility for the odd scalar: vector<byte>. */
+TEST_P(YamlReadArchiveTest, OptionalBytes) {
+  const auto& x = AcceptNoThrow<OptionalBytesStruct>(
+      Load("doc:\n  value: !!binary b3RoZXID/3N0dWZm"));
+  ASSERT_TRUE(x.value.has_value());
+  EXPECT_EQ(x.value.value(), StringToByteVector("other\x03\xffstuff"));
+}
+
 TEST_P(YamlReadArchiveTest, Variant) {
   const auto test = [](const std::string& doc, const Variant4& expected) {
     const auto& x = AcceptNoThrow<VariantStruct>(Load(doc));
@@ -618,6 +718,8 @@ TEST_P(YamlReadArchiveTest, PrimitiveVariant) {
   test("doc:\n  value: !!float '1.0'", 1.0);
   test("doc:\n  value: !!str foo", std::string("foo"));
   test("doc:\n  value: !!str 'foo'", std::string("foo"));
+  test("doc:\n  value: !!binary A3Rlc3Rfc3RyAw==",
+       StringToByteVector("\x03test_str\x03"));
 
   // It might be sensible for this case to pass, but for now we'll require that
   // non-0'th variant indices always use a tag even where it could be inferred.

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -69,6 +69,17 @@ TEST_F(YamlWriteArchiveTest, Double) {
   test(-std::numeric_limits<double>::infinity(), "-.inf");
 }
 
+TEST_F(YamlWriteArchiveTest, Bytes) {
+  const auto test = [](const std::string& value, const std::string& expected) {
+    const BytesStruct x{StringToByteVector(value)};
+    EXPECT_EQ(Save(x), WrapDoc(expected));
+  };
+
+  test("", "!!binary \"\"");
+  test("all ascii", "!!binary YWxsIGFzY2lp");
+  test("other\x03\xffstuff", "!!binary b3RoZXID/3N0dWZm");
+}
+
 TEST_F(YamlWriteArchiveTest, String) {
   const auto test = [](const std::string& value, const std::string& expected) {
     const StringStruct x{value};
@@ -117,6 +128,7 @@ TEST_F(YamlWriteArchiveTest, AllScalars) {
   x.some_uint64 = 105;
   x.some_string = "foo";
   x.some_path = "/test/path";
+  x.some_bytes = StringToByteVector("\x05\x06\x07");
   EXPECT_EQ(Save(x), R"""(doc:
   some_bool: true
   some_float: 100.0
@@ -127,6 +139,7 @@ TEST_F(YamlWriteArchiveTest, AllScalars) {
   some_uint64: 105
   some_string: foo
   some_path: /test/path
+  some_bytes: !!binary BQYH
 )""");
 }
 
@@ -270,6 +283,18 @@ TEST_F(YamlWriteArchiveTest, Optional) {
   test(1.0, "doc:\n  value: 1.0\n");
 }
 
+TEST_F(YamlWriteArchiveTest, OptionalBytes) {
+  // Smoke test for compatibility for the odd scalar: vector<byte>.
+  const auto test_bytes = [](const std::optional<std::vector<std::byte>>& value,
+                             const std::string& expected) {
+    const OptionalBytesStruct x(value);
+    EXPECT_EQ(Save(x), expected);
+  };
+  test_bytes(std::nullopt, "doc:\n");
+  test_bytes(StringToByteVector("other\x03\xffstuff"),
+             "doc:\n  value: !!binary b3RoZXID/3N0dWZm\n");
+}
+
 TEST_F(YamlWriteArchiveTest, Variant) {
   const auto test = [](const Variant4& value, const std::string& expected) {
     const VariantStruct x{value};
@@ -296,6 +321,7 @@ TEST_F(YamlWriteArchiveTest, PrimitiveVariant) {
   test(10, "!!int 10");
   test(1.0, "!!float 1.0");
   test(std::string("foo"), "!!str foo");
+  test(StringToByteVector("other\x03\xffstuff"), "!!binary b3RoZXID/3N0dWZm");
 }
 
 TEST_F(YamlWriteArchiveTest, EigenVector) {

--- a/common/yaml/yaml_node.h
+++ b/common/yaml/yaml_node.h
@@ -171,6 +171,9 @@ class Node final {
   // https://yaml.org/spec/1.2.2/#generic-string
   static constexpr std::string_view kTagStr{"tag:yaml.org,2002:str"};
 
+  // https://yaml.org/type/binary.html
+  static constexpr std::string_view kTagBinary{"tag:yaml.org,2002:binary"};
+
   /* Sets the filename where this Node was read from. A nullopt indicates that
   the filename is not known. */
   void SetFilename(std::optional<std::string> filename);

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -220,10 +220,26 @@ internal::Node YamlReadArchive::LoadStringAsNode(
 }
 
 template <typename T>
-void YamlReadArchive::ParseScalarImpl(const std::string& value, T* result) {
+void YamlReadArchive::ParseScalarImpl(const internal::Node& scalar, T* result) {
   DRAKE_DEMAND(result != nullptr);
+
+  // Detect one specific case of tag mismatch. Ideally we should detect any kind
+  // of tag incompatiblity, but for now we'll just check for this one.
+  if (scalar.GetTag() == internal::Node::kTagBinary) {
+    ReportError(
+        fmt::format("has incompatible !!binary tag in yaml document for",
+                    drake::NiceTypeName::Get<T>()));
+    return;
+  }
+
+  if constexpr (std::is_same_v<T, std::string>) {
+    *result = scalar.GetScalar();
+    return;
+  }
+
   // For the decode-able types, see /usr/include/yaml-cpp/node/convert.h.
   // Generally, all of the POD types are supported.
+  const std::string& value = scalar.GetScalar();
   bool success = YAML::convert<T>::decode(YAML::Node(value), *result);
   if (!success) {
     ReportError(
@@ -231,46 +247,83 @@ void YamlReadArchive::ParseScalarImpl(const std::string& value, T* result) {
   }
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value, bool* result) {
-  ParseScalarImpl<bool>(value, result);
+void YamlReadArchive::ParseScalar(const internal::Node& scalar, bool* result) {
+  ParseScalarImpl<bool>(scalar, result);
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value, float* result) {
-  ParseScalarImpl<float>(value, result);
+void YamlReadArchive::ParseScalar(const internal::Node& scalar, float* result) {
+  ParseScalarImpl<float>(scalar, result);
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value, double* result) {
-  ParseScalarImpl<double>(value, result);
+void YamlReadArchive::ParseScalar(const internal::Node& scalar,
+                                  double* result) {
+  ParseScalarImpl<double>(scalar, result);
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value, int32_t* result) {
-  ParseScalarImpl<int32_t>(value, result);
+void YamlReadArchive::ParseScalar(const internal::Node& scalar,
+                                  int32_t* result) {
+  ParseScalarImpl<int32_t>(scalar, result);
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value, uint32_t* result) {
-  ParseScalarImpl<uint32_t>(value, result);
+void YamlReadArchive::ParseScalar(const internal::Node& scalar,
+                                  uint32_t* result) {
+  ParseScalarImpl<uint32_t>(scalar, result);
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value, int64_t* result) {
-  ParseScalarImpl<int64_t>(value, result);
+void YamlReadArchive::ParseScalar(const internal::Node& scalar,
+                                  int64_t* result) {
+  ParseScalarImpl<int64_t>(scalar, result);
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value, uint64_t* result) {
-  ParseScalarImpl<uint64_t>(value, result);
+void YamlReadArchive::ParseScalar(const internal::Node& scalar,
+                                  uint64_t* result) {
+  ParseScalarImpl<uint64_t>(scalar, result);
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value,
+void YamlReadArchive::ParseScalar(const internal::Node& scalar,
                                   std::string* result) {
-  DRAKE_DEMAND(result != nullptr);
-  *result = value;
+  ParseScalarImpl<std::string>(scalar, result);
 }
 
-void YamlReadArchive::ParseScalar(const std::string& value,
+void YamlReadArchive::ParseScalar(const internal::Node& scalar,
                                   std::filesystem::path* result) {
   DRAKE_DEMAND(result != nullptr);
+  std::string string_value;
+  ParseScalarImpl<std::string>(scalar, &string_value);
   // Python deserialization normalizes paths (i.e., a//b becomes a/b). We'll
   // mirror that behavior for consistency's sake.
-  *result = std::filesystem::path(value).lexically_normal();
+  *result = std::filesystem::path(std::move(string_value)).lexically_normal();
+}
+
+void YamlReadArchive::ParseScalar(const internal::Node& scalar,
+                                  std::vector<std::byte>* result) {
+  DRAKE_DEMAND(result != nullptr);
+
+  if (scalar.GetTag() != internal::Node::kTagBinary) {
+    ReportError(fmt::format(
+        "must be base64 encoded with the !!binary tag (not {}) in the",
+        scalar.GetTag()));
+    return;
+  }
+
+  const std::string& encoded = scalar.GetScalar();
+  std::vector<unsigned char> chars = YAML::DecodeBase64(encoded);
+  std::string decoded(chars.begin(), chars.end());
+  if (decoded.empty() != encoded.empty()) {
+    // Decoded should only be empty if the input is empty. This is a good but
+    // imperfect test. If `encoded` were nothing but whitespace, it would
+    // *functionally* be an empty base64 string and *should* produce an empty
+    // result. If necessary, we can attempt stripping whitespace from encoded.
+
+    // Grab the leading snippet of encoded text for the error message.
+    const std::string_view head = encoded.substr(0, 25);
+    ReportError(fmt::format("contains invalid base64 text '{}{}'", head,
+                            head.size() < encoded.size() ? "..." : ""));
+    return;
+  }
+
+  const std::byte* data = reinterpret_cast<const std::byte*>(decoded.data());
+  *result = std::vector<std::byte>(data, data + decoded.size());
 }
 
 const internal::Node* YamlReadArchive::MaybeGetSubNode(const char* name) const {

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <map>
@@ -170,6 +171,15 @@ class YamlReadArchive final {
     this->VisitVector(nvp);
   }
 
+  // For std::vector<std::byte>. Since a `std::byte` is not any kind of YAML
+  // scalar (semantically it's neither an integer nor a string), it would be
+  // impossible to have a YAML sequence of std::byte elements. Therefore, we
+  // will treat the std::vector<std::byte> C++ type as a yaml !!binary scalar.
+  template <typename NVP>
+  void DoVisit(const NVP& nvp, const std::vector<std::byte>&, int32_t) {
+    this->VisitScalar(nvp);
+  }
+
   // For std::array.
   template <typename NVP, typename T, std::size_t N>
   void DoVisit(const NVP& nvp, const std::array<T, N>&, int32_t) {
@@ -245,7 +255,7 @@ class YamlReadArchive final {
     if (sub_node == nullptr) {
       return;
     }
-    ParseScalar(sub_node->GetScalar(), nvp.value());
+    ParseScalar(*sub_node, nvp.value());
   }
 
   template <typename NVP>
@@ -334,7 +344,7 @@ class YamlReadArchive final {
   // Checks if the given yaml type `tag` matches the C++ type `T`.
   template <typename T>
   static bool IsTagMatch(std::string_view tag) {
-    // Check against the JSON schema tags.
+    // Check against the tags Drake supports (e.g., JSON, binary, Drake's, etc.)
     if constexpr (std::is_same_v<T, bool>) {
       return tag == internal::Node::kTagBool;
     } else if constexpr (std::is_integral_v<T>) {
@@ -343,8 +353,10 @@ class YamlReadArchive final {
       return tag == internal::Node::kTagFloat;
     } else if constexpr (std::is_same_v<T, std::string>) {
       return tag == internal::Node::kTagStr;
+    } else if constexpr (std::is_same_v<T, std::vector<std::byte>>) {
+      return tag == internal::Node::kTagBinary;
     } else {
-      // Not a JSON schema. Check the drake-specific tag.
+      // Not a Drake-supported YAML tag. Check the drake-specific tag.
       return IsTagMatch(drake::NiceTypeName::GetFromStorage<T>(), tag);
     }
   }
@@ -509,18 +521,20 @@ class YamlReadArchive final {
 
   // These are the only scalar types that Drake supports.
   // Users cannot add de-string-ification functions for custom scalars.
-  void ParseScalar(const std::string& value, bool* result);
-  void ParseScalar(const std::string& value, float* result);
-  void ParseScalar(const std::string& value, double* result);
-  void ParseScalar(const std::string& value, int32_t* result);
-  void ParseScalar(const std::string& value, uint32_t* result);
-  void ParseScalar(const std::string& value, int64_t* result);
-  void ParseScalar(const std::string& value, uint64_t* result);
-  void ParseScalar(const std::string& value, std::string* result);
-  void ParseScalar(const std::string& value, std::filesystem::path* result);
+  void ParseScalar(const internal::Node& scalar, bool* result);
+  void ParseScalar(const internal::Node& scalar, float* result);
+  void ParseScalar(const internal::Node& scalar, double* result);
+  void ParseScalar(const internal::Node& scalar, int32_t* result);
+  void ParseScalar(const internal::Node& scalar, uint32_t* result);
+  void ParseScalar(const internal::Node& scalar, int64_t* result);
+  void ParseScalar(const internal::Node& scalar, uint64_t* result);
+  void ParseScalar(const internal::Node& scalar, std::string* result);
+  void ParseScalar(const internal::Node& scalar, std::filesystem::path* result);
+  void ParseScalar(const internal::Node& scalar,
+                   std::vector<std::byte>* result);
 
   template <typename T>
-  void ParseScalarImpl(const std::string& value, T* result);
+  void ParseScalarImpl(const internal::Node& scalar, T* result);
 
   // --------------------------------------------------------------------------
   // @name Helpers, utilities, and member variables.

--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -118,6 +118,8 @@ void RecursiveEmit(const internal::Node& node, YAML::Emitter* emitter,
       emitted_tag = std::string("!!");
       emitted_tag.append(node_tag.substr(18));
     }
+  } else if (node_tag == internal::Node::kTagBinary) {
+    emitted_tag = "!!binary";
   } else {
     emitted_tag = node_tag;
   }
@@ -405,6 +407,12 @@ void DoEraseMatchingMaps(internal::Node* x, const internal::Node* y) {
 
 void YamlWriteArchive::EraseMatchingMaps(const YamlWriteArchive& other) {
   DoEraseMatchingMaps(&(this->root_), &(other.root_));
+}
+
+std::string YamlWriteArchive::EncodeBase64(
+    const std::vector<std::byte>& bytes) {
+  const auto* data = reinterpret_cast<const unsigned char*>(bytes.data());
+  return YAML::EncodeBase64(data, bytes.size());
 }
 
 }  // namespace internal

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -150,6 +150,12 @@ class YamlWriteArchive final {
                             data.empty() ? nullptr : &data.at(0));
   }
 
+  // We treat std::vector<byte> as a base64-encoded scalar.
+  template <typename NVP>
+  void DoVisit(const NVP& nvp, const std::vector<std::byte>&, int32_t) {
+    this->VisitScalar(nvp);
+  }
+
   // For std::array.
   template <typename NVP, typename T, std::size_t N>
   void DoVisit(const NVP& nvp, const std::array<T, N>&, int32_t) {
@@ -218,38 +224,49 @@ class YamlWriteArchive final {
     root_.Add(nvp.name(), std::move(sub_archive.root_));
   }
 
+  // Encodes vector of bytes into a base64 string.
+  static std::string EncodeBase64(const std::vector<std::byte>& bytes);
+
   // This is used for simple types that can be converted to a string.
   template <typename NVP>
   void VisitScalar(const NVP& nvp) {
     using T = typename NVP::value_type;
     const T& value = *nvp.value();
     std::string text;
-    JsonSchemaTag tag;
+    // Every scalar must set tag to either json enum or full tag string.
+    std::variant<JsonSchemaTag, std::string> tag;
     if constexpr (std::is_same_v<T, std::string>) {
       text = value;
-      tag = internal::JsonSchemaTag::kStr;
+      tag = JsonSchemaTag::kStr;
     } else if constexpr (std::is_same_v<T, std::filesystem::path>) {
       // We'll treat fs::path exactly like a std::string.
       text = value.string();
-      tag = internal::JsonSchemaTag::kStr;
+      tag = JsonSchemaTag::kStr;
     } else if constexpr (std::is_same_v<T, bool>) {
       text = value ? "true" : "false";
-      tag = internal::JsonSchemaTag::kBool;
+      tag = JsonSchemaTag::kBool;
     } else if constexpr (std::is_integral_v<T>) {
       text = fmt::to_string(value);
-      tag = internal::JsonSchemaTag::kInt;
+      tag = JsonSchemaTag::kInt;
     } else if constexpr (std::is_floating_point_v<T>) {
       text = std::isfinite(value) ? fmt_floating_point(value)
              : std::isnan(value)  ? ".nan"
              : (value > 0)        ? ".inf"
                                   : "-.inf";
-      tag = internal::JsonSchemaTag::kFloat;
+      tag = JsonSchemaTag::kFloat;
+    } else if constexpr (std::is_same_v<T, std::vector<std::byte>>) {
+      text = EncodeBase64(value);
+      tag = std::string(internal::Node::kTagBinary);
     } else {
       text = fmt::format("{}", value);
-      tag = internal::JsonSchemaTag::kStr;
+      tag = JsonSchemaTag::kStr;
     }
     internal::Node scalar = internal::Node::MakeScalar(std::move(text));
-    scalar.SetTag(tag);
+    std::visit(
+        [&scalar](auto&& arg) {
+          scalar.SetTag(std::move(arg));
+        },
+        tag);
     root_.Add(nvp.name(), std::move(scalar));
   }
 
@@ -288,8 +305,7 @@ class YamlWriteArchive final {
         [this, name, needs_tag](auto&& unwrapped) {
           this->Visit(drake::MakeNameValue(name, &unwrapped));
           if (needs_tag) {
-            // TODO(jwnimmer-tri) Spell this as remove_cvref_t in C++20.
-            using T = std::decay_t<decltype(unwrapped)>;
+            using T = std::remove_cvref_t<decltype(unwrapped)>;
             Node& node = root_.At(name);
             if constexpr (std::is_same_v<T, bool>) {
               node.SetTag(JsonSchemaTag::kBool, /* important = */ true);
@@ -299,6 +315,8 @@ class YamlWriteArchive final {
               node.SetTag(JsonSchemaTag::kFloat, /* important = */ true);
             } else if constexpr (std::is_same_v<T, std::string>) {
               node.SetTag(JsonSchemaTag::kStr, /* important = */ true);
+            } else if constexpr (std::is_same_v<T, std::vector<std::byte>>) {
+              node.SetTag(std::string(internal::Node::kTagBinary));
             } else {
               node.SetTag(YamlWriteArchive::GetVariantTag<T>());
             }

--- a/tools/workspace/yaml_cpp_internal/patches/upstream/b64_decode_failure_is_empty.patch
+++ b/tools/workspace/yaml_cpp_internal/patches/upstream/b64_decode_failure_is_empty.patch
@@ -1,0 +1,42 @@
+DecodeBase64 will return an empty result in one of three circumstances:
+  - The input is an empty string.
+  - The input is nothing but whitespace (a functionally empty string).
+  - The input has an invalid character.
+
+However, if the input doesn't have the proper number of encoding characters (a
+multiple of 4), instead of reporting an error, it simply returns a truncated
+result with no hint of any error.
+
+This changes the function to detect the lack of sufficient data and signals by
+returning an empty string. This gives the caller enough information to infer
+a problem (and even the cause).
+
+
+--- src/binary.cpp
++++ src/binary.cpp
+@@ -74,7 +74,8 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
+   unsigned char *out = &ret[0];
+ 
+   unsigned value = 0;
+-  for (std::size_t i = 0, cnt = 0; i < input.size(); i++) {
++  std::size_t cnt = 0;
++  for (std::size_t i = 0; i < input.size(); i++) {
+     if (std::isspace(static_cast<unsigned char>(input[i]))) {
+       // skip newlines
+       continue;
+@@ -90,9 +91,14 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
+         *out++ = value >> 8;
+       if (input[i] != '=')
+         *out++ = value;
++      cnt = 0;
++    } else {
++      ++cnt;
+     }
+-    ++cnt;
+   }
++  // An invalid number of characters were encountered.
++  if (cnt != 0)
++    return ret_type();
+ 
+   ret.resize(out - &ret[0]);
+   return ret;

--- a/tools/workspace/yaml_cpp_internal/repository.bzl
+++ b/tools/workspace/yaml_cpp_internal/repository.bzl
@@ -10,6 +10,7 @@ def yaml_cpp_internal_repository(
         sha256 = "fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
+            ":patches/upstream/b64_decode_failure_is_empty.patch",
             ":patches/emit-local-tag.patch",
         ],
         mirrors = mirrors,


### PR DESCRIPTION
Adds the ability for Drake to treat the yaml `!!binary` tag in a consistent and coherent manner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22318)
<!-- Reviewable:end -->
