### PR TITLE
[mujoco parser] Truncate rgba values to [0, 1]

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -918,6 +918,9 @@ class MujocoParser {
     }
     // rgba takes precedence over materials, so must be parsed after.
     ParseVectorAttribute(node, "rgba", &geom.rgba);
+    // Clamp rgba values to [0, 1]. (The MuJoCo parser passively allows values
+    // outside of this range, but Drake's Rgba will throw.)
+    geom.rgba = geom.rgba.cwiseMax(0.0).cwiseMin(1.0);
 
     // Note: The documentation suggests that at least 3 friction parameters
     // should be specified.  But humanoid_CMU.xml in the DeepMind suite

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -503,6 +503,7 @@ TEST_F(MujocoParserTest, GeometryProperties) {
           class="default_rgba"/>
     <geom name="no_collision" contype="0" conaffinity="0" />
     <geom name="no_visual" size="0.1" group="3" />
+    <geom name="rgba_out_of_range" type="sphere" size="0.1" rgba="2 0 0 1"/>
   </worldbody>
 </mujoco>
 )""";
@@ -578,6 +579,8 @@ TEST_F(MujocoParserTest, GeometryProperties) {
                   false /* has collision */, true /* has visual */);
   CheckProperties("no_visual", 1.0, Vector4d{.5, .5, .5, 1},
                   true /* has collision */, false /* has visual */);
+  // Rgba(2,0,0,1) is clamped to (1,0,0,1).
+  CheckProperties("rgba_out_of_range", 1.0, Vector4d{1, 0, 0, 1});
 
   // Confirm that the default geometry is a zero-radius sphere.
   GeometryId no_collision_id = inspector.GetGeometryIdByName(


### PR DESCRIPTION
The franka_kitchen model has rgba values outside of the normal range https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/2d1c1f95ecd9179849248a5bced308d43775e732/gymnasium_robotics/envs/assets/kitchen_franka/kitchen_assets/item_assets/oven_asset.xml#L23 . MuJoCo lets them throught, but Drake throws a Runtime error in Rgba.

This PR truncates the range so that the parser is more forgiving.

+@SeanCurtis-tri for feature review please.
Related to https://github.shared-services.aws.tri.global/robotics/anzu/issues/13763 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22445)
<!-- Reviewable:end -->
