### PR TITLE
[geometry] Remove ultra-fine resolution testing from cylinder mesh test

### DIFF
--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -351,7 +351,7 @@ GTEST_TEST(MakeCylinderVolumeMesh, VolumeConvergence) {
 
   EXPECT_NEAR(volume0, expected_volume_0, kTolerance);
 
-  for (int level = 1; level < 6; ++level) {
+  for (int level = 1; level < 4; ++level) {
     resolution_hint /= 2.0;
     auto mesh = MakeCylinderVolumeMesh<double>(
         drake::geometry::Cylinder(radius, height), resolution_hint);
@@ -389,7 +389,7 @@ GTEST_TEST(MakeCylinderVolumeMesh, EulerCharacteristic) {
 
   const int expected_euler_characteristic = 1;
 
-  for (const double resolution_hint : {2., 1., 0.5, 0.25, 0.125, 0.0625}) {
+  for (const double resolution_hint : {2., 1., 0.5, 0.25}) {
     auto mesh = MakeCylinderVolumeMesh<double>(
         drake::geometry::Cylinder(radius, height), resolution_hint);
 


### PR DESCRIPTION
Removes unnecessarily fine geometry from `make_cylinder_mesh_test` that is causing timeouts in nightly debug builds (see https://drake-jenkins.csail.mit.edu/job/linux-jammy-gcc-bazel-nightly-everything-debug/302/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22337)
<!-- Reviewable:end -->
