### PR TITLE
[planning] Fix GetParam-based gtest names

### DIFF
--- a/planning/dev/BUILD.bazel
+++ b/planning/dev/BUILD.bazel
@@ -207,6 +207,7 @@ drake_cc_library(
     ],
     deps = [
         ":sphere_robot_model_collision_checker",
+        "//common:nice_type_name",
         "//planning:collision_checker",
         "@gtest//:without_main",
     ],

--- a/planning/dev/test/mbp_environment_collision_checker_test.cc
+++ b/planning/dev/test/mbp_environment_collision_checker_test.cc
@@ -36,7 +36,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     MbpEnvironmentCollisionCheckerTest2,
     SphereRobotModelCollisionCheckerAbstractTestSuite,
-    testing::Values(MakeMbpEnvironmentCollisionCheckerParams().checker));
+    testing::Values(SphereRobotModelCollisionCheckerTestParams{
+        MakeMbpEnvironmentCollisionCheckerParams().checker}));
 
 }  // namespace test
 }  // namespace planning

--- a/planning/dev/test/sphere_robot_model_collision_checker_abstract_test_suite.cc
+++ b/planning/dev/test/sphere_robot_model_collision_checker_abstract_test_suite.cc
@@ -3,12 +3,20 @@
 #include <unordered_map>
 #include <vector>
 
+#include "drake/common/nice_type_name.h"
+
 namespace drake {
 namespace planning {
 namespace test {
 
+std::ostream& operator<<(std::ostream& out,
+                         const SphereRobotModelCollisionCheckerTestParams& p) {
+  out << drake::NiceTypeName::Get(*p.checker);
+  return out;
+}
+
 TEST_P(SphereRobotModelCollisionCheckerAbstractTestSuite, SphereChecker) {
-  std::shared_ptr<CollisionChecker> checker = GetParam();
+  std::shared_ptr<CollisionChecker> checker = GetParam().checker;
   auto& sphere_checker =
       dynamic_cast<SphereRobotModelCollisionChecker&>(*checker);
 

--- a/planning/dev/test/sphere_robot_model_collision_checker_abstract_test_suite.h
+++ b/planning/dev/test/sphere_robot_model_collision_checker_abstract_test_suite.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <ostream>
 
 #include <gtest/gtest.h>
 
@@ -10,12 +11,24 @@ namespace drake {
 namespace planning {
 namespace test {
 
+/* These parameters are passed to the abstract test cases to make them concrete,
+for now just a collision checker of some derived type */
+struct SphereRobotModelCollisionCheckerTestParams {
+  std::shared_ptr<CollisionChecker> checker;
+};
+
+std::ostream& operator<<(std::ostream& out,
+                         const SphereRobotModelCollisionCheckerTestParams& p);
+
 // Even though the static type of the parameterized test value is just
 // CollisionChecker, the runtime param value should always be a
 // subclass of SphereRobotModelCollisionChecker.
 class SphereRobotModelCollisionCheckerAbstractTestSuite
-    : public testing::TestWithParam<std::shared_ptr<CollisionChecker>> {};
+    : public testing::TestWithParam<
+          SphereRobotModelCollisionCheckerTestParams> {};
 
 }  // namespace test
 }  // namespace planning
 }  // namespace drake
+
+// testing::PrintToString

--- a/planning/dev/test/voxelized_environment_collision_checker_test.cc
+++ b/planning/dev/test/voxelized_environment_collision_checker_test.cc
@@ -89,7 +89,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     VoxelizedEnvironmentCollisionCheckerTest2,
     SphereRobotModelCollisionCheckerAbstractTestSuite,
-    testing::Values(MakeVoxelizedEnvironmentCollisionCheckerParams().checker));
+    testing::Values(SphereRobotModelCollisionCheckerTestParams{
+        MakeVoxelizedEnvironmentCollisionCheckerParams().checker}));
 
 }  // namespace test
 }  // namespace planning

--- a/planning/test_utilities/BUILD.bazel
+++ b/planning/test_utilities/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_library(
         "@drake_models//:iiwa_description",
     ],
     deps = [
+        "//common:nice_type_name",
         "//multibody/parsing",
         "//planning:collision_avoidance",
         "//planning:collision_checker",

--- a/planning/test_utilities/collision_checker_abstract_test_suite.cc
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.cc
@@ -4,6 +4,7 @@
 
 #include <common_robotics_utilities/print.hpp>
 
+#include "drake/common/nice_type_name.h"
 #include "drake/common/text_logging.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/planning/collision_avoidance.h"
@@ -42,7 +43,7 @@ multibody::parsing::ModelDirectives MakeCollisionCheckerTestScene() {
 
 std::ostream& operator<<(std::ostream& out,
                          const CollisionCheckerTestParams& p) {
-  out << "checker = " << p.checker;
+  out << "checker = " << NiceTypeName::Get(*p.checker);
   out << ", supports_added_world_obstacles = "
       << p.supports_added_world_obstacles;
   out << ", thread_stress_iterations = " << p.thread_stress_iterations;


### PR DESCRIPTION
We should print the type of the checker, not dump its memory buffer.

Amends #21561.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22485)
<!-- Reviewable:end -->
