### PR TITLE
[workspace] Fix typo in deprecation.bzl

### DIFF
--- a/tools/workspace/deprecation.bzl
+++ b/tools/workspace/deprecation.bzl
@@ -7,7 +7,7 @@ def _impl(repo_ctx):
 
     build = "load(\"@drake//tools/skylark:cc.bzl\", \"cc_library\")\n"
     build += "load(\"@drake//tools/skylark:py.bzl\", \"py_library\")\n"
-    build = "package(default_visibility = [\"//visibility:public\"])\n"
+    build += "package(default_visibility = [\"//visibility:public\"])\n"
     deprecation = "".join([
         "DRAKE DEPRECATED: The @{} external is deprecated".format(name),
         " and will be removed from Drake on or after {}.".format(date),


### PR DESCRIPTION
The load statements are not always required due to Bazel's built-in rules, so I guess we never noticed this before.

Amends #20230.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22422)
<!-- Reviewable:end -->
