### PR TITLE
Rename .deb files to skip per-distro subdirectories in S3

### DIFF
--- a/tools/release_engineering/dev/README.md
+++ b/tools/release_engineering/dev/README.md
@@ -90,7 +90,7 @@ has `<version>` tags for each supported configuration (e.g. jammy and noble).
 
 1. The `*.deb` files are in AWS
 [s3://drake-packages/drake/release](https://s3.console.aws.amazon.com/s3/buckets/drake-packages?region=us-east-1&prefix=drake/release/&showversions=false)
-`/<configuration>/drake-dev_<version>-1_amd64.deb` for each supported configuration (e.g. jammy and noble)
+`/drake-dev_<version>-1_amd64-<configuration>.deb` for each supported configuration (e.g. jammy and noble)
 
 ## Run script for apt
 

--- a/tools/release_engineering/dev/push_release
+++ b/tools/release_engineering/dev/push_release
@@ -98,13 +98,14 @@ if [[ "${push_apt}" -ne 0 ]]; then
     mkdir -p "${platform}"
     pushd "${platform}"
 
-    filename="drake-dev_${source_version}-1_amd64-${platform}.deb"
+    readonly remote_filename="drake-dev_${source_version}-1_amd64-${platform}.deb"
+    readonly local_filename="drake-dev_${source_version}-1_amd64.deb"
 
-    curl --fail --location --remote-name \
-      "https://drake-packages.csail.mit.edu/drake/release/${filename}"
+    curl --fail --location -o "${local_filename}" \
+      "https://drake-packages.csail.mit.edu/drake/release/${remote_filename}"
 
     # Add the Debian package to the aptly database.
-    aptly repo add "drake-${platform}" "${filename}"
+    aptly repo add "drake-${platform}" "${local_filename}"
     aptly snapshot create "drake-${platform}-${source_version}" \
       from repo "drake-${platform}"
 

--- a/tools/release_engineering/dev/push_release
+++ b/tools/release_engineering/dev/push_release
@@ -98,8 +98,10 @@ if [[ "${push_apt}" -ne 0 ]]; then
     mkdir -p "${platform}"
     pushd "${platform}"
 
+    filename="drake-dev_${source_version}-1_amd64-${platform}.deb"
+
     curl --fail --location --remote-name \
-      "https://drake-packages.csail.mit.edu/drake/release/drake-dev_${source_version}-1_amd64-${platform}.deb"
+      "https://drake-packages.csail.mit.edu/drake/release/${filename}"
 
     # Add the Debian package to the aptly database.
     aptly repo add "drake-${platform}" "${filename}"

--- a/tools/release_engineering/dev/push_release
+++ b/tools/release_engineering/dev/push_release
@@ -98,10 +98,8 @@ if [[ "${push_apt}" -ne 0 ]]; then
     mkdir -p "${platform}"
     pushd "${platform}"
 
-    filename="drake-dev_${source_version}-1_amd64.deb"
-
     curl --fail --location --remote-name \
-      "https://drake-packages.csail.mit.edu/drake/release/${platform}/${filename}"
+      "https://drake-packages.csail.mit.edu/drake/release/drake-dev_${source_version}-1_amd64-${platform}.deb"
 
     # Add the Debian package to the aptly database.
     aptly repo add "drake-${platform}" "${filename}"

--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -354,8 +354,9 @@ def _push_deb(state: _State):
     Downloads .deb artifacts and push them to S3.
     """
     for deb in state.find_artifacts(_Manifest.RE_DEB):
-        dest_name = f'drake/release/drake-dev_{deb.version}_{deb.arch}-{deb.platform}.{deb.ext}'
-        state.push_artifact(deb, _AWS_BUCKET, dest_name)
+        dest_path_suffix = f'{deb.version}_{deb.arch}-{deb.platform}.{deb.ext}'
+        dest_path = f'drake/release/drake-dev_{dest_path_suffix}'
+        state.push_artifact(deb, _AWS_BUCKET, dest_path)
 
 
 def _push_docker(state: _State):

--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -354,9 +354,8 @@ def _push_deb(state: _State):
     Downloads .deb artifacts and push them to S3.
     """
     for deb in state.find_artifacts(_Manifest.RE_DEB):
-        dest_name = f'drake-dev_{deb.version}_{deb.arch}.{deb.ext}'
-        dest_path = f'drake/release/{deb.platform}/{dest_name}'
-        state.push_artifact(deb, _AWS_BUCKET, dest_path)
+        dest_name = f'drake/release/drake-dev_{deb.version}_{deb.arch}-{deb.platform}.{deb.ext}'
+        state.push_artifact(deb, _AWS_BUCKET, dest_name)
 
 
 def _push_docker(state: _State):


### PR DESCRIPTION
Issue: #19735 

* Change `_push_deb` in `push_release.py` to copy artifacts directly to the `drake_release` folder in S3, rather than the per-distro subdirectories. The platform name is hyphenated at the end of the filename.
* Change `push_release` to copy the corresponding filename convention.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22471)
<!-- Reviewable:end -->
