### PR TITLE
[build] Small fixes in prep for bzlmod (part deux)

### DIFF
--- a/tools/workspace/gtest/package.BUILD.bazel
+++ b/tools/workspace/gtest/package.BUILD.bazel
@@ -43,8 +43,7 @@ cc_library(
     ],
     linkopts = select({
         ":linux": ["-pthread"],
-        # This is a bazel-default rule, and does not need @drake//
-        "@//conditions:default": [],
+        "//conditions:default": [],
     }),
     linkstatic = 1,
     deps = [

--- a/tools/workspace/nlopt_internal/package.BUILD.bazel
+++ b/tools/workspace/nlopt_internal/package.BUILD.bazel
@@ -367,7 +367,7 @@ exports_files(
         "src/api/nlopt-in.hpp",
         "src/api/nlopt.h",
     ],
-    visibility = ["@//tools/workspace/nlopt_internal:__pkg__"],
+    visibility = ["@drake//tools/workspace/nlopt_internal:__pkg__"],
 )
 
 cc_library_vendored(

--- a/tools/workspace/spdlog/package.BUILD.bazel
+++ b/tools/workspace/spdlog/package.BUILD.bazel
@@ -65,8 +65,7 @@ cc_binary(
             "-pthread",
             "-Wl,-soname,libdrake_spdlog.so",
         ],
-        # This is a bazel-default rule, and does not need @drake//
-        "@//conditions:default": [],
+        "//conditions:default": [],
     }),
     # These two lines are how you tell Bazel to create a shared library.
     linkshared = True,


### PR DESCRIPTION
In #22330, I missed a couple more instances of `@//` which didn't show up in drake-external-examples testing but did show up in Anzu.  Now I've grepped the whole tree and fixed all of the stragglers.

Towards #20731.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22342)
<!-- Reviewable:end -->
