### PR TITLE
Relax the tolerance in IpoptSolver.

### DIFF
--- a/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
+++ b/planning/trajectory_optimization/test/gcs_trajectory_optimization_test.cc
@@ -2598,7 +2598,7 @@ GTEST_TEST(GcsTrajectoryOptimizationTest, ZeroTimeTrajectory) {
 
 GTEST_TEST(GcsTrajectoryOptimizationTest, GenericSubgraphVertexCostConstraint) {
   GcsTrajectoryOptimization gcs(1);
-  const double kTol = 1e-9;
+  const double kTol = 1e-7;
   const double kMinimumDuration = 0.1;
   auto& start = gcs.AddRegions(MakeConvexSets(Point(Vector1d(0))), 0, 0);
   auto& middle = gcs.AddRegions(

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -61,14 +61,6 @@ void SetAppOptions(const std::string& default_linear_solver,
     set_string_option("linear_solver", default_linear_solver);
   }
 
-  // The default tolerance.
-  const double tol = 1.05e-10;  // Note: SNOPT is only 1e-6, but in #3712 we
-  // diagnosed that the CompareMatrices tolerance needed to be the sqrt of the
-  // constr_viol_tol
-  set_double_option("tol", tol);
-  set_double_option("constr_viol_tol", tol);
-  set_double_option("acceptable_tol", tol);
-  set_double_option("acceptable_constr_viol_tol", tol);
   set_string_option("hessian_approximation", "limited-memory");
 
   // Any user-supplied options handled below will overwrite the above defaults.

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -206,7 +206,7 @@ GTEST_TEST(IpoptSolverTest, AcceptableResult) {
 GTEST_TEST(IpoptSolverTest, QPDualSolution1) {
   IpoptSolver solver;
   ConfigureIpopt(&solver);
-  TestQPDualSolution1(solver, {} /* solver_options */, 1e-5);
+  TestQPDualSolution1(solver, {} /* solver_options */, /*tol=*/1e-4);
 }
 
 GTEST_TEST(IpoptSolverTest, QPDualSolution2) {
@@ -273,7 +273,7 @@ GTEST_TEST(IpoptSolverTest, TestNonconvexQP) {
   IpoptSolver solver;
   ConfigureIpopt(&solver);
   if (solver.available()) {
-    TestNonconvexQP(solver, false);
+    TestNonconvexQP(solver, false, /*tol=*/1E-4);
   }
 }
 

--- a/solvers/test/optimization_examples.cc
+++ b/solvers/test/optimization_examples.cc
@@ -283,7 +283,7 @@ void NonConvexQPproblem1::CheckSolution(
     const MathematicalProgramResult& result) const {
   const auto& x_value = result.GetSolution(x_);
   EXPECT_TRUE(
-      CompareMatrices(x_value, x_expected_, 1E-9, MatrixCompareType::absolute));
+      CompareMatrices(x_value, x_expected_, 1E-8, MatrixCompareType::absolute));
   ExpectSolutionCostAccurate(*prog_, result, 1E-5);
 }
 


### PR DESCRIPTION
Previously we set the tolerance to 1.05E-10, this tolerance is too tight and causing numeric problems. We switch back to IPOPT default tolerance.

This is motivated by https://github.com/RobotLocomotion/drake/pull/22361#pullrequestreview-2538121269

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22426)
<!-- Reviewable:end -->
