### PR TITLE
[multibody] Add URDF and SDF Parsing for Curvilinear Joints (#22196)

### DIFF
--- a/common/trajectories/piecewise_constant_curvature_trajectory.cc
+++ b/common/trajectories/piecewise_constant_curvature_trajectory.cc
@@ -206,18 +206,18 @@ PiecewiseConstantCurvatureTrajectory<T>::MakeBreakPoses(
       breaks_eigen.tail(num_segments) - breaks_eigen.head(num_segments);
 
   // Build frames for the start of each segment.
-  std::vector<math::RigidTransform<T>> segment_start_poses;
-  segment_start_poses.reserve(num_breaks);
-  segment_start_poses.push_back(initial_pose);  // X_AM(0)
+  std::vector<math::RigidTransform<T>> segment_break_poses;
+  segment_break_poses.reserve(num_breaks);
+  segment_break_poses.push_back(initial_pose);  // X_AM(0)
 
   for (size_t i = 0; i < (num_breaks - 1); i++) {
     math::RigidTransform<T> X_MiMip1 =
         CalcRelativePoseInSegment(turning_rates[i], segment_durations[i]);
     // X_AM(i+1)
-    segment_start_poses.push_back(segment_start_poses.back() * X_MiMip1);
+    segment_break_poses.push_back(segment_break_poses.back() * X_MiMip1);
   }
 
-  return segment_start_poses;
+  return segment_break_poses;
 }
 
 // Explicit instantiation for the types specified in the header

--- a/common/trajectories/piecewise_constant_curvature_trajectory.cc
+++ b/common/trajectories/piecewise_constant_curvature_trajectory.cc
@@ -10,8 +10,10 @@ template <typename T>
 PiecewiseConstantCurvatureTrajectory<T>::PiecewiseConstantCurvatureTrajectory(
     const std::vector<T>& breaks, const std::vector<T>& turning_rates,
     const Vector3<T>& initial_curve_tangent, const Vector3<T>& plane_normal,
-    const Vector3<T>& initial_position, double periodicity_tolerance)
-    : PiecewiseTrajectory<T>(breaks), segment_turning_rates_(turning_rates) {
+    const Vector3<T>& initial_position, bool is_periodic)
+    : PiecewiseTrajectory<T>(breaks),
+      segment_turning_rates_(turning_rates),
+      is_periodic_(is_periodic) {
   if (turning_rates.size() != breaks.size() - 1) {
     throw std::logic_error(
         "The number of turning rates must be equal to the number of segments.");
@@ -37,7 +39,6 @@ PiecewiseConstantCurvatureTrajectory<T>::PiecewiseConstantCurvatureTrajectory(
   segment_start_poses_ = MakeSegmentStartPoses(
       MakeInitialPose(initial_curve_tangent, plane_normal, initial_position),
       breaks, turning_rates);
-  is_periodic_ = IsNearlyPeriodic(periodicity_tolerance);
 }
 
 template <typename T>
@@ -117,7 +118,7 @@ PiecewiseConstantCurvatureTrajectory<T>::CalcSpatialAccelerationInM(
 }
 
 template <typename T>
-boolean<T> PiecewiseConstantCurvatureTrajectory<T>::IsNearlyPeriodic(
+boolean<T> PiecewiseConstantCurvatureTrajectory<T>::EndpointsAreNearlyEqual(
     double tolerance) const {
   return CalcPose(0.).IsNearlyEqualTo(CalcPose(length()), tolerance);
 }
@@ -130,7 +131,7 @@ PiecewiseConstantCurvatureTrajectory<T>::DoClone() const {
   return std::make_unique<PiecewiseConstantCurvatureTrajectory<T>>(
       this->breaks(), segment_turning_rates_,
       initial_frame.col(kCurveTangentIndex),
-      initial_frame.col(kPlaneNormalIndex), initial_pose.translation());
+      initial_frame.col(kPlaneNormalIndex), initial_pose.translation(), is_periodic_);
 }
 
 template <typename T>

--- a/common/trajectories/piecewise_constant_curvature_trajectory.h
+++ b/common/trajectories/piecewise_constant_curvature_trajectory.h
@@ -109,13 +109,10 @@ class PiecewiseConstantCurvatureTrajectory final
    lies, expressed in the parent frame, p̂_A = Mz_A (constant).
    @param initial_position The initial position of the curve expressed in
    the parent frame, p_AoMo_A(s₀).
-   @param periodicity_tolerance Tolerance used to determine if the resulting
-   trajectory is periodic, according to the metric defined by
-   IsNearlyPeriodic(). If IsNearlyPeriodic(periodicity_tolerance) is true, then
-   the newly constructed trajectory will be periodic. That is,
-   X_AM(s) = X_AM(s + k⋅L) ∀ k ∈ ℤ, where L equals length(). Subsequent calls to
-   is_periodic() will return `true`.
-
+   @param is_periodic If true, then the newly constructed trajectory will be
+   periodic. That is, X_AM(s) = X_AM(s + k⋅L) ∀ k ∈ ℤ, where L equals length().
+   Subsequent calls to is_periodic() will return `true`.
+   
    @throws std::exception if the number of turning rates does not match
    the number of segments
    @throws std::exception if or s₀ is not 0.
@@ -128,7 +125,7 @@ class PiecewiseConstantCurvatureTrajectory final
                                        const Vector3<T>& initial_curve_tangent,
                                        const Vector3<T>& plane_normal,
                                        const Vector3<T>& initial_position,
-                                       double periodicity_tolerance = 1e-8);
+                                       bool is_periodic = false);
 
   /** Scalar conversion constructor. See @ref system_scalar_conversion. */
   template <typename U>
@@ -146,19 +143,21 @@ class PiecewiseConstantCurvatureTrajectory final
                 .col(kPlaneNormalIndex)
                 .unaryExpr(ScalarValueConverter<U>{}),
             other.get_initial_pose().translation().unaryExpr(
-                ScalarValueConverter<U>{})) {}
+                ScalarValueConverter<U>{}),
+            other.is_periodic()) {}
 
   /** @returns the total arclength of the curve in meters. */
   T length() const { return this->end_time(); }
 
-  /** Returns `true` if `this` trajectory is periodic.
+  /** @returns `true` if `this` trajectory is periodic.
    That is, X_AM(s) = X_AM(s + k⋅L) ∀ k ∈ ℤ, where L equals length(). */
-  boolean<T> is_periodic() const { return is_periodic_; }
+  bool is_periodic() const { return is_periodic_; }
 
   /** Calculates the trajectory's pose X_AM(s) at the given arclength s.
 
-   @note For s < 0 and s > length() the pose is extrapolated as if the curve
-   continued with the curvature of the corresponding end segment.
+   @note If the trajectory is aperiodic, for s < 0 and s > length() the pose is
+   extrapolated as if the curve continued with the curvature of the
+   corresponding end segment.
 
    @param s The query arclength in meters.
    @returns the pose X_AM(s). */
@@ -267,8 +266,8 @@ class PiecewiseConstantCurvatureTrajectory final
    X_AM(sₙ) being equal up to the same tolerance, checked via
    RigidTransform::IsNearlyEqualTo() using `tolerance`.
 
-   @param tolerance The tolerance for periodicity check. */
-  boolean<T> IsNearlyPeriodic(double tolerance) const;
+   @param tolerance The tolerance for the pose equality check. */
+  boolean<T> EndpointsAreNearlyEqual(double tolerance) const;
 
  private:
   template <typename U>
@@ -362,8 +361,8 @@ class PiecewiseConstantCurvatureTrajectory final
   }
 
   std::vector<T> segment_turning_rates_;
+  bool is_periodic_;
   std::vector<math::RigidTransform<T>> segment_start_poses_;
-  boolean<T> is_periodic_{false};
 
   static inline constexpr size_t kCurveTangentIndex = 0;
   static inline constexpr size_t kCurveNormalIndex = 1;

--- a/common/trajectories/piecewise_constant_curvature_trajectory.h
+++ b/common/trajectories/piecewise_constant_curvature_trajectory.h
@@ -112,7 +112,7 @@ class PiecewiseConstantCurvatureTrajectory final
    @param is_periodic If true, then the newly constructed trajectory will be
    periodic. That is, X_AM(s) = X_AM(s + k⋅L) ∀ k ∈ ℤ, where L equals length().
    Subsequent calls to is_periodic() will return `true`.
-   
+
    @throws std::exception if the number of turning rates does not match
    the number of segments
    @throws std::exception if or s₀ is not 0.
@@ -340,15 +340,15 @@ class PiecewiseConstantCurvatureTrajectory final
   /* Calculates pose X_AM at the beginning of each segment.
 
    For each segment i, the returned vector's i-th element contains the
-   relative transform X_AMi = X_AM(sᵢ), for 0 <= i < to turning_rates.size().
+   relative transform X_AMi = X_AM(sᵢ), for 0 <= i < to breaks.size().
 
    @param initial_pose The initial pose of the trajectory (at s₀ = 0).
    @param breaks The vector of break points sᵢ between segments.
    @param turning_rates The vector of turning rates ρᵢ for each segment.
 
-   @returns A vector with as many entries as segments, storing at element i the
-            pose X_AMi at the beginning of the i-th segment. */
-  static std::vector<math::RigidTransform<T>> MakeSegmentStartPoses(
+   @returns A vector with as many entries as breaks, storing at element i the
+   pose X_AMi at the i-th break. */
+  static std::vector<math::RigidTransform<T>> MakeBreakPoses(
       const math::RigidTransform<T>& initial_pose, const std::vector<T>& breaks,
       const std::vector<T>& turning_rates);
 
@@ -357,12 +357,12 @@ class PiecewiseConstantCurvatureTrajectory final
    @pre Trajectory must not be empty.
   */
   const math::RigidTransform<T>& get_initial_pose() const {
-    return segment_start_poses_[0];
+    return break_poses_[0];
   }
 
   std::vector<T> segment_turning_rates_;
   bool is_periodic_;
-  std::vector<math::RigidTransform<T>> segment_start_poses_;
+  std::vector<math::RigidTransform<T>> break_poses_;
 
   static inline constexpr size_t kCurveTangentIndex = 0;
   static inline constexpr size_t kCurveNormalIndex = 1;

--- a/common/trajectories/test/piecewise_constant_curvature_trajectory_test.cc
+++ b/common/trajectories/test/piecewise_constant_curvature_trajectory_test.cc
@@ -246,16 +246,16 @@ GTEST_TEST(TestPiecewiseConstantCurvatureTrajectory, TestPeriodicity) {
   const Vector3d curve_tangent = Vector3d::UnitX();
   const PiecewiseConstantCurvatureTrajectory<double> periodic_trajectory(
       segment_breaks_periodic, turning_rates, curve_tangent, plane_normal,
-      Vector3d::Zero());
+      Vector3d::Zero(), true);
 
   const PiecewiseConstantCurvatureTrajectory<double> aperiodic_trajectory(
       segment_breaks_aperiodic, turning_rates, curve_tangent, plane_normal,
       Vector3d::Zero());
 
   EXPECT_TRUE(periodic_trajectory.is_periodic());
-  EXPECT_TRUE(periodic_trajectory.IsNearlyPeriodic(kTolerance));
+  EXPECT_TRUE(periodic_trajectory.EndpointsAreNearlyEqual(kTolerance));
   EXPECT_FALSE(aperiodic_trajectory.is_periodic());
-  EXPECT_FALSE(aperiodic_trajectory.IsNearlyPeriodic(kTolerance));
+  EXPECT_FALSE(aperiodic_trajectory.EndpointsAreNearlyEqual(kTolerance));
 
   // Test periodicity for at arbitrary value.
   const double s = 1.5;
@@ -282,11 +282,17 @@ GTEST_TEST(TestPiecewiseConstantCurvatureTrajectory, TestScalarConversion) {
   const Vector3d plane_normal = Vector3d::UnitZ();
   const Vector3d curve_tangent = Vector3d::UnitX();
   const PiecewiseConstantCurvatureTrajectory<double> double_trajectory(
-      breaks, turning_rates, curve_tangent, plane_normal, Vector3d::Zero());
+      breaks, turning_rates, curve_tangent, plane_normal, Vector3d::Zero(),
+      true);
   const PiecewiseConstantCurvatureTrajectory<AutoDiffXd> autodiff_trajectory(
       double_trajectory);
   const PiecewiseConstantCurvatureTrajectory<symbolic::Expression>
       expression_trajectory(double_trajectory);
+
+  EXPECT_TRUE(autodiff_trajectory.is_periodic() ==
+              double_trajectory.is_periodic());
+  EXPECT_TRUE(expression_trajectory.is_periodic() ==
+              double_trajectory.is_periodic());
 
   const double s_dot = 2.;
   const double s_ddot = 3.;

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -467,7 +467,7 @@ void UrdfParser::ParseCurvilinearJointCurves(
         return;
       } else if (radius <= 0.0) {
         Error(*curveNode,
-              "A curvilinear joint contains a <drake:circular_arc> with an zero "
+              "A curvilinear joint contains a <drake:circular_arc> with a zero "
               "or negative 'radius' attribute.");
         breaks->clear();
         turning_rates->clear();
@@ -482,7 +482,6 @@ void UrdfParser::ParseCurvilinearJointCurves(
         return;
       }
       length = std::abs(angle) * radius;
-      
     } else {
       Error(*root, "A curvilinear joint contains an invalid curve node.");
       breaks->clear();
@@ -723,8 +722,7 @@ void UrdfParser::ParseJoint(JointEffortLimits* joint_effort_limits,
     XMLElement* initial_tangent_node =
         node->FirstChildElement("drake:initial_tangent");
     if (initial_tangent_node) {
-      ParseVectorAttribute(initial_tangent_node, "xyz",
-                           &initial_tangent);
+      ParseVectorAttribute(initial_tangent_node, "xyz", &initial_tangent);
     }
     XMLElement* planar_normal_node =
         node->FirstChildElement("drake:plane_normal");
@@ -744,8 +742,8 @@ void UrdfParser::ParseJoint(JointEffortLimits* joint_effort_limits,
     // Note: Using initial_position = [0, 0, 0], as origin in parent frame
     // already allows user to place start of trajectory.
     PiecewiseConstantCurvatureTrajectory<double> trajectory(
-        breaks, turning_rates, initial_tangent, plane_normal,
-        Vector3d::Zero(), is_periodic);
+        breaks, turning_rates, initial_tangent, plane_normal, Vector3d::Zero(),
+        is_periodic);
     const RigidTransformd& X_PF = X_PB;
     index =
         plant

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -17,6 +17,7 @@
 #include <tinyxml2.h>
 
 #include "drake/common/sorted_pair.h"
+#include "drake/common/trajectories/piecewise_constant_curvature_trajectory.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/detail_make_model_name.h"
 #include "drake/multibody/parsing/detail_path_utils.h"
@@ -26,6 +27,7 @@
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/ball_rpy_joint.h"
+#include "drake/multibody/tree/curvilinear_joint.h"
 #include "drake/multibody/tree/fixed_offset_frame.h"
 #include "drake/multibody/tree/planar_joint.h"
 #include "drake/multibody/tree/prismatic_joint.h"
@@ -96,6 +98,9 @@ class UrdfParser {
                            std::string* type, std::string* parent_link_name,
                            std::string* child_link_name);
   void ParseScrewJointThreadPitch(XMLElement* node, double* screw_thread_pitch);
+  void ParseCurvilinearJointCurves(XMLElement* node,
+                                   std::vector<double>* breaks,
+                                   std::vector<double>* turning_rates);
   void ParseCollisionFilterGroup(XMLElement* node);
   void ParseBody(XMLElement* node, MaterialMap* materials);
   SpatialInertia<double> ExtractSpatialInertiaAboutBoExpressedInB(
@@ -419,6 +424,99 @@ void UrdfParser::ParseScrewJointThreadPitch(XMLElement* node,
   }
 }
 
+void UrdfParser::ParseCurvilinearJointCurves(
+    XMLElement* node, std::vector<double>* breaks,
+    std::vector<double>* turning_rates) {
+  XMLElement* root = node->FirstChildElement("drake:curves");
+  if (!root) {
+    Error(*node, "A curvilinear joint is missing the <drake:curves> list.");
+    return;
+  }
+  breaks->clear();
+  breaks->push_back(0.0);  // breaks needs to start with a leading 0.0 element
+  turning_rates->clear();
+  for (XMLElement* curveNode = root->FirstChildElement(); curveNode != NULL;
+       curveNode = curveNode->NextSiblingElement()) {
+    std::string nodeValue = curveNode->Value();
+    if (nodeValue != "drake:line_segment" &&
+        nodeValue != "drake:circular_arc") {
+      Error(*root, "A curvilinear joint contains an invalid curve node.");
+      breaks->clear();
+      turning_rates->clear();
+      return;
+    }
+    double length = 0.0;
+    if (!ParseScalarAttribute(curveNode, "length", &length)) {
+      Error(*curveNode,
+            "A curvilinear joint contains a <drake:line_segment> that is "
+            "missing the 'length' attribute.");
+      breaks->clear();
+      turning_rates->clear();
+      return;
+    } else if (length <= 0.0) {
+      Error(*curveNode,
+            "A curvilinear joint contains a <drake:line_segment> with an zero "
+            "or negative 'length' attribute.");
+      breaks->clear();
+      turning_rates->clear();
+      return;
+    }
+
+    double turning_rate = 0.0;
+    if (nodeValue == "drake:circular_arc") {
+      double radius = 0.0;
+      std::string direction = "";
+
+      if (!ParseScalarAttribute(curveNode, "radius", &radius)) {
+        Error(*curveNode,
+              "A curvilinear joint contains a <drake:circular_arc> that is "
+              "missing the 'radius' attribute.");
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      } else if (radius <= 0.0) {
+        Error(*curveNode,
+              "A curvilinear joint contains a <drake:circular_arc> with an "
+              "zero or negative 'radius' attribute.");
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      }
+
+      if (!ParseStringAttribute(curveNode, "direction", &direction)) {
+        Error(*curveNode,
+              fmt::format("A curvilinear joint contains a <drake:circular_arc> "
+                          "that is missing the 'direction' attribute",
+                          direction));
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      }
+      if (direction != "clockwise" && direction != "counterclockwise") {
+        Error(*curveNode,
+              fmt::format("A curvilinear joint contains a <drake:circular_arc> "
+                          "with a direction attribute which is neither "
+                          "'clockwise' nor 'counterclockwise': '{}'",
+                          direction));
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      }
+      turning_rate = direction == "counterclockwise" ? 1 / radius : -1 / radius;
+    }
+
+    breaks->push_back(breaks->back() + length);
+    turning_rates->push_back(turning_rate);  // lines have zero curvature
+  }
+
+  if (breaks->size() == 1) {
+    Error(*root, "A curvilinear joint contains an empty curves list.");
+    breaks->clear();
+    turning_rates->clear();
+    return;
+  }
+}
+
 const RigidBody<double>* UrdfParser::GetBodyForElement(
     const std::string& element_name, const std::string& link_name) {
   auto plant = w_.plant;
@@ -632,6 +730,43 @@ void UrdfParser::ParseJoint(JointEffortLimits* joint_effort_limits,
                 ->AddJoint<UniversalJoint>(name, *parent_body, X_PF,
                                            *child_body, std::nullopt, damping)
                 .index();
+  } else if (type.compare("curvilinear") == 0) {
+    throw_on_custom_joint(true);
+    ParseJointDynamics(node, &damping);
+    Vector3d initial_curve_tangent(1, 0, 0);
+    Vector3d plane_normal(0, 0, 1);
+    XMLElement* initial_curve_tangent_node =
+        node->FirstChildElement("drake:initial_curve_tangent");
+    if (initial_curve_tangent_node) {
+      ParseVectorAttribute(initial_curve_tangent_node, "xyz",
+                           &initial_curve_tangent);
+    }
+    XMLElement* planar_normal_node =
+        node->FirstChildElement("drake:plane_normal");
+    if (planar_normal_node) {
+      ParseVectorAttribute(planar_normal_node, "xyz", &plane_normal);
+    }
+    bool is_periodic = false;
+    std::string is_periodic_string = "";
+    XMLElement* is_periodic_node = node->FirstChildElement("drake:is_periodic");
+    if (is_periodic_node) {
+      ParseStringAttribute(is_periodic_node, "value", &is_periodic_string);
+      is_periodic = (is_periodic_string == "true" ? true : false);
+    }
+    std::vector<double> breaks;
+    std::vector<double> turning_rates;
+    ParseCurvilinearJointCurves(node, &breaks, &turning_rates);
+    // Note: Using initial_position = [0, 0, 0], as origin in parent frame
+    // already allows user to place start of trajectory.
+    PiecewiseConstantCurvatureTrajectory<double> trajectory(
+        breaks, turning_rates, initial_curve_tangent, plane_normal,
+        Vector3d::Zero(), is_periodic);
+    const RigidTransformd& X_PF = X_PB;
+    index =
+        plant
+            ->AddJoint<CurvilinearJoint>(name, *parent_body, X_PF, *child_body,
+                                         std::nullopt, trajectory, damping)
+            .index();
   } else {
     Error(*node,
           fmt::format("Joint '{}' has unrecognized type: '{}'", name, type));

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -438,34 +438,53 @@ void UrdfParser::ParseCurvilinearJointCurves(
   for (XMLElement* curveNode = root->FirstChildElement(); curveNode != NULL;
        curveNode = curveNode->NextSiblingElement()) {
     std::string nodeValue = curveNode->Value();
-    if (nodeValue != "drake:curve") {
-      Error(*root, "A curvilinear joint contains an invalid curve node.");
-      breaks->clear();
-      turning_rates->clear();
-      return;
-    }
     double length = 0.0;
-    if (!ParseScalarAttribute(curveNode, "length", &length)) {
-      Error(*curveNode,
-            "A curvilinear joint contains a <drake:curve> that is "
-            "missing the 'length' attribute.");
-      breaks->clear();
-      turning_rates->clear();
-      return;
-    } else if (length <= 0.0) {
-      Error(*curveNode,
-            "A curvilinear joint contains a <drake:curve> with an zero "
-            "or negative 'length' attribute.");
-      breaks->clear();
-      turning_rates->clear();
-      return;
-    }
-
     double angle = 0.0;
-    if (!ParseScalarAttribute(curveNode, "angle", &angle)) {
-      Error(*curveNode,
-            "A curvilinear joint contains a <drake:curve> that is "
-            "missing the 'angle' attribute.");
+    if (nodeValue == "drake:line_segment") {
+      if (!ParseScalarAttribute(curveNode, "length", &length)) {
+        Error(*curveNode,
+              "A curvilinear joint contains a <drake:line_segment> that is "
+              "missing the 'length' attribute.");
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      } else if (length <= 0.0) {
+        Error(*curveNode,
+              "A curvilinear joint contains a <drake:line_segment> with a zero "
+              "or negative 'length' attribute.");
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      }
+    } else if (nodeValue == "drake:circular_arc") {
+      double radius = 0.0;
+      if (!ParseScalarAttribute(curveNode, "radius", &radius)) {
+        Error(*curveNode,
+              "A curvilinear joint contains a <drake:circular_arc> that is "
+              "missing the 'radius' attribute.");
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      } else if (radius <= 0.0) {
+        Error(*curveNode,
+              "A curvilinear joint contains a <drake:circular_arc> with an zero "
+              "or negative 'radius' attribute.");
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      }
+      if (!ParseScalarAttribute(curveNode, "angle", &angle)) {
+        Error(*curveNode,
+              "A curvilinear joint contains a <drake:circular_arc> that is "
+              "missing the 'angle' attribute.");
+        breaks->clear();
+        turning_rates->clear();
+        return;
+      }
+      length = std::abs(angle) * radius;
+      
+    } else {
+      Error(*root, "A curvilinear joint contains an invalid curve node.");
       breaks->clear();
       turning_rates->clear();
       return;

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -17,6 +17,8 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/trajectories/piecewise_constant_curvature_trajectory.h"
+#include "drake/common/trajectories/trajectory.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
@@ -27,6 +29,7 @@
 #include "drake/multibody/parsing/detail_urdf_parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/ball_rpy_joint.h"
+#include "drake/multibody/tree/curvilinear_joint.h"
 #include "drake/multibody/tree/linear_bushing_roll_pitch_yaw.h"
 #include "drake/multibody/tree/planar_joint.h"
 #include "drake/multibody/tree/prismatic_joint.h"
@@ -47,6 +50,8 @@ using ::testing::MatchesRegex;
 
 using drake::internal::DiagnosticDetail;
 using drake::internal::DiagnosticPolicy;
+using drake::trajectories::PiecewiseConstantCurvatureTrajectory;
+using drake::trajectories::Trajectory;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using geometry::GeometryId;
@@ -1627,6 +1632,94 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_TRUE(
       CompareMatrices(screw_joint.acceleration_lower_limits(), neg_inf));
   EXPECT_TRUE(CompareMatrices(screw_joint.acceleration_upper_limits(), inf));
+
+  // periodic curvilinear joint
+  DRAKE_EXPECT_NO_THROW(
+      plant_.GetJointByName<CurvilinearJoint>("curvilinear_joint_periodic"));
+  const CurvilinearJoint<double>& curvilinear_joint =
+      plant_.GetJointByName<CurvilinearJoint>("curvilinear_joint_periodic");
+  EXPECT_EQ(curvilinear_joint.name(), "curvilinear_joint_periodic");
+  EXPECT_EQ(curvilinear_joint.parent_body().name(), "link9");
+  EXPECT_EQ(curvilinear_joint.child_body().name(), "link10");
+  EXPECT_EQ(curvilinear_joint.default_damping(), 0.1);
+  EXPECT_TRUE(
+      CompareMatrices(curvilinear_joint.position_lower_limits(),
+                      Vector1d(-std::numeric_limits<double>::infinity())));
+  EXPECT_TRUE(
+      CompareMatrices(curvilinear_joint.position_upper_limits(),
+                      Vector1d(std::numeric_limits<double>::infinity())));
+  EXPECT_TRUE(
+      CompareMatrices(curvilinear_joint.velocity_lower_limits(),
+                      Vector1d(-std::numeric_limits<double>::infinity())));
+  EXPECT_TRUE(
+      CompareMatrices(curvilinear_joint.velocity_upper_limits(),
+                      Vector1d(std::numeric_limits<double>::infinity())));
+  std::unique_ptr<Trajectory<double>> joint_curve_base =
+      curvilinear_joint.get_curve_clone();
+  PiecewiseConstantCurvatureTrajectory<double>* joint_curve =
+      dynamic_cast<PiecewiseConstantCurvatureTrajectory<double>*>(
+          joint_curve_base.get());
+  EXPECT_EQ(joint_curve->is_periodic(), true);
+  std::vector<double> breaks_expected{0., 1., 1. + M_PI, 1. + 2 * M_PI};
+  std::vector<double> turning_rates_expected{0., 2., -2.};
+
+  PiecewiseConstantCurvatureTrajectory<double> joint_curve_expected{
+      breaks_expected,   turning_rates_expected, Vector3d::UnitZ(),
+      Vector3d::UnitX(), Vector3d::Zero(),       true};
+  const double curve_length = joint_curve->length();
+  const double kEpsilon = 10 * std::numeric_limits<double>::epsilon();
+  EXPECT_NEAR(curve_length, joint_curve_expected.length(), kEpsilon);
+  EXPECT_TRUE(joint_curve->CalcPose(0.).IsNearlyEqualTo(
+      joint_curve_expected.CalcPose(0.), kEpsilon));
+  EXPECT_TRUE(joint_curve->CalcPose(curve_length - kEpsilon)
+                  .IsNearlyEqualTo(
+                      joint_curve_expected.CalcPose(curve_length - kEpsilon),
+                      kEpsilon));
+  EXPECT_TRUE(
+      joint_curve->CalcPose(curve_length * 1.5)
+          .IsNearlyEqualTo(joint_curve_expected.CalcPose(curve_length * 1.5),
+                           kEpsilon));
+
+  // non-periodic curvilinear planar joint
+  DRAKE_EXPECT_NO_THROW(
+      plant_.GetJointByName<CurvilinearJoint>("curvilinear_joint_aperiodic"));
+  const CurvilinearJoint<double>& curvilinear_joint2 =
+      plant_.GetJointByName<CurvilinearJoint>("curvilinear_joint_aperiodic");
+  std::unique_ptr<Trajectory<double>> joint2_curve_base =
+      curvilinear_joint2.get_curve_clone();
+  PiecewiseConstantCurvatureTrajectory<double>* joint2_curve =
+      dynamic_cast<PiecewiseConstantCurvatureTrajectory<double>*>(
+          joint2_curve_base.get());
+  EXPECT_EQ(curvilinear_joint2.name(), "curvilinear_joint_aperiodic");
+  EXPECT_EQ(curvilinear_joint2.parent_body().name(), "link10");
+  EXPECT_EQ(curvilinear_joint2.child_body().name(), "link11");
+  EXPECT_EQ(curvilinear_joint2.default_damping(), 0.1);
+  EXPECT_TRUE(CompareMatrices(curvilinear_joint2.position_lower_limits(),
+                              Vector1d(0.)));
+  EXPECT_TRUE(CompareMatrices(curvilinear_joint2.position_upper_limits(),
+                              Vector1d(joint2_curve->length())));
+  EXPECT_TRUE(
+      CompareMatrices(curvilinear_joint2.velocity_lower_limits(),
+                      Vector1d(-std::numeric_limits<double>::infinity())));
+  EXPECT_TRUE(
+      CompareMatrices(curvilinear_joint2.velocity_upper_limits(),
+                      Vector1d(std::numeric_limits<double>::infinity())));
+  PiecewiseConstantCurvatureTrajectory<double> joint2_curve_expected{
+      breaks_expected,   turning_rates_expected, Vector3d::UnitZ(),
+      Vector3d::UnitX(), Vector3d::Zero(),       false};
+  EXPECT_EQ(joint2_curve->is_periodic(), false);
+  const double curve2_length = joint2_curve->length();
+  EXPECT_NEAR(curve2_length, joint2_curve_expected.length(), kEpsilon);
+  EXPECT_TRUE(joint2_curve->CalcPose(0.).IsNearlyEqualTo(
+      joint2_curve_expected.CalcPose(0.), kEpsilon));
+  EXPECT_TRUE(joint2_curve->CalcPose(curve_length - kEpsilon)
+                  .IsNearlyEqualTo(
+                      joint2_curve_expected.CalcPose(curve_length - kEpsilon),
+                      kEpsilon));
+  EXPECT_TRUE(
+      joint2_curve->CalcPose(curve_length * 1.5)
+          .IsNearlyEqualTo(joint2_curve_expected.CalcPose(curve_length * 1.5),
+                           kEpsilon));
 }
 
 // Tests the error handling for an unsupported joint type (when actuated).

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1654,29 +1654,26 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_TRUE(
       CompareMatrices(curvilinear_joint.velocity_upper_limits(),
                       Vector1d(std::numeric_limits<double>::infinity())));
-  std::unique_ptr<Trajectory<double>> joint_curve_base =
-      curvilinear_joint.get_curve_clone();
-  PiecewiseConstantCurvatureTrajectory<double>* joint_curve =
-      dynamic_cast<PiecewiseConstantCurvatureTrajectory<double>*>(
-          joint_curve_base.get());
-  EXPECT_EQ(joint_curve->is_periodic(), true);
+  const PiecewiseConstantCurvatureTrajectory<double> joint_curve =
+      curvilinear_joint.get_trajectory();
+  EXPECT_EQ(joint_curve.is_periodic(), true);
   std::vector<double> breaks_expected{0., 1., 1. + M_PI, 1. + 2 * M_PI};
   std::vector<double> turning_rates_expected{0., 2., -2.};
 
   PiecewiseConstantCurvatureTrajectory<double> joint_curve_expected{
       breaks_expected,   turning_rates_expected, Vector3d::UnitZ(),
       Vector3d::UnitX(), Vector3d::Zero(),       true};
-  const double curve_length = joint_curve->length();
+  const double curve_length = joint_curve.length();
   const double kEpsilon = 10 * std::numeric_limits<double>::epsilon();
   EXPECT_NEAR(curve_length, joint_curve_expected.length(), kEpsilon);
-  EXPECT_TRUE(joint_curve->CalcPose(0.).IsNearlyEqualTo(
+  EXPECT_TRUE(joint_curve.CalcPose(0.).IsNearlyEqualTo(
       joint_curve_expected.CalcPose(0.), kEpsilon));
-  EXPECT_TRUE(joint_curve->CalcPose(curve_length - kEpsilon)
+  EXPECT_TRUE(joint_curve.CalcPose(curve_length - kEpsilon)
                   .IsNearlyEqualTo(
                       joint_curve_expected.CalcPose(curve_length - kEpsilon),
                       kEpsilon));
   EXPECT_TRUE(
-      joint_curve->CalcPose(curve_length * 1.5)
+      joint_curve.CalcPose(curve_length * 1.5)
           .IsNearlyEqualTo(joint_curve_expected.CalcPose(curve_length * 1.5),
                            kEpsilon));
 
@@ -1685,11 +1682,8 @@ TEST_F(SdfParserTest, JointParsingTest) {
       plant_.GetJointByName<CurvilinearJoint>("curvilinear_joint_aperiodic"));
   const CurvilinearJoint<double>& curvilinear_joint2 =
       plant_.GetJointByName<CurvilinearJoint>("curvilinear_joint_aperiodic");
-  std::unique_ptr<Trajectory<double>> joint2_curve_base =
-      curvilinear_joint2.get_curve_clone();
-  PiecewiseConstantCurvatureTrajectory<double>* joint2_curve =
-      dynamic_cast<PiecewiseConstantCurvatureTrajectory<double>*>(
-          joint2_curve_base.get());
+  const PiecewiseConstantCurvatureTrajectory<double> joint2_curve =
+      curvilinear_joint2.get_trajectory();
   EXPECT_EQ(curvilinear_joint2.name(), "curvilinear_joint_aperiodic");
   EXPECT_EQ(curvilinear_joint2.parent_body().name(), "link10");
   EXPECT_EQ(curvilinear_joint2.child_body().name(), "link11");
@@ -1697,7 +1691,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
   EXPECT_TRUE(CompareMatrices(curvilinear_joint2.position_lower_limits(),
                               Vector1d(0.)));
   EXPECT_TRUE(CompareMatrices(curvilinear_joint2.position_upper_limits(),
-                              Vector1d(joint2_curve->length())));
+                              Vector1d(joint2_curve.length())));
   EXPECT_TRUE(
       CompareMatrices(curvilinear_joint2.velocity_lower_limits(),
                       Vector1d(-std::numeric_limits<double>::infinity())));
@@ -1707,17 +1701,17 @@ TEST_F(SdfParserTest, JointParsingTest) {
   PiecewiseConstantCurvatureTrajectory<double> joint2_curve_expected{
       breaks_expected,   turning_rates_expected, Vector3d::UnitZ(),
       Vector3d::UnitX(), Vector3d::Zero(),       false};
-  EXPECT_EQ(joint2_curve->is_periodic(), false);
-  const double curve2_length = joint2_curve->length();
+  EXPECT_EQ(joint2_curve.is_periodic(), false);
+  const double curve2_length = joint2_curve.length();
   EXPECT_NEAR(curve2_length, joint2_curve_expected.length(), kEpsilon);
-  EXPECT_TRUE(joint2_curve->CalcPose(0.).IsNearlyEqualTo(
+  EXPECT_TRUE(joint2_curve.CalcPose(0.).IsNearlyEqualTo(
       joint2_curve_expected.CalcPose(0.), kEpsilon));
-  EXPECT_TRUE(joint2_curve->CalcPose(curve_length - kEpsilon)
+  EXPECT_TRUE(joint2_curve.CalcPose(curve_length - kEpsilon)
                   .IsNearlyEqualTo(
                       joint2_curve_expected.CalcPose(curve_length - kEpsilon),
                       kEpsilon));
   EXPECT_TRUE(
-      joint2_curve->CalcPose(curve_length * 1.5)
+      joint2_curve.CalcPose(curve_length * 1.5)
           .IsNearlyEqualTo(joint2_curve_expected.CalcPose(curve_length * 1.5),
                            kEpsilon));
 }

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1658,7 +1658,7 @@ TEST_F(SdfParserTest, JointParsingTest) {
       curvilinear_joint.get_trajectory();
   EXPECT_EQ(joint_curve.is_periodic(), true);
   std::vector<double> breaks_expected{0., 1., 1. + M_PI, 1. + 2 * M_PI};
-  std::vector<double> turning_rates_expected{0., 2., -2.};
+  std::vector<double> turning_rates_expected{0., 0.5, -0.5};
 
   PiecewiseConstantCurvatureTrajectory<double> joint_curve_expected{
       breaks_expected,   turning_rates_expected, Vector3d::UnitZ(),

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -1123,7 +1123,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
       curvilinear_joint.get_trajectory();
   EXPECT_EQ(joint_curve.is_periodic(), true);
   std::vector<double> breaks_expected{0., 1., 1. + M_PI, 1. + 2 * M_PI};
-  std::vector<double> turning_rates_expected{0., 2., -2.};
+  std::vector<double> turning_rates_expected{0., 0.5, -0.5};
 
   PiecewiseConstantCurvatureTrajectory<double> joint_curve_expected{
       breaks_expected,   turning_rates_expected, Vector3d::UnitZ(),

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -1119,29 +1119,26 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   EXPECT_TRUE(
       CompareMatrices(curvilinear_joint.velocity_upper_limits(),
                       Vector1d(std::numeric_limits<double>::infinity())));
-  std::unique_ptr<Trajectory<double>> joint_curve_base =
-      curvilinear_joint.get_curve_clone();
-  PiecewiseConstantCurvatureTrajectory<double>* joint_curve =
-      dynamic_cast<PiecewiseConstantCurvatureTrajectory<double>*>(
-          joint_curve_base.get());
-  EXPECT_EQ(joint_curve->is_periodic(), true);
+  const PiecewiseConstantCurvatureTrajectory<double> joint_curve =
+      curvilinear_joint.get_trajectory();
+  EXPECT_EQ(joint_curve.is_periodic(), true);
   std::vector<double> breaks_expected{0., 1., 1. + M_PI, 1. + 2 * M_PI};
   std::vector<double> turning_rates_expected{0., 2., -2.};
 
   PiecewiseConstantCurvatureTrajectory<double> joint_curve_expected{
       breaks_expected,   turning_rates_expected, Vector3d::UnitZ(),
       Vector3d::UnitX(), Vector3d::Zero(),       true};
-  const double curve_length = joint_curve->length();
+  const double curve_length = joint_curve.length();
   const double kEpsilon = 10 * std::numeric_limits<double>::epsilon();
   EXPECT_NEAR(curve_length, joint_curve_expected.length(), kEpsilon);
-  EXPECT_TRUE(joint_curve->CalcPose(0.).IsNearlyEqualTo(
+  EXPECT_TRUE(joint_curve.CalcPose(0.).IsNearlyEqualTo(
       joint_curve_expected.CalcPose(0.), kEpsilon));
-  EXPECT_TRUE(joint_curve->CalcPose(curve_length - kEpsilon)
+  EXPECT_TRUE(joint_curve.CalcPose(curve_length - kEpsilon)
                   .IsNearlyEqualTo(
                       joint_curve_expected.CalcPose(curve_length - kEpsilon),
                       kEpsilon));
   EXPECT_TRUE(
-      joint_curve->CalcPose(curve_length * 1.5)
+      joint_curve.CalcPose(curve_length * 1.5)
           .IsNearlyEqualTo(joint_curve_expected.CalcPose(curve_length * 1.5),
                            kEpsilon));
 
@@ -1150,11 +1147,8 @@ TEST_F(UrdfParserTest, JointParsingTest) {
       plant_.GetJointByName<CurvilinearJoint>("curvilinear_aperiodic"));
   const CurvilinearJoint<double>& curvilinear_joint2 =
       plant_.GetJointByName<CurvilinearJoint>("curvilinear_aperiodic");
-  std::unique_ptr<Trajectory<double>> joint2_curve_base =
-      curvilinear_joint2.get_curve_clone();
-  PiecewiseConstantCurvatureTrajectory<double>* joint2_curve =
-      dynamic_cast<PiecewiseConstantCurvatureTrajectory<double>*>(
-          joint2_curve_base.get());
+  const PiecewiseConstantCurvatureTrajectory<double> joint2_curve =
+      curvilinear_joint2.get_trajectory();
   EXPECT_EQ(curvilinear_joint2.name(), "curvilinear_aperiodic");
   EXPECT_EQ(curvilinear_joint2.parent_body().name(), "link13");
   EXPECT_EQ(curvilinear_joint2.child_body().name(), "link14");
@@ -1162,7 +1156,7 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   EXPECT_TRUE(CompareMatrices(curvilinear_joint2.position_lower_limits(),
                               Vector1d(0.)));
   EXPECT_TRUE(CompareMatrices(curvilinear_joint2.position_upper_limits(),
-                              Vector1d(joint2_curve->length())));
+                              Vector1d(joint2_curve.length())));
   EXPECT_TRUE(
       CompareMatrices(curvilinear_joint2.velocity_lower_limits(),
                       Vector1d(-std::numeric_limits<double>::infinity())));
@@ -1172,17 +1166,17 @@ TEST_F(UrdfParserTest, JointParsingTest) {
   PiecewiseConstantCurvatureTrajectory<double> joint2_curve_expected{
       breaks_expected,   turning_rates_expected, Vector3d::UnitZ(),
       Vector3d::UnitX(), Vector3d::Zero(),       false};
-  EXPECT_EQ(joint2_curve->is_periodic(), false);
-  const double curve2_length = joint2_curve->length();
+  EXPECT_EQ(joint2_curve.is_periodic(), false);
+  const double curve2_length = joint2_curve.length();
   EXPECT_NEAR(curve2_length, joint2_curve_expected.length(), kEpsilon);
-  EXPECT_TRUE(joint2_curve->CalcPose(0.).IsNearlyEqualTo(
+  EXPECT_TRUE(joint2_curve.CalcPose(0.).IsNearlyEqualTo(
       joint2_curve_expected.CalcPose(0.), kEpsilon));
-  EXPECT_TRUE(joint2_curve->CalcPose(curve_length - kEpsilon)
+  EXPECT_TRUE(joint2_curve.CalcPose(curve_length - kEpsilon)
                   .IsNearlyEqualTo(
                       joint2_curve_expected.CalcPose(curve_length - kEpsilon),
                       kEpsilon));
   EXPECT_TRUE(
-      joint2_curve->CalcPose(curve_length * 1.5)
+      joint2_curve.CalcPose(curve_length * 1.5)
           .IsNearlyEqualTo(joint2_curve_expected.CalcPose(curve_length * 1.5),
                            kEpsilon));
 }

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -255,32 +255,31 @@ Defines an SDF model with various types of joints used for testing the parser.
         </inertial>
       </link>
       <frame name='frame9' attached_to='link9'/>
-      <frame name='frame10' attached_to='link10'/>      
+      <frame name='frame10' attached_to='link10'/>
       <drake:joint name="curvilinear_joint_periodic" type="curvilinear">
         <drake:parent>frame9</drake:parent>
         <drake:child>frame10</drake:child>
         <drake:damping>0.1</drake:damping>
-        <drake:initial_curve_tangent>
+        <drake:initial_tangent>
           <xyz>0 0 1</xyz>
-        </drake:initial_curve_tangent>
+        </drake:initial_tangent>
         <drake:plane_normal>
           <xyz>1 0 0</xyz>
         </drake:plane_normal>
         <drake:is_periodic>true</drake:is_periodic>
         <drake:curves>
-          <drake:line_segment>
+          <drake:curve>
             <drake:length>1.0</drake:length>
-          </drake:line_segment>
-          <drake:circular_arc>
+            <drake:angle>0.0</drake:angle>
+          </drake:curve>
+          <drake:curve>
             <drake:length>3.14159265358979323846</drake:length>
-            <drake:radius>0.5</drake:radius>
-            <drake:direction>counterclockwise</drake:direction>
-          </drake:circular_arc>
-          <drake:circular_arc>
+            <drake:angle>1.57079632679489661923</drake:angle>
+          </drake:curve>
+          <drake:curve>
             <drake:length>3.14159265358979323846</drake:length>
-            <drake:radius>0.5</drake:radius>
-            <drake:direction>clockwise</drake:direction>
-          </drake:circular_arc>
+            <drake:angle>-1.57079632679489661923</drake:angle>
+          </drake:curve>
         </drake:curves>
       </drake:joint>
       <link name="link11">
@@ -301,27 +300,26 @@ Defines an SDF model with various types of joints used for testing the parser.
         <drake:parent>frame10</drake:parent>
         <drake:child>frame11</drake:child>
         <drake:damping>0.1</drake:damping>
-        <drake:initial_curve_tangent>
+        <drake:initial_tangent>
           <xyz>0 0 1</xyz>
-        </drake:initial_curve_tangent>
+        </drake:initial_tangent>
         <drake:plane_normal>
           <xyz>1 0 0</xyz>
         </drake:plane_normal>
         <drake:is_periodic>false</drake:is_periodic>
         <drake:curves>
-          <drake:line_segment>
+          <drake:curve>
             <drake:length>1.0</drake:length>
-          </drake:line_segment>
-          <drake:circular_arc>
+            <drake:angle>0.0</drake:angle>
+          </drake:curve>
+          <drake:curve>
             <drake:length>3.14159265358979323846</drake:length>
-            <drake:radius>0.5</drake:radius>
-            <drake:direction>counterclockwise</drake:direction>
-          </drake:circular_arc>
-          <drake:circular_arc>
+            <drake:angle>1.57079632679489661923</drake:angle>
+          </drake:curve>
+          <drake:curve>
             <drake:length>3.14159265358979323846</drake:length>
-            <drake:radius>0.5</drake:radius>
-            <drake:direction>clockwise</drake:direction>
-          </drake:circular_arc>
+            <drake:angle>-1.57079632679489661923</drake:angle>
+          </drake:curve>
         </drake:curves>
       </drake:joint>
     </model>

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -268,18 +268,17 @@ Defines an SDF model with various types of joints used for testing the parser.
         </drake:plane_normal>
         <drake:is_periodic>true</drake:is_periodic>
         <drake:curves>
-          <drake:curve>
+          <drake:line_segment>
             <drake:length>1.0</drake:length>
-            <drake:angle>0.0</drake:angle>
-          </drake:curve>
-          <drake:curve>
-            <drake:length>3.14159265358979323846</drake:length>
+          </drake:line_segment>
+          <drake:circular_arc>
+            <drake:radius>2.0</drake:radius>
             <drake:angle>1.57079632679489661923</drake:angle>
-          </drake:curve>
-          <drake:curve>
-            <drake:length>3.14159265358979323846</drake:length>
+          </drake:circular_arc>
+          <drake:circular_arc>
+            <drake:radius>2.0</drake:radius>
             <drake:angle>-1.57079632679489661923</drake:angle>
-          </drake:curve>
+          </drake:circular_arc>
         </drake:curves>
       </drake:joint>
       <link name="link11">
@@ -308,18 +307,17 @@ Defines an SDF model with various types of joints used for testing the parser.
         </drake:plane_normal>
         <drake:is_periodic>false</drake:is_periodic>
         <drake:curves>
-          <drake:curve>
+          <drake:line_segment>
             <drake:length>1.0</drake:length>
-            <drake:angle>0.0</drake:angle>
-          </drake:curve>
-          <drake:curve>
-            <drake:length>3.14159265358979323846</drake:length>
+          </drake:line_segment>
+          <drake:circular_arc>
+            <drake:radius>2.0</drake:radius>
             <drake:angle>1.57079632679489661923</drake:angle>
-          </drake:curve>
-          <drake:curve>
-            <drake:length>3.14159265358979323846</drake:length>
+          </drake:circular_arc>
+          <drake:circular_arc>
+            <drake:radius>2.0</drake:radius>
             <drake:angle>-1.57079632679489661923</drake:angle>
-          </drake:curve>
+          </drake:circular_arc>
         </drake:curves>
       </drake:joint>
     </model>

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -241,6 +241,89 @@ Defines an SDF model with various types of joints used for testing the parser.
           </dynamics>
         </axis>
       </joint>
+      <link name="link10">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <frame name='frame9' attached_to='link9'/>
+      <frame name='frame10' attached_to='link10'/>      
+      <drake:joint name="curvilinear_joint_periodic" type="curvilinear">
+        <drake:parent>frame9</drake:parent>
+        <drake:child>frame10</drake:child>
+        <drake:damping>0.1</drake:damping>
+        <drake:initial_curve_tangent>
+          <xyz>0 0 1</xyz>
+        </drake:initial_curve_tangent>
+        <drake:plane_normal>
+          <xyz>1 0 0</xyz>
+        </drake:plane_normal>
+        <drake:is_periodic>true</drake:is_periodic>
+        <drake:curves>
+          <drake:line_segment>
+            <drake:length>1.0</drake:length>
+          </drake:line_segment>
+          <drake:circular_arc>
+            <drake:length>3.14159265358979323846</drake:length>
+            <drake:radius>0.5</drake:radius>
+            <drake:direction>counterclockwise</drake:direction>
+          </drake:circular_arc>
+          <drake:circular_arc>
+            <drake:length>3.14159265358979323846</drake:length>
+            <drake:radius>0.5</drake:radius>
+            <drake:direction>clockwise</drake:direction>
+          </drake:circular_arc>
+        </drake:curves>
+      </drake:joint>
+      <link name="link11">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <frame name='frame11' attached_to='link11'/>
+      <drake:joint name="curvilinear_joint_aperiodic" type="curvilinear">
+        <drake:parent>frame10</drake:parent>
+        <drake:child>frame11</drake:child>
+        <drake:damping>0.1</drake:damping>
+        <drake:initial_curve_tangent>
+          <xyz>0 0 1</xyz>
+        </drake:initial_curve_tangent>
+        <drake:plane_normal>
+          <xyz>1 0 0</xyz>
+        </drake:plane_normal>
+        <drake:is_periodic>false</drake:is_periodic>
+        <drake:curves>
+          <drake:line_segment>
+            <drake:length>1.0</drake:length>
+          </drake:line_segment>
+          <drake:circular_arc>
+            <drake:length>3.14159265358979323846</drake:length>
+            <drake:radius>0.5</drake:radius>
+            <drake:direction>counterclockwise</drake:direction>
+          </drake:circular_arc>
+          <drake:circular_arc>
+            <drake:length>3.14159265358979323846</drake:length>
+            <drake:radius>0.5</drake:radius>
+            <drake:direction>clockwise</drake:direction>
+          </drake:circular_arc>
+        </drake:curves>
+      </drake:joint>
     </model>
     <model name="joint_parsing_test2">
       <link name="link6">

--- a/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
@@ -172,9 +172,9 @@ Defines a URDF model with various types of joints.
     <drake:is_periodic value="true"/>
     <dynamics damping="0.1"/>
     <drake:curves>
-      <drake:curve length="1.0" angle="0.0"/>
-      <drake:curve length="3.14159265358979323846" angle="1.57079632679489661923"/>
-      <drake:curve length="3.14159265358979323846" angle="-1.57079632679489661923"/>
+      <drake:line_segment length="1.0"/>
+      <drake:circular_arc radius="2.0" angle="1.57079632679489661923"/>
+      <drake:circular_arc radius="2.0" angle="-1.57079632679489661923"/>
     </drake:curves>
   </drake:joint>
   <drake:joint name="curvilinear_aperiodic" type="curvilinear">
@@ -186,9 +186,9 @@ Defines a URDF model with various types of joints.
     <drake:is_periodic value="false"/>
     <dynamics damping="0.1"/>
     <drake:curves>
-      <drake:curve length="1.0" angle="0.0"/>
-      <drake:curve length="3.14159265358979323846" angle="1.57079632679489661923"/>
-      <drake:curve length="3.14159265358979323846" angle="-1.57079632679489661923"/>
+      <drake:line_segment length="1.0"/>
+      <drake:circular_arc radius="2.0" angle="1.57079632679489661923"/>
+      <drake:circular_arc radius="2.0" angle="-1.57079632679489661923"/>
     </drake:curves>
   </drake:joint>
   <!-- Normal transmission/joint, should be created with appropriate

--- a/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
@@ -75,6 +75,18 @@ Defines a URDF model with various types of joints.
       <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
     </inertial>
   </link>
+  <link name="link13">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+  </link>
+  <link name="link14">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+  </link>
   <joint name="fixed_joint" type="fixed">
     <parent link="world"/>
     <child link="link1"/>
@@ -151,6 +163,34 @@ Defines a URDF model with various types of joints.
     <child link="link12"/>
     <mimic joint="revolute_joint_to_mimic" multiplier="6.54" offset="3.21"/>
   </joint>
+  <drake:joint name="curvilinear_periodic" type="curvilinear">
+    <origin xyz="3 2 1" rpy="0 0 0"/>
+    <parent link="link12"/>
+    <child link="link13"/>
+		<drake:initial_curve_tangent xyz="0 0 1"/>
+		<drake:plane_normal xyz="1 0 0"/>
+    <drake:is_periodic value="true"/>
+    <dynamics damping="0.1"/>
+		<drake:curves>
+			<drake:line_segment length="1.0"/>
+			<drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="counterclockwise"/>
+      <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="clockwise"/>
+		</drake:curves>
+  </drake:joint>
+  <drake:joint name="curvilinear_aperiodic" type="curvilinear">
+    <origin xyz="3 2 1" rpy="0 0 0"/>
+    <parent link="link13"/>
+    <child link="link14"/>
+		<drake:initial_curve_tangent xyz="0 0 1"/>
+		<drake:plane_normal xyz="1 0 0"/>
+    <drake:is_periodic value="false"/>
+    <dynamics damping="0.1"/>
+		<drake:curves>
+			<drake:line_segment length="1.0"/>
+			<drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="counterclockwise"/>
+      <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="clockwise"/>
+		</drake:curves>
+  </drake:joint>
   <!-- Normal transmission/joint, should be created with appropriate
   effort limit. -->
   <transmission>

--- a/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
@@ -167,28 +167,28 @@ Defines a URDF model with various types of joints.
     <origin xyz="3 2 1" rpy="0 0 0"/>
     <parent link="link12"/>
     <child link="link13"/>
-    <drake:initial_curve_tangent xyz="0 0 1"/>
+    <drake:initial_tangent xyz="0 0 1"/>
     <drake:plane_normal xyz="1 0 0"/>
     <drake:is_periodic value="true"/>
     <dynamics damping="0.1"/>
     <drake:curves>
-      <drake:line_segment length="1.0"/>
-      <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="counterclockwise"/>
-      <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="clockwise"/>
+      <drake:curve length="1.0" angle="0.0"/>
+      <drake:curve length="3.14159265358979323846" angle="1.57079632679489661923"/>
+      <drake:curve length="3.14159265358979323846" angle="-1.57079632679489661923"/>
     </drake:curves>
   </drake:joint>
   <drake:joint name="curvilinear_aperiodic" type="curvilinear">
     <origin xyz="3 2 1" rpy="0 0 0"/>
     <parent link="link13"/>
     <child link="link14"/>
-    <drake:initial_curve_tangent xyz="0 0 1"/>
+    <drake:initial_tangent xyz="0 0 1"/>
     <drake:plane_normal xyz="1 0 0"/>
     <drake:is_periodic value="false"/>
     <dynamics damping="0.1"/>
     <drake:curves>
-      <drake:line_segment length="1.0"/>
-      <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="counterclockwise"/>
-      <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="clockwise"/>
+      <drake:curve length="1.0" angle="0.0"/>
+      <drake:curve length="3.14159265358979323846" angle="1.57079632679489661923"/>
+      <drake:curve length="3.14159265358979323846" angle="-1.57079632679489661923"/>
     </drake:curves>
   </drake:joint>
   <!-- Normal transmission/joint, should be created with appropriate

--- a/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
@@ -167,29 +167,29 @@ Defines a URDF model with various types of joints.
     <origin xyz="3 2 1" rpy="0 0 0"/>
     <parent link="link12"/>
     <child link="link13"/>
-		<drake:initial_curve_tangent xyz="0 0 1"/>
-		<drake:plane_normal xyz="1 0 0"/>
+    <drake:initial_curve_tangent xyz="0 0 1"/>
+    <drake:plane_normal xyz="1 0 0"/>
     <drake:is_periodic value="true"/>
     <dynamics damping="0.1"/>
-		<drake:curves>
-			<drake:line_segment length="1.0"/>
-			<drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="counterclockwise"/>
+    <drake:curves>
+      <drake:line_segment length="1.0"/>
+      <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="counterclockwise"/>
       <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="clockwise"/>
-		</drake:curves>
+    </drake:curves>
   </drake:joint>
   <drake:joint name="curvilinear_aperiodic" type="curvilinear">
     <origin xyz="3 2 1" rpy="0 0 0"/>
     <parent link="link13"/>
     <child link="link14"/>
-		<drake:initial_curve_tangent xyz="0 0 1"/>
-		<drake:plane_normal xyz="1 0 0"/>
+    <drake:initial_curve_tangent xyz="0 0 1"/>
+    <drake:plane_normal xyz="1 0 0"/>
     <drake:is_periodic value="false"/>
     <dynamics damping="0.1"/>
-		<drake:curves>
-			<drake:line_segment length="1.0"/>
-			<drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="counterclockwise"/>
+    <drake:curves>
+      <drake:line_segment length="1.0"/>
+      <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="counterclockwise"/>
       <drake:circular_arc length="3.14159265358979323846" radius="0.5" direction="clockwise"/>
-		</drake:curves>
+    </drake:curves>
   </drake:joint>
   <!-- Normal transmission/joint, should be created with appropriate
   effort limit. -->

--- a/multibody/tree/curvilinear_joint.h
+++ b/multibody/tree/curvilinear_joint.h
@@ -254,8 +254,8 @@ class CurvilinearJoint final : public Joint<T> {
   }
 
   /** @returns copy of underlying curve of joint. */
-  std::unique_ptr<trajectories::Trajectory<double>> get_curve_clone() const {
-    return curvilinear_path_.Clone();
+  const PiecewiseConstantCurvatureTrajectory<double>& get_trajectory() const {
+    return curvilinear_path_;
   }
 
  protected:

--- a/multibody/tree/curvilinear_joint.h
+++ b/multibody/tree/curvilinear_joint.h
@@ -253,6 +253,11 @@ class CurvilinearJoint final : public Joint<T> {
     this->AddInOneForce(context, 0, force, forces);
   }
 
+  /** @returns copy of underlying curve of joint. */
+  std::unique_ptr<trajectories::Trajectory<double>> get_curve_clone() const {
+    return curvilinear_path_.Clone();
+  }
+
  protected:
   /** Joint<T> override called through public NVI, Joint::AddInForce().
    Arguments already checked to be valid by Joint::AddInForce().

--- a/multibody/tree/curvilinear_joint.h
+++ b/multibody/tree/curvilinear_joint.h
@@ -253,7 +253,7 @@ class CurvilinearJoint final : public Joint<T> {
     this->AddInOneForce(context, 0, force, forces);
   }
 
-  /** @returns copy of underlying curve of joint. */
+  /** @returns A reference to the underlying trajectory. */
   const PiecewiseConstantCurvatureTrajectory<double>& get_trajectory() const {
     return curvilinear_path_;
   }

--- a/multibody/tree/test/curvilinear_mobilizer_test.cc
+++ b/multibody/tree/test/curvilinear_mobilizer_test.cc
@@ -55,8 +55,10 @@ class CurvilinearMobilizerTest : public MobilizerTester {
   const Vector3d tangent_axis_{1., -std::sqrt(2.), 1.};
   const Vector3d plane_axis_{1., std::sqrt(2.), 1.};
   const Vector3d initial_position_{1., 2., 3.};
+  const bool is_periodic_{true};
   const PiecewiseConstantCurvatureTrajectory<double> trajectory_{
-      breaks_, turning_rates_, tangent_axis_, plane_axis_, initial_position_};
+      breaks_,     turning_rates_,    tangent_axis_,
+      plane_axis_, initial_position_, is_periodic_};
 };
 
 TEST_F(CurvilinearMobilizerTest, CanRotateAndTranslate) {


### PR DESCRIPTION
Adds tags and joint configuration structure to URDF and SDF parsers for CurvilinearJoint, completing implementation of #22196.

Implements new `drake:` namespace XML tags to handle description of line segment and curve shapes. Format prioritizes human readability without knowledge of the particular API for the internal PiecewiseConstantCurvatureTrajectory -- for instance expressing the curves with a radius and clockwise/counterclockwise direction rather than a `turning_rate`. A sample URDF specification is provided below.

```
<drake:joint name="curvilinear_periodic" type="curvilinear">
  <origin xyz="3 2 1" rpy="0 0 0"/>
  <parent link="link12"/>
  <child link="link13"/>
  <drake:initial_curve_tangent xyz="0 0 1"/>
  <drake:plane_normal xyz="1 0 0"/>
  <drake:is_periodic value="true"/>
  <dynamics damping="0.1"/>
  <drake:curves>
    <drake:line_segment length="1.0"/>
    <drake:circular_arc length="3.14159" radius="0.5" direction="counterclockwise"/>
    <drake:circular_arc length="3.14159" radius="0.5" direction="clockwise"/>
  </drake:curves>
</drake:joint>
```

Per offline discussion, the API for periodicity of the PiecewiseConstantCurvatureTrajectory has been migrated to an explicit constructor argument `bool is_periodic`.

Some preexisting parsing files appear to not have been recently clang-formatted on mainline, so the line change count is significantly inflated due to whitespace changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22469)
<!-- Reviewable:end -->
