### PR TITLE
Add remaining menagerie models

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -669,10 +669,7 @@ drake_cc_googletest(
         ":test_models",
         "//geometry:test_obj_files",
         "//geometry:test_stl_files",
-        "@mujoco_menagerie_internal//:google_robot",
         "@mujoco_menagerie_internal//:hello_robot_stretch",
-        "@mujoco_menagerie_internal//:kuka_iiwa_14",
-        "@mujoco_menagerie_internal//:rethink_robotics_sawyer",
     ] + _DM_CONTROL_MUJOCO_FILES,
     deps = [
         ":detail_mujoco_parser",
@@ -684,6 +681,20 @@ drake_cc_googletest(
         "//common/test_utilities:maybe_pause_for_user",
         "//geometry/test_utilities:meshcat_environment",
         "//visualization",
+    ],
+)
+
+drake_cc_googletest(
+    name = "detail_mujoco_parser_examples_test",
+    data = [
+        "@mujoco_menagerie_internal//:menagerie",
+    ] + _DM_CONTROL_MUJOCO_FILES,
+    shard_count = 4,
+    deps = [
+        ":detail_mujoco_parser",
+        "//common:find_resource",
+        "//common:find_runfiles",
+        "//common/test_utilities:diagnostic_policy_test_base",
     ],
 )
 

--- a/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
@@ -1,0 +1,289 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/find_runfiles.h"
+#include "drake/common/test_utilities/diagnostic_policy_test_base.h"
+#include "drake/multibody/parsing/detail_mujoco_parser.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using ::testing::MatchesRegex;
+
+class MujocoParserExamplesTest : public test::DiagnosticPolicyTestBase {
+ public:
+  MujocoParserExamplesTest() {
+    plant_.RegisterAsSourceForSceneGraph(&scene_graph_);
+  }
+
+  std::optional<ModelInstanceIndex> AddModelFromFile(
+      const std::string& file_name,
+      const std::string& model_name) {
+    internal::CollisionFilterGroupResolver resolver{&plant_};
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+                       &plant_, &resolver, NoSelect};
+    auto result = wrapper_.AddModel(
+        {DataSource::kFilename, &file_name}, model_name, {}, w);
+    resolver.Resolve(diagnostic_policy_);
+    return result;
+  }
+
+  // Mujoco cannot delegate to any other parsers.
+  static ParserInterface& NoSelect(
+      const drake::internal::DiagnosticPolicy&, const std::string&) {
+    DRAKE_UNREACHABLE();
+  }
+
+ protected:
+  ParsingOptions options_;
+  PackageMap package_map_;
+  MultibodyPlant<double> plant_{0.1};
+  geometry::SceneGraph<double> scene_graph_;
+  MujocoParserWrapper wrapper_;
+};
+
+// Given a name for a TEST_SUITE_P test case, returns a safe version of the
+// string (i.e., with only alphanumeric characters). Google Test case names
+// must not contain any other kinds of characters.
+std::string MakeSafeTestCaseName(std::string_view name) {
+  std::string result{name};
+  std::replace_if(
+      result.begin(), result.end(),
+      [](char c) {
+        return !std::isalnum(c);
+      },
+      '_');
+  return result;
+}
+
+class DeepMindControlTest : public MujocoParserExamplesTest,
+                            public testing::WithParamInterface<const char*> {};
+
+TEST_P(DeepMindControlTest, DeepMindControl) {
+  // Confirm successful parsing of the MuJoCo models in the DeepMind control
+  // suite.
+  std::string model{GetParam()};
+  const std::string filename = FindResourceOrThrow(
+      fmt::format("drake/multibody/parsing/dm_control/suite/{}.xml", model));
+  AddModelFromFile(filename, model);
+
+  EXPECT_TRUE(plant_.HasModelInstanceNamed(model));
+
+  // For this test, ignore all warnings.
+  warning_records_.clear();
+}
+
+const char* dm_control_models[] = {
+    "acrobot",  "cartpole",   "cheetah",      "finger",  "fish",
+    "hopper",   "humanoid",   "humanoid_CMU", "lqr",     "manipulator",
+    "pendulum", "point_mass", "quadruped",    "reacher", "stacker",
+    "swimmer",  "walker"};
+INSTANTIATE_TEST_SUITE_P(DeepMindControl, DeepMindControlTest,
+                         testing::ValuesIn(dm_control_models),
+                         ([](const auto& test_info) {
+                           // This lambda provides a nice human-readable test
+                           // case name while running the test, or in case the
+                           // test case fails.
+                           const auto& model = test_info.param;
+                           return MakeSafeTestCaseName(model);
+                         }));
+
+constexpr std::string_view kItWorks{""};
+constexpr std::string_view kSkipMe{"skip me"};
+namespace KnownErrors {
+constexpr std::string_view kNonUniformScale{".*non-uniform scale.*"};  // #22046
+constexpr std::string_view kMoreThanOneOrientation{
+    ".*more than one orientation.*"};
+constexpr std::string_view kCapsuleSize{".*size attribute for capsule geom.*"};
+}  // namespace KnownErrors
+
+class MujocoMenagerieTest : public MujocoParserExamplesTest,
+                            public testing::WithParamInterface<
+                                std::pair<const char*, std::string_view>> {};
+
+TEST_P(MujocoMenagerieTest, MujocoMenagerie) {
+  // Confirm successful parsing of the MuJoCo models in the DeepMind control
+  // suite.
+  auto [model, error_regex] = GetParam();
+  if (error_regex == kSkipMe) {
+    GTEST_SKIP_("Skipping this test case.");
+  }
+  const RlocationOrError rlocation = FindRunfile(
+      fmt::format("mujoco_menagerie_internal/{}.xml", model));
+  ASSERT_EQ(rlocation.error, "");
+  AddModelFromFile(rlocation.abspath, model);
+
+  EXPECT_TRUE(plant_.HasModelInstanceNamed(model));
+
+  // For this test, ignore all warnings.
+  warning_records_.clear();
+
+  if (!error_regex.empty()) {
+    EXPECT_THAT(TakeError(), MatchesRegex(error_regex));
+    // For now, we'll just capture the *first* error.
+    error_records_.clear();
+  }
+}
+
+// TODO(russt): Add logic to check for warnings, too. Some are
+// acceptable/expected, but warnings like the stl2obj message make the model
+// unusable.
+
+const std::pair<const char*, std::string_view> mujoco_menagerie_models[] = {
+    {"agility_cassie/cassie", KnownErrors::kNonUniformScale},
+    {"agility_cassie/scene", KnownErrors::kNonUniformScale},
+    {"aloha/aloha", kItWorks},
+    {"aloha/scene", kItWorks},
+    {"anybotics_anymal_b/anymal_b", KnownErrors::kMoreThanOneOrientation},
+    {"anybotics_anymal_b/scene", KnownErrors::kMoreThanOneOrientation},
+    {"anybotics_anymal_c/anymal_c", kItWorks},
+    {"anybotics_anymal_c/anymal_c_mjx", kItWorks},
+    {"anybotics_anymal_c/scene", kItWorks},
+    {"anybotics_anymal_c/scene_mjx", kItWorks},
+    {"berkeley_humanoid/berkeley_humanoid", kItWorks},
+    {"berkeley_humanoid/scene", kItWorks},
+    {"bitcraze_crazyflie_2/cf2", kItWorks},
+    {"bitcraze_crazyflie_2/scene", kItWorks},
+    {"boston_dynamics_spot/scene", kItWorks},
+    {"boston_dynamics_spot/scene_arm", kItWorks},
+    {"boston_dynamics_spot/spot", kItWorks},
+    {"boston_dynamics_spot/spot_arm", kItWorks},
+    {"flybody/fruitfly", kSkipMe},  // works, but too slow in debug mode.
+    {"flybody/scene", kSkipMe},     // works, but too slow in debug mode.
+    {"franka_emika_panda/hand", kItWorks},
+    {"franka_emika_panda/mjx_panda", kItWorks},
+    {"franka_emika_panda/mjx_scene", kItWorks},
+    {"franka_emika_panda/mjx_single_cube", kItWorks},
+    {"franka_emika_panda/panda",
+     kSkipMe},  // works, but too slow in debug mode.
+    {"franka_emika_panda/panda_nohand",
+     kSkipMe},  // works, but too slow in debug mode.
+    {"franka_emika_panda/scene",
+     kSkipMe},                      // works, but too slow in debug mode.
+    {"franka_fr3/fr3", kSkipMe},    // works, but too slow in debug mode.
+    {"franka_fr3/scene", kSkipMe},  // works, but too slow in debug mode.
+    {"google_barkour_v0/barkour_v0", kItWorks},
+    {"google_barkour_v0/barkour_v0_mjx", kItWorks},
+    {"google_barkour_v0/scene", kItWorks},
+    {"google_barkour_v0/scene_barkour", kItWorks},
+    {"google_barkour_v0/scene_mjx", kItWorks},
+    {"google_barkour_vb/barkour_vb", kItWorks},
+    {"google_barkour_vb/barkour_vb_mjx", kItWorks},
+    {"google_barkour_vb/scene", kItWorks},
+    {"google_barkour_vb/scene_hfield_mjx", kItWorks},
+    {"google_barkour_vb/scene_mjx", kItWorks},
+    {"google_robot/robot", kItWorks},
+    {"google_robot/scene", kItWorks},
+    /* The hello_robot_stretch and hello_robot_stretch_3 models currently throw
+       in RotationalInertia<T>::ThrowNotPhysicallyValid(), but only in Debug
+       mode. This is possibly due to the fact that the stl geometries are not
+       being parsed, so the proper inertias are not being computed. They _also_
+       fail with KnownErrors::kNonUniformScale in release mode. */
+    {"hello_robot_stretch/scene", kSkipMe},
+    {"hello_robot_stretch/stretch", kSkipMe},
+    {"hello_robot_stretch_3/scene", kSkipMe},
+    {"hello_robot_stretch_3/stretch", kSkipMe},
+    {"kinova_gen3/gen3", kItWorks},
+    {"kinova_gen3/scene", kItWorks},
+    {"kuka_iiwa_14/iiwa14", kItWorks},
+    {"kuka_iiwa_14/scene", kItWorks},
+    {"leap_hand/left_hand", kItWorks},
+    {"leap_hand/right_hand", kItWorks},
+    {"leap_hand/scene_left", kItWorks},
+    {"leap_hand/scene_right", kItWorks},
+    {"pal_talos/scene_motor", KnownErrors::kNonUniformScale},
+    {"pal_talos/scene_position", KnownErrors::kNonUniformScale},
+    {"pal_talos/talos", KnownErrors::kNonUniformScale},
+    {"pal_talos/talos_motor", KnownErrors::kNonUniformScale},
+    {"pal_talos/talos_position", KnownErrors::kNonUniformScale},
+    {"pal_tiago/scene_motor", KnownErrors::kNonUniformScale},
+    {"pal_tiago/scene_position", KnownErrors::kNonUniformScale},
+    {"pal_tiago/scene_velocity", KnownErrors::kNonUniformScale},
+    {"pal_tiago/tiago", KnownErrors::kNonUniformScale},
+    {"pal_tiago/tiago_motor", KnownErrors::kNonUniformScale},
+    {"pal_tiago/tiago_position", KnownErrors::kNonUniformScale},
+    {"pal_tiago/tiago_velocity", KnownErrors::kNonUniformScale},
+    {"pal_tiago_dual/scene_motor", KnownErrors::kNonUniformScale},
+    {"pal_tiago_dual/scene_position", KnownErrors::kNonUniformScale},
+    {"pal_tiago_dual/scene_velocity", KnownErrors::kNonUniformScale},
+    {"pal_tiago_dual/tiago_dual", KnownErrors::kNonUniformScale},
+    {"pal_tiago_dual/tiago_dual_motor", KnownErrors::kNonUniformScale},
+    {"pal_tiago_dual/tiago_dual_position", KnownErrors::kNonUniformScale},
+    {"pal_tiago_dual/tiago_dual_velocity", KnownErrors::kNonUniformScale},
+    {"realsense_d435i/d435i", KnownErrors::kCapsuleSize},
+    {"rethink_robotics_sawyer/scene", kItWorks},
+    {"rethink_robotics_sawyer/sawyer", kItWorks},
+    {"robotiq_2f85/2f85", kItWorks},
+    {"robotiq_2f85/scene", kItWorks},
+    {"robotiq_2f85_v4/2f85", kItWorks},
+    {"robotiq_2f85_v4/scene", kItWorks},
+    {"robotis_op3/op3", kItWorks},
+    {"robotis_op3/scene", kItWorks},
+    {"shadow_dexee/scene", kItWorks},
+    {"shadow_dexee/shadow_dexee", kItWorks},
+    {"shadow_hand/keyframes", kItWorks},
+    {"shadow_hand/left_hand", KnownErrors::kNonUniformScale},
+    {"shadow_hand/right_hand", kItWorks},
+    {"shadow_hand/scene_left", KnownErrors::kNonUniformScale},
+    {"shadow_hand/scene_right", kItWorks},
+    {"skydio_x2/scene", kItWorks},
+    {"skydio_x2/x2", kItWorks},
+    {"trossen_vx300s/scene", kItWorks},
+    {"trossen_vx300s/vx300s", kItWorks},
+    {"trossen_wx250s/scene", kItWorks},
+    {"trossen_wx250s/wx250s", kItWorks},
+    {"trs_so_arm100/scene", kItWorks},
+    {"trs_so_arm100/so_arm100", kItWorks},
+    {"ufactory_lite6/lite6", kItWorks},
+    {"ufactory_lite6/lite6_gripper_narrow", kItWorks},
+    {"ufactory_lite6/lite6_gripper_wide", kItWorks},
+    {"ufactory_lite6/scene", kItWorks},
+    {"ufactory_xarm7/hand", kItWorks},
+    {"ufactory_xarm7/scene", kItWorks},
+    {"ufactory_xarm7/xarm7", kItWorks},
+    {"ufactory_xarm7/xarm7_nohand", kItWorks},
+    {"unitree_a1/a1", kItWorks},
+    {"unitree_a1/scene", kItWorks},
+    {"unitree_g1/g1", kItWorks},
+    {"unitree_g1/g1_with_hands", kItWorks},
+    {"unitree_g1/scene", kItWorks},
+    {"unitree_g1/scene_with_hands", kItWorks},
+    {"unitree_go1/go1", kItWorks},
+    {"unitree_go1/scene", kItWorks},
+    {"unitree_go2/go2", kItWorks},
+    {"unitree_go2/go2_mjx", kItWorks},
+    {"unitree_go2/scene", kItWorks},
+    {"unitree_go2/scene_mjx", kItWorks},
+    {"unitree_h1/h1", kItWorks},
+    {"unitree_h1/scene", kItWorks},
+    {"unitree_z1/scene", kItWorks},
+    {"unitree_z1/z1", kItWorks},
+    {"unitree_z1/z1_gripper", kItWorks},
+    {"universal_robots_ur10e/scene", kItWorks},
+    {"universal_robots_ur10e/ur10e", kItWorks},
+    {"universal_robots_ur5e/scene", kItWorks},
+    {"universal_robots_ur5e/ur5e", kItWorks},
+    {"wonik_allegro/left_hand", kItWorks},
+    {"wonik_allegro/right_hand", kItWorks},
+    {"wonik_allegro/scene_left", kItWorks},
+    {"wonik_allegro/scene_right", kItWorks},
+};
+
+INSTANTIATE_TEST_SUITE_P(MujocoMenagerie, MujocoMenagerieTest,
+                         testing::ValuesIn(mujoco_menagerie_models),
+                         ([](const auto& test_info) {
+                           // This lambda provides a nice human-readable test
+                           // case name while running the test, or in case the
+                           // test case fails.
+                           const auto& [model, error_regex] = test_info.param;
+                           return MakeSafeTestCaseName(model);
+                         }));
+
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -119,58 +119,6 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
       "drake/multibody/parsing/test/box_package/urdfs/box.urdf"))};
 };
 
-class DeepMindControlTest : public MujocoParserTest,
-                            public testing::WithParamInterface<const char*> {};
-
-TEST_P(DeepMindControlTest, DeepMindControl) {
-  // Confirm successful parsing of the MuJoCo models in the DeepMind control
-  // suite.
-  std::string model{GetParam()};
-  const std::string filename = FindResourceOrThrow(
-      fmt::format("drake/multibody/parsing/dm_control/suite/{}.xml", model));
-  AddModelFromFile(filename, model);
-
-  EXPECT_TRUE(plant_.HasModelInstanceNamed(model));
-
-  // For this test, ignore all warnings.
-  warning_records_.clear();
-}
-
-const char* dm_control_models[] = {
-    "acrobot",  "cartpole",   "cheetah",      "finger",  "fish",
-    "hopper",   "humanoid",   "humanoid_CMU", "lqr",     "manipulator",
-    "pendulum", "point_mass", "quadruped",    "reacher", "stacker",
-    "swimmer",  "walker"};
-INSTANTIATE_TEST_SUITE_P(DeepMindControl, DeepMindControlTest,
-                         testing::ValuesIn(dm_control_models));
-
-class MujocoMenagerieTest : public MujocoParserTest,
-                            public testing::WithParamInterface<const char*> {};
-
-TEST_P(MujocoMenagerieTest, MujocoMenagerie) {
-  // Confirm successful parsing of the MuJoCo models in the DeepMind control
-  // suite.
-  std::string model{GetParam()};
-  const RlocationOrError rlocation = FindRunfile(
-      fmt::format("mujoco_menagerie_internal/{}.xml", model));
-  ASSERT_EQ(rlocation.error, "");
-  AddModelFromFile(rlocation.abspath, model);
-
-  EXPECT_TRUE(plant_.HasModelInstanceNamed(model));
-
-  // For this test, ignore all warnings.
-  warning_records_.clear();
-}
-
-const char* mujoco_menagerie_models[] = {"google_robot/robot",
-                                         "kuka_iiwa_14/iiwa14",
-                                         "rethink_robotics_sawyer/sawyer"};
-// TODO(russt): Add the remaining models, once they can be parsed correctly, as
-// tracked in #20444.
-
-INSTANTIATE_TEST_SUITE_P(MujocoMenagerie, MujocoMenagerieTest,
-                         testing::ValuesIn(mujoco_menagerie_models));
-
 // In addition to confirming that the parser can successfully parse the model,
 // this test can be used to manually inspect the resulting visualization.
 GTEST_TEST(MujocoParserExtraTest, Visualize) {
@@ -840,7 +788,7 @@ TEST_F(MujocoParserTest, MeshFileRelativePathFromFile) {
   EXPECT_EQ(mesh->scale(), 1.0);
 }
 
-TEST_F(MujocoParserTest, InertiaFromGeometry) {
+TEST_F(MujocoParserTest, InertialFromGeometry) {
   std::string xml = fmt::format(R"""(
 <mujoco model="test">
   <default class="main">

--- a/tools/workspace/mujoco_menagerie_internal/package.BUILD.bazel
+++ b/tools/workspace/mujoco_menagerie_internal/package.BUILD.bazel
@@ -8,11 +8,199 @@ package(default_visibility = ["//visibility:public"])
 # DO NOT ADD new subdirectories here unless and until you vet their LICENSE.
 
 filegroup(
+    name = "menagerie",
+    srcs = [
+        ":agility_cassie",
+        ":aloha",
+        ":anybotics_anymal_b",
+        ":anybotics_anymal_c",
+        ":berkeley_humanoid",
+        ":bitcraze_crazyflie_2",
+        ":boston_dynamics_spot",
+        ":flybody",
+        ":franka_emika_panda",
+        ":franka_fr3",
+        ":google_barkour_v0",
+        ":google_barkour_vb",
+        ":google_robot",
+        ":hello_robot_stretch",
+        ":hello_robot_stretch_3",
+        ":kinova_gen3",
+        ":kuka_iiwa_14",
+        ":leap_hand",
+        ":pal_talos",
+        ":pal_tiago",
+        ":pal_tiago_dual",
+        ":realsense_d435i",
+        ":rethink_robotics_sawyer",
+        ":robotiq_2f85",
+        ":robotiq_2f85_v4",
+        ":robotis_op3",
+        ":shadow_dexee",
+        ":shadow_hand",
+        ":skydio_x2",
+        ":trossen_vx300s",
+        ":trossen_wx250s",
+        ":trs_so_arm100",
+        ":ufactory_lite6",
+        ":ufactory_xarm7",
+        ":unitree_a1",
+        ":unitree_g1",
+        ":unitree_go1",
+        ":unitree_go2",
+        ":unitree_h1",
+        ":unitree_z1",
+        ":universal_robots_ur10e",
+        ":universal_robots_ur5e",
+        ":wonik_allegro",
+    ],
+)
+
+filegroup(
+    name = "agility_cassie",
+    srcs = [
+        "agility_cassie/LICENSE",
+        "agility_cassie/cassie.png",
+        "agility_cassie/cassie.xml",
+        "agility_cassie/scene.xml",
+    ] + glob([
+        "agility_cassie/assets/*.obj",
+        "agility_cassie/assets/*.png",
+    ]),
+)
+
+filegroup(
+    name = "aloha",
+    srcs = [
+        "aloha/LICENSE",
+    ] + glob([
+        "aloha/*.png",
+        "aloha/*.xml",
+        "aloha/assets/*.obj",
+        "aloha/assets/*.png",
+        "aloha/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "anybotics_anymal_b",
+    srcs = [
+        "anybotics_anymal_b/LICENSE",
+        "anybotics_anymal_b/anymal_b.png",
+        "anybotics_anymal_b/anymal_b.xml",
+        "anybotics_anymal_b/scene.xml",
+    ] + glob([
+        "anybotics_anymal_b/assets/*.obj",
+        "anybotics_anymal_b/assets/*.png",
+    ]),
+)
+
+filegroup(
+    name = "anybotics_anymal_c",
+    srcs = [
+        "anybotics_anymal_c/LICENSE",
+    ] + glob([
+        "anybotics_anymal_c/*.png",
+        "anybotics_anymal_c/*.xml",
+        "anybotics_anymal_c/assets/*.obj",
+        "anybotics_anymal_c/assets/*.png",
+    ]),
+)
+
+filegroup(
+    name = "berkeley_humanoid",
+    srcs = [
+        "berkeley_humanoid/LICENSE",
+    ] + glob([
+        "berkeley_humanoid/*.png",
+        "berkeley_humanoid/*.xml",
+        "berkeley_humanoid/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "bitcraze_crazyflie_2",
+    srcs = [
+        "bitcraze_crazyflie_2/LICENSE",
+    ] + glob([
+        "bitcraze_crazyflie_2/*.png",
+        "bitcraze_crazyflie_2/*.xml",
+        "bitcraze_crazyflie_2/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "boston_dynamics_spot",
+    srcs = [
+        "boston_dynamics_spot/LICENSE",
+    ] + glob([
+        "boston_dynamics_spot/*.png",
+        "boston_dynamics_spot/*.xml",
+        "boston_dynamics_spot/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "flybody",
+    srcs = [
+        "flybody/LICENSE",
+    ] + glob([
+        "flybody/*.png",
+        "flybody/*.xml",
+        "flybody/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "franka_emika_panda",
+    srcs = [
+        "franka_emika_panda/LICENSE",
+    ] + glob([
+        "franka_emika_panda/*.png",
+        "franka_emika_panda/*.xml",
+        "franka_emika_panda/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "franka_fr3",
+    srcs = [
+        "franka_fr3/LICENSE",
+    ] + glob([
+        "franka_fr3/*.png",
+        "franka_fr3/*.xml",
+        "franka_fr3/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "google_barkour_v0",
+    srcs = [
+        "google_barkour_v0/LICENSE",
+    ] + glob([
+        "google_barkour_v0/*.xml",
+        "google_barkour_v0/assets/*.png",
+        "google_barkour_v0/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "google_barkour_vb",
+    srcs = [
+        "google_barkour_vb/LICENSE",
+    ] + glob([
+        "google_barkour_vb/*.xml",
+        "google_barkour_vb/assets/*.png",
+        "google_barkour_vb/assets/*.stl",
+    ]),
+)
+
+filegroup(
     name = "google_robot",
     srcs = [
-        "google_robot/robot.xml",
         "google_robot/LICENSE",
     ] + glob([
+        "google_robot/*.xml",
         "google_robot/assets/*.obj",
         "google_robot/assets/*.png",
         "google_robot/assets/*.stl",
@@ -22,9 +210,9 @@ filegroup(
 filegroup(
     name = "hello_robot_stretch",
     srcs = [
-        "hello_robot_stretch/stretch.xml",
         "hello_robot_stretch/LICENSE",
     ] + glob([
+        "hello_robot_stretch/*.xml",
         "hello_robot_stretch/assets/*.obj",
         "hello_robot_stretch/assets/*.png",
         "hello_robot_stretch/assets/*.stl",
@@ -32,19 +220,319 @@ filegroup(
 )
 
 filegroup(
+    name = "hello_robot_stretch_3",
+    srcs = [
+        "hello_robot_stretch_3/LICENSE",
+    ] + glob([
+        "hello_robot_stretch_3/*.xml",
+        "hello_robot_stretch_3/assets/*.obj",
+        "hello_robot_stretch_3/assets/*.png",
+        "hello_robot_stretch_3/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "kinova_gen3",
+    srcs = [
+        "kinova_gen3/LICENSE",
+    ] + glob([
+        "kinova_gen3/*.png",
+        "kinova_gen3/*.xml",
+        "kinova_gen3/assets/*.stl",
+    ]),
+)
+
+filegroup(
     name = "kuka_iiwa_14",
     srcs = [
-        "kuka_iiwa_14/iiwa14.xml",
         "kuka_iiwa_14/LICENSE",
-    ] + glob(["kuka_iiwa_14/assets/*.obj"]),
+    ] + glob([
+        "kuka_iiwa_14/*.xml",
+        "kuka_iiwa_14/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "leap_hand",
+    srcs = [
+        "leap_hand/LICENSE",
+    ] + glob([
+        "leap_hand/*.png",
+        "leap_hand/*.xml",
+        "leap_hand/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "pal_talos",
+    srcs = [
+        "pal_talos/LICENSE",
+    ] + glob([
+        "pal_talos/*.xml",
+        "pal_talos/assets/**/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "pal_tiago",
+    srcs = [
+        "pal_tiago/LICENSE",
+    ] + glob([
+        "pal_tiago/*.xml",
+        "pal_tiago/assets/**/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "pal_tiago_dual",
+    srcs = [
+        "pal_tiago_dual/LICENSE",
+    ] + glob([
+        "pal_tiago_dual/*.xml",
+        "pal_tiago_dual/assets/**/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "realsense_d435i",
+    srcs = [
+        "realsense_d435i/LICENSE",
+    ] + glob([
+        "realsense_d435i/*.png",
+        "realsense_d435i/*.xml",
+        "realsense_d435i/assets/*.obj",
+    ]),
 )
 
 filegroup(
     name = "rethink_robotics_sawyer",
     srcs = [
-        "rethink_robotics_sawyer/sawyer.xml",
         "rethink_robotics_sawyer/LICENSE",
     ] + glob([
+        "rethink_robotics_sawyer/*.xml",
         "rethink_robotics_sawyer/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "robotiq_2f85",
+    srcs = [
+        "robotiq_2f85/LICENSE",
+    ] + glob([
+        "robotiq_2f85/*.png",
+        "robotiq_2f85/*.xml",
+        "robotiq_2f85/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "robotiq_2f85_v4",
+    srcs = [
+        "robotiq_2f85_v4/LICENSE",
+    ] + glob([
+        "robotiq_2f85_v4/*.png",
+        "robotiq_2f85_v4/*.xml",
+        "robotiq_2f85_v4/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "robotis_op3",
+    srcs = [
+        "robotis_op3/LICENSE",
+    ] + glob([
+        "robotis_op3/*.png",
+        "robotis_op3/*.xml",
+        "robotis_op3/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "shadow_dexee",
+    srcs = [
+        "shadow_dexee/LICENSE",
+    ] + glob([
+        "shadow_dexee/*.png",
+        "shadow_dexee/*.xml",
+        "shadow_dexee/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "shadow_hand",
+    srcs = [
+        "shadow_hand/LICENSE",
+    ] + glob([
+        "shadow_hand/*.png",
+        "shadow_hand/*.xml",
+        "shadow_hand/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "skydio_x2",
+    srcs = [
+        "skydio_x2/LICENSE",
+    ] + glob([
+        "skydio_x2/*.png",
+        "skydio_x2/*.xml",
+        "skydio_x2/assets/*.obj",
+        "skydio_x2/assets/*.png",
+    ]),
+)
+
+filegroup(
+    name = "trossen_vx300s",
+    srcs = [
+        "trossen_vx300s/LICENSE",
+    ] + glob([
+        "trossen_vx300s/*.png",
+        "trossen_vx300s/*.xml",
+        "trossen_vx300s/assets/*.png",
+        "trossen_vx300s/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "trossen_wx250s",
+    srcs = [
+        "trossen_wx250s/LICENSE",
+    ] + glob([
+        "trossen_wx250s/*.png",
+        "trossen_wx250s/*.xml",
+        "trossen_wx250s/assets/*.png",
+        "trossen_wx250s/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "trs_so_arm100",
+    srcs = [
+        "trs_so_arm100/LICENSE",
+    ] + glob([
+        "trs_so_arm100/*.png",
+        "trs_so_arm100/*.xml",
+        "trs_so_arm100/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "ufactory_lite6",
+    srcs = [
+        "ufactory_lite6/LICENSE",
+    ] + glob([
+        "ufactory_lite6/*.xml",
+        "ufactory_lite6/assets/**/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "ufactory_xarm7",
+    srcs = [
+        "ufactory_xarm7/LICENSE",
+    ] + glob([
+        "ufactory_xarm7/*.xml",
+        "ufactory_xarm7/assets/**/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "unitree_a1",
+    srcs = [
+        "unitree_a1/LICENSE",
+    ] + glob([
+        "unitree_a1/*.png",
+        "unitree_a1/*.xml",
+        "unitree_a1/assets/*.obj",
+        "unitree_a1/assets/*.png",
+    ]),
+)
+
+filegroup(
+    name = "unitree_g1",
+    srcs = [
+        "unitree_g1/LICENSE",
+    ] + glob([
+        "unitree_g1/*.png",
+        "unitree_g1/*.xml",
+        "unitree_g1/assets/*.STL",
+    ]),
+)
+
+filegroup(
+    name = "unitree_go1",
+    srcs = [
+        "unitree_go1/LICENSE",
+        "unitree_go1/go1.png",
+        "unitree_go1/go1.xml",
+        "unitree_go1/scene.xml",
+    ] + glob([
+        "unitree_go1/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "unitree_go2",
+    srcs = [
+        "unitree_go2/LICENSE",
+    ] + glob([
+        "unitree_go2/*.png",
+        "unitree_go2/*.xml",
+        "unitree_go2/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "unitree_h1",
+    srcs = [
+        "unitree_h1/LICENSE",
+    ] + glob([
+        "unitree_h1/*.png",
+        "unitree_h1/*.xml",
+        "unitree_h1/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "unitree_z1",
+    srcs = [
+        "unitree_z1/LICENSE",
+    ] + glob([
+        "unitree_z1/*.png",
+        "unitree_z1/*.xml",
+        "unitree_z1/assets/*.stl",
+    ]),
+)
+
+filegroup(
+    name = "universal_robots_ur10e",
+    srcs = [
+        "universal_robots_ur10e/LICENSE",
+    ] + glob([
+        "universal_robots_ur10e/*.png",
+        "universal_robots_ur10e/*.xml",
+        "universal_robots_ur10e/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "universal_robots_ur5e",
+    srcs = [
+        "universal_robots_ur5e/LICENSE",
+    ] + glob([
+        "universal_robots_ur5e/*.png",
+        "universal_robots_ur5e/*.xml",
+        "universal_robots_ur5e/assets/*.obj",
+    ]),
+)
+
+filegroup(
+    name = "wonik_allegro",
+    srcs = [
+        "wonik_allegro/LICENSE",
+    ] + glob([
+        "wonik_allegro/*.png",
+        "wonik_allegro/*.xml",
+        "wonik_allegro/assets/*.stl",
     ]),
 )

--- a/tools/workspace/mujoco_menagerie_internal/repository.bzl
+++ b/tools/workspace/mujoco_menagerie_internal/repository.bzl
@@ -6,8 +6,8 @@ def mujoco_menagerie_internal_repository(
     github_archive(
         name = name,
         repository = "google-deepmind/mujoco_menagerie",
-        commit = "bd9709b540d58e1dcf417e4ffeffc7d54318280d",
-        sha256 = "73e4cecf8c2cd92ebfabdecc365d2dfa8ef3dc77ba6994bf6202cecbfd7fa7d7",  # noqa
+        commit = "469893211c41d5da9c314f5ab58059fa17c8e360",
+        sha256 = "1cfe0ebde2c6dd80405977e0b3a6f72e1b062d8a79f9f0437ebebe463c9c85f7",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Towards #20444

Brings the remaining models from the menagerie under test for the mujoco parser. All of them are permissively licensed (but this requires manual confirmation).

The non-uniform mesh error is being tracked in #22046. My plan is to follow-up immediately with fixes for the other two known errors that are being documented in the expanded test.

+@jwnimmer-tri for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22370)
<!-- Reviewable:end -->
