### PR TITLE
Avoid spdlog in inlined header functions

### DIFF
--- a/common/scoped_singleton.h
+++ b/common/scoped_singleton.h
@@ -6,7 +6,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/never_destroyed.h"
-#include "drake/common/text_logging.h"
 
 namespace drake {
 

--- a/common/symbolic/expression/test/expression_matrix_test.cc
+++ b/common/symbolic/expression/test/expression_matrix_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace symbolic {

--- a/common/test_utilities/eigen_matrix_compare.h
+++ b/common/test_utilities/eigen_matrix_compare.h
@@ -9,7 +9,6 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/fmt_eigen.h"
-#include "drake/common/text_logging.h"
 
 namespace drake {
 

--- a/examples/planar_gripper/planar_gripper_common.cc
+++ b/examples/planar_gripper/planar_gripper_common.cc
@@ -8,6 +8,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/text_logging.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
 namespace drake {

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -8,6 +8,7 @@
 #include <common_robotics_utilities/parallelism.hpp>
 
 #include "drake/common/is_approx_equal_abstol.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/optimization/hyperrectangle.h"
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/choose_best_solver.h"

--- a/geometry/optimization/cspace_free_internal.cc
+++ b/geometry/optimization/cspace_free_internal.cc
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "drake/common/text_logging.h"
 #include "drake/multibody/rational/rational_forward_kinematics.h"
 #include "drake/multibody/rational/rational_forward_kinematics_internal.h"
 #include "drake/solvers/choose_best_solver.h"

--- a/geometry/optimization/cspace_free_polytope.cc
+++ b/geometry/optimization/cspace_free_polytope.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <thread>
 
+#include "drake/common/text_logging.h"
 #include "drake/geometry/optimization/cspace_free_internal.h"
 #include "drake/multibody/rational/rational_forward_kinematics.h"
 #include "drake/multibody/rational/rational_forward_kinematics_internal.h"

--- a/geometry/optimization/cspace_free_polytope_base.cc
+++ b/geometry/optimization/cspace_free_polytope_base.cc
@@ -7,6 +7,7 @@
 #include <thread>
 #include <utility>
 
+#include "drake/common/text_logging.h"
 #include "drake/geometry/optimization/cspace_free_internal.h"
 #include "drake/multibody/rational/rational_forward_kinematics_internal.h"
 

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -15,6 +15,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/parallelism.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/quadratic_form.h"
 #include "drake/solvers/choose_best_solver.h"
 #include "drake/solvers/create_constraint.h"

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -19,6 +19,7 @@
 
 #include "drake/common/overloaded.h"
 #include "drake/common/ssize.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/optimization/affine_subspace.h"
 #include "drake/geometry/optimization/vpolytope.h"
 #include "drake/math/matrix_util.h"

--- a/geometry/optimization/hyperrectangle.cc
+++ b/geometry/optimization/hyperrectangle.cc
@@ -13,6 +13,7 @@
 #include <Eigen/Eigenvalues>
 #include <fmt/format.h>
 
+#include "drake/common/text_logging.h"
 #include "drake/geometry/optimization/affine_subspace.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/solvers/solve.h"

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "drake/common/symbolic/expression.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/optimization/affine_ball.h"
 #include "drake/geometry/optimization/cartesian_product.h"
 #include "drake/geometry/optimization/convex_set.h"

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"

--- a/geometry/optimization/test/iris_in_configuration_space_test.cc
+++ b/geometry/optimization/test/iris_in_configuration_space_test.cc
@@ -4,6 +4,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/maybe_pause_for_user.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/iris.h"

--- a/geometry/proximity/deformable_contact_geometries.h
+++ b/geometry/proximity/deformable_contact_geometries.h
@@ -7,7 +7,6 @@
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/text_logging.h"
 #include "drake/geometry/deformable_mesh_with_bvh.h"
 #include "drake/geometry/proximity/hydroelastic_internal.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"

--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/proximity/deformable_contact_geometries.h"
 #include "drake/geometry/proximity/deformable_field_intersection.h"
 #include "drake/geometry/proximity/deformable_mesh_intersection.h"

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -9,6 +9,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/text_logging.h"
 #include "drake/geometry/proximity/inflate_mesh.h"
 #include "drake/geometry/proximity/make_box_field.h"
 #include "drake/geometry/proximity/make_box_mesh.h"
@@ -311,6 +312,14 @@ class NonNegativeDouble : public Validator<double> {
 
 }  // namespace
 
+void WarnNoRigidRepresentation(std::string_view shape_type_name) {
+  static const logging::Warn log_once(
+      "Rigid {} shapes are not currently supported for hydroelastic "
+      "contact; registration is allowed, but an error will be thrown "
+      "during contact.",
+      shape_type_name);
+}
+
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const HalfSpace& hs, const ProximityProperties&) {
   return RigidGeometry(hs);
@@ -401,6 +410,13 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
   // Simply use the Convex's GetConvexHull().
   return RigidGeometry(RigidMesh(make_unique<TriangleSurfaceMesh<double>>(
       MakeTriangleFromPolygonMesh(convex_spec.GetConvexHull()))));
+}
+
+void WarnNoSoftRepresentation(std::string_view shape_type_name) {
+  static const logging::Warn log_once(
+      "Soft {} shapes are not currently supported for hydroelastic contact; "
+      "registration is allowed, but an error will be thrown during contact.",
+      shape_type_name);
 }
 
 std::optional<SoftGeometry> MakeSoftRepresentation(

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -10,7 +10,6 @@
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/text_logging.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/proximity/bvh.h"
@@ -460,16 +459,15 @@ class Geometries final : public ShapeReifier {
  type is declared below.  */
 //@{
 
+/* Warning utility function for MakeRigidRepresentation(). */
+void WarnNoRigidRepresentation(std::string_view shape_type_name);
+
 /* Generic interface for handling unsupported rigid Shapes. Unsupported
  geometries will return a std::nullopt.  */
 template <typename Shape>
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Shape& shape, const ProximityProperties&) {
-  static const logging::Warn log_once(
-      "Rigid {} shapes are not currently supported for hydroelastic "
-      "contact; registration is allowed, but an error will be thrown "
-      "during contact.",
-      shape.type_name());
+  WarnNoRigidRepresentation(shape.type_name());
   return {};
 }
 
@@ -513,15 +511,15 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const HalfSpace& half_space, const ProximityProperties& props);
 
+/* Warning utility function for MakeSoftRepresentation(). */
+void WarnNoSoftRepresentation(std::string_view shape_type_name);
+
 /* Generic interface for handling unsupported soft Shapes. Unsupported
  geometries will return a std::nullopt.  */
 template <typename Shape>
 std::optional<SoftGeometry> MakeSoftRepresentation(const Shape& shape,
                                                    const ProximityProperties&) {
-  static const logging::Warn log_once(
-      "Soft {} shapes are not currently supported for hydroelastic contact; "
-      "registration is allowed, but an error will be thrown during contact.",
-      shape.type_name());
+  WarnNoSoftRepresentation(shape.type_name());
   return {};
 }
 

--- a/geometry/render_gl/test/thread_test.cc
+++ b/geometry/render_gl/test/thread_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/render_gl/factory.h"

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -26,6 +26,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/read_gltf_to_memory.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -8,6 +8,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/nice_type_name.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/systems/framework/context.h"

--- a/manipulation/util/make_arm_controller_model.cc
+++ b/manipulation/util/make_arm_controller_model.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/text_logging.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/parsing/scoped_names.h"

--- a/manipulation/util/move_ik_demo_base.cc
+++ b/manipulation/util/move_ik_demo_base.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/drake_throw.h"
 #include "drake/common/fmt_eigen.h"
+#include "drake/common/text_logging.h"
 #include "drake/manipulation/util/robot_plan_utils.h"
 #include "drake/multibody/parsing/parser.h"
 

--- a/manipulation/util/robot_plan_utils.cc
+++ b/manipulation/util/robot_plan_utils.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace manipulation {

--- a/multibody/contact_solvers/newton_with_bisection.h
+++ b/multibody/contact_solvers/newton_with_bisection.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <cmath>
 #include <functional>
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
-#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/contact_solvers/sap/sap_solver.cc
+++ b/multibody/contact_solvers/sap/sap_solver.cc
@@ -9,6 +9,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/extract_double.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/linear_solve.h"
 #include "drake/multibody/contact_solvers/block_sparse_supernodal_solver.h"
 #include "drake/multibody/contact_solvers/conex_supernodal_solver.h"

--- a/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
@@ -6,6 +6,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/maybe_pause_for_user.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/math/compute_numerical_gradient.h"
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
@@ -11,6 +11,7 @@
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/text_logging.h"
 #include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/parsing/parser.h"

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.cc
@@ -5,6 +5,7 @@
 
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
 #include "drake/multibody/parsing/parser.h"

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -11,6 +11,7 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/overloaded.h"
 #include "drake/common/scope_exit.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/geometry/meshcat_graphviz.h"
 

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -4,6 +4,7 @@
 #include <forward_list>
 #include <limits>
 
+#include "drake/common/text_logging.h"
 #include "drake/solvers/choose_best_solver.h"
 #include "drake/solvers/clp_solver.h"
 #include "drake/solvers/mathematical_program_result.h"

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -420,6 +420,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "model_directives",
+    srcs = ["model_directives.cc"],
     hdrs = ["model_directives.h"],
     visibility = ["//visibility:public"],
     deps = [

--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -4,6 +4,7 @@
 #include <memory>
 #include <set>
 
+#include "drake/common/text_logging.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/multibody/parsing/detail_make_model_name.h"
 #include "drake/multibody/parsing/detail_path_utils.h"

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -14,6 +14,7 @@
 #include <fmt/format.h>
 #include <tinyxml2.h>
 
+#include "drake/common/text_logging.h"
 #include "drake/geometry/proximity/obb.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
 #include "drake/geometry/shape_specification.h"

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -20,6 +20,7 @@
 #include <sdf/Root.hh>
 #include <sdf/World.hh>
 
+#include "drake/common/text_logging.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"

--- a/multibody/parsing/detail_usd_parser.cc
+++ b/multibody/parsing/detail_usd_parser.cc
@@ -18,6 +18,7 @@
 
 #include "drake/common/find_runfiles.h"
 #include "drake/common/temp_directory.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/multibody/parsing/detail_common.h"
 #include "drake/multibody/parsing/detail_make_model_name.h"

--- a/multibody/parsing/model_directives.cc
+++ b/multibody/parsing/model_directives.cc
@@ -1,0 +1,132 @@
+#include "drake/multibody/parsing/model_directives.h"
+
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace multibody {
+namespace parsing {
+
+bool AddWeld::IsValid() const {
+  if (parent.empty()) {
+    drake::log()->error("add_weld: `parent` must be non-empty");
+    return false;
+  } else if (child.empty()) {
+    drake::log()->error("add_weld: `child` must be non-empty");
+    return false;
+  }
+  if (X_PC) {
+    if (X_PC->base_frame) {
+      drake::log()->error(
+          "add_weld: `X_PC` must not specify a `base_frame`; the pose is "
+          "always in the parent frame.");
+      return false;
+    }
+    if (!X_PC->IsDeterministic()) {
+      drake::log()->error(
+          "add_weld: `X_PC` must specify a deterministic transform, not a "
+          "distribution.");
+      return false;
+    }
+  }
+  return true;
+}
+
+bool AddModel::IsValid() const {
+  if (file.empty()) {
+    drake::log()->error("add_model: `file` must be non-empty");
+    return false;
+  } else if (name.empty()) {
+    drake::log()->error("add_model: `name` must be non-empty");
+    return false;
+  }
+  for (const auto& [body_name, pose] : default_free_body_pose) {
+    if (!pose.IsDeterministic()) {
+      drake::log()->error(
+          "add_model: `default_free_body_pose` must specify a "
+          "deterministic transform, not a distribution.");
+      return false;
+    }
+  }
+  return true;
+}
+
+bool AddModelInstance::IsValid() const {
+  if (name.empty()) {
+    drake::log()->error("add_model_instance: `name` must be non-empty");
+    return false;
+  }
+  return true;
+}
+
+bool AddFrame::IsValid() const {
+  if (name.empty()) {
+    drake::log()->error("add_frame: `name` must be non-empty");
+    return false;
+  } else if (!X_PF.base_frame || X_PF.base_frame->empty()) {
+    drake::log()->error("add_frame: `X_PF.base_frame` must be defined");
+    return false;
+  } else if (!X_PF.IsDeterministic()) {
+    drake::log()->error(
+        "add_frame: `X_PF` must specify a deterministic transform, not a "
+        "distribution.");
+    return false;
+  }
+  return true;
+}
+
+bool AddCollisionFilterGroup::IsValid() const {
+  if (name.empty()) {
+    drake::log()->error("add_collision_filter_group: `name` must be non-empty");
+    return false;
+  } else if (members.empty() && member_groups.empty()) {
+    drake::log()->error(
+        "add_collision_filter_group:"
+        " at least one of `members` or `member_groups` must be non-empty");
+    return false;
+  }
+  return true;
+}
+
+bool AddDirectives::IsValid() const {
+  if (file.empty()) {
+    drake::log()->error("add_directives: `file` must be non-empty");
+    return false;
+  }
+  return true;
+}
+
+bool ModelDirective::IsValid() const {
+  const bool unique = (add_model.has_value() + add_model_instance.has_value() +
+                       add_frame.has_value() + add_weld.has_value() +
+                       add_collision_filter_group.has_value() +
+                       add_directives.has_value()) == 1;
+  if (!unique) {
+    drake::log()->error(
+        "directive: Specify one of `add_model`, `add_model_instance`, "
+        "`add_frame`, `add_collision_filter_group`, or `add_directives`");
+    return false;
+  } else if (add_model) {
+    return add_model->IsValid();
+  } else if (add_model_instance) {
+    return add_model_instance->IsValid();
+  } else if (add_frame) {
+    return add_frame->IsValid();
+  } else if (add_weld) {
+    return add_weld->IsValid();
+  } else if (add_collision_filter_group) {
+    return add_collision_filter_group->IsValid();
+  } else {
+    return add_directives->IsValid();
+  }
+}
+
+bool ModelDirectives::IsValid() const {
+  for (auto& directive : directives) {
+    if (!directive.IsValid()) return false;
+  }
+  return true;
+}
+
+}  // namespace parsing
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -17,6 +17,7 @@
 #include "drake/common/test_utilities/diagnostic_policy_test_base.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/rgba.h"

--- a/multibody/parsing/test/parser_manual_test.cc
+++ b/multibody/parsing/test/parser_manual_test.cc
@@ -2,6 +2,7 @@
 
 #include <gflags/gflags.h>
 
+#include "drake/common/text_logging.h"
 #include "drake/multibody/parsing/parser.h"
 
 DEFINE_bool(scene_graph, true, "include/exclude scene graph");

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -10,6 +10,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/multibody_plant.h"

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -13,7 +13,6 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_ostream.h"
-#include "drake/common/text_logging.h"
 #include "drake/math/cross_product.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -19,6 +19,7 @@
 
 #include "drake/common/drake_throw.h"
 #include "drake/common/fmt_eigen.h"
+#include "drake/common/text_logging.h"
 #include "drake/planning/linear_distance_and_interpolation_provider.h"
 
 namespace drake {

--- a/planning/iris/iris_from_clique_cover.cc
+++ b/planning/iris/iris_from_clique_cover.cc
@@ -14,6 +14,7 @@
 #include <common_robotics_utilities/parallelism.hpp>
 
 #include "drake/common/ssize.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/optimization/iris.h"
 #include "drake/planning/collision_checker.h"
 #include "drake/planning/scene_graph_collision_checker.h"

--- a/planning/iris/iris_zo.cc
+++ b/planning/iris/iris_zo.cc
@@ -6,6 +6,7 @@
 #include <common_robotics_utilities/parallelism.hpp>
 
 #include "drake/common/fmt_eigen.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/vpolytope.h"

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/maybe_pause_for_user.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/vpolytope.h"

--- a/planning/scene_graph_collision_checker.cc
+++ b/planning/scene_graph_collision_checker.cc
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "drake/common/fmt_eigen.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/scene_graph.h"

--- a/planning/test/scene_graph_collision_checker_test.cc
+++ b/planning/test/scene_graph_collision_checker_test.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/text_logging.h"
 #include "drake/planning/linear_distance_and_interpolation_provider.h"
 #include "drake/planning/robot_diagram_builder.h"
 #include "drake/planning/test/planning_test_helpers.h"

--- a/planning/test_utilities/collision_checker_abstract_test_suite.cc
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.cc
@@ -4,6 +4,7 @@
 
 #include <common_robotics_utilities/print.hpp>
 
+#include "drake/common/text_logging.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/planning/collision_avoidance.h"
 

--- a/planning/visibility_graph.cc
+++ b/planning/visibility_graph.cc
@@ -6,6 +6,8 @@
 
 #include <common_robotics_utilities/parallelism.hpp>
 
+#include "drake/common/text_logging.h"
+
 using common_robotics_utilities::parallelism::DegreeOfParallelism;
 using common_robotics_utilities::parallelism::DynamicParallelForIndexLoop;
 using common_robotics_utilities::parallelism::ParallelForBackend;

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -25,6 +25,7 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/constraint.h"
 #include "drake/solvers/decision_variable.h"

--- a/systems/analysis/integrator_base.cc
+++ b/systems/analysis/integrator_base.cc
@@ -462,6 +462,28 @@ typename IntegratorBase<T>::StepResult
   }
 }
 
+template <typename T>
+void IntegratorBase<T>::ValidateSmallerStepSize(const T& current_step_size,
+                                                const T& new_step_size) const {
+  if (new_step_size < get_working_minimum_step_size() &&
+      new_step_size < current_step_size &&  // Verify step adjusted downward.
+      min_step_exceeded_throws_) {
+    DRAKE_LOGGER_DEBUG(
+        "Integrator wants to select too small step "
+        "size of {}; working minimum is ",
+        new_step_size, get_working_minimum_step_size());
+    std::ostringstream str;
+    // TODO(russt): Link to the "debugging dynamical systems" tutorial
+    // (#17249) once it exists.
+    str << "Error control wants to select step smaller than minimum"
+        << " allowed (" << get_working_minimum_step_size()
+        << "). This is typically an indication that some part of your system "
+           "*with continuous state* is going unstable and/or is producing "
+           "excessively large derivatives.";
+    throw std::runtime_error(str.str());
+  }
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -1548,24 +1548,7 @@ class IntegratorBase {
   // Validates that a smaller step size does not fall below the working minimum
   // and throws an exception if desired.
   void ValidateSmallerStepSize(const T& current_step_size,
-                               const T& new_step_size) const {
-    if (new_step_size < get_working_minimum_step_size() &&
-        new_step_size < current_step_size &&  // Verify step adjusted downward.
-        min_step_exceeded_throws_) {
-      DRAKE_LOGGER_DEBUG("Integrator wants to select too small step "
-          "size of {}; working minimum is ", new_step_size,
-          get_working_minimum_step_size());
-      std::ostringstream str;
-      // TODO(russt): Link to the "debugging dynamical systems" tutorial
-      // (#17249) once it exists.
-      str << "Error control wants to select step smaller than minimum"
-          << " allowed (" << get_working_minimum_step_size()
-          << "). This is typically an indication that some part of your system "
-             "*with continuous state* is going unstable and/or is producing "
-             "excessively large derivatives.";
-      throw std::runtime_error(str.str());
-    }
-  }
+                               const T& new_step_size) const;
 
   // Updates the integrator statistics, accounting for a step just taken of
   // size h.

--- a/systems/analysis/test/lyapunov_test.cc
+++ b/systems/analysis/test/lyapunov_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/text_logging.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/systems/framework/vector_system.h"
 

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -13,7 +13,6 @@ trackers. */
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/text_logging.h"
 #include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/framework_common.h"
 
@@ -334,24 +333,7 @@ class DependencyTracker {
   // final steps until the pointer fixup phase.
   DependencyTracker(DependencyTicket ticket, std::string description,
                     const internal::ContextMessageInterface* owning_subcontext,
-                    CacheEntryValue* cache_value)
-      : ticket_(ticket),
-        description_(std::move(description)),
-        owning_subcontext_(owning_subcontext),  // may be nullptr
-        has_associated_cache_entry_(cache_value != nullptr),
-        cache_value_(cache_value) {
-    // If we can, connect non-cache tracker to the dummy cache entry value now.
-    if (!has_associated_cache_entry_ && owning_subcontext != nullptr)
-      cache_value_ = &owning_subcontext->dummy_cache_entry_value();
-
-    DRAKE_LOGGER_DEBUG(
-        "Tracker #{} '{}' constructed {} invalidation {:#x}{}.", ticket_,
-        description_, has_associated_cache_entry_ ? "with" : "without",
-        size_t(cache_value),
-        has_associated_cache_entry_
-            ? " cache entry " + std::to_string(cache_value->cache_index())
-            : "");
-  }
+                    CacheEntryValue* cache_value);
 
   // Copies the current tracker but with all pointers set to null, and all
   // counters reset to their default-constructed values (0 for statistics, an

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/system_visitor.h"
 

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -12,6 +12,7 @@
 #include <fmt/ranges.h>
 
 #include "drake/common/hash.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
 

--- a/systems/lcm/lcm_config_functions.cc
+++ b/systems/lcm/lcm_config_functions.cc
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "drake/common/drake_throw.h"
+#include "drake/common/text_logging.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/lcm/lcm_interface_system.h"
 #include "drake/systems/primitives/shared_pointer_system.h"

--- a/visualization/meshcat_pose_sliders.cc
+++ b/visualization/meshcat_pose_sliders.cc
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/scope_exit.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/geometry/meshcat_graphviz.h"
 


### PR DESCRIPTION
To comply with https://drake.mit.edu/styleguide/cppguide.html#Inline_Functions.

This also might help out down the road -- I anticipate conditionally hiding spdlog from our public API and [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22468)
<!-- Reviewable:end -->
