### PR TITLE
[systems] LuenbergerObserver and KalmanFilter use shared_ptr

### DIFF
--- a/systems/estimators/kalman_filter.h
+++ b/systems/estimators/kalman_filter.h
@@ -44,19 +44,17 @@ Eigen::MatrixXd SteadyStateKalmanFilter(
 /// Creates a Luenberger observer system using the optimal steady-state Kalman
 /// filter gain matrix, L, as described above.
 ///
-/// @param system A unique_ptr to a LinearSystem describing the system to be
-/// observed.  The new observer will take and maintain ownership of this
-/// pointer.
+/// @param system The LinearSystem describing the system to be observed.
 /// @param W The process noise covariance matrix, E[ww'], of size num_states x
 /// num_states.
 /// @param V The measurement noise covariance matrix, E[vv'], of size num_.
-/// @returns A unique_ptr to the constructed observer system.
+/// @returns The constructed observer system.
 ///
 /// @throws std::exception if V is not positive definite.
 /// @ingroup estimator_systems
 /// @pydrake_mkdoc_identifier{linear_system}
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
-    std::unique_ptr<LinearSystem<double>> system,
+    std::shared_ptr<const LinearSystem<double>> system,
     const Eigen::Ref<const Eigen::MatrixXd>& W,
     const Eigen::Ref<const Eigen::MatrixXd>& V);
 
@@ -70,24 +68,29 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
 /// then the resulting observer will have the form
 ///   dx̂/dt = f(x̂,u) + L(y - g(x̂,u)),
 /// where x̂ is the estimated state and the gain matrix, L, is designed
-/// as a steady-state Kalman filter using a linearization of f(x,u) at @p
-/// context as described above.
+/// as a steady-state Kalman filter using a linearization of f(x,u) at
+/// `context` as described above.
 ///
-/// @param system A unique_ptr to a System describing the system to be
-/// observed.  The new observer will take and maintain ownership of this
-/// pointer.
-/// @param context A unique_ptr to the context describing a fixed-point of the
-/// system (plus any additional parameters).  The new observer will take and
-/// maintain ownership of this pointer for use in its internal forward
-/// simulation.
+/// @param system The System describing the system to be observed.
+/// @param context The context describing a fixed-point of the system (plus any
+/// additional parameters).
 /// @param W The process noise covariance matrix, E[ww'], of size num_states x
 /// num_states.
 /// @param V The measurement noise covariance matrix, E[vv'], of size num_.
-/// @returns A unique_ptr to the constructed observer system.
+/// @returns The constructed observer system.
 ///
 /// @throws std::exception if V is not positive definite.
 /// @ingroup estimator_systems
 /// @pydrake_mkdoc_identifier{system}
+std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
+    std::shared_ptr<const System<double>> system,
+    const Context<double>& context,
+    const Eigen::Ref<const Eigen::MatrixXd>& W,
+    const Eigen::Ref<const Eigen::MatrixXd>& V);
+
+// TODO(jwnimmer-tri) Add deprecation marker on or about 2025-02-01.
+/// (To be deprecated) An overload that accepts `context` by unique_ptr.
+/// @exclude_from_pydrake_mkdoc{This is not bound.}
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::unique_ptr<System<double>> system,
     std::unique_ptr<Context<double>> context,

--- a/systems/estimators/luenberger_observer.cc
+++ b/systems/estimators/luenberger_observer.cc
@@ -10,13 +10,12 @@ namespace estimators {
 
 template <typename T>
 LuenbergerObserver<T>::LuenbergerObserver(
-    const System<T>* system, std::unique_ptr<System<T>> owned_system,
+    std::shared_ptr<const System<T>> observed_system,
     const Context<T>& observed_system_context,
     const Eigen::Ref<const Eigen::MatrixXd>& observer_gain)
-    : owned_system_(std::move(owned_system)),
-      observed_system_(owned_system_ ? owned_system_.get() : system),
+    : observed_system_(std::move(observed_system)),
       observer_gain_(observer_gain) {
-  DRAKE_DEMAND(observed_system_ != nullptr);
+  DRAKE_THROW_UNLESS(observed_system_ != nullptr);
   observed_system_->ValidateContext(observed_system_context);
 
   // Note: Could potentially extend this to MIMO systems.
@@ -83,15 +82,9 @@ template <typename T>
 LuenbergerObserver<T>::LuenbergerObserver(
     const System<T>& observed_system, const Context<T>& observed_system_context,
     const Eigen::Ref<const Eigen::MatrixXd>& observer_gain)
-    : LuenbergerObserver(&observed_system, nullptr, observed_system_context,
-                         observer_gain) {}
-
-template <typename T>
-LuenbergerObserver<T>::LuenbergerObserver(
-    std::unique_ptr<System<T>> observed_system,
-    const Context<T>& observed_system_context,
-    const Eigen::Ref<const Eigen::MatrixXd>& observer_gain)
-    : LuenbergerObserver(nullptr, std::move(observed_system),
+    : LuenbergerObserver(std::shared_ptr<const System<T>>(
+                             /* managed object = */ std::shared_ptr<void>{},
+                             /* stored pointer = */ &observed_system),
                          observed_system_context, observer_gain) {}
 
 template <typename T>

--- a/systems/estimators/luenberger_observer.h
+++ b/systems/estimators/luenberger_observer.h
@@ -50,16 +50,15 @@ class LuenbergerObserver final: public LeafSystem<T> {
   /// of @p observed_system.
   ///
   /// @pre The observed_system output port must be vector-valued.
-  ///
-  /// Note: The `observed_system` reference must remain valid for the lifetime
-  /// of this system.
-  LuenbergerObserver(const System<T>& observed_system,
+  LuenbergerObserver(std::shared_ptr<const System<T>> observed_system,
                      const Context<T>& observed_system_context,
                      const Eigen::Ref<const Eigen::MatrixXd>& observer_gain);
 
-  /// Constructs the observer, taking ownership of `observed_system`.
+  /// Constructs the observer, without claiming ownership of `observed_system`.
+  /// Note: The `observed_system` reference must remain valid for the lifetime
+  /// of this system.
   /// @exclude_from_pydrake_mkdoc{This constructor is not bound.}
-  LuenbergerObserver(std::unique_ptr<System<T>> observed_system,
+  LuenbergerObserver(const System<T>& observed_system,
                      const Context<T>& observed_system_context,
                      const Eigen::Ref<const Eigen::MatrixXd>& observer_gain);
 
@@ -88,13 +87,6 @@ class LuenbergerObserver final: public LeafSystem<T> {
   const Eigen::MatrixXd& L() { return observer_gain_; }
 
  private:
-  // All constructors delegate here.  Exactly one of system or owned_system must
-  // be non-null.
-  LuenbergerObserver(const System<T>* system,
-                     std::unique_ptr<System<T>> owned_system,
-                     const Context<T>& context,
-                     const Eigen::Ref<const Eigen::MatrixXd>& observer_gain);
-
   // Advance the state estimate using forward dynamics and the observer
   // gains.
   void DoCalcTimeDerivatives(const Context<T>& context,
@@ -107,8 +99,7 @@ class LuenbergerObserver final: public LeafSystem<T> {
   void UpdateObservedSystemContext(const Context<T>& context,
                                    Context<T>* observed_system_context) const;
 
-  const std::unique_ptr<System<T>> owned_system_{};
-  const System<T>* const observed_system_;
+  const std::shared_ptr<const System<T>> observed_system_;
   const Eigen::MatrixXd observer_gain_;  // Gain matrix (often called "L").
 
   const CacheEntry* observed_system_context_cache_entry_{};

--- a/systems/estimators/test/kalman_filter_test.cc
+++ b/systems/estimators/test/kalman_filter_test.cc
@@ -38,20 +38,25 @@ GTEST_TEST(TestKalman, DoubleIntegrator) {
   EXPECT_TRUE(CompareMatrices(SteadyStateKalmanFilter(A, C, W, V), L, tol));
 
   // Test LinearSystem version of the Kalman filter.
-  auto linear_filter = SteadyStateKalmanFilter(
-      std::make_unique<LinearSystem<double>>(A, B, C, D), W, V);
-
+  auto sys = std::make_shared<const LinearSystem<double>>(A, B, C, D);
+  auto linear_filter = SteadyStateKalmanFilter(sys, W, V);
   EXPECT_TRUE(CompareMatrices(linear_filter->L(), L, tol));
 
   // Call it as a generic System (by passing in a Context).
   // Should get the same result, but as an affine system.
-  auto sys = std::make_unique<LinearSystem<double>>(A, B, C, D);
   auto context = sys->CreateDefaultContext();
   sys->get_input_port().FixValue(context.get(), 0.0);
   context->SetContinuousState(Eigen::Vector2d::Zero());
-  auto filter =
-      SteadyStateKalmanFilter(std::move(sys), std::move(context), W, V);
+  auto filter = SteadyStateKalmanFilter(sys, *context, W, V);
+  context.reset();
+  EXPECT_TRUE(CompareMatrices(filter->L(), L, tol));
 
+  // Also check the to-be-deprecated overload that accepts a unique_ptr context.
+  auto owned = std::make_unique<LinearSystem<double>>(A, B, C, D);
+  context = owned->CreateDefaultContext();
+  owned->get_input_port().FixValue(context.get(), 0.0);
+  context->SetContinuousState(Eigen::Vector2d::Zero());
+  filter = SteadyStateKalmanFilter(std::move(owned), std::move(context), W, V);
   EXPECT_TRUE(CompareMatrices(filter->L(), L, tol));
 }
 


### PR DESCRIPTION
Towards #5842 and #21968.  We must stop passing `unique_ptr` as an argument from Python down to C++... passing `unique_ptr` in an argument of a call from Python into C++ is made possible by Drake-specific hacks to pybind11, and we need to get rid of the hacks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22351)
<!-- Reviewable:end -->
