### PR TITLE
[trajectories] Deprecate overriding public virtual functions

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -373,6 +373,7 @@ drake_py_unittest(
     name = "trajectories_test",
     deps = [
         ":trajectories_py",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
         "//bindings/pydrake/common/test_utilities:numpy_compare_py",
         "//bindings/pydrake/common/test_utilities:pickle_compare_py",
         "//bindings/pydrake/common/test_utilities:scipy_stub_py",

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -8,6 +8,7 @@ import scipy.sparse
 from pydrake.common import ToleranceType
 from pydrake.common.eigen_geometry import AngleAxis_, Quaternion_
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.common.value import AbstractValue
 from pydrake.common.yaml import yaml_load_typed
@@ -31,26 +32,71 @@ from pydrake.trajectories import (
 from pydrake.symbolic import Variable, Expression
 
 
-# Custom trajectory class used to test Trajectory subclassing in python.
+# Custom trajectory class used to test Trajectory subclassing in Python.
 class CustomTrajectory(Trajectory):
     def __init__(self):
         Trajectory.__init__(self)
 
+    # TODO(jwnimmer-tri) Should be __deepcopy__ not Clone.
     def Clone(self):
         return CustomTrajectory()
 
+    def do_value(self, t):
+        return np.array([[t + 1.0, t + 2.0]])
+
+    def do_has_derivative(self):
+        return True
+
+    def DoEvalDerivative(self, t, derivative_order):
+        if derivative_order >= 2:
+            return np.zeros((1, 2))
+        elif derivative_order == 1:
+            return np.ones((1, 2))
+        elif derivative_order == 0:
+            return self.value(t)
+
+    def DoMakeDerivative(self, derivative_order):
+        return DerivativeTrajectory_[float](self, derivative_order)
+
+    def do_rows(self):
+        return 1
+
+    def do_cols(self):
+        return 2
+
+    def do_start_time(self):
+        return 3.0
+
+    def do_end_time(self):
+        return 4.0
+
+
+# Legacy custom trajectory class used to test Trajectory subclassing in Python.
+# This uses the old spellings for how to override the NVI functions.
+class LegacyCustomTrajectory(Trajectory):
+    def __init__(self):
+        Trajectory.__init__(self)
+
+    def Clone(self):
+        return LegacyCustomTrajectory()
+
+    # This spelling of the virtual override is deprecated.
     def rows(self):
         return 1
 
+    # This spelling of the virtual override is deprecated.
     def cols(self):
         return 2
 
+    # This spelling of the virtual override is deprecated.
     def start_time(self):
         return 3.0
 
+    # This spelling of the virtual override is deprecated.
     def end_time(self):
         return 4.0
 
+    # This spelling of the virtual override is deprecated.
     def value(self, t):
         return np.array([[t + 1.0, t + 2.0]])
 
@@ -97,6 +143,38 @@ class TestTrajectories(unittest.TestCase):
         deriv = trajectory.MakeDerivative(derivative_order=1)
         numpy_compare.assert_float_equal(
             deriv.value(t=2.3), np.ones((1, 2)))
+
+    def test_legacy_custom_trajectory(self):
+        trajectory = LegacyCustomTrajectory()
+        self.assertEqual(trajectory.rows(), 1)
+        self.assertEqual(trajectory.cols(), 2)
+        self.assertEqual(trajectory.start_time(), 3.0)
+        self.assertEqual(trajectory.end_time(), 4.0)
+        self.assertTrue(trajectory.has_derivative())
+        numpy_compare.assert_float_equal(trajectory.value(t=1.5),
+                                         np.array([[2.5, 3.5]]))
+        numpy_compare.assert_float_equal(
+            trajectory.EvalDerivative(t=2.3, derivative_order=1),
+            np.ones((1, 2)))
+        numpy_compare.assert_float_equal(
+            trajectory.EvalDerivative(t=2.3, derivative_order=2),
+            np.zeros((1, 2)))
+
+        # Use StackedTrajectory to call the deprecated overrides from C++ so
+        # that we trigger the deprecation warnings.
+        stacked = StackedTrajectory_[float]()
+        with catch_drake_warnings():
+            # The C++ code calls rows() and cols() -- both of which cause
+            # deprecation warnings with the legacy overrides -- but the total
+            # number of calls varies between Debug and Release, so we don't
+            # check the exact tally here.
+            stacked.Append(trajectory)
+        with catch_drake_warnings(expected_count=1):
+            stacked.value(t=1.5)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(stacked.start_time(), 3.0)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(stacked.end_time(), 4.0)
 
     @numpy_compare.check_all_types
     def test_bezier_curve(self, T):

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -1,9 +1,11 @@
 #include "pybind11/eval.h"
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/polynomial_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/nice_type_name.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/trajectories/bezier_curve.h"
 #include "drake/common/trajectories/bspline_trajectory.h"
@@ -158,15 +160,13 @@ struct Impl {
     TrajectoryPublic() = default;
 
     // Virtual methods, for explicit bindings.
-    using Base::Clone;
-    using Base::cols;
+    using Base::do_cols;
+    using Base::do_end_time;
     using Base::do_has_derivative;
-    using Base::DoEvalDerivative;
-    using Base::DoMakeDerivative;
-    using Base::end_time;
-    using Base::rows;
-    using Base::start_time;
-    using Base::value;
+    using Base::do_rows;
+    using Base::do_start_time;
+    using Base::do_value;
+    using Base::DoClone;
   };
 
   class PyTrajectory : public py::wrapper<TrajectoryPublic> {
@@ -174,35 +174,40 @@ struct Impl {
     using Base = py::wrapper<TrajectoryPublic>;
     using Base::Base;
 
+    void WarnDeprecatedOverride(std::string_view func_name) const {
+      WarnDeprecated(
+          fmt::format(
+              "Support for overriding {}.{} as a virtual function is "
+              "deprecated. Subclasses should override the do_{} virtual "
+              "function, instead.",
+              NiceTypeName::Get(*this), func_name, func_name),
+          "2025-08-01");
+    }
+
     // Trampoline virtual methods.
-    MatrixX<T> value(const T& t) const override {
-      PYBIND11_OVERLOAD_PURE(MatrixX<T>, Trajectory<T>, value, t);
+
+    std::unique_ptr<Trajectory<T>> DoClone() const final {
+      // TODO(jwnimmer-tri) Rewrite cloning to use __deepcopy__ in lieu of
+      // Clone (or DoClone).
+      PYBIND11_OVERLOAD_PURE(
+          std::unique_ptr<Trajectory<T>>, Trajectory<T>, Clone);
     }
 
-    T start_time() const override {
-      PYBIND11_OVERLOAD_PURE(T, Trajectory<T>, start_time);
+    MatrixX<T> do_value(const T& t) const final {
+      PYBIND11_OVERLOAD_INT(MatrixX<T>, Trajectory<T>, "do_value", t);
+      WarnDeprecatedOverride("value");
+      PYBIND11_OVERLOAD_INT(MatrixX<T>, Trajectory<T>, "value", t);
+      // If the macro did not return, use default functionality.
+      return Base::do_value(t);
     }
 
-    T end_time() const override {
-      PYBIND11_OVERLOAD_PURE(T, Trajectory<T>, end_time);
-    }
-
-    Eigen::Index rows() const override {
-      PYBIND11_OVERLOAD_PURE(Eigen::Index, Trajectory<T>, rows);
-    }
-
-    Eigen::Index cols() const override {
-      PYBIND11_OVERLOAD_PURE(Eigen::Index, Trajectory<T>, cols);
-    }
-
-    bool do_has_derivative() const override {
+    bool do_has_derivative() const final {
       PYBIND11_OVERLOAD_INT(bool, Trajectory<T>, "do_has_derivative");
       // If the macro did not return, use default functionality.
       return Base::do_has_derivative();
     }
 
-    MatrixX<T> DoEvalDerivative(
-        const T& t, int derivative_order) const override {
+    MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final {
       PYBIND11_OVERLOAD_INT(
           MatrixX<T>, Trajectory<T>, "DoEvalDerivative", t, derivative_order);
       // If the macro did not return, use default functionality.
@@ -210,16 +215,43 @@ struct Impl {
     }
 
     std::unique_ptr<Trajectory<T>> DoMakeDerivative(
-        int derivative_order) const override {
+        int derivative_order) const final {
       PYBIND11_OVERLOAD_INT(std::unique_ptr<Trajectory<T>>, Trajectory<T>,
           "DoMakeDerivative", derivative_order);
       // If the macro did not return, use default functionality.
       return Base::DoMakeDerivative(derivative_order);
     }
 
-    std::unique_ptr<Trajectory<T>> Clone() const override {
-      PYBIND11_OVERLOAD_PURE(
-          std::unique_ptr<Trajectory<T>>, Trajectory<T>, Clone);
+    T do_start_time() const final {
+      PYBIND11_OVERLOAD_INT(T, Trajectory<T>, "do_start_time");
+      WarnDeprecatedOverride("start_time");
+      PYBIND11_OVERLOAD_INT(T, Trajectory<T>, "start_time");
+      // If the macro did not return, use default functionality.
+      return Base::do_start_time();
+    }
+
+    T do_end_time() const final {
+      PYBIND11_OVERLOAD_INT(T, Trajectory<T>, "do_end_time");
+      WarnDeprecatedOverride("end_time");
+      PYBIND11_OVERLOAD_INT(T, Trajectory<T>, "end_time");
+      // If the macro did not return, use default functionality.
+      return Base::do_end_time();
+    }
+
+    Eigen::Index do_rows() const final {
+      PYBIND11_OVERLOAD_INT(Eigen::Index, Trajectory<T>, "do_rows");
+      WarnDeprecatedOverride("rows");
+      PYBIND11_OVERLOAD_INT(Eigen::Index, Trajectory<T>, "rows");
+      // If the macro did not return, use default functionality.
+      return Base::do_rows();
+    }
+
+    Eigen::Index do_cols() const final {
+      PYBIND11_OVERLOAD_INT(Eigen::Index, Trajectory<T>, "do_cols");
+      WarnDeprecatedOverride("cols");
+      PYBIND11_OVERLOAD_INT(Eigen::Index, Trajectory<T>, "cols");
+      // If the macro did not return, use default functionality.
+      return Base::do_cols();
     }
   };
 
@@ -252,6 +284,11 @@ struct Impl {
           .def("end_time", &Class::end_time, cls_doc.end_time.doc)
           .def("rows", &Class::rows, cls_doc.rows.doc)
           .def("cols", &Class::cols, cls_doc.cols.doc);
+      // This binds Clone() and __copy__ and __deepcopy__. For final subclasses
+      // of Trajectory that offer a public copy constructor, in their bindings
+      // we also call DefCopyAndDeepCopy to override __copy__ and __deepcopy__
+      // with a more efficient implementation.
+      DefClone(&cls);
     }
 
     {
@@ -298,7 +335,6 @@ struct Impl {
               py::arg("basis"), py::arg("control_points"), cls_doc.ctor.doc)
           .def(py::init<math::BsplineBasis<T>, std::vector<MatrixX<T>>>(),
               py::arg("basis"), py::arg("control_points"), cls_doc.ctor.doc)
-          .def("Clone", &Class::Clone, cls_doc.Clone.doc)
           .def("num_control_points", &Class::num_control_points,
               cls_doc.num_control_points.doc)
           .def("control_points", &Class::control_points,
@@ -330,8 +366,7 @@ struct Impl {
           m, "DerivativeTrajectory", param, cls_doc.doc);
       cls  // BR
           .def(py::init<const Trajectory<T>&, int>(), py::arg("nominal"),
-              py::arg("derivative_order") = 1, cls_doc.ctor.doc)
-          .def("Clone", &Class::Clone, cls_doc.Clone.doc);
+              py::arg("derivative_order") = 1, cls_doc.ctor.doc);
       DefCopyAndDeepCopy(&cls);
     }
 
@@ -348,8 +383,7 @@ struct Impl {
               py::arg("end_time") = std::numeric_limits<double>::infinity(),
               cls_doc.ctor.doc)
           .def("set_derivative", &Class::set_derivative, py::arg("func"),
-              cls_doc.set_derivative.doc)
-          .def("Clone", &Class::Clone, cls_doc.Clone.doc);
+              cls_doc.set_derivative.doc);
       DefCopyAndDeepCopy(&cls);
     }
 
@@ -361,7 +395,6 @@ struct Impl {
       cls  // BR
           .def(py::init<const Trajectory<T>&, const Trajectory<T>&>(),
               py::arg("path"), py::arg("time_scaling"), cls_doc.ctor.doc)
-          .def("Clone", &Class::Clone, cls_doc.Clone.doc)
           .def("path", &Class::path, py_rvp::reference_internal,
               cls_doc.path.doc)
           .def("time_scaling", &Class::time_scaling, py_rvp::reference_internal,
@@ -413,7 +446,6 @@ struct Impl {
           .def(py::init<std::vector<Polynomial<T>> const&,
                    std::vector<T> const&>(),
               cls_doc.ctor.doc_2args_polynomials_breaks)
-          .def("Clone", &Class::Clone, cls_doc.Clone.doc)
           .def_static(
               "ZeroOrderHold",
               // This serves the same purpose as the C++
@@ -632,7 +664,6 @@ struct Impl {
                   }),
               py::arg("K"), py::arg("A"), py::arg("alpha"),
               py::arg("piecewise_polynomial_part"), cls_doc.ctor.doc)
-          .def("Clone", &Class::Clone, cls_doc.Clone.doc)
           .def("shiftRight", &Class::shiftRight, py::arg("offset"),
               cls_doc.shiftRight.doc);
       DefCopyAndDeepCopy(&cls);
@@ -723,7 +754,6 @@ struct Impl {
           m, "StackedTrajectory", param, cls_doc.doc);
       cls  // BR
           .def(py::init<bool>(), py::arg("rowwise") = true, cls_doc.ctor.doc)
-          .def("Clone", &Class::Clone, cls_doc.Clone.doc)
           .def("Append",
               py::overload_cast<const Trajectory<T>&>(&Class::Append),
               /* N.B. We choose to omit any py::arg name here. */

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -214,6 +214,8 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
         "//common:unused",
+        # Remove with deprecation 2025-08-01.
+        "//common:nice_type_name",
     ],
 )
 

--- a/common/trajectories/bezier_curve.cc
+++ b/common/trajectories/bezier_curve.cc
@@ -36,18 +36,6 @@ T BezierCurve<T>::BernsteinBasis(int i, const T& time,
 }
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> BezierCurve<T>::Clone() const {
-  return std::make_unique<BezierCurve<T>>(start_time_, end_time_,
-                                          control_points_);
-}
-
-template <typename T>
-MatrixX<T> BezierCurve<T>::value(const T& time) const {
-  using std::clamp;
-  return EvaluateT(clamp(time, T{start_time_}, T{end_time_}));
-}
-
-template <typename T>
 VectorX<symbolic::Expression> BezierCurve<T>::GetExpression(
     symbolic::Variable time) const {
   if constexpr (scalar_predicate<T>::is_bool) {
@@ -80,7 +68,7 @@ VectorX<symbolic::Expression> BezierCurve<T>::GetExpression(
 template <typename T>
 void BezierCurve<T>::ElevateOrder() {
   if (order() < 0) {
-    control_points_ = MatrixX<T>::Zero(rows(), cols());
+    control_points_ = MatrixX<T>::Zero(this->rows(), this->cols());
     return;
   }
   // https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/Bezier/bezier-elev.html
@@ -141,6 +129,57 @@ SparseMatrix<double> BezierCurve<T>::AsLinearInControlPoints(
 }
 
 template <typename T>
+std::unique_ptr<Trajectory<T>> BezierCurve<T>::DoClone() const {
+  return std::make_unique<BezierCurve<T>>(start_time_, end_time_,
+                                          control_points_);
+}
+
+template <typename T>
+MatrixX<T> BezierCurve<T>::do_value(const T& time) const {
+  using std::clamp;
+  return EvaluateT(clamp(time, T{start_time_}, T{end_time_}));
+}
+
+template <typename T>
+MatrixX<T> BezierCurve<T>::DoEvalDerivative(const T& time,
+                                            int derivative_order) const {
+  DRAKE_DEMAND(derivative_order >= 0);
+  if (derivative_order == 0) {
+    return this->value(time);
+  }
+  if (derivative_order > order()) {
+    return VectorX<T>::Zero(this->rows());
+  }
+
+  MatrixX<T> points = CalcDerivativePoints(derivative_order);
+  using std::clamp;
+  const T ctime = clamp(time, T{start_time_}, T{end_time_});
+
+  MatrixX<T> v = VectorX<T>::Zero(this->rows());
+  for (int i = 0; i < points.cols(); ++i) {
+    v += BernsteinBasis(i, ctime, order() - derivative_order) * points.col(i);
+  }
+  return v;
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> BezierCurve<T>::DoMakeDerivative(
+    int derivative_order) const {
+  DRAKE_DEMAND(derivative_order >= 0);
+  if (derivative_order == 0) {
+    return this->Clone();
+  }
+  if (derivative_order > order()) {
+    // Then return the zero curve.
+    return std::make_unique<BezierCurve<T>>(start_time_, end_time_,
+                                            VectorX<T>::Zero(this->rows()));
+  }
+
+  return std::make_unique<BezierCurve<T>>(
+      start_time_, end_time_, CalcDerivativePoints(derivative_order));
+}
+
+template <typename T>
 MatrixX<T> BezierCurve<T>::CalcDerivativePoints(int derivative_order) const {
   DRAKE_DEMAND(derivative_order <= order());
   int n = order();
@@ -156,51 +195,12 @@ MatrixX<T> BezierCurve<T>::CalcDerivativePoints(int derivative_order) const {
 }
 
 template <typename T>
-MatrixX<T> BezierCurve<T>::DoEvalDerivative(const T& time,
-                                            int derivative_order) const {
-  DRAKE_DEMAND(derivative_order >= 0);
-  if (derivative_order == 0) {
-    return this->value(time);
-  }
-  if (derivative_order > order()) {
-    return VectorX<T>::Zero(rows());
-  }
-
-  MatrixX<T> points = CalcDerivativePoints(derivative_order);
-  using std::clamp;
-  const T ctime = clamp(time, T{start_time_}, T{end_time_});
-
-  MatrixX<T> v = VectorX<T>::Zero(rows());
-  for (int i = 0; i < points.cols(); ++i) {
-    v += BernsteinBasis(i, ctime, order() - derivative_order) * points.col(i);
-  }
-  return v;
-}
-
-template <typename T>
 VectorX<T> BezierCurve<T>::EvaluateT(const T& time) const {
-  VectorX<T> v = VectorX<T>::Zero(rows());
+  VectorX<T> v = VectorX<T>::Zero(this->rows());
   for (int i = 0; i < control_points_.cols(); ++i) {
     v += BernsteinBasis(i, time) * control_points_.col(i);
   }
   return v;
-}
-
-template <typename T>
-std::unique_ptr<Trajectory<T>> BezierCurve<T>::DoMakeDerivative(
-    int derivative_order) const {
-  DRAKE_DEMAND(derivative_order >= 0);
-  if (derivative_order == 0) {
-    return this->Clone();
-  }
-  if (derivative_order > order()) {
-    // Then return the zero curve.
-    return std::make_unique<BezierCurve<T>>(start_time_, end_time_,
-                                            VectorX<T>::Zero(rows()));
-  }
-
-  return std::make_unique<BezierCurve<T>>(
-      start_time_, end_time_, CalcDerivativePoints(derivative_order));
 }
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -45,10 +45,7 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
       : BsplineTrajectory(math::BsplineBasis<T>(basis), control_points) {}
 #endif
 
-  ~BsplineTrajectory() override;
-
-  // Required methods for trajectories::Trajectory interface.
-  std::unique_ptr<trajectories::Trajectory<T>> Clone() const override;
+  ~BsplineTrajectory() final;
 
   /** Evaluates the BsplineTrajectory at the given time t.
   @param t The time at which to evaluate the %BsplineTrajectory.
@@ -58,17 +55,11 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
            trajectory will silently be evaluated at the closest
            valid value of time to t. For example, `value(-1)` will return
            `value(0)` for a trajectory defined over [0, 1]. */
-  MatrixX<T> value(const T& time) const override;
+  MatrixX<T> value(const T& t) const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return Trajectory<T>::value(t);
+  }
 
-  Eigen::Index rows() const override { return control_points()[0].rows(); }
-
-  Eigen::Index cols() const override { return control_points()[0].cols(); }
-
-  T start_time() const override { return basis_.initial_parameter_value(); }
-
-  T end_time() const override { return basis_.final_parameter_value(); }
-
-  // Other methods
   /** Returns the number of control points in this curve. */
   int num_control_points() const { return basis_.num_basis_functions(); }
 
@@ -135,12 +126,17 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
   }
 
  private:
-  bool do_has_derivative() const override;
-
-  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
-
+  // Trajectory overrides.
+  std::unique_ptr<trajectories::Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
+  bool do_has_derivative() const final;
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
   std::unique_ptr<trajectories::Trajectory<T>> DoMakeDerivative(
-      int derivative_order) const override;
+      int derivative_order) const final;
+  Eigen::Index do_rows() const final { return control_points()[0].rows(); }
+  Eigen::Index do_cols() const final { return control_points()[0].cols(); }
+  T do_start_time() const final { return basis_.initial_parameter_value(); }
+  T do_end_time() const final { return basis_.final_parameter_value(); }
 
   void CheckInvariants() const;
 

--- a/common/trajectories/composite_trajectory.cc
+++ b/common/trajectories/composite_trajectory.cc
@@ -51,32 +51,12 @@ template <typename T>
 CompositeTrajectory<T>::~CompositeTrajectory() = default;
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> CompositeTrajectory<T>::Clone() const {
+std::unique_ptr<Trajectory<T>> CompositeTrajectory<T>::DoClone() const {
   return std::make_unique<CompositeTrajectory<T>>(segments_);
 }
 
 template <typename T>
-Eigen::Index CompositeTrajectory<T>::rows() const {
-  if (segments_.size() > 0) {
-    return segments_[0]->rows();
-  } else {
-    throw std::runtime_error(
-        "CompositeTrajectory has no segments. Number of rows is undefined.");
-  }
-}
-
-template <typename T>
-Eigen::Index CompositeTrajectory<T>::cols() const {
-  if (segments_.size() > 0) {
-    return segments_[0]->cols();
-  } else {
-    throw std::runtime_error(
-        "CompositeTrajectory has no segments. Number of cols is undefined.");
-  }
-}
-
-template <typename T>
-MatrixX<T> CompositeTrajectory<T>::value(const T& time) const {
+MatrixX<T> CompositeTrajectory<T>::do_value(const T& time) const {
   const int segment_index = this->get_segment_index(time);
   DRAKE_DEMAND(static_cast<int>(segments_.size()) > segment_index);
   return this->segments_[segment_index]->value(time);
@@ -111,6 +91,26 @@ std::unique_ptr<Trajectory<T>> CompositeTrajectory<T>::DoMakeDerivative(
     derivative_curves[i] = segments_[i]->MakeDerivative(derivative_order);
   }
   return std::make_unique<CompositeTrajectory<T>>(std::move(derivative_curves));
+}
+
+template <typename T>
+Eigen::Index CompositeTrajectory<T>::do_rows() const {
+  if (segments_.size() > 0) {
+    return segments_[0]->rows();
+  } else {
+    throw std::runtime_error(
+        "CompositeTrajectory has no segments. Number of rows is undefined.");
+  }
+}
+
+template <typename T>
+Eigen::Index CompositeTrajectory<T>::do_cols() const {
+  if (segments_.size() > 0) {
+    return segments_[0]->cols();
+  } else {
+    throw std::runtime_error(
+        "CompositeTrajectory has no segments. Number of cols is undefined.");
+  }
 }
 
 template <typename T>

--- a/common/trajectories/composite_trajectory.h
+++ b/common/trajectories/composite_trajectory.h
@@ -33,18 +33,15 @@ class CompositeTrajectory final : public trajectories::PiecewiseTrajectory<T> {
 
   ~CompositeTrajectory() final;
 
-  std::unique_ptr<trajectories::Trajectory<T>> Clone() const final;
-
   /** Evaluates the curve at the given time.
   @warning If t does not lie in the range [start_time(), end_time()], the
   trajectory will silently be evaluated at the closest valid value of time to
   `time`. For example, `value(-1)` will return `value(0)` for a trajectory
   defined over [0, 1]. */
-  MatrixX<T> value(const T& time) const final;
-
-  Eigen::Index rows() const final;
-
-  Eigen::Index cols() const final;
+  MatrixX<T> value(const T& t) const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return PiecewiseTrajectory<T>::value(t);
+  }
 
   /** Returns a reference to the `segment_index` trajectory. */
   const Trajectory<T>& segment(int segment_index) const {
@@ -62,12 +59,15 @@ class CompositeTrajectory final : public trajectories::PiecewiseTrajectory<T> {
       const std::vector<copyable_unique_ptr<Trajectory<T>>>& segments);
 
  private:
+  // Trajectory overrides.
+  std::unique_ptr<trajectories::Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
   bool do_has_derivative() const final;
-
   MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
-
   std::unique_ptr<trajectories::Trajectory<T>> DoMakeDerivative(
       int derivative_order) const final;
+  Eigen::Index do_rows() const final;
+  Eigen::Index do_cols() const final;
 
   std::vector<copyable_unique_ptr<Trajectory<T>>> segments_{};
 };

--- a/common/trajectories/derivative_trajectory.cc
+++ b/common/trajectories/derivative_trajectory.cc
@@ -21,33 +21,13 @@ template <typename T>
 DerivativeTrajectory<T>::~DerivativeTrajectory() = default;
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> DerivativeTrajectory<T>::Clone() const {
+std::unique_ptr<Trajectory<T>> DerivativeTrajectory<T>::DoClone() const {
   return std::make_unique<DerivativeTrajectory>(*nominal_, derivative_order_);
 }
 
 template <typename T>
-MatrixX<T> DerivativeTrajectory<T>::value(const T& t) const {
+MatrixX<T> DerivativeTrajectory<T>::do_value(const T& t) const {
   return nominal_->EvalDerivative(t, derivative_order_);
-}
-
-template <typename T>
-Eigen::Index DerivativeTrajectory<T>::rows() const {
-  return rows_;
-}
-
-template <typename T>
-Eigen::Index DerivativeTrajectory<T>::cols() const {
-  return cols_;
-}
-
-template <typename T>
-T DerivativeTrajectory<T>::start_time() const {
-  return nominal_->start_time();
-}
-
-template <typename T>
-T DerivativeTrajectory<T>::end_time() const {
-  return nominal_->end_time();
 }
 
 template <typename T>
@@ -61,6 +41,26 @@ std::unique_ptr<Trajectory<T>> DerivativeTrajectory<T>::DoMakeDerivative(
     int derivative_order) const {
   return std::make_unique<DerivativeTrajectory<T>>(
       *nominal_, derivative_order_ + derivative_order);
+}
+
+template <typename T>
+Eigen::Index DerivativeTrajectory<T>::do_rows() const {
+  return rows_;
+}
+
+template <typename T>
+Eigen::Index DerivativeTrajectory<T>::do_cols() const {
+  return cols_;
+}
+
+template <typename T>
+T DerivativeTrajectory<T>::do_start_time() const {
+  return nominal_->start_time();
+}
+
+template <typename T>
+T DerivativeTrajectory<T>::do_end_time() const {
+  return nominal_->end_time();
 }
 
 }  // namespace trajectories

--- a/common/trajectories/derivative_trajectory.h
+++ b/common/trajectories/derivative_trajectory.h
@@ -39,21 +39,18 @@ class DerivativeTrajectory final : public Trajectory<T> {
 
   ~DerivativeTrajectory() final;
 
-  // Trajectory overrides.
-  std::unique_ptr<Trajectory<T>> Clone() const final;
-  MatrixX<T> value(const T& t) const final;
-  Eigen::Index rows() const final;
-  Eigen::Index cols() const final;
-  T start_time() const final;
-  T end_time() const final;
-
  private:
   // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
   bool do_has_derivative() const final { return true; }
-
   MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
   std::unique_ptr<Trajectory<T>> DoMakeDerivative(
       int derivative_order) const final;
+  Eigen::Index do_rows() const final;
+  Eigen::Index do_cols() const final;
+  T do_start_time() const final;
+  T do_end_time() const final;
 
   copyable_unique_ptr<Trajectory<T>> nominal_;
   reset_after_move<int> derivative_order_;

--- a/common/trajectories/discrete_time_trajectory.cc
+++ b/common/trajectories/discrete_time_trajectory.cc
@@ -67,13 +67,13 @@ const std::vector<T>& DiscreteTimeTrajectory<T>::get_times() const {
 }
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> DiscreteTimeTrajectory<T>::Clone() const {
+std::unique_ptr<Trajectory<T>> DiscreteTimeTrajectory<T>::DoClone() const {
   return std::make_unique<DiscreteTimeTrajectory<T>>(
       times_, values_, time_comparison_tolerance_);
 }
 
 template <typename T>
-MatrixX<T> DiscreteTimeTrajectory<T>::value(const T& t) const {
+MatrixX<T> DiscreteTimeTrajectory<T>::do_value(const T& t) const {
   using std::abs;
   const double time = ExtractDoubleOrThrow(t);
   static constexpr const char* kNoMatchingTimeStr =
@@ -93,25 +93,25 @@ MatrixX<T> DiscreteTimeTrajectory<T>::value(const T& t) const {
 }
 
 template <typename T>
-Eigen::Index DiscreteTimeTrajectory<T>::rows() const {
+Eigen::Index DiscreteTimeTrajectory<T>::do_rows() const {
   DRAKE_DEMAND(times_.size() > 0);
   return values_[0].rows();
 }
 
 template <typename T>
-Eigen::Index DiscreteTimeTrajectory<T>::cols() const {
+Eigen::Index DiscreteTimeTrajectory<T>::do_cols() const {
   DRAKE_DEMAND(times_.size() > 0);
   return values_[0].cols();
 }
 
 template <typename T>
-T DiscreteTimeTrajectory<T>::start_time() const {
+T DiscreteTimeTrajectory<T>::do_start_time() const {
   DRAKE_DEMAND(times_.size() > 0);
   return times_[0];
 }
 
 template <typename T>
-T DiscreteTimeTrajectory<T>::end_time() const {
+T DiscreteTimeTrajectory<T>::do_end_time() const {
   DRAKE_DEMAND(times_.size() > 0);
   return times_[times_.size() - 1];
 }

--- a/common/trajectories/discrete_time_trajectory.h
+++ b/common/trajectories/discrete_time_trajectory.h
@@ -86,7 +86,7 @@ class DiscreteTimeTrajectory final : public Trajectory<T> {
                          double time_comparison_tolerance =
                              std::numeric_limits<double>::epsilon());
 
-  ~DiscreteTimeTrajectory() override;
+  ~DiscreteTimeTrajectory() final;
 
   /** Converts the discrete-time trajectory using
   PiecewisePolynomial<T>::ZeroOrderHold(). */
@@ -104,31 +104,51 @@ class DiscreteTimeTrajectory final : public Trajectory<T> {
   /** Returns the times where the trajectory value is defined. */
   const std::vector<T>& get_times() const;
 
-  /** Returns a deep copy of the trajectory. */
-  std::unique_ptr<Trajectory<T>> Clone() const override;
-
   /** Returns the value of the trajectory at @p t.
   @throws std::exception if t is not within tolerance of one of the sample
   times. */
-  MatrixX<T> value(const T& t) const override;
+  MatrixX<T> value(const T& t) const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return Trajectory<T>::value(t);
+  }
 
   /** Returns the number of rows in the MatrixX<T> returned by value().
   @pre num_times() > 0. */
-  Eigen::Index rows() const override;
+  Eigen::Index rows() const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return Trajectory<T>::rows();
+  }
 
   /** Returns the number of cols in the MatrixX<T> returned by value().
   @pre num_times() > 0. */
-  Eigen::Index cols() const override;
+  Eigen::Index cols() const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return Trajectory<T>::cols();
+  }
 
   /** Returns the minimum value of get_times().
   @pre num_times() > 0. */
-  T start_time() const override;
+  T start_time() const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return Trajectory<T>::start_time();
+  }
 
   /** Returns the maximum value of get_times().
   @pre num_times() > 0. */
-  T end_time() const override;
+  T end_time() const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return Trajectory<T>::end_time();
+  }
 
  private:
+  // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
+  Eigen::Index do_rows() const final;
+  Eigen::Index do_cols() const final;
+  T do_start_time() const final;
+  T do_end_time() const final;
+
   std::vector<T> times_;
   std::vector<MatrixX<T>> values_;
   double time_comparison_tolerance_{};

--- a/common/trajectories/exponential_plus_piecewise_polynomial.cc
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.cc
@@ -28,22 +28,6 @@ ExponentialPlusPiecewisePolynomial<T>::~ExponentialPlusPiecewisePolynomial() =
     default;
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> ExponentialPlusPiecewisePolynomial<T>::Clone()
-    const {
-  return std::make_unique<ExponentialPlusPiecewisePolynomial<T>>(*this);
-}
-
-template <typename T>
-MatrixX<T> ExponentialPlusPiecewisePolynomial<T>::value(const T& t) const {
-  int segment_index = this->get_segment_index(t);
-  MatrixX<T> ret = piecewise_polynomial_part_.value(t);
-  double tj = this->start_time(segment_index);
-  auto exponential = (A_ * (t - tj)).eval().exp().eval();
-  ret.noalias() += K_ * exponential * alpha_.col(segment_index);
-  return ret;
-}
-
-template <typename T>
 ExponentialPlusPiecewisePolynomial<T>
 ExponentialPlusPiecewisePolynomial<T>::derivative(int derivative_order) const {
   DRAKE_ASSERT(derivative_order >= 0);
@@ -59,22 +43,38 @@ ExponentialPlusPiecewisePolynomial<T>::derivative(int derivative_order) const {
 }
 
 template <typename T>
-Eigen::Index ExponentialPlusPiecewisePolynomial<T>::rows() const {
-  return piecewise_polynomial_part_.rows();
-}
-
-template <typename T>
-Eigen::Index ExponentialPlusPiecewisePolynomial<T>::cols() const {
-  return piecewise_polynomial_part_.cols();
-}
-
-template <typename T>
 void ExponentialPlusPiecewisePolynomial<T>::shiftRight(double offset) {
   std::vector<double>& breaks = this->get_mutable_breaks();
   for (auto it = breaks.begin(); it != breaks.end(); ++it) {
     *it += offset;
   }
   piecewise_polynomial_part_.shiftRight(offset);
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> ExponentialPlusPiecewisePolynomial<T>::DoClone()
+    const {
+  return std::make_unique<ExponentialPlusPiecewisePolynomial<T>>(*this);
+}
+
+template <typename T>
+MatrixX<T> ExponentialPlusPiecewisePolynomial<T>::do_value(const T& t) const {
+  int segment_index = this->get_segment_index(t);
+  MatrixX<T> ret = piecewise_polynomial_part_.value(t);
+  double tj = this->start_time(segment_index);
+  auto exponential = (A_ * (t - tj)).eval().exp().eval();
+  ret.noalias() += K_ * exponential * alpha_.col(segment_index);
+  return ret;
+}
+
+template <typename T>
+Eigen::Index ExponentialPlusPiecewisePolynomial<T>::do_rows() const {
+  return piecewise_polynomial_part_.rows();
+}
+
+template <typename T>
+Eigen::Index ExponentialPlusPiecewisePolynomial<T>::do_cols() const {
+  return piecewise_polynomial_part_.cols();
 }
 
 template class ExponentialPlusPiecewisePolynomial<double>;

--- a/common/trajectories/exponential_plus_piecewise_polynomial.h
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.h
@@ -55,13 +55,13 @@ class ExponentialPlusPiecewisePolynomial final : public PiecewiseTrajectory<T> {
         A_(A),
         alpha_(alpha),
         piecewise_polynomial_part_(piecewise_polynomial_part) {
-    DRAKE_ASSERT(K.rows() == rows());
+    DRAKE_ASSERT(K.rows() == this->rows());
     DRAKE_ASSERT(K.cols() == A.rows());
     DRAKE_ASSERT(A.rows() == A.cols());
     DRAKE_ASSERT(alpha.rows() == A.cols());
     DRAKE_ASSERT(alpha.cols() ==
                  piecewise_polynomial_part.get_number_of_segments());
-    DRAKE_ASSERT(piecewise_polynomial_part.rows() == rows());
+    DRAKE_ASSERT(piecewise_polynomial_part.rows() == this->rows());
     DRAKE_ASSERT(piecewise_polynomial_part.cols() == 1);
   }
 
@@ -69,25 +69,18 @@ class ExponentialPlusPiecewisePolynomial final : public PiecewiseTrajectory<T> {
   ExponentialPlusPiecewisePolynomial(
       const PiecewisePolynomial<T>& piecewise_polynomial_part);
 
-  ~ExponentialPlusPiecewisePolynomial() override;
-
-  std::unique_ptr<Trajectory<T>> Clone() const override;
-
-  MatrixX<T> value(const T& t) const override;
+  ~ExponentialPlusPiecewisePolynomial() final;
 
   ExponentialPlusPiecewisePolynomial derivative(int derivative_order = 1) const;
-
-  Eigen::Index rows() const override;
-
-  Eigen::Index cols() const override;
 
   void shiftRight(double offset);
 
  private:
-  std::unique_ptr<Trajectory<T>> DoMakeDerivative(
-      int derivative_order = 1) const override {
-    return derivative(derivative_order).Clone();
-  };
+  // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
+  Eigen::Index do_rows() const final;
+  Eigen::Index do_cols() const final;
 
   MatrixX<T> K_;
   MatrixX<T> A_;

--- a/common/trajectories/function_handle_trajectory.cc
+++ b/common/trajectories/function_handle_trajectory.cc
@@ -29,14 +29,14 @@ FunctionHandleTrajectory<T>::FunctionHandleTrajectory(
   // Call value() once to confirm that function returns the correct size. We
   // must do the check in the value() method, because the func_ could produce
   // differently sized outputs at different times.
-  value(start_time);
+  this->value(start_time);
 }
 
 template <typename T>
 FunctionHandleTrajectory<T>::~FunctionHandleTrajectory() = default;
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> FunctionHandleTrajectory<T>::Clone() const {
+std::unique_ptr<Trajectory<T>> FunctionHandleTrajectory<T>::DoClone() const {
   using Self = FunctionHandleTrajectory<T>;
   auto clone =
       std::make_unique<Self>(func_, rows_, cols_, start_time_, end_time_);
@@ -45,7 +45,7 @@ std::unique_ptr<Trajectory<T>> FunctionHandleTrajectory<T>::Clone() const {
 }
 
 template <typename T>
-MatrixX<T> FunctionHandleTrajectory<T>::value(const T& t) const {
+MatrixX<T> FunctionHandleTrajectory<T>::do_value(const T& t) const {
   if (rows_ == 0 || cols_ == 0) {
     // Handle the empty (default) case; which can happen after a move operation.
     return MatrixX<T>::Zero(0, 0);
@@ -65,7 +65,7 @@ template <typename T>
 MatrixX<T> FunctionHandleTrajectory<T>::DoEvalDerivative(
     const T& t, int derivative_order) const {
   if (derivative_order == 0) {
-    return value(t);
+    return this->value(t);
   }
   DRAKE_THROW_UNLESS(derivative_func_ != nullptr);
   MatrixX<T> derivative = derivative_func_(t, derivative_order);
@@ -83,7 +83,7 @@ template <typename T>
 std::unique_ptr<Trajectory<T>> FunctionHandleTrajectory<T>::DoMakeDerivative(
     int derivative_order) const {
   if (derivative_order == 0) {
-    return Clone();
+    return this->Clone();
   }
   DRAKE_THROW_UNLESS(derivative_func_ != nullptr);
   return std::make_unique<DerivativeTrajectory<T>>(*this, derivative_order);

--- a/common/trajectories/function_handle_trajectory.h
+++ b/common/trajectories/function_handle_trajectory.h
@@ -58,26 +58,22 @@ class FunctionHandleTrajectory final : public Trajectory<T> {
     derivative_func_ = func;
   }
 
-  // Trajectory overrides.
-  std::unique_ptr<Trajectory<T>> Clone() const final;
-  MatrixX<T> value(const T& t) const final;
-  Eigen::Index rows() const final { return rows_; };
-  Eigen::Index cols() const final { return cols_; };
-  T start_time() const final { return start_time_; };
-  T end_time() const final { return end_time_; };
-
  private:
   // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
   bool do_has_derivative() const final { return derivative_func_ != nullptr; }
-
   // This method throws a std::exception if derivative_order != 0 and
   // derivative_func_ == nullptr.
-  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
-
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
   // This method throws a std::exception if derivative_order != 0 and
   // derivative_func_ == nullptr.
   std::unique_ptr<Trajectory<T>> DoMakeDerivative(
-      int derivative_order) const override;
+      int derivative_order) const final;
+  Eigen::Index do_rows() const final { return rows_; };
+  Eigen::Index do_cols() const final { return cols_; };
+  T do_start_time() const final { return start_time_; };
+  T do_end_time() const final { return end_time_; };
 
   std::function<MatrixX<T>(const T&)> func_{};
   std::function<MatrixX<T>(const T&, int)> derivative_func_{};

--- a/common/trajectories/path_parameterized_trajectory.cc
+++ b/common/trajectories/path_parameterized_trajectory.cc
@@ -22,12 +22,12 @@ template <typename T>
 PathParameterizedTrajectory<T>::~PathParameterizedTrajectory() = default;
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> PathParameterizedTrajectory<T>::Clone() const {
+std::unique_ptr<Trajectory<T>> PathParameterizedTrajectory<T>::DoClone() const {
   return std::make_unique<PathParameterizedTrajectory<T>>(*this);
 }
 
 template <typename T>
-MatrixX<T> PathParameterizedTrajectory<T>::value(const T& t) const {
+MatrixX<T> PathParameterizedTrajectory<T>::do_value(const T& t) const {
   using std::clamp;
   const T time =
       clamp(t, time_scaling_->start_time(), time_scaling_->end_time());
@@ -67,7 +67,7 @@ MatrixX<T> PathParameterizedTrajectory<T>::DoEvalDerivative(
     }
     // Derivative is calculated using Faà di Bruno's formula with Bell
     // polynomials: https://en.wikipedia.org/wiki/Fa%C3%A0_di_Bruno%27s_formula
-    MatrixX<T> derivative = MatrixX<T>::Zero(rows(), cols());
+    MatrixX<T> derivative = MatrixX<T>::Zero(this->rows(), this->cols());
     for (int order = 1; order <= derivative_order; ++order) {
       MatrixX<T> path_partial =
           path_->EvalDerivative(time_scaling_->value(time)(0, 0), order);

--- a/common/trajectories/path_parameterized_trajectory.h
+++ b/common/trajectories/path_parameterized_trajectory.h
@@ -32,9 +32,6 @@ class PathParameterizedTrajectory final : public Trajectory<T> {
 
   ~PathParameterizedTrajectory() final;
 
-  // Required methods for trajectories::Trajectory interface.
-  std::unique_ptr<trajectories::Trajectory<T>> Clone() const override;
-
   /** Evaluates the PathParameterizedTrajectory at the given time t.
   @param t The time at which to evaluate the %PathParameterizedTrajectory.
   @return The matrix of evaluated values.
@@ -43,15 +40,10 @@ class PathParameterizedTrajectory final : public Trajectory<T> {
            trajectory will silently be evaluated at the closest
            valid value of time to t. For example, `value(-1)` will return
            `value(0)` for a trajectory defined over [0, 1]. */
-  MatrixX<T> value(const T& t) const override;
-
-  Eigen::Index rows() const override { return path_->rows(); }
-
-  Eigen::Index cols() const override { return path_->cols(); }
-
-  T start_time() const override { return time_scaling_->start_time(); }
-
-  T end_time() const override { return time_scaling_->end_time(); }
+  MatrixX<T> value(const T& t) const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return Trajectory<T>::value(t);
+  }
 
   /** Returns the path of this trajectory. */
   const trajectories::Trajectory<T>& path() const { return *path_; }
@@ -62,26 +54,24 @@ class PathParameterizedTrajectory final : public Trajectory<T> {
   }
 
  private:
-  // Evaluates the %PathParameterizedTrajectory derivative at the given time @p
-  // t. Returns the nth derivative, where `n` is the value of @p
-  // derivative_order.
-  //
-  // @warning This method comes with the same caveats as value(). See value()
-  // @pre derivative_order must be non-negative.
-  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
-
-  // Uses DerivativeTrajectory to provide a derivative object.
+  // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
+  bool do_has_derivative() const final {
+    return path_->has_derivative() && time_scaling_->has_derivative();
+  }
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
   std::unique_ptr<Trajectory<T>> DoMakeDerivative(
       int derivative_order) const final;
+  Eigen::Index do_rows() const final { return path_->rows(); }
+  Eigen::Index do_cols() const final { return path_->cols(); }
+  T do_start_time() const final { return time_scaling_->start_time(); }
+  T do_end_time() const final { return time_scaling_->end_time(); }
 
   // Evaluates the Bell Polynomial B_n,k(x) for use in calculating the
   // derivative.
   // @pre n and k must be non-negative and the length of x must be at least n.
   T BellPolynomial(int n, int k, const VectorX<T>& x) const;
-
-  bool do_has_derivative() const override {
-    return path_->has_derivative() && time_scaling_->has_derivative();
-  }
 
   copyable_unique_ptr<Trajectory<T>> path_;
   copyable_unique_ptr<Trajectory<T>> time_scaling_;

--- a/common/trajectories/piecewise_constant_curvature_trajectory.cc
+++ b/common/trajectories/piecewise_constant_curvature_trajectory.cc
@@ -40,17 +40,6 @@ PiecewiseConstantCurvatureTrajectory<T>::PiecewiseConstantCurvatureTrajectory(
 }
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> PiecewiseConstantCurvatureTrajectory<T>::Clone()
-    const {
-  auto initial_pose = get_initial_pose();
-  auto initial_frame = initial_pose.rotation();
-  return std::make_unique<PiecewiseConstantCurvatureTrajectory<T>>(
-      this->breaks(), segment_turning_rates_,
-      initial_frame.col(kCurveTangentIndex),
-      initial_frame.col(kPlaneNormalIndex), initial_pose.translation());
-}
-
-template <typename T>
 math::RigidTransform<T> PiecewiseConstantCurvatureTrajectory<T>::CalcPose(
     const T& s) const {
   int segment_index = this->get_segment_index(s);
@@ -113,6 +102,17 @@ template <typename T>
 boolean<T> PiecewiseConstantCurvatureTrajectory<T>::IsNearlyPeriodic(
     double tolerance) const {
   return CalcPose(0.).IsNearlyEqualTo(CalcPose(length()), tolerance);
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>>
+PiecewiseConstantCurvatureTrajectory<T>::DoClone() const {
+  auto initial_pose = get_initial_pose();
+  auto initial_frame = initial_pose.rotation();
+  return std::make_unique<PiecewiseConstantCurvatureTrajectory<T>>(
+      this->breaks(), segment_turning_rates_,
+      initial_frame.col(kCurveTangentIndex),
+      initial_frame.col(kPlaneNormalIndex), initial_pose.translation());
 }
 
 template <typename T>

--- a/common/trajectories/piecewise_constant_curvature_trajectory.h
+++ b/common/trajectories/piecewise_constant_curvature_trajectory.h
@@ -125,12 +125,6 @@ class PiecewiseConstantCurvatureTrajectory final
                 .template cast<U>(),
             other.get_initial_pose().translation().template cast<U>()) {}
 
-  /** @returns the number of rows in the output of value(). */
-  Eigen::Index rows() const override { return 3; }
-
-  /** @returns the number of columns in the output of value(). */
-  Eigen::Index cols() const override { return 1; }
-
   /** @returns the total arclength of the curve in meters. */
   T length() const { return this->end_time(); }
 
@@ -148,12 +142,10 @@ class PiecewiseConstantCurvatureTrajectory final
 
    @param s The query arclength in meters.
    @returns position vector r(s). */
-  MatrixX<T> value(const T& s) const override {
-    return CalcPose(s).translation();
+  MatrixX<T> value(const T& s) const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return PiecewiseTrajectory<T>::value(s);
   }
-
-  /** @returns a deep copy of `this` trajectory. */
-  std::unique_ptr<Trajectory<T>> Clone() const override;
 
   /** Computes the spatial velocity V_AF_A(s) of frame F measured and expressed
    in the reference frame A. See the class's documentation for frame
@@ -213,6 +205,14 @@ class PiecewiseConstantCurvatureTrajectory final
  private:
   template <typename U>
   friend class PiecewiseConstantCurvatureTrajectory;
+
+  // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& s) const final {
+    return CalcPose(s).translation();
+  }
+  Eigen::Index do_rows() const final { return 3; }
+  Eigen::Index do_cols() const final { return 1; }
 
   /* Helper function to scalar convert a std::vector<U> into a std::vector<T>.
    @param segment_data std::vector storing types U.

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -61,7 +61,7 @@ template <typename T>
 PiecewisePolynomial<T>::~PiecewisePolynomial() = default;
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> PiecewisePolynomial<T>::Clone() const {
+std::unique_ptr<Trajectory<T>> PiecewisePolynomial<T>::DoClone() const {
   return std::make_unique<PiecewisePolynomial<T>>(*this);
 }
 
@@ -648,7 +648,7 @@ T PiecewisePolynomial<T>::EvaluateSegmentAbsoluteTime(
 }
 
 template <typename T>
-Eigen::Index PiecewisePolynomial<T>::rows() const {
+Eigen::Index PiecewisePolynomial<T>::do_rows() const {
   if (polynomials_.size() > 0) {
     return polynomials_[0].rows();
   } else {
@@ -658,7 +658,7 @@ Eigen::Index PiecewisePolynomial<T>::rows() const {
 }
 
 template <typename T>
-Eigen::Index PiecewisePolynomial<T>::cols() const {
+Eigen::Index PiecewisePolynomial<T>::do_cols() const {
   if (polynomials_.size() > 0) {
     return polynomials_[0].cols();
   } else {

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -181,9 +181,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
                       const std::vector<T>& breaks);
   // @}
 
-  ~PiecewisePolynomial() override;
-
-  std::unique_ptr<Trajectory<T>> Clone() const override;
+  ~PiecewisePolynomial() final;
 
   /**
    * @anchor coefficient_construction_methods
@@ -512,9 +510,9 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * @warning See warning in the @ref polynomial_warning "constructor overview"
    *          above.
    */
-  MatrixX<T> value(const T& t) const override {
-    const int derivative_order = 0;
-    return DoEvalDerivative(t, derivative_order);
+  MatrixX<T> value(const T& t) const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return PiecewiseTrajectory<T>::value(t);
   }
 
   /**
@@ -545,13 +543,19 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * Returns the row count of the output matrices.
    * @throws std::exception if empty().
    */
-  Eigen::Index rows() const override;
+  Eigen::Index rows() const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return PiecewiseTrajectory<T>::rows();
+  }
 
   /**
    * Returns the column count of the output matrices.
    * @throws std::exception if empty().
    */
-  Eigen::Index cols() const override;
+  Eigen::Index cols() const final {
+    // We shadowed the base class to add documentation, not to change logic.
+    return PiecewiseTrajectory<T>::cols();
+  }
 
   /**
    * Reshapes the dimensions of the Eigen::MatrixX<T> returned by value(),
@@ -804,19 +808,25 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   }
 
  private:
+  // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final {
+    const int derivative_order = 0;
+    return DoEvalDerivative(t, derivative_order);
+  }
   // Evaluates the %PiecwisePolynomial derivative at the given time @p t.
   // Returns the nth derivative, where `n` is the value of @p derivative_order.
   //
   // @warning This method comes with the same caveats as value(). See value()
   // @pre derivative_order must be non-negative.
-  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
-
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
   std::unique_ptr<Trajectory<T>> DoMakeDerivative(
-      int derivative_order) const override {
+      int derivative_order) const final {
     return derivative(derivative_order).Clone();
   }
-
-  bool do_has_derivative() const override { return true; }
+  bool do_has_derivative() const final { return true; }
+  Eigen::Index do_rows() const final;
+  Eigen::Index do_cols() const final;
 
   T EvaluateSegmentAbsoluteTime(int segment_index, const T& t, Eigen::Index row,
                                 Eigen::Index col,

--- a/common/trajectories/piecewise_pose.cc
+++ b/common/trajectories/piecewise_pose.cc
@@ -59,11 +59,6 @@ PiecewisePose<T> PiecewisePose<T>::MakeCubicLinearWithEndLinearVelocity(
 }
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> PiecewisePose<T>::Clone() const {
-  return std::make_unique<PiecewisePose>(*this);
-}
-
-template <typename T>
 math::RigidTransform<T> PiecewisePose<T>::GetPose(const T& time) const {
   return math::RigidTransform<T>(orientation_.orientation(time),
                                  position_.value(time));
@@ -110,6 +105,11 @@ bool PiecewisePose<T>::IsApprox(const PiecewisePose<T>& other,
 }
 
 template <typename T>
+std::unique_ptr<Trajectory<T>> PiecewisePose<T>::DoClone() const {
+  return std::make_unique<PiecewisePose>(*this);
+}
+
+template <typename T>
 bool PiecewisePose<T>::do_has_derivative() const {
   return true;
 }
@@ -118,7 +118,7 @@ template <typename T>
 MatrixX<T> PiecewisePose<T>::DoEvalDerivative(const T& t,
                                               int derivative_order) const {
   if (derivative_order == 0) {
-    return value(t);
+    return this->value(t);
   }
   Vector6<T> derivative;
   derivative.template head<3>() =

--- a/common/trajectories/piecewise_pose.h
+++ b/common/trajectories/piecewise_pose.h
@@ -37,7 +37,7 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
   PiecewisePose(const PiecewisePolynomial<T>& position_trajectory,
                 const PiecewiseQuaternionSlerp<T>& orientation_trajectory);
 
-  ~PiecewisePose() override;
+  ~PiecewisePose() final;
 
   /**
    * Constructs a PiecewisePose from given @p times and @p poses. The positions
@@ -67,20 +67,10 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
       const Vector3<T>& start_vel = Vector3<T>::Zero(),
       const Vector3<T>& end_vel = Vector3<T>::Zero());
 
-  std::unique_ptr<Trajectory<T>> Clone() const override;
-
-  Eigen::Index rows() const override { return 4; }
-
-  Eigen::Index cols() const override { return 4; }
-
   /**
    * Returns the interpolated pose at @p time.
    */
   math::RigidTransform<T> GetPose(const T& time) const;
-
-  MatrixX<T> value(const T& t) const override {
-    return GetPose(t).GetAsMatrix4();
-  }
 
   /**
    * Returns the interpolated velocity at @p time or zero if @p time is before
@@ -115,12 +105,17 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
   }
 
  private:
-  bool do_has_derivative() const override;
-
-  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
-
+  // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final {
+    return GetPose(t).GetAsMatrix4();
+  }
+  bool do_has_derivative() const final;
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
   std::unique_ptr<Trajectory<T>> DoMakeDerivative(
-      int derivative_order) const override;
+      int derivative_order) const final;
+  Eigen::Index do_rows() const final { return 4; }
+  Eigen::Index do_cols() const final { return 4; }
 
   PiecewisePolynomial<T> position_;
   PiecewisePolynomial<T> velocity_;

--- a/common/trajectories/piecewise_quaternion.cc
+++ b/common/trajectories/piecewise_quaternion.cc
@@ -125,11 +125,6 @@ template <typename T>
 PiecewiseQuaternionSlerp<T>::~PiecewiseQuaternionSlerp() = default;
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> PiecewiseQuaternionSlerp<T>::Clone() const {
-  return std::make_unique<PiecewiseQuaternionSlerp>(*this);
-}
-
-template <typename T>
 T PiecewiseQuaternionSlerp<T>::ComputeInterpTime(int segment_index,
                                                  const T& time) const {
   T interp_time =
@@ -192,6 +187,11 @@ void PiecewiseQuaternionSlerp<T>::Append(const T& time,
 }
 
 template <typename T>
+std::unique_ptr<Trajectory<T>> PiecewiseQuaternionSlerp<T>::DoClone() const {
+  return std::make_unique<PiecewiseQuaternionSlerp>(*this);
+}
+
+template <typename T>
 bool PiecewiseQuaternionSlerp<T>::do_has_derivative() const {
   return true;
 }
@@ -200,7 +200,7 @@ template <typename T>
 MatrixX<T> PiecewiseQuaternionSlerp<T>::DoEvalDerivative(
     const T& t, int derivative_order) const {
   if (derivative_order == 0) {
-    return value(t);
+    return this->value(t);
   } else if (derivative_order == 1) {
     return angular_velocity(t);
   }

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -74,13 +74,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   PiecewiseQuaternionSlerp(const std::vector<T>& breaks,
                            const std::vector<AngleAxis<T>>& angle_axes);
 
-  ~PiecewiseQuaternionSlerp() override;
-
-  std::unique_ptr<Trajectory<T>> Clone() const override;
-
-  Eigen::Index rows() const override { return 4; }
-
-  Eigen::Index cols() const override { return 1; }
+  ~PiecewiseQuaternionSlerp() final;
 
   /**
    * Interpolates orientation.
@@ -88,11 +82,6 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * @return The interpolated quaternion at `time`.
    */
   Quaternion<T> orientation(const T& time) const;
-
-  MatrixX<T> value(const T& time) const override {
-    const Quaternion<T> quat = orientation(time);
-    return Vector4<T>(quat.w(), quat.x(), quat.y(), quat.z());
-  }
 
   /**
    * Interpolates angular velocity.
@@ -154,12 +143,18 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   // Computes the interpolation time within each segment. Result is in [0, 1].
   T ComputeInterpTime(int segment_index, const T& time) const;
 
-  bool do_has_derivative() const override;
-
-  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
-
+  // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& time) const final {
+    const Quaternion<T> quat = orientation(time);
+    return Vector4<T>(quat.w(), quat.x(), quat.y(), quat.z());
+  }
+  bool do_has_derivative() const final;
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
   std::unique_ptr<Trajectory<T>> DoMakeDerivative(
-      int derivative_order) const override;
+      int derivative_order) const final;
+  Eigen::Index do_rows() const final { return 4; }
+  Eigen::Index do_cols() const final { return 1; }
 
   std::vector<Quaternion<T>> quaternions_;
   std::vector<Vector3<T>> angular_velocities_;

--- a/common/trajectories/piecewise_trajectory.cc
+++ b/common/trajectories/piecewise_trajectory.cc
@@ -51,16 +51,6 @@ T PiecewiseTrajectory<T>::duration(int segment_number) const {
 }
 
 template <typename T>
-T PiecewiseTrajectory<T>::start_time() const {
-  return start_time(0);
-}
-
-template <typename T>
-T PiecewiseTrajectory<T>::end_time() const {
-  return end_time(get_number_of_segments() - 1);
-}
-
-template <typename T>
 int PiecewiseTrajectory<T>::GetSegmentIndexRecursive(const T& time, int start,
                                                      int end) const {
   DRAKE_DEMAND(end >= start);
@@ -119,6 +109,16 @@ std::vector<T> PiecewiseTrajectory<T>::RandomSegmentTimes(
     breaks.push_back(breaks[i] + duration);
   }
   return breaks;
+}
+
+template <typename T>
+T PiecewiseTrajectory<T>::do_start_time() const {
+  return start_time(0);
+}
+
+template <typename T>
+T PiecewiseTrajectory<T>::do_end_time() const {
+  return end_time(get_number_of_segments() - 1);
 }
 
 template <typename T>

--- a/common/trajectories/piecewise_trajectory.h
+++ b/common/trajectories/piecewise_trajectory.h
@@ -29,14 +29,12 @@ class PiecewiseTrajectory : public Trajectory<T> {
   int get_number_of_segments() const;
 
   T start_time(int segment_number) const;
+  using Trajectory<T>::start_time;  // Don't shadow the base class.
 
   T end_time(int segment_number) const;
+  using Trajectory<T>::end_time;  // Don't shadow the base class.
 
   T duration(int segment_number) const;
-
-  T start_time() const override;
-
-  T end_time() const override;
 
   /**
    * Returns true iff `t >= getStartTime() && t <= getEndTime()`.
@@ -60,6 +58,10 @@ class PiecewiseTrajectory : public Trajectory<T> {
 
   /// @p breaks increments must be greater or equal to kEpsilonTime.
   explicit PiecewiseTrajectory(const std::vector<T>& breaks);
+
+  // Trajectory overrides.
+  T do_start_time() const override;
+  T do_end_time() const override;
 
   bool SegmentTimesEqual(const PiecewiseTrajectory& b,
                          double tol = kEpsilonTime) const;

--- a/common/trajectories/stacked_trajectory.h
+++ b/common/trajectories/stacked_trajectory.h
@@ -47,14 +47,6 @@ class StackedTrajectory final : public Trajectory<T> {
   @throws std::exception if the matrix dimension is incompatible. */
   void Append(const Trajectory<T>& traj);
 
-  // Trajectory overrides.
-  std::unique_ptr<Trajectory<T>> Clone() const final;
-  MatrixX<T> value(const T& t) const final;
-  Eigen::Index rows() const final;
-  Eigen::Index cols() const final;
-  T start_time() const final;
-  T end_time() const final;
-
  private:
   void CheckInvariants() const;
 
@@ -62,10 +54,16 @@ class StackedTrajectory final : public Trajectory<T> {
   void Append(std::unique_ptr<Trajectory<T>> traj);
 
   // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
   bool do_has_derivative() const final;
   MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
   std::unique_ptr<Trajectory<T>> DoMakeDerivative(
       int derivative_order) const final;
+  Eigen::Index do_rows() const final;
+  Eigen::Index do_cols() const final;
+  T do_start_time() const final;
+  T do_end_time() const final;
 
   bool rowwise_{};
   std::vector<copyable_unique_ptr<Trajectory<T>>> children_;

--- a/common/trajectories/trajectory.cc
+++ b/common/trajectories/trajectory.cc
@@ -2,11 +2,19 @@
 
 #include "drake/common/unused.h"
 
+// Remove 2025-08-01 with deprecation.
+#include "drake/common/nice_type_name.h"
+
 namespace drake {
 namespace trajectories {
 
 template <typename T>
 Trajectory<T>::~Trajectory() = default;
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> Trajectory<T>::Clone() const {
+  return DoClone();
+}
 
 template <typename T>
 MatrixX<T> Trajectory<T>::vector_values(const std::vector<T>& t) const {
@@ -32,6 +40,23 @@ MatrixX<T> Trajectory<T>::vector_values(
     values.row(i) = value(t[i]);
   }
   return values;
+}
+
+// Switch to be pure virtual on 2025-08-01.
+template <typename T>
+std::unique_ptr<Trajectory<T>> Trajectory<T>::DoClone() const {
+  throw std::logic_error(
+      fmt::format("{} is implemented incorrectly: it failed to override {}",
+                  drake::NiceTypeName::Get(*this), __func__));
+}
+
+// Switch to be pure virtual on 2025-08-01.
+template <typename T>
+MatrixX<T> Trajectory<T>::do_value(const T& t) const {
+  unused(t);
+  throw std::logic_error(
+      fmt::format("{} is implemented incorrectly: it failed to override {}",
+                  drake::NiceTypeName::Get(*this), __func__));
 }
 
 template <typename T>
@@ -87,6 +112,38 @@ std::unique_ptr<Trajectory<T>> Trajectory<T>::DoMakeDerivative(
         "You asked for derivatives from a class that does not support "
         "derivatives.");
   }
+}
+
+// Switch to be pure virtual on 2025-08-01.
+template <typename T>
+Eigen::Index Trajectory<T>::do_rows() const {
+  throw std::logic_error(
+      fmt::format("{} is implemented incorrectly: it failed to override {}",
+                  drake::NiceTypeName::Get(*this), __func__));
+}
+
+// Switch to be pure virtual on 2025-08-01.
+template <typename T>
+Eigen::Index Trajectory<T>::do_cols() const {
+  throw std::logic_error(
+      fmt::format("{} is implemented incorrectly: it failed to override {}",
+                  drake::NiceTypeName::Get(*this), __func__));
+}
+
+// Switch to be pure virtual on 2025-08-01.
+template <typename T>
+T Trajectory<T>::do_start_time() const {
+  throw std::logic_error(
+      fmt::format("{} is implemented incorrectly: it failed to override {}",
+                  drake::NiceTypeName::Get(*this), __func__));
+}
+
+// Switch to be pure virtual on 2025-08-01.
+template <typename T>
+T Trajectory<T>::do_end_time() const {
+  throw std::logic_error(
+      fmt::format("{} is implemented incorrectly: it failed to override {}",
+                  drake::NiceTypeName::Get(*this), __func__));
 }
 
 }  // namespace trajectories

--- a/common/trajectories/trajectory.h
+++ b/common/trajectories/trajectory.h
@@ -25,15 +25,23 @@ class Trajectory {
 
   /**
    * @return A deep copy of this Trajectory.
+   *
+   * @warning Support for overriding this as a virtual function is deprecated
+   * and will be removed on or after 2025-08-01. Subclasses should override the
+   * protected function DoClone(), instead.
    */
-  virtual std::unique_ptr<Trajectory<T>> Clone() const = 0;
+  virtual std::unique_ptr<Trajectory<T>> Clone() const;
 
   /**
    * Evaluates the trajectory at the given time \p t.
    * @param t The time at which to evaluate the trajectory.
    * @return The matrix of evaluated values.
+   *
+   * @warning Support for overriding this as a virtual function is deprecated
+   * and will be removed on or after 2025-08-01. Subclasses should override the
+   * protected function do_value(), instead.
    */
-  virtual MatrixX<T> value(const T& t) const = 0;
+  virtual MatrixX<T> value(const T& t) const { return do_value(t); }
 
   /**
    * If cols()==1, then evaluates the trajectory at each time @p t, and returns
@@ -82,22 +90,46 @@ class Trajectory {
 
   /**
    * @return The number of rows in the matrix returned by value().
+   *
+   * @warning Support for overriding this as a virtual function is deprecated
+   * and will be removed on or after 2025-08-01. Subclasses should override the
+   * protected function do_rows(), instead.
    */
-  virtual Eigen::Index rows() const = 0;
+  virtual Eigen::Index rows() const { return do_rows(); }
 
   /**
    * @return The number of columns in the matrix returned by value().
+   *
+   * @warning Support for overriding this as a virtual function is deprecated
+   * and will be removed on or after 2025-08-01. Subclasses should override the
+   * protected function do_cols(), instead.
    */
-  virtual Eigen::Index cols() const = 0;
+  virtual Eigen::Index cols() const { return do_cols(); }
 
-  virtual T start_time() const = 0;
+  /**
+   * @warning Support for overriding this as a virtual function is deprecated
+   * and will be removed on or after 2025-08-01. Subclasses should override the
+   * protected function do_start_time(), instead.
+   */
+  virtual T start_time() const { return do_start_time(); }
 
-  virtual T end_time() const = 0;
+  /**
+   * @warning Support for overriding this as a virtual function is deprecated
+   * and will be removed on or after 2025-08-01. Subclasses should override the
+   * protected function do_end_time(), instead.
+   */
+  virtual T end_time() const { return do_end_time(); }
 
  protected:
   // Final subclasses are allowed to make copy/move/assign public.
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory);
   Trajectory() = default;
+
+  // This will become pure virtual on 2025-08-01.
+  virtual std::unique_ptr<Trajectory<T>> DoClone() const;
+
+  // This will become pure virtual on 2025-08-01.
+  virtual MatrixX<T> do_value(const T& t) const;
 
   virtual bool do_has_derivative() const;
 
@@ -105,6 +137,18 @@ class Trajectory {
 
   virtual std::unique_ptr<Trajectory<T>> DoMakeDerivative(
       int derivative_order) const;
+
+  // This will become pure virtual on 2025-08-01.
+  virtual Eigen::Index do_rows() const;
+
+  // This will become pure virtual on 2025-08-01.
+  virtual Eigen::Index do_cols() const;
+
+  // This will become pure virtual on 2025-08-01.
+  virtual T do_start_time() const;
+
+  // This will become pure virtual on 2025-08-01.
+  virtual T do_end_time() const;
 };
 
 }  // namespace trajectories


### PR DESCRIPTION
Subclasses must switch to using NVI overrides, instead.

Towards #5842 and #21968.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22395)
<!-- Reviewable:end -->
