### PR TITLE
[build] Use modern spelling for Bazel config options

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -103,8 +103,8 @@ drake_py_unittest(
 drake_py_unittest(
     name = "clarabel_solver_test",
     args = select({
-        "//tools:no_clarabel": ["TestClarabelSolver.unavailable"],
-        "//conditions:default": [],
+        "//tools/workspace/clarabel_cpp_internal:enabled": [],
+        "//conditions:default": ["TestClarabelSolver.unavailable"],
     }),
     deps = [
         ":solvers",
@@ -115,8 +115,8 @@ drake_py_unittest(
 drake_py_unittest(
     name = "clp_solver_test",
     args = select({
-        "//tools:no_clp": ["TestClpSolver.unavailable"],
-        "//conditions:default": [],
+        "//tools/workspace/clp_internal:enabled": [],
+        "//conditions:default": ["TestClpSolver.unavailable"],
     }),
     deps = [
         ":solvers",
@@ -127,8 +127,8 @@ drake_py_unittest(
 drake_py_unittest(
     name = "csdp_solver_test",
     args = select({
-        "//tools:no_csdp": ["TestCsdptSolver.unavailable"],
-        "//conditions:default": [],
+        "//tools/workspace/csdp_internal:enabled": [],
+        "//conditions:default": ["TestCsdptSolver.unavailable"],
     }),
     deps = [
         ":solvers",
@@ -148,8 +148,8 @@ drake_py_unittest(
 drake_py_unittest(
     name = "ipopt_solver_test",
     args = select({
-        "//tools:no_ipopt": ["TestIpoptSolver.unavailable"],
-        "//conditions:default": [],
+        "//tools/workspace/ipopt_internal:enabled": [],
+        "//conditions:default": ["TestIpoptSolver.unavailable"],
     }),
     deps = [
         ":solvers",
@@ -184,8 +184,8 @@ drake_py_unittest(
 drake_py_unittest(
     name = "nlopt_solver_test",
     args = select({
-        "//tools:no_nlopt": ["TestNloptSolver.unavailable"],
-        "//conditions:default": [],
+        "//tools/workspace/nlopt_internal:enabled": [],
+        "//conditions:default": ["TestNloptSolver.unavailable"],
     }),
     deps = [
         ":solvers",
@@ -196,8 +196,8 @@ drake_py_unittest(
 drake_py_unittest(
     name = "osqp_solver_test",
     args = select({
-        "//tools:no_osqp": ["TestOsqpSolver.unavailable"],
-        "//conditions:default": [],
+        "//tools/workspace/osqp_internal:enabled": [],
+        "//conditions:default": ["TestOsqpSolver.unavailable"],
     }),
     deps = [
         ":solvers",
@@ -207,8 +207,8 @@ drake_py_unittest(
 drake_py_unittest(
     name = "scs_solver_test",
     args = select({
-        "//tools:no_scs": ["TestScsSolver.unavailable"],
-        "//conditions:default": [],
+        "//tools/workspace/scs_internal:enabled": [],
+        "//conditions:default": ["TestScsSolver.unavailable"],
     }),
     deps = [
         ":solvers",

--- a/doc/_pages/stable.md
+++ b/doc/_pages/stable.md
@@ -102,6 +102,9 @@ part of the "Stable API":
   <a href="https://docs.bazel.build/versions/main/build-ref.html#load">loading</a>
   Drake's bzl macros (e.g., `load("@drake//foo:bar.bzl", "bar_macro")`.
 
+Additionally, Drake's Bazel configuration flags at `@drake//tools/flags:*` are
+part of the Stable API.
+
 For Drake's dependencies:
 
 * The `add_default_...` macros defined in `@drake//tools/workspace:default.bzl`

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -818,7 +818,7 @@ drake_cc_library(
 # code that fails at runtime.
 drake_cc_variant_library(
     name = "gurobi_solver",
-    opt_in_condition = "//tools:with_gurobi",
+    opt_in_condition = "//tools/workspace/gurobi:enabled",
     srcs_always = ["gurobi_solver_common.cc"],
     srcs_enabled = ["gurobi_solver.cc"],
     srcs_disabled = ["no_gurobi.cc"],
@@ -844,7 +844,7 @@ drake_cc_variant_library(
 
 drake_cc_optional_library(
     name = "gurobi_solver_internal",
-    opt_in_condition = "//tools:with_gurobi",
+    opt_in_condition = "//tools/workspace/gurobi:enabled",
     srcs = ["gurobi_solver_internal.cc"],
     hdrs = ["gurobi_solver_internal.h"],
     deps = [":mathematical_program_result"],
@@ -861,7 +861,7 @@ drake_cc_optional_library(
 # code that fails at runtime.
 drake_cc_variant_library(
     name = "mosek_solver",
-    opt_in_condition = "//tools:with_mosek",
+    opt_in_condition = "//tools/workspace/mosek:enabled",
     srcs_always = ["mosek_solver_common.cc"],
     srcs_enabled = ["mosek_solver.cc"],
     srcs_disabled = ["no_mosek.cc"],
@@ -884,7 +884,7 @@ drake_cc_variant_library(
 
 drake_cc_optional_library(
     name = "mosek_solver_internal",
-    opt_in_condition = "//tools:with_mosek",
+    opt_in_condition = "//tools/workspace/mosek:enabled",
     srcs = ["mosek_solver_internal.cc"],
     hdrs = ["mosek_solver_internal.h"],
     deps = [":mathematical_program_result"],
@@ -903,7 +903,7 @@ drake_cc_optional_library(
 # code that fails at runtime.
 drake_cc_variant_library(
     name = "snopt_solver",
-    opt_in_condition = "//tools:with_snopt",
+    opt_in_condition = "//tools/workspace/snopt:enabled",
     srcs_always = ["snopt_solver_common.cc"],
     srcs_enabled = ["snopt_solver.cc"],
     srcs_disabled = ["no_snopt.cc"],
@@ -923,7 +923,7 @@ drake_cc_variant_library(
 
 drake_cc_variant_library(
     name = "clp_solver",
-    opt_out_condition = "//tools:no_clp",
+    opt_in_condition = "//tools/workspace/clp_internal:enabled",
     srcs_always = ["clp_solver_common.cc"],
     srcs_enabled = ["clp_solver.cc"],
     srcs_disabled = ["no_clp.cc"],
@@ -944,7 +944,7 @@ drake_cc_variant_library(
 
 drake_cc_optional_library(
     name = "ipopt_solver_internal",
-    opt_out_condition = "//tools:no_ipopt",
+    opt_in_condition = "//tools/workspace/ipopt_internal:enabled",
     srcs = ["ipopt_solver_internal.cc"],
     hdrs = ["ipopt_solver_internal.h"],
     deps = [
@@ -957,7 +957,7 @@ drake_cc_optional_library(
 
 drake_cc_variant_library(
     name = "ipopt_solver",
-    opt_out_condition = "//tools:no_ipopt",
+    opt_in_condition = "//tools/workspace/ipopt_internal:enabled",
     srcs_always = ["ipopt_solver_common.cc"],
     srcs_enabled = [
         "ipopt_solver.cc",
@@ -982,7 +982,7 @@ drake_cc_variant_library(
 
 drake_cc_variant_library(
     name = "nlopt_solver",
-    opt_out_condition = "//tools:no_nlopt",
+    opt_in_condition = "//tools/workspace/nlopt_internal:enabled",
     srcs_always = ["nlopt_solver_common.cc"],
     srcs_enabled = ["nlopt_solver.cc"],
     srcs_disabled = ["no_nlopt.cc"],
@@ -1001,7 +1001,7 @@ drake_cc_variant_library(
 
 drake_cc_variant_library(
     name = "osqp_solver",
-    opt_out_condition = "//tools:no_osqp",
+    opt_in_condition = "//tools/workspace/osqp_internal:enabled",
     srcs_always = ["osqp_solver_common.cc"],
     srcs_enabled = ["osqp_solver.cc"],
     srcs_disabled = ["no_osqp.cc"],
@@ -1021,7 +1021,7 @@ drake_cc_variant_library(
 
 drake_cc_variant_library(
     name = "clarabel_solver",
-    opt_out_condition = "//tools:no_clarabel",
+    opt_in_condition = "//tools/workspace/clarabel_cpp_internal:enabled",
     srcs_always = ["clarabel_solver_common.cc"],
     srcs_enabled = ["clarabel_solver.cc"],
     srcs_disabled = ["no_clarabel.cc"],
@@ -1056,7 +1056,7 @@ drake_cc_library(
 
 drake_cc_variant_library(
     name = "scs_solver",
-    opt_out_condition = "//tools:no_scs",
+    opt_in_condition = "//tools/workspace/scs_internal:enabled",
     srcs_always = ["scs_solver_common.cc"],
     srcs_enabled = ["scs_solver.cc"],
     srcs_disabled = ["no_scs.cc"],
@@ -1113,7 +1113,7 @@ drake_cc_library(
 
 drake_cc_optional_library(
     name = "csdp_solver_error_handling",
-    opt_out_condition = "//tools:no_csdp",
+    opt_in_condition = "//tools/workspace/csdp_internal:enabled",
     srcs = ["csdp_solver_error_handling.cc"],
     hdrs = ["csdp_solver_error_handling.h"],
     copts = ["-fvisibility=hidden"],
@@ -1125,7 +1125,7 @@ drake_cc_optional_library(
 
 drake_cc_optional_library(
     name = "csdp_cpp_wrapper",
-    opt_out_condition = "//tools:no_csdp",
+    opt_in_condition = "//tools/workspace/csdp_internal:enabled",
     srcs = ["csdp_cpp_wrapper.cc"],
     hdrs = ["csdp_cpp_wrapper.h"],
     deps = [
@@ -1138,7 +1138,7 @@ drake_cc_optional_library(
 
 drake_cc_optional_library(
     name = "csdp_solver_internal",
-    opt_out_condition = "//tools:no_csdp",
+    opt_in_condition = "//tools/workspace/csdp_internal:enabled",
     srcs = ["csdp_solver_internal.cc"],
     hdrs = ["csdp_solver_internal.h"],
     deps = [
@@ -1149,7 +1149,7 @@ drake_cc_optional_library(
 
 drake_cc_variant_library(
     name = "csdp_solver",
-    opt_out_condition = "//tools:no_csdp",
+    opt_in_condition = "//tools/workspace/csdp_internal:enabled",
     srcs_always = ["csdp_solver_common.cc"],
     srcs_enabled = ["csdp_solver.cc"],
     srcs_disabled = ["no_csdp.cc"],
@@ -1330,7 +1330,7 @@ drake_cc_googletest(
 
 drake_cc_optional_googletest(
     name = "csdp_solver_internal_test",
-    opt_out_condition = "//tools:no_csdp",
+    opt_in_condition = "//tools/workspace/csdp_internal:enabled",
     deps = [
         ":csdp_solver_internal",
         ":csdp_test_examples",
@@ -1340,7 +1340,7 @@ drake_cc_optional_googletest(
 
 drake_cc_optional_googletest(
     name = "csdp_cpp_wrapper_test",
-    opt_out_condition = "//tools:no_csdp",
+    opt_in_condition = "//tools/workspace/csdp_internal:enabled",
     tags = [
         # The longjmp handling definitely leaks memory, and we've decided to
         # just live with that. If we see the longjmp handler triggering when
@@ -1379,6 +1379,27 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "disabled_solvers_test",
+    deps = [
+        # The ":foo_disabled" targets are magic secondary outputs of the
+        # drake_cc_variant_library(...) stanzas above, e.g., the
+        # `drake_cc_variant_library(name = "clarabel_solver", ...)`
+        # creates both ":clarabel_solver" and ":clarabel_solver_disabled".
+        ":clarabel_solver_disabled",
+        ":clp_solver_disabled",
+        ":csdp_solver_disabled",
+        ":gurobi_solver_disabled",
+        ":ipopt_solver_disabled",
+        ":mosek_solver_disabled",
+        ":nlopt_solver_disabled",
+        ":osqp_solver_disabled",
+        ":scs_solver_disabled",
+        ":snopt_solver_disabled",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
     name = "equality_constrained_qp_solver_test",
     deps = [
         ":equality_constrained_qp_solver",
@@ -1400,7 +1421,7 @@ drake_cc_googletest(
 
 drake_cc_optional_googletest(
     name = "gurobi_solver_internal_test",
-    opt_in_condition = "//tools:with_gurobi",
+    opt_in_condition = "//tools/workspace/gurobi:enabled",
     use_default_main = False,
     deps = [
         ":gurobi_solver",
@@ -1476,33 +1497,30 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "ipopt_solver_internal_test",
     copts = select({
-        "//conditions:default": [
+        "//tools/workspace/ipopt_internal:enabled": [
             "-DDRAKE_IPOPT_SOLVER_INTERNAL_TEST_HAS_IPOPT=1",
         ],
-        "//tools:no_ipopt": [
-        ],
+        "//conditions:default": [],
     }),
     deps = [
         ":mathematical_program",
         "//common/test_utilities:eigen_matrix_compare",
     ] + select({
-        "//conditions:default": [
+        "//tools/workspace/ipopt_internal:enabled": [
             ":ipopt_solver_internal",
             "@ipopt_internal//:ipopt",
         ],
-        "//tools:no_ipopt": [
-        ],
+        "//conditions:default": [],
     }),
 )
 
 drake_cc_googletest(
     name = "ipopt_solver_test",
     copts = select({
-        "//conditions:default": [
+        "//tools/workspace/ipopt_internal:enabled": [
             "-DDRAKE_IPOPT_SOLVER_TEST_HAS_IPOPT=1",
         ],
-        "//tools:no_ipopt": [
-        ],
+        "//conditions:default": [],
     }),
     deps = [
         ":linear_program_examples",
@@ -1515,11 +1533,10 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
     ] + select({
-        "//conditions:default": [
+        "//tools/workspace/ipopt_internal:enabled": [
             "@ipopt_internal//:ipopt",
         ],
-        "//tools:no_ipopt": [
-        ],
+        "//conditions:default": [],
     }),
 )
 
@@ -1618,7 +1635,7 @@ drake_cc_googletest(
 
 drake_cc_optional_googletest(
     name = "mosek_solver_internal_test",
-    opt_in_condition = "//tools:with_mosek",
+    opt_in_condition = "//tools/workspace/mosek:enabled",
     use_default_main = False,
     deps = [
         ":mosek_solver",

--- a/solvers/test/disabled_solvers_test.cc
+++ b/solvers/test/disabled_solvers_test.cc
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/solvers/clarabel_solver.h"
+#include "drake/solvers/clp_solver.h"
+#include "drake/solvers/csdp_solver.h"
+#include "drake/solvers/gurobi_solver.h"
+#include "drake/solvers/ipopt_solver.h"
+#include "drake/solvers/mosek_solver.h"
+#include "drake/solvers/nlopt_solver.h"
+#include "drake/solvers/osqp_solver.h"
+#include "drake/solvers/scs_solver.h"
+#include "drake/solvers/snopt_solver.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+
+template <typename SomeSolver>
+class DisabledSolverTest : public testing::Test {};
+
+TYPED_TEST_SUITE_P(DisabledSolverTest);
+
+TYPED_TEST_P(DisabledSolverTest, SmokeTest) {
+  std::unique_ptr<SolverInterface> dut;
+  EXPECT_NO_THROW(dut = std::make_unique<TypeParam>());
+
+  EXPECT_FALSE(dut->available());
+  EXPECT_NO_THROW(dut->enabled());
+  EXPECT_FALSE(dut->solver_id().name().empty());
+
+  const MathematicalProgram prog;
+  EXPECT_NO_THROW(dut->AreProgramAttributesSatisfied(prog));
+  EXPECT_NO_THROW(dut->ExplainUnsatisfiedProgramAttributes(prog));
+
+  MathematicalProgramResult result;
+  DRAKE_EXPECT_THROWS_MESSAGE(dut->Solve(prog, {}, {}, &result),
+                              ".*has not been compiled.*");
+}
+
+REGISTER_TYPED_TEST_SUITE_P(DisabledSolverTest, SmokeTest);
+
+using AllSolvers = ::testing::Types<  //
+    ClarabelSolver,                   //
+    ClpSolver,                        //
+    CsdpSolver,                       //
+    GurobiSolver,                     //
+    IpoptSolver,                      //
+    MosekSolver,                      //
+    NloptSolver,                      //
+    OsqpSolver,                       //
+    ScsSolver,                        //
+    SnoptSolver>;
+INSTANTIATE_TYPED_TEST_SUITE_P(All, DisabledSolverTest, AllSolvers);
+
+}  // namespace
+}  // namespace solvers
+}  // namespace drake

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -42,22 +42,7 @@ alias(
     actual = "//bindings/pydrake/multibody:fix_inertia",
 )
 
-# === config_setting rules ===
-
-config_setting(
-    name = "with_gurobi",
-    values = {"define": "WITH_GUROBI=ON"},
-)
-
-config_setting(
-    name = "with_mosek",
-    values = {"define": "WITH_MOSEK=ON"},
-)
-
-config_setting(
-    name = "with_snopt",
-    values = {"define": "WITH_SNOPT=ON"},
-)
+# === config_setting rules (internal use only) ===
 
 config_setting(
     name = "using_sanitizer",
@@ -67,76 +52,6 @@ config_setting(
 config_setting(
     name = "using_memcheck",
     values = {"define": "USING_MEMCHECK=ON"},
-)
-
-# Clarabel is an open-source solver, and is included in the Drake build by
-# default. The Clarabel solver is irrelevant to some users of
-# MathematicalProgram, so we provide a hidden switch to shut it off for
-# developers who don't actually need it. This is not a supported configuration.
-# Use at your own risk: --define=NO_CLARABEL=ON
-config_setting(
-    name = "no_clarabel",
-    values = {"define": "NO_CLARABEL=ON"},
-)
-
-# CLP is an open-source solver, and is included in the Drake build by
-# default. The CLP solver is irrelevant to some users of MathematicalProgram,
-# so we provide a hidden switch to shut it off for developers who don't
-# actually need it.  This is not a supported configuration. Use at your own
-# risk: --define=NO_CLP=ON
-config_setting(
-    name = "no_clp",
-    values = {"define": "NO_CLP=ON"},
-)
-
-# CSDP is an open-source solver, and is included in the Drake build by default.
-# The CSDP solver is irrelevant to some users of MathematicalProgram, so we
-# provide a hidden switch to shut it off for developers who don't actually need
-# it. This is not a supported configuration. Use at your own risk:
-# --define=NO_CSDP=ON
-config_setting(
-    name = "no_csdp",
-    values = {"define": "NO_CSDP=ON"},
-)
-
-# IPOPT is an open-source solver, and is included in the Drake build by
-# default. The IPOPT solver is irrelevant to some users of MathematicalProgram,
-# so we provide a hidden switch to shut it off for developers who don't
-# actually need it.  This is not a supported configuration. Use at your own
-# risk: --define=NO_IPOPT=ON
-config_setting(
-    name = "no_ipopt",
-    values = {"define": "NO_IPOPT=ON"},
-)
-
-# NLOPT is an open-source solver, and is included in the Drake build by
-# default. The NLOPT solver is irrelevant to some users of MathematicalProgram,
-# so we provide a hidden switch to shut it off for developers who don't
-# actually need it.  This is not a supported configuration. Use at your own
-# risk: --define=NO_NLOPT=ON
-config_setting(
-    name = "no_nlopt",
-    values = {"define": "NO_NLOPT=ON"},
-)
-
-# OSQP is an open-source solver, and is included in the Drake build by
-# default. The OSQP solver is irrelevant to some users of MathematicalProgram,
-# so we provide a hidden switch to shut it off for developers who don't
-# actually need it.  This is not a supported configuration. Use at your own
-# risk: --define=NO_OSQP=ON
-config_setting(
-    name = "no_osqp",
-    values = {"define": "NO_OSQP=ON"},
-)
-
-# SCS is an open-source solver, and is included in the Drake build by default.
-# The SCS solver is irrelevant to some users of MathematicalProgram, so we
-# provide a hidden switch to shut it off for developers who don't actually need
-# it. This is not a supported configuration. Use at your own risk:
-# --define=NO_SCS=ON
-config_setting(
-    name = "no_scs",
-    values = {"define": "NO_SCS=ON"},
 )
 
 # We are exploring adding USD support to Drake. For the moment, it is opt-in.

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -67,8 +67,8 @@ build:everything --test_tag_filters=-no_everything
 # -- To run tests where Gurobi is used, ensure that you include
 # -- "gurobi_test_tags()" from //tools/skylark:test_tags.bzl.
 # -- If Gurobi is optional, set gurobi_required=False.
-build:gurobi --define=WITH_GUROBI=ON
-build:everything --define=WITH_GUROBI=ON
+build:gurobi --@drake//tools/flags:with_gurobi=True
+build:everything --@drake//tools/flags:with_gurobi=True
 # N.B. The build:packaging configuration does NOT use Gurobi (yet).
 # See https://github.com/RobotLocomotion/drake/issues/10804.
 build:packaging --test_tag_filters=-gurobi
@@ -80,9 +80,9 @@ build:packaging --test_tag_filters=-gurobi
 # -- To run tests where MOSEK™ is used, ensure that you include
 # -- "mosek_test_tags()" from //tools/skylark:test_tags.bzl.
 # -- If MOSEK™ is optional, set mosek_required=False.
-build:mosek --define=WITH_MOSEK=ON
-build:packaging --define=WITH_MOSEK=ON
-build:everything --define=WITH_MOSEK=ON
+build:mosek --@drake//tools/flags:with_mosek=True
+build:packaging --@drake//tools/flags:with_mosek=True
+build:everything --@drake//tools/flags:with_mosek=True
 
 ### A configuration that enables SNOPT. ###
 # -- To use this config, you must have access to the private repository
@@ -91,6 +91,6 @@ build:everything --define=WITH_MOSEK=ON
 #
 # -- To run tests that require SNOPT, also specify a set of test_tag_filters
 # -- that does not exclude the "snopt" tag.
-build:snopt --define=WITH_SNOPT=ON
-build:packaging --define=WITH_SNOPT=ON
-build:everything --define=WITH_SNOPT=ON
+build:snopt --@drake//tools/flags:with_snopt=True
+build:packaging --@drake//tools/flags:with_snopt=True
+build:everything --@drake//tools/flags:with_snopt=True

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -21,9 +21,9 @@ build:kcov --test_timeout=1200,6000,19000,72000
 
 ### Kcov everything build. ###
 build:kcov_everything --build_tests_only
-build:kcov_everything --define=WITH_GUROBI=ON
-build:kcov_everything --define=WITH_MOSEK=ON
-build:kcov_everything --define=WITH_SNOPT=ON
+build:kcov_everything --@drake//tools/flags:with_gurobi=True
+build:kcov_everything --@drake//tools/flags:with_mosek=True
+build:kcov_everything --@drake//tools/flags:with_snopt=True
 build:kcov_everything --copt -g
 build:kcov_everything --copt -O0
 build:kcov_everything --strategy=TestRunner=local
@@ -69,9 +69,9 @@ build:asan --auto_output_filter=all
 build:asan_everything --build_tests_only
 # We cannot reasonably use binary-only GUROBI and MOSEK libraries,
 # since they lack the sanitizer instrumentation.
-build:asan_everything --define=WITH_GUROBI=OFF
-build:asan_everything --define=WITH_MOSEK=OFF
-build:asan_everything --define=WITH_SNOPT=ON
+build:asan_everything --@drake//tools/flags:with_gurobi=False
+build:asan_everything --@drake//tools/flags:with_mosek=False
+build:asan_everything --@drake//tools/flags:with_snopt=True
 build:asan_everything --copt=-g
 # https://github.com/google/sanitizers/wiki/AddressSanitizer#faq
 build:asan_everything --copt=-fno-common
@@ -120,9 +120,9 @@ build:lsan --define=USING_SANITIZER=ON
 build:lsan_everything --build_tests_only
 # We cannot reasonably use binary-only GUROBI and MOSEK libraries,
 # since they lack the sanitizer instrumentation.
-build:lsan_everything --define=WITH_GUROBI=OFF
-build:lsan_everything --define=WITH_MOSEK=OFF
-build:lsan_everything --define=WITH_SNOPT=ON
+build:lsan_everything --@drake//tools/flags:with_gurobi=False
+build:lsan_everything --@drake//tools/flags:with_mosek=False
+build:lsan_everything --@drake//tools/flags:with_snopt=True
 build:lsan_everything --copt=-g
 build:lsan_everything --copt=-fno-common
 build:lsan_everything --copt=-fsanitize=leak
@@ -163,9 +163,9 @@ build:tsan --define=USING_SANITIZER=ON
 build:tsan_everything --build_tests_only
 # We cannot reasonably use binary-only GUROBI and MOSEK libraries,
 # since they lack the sanitizer instrumentation.
-build:tsan_everything --define=WITH_GUROBI=OFF
-build:tsan_everything --define=WITH_MOSEK=OFF
-build:tsan_everything --define=WITH_SNOPT=ON
+build:tsan_everything --@drake//tools/flags:with_gurobi=False
+build:tsan_everything --@drake//tools/flags:with_mosek=False
+build:tsan_everything --@drake//tools/flags:with_snopt=True
 build:tsan_everything --copt -g
 build:tsan_everything --copt -fsanitize=thread
 build:tsan_everything --copt -O1
@@ -213,9 +213,9 @@ build:ubsan --define=USING_SANITIZER=ON
 build:ubsan_everything --build_tests_only
 # We cannot reasonably use binary-only GUROBI and MOSEK libraries,
 # since they lack the sanitizer instrumentation.
-build:ubsan_everything --define=WITH_GUROBI=OFF
-build:ubsan_everything --define=WITH_MOSEK=OFF
-build:ubsan_everything --define=WITH_SNOPT=ON
+build:ubsan_everything --@drake//tools/flags:with_gurobi=False
+build:ubsan_everything --@drake//tools/flags:with_mosek=False
+build:ubsan_everything --@drake//tools/flags:with_snopt=True
 build:ubsan_everything --copt -g
 build:ubsan_everything --copt -fsanitize=undefined
 # Since Bazel uses clang instead of clang++, enabling -fsanitize=function,vptr
@@ -260,9 +260,9 @@ build:memcheck --define=USING_MEMCHECK=ON
 build:memcheck_everything --build_tests_only
 # We cannot reasonably use binary-only GUROBI and MOSEK libraries,
 # since they lack the sanitizer instrumentation.
-build:memcheck_everything --define=WITH_GUROBI=OFF
-build:memcheck_everything --define=WITH_MOSEK=OFF
-build:memcheck_everything --define=WITH_SNOPT=ON
+build:memcheck_everything --@drake//tools/flags:with_gurobi=False
+build:memcheck_everything --@drake//tools/flags:with_mosek=False
+build:memcheck_everything --@drake//tools/flags:with_snopt=True
 build:memcheck_everything --copt -gdwarf-4
 # https://sourceforge.net/p/valgrind/mailman/valgrind-developers/?viewmonth=201806&viewday=11&style=flat
 build:memcheck_everything --copt -O2
@@ -306,9 +306,9 @@ build:drd --config=_drd
 build:drd --test_tag_filters=-lint,-gurobi,-mosek,-snopt,-no_drd,-no_valgrind_tools
 
 build:drd_everything --config=_drd
-build:drd_everything --define=WITH_GUROBI=OFF
-build:drd_everything --define=WITH_MOSEK=OFF
-build:drd_everything --define=WITH_SNOPT=ON
+build:drd_everything --@drake//tools/flags:with_gurobi=False
+build:drd_everything --@drake//tools/flags:with_mosek=False
+build:drd_everything --@drake//tools/flags:with_snopt=True
 build:drd_everything --test_tag_filters=-lint,-gurobi,-mosek,-no_drd,-no_valgrind_tools
 
 ### Helgrind: A Valgrind thread error detector ###
@@ -325,7 +325,7 @@ build:helgrind --config=_helgrind
 build:helgrind --test_tag_filters=-gurobi,-lint,-mosek,-snopt,-no_helgrind,-no_valgrind_tools
 
 build:helgrind_everything --config=_helgrind
-build:helgrind_everything --define=WITH_GUROBI=OFF
-build:helgrind_everything --define=WITH_MOSEK=OFF
-build:helgrind_everything --define=WITH_SNOPT=ON
+build:helgrind_everything --@drake//tools/flags:with_gurobi=False
+build:helgrind_everything --@drake//tools/flags:with_mosek=False
+build:helgrind_everything --@drake//tools/flags:with_snopt=True
 build:helgrind_everything --test_tag_filters=-lint,-gurobi,-mosek,-no_helgrind,-no_valgrind_tools

--- a/tools/flags/BUILD.bazel
+++ b/tools/flags/BUILD.bazel
@@ -1,0 +1,89 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+# The package introduces flags that Drake developers and users may use to
+# configure Drake's options. A flag may be set either on the command line
+# or equivalently in a `.bazelrc` file (https://bazel.build/run/bazelrc).
+#
+# Command line example:
+#   bazel build //:something --@drake//tools/flags:with_mosek=True
+#
+# bazelrc example:
+#   common --@drake//tools/flags:with_mosek=True
+
+# -----------------------------------------------------------------------------
+# Configuration for solver back-ends.
+#
+# Drake's SolverInterface wraps third-party solver libraries into common API.
+# Drake can be compiled with various third-party solvers enabled or disabled.
+#
+# By default, when building from source, all open-source libraries will be
+# enabled and all proprietary libraries will be disabled. (However, be aware
+# that Drake's packaging builds opt-in to some proprietary libraries by default
+# for our binary releases.)
+#
+# If you build from source and disable one of the open-source libraries that is
+# enabled by default, Drake's Stable API will build and install correctly, but
+# we cannot guarantee that all tests will pass or that all Drake features will
+# operate correctly. In other words, we cannot guarantee Drake's correctness
+# when a default-enabled solver is opted-out of.
+
+# Open-source solvers.
+
+bool_flag(
+    name = "with_clarabel",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "with_clp",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "with_csdp",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "with_ipopt",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "with_nlopt",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "with_osqp",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "with_scs",
+    build_setting_default = True,
+)
+
+# Proprietary solvers.
+
+bool_flag(
+    name = "with_gurobi",
+    build_setting_default = False,
+)
+
+bool_flag(
+    name = "with_mosek",
+    build_setting_default = False,
+)
+
+bool_flag(
+    name = "with_snopt",
+    build_setting_default = False,
+)
+
+# -----------------------------------------------------------------------------
+
+add_lint_tests()

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -159,7 +159,7 @@ install(
 cc_library(
     name = "gurobi_deps",
     deps = select({
-        "//tools:with_gurobi": ["@gurobi//:gurobi_c"],
+        "//tools/workspace/gurobi:enabled": ["@gurobi//:gurobi_c"],
         "//conditions:default": [],
     }),
 )
@@ -168,7 +168,7 @@ cc_library(
 cc_library(
     name = "mosek_deps",
     deps = select({
-        "//tools:with_mosek": ["@mosek"],
+        "//tools/workspace/mosek:enabled": ["@mosek"],
         "//conditions:default": [],
     }),
 )

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -509,6 +509,7 @@ def _raw_drake_cc_library(
             deps = [":" + compiled_name],
             visibility = ["//visibility:private"],
             tags = tags,
+            testonly = testonly,
         )
         cc_library(
             name = name,

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -151,32 +151,32 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "highway_internal",
     "libjpeg_turbo_internal",
 ]] + select({
-    "//conditions:default": ["@csdp_internal//:install"],
-    "//tools:no_csdp": [],
+    "//tools/workspace/csdp_internal:enabled": ["@csdp_internal//:install"],
+    "//conditions:default": [],
 }) + select({
-    "//conditions:default": [
+    "//tools/workspace/clarabel_cpp_internal:enabled": [
         "//tools/workspace/crate_universe:install",
         "@clarabel_cpp_internal//:install",
     ],
-    "//tools:no_clarabel": [],
-}) + select({
-    "//tools:with_gurobi": ["@gurobi//:install"],
     "//conditions:default": [],
 }) + select({
-    "//tools:with_mosek": ["@mosek//:install"],
+    "//tools/workspace/gurobi:enabled": ["@gurobi//:install"],
     "//conditions:default": [],
 }) + select({
-    "//tools:with_snopt": ["//tools/workspace/snopt:install"],
+    "//tools/workspace/mosek:enabled": ["@mosek//:install"],
     "//conditions:default": [],
 }) + select({
-    "//conditions:default": [
+    "//tools/workspace/snopt:enabled": ["//tools/workspace/snopt:install"],
+    "//conditions:default": [],
+}) + select({
+    "//tools/workspace/osqp_internal:enabled": [
         "@osqp_internal//:install",
         "@qdldl_internal//:install",
     ],
-    "//tools:no_osqp": [],
+    "//conditions:default": [],
 }) + select({
-    "//conditions:default": ["@scs_internal//:install"],
-    "//tools:no_scs": [],
+    "//tools/workspace/scs_internal:enabled": ["@scs_internal//:install"],
+    "//conditions:default": [],
 }) + select({
     "//tools:with_usd": ["@onetbb_internal//:install"],
     "//conditions:default": [],

--- a/tools/workspace/clarabel_cpp_internal/BUILD.bazel
+++ b/tools/workspace/clarabel_cpp_internal/BUILD.bazel
@@ -2,6 +2,11 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:drake_cc.bzl", "drake_cc_library")
 load("//tools/skylark:drake_py.bzl", "drake_py_binary", "drake_py_unittest")
 
+config_setting(
+    name = "enabled",
+    flag_values = {"//tools/flags:with_clarabel": "True"},
+)
+
 drake_cc_library(
     name = "serialize",
     hdrs = [":serialize.h"],

--- a/tools/workspace/clp_internal/BUILD.bazel
+++ b/tools/workspace/clp_internal/BUILD.bazel
@@ -1,5 +1,10 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+config_setting(
+    name = "enabled",
+    flag_values = {"//tools/flags:with_clp": "True"},
+)
+
 # Drake must redistribute any code changes, per Clp's EPL-2.0 license.
 # Here we'll glob all of the patch files from their conventional home.
 #

--- a/tools/workspace/csdp_internal/BUILD.bazel
+++ b/tools/workspace/csdp_internal/BUILD.bazel
@@ -1,3 +1,8 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+config_setting(
+    name = "enabled",
+    flag_values = {"//tools/flags:with_csdp": "True"},
+)
+
 add_lint_tests()

--- a/tools/workspace/gurobi/BUILD.bazel
+++ b/tools/workspace/gurobi/BUILD.bazel
@@ -1,6 +1,23 @@
-# This file exists to make our directory into a Bazel package, so that our
-# neighboring *.bzl file can be loaded elsewhere.
-
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+selects.config_setting_group(
+    name = "enabled",
+    match_any = [
+        ":enabled_via_flag",
+        ":enabled_via_define",
+    ],
+)
+
+config_setting(
+    name = "enabled_via_flag",
+    flag_values = {"//tools/flags:with_gurobi": "True"},
+)
+
+config_setting(
+    name = "enabled_via_define",
+    # N.B. This is the legacy spelling. Users shouldn't use this in new code.
+    values = {"define": "WITH_GUROBI=ON"},
+)
 
 add_lint_tests(bazel_lint_extra_srcs = glob(["*.BUILD.bazel.in"]))

--- a/tools/workspace/ipopt_internal/BUILD.bazel
+++ b/tools/workspace/ipopt_internal/BUILD.bazel
@@ -1,6 +1,11 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
 
+config_setting(
+    name = "enabled",
+    flag_values = {"//tools/flags:with_ipopt": "True"},
+)
+
 # Drake must redistribute any code changes, per Ipopts's EPL-2.0 license.
 # Here we'll glob all of the patch files from their conventional home.
 #

--- a/tools/workspace/mosek/BUILD.bazel
+++ b/tools/workspace/mosek/BUILD.bazel
@@ -1,7 +1,24 @@
-# This file exists to make our directory into a Bazel package, so that our
-# neighboring *.bzl file can be loaded elsewhere.
-
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+selects.config_setting_group(
+    name = "enabled",
+    match_any = [
+        ":enabled_via_flag",
+        ":enabled_via_define",
+    ],
+)
+
+config_setting(
+    name = "enabled_via_flag",
+    flag_values = {"//tools/flags:with_mosek": "True"},
+)
+
+config_setting(
+    name = "enabled_via_define",
+    # N.B. This is the legacy spelling. Users shouldn't use this in new code.
+    values = {"define": "WITH_MOSEK=ON"},
+)
 
 exports_files([
     "drake_mosek_redistribution.txt",

--- a/tools/workspace/nlopt_internal/BUILD.bazel
+++ b/tools/workspace/nlopt_internal/BUILD.bazel
@@ -1,6 +1,11 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
 
+config_setting(
+    name = "enabled",
+    flag_values = {"//tools/flags:with_nlopt": "True"},
+)
+
 exports_files(
     ["patches/gen_enums.patch"],
     visibility = ["@nlopt_internal//:__pkg__"],

--- a/tools/workspace/osqp_internal/BUILD.bazel
+++ b/tools/workspace/osqp_internal/BUILD.bazel
@@ -1,3 +1,8 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+config_setting(
+    name = "enabled",
+    flag_values = {"//tools/flags:with_osqp": "True"},
+)
+
 add_lint_tests()

--- a/tools/workspace/scs_internal/BUILD.bazel
+++ b/tools/workspace/scs_internal/BUILD.bazel
@@ -1,3 +1,8 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+config_setting(
+    name = "enabled",
+    flag_values = {"//tools/flags:with_scs": "True"},
+)
+
 add_lint_tests()

--- a/tools/workspace/snopt/BUILD.bazel
+++ b/tools/workspace/snopt/BUILD.bazel
@@ -1,8 +1,25 @@
-# This file exists to make our directory into a Bazel package, so that our
-# neighboring *.bzl file can be loaded elsewhere.
-
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+selects.config_setting_group(
+    name = "enabled",
+    match_any = [
+        ":enabled_via_flag",
+        ":enabled_via_define",
+    ],
+)
+
+config_setting(
+    name = "enabled_via_flag",
+    flag_values = {"//tools/flags:with_snopt": "True"},
+)
+
+config_setting(
+    name = "enabled_via_define",
+    # N.B. This is the legacy spelling. Users shouldn't use this in new code.
+    values = {"define": "WITH_SNOPT=ON"},
+)
 
 # Install our (custom) license file.
 install(


### PR DESCRIPTION
Towards #20731.

See https://bazel.build/configure/attributes for background.

This just gets us started with the solvers flags.  More flags are on the way in the future (eigen, fmt, spdlog).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22393)
<!-- Reviewable:end -->
