### PR TITLE
Add functionality to create Convex shapes from vertices

### DIFF
--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/optimization/vpolytope.h"
 
 #include <limits>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -301,12 +302,16 @@ GTEST_TEST(VPolytopeTest, ToShapeConvex) {
   vertices.col(2) << 0, 1, 0;
   vertices.col(3) << 0, 0, 1;
 
+  const std::string convex_label = "a_convex";
+
   const VPolytope V(vertices);
-  const Convex convex = V.ToShapeConvex();
+  const Convex convex = V.ToShapeConvex(convex_label);
 
   int num_vertices_of_convex = convex.GetConvexHull().num_vertices();
 
   EXPECT_EQ(vertices.cols(), num_vertices_of_convex);
+  EXPECT_EQ(convex.source().in_memory().mesh_file.filename_hint(),
+            convex_label);
 }
 
 GTEST_TEST(VPolytopeTest, UnitBox6DTest) {

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -305,7 +305,7 @@ GTEST_TEST(VPolytopeTest, ToShapeConvex) {
   VPolytope V(vertices);
   const Convex convex = V.ToShapeConvex();
 
-  auto vertices = convex.GetConvexHull().num_vertices();
+  auto num_vertices = convex.GetConvexHull().num_vertices();
 
   EXPECT_EQ(vertices.cols(), num_vertices);
 }

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -312,6 +312,12 @@ GTEST_TEST(VPolytopeTest, ToShapeConvex) {
   EXPECT_EQ(vertices.cols(), num_vertices_of_convex);
   EXPECT_EQ(convex.source().in_memory().mesh_file.filename_hint(),
             convex_label);
+
+  // When no convex label is specified, a default label gets applied.
+  const Convex convex2 = V.ToShapeConvex();
+  ASSERT_TRUE(convex2.source().is_in_memory());
+  EXPECT_EQ(convex2.source().in_memory().mesh_file.filename_hint(),
+            "convex_from_vpolytope");
 }
 
 GTEST_TEST(VPolytopeTest, UnitBox6DTest) {

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -294,6 +294,22 @@ GTEST_TEST(VPolytopeTest, NonconvexMesh) {
   EXPECT_TRUE(V.PointInSet(V.MaybeGetFeasiblePoint().value()));
 }
 
+GTEST_TEST(VPolytopeTest, ToShapeConvex) {
+  const int num_vertices = 4;
+  Eigen::Matrix<double, 3, 4> vertices;
+  vertices.col(0) << 0, 0, 0;
+  vertices.col(1) << 1, 0, 0;
+  vertices.col(2) << 0, 1, 0;
+  vertices.col(3) << 0, 0, 1;
+
+  VPolytope V(vertices);
+  const Convex convex = V.ToShapeConvex();
+
+  auto vertices = convex.GetConvexHull().num_vertices();
+
+  EXPECT_EQ(vertices.cols(), num_vertices);
+}
+
 GTEST_TEST(VPolytopeTest, UnitBox6DTest) {
   VPolytope V = VPolytope::MakeUnitBox(6);
   EXPECT_EQ(V.ambient_dimension(), 6);

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -301,7 +301,7 @@ GTEST_TEST(VPolytopeTest, ToShapeConvex) {
   vertices.col(2) << 0, 1, 0;
   vertices.col(3) << 0, 0, 1;
 
-  VPolytope V(vertices);
+  const VPolytope V(vertices);
   const Convex convex = V.ToShapeConvex();
 
   int num_vertices_of_convex = convex.GetConvexHull().num_vertices();

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -295,7 +295,6 @@ GTEST_TEST(VPolytopeTest, NonconvexMesh) {
 }
 
 GTEST_TEST(VPolytopeTest, ToShapeConvex) {
-  const int num_vertices = 4;
   Eigen::Matrix<double, 3, 4> vertices;
   vertices.col(0) << 0, 0, 0;
   vertices.col(1) << 1, 0, 0;
@@ -305,9 +304,9 @@ GTEST_TEST(VPolytopeTest, ToShapeConvex) {
   VPolytope V(vertices);
   const Convex convex = V.ToShapeConvex();
 
-  auto num_vertices = convex.GetConvexHull().num_vertices();
+  int num_vertices_of_convex = convex.GetConvexHull().num_vertices();
 
-  EXPECT_EQ(vertices.cols(), num_vertices);
+  EXPECT_EQ(vertices.cols(), num_vertices_of_convex);
 }
 
 GTEST_TEST(VPolytopeTest, UnitBox6DTest) {

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -492,6 +492,11 @@ void VPolytope::WriteObj(const std::filesystem::path& filename) const {
   file.close();
 }
 
+Convex VPolytope::ToShapeConvex() const {
+  DRAKE_THROW_UNLESS(ambient_dimension() == 3);
+  return Convex(vertices_);
+}
+
 std::unique_ptr<ConvexSet> VPolytope::DoClone() const {
   return std::make_unique<VPolytope>(*this);
 }

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -492,9 +492,9 @@ void VPolytope::WriteObj(const std::filesystem::path& filename) const {
   file.close();
 }
 
-Convex VPolytope::ToShapeConvex() const {
+Convex VPolytope::ToShapeConvex(const std::string& convex_label) const {
   DRAKE_THROW_UNLESS(ambient_dimension() == 3);
-  return Convex(vertices_);
+  return Convex(vertices_, convex_label);
 }
 
 std::unique_ptr<ConvexSet> VPolytope::DoClone() const {

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -98,9 +99,11 @@ class VPolytope final : public ConvexSet {
   @pre ambient_dimension() == 3. */
   void WriteObj(const std::filesystem::path& filename) const;
 
-  /** Creates a geometry::Convex shape using the vertices of this VPolytope.
+  /** Creates a geometry::Convex shape using the vertices of this VPolytope. The
+  convex_label is passed as the 'label' of the Convex object.
   @pre ambient_dimension() == 3. */
-  Convex ToShapeConvex() const;
+  Convex ToShapeConvex(
+      const std::string& convex_label = "convex_from_vpolytope") const;
 
   /** Computes the volume of this V-Polytope.
   @note this function calls qhull to compute the volume. */

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -98,6 +98,10 @@ class VPolytope final : public ConvexSet {
   @pre ambient_dimension() == 3. */
   void WriteObj(const std::filesystem::path& filename) const;
 
+  /** Creates a geometry::Convex shape using the vertices of this VPolytope.
+  @pre ambient_dimension() == 3. */
+  Convex ToShapeConvex() const;
+
   /** Computes the volume of this V-Polytope.
   @note this function calls qhull to compute the volume. */
   using ConvexSet::CalcVolume;

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -19,13 +19,12 @@
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 
 namespace {
-std::string VerticesToString(const Eigen::Matrix3X<double>& vertices) {
+std::string PointsToObjString(const Eigen::Matrix3X<double>& points) {
   std::string result = "";
 
-  result += fmt::format("# Vertices: {}\n", vertices.cols());
-  for (int i = 0; i < vertices.cols(); i++) {
-    result += fmt::format("v {} {} {}\n", vertices(0, i), vertices(1, i),
-                          vertices(2, i));
+  for (int i = 0; i < points.cols(); i++) {
+    result +=
+        fmt::format("v {} {} {}\n", points(0, i), points(1, i), points(2, i));
   }
   result += "\n";
 
@@ -147,12 +146,14 @@ Convex::Convex(MeshSource source, double scale)
   ThrowForBadScale(scale, "Convex");
 }
 
-Convex::Convex(const Eigen::Matrix3X<double>& vertices,
-               const std::string& filename_hint, double scale)
-    : Convex(InMemoryMesh(
-                 MemoryFile(VerticesToString(vertices), ".OBJ", filename_hint),
-                 {}),
-             scale) {}
+Convex::Convex(const Eigen::Matrix3X<double>& points,
+               const std::string& convex_label, double scale)
+    : Convex(
+          InMemoryMesh{
+              .mesh_file =
+                  MemoryFile(PointsToObjString(points), ".obj", convex_label),
+          },
+          scale) {}
 
 std::string Convex::filename() const {
   if (source_.is_path()) {

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -22,7 +22,7 @@ namespace {
 std::string PointsToObjString(const Eigen::Matrix3X<double>& points) {
   std::string result = "";
 
-  for (int i = 0; i < points.cols(); i++) {
+  for (int i = 0; i < points.cols(); ++i) {
     result +=
         fmt::format("v {} {} {}\n", points(0, i), points(1, i), points(2, i));
   }
@@ -145,14 +145,12 @@ Convex::Convex(MeshSource source, double scale)
   ThrowForBadScale(scale, "Convex");
 }
 
-Convex::Convex(const Eigen::Matrix3X<double>& points,
-               const std::string& convex_label, double scale)
-    : Convex(
-          InMemoryMesh{
-              .mesh_file =
-                  MemoryFile(PointsToObjString(points), ".obj", convex_label),
-          },
-          scale) {}
+Convex::Convex(const Eigen::Matrix3X<double>& points, const std::string& label,
+               double scale)
+    : Convex(InMemoryMesh{.mesh_file = MemoryFile(
+                              PointsToObjString(points), ".obj",
+                              label.empty() ? "convex-from-points" : label)},
+             scale) {}
 
 std::string Convex::filename() const {
   if (source_.is_path()) {

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -147,9 +147,8 @@ Convex::Convex(MeshSource source, double scale)
 
 Convex::Convex(const Eigen::Matrix3X<double>& points, const std::string& label,
                double scale)
-    : Convex(InMemoryMesh{.mesh_file = MemoryFile(
-                              PointsToObjString(points), ".obj",
-                              label.empty() ? "convex-from-points" : label)},
+    : Convex(InMemoryMesh{.mesh_file = MemoryFile(PointsToObjString(points),
+                                                  ".obj", label)},
              scale) {}
 
 std::string Convex::filename() const {

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -18,6 +18,21 @@
 #include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 
+namespace {
+std::string VerticesToString(const Eigen::Matrix3X<double>& vertices) {
+  std::string result = "";
+
+  result += fmt::format("# Vertices: {}\n", vertices.cols());
+  for (int i = 0; i < vertices.cols(); i++) {
+    result += fmt::format("v {} {} {}\n", vertices(0, i), vertices(1, i),
+                          vertices(2, i));
+  }
+  result += "\n";
+
+  return result;
+}
+}  // namespace
+
 namespace drake {
 namespace geometry {
 namespace {
@@ -131,6 +146,13 @@ Convex::Convex(MeshSource source, double scale)
   // mesh of unsupported type is used, but only processed by client code.
   ThrowForBadScale(scale, "Convex");
 }
+
+Convex::Convex(const Eigen::Matrix3X<double>& vertices,
+               const std::string& filename_hint, double scale)
+    : Convex(InMemoryMesh(
+                 MemoryFile(VerticesToString(vertices), ".OBJ", filename_hint),
+                 {}),
+             scale) {}
 
 std::string Convex::filename() const {
   if (source_.is_path()) {

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -26,7 +26,6 @@ std::string PointsToObjString(const Eigen::Matrix3X<double>& points) {
     result +=
         fmt::format("v {} {} {}\n", points(0, i), points(1, i), points(2, i));
   }
-  result += "\n";
 
   return result;
 }

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -301,7 +301,7 @@ class Convex final : public Shape {
    @throws std::exception       if label contains newlines.
    @throws std::exception       if |scale| < 1e-8. */
   explicit Convex(const Eigen::Matrix3X<double>& points,
-                  const std::string& label = {}, double scale = 1.0);
+                  const std::string& label, double scale = 1.0);
 
   ~Convex() final;
 

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -292,7 +292,7 @@ class Convex final : public Shape {
    expected to be in the canonical frame of the shape. Optionally uniformly
    scaled by the given scale factor.
 
-   @param points      The points whose convex hull define the shape.
+   @param points        The points whose convex hull define the shape.
    @param convex_label  A label for the object. The label is used for warning
                         and error messages. Otherwise, the label has no other
                         functional purpose. It must consist of a single line.

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -286,23 +286,22 @@ class Convex final : public Shape {
    @param scale    An optional scale to coordinates. */
   explicit Convex(MeshSource source, double scale = 1.0);
 
-  /** Constructs a convex shape specification from the given `vertices`.
+  /** Constructs an in-memory convex shape specification from the given points.
 
-   The convex hull is computed from the vertices provided. The vertices are
+   The convex hull is computed from the points provided. The points are
    expected to be in the canonical frame of the shape. Optionally uniformly
    scaled by the given scale factor.
 
-   @param vertices      The vertices of the convex hull.
-   @param filename_hint A label for the file. The label is used for warning and
-                        error messages. Otherwise, the label has no other
-                        functional purpose. It need not be a valid file name,
-                        but must consist of a single line (no newlines).
+   @param points      The points whose convex hull define the shape.
+   @param convex_label  A label for the object. The label is used for warning
+                        and error messages. Otherwise, the label has no other
+                        functional purpose. It must consist of a single line.
    @param scale         An optional scale to coordinates.
 
-   @throws std::exception       if filename_hint contains newlines.
+   @throws std::exception       if convex_label contains newlines.
    @throws std::exception       if |scale| < 1e-8. */
-  explicit Convex(const Eigen::Matrix3X<double>& vertices,
-                  const std::string& filename_hint = {}, double scale = 1.0);
+  explicit Convex(const Eigen::Matrix3X<double>& points,
+                  const std::string& convex_label = {}, double scale = 1.0);
 
   ~Convex() final;
 

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -286,6 +286,24 @@ class Convex final : public Shape {
    @param scale    An optional scale to coordinates. */
   explicit Convex(MeshSource source, double scale = 1.0);
 
+  /** Constructs a convex shape specification from the given `vertices`.
+
+   The convex hull is computed from the vertices provided. The vertices are
+   expected to be in the canonical frame of the shape. Optionally uniformly
+   scaled by the given scale factor.
+
+   @param vertices      The vertices of the convex hull.
+   @param filename_hint A label for the file. The label is used for warning and
+                        error messages. Otherwise, the label has no other
+                        functional purpose. It need not be a valid file name,
+                        but must consist of a single line (no newlines).
+   @param scale         An optional scale to coordinates.
+
+   @throws std::exception       if filename_hint contains newlines.
+   @throws std::exception       if |scale| < 1e-8. */
+  explicit Convex(const Eigen::Matrix3X<double>& vertices,
+                  const std::string& filename_hint = {}, double scale = 1.0);
+
   ~Convex() final;
 
   /** Returns the source for this specification's mesh data. When working with

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -292,16 +292,16 @@ class Convex final : public Shape {
    expected to be in the canonical frame of the shape. Optionally uniformly
    scaled by the given scale factor.
 
-   @param points        The points whose convex hull define the shape.
-   @param convex_label  A label for the object. The label is used for warning
-                        and error messages. Otherwise, the label has no other
-                        functional purpose. It must consist of a single line.
-   @param scale         An optional scale to coordinates.
+   @param points  The points whose convex hull define the shape.
+   @param label   A label for the object. The label is used for warning and
+                  error messages. Otherwise, the label has no other functional
+                  purpose. It must consist of a single line.
+   @param scale   An optional scale to coordinates.
 
-   @throws std::exception       if convex_label contains newlines.
+   @throws std::exception       if label contains newlines.
    @throws std::exception       if |scale| < 1e-8. */
   explicit Convex(const Eigen::Matrix3X<double>& points,
-                  const std::string& convex_label = {}, double scale = 1.0);
+                  const std::string& label = {}, double scale = 1.0);
 
   ~Convex() final;
 

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -686,28 +686,11 @@ GTEST_TEST(ShapeTest, ConvexFromVertices) {
   EXPECT_EQ(hull.num_vertices(), 4);
   EXPECT_EQ(hull.num_elements(), 4);
 
-  // Confirm that the vertices of the convex hull are the expected ones.
-  Eigen::Matrix<double, 3, 4> expected_hull_points;
-  expected_hull_points.col(0) << 0, 0, 0;
-  expected_hull_points.col(1) << 1, 0, 0;
-  expected_hull_points.col(2) << 0, 1, 0;
-  expected_hull_points.col(3) << 0, 0, 1;
-
-  expected_hull_points *= scale;
-
-  std::vector<Eigen::VectorXd> hull_points;
-  for (int i = 0; i < hull.num_vertices(); ++i) {
-    hull_points.push_back(hull.vertex(i));
-  }
-
-  for (int i = 0; i < hull.num_vertices(); ++i) {
-    EXPECT_TRUE(
-        std::find_if(hull_points.begin(), hull_points.end(),
-                     [&expected_hull_points, &i](const Eigen::Vector3d& v) {
-                       return CompareMatrices(v, expected_hull_points.col(i),
-                                              1e-14);
-                     }) != hull_points.end());
-  }
+  // Confirm that the cntents of the in-memory mesh file are as expected.
+  EXPECT_EQ(source.in_memory().mesh_file.contents(),
+            std::string("v 0 0 0\n") + std::string("v 1 0 0\n") +
+                std::string("v 0.25 0.25 0.25\n") + std::string("v 0 1 0\n") +
+                std::string("v 0 0 1\n"));
 }
 
 GTEST_TEST(ShapeTest, MeshFromMemory) {

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -662,6 +662,33 @@ GTEST_TEST(ShapeTest, ConvexFromMemory) {
   EXPECT_EQ(hull.num_elements(), 6);
 }
 
+GTEST_TEST(ShapeTest, ConvexFromVertices) {
+  // This will get normalized to ".obj".
+  Eigen::MatrixXd vertices(3, 8);
+  vertices.col(0) << 0, 0, 0;
+  vertices.col(1) << 1, 0, 0;
+  vertices.col(2) << 1, 1, 0;
+  vertices.col(3) << 0, 1, 0;
+  vertices.col(4) << 0, 0, 1;
+  vertices.col(5) << 1, 0, 1;
+  vertices.col(6) << 1, 1, 1;
+  vertices.col(7) << 0, 1, 1;
+  const std::string mesh_name = "a_convex.obj";
+  const Convex convex(vertices, mesh_name, 2.0);
+
+  EXPECT_EQ(convex.scale(), 2.0);
+  EXPECT_EQ(convex.extension(), ".obj");
+  const MeshSource& source = convex.source();
+  ASSERT_TRUE(source.is_in_memory());
+  EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
+
+  EXPECT_THROW(convex.filename(), std::exception);
+
+  const PolygonSurfaceMesh<double>& hull = convex.GetConvexHull();
+  EXPECT_EQ(hull.num_vertices(), 8);
+  EXPECT_EQ(hull.num_elements(), 6);
+}
+
 GTEST_TEST(ShapeTest, MeshFromMemory) {
   // This will get normalized to ".obj".
   const std::string mesh_name = "a_mesh.OBJ";

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -682,8 +682,6 @@ GTEST_TEST(ShapeTest, ConvexFromVertices) {
   ASSERT_TRUE(source.is_in_memory());
   EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
 
-  EXPECT_THROW(convex.filename(), std::exception);
-
   const PolygonSurfaceMesh<double>& hull = convex.GetConvexHull();
   EXPECT_EQ(hull.num_vertices(), 8);
   EXPECT_EQ(hull.num_elements(), 6);

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -663,40 +663,26 @@ GTEST_TEST(ShapeTest, ConvexFromMemory) {
 }
 
 GTEST_TEST(ShapeTest, ConvexFromVertices) {
-  // This will get normalized to ".obj".
-  Eigen::Matrix<double, 3, 4> vertices;
-  vertices.col(0) << 0, 0, 0;
-  vertices.col(1) << 1, 0, 0;
-  vertices.col(2) << 0, 1, 0;
-  vertices.col(3) << 0, 0, 1;
-
-  const std::string mesh_name = "a_convex.obj";
-  const Convex convex_from_verts(vertices, mesh_name, 2.0);
-
-  EXPECT_EQ(convex_from_verts.scale(), 2.0);
-  EXPECT_EQ(convex_from_verts.extension(), ".obj");
-  const MeshSource& source = convex_from_verts.source();
-  ASSERT_TRUE(source.is_in_memory());
-  EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
-
-  const PolygonSurfaceMesh<double>& hull = convex_from_verts.GetConvexHull();
-  EXPECT_EQ(hull.num_vertices(), 4);
-  EXPECT_EQ(hull.num_elements(), 4);
-
-  // make sure the convex hull is automatically taken.
+  // Make sure the convex hull is automatically taken.
   Eigen::Matrix<double, 3, 5> points;
   points.col(0) << 0, 0, 0;
   points.col(1) << 1, 0, 0;
-  points.col(2) << 0, 1, 0;
-  points.col(3) << 0, 0, 1;
-  points.col(4) << 0.25, 0.25, 0.25;
+  points.col(2) << 0.25, 0.25, 0.25;
+  points.col(3) << 0, 1, 0;
+  points.col(4) << 0, 0, 1;
 
-  const std::string mesh_name2 = "a_convex2.obj";
-  const Convex convex_from_points(points, mesh_name2, 2.0);
+  const std::string mesh_name = "a_convex";
+  const Convex convex(points, mesh_name, 2.0);
 
-  const PolygonSurfaceMesh<double>& hull2 = convex_from_points.GetConvexHull();
-  EXPECT_EQ(hull2.num_vertices(), 4);
-  EXPECT_EQ(hull2.num_elements(), 4);
+  EXPECT_EQ(convex.scale(), 2.0);
+  EXPECT_EQ(convex.extension(), ".obj");
+  const MeshSource& source = convex.source();
+  ASSERT_TRUE(source.is_in_memory());
+  EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
+
+  const PolygonSurfaceMesh<double>& hull = convex.GetConvexHull();
+  EXPECT_EQ(hull.num_vertices(), 4);
+  EXPECT_EQ(hull.num_elements(), 4);
 }
 
 GTEST_TEST(ShapeTest, MeshFromMemory) {

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -664,27 +664,39 @@ GTEST_TEST(ShapeTest, ConvexFromMemory) {
 
 GTEST_TEST(ShapeTest, ConvexFromVertices) {
   // This will get normalized to ".obj".
-  Eigen::MatrixXd vertices(3, 8);
+  Eigen::Matrix<double, 3, 4> vertices;
   vertices.col(0) << 0, 0, 0;
   vertices.col(1) << 1, 0, 0;
-  vertices.col(2) << 1, 1, 0;
-  vertices.col(3) << 0, 1, 0;
-  vertices.col(4) << 0, 0, 1;
-  vertices.col(5) << 1, 0, 1;
-  vertices.col(6) << 1, 1, 1;
-  vertices.col(7) << 0, 1, 1;
-  const std::string mesh_name = "a_convex.obj";
-  const Convex convex(vertices, mesh_name, 2.0);
+  vertices.col(2) << 0, 1, 0;
+  vertices.col(3) << 0, 0, 1;
 
-  EXPECT_EQ(convex.scale(), 2.0);
-  EXPECT_EQ(convex.extension(), ".obj");
-  const MeshSource& source = convex.source();
+  const std::string mesh_name = "a_convex.obj";
+  const Convex convex_from_verts(vertices, mesh_name, 2.0);
+
+  EXPECT_EQ(convex_from_verts.scale(), 2.0);
+  EXPECT_EQ(convex_from_verts.extension(), ".obj");
+  const MeshSource& source = convex_from_verts.source();
   ASSERT_TRUE(source.is_in_memory());
   EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
 
-  const PolygonSurfaceMesh<double>& hull = convex.GetConvexHull();
-  EXPECT_EQ(hull.num_vertices(), 8);
-  EXPECT_EQ(hull.num_elements(), 6);
+  const PolygonSurfaceMesh<double>& hull = convex_from_verts.GetConvexHull();
+  EXPECT_EQ(hull.num_vertices(), 4);
+  EXPECT_EQ(hull.num_elements(), 4);
+
+  // make sure the convex hull is automatically taken.
+  Eigen::Matrix<double, 3, 5> points;
+  points.col(0) << 0, 0, 0;
+  points.col(1) << 1, 0, 0;
+  points.col(2) << 0, 1, 0;
+  points.col(3) << 0, 0, 1;
+  points.col(4) << 0.25, 0.25, 0.25;
+
+  const std::string mesh_name2 = "a_convex2.obj";
+  const Convex convex_from_points(points, mesh_name2, 2.0);
+
+  const PolygonSurfaceMesh<double>& hull2 = convex_from_points.GetConvexHull();
+  EXPECT_EQ(hull2.num_vertices(), 4);
+  EXPECT_EQ(hull2.num_elements(), 4);
 }
 
 GTEST_TEST(ShapeTest, MeshFromMemory) {
@@ -785,7 +797,6 @@ TEST_F(OverrideDefaultGeometryTest, UnsupportedGeometry) {
   EXPECT_NO_THROW(this->ImplementGeometry(Sphere(0.5), nullptr));
 }
 
-
 GTEST_TEST(ShapeTest, TypeNameAndToString) {
   // In-memory mesh we'll use on Convex and Mesh.
   const InMemoryMesh in_memory{
@@ -852,7 +863,6 @@ GTEST_TEST(ShapeTest, TypeNameAndToString) {
   EXPECT_EQ(base.to_string(), "Box(width=1.5, depth=2.5, height=3.5)");
   EXPECT_EQ(fmt::to_string(base), "Box(width=1.5, depth=2.5, height=3.5)");
 }
-
 
 GTEST_TEST(ShapeTest, Volume) {
   EXPECT_NEAR(CalcVolume(Box(1, 2, 3)), 6.0, 1e-14);

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -677,14 +677,8 @@ GTEST_TEST(ShapeTest, ConvexFromVertices) {
   const Convex convex(points, mesh_name, scale);
 
   EXPECT_EQ(convex.scale(), scale);
-  EXPECT_EQ(convex.extension(), ".obj");
   const MeshSource& source = convex.source();
-  ASSERT_TRUE(source.is_in_memory());
   EXPECT_EQ(source.in_memory().mesh_file.filename_hint(), mesh_name);
-
-  const PolygonSurfaceMesh<double>& hull = convex.GetConvexHull();
-  EXPECT_EQ(hull.num_vertices(), 4);
-  EXPECT_EQ(hull.num_elements(), 4);
 
   // Confirm that the contents of the in-memory mesh file are as expected. Note:
   // We prefix a "\n" to match leading "\n" in the nicely readable raw string.

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -686,11 +686,16 @@ GTEST_TEST(ShapeTest, ConvexFromVertices) {
   EXPECT_EQ(hull.num_vertices(), 4);
   EXPECT_EQ(hull.num_elements(), 4);
 
-  // Confirm that the cntents of the in-memory mesh file are as expected.
-  EXPECT_EQ(source.in_memory().mesh_file.contents(),
-            std::string("v 0 0 0\n") + std::string("v 1 0 0\n") +
-                std::string("v 0.25 0.25 0.25\n") + std::string("v 0 1 0\n") +
-                std::string("v 0 0 1\n"));
+  // Confirm that the contents of the in-memory mesh file are as expected. Note:
+  // We prefix a "\n" to match leading "\n" in the nicely readable raw string.
+  EXPECT_EQ("\n" + source.in_memory().mesh_file.contents(),
+            R"""(
+v 0 0 0
+v 1 0 0
+v 0.25 0.25 0.25
+v 0 1 0
+v 0 0 1
+)""");
 }
 
 GTEST_TEST(ShapeTest, MeshFromMemory) {


### PR DESCRIPTION
This PR adds functionality to create Convex Shapes given sets of vertices. It addresses issue #22386.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22390)
<!-- Reviewable:end -->
