### PR TITLE
[build] Silence console spam from the snopt repository rule

### DIFF
--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -45,13 +45,22 @@ def snopt_repository(
         commit = "0254e961cb8c60193b0862a0428fd6a42bfb5243"
         shallow_since = "1546539374 -0500"
 
+    # Passing None to the repository rule causes DEBUG output spam from Bazel
+    # asking us to drop the unused argument, so we'll only pass non-None.
+    kwargs = dict()
+    if commit != None:
+        kwargs.update(commit = commit)
+    if shallow_since != None:
+        kwargs.update(shallow_since = shallow_since)
+    if tag != None:
+        kwargs.update(tag = tag)
+    if branch != None:
+        kwargs.update(branch = branch)
+
     _snopt_repository(
         name = name,
         remote = remote,
-        commit = commit,
-        shallow_since = shallow_since,
-        tag = tag,
-        branch = branch,
+        **kwargs
     )
 
 def _setup_git(repo_ctx):


### PR DESCRIPTION
It seems bzlmod mode is better about forwarding gripes from repository rules back to the console than workspace mode was.

```
[6:44:29 PM]  DEBUG: Rule 'drake++drake_dep_repositories+snopt' indicated that a canonical reproducible form can be obtained by dropping arguments ["tag", "branch"]
[6:44:29 PM]  DEBUG: Repository drake++drake_dep_repositories+snopt instantiated at:
[6:44:29 PM]    <builtin>: in <toplevel>
[6:44:29 PM]  Repository rule _snopt_repository defined at:
[6:44:29 PM]    external/drake+/tools/workspace/snopt/repository.bzl:209:36: in <toplevel>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22431)
<!-- Reviewable:end -->
