### PR TITLE
[py trajectories] Adjust Clone and MakeDerivative for unique_ptr

### DIFF
--- a/bindings/pydrake/_trajectories_extra.py
+++ b/bindings/pydrake/_trajectories_extra.py
@@ -1,4 +1,7 @@
-from pydrake.common import _MangledName
+from pydrake.common import (
+    _MangledName,
+    pretty_class_name as _pretty_class_name,
+)
 
 
 def __getattr__(name):
@@ -7,3 +10,17 @@ def __getattr__(name):
     """
     return _MangledName.module_getattr(
         module_name=__name__, module_globals=globals(), name=name)
+
+
+def _wrapped_trajectory_repr(wrapped_trajectory):
+    cls = type(wrapped_trajectory)
+    return f"{_pretty_class_name(cls)}({wrapped_trajectory.unwrap()!r})"
+
+
+def _add_repr_functions():
+    for param in _WrappedTrajectory_.param_list:
+        cls = _WrappedTrajectory_[param]
+        setattr(cls, "__repr__", _wrapped_trajectory_repr)
+
+
+_add_repr_functions()

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -27,7 +27,8 @@ from pydrake.trajectories import (
     PiecewiseQuaternionSlerp_,
     StackedTrajectory_,
     Trajectory,
-    Trajectory_
+    Trajectory_,
+    _WrappedTrajectory_,
 )
 from pydrake.symbolic import Variable, Expression
 
@@ -37,9 +38,11 @@ class CustomTrajectory(Trajectory):
     def __init__(self):
         Trajectory.__init__(self)
 
-    # TODO(jwnimmer-tri) Should be __deepcopy__ not Clone.
-    def Clone(self):
+    def __deepcopy__(self, memo):
         return CustomTrajectory()
+
+    def __repr__(self):
+        return "CustomTrajectory()"
 
     def do_value(self, t):
         return np.array([[t + 1.0, t + 2.0]])
@@ -129,6 +132,7 @@ class TestTrajectories(unittest.TestCase):
         self.assertEqual(trajectory.start_time(), 3.0)
         self.assertEqual(trajectory.end_time(), 4.0)
         self.assertTrue(trajectory.has_derivative())
+        self.assertEqual(repr(trajectory), "CustomTrajectory()")
         numpy_compare.assert_float_equal(trajectory.value(t=1.5),
                                          np.array([[2.5, 3.5]]))
         numpy_compare.assert_float_equal(
@@ -137,12 +141,18 @@ class TestTrajectories(unittest.TestCase):
         numpy_compare.assert_float_equal(
             trajectory.EvalDerivative(t=2.3, derivative_order=2),
             np.zeros((1, 2)))
+
         clone = trajectory.Clone()
         numpy_compare.assert_float_equal(clone.value(t=1.5),
                                          np.array([[2.5, 3.5]]))
+        self.assertEqual(repr(clone), "_WrappedTrajectory(CustomTrajectory())")
+
         deriv = trajectory.MakeDerivative(derivative_order=1)
         numpy_compare.assert_float_equal(
             deriv.value(t=2.3), np.ones((1, 2)))
+        self.assertIn(
+            "_WrappedTrajectory(<pydrake.trajectories.DerivativeTrajectory",
+            repr(deriv))
 
     def test_legacy_custom_trajectory(self):
         trajectory = LegacyCustomTrajectory()
@@ -164,10 +174,10 @@ class TestTrajectories(unittest.TestCase):
         # that we trigger the deprecation warnings.
         stacked = StackedTrajectory_[float]()
         with catch_drake_warnings():
-            # The C++ code calls rows() and cols() -- both of which cause
-            # deprecation warnings with the legacy overrides -- but the total
-            # number of calls varies between Debug and Release, so we don't
-            # check the exact tally here.
+            # The C++ code calls rows() and cols() and Clone() -- all of which
+            # cause deprecation warnings with the legacy overrides -- but the
+            # total number of calls varies between Debug and Release, so we
+            # don't check the exact tally here.
             stacked.Append(trajectory)
         with catch_drake_warnings(expected_count=1):
             stacked.value(t=1.5)
@@ -798,3 +808,19 @@ class TestTrajectories(unittest.TestCase):
         dut.Clone()
         copy.copy(dut)
         copy.deepcopy(dut)
+
+    @numpy_compare.check_all_types
+    def test_wrapped_trajectory(self, T):
+        breaks = [0, 1, 2]
+        samples = [[[0]], [[1]], [[2]]]
+        zoh = PiecewisePolynomial_[T].ZeroOrderHold(breaks, samples)
+        dut = _WrappedTrajectory_[T](trajectory=zoh)
+        self.assertEqual(dut.rows(), 1)
+        self.assertEqual(dut.cols(), 1)
+        if T is float:
+            self.assertIn("_WrappedTrajectory(", repr(dut))
+        else:
+            self.assertIn("_WrappedTrajectory_[", repr(dut))
+        self.assertIn("PiecewisePolynomial", repr(dut))
+        clone = dut.Clone()
+        self.assertIn("PiecewisePolynomial", repr(clone))

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -7,6 +7,7 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/polynomial.h"
+#include "drake/common/scope_exit.h"
 #include "drake/common/trajectories/bezier_curve.h"
 #include "drake/common/trajectories/bspline_trajectory.h"
 #include "drake/common/trajectories/composite_trajectory.h"
@@ -19,6 +20,7 @@
 #include "drake/common/trajectories/piecewise_quaternion.h"
 #include "drake/common/trajectories/stacked_trajectory.h"
 #include "drake/common/trajectories/trajectory.h"
+#include "drake/common/trajectories/wrapped_trajectory.h"
 
 namespace drake {
 namespace pydrake {
@@ -184,13 +186,58 @@ struct Impl {
           "2025-08-01");
     }
 
+    // Utility function that takes a Python object which is-a Trajectory and
+    // wraps it in a unique_ptr that manages object lifetime when returned back
+    // to C++.
+    static std::unique_ptr<Trajectory<T>> WrapPyTrajectory(py::object py_traj) {
+      DRAKE_THROW_UNLESS(!py_traj.is_none());
+      // Convert py_traj to a shared_ptr<Trajectory<T>> whose C++ lifetime keeps
+      // the python object alive.
+      Trajectory<T>* cpp_traj = py::cast<Trajectory<T>*>(py_traj);
+      DRAKE_THROW_UNLESS(cpp_traj != nullptr);
+      std::shared_ptr<Trajectory<T>> shared_cpp_traj(
+          /* stored pointer = */ cpp_traj,
+          /* deleter = */ [captured_py_traj = std::move(py_traj)](  // BR
+                              void*) mutable {
+            py::gil_scoped_acquire deleter_guard;
+            captured_py_traj = py::none();
+          });
+      // Wrap the shared_ptr inside a WrappedTrajectory and return that via
+      // unique_ptr to meet our required return signature.
+      return std::make_unique<trajectories::internal::WrappedTrajectory<T>>(
+          std::move(shared_cpp_traj));
+    }
+
     // Trampoline virtual methods.
 
     std::unique_ptr<Trajectory<T>> DoClone() const final {
-      // TODO(jwnimmer-tri) Rewrite cloning to use __deepcopy__ in lieu of
-      // Clone (or DoClone).
-      PYBIND11_OVERLOAD_PURE(
-          std::unique_ptr<Trajectory<T>>, Trajectory<T>, Clone);
+      py::gil_scoped_acquire guard;
+      // Trajectory subclasses in Python must implement cloning by defining
+      // either a __deepcopy__ (preferred) or Clone (legacy) method. We'll try
+      // Clone first so it has priority, but if it doesn't exist we'll fall back
+      // to __deepcopy__ and just let the "no such method deepcopy" error
+      // message propagate if both were missing. Because the
+      // PYBIND11_OVERLOAD_INT macro embeds a conditional `return ...;`
+      // statement, we must wrap it in lambda so that we can post-process the
+      // return value in case it does return.
+      bool used_legacy_clone = true;
+      auto make_python_deepcopy = [&]() -> py::object {
+        PYBIND11_OVERLOAD_INT(py::object, Trajectory<T>, "Clone");
+        used_legacy_clone = false;
+        auto deepcopy = py::module_::import("copy").attr("deepcopy");
+        return deepcopy(this);
+      };
+      py::object copied = make_python_deepcopy();
+      if (used_legacy_clone) {
+        WarnDeprecated(
+            fmt::format(
+                "Support for overriding {}.Clone as a virtual function is "
+                "deprecated. Subclasses should implement __deepcopy__, "
+                "instead.",
+                NiceTypeName::Get(*this)),
+            "2025-08-01");
+      }
+      return WrapPyTrajectory(std::move(copied));
     }
 
     MatrixX<T> do_value(const T& t) const final {
@@ -216,10 +263,18 @@ struct Impl {
 
     std::unique_ptr<Trajectory<T>> DoMakeDerivative(
         int derivative_order) const final {
-      PYBIND11_OVERLOAD_INT(std::unique_ptr<Trajectory<T>>, Trajectory<T>,
-          "DoMakeDerivative", derivative_order);
-      // If the macro did not return, use default functionality.
-      return Base::DoMakeDerivative(derivative_order);
+      py::gil_scoped_acquire guard;
+      // Because the PYBIND11_OVERLOAD_INT macro embeds a `return ...;`
+      // statement, we must wrap it in lambda so that we can post-process the
+      // return value.
+      auto make_python_derivative = [&]() -> py::object {
+        PYBIND11_OVERLOAD_INT(
+            py::object, Trajectory<T>, "DoMakeDerivative", derivative_order);
+        // If the macro did not return, use the base class error message.
+        Base::DoMakeDerivative(derivative_order);
+        DRAKE_UNREACHABLE();
+      };
+      return WrapPyTrajectory(make_python_derivative());
     }
 
     T do_start_time() const final {
@@ -759,6 +814,23 @@ struct Impl {
               /* N.B. We choose to omit any py::arg name here. */
               cls_doc.Append.doc);
       DefCopyAndDeepCopy(&cls);
+    }
+
+    {
+      using Class = trajectories::internal::WrappedTrajectory<T>;
+      auto cls = DefineTemplateClassWithDefault<Class, Trajectory<T>>(
+          m, "_WrappedTrajectory", param, "(Internal use only)");
+      cls  // BR
+          .def(py::init([](const Trajectory<T>& trajectory) {
+            // The keep_alive is responsible for object lifetime, so we'll give
+            // the constructor an unowned pointer.
+            return std::make_unique<Class>(
+                make_unowned_shared_ptr_from_raw(&trajectory));
+          }),
+              py::arg("trajectory"),
+              // Keep alive, ownership: `return` keeps `trajectory` alive.
+              py::keep_alive<0, 1>())
+          .def("unwrap", &Class::unwrap, py_rvp::reference_internal);
     }
   }
 };

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_package_library(
         ":piecewise_trajectory",
         ":stacked_trajectory",
         ":trajectory",
+        ":wrapped_trajectory",
     ],
 )
 
@@ -219,6 +220,15 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "wrapped_trajectory",
+    srcs = ["wrapped_trajectory.cc"],
+    hdrs = ["wrapped_trajectory.h"],
+    deps = [
+        ":trajectory",
+    ],
+)
+
 # === test/ ===
 
 drake_cc_googletest(
@@ -384,6 +394,15 @@ drake_cc_googletest(
     name = "trajectory_test",
     deps = [
         ":trajectory",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "wrapped_trajectory_test",
+    deps = [
+        ":function_handle_trajectory",
+        ":wrapped_trajectory",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/common/trajectories/test/wrapped_trajectory_test.cc
+++ b/common/trajectories/test/wrapped_trajectory_test.cc
@@ -1,0 +1,60 @@
+#include "drake/common/trajectories/wrapped_trajectory.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/trajectories/function_handle_trajectory.h"
+
+namespace drake {
+namespace trajectories {
+namespace internal {
+namespace {
+
+Eigen::Vector2d Circle(const double& t) {
+  return Eigen::Vector2d(std::sin(t), std::cos(t));
+}
+
+Eigen::Vector2d CircleDerivative(const double& t, int order) {
+  DRAKE_DEMAND(order == 2);
+  return -Circle(t);
+}
+
+std::shared_ptr<const Trajectory<double>> MakeFunctionHandleTrajectory() {
+  const double start_time = 0;
+  const double end_time = 1;
+  auto result = std::make_shared<FunctionHandleTrajectory<double>>(
+      &Circle, 2, 1, start_time, end_time);
+  result->set_derivative(&CircleDerivative);
+  return result;
+}
+
+GTEST_TEST(WrappedTrajectoryTest, BasicTest) {
+  const WrappedTrajectory<double> dut(MakeFunctionHandleTrajectory());
+  EXPECT_EQ(dut.rows(), 2);
+  EXPECT_EQ(dut.cols(), 1);
+  EXPECT_EQ(dut.start_time(), 0);
+  EXPECT_EQ(dut.end_time(), 1);
+  EXPECT_TRUE(dut.has_derivative());
+  const double t = 0.25;
+  EXPECT_EQ(dut.value(t), Circle(t));
+  EXPECT_EQ(dut.EvalDerivative(t, 2), -Circle(t));
+  EXPECT_EQ(dut.MakeDerivative(2)->value(t), -Circle(t));
+
+  auto clone = dut.Clone();
+  EXPECT_EQ(clone->rows(), 2);
+  EXPECT_EQ(clone->cols(), 1);
+  EXPECT_EQ(clone->start_time(), 0);
+  EXPECT_EQ(clone->end_time(), 1);
+  EXPECT_TRUE(clone->has_derivative());
+  EXPECT_EQ(clone->value(t), Circle(t));
+  EXPECT_EQ(clone->EvalDerivative(t, 2), -Circle(t));
+  EXPECT_EQ(clone->MakeDerivative(2)->value(t), -Circle(t));
+  // We want a FunctionHandleTrajectory, not wrapped. See comment in cc file.
+  EXPECT_TRUE(
+      dynamic_cast<const FunctionHandleTrajectory<double>*>(clone.get()));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace trajectories
+}  // namespace drake

--- a/common/trajectories/wrapped_trajectory.cc
+++ b/common/trajectories/wrapped_trajectory.cc
@@ -1,0 +1,81 @@
+#include "drake/common/trajectories/wrapped_trajectory.h"
+
+namespace drake {
+namespace trajectories {
+namespace internal {
+
+template <typename T>
+WrappedTrajectory<T>::WrappedTrajectory(
+    std::shared_ptr<const Trajectory<T>> trajectory)
+    : trajectory_(std::move(trajectory)) {
+  DRAKE_THROW_UNLESS(trajectory_ != nullptr);
+}
+
+template <typename T>
+WrappedTrajectory<T>::~WrappedTrajectory() = default;
+
+template <typename T>
+const Trajectory<T>* WrappedTrajectory<T>::unwrap() const {
+  return trajectory_.get();
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> WrappedTrajectory<T>::DoClone() const {
+  // N.B. It's important that we directly return the nested clone, instead of
+  // wrapping it again in a WrappedTrajectory. If the class we're calling itself
+  // returns a WrappedTrajectory internally, then the number of wrappers will
+  // grow longer with each successive call to Clone(), possibly leading to
+  // accidentally quadratic runtime behavior. (Possibly we could conditionally
+  // re-wrap the result only in case it wasn't already wrapped, but why go to
+  // all of that trouble?)
+  return trajectory_->Clone();
+}
+
+template <typename T>
+MatrixX<T> WrappedTrajectory<T>::do_value(const T& t) const {
+  return trajectory_->value(t);
+}
+
+template <typename T>
+bool WrappedTrajectory<T>::do_has_derivative() const {
+  return trajectory_->has_derivative();
+}
+
+template <typename T>
+MatrixX<T> WrappedTrajectory<T>::DoEvalDerivative(const T& t,
+                                                  int derivative_order) const {
+  return trajectory_->EvalDerivative(t, derivative_order);
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> WrappedTrajectory<T>::DoMakeDerivative(
+    int derivative_order) const {
+  return trajectory_->MakeDerivative(derivative_order);
+}
+
+template <typename T>
+Eigen::Index WrappedTrajectory<T>::do_rows() const {
+  return trajectory_->rows();
+}
+
+template <typename T>
+Eigen::Index WrappedTrajectory<T>::do_cols() const {
+  return trajectory_->cols();
+}
+
+template <typename T>
+T WrappedTrajectory<T>::do_start_time() const {
+  return trajectory_->start_time();
+}
+
+template <typename T>
+T WrappedTrajectory<T>::do_end_time() const {
+  return trajectory_->end_time();
+}
+
+}  // namespace internal
+}  // namespace trajectories
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::internal::WrappedTrajectory);

--- a/common/trajectories/wrapped_trajectory.h
+++ b/common/trajectories/wrapped_trajectory.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/trajectories/trajectory.h"
+
+namespace drake {
+namespace trajectories {
+namespace internal {
+
+/* WrappedTrajectory implements the abstract Trajectory interface using a
+pre-existing concrete Trajectory object held internally as a shared_ptr
+(i.e., the "decorator" design pattern). All calls are forwarded to the nested
+Trajectory object; this is true even for the Clone() function: calling Clone
+will not necessarily return a `class WrappedTrajectory`, it will return
+whatever the underlying `trajectory->Clone()` returned.
+
+Currently, this is only used to facilitate the pydrake bindings for Trajectory.
+
+@tparam_default_scalar */
+template <typename T>
+class WrappedTrajectory final : public Trajectory<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(WrappedTrajectory);
+
+  /* Wraps the given trajectory, which must not be nullptr. */
+  explicit WrappedTrajectory(std::shared_ptr<const Trajectory<T>> trajectory);
+
+  ~WrappedTrajectory() final;
+
+  /* Returns the underlying Trajectory. */
+  const Trajectory<T>* unwrap() const;
+
+ private:
+  // Trajectory overrides.
+  std::unique_ptr<Trajectory<T>> DoClone() const final;
+  MatrixX<T> do_value(const T& t) const final;
+  bool do_has_derivative() const final;
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final;
+  std::unique_ptr<Trajectory<T>> DoMakeDerivative(
+      int derivative_order) const final;
+  Eigen::Index do_rows() const final;
+  Eigen::Index do_cols() const final;
+  T do_start_time() const final;
+  T do_end_time() const final;
+
+  std::shared_ptr<const Trajectory<T>> trajectory_;
+};
+
+}  // namespace internal
+}  // namespace trajectories
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::internal::WrappedTrajectory);


### PR DESCRIPTION
Towards #5842 and #21968.

The situation with `Trajectory` is a bit different that some of our other similar changes to bindings for those issues.  In most other cases, the only trouble comes from `Clone`, but with `Trajectory` we also have an instance factory method `MakeDerivative()` that also needs a solution.  So in this case, we'll use the **decorator** pattern to solve the ownership problem (via `internal::WrappedTrajectory`) instead of trying to deal with `Clone` directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22399)
<!-- Reviewable:end -->
