### PR TITLE
[workspace] Factor to single point of control for Fortran

### DIFF
--- a/tools/workspace/gfortran/BUILD.bazel
+++ b/tools/workspace/gfortran/BUILD.bazel
@@ -1,6 +1,21 @@
-# This file exists to make our directory into a Bazel package, so that our
-# neighboring *.bzl file can be loaded elsewhere.
-
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+# Provides a single point of control within Drake for which fortran compiler
+# to use. This is cited by our fortran.bzl rules in the current directory.
+alias(
+    name = "compiler",
+    actual = "@gfortran//:compiler",
+    visibility = ["//visibility:public"],
+)
+
+# Provides a single point of control within Drake for which fortran runtime
+# libraries to link to. This may be used like it was a cc_library target that
+# listed linkopts= for any libraries used by Fortran. This is cited by our
+# fortran.bzl rules in the current directory.
+alias(
+    name = "runtime",
+    actual = "@gfortran//:runtime",
+    visibility = ["//visibility:public"],
+)
 
 add_lint_tests()

--- a/tools/workspace/gfortran/fortran.bzl
+++ b/tools/workspace/gfortran/fortran.bzl
@@ -18,7 +18,7 @@ def _fortran_object(
     output_mods: (Optional) List of *.mod files that this module provides.
     fopts: (Optional) Extra options to pass to the fortran compiler.
     """
-    compiler = "@gfortran//:compiler"
+    compiler = "@drake//tools/workspace/gfortran:compiler"
     compiler_args = ["-fPIC"] + fopts
     inputs = [src] + input_mods
     outputs = [obj] + output_mods
@@ -93,7 +93,7 @@ def fortran_library(
     # Provide a cc_library with the final result.
     kwargs = amend(kwargs, "deps", prepend = [
         "_{}_archive_hidden".format(name),
-        "@gfortran//:runtime",
+        "@drake//tools/workspace/gfortran:runtime",
     ])
     cc_library(
         name = name,

--- a/tools/workspace/snopt/package.BUILD.bazel
+++ b/tools/workspace/snopt/package.BUILD.bazel
@@ -1,8 +1,7 @@
 # -*- bazel -*-
 
 load("@drake//tools/skylark:cc.bzl", "cc_library")
-load("@gfortran//:version.bzl", COMPILER_MAJOR = "MAJOR")
-load(":fortran.bzl", "fortran_library")
+load("@drake//tools/workspace/gfortran:fortran.bzl", "fortran_library")
 
 licenses(["by_exception_only"])  # SNOPT
 
@@ -32,7 +31,7 @@ fortran_library(
         "-fopenmp",
     ] + [
         # We need this for SNOPT 7.6 which has non-conforming code.
-        "-fallow-argument-mismatch" if COMPILER_MAJOR >= 10 else "",
+        "-fallow-argument-mismatch",
     ],
     # Link statically per note (1) above.
     linkstatic = 1,

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -179,12 +179,6 @@ def _impl(repo_ctx):
         # This case uses deferred error handling, since doing so is easy.
         _setup_local_archive(repo_ctx, snopt_path)
 
-    # Add in the helper.
-    repo_ctx.symlink(
-        Label("@drake//tools/workspace/snopt:fortran.bzl"),
-        "fortran.bzl",
-    )
-
     return updated_attrs
 
 _attrs = {

--- a/tools/workspace/spral_internal/package.BUILD.bazel
+++ b/tools/workspace/spral_internal/package.BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@drake//tools/install:install.bzl", "install")
 load("@drake//tools/skylark:cc.bzl", "cc_library")
-load("@drake//tools/workspace/snopt:fortran.bzl", "fortran_module")
+load("@drake//tools/workspace/gfortran:fortran.bzl", "fortran_module")
 
 licenses(["notice"])  # BSD-3-Clause
 


### PR DESCRIPTION
As with recent work on to centralize C++ and Python toolchains, changes Drake's citations for Fortran targets and macros to use a single point of control.

Towards #20731.  (This will allow downstream code like Anzu to call the `snopt_repository` rule without ever directly depending on `@gfortran`.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22398)
<!-- Reviewable:end -->
