### PR TITLE
Updates notes about gravity comp in InverseDynamics and IDC

### DIFF
--- a/systems/controllers/inverse_dynamics.h
+++ b/systems/controllers/inverse_dynamics.h
@@ -36,7 +36,8 @@ namespace controllers {
  *
  * @note As an alternative to adding a controller to your diagram, gravity
  * compensation can be modeled by disabling gravity for a given model instance,
- * see MultibodyPlant::set_gravity_enabled().
+ * see MultibodyPlant::set_gravity_enabled(), unless the gravity compensation
+ * needs to be accounted for when evaluating effort limits.
  *
  * InverseDynamicsController uses a PID controller to generate desired
  * acceleration and uses this class to compute generalized forces. Use this

--- a/systems/controllers/inverse_dynamics_controller.h
+++ b/systems/controllers/inverse_dynamics_controller.h
@@ -43,12 +43,6 @@ namespace controllers {
  * - generalized_force
  * @endsystem
  *
- * @note As an alternative to adding a separate controller system to your
- * diagram, you can model gravity compensation with PD controllers using
- * MultibodyPlant APIs. Refer to MultibodyPlant::set_gravity_enabled() as an
- * alternative to modeling gravity compensation. To model PD controlled
- * actuators, refer to @ref mbp_actuation "Actuation".
- *
  * The desired acceleration port shown in <span style="color:gray">gray</span>
  * may be absent, depending on the arguments passed to the constructor.
  *

--- a/systems/controllers/joint_stiffness_controller.h
+++ b/systems/controllers/joint_stiffness_controller.h
@@ -56,6 +56,13 @@ namespace controllers {
  * model the actual elastic joints and rotor-inertia shaping). See
  * https://manipulation.csail.mit.edu/force.html for more details.
  *
+ * @note As an alternative to adding a separate controller system to your
+ * diagram, you can model a JointStiffness controller using MultibodyPlant
+ * APIs. Refer to MultibodyPlant::set_gravity_enabled() as an alternative to
+ * modeling gravity compensation (unless the gravity compensation terms need to
+ * be accounted for when computing effort limits). To model PD controlled
+ * actuators, refer to @ref mbp_actuation "Actuation".
+ *
  * @tparam_default_scalar
  * @ingroup control_systems
  */


### PR DESCRIPTION
The note on IDC was misplaced... gravity comp + PD is a joint stiffness controller, not an inverse dynamics controller.

+@amcastro-tri for feature review, please.
+@sherm1 for platform review, please (since you're today and you're relevant!)