### PR TITLE
[py systems] Change how ValueProducer callbacks work

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -62,6 +62,8 @@ drake_pybind_library(
         "framework_py_systems.h",
         "framework_py_values.cc",
         "framework_py_values.h",
+        "value_producer_pybind.cc",
+        "value_producer_pybind.h",
     ],
     package_info = PACKAGE_INFO,
     py_deps = [

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -9,6 +9,7 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/systems/builder_life_support_pybind.h"
+#include "drake/bindings/pydrake/systems/value_producer_pybind.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/event.h"
@@ -253,10 +254,11 @@ void DoScalarIndependentDefinitions(py::module m) {
     using Class = ValueProducer;
     constexpr auto& cls_doc = doc.ValueProducer;
     py::class_<Class>(m, "ValueProducer", cls_doc.doc)
-        .def(py::init(WrapCallbacks([](ValueProducer::AllocateCallback allocate,
-                                        ValueProducer::CalcCallback calc) {
-          return Class(allocate, calc);
-        })),
+        .def(py::init([](py::function allocate,
+                          std::function<void(py::object, py::object)> calc) {
+          return Class(MakeCppCompatibleAllocateCallback(std::move(allocate)),
+              MakeCppCompatibleCalcCallback(std::move(calc)));
+        }),
             py::arg("allocate"), py::arg("calc"), cls_doc.ctor.doc_overload_5d)
         .def_static("NoopCalc", &Class::NoopCalc, cls_doc.NoopCalc.doc);
   }

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -329,6 +329,34 @@ class TestCustom(unittest.TestCase):
         data_const = cache_entry_value_const.GetValueOrThrow()
         self.assertIs(data_const, data)
 
+    def test_value_producer_error_reporting_allocate_none(self):
+        def broken_alloc_callback():
+            pass
+        system = LeafSystem()
+        cache_entry = system.DeclareCacheEntry(
+            description="",
+            value_producer=ValueProducer(
+                allocate=broken_alloc_callback,
+                calc=lambda context, output: None))
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "broken_alloc_callback.*Value.*not None"):
+            system.CreateDefaultContext()
+
+    def test_value_producer_error_reporting_allocate_mistyped(self):
+        def broken_alloc_callback():
+            return "hello"
+        system = LeafSystem()
+        cache_entry = system.DeclareCacheEntry(
+            description="",
+            value_producer=ValueProducer(
+                allocate=broken_alloc_callback,
+                calc=lambda context, output: None))
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "broken_alloc_callback.*return.*Value.*not.*str"):
+            system.CreateDefaultContext()
+
     def test_leaf_system_issue13792(self):
         """
         Ensures that users get a better error when forgetting to explicitly

--- a/bindings/pydrake/systems/value_producer_pybind.cc
+++ b/bindings/pydrake/systems/value_producer_pybind.cc
@@ -1,0 +1,53 @@
+#include "drake/bindings/pydrake/systems/value_producer_pybind.h"
+
+namespace drake {
+namespace pydrake {
+
+std::function<std::unique_ptr<AbstractValue>()>
+MakeCppCompatibleAllocateCallback(py::function allocate) {
+  return [allocate = std::move(allocate)]() -> std::unique_ptr<AbstractValue> {
+    py::gil_scoped_acquire guard;
+
+    // Invoke the Python allocate function.
+    py::object result_py = allocate();
+    if (result_py.is_none()) {
+      throw std::runtime_error(
+          fmt::format("The allocate callback function {} must return a "
+                      "pydrake.common.value.Value[...] or"
+                      "pydrake.common.value.AbstractValue object, not None",
+              py::repr(allocate).cast<std::string>()));
+    }
+
+    // Verify its return type.
+    const AbstractValue* result_cpp;
+    try {
+      result_cpp = result_py.cast<const AbstractValue*>();
+    } catch (const py::cast_error& e) {
+      throw std::runtime_error(
+          fmt::format("The allocate callback function {} must return a "
+                      "pydrake.common.value.Value[...] or"
+                      "pydrake.common.value.AbstractValue object, not {}",
+              py::repr(allocate).cast<std::string>(),
+              py::str(py::type::handle_of(result_py)).cast<std::string>()));
+    }
+
+    // Our signature requires returning a unique_ptr; the only way we can do
+    // that is via cloning.
+    return result_cpp->Clone();
+  };
+}
+
+std::function<void(const systems::ContextBase&, AbstractValue*)>
+MakeCppCompatibleCalcCallback(
+    std::function<void(py::object, py::object)> calc) {
+  return [calc = std::move(calc)](const systems::ContextBase& context_cpp,
+             AbstractValue* output_cpp) -> void {
+    py::gil_scoped_acquire guard;
+    py::object context_py = py::cast(context_cpp, py_rvp::reference);
+    py::object output_py = py::cast(output_cpp, py_rvp::reference);
+    calc(context_py, output_py);
+  };
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/systems/value_producer_pybind.h
+++ b/bindings/pydrake/systems/value_producer_pybind.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/value.h"
+#include "drake/systems/framework/context_base.h"
+
+namespace drake {
+namespace pydrake {
+
+// The C++ framework uses ValueProducer::AllocateCallback to allocate storage
+// for values in the Context, and that function returns a unique_ptr. Python
+// cannot return unique_ptr, so we need to wrap the call to match signatures.
+// The argument is the Python callback; the return value is the C++ callback.
+std::function<std::unique_ptr<AbstractValue>()>
+MakeCppCompatibleAllocateCallback(py::function allocate);
+
+// For parity with `allocate`, we also provide a wrapper for `calc`. It doesn't
+// do any special tricks (our nominal WrapCallbacks() technique could've handled
+// it), but it's easier to avoid WrapCallbacks entirely once we need to special-
+// case the `allocate` callback.
+std::function<void(const systems::ContextBase&, AbstractValue*)>
+MakeCppCompatibleCalcCallback(std::function<void(py::object, py::object)> calc);
+
+}  // namespace pydrake
+}  // namespace drake

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1457,6 +1457,11 @@ class LeafSystem : public System<T> {
   /** (Advanced) Declares an abstract-valued output port using the given
   allocator and calculator functions provided in their most generic forms.
   If you have a member function available use one of the other signatures.
+  @param alloc Callback function that allocates storage for the value. It takes
+  no arguments and must return an AbstractValue.
+  @param calc Callback function that computes the value. It takes two arguments
+  (context, value) and does not return anything; instead, it should mutate the
+  AbstractValue object pointed to by `value` with the new result.
   @see LeafOutputPort::AllocCallback, LeafOutputPort::CalcCallback */
   LeafOutputPort<T>& DeclareAbstractOutputPort(
       std::variant<std::string, UseDefaultName> name,

--- a/systems/framework/value_producer.h
+++ b/systems/framework/value_producer.h
@@ -391,8 +391,13 @@ class ValueProducer final {
       : ValueProducer(make_allocate_mode_c(instance, allocate),
                       std::move(calc)) {}
 
-  /** Overload (5d). Refer to the
-  @ref ValueProducer_constructors "Constructor overloads" for details.
+  /** Overload (5d). Refer to the C++
+  @ref ValueProducer_constructors "Constructor overloads" for further details.
+  @param allocate Callback function that allocates storage for the value. It
+  takes no arguments and must return an AbstractValue.
+  @param calc Callback function that computes the value. It takes two arguments
+  (context, value) and does not return anything; instead, it should mutate the
+  AbstractValue object pointed to by `value` with the new result.
   @pydrake_mkdoc_identifier{overload_5d} */
   ValueProducer(AllocateCallback allocate, CalcCallback calc);
 


### PR DESCRIPTION
(1) Add better error reporting in case the user's function is incorrectly implemented or otherwise misbehaves.

(2) Don't rely on pybind11 to cast the result of allocate() to a unique_ptr (this is an RLG/pybind11-specific feature).

Towards #21968.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22470)
<!-- Reviewable:end -->
