### PR TITLE
[setup] Remove dead code from macOS install_prereqs

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -53,16 +53,10 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 # completes or wait for the next automatic cleanup if necessary.
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
-binary_distribution_called_update=0
-
 if [[ "${with_update}" -eq 1 ]]; then
   # Note that brew update uses git, so HOMEBREW_CURL_RETRIES does not take
   # effect.
   brew update || (sleep 30; brew update)
-
-  # Do NOT call brew update again when installing prerequisites for source
-  # distributions.
-  binary_distribution_called_update=1
 fi
 
 brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock

--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -19,7 +19,6 @@ while [ "${1:-}" != "" ]; do
     # Do NOT call brew update during execution of this script.
     --without-update)
       binary_distribution_args+=(--without-update)
-      source_distribution_args+=(--without-update)
       ;;
     *)
       echo 'Invalid command line argument' >&2

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -8,7 +8,6 @@
 set -euxo pipefail
 
 with_test_only=1
-with_update=1
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
@@ -17,10 +16,6 @@ while [ "${1:-}" != "" ]; do
     # bazel { build, run } //:install.
     --without-test-only)
       with_test_only=0
-      ;;
-    # Do NOT call brew update during execution of this script.
-    --without-update)
-      with_update=0
       ;;
     *)
       echo 'Invalid command line argument' >&2
@@ -37,10 +32,6 @@ fi
 if ! command -v brew &>/dev/null; then
   echo 'ERROR: brew is NOT installed. Please ensure that the prerequisites for binary distributions have been installed.' >&2
   exit 4
-fi
-
-if [[ "${with_update}" -eq 1 && "${binary_distribution_called_update:-0}" -ne 1 ]]; then
-  brew update || (sleep 30; brew update)
 fi
 
 brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock

--- a/tools/macos-arch-i386.bazelrc
+++ b/tools/macos-arch-i386.bazelrc
@@ -1,7 +1,0 @@
-# Options for macOS when running on i386 as reported by `arch` (i.e., x86_64).
-
-# N.B. Ensure this is consistent with `execute.bzl`.
-build --action_env=PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
-
-# Releases on macOS x86_64 no longer contain IPOPT.
-build:packaging --define=NO_IPOPT=ON


### PR DESCRIPTION
I noticed this during the rewrite of the Ubuntu side in #22055.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22364)
<!-- Reviewable:end -->
