### PR TITLE
Adding Brom to the list of Third-Party Drake Projects?

### DIFF
--- a/doc/_pages/gallery.md
+++ b/doc/_pages/gallery.md
@@ -178,3 +178,14 @@ The project is open-sourced to support education and research of brachiation wit
 
 *Source Code:* [AcroMonk](https://github.com/dfki-ric-underactuated-lab/acromonk)
 
+## brom_drake: A Helper Library for Pydrake (Python)
+
+`brom_drake` is a pip-installable library that simplifies the process of debugging algorithms in `pydrake`. Some of its notable features are:
+- The `DiagramWatcher` object which will automatically add loggers to your Drake diagram, simplifying the process of monitoring "what's going on" between systems. (By default, the data from each of these loggers will get saved locally to your machine after the simulation is run.)
+- The `drakeify_my_urdf` function which will use open-source tools to convert many Drake-incompatible `.urdf` files into ones that are compatible with Drake.
+- `Production` objects which are partially complete scenes that you can use to debug common algorithms (for example, motion planning algorithms).
+
+<img class="gallery" height="224px" src="https://raw.githubusercontent.com/kwesiRutledge/brom_drake-py/refs/heads/main/promo/productions/motion_planning/kinematic/Chem-Lab-Demo.gif"/>
+
+*Source Code:* [https://github.com/kwesiRutledge/brom_drake-py](https://github.com/kwesiRutledge/brom_drake-py)
+


### PR DESCRIPTION
Hello!

I'm submitting this PR to suggest that [brom_drake](https://github.com/kwesiRutledge/brom_drake-py) be included in the gallery of projects using Drake! We think that Drake is a powerful tool that enables a lot of great experimentation on our end! Our team created a few extra features on top of Drake that we think would be helpful for the broader community including:
- the `DiagramWatcher`,
- the `drakeify_my_urdf` function, and
- the concept of `brom_drake` `Production` objects.

Would you mind including this project in the gallery?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22371)
<!-- Reviewable:end -->
