### PR TITLE
Re-apply fixed "[pydrake] Fix diagram memory leaks"

### DIFF
--- a/bindings/pydrake/common/ref_cycle_pybind.h
+++ b/bindings/pydrake/common/ref_cycle_pybind.h
@@ -10,8 +10,8 @@ namespace internal {
 
 /* pydrake::internal::ref_cycle is a custom call policy for pybind11.
 
-   For an overview of other call policies, See
-   https://pybind11.readthedocs.io/en/stable/advanced/functions.html#additional-call-policies
+  For an overview of other call policies, See
+  https://pybind11.readthedocs.io/en/stable/advanced/functions.html#additional-call-policies
 
   `ref_cycle` creates a reference count cycle that Python's cyclic garbage
   collection can find and collect, once the cycle's objects are no longer

--- a/bindings/pydrake/geometry/BUILD.bazel
+++ b/bindings/pydrake/geometry/BUILD.bazel
@@ -38,11 +38,13 @@ drake_pybind_library(
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:identifier_pybind",
+        "//bindings/pydrake/common:ref_cycle_pybind",
         "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:sorted_pair_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:type_safe_index_pybind",
         "//bindings/pydrake/common:value_pybind",
+        "//bindings/pydrake/systems:builder_life_support_pybind",
     ],
     cc_so_name = "__init__",
     cc_srcs = [
@@ -180,6 +182,7 @@ drake_py_unittest(
         "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/systems:analysis_py",
         "//bindings/pydrake/systems:lcm_py",
+        "//bindings/pydrake/systems:test_util_py",
     ],
 )
 

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -3,11 +3,13 @@
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
+#include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/type_safe_index_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/geometry/geometry_py.h"
+#include "drake/bindings/pydrake/systems/builder_life_support_pybind.h"
 #include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/meshcat_animation.h"
@@ -53,10 +55,14 @@ void DefineDrakeVisualizer(py::module m, T) {
             py::arg("builder"), py::arg("scene_graph"),
             py::arg("lcm") = nullptr,
             py::arg("params") = DrakeVisualizerParams{},
-            // Keep alive, ownership: `return` keeps `builder` alive.
-            py::keep_alive<0, 1>(),
-            // Keep alive, reference: `builder` keeps `lcm` alive.
-            py::keep_alive<1, 3>(), py_rvp::reference,
+            // `return` and `builder` join ref cycle.
+            internal::ref_cycle<0, 1>(),
+            // Using builder_life_support_stash makes the builder temporarily
+            // immortal (uncollectible self cycle). This will be resolved by
+            // the Build() step. See BuilderLifeSupport for rationale.
+            internal::builder_life_support_stash<T, 1>(),
+            // Keep alive, reference: `return` keeps `lcm` alive.
+            py::keep_alive<0, 3>(), py_rvp::reference,
             cls_doc.AddToBuilder.doc_4args_builder_scene_graph_lcm_params)
         .def_static("AddToBuilder",
             py::overload_cast<systems::DiagramBuilder<T>*,
@@ -65,10 +71,14 @@ void DefineDrakeVisualizer(py::module m, T) {
             py::arg("builder"), py::arg("query_object_port"),
             py::arg("lcm") = nullptr,
             py::arg("params") = DrakeVisualizerParams{},
-            // Keep alive, ownership: `return` keeps `builder` alive.
-            py::keep_alive<0, 1>(),
-            // Keep alive, reference: `builder` keeps `lcm` alive.
-            py::keep_alive<1, 3>(), py_rvp::reference,
+            // `return` and `builder` join ref cycle.
+            internal::ref_cycle<0, 1>(),
+            // Using builder_life_support_stash makes the builder temporarily
+            // immortal (uncollectible self cycle). This will be resolved by
+            // the Build() step. See BuilderLifeSupport for rationale.
+            internal::builder_life_support_stash<T, 1>(),
+            // Keep alive, reference: `return` keeps `lcm` alive.
+            py::keep_alive<0, 3>(), py_rvp::reference,
             cls_doc.AddToBuilder.doc_4args_builder_query_object_port_lcm_params)
         .def_static("DispatchLoadMessage",
             &DrakeVisualizer<T>::DispatchLoadMessage, py::arg("scene_graph"),

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -1,8 +1,11 @@
 import pydrake.geometry as mut
 
 import copy
+import gc
+import itertools
 import unittest
 import urllib.request
+import weakref
 
 import numpy as np
 import umsgpack
@@ -15,6 +18,7 @@ from pydrake.math import RigidTransform
 from pydrake.perception import PointCloud
 from pydrake.systems.analysis import Simulator_
 from pydrake.systems.framework import DiagramBuilder_, InputPort_
+from pydrake.systems.test.test_util import call_build_from_cpp
 
 # TODO(mwoehlke-kitware): Remove this when Jammy's python3-u-msgpack has been
 # updated to 2.5.2 or later.
@@ -30,7 +34,6 @@ class TestGeometryVisualizers(unittest.TestCase):
         SceneGraph = mut.SceneGraph_[T]
         DiagramBuilder = DiagramBuilder_[T]
         Simulator = Simulator_[T]
-        lcm = DrakeLcm()
         role = mut.Role.kIllustration
         params = mut.DrakeVisualizerParams(
             publish_period=0.1, role=mut.Role.kIllustration,
@@ -41,39 +44,77 @@ class TestGeometryVisualizers(unittest.TestCase):
         copy.copy(params)
 
         # Add some subscribers to detect message broadcast.
-        load_channel = "DRAKE_VIEWER_LOAD_ROBOT"
-        draw_channel = "DRAKE_VIEWER_DRAW"
-        load_subscriber = Subscriber(
-            lcm, load_channel, lcmt_viewer_load_robot)
-        draw_subscriber = Subscriber(
-            lcm, draw_channel, lcmt_viewer_draw)
+        def add_subscribers(lcm):
+            load_channel = "DRAKE_VIEWER_LOAD_ROBOT"
+            draw_channel = "DRAKE_VIEWER_DRAW"
+            load_subscriber = Subscriber(
+                lcm, load_channel, lcmt_viewer_load_robot)
+            draw_subscriber = Subscriber(
+                lcm, draw_channel, lcmt_viewer_draw)
+            return load_subscriber, draw_subscriber
 
-        # There are three ways to configure DrakeVisualizer.
+        # There are three ways to place DrakeVisualizer into a Diagram. We'll
+        # declare a helper functions for each of the ways. All of the helpers
+        # return a weak reference to the DrakeLcm object that they create, so
+        # that the test logic can verify correct object lifetimes.
         def by_hand(builder, scene_graph, params):
+            lcm = DrakeLcm()
             visualizer = builder.AddSystem(
                 mut.DrakeVisualizer_[T](lcm=lcm, params=params))
             builder.Connect(scene_graph.get_query_output_port(),
                             visualizer.query_object_input_port())
+            return weakref.finalize(lcm, lambda: None)
 
         def auto_connect_to_system(builder, scene_graph, params):
+            lcm = DrakeLcm()
             mut.DrakeVisualizer_[T].AddToBuilder(builder=builder,
                                                  scene_graph=scene_graph,
                                                  lcm=lcm, params=params)
+            return weakref.finalize(lcm, lambda: None)
 
         def auto_connect_to_port(builder, scene_graph, params):
+            lcm = DrakeLcm()
             mut.DrakeVisualizer_[T].AddToBuilder(
                 builder=builder,
                 query_object_port=scene_graph.get_query_output_port(),
                 lcm=lcm, params=params)
+            return weakref.finalize(lcm, lambda: None)
 
-        for func in [by_hand, auto_connect_to_system, auto_connect_to_port]:
+        # After adding the visualizer, there are two ways to build the
+        # diagram.
+
+        def python_builder_build(builder):
+            # The pydrake binding ensures object lifetimes properly.
+            return builder.Build()
+
+        def cxx_builder_build(builder):
+            # Calling build on a python-populated diagram builder from c++ is
+            # dodgy at best, but don't worry -- all will be well if something
+            # retains ownership of the diagram.
+            return call_build_from_cpp(builder)
+
+        for add_function, build_function in itertools.product(
+                    [by_hand, auto_connect_to_system, auto_connect_to_port],
+                    [python_builder_build, cxx_builder_build]):
             # Build the diagram.
             builder = DiagramBuilder()
             scene_graph = builder.AddSystem(SceneGraph())
-            func(builder, scene_graph, params)
+            lcm_spy = add_function(builder, scene_graph, params)
+            diagram = build_function(builder)
+
+            # Remove extraneous references, and collect garbage for good
+            # measure.
+            del builder
+            del scene_graph
+            gc.collect()
+
+            # Check the lcm object is still alive, recover a reference, and set
+            # receivers.
+            assert lcm_spy.alive
+            lcm = lcm_spy.peek()[0]
+            load_subscriber, draw_subscriber = add_subscribers(lcm)
 
             # Simulate to t = 0 to send initial load and draw messages.
-            diagram = builder.Build()
             Simulator(diagram).AdvanceTo(0)
             lcm.HandleSubscriptions(0)
             self.assertEqual(load_subscriber.count, 1)
@@ -81,7 +122,18 @@ class TestGeometryVisualizers(unittest.TestCase):
             load_subscriber.clear()
             draw_subscriber.clear()
 
+            # The diagram is mortal.
+            diagram_spy = weakref.finalize(diagram, lambda: None)
+            del diagram
+            del lcm
+            gc.collect()
+            self.assertFalse(diagram_spy.alive)
+            self.assertFalse(lcm_spy.alive)
+
         # Ad hoc broadcasting.
+        # Recreate some items deleted above.
+        lcm = DrakeLcm()
+        load_subscriber, draw_subscriber = add_subscribers(lcm)
         scene_graph = SceneGraph()
 
         mut.DrakeVisualizer_[T].DispatchLoadMessage(

--- a/bindings/pydrake/manipulation/BUILD.bazel
+++ b/bindings/pydrake/manipulation/BUILD.bazel
@@ -25,7 +25,9 @@ drake_pybind_library(
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:eigen_pybind",
+        "//bindings/pydrake/common:ref_cycle_pybind",
         "//bindings/pydrake/common:serialize_pybind",
+        "//bindings/pydrake/systems:builder_life_support_pybind",
     ],
     cc_so_name = "__init__",
     cc_srcs = [
@@ -56,6 +58,7 @@ drake_py_unittest(
         ":manipulation",
         "//bindings/pydrake/multibody",
         "//bindings/pydrake/systems",
+        "//bindings/pydrake/systems:test_util_py",
     ],
 )
 

--- a/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
@@ -1,7 +1,9 @@
+#include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/manipulation/manipulation_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/systems/builder_life_support_pybind.h"
 #include "drake/manipulation/kuka_iiwa/build_iiwa_control.h"
 #include "drake/manipulation/kuka_iiwa/iiwa_command_receiver.h"
 #include "drake/manipulation/kuka_iiwa/iiwa_command_sender.h"
@@ -179,10 +181,15 @@ void DefineManipulationKukaIiwa(py::module m) {
             py::arg("plant"), py::arg("iiwa_instance"),
             py::arg("controller_plant"), py::arg("ext_joint_filter_tau"),
             py::arg("desired_iiwa_kp_gains"), py::arg("control_mode"),
-            // Keep alive, ownership: `return` keeps `builder` alive.
-            py::keep_alive<0, 1>(),
-            // Keep alive, reference: `builder` keeps `controller_plant` alive.
-            py::keep_alive<1, 4>(), py_rvp::reference,
+            // Using builder_life_support_stash makes the
+            // builder temporarily immortal (uncollectible self cycle). This
+            // will be resolved by the Build() step. See BuilderLifeSupport
+            // for rationale.
+            internal::builder_life_support_stash<double, 1>(),
+            // `return` and `builder` join ref cycle.
+            internal::ref_cycle<0, 1>(),
+            // Keep alive, reference: `return` keeps `controller_plant` alive.
+            py::keep_alive<0, 4>(), py_rvp::reference,
             cls_doc.AddToBuilder.doc);
   }
 
@@ -197,7 +204,16 @@ void DefineManipulationKukaIiwa(py::module m) {
         py::arg("builder"), py::arg("ext_joint_filter_tau") = 0.01,
         py::arg("desired_iiwa_kp_gains") = std::nullopt,
         py::arg("control_mode") = IiwaControlMode::kPositionAndTorque,
-        // Keep alive, reference: `builder` keeps `controller_plant` alive.
+        // Using builder_life_support_stash makes the
+        // builder temporarily immortal (uncollectible self cycle). This
+        // will be resolved by the Build() step. See BuilderLifeSupport
+        // for rationale.
+        internal::builder_life_support_stash<double, 5>(),
+        // Keep alive, reference: `builder` keeps `controller_plant` alive.  It
+        // would be preferable to attach the keep-alive to the SimIiwaDriver
+        // diagram/system, but it does not appear in the function signature.
+        // Use the builder as an adequate lifetime proxy, since it will be kept
+        // alive via lifetime management associated with Build() calls.
         py::keep_alive<5, 3>(), doc.BuildIiwaControl.doc);
   }
 }

--- a/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
+++ b/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
@@ -2,8 +2,10 @@
 
 import pydrake.manipulation as mut
 
+import gc
 import unittest
 import numpy as np
+import weakref
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.lcm import DrakeLcm
@@ -19,7 +21,9 @@ from pydrake.systems.framework import (
     InputPort,
     OutputPort,
 )
+from pydrake.systems.analysis import Simulator
 from pydrake.systems.lcm import LcmBuses
+from pydrake.systems.test.test_util import call_build_from_cpp
 
 
 class TestKukaIiwa(unittest.TestCase):
@@ -187,3 +191,114 @@ class TestKukaIiwa(unittest.TestCase):
         self.assertGreater(dut1.num_input_ports(), 0)
         self.assertGreater(dut1.num_output_ports(), 0)
         self.assertGreater(len(builder.GetSystems()), tare)
+
+    def test_kuka_iiwa_sim_driver_lifetime_init(self):
+
+        def make_diagram():
+            builder, plant, controller_plant = (
+                self.make_builder_plant_controller_plant()
+            )
+            # `dut` is a diagram; its init() promises to keep
+            # `controller_plant` alive.
+            dut = mut.SimIiwaDriver(
+                control_mode=mut.IiwaControlMode.kPositionAndTorque,
+                controller_plant=controller_plant,
+                ext_joint_filter_tau=0.1,
+                kp_gains=np.full(7, 100.0),
+            )
+            return dut
+
+        diagram = make_diagram()
+        gc.collect()
+        # Crashes if controller_plant is not kept alive by bindings.
+        ad_diagram = diagram.ToAutoDiffXd()
+
+    def call_build_from(self, diagram_builder, language):
+        assert language in ["python", "c++"]
+        if language == "python":
+            # The pydrake binding ensures object lifetimes properly.
+            return diagram_builder.Build()
+        else:
+            # Calling build on a python-populated diagram builder from c++ is
+            # dodgy at best, but don't worry -- all will be well if something
+            # retains ownership of the diagram.
+            return call_build_from_cpp(diagram_builder)
+
+    def test_kuka_iiwa_sim_driver_lifetime_add_to_builder(self):
+
+        def make_diagram(call_build_from_language):
+            builder, plant, controller_plant = (
+                self.make_builder_plant_controller_plant()
+            )
+            dut = mut.SimIiwaDriver.AddToBuilder(
+                builder=builder,
+                plant=plant,
+                iiwa_instance=plant.GetModelInstanceByName("iiwa7"),
+                controller_plant=controller_plant,
+                ext_joint_filter_tau=0.1,
+                desired_iiwa_kp_gains=np.full(7, 100.0),
+                control_mode=mut.IiwaControlMode.kPositionAndTorque,
+            )
+            diagram = self.call_build_from(builder, call_build_from_language)
+            return diagram, dut
+
+        for call_build_from_language in ["python", "c++"]:
+            # In either case here, the diagram reference is sufficient to keep
+            # the whole diagram and its dependencies alive.
+            diagram, dut = make_diagram(call_build_from_language)
+            del dut
+            gc.collect()
+            # Crashes if controller_plant is not kept alive by bindings.
+            ad_diagram = diagram.ToAutoDiffXd()
+            # The diagram is mortal.
+            spy = weakref.finalize(diagram, lambda: None)
+            del diagram
+            gc.collect()
+            self.assertFalse(spy.alive)
+
+        # In a python-only program, any subsystem should be sufficient to keep
+        # everything alive.
+        diagram, dut = make_diagram("python")
+        del diagram
+        gc.collect()
+        # Crashes if controller_plant is not kept alive by bindings.
+        ad_dut = dut.ToAutoDiffXd()
+        # The dut is mortal.
+        spy = weakref.finalize(dut, lambda: None)
+        del dut
+        gc.collect()
+        self.assertFalse(spy.alive)
+
+    def test_kuka_iiwa_sim_driver_lifetime_build_iiwa_control(self):
+
+        def make_diagram(oblivious=False):
+            builder, plant, controller_plant = (
+                self.make_builder_plant_controller_plant()
+            )
+            mut.BuildIiwaControl(
+                plant=plant,
+                iiwa_instance=plant.GetModelInstanceByName("iiwa7"),
+                controller_plant=controller_plant, lcm=DrakeLcm(),
+                builder=builder, ext_joint_filter_tau=0.12,
+                desired_iiwa_kp_gains=np.arange(7),
+                control_mode=mut.IiwaControlMode.kPositionAndTorque)
+            if oblivious:
+                diagram = call_build_from_cpp(builder)
+            else:
+                diagram = builder.Build()
+            return diagram, weakref.finalize(controller_plant, lambda: None)
+
+        for call_build_from_language in ["python", "c++"]:
+            # In either case here, the diagram reference is sufficient to keep
+            # the whole diagram and its dependencies alive. In this case, we
+            # care about the lifetime of controller_plant, but we can't use
+            # scalar conversion to flush it out. Use the returned weakref spy
+            # instead.
+            diagram, spy = make_diagram(call_build_from_language)
+            gc.collect()
+            self.assertTrue(spy.alive, (spy.alive, call_build_from_language))
+            # The diagram and its dependencies are mortal.
+            spy = weakref.finalize(diagram, lambda: None)
+            del diagram
+            gc.collect()
+            self.assertFalse(spy.alive)

--- a/bindings/pydrake/planning/BUILD.bazel
+++ b/bindings/pydrake/planning/BUILD.bazel
@@ -27,8 +27,10 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:ref_cycle_pybind",
         "//bindings/pydrake/common:wrap_pybind",
         "//bindings/pydrake/geometry:optimization_pybind",
+        "//bindings/pydrake/systems:builder_life_support_pybind",
     ],
     cc_so_name = "__init__",
     cc_srcs = [
@@ -97,6 +99,7 @@ drake_py_unittest(
     deps = [
         ":planning",
         "//bindings/pydrake/common/test_utilities:numpy_compare_py",
+        "//bindings/pydrake/systems:controllers_py",
     ],
 )
 

--- a/bindings/pydrake/planning/planning_py_robot_diagram.cc
+++ b/bindings/pydrake/planning/planning_py_robot_diagram.cc
@@ -1,8 +1,10 @@
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/systems/builder_life_support_pybind.h"
 #include "drake/planning/robot_diagram.h"
 #include "drake/planning/robot_diagram_builder.h"
 
@@ -50,6 +52,7 @@ void DefinePlanningRobotDiagram(py::module m) {
     }
 
     {
+      using internal::BuilderLifeSupport;
       using Class = RobotDiagramBuilder<T>;
       constexpr auto& cls_doc = doc.RobotDiagramBuilder;
       auto cls = DefineTemplateClassWithDefault<Class>(
@@ -79,13 +82,35 @@ void DefinePlanningRobotDiagram(py::module m) {
               cls_doc.scene_graph.doc_0args_nonconst)
           .def("IsDiagramBuilt", &Class::IsDiagramBuilt,
               cls_doc.IsDiagramBuilt.doc)
-          .def("Build", &Class::Build,
-              // Keep alive, ownership (tr.): `self` keeps `return` alive.
-              // Any prior reference access to our owned systems (e.g., plant())
-              // must remain valid, so the RobotDiagram cannot be destroyed
-              // until the builder (and all of its internal references) are
-              // finished.
-              py::keep_alive<1, 0>(), cls_doc.Build.doc);
+          .def(
+              "Build",
+              [](RobotDiagramBuilder<T>* self) {
+                // Construct a ref_cycle between the DiagramBuilder python
+                // wrapper and the RobotDiagram python wrapper, to maintain the
+                // lifetime semantics attached to the DiagramBuilder python
+                // wrapper. To avoid leaks, also abandon the builder's
+                // BuilderLifeSupport. This is a very delicate dance.
+                systems::DiagramBuilder<T>& cpp_builder = self->builder();
+                // We *must* take a non-owning py::object *before* we delete
+                // the one stashed in BuilderLifeSupport. This prevents
+                // grievous errors.
+                py::object py_builder =
+                    py::cast(&cpp_builder, py_rvp::reference);
+                // Abandon life support before Build(), after which it would
+                // be too late.
+                BuilderLifeSupport<T>::abandon(&cpp_builder);
+                // Build the diagram.
+                std::unique_ptr<RobotDiagram<T>> cpp_diagram = self->Build();
+                // Transfer ownership of the diagram to a py::object.
+                py::object py_diagram =
+                    py::cast(cpp_diagram.release(), py_rvp::take_ownership);
+                // Make the ref_cycle.
+                internal::make_arbitrary_ref_cycle(
+                    py_builder, py_diagram, "RobotDiagramBuilder::Build");
+                // Return the py::object that owns the diagram.
+                return py_diagram;
+              },
+              cls_doc.Build.doc);
     }
   };
   type_visit(bind_common_scalar_types, CommonScalarPack{});

--- a/bindings/pydrake/planning/test/robot_diagram_test.py
+++ b/bindings/pydrake/planning/test/robot_diagram_test.py
@@ -1,12 +1,17 @@
 import pydrake.planning as mut
 
+import gc
 import unittest
+import weakref
+
+import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.geometry import SceneGraph_
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import MultibodyPlant_, MultibodyPlantConfig
+from pydrake.systems.controllers import InverseDynamicsController
 from pydrake.systems.framework import Context_, DiagramBuilder_
 
 
@@ -68,3 +73,85 @@ class TestRobotDiagram(unittest.TestCase):
         self.assertIsInstance(
             dut.scene_graph_context(root_context=root_context),
             Context_[T])
+
+    def test_lifetime_robot(self):
+        """Ensure that diagrams built using RobotDiagram/Builder neither become
+        immortal (leak memory forever), nor have unprotected object lifetimes,
+        leading to crashes.
+
+        For examples of crashes, see:
+        https://github.com/RobotLocomotion/drake/issues/14355
+        For examples of immortality, see:
+        https://github.com/RobotLocomotion/drake/issues/14387
+
+        Owing, in part, to the immortality problems, there is now the
+        expectation that any system reference will keep the diagram
+        alive. Ensure that either a system reference or a diagram reference
+        will work.
+        """
+
+        def make_diagram():
+            # Use a nested function to ensure that all locals get garbage
+            # collected quickly.
+
+            # Construct a trivial plant and ID controller.
+            # N.B. We explicitly do *not* add this plant to the diagram.
+            controller_plant = MultibodyPlant_[float](time_step=0.002)
+            controller_plant.Finalize()
+            builder = mut.RobotDiagramBuilder()
+            controller = builder.builder().AddSystem(
+                InverseDynamicsController(
+                    controller_plant,
+                    kp=[],
+                    ki=[],
+                    kd=[],
+                    has_reference_acceleration=False,
+                )
+            )
+            # Forward ports for ease of testing.
+            builder.builder().ExportInput(
+                controller.get_input_port_estimated_state(), "estimated_state")
+            builder.builder().ExportInput(
+                controller.get_input_port_desired_state(), "desired_state")
+            builder.builder().ExportOutput(
+                controller.get_output_port_control(), "generalized_force")
+            diagram = builder.Build()
+            return diagram, controller
+
+        # Manage lifetime via diagram reference.
+        diagram, controller = make_diagram()
+        del controller
+        gc.collect()
+        # N.B. Without fixes for #14355, we get a segfault when
+        # creating the context.
+        context = diagram.CreateDefaultContext()
+        diagram.GetInputPort("estimated_state").FixValue(context, [])
+        diagram.GetInputPort("desired_state").FixValue(context, [])
+        u = diagram.GetOutputPort("generalized_force").Eval(context)
+        np.testing.assert_equal(u, [])
+
+        # N.B. Without fixes for #14387, the diagram survives all garbage
+        # collection attempts.
+        spy = weakref.finalize(diagram, lambda: None)
+        del diagram
+        gc.collect()
+        self.assertFalse(spy.alive)
+
+        # Manage lifetime via controller reference
+        diagram, controller = make_diagram()
+        del diagram
+        gc.collect()
+        # N.B. Without fixes for #14355, we get a segfault when
+        # creating the context.
+        context = controller.CreateDefaultContext()
+        controller.GetInputPort("estimated_state").FixValue(context, [])
+        controller.GetInputPort("desired_state").FixValue(context, [])
+        u = controller.GetOutputPort("generalized_force").Eval(context)
+        np.testing.assert_equal(u, [])
+
+        # N.B. Without fixes for #14387, the controller survives all garbage
+        # collection attempts.
+        spy = weakref.finalize(controller, lambda: None)
+        del controller
+        gc.collect()
+        self.assertFalse(spy.alive)

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -48,9 +48,11 @@ drake_pybind_library(
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_pybind",
+        "//bindings/pydrake/common:ref_cycle_pybind",
         "//bindings/pydrake/common:type_safe_index_pybind",
         "//bindings/pydrake/common:value_pybind",
         "//bindings/pydrake/common:wrap_pybind",
+        "//bindings/pydrake/systems:builder_life_support_pybind",
     ],
     cc_srcs = [
         "framework_py.cc",
@@ -124,6 +126,7 @@ drake_pybind_library(
     cc_srcs = ["controllers_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
+        ":analysis_py",
         ":framework_py",
         ":module_py",
         ":primitives_py",
@@ -198,6 +201,14 @@ drake_py_library(
     srcs = ["drawing.py"],
     imports = PACKAGE_INFO.py_imports,
     deps = [":module_py"],
+)
+
+drake_cc_library(
+    name = "builder_life_support_pybind",
+    hdrs = ["builder_life_support_pybind.h"],
+    declare_installed_headers = False,
+    visibility = ["//bindings/pydrake:__subpackages__"],
+    deps = [],
 )
 
 drake_cc_library(
@@ -390,7 +401,10 @@ drake_pybind_library(
     add_install = False,
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:cpp_template_pybind",
+        "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:value_pybind",
+        "//bindings/pydrake/systems:builder_life_support_pybind",
     ],
     cc_so_name = "test/test_util",
     cc_srcs = ["test/test_util_py.cc"],
@@ -399,7 +413,7 @@ drake_pybind_library(
         ":framework_py",
         ":primitives_py",
     ],
-    visibility = ["//visibility:private"],
+    visibility = ["//bindings/pydrake:__subpackages__"],
 )
 
 drake_py_unittest(
@@ -409,6 +423,18 @@ drake_py_unittest(
         ":framework_py",
         ":primitives_py",
         "//bindings/pydrake:trajectories_py",
+        "//bindings/pydrake/common/test_utilities",
+    ],
+)
+
+drake_py_unittest(
+    name = "builder_life_support_test",
+    # Somehow kcov and pybind11 objects interact to spoil reference counting
+    # heuristics. In any case, kcov can't really introspect mixed-language
+    # programs.
+    tags = ["no_kcov"],
+    deps = [
+        ":test_util_py",
         "//bindings/pydrake/common/test_utilities",
     ],
 )
@@ -459,6 +485,7 @@ drake_py_unittest(
     ],
     deps = [
         ":controllers_py",
+        ":test_util_py",
         "//bindings/pydrake/examples",
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",

--- a/bindings/pydrake/systems/builder_life_support_pybind.h
+++ b/bindings/pydrake/systems/builder_life_support_pybind.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <any>
+
+#include <fmt/format.h>
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/string_map.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+
+namespace systems {
+template <typename T>
+class DiagramBuilder;
+}  // namespace systems
+
+namespace pydrake {
+namespace internal {
+
+/* BuilderLifeSupport provides helper functions to implement a last-resort
+  defense against programs that add systems in python, and then issue a Build()
+  call from c++.
+
+  The hazard is that lifetime annotations belonging to added systems get
+  deleted early, leaving invalid pointers (see #14355). If python calls
+  Build(), the diagram, builder, and systems are all joined by
+  garbage-collectible ref-cycles, and will remain alive until the next
+  collection after losing reachability. If c++ calls Build(), then the
+  builder-diagram cycle doesn't get added, and then builder, systems, and their
+  associates are at risk.
+
+  BuilderLifeSupport helps by exposing the ability (via stash()) to place a
+  strong reference to the python builder in the ownership of the c++
+  builder. The c++ builder will automatically transfer that reference to the
+  diagram, so that a c++ Build() call will still result in a one-way reference
+  from the c++ diagram to the python builder and its associates.
+
+  For mixed-language programs, the one-way reference is typically good
+  enough. However, for python programs, the Build() annotations are strictly
+  better. Using both is bad, since it leads to diagram immortality (see
+  #14387). Python Build() avoids immortality by calling abandon() to release
+  the extra strong reference. */
+template <typename T>
+struct BuilderLifeSupport {
+  static constexpr char kKey[] = "_pydrake_internal_life_support";
+
+  // Store a strong reference to the python builder into the c++ builder's life
+  // support attributes.
+  static void stash(systems::DiagramBuilder<T>* builder) {
+    BuilderLifeSupport<T>::attrs(builder).emplace(kKey, py::cast(builder));
+  }
+
+  // Delete a previously stored strong reference to the python builder from the
+  // c++ builder's life support attributes.
+  static void abandon(systems::DiagramBuilder<T>* builder) {
+    BuilderLifeSupport<T>::attrs(builder).erase(kKey);
+  }
+
+  // (Internal use only) Return a reference to a map of attributes stored in
+  // life support.
+  static string_map<std::any>& attrs(systems::DiagramBuilder<T>* builder) {
+    return builder->get_mutable_life_support().attributes;
+  }
+};
+
+/* pydrake::internal::builder_life_support_stash is a custom call policy for
+  pybind11.
+
+  For an overview of other call policies, See
+  https://pybind11.readthedocs.io/en/stable/advanced/functions.html#additional-call-policies
+
+  `builder_life_support_stash` applies the equivalent of
+  BuilderLifeSupport::stash(), as a post-call step. Note that it stores a
+  strong reference to the builder's python wrapper, in a place inaccessible to
+  garbage collection. To avoid leaks, the complete builder workflow should call
+  BuilderLifeSupport::abandon() before the actual build step.
+
+  @tparam T the scalar type in use for DiagramBuilder
+  @tparam Builder an argument index
+
+  The argument index starts at 1; for methods, `self` is at index 1. Index 0
+  denotes the return value.
+*/
+template <typename T, size_t Builder>
+struct builder_life_support_stash {};
+
+template <typename T>
+void builder_life_support_stash_impl(size_t builder_index,
+    const py::detail::function_call& call, py::handle ret) {
+  // Returns the handle selected by the given index. Throws if the index is
+  // invalid.
+  auto get_arg = [&](size_t n) -> py::handle {
+    if (n == 0) {
+      return ret;
+    }
+    if (n == 1 && call.init_self) {
+      return call.init_self;
+    }
+    if (n <= call.args.size()) {
+      return call.args[n - 1];
+    }
+    py::pybind11_fail(
+        fmt::format("Could not activate builder_life_support_stash: index {} "
+                    "is invalid for function '{}'",
+            n, call.func.name));
+  };
+  py::handle builder_handle = get_arg(builder_index);
+  if (builder_handle.is_none()) {
+    // Nothing useful to stash.
+    return;
+  }
+  // Convert the handle to a strong reference for later stashing.
+  py::object py_builder = py::cast<py::object>(builder_handle);
+  // Recover the c++ pointer; pybind11 will throw if the cast can't work.
+  systems::DiagramBuilder<T>* cc_builder =
+      py::cast<systems::DiagramBuilder<T>*>(py_builder);
+  DRAKE_ASSERT(cc_builder != nullptr);
+  // Do the equivalent of stash(); we don't use the method since we've already
+  // had to recover the python and c++ objects in a different order.
+  BuilderLifeSupport<T>::attrs(cc_builder)
+      .emplace(BuilderLifeSupport<T>::kKey, py_builder);
+}
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake
+
+namespace pybind11 {
+namespace detail {
+
+// Provide a specialization of the pybind11 internal process_attribute
+// template; this allows writing an annotation that works seamlessly in
+// bindings definitions.
+template <typename T, size_t Builder>
+class process_attribute<
+    drake::pydrake::internal::builder_life_support_stash<T, Builder>>
+    : public process_attribute_default<
+          drake::pydrake::internal::builder_life_support_stash<T, Builder>> {
+ public:
+  // NOLINTNEXTLINE(runtime/references)
+  static void postcall(function_call& call, handle ret) {
+    drake::pydrake::internal::builder_life_support_stash_impl<T>(
+        Builder, call, ret);
+  }
+};
+
+}  // namespace detail
+}  // namespace pybind11

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -3,10 +3,12 @@
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
+#include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/common/type_safe_index_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/systems/builder_life_support_pybind.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/event.h"
@@ -590,36 +592,35 @@ void DefineEventAndEventSubclasses(py::module m) {
 
 template <typename T>
 void DoDefineFrameworkDiagramBuilder(py::module m) {
-  DefineTemplateClassWithDefault<DiagramBuilder<T>>(
-      m, "DiagramBuilder", GetPyParam<T>(), doc.DiagramBuilder.doc)
+  using internal::BuilderLifeSupport;
+  DefineTemplateClassWithDefault<DiagramBuilder<T>>(m, "DiagramBuilder",
+      GetPyParam<T>(), doc.DiagramBuilder.doc, std::nullopt, py::dynamic_attr())
       .def(py::init<>(), doc.DiagramBuilder.ctor.doc)
       .def(
           "AddSystem",
           [](DiagramBuilder<T>* self, unique_ptr<System<T>> system) {
+            // Using BuilderLifeSupport::stash makes the builder
+            // temporarily immortal (uncollectible self cycle). This will be
+            // resolved by the Build() step. See BuilderLifeSupport for
+            // rationale.
+            BuilderLifeSupport<T>::stash(self);
             return self->AddSystem(std::move(system));
           },
-          py::arg("system"),
-          // TODO(eric.cousineau): These two keep_alive's purposely form a
-          // reference cycle as a workaround for #14355. We should find a
-          // better way?
-          // Keep alive, reference: `self` keeps `return` alive.
-          py::keep_alive<1, 0>(),
-          // Keep alive, ownership: `system` keeps `self` alive.
-          py::keep_alive<2, 1>(), doc.DiagramBuilder.AddSystem.doc)
+          py::arg("system"), internal::ref_cycle<1, 2>(),
+          doc.DiagramBuilder.AddSystem.doc)
       .def(
           "AddNamedSystem",
           [](DiagramBuilder<T>* self, std::string& name,
               unique_ptr<System<T>> system) {
+            // Using BuilderLifeSupport::stash makes the builder
+            // temporarily immortal (uncollectible self cycle). This will be
+            // resolved by the Build() step. See BuilderLifeSupport for
+            // rationale.
+            BuilderLifeSupport<T>::stash(self);
             return self->AddNamedSystem(name, std::move(system));
           },
-          py::arg("name"), py::arg("system"),
-          // TODO(eric.cousineau): These two keep_alive's purposely form a
-          // reference cycle as a workaround for #14355. We should find a
-          // better way?
-          // Keep alive, reference: `self` keeps `return` alive.
-          py::keep_alive<1, 0>(),
-          // Keep alive, ownership: `system` keeps `self` alive.
-          py::keep_alive<3, 1>(), doc.DiagramBuilder.AddNamedSystem.doc)
+          py::arg("name"), py::arg("system"), internal::ref_cycle<1, 3>(),
+          doc.DiagramBuilder.AddNamedSystem.doc)
       .def("RemoveSystem", &DiagramBuilder<T>::RemoveSystem, py::arg("system"),
           doc.DiagramBuilder.RemoveSystem.doc)
       .def("empty", &DiagramBuilder<T>::empty, doc.DiagramBuilder.empty.doc)
@@ -694,12 +695,33 @@ void DoDefineFrameworkDiagramBuilder(py::module m) {
       .def("ExportOutput", &DiagramBuilder<T>::ExportOutput, py::arg("output"),
           py::arg("name") = kUseDefaultName, py_rvp::reference_internal,
           doc.DiagramBuilder.ExportOutput.doc)
-      .def("Build", &DiagramBuilder<T>::Build,
-          // Keep alive, ownership (tr.): `self` keeps `return` alive.
-          py::keep_alive<1, 0>(), doc.DiagramBuilder.Build.doc)
-      .def("BuildInto", &DiagramBuilder<T>::BuildInto, py::arg("target"),
-          // Keep alive, ownership (tr.): `target` keeps `self` alive.
-          py::keep_alive<2, 1>(), doc.DiagramBuilder.BuildInto.doc)
+      .def(
+          "Build",
+          [](DiagramBuilder<T>* self) {
+            // The c++ Build() step would pass life support to the
+            // diagram. Instead of relying on its one-way, uncollectible
+            // support here, abandon it in favor of the builder-diagram
+            // ref_cycle invoked below. We can't have both; that would create
+            // an uncollectible builder-diagram cycle and make those objects
+            // immortal.
+            BuilderLifeSupport<T>::abandon(self);
+            return self->Build();
+          },
+          internal::ref_cycle<0, 1>(), doc.DiagramBuilder.Build.doc)
+      .def(
+          "BuildInto",
+          [](DiagramBuilder<T>* self, Diagram<T>* target) {
+            // The c++ BuildInto() step would pass life support to the
+            // diagram. Instead of relying on its one-way, uncollectible
+            // support here, abandon it in favor of the builder-diagram
+            // ref_cycle invoked below. We can't have both; that would create
+            // an uncollectible builder-diagram cycle and make those objects
+            // immortal.
+            BuilderLifeSupport<T>::abandon(self);
+            self->BuildInto(target);
+          },
+          internal::ref_cycle<1, 2>(), py::arg("target"),
+          doc.DiagramBuilder.BuildInto.doc)
       .def("IsConnectedOrExported", &DiagramBuilder<T>::IsConnectedOrExported,
           py::arg("port"), doc.DiagramBuilder.IsConnectedOrExported.doc)
       .def("num_input_ports", &DiagramBuilder<T>::num_input_ports,

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -302,8 +302,9 @@ struct Impl {
     // TODO(eric.cousineau): Show constructor, but somehow make sure `pybind11`
     // knows this is abstract?
     auto system_cls =
-        DefineTemplateClassWithDefault<System<T>, SystemBase, PySystem>(
-            m, "System", GetPyParam<T>(), doc.System.doc);
+        DefineTemplateClassWithDefault<System<T>, SystemBase, PySystem>(m,
+            "System", GetPyParam<T>(), doc.System.doc, std::nullopt,
+            py::dynamic_attr());
     system_cls
         // Resource allocation and initialization.
         .def("AllocateContext", &System<T>::AllocateContext,

--- a/bindings/pydrake/systems/test/builder_life_support_test.py
+++ b/bindings/pydrake/systems/test/builder_life_support_test.py
@@ -1,0 +1,66 @@
+"""Unit test for builder_life_support_stash<>() annotation.
+
+See also systems/test/test_util_py.cc for the bindings used in the tests.
+"""
+import gc
+import unittest
+import weakref
+
+from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.test_utilities.memory_test_util import actual_ref_count
+from pydrake.systems.test.test_util import (
+    Arbitrary, DiagramBuilderTestAdversary_)
+
+
+class TestBuilderLifeSupport(unittest.TestCase):
+    @numpy_compare.check_all_types
+    def test_invalid_index(self, T):
+        DiagramBuilderTestAdversary = DiagramBuilderTestAdversary_[T]
+        adversary = DiagramBuilderTestAdversary()
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "Could not activate builder_life_support_stash.*"):
+            adversary.StashBadIndex()
+        self.assertEqual(actual_ref_count(adversary), 1)
+
+    @numpy_compare.check_all_types
+    def test_wrong_type(self, T):
+        DiagramBuilderTestAdversary = DiagramBuilderTestAdversary_[T]
+        adversary = DiagramBuilderTestAdversary()
+        with self.assertRaisesRegex(RuntimeError, "Unable to cast.*"):
+            adversary.StashWrongType(Arbitrary())
+        self.assertEqual(actual_ref_count(adversary), 1)
+
+    @numpy_compare.check_all_types
+    def test_bind_at_init(self, T):
+        DiagramBuilderTestAdversary = DiagramBuilderTestAdversary_[T]
+        # The int-accepting constructor also stashes.
+        adversary = DiagramBuilderTestAdversary(10)
+        self.assertEqual(actual_ref_count(adversary), 2)
+        adversary.Abandon()
+        self.assertEqual(actual_ref_count(adversary), 1)
+
+    @numpy_compare.check_all_types
+    def test_bind_self(self, T):
+        DiagramBuilderTestAdversary = DiagramBuilderTestAdversary_[T]
+        adversary = DiagramBuilderTestAdversary()
+        adversary.StashSelf()
+        self.assertEqual(actual_ref_count(adversary), 2)
+        adversary.Abandon()
+        self.assertEqual(actual_ref_count(adversary), 1)
+
+    @numpy_compare.check_all_types
+    def test_bind_returned_self(self, T):
+        DiagramBuilderTestAdversary = DiagramBuilderTestAdversary_[T]
+        adversary = DiagramBuilderTestAdversary()
+        adversary.StashReturnedSelf()
+        self.assertEqual(actual_ref_count(adversary), 2)
+        adversary.Abandon()
+        self.assertEqual(actual_ref_count(adversary), 1)
+
+    @numpy_compare.check_all_types
+    def test_bind_returned_none(self, T):
+        DiagramBuilderTestAdversary = DiagramBuilderTestAdversary_[T]
+        adversary = DiagramBuilderTestAdversary()
+        adversary.StashReturnedNull()
+        self.assertEqual(actual_ref_count(adversary), 1)

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -1,7 +1,11 @@
+#include "drake/bindings/pydrake/common/cpp_template_pybind.h"
+#include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/systems/builder_life_support_pybind.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/vector_system.h"
 
@@ -15,6 +19,81 @@ using systems::Simulator;
 
 namespace pydrake {
 namespace {
+
+template <typename T>
+class DiagramBuilderTestAdversary final : public systems::DiagramBuilder<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramBuilderTestAdversary);
+
+  DiagramBuilderTestAdversary() = default;
+  // The int-accepting constructor will be annotated in the wrapper.
+  explicit DiagramBuilderTestAdversary(int) {}
+  ~DiagramBuilderTestAdversary() final = default;
+};
+
+// The Arbitrary type exists to test annotations pointing to a wrong-typed
+// argument.
+class Arbitrary {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Arbitrary);
+
+  Arbitrary() = default;
+  ~Arbitrary() = default;
+};
+
+void DeclareBuilderLifeSupportTestHelpers(py::module m) {
+  // the Arbitrary type exists to test annotations pointing to a wrong-typed
+  // argument.
+  py::class_<Arbitrary>(m, "Arbitrary").def(py::init<>());
+
+  type_visit(
+      [&m](auto dummy) {
+        using systems::DiagramBuilder;
+        using T = decltype(dummy);
+        // Use this in tests to approximate a mixed-language program that
+        // populates a DiagramBuilder in Python, but calls the Build() step from
+        // C++. This version of Build() deliberately ignores any python-specific
+        // object lifetime issues.
+        m.def("call_build_from_cpp",
+            [](DiagramBuilder<T>* builder) { return builder->Build(); });
+
+        // Use this in tests to probe the failure modes of programming errors
+        // with builder life support annotations.
+        using internal::builder_life_support_stash;
+        DefineTemplateClassWithDefault<DiagramBuilderTestAdversary<T>,
+            DiagramBuilder<T>>(m, "DiagramBuilderTestAdversary",
+            GetPyParam<T>(), "for testing", std::nullopt, py::dynamic_attr())
+            .def(py::init<>())
+            // The int-accepting constructor exists to test init-time use of
+            // argument index 1.
+            .def(py::init<int>(), builder_life_support_stash<T, 1>())
+            .def(
+                "StashSelf", [](DiagramBuilderTestAdversary<T>*) { return; },
+                builder_life_support_stash<T, 1>())
+            .def(
+                "StashReturnedSelf",
+                [](DiagramBuilderTestAdversary<T>* self) { return self; },
+                builder_life_support_stash<T, 0>())
+            .def(
+                "StashReturnedNull",
+                [](DiagramBuilderTestAdversary<T>*) { return nullptr; },
+                builder_life_support_stash<T, 0>())
+            .def(
+                "StashBadIndex",
+                [](DiagramBuilderTestAdversary<T>*) { return; },
+                builder_life_support_stash<T, 2>())
+            .def(
+                "StashWrongType",
+                [](DiagramBuilderTestAdversary<T>*, Arbitrary*) { return; },
+                builder_life_support_stash<T, 2>())
+            // Use this in case it is needed to undo any test-only immortality
+            // problems.
+            .def("Abandon", [](DiagramBuilderTestAdversary<T>* self) {
+              internal::BuilderLifeSupport<T>::abandon(self);
+            });
+      },
+      CommonScalarPack{});
+}
 
 using T = double;
 
@@ -55,7 +134,6 @@ class MyVector2 : public BasicVector<T> {
     return new MyVector2(this->get_value());
   }
 };
-
 }  // namespace
 
 PYBIND11_MODULE(test_util, m) {
@@ -145,6 +223,8 @@ PYBIND11_MODULE(test_util, m) {
         system.CalcOutput(*context, output.get());
         return output;
       });
+
+  DeclareBuilderLifeSupportTestHelpers(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/test/memory_leak_test.py
+++ b/bindings/pydrake/test/memory_leak_test.py
@@ -316,18 +316,10 @@ class TestMemoryLeaks(unittest.TestCase):
         self.do_test(dut=_dut_simple_source, count=10)
 
     def test_trivial_simulator(self):
-        self.do_test(
-            dut=_dut_trivial_simulator,
-            count=5,
-            # TODO(rpoyner-tri): Allow 0 leaks.
-            leaks_allowed=5, leaks_required=1)
+        self.do_test(dut=_dut_trivial_simulator, count=5)
 
     def test_mixed_language_simulator(self):
-        self.do_test(
-            dut=_dut_mixed_language_simulator,
-            count=5,
-            # TODO(rpoyner-tri): Allow 0 leaks.
-            leaks_allowed=5, leaks_required=1)
+        self.do_test(dut=_dut_mixed_language_simulator, count=5)
 
     def test_full_example(self):
         # Note: this test doesn't invoke the #14355 deliberate cycle.


### PR DESCRIPTION
This re-applies 0bbde17e (by reverting the revert 7b5bb38f).

Adjust the original commit by disabling one test under kcov. Somehow kcov spoils reference counting checks for pybind11 objects only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22343)
<!-- Reviewable:end -->
