### PR TITLE
[build] Hotfix macOS CMake builds for MODULE.bazel

### DIFF
--- a/cmake/MODULE.bazel.in
+++ b/cmake/MODULE.bazel.in
@@ -1,5 +1,6 @@
 module(name = "drake_cmake")
 
+bazel_dep(name = "apple_support", version = "1.17.1")
 bazel_dep(name = "rules_python", version = "0.40.0")
 
 bazel_dep(name = "drake")


### PR DESCRIPTION
The ObjC toolchain must be registered by the main MODULE (which is here, in our CMake builds).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22435)
<!-- Reviewable:end -->
