### PR TITLE
Revert "[build] Hotfix CTest regex for MODULE.bazel build output"

### DIFF
--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -13,9 +13,23 @@ string(ASCII 27 ESC)
 # (i.e., [ without matching ]) and that element must be the last element of the
 # list.
 
-# Never ever EVER _**EVER**_ should CTest fail the build of its own accord.
+# "DEBUG" emitted by Bazel may be colored yellow (CSI 33m), "WARNING" emitted
+# by Bazel may be colored magenta (CSI 35m), and "warning" emitted by Clang may
+# be colored magenta (CSI 35m) and bolded (CSI 1m).
 list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
-  ".*"
+  "^DEBUG: "
+  ": DrakeDeprecationWarning: "
+  ": SyntaxWarning: invalid escape sequence "
+  "^WARNING: "
+  ": warning: "
+  ":[0-9]+: Failure$"
+  "(^${ESC}\\[33mDEBUG|^${ESC}\\[35mWARNING|: ${ESC}\\[0m${ESC}\\[0\;1\;35mwarning): ${ESC}\\[0m"
+)
+
+# "ERROR" emitted by Bazel may be colored red (CSI 31m) and bolded (CSI 1m).
+list(APPEND CTEST_CUSTOM_ERROR_MATCH
+  "^ERROR: "
+  "^${ESC}\\[31m${ESC}\\[1mERROR: ${ESC}\\[0m"
 )
 
 # Ignore various Mac CROSSTOOL-related warnings.

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -45,22 +45,13 @@ def snopt_repository(
         commit = "0254e961cb8c60193b0862a0428fd6a42bfb5243"
         shallow_since = "1546539374 -0500"
 
-    # Passing None to the repository rule causes DEBUG output spam from Bazel
-    # asking us to drop the unused argument, so we'll only pass non-None.
-    kwargs = dict()
-    if commit != None:
-        kwargs.update(commit = commit)
-    if shallow_since != None:
-        kwargs.update(shallow_since = shallow_since)
-    if tag != None:
-        kwargs.update(tag = tag)
-    if branch != None:
-        kwargs.update(branch = branch)
-
     _snopt_repository(
         name = name,
         remote = remote,
-        **kwargs
+        commit = commit,
+        shallow_since = shallow_since,
+        tag = tag,
+        branch = branch,
     )
 
 def _setup_git(repo_ctx):


### PR DESCRIPTION
This reverts commit 0783097836777a2b3906b4d08de2a3a5d740580a.

For now it's just testing https://github.com/RobotLocomotion/drake-ci/pull/300 but we hope once that lands we can actually revert this for real.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22436)
<!-- Reviewable:end -->
