### PR TITLE
[py parsing] Fix signatures to use Python types (not C++)

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -24,6 +24,7 @@ PYBIND11_MODULE(parsing, m) {
   constexpr auto& doc = pydrake_doc.drake.multibody;
 
   py::module::import("pydrake.common.schema");
+  py::module::import("pydrake.geometry");
   py::module::import("pydrake.multibody.tree");
 
   // CollisionFilterGroups


### PR DESCRIPTION
Towards #22450 and #17520.  Amends #22317.

See [here](https://drake.mit.edu/pydrake/pydrake.multibody.parsing.html#pydrake.multibody.parsing.Parser.scene_graph) for the C++ infection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22451)
<!-- Reviewable:end -->
