### PR TITLE
Adds MathematicalProgram::AddQuadraticCost w*|x-x_d|^2

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -729,13 +729,22 @@ void BindMathematicalProgram(py::module m) {
           py::arg("is_convex") = py::none(),
           doc.MathematicalProgram.AddQuadraticCost.doc_5args)
       .def("AddQuadraticErrorCost",
+          static_cast<Binding<QuadraticCost> (MathematicalProgram::*)(double,
+              const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              &MathematicalProgram::AddQuadraticErrorCost),
+          py::arg("w"), py::arg("x_desired"), py::arg("vars"),
+          doc.MathematicalProgram.AddQuadraticErrorCost
+              .doc_3args_w_x_desired_vars)
+      .def("AddQuadraticErrorCost",
           overload_cast_explicit<Binding<QuadraticCost>,
               const Eigen::Ref<const Eigen::MatrixXd>&,
               const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const VectorXDecisionVariable>&>(
               &MathematicalProgram::AddQuadraticErrorCost),
           py::arg("Q"), py::arg("x_desired"), py::arg("vars"),
-          doc.MathematicalProgram.AddQuadraticErrorCost.doc)
+          doc.MathematicalProgram.AddQuadraticErrorCost
+              .doc_3args_Q_x_desired_vars)
       .def("Add2NormSquaredCost",
           overload_cast_explicit<Binding<QuadraticCost>,
               const Eigen::Ref<const Eigen::MatrixXd>&,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -212,9 +212,10 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddQuadraticCost(np.eye(2), np.zeros(2), x, is_convex=True)
         prog.AddQuadraticCost(np.eye(2), np.zeros(2), 1, x, is_convex=True)
         prog.AddQuadraticCost(x.dot(x) + 2, is_convex=True)
-        # Redundant cost just to check the spelling.
+        # Redundant costs just to check the spelling.
         prog.AddQuadraticErrorCost(vars=x, Q=np.eye(2),
                                    x_desired=np.zeros(2))
+        prog.AddQuadraticErrorCost(vars=x, w=1, x_desired=np.ones(2))
         prog.Add2NormSquaredCost(A=np.eye(2), b=np.zeros(2), vars=x)
 
         result = mp.Solve(prog)

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -520,6 +520,21 @@ Binding<QuadraticCost> MathematicalProgram::AddQuadraticCost(
 Binding<QuadraticCost> MathematicalProgram::AddQuadraticErrorCost(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::VectorXd>& x_desired,
+    const VariableRefList& vars) {
+  return AddQuadraticErrorCost(Q, x_desired, ConcatenateVariableRefList(vars));
+}
+
+Binding<QuadraticCost> MathematicalProgram::AddQuadraticErrorCost(
+    double w, const Eigen::Ref<const Eigen::VectorXd>& x_desired,
+    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+  return AddQuadraticErrorCost(
+      w * Eigen::MatrixXd::Identity(x_desired.size(), x_desired.size()),
+      x_desired, vars);
+}
+
+Binding<QuadraticCost> MathematicalProgram::AddQuadraticErrorCost(
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::VectorXd>& x_desired,
     const Eigen::Ref<const VectorXDecisionVariable>& vars) {
   return AddCost(MakeQuadraticErrorCost(Q, x_desired), vars);
 }

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1118,15 +1118,29 @@ class MathematicalProgram {
       std::optional<bool> is_convex = std::nullopt);
 
   /**
+   * Adds a cost term of the form w*|x-x_desired|^2.
+   */
+  Binding<QuadraticCost> AddQuadraticErrorCost(
+      double w, const Eigen::Ref<const Eigen::VectorXd>& x_desired,
+      const VariableRefList& vars) {
+    return AddQuadraticErrorCost(w, x_desired,
+                                 ConcatenateVariableRefList(vars));
+  }
+
+  /**
+   * Adds a cost term of the form w*|x-x_desired|^2.
+   */
+  Binding<QuadraticCost> AddQuadraticErrorCost(
+      double w, const Eigen::Ref<const Eigen::VectorXd>& x_desired,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
+
+  /**
    * Adds a cost term of the form (x-x_desired)'*Q*(x-x_desired).
    */
   Binding<QuadraticCost> AddQuadraticErrorCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& x_desired,
-      const VariableRefList& vars) {
-    return AddQuadraticErrorCost(Q, x_desired,
-                                 ConcatenateVariableRefList(vars));
-  }
+      const VariableRefList& vars);
 
   /**
    * Adds a cost term of the form (x-x_desired)'*Q*(x-x_desired).

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3340,6 +3340,23 @@ GTEST_TEST(TestMathematicalProgram, Test2NormSquaredCost) {
   }
 }
 
+GTEST_TEST(TestMathematicalProgram, AddQuadraticErrorCost) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  const Eigen::Vector2d x_desired(1.24, 2.3);
+  const double w1 = 3.4;
+  auto obj1 = prog.AddQuadraticErrorCost(w1, x_desired, x);
+  const double w2 = -1.23;
+  auto obj2 = prog.AddQuadraticErrorCost(w2, x_desired, x);
+  const Eigen::Vector2d x_test(7.6, 8.7);
+  Eigen::VectorXd y(1);
+  obj1.evaluator()->Eval(x_test, &y);
+  const double tol = 1e-13;
+  EXPECT_NEAR(y[0], w1 * (x_test - x_desired).squaredNorm(), tol);
+  obj2.evaluator()->Eval(x_test, &y);
+  EXPECT_NEAR(y[0], w2 * (x_test - x_desired).squaredNorm(), tol);
+}
+
 GTEST_TEST(TestMathematicalProgram, AddL2NormCost) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();


### PR DESCRIPTION
Adds one more entry point to make the most common case cleaner. Mostly this will improve code readability.

+@hongkai-dai for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22424)
<!-- Reviewable:end -->
