### PR TITLE
[solvers] Ipopt uses SPRAL (not MUMPS) by default

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1526,19 +1526,18 @@ config_setting(
     constraint_values = ["@platforms//os:osx"],
 )
 
-# Re-run ipopt_solver_test, but with the SPRAL linear solver.
+# Re-run ipopt_solver_test, but with the MUMPS linear solver.
+# Remove on 2025-05-01.
 drake_sh_test(
-    name = "ipopt_solver_spral_test",
+    name = "ipopt_solver_mumps_test",
     srcs = [":ipopt_solver_test"],
     args = select({
         ":osx": [
-            # SPRAL is the default on macOS, so ipopt_solver_test already has
-            # us covered. Only on Ubuntu (where MUMPS is the default) do we
-            # need to re-run this test.
+            # MUMPS only exists on Ubuntu (not macOS).
             "--gtest_filter=-*",
         ],
         "//conditions:default": [
-            "--linear_solver=spral",
+            "--linear_solver=mumps",
         ],
     }),
     data = [":ipopt_solver_test"],

--- a/solvers/benchmarking/BUILD.bazel
+++ b/solvers/benchmarking/BUILD.bazel
@@ -29,7 +29,10 @@ drake_cc_googlebench_binary(
     name = "benchmark_ipopt_solver",
     srcs = ["benchmark_ipopt_solver.cc"],
     add_test_rule = True,
-    test_timeout = "moderate",
+    test_args = [
+        # When testing, only run the smallest test.
+        "--benchmark_filter=.*/10$$",
+    ],
     deps = [
         "//common:add_text_logging_gflags",
         "//solvers:ipopt_solver",

--- a/solvers/benchmarking/benchmark_ipopt_solver.cc
+++ b/solvers/benchmarking/benchmark_ipopt_solver.cc
@@ -8,12 +8,12 @@ namespace {
 
 static void BenchmarkIpoptSolver(benchmark::State& state) {  // NOLINT
   // Number of decision variables.
-  const int nx = 1000;
+  const int nx = state.range(0);
   // Create the mathematical program and the solver.
   MathematicalProgram prog;
   IpoptSolver solver;
   // Create decision variables.
-  auto x = prog.NewContinuousVariables<nx>();
+  auto x = prog.NewContinuousVariables(nx);
   // Add bounding box constraints.
   auto lbx = -1e0 * Eigen::VectorXd::Ones(nx);
   auto ubx = +1e0 * Eigen::VectorXd::Ones(nx);
@@ -42,7 +42,7 @@ static void BenchmarkIpoptSolver(benchmark::State& state) {  // NOLINT
   DRAKE_DEMAND(result.is_success());
 }
 
-BENCHMARK(BenchmarkIpoptSolver);
+BENCHMARK(BenchmarkIpoptSolver)->ArgsProduct({{10, 100, 1000}});
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/ipopt_solver.h
+++ b/solvers/ipopt_solver.h
@@ -45,11 +45,9 @@ struct IpoptSolverDetails {
  * <a href="https://coin-or.github.io/Ipopt/">Ipopt</a>
  * using Drake's MathematicalProgram.
  *
- * The IpoptSolver is NOT threadsafe to call in parallel. This is due to Ipopt's
- * reliance on the MUMPS linear solver which is not safe to call concurrently
- * (see https://github.com/coin-or/Ipopt/issues/733). This can be resolved by
- * enabling the SPRAL solver (see Drake issue
- * https://github.com/RobotLocomotion/drake/issues/21476).
+ * @warning Setting the Ipopt option "linear_solver" to "mumps" is deprecated
+ * and will be removed on or after 2025-05-01. Using MUMPS is NOT threadsafe
+ * (see https://github.com/coin-or/Ipopt/issues/733).
  */
 class IpoptSolver final : public SolverBase {
  public:
@@ -61,6 +59,7 @@ class IpoptSolver final : public SolverBase {
   IpoptSolver();
   ~IpoptSolver() final;
 
+  // Remove on 2025-05-01.
   /// Changes the default value for Ipopt's "linerar_solver" solver option. This
   /// is the lowest precedence default -- setting the "linear_solver" option in
   /// SolverOptions will override this default.
@@ -83,6 +82,7 @@ class IpoptSolver final : public SolverBase {
                 internal::SpecificOptions*,
                 MathematicalProgramResult*) const final;
 
+  // Remove 2025-05-01.
   std::string default_linear_solver_;
 };
 

--- a/solvers/ipopt_solver_internal.cc
+++ b/solvers/ipopt_solver_internal.cc
@@ -764,22 +764,22 @@ void IpoptSolver_NLP::EvaluateConstraints(Index n, const Number* x,
   }
 }
 
+// Remove 2025-05-01.
 std::vector<std::string_view> GetSupportedIpoptLinearSolvers() {
   std::vector<std::string_view> result;
   // IPOPT's upstream default linear solver is MA27, but it is not freely
   // redistributable so Drake cannot use it. In Drake's Ubuntu and macOS build
-  // recipes for IPOPT, one or both of MUMPS or SPRAL linear solvers will be
+  // recipes for IPOPT, one or both of SPRAL or MUMPS linear solvers will be
   // available. We'll ask IPOPT which of those two linear solver(s) have been
   // built into Drake.
   const IpoptLinearSolver solver_mask =
       IpoptGetAvailableLinearSolvers(/* buildinonly = */ 1);
   // The first item in the result will be Drake's default linear solver.
-  // We'll prefer MUMPS because it has been our traditional choice.
-  if (solver_mask & IPOPTLINEARSOLVER_MUMPS) {
-    result.emplace_back("mumps");
-  }
   if (solver_mask & IPOPTLINEARSOLVER_SPRAL) {
     result.emplace_back("spral");
+  }
+  if (solver_mask & IPOPTLINEARSOLVER_MUMPS) {
+    result.emplace_back("mumps");
   }
   return result;
 }

--- a/solvers/solve.cc
+++ b/solvers/solve.cc
@@ -95,7 +95,8 @@ std::vector<MathematicalProgramResult> SolveInParallel(
 
     // IPOPT's MUMPS linear solver is not thread-safe. Therefore, if we are
     // operating in parallel we need to skip this program.
-    // TODO(#21476) Only force serial mode when MUMPS is used (not for SPRAL).
+    // TODO(#21476) Only force serial mode when MUMPS is used (not for SPRAL),
+    // or we can safely remove this guard on 2025-05-01 after MUMPS is purged.
     if (in_parallel && solver_id == IpoptSolver::id()) {
       static const logging::Warn log_once(
           "IpoptSolver cannot currently solve programs in parallel, so will be "

--- a/solvers/test/ipopt_solver_internal_test.cc
+++ b/solvers/test/ipopt_solver_internal_test.cc
@@ -281,13 +281,10 @@ constexpr bool kApple = false;
 GTEST_TEST(TestIpoptSolver, SupportedLinearSolvers) {
   const std::vector<std::string_view> actual = GetSupportedIpoptLinearSolvers();
   std::vector<std::string_view> expected;
-  if (kApple) {
-    // Homebrew doesn't provide a usable MUMPS library for us to build against,
-    // so SPRAL is the only available option.
-    expected.emplace_back("spral");
-  } else {
+  expected.emplace_back("spral");
+  if (!kApple) {
+    // Homebrew doesn't provide a usable MUMPS library for us to build against.
     expected.emplace_back("mumps");
-    expected.emplace_back("spral");
   }
   EXPECT_EQ(actual, expected);
 }

--- a/tools/wheel/image/build-dependencies.sh
+++ b/tools/wheel/image/build-dependencies.sh
@@ -16,6 +16,7 @@ ninja
 if [[ "$(uname)" == "Linux" ]]; then
     # Libraries we get from the distro that get bundled into the wheel need to
     # have their licenses bundled also.
+    # Remove mumps install on 2025-05-01.
     mkdir -p /opt/drake-dependencies/licenses/mumps
     cp -t /opt/drake-dependencies/licenses/mumps \
         /usr/share/doc/libmumps-seq-dev/copyright

--- a/tools/wheel/image/packages-jammy
+++ b/tools/wheel/image/packages-jammy
@@ -30,8 +30,11 @@ zip
 # Build dependencies (general).
 libgl1-mesa-dev
 libglib2.0-dev
-libmumps-seq-dev
 libxt-dev
 # Build dependencies (OpenCL).
 opencl-headers
 ocl-icd-opencl-dev
+
+# Remove on 2025-05-01.
+# Likewise remove mumps from setup/**.txt files.
+libmumps-seq-dev

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -258,6 +258,7 @@ def add_default_repositories(
     if "mujoco_menagerie_internal" not in excludes:
         mujoco_menagerie_internal_repository(name = "mujoco_menagerie_internal", mirrors = mirrors)  # noqa
     if "mumps_internal" not in excludes:
+        # Remove on 2025-05-01.
         mumps_internal_repository(name = "mumps_internal")
     if "mypy_extensions_internal" not in excludes:
         mypy_extensions_internal_repository(name = "mypy_extensions_internal", mirrors = mirrors)  # noqa


### PR DESCRIPTION
Users can temporarily revert to MUMPS by setting the Ipopt solver option "linear_solver" to "mumps", but that option is deprecated and will be removed on 2025-05-01. Please let us know if you find programs that SPRAL does not handle well.

Note that this only affects Ubuntu.  On macOS, SPRAL is already the sole option.

Closes #21476.
Towards #17231 and #14967.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22385)
<!-- Reviewable:end -->
