### PR TITLE
[workspace] Disable unwanted highway targets globally

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -387,44 +387,6 @@ drake_cc_library(
         "hwy_dynamic.h",
         "hwy_dynamic_impl.h",
     ],
-    defines = [
-        # Highway automatically compiles our code that uses it for multiple CPU
-        # targets, so that the code is tuned as best as possible for the user's
-        # CPU that it will run on.
-        #
-        # By default Highway compiles to a ~dozen different CPU targets, but
-        # in practice Drake only cares about a few of them. We'll disable the
-        # default list of targets and write down the CPUs we care about one by
-        # one so that the test / support burden is better matched to our needs.
-        #
-        # If you change this list, you must also fix common/cpu_capabilities.cc
-        # to allow opt-out of the new CPU feature with an environment variable.
-        #
-        # Highway represents target sets using a bitmask. Each target is given
-        # a single bit (e.g., '#define HWY_AVX2 (1LL << 9)'). To express a set
-        # of targets (e.g., to set HWY_DISABLED_TARGETS) we must binary-or the
-        # per-target constants together.
-        #
-        # Highway only offers a deny-list for targets, so we'll need to deny
-        # everything and then un-deny what we want to allow. Per De Morgan's
-        # law, an ENABLE list folded over OR is the same as the negation of the
-        # same list folded over NAND; to end up with a DISABLE list, we can
-        # just drop the outermost negation, i.e., ENABLE list folded over NAND.
-        "HWY_DISABLED_TARGETS=(" + "&".join([
-            "(~({}))".format(name)
-            for name in [
-                # We must always provide a portable fallback.
-                "HWY_BASELINE_SCALAR",
-                # x86: SIMD with 256-bit lanes and FMA.
-                "HWY_AVX2",
-                # x86: SIMD with the improved 512VL encodings.
-                "HWY_AVX3",
-                # arm: SIMD that has fixed 256-bit lanes.
-                # TODO(jwnimmer-tri) Enable this once we can test it.
-                # "HWY_SVE_256",
-            ]
-        ]) + ")",
-    ],
     internal = True,
     visibility = ["//:__subpackages__"],
     deps = [

--- a/common/test/hwy_dynamic_test.cc
+++ b/common/test/hwy_dynamic_test.cc
@@ -18,6 +18,10 @@ namespace {
 using Eigen::ArrayXd;
 using Eigen::VectorXd;
 
+// TODO(jwnimmer-tri) This similar of fixture (using hwy_gtest.h) is duplicated
+// in two other places (//math and //geometry/proximity). We should probably
+// seek a more elegant way to do this, instead of copying it to more places.
+
 /* This hwy-infused test fixture replicates every test case to be run against
 every target architecture variant (e.g., SSE4, AVX2, AVX512VL, etc). When run,
 it filters the suite to only run tests that the current CPU can handle. */
@@ -33,6 +37,7 @@ class Fixture : public hwy::TestWithParamTarget {
   }
 };
 
+// Instatiate the suite for all CPU targets (using the HWY macro).
 HWY_TARGET_INSTANTIATE_TEST_SUITE_P(Fixture);
 
 TEST_P(Fixture, ArrayMulTest) {

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -1059,11 +1059,13 @@ drake_cc_googletest(
     name = "boxes_overlap_test",
     deps = [
         ":boxes_overlap",
+        "//common:hwy_dynamic",
         "//common/test_utilities:maybe_pause_for_user",
         "//geometry:meshcat",
         "//geometry:rgba",
         "//geometry:shape_specification",
         "//geometry/test_utilities:boxes_overlap_transforms",
+        "@highway_internal//:hwy_test_util",
     ],
 )
 

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -149,15 +149,13 @@ drake_cc_library(
 drake_cc_library(
     name = "geometric_transform",
     srcs = [
+        "fast_pose_composition_functions.cc",
         "hopf_coordinate.cc",
         "quaternion.cc",
         "random_rotation.cc",
         "rigid_transform.cc",
         "roll_pitch_yaw.cc",
         "rotation_matrix.cc",
-        # TODO(jeremy.nimmer) For now, this filename is inconsistent with its
-        # header name. We plan to rename it after the editing churn finishes.
-        "fast_pose_composition_functions_avx2_fma.cc",
     ],
     hdrs = [
         "fast_pose_composition_functions.h",

--- a/math/fast_pose_composition_functions.cc
+++ b/math/fast_pose_composition_functions.cc
@@ -7,7 +7,7 @@
 
 // This is the magic juju that compiles our impl functions for multiple CPUs.
 #undef HWY_TARGET_INCLUDE
-#define HWY_TARGET_INCLUDE "math/fast_pose_composition_functions_avx2_fma.cc"
+#define HWY_TARGET_INCLUDE "math/fast_pose_composition_functions.cc"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include "hwy/foreach_target.h"

--- a/math/test/fast_pose_composition_functions_test.cc
+++ b/math/test/fast_pose_composition_functions_test.cc
@@ -76,6 +76,10 @@ struct Param {
   }
 };
 
+// TODO(jwnimmer-tri) This similar of fixture (using hwy_gtest.h) is duplicated
+// in two other places (//common and //geometry/proximity). We should probably
+// seek a more elegant way to do this, instead of copying it to more places.
+
 /* This hwy-infused test fixture replicates every test case to be run against
 every target architecture variant (e.g., SSE4, AVX2, AVX512VL, etc). When run,
 it filters the suite to only run tests that the current CPU can handle. */
@@ -102,6 +106,8 @@ auto MakePermutations() {
                            Param{.args = "AAA", .inverse = true});
 }
 
+// Instatiate the suite for all CPU targets (using the HWY macro), crossed with
+// all Param permutations from MakePermutations().
 HWY_TARGET_INSTANTIATE_TEST_SUITE_P_T(FastPoseCompositionFunctions,
                                       MakePermutations());
 

--- a/tools/workspace/highway_internal/patches/disabled_targets.patch
+++ b/tools/workspace/highway_internal/patches/disabled_targets.patch
@@ -1,0 +1,52 @@
+[highway_internal] Disable all targets except what Drake wants
+
+Reasoning for not upstreaming this patch: Drake-specific build configuration.
+
+--- BUILD
++++ BUILD
+@@ -138,7 +138,44 @@
+     ":compiler_msvc": ["HWY_SHARED_DEFINE"],
+     ":compiler_clangcl": ["HWY_SHARED_DEFINE"],
+     "//conditions:default": [],
+-})
++}) + [
++    # Highway automatically compiles our code that uses it for multiple CPU
++    # targets, so that the code is tuned as best as possible for the user's
++    # CPU that it will run on.
++    #
++    # By default Highway compiles to a ~dozen different CPU targets, but
++    # in practice Drake only cares about a few of them. We'll disable the
++    # default list of targets and write down the CPUs we care about one by
++    # one so that the test / support burden is better matched to our needs.
++    #
++    # If you change this list, you must also fix common/cpu_capabilities.cc
++    # to allow opt-out of the new CPU feature with an environment variable.
++    #
++    # Highway represents target sets using a bitmask. Each target is given
++    # a single bit (e.g., '#define HWY_AVX2 (1LL << 9)'). To express a set
++    # of targets (e.g., to set HWY_DISABLED_TARGETS) we must binary-or the
++    # per-target constants together.
++    #
++    # Highway only offers a deny-list for targets, so we'll need to deny
++    # everything and then un-deny what we want to allow. Per De Morgan's
++    # law, an ENABLE list folded over OR is the same as the negation of the
++    # same list folded over NAND; to end up with a DISABLE list, we can
++    # just drop the outermost negation, i.e., ENABLE list folded over NAND.
++    "HWY_DISABLED_TARGETS=(" + "&".join([
++        "(~({}))".format(name)
++        for name in [
++            # We must always provide a portable fallback.
++            "HWY_BASELINE_SCALAR",
++            # x86: SIMD with 256-bit lanes and FMA.
++            "HWY_AVX2",
++            # x86: SIMD with the improved 512VL encodings.
++            "HWY_AVX3",
++            # arm: SIMD that has fixed 256-bit lanes.
++            # TODO(jwnimmer-tri) Enable this once we can test it.
++            # "HWY_SVE_256",
++        ]
++    ]) + ")",
++]
+ 
+ # Unused on Bazel builds, where this is not defined/known; Copybara replaces
+ # usages with an empty list.

--- a/tools/workspace/highway_internal/repository.bzl
+++ b/tools/workspace/highway_internal/repository.bzl
@@ -9,6 +9,7 @@ def highway_internal_repository(
         commit = "1.2.0",
         sha256 = "7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343",  # noqa
         patches = [
+            ":patches/disabled_targets.patch",
             ":patches/linkstatic.patch",
             ":patches/target_get_index_inline_always.patch",
             ":patches/target_update_noinline.patch",


### PR DESCRIPTION
This reduces the risk of accidental ODR violations.

Also tidies up some other highway residue:
- Upgrade the boxes_overlap_test to loop through all targets.
- Finish renaming the pose functions file.

Closes #21850.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22456)
<!-- Reviewable:end -->
