### PR TITLE
Meschat AddSlider and SetSliderValue return rounded/truncated value

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1635,7 +1635,7 @@ class Meshcat::Impl {
   }
 
   // This function is public via the PIMPL.
-  void AddSlider(std::string name, double min, double max, double step,
+  double AddSlider(std::string name, double min, double max, double step,
                  double value, std::string decrement_keycode,
                  std::string increment_keycode) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
@@ -1683,10 +1683,11 @@ class Meshcat::Impl {
       msgpack::pack(message_stream, data);
       app_->publish("all", message_stream.str(), uWS::OpCode::BINARY, false);
     });
+    return value;
   }
 
   // This function is public via the PIMPL.
-  void SetSliderValue(std::string name, double value) {
+  double SetSliderValue(std::string name, double value) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     {
@@ -1714,6 +1715,7 @@ class Meshcat::Impl {
       msgpack::pack(message_stream, data);
       app_->publish("all", message_stream.str(), uWS::OpCode::BINARY, false);
     });
+    return value;
   }
 
   // This function is public via the PIMPL.
@@ -2783,15 +2785,16 @@ bool Meshcat::DeleteButton(std::string name, bool strict) {
   return impl().DeleteButton(std::move(name), strict);
 }
 
-void Meshcat::AddSlider(std::string name, double min, double max, double step,
+double Meshcat::AddSlider(std::string name, double min, double max, double step,
                         double value, std::string decrement_keycode,
                         std::string increment_keycode) {
-  impl().AddSlider(std::move(name), min, max, step, value,
-                   std::move(decrement_keycode), std::move(increment_keycode));
+  return impl().AddSlider(std::move(name), min, max, step, value,
+                          std::move(decrement_keycode),
+                          std::move(increment_keycode));
 }
 
-void Meshcat::SetSliderValue(std::string name, double value) {
-  impl().SetSliderValue(std::move(name), value);
+double Meshcat::SetSliderValue(std::string name, double value) {
+  return impl().SetSliderValue(std::move(name), value);
 }
 
 double Meshcat::GetSliderValue(std::string_view name) const {

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -783,9 +783,10 @@ class Meshcat {
    then keydown callbacks will be registered in the GUI that will move the
    slider by @p step (within the limits) when those buttons are pressed.
 
+   @returns the truncated and rounded value that was actually set.
    @throws std::exception if `name` has already been added as any type of
    control (e.g., either button or slider). */
-  void AddSlider(std::string name, double min, double max, double step,
+  double AddSlider(std::string name, double min, double max, double step,
                  double value, std::string decrement_keycode = "",
                  std::string increment_keycode = "");
 
@@ -793,8 +794,9 @@ class Meshcat {
    to the slider range and rounded to the nearest increment specified by the
    slider `step`. This will update the slider element in all connected meshcat
    browsers.
+   @returns the truncated and rounded value that was actually set.
    @throws std::exception if `name` is not a registered slider. */
-  void SetSliderValue(std::string name, double value);
+  double SetSliderValue(std::string name, double value);
 
   /** Gets the current `value` of the slider `name`.
    @throws std::exception if `name` is not a registered slider. */

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -986,6 +986,14 @@ GTEST_TEST(MeshcatTest, Sliders) {
 
   slider_names = meshcat.GetSliderNames();
   EXPECT_EQ(slider_names.size(), 0);
+
+  // AddSlider and SetSliderValue return the rounded/truncated values.
+  EXPECT_NEAR(meshcat.AddSlider("slider_rounded1", 0.2, 1.5, 0.1, 0.512), 0.5,
+              1e-14);
+  EXPECT_NEAR(meshcat.AddSlider("slider_rounded2", 0.2, 1.5, 0.1, 0.1), 0.2,
+              1e-14);
+  EXPECT_NEAR(meshcat.SetSliderValue("slider_rounded1", 1.7), 1.5, 1e-14);
+  EXPECT_NEAR(meshcat.SetSliderValue("slider_rounded2", 1.234), 1.2, 1e-14);
 }
 
 GTEST_TEST(MeshcatTest, DuplicateMixedControls) {


### PR DESCRIPTION
They are computing this anyhow, so it is no burden to return them. And it turns out to be useful for my follow-up PR to JointSliders which has to reason explicitly about the rounding happening in the sliders.

+@joemasterjohn for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22495)
<!-- Reviewable:end -->
