### PR TITLE
Clarify coordinates of MultibodyPlant's actuation input ports

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -534,9 +534,11 @@ get_actuation_input_port()) and for each individual @ref model_instances
 "model instance" in the %MultibodyPlant (see
 @ref get_actuation_input_port(ModelInstanceIndex)const
 "get_actuation_input_port(ModelInstanceIndex)").
-Any actuation input ports not connected are assumed to be zero. Actuation values
-from the full %MultibodyPlant model port (get_actuation_input_port()) and from
-the per model-instance ports (
+- Actuation inputs and actuation effort limits are taken to be in joint
+  coordinates (they are not affected by the actuator gear ratio).
+- Any actuation input ports not connected are assumed to be zero.
+- Actuation values from the full %MultibodyPlant model port
+  (get_actuation_input_port()) and from the per model-instance ports (
 @ref get_actuation_input_port(ModelInstanceIndex)const
 "get_actuation_input_port(ModelInstanceIndex)") are summed up.
 


### PR DESCRIPTION
Resolves #20993. We've decided to document the existing case: the inputs are in joint coordinates, not motor coordinates.

<img width="763" alt="image" src="https://github.com/user-attachments/assets/4d2d41a2-b8c0-4f9c-822f-36a1bc63def2" />

+@joemasterjohn for feature review, please.
cc @amcastro-tri , @sherm1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22367)
<!-- Reviewable:end -->
