### PR TITLE
[doc] Streamline Drake build instructions

### DIFF
--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -1,42 +1,81 @@
 ---
-title: Bazel build system
+title: Developing Drake using Bazel
 ---
 
-Drake's primary build system is Bazel.  For more information about Bazel, see
-[https://bazel.build/](https://bazel.build/).
+# New Users
 
-Drake also offers a CMake build system wrapper that invokes Bazel under the
-hood.
+For first-time users, we strongly suggest using one of the pre-compiled binaries
+described on our [installation](/installation.html) page. If you need to install
+Drake from source please refer to the
+[CMake instructions](from_source.html#supported-configurations).
+If your organization already uses Bazel for its builds, you can build Drake as a
+Bazel external; see [Building with Bazel](/from_source.html#building-with-bazel).
 
-# Bazel Installation
+This page describes how Drake Developers (and contributors making pull requests)
+should develop and test their changes locally.
 
-Follow Drake's
-[platform-specific setup instructions](/from_source.html#mandatory-platform-specific-instructions)
-to install bazelisk at ``/usr/bin/bazel``, which will then automatically
-download the correct version of Bazel necessary for the build.
+# Introduction
 
-# Drake clone and platform setup
+Drake's primary build system is [Bazel](https://bazel.build/), which our
+developers use to build and test locally and in CI. Bazel enables speedy
+development via fine-grained caching of all actions, including tests.
 
-* Start with a **git clone** of drake, per the [Getting Drake](/from_source.html#getting-drake)
-  instructions.
-* Continue with the *"Mandatory platform-specific instructions"* on the same
-  page.
+For end users, Drake also offers a CMake build system wrapper that invokes Bazel
+as a subprocess and maps CMake build options into Bazel build options, so that
+users can install Drake via standard tools without knowing anything about Bazel.
+See the
+[CMake instructions](from_source.html#supported-configurations)
+for details.
+
+# Getting Drake
+
+Run:
+
+```bash
+# Get the sources.
+git clone --filter=blob:none https://github.com/RobotLocomotion/drake.git
+
+# Install the developer dependencies.
+drake/setup/install_prereqs --developer
+```
+
+We suggest you keep the default clone directory name (``drake``) and not rename
+it (e.g., ``drake2``). The CLion integration will suffer if the checkout is not
+named ``drake``. (See [CLion IDE setup](clion.html) for details.)
+
+## Using a fork of Drake
+
+The above ``git clone`` command will configure Drake's primary repository as a
+remote called ``origin``. If you plan to fork Drake for development, we
+recommend that you configure your fork of Drake's primary repository as the
+``origin`` remote and Drake's primary repository as the ``upstream``
+remote. This can be done by executing the following commands:
+
+```bash
+cd drake
+git remote set-url origin git@github.com:[your github user name]/drake.git
+git remote add upstream https://github.com/RobotLocomotion/drake.git
+git remote set-url --push upstream no_push
+```
+
+We recommend that you
+[setup SSH access to github.com](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/)
+to avoid needing to type your password each time you access it.
 
 # Developing Drake using Bazel
 
-To build or test Drake, run **bazel build** or **bazel test** with the desired
-target label (and optional configuration options if desired).  We give some
-typical examples below; for more reading about target patterns, see:
-[https://docs.bazel.build/versions/main/user-manual.html#target-patterns](https://docs.bazel.build/versions/main/user-manual.html#target-patterns).
+To build or test Drake, run `bazel build` or `bazel test` with the desired
+target label (and optional configuration options if desired). We give some
+typical examples below; for more reading about target patterns, see
+[target patterns](https://bazel.build/docs/user-manual#target-patterns).
 
-On Ubuntu, the default compiler is the first ``gcc`` compiler in the ``PATH``.
-On macOS, the default compiler is the Apple LLVM compiler. To use Clang on
-Ubuntu, add ``--config=clang`` after any **bazel build**, **bazel test** or any
-other **bazel** commands.
+On Ubuntu, the default compiler is GCC. On macOS, the default compiler is the
+Apple LLVM compiler. To use Clang on Ubuntu, add ``--config=clang`` after any
+`bazel` command.
 
 Cheat sheet for operating on the entire project:
 
-```
+```bash
 cd /path/to/drake
 bazel build //...                 # Build the entire project.
 bazel test //...                  # Build and test the entire project.
@@ -46,17 +85,12 @@ bazel test --config=clang //...   # Build and test using Clang on Ubuntu.
 ```
 
 * The "``//``" means "starting from the root of the project".
-* The "``...``" means "everything including the subdirectories' ``BUILD`` files".
-    * Contrast with, e.g., the "``bazel build common:*``" explained below, where
-      only targets declared *directly* in ``drake/common/BUILD`` are compiled,
-      and not the targets in ``drake/common/trajectories/BUILD``.  The "``*``"
-      matches targets in that directory; the "``...``" also matches down into
-      subdirectories.
+* The "``...``" means "everything, recursing into subdirectories".
 
 You may use relative pathnames if your shell's working directory is not at the
 project root:
 
-```
+```bash
 cd /path/to/drake/common
 bazel build ...                   # Build everything in common and its child subdirectories.
 bazel test ...                    # Test everything in common and its child subdirectories.
@@ -64,7 +98,7 @@ bazel build //...                 # Build the entire project.
 bazel test //...                  # Build and test the entire project.
 ```
 
-* As before, the "``...``" above means "everything including subdirectories".
+* As before, the "``...``" means "everything, recursing into subdirectories".
     * In the first two lines we did not precede "``...``" with "``//``", so the
       search begins in the current directory (``common``) and not from the
       ``drake`` root.
@@ -74,17 +108,17 @@ bazel test //...                  # Build and test the entire project.
 
 Cheat sheet for operating on specific portions of the project:
 
-```
+```bash
 cd /path/to/drake
 bazel build common/...                               # Build everything in common and its child subdirectories.
 bazel build common                                   # Build libcommon.
 bazel build common:polynomial                        # Build libpolynomial.
-bazel build common:*                                 # Build everything in common but NOT its children.
+bazel build common:all                               # Build everything in common but NOT its children.
 
 bazel test common:polynomial_test                    # Run one test.
 bazel test -c dbg common:polynomial_test             # Run one test in debug mode.
 bazel test --config=memcheck common:polynomial_test  # Run one test under memcheck (valgrind).
-bazel test --config=fastmemcheck common:*            # Run common's tests under memcheck, with minimal recompiling.
+bazel test --config=fastmemcheck common:all          # Run common's tests under memcheck, with minimal recompiling.
 bazel test --config=kcov common:polynomial_test      # Run one test under kcov (see instructions below).
 bazel build -c dbg common:polynomial_test && \
   gdb bazel-bin/common/polynomial_test               # Run one test under gdb.
@@ -96,11 +130,10 @@ bazel test --config lint //...                       # Only run style checks; do
 
 * The "``:``" syntax separates target names from the directory path of the
   ``BUILD`` file they appear in. In this case, for example,
-  ``drake/common/BUILD`` specifies ``cc_test(name = "polynomial_test")``.
+  ``drake/common/BUILD`` specifies ``drake_cc_test(name = "polynomial_test")``.
 * Note that the configuration switches (``-c`` and ``--config``) influence the
   entire command. For example, running a test in ``dbg`` mode means that its
   prerequisite libraries are also compiled and linked in ``dbg`` mode.
-* For the definitions of the "``--config``" options see ``drake/tools/bazel.rc``.
 
 ## Running with Flags
 
@@ -109,7 +142,7 @@ bazel test --config lint //...                       # Only run style checks; do
 In general, to figure out what binary-specific arguments are available, add
 "``-- --help``" to your ``bazel run`` command. An an example,
 
-```
+```bash
 bazel run //examples/acrobot:run_passive -- --help
 ```
 
@@ -122,31 +155,34 @@ For running tests, you may pass custom arguments to the test program via
 
 For a C++ unittest that uses ``drake_cc_googletest``, for example:
 
-```
-bazel test multibody/plant:multibody_plant_test --test_output=streamed --nocache_test_results --test_arg=--gtest_filter='*SimpleModelCreation*'
+```bash
+bazel test //multibody/plant:multibody_plant_test --test_output=streamed --nocache_test_results --test_arg=--gtest_filter='*SimpleModelCreation*'
 ```
 
 For a Python unittest that uses ``drake_py_unittest``, for example:
 
-```
-bazel test bindings/pydrake:py/symbolic_test --test_output=streamed --nocache_test_results --test_arg=--trace=user --test_arg=TestSymbolicVariable
+```bash
+bazel test //bindings/pydrake:py/symbolic_test --test_output=streamed --nocache_test_results --test_arg=--trace=user --test_arg=TestSymbolicVariable
 ```
 
 # Updating BUILD files
 
-Please use the "``buildifier``" tool to format edits to ``BUILD`` files (in the
-same spirit as ``clang-format`` formatting C++ code):
+We use the "``buildifier``" tool to auto-format our ``BUILD`` files (in the same
+spirit as ``clang-format`` formatting C++ code):
 
-```
+```bash
 cd /path/to/drake
 bazel-bin/tools/lint/buildifier --all         # Reformat all Bazel files.
 bazel-bin/tools/lint/buildifier common/BUILD  # Only reformat one file.
 ```
 
+If a BUILD file is mis-formatted, you we see a test failure with instructions
+how to fix the problem.
+
 In most cases the ``bazel-bin/tools/lint/buildifier`` will already be compiled
 by the time you need it.  In case it's absent, you can compile it via:
 
-```
+```bash
 cd /path/to/drake
 bazel build //tools/lint:buildifier
 ```

--- a/doc/_pages/developers.md
+++ b/doc/_pages/developers.md
@@ -68,7 +68,7 @@ having been tested on Continuous Integration.
 
 Due to how the Debian ``apt`` and Homebrew package managers work, you may not
 have these exact versions on your system when (re)running
-``install_prereqs.sh``. In general, later minor versions for more stable
+``install_prereqs``. In general, later minor versions for more stable
 packages (e.g. CMake, compilers) should not prove to be too much of an issue.
 
 If you have tried and are unable to configure your system by

--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -22,7 +22,7 @@ Before getting started, install Drake's prerequisites with the additional
 ``--with-doc-only`` command line option, i.e.:
 
 ```sh
-$ sudo setup/ubuntu/install_prereqs.sh --with-doc-only
+$ setup/install_prereqs --with-doc-only
 ```
 
 # Previewing changes

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -2,10 +2,16 @@
 title: Source Installation
 ---
 
+# New Users
+
+For first-time users, we strongly suggest using one of the pre-compiled binaries
+described on our [installation](/installation.html) page. This page explains how
+to build Drake from source, which is somewhat more challenging.
+
 # Supported Configurations
 
 The following table shows the configurations and platforms that Drake
-officially supports:
+officially supports when building from source:
 
 <!-- The operating system requirements should match those listed in the root
      CMakeLists.txt. -->
@@ -41,113 +47,93 @@ setup steps.
 
 ⁽³⁾ Drake requires a compiler running in C++20 (or greater) mode.
 
-# Getting Drake
+# Building with CMake
 
-Run:
+For sample projects that show how to import Drake as a CMake external project
+(either by building Drake from source, or by downloading a pre-compiled Drake
+release) please see our gallery of
+[external examples](https://github.com/RobotLocomotion/drake-external-examples).
 
-```
-git clone --filter=blob:none https://github.com/RobotLocomotion/drake.git
-```
-
-Note: we suggest you keep the default clone directory name (``drake``) and not
-rename it (such as ``drake2``).  The CLion integration will suffer if the
-checkout directory is not named ``drake``.  (See [CLion IDE setup](clion.html) for details.)
-
-Note: the build process may encounter problems if you have unusual characters
-like parentheses in the absolute path to the drake directory
-(see [#394](https://github.com/RobotLocomotion/drake/issues/394)).
-
-## Using a fork of Drake
-
-The above ``git clone`` command will configure Drake's primary repository as a
-remote called ``origin``. If you plan to fork Drake for development, we
-recommend that you configure your fork of Drake's primary repository as the
-``origin`` remote and Drake's primary repository as the ``upstream``
-remote. This can be done by executing the following commands:
-
-```
-cd drake
-git remote set-url origin git@github.com:[your github user name]/drake.git
-git remote add upstream https://github.com/RobotLocomotion/drake.git
-git remote set-url --push upstream no_push
-```
-
-We recommend that you
-[setup SSH access to github.com](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/)
-to avoid needing to type your password each time you access it.
-
-# Mandatory platform-specific instructions
-
-Before running the build, you must follow some one-time platform-specific
-setup steps.
-
-*Ubuntu:*
-
-```
-sudo ./setup/ubuntu/install_prereqs.sh
-```
-
-*macOS:*
-
-We assume that you have already installed Xcode
-([from the Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835)).
-
-After that, run:
-
-```
-./setup/mac/install_prereqs.sh
-```
-
-# Build with Bazel
-
-For instructions, jump to
-[Developing Drake using Bazel](/bazel.html#developing-drake-using-bazel),
-or check out the full details at:
-
-* [Bazel build system](/bazel.html)
-
-## Building the Python Bindings
-
-To use the Python bindings from Drake externally, we recommend using CMake.
-As an example:
+Otherwise, you can run a build from source by hand like this:
 
 ```bash
-git clone https://github.com/RobotLocomotion/drake.git
+# Get the sources.
+git clone --filter=blob:none https://github.com/RobotLocomotion/drake.git
+
+# Install the build dependencies.
+drake/setup/install_prereqs
+
+# Build and install using standard CMake commands.
 mkdir drake-build
 cd drake-build
 cmake ../drake
 make install
 ```
 
-Note that a concurrency limit passed to `make` (e.g., `make -j 2`) has almost no
-effect on the Drake build. You might need to add a bazel configuration dotfile
+To change the build options, you can run one of the standard CMake GUIs (e.g.,
+`ccmake` or `cmake-gui`) or specify command-line options with `-D` to `cmake`.
+
+## CMake options which are Drake-specific
+
+These options can be set using `-DFOO=bar` on the CMake command line, or in one
+of the CMake GUIs.
+
+Adjusting open-source dependencies:
+
+* WITH_USER_EIGEN (default OFF). When ON, uses `find_package(Eigen3)`
+  to locate a user-provided `Eigen3::Eigen` library
+  instead of hard-coding to the operating system version.
+* WITH_USER_FMT (default OFF). When ON, uses `find_package(fmt)`
+  to locate a user-provided `fmt::fmt` library
+  instead of hard-coding to the operating system version.
+* WITH_USER_SPDLOG (default OFF). When ON, uses `find_package(spdlog)`
+  to locate a user-provided `spdlog::spdlog` library
+  instead of hard-coding to the operating system version.
+
+Adjusting closed-source (commercial) software dependencies:
+
+* WITH_GUROBI (default OFF). When ON, enables the `GurobiSolver` in the build.
+  * When enabled, you must download and install Gurobi 10.0 yourself prior to
+    running Drake's CMake configure script; Drake does not automatically
+    download Gurobi. If Gurobi is not installed to its standard location, you
+    must also `export GUROBI_HOME=${...GUROBI_UNZIP_PATH...}/linux64`
+    in your terminal so that `find_package(Gurobi)` will be able to find it.
+* WITH_MOSEK (default OFF). When ON, enables the `MosekSolver` in the build.
+  * When enabled, Drake automatically downloads the MOSEK™ software from
+    `mosek.com` and installs it as part of the Drake build. The selected
+    version is hard-coded in Drake and cannot be configured.
+* WITH_SNOPT (default OFF). When ON, enables the `SnoptSolver` in the build.
+  * This option is mutally exclusive with `WITH_ROBOTLOCOMOTION_SNOPT`.
+* SNOPT_PATH (no default). When `WITH_SNOPT` is ON, this must be set to a SNOPT
+  source code archive path (e.g., `/home/user/Downloads/snopt7.4.tar.gz`) with
+  SNOPT version 7.4 (recommended) or version 7.6.
+  * Drake does not support using a SNOPT binary release (i.e., shared library);
+    it requires a source archive (i.e., the Fortran code).
+* WITH_ROBOTLOCOMOTION_SNOPT (default OFF). When ON, enables the `SnoptSolver`
+  in the build, using a hard-coded and access-controlled download of SNOPT.
+  This option is only valid for MIT- or TRI-affiliated Drake developers.
+  * This option is mutally exclusive with `WITH_SNOPT`.
+
+## CMake caveats
+
+Note that a concurrency limit passed to `make` (e.g., `make -j 2`) for a Drake
+build has almost no effect. You might need to add a bazel configuration dotfile
 to your home directory if your build is running out of memory. See the
 [troubleshooting](/troubleshooting.html#build-oom) page for details.
 
 Be aware that repeatedly running `make install` will install the recompiled
 version of Drake *on top of* the prior version. This will lead to disaster
 unless the set of installed filenames is exactly the same (because old files
-will be hanging around polluting your PYTHONPATH). It is safe if you are merely
-tweaking a source code file and repeatedly installing, without any changes to
-the build system. For any kind of larger change (e.g., upgrading to a newer
-Drake), we strongly advise that you delete the prior tree (within the `install`
-sub-directory) before running `make`.
+will be hanging around, e.g., polluting your PYTHONPATH). It is safe if you are
+merely tweaking a source code file and repeatedly installing, without any
+changes to the build system. For any kind of larger change (e.g., upgrading to a
+newer Drake), we strongly advise that you delete the prior tree (within the
+`install` sub-directory) before running `make`.
 
-Please note the additional CMake options which affect the Python bindings:
+## Running the Python Bindings after a CMake install
 
-* ``-DWITH_GUROBI={ON, [OFF]}`` - Build with Gurobi enabled.
-* ``-DWITH_MOSEK={ON, [OFF]}`` - Build with MOSEK™ enabled.
-* ``-DWITH_SNOPT={ON, [OFF]}`` - Build with SNOPT enabled.
-
-``{...}`` means a list of options, and the option surrounded by ``[...]`` is
-the default option. An example of building ``pydrake`` with both Gurobi and
-MOSEK™, without building tests:
-
-```bash
-cmake -DWITH_GUROBI=ON -DWITH_MOSEK=ON ../drake
-```
-
-You will also need to have your ``PYTHONPATH`` configured correctly.
+To run the installed copy of `pydrake`, you will also need to have your
+``PYTHONPATH`` configured correctly.
 
 *Ubuntu 22.04 (Jammy):*
 
@@ -169,3 +155,32 @@ export PYTHONPATH=${PWD}/install/lib/python3.12/site-packages:${PYTHONPATH}
 cd drake-build
 export PYTHONPATH=${PWD}/install/lib/python3.12/site-packages:${PYTHONPATH}
 ```
+
+# Building with Bazel
+
+If your organization already uses Bazel for its builds, you can build Drake as
+a Bazel external. For sample projects that show how to import Drake as a Bazel
+external (either by building Drake from source, or by downloading a pre-compiled
+Drake release) please see our gallery of
+[drake-external-examples](https://github.com/RobotLocomotion/drake-external-examples),
+either
+[drake_bazel_external](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_bazel_external)
+(to build from source) or
+[drake_bazel_download](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_bazel_download)
+(to download a precompiled release).
+
+When building Drake from source as a Bazel external, we offer flags for
+customization. Refer to the comments in
+[drake/tools/flags/BUILD.bazel](https://github.com/RobotLocomotion/drake/blob/master/tools/flags/BUILD.bazel)
+for details. The `drake_bazel_external` example demonstrates a few of the flags.
+If you enable any of proprietary solvers flags, then you must first install
+the solver and set environment variables per the
+[Proprietary Solvers](/bazel.html#proprietary-solvers) instructions.
+
+There is no way to install Drake from Bazel. To install Drake, use CMake (see
+above).
+
+# Making changes to Drake
+
+Drake developers use Bazel for development. Refer to our [Bazel
+instructions](/bazel.html) for details.

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -106,7 +106,10 @@ To use Gurobi, you must build Drake from source.
 For Python, refer to
 [Using the Python Bindings](/python_bindings.html#using-the-python-bindings).
 
-For C++, refer to either the
+For C++ sample projects that show how to import Drake as a CMake external
+project, please see our gallery of
+[external examples](https://github.com/RobotLocomotion/drake-external-examples),
+specifically either the
 [example CMake project for apt (deb)](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed_apt)
 or the
 [example CMake project for tar.gz download](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed).

--- a/doc/defs.bzl
+++ b/doc/defs.bzl
@@ -2,8 +2,8 @@
 # documentation targets (i.e., these should only be used for BUILD files
 # within @drake//doc/...).
 
-# Unless `setup/ubuntu/install_prereqs.sh --with-doc-only` has been run, most
-# tests in //doc/... will fail to pass, so by default we'll disable them.
+# Unless `setup/install_prereqs --with-doc-only` has been run, most tests
+# in //doc/... will fail to pass, so by default we'll disable them.
 #
 # A developer will have to explicitly opt-in in order to test these.
 DEFAULT_TEST_TAGS = [

--- a/doc/pydrake/build.py
+++ b/doc/pydrake/build.py
@@ -118,7 +118,7 @@ def _build(*, out_dir, temp_dir, modules):
 
     sphinx_build = "/usr/share/sphinx/scripts/python3/sphinx-build"
     if not os.path.isfile(sphinx_build):
-        print("Please re-run 'sudo setup/ubuntu/install_prereqs.sh' with the "
+        print("Please re-run 'setup/install_prereqs' with the "
               "'--with-doc-only' flag")
         sys.exit(1)
 

--- a/setup/install_prereqs
+++ b/setup/install_prereqs
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Install Drake prerequisites.
+
+set -euo pipefail
+
+# This script should be run as the normal user (i.e., `setup/install_prereqs`),
+# not under sudo (i.e., not `sudo setup/install_prereqs`). On the other hand, if
+# the normal user *is* the root user (e.g., inside Docker) then we allow it, or
+# if sudo is being used to switch users (i.e., `sudo -u otheruser ...`) then we
+# allow it. The only mistake we're trying to catch here is accidentally using
+# `sudo` out of habit (since that's what Drake previously required).
+if [[ "${EUID}" -eq 0 && -n "${SUDO_USER:+D}" ]]; then
+  echo 'This script must NOT be run through sudo' >&2
+  exit 1
+fi
+
+# We'll default to installing only the prerequisites necessary to build Drake.
+# To run tests, developers should pass the "--developer" flag. For details, see
+# https://drake.mit.edu/bazel.html and https://drake.mit.edu/from_source.html.
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  exec "${BASH_SOURCE%/*}/mac/install_prereqs.sh" \
+    --without-test-only "$@"
+else
+  maybe_sudo=
+  if [[ "${EUID}" -ne 0 ]]; then
+    maybe_sudo=sudo
+  fi
+  exec ${maybe_sudo} "${BASH_SOURCE%/*}/ubuntu/install_prereqs.sh" \
+    --without-test-only --without-bazel --without-clang "$@"
+fi

--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -10,6 +10,9 @@ source_distribution_args=()
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
+    --developer)
+      source_distribution_args+=(--developer)
+      ;;
     # Do NOT install prerequisites that are only needed to build and/or run
     # unit tests, i.e., those prerequisites that are not dependencies of
     # bazel { build, run } //:install.

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -11,6 +11,9 @@ with_test_only=1
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
+    --developer)
+      with_test_only=1
+      ;;
     # Do NOT install prerequisites that are only needed to build and/or run
     # unit tests, i.e., those prerequisites that are not dependencies of
     # bazel { build, run } //:install.

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -30,6 +30,9 @@ source_distribution_args=()
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
+    --developer)
+      source_distribution_args+=(--developer)
+      ;;
     # Install prerequisites that are only needed to build documentation,
     # i.e., those prerequisites that are dependencies of bazel run //doc:build.
     --with-doc-only)

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -20,6 +20,11 @@ with_asking=1
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
+    --developer)
+      with_bazel=1
+      with_clang=1
+      with_test_only=1
+      ;;
     # Install prerequisites that are only needed to build documentation,
     # i.e., those prerequisites that are dependencies of bazel run //doc:build.
     --with-doc-only)


### PR DESCRIPTION
There is now a single install_prereqs script for all platforms, which defaults to installing only the build prereqs (not developer prereqs). (Future work will further consolidate the implementation of the prereqs into simpler files.)

Retool our from_source (user) and bazel (developer) pages to use the new script and generally rewrite large chunks for improved clarity.

---

There are basically four main flows we focus on now:

(1) Typical users who install from binary (`installation.html`).

(2) Advanced users who need/decide to install from source (`from_source.html`).

(3) Drake developers/contributors (`bazel.html`).

(4) Downstream projects that already use Bazel (the small tail end of `from_source.html`).

The goal here is to make each of those four flows have a particular home in our docs, to have each of their flows be simple / easy / robust, and to redirect people who start from the wrong page (wrong flow) back into the flow they _should_ be using.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22461)
<!-- Reviewable:end -->
