### PR TITLE
[build] Hotfix for drake_cmake_external

### DIFF
--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -15,6 +15,9 @@ common --announce_rc
 # the module path to refer to what the user provided.
 common --@drake//tools/flags:public_repo_default=module
 
+# TODO(jwnimmer-tri) Ideally this would be automatically inferred.
+common --@drake//tools/install/libdrake:spdlog_dynamic=True
+
 # Flags that tweak repository rules (if any).
 common @BAZEL_REPO_ENV@
 

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load(
     "@drake//tools/workspace:cmake_configure_file.bzl",
@@ -220,7 +221,8 @@ cc_library(
 #
 # TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
 # *.so files for us, without us having to know up-front here which dependencies
-# are coming from the WORKSPACE in the form of *.so.
+# are coming from the WORKSPACE in the form of *.so. This leaks out into the
+# hacky ":is_spdlog_dynamic_true" immediately below.
 cc_library(
     name = "libdrake_runtime_so_deps",
     deps = [
@@ -230,7 +232,23 @@ cc_library(
         ":x11_deps",
         "//common:drake_marker_shared_library",
         "@lcm",
-    ],
+    ] + select({
+        ":is_spdlog_dynamic_true": ["@spdlog"],
+        "//conditions:default": [],
+    }),
+)
+
+# TODO(jwnimmer-tri) This is a hack. Find a better solution.
+bool_flag(
+    name = "spdlog_dynamic",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "is_spdlog_dynamic_true",
+    flag_values = {
+        ":spdlog_dynamic": "True",
+    },
 )
 
 # The list of depended-on header-only libraries that libdrake's header files

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -19,6 +19,8 @@ build --repo_env=DRAKE_WHEEL=1
 build --repo_env=SNOPT_PATH=${SNOPT_PATH}
 build --config=packaging
 build --define=LCM_INSTALL_JAVA=OFF
+# TODO(jwnimmer-tri) Ideally this would be automatically inferred.
+common --@drake//tools/install/libdrake:spdlog_dynamic=False
 EOF
 
 # Install Drake using our wheel-build-specific Python interpreter.

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -58,6 +58,8 @@ build --config=packaging
 build --define=LCM_INSTALL_JAVA=OFF
 # See tools/wheel/wheel_builder/macos.py for more on this env variable.
 build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
+# TODO(jwnimmer-tri) Ideally this would be automatically inferred.
+common --@drake//tools/install/libdrake:spdlog_dynamic=False
 EOF
 
 # Install Drake.


### PR DESCRIPTION
Amends #22432.

When using CMake (but not during wheel builds, which link spdlog statically into libdrake), we must preserve the linker flags to find `libspdlog.so.#` and `libfmt.so.#`.  This is tested by [drake_cmake_external](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_external) downstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22467)
<!-- Reviewable:end -->
