### PR TITLE
Unify validity tests and messages for SpatialInertia class.

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -1026,9 +1026,10 @@ class MujocoParser {
       }
       SpatialInertia<double> M_GGo_G(mass, p_GoGcm_G, G_GGo_G,
                                      /*skip_validity_check=*/true);
-      if (!M_GGo_G.IsPhysicallyValid()) {
-        Error(*node, fmt::format("geom {} {}", geom.name,
-                                 M_GGo_G.CriticizeNotPhysicallyValid()));
+      std::optional<std::string> invalidity_report =
+          M_GGo_G.CreateInvalidityReport();
+      if (invalidity_report.has_value()) {
+        Error(*node, fmt::format("geom {} {}", geom.name, *invalidity_report));
         return geom;
       }
 

--- a/multibody/tree/geometry_spatial_inertia.cc
+++ b/multibody/tree/geometry_spatial_inertia.cc
@@ -194,10 +194,10 @@ CalcSpatialInertiaResult CalcSpatialInertiaImpl(
 
   auto result = SpatialInertia<double>{mass, p_GoGcm, G_GGo_G,
                                        /* skip_validity_check = */ true};
-  std::string message = result.CriticizeNotPhysicallyValid();
-  if (!message.empty()) {
-    return message;
-  }
+  std::optional<std::string> invalidity_report =
+      result.CreateInvalidityReport();
+  if (invalidity_report.has_value()) return *invalidity_report;
+
   return result;
 }
 

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -372,6 +372,11 @@ std::optional<std::string> SpatialInertia<T>::CreateInvalidityReport() const {
 }
 
 template <typename T>
+boolean<T> SpatialInertia<T>::IsPhysicallyValid() const {
+  return boolean<T>(!CreateInvalidityReport().has_value());
+}
+
+template <typename T>
 void SpatialInertia<T>::ThrowIfNotPhysicallyValidImpl() const {
   const std::optional<std::string> invalidity_report = CreateInvalidityReport();
   if (invalidity_report.has_value()) {

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -347,28 +347,28 @@ std::optional<std::string> SpatialInertia<T>::CreateInvalidityReport() const {
         fmt::format("\nmass = {} is negative or not finite.\n", mass);
 
   } else if (p_PBcm.array().isNaN().any()) {
-      error_message +=
+    error_message +=
         fmt::format("\nPosition vector [{}  {}  {}] has non-finite elements.\n",
-            p_PBcm(0), p_PBcm(1), p_PBcm(2));
+                    p_PBcm(0), p_PBcm(1), p_PBcm(2));
   } else {
-     // Is invalid if rotational inertia about-point P is invalid.
-     // Note: If mass = 0, `this` spatial inertia's unit inertia may be invalid,
-     // but the rotational inertia is valid (due to multiplying by zero).
-     const RotationalInertia<T> I_SP_E =
-       get_unit_inertia().MultiplyByScalarSkipValidityCheck(mass);
-     if(!I_SP_E.CouldBePhysicallyValid())
-       WriteExtraCentralInertiaProperties(&error_message);
-     else {
-       // Is invalid if rotational inertia about Bcm is invalid.
-       // To avoid a validity check in RotationalInertia::ShiftToCenterOfMass()
-       // that throws an exception, use SpatialInertia::ShiftToCenterOfMass().
-       const SpatialInertia<T> M_SScm_E = ShiftToCenterOfMass();
-       const UnitInertia<T>& G_SScm_E = M_SScm_E.get_unit_inertia();
-       const RotationalInertia<T> I_SScm_E =
-           G_SScm_E.MultiplyByScalarSkipValidityCheck(mass_);
-       if(!I_SScm_E.CouldBePhysicallyValid())
-         WriteExtraCentralInertiaProperties(&error_message);
-     }
+    // Is invalid if rotational inertia about-point P is invalid.
+    // Note: If mass = 0, `this` spatial inertia's unit inertia may be invalid,
+    // but the rotational inertia is valid (due to multiplying by zero).
+    const RotationalInertia<T> I_SP_E =
+        get_unit_inertia().MultiplyByScalarSkipValidityCheck(mass);
+    if (!I_SP_E.CouldBePhysicallyValid()) {
+      WriteExtraCentralInertiaProperties(&error_message);
+    } else {
+      // Is invalid if rotational inertia about Bcm is invalid.
+      // To avoid a validity check in RotationalInertia::ShiftToCenterOfMass()
+      // that throws an exception, use SpatialInertia::ShiftToCenterOfMass().
+      const SpatialInertia<T> M_SScm_E = ShiftToCenterOfMass();
+      const UnitInertia<T>& G_SScm_E = M_SScm_E.get_unit_inertia();
+      const RotationalInertia<T> I_SScm_E =
+          G_SScm_E.MultiplyByScalarSkipValidityCheck(mass_);
+      if (!I_SScm_E.CouldBePhysicallyValid())
+        WriteExtraCentralInertiaProperties(&error_message);
+    }
   }
   if (error_message.empty()) return std::nullopt;
   return error_message;

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -336,18 +336,18 @@ SpatialInertia<T> SpatialInertia<T>::SolidTetrahedronAboutVertexWithDensity(
 
 template <typename T>
 std::optional<std::string> SpatialInertia<T>::CreateInvalidityReport() const {
-  // Default return value is an empty string (this SpatialInertia is valid).
+  // Default return value is an empty optional (this SpatialInertia is valid).
   std::string error_message;
   const Vector3<T>& p_PBcm = get_com();
 
   // Is invalid if the mass is negative or non-finite.
   const T& mass = get_mass();
   if (!is_nonnegative_finite(mass)) {
-    error_message +=
+    error_message =
         fmt::format("\nmass = {} is negative or not finite.\n", mass);
 
-  } else if (p_PBcm.array().isNaN().any()) {
-    error_message +=
+  } else if (!p_PBcm.array().isFinite().all()) {
+    error_message =
         fmt::format("\nPosition vector [{}  {}  {}] has non-finite elements.\n",
                     p_PBcm(0), p_PBcm(1), p_PBcm(2));
   } else {

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -594,7 +594,9 @@ class SpatialInertia {
   /// invalid, otherwise returns an empty optional.
   std::optional<std::string> CreateInvalidityReport() const;
 
-  DRAKE_DEPRECATED("2025-06-01", "Use SpatialInertia::CreateInvalidityReport()")
+  DRAKE_DEPRECATED("2025-06-01",
+                   "Will be removed.  There is no replacement. "
+                   " File an issue if that is a problem.")
   std::string CriticizeNotPhysicallyValid() const {
     std::optional<std::string> invalidity_report = CreateInvalidityReport();
     if (invalidity_report.has_value()) return *invalidity_report;

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -590,8 +590,8 @@ class SpatialInertia {
   /// @see RotationalInertia::CouldBePhysicallyValid().
   boolean<T> IsPhysicallyValid() const;
 
-  /// Returns an optional string if this SpatialInertia is invalid, otherwise
-  /// returns an empty optional. Check the return value with has_value().
+  /// (Internal use only). Returns an optional string if this SpatialInertia is
+  /// invalid, otherwise returns an empty optional.
   std::optional<std::string> CreateInvalidityReport() const;
 
   DRAKE_DEPRECATED("2025-06-01", "Use SpatialInertia::CreateInvalidityReport()")

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -12,6 +12,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/math/cross_product.h"
@@ -587,12 +588,13 @@ class SpatialInertia {
   /// condition when performed on a rotational inertia about a body's center of
   /// mass.
   /// @see RotationalInertia::CouldBePhysicallyValid().
-  boolean<T> IsPhysicallyValid() const {
-    return boolean<T>(!CreateInvalidityReport().has_value());
-  }
+  boolean<T> IsPhysicallyValid() const;
 
-  /// Performs the same checks as the boolean typed IsPhysicallyValid().
-  /// @returns empty string if valid, otherwise, a detailed error message.
+  /// Returns an optional string if this SpatialInertia is invalid, otherwise
+  /// returns an empty optional. Check the return value with has_value().
+  std::optional<std::string> CreateInvalidityReport() const;
+
+  DRAKE_DEPRECATED("2025-06-01", "Use SpatialInertia::CreateInvalidityReport()")
   std::string CriticizeNotPhysicallyValid() const {
     std::optional<std::string> invalidity_report = CreateInvalidityReport();
     if (invalidity_report.has_value()) return *invalidity_report;
@@ -901,9 +903,6 @@ class SpatialInertia {
     return std::numeric_limits<
         typename Eigen::NumTraits<T>::Literal>::quiet_NaN();
   }
-
-  // Returns an error string if `this` SpatialInertia is invalid.
-  std::optional<std::string> CreateInvalidityReport() const;
 
   // If type T is Symbolic, validity is not checked and no exception is thrown.
   void ThrowIfNotPhysicallyValid() {

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <exception>
 #include <limits>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -570,8 +571,7 @@ class SpatialInertia {
   }
 
   /// Performs a number of checks to verify that this is a physically valid
-  /// spatial inertia.
-  /// The checks performed are:
+  /// spatial inertia. The checks performed include:
   ///
   /// - No NaN entries.
   /// - Non-negative mass.
@@ -587,7 +587,9 @@ class SpatialInertia {
   /// condition when performed on a rotational inertia about a body's center of
   /// mass.
   /// @see RotationalInertia::CouldBePhysicallyValid().
-  boolean<T> IsPhysicallyValid() const;
+  boolean<T> IsPhysicallyValid() const {
+    return boolean<T>(!CreateInvalidityReport().has_value());
+  }
 
   /// Performs the same checks as the boolean typed IsPhysicallyValid().
   /// @returns empty string if valid, otherwise, a detailed error message.
@@ -917,6 +919,10 @@ class SpatialInertia {
   // Throws an exception with a detailed error message.
   // @pre !IsPhysicallyValid() (not checked).
   [[noreturn]] void ThrowNotPhysicallyValid() const;
+
+  // Returns an error string if `this` RotationalInertia is verifiably invalid.
+  // Note: Not returning an error string does not _guarantee_ validity.
+  std::optional<std::string> CreateInvalidityReport() const;
 
   // Returns a detailed error message.
   // @pre !IsPhysicallyValid() (not checked).

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -952,6 +952,37 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithZeroMass) {
       expected_message);
 }
 
+// Test that it is not possible to create a spatial inertia with a negative
+// or NaN mass.
+GTEST_TEST(SpatialInertia, IsInvalidDueToBadMassOrPositionVector) {
+  Vector3<double> p_PBcm_E = Vector3<double>(0.0, 0.0, 0.0);
+  const double Gxx = 2.0, Gyy = 3.0, Gzz = 4.0;
+  const UnitInertia<double> G_BP_E(Gxx, Gyy, Gzz, 0, 0, 0);
+
+  // Ensure a negative mass throws an exception.
+  double mass = -1.0;
+  std::string expected_message =
+      "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
+      "mass = -1(\\.0)? is negative or not finite.\n";
+  DRAKE_EXPECT_THROWS_MESSAGE(SpatialInertia(mass, p_PBcm_E, G_BP_E),
+                              expected_message);
+
+  // Ensure a NaN mass throws an exception.
+  mass = std::numeric_limits<double>::infinity();
+  expected_message =
+      "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
+      "mass = inf is negative or not finite.\n";
+  DRAKE_EXPECT_THROWS_MESSAGE(SpatialInertia(mass, p_PBcm_E, G_BP_E),
+                              expected_message);
+
+  // Ensure a position vector with a NaN element throws an exception.
+  p_PBcm_E = Vector3<double>(0.0, 0.0, std::numeric_limits<double>::infinity());
+  expected_message =
+      "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
+      "Position vector [0(\\.0)?  0(\\.0)?  inf\\] "
+      "has non-finite elements.\n";
+}
+
 // Test that it is not possible to create a spatial inertia with a bad
 // rotational inertia negative mass.
 GTEST_TEST(SpatialInertia, IsPhysicallyValidWithBadInertia) {

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -967,7 +967,7 @@ GTEST_TEST(SpatialInertia, IsInvalidDueToBadMassOrPositionVector) {
   DRAKE_EXPECT_THROWS_MESSAGE(SpatialInertia(mass, p_PBcm_E, G_BP_E),
                               expected_message);
 
-  // Ensure a NaN mass throws an exception.
+  // Ensure a non-finite mass throws an exception.
   mass = std::numeric_limits<double>::infinity();
   expected_message =
       "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
@@ -975,12 +975,20 @@ GTEST_TEST(SpatialInertia, IsInvalidDueToBadMassOrPositionVector) {
   DRAKE_EXPECT_THROWS_MESSAGE(SpatialInertia(mass, p_PBcm_E, G_BP_E),
                               expected_message);
 
-  // Ensure a position vector with a NaN element throws an exception.
+  // Ensure a position vector with a non-finite element throws an exception.
   p_PBcm_E = Vector3<double>(0.0, 0.0, std::numeric_limits<double>::infinity());
   expected_message =
       "Spatial inertia fails SpatialInertia::IsPhysicallyValid\\(\\).\n"
       "Position vector [0(\\.0)?  0(\\.0)?  inf\\] "
       "has non-finite elements.\n";
+
+  // Ensure a zero mass does not throw an exception.
+  p_PBcm_E = Vector3<double>(0.0, 0.0, 0.0);
+  mass = 0.0;
+  DRAKE_EXPECT_NO_THROW(SpatialInertia(mass, p_PBcm_E, G_BP_E));
+
+  // TODO(Mitiguy) Ensure a zero mass with a bad unit inertia throws
+  //  a sensible message. Currently (Feb 2025) it does not.
 }
 
 // Test that it is not possible to create a spatial inertia with a bad


### PR DESCRIPTION
Unifies SpatialInertia tests and error messages for mass, center of mass, and inertia properties.  Code is consolidated (reduced) and inconsistent detection and message construction are fixed.  The public SpatialInertia method CriticizeNotPhysicallyValid() was deprecated in favor of the new internal-use only function CreateInvalidityReport().

Resolves #22017, resolves #22651.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22474)
<!-- Reviewable:end -->
