### PR TITLE
Fixup JointStiffnessController to output actuation instead of generalized_force

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -486,6 +486,7 @@ drake_py_unittest(
     deps = [
         ":controllers_py",
         ":test_util_py",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
         "//bindings/pydrake/examples",
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -150,26 +150,33 @@ PYBIND11_MODULE(controllers, m) {
   {
     using Class = JointStiffnessController<double>;
     constexpr auto& cls_doc = doc.JointStiffnessController;
-    py::class_<Class, LeafSystem<double>>(
-        m, "JointStiffnessController", cls_doc.doc)
-        .def(py::init<const MultibodyPlant<double>&,
-                 const Eigen::Ref<const Eigen::VectorXd>&,
-                 const Eigen::Ref<const Eigen::VectorXd>&>(),
-            py::arg("plant"), py::arg("kp"), py::arg("kd"),
-            // Keep alive, reference: `self` keeps `robot` alive.
-            py::keep_alive<1, 2>(), cls_doc.ctor.doc)
+    py::class_<Class, LeafSystem<double>> cls(
+        m, "JointStiffnessController", cls_doc.doc);
+    cls.def(py::init<const MultibodyPlant<double>&,
+                const Eigen::Ref<const Eigen::VectorXd>&,
+                const Eigen::Ref<const Eigen::VectorXd>&>(),
+           py::arg("plant"), py::arg("kp"), py::arg("kd"),
+           // Keep alive, reference: `self` keeps `robot` alive.
+           py::keep_alive<1, 2>(), cls_doc.ctor.doc)
         .def("get_input_port_estimated_state",
             &Class::get_input_port_estimated_state, py_rvp::reference_internal,
             cls_doc.get_input_port_estimated_state.doc)
         .def("get_input_port_desired_state",
             &Class::get_input_port_desired_state, py_rvp::reference_internal,
             cls_doc.get_input_port_desired_state.doc)
-        .def("get_output_port_generalized_force",
-            &Class::get_output_port_generalized_force,
-            py_rvp::reference_internal,
-            cls_doc.get_output_port_generalized_force.doc)
+        .def("get_output_port_actuation", &Class::get_output_port_actuation,
+            py_rvp::reference_internal, cls_doc.get_output_port_actuation.doc)
         .def("get_multibody_plant", &Class::get_multibody_plant,
             py_rvp::reference_internal, cls_doc.get_multibody_plant.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.def("get_output_port_generalized_force",
+        WrapDeprecated(cls_doc.get_output_port_generalized_force.doc_deprecated,
+            &Class::get_output_port_generalized_force),
+        py_rvp::reference_internal,
+        cls_doc.get_output_port_generalized_force.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 
   {

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -5,7 +5,7 @@ import weakref
 
 import numpy as np
 
-from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.examples import PendulumPlant
 from pydrake.multibody.tree import MultibodyForces
 from pydrake.multibody.plant import MultibodyPlant
@@ -128,8 +128,12 @@ class TestControllers(unittest.TestCase):
         self.assertEqual(controller.get_input_port_estimated_state().size(),
                          14)
         self.assertEqual(controller.get_input_port_desired_state().size(), 14)
-        self.assertEqual(controller.get_output_port_generalized_force().size(),
+        self.assertEqual(controller.get_output_port_actuation().size(),
                          7)
+
+        with catch_drake_warnings(expected_count=1) as w:
+            controller.get_output_port_generalized_force()
+
         self.assertIsInstance(controller.get_multibody_plant(), MultibodyPlant)
 
     def test_inverse_dynamics(self):

--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -202,7 +202,6 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "joint_stiffness_controller_test",
     data = [
-        "//multibody/benchmarks/acrobot:models",
         "@drake_models//:iiwa_description",
     ],
     deps = [

--- a/systems/controllers/joint_stiffness_controller.h
+++ b/systems/controllers/joint_stiffness_controller.h
@@ -18,16 +18,16 @@ namespace controllers {
 /**
  * Implements a joint-space stiffness controller of the form
  * <pre>
- *   τ_control = −τ_g(q) − τ_app + kp⊙(q_d − q) + kd⊙(v_d − v)
+ *   τ_control = B⁻¹[−τ_g(q) − τ_app + kp⊙(q_d − q) + kd⊙(v_d − v)]
  * </pre>
  * where `Kp` and `Kd` are the joint stiffness and damping coefficients,
  * respectively, `τ_g(q)` is the vector of generalized forces due to gravity,
  * and `τ_app` contains applied forces from force elements added to the
  * multibody model (this can include damping, springs, etc. See
- * MultibodyPlant::CalcForceElementsContribution()).  `q_d` and `v_d` are the
- * desired (setpoint) values for the multibody positions and velocities,
- * respectively. `kd` and `kp` are taken as vectors, and ⊙ represents
- * elementwise multiplication.
+ * MultibodyPlant::CalcForceElementsContribution()). B⁻¹ is the inverse of the
+ * actuation matrix. `q_d` and `v_d` are the desired (setpoint) values for the
+ * multibody positions and velocities, respectively. `kd` and `kp` are taken as
+ * vectors, and ⊙ represents elementwise multiplication.
  *
  * The goal of this controller is to produce a closed-loop dynamics that
  * resembles a spring-damper dynamics at the joints around the setpoint:
@@ -48,7 +48,7 @@ namespace controllers {
  * - estimated_state
  * - desired_state
  * output_ports:
- * - generalized_force
+ * - actuation
  * @endsystem
  *
  * Note that the joint impedance control as implemented on Kuka's iiwa and
@@ -129,8 +129,19 @@ class JointStiffnessController final : public LeafSystem<T> {
   /**
    * Returns the output port for the generalized forces implementing the
    * control. */
+  DRAKE_DEPRECATED("2025-04-01",
+                   "Use get_output_port_actuation() instead, which multiplies "
+                   "the generalized force by B⁻¹ to be consumed by "
+                   "MultibodyPlant's actuation input port.")
   const OutputPort<T>& get_output_port_generalized_force() const {
     return this->get_output_port(output_port_index_force_);
+  }
+
+  /**
+   * Returns the output port implementing the control in the form (and order)
+   * expected for the plant's actuation input port. */
+  const OutputPort<T>& get_output_port_actuation() const {
+    return this->get_output_port(output_port_index_actuation_);
   }
 
   /**
@@ -150,9 +161,12 @@ class JointStiffnessController final : public LeafSystem<T> {
 
   template <typename> friend class JointStiffnessController;
 
+  // Calculator for the deprecated output port.
+  void CalcOutputForce(const Context<T>& context, BasicVector<T>* force) const;
+
   // This is the calculator method for the output port.
-  void CalcOutputForce(const Context<T>& context,
-                       BasicVector<T>* force) const;
+  void CalcOutputActuation(const Context<T>& context,
+                           BasicVector<T>* force) const;
 
   // Methods for updating cache entries.
   void SetMultibodyContext(const Context<T>&, Context<T>*) const;
@@ -164,9 +178,11 @@ class JointStiffnessController final : public LeafSystem<T> {
 
   int input_port_index_estimated_state_{0};
   int input_port_index_desired_state_{0};
+  int output_port_index_actuation_{0};
   int output_port_index_force_{0};
 
   Eigen::VectorXd kp_, kd_;
+  Eigen::SparseMatrix<double> Binv_;
 
   drake::systems::CacheIndex applied_forces_cache_index_;
   drake::systems::CacheIndex plant_context_cache_index_;


### PR DESCRIPTION
Follows #22315, which implemented the same fix for InverseDynamicsController.

Previously there was a tacit assumption that the actuators were declared in the same order as the joints. This PR resolves that, and (to make this clear) renames the output port from `generalized_force` to `actuation`.

+@sammy-tri for feature review, please?
+@sherm1 for platform review, please?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22329)
<!-- Reviewable:end -->
