### PR TITLE
fix: DiagnosticPolicy was going out of range if records were empty

### DIFF
--- a/common/test_utilities/diagnostic_policy_test_base.h
+++ b/common/test_utilities/diagnostic_policy_test_base.h
@@ -40,14 +40,20 @@ class DiagnosticPolicyTestBase : public ::testing::Test {
   /// Remove an error from internal records and return its formatted string.
   std::string TakeError() {
     ScopedTrace trace;
-    EXPECT_FALSE(error_records_.empty());
+    if (error_records_.empty()) {
+      EXPECT_FALSE(error_records_.empty());
+      return {};
+    }
     return Take(&error_records_).FormatError();
   }
 
   /// Remove a warning from internal records and return its formatted string.
   std::string TakeWarning() {
     ScopedTrace trace;
-    EXPECT_FALSE(warning_records_.empty());
+    if (warning_records_.empty()) {
+      EXPECT_FALSE(warning_records_.empty());
+      return {};
+    }
     return Take(&warning_records_).FormatWarning();
   }
 


### PR DESCRIPTION
e.g. calling `policy.ClearDiagnositics()` then either `TakeWarning()` or `TakeError()` resulted in throwing an out of range exception.

I don't see any local test coverage for these methods, but I think that the two one-line fixes are an obvious improvement.

+@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22402)
<!-- Reviewable:end -->
