### PR TITLE
[build] CMake prefers find_package over pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ macro(override_repository NAME)
   list(APPEND BAZEL_WORKSPACE_EXCLUDES "${NAME}")
 endmacro()
 
-option(WITH_USER_EIGEN "Use user-provided Eigen3" OFF)
+option(WITH_USER_EIGEN "Use user-provided Eigen3" ON)
 
 if(WITH_USER_EIGEN)
   find_package(Eigen3 CONFIG REQUIRED)
@@ -382,7 +382,7 @@ if(WITH_USER_EIGEN)
   override_repository(eigen)
 endif()
 
-option(WITH_USER_FMT "Use user-provided fmt" OFF)
+option(WITH_USER_FMT "Use user-provided fmt" ON)
 
 if(WITH_USER_FMT)
   find_package(fmt CONFIG REQUIRED)
@@ -397,7 +397,7 @@ if(WITH_USER_FMT)
   override_repository(fmt)
 endif()
 
-option(WITH_USER_SPDLOG "Use user-provided spdlog" OFF)
+option(WITH_USER_SPDLOG "Use user-provided spdlog" ON)
 
 if(WITH_USER_SPDLOG)
   if(NOT WITH_USER_FMT)

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -23,6 +23,9 @@ EOF
 
 # Install Drake using our wheel-build-specific Python interpreter.
 cmake ../drake \
+    -DWITH_USER_EIGEN=OFF \
+    -DWITH_USER_FMT=OFF \
+    -DWITH_USER_SPDLOG=OFF \
     -DDRAKE_VERSION_OVERRIDE="${DRAKE_VERSION}" \
     -DDRAKE_GIT_SHA_OVERRIDE="${DRAKE_GIT_SHA}" \
     -DCMAKE_INSTALL_PREFIX=/opt/drake \


### PR DESCRIPTION
When we still used to support Ubuntu 18.04 we couldn't do this (since Bazel didn't use pkg-config there), but today Bazel is always just a veneer over pkg-config (for these three externals (except in wheel builds)) so doesn't add anything useful anymore.

Towards #20731.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22421)
<!-- Reviewable:end -->
