### PR TITLE
[common] Enable AVX512 when available

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -24,6 +24,7 @@ drake_cc_package_library(
         ":bit_cast",
         ":cond",
         ":copyable_unique_ptr",
+        ":cpu_capabilities",
         ":default_scalars",
         ":diagnostic_policy",
         ":double",
@@ -125,6 +126,16 @@ drake_cc_library(
     hdrs = ["cond.h"],
     deps = [
         ":double",
+    ],
+)
+
+drake_cc_library(
+    name = "cpu_capabilities",
+    srcs = ["cpu_capabilities.cc"],
+    hdrs = ["cpu_capabilities.h"],
+    implementation_deps = [
+        ":essential",
+        "@highway_internal//:hwy",
     ],
 )
 
@@ -386,6 +397,9 @@ drake_cc_library(
         # default list of targets and write down the CPUs we care about one by
         # one so that the test / support burden is better matched to our needs.
         #
+        # If you change this list, you must also fix common/cpu_capabilities.cc
+        # to allow opt-out of the new CPU feature with an environment variable.
+        #
         # Highway represents target sets using a bitmask. Each target is given
         # a single bit (e.g., '#define HWY_AVX2 (1LL << 9)'). To express a set
         # of targets (e.g., to set HWY_DISABLED_TARGETS) we must binary-or the
@@ -404,9 +418,7 @@ drake_cc_library(
                 # x86: SIMD with 256-bit lanes and FMA.
                 "HWY_AVX2",
                 # x86: SIMD with the improved 512VL encodings.
-                # TODO(jwnimmer-tri) Enable this once we support opt-out of CPU
-                # targets via NPY_DISABLE_CPU_FEATURES environment variable.
-                # "HWY_AVX3",
+                "HWY_AVX3",
                 # arm: SIMD that has fixed 256-bit lanes.
                 # TODO(jwnimmer-tri) Enable this once we can test it.
                 # "HWY_SVE_256",
@@ -416,6 +428,7 @@ drake_cc_library(
     internal = True,
     visibility = ["//:__subpackages__"],
     deps = [
+        ":cpu_capabilities",
         ":essential",
     ],
 )
@@ -738,6 +751,26 @@ drake_cc_googletest(
     name = "bit_cast_test",
     deps = [
         ":bit_cast",
+    ],
+)
+
+drake_cc_binary(
+    name = "cpu_capabilities_test_device",
+    testonly = True,
+    srcs = ["test/cpu_capabilities_test_device.cc"],
+    deps = [
+        ":cpu_capabilities",
+        "@highway_internal//:hwy",
+    ],
+)
+
+drake_py_unittest(
+    name = "cpu_capabilities_test",
+    data = [
+        ":cpu_capabilities_test_device",
+    ],
+    deps = [
+        "@rules_python//python/runfiles",
     ],
 )
 

--- a/common/cpu_capabilities.cc
+++ b/common/cpu_capabilities.cc
@@ -1,0 +1,105 @@
+#include "drake/common/cpu_capabilities.h"
+
+#include <cstdlib>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "hwy/detect_targets.h"
+
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace internal {
+namespace {
+
+std::string_view GetDisableCpuFeaturesEnvVar() {
+  const char* const drake_env = std::getenv("DRAKE_DISABLE_CPU_FEATURES");
+  if (drake_env != nullptr) {
+    return std::string_view{drake_env};
+  }
+  const char* const npy_env = std::getenv("NPY_DISABLE_CPU_FEATURES");
+  if (npy_env != nullptr) {
+    return std::string_view{npy_env};
+  }
+  return std::string_view{};
+}
+
+// A comma-, tab-, or space-separated list of features to disable.
+// https://numpy.org/devdocs/reference/simd/build-options.html#runtime-dispatch
+std::vector<std::string_view> GetParsedDisableCpuFeaturesEnvVar() {
+  std::vector<std::string_view> result;
+  std::string_view remaining = GetDisableCpuFeaturesEnvVar();
+  while (!remaining.empty()) {
+    std::string_view token;
+    const size_t separator = remaining.find_first_of(",\t ");
+    if (separator != std::string_view::npos) {
+      token = remaining.substr(0, separator);
+      remaining = remaining.substr(separator + 1);
+      // Note that remaining might still begin with a separator in case there
+      // were two in a row, but that's fine -- we skip over empty tokens below.
+    } else {
+      token = remaining;
+      remaining = {};
+    }
+    if (!token.empty()) {
+      result.push_back(token);
+    }
+  }
+  return result;
+}
+
+struct Capabilities {
+  bool allow_avx2{true};
+  bool allow_avx3{true};
+};
+
+/* Returns the allowed capabilities while accounting for environment variables.
+The environment variables let the user turn off certain instructions. If they
+request to turn off an instruction that could be used by our HWY_AVX2 code then
+we turn off HWY_AVX2. If they request to turn off an instruction that could be
+used by our HWY_AVX3 code then we turn off HWY_AVX3. In short, our job here is
+to parse through which instructions the user has requested to turn off, combine
+that with our knowledge of which instructions each HWY level might use, and turn
+off enough HWY levels to meet the user's request. */
+Capabilities CalcCapabilities() {
+  Capabilities result;
+  for (std::string_view disabled : GetParsedDisableCpuFeaturesEnvVar()) {
+    if (disabled == "AVX2") {
+      result.allow_avx2 = false;
+      result.allow_avx3 = false;
+    } else if (disabled.substr(0, 3) == "FMA") {
+      result.allow_avx2 = false;
+      result.allow_avx3 = false;
+    } else if (disabled.substr(0, 6) == "AVX512") {
+      // This is slightly conservative. The user might have only asked to turn
+      // off e.g. AVX512_SPR which is not part of HWY_AVX3 anyway, but rather
+      // than try to fiddle with the innumerable 512-bit vector instruction
+      // capabilities matrix, we'll just shut it all down (╯°□°)╯︵ ┻━┻ .
+      result.allow_avx3 = false;
+    }
+  }
+  return result;
+}
+
+const Capabilities& GetCapabilitiesSingleton() {
+  static never_destroyed<Capabilities> singleton{CalcCapabilities()};
+  return singleton.access();
+}
+
+}  // namespace
+
+int64_t GetHighwayAllowedTargetMask() {
+  const Capabilities& capabilities = GetCapabilitiesSingleton();
+  int64_t disallowed = 0;
+  if (!capabilities.allow_avx2) {
+    disallowed = disallowed | HWY_AVX2;
+  }
+  if (!capabilities.allow_avx3) {
+    disallowed = disallowed | HWY_AVX3;
+  }
+  return ~disallowed;
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/cpu_capabilities.h
+++ b/common/cpu_capabilities.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+
+namespace drake {
+
+/** @addtogroup environment_variables
+@{
+@defgroup drake_disable_cpu_features DRAKE_DISABLE_CPU_FEATURES
+
+Certain low-level code in Drake will scan for available CPU features at runtime
+and dispatch to CPU-optimized implementations.
+
+This offers the best performance, but can lead to different results when running
+on different hardware.  Users can set the environment variable
+`DRAKE_DISABLE_CPU_FEATURES` to a comma-separated list of CPU features to not
+use at runtime. This is the same idea as <a
+href="https://numpy.org/devdocs/reference/simd/build-options.html#runtime-dispatch">NumPy's
+runtime dispatch</a>.  Drake first checks if `DRAKE_DISABLE_CPU_FEATURES` is set
+and if not then falls back to check `NPY_DISABLE_CPU_FEATURES` instead, so that
+users only need to set one variable.
+
+If both `DRAKE_DISABLE_CPU_FEATURES` and `NPY_DISABLE_CPU_FEATURES` are unset,
+then all runtime dispach features are enabled (maximum performance). If
+`DRAKE_DISABLE_CPU_FEATURES` is set to the empty string, then all runtime
+dispach features are enabled (maximum performance). This is true even when
+`NPY_DISABLE_CPU_FEATURES` is set. The Drake option always has precedence.
+
+For the full list of feature strings which can be disabled, refer to the <a
+href="https://numpy.org/devdocs/reference/simd/build-options.html#supported-features">NumPy
+list of features</a>.
+
+For example, to disallow 512-bit Intel SIMD extensions:
+@code{.sh}
+export DRAKE_DISABLE_CPU_FEATURES=AVX512F
+@endcode
+@} */
+
+/* Note to Drake Developers: with our current settings in common/BUILD.bazel,
+for x86 there are only three flavors of Highway targets, which it names as:
+- PLAIN
+- AVX2
+- AVX3
+
+To force the PLAIN target at runtime, export DRAKE_DISABLE_CPU_FEATURES=AVX2.
+
+To force the AVX2 target at runtime, export DRAKE_DISABLE_CPU_FEATURES=AVX512F
+and run on a computer that actually has AVX2.
+
+To use the AVX3 target at runtime, don't set any environment variable; just run
+on a computer that actually has AVX3. */
+
+namespace internal {
+
+/* For use by hwy_dynamic_impl.h. Returns a target bitmask that is set to all
+ones except for the bits associated with targets disallowed by the environment
+variables documented above. (Therefore, in the typical case the return value
+will be all ones, i.e., -1.) */
+int64_t GetHighwayAllowedTargetMask();
+
+}  // namespace internal
+}  // namespace drake

--- a/common/hwy_dynamic_impl.h
+++ b/common/hwy_dynamic_impl.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <utility>
 
+#include "drake/common/cpu_capabilities.h"
 #include "drake/common/hwy_dynamic.h"
 
 // This file should only ever be included from `*.cc` implementation files,
@@ -63,7 +64,8 @@ class LateBoundFunction {
     drake::internal::HwyDynamicRegisterResetFunction(&Reset);
     // Force highway to select a CPU target, if it hasn't already.
     if (auto& target = hwy::GetChosenTarget(); !target.IsInitialized()) {
-      target.Update(hwy::SupportedTargets());
+      target.Update(hwy::SupportedTargets() &
+                    drake::internal::GetHighwayAllowedTargetMask());
     }
     // Retrieve the CPU-specific function pointer from the table of pointers.
     auto impl = ChooseFunctor()();

--- a/common/test/cpu_capabilities_test.py
+++ b/common/test/cpu_capabilities_test.py
@@ -1,0 +1,103 @@
+import json
+from pathlib import Path
+import subprocess
+import unittest
+
+from python import runfiles
+
+
+class TestCpuCapabilities(unittest.TestCase):
+
+    def setUp(self):
+        manifest = runfiles.Create()
+        self.device = Path(manifest.Rlocation(
+            "drake/common/cpu_capabilities_test_device"))
+
+    def _check(self, env=None, expect_avx2=True, expect_avx3=True):
+        """Runs the test device under the given environment vars, and checks
+        that it produced the expected result.
+        """
+        env = env or {}
+        with self.subTest(env=env, expect_avx2=expect_avx2,
+                          expect_avx3=expect_avx3):
+            stdout = subprocess.check_output([self.device], env=env)
+            actual = json.loads(stdout)
+            self.assertEqual(actual, dict(allow_avx2=expect_avx2,
+                                          allow_avx3=expect_avx3))
+
+    def test_default(self):
+        """No environment vars are set."""
+        self._check()
+
+    def test_drake_env(self):
+        """Only the Drake environment var is set."""
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="FMA3"),
+                    expect_avx2=False,
+                    expect_avx3=False)
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="AVX2"),
+                    expect_avx2=False,
+                    expect_avx3=False)
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="AVX512F"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="MagicPony"),
+                    expect_avx2=True,
+                    expect_avx3=True)
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="Magic,AVX512F"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="AVX512F,Pony"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+
+    def test_numpy_env(self):
+        """Only the NumPy environment var is set."""
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="FMA3"),
+                    expect_avx2=False,
+                    expect_avx3=False)
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="AVX2"),
+                    expect_avx2=False,
+                    expect_avx3=False)
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="AVX512F"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="MagicPony"),
+                    expect_avx2=True,
+                    expect_avx3=True)
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="Magic,AVX512F"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="AVX512F,Pony"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+
+        # NumPy allows tab and space beyond just comma.
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="Magic AVX512F"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="Magic  AVX512F"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="Magic\tAVX512F"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+        self._check(env=dict(NPY_DISABLE_CPU_FEATURES="Magic \t AVX512F"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+
+    def test_mixed_env(self):
+        """Both the Drake and NumPy environment vars are set.
+        Drake always wins.
+        """
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="",
+                             NPY_DISABLE_CPU_FEATURES="AVX2"),
+                    expect_avx2=True,
+                    expect_avx3=True)
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="AVX512F",
+                             NPY_DISABLE_CPU_FEATURES="AVX2"),
+                    expect_avx2=True,
+                    expect_avx3=False)
+        self._check(env=dict(DRAKE_DISABLE_CPU_FEATURES="AVX512F",
+                             NPY_DISABLE_CPU_FEATURES=""),
+                    expect_avx2=True,
+                    expect_avx3=False)

--- a/common/test/cpu_capabilities_test_device.cc
+++ b/common/test/cpu_capabilities_test_device.cc
@@ -1,0 +1,15 @@
+#include <iostream>
+
+#include "hwy/detect_targets.h"
+
+#include "drake/common/cpu_capabilities.h"
+
+int main() {
+  const int64_t allowed = drake::internal::GetHighwayAllowedTargetMask();
+  std::cout << "{ "
+            << "\"allow_avx2\": " << ((allowed & HWY_AVX2) ? "true" : "false")
+            << ", "
+            << "\"allow_avx3\": " << ((allowed & HWY_AVX3) ? "true" : "false")
+            << "}" << std::endl;
+  return 0;
+}

--- a/doc/doxygen_cxx/doxygen.h
+++ b/doc/doxygen_cxx/doxygen.h
@@ -236,6 +236,7 @@ namespace solvers {
  This section provides an inventory of environment variables relevant to Drake.
 
  - <b>\ref allow_network "DRAKE_ALLOW_NETWORK"</b>
+ - <b>\ref drake_disable_cpu_features "DRAKE_DISABLE_CPU_FEATURES"</b>
  - <b>\ref drake::Parallelism "DRAKE_NUM_THREADS"</b>
  - <b>\ref pydrake_python_logging "DRAKE_PYTHON_LOGGING"</b>
  - <b>\ref drake::common::FindResource() "DRAKE_RESOURCE_ROOT"</b>
@@ -246,6 +247,7 @@ namespace solvers {
  - <b>HOME</b>
  - <b>\ref drake::solvers::MosekSolver "MOSEKLM_LICENSE_FILE"</b> (see also
    <a href="https://docs.mosek.com/latest/licensing/client-setup.html">upstream documentation</a>)
+ - <b>\ref drake_disable_cpu_features "NPY_DISABLE_CPU_FEATURES"</b>
  - <b>OMP_NUM_THREADS</b> (see
    <a href="https://www.openmp.org/spec-html/5.0/openmpse50.html">upstream documentation</a>)
  - <b>\ref drake::multibody::PackageMap::PopulateFromRosPackagePath() "ROS_PACKAGE_PATH"</b> (see also


### PR DESCRIPTION
Towards #21850.  This doesn't yet solve the part (3) of cleaning up the build system; I'll do that in a follow-up that only focused on the build.

I didn't run a careful benchmark, but it looks like on my computer for the boxes overlap benchmark, AVX3 is about 10% faster than AVX2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22423)
<!-- Reviewable:end -->
