### PR TITLE
[py solvers] Fix signatures to use Python types (not C++)

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -60,6 +60,7 @@ drake_pybind_library(
         "solvers_py_csdp.cc",
         "solvers_py_evaluators.cc",
         "solvers_py_gurobi.cc",
+        "solvers_py_ids.cc",
         "solvers_py_ipopt.cc",
         "solvers_py_mathematicalprogram.cc",
         "solvers_py_mixed_integer_optimization_util.cc",

--- a/bindings/pydrake/solvers/solvers_py.cc
+++ b/bindings/pydrake/solvers/solvers_py.cc
@@ -20,6 +20,7 @@ top-level documentation for :py:mod:`pydrake.math`.
   // The order of these calls matters. Some modules rely on prior definitions.
   internal::DefineSolversEvaluators(m);
   internal::DefineProgramAttribute(m);
+  internal::DefineSolversIds(m);
   internal::DefineSolversOptions(m);
   internal::DefineSolversMathematicalProgram(m);
   internal::DefineSolversAugmentedLagrangian(m);

--- a/bindings/pydrake/solvers/solvers_py.h
+++ b/bindings/pydrake/solvers/solvers_py.h
@@ -33,6 +33,9 @@ void DefineSolversEvaluators(py::module m);
 /* Defines the GUROBI bindings. See solvers_py_gurobi.cc. */
 void DefineSolversGurobi(py::module m);
 
+/* Defines bindings per solvers_py_ids.cc */
+void DefineSolversIds(py::module m);
+
 /* Defines the IPOPT bindings. See solvers_py_ipopt.cc. */
 void DefineSolversIpopt(py::module m);
 

--- a/bindings/pydrake/solvers/solvers_py_ids.cc
+++ b/bindings/pydrake/solvers/solvers_py_ids.cc
@@ -1,0 +1,55 @@
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/solvers/solvers_py.h"
+#include "drake/solvers/solver_id.h"
+#include "drake/solvers/solver_type.h"
+
+namespace drake {
+namespace pydrake {
+namespace internal {
+
+using solvers::SolverId;
+using solvers::SolverType;
+
+void DefineSolversIds(py::module m) {
+  constexpr auto& doc = pydrake_doc.drake.solvers;
+  py::class_<SolverId>(m, "SolverId", doc.SolverId.doc)
+      .def(py::init<std::string>(), py::arg("name"), doc.SolverId.ctor.doc)
+      .def("name", &SolverId::name, doc.SolverId.name.doc)
+      .def("__hash__",
+          [](const SolverId& self) { return std::hash<SolverId>{}(self); })
+      .def(
+          "__eq__",
+          [](const SolverId& self, const SolverId& other) {
+            return self == other;
+          },
+          py::is_operator())
+      .def(
+          "__ne__",
+          [](const SolverId& self, const SolverId& other) {
+            return self != other;
+          },
+          py::is_operator());
+
+  py::enum_<SolverType> solver_type(m, "SolverType", doc.SolverType.doc);
+  solver_type  // BR
+      .value("kClp", SolverType::kClp, doc.SolverType.kClp.doc)
+      .value("kCsdp", SolverType::kCsdp, doc.SolverType.kCsdp.doc)
+      .value("kEqualityConstrainedQP", SolverType::kEqualityConstrainedQP,
+          doc.SolverType.kEqualityConstrainedQP.doc)
+      .value("kGurobi", SolverType::kGurobi, doc.SolverType.kGurobi.doc)
+      .value("kIpopt", SolverType::kIpopt, doc.SolverType.kIpopt.doc)
+      .value("kLinearSystem", SolverType::kLinearSystem,
+          doc.SolverType.kLinearSystem.doc)
+      .value("kMobyLCP", SolverType::kMobyLCP, doc.SolverType.kMobyLCP.doc)
+      .value("kMosek", SolverType::kMosek, doc.SolverType.kMosek.doc)
+      .value("kNlopt", SolverType::kNlopt, doc.SolverType.kNlopt.doc)
+      .value("kOsqp", SolverType::kOsqp, doc.SolverType.kOsqp.doc)
+      .value("kScs", SolverType::kScs, doc.SolverType.kScs.doc)
+      .value("kSnopt", SolverType::kSnopt, doc.SolverType.kSnopt.doc)
+      .value("kUnrevisedLemke", SolverType::kUnrevisedLemke,
+          doc.SolverType.kUnrevisedLemke.doc);
+}
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -336,46 +336,6 @@ void BindSolverInterface(py::module m) {
           [](const SolverInterface& self) { return self.solver_id().name(); });
 }
 
-void BindSolverIdAndType(py::module m) {
-  constexpr auto& doc = pydrake_doc.drake.solvers;
-  py::class_<SolverId>(m, "SolverId", doc.SolverId.doc)
-      .def(py::init<std::string>(), py::arg("name"), doc.SolverId.ctor.doc)
-      .def("name", &SolverId::name, doc.SolverId.name.doc)
-      .def("__hash__",
-          [](const SolverId& self) { return std::hash<SolverId>{}(self); })
-      .def(
-          "__eq__",
-          [](const SolverId& self, const SolverId& other) {
-            return self == other;
-          },
-          py::is_operator())
-      .def(
-          "__ne__",
-          [](const SolverId& self, const SolverId& other) {
-            return self != other;
-          },
-          py::is_operator());
-
-  py::enum_<SolverType> solver_type(m, "SolverType", doc.SolverType.doc);
-  solver_type  // BR
-      .value("kClp", SolverType::kClp, doc.SolverType.kClp.doc)
-      .value("kCsdp", SolverType::kCsdp, doc.SolverType.kCsdp.doc)
-      .value("kEqualityConstrainedQP", SolverType::kEqualityConstrainedQP,
-          doc.SolverType.kEqualityConstrainedQP.doc)
-      .value("kGurobi", SolverType::kGurobi, doc.SolverType.kGurobi.doc)
-      .value("kIpopt", SolverType::kIpopt, doc.SolverType.kIpopt.doc)
-      .value("kLinearSystem", SolverType::kLinearSystem,
-          doc.SolverType.kLinearSystem.doc)
-      .value("kMobyLCP", SolverType::kMobyLCP, doc.SolverType.kMobyLCP.doc)
-      .value("kMosek", SolverType::kMosek, doc.SolverType.kMosek.doc)
-      .value("kNlopt", SolverType::kNlopt, doc.SolverType.kNlopt.doc)
-      .value("kOsqp", SolverType::kOsqp, doc.SolverType.kOsqp.doc)
-      .value("kScs", SolverType::kScs, doc.SolverType.kScs.doc)
-      .value("kSnopt", SolverType::kSnopt, doc.SolverType.kSnopt.doc)
-      .value("kUnrevisedLemke", SolverType::kUnrevisedLemke,
-          doc.SolverType.kUnrevisedLemke.doc);
-}
-
 void BindMathematicalProgramResult(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.solvers;
   py::class_<MathematicalProgramResult>(
@@ -1727,7 +1687,6 @@ namespace internal {
 void DefineSolversMathematicalProgram(py::module m) {
   // This list must remain in topological dependency order.
   BindPyFunctionConstraint(m);
-  BindSolverIdAndType(m);
   BindMathematicalProgram(m);
   BindSolutionResult(m);
   BindMathematicalProgramResult(m);


### PR DESCRIPTION
Towards #22450 and #17520.

See [here](https://drake.mit.edu/pydrake/pydrake.solvers.html#pydrake.solvers.SolverOptions.SetOption) for the C++ infection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22452)
<!-- Reviewable:end -->
