### PR TITLE
[systems] Remove global destructors in initial_value_program

### DIFF
--- a/systems/analysis/initial_value_problem.cc
+++ b/systems/analysis/initial_value_problem.cc
@@ -91,10 +91,10 @@ template <typename T>
 const double InitialValueProblem<T>::kDefaultAccuracy = 1e-4;
 
 template <typename T>
-const T InitialValueProblem<T>::kInitialStepSize = static_cast<T>(1e-4);
+const double InitialValueProblem<T>::kInitialStepSize = 1e-4;
 
 template <typename T>
-const T InitialValueProblem<T>::kMaxStepSize = static_cast<T>(1e-1);
+const double InitialValueProblem<T>::kMaxStepSize = 1e-1;
 
 template <typename T>
 InitialValueProblem<T>::InitialValueProblem(

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -63,9 +63,9 @@ class InitialValueProblem {
   /// Default integration accuracy in the relative tolerance sense.
   static const double kDefaultAccuracy;
   /// Default initial integration step size.
-  static const T kInitialStepSize;
+  static const double kInitialStepSize;
   /// Default maximum integration step size.
-  static const T kMaxStepSize;
+  static const double kMaxStepSize;
 
   /// General ODE system d𝐱/dt = f(t, 𝐱; 𝐤) function type.
   ///


### PR DESCRIPTION
Scalar-typed variables cannot be globals, since they have non-trivial destructors.

This is a (probably un-noticable) breaking change to the data type of a constant.

---

This was flagged by a new linter I'm working on to find global destructors in libdrake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22358)
<!-- Reviewable:end -->
