### PR TITLE
Use AddMultibodyPlantConstraints in InverseKinematics

### DIFF
--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -87,7 +87,7 @@ class TestInverseKinematics(unittest.TestCase):
             q=self.q,
             prog=self.prog,
             plant_context=self.ik_two_bodies.context())
-        self.assertEqual(len(bindings), 2)
+        self.assertEqual(len(bindings), 3)
 
     def test_AddPositionConstraint1(self):
         p_BQ = np.array([0.2, 0.3, 0.5])

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -135,6 +135,7 @@ drake_cc_library(
     ],
     visibility = ["//visibility:private"],
     deps = [
+        ":add_multibody_plant_constraints",
         ":kinematic_evaluators",
         "//multibody/plant",
         "//solvers:mathematical_program",
@@ -167,6 +168,7 @@ drake_cc_googletest(
     srcs = ["test/add_multibody_plant_constraints_test.cc"],
     deps = [
         ":add_multibody_plant_constraints",
+        "//common/test_utilities:eigen_matrix_compare",
         "//solvers:snopt_solver",
         "//solvers:solve",
     ],

--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
@@ -19,6 +19,9 @@ std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
     solvers::MathematicalProgram* prog,
     systems::Context<double>* plant_context) {
   DRAKE_THROW_UNLESS(prog != nullptr);
+  if (plant_context) {
+    plant.ValidateContext(*plant_context);
+  }
   // AddMultibodyPlantConstraints only supports coupler, ball, distance, and
   // weld.
   int num_supported_constraints =
@@ -36,49 +39,144 @@ std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
         "not supported here yet (but likely should be)",
         plant.num_constraints(), num_supported_constraints));
   }
-  std::vector<Binding<Constraint>> bindings =
-      AddUnitQuaternionConstraintOnPlant(plant, q, prog);
+  std::vector<Binding<Constraint>> bindings;
+
+  // Joint limits.
+  const int nq = plant.num_positions();
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  Eigen::VectorXd lb = plant.GetPositionLowerLimits();
+  Eigen::VectorXd ub = plant.GetPositionUpperLimits();
+
+  // Joint locking.
+  VectorX<bool> is_locked = VectorX<bool>::Constant(nq, false);
+  Eigen::VectorXd current_positions(nq);
+  if (plant_context) {
+    current_positions = plant.GetPositions(*plant_context);
+    for (JointIndex i : plant.GetJointIndices()) {
+      const Joint<double>& joint = plant.get_joint(i);
+      if (joint.is_locked(*plant_context)) {
+        const int start = joint.position_start();
+        const int size = joint.num_positions();
+        lb.segment(start, size).setConstant(-kInf);
+        ub.segment(start, size).setConstant(kInf);
+        bindings
+            .emplace_back(prog->AddLinearEqualityConstraint(
+                Eigen::MatrixXd::Identity(size, size),
+                current_positions.segment(start, size), q.segment(start, size)))
+            .evaluator()
+            ->set_description(fmt::format("Joint {} lock", joint.name()));
+        is_locked.segment(start, size).array() = true;
+      }
+    }
+  }
+
+  // Add the unit quaternion constraints.
+  for (BodyIndex i{0}; i < plant.num_bodies(); ++i) {
+    const RigidBody<double>& body = plant.get_body(i);
+    if (body.has_quaternion_dofs()) {
+      const int start = body.floating_positions_start();
+      constexpr int size = 4;
+      // TODO(russt): Probably the joint limits should be [-1, 1] coming
+      // right out of the MultibodyPlant.
+      lb.segment<size>(start) = -Eigen::Vector4d::Ones();
+      ub.segment<size>(start) = Eigen::Vector4d::Ones();
+      if (plant_context && is_locked.segment<size>(start).any()) {
+        // Sanity check the MultibodyTree invariant.
+        DRAKE_DEMAND(is_locked.segment<size>(start).all());
+        // Lock to the normalized value, in lieu of a unit norm constraint.
+        const Eigen::Vector4d quat =
+            current_positions.segment<size>(start).normalized();
+        bindings
+            .emplace_back(prog->AddLinearEqualityConstraint(
+                Eigen::Matrix4d::Identity(),
+                quat, q.segment<size>(start)))
+            .evaluator()
+            ->set_description(fmt::format("Body {} lock", body.name()));
+        prog->SetInitialGuess(q.segment<size>(start), quat);
+      } else {
+        bindings
+            .emplace_back(
+                prog->AddConstraint(solvers::Binding<solvers::Constraint>(
+                    std::make_shared<UnitQuaternionConstraint>(),
+                    q.segment<size>(start))))
+            .evaluator()
+            ->set_description(fmt::format(
+                "Unit quaternion constraint for body {}", body.name()));
+        prog->SetInitialGuess(q.segment<size>(start),
+                              Eigen::Vector4d{1, 0, 0, 0});
+      }
+    }
+  }
+  bindings.emplace_back(prog->AddBoundingBoxConstraint(lb, ub, q))
+      .evaluator()
+      ->set_description("Joint limits");
+
   for (const auto& [id, spec] : plant.get_coupler_constraint_specs()) {
     const int q0_index = plant.get_joint(spec.joint0_index).position_start();
     const int q1_index = plant.get_joint(spec.joint1_index).position_start();
-    bindings.emplace_back(prog->AddLinearEqualityConstraint(
-        q[q0_index] == spec.gear_ratio * q[q1_index] + spec.offset));
+    bindings
+        .emplace_back(prog->AddLinearEqualityConstraint(
+            q[q0_index] == spec.gear_ratio * q[q1_index] + spec.offset))
+        .evaluator()
+        ->set_description(
+            fmt::format("Coupler constraint for joint {} and joint {}",
+                        spec.joint0_index, spec.joint1_index));
   }
   for (const auto& [id, spec] : plant.get_distance_constraint_specs()) {
     DRAKE_THROW_UNLESS(plant_context != nullptr);
     // d(q) == d₀.
-    bindings.emplace_back(prog->AddConstraint(
-        std::make_shared<PointToPointDistanceConstraint>(
-            &plant, plant.get_body(spec.body_A).body_frame(), spec.p_AP,
-            plant.get_body(spec.body_B).body_frame(), spec.p_BQ, spec.distance,
-            spec.distance, plant_context),
-        q));
+    bindings
+        .emplace_back(prog->AddConstraint(
+            std::make_shared<PointToPointDistanceConstraint>(
+                &plant, plant.get_body(spec.body_A).body_frame(), spec.p_AP,
+                plant.get_body(spec.body_B).body_frame(), spec.p_BQ,
+                spec.distance, spec.distance, plant_context),
+            q))
+        .evaluator()
+        ->set_description(
+            fmt::format("Distance constraint between body {} and body {}",
+                        spec.body_A, spec.body_B));
   }
   for (const auto& [id, spec] : plant.get_ball_constraint_specs()) {
     DRAKE_THROW_UNLESS(plant_context != nullptr);
-    bindings.emplace_back(prog->AddConstraint(
-        std::make_shared<PositionConstraint>(
-            &plant, plant.get_body(spec.body_A).body_frame(), spec.p_AP,
-            spec.p_AP, plant.get_body(spec.body_B).body_frame(), *spec.p_BQ,
-            plant_context),
-        q));
+    bindings
+        .emplace_back(prog->AddConstraint(
+            std::make_shared<PositionConstraint>(
+                &plant, plant.get_body(spec.body_A).body_frame(), spec.p_AP,
+                spec.p_AP, plant.get_body(spec.body_B).body_frame(), *spec.p_BQ,
+                plant_context),
+            q))
+        .evaluator()
+        ->set_description(
+            fmt::format("Ball constraint between body {} and body {}",
+                        spec.body_A, spec.body_B));
   }
   for (const auto& [id, spec] : plant.get_weld_constraint_specs()) {
     DRAKE_THROW_UNLESS(plant_context != nullptr);
     // TODO(russt): Consider implementing a WeldConstraint.
-    bindings.emplace_back(prog->AddConstraint(
-        std::make_shared<PositionConstraint>(
-            &plant, plant.get_body(spec.body_A).body_frame(),
-            spec.X_AP.translation(), spec.X_AP.translation(),
-            plant.get_body(spec.body_B).body_frame(), spec.X_BQ.translation(),
-            plant_context),
-        q));
-    bindings.emplace_back(prog->AddConstraint(
-        std::make_shared<OrientationConstraint>(
-            &plant, plant.get_body(spec.body_A).body_frame(),
-            spec.X_AP.rotation(), plant.get_body(spec.body_B).body_frame(),
-            spec.X_BQ.rotation(), 0.0, plant_context),
-        q));
+    bindings
+        .emplace_back(prog->AddConstraint(
+            std::make_shared<PositionConstraint>(
+                &plant, plant.get_body(spec.body_A).body_frame(),
+                spec.X_AP.translation(), spec.X_AP.translation(),
+                plant.get_body(spec.body_B).body_frame(),
+                spec.X_BQ.translation(), plant_context),
+            q))
+        .evaluator()
+        ->set_description(
+            fmt::format("Weld position constraint between body {} and body {}",
+                        spec.body_A, spec.body_B));
+    bindings
+        .emplace_back(prog->AddConstraint(
+            std::make_shared<OrientationConstraint>(
+                &plant, plant.get_body(spec.body_A).body_frame(),
+                spec.X_AP.rotation(), plant.get_body(spec.body_B).body_frame(),
+                spec.X_BQ.rotation(), 0.0, plant_context),
+            q))
+        .evaluator()
+        ->set_description(fmt::format(
+            "Weld orientation constraint between body {} and body {}",
+            spec.body_A, spec.body_B));
   }
   return bindings;
 }

--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.h
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.h
@@ -8,9 +8,13 @@
 namespace drake {
 namespace multibody {
 
-/** For unit quaternion and (holonomic) constraints registered with `plant` adds
-a corresponding solver::Constraint to `prog`, using decision variables `q` to
-represent the generalized positions of the plant.
+/** For all kinematic constraints associated with `plant` adds a corresponding
+solver::Constraint to `prog`, using decision variables `q` to represent the
+generalized positions of the plant.
+
+Adds joint limits constraints, unit quaternion constraints, and constraints for
+any locked joints (via Joint::Lock()). Note that you must pass a valid
+`plant_context` to use joint locking.
 
 Adds constraints for coupler, distance, ball, and weld constraints. The
 distance constraint is implemented here as a hard kinematic constraint (i.e.,

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -3,6 +3,7 @@
 #include <limits>
 #include <utility>
 
+#include "drake/multibody/inverse_kinematics/add_multibody_plant_constraints.h"
 #include "drake/multibody/inverse_kinematics/angle_between_vectors_constraint.h"
 #include "drake/multibody/inverse_kinematics/angle_between_vectors_cost.h"
 #include "drake/multibody/inverse_kinematics/distance_constraint.h"
@@ -51,64 +52,21 @@ InverseKinematics::InverseKinematics(
   }
   DRAKE_DEMAND(context_ != nullptr);  // Sanity check.
 
-  // We're about to add constraints for position limits (if requested), locked
-  // joints, and quaternions (unit norm). When a quaternion is locked, we'll use
-  // the lock constraint instead of the unit norm constraint.
+  AddMultibodyPlantConstraints(plant, q_, prog_.get(), context_);
 
-  // Obey the joint limits (if requested).
-  const int nq = plant.num_positions();
-  Eigen::VectorXd lb;
-  Eigen::VectorXd ub;
-  if (with_joint_limits) {
-    lb = plant.GetPositionLowerLimits();
-    ub = plant.GetPositionUpperLimits();
-  } else {
-    lb = Eigen::VectorXd::Constant(nq, -kInf);
-    ub = Eigen::VectorXd::Constant(nq, +kInf);
-  }
-
-  // Obey joint locking. Joint locking trumps joint limits.
-  const Eigen::VectorXd current_positions = plant.GetPositions(context());
-  VectorX<bool> is_locked = VectorX<bool>::Constant(nq, false);
-  for (JointIndex i : plant.GetJointIndices()) {
-    const Joint<double>& joint = plant.get_joint(i);
-    if (joint.is_locked(context())) {
-      const int start = joint.position_start();
-      const int size = joint.num_positions();
-      lb.segment(start, size) = current_positions.segment(start, size);
-      ub.segment(start, size) = current_positions.segment(start, size);
-      is_locked.segment(start, size).array() = true;
-    }
-  }
-
-  // Add the unit quaternion constraints.
-  for (BodyIndex i{0}; i < plant.num_bodies(); ++i) {
-    const RigidBody<double>& body = plant.get_body(i);
-    if (body.has_quaternion_dofs()) {
-      const int start = body.floating_positions_start();
-      constexpr int size = 4;
-      if (is_locked.segment<size>(start).any()) {
-        // Sanity check the MultibodyTree invariant.
-        DRAKE_DEMAND(is_locked.segment<size>(start).all());
-        // Lock to the normalized value, in lieu of a unit norm constraint.
-        const Eigen::Vector4d quat =
-            current_positions.segment<size>(start).normalized();
-        lb.segment<size>(start) = quat;
-        ub.segment<size>(start) = quat;
-        prog_->SetInitialGuess(q_.segment<size>(start), quat);
-      } else {
-        prog_->AddConstraint(solvers::Binding<solvers::Constraint>(
-            std::make_shared<UnitQuaternionConstraint>(),
-            q_.segment<size>(start)));
-        // Set a non-zero initial guess to help avoid singularities.
-        prog_->SetInitialGuess(q_.segment<size>(start),
-                              Eigen::Vector4d{1, 0, 0, 0});
+  if (!with_joint_limits) {
+    // Remove only the joint limit constraint.
+    const auto& bbox_bindings = prog_->bounding_box_constraints();
+    bool removed_joint_limits = false;
+    for (const auto& binding : bbox_bindings) {
+      if (binding.evaluator()->get_description() == "Joint limits") {
+        prog_->RemoveConstraint(binding);
+        removed_joint_limits = true;
+        break;
       }
     }
+    DRAKE_DEMAND(removed_joint_limits);
   }
-
-  // Now we can finally add the bbox constraint for joint limits and locking.
-  prog_->AddBoundingBoxConstraint(lb, ub, q_);
 }
 
 solvers::Binding<solvers::Constraint> InverseKinematics::AddPositionConstraint(

--- a/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
+++ b/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/solvers/snopt_solver.h"
 #include "drake/solvers/solve.h"
@@ -14,6 +16,7 @@ using Eigen::MatrixXd;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 using math::RigidTransformd;
+constexpr double kInf = std::numeric_limits<double>::infinity();
 
 bool SnoptSolverUnavailable() {
   return !(solvers::SnoptSolver::is_available() &&
@@ -44,7 +47,7 @@ class AddMultibodyPlantConstraintsTest : public ::testing::Test {
         RigidTransformd(), Vector3d::UnitZ());
   }
 
-  void CheckConstraints(int expected_num_constraints = 1, double tol = 1e-6) {
+  void CheckConstraints(int expected_num_constraints = 2, double tol = 1e-6) {
     if (!plant_.is_finalized()) {
       plant_.Finalize();
     }
@@ -120,8 +123,138 @@ TEST_F(AddMultibodyPlantConstraintsTest, WeldConstraint) {
     // IPOPT is flakey on this test.
     return;
   }
-  const int expected_num_constraints = 3;  // 1 for quaternion, 2 for weld.
+  const int expected_num_constraints =
+      4;  // 1 joint limits, 1 unit quaternion, 2 for weld.
   CheckConstraints(expected_num_constraints, /* tol = */ 1e-2);
+}
+
+GTEST_TEST(AdditionalTests, QuaternionsAndJointLimitsAndLocks) {
+  MultibodyPlant<double> plant(0);
+
+  // Create a plant with four bodies.
+  const auto& world = plant.world_body();
+  const auto M = SpatialInertia<double>::SolidCubeWithMass(1.0, 0.1);
+  const auto& body1 = plant.AddRigidBody("body1", M);
+  const auto& body2 = plant.AddRigidBody("body2", M);
+  const auto& body3 = plant.AddRigidBody("body3", M);
+  const auto& body4 = plant.AddRigidBody("body4", M);
+
+  // Attach a specific joint to each body:
+  // (1) A quaternion floating joint that will not be locked.
+  // (2) A quaternion floating joint that we'll lock to its initial position.
+  // (3) A revolute joint that will not be locked.
+  // (4) A revolute joint that we'll lock to its initial position.
+  math::RigidTransform<double> I;
+  Eigen::Vector3d X = Eigen::Vector3d::UnitX();
+  const auto& joint1 =
+      plant.AddJoint<QuaternionFloatingJoint>("joint1", world, I, body1, I);
+  const auto& joint2 =
+      plant.AddJoint<QuaternionFloatingJoint>("joint2", world, I, body2, I);
+  const auto& joint3 =
+      plant.AddJoint<RevoluteJoint>("joint3", world, I, body3, I, X);
+  const auto& joint4 =
+      plant.AddJoint<RevoluteJoint>("joint4", world, I, body4, I, X);
+  plant.Finalize();
+  auto context = plant.CreateDefaultContext();
+
+  // Leave joint1 unlocked.
+
+  // Lock body2's floating joint to an un-normalized initial value.
+  joint2.SetQuaternion(&*context, Eigen::Quaternion<double>(0, 3.0, 0, 0));
+  joint2.Lock(&*context);
+
+  // Set limits on joint3, but do not lock it.
+  dynamic_cast<RevoluteJoint<double>&>(plant.get_mutable_joint(joint3.index()))
+      .set_position_limits(Vector1d{-0.5}, Vector1d{0.5});
+
+  // Lock body4's revolute joint beyond its limit.
+  dynamic_cast<RevoluteJoint<double>&>(plant.get_mutable_joint(joint4.index()))
+      .set_position_limits(Vector1d{-1}, Vector1d{1});
+  joint4.set_angle(&*context, 1.1);
+  joint4.Lock(&*context);
+
+  solvers::MathematicalProgram prog;
+  auto q = prog.NewContinuousVariables(plant.num_positions());
+  AddMultibodyPlantConstraints(plant, q, &prog, context.get());
+
+  // The initial guess is set for the two quaternion floating joints.
+  EXPECT_TRUE(CompareMatrices(
+      prog.GetInitialGuess(q.segment(joint1.position_start(), 4)),
+      Eigen::Vector4d(1, 0, 0, 0)));
+  EXPECT_TRUE(CompareMatrices(
+      prog.GetInitialGuess(q.segment(joint2.position_start(), 4)),
+      Eigen::Vector4d(0, 1, 0, 0)));
+
+  // We only expect one bounding box constraint, which is the joint limits.
+  ASSERT_EQ(prog.bounding_box_constraints().size(), 1);
+  const solvers::Binding<solvers::BoundingBoxConstraint>& limits =
+      prog.bounding_box_constraints().front();
+
+  // joint 1 is unlocked, we expect a unit quaternion constraint and limits of
+  // [-1, 1].
+  ASSERT_EQ(prog.generic_constraints().size(), 1);
+  const solvers::Binding<solvers::Constraint>& unit_quat =
+      prog.generic_constraints().front();
+  ASSERT_EQ(unit_quat.variables().size(), 4);
+  EXPECT_EQ(symbolic::Variables(unit_quat.variables()),
+            symbolic::Variables(q.segment(joint1.position_start(), 4)));
+  EXPECT_TRUE(CompareMatrices(limits.evaluator()->lower_bound().segment<4>(
+                                  joint1.position_start()),
+                              Eigen::Vector4d(-1, -1, -1, -1)));
+  EXPECT_TRUE(CompareMatrices(limits.evaluator()->upper_bound().segment<4>(
+                                  joint1.position_start()),
+                              Eigen::Vector4d(1, 1, 1, 1)));
+
+  // joint2 is locked, so we expect a linear equality constraint and limits of
+  // [-1, 1].
+  const int j2_start = joint2.position_start();
+  bool found_lock = false;
+  for (const solvers::Binding<solvers::LinearEqualityConstraint>& c :
+       prog.linear_equality_constraints()) {
+    if (c.evaluator()->get_description() == "Body body2 lock") {
+      found_lock = true;
+      EXPECT_EQ(symbolic::Variables(c.variables()),
+                symbolic::Variables(q.segment<4>(j2_start)));
+      const Eigen::Vector4d expected_value(0, 1, 0, 0);
+      EXPECT_TRUE(
+          CompareMatrices(c.evaluator()->lower_bound(), expected_value));
+    }
+  }
+  EXPECT_TRUE(found_lock);
+  EXPECT_TRUE(
+      CompareMatrices(limits.evaluator()->lower_bound().segment<4>(j2_start),
+                      Eigen::Vector4d(-1, -1, -1, -1)));
+  EXPECT_TRUE(
+      CompareMatrices(limits.evaluator()->upper_bound().segment<4>(j2_start),
+                      Eigen::Vector4d(1, 1, 1, 1)));
+
+  // joint3 is unlocked, so we expect the joint limits to be enforced.
+  const int j3_start = joint3.position_start();
+  EXPECT_EQ(limits.evaluator()->lower_bound()[j3_start], -0.5);
+  EXPECT_EQ(limits.evaluator()->upper_bound()[j3_start], +0.5);
+
+  // joint4 is locked. Locked revolute joints obey their initial position,
+  // ignoring limits.
+  const int j4_start = joint4.position_start();
+  EXPECT_EQ(limits.evaluator()->lower_bound()[j4_start], -kInf);
+  EXPECT_EQ(limits.evaluator()->upper_bound()[j4_start], kInf);
+  found_lock = false;
+  for (const solvers::Binding<solvers::LinearEqualityConstraint>& c :
+       prog.linear_equality_constraints()) {
+    if (c.evaluator()->get_description() == "Joint joint4 lock") {
+      EXPECT_EQ(c.GetNumElements(), 1);
+      EXPECT_EQ(c.variables()[0], q[j4_start]);
+      EXPECT_EQ(c.evaluator()->lower_bound()[0], 1.1);
+      found_lock = true;
+    }
+  }
+  EXPECT_TRUE(found_lock);
+
+  // If we don't pass in the context, then we will not get the locked joints.
+  solvers::MathematicalProgram prog2;
+  auto q2 = prog2.NewContinuousVariables(plant.num_positions());
+  AddMultibodyPlantConstraints(plant, q2, &prog2);
+  EXPECT_EQ(prog2.linear_equality_constraints().size(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
Also moves the joint limits / joint locking logic from the IK constructor to AddMultibodyPlantConstraints.

Towards #18917.