### PR TITLE
[framework] Fix diagram scalar conversion losing external constraints

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -99,6 +99,7 @@ void DoScalarIndependentDefinitions(py::module m) {
   BindTypeSafeIndex<AbstractStateIndex>(m, "AbstractStateIndex");
   BindTypeSafeIndex<NumericParameterIndex>(m, "NumericParameterIndex");
   BindTypeSafeIndex<AbstractParameterIndex>(m, "AbstractParameterIndex");
+  BindTypeSafeIndex<SystemConstraintIndex>(m, "SystemConstraintIndex");
 
   py::class_<FixedInputPortValue>(
       m, "FixedInputPortValue", doc.FixedInputPortValue.doc)
@@ -330,6 +331,17 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("ticket", &Class::ticket, cls_doc.ticket.doc)
         .def("has_default_prerequisites", &Class::has_default_prerequisites,
             cls_doc.has_default_prerequisites.doc);
+  }
+
+  {
+    // Binding this full feature in pydrake is non-trivial effort. For now,
+    // we'll just provide the default constructor for use in our unit tests,
+    // and mark the class itself with private visibility since it's not very
+    // useful without the full bindings.
+    using Class = ExternalSystemConstraint;
+    constexpr auto& cls_doc = doc.ExternalSystemConstraint;
+    py::class_<Class>(m, "_ExternalSystemConstraint", cls_doc.doc)
+        .def(py::init<>(), cls_doc.ctor.doc_0args);
   }
 }
 

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -368,6 +368,12 @@ struct Impl {
             py::arg("context"), py::arg("port_index"), py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), doc.System.EvalVectorInput.doc)
+        // Constraints.
+        .def("num_constraints", &System<T>::num_constraints,
+            doc.System.num_constraints.doc)
+        // (For now, bind privately since ExternalSystemConstraint is private.)
+        .def("_AddExternalConstraint", &System<T>::AddExternalConstraint,
+            py::arg("constraint"), doc.System.AddExternalConstraint.doc)
         // Calculations.
         .def("CalcTimeDerivatives", &System<T>::CalcTimeDerivatives,
             py::arg("context"), py::arg("derivatives"),

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -55,6 +55,7 @@ from pydrake.systems.framework import (
     VectorBase, VectorBase_,
     TriggerType,
     VectorSystem, VectorSystem_,
+    _ExternalSystemConstraint,
     )
 from pydrake.systems.primitives import (
     Adder, Adder_,
@@ -846,6 +847,15 @@ class TestGeneral(unittest.TestCase):
         system = PassThrough_[T](Value("a"))
         value = system.AllocateInputAbstract(system.get_input_port())
         self.assertIsInstance(value, Value[str])
+
+    @numpy_compare.check_all_types
+    def test_constaints_api(self, T):
+        system = PassThrough_[T](1)
+        self.assertEqual(system.num_constraints(), 0)
+        system._AddExternalConstraint(constraint=_ExternalSystemConstraint())
+        self.assertEqual(system.num_constraints(), 1)
+        cloned = system.Clone()
+        self.assertEqual(cloned.num_constraints(), 1)
 
     def test_event_status(self):
         system = ZeroOrderHold(period_sec=0.1, vector_size=1)

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1385,6 +1385,13 @@ Diagram<T>::ConvertScalarType() const {
         template Convert<NewType>(*old_system);
     DRAKE_DEMAND(new_system != nullptr);
 
+    // Because we called the scalar converter directly without going through
+    // System::ToScalarTypeMaybe, we need to re-implement its logic to copy any
+    // external constraints. Note that we must call this function on Diagram for
+    // reasons of access control, but it's really a System<NewType> function.
+    Diagram<NewType>::HandlePostConstructionScalarConversion(*old_system,
+                                                             new_system.get());
+
     // Update our mapping and take ownership.
     old_to_new_map[old_system.get()] = new_system.get();
     new_systems.push_back(std::move(new_system));

--- a/systems/framework/system_scalar_conversion_doxygen.h
+++ b/systems/framework/system_scalar_conversion_doxygen.h
@@ -330,7 +330,7 @@ class SpecialDiagram<T> final : public Diagram<T> {
   // Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
   explicit SpecialDiagram(const SpecialDiagram<U>& other)
-      : SpecialDiagram<T>(SystemTypeTag<SpecialDiagram>{}, other) {}
+      : Diagram<T>(SystemTypeTag<SpecialDiagram>{}, other) {}
 };
 @endcode
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -3783,9 +3783,12 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
   systems::DiagramBuilder<double> builder;
   auto sys1 = builder.AddSystem<ConstraintTestSystem<double>>();
   auto sys2 = builder.AddSystem<ConstraintTestSystem<double>>();
-
+  sys2->AddExternalConstraint(ExternalSystemConstraint{});
   auto diagram = builder.Build();
-  EXPECT_EQ(diagram->num_constraints(), 4);  // two from each system
+
+  // We have two constraints from each system, plus one external.
+  const int expected_num_constraints = 5;
+  EXPECT_EQ(diagram->num_constraints(), expected_num_constraints);
 
   auto context = diagram->CreateDefaultContext();
 
@@ -3845,7 +3848,7 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
 
   // Check that constraints survive ToAutoDiffXd.
   auto autodiff_diagram = diagram->ToAutoDiffXd();
-  EXPECT_EQ(autodiff_diagram->num_constraints(), 4);
+  EXPECT_EQ(autodiff_diagram->num_constraints(), expected_num_constraints);
   auto autodiff_context = autodiff_diagram->CreateDefaultContext();
   autodiff_context->SetTimeStateAndParametersFrom(*context);
   const SystemConstraint<AutoDiffXd>& autodiff_constraint =
@@ -3856,7 +3859,7 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
 
   // Check that constraints survive ToSymbolic.
   auto symbolic_diagram = diagram->ToSymbolic();
-  EXPECT_EQ(symbolic_diagram->num_constraints(), 4);
+  EXPECT_EQ(symbolic_diagram->num_constraints(), expected_num_constraints);
   auto symbolic_context = symbolic_diagram->CreateDefaultContext();
   symbolic_context->SetTimeStateAndParametersFrom(*context);
   const SystemConstraint<symbolic::Expression>& symbolic_constraint =


### PR DESCRIPTION
When a subsystem in a diagram had an ExternalSystemConstraint attached to it, the constraint wasn't being propagated through scalar conversion.

(I noticed this while testing the forthcoming new Python logic for scalar conversion in #21968.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22490)
<!-- Reviewable:end -->
