### PR TITLE
Find correct python3 version in pybind11-config

### DIFF
--- a/tools/workspace/pybind11/pybind11-config.cmake
+++ b/tools/workspace/pybind11/pybind11-config.cmake
@@ -24,7 +24,9 @@ if(${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX STREQUAL "/")
 endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
-find_package(Python3)
+if (NOT Python_FOUND AND NOT Python3_FOUND)
+  find_package(Python3 COMPONENTS Interpreter Development)
+endif()
 set(_expectedTargets pybind11::embed pybind11::module pybind11::pybind11 pybind11::lto pybind11::thin_lto pybind11::python_link_helper pybind11::python2_no_register pybind11::windows_extras pybind11::opt_size)
 
 set(_targetsDefined)

--- a/tools/workspace/pybind11/pybind11-config.cmake
+++ b/tools/workspace/pybind11/pybind11-config.cmake
@@ -24,9 +24,7 @@ if(${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX STREQUAL "/")
 endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
-if (NOT Python_FOUND AND NOT Python3_FOUND)
-  find_package(Python3 COMPONENTS Interpreter Development)
-endif()
+find_package(Python3 ${drake_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 set(_expectedTargets pybind11::embed pybind11::module pybind11::pybind11 pybind11::lto pybind11::thin_lto pybind11::python_link_helper pybind11::python2_no_register pybind11::windows_extras pybind11::opt_size)
 
 set(_targetsDefined)


### PR DESCRIPTION
Improves logic so Python3 will not be set by pybind11-config file unless a user has not already set the python version

Resolves [#22051](https://github.com/RobotLocomotion/drake/issues/22051)
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22333)
<!-- Reviewable:end -->
