### PR TITLE
Add ResolveConstraints logic to JointSliders (=> ModelVisualizer)

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -167,6 +167,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:type_pack",
     ],
@@ -446,6 +447,7 @@ drake_py_unittest(
     deps = [
         ":meshcat_py",
         ":parsing_py",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
         "//bindings/pydrake/common/test_utilities:numpy_compare_py",
     ],
 )

--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -1,5 +1,6 @@
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -167,20 +168,22 @@ void DoScalarDependentDefinitions(py::module m, T) {
   {
     using Class = JointSliders<T>;
     constexpr auto& cls_doc = doc.JointSliders;
-    DefineTemplateClassWithDefault<JointSliders<T>, LeafSystem<T>>(
-        m, "JointSliders", param, doc.JointSliders.doc)
+    auto cls = DefineTemplateClassWithDefault<JointSliders<T>, LeafSystem<T>>(
+        m, "JointSliders", param, doc.JointSliders.doc);
+    cls  // BR
         .def(py::init<std::shared_ptr<geometry::Meshcat>,
                  const MultibodyPlant<T>*, std::optional<Eigen::VectorXd>,
                  std::variant<std::monostate, double, Eigen::VectorXd>,
                  std::variant<std::monostate, double, Eigen::VectorXd>,
                  std::variant<std::monostate, double, Eigen::VectorXd>,
-                 std::vector<std::string>, std::vector<std::string>>(),
+                 std::vector<std::string>, std::vector<std::string>, double>(),
             py::arg("meshcat"), py::arg("plant"),
             py::arg("initial_value") = py::none(),
             py::arg("lower_limit") = py::none(),
             py::arg("upper_limit") = py::none(), py::arg("step") = py::none(),
             py::arg("decrement_keycodes") = std::vector<std::string>(),
             py::arg("increment_keycodes") = std::vector<std::string>(),
+            py::arg("time_step") = 1.0 / 32.0,
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 3>(),  // BR
             cls_doc.ctor.doc)
@@ -191,8 +194,20 @@ void DoScalarDependentDefinitions(py::module m, T) {
             // This is a long-running function that sleeps; for both reasons, we
             // must release the GIL.
             py::call_guard<py::gil_scoped_release>(), cls_doc.Run.doc)
-        .def("SetPositions", &Class::SetPositions, py::arg("q"),
-            cls_doc.SetPositions.doc);
+        .def("SetPositions",
+            py::overload_cast<systems::Context<T>*, const Eigen::VectorXd&>(
+                &Class::SetPositions),
+            py::arg("context"), py::arg("q"), cls_doc.SetPositions.doc)
+        .def("has_constraints_to_solve", &Class::has_constraints_to_solve,
+            cls_doc.has_constraints_to_solve.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.def("SetPositions",
+        WrapDeprecated(doc.JointSliders.SetPositions.doc_deprecated,
+            py::overload_cast<const Eigen::VectorXd&>(&Class::SetPositions)),
+        py::arg("q"), doc.JointSliders.SetPositions.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 }
 }  // namespace

--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -406,7 +406,8 @@ class ModelVisualizer:
             self._diagram.plant().SetPositions(
                 self._diagram.plant().GetMyContextFromRoot(self._context),
                 position)
-            self._sliders.SetPositions(position)
+            self._sliders.SetPositions(
+                self._sliders.GetMyContextFromRoot(self._context), position)
 
         # Use Simulator to dispatch initialization events.
         # TODO(eric.cousineau): Simplify as part of #13776 (was #10015).
@@ -521,9 +522,12 @@ class ModelVisualizer:
             if position is not None and len(position) > 0:
                 self._raise_if_invalid_positions(position)
                 self._diagram.plant().SetPositions(
-                    self._diagram.plant().GetMyContextFromRoot(self._context),
+                    self._diagram.plant().GetMyMutableContextFromRoot(
+                        self._context),
                     position)
-                self._sliders.SetPositions(position)
+                self._sliders.SetPositions(
+                    self._sliders.GetMyMutableContextFromRoot(self._context),
+                    position)
                 self._diagram.ForcedPublish(self._context)
 
         # Everything is finally fully configured. We can open the window now.
@@ -566,11 +570,15 @@ class ModelVisualizer:
                     self._reload()
                     self._set_slider_values(slider_values)
                     self._meshcat.AddButton(stop_button_name, "Escape")
+                updated = self._sliders.EvalUniquePeriodicDiscreteUpdate(
+                    self._sliders.GetMyContextFromRoot(self._context))
+                self._sliders.GetMyMutableContextFromRoot(
+                    self._context).SetDiscreteState(updated)
                 q = self._sliders.get_output_port().Eval(
                     self._sliders.GetMyContextFromRoot(self._context))
                 self._diagram.plant().SetPositions(
-                    self._diagram.plant().GetMyContextFromRoot(self._context),
-                    q)
+                    self._diagram.plant().GetMyMutableContextFromRoot(
+                        self._context), q)
                 self._diagram.ForcedPublish(self._context)
                 if loop_once or has_clicks(stop_button_name):
                     break

--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.h
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.h
@@ -11,11 +11,12 @@ namespace multibody {
 
 /** For all kinematic constraints associated with `plant` adds a corresponding
 solver::Constraint to `prog`, using decision variables `q` to represent the
-generalized positions of the plant.
+generalized positions of the plant. The `plant` must stay alive for the
+lifetime of the added constraints.
 
-Adds joint limits constraints, unit quaternion constraints, and constraints for
-any locked joints (via Joint::Lock()). Note that you must pass a valid
-`plant_context` to use joint locking.
+Adds joint limits constraints (always), unit quaternion constraints, and
+constraints for any locked joints (via Joint::Lock()). Note that you must pass
+a valid `plant_context` to use joint locking.
 
 Adds constraints for coupler, distance, ball, and weld constraints. The
 distance constraint is implemented here as a hard kinematic constraint (i.e.,

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -71,12 +71,12 @@ class InverseKinematics {
    * auto plant_context = &(diagram->GetMutableSubsystemContext(items.plant,
    * diagram_context.get()));
    * ```
-   * This context will be modified during calling ik.prog.Solve(...). When
-   * Solve() returns `result`, context will store the optimized posture, namely
-   * plant.GetPositions(*context) will be the same as in
-   * result.GetSolution(ik.q()). The user could then use this context to perform
-   * kinematic computation (like computing the position of the end-effector
-   * etc.).
+   * This context will be modified during calling solvers::Solve(ik.prog, ...).
+   * When Solve() returns `result`, context will store the optimized posture,
+   * namely plant.GetPositions(*context) will be the same as in
+   * result.GetSolution(ik.q()). The user could then use this context to
+   * perform kinematic computation (like computing the position of the
+   * end-effector etc.).
    * @param with_joint_limits If set to true, then the constructor imposes the
    * joint limits (obtained from plant.GetPositionLowerLimits() and
    * plant.GetPositionUpperLimits(), and from any body/joint locks set in

--- a/multibody/meshcat/BUILD.bazel
+++ b/multibody/meshcat/BUILD.bazel
@@ -88,7 +88,10 @@ drake_cc_library(
         "//common:scope_exit",
         "//geometry:meshcat",
         "//geometry:meshcat_graphviz",
+        "//multibody/inverse_kinematics:add_multibody_plant_constraints",
         "//multibody/plant",
+        "//solvers:choose_best_solver",
+        "//solvers:solve",
     ],
 )
 

--- a/multibody/meshcat/joint_sliders.h
+++ b/multibody/meshcat/joint_sliders.h
@@ -5,11 +5,14 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
 #include "drake/geometry/meshcat.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/solver_interface.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -31,14 +34,12 @@ output_ports:
 The output port is of size `plant.num_positions()`, and the order of its
 elements matches `plant.GetPositions()`.
 
-Only positions associated with joints get sliders. All other positions are fixed
-at nominal values.
-
-Beware that the output port of this system always provides the sliders' current
-values, even if evaluated by multiple different downstream input ports during a
-single computation.  If you need to have a synchronized view of the slider data,
-place a systems::ZeroOrderHold system between the sliders and downstream
-calculations.
+If the plant has constraints (@see AddMultibodyPlantConstraints), then a
+MathematicalProgram is used to resolve those constraints. The sliders in the
+gui will be updated (via a periodic or forced publish event) to reflect the
+resolved values. There is one nuance: the slider values in the gui only take
+values that are integer multiples of the slider step size; the constraint
+resolver solves to normal precision and publishes the nearest rounded values.
 
 @tparam_nonsymbolic_scalar
 @ingroup visualization */
@@ -80,6 +81,9 @@ class JointSliders final : public systems::LeafSystem<T> {
   @param increment_keycodes (Optional) A vector of length plant.num_positions()
   with keycodes to assign to increment the value of each individual joint
   slider. See Meshcat::AddSlider for more details.
+
+  @param time_step (Optional). The slider values are updated at discrete
+  intervals of this duration.
   */
   JointSliders(
       std::shared_ptr<geometry::Meshcat> meshcat,
@@ -89,7 +93,8 @@ class JointSliders final : public systems::LeafSystem<T> {
       std::variant<std::monostate, double, Eigen::VectorXd> upper_limit = {},
       std::variant<std::monostate, double, Eigen::VectorXd> step = {},
       std::vector<std::string> decrement_keycodes = {},
-      std::vector<std::string> increment_keycodes = {});
+      std::vector<std::string> increment_keycodes = {},
+      double time_step = 1 / 32.0);
 
   /** Removes our sliders from the associated meshcat instance.
 
@@ -131,20 +136,46 @@ class JointSliders final : public systems::LeafSystem<T> {
                       std::optional<double> timeout = std::nullopt,
                       std::string stop_button_keycode = "Escape") const;
 
-  /** Sets all robot positions (corresponding to joint positions and potentially
-  positions not associated with any joint) to the values in `q`.  The meshcat
-  sliders associated with any joint positions described by `q` will have their
-  value updated.  Additionally, the "initial state" vector of positions tracked
-  by this instance will be updated to the values in `q`.  This "initial state"
-  vector update will persist even if sliders are removed (e.g., via Delete).
+  /** Sets all robot positions (corresponding to joint positions and
+  potentially positions not associated with any joint) to the values in `q`.
+  The meshcat sliders associated with any joint positions described by `q`
+  will have their value updated. This _does not_ update the value of the
+  sliders in the context; see the SetPositions() overload which takes a
+  Context for that.
 
   @param q A vector whose length is equal to the associated
   MultibodyPlant::num_positions().
   */
+  DRAKE_DEPRECATED("2025-05-01", "Use SetPositions(context, q) instead.")
   void SetPositions(const Eigen::VectorXd& q);
 
+  /** Sets all robot positions (corresponding to joint positions and potentially
+  positions not associated with any joint) to the values in `q`.  The meshcat
+  sliders associated with any joint positions described by `q` will have their
+  value updated.
+
+  @param q A vector whose length is equal to the associated
+  MultibodyPlant::num_positions().
+  */
+  void SetPositions(systems::Context<T>* context, const Eigen::VectorXd& q);
+
+  /** Returns true if the sliders have constraints to solve, not including the
+  slider range limits which are enforced automatically. */
+  bool has_constraints_to_solve() const { return has_constraints_to_solve_; }
+
  private:
-  void CalcOutput(const systems::Context<T>&, systems::BasicVector<T>*) const;
+  std::pair<Eigen::VectorXd, solvers::SolutionResult> ResolveConstraints(
+      const Eigen::Ref<const Eigen::VectorXd>& target_values,
+      const Eigen::Ref<const Eigen::VectorXd>& previous_values,
+      const Eigen::Ref<const Eigen::VectorXd>& initial_guess) const;
+
+  Eigen::VectorXd RoundSliderValues(
+      const Eigen::Ref<const Eigen::VectorXd>& values) const;
+
+  systems::EventStatus Update(const systems::Context<T>& context,
+                              systems::DiscreteValues<T>* updates) const;
+
+  systems::EventStatus Publish(const systems::Context<T>& context) const;
 
   typename systems::LeafSystem<T>::GraphvizFragment DoGetGraphvizFragment(
       const typename systems::LeafSystem<T>::GraphvizFragmentParams& params)
@@ -152,11 +183,23 @@ class JointSliders final : public systems::LeafSystem<T> {
 
   std::shared_ptr<geometry::Meshcat> meshcat_;
   const MultibodyPlant<T>* const plant_;
+  std::shared_ptr<const MultibodyPlant<double>> double_plant_{nullptr};
   const std::map<int, std::string> position_names_;
-  /* The nominal values for all positions; positions with sliders will not use
-   their nominal value except for defining the slider's initial value. */
-  Eigen::VectorXd nominal_value_;
+  Eigen::VectorXd lower_{}, upper_{}, step_{};
   std::atomic<bool> is_registered_;
+  bool has_constraints_to_solve_{false};
+  systems::DiscreteStateIndex slider_values_index_;
+  /* If has_constraints_to_solve_ == true, then we keep an additional copy of
+  the positions as state. The slider values are restricted to multiples of the
+  step size, but may not satisfy the plant constraints. The constrained_values
+  are approximations of the slider values which do satisfy the plant
+  constraints. */
+  systems::DiscreteStateIndex constrained_values_index_;
+  systems::DiscreteStateIndex result_index_;
+  solvers::MathematicalProgram prog_;
+  solvers::VectorXDecisionVariable q_;
+  std::unique_ptr<const solvers::SolverInterface> solver_{};
+  std::unique_ptr<systems::Context<double>> double_plant_context_{};
 };
 
 }  // namespace meshcat

--- a/multibody/meshcat/test/joint_sliders_test.cc
+++ b/multibody/meshcat/test/joint_sliders_test.cc
@@ -7,8 +7,11 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/meshcat_visualizer.h"
 #include "drake/geometry/test_utilities/meshcat_environment.h"
+#include "drake/multibody/inverse_kinematics/add_multibody_plant_constraints.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/revolute_joint.h"
+#include "drake/solvers/mathematical_program.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/test_utilities/initialization_test_system.h"
 
@@ -18,17 +21,19 @@ namespace meshcat {
 namespace {
 
 using Eigen::Vector2d;
+using Eigen::Vector3d;
 using Eigen::VectorXd;
 using geometry::Meshcat;
 using geometry::MeshcatVisualizer;
 using geometry::SceneGraph;
+using math::RigidTransformd;
 
 class JointSlidersTest : public ::testing::Test {
  public:
   JointSlidersTest()
       : meshcat_{geometry::GetTestEnvironmentMeshcat()},
         builder_{},
-        plant_and_scene_graph_{AddMultibodyPlantSceneGraph(&builder_, 0.0)},
+        plant_and_scene_graph_{AddMultibodyPlantSceneGraph(&builder_, 0.001)},
         plant_{plant_and_scene_graph_.plant},
         scene_graph_{plant_and_scene_graph_.scene_graph} {}
 
@@ -77,6 +82,7 @@ TEST_F(JointSlidersTest, NarrowConstructor) {
   // Add the sliders.
   const JointSliders<double> dut(meshcat_, &plant_);
   auto context = dut.CreateDefaultContext();
+  EXPECT_FALSE(dut.has_constraints_to_solve());
 
   // Sliders start at their default context value.
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), default_angle_1);
@@ -89,6 +95,7 @@ TEST_F(JointSlidersTest, NarrowConstructor) {
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), min_angle_1);
   meshcat_->SetSliderValue(kAcrobotJoint1, 9999);
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), max_angle_1);
+  context->SetDiscreteState(dut.EvalUniquePeriodicDiscreteUpdate(*context));
   EXPECT_EQ(dut.get_output_port().Eval(*context),
             Vector2d(max_angle_1, default_angle_2));
 
@@ -136,6 +143,7 @@ TEST_F(JointSlidersTest, WideConstructorWithVectors) {
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), min_angle_1);
   meshcat_->SetSliderValue(kAcrobotJoint1, 9999);
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), max_angle_1);
+  context->SetDiscreteState(dut.EvalUniquePeriodicDiscreteUpdate(*context));
   EXPECT_EQ(dut.get_output_port().Eval(*context),
             Vector2d(max_angle_1, default_angle_2));
 
@@ -173,6 +181,7 @@ TEST_F(JointSlidersTest, WideConstructorWithScalars) {
   meshcat_->SetSliderValue(kAcrobotJoint2, 9999);
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), max_angle);
   EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), max_angle);
+  context->SetDiscreteState(dut.EvalUniquePeriodicDiscreteUpdate(*context));
   EXPECT_EQ(dut.get_output_port().Eval(*context),
             Vector2d::Constant(max_angle));
 
@@ -226,8 +235,9 @@ TEST_F(JointSlidersTest, MultiDofJoint) {
   Add("package://drake/multibody/meshcat/test/universal_joint.sdf");
   plant_.Finalize();
   const JointSliders<double> dut(meshcat_, &plant_);
+  EXPECT_FALSE(dut.has_constraints_to_solve());
 
-  // Confirm the names hasve the per-dof suffix.
+  // Confirm the names have the per-dof suffix.
   EXPECT_EQ(meshcat_->GetSliderValue("charlie_qx"), 0.0);
   EXPECT_EQ(meshcat_->GetSliderValue("charlie_qy"), 0.0);
 }
@@ -239,6 +249,7 @@ TEST_F(JointSlidersTest, FreeBody) {
   Add("package://drake/multibody/models/box.urdf");
   plant_.Finalize();
   const JointSliders<double> dut(meshcat_, &plant_);
+  EXPECT_TRUE(dut.has_constraints_to_solve());  // unit quaternion constraint.
   EXPECT_EQ(dut.get_output_port().size(), 7);
 }
 
@@ -322,7 +333,8 @@ TEST_F(JointSlidersTest, Run) {
 TEST_F(JointSlidersTest, SetPositionsWrongNumPositions) {
   AddAcrobot();
   JointSliders<double> dut(meshcat_, &plant_);
-  DRAKE_EXPECT_THROWS_MESSAGE(dut.SetPositions(Vector1d::Zero()),
+  auto context = dut.CreateDefaultContext();
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.SetPositions(context.get(), Vector1d::Zero()),
                               "Expected q of size 2, but got size 1 instead");
 }
 
@@ -346,7 +358,7 @@ TEST_F(JointSlidersTest, SetPositionsAcrobot) {
    Do not initialize q to something outside of (lower_limit, upper_limit), which
    defaults to (-10, 10). */
   const Vector2d q{-4, 7};
-  dut.SetPositions(q);
+  dut.SetPositions(context.get(), q);
   positions = dut.get_output_port().Eval(*context);
   EXPECT_EQ(positions[0], q[0]);
   EXPECT_EQ(positions[1], q[1]);
@@ -365,6 +377,119 @@ TEST_F(JointSlidersTest, SetPositionsAcrobot) {
 /* Tests the "SetPositions" function with the Kuka IIWA Robot model (number of
  positions on the MultibodyPlant not equal to the number of joints). */
 TEST_F(JointSlidersTest, SetPositionsKukaIiwaRobot) {
+  // Kuka IIWA has 14 positions, 7 of them are joints.
+  static constexpr char kKukaIiwaJoint1[] = "iiwa_joint_1";  // Index: 7
+  static constexpr char kKukaIiwaJoint2[] = "iiwa_joint_2";  // Index: 8
+  static constexpr char kKukaIiwaJoint3[] = "iiwa_joint_3";  // Index: 9
+  static constexpr char kKukaIiwaJoint4[] = "iiwa_joint_4";  // Index: 10
+  static constexpr char kKukaIiwaJoint5[] = "iiwa_joint_5";  // Index: 11
+  static constexpr char kKukaIiwaJoint6[] = "iiwa_joint_6";  // Index: 12
+  static constexpr char kKukaIiwaJoint7[] = "iiwa_joint_7";  // Index: 13
+  Add("package://drake_models/iiwa_description/urdf/"
+      "iiwa14_primitive_collision.urdf");
+  plant_.Finalize();
+  JointSliders<double> dut(meshcat_, &plant_);
+  EXPECT_TRUE(dut.has_constraints_to_solve());  // unit quaternion constraint.
+  auto context = dut.CreateDefaultContext();
+  EXPECT_EQ(dut.get_output_port().size(), 14);
+
+  /* The initial configuration should should be [1, 0, ..., 0] -- the first
+   index should be 1, everything else 0.  Therefore, every joint slider should
+   have a value of 0 as well. */
+  VectorXd initial = VectorXd::Zero(14);
+  initial[0] = 1;
+  auto positions = dut.get_output_port().Eval(*context);
+  EXPECT_TRUE(CompareMatrices(positions, initial));
+  VectorXd slider_values = VectorXd(7);
+  slider_values << meshcat_->GetSliderValue(kKukaIiwaJoint1),
+      meshcat_->GetSliderValue(kKukaIiwaJoint2),
+      meshcat_->GetSliderValue(kKukaIiwaJoint3),
+      meshcat_->GetSliderValue(kKukaIiwaJoint4),
+      meshcat_->GetSliderValue(kKukaIiwaJoint5),
+      meshcat_->GetSliderValue(kKukaIiwaJoint6),
+      meshcat_->GetSliderValue(kKukaIiwaJoint7);
+  EXPECT_TRUE(CompareMatrices(slider_values, VectorXd::Zero(7)));
+
+  // Setting the positions should update both the initial value and sliders.
+  VectorXd q(14);
+  q << 0, 0, 0, 1,                               // floating base quaternion
+      -3, -2, -1,                                // floating base position
+      0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07;  // iiwa joints
+  dut.SetPositions(context.get(), q);
+  positions = dut.get_output_port().Eval(*context);
+  EXPECT_TRUE(CompareMatrices(positions, q, 1e-6));
+  slider_values << meshcat_->GetSliderValue(kKukaIiwaJoint1),
+      meshcat_->GetSliderValue(kKukaIiwaJoint2),
+      meshcat_->GetSliderValue(kKukaIiwaJoint3),
+      meshcat_->GetSliderValue(kKukaIiwaJoint4),
+      meshcat_->GetSliderValue(kKukaIiwaJoint5),
+      meshcat_->GetSliderValue(kKukaIiwaJoint6),
+      meshcat_->GetSliderValue(kKukaIiwaJoint7);
+  EXPECT_TRUE(CompareMatrices(slider_values, q.tail<7>()));
+
+  // Deleting should remove the sliders, but the positions should remain.
+  dut.Delete();
+  positions = dut.get_output_port().Eval(*context);
+  EXPECT_TRUE(CompareMatrices(positions, q, 1e-6));
+  EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint1), std::exception);
+  EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint2), std::exception);
+  EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint3), std::exception);
+  EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint4), std::exception);
+  EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint5), std::exception);
+  EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint6), std::exception);
+  EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint7), std::exception);
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// Tests that SetPositions diagnoses num_positions mismatches.
+TEST_F(JointSlidersTest, DeprecatedSetPositionsWrongNumPositions) {
+  AddAcrobot();
+  JointSliders<double> dut(meshcat_, &plant_);
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.SetPositions(Vector1d::Zero()),
+                              "Expected q of size 2, but got size 1 instead");
+}
+
+/* Tests the "SetPositions" function with the Acrobot model (number of positions
+ on the MultibodyPlant equal to the number of joints). */
+TEST_F(JointSlidersTest, DeprecatedSetPositionsAcrobot) {
+  // Acrobot has two positions, both of them joints.
+  AddAcrobot();
+  JointSliders<double> dut(meshcat_, &plant_);
+  auto context = dut.CreateDefaultContext();
+  ASSERT_EQ(dut.get_output_port().size(), 2);
+
+  // The initial configuration should set both joints to 0.
+  auto positions = dut.get_output_port().Eval(*context);
+  EXPECT_EQ(positions[0], 0);
+  EXPECT_EQ(positions[1], 0);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), 0);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), 0);
+
+  /* Setting the positions should update both the initial value and sliders.
+   Do not initialize q to something outside of (lower_limit, upper_limit), which
+   defaults to (-10, 10). */
+  const Vector2d q{-4, 7};
+  dut.SetPositions(q);
+  context->SetDiscreteState(dut.EvalUniquePeriodicDiscreteUpdate(*context));
+  positions = dut.get_output_port().Eval(*context);
+  EXPECT_EQ(positions[0], q[0]);
+  EXPECT_EQ(positions[1], q[1]);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint1), q[0]);
+  EXPECT_EQ(meshcat_->GetSliderValue(kAcrobotJoint2), q[1]);
+
+  // Deleting should remove the sliders, but the positions should remain.
+  dut.Delete();
+  positions = dut.get_output_port().Eval(*context);
+  EXPECT_EQ(positions[0], q[0]);
+  EXPECT_EQ(positions[1], q[1]);
+  EXPECT_THROW(meshcat_->GetSliderValue(kAcrobotJoint1), std::exception);
+  EXPECT_THROW(meshcat_->GetSliderValue(kAcrobotJoint2), std::exception);
+}
+
+/* Tests the "SetPositions" function with the Kuka IIWA Robot model (number of
+ positions on the MultibodyPlant not equal to the number of joints). */
+TEST_F(JointSlidersTest, DeprecatedSetPositionsKukaIiwaRobot) {
   // Kuka IIWA has 14 positions, 7 of them are joints.
   static constexpr char kKukaIiwaJoint1[] = "iiwa_joint_1";  // Index: 7
   static constexpr char kKukaIiwaJoint2[] = "iiwa_joint_2";  // Index: 8
@@ -403,8 +528,9 @@ TEST_F(JointSlidersTest, SetPositionsKukaIiwaRobot) {
       -3, -2, -1,                                // floating base position
       0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07;  // iiwa joints
   dut.SetPositions(q);
+  context->SetDiscreteState(dut.EvalUniquePeriodicDiscreteUpdate(*context));
   positions = dut.get_output_port().Eval(*context);
-  EXPECT_TRUE(CompareMatrices(positions, q));
+  EXPECT_TRUE(CompareMatrices(positions, q, 1e-6));
   slider_values << meshcat_->GetSliderValue(kKukaIiwaJoint1),
       meshcat_->GetSliderValue(kKukaIiwaJoint2),
       meshcat_->GetSliderValue(kKukaIiwaJoint3),
@@ -417,7 +543,7 @@ TEST_F(JointSlidersTest, SetPositionsKukaIiwaRobot) {
   // Deleting should remove the sliders, but the positions should remain.
   dut.Delete();
   positions = dut.get_output_port().Eval(*context);
-  EXPECT_TRUE(CompareMatrices(positions, q));
+  EXPECT_TRUE(CompareMatrices(positions, q, 1e-6));
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint1), std::exception);
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint2), std::exception);
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint3), std::exception);
@@ -425,6 +551,68 @@ TEST_F(JointSlidersTest, SetPositionsKukaIiwaRobot) {
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint5), std::exception);
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint6), std::exception);
   EXPECT_THROW(meshcat_->GetSliderValue(kKukaIiwaJoint7), std::exception);
+}
+#pragma GCC diagnostic pop
+
+TEST_F(JointSlidersTest, ConstraintsTest) {
+  const RigidBody<double>* body_A = &plant_.AddRigidBody(
+      "body_A", SpatialInertia<double>::SolidBoxWithMass(1, 1, 1, 1));
+  const RigidBody<double>* body_B = &plant_.AddRigidBody(
+      "body_B", SpatialInertia<double>::SolidBoxWithMass(1, 1, 1, 1));
+  plant_.AddJoint<RevoluteJoint>("world_A", plant_.world_body(),
+                                 RigidTransformd(Vector3d(-1, 0, 0)), *body_A,
+                                 RigidTransformd(), Vector3d::UnitZ());
+  plant_.AddJoint<RevoluteJoint>("A_B", *body_A,
+                                 RigidTransformd(Vector3d(1, 0, 0)), *body_B,
+                                 RigidTransformd(), Vector3d::UnitZ());
+  plant_.AddDistanceConstraint(*body_A, Vector3d(0.0, 1.0, 0.0), *body_B,
+                               Vector3d(0.0, 1.0, 0.0), 1.5);
+  plant_.Finalize();
+  JointSliders<double> dut(meshcat_, &plant_);
+  auto context = dut.CreateDefaultContext();
+  EXPECT_TRUE(dut.has_constraints_to_solve());
+
+  // Create a program for easily checking the constraints.
+  solvers::MathematicalProgram prog;
+  auto q = prog.NewContinuousVariables(plant_.num_positions());
+  std::shared_ptr<const MultibodyPlant<double>> shared_plant{
+      /* managed object = */ std::shared_ptr<void>{},
+      /* stored pointer = */ &plant_};
+  auto plant_context = plant_.CreateDefaultContext();
+  AddMultibodyPlantConstraints(shared_plant, q, &prog, plant_context.get());
+  EXPECT_EQ(prog.generic_constraints().size(), 1);  // distance constraint.
+  auto distance_binding = prog.generic_constraints()[0];
+
+  // The initial configuration satisfies the constraint.
+  VectorXd q0 = dut.get_output_port().Eval(*context);
+  EXPECT_TRUE(distance_binding.evaluator()->CheckSatisfied(q0));
+
+  // Create an arbitrary configuration that does not satisfy the constraint.
+  VectorXd q_invalid = Vector2d{1.1, 2.3};
+  EXPECT_FALSE(distance_binding.evaluator()->CheckSatisfied(q_invalid));
+
+  // Set the sliders to the invalid configuration.
+  dut.SetPositions(context.get(), q_invalid);
+  // The sliders are updated, but still satisfy the constraint.
+  VectorXd q_resolved = dut.get_output_port().Eval(*context);
+  EXPECT_TRUE(distance_binding.evaluator()->CheckSatisfied(q_resolved));
+  // The slider values are updated, but are rounded to the nearest 0.1.
+  EXPECT_NEAR(meshcat_->GetSliderValue("world_A"), q_resolved[0], 0.1);
+  EXPECT_NEAR(meshcat_->GetSliderValue("A_B"), q_resolved[1], 0.1);
+
+  // After changing the slider in meshcat, JointSliders resolves the constraint
+  // but respects the most recently changed slider.
+  meshcat_->SetSliderValue("world_A", 1.1);
+  context->SetDiscreteState(dut.EvalUniquePeriodicDiscreteUpdate(*context));
+  VectorXd q_resolved2 = dut.get_output_port().Eval(*context);
+  EXPECT_NEAR(q_resolved2[0], 1.1, 1e-6);
+  EXPECT_TRUE(distance_binding.evaluator()->CheckSatisfied(q_resolved));
+
+  // Until publishing, the other slider still has its previous value.
+  EXPECT_NEAR(meshcat_->GetSliderValue("A_B"), q_resolved[1], 0.1);
+  dut.ForcedPublish(*context);
+  // After publishing, it has the newly resolved value.
+  EXPECT_NEAR(meshcat_->GetSliderValue("A_B"), q_resolved2[1], 0.1);
 }
 
 TEST_F(JointSlidersTest, Graphviz) {


### PR DESCRIPTION
Updates JointSliders to have discrete state (previously it was
stateless). Additionally, if the new ResolveConstraints logic is
active, we publish the (rounded) resolved constraints back to Meshcat,
so that the other sliders are updated.

Since ModelVisualizer uses JointSliders, now ModelVisualizer also
satisfies the multibody constraints.

Resolves https://github.com/RobotLocomotion/drake/issues/18917.

Deprecates `JointSliders::SetPositions(q)`, which has been replaced with
`JointSliders::SetPositions(context, q)`.

https://github.com/user-attachments/assets/3abb096e-d4ef-48fb-8976-b5729beb7f9e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22496)
<!-- Reviewable:end -->
