### PR TITLE
[planning] Deprecate MaxCliqueSolverBase::Clone

### DIFF
--- a/bindings/pydrake/planning/planning_py_graph_algorithms.cc
+++ b/bindings/pydrake/planning/planning_py_graph_algorithms.cc
@@ -27,9 +27,10 @@ void DefinePlanningGraphAlgorithms(py::module m) {
             DoSolveMaxClique, adjacency_matrix);
       }
 
+      // Deprecated 2025-05-01.
       std::unique_ptr<MaxCliqueSolverBase> DoClone() const override {
-        PYBIND11_OVERRIDE_PURE(
-            std::unique_ptr<MaxCliqueSolverBase>, MaxCliqueSolverBase, DoClone);
+        throw std::logic_error(
+            "Python subclasses of MaxCliqueSolverBase do not support Clone()");
       };
     };
     const auto& cls_doc = doc.MaxCliqueSolverBase;
@@ -91,9 +92,17 @@ void DefinePlanningGraphAlgorithms(py::module m) {
     const auto& cls_doc = doc.MinCliqueCoverSolverViaGreedy;
     py::class_<MinCliqueCoverSolverViaGreedy, MinCliqueCoverSolverBase>(
         m, "MinCliqueCoverSolverViaGreedy", cls_doc.doc)
-        .def(py::init<const MaxCliqueSolverBase&, int>(),
+        .def(py::init([](MaxCliqueSolverBase& max_clique_solver,
+                          int min_clique_size) {
+          // The keep_alive is responsible for object lifetime, so we'll give
+          // the constructor an unowned pointer.
+          return std::make_unique<MinCliqueCoverSolverViaGreedy>(
+              make_unowned_shared_ptr_from_raw(&max_clique_solver),
+              min_clique_size);
+        }),
             py::arg("max_clique_solver"), py::arg("min_clique_size") = 1,
-            cls_doc.ctor.doc)
+            // Keep alive, reference: `self` keeps `max_clique_solver` alive.
+            py::keep_alive<1, 2>(), cls_doc.ctor.doc)
         .def("set_min_clique_size",
             &MinCliqueCoverSolverViaGreedy::set_min_clique_size,
             py::arg("min_clique_size"), cls_doc.set_min_clique_size.doc)

--- a/planning/graph_algorithms/max_clique_solver_base.cc
+++ b/planning/graph_algorithms/max_clique_solver_base.cc
@@ -6,6 +6,8 @@ namespace drake {
 namespace planning {
 namespace graph_algorithms {
 
+MaxCliqueSolverBase::~MaxCliqueSolverBase() = default;
+
 VectorX<bool> MaxCliqueSolverBase::SolveMaxClique(
     const Eigen::SparseMatrix<bool>& adjacency_matrix) const {
   DRAKE_THROW_UNLESS(adjacency_matrix.rows() == adjacency_matrix.cols());
@@ -13,8 +15,12 @@ VectorX<bool> MaxCliqueSolverBase::SolveMaxClique(
   return DoSolveMaxClique(adjacency_matrix);
 }
 
+// Deprecated 2025-05-01.
 std::unique_ptr<MaxCliqueSolverBase> MaxCliqueSolverBase::Clone() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return DoClone();
+#pragma GCC diagnostic pop
 }
 
 }  // namespace graph_algorithms

--- a/planning/graph_algorithms/max_clique_solver_base.h
+++ b/planning/graph_algorithms/max_clique_solver_base.h
@@ -3,6 +3,7 @@
 
 #include <Eigen/Sparse>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -16,7 +17,7 @@ namespace graph_algorithms {
  */
 class MaxCliqueSolverBase {
  public:
-  virtual ~MaxCliqueSolverBase() {}
+  virtual ~MaxCliqueSolverBase();
 
   /**
    * Given the adjacency matrix of an undirected graph, find the maximum clique
@@ -38,7 +39,7 @@ class MaxCliqueSolverBase {
   [[nodiscard]] VectorX<bool> SolveMaxClique(
       const Eigen::SparseMatrix<bool>& adjacency_matrix) const;
 
-  /** Creates a unique deep copy of this set. */
+  DRAKE_DEPRECATED("2025-05-01", "Clone is not useful and so is being removed")
   [[nodiscard]] std::unique_ptr<MaxCliqueSolverBase> Clone() const;
 
  protected:
@@ -52,6 +53,8 @@ class MaxCliqueSolverBase {
   virtual VectorX<bool> DoSolveMaxClique(
       const Eigen::SparseMatrix<bool>& adjacency_matrix) const = 0;
 
+  DRAKE_DEPRECATED("2025-05-01",
+                   "Clone and DoClone are not useful and so are being removed")
   [[nodiscard]] virtual std::unique_ptr<MaxCliqueSolverBase> DoClone()
       const = 0;
 };

--- a/planning/graph_algorithms/min_clique_cover_solver_base.cc
+++ b/planning/graph_algorithms/min_clique_cover_solver_base.cc
@@ -6,6 +6,8 @@ namespace drake {
 namespace planning {
 namespace graph_algorithms {
 
+MinCliqueCoverSolverBase::~MinCliqueCoverSolverBase() = default;
+
 std::vector<std::set<int>> MinCliqueCoverSolverBase::SolveMinCliqueCover(
     const Eigen::SparseMatrix<bool>& adjacency_matrix, bool partition) {
   DRAKE_THROW_UNLESS(adjacency_matrix.rows() == adjacency_matrix.cols());

--- a/planning/graph_algorithms/min_clique_cover_solver_base.h
+++ b/planning/graph_algorithms/min_clique_cover_solver_base.h
@@ -13,7 +13,7 @@ namespace graph_algorithms {
 
 class MinCliqueCoverSolverBase {
  public:
-  virtual ~MinCliqueCoverSolverBase() {}
+  virtual ~MinCliqueCoverSolverBase();
 
   /**
    * Given the adjacency matrix of an undirected graph, finds a (potentially

--- a/planning/graph_algorithms/min_clique_cover_solver_via_greedy.cc
+++ b/planning/graph_algorithms/min_clique_cover_solver_via_greedy.cc
@@ -37,10 +37,21 @@ void MakeFalseRowsAndColumns(const VectorX<bool>& mask, bool partition,
 }  // namespace
 
 MinCliqueCoverSolverViaGreedy::MinCliqueCoverSolverViaGreedy(
-    const MaxCliqueSolverBase& max_clique_solver, int min_clique_size)
+    std::shared_ptr<MaxCliqueSolverBase> max_clique_solver, int min_clique_size)
     : MinCliqueCoverSolverBase(),
-      max_clique_solver_(max_clique_solver.Clone()),
-      min_clique_size_(min_clique_size) {}
+      max_clique_solver_(std::move(max_clique_solver)),
+      min_clique_size_(min_clique_size) {
+  DRAKE_THROW_UNLESS(max_clique_solver_ != nullptr);
+}
+
+// Deprecated 2025-05-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+MinCliqueCoverSolverViaGreedy::MinCliqueCoverSolverViaGreedy(
+    const MaxCliqueSolverBase& max_clique_solver, int min_clique_size)
+    : MinCliqueCoverSolverViaGreedy(max_clique_solver.Clone(),
+                                    min_clique_size) {}
+#pragma GCC diagnostic pop
 
 std::vector<std::set<int>> MinCliqueCoverSolverViaGreedy::DoSolveMinCliqueCover(
     const Eigen::SparseMatrix<bool>& original_matrix, bool partition) {

--- a/planning/graph_algorithms/min_clique_cover_solver_via_greedy.h
+++ b/planning/graph_algorithms/min_clique_cover_solver_via_greedy.h
@@ -6,6 +6,7 @@
 
 #include <Eigen/Sparse>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/planning/graph_algorithms/max_clique_solver_base.h"
 #include "drake/planning/graph_algorithms/min_clique_cover_solver_base.h"
 
@@ -28,8 +29,14 @@ class MinCliqueCoverSolverViaGreedy final : public MinCliqueCoverSolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MinCliqueCoverSolverViaGreedy);
 
-  MinCliqueCoverSolverViaGreedy(const MaxCliqueSolverBase& max_clique_solver,
-                                int min_clique_size = 1);
+  /** Constructs using the given max clique solver. */
+  explicit MinCliqueCoverSolverViaGreedy(
+      std::shared_ptr<MaxCliqueSolverBase> max_clique_solver,
+      int min_clique_size = 1);
+
+  DRAKE_DEPRECATED("2025-05-01", "Pass the solver by shared_ptr not const-ref")
+  explicit MinCliqueCoverSolverViaGreedy(
+      const MaxCliqueSolverBase& max_clique_solver, int min_clique_size = 1);
 
   /**
    * Set the minimum clique size. Throws if this is less than 1.
@@ -47,7 +54,7 @@ class MinCliqueCoverSolverViaGreedy final : public MinCliqueCoverSolverBase {
       const Eigen::SparseMatrix<bool>& adjacency_matrix,
       bool partition = false) final;
 
-  std::unique_ptr<MaxCliqueSolverBase> max_clique_solver_;
+  std::shared_ptr<MaxCliqueSolverBase> max_clique_solver_;
 
   int min_clique_size_{1};
 };

--- a/planning/graph_algorithms/test/max_clique_solver_via_greedy_test.cc
+++ b/planning/graph_algorithms/test/max_clique_solver_via_greedy_test.cc
@@ -35,10 +35,15 @@ void TestMaxCliqueViaGreedy(
   EXPECT_TRUE(solution_match_found);
 }
 
-GTEST_TEST(MaxCliqueSolverViaGreedyTest, TestConstructorAndClone) {
+GTEST_TEST(MaxCliqueSolverViaGreedyTest, TestConstructor) {
   // Test the default constructor.
   MaxCliqueSolverViaGreedy solver{};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // Deprecated 2025-05-01.
   std::unique_ptr<MaxCliqueSolverBase> solver_clone = solver.Clone();
+#pragma GCC diagnostic pop
   // Clone provides a deep copy.
   EXPECT_NE(&solver, solver_clone.get());
 }

--- a/planning/graph_algorithms/test/max_clique_solver_via_mip_test.cc
+++ b/planning/graph_algorithms/test/max_clique_solver_via_mip_test.cc
@@ -77,6 +77,9 @@ GTEST_TEST(MaxCliqueSolverViaMipTest, TestConstructorSettersAndGetters) {
   EXPECT_EQ(solver2.GetSolverOptions(), options);
 }
 
+// Deprecated 2025-05-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(MaxCliqueSolverViaMipTest, TestClone) {
   const Eigen::Vector2d initial_guess = Eigen::Vector2d::Ones();
   solvers::SolverOptions options{};
@@ -90,6 +93,7 @@ GTEST_TEST(MaxCliqueSolverViaMipTest, TestClone) {
                               solver_clone_mip->GetInitialGuess().value()));
   EXPECT_EQ(solver_clone_mip->GetSolverOptions(), options);
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(MaxCliqueSolverViaMipTest, CompleteGraph) {
   for (const auto n : {3, 8}) {

--- a/planning/graph_algorithms/test/min_clique_cover_solver_via_greedy_test.cc
+++ b/planning/graph_algorithms/test/min_clique_cover_solver_via_greedy_test.cc
@@ -50,11 +50,27 @@ void TestMinCliqueCover(
   EXPECT_TRUE(solution_match_found);
 }
 
+// Deprecated 2025-05-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(MinCliqueCoverSolverViaGreedyTest,
-           TestConstructorSettersAndGetters) {
+           DeprecatedTestConstructorSettersAndGetters) {
   // Test the default constructor.
   MaxCliqueSolverViaGreedy max_clique_solver{};
   MinCliqueCoverSolverViaGreedy solver{max_clique_solver, 3};
+
+  EXPECT_EQ(solver.get_min_clique_size(), 3);
+
+  solver.set_min_clique_size(5);
+  EXPECT_EQ(solver.get_min_clique_size(), 5);
+}
+#pragma GCC diagnostic pop
+
+GTEST_TEST(MinCliqueCoverSolverViaGreedyTest,
+           TestConstructorSettersAndGetters) {
+  // Test the default constructor.
+  MinCliqueCoverSolverViaGreedy solver{
+      std::make_unique<MaxCliqueSolverViaGreedy>(), 3};
 
   EXPECT_EQ(solver.get_min_clique_size(), 3);
 
@@ -76,7 +92,8 @@ GTEST_TEST(MinCliqueCoverSolverViaGreedyTestTest, CompleteGraph) {
   std::vector<comparable_clique_solution_type> possible_solutions;
   possible_solutions.push_back(solution);
 
-  MinCliqueCoverSolverViaGreedy solver{MaxCliqueSolverViaGreedy(), 1};
+  MinCliqueCoverSolverViaGreedy solver{
+      std::make_unique<MaxCliqueSolverViaGreedy>(), 1};
 
   // There is only one clique so the min clique cover is the whole graph.
   TestMinCliqueCover(graph, false, possible_solutions, &solver);
@@ -85,7 +102,8 @@ GTEST_TEST(MinCliqueCoverSolverViaGreedyTestTest, CompleteGraph) {
 
 GTEST_TEST(MinCliqueCoverSolverViaGreedyTestTest, BullGraph) {
   Eigen::SparseMatrix<bool> graph = internal::BullGraph();
-  MinCliqueCoverSolverViaGreedy solver{MaxCliqueSolverViaGreedy(), 1};
+  MinCliqueCoverSolverViaGreedy solver{
+      std::make_unique<MaxCliqueSolverViaGreedy>(), 1};
 
   // The solution when vertices are allowed to be repeated.
   comparable_clique_solution_type solution;
@@ -117,7 +135,8 @@ GTEST_TEST(MinCliqueCoverSolverViaGreedyTestTest, BullGraph) {
 
 GTEST_TEST(MinCliqueCoverSolverViaGreedyTestTest, ButterflyGraph) {
   Eigen::SparseMatrix<bool> graph = internal::ButterflyGraph();
-  MinCliqueCoverSolverViaGreedy solver{MaxCliqueSolverViaGreedy(), 1};
+  MinCliqueCoverSolverViaGreedy solver{
+      std::make_unique<MaxCliqueSolverViaGreedy>(), 1};
 
   comparable_clique_solution_type solution;
   solution.insert(std::initializer_list<int>{0, 1, 2});
@@ -164,7 +183,8 @@ GTEST_TEST(MinCliqueCoverSolverViaGreedyTestTest, ButterflyGraph) {
 
 GTEST_TEST(MinCliqueCoverSolverViaGreedyTestTest, PetersenGraph) {
   Eigen::SparseMatrix<bool> graph = internal::PetersenGraph();
-  MinCliqueCoverSolverViaGreedy solver{MaxCliqueSolverViaGreedy(), 1};
+  MinCliqueCoverSolverViaGreedy solver{
+      std::make_unique<MaxCliqueSolverViaGreedy>(), 1};
 
   // The largest clique is of size 2, so if we ask for a cover which allows
   // repeated vertices, we will get all the edges of the adjacency matrix.


### PR DESCRIPTION
Amends #21892.  I don't understand why we offered cloning in the first place.  All of the base class methods are const.

Towards #21968.  Specifically, `PYBIND11_OVERRIDE_...(std::unique_ptr<...>, ...)` is no longer an allowed concept (Python cannot return uniquely-owned objects).  There are complicated ways around this, but in this case dropping the feature seems easiest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22425)
<!-- Reviewable:end -->
