### PR TITLE
Improve meshcat mtl processing

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -421,9 +421,9 @@ class MeshcatShapeReifier : public ShapeReifier {
         //  - "map_.+" matches the map_ plus any options,
         //  - "\s" matches one whitespace (before the image_name),
         //  - "[^\s]+" matches the image_name, and
-        //  - "[$\r\n]" matches the end of string or end of line.
+        //  - "(?:$|\r|\n)" matches the end of string or end of line.
         // TODO(russt): This parsing could still be more robust.
-        std::regex map_regex(R"""(map_.+\s([^\s]+)\s*[$\r\n])""");
+        std::regex map_regex(R"""(map_.+\s([^\s]+)\s*(?:$|\r|\n))""");
         for (std::sregex_iterator iter(meshfile_object.mtl_library.begin(),
                                        meshfile_object.mtl_library.end(),
                                        map_regex);


### PR DESCRIPTION
Previously it failed to find map_* lines which were on the last line of the file (with no trailing newline).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22487)
<!-- Reviewable:end -->
