### PR TITLE
[build] Hotfix for legacy downstreams that reuse our spdlog

### DIFF
--- a/tools/workspace/spdlog/repository.bzl
+++ b/tools/workspace/spdlog/repository.bzl
@@ -13,6 +13,8 @@ spdlog_repository = repository_rule(
         "modname": attr.string(default = "spdlog"),
         # Offered for backwards compatibility, but ignored.
         "mirrors": attr.string_list_dict(),
+        # TODO(jwnimmer-tri) Remove this line when we drop WORKSPACE support.
+        "extra_defines": attr.string_list(default = ["HAVE_SPDLOG"]),
     },
     local = True,
     configure = True,


### PR DESCRIPTION
Amends #22432.

When using bzlmod this line defines the constant:
https://github.com/RobotLocomotion/drake/blob/7e2582fd4b60267ea91aa1cdc5e82b1730a041b1/tools/workspace/spdlog/BUILD.bazel#L54

However, legacy WORKSPACE users don't end up interacting with that line, so it turns out that still need to define it in the repository rule, too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22465)
<!-- Reviewable:end -->
