### PR TITLE
AddUnitQuaternionConstraintOnPlant also adds quat ∈ [-1,1]

### DIFF
--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -87,7 +87,7 @@ class TestInverseKinematics(unittest.TestCase):
             q=self.q,
             prog=self.prog,
             plant_context=self.ik_two_bodies.context())
-        self.assertEqual(len(bindings), 2)
+        self.assertEqual(len(bindings), 4)
 
     def test_AddPositionConstraint1(self):
         p_BQ = np.array([0.2, 0.3, 0.5])

--- a/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
+++ b/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
@@ -120,7 +120,7 @@ TEST_F(AddMultibodyPlantConstraintsTest, WeldConstraint) {
     // IPOPT is flakey on this test.
     return;
   }
-  const int expected_num_constraints = 3;  // 1 for quaternion, 2 for weld.
+  const int expected_num_constraints = 4;  // 2 for quaternion, 2 for weld.
   CheckConstraints(expected_num_constraints, /* tol = */ 1e-2);
 }
 

--- a/multibody/inverse_kinematics/test/unit_quaternion_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/unit_quaternion_constraint_test.cc
@@ -51,8 +51,9 @@ TEST_F(TwoFreeBodiesConstraintTest, AddUnitQuaternionConstraintOnPlant) {
       q.segment<4>(plant_->GetBodyByName("body1").floating_positions_start()),
       body1_guess);
   auto bindings = AddUnitQuaternionConstraintOnPlant(*plant_, q, &prog);
-  EXPECT_EQ(bindings.size(), 2);
+  EXPECT_EQ(bindings.size(), 4);
   EXPECT_EQ(prog.generic_constraints().size(), 2);
+  EXPECT_EQ(prog.bounding_box_constraints().size(), 2);
   // Confirm that body 1's non-default initial guess was not overwritten.
   EXPECT_TRUE(CompareMatrices(
       prog.GetInitialGuess(q.segment<4>(

--- a/multibody/inverse_kinematics/unit_quaternion_constraint.cc
+++ b/multibody/inverse_kinematics/unit_quaternion_constraint.cc
@@ -40,6 +40,7 @@ AddUnitQuaternionConstraintOnPlant(
       bindings.emplace_back(
           prog->AddConstraint(solvers::Binding<solvers::Constraint>(
               std::make_shared<UnitQuaternionConstraint>(), quat_vars)));
+      bindings.emplace_back(prog->AddBoundingBoxConstraint(-1, 1, quat_vars));
       if (prog->GetInitialGuess(quat_vars).array().isNaN().all()) {
         prog->SetInitialGuess(quat_vars, Eigen::Vector4d(1, 0, 0, 0));
       }

--- a/multibody/inverse_kinematics/unit_quaternion_constraint.h
+++ b/multibody/inverse_kinematics/unit_quaternion_constraint.h
@@ -51,7 +51,8 @@ class UnitQuaternionConstraint : public solvers::Constraint {
 /**
  Add unit length constraints to all the variables representing quaternion in
  `q_vars`. Namely the quaternions for floating base joints in `plant` will be
- enforced to have a unit length.
+ enforced to have a unit length, and all quaternion variables will be bounded to
+ be within [-1, 1].
 
  Additionally, if the initial guess for the quaternion variables has not been
  set (it is nan), then this method calls MathematicalProgram::SetInitialGuess()


### PR DESCRIPTION
As [discussed](https://drakedevelopers.slack.com/archives/C3L92BM2Q/p1734528939754169) on drake-developers slack.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22373)
<!-- Reviewable:end -->
