### PR TITLE
[tools] Add always_optimize option for drake_cc_library

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -99,6 +99,7 @@ drake_cc_library(
         "aabb.h",
         "obb.h",
     ],
+    always_optimize = True,
     deps = [
         ":boxes_overlap",
         ":posed_half_space",

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -566,6 +566,7 @@ def drake_cc_library(
         clang_copts = [],
         gcc_copts = [],
         linkstatic = 1,
+        always_optimize = True,
         internal = False,
         compile_once_per_scalar = False,
         declare_installed_headers = 1,
@@ -595,6 +596,11 @@ def drake_cc_library(
     part of Drake).  In other words, all of Drake's C++ libraries must be
     declared using the drake_cc_library macro.
 
+    Setting `always_optimize = True` builds the library with optimizations
+    enabled even in Debug builds. This can be used (sparingly) for low-level
+    libraries whose performance without optimizations is so bad as to make
+    the whole project suffer.
+
     Setting `internal = True` is convenient sugar to flag code that is never
     used by Drake's installed headers. This is especially helpful when the
     header_lint tool is complaining about third-party dependency pollution.
@@ -618,6 +624,11 @@ def drake_cc_library(
     should be surrounded with `#if DRAKE_ONCE_PER_SCALAR_PHASE == 0`.
     """
     new_copts = _platform_copts(copts, gcc_copts, clang_copts)
+    if always_optimize:
+        new_copts = new_copts + [
+            "-O2",
+            "-DNDEBUG",
+        ]
     new_tags = kwargs.pop("tags", None) or []
     if internal:
         if install_hdrs_exclude != []:


### PR DESCRIPTION
Use it in our low-level OBB code.

Motivated by #22370.  In that instance, this brings one test case out of a larger test program down from 11.0 seconds to 3.4 seconds of wall time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22380)
<!-- Reviewable:end -->
