### PR TITLE
Re-enable render vtk tests

### DIFF
--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -150,7 +150,7 @@ drake_cc_googletest(
         # Most tests do not render correctly on macOS CI. Instead of trying to
         # select the few that randomly happen to pass, we'll skip everything.
         # TODO(#19424) Re-enable the tests.
-        ":osx": ["--gtest_filter=-*"],
+        ":osx": ["--gtest_filter=-RenderEngineVtkTest.MeshTest"],
         "//conditions:default": [],
     }),
     data = [


### PR DESCRIPTION
Tests the current state of the render vtk tests via re-enabling them