### PR TITLE
[lcmtypes] Add benchmark

### DIFF
--- a/lcmtypes/benchmarking/BUILD.bazel
+++ b/lcmtypes/benchmarking/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load(
+    "//tools/performance:defs.bzl",
+    "drake_cc_googlebench_binary",
+    "drake_py_experiment_binary",
+)
+
+package(default_visibility = ["//visibility:private"])
+
+drake_cc_googlebench_binary(
+    name = "benchmark",
+    srcs = ["benchmark.cc"],
+    add_test_rule = True,
+    deps = [
+        "//lcm",
+        "//lcmtypes:lcmtypes_drake_cc",
+        "//tools/performance:fixture_common",
+        "//tools/performance:gflags_main",
+    ],
+)
+
+drake_py_experiment_binary(
+    name = "experiment",
+    googlebench_binary = ":benchmark",
+)
+
+add_lint_tests()

--- a/lcmtypes/benchmarking/benchmark.cc
+++ b/lcmtypes/benchmarking/benchmark.cc
@@ -1,0 +1,196 @@
+#include <benchmark/benchmark.h>
+
+#include "drake/lcmt_image.hpp"
+#include "drake/lcmt_image_array.hpp"
+#include "drake/lcmt_panda_command.hpp"
+#include "drake/lcmt_panda_status.hpp"
+#include "drake/lcmt_viewer_draw.hpp"
+#include "drake/tools/performance/fixture_common.h"
+
+/* A collection of LCM encoding / decoding scenarios. */
+
+namespace drake {
+namespace {
+
+class LcmFixture : public benchmark::Fixture {
+ public:
+  LcmFixture() {
+    tools::performance::AddMinMaxStatistics(this);
+    this->Unit(benchmark::kMicrosecond);
+  }
+
+  static lcmt_image MakeImage(std::string frame_name, int bytes_per_pixel) {
+    lcmt_image message{};
+    message.header.frame_name = frame_name, message.width = 848;
+    message.height = 480;
+    message.data.resize(message.width * message.height * bytes_per_pixel);
+    message.size = message.data.size();
+    return message;
+  }
+
+  static lcmt_image_array MakeImageArray() {
+    lcmt_image_array message{};
+    message.header.seq = 1;
+    message.header.utime = 2;
+    message.header.frame_name = "frame";
+    message.images.push_back(MakeImage("color", 4));
+    message.images.push_back(MakeImage("depth", 2));
+    message.num_images = message.images.size();
+    return message;
+  }
+
+  static lcmt_panda_command MakePandaCommand() {
+    lcmt_panda_command message{};
+    const int n = 7;
+    message.num_joint_position = n;
+    message.joint_position.resize(n, 0);
+    message.num_joint_torque = n;
+    message.joint_torque.resize(n, 0);
+    return message;
+  }
+
+  static lcmt_panda_status MakePandaStatus() {
+    lcmt_panda_status message{};
+    const int n = 7;
+    message.num_joints = n;
+    message.joint_position.resize(n, 0);
+    message.joint_position_desired.resize(n, 0);
+    message.joint_velocity.resize(n, 0);
+    message.joint_velocity_desired.resize(n, 0);
+    message.joint_acceleration_desired.resize(n, 0);
+    message.joint_torque.resize(n, 0);
+    message.joint_torque_desired.resize(n, 0);
+    message.joint_torque_external.resize(n, 0);
+    return message;
+  }
+
+  static lcmt_viewer_draw MakeViewerDraw() {
+    lcmt_viewer_draw message{};
+    const int n = 500;
+    message.num_links = n;
+    message.link_name.resize(n, "parsers_make_very_long_names");
+    message.robot_num.resize(n, 0);
+    message.position.resize(n, {0, 0, 0});
+    message.quaternion.resize(n, {0, 0, 0, 0});
+    return message;
+  }
+};
+
+template <typename Message>
+__attribute__((noinline)) bool Encode(const Message& message,
+                                      std::vector<uint8_t>* bytes) {
+  const int64_t num_bytes = message.getEncodedSize();
+  bytes->resize(num_bytes);
+  message.encode(bytes->data(), 0, num_bytes);
+  return true;
+}
+
+template <typename Message>
+__attribute__((noinline)) bool Decode(const std::vector<uint8_t>& bytes,
+                                      Message* message) {
+  message->decode(bytes.data(), 0, bytes.size());
+  return true;
+}
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_DEFINE_F(LcmFixture, ImageArrayEncode)(benchmark::State& state) {
+  const auto message = MakeImageArray();
+  for (auto _ : state) {
+    std::vector<uint8_t> bytes;
+    benchmark::DoNotOptimize(Encode(message, &bytes));
+  }
+}
+
+BENCHMARK_REGISTER_F(LcmFixture, ImageArrayEncode)
+    ->Unit(benchmark::kMicrosecond);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_DEFINE_F(LcmFixture, ImageArrayDecode)(benchmark::State& state) {
+  std::vector<uint8_t> bytes;
+  Encode(MakeImageArray(), &bytes);
+  for (auto _ : state) {
+    lcmt_image_array message{};
+    benchmark::DoNotOptimize(Decode(bytes, &message));
+  }
+}
+
+BENCHMARK_REGISTER_F(LcmFixture, ImageArrayDecode)
+    ->Unit(benchmark::kMicrosecond);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_DEFINE_F(LcmFixture, PandaCommandEncode)(benchmark::State& state) {
+  const auto message = MakePandaCommand();
+  for (auto _ : state) {
+    std::vector<uint8_t> bytes;
+    benchmark::DoNotOptimize(Encode(message, &bytes));
+  }
+}
+
+BENCHMARK_REGISTER_F(LcmFixture, PandaCommandEncode)
+    ->Unit(benchmark::kNanosecond);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_DEFINE_F(LcmFixture, PandaCommandDecode)(benchmark::State& state) {
+  std::vector<uint8_t> bytes;
+  Encode(MakePandaCommand(), &bytes);
+  for (auto _ : state) {
+    lcmt_image_array message{};
+    benchmark::DoNotOptimize(Decode(bytes, &message));
+  }
+}
+
+BENCHMARK_REGISTER_F(LcmFixture, PandaCommandDecode)
+    ->Unit(benchmark::kNanosecond);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_DEFINE_F(LcmFixture, PandaStatusEncode)(benchmark::State& state) {
+  const auto message = MakePandaStatus();
+  for (auto _ : state) {
+    std::vector<uint8_t> bytes;
+    benchmark::DoNotOptimize(Encode(message, &bytes));
+  }
+}
+
+BENCHMARK_REGISTER_F(LcmFixture, PandaStatusEncode)
+    ->Unit(benchmark::kNanosecond);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_DEFINE_F(LcmFixture, PandaStatusDecode)(benchmark::State& state) {
+  std::vector<uint8_t> bytes;
+  Encode(MakePandaStatus(), &bytes);
+  for (auto _ : state) {
+    lcmt_image_array message{};
+    benchmark::DoNotOptimize(Decode(bytes, &message));
+  }
+}
+
+BENCHMARK_REGISTER_F(LcmFixture, PandaStatusDecode)
+    ->Unit(benchmark::kNanosecond);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_DEFINE_F(LcmFixture, ViewerDrawEncode)(benchmark::State& state) {
+  const auto message = MakeViewerDraw();
+  for (auto _ : state) {
+    std::vector<uint8_t> bytes;
+    benchmark::DoNotOptimize(Encode(message, &bytes));
+  }
+}
+
+BENCHMARK_REGISTER_F(LcmFixture, ViewerDrawEncode)
+    ->Unit(benchmark::kMicrosecond);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_DEFINE_F(LcmFixture, ViewerDrawDecode)(benchmark::State& state) {
+  std::vector<uint8_t> bytes;
+  Encode(MakeViewerDraw(), &bytes);
+  for (auto _ : state) {
+    lcmt_image_array message{};
+    benchmark::DoNotOptimize(Decode(bytes, &message));
+  }
+}
+
+BENCHMARK_REGISTER_F(LcmFixture, ViewerDrawDecode)
+    ->Unit(benchmark::kNanosecond);
+
+}  // namespace
+}  // namespace drake

--- a/tools/performance/BUILD.bazel
+++ b/tools/performance/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = [
     # All benchmarks should be in folders named "benchmarking".
     "//common/benchmarking:__pkg__",
     "//geometry/benchmarking:__pkg__",
+    "//lcmtypes/benchmarking:__pkg__",
     "//multibody/benchmarking:__pkg__",
     "//solvers/benchmarking:__pkg__",
     "//systems/benchmarking:__pkg__",


### PR DESCRIPTION
Towards #20761 and therefore towards #17231 and #21868.

The objective here is to have sufficient benchmark coverage that we feel confident switching over the implementation.

Sample output:
```
----------------------------------------------------------------------------------
Benchmark                              Time             CPU    Allocs   Iterations
----------------------------------------------------------------------------------
LcmFixture/ImageArrayEncode         82.9 us         82.9 us     1.375         7994
LcmFixture/ImageArrayDecode         80.1 us         80.1 us    3.4375         8633
LcmFixture/PandaCommandEncode       29.6 ns         29.6 ns      1.25     24645732
LcmFixture/PandaCommandDecode       3.28 ns         3.28 ns    0.3125    216860095
LcmFixture/PandaStatusEncode        71.0 ns         71.0 ns     1.625      9747702
LcmFixture/PandaStatusDecode        3.12 ns         3.12 ns    0.6875    224399289
LcmFixture/ViewerDrawEncode         4.84 us         4.84 us   95.3125       144837
LcmFixture/ViewerDrawDecode         3.12 ns         3.12 ns    94.375    224434971
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22480)
<!-- Reviewable:end -->
