### PR TITLE
[py multibody] Adjust element-adding API to avoid unique_ptr

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -220,8 +220,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.SetUseSampledOutputPorts.doc)
         .def(
             "AddJoint",
-            [](Class * self, std::unique_ptr<Joint<T>> joint) -> auto& {
-              return self->AddJoint(std::move(joint));
+            [](Class* self, const Joint<T>& joint) {
+              return &self->AddJoint(joint.ShallowClone());
             },
             py::arg("joint"), py_rvp::reference_internal,
             cls_doc.AddJoint.doc_1args)
@@ -235,8 +235,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("actuator"), cls_doc.RemoveJointActuator.doc)
         .def(
             "AddFrame",
-            [](Class * self, std::unique_ptr<Frame<T>> frame) -> auto& {
-              return self->AddFrame(std::move(frame));
+            [](Class* self, const Frame<T>& frame) {
+              return &self->AddFrame(frame.ShallowClone());
             },
             py_rvp::reference_internal, py::arg("frame"), cls_doc.AddFrame.doc)
         .def("AddModelInstance", &Class::AddModelInstance, py::arg("name"),
@@ -265,10 +265,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py_rvp::reference_internal, cls_doc.WeldFrames.doc)
         .def(
             "AddForceElement",
-            [](Class * self,
-                std::unique_ptr<ForceElement<T>> force_element) -> auto& {
-              return self->template AddForceElement<ForceElement>(
-                  std::move(force_element));
+            [](Class* self, const ForceElement<T>& force_element) {
+              return &(self->template AddForceElement<ForceElement>(
+                  force_element.ShallowClone()));
             },
             py::arg("force_element"), py_rvp::reference_internal,
             cls_doc.AddForceElement.doc)
@@ -948,10 +947,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("diffuse_color"),
             cls_doc.RegisterVisualGeometry
                 .doc_5args_body_X_BG_shape_name_diffuse_color)
-        .def("RegisterVisualGeometry",
-            py::overload_cast<const RigidBody<T>&,
-                std::unique_ptr<geometry::GeometryInstance>>(
-                &Class::RegisterVisualGeometry),
+        .def(
+            "RegisterVisualGeometry",
+            [](Class& self, const RigidBody<T>& body,
+                const geometry::GeometryInstance& geometry_instance) {
+              return self.RegisterVisualGeometry(
+                  body, std::make_unique<geometry::GeometryInstance>(
+                            geometry_instance));
+            },
             py::arg("body"), py::arg("geometry_instance"),
             cls_doc.RegisterVisualGeometry.doc_2args_body_geometry_instance)
         .def("RegisterCollisionGeometry",
@@ -1654,7 +1657,16 @@ PYBIND11_MODULE(plant, m) {
     cls  // BR
         .def(py::init<MultibodyPlant<T>*>(), cls_doc.ctor.doc)
         .def("num_bodies", &Class::num_bodies, cls_doc.num_bodies.doc)
-        .def("RegisterDeformableBody", &Class::RegisterDeformableBody,
+        .def(
+            "RegisterDeformableBody",
+            [](Class& self, const geometry::GeometryInstance& geometry_instance,
+                const fem::DeformableBodyConfig<T>& config,
+                double resolution_hint) {
+              return self.RegisterDeformableBody(
+                  std::make_unique<geometry::GeometryInstance>(
+                      geometry_instance),
+                  config, resolution_hint);
+            },
             py::arg("geometry_instance"), py::arg("config"),
             py::arg("resolution_hint"), cls_doc.RegisterDeformableBody.doc)
         .def("SetWallBoundaryCondition", &Class::SetWallBoundaryCondition,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -2115,10 +2115,8 @@ class TestPlant(unittest.TestCase):
         def loop_body(make_joint, time_step):
             plant = MultibodyPlant_[T](time_step)
             child = plant.AddRigidBody("Child")
-            joint = make_joint(
-                plant=plant, P=plant.world_frame(), C=child.body_frame())
-            joint_out = plant.AddJoint(joint)
-            self.assertIs(joint, joint_out)
+            joint = plant.AddJoint(joint=make_joint(
+                plant=plant, P=plant.world_frame(), C=child.body_frame()))
             if joint.num_velocities() == 1:
                 self.assertFalse(plant.HasJointActuatorNamed("tau"))
                 self.assertFalse(plant.HasJointActuatorNamed(

--- a/multibody/plant/test/sap_driver_multidof_joints_test.cc
+++ b/multibody/plant/test/sap_driver_multidof_joints_test.cc
@@ -143,6 +143,9 @@ class MultiDofJointWithLimits final : public Joint<T> {
       const internal::MultibodyTree<symbolic::Expression>&) const override {
     DRAKE_UNREACHABLE();
   }
+  std::unique_ptr<Joint<T>> DoShallowClone() const override {
+    DRAKE_UNREACHABLE();
+  }
 };
 
 // Verify that SapDriver throws when the model contains multi-DOF

--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -59,6 +59,13 @@ std::unique_ptr<Joint<symbolic::Expression>> BallRpyJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> BallRpyJoint<T>::DoShallowClone() const {
+  return std::make_unique<BallRpyJoint<T>>(
+      this->name(), this->frame_on_parent(), this->frame_on_child(),
+      this->default_damping());
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -252,6 +252,8 @@ class BallRpyJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+
   // Make BallRpyJoint templated on every other scalar type a friend of
   // BallRpyJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of BallRpyJoint<T>.

--- a/multibody/tree/curvilinear_joint.cc
+++ b/multibody/tree/curvilinear_joint.cc
@@ -91,6 +91,14 @@ CurvilinearJoint<T>::DoCloneToScalar(
 }
 
 template <typename T>
+std::unique_ptr<Joint<T>> CurvilinearJoint<T>::DoShallowClone() const {
+  return std::make_unique<CurvilinearJoint<T>>(
+      this->name(), this->frame_on_parent(), this->frame_on_child(),
+      curvilinear_path_, this->position_lower_limit(),
+      this->position_upper_limit(), this->default_damping());
+}
+
+template <typename T>
 std::unique_ptr<typename Joint<T>::BluePrint>
 CurvilinearJoint<T>::MakeImplementationBlueprint(
     const internal::SpanningForest::Mobod& mobod) const {

--- a/multibody/tree/curvilinear_joint.h
+++ b/multibody/tree/curvilinear_joint.h
@@ -338,6 +338,8 @@ class CurvilinearJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+
   // Make CurvilinearJoint templated on every other scalar type a friend of
   // CurvilinearJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of CurvilinearJoint<T>.

--- a/multibody/tree/door_hinge.cc
+++ b/multibody/tree/door_hinge.cc
@@ -210,6 +210,13 @@ std::unique_ptr<ForceElement<Expression>> DoorHinge<T>::DoCloneToScalar(
   return TemplatedClone(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<ForceElement<T>> DoorHinge<T>::DoShallowClone() const {
+  // N.B. We use the private constructor since joint() requires a MbT pointer.
+  return std::unique_ptr<ForceElement<T>>(
+      new DoorHinge<T>(this->model_instance(), joint_index_, config_));
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/door_hinge.h
+++ b/multibody/tree/door_hinge.h
@@ -214,6 +214,8 @@ class DoorHinge final : public ForceElement<T> {
   std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<ForceElement<T>> DoShallowClone() const override;
+
  private:
   // For unit test only.
   friend class DoorHingeTest;

--- a/multibody/tree/fixed_offset_frame.cc
+++ b/multibody/tree/fixed_offset_frame.cc
@@ -77,6 +77,12 @@ FixedOffsetFrame<T>::DoCloneToScalar(
 }
 
 template <typename T>
+std::unique_ptr<Frame<T>> FixedOffsetFrame<T>::DoShallowClone() const {
+  return std::make_unique<FixedOffsetFrame<T>>(this->name(), parent_frame_,
+                                               X_PF_);
+}
+
+template <typename T>
 math::RigidTransform<T> FixedOffsetFrame<T>::DoCalcPoseInBodyFrame(
     const systems::Parameters<T>& parameters) const {
   // X_BF = X_BP * X_PF

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -96,15 +96,6 @@ class FixedOffsetFrame final : public Frame<T> {
   }
 
  protected:
-  /// @name Methods to make a clone templated on different scalar types.
-  ///
-  /// These methods provide implementations to the different overrides of
-  /// Frame::DoCloneToScalar().
-  /// The only const argument to these methods is the new MultibodyTree clone
-  /// under construction, which is required to already own the clone to the
-  /// parent frame of the frame being cloned.
-  /// @{
-
   /// @pre The parent frame to this frame already has a clone in `tree_clone`.
   std::unique_ptr<Frame<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const override;
@@ -115,7 +106,8 @@ class FixedOffsetFrame final : public Frame<T> {
 
   std::unique_ptr<Frame<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
-  /// @}
+
+  std::unique_ptr<Frame<T>> DoShallowClone() const override;
 
   math::RigidTransform<T> DoCalcPoseInBodyFrame(
       const systems::Parameters<T>& parameters) const override;

--- a/multibody/tree/force_element.cc
+++ b/multibody/tree/force_element.cc
@@ -1,12 +1,26 @@
 #include "drake/multibody/tree/force_element.h"
 
 #include "drake/common/default_scalars.h"
+#include "drake/common/nice_type_name.h"
 
 namespace drake {
 namespace multibody {
 
 template <typename T>
 ForceElement<T>::~ForceElement() = default;
+
+template <typename T>
+std::unique_ptr<ForceElement<T>> ForceElement<T>::ShallowClone() const {
+  std::unique_ptr<ForceElement<T>> result = DoShallowClone();
+  DRAKE_THROW_UNLESS(result != nullptr);
+  return result;
+}
+
+template <typename T>
+std::unique_ptr<ForceElement<T>> ForceElement<T>::DoShallowClone() const {
+  throw std::logic_error(fmt::format("{} failed to override DoShallowClone()",
+                                     NiceTypeName::Get(*this)));
+}
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/force_element.h
+++ b/multibody/tree/force_element.h
@@ -166,6 +166,13 @@ class ForceElement : public MultibodyElement<T> {
   }
   /// @endcond
 
+  /// @cond
+  // (Internal use only) Returns a shallow clone (i.e., dependent elements such
+  // as joints are aliased, not copied) that is not associated with any MbT (so
+  // the assigned index, if any, is discarded).
+  std::unique_ptr<ForceElement<T>> ShallowClone() const;
+  /// @endcond
+
  protected:
   /// This method is called only from the public non-virtual
   /// CalcAndAddForceContributions() which will already have error-checked
@@ -259,6 +266,9 @@ class ForceElement : public MultibodyElement<T> {
   virtual std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const = 0;
   /// @}
+
+  /// NVI for ShallowClone().
+  virtual std::unique_ptr<ForceElement<T>> DoShallowClone() const;
 
  private:
   // Implementation for MultibodyElement::DoSetTopology().

--- a/multibody/tree/frame.cc
+++ b/multibody/tree/frame.cc
@@ -1,7 +1,7 @@
 #include "drake/multibody/tree/frame.h"
 
 #include "drake/common/identifier.h"
-#include "drake/common/text_logging.h"
+#include "drake/common/nice_type_name.h"
 #include "drake/multibody/tree/rigid_body.h"
 
 namespace drake {
@@ -175,6 +175,19 @@ SpatialAcceleration<T> Frame<T>::CalcSpatialAcceleration(
   const math::RotationMatrix<T> R_WE =
       frame_E.CalcRotationMatrixInWorld(context);
   return R_WE.inverse() * A_MF_W;  // returns A_MF_E.
+}
+
+template <typename T>
+std::unique_ptr<Frame<T>> Frame<T>::ShallowClone() const {
+  std::unique_ptr<Frame<T>> result = DoShallowClone();
+  DRAKE_THROW_UNLESS(result != nullptr);
+  return result;
+}
+
+template <typename T>
+std::unique_ptr<Frame<T>> Frame<T>::DoShallowClone() const {
+  throw std::logic_error(fmt::format("{} failed to override DoShallowClone()",
+                                     NiceTypeName::Get(*this)));
 }
 
 }  // namespace multibody

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -498,6 +498,11 @@ class Frame : public MultibodyElement<T> {
     return DoCloneToScalar(tree_clone);
   }
 
+  /// (Internal use only) Returns a shallow clone (i.e., dependent elements such
+  /// as bodies are aliased, not copied) that is not associated with any MbT (so
+  /// the assigned index, if any, is discarded).
+  std::unique_ptr<Frame<T>> ShallowClone() const;
+
   /// @name Internal use only
   /// These functions work directly with the frame body pose cache entry.
   //@{
@@ -562,9 +567,10 @@ class Frame : public MultibodyElement<T> {
   /// to set their sub-class specific parameters.
   virtual void DoSetDefaultFrameParameters(systems::Parameters<T>*) const {}
 
-  /// @name Methods to make a clone templated on different scalar types.
+  /// @name Methods to make a clone, optionally templated on different scalar
+  /// types.
   ///
-  /// These methods are meant to be called by MultibodyTree::CloneToScalar()
+  /// The first three are meant to be called by MultibodyTree::CloneToScalar()
   /// when making a clone of the entire tree or a new instance templated on a
   /// different scalar type. The only const argument to these methods is the
   /// new MultibodyTree clone under construction. Specific %Frame subclasses
@@ -584,6 +590,9 @@ class Frame : public MultibodyElement<T> {
 
   virtual std::unique_ptr<Frame<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const = 0;
+
+  /// NVI for ShallowClone().
+  virtual std::unique_ptr<Frame<T>> DoShallowClone() const;
   /// @}
 
   // NVI for CalcPoseInBodyFrame.

--- a/multibody/tree/joint.cc
+++ b/multibody/tree/joint.cc
@@ -74,6 +74,27 @@ Eigen::Ref<const VectorX<T>> Joint<T>::GetVelocities(
 }
 
 template <typename T>
+std::unique_ptr<Joint<T>> Joint<T>::ShallowClone() const {
+  std::unique_ptr<Joint<T>> result = DoShallowClone();
+  DRAKE_THROW_UNLESS(result != nullptr);
+  // N.B. We can't call set_default_damping_vector because it segfaults when
+  // there's no parent tree.
+  result->damping_ = this->damping_;
+  result->set_position_limits(position_lower_limits(), position_upper_limits());
+  result->set_velocity_limits(velocity_lower_limits(), velocity_upper_limits());
+  result->set_acceleration_limits(acceleration_lower_limits(),
+                                  acceleration_upper_limits());
+  result->set_default_positions(default_positions());
+  return result;
+}
+
+template <typename T>
+std::unique_ptr<Joint<T>> Joint<T>::DoShallowClone() const {
+  throw std::logic_error(fmt::format(
+      "The {} joint failed to override DoShallowClone()", type_name()));
+}
+
+template <typename T>
 void Joint<T>::SetSpatialVelocityImpl(systems::Context<T>* context,
                                       const SpatialVelocity<T>& V_FM,
                                       const char* func) const {

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -763,6 +763,11 @@ class Joint : public MultibodyElement<T> {
     return joint_clone;
   }
 
+  // (Internal use only) Returns a shallow clone (i.e., dependent elements such
+  // as frames are aliased, not copied) that is not associated with any MbT (so
+  // the assigned index, if any, is discarded).
+  std::unique_ptr<Joint<T>> ShallowClone() const;
+
   const internal::Mobilizer<T>& GetMobilizerInUse() const {
     // Currently we model each joint with a mobilizer.
     DRAKE_DEMAND(get_implementation().has_mobilizer());
@@ -949,7 +954,8 @@ class Joint : public MultibodyElement<T> {
   // though we could require them to have one in the future.
   void DoSetTopology(const internal::MultibodyTreeTopology&) override {}
 
-  /// @name Methods to make a clone templated on different scalar types.
+  /// @name Methods to make a clone, optionally templated on different scalar
+  /// types.
   /// @{
   /// Clones this %Joint (templated on T) to a joint templated on `double`.
   virtual std::unique_ptr<Joint<double>> DoCloneToScalar(
@@ -961,6 +967,12 @@ class Joint : public MultibodyElement<T> {
 
   virtual std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const = 0;
+
+  /// NVI for ShallowClone(). The public Joint::ShallowClone in this base class
+  /// is responsible for copying the mutable Joint data (damping, all limits,
+  /// default positions, etc.) into the return value. The subclass only needs to
+  /// handle subclass-specific details.
+  virtual std::unique_ptr<Joint<T>> DoShallowClone() const;
   /// @}
 
   /// This method must be implemented by derived classes in order to provide

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.cc
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.cc
@@ -375,6 +375,17 @@ LinearBushingRollPitchYaw<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<ForceElement<T>> LinearBushingRollPitchYaw<T>::DoShallowClone()
+    const {
+  // N.B. We use the private constructor since the frameA() and frameC()
+  // accessors require a MbT pointer.
+  return std::unique_ptr<ForceElement<T>>(new LinearBushingRollPitchYaw<T>(
+      this->model_instance(), frameA_index_, frameC_index_,
+      torque_stiffness_constants(), torque_damping_constants(),
+      force_stiffness_constants(), force_damping_constants()));
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.h
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.h
@@ -604,6 +604,8 @@ class LinearBushingRollPitchYaw final : public ForceElement<T> {
   std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<ForceElement<T>> DoShallowClone() const override;
+
   // Calculate R_AC, the rotation matrix that relates frames A and C.
   // @param[in] context The state of the multibody system.
   math::RotationMatrix<T> CalcR_AC(const systems::Context<T>& context) const {

--- a/multibody/tree/linear_spring_damper.cc
+++ b/multibody/tree/linear_spring_damper.cc
@@ -176,6 +176,12 @@ LinearSpringDamper<T>::DoCloneToScalar(
 }
 
 template <typename T>
+std::unique_ptr<ForceElement<T>> LinearSpringDamper<T>::DoShallowClone() const {
+  return std::make_unique<LinearSpringDamper<T>>(
+      bodyA(), p_AP(), bodyB(), p_BQ(), free_length(), stiffness(), damping());
+}
+
+template <typename T>
 T LinearSpringDamper<T>::SafeSoftNorm(const Vector3<T>& x) const {
   using std::sqrt;
   const double epsilon_length =

--- a/multibody/tree/linear_spring_damper.h
+++ b/multibody/tree/linear_spring_damper.h
@@ -116,6 +116,8 @@ class LinearSpringDamper final : public ForceElement<T> {
   std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<ForceElement<T>> DoShallowClone() const override;
+
  private:
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -58,6 +58,13 @@ std::unique_ptr<Joint<symbolic::Expression>> PlanarJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> PlanarJoint<T>::DoShallowClone() const {
+  return std::make_unique<PlanarJoint<T>>(this->name(), this->frame_on_parent(),
+                                          this->frame_on_child(),
+                                          this->default_damping());
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -333,6 +333,8 @@ class PlanarJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const final;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+
   // Make PlanarJoint templated on every other scalar type a friend of
   // PlanarJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of PlanarJoint<T>.

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -89,6 +89,14 @@ std::unique_ptr<Joint<symbolic::Expression>> PrismaticJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> PrismaticJoint<T>::DoShallowClone() const {
+  return std::make_unique<PrismaticJoint<T>>(
+      this->name(), this->frame_on_parent(), this->frame_on_child(),
+      this->translation_axis(), this->position_lower_limit(),
+      this->position_upper_limit(), this->default_damping());
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -321,6 +321,8 @@ class PrismaticJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const final;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+
   // Make PrismaticJoint templated on every other scalar type a friend of
   // PrismaticJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of PrismaticJoint<T>.

--- a/multibody/tree/prismatic_spring.cc
+++ b/multibody/tree/prismatic_spring.cc
@@ -113,6 +113,13 @@ PrismaticSpring<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<ForceElement<T>> PrismaticSpring<T>::DoShallowClone() const {
+  // N.B. We use the private constructor since joint() requires a MbT pointer.
+  return std::unique_ptr<ForceElement<T>>(new PrismaticSpring<T>(
+      this->model_instance(), joint_index_, nominal_position(), stiffness()));
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/prismatic_spring.h
+++ b/multibody/tree/prismatic_spring.h
@@ -79,6 +79,8 @@ class PrismaticSpring final : public ForceElement<T> {
   std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<ForceElement<T>> DoShallowClone() const override;
+
   // Allow different specializations to access each other's private data for
   // scalar conversion.
   template <typename U>

--- a/multibody/tree/quaternion_floating_joint.cc
+++ b/multibody/tree/quaternion_floating_joint.cc
@@ -55,6 +55,13 @@ QuaternionFloatingJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> QuaternionFloatingJoint<T>::DoShallowClone() const {
+  return std::make_unique<QuaternionFloatingJoint<T>>(
+      this->name(), this->frame_on_parent(), this->frame_on_child(),
+      this->default_angular_damping(), this->default_translational_damping());
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -429,6 +429,8 @@ class QuaternionFloatingJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+
   // Make QuaternionFloatingJoint templated on every other scalar type a friend
   // of QuaternionFloatingJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can
   // access private members of QuaternionFloatingJoint<T>.

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -89,6 +89,14 @@ std::unique_ptr<Joint<symbolic::Expression>> RevoluteJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> RevoluteJoint<T>::DoShallowClone() const {
+  return std::make_unique<RevoluteJoint<T>>(
+      this->name(), this->frame_on_parent(), this->frame_on_child(),
+      this->revolute_axis(), this->position_lower_limits()[0],
+      this->position_upper_limit(), this->default_damping());
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -342,6 +342,8 @@ class RevoluteJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+
   // Make RevoluteJoint templated on every other scalar type a friend of
   // RevoluteJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of RevoluteJoint<T>.

--- a/multibody/tree/revolute_spring.cc
+++ b/multibody/tree/revolute_spring.cc
@@ -112,6 +112,13 @@ RevoluteSpring<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<ForceElement<T>> RevoluteSpring<T>::DoShallowClone() const {
+  // N.B. We use the private constructor since joint() requires a MbT pointer.
+  return std::unique_ptr<ForceElement<T>>(new RevoluteSpring<T>(
+      this->model_instance(), joint_index_, nominal_angle(), stiffness()));
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/revolute_spring.h
+++ b/multibody/tree/revolute_spring.h
@@ -73,6 +73,8 @@ class RevoluteSpring final : public ForceElement<T> {
   std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<ForceElement<T>> DoShallowClone() const override;
+
  private:
   // Allow different specializations to access each other's private data for
   // scalar conversion.

--- a/multibody/tree/rigid_body.cc
+++ b/multibody/tree/rigid_body.cc
@@ -42,6 +42,14 @@ std::unique_ptr<Frame<symbolic::Expression>> RigidBodyFrame<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Frame<T>> RigidBodyFrame<T>::DoShallowClone() const {
+  // RigidBodyFrame's constructor cannot be called from std::make_unique since
+  // it is private and therefore we use "new".
+  return std::unique_ptr<RigidBodyFrame<T>>(
+      new RigidBodyFrame<T>(this->body()));
+}
+
 // RigidBody function definitions.
 
 template <typename T>

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -91,6 +91,8 @@ class RigidBodyFrame final : public Frame<T> {
   std::unique_ptr<Frame<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<Frame<T>> DoShallowClone() const override;
+
   math::RigidTransform<T> DoCalcPoseInBodyFrame(
       const systems::Parameters<T>&) const override {
     return math::RigidTransform<T>::Identity();

--- a/multibody/tree/rpy_floating_joint.cc
+++ b/multibody/tree/rpy_floating_joint.cc
@@ -60,6 +60,13 @@ RpyFloatingJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> RpyFloatingJoint<T>::DoShallowClone() const {
+  return std::make_unique<RpyFloatingJoint<T>>(
+      this->name(), this->frame_on_parent(), this->frame_on_child(),
+      this->default_angular_damping(), this->default_translational_damping());
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -439,6 +439,8 @@ class RpyFloatingJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const final;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+
   // Make RpyFloatingJoint templated on every other scalar type a friend of
   // RpyFloatingJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of RpyFloatingJoint<T>.

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -89,6 +89,13 @@ std::unique_ptr<Joint<symbolic::Expression>> ScrewJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> ScrewJoint<T>::DoShallowClone() const {
+  return std::make_unique<ScrewJoint<T>>(
+      this->name(), this->frame_on_parent(), this->frame_on_child(),
+      this->screw_axis(), this->screw_pitch(), this->default_damping());
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -361,6 +361,8 @@ class ScrewJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const final;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+
   // Make ScrewJoint templated on every other scalar type a friend of
   // ScrewJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of ScrewJoint<T>.

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -172,28 +172,31 @@ TEST_F(BallRpyJointTest, AddInDampingForces) {
 
 TEST_F(BallRpyJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
-  const auto& joint_clone = dynamic_cast<const BallRpyJoint<AutoDiffXd>&>(
+  const auto& joint_clone1 = dynamic_cast<const BallRpyJoint<AutoDiffXd>&>(
       model_clone->get_variant(*joint_));
 
-  EXPECT_EQ(joint_clone.name(), joint_->name());
-  EXPECT_EQ(joint_clone.frame_on_parent().index(),
-            joint_->frame_on_parent().index());
-  EXPECT_EQ(joint_clone.frame_on_child().index(),
-            joint_->frame_on_child().index());
-  EXPECT_EQ(joint_clone.position_lower_limits(),
-            joint_->position_lower_limits());
-  EXPECT_EQ(joint_clone.position_upper_limits(),
-            joint_->position_upper_limits());
-  EXPECT_EQ(joint_clone.velocity_lower_limits(),
-            joint_->velocity_lower_limits());
-  EXPECT_EQ(joint_clone.velocity_upper_limits(),
-            joint_->velocity_upper_limits());
-  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
-            joint_->acceleration_lower_limits());
-  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
-            joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.default_damping(), joint_->default_damping());
-  EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint_clone1.ShallowClone();
+  const auto& joint_clone2 =
+      dynamic_cast<const BallRpyJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint_clone1, &joint_clone2}) {
+    EXPECT_EQ(clone->name(), joint_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint_->frame_on_child().index());
+    EXPECT_EQ(clone->position_lower_limits(), joint_->position_lower_limits());
+    EXPECT_EQ(clone->position_upper_limits(), joint_->position_upper_limits());
+    EXPECT_EQ(clone->velocity_lower_limits(), joint_->velocity_lower_limits());
+    EXPECT_EQ(clone->velocity_upper_limits(), joint_->velocity_upper_limits());
+    EXPECT_EQ(clone->acceleration_lower_limits(),
+              joint_->acceleration_lower_limits());
+    EXPECT_EQ(clone->acceleration_upper_limits(),
+              joint_->acceleration_upper_limits());
+    EXPECT_EQ(clone->default_damping(), joint_->default_damping());
+    EXPECT_EQ(clone->get_default_angles(), joint_->get_default_angles());
+  }
 }
 
 TEST_F(BallRpyJointTest, SetVelocityAndAccelerationLimits) {

--- a/multibody/tree/test/curvilinear_joint_test.cc
+++ b/multibody/tree/test/curvilinear_joint_test.cc
@@ -216,29 +216,31 @@ TEST_F(CurvilinearJointTest, AddInDampingForces) {
 
 TEST_F(CurvilinearJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
-  const auto& joint1_clone = dynamic_cast<const CurvilinearJoint<AutoDiffXd>&>(
+  const auto& joint1_clone1 = dynamic_cast<const CurvilinearJoint<AutoDiffXd>&>(
       model_clone->get_variant(*joint1_));
 
-  EXPECT_EQ(joint1_clone.name(), joint1_->name());
-  EXPECT_EQ(joint1_clone.frame_on_parent().index(),
-            joint1_->frame_on_parent().index());
-  EXPECT_EQ(joint1_clone.frame_on_child().index(),
-            joint1_->frame_on_child().index());
-  EXPECT_EQ(joint1_clone.position_lower_limits(),
-            joint1_->position_lower_limits());
-  EXPECT_EQ(joint1_clone.position_upper_limits(),
-            joint1_->position_upper_limits());
-  EXPECT_EQ(joint1_clone.velocity_lower_limits(),
-            joint1_->velocity_lower_limits());
-  EXPECT_EQ(joint1_clone.velocity_upper_limits(),
-            joint1_->velocity_upper_limits());
-  EXPECT_EQ(joint1_clone.acceleration_lower_limits(),
-            joint1_->acceleration_lower_limits());
-  EXPECT_EQ(joint1_clone.acceleration_upper_limits(),
-            joint1_->acceleration_upper_limits());
-  EXPECT_EQ(joint1_clone.default_damping(), joint1_->default_damping());
-  EXPECT_EQ(joint1_clone.get_default_distance(),
-            joint1_->get_default_distance());
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint1_clone1.ShallowClone();
+  const auto& joint1_clone2 =
+      dynamic_cast<const CurvilinearJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint1_clone1, &joint1_clone2}) {
+    EXPECT_EQ(clone->name(), joint1_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint1_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint1_->frame_on_child().index());
+    EXPECT_EQ(clone->position_lower_limits(), joint1_->position_lower_limits());
+    EXPECT_EQ(clone->position_upper_limits(), joint1_->position_upper_limits());
+    EXPECT_EQ(clone->velocity_lower_limits(), joint1_->velocity_lower_limits());
+    EXPECT_EQ(clone->velocity_upper_limits(), joint1_->velocity_upper_limits());
+    EXPECT_EQ(clone->acceleration_lower_limits(),
+              joint1_->acceleration_lower_limits());
+    EXPECT_EQ(clone->acceleration_upper_limits(),
+              joint1_->acceleration_upper_limits());
+    EXPECT_EQ(clone->default_damping(), joint1_->default_damping());
+    EXPECT_EQ(clone->get_default_distance(), joint1_->get_default_distance());
+  }
 }
 
 TEST_F(CurvilinearJointTest, CanRotateAndTranslate) {

--- a/multibody/tree/test/door_hinge_test.cc
+++ b/multibody/tree/test/door_hinge_test.cc
@@ -211,17 +211,25 @@ TEST_F(DoorHingeTest, CloneTest) {
   const DoorHinge<AutoDiffXd>& door_hinge_ad =
       plant_ad->GetForceElement<DoorHinge>(ForceElementIndex(1));
 
-  EXPECT_EQ(door_hinge_ad.config().spring_zero_angle_rad,
-            config.spring_zero_angle_rad);
-  EXPECT_EQ(door_hinge_ad.config().spring_constant, config.spring_constant);
-  EXPECT_EQ(door_hinge_ad.config().dynamic_friction_torque,
-            config.dynamic_friction_torque);
-  EXPECT_EQ(door_hinge_ad.config().static_friction_torque,
-            config.static_friction_torque);
-  EXPECT_EQ(door_hinge_ad.config().viscous_friction, config.viscous_friction);
-  EXPECT_EQ(door_hinge_ad.config().catch_width, config.catch_width);
-  EXPECT_EQ(door_hinge_ad.config().catch_torque, config.catch_torque);
-  EXPECT_EQ(door_hinge_ad.config().motion_threshold, config.motion_threshold);
+  // Clone just the hinge again (shallow).
+  std::unique_ptr<ForceElement<AutoDiffXd>> shallow =
+      door_hinge_ad.ShallowClone();
+  const DoorHinge<AutoDiffXd>& door_hinge_ad_shallow =
+      dynamic_cast<const DoorHinge<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&door_hinge_ad, &door_hinge_ad_shallow}) {
+    EXPECT_EQ(clone->config().spring_zero_angle_rad,
+              config.spring_zero_angle_rad);
+    EXPECT_EQ(clone->config().spring_constant, config.spring_constant);
+    EXPECT_EQ(clone->config().dynamic_friction_torque,
+              config.dynamic_friction_torque);
+    EXPECT_EQ(clone->config().static_friction_torque,
+              config.static_friction_torque);
+    EXPECT_EQ(clone->config().viscous_friction, config.viscous_friction);
+    EXPECT_EQ(clone->config().catch_width, config.catch_width);
+    EXPECT_EQ(clone->config().catch_torque, config.catch_torque);
+    EXPECT_EQ(clone->config().motion_threshold, config.motion_threshold);
+  }
 }
 
 // Test with only the torsional spring torque, the corresponding energy

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -338,6 +338,9 @@ TEST_F(FrameTests, HasFrameNamed) {
   }
 }
 
+// TODO(jwnimmer-tri) This file is missing tests of the clone-related functions,
+// for RigidBodyFrame and FixedOffsetFrame.
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -772,6 +772,8 @@ GTEST_TEST(LinearBushingRollPitchYawTest, BushingParameters) {
   EXPECT_TRUE(CompareMatrices(new_force_damping, new_default_force_damping));
 }
 
+// TODO(jwnimmer-tri) This file is missing tests of the clone-related functions.
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/linear_spring_damper_test.cc
+++ b/multibody/tree/test/linear_spring_damper_test.cc
@@ -283,6 +283,8 @@ TEST_F(SpringDamperTester, Power) {
   EXPECT_EQ(plant_.EvalNonConservativePower(*context_), non_conservative_power);
 }
 
+// TODO(jwnimmer-tri) This file is missing tests of the clone-related functions.
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -208,30 +208,33 @@ TEST_F(PlanarJointTest, AddInDampingForces) {
 
 TEST_F(PlanarJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
-  const auto& joint_clone = dynamic_cast<const PlanarJoint<AutoDiffXd>&>(
+  const auto& joint1_clone1 = dynamic_cast<const PlanarJoint<AutoDiffXd>&>(
       model_clone->get_variant(*joint_));
 
-  EXPECT_EQ(joint_clone.name(), joint_->name());
-  EXPECT_EQ(joint_clone.frame_on_parent().index(),
-            joint_->frame_on_parent().index());
-  EXPECT_EQ(joint_clone.frame_on_child().index(),
-            joint_->frame_on_child().index());
-  EXPECT_EQ(joint_clone.position_lower_limits(),
-            joint_->position_lower_limits());
-  EXPECT_EQ(joint_clone.position_upper_limits(),
-            joint_->position_upper_limits());
-  EXPECT_EQ(joint_clone.velocity_lower_limits(),
-            joint_->velocity_lower_limits());
-  EXPECT_EQ(joint_clone.velocity_upper_limits(),
-            joint_->velocity_upper_limits());
-  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
-            joint_->acceleration_lower_limits());
-  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
-            joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.default_damping(), joint_->default_damping());
-  EXPECT_EQ(joint_clone.get_default_rotation(), joint_->get_default_rotation());
-  EXPECT_EQ(joint_clone.get_default_translation(),
-            joint_->get_default_translation());
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint1_clone1.ShallowClone();
+  const auto& joint1_clone2 =
+      dynamic_cast<const PlanarJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint1_clone1, &joint1_clone2}) {
+    EXPECT_EQ(clone->name(), joint_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint_->frame_on_child().index());
+    EXPECT_EQ(clone->position_lower_limits(), joint_->position_lower_limits());
+    EXPECT_EQ(clone->position_upper_limits(), joint_->position_upper_limits());
+    EXPECT_EQ(clone->velocity_lower_limits(), joint_->velocity_lower_limits());
+    EXPECT_EQ(clone->velocity_upper_limits(), joint_->velocity_upper_limits());
+    EXPECT_EQ(clone->acceleration_lower_limits(),
+              joint_->acceleration_lower_limits());
+    EXPECT_EQ(clone->acceleration_upper_limits(),
+              joint_->acceleration_upper_limits());
+    EXPECT_EQ(clone->default_damping(), joint_->default_damping());
+    EXPECT_EQ(clone->get_default_rotation(), joint_->get_default_rotation());
+    EXPECT_EQ(clone->get_default_translation(),
+              joint_->get_default_translation());
+  }
 }
 
 TEST_F(PlanarJointTest, CanRotateOrTranslate) {

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -202,30 +202,33 @@ TEST_F(PrismaticJointTest, AddInDampingForces) {
 
 TEST_F(PrismaticJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
-  const auto& joint1_clone = dynamic_cast<const PrismaticJoint<AutoDiffXd>&>(
+  const auto& joint1_clone1 = dynamic_cast<const PrismaticJoint<AutoDiffXd>&>(
       model_clone->get_variant(*joint1_));
 
-  EXPECT_EQ(joint1_clone.name(), joint1_->name());
-  EXPECT_EQ(joint1_clone.frame_on_parent().index(),
-            joint1_->frame_on_parent().index());
-  EXPECT_EQ(joint1_clone.frame_on_child().index(),
-            joint1_->frame_on_child().index());
-  EXPECT_EQ(joint1_clone.translation_axis(), joint1_->translation_axis());
-  EXPECT_EQ(joint1_clone.position_lower_limits(),
-            joint1_->position_lower_limits());
-  EXPECT_EQ(joint1_clone.position_upper_limits(),
-            joint1_->position_upper_limits());
-  EXPECT_EQ(joint1_clone.velocity_lower_limits(),
-            joint1_->velocity_lower_limits());
-  EXPECT_EQ(joint1_clone.velocity_upper_limits(),
-            joint1_->velocity_upper_limits());
-  EXPECT_EQ(joint1_clone.acceleration_lower_limits(),
-            joint1_->acceleration_lower_limits());
-  EXPECT_EQ(joint1_clone.acceleration_upper_limits(),
-            joint1_->acceleration_upper_limits());
-  EXPECT_EQ(joint1_clone.default_damping(), joint1_->default_damping());
-  EXPECT_EQ(joint1_clone.get_default_translation(),
-            joint1_->get_default_translation());
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint1_clone1.ShallowClone();
+  const auto& joint1_clone2 =
+      dynamic_cast<const PrismaticJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint1_clone1, &joint1_clone2}) {
+    EXPECT_EQ(clone->name(), joint1_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint1_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint1_->frame_on_child().index());
+    EXPECT_EQ(clone->translation_axis(), joint1_->translation_axis());
+    EXPECT_EQ(clone->position_lower_limits(), joint1_->position_lower_limits());
+    EXPECT_EQ(clone->position_upper_limits(), joint1_->position_upper_limits());
+    EXPECT_EQ(clone->velocity_lower_limits(), joint1_->velocity_lower_limits());
+    EXPECT_EQ(clone->velocity_upper_limits(), joint1_->velocity_upper_limits());
+    EXPECT_EQ(clone->acceleration_lower_limits(),
+              joint1_->acceleration_lower_limits());
+    EXPECT_EQ(clone->acceleration_upper_limits(),
+              joint1_->acceleration_upper_limits());
+    EXPECT_EQ(clone->default_damping(), joint1_->default_damping());
+    EXPECT_EQ(clone->get_default_translation(),
+              joint1_->get_default_translation());
+  }
 }
 
 TEST_F(PrismaticJointTest, CanRotateOrTranslate) {

--- a/multibody/tree/test/prismatic_spring_test.cc
+++ b/multibody/tree/test/prismatic_spring_test.cc
@@ -170,13 +170,25 @@ TEST_F(SpringTester, Clone) {
    force element we have, which is the PrismaticSpring. */
   const auto& force_element_clone =
       model_clone->get_force_element(ForceElementIndex(1));
-  const PrismaticSpring<AutoDiffXd>* spring_clone =
+  const PrismaticSpring<AutoDiffXd>* spring_clone1 =
       dynamic_cast<const PrismaticSpring<AutoDiffXd>*>(&force_element_clone);
-  ASSERT_NE(spring_clone, nullptr);
+  ASSERT_NE(spring_clone1, nullptr);
+
+  /* Clone just the element (shallow), once more. */
+  std::unique_ptr<ForceElement<AutoDiffXd>> shallow =
+      spring_clone1->ShallowClone();
+  const PrismaticSpring<AutoDiffXd>* spring_clone2 =
+      dynamic_cast<const PrismaticSpring<AutoDiffXd>*>(shallow.get());
+  ASSERT_NE(spring_clone2, nullptr);
+
   /* Verify all quantities are truthfully copied. */
-  EXPECT_EQ(spring_->joint().index(), spring_clone->joint().index());
-  EXPECT_EQ(spring_->stiffness(), spring_clone->stiffness());
-  EXPECT_EQ(spring_->nominal_position(), spring_clone->nominal_position());
+  for (const auto* clone : {spring_clone1, spring_clone2}) {
+    if (clone != spring_clone2) {
+      EXPECT_EQ(spring_->joint().index(), clone->joint().index());
+    }
+    EXPECT_EQ(spring_->stiffness(), clone->stiffness());
+    EXPECT_EQ(spring_->nominal_position(), clone->nominal_position());
+  }
 }
 
 }  // namespace

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -383,6 +383,8 @@ TEST_F(QuaternionFloatingJointTest, RandomState) {
   EXPECT_FALSE(joint_->GetPose(*context_).IsExactlyIdentity());
 }
 
+// TODO(jwnimmer-tri) This file is missing tests of the clone-related functions.
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -202,29 +202,32 @@ TEST_F(RevoluteJointTest, AddInDampingForces) {
 
 TEST_F(RevoluteJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
-  const auto& joint1_clone = dynamic_cast<const RevoluteJoint<AutoDiffXd>&>(
+  const auto& joint1_clone1 = dynamic_cast<const RevoluteJoint<AutoDiffXd>&>(
       model_clone->get_variant(*joint1_));
 
-  EXPECT_EQ(joint1_clone.name(), joint1_->name());
-  EXPECT_EQ(joint1_clone.frame_on_parent().index(),
-            joint1_->frame_on_parent().index());
-  EXPECT_EQ(joint1_clone.frame_on_child().index(),
-            joint1_->frame_on_child().index());
-  EXPECT_EQ(joint1_clone.revolute_axis(), joint1_->revolute_axis());
-  EXPECT_EQ(joint1_clone.position_lower_limits(),
-            joint1_->position_lower_limits());
-  EXPECT_EQ(joint1_clone.position_upper_limits(),
-            joint1_->position_upper_limits());
-  EXPECT_EQ(joint1_clone.velocity_lower_limits(),
-            joint1_->velocity_lower_limits());
-  EXPECT_EQ(joint1_clone.velocity_upper_limits(),
-            joint1_->velocity_upper_limits());
-  EXPECT_EQ(joint1_clone.acceleration_lower_limits(),
-            joint1_->acceleration_lower_limits());
-  EXPECT_EQ(joint1_clone.acceleration_upper_limits(),
-            joint1_->acceleration_upper_limits());
-  EXPECT_EQ(joint1_clone.default_damping(), joint1_->default_damping());
-  EXPECT_EQ(joint1_clone.get_default_angle(), joint1_->get_default_angle());
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint1_clone1.ShallowClone();
+  const auto& joint1_clone2 =
+      dynamic_cast<const RevoluteJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint1_clone1, &joint1_clone2}) {
+    EXPECT_EQ(clone->name(), joint1_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint1_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint1_->frame_on_child().index());
+    EXPECT_EQ(clone->revolute_axis(), joint1_->revolute_axis());
+    EXPECT_EQ(clone->position_lower_limits(), joint1_->position_lower_limits());
+    EXPECT_EQ(clone->position_upper_limits(), joint1_->position_upper_limits());
+    EXPECT_EQ(clone->velocity_lower_limits(), joint1_->velocity_lower_limits());
+    EXPECT_EQ(clone->velocity_upper_limits(), joint1_->velocity_upper_limits());
+    EXPECT_EQ(clone->acceleration_lower_limits(),
+              joint1_->acceleration_lower_limits());
+    EXPECT_EQ(clone->acceleration_upper_limits(),
+              joint1_->acceleration_upper_limits());
+    EXPECT_EQ(clone->default_damping(), joint1_->default_damping());
+    EXPECT_EQ(clone->get_default_angle(), joint1_->get_default_angle());
+  }
 }
 
 TEST_F(RevoluteJointTest, SetVelocityAndAccelerationLimits) {

--- a/multibody/tree/test/revolute_spring_test.cc
+++ b/multibody/tree/test/revolute_spring_test.cc
@@ -166,6 +166,8 @@ TEST_F(SpringTester, Power) {
               kTolerance);
 }
 
+// TODO(jwnimmer-tri) This file is missing tests of the clone-related functions.
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/tree/test/rpy_floating_joint_test.cc
+++ b/multibody/tree/test/rpy_floating_joint_test.cc
@@ -228,33 +228,36 @@ TEST_F(RpyFloatingJointTest, AddInDampingForces) {
 
 TEST_F(RpyFloatingJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
-  const auto& joint_clone = dynamic_cast<const RpyFloatingJoint<AutoDiffXd>&>(
+  const auto& joint_clone1 = dynamic_cast<const RpyFloatingJoint<AutoDiffXd>&>(
       model_clone->get_variant(*joint_));
 
-  EXPECT_EQ(joint_clone.name(), joint_->name());
-  EXPECT_EQ(joint_clone.frame_on_parent().index(),
-            joint_->frame_on_parent().index());
-  EXPECT_EQ(joint_clone.frame_on_child().index(),
-            joint_->frame_on_child().index());
-  EXPECT_EQ(joint_clone.position_lower_limits(),
-            joint_->position_lower_limits());
-  EXPECT_EQ(joint_clone.position_upper_limits(),
-            joint_->position_upper_limits());
-  EXPECT_EQ(joint_clone.velocity_lower_limits(),
-            joint_->velocity_lower_limits());
-  EXPECT_EQ(joint_clone.velocity_upper_limits(),
-            joint_->velocity_upper_limits());
-  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
-            joint_->acceleration_lower_limits());
-  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
-            joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.default_angular_damping(),
-            joint_->default_angular_damping());
-  EXPECT_EQ(joint_clone.default_translational_damping(),
-            joint_->default_translational_damping());
-  EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
-  EXPECT_EQ(joint_clone.get_default_translation(),
-            joint_->get_default_translation());
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint_clone1.ShallowClone();
+  const auto& joint_clone2 =
+      dynamic_cast<const RpyFloatingJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint_clone1, &joint_clone2}) {
+    EXPECT_EQ(clone->name(), joint_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint_->frame_on_child().index());
+    EXPECT_EQ(clone->position_lower_limits(), joint_->position_lower_limits());
+    EXPECT_EQ(clone->position_upper_limits(), joint_->position_upper_limits());
+    EXPECT_EQ(clone->velocity_lower_limits(), joint_->velocity_lower_limits());
+    EXPECT_EQ(clone->velocity_upper_limits(), joint_->velocity_upper_limits());
+    EXPECT_EQ(clone->acceleration_lower_limits(),
+              joint_->acceleration_lower_limits());
+    EXPECT_EQ(clone->acceleration_upper_limits(),
+              joint_->acceleration_upper_limits());
+    EXPECT_EQ(clone->default_angular_damping(),
+              joint_->default_angular_damping());
+    EXPECT_EQ(clone->default_translational_damping(),
+              joint_->default_translational_damping());
+    EXPECT_EQ(clone->get_default_angles(), joint_->get_default_angles());
+    EXPECT_EQ(clone->get_default_translation(),
+              joint_->get_default_translation());
+  }
 }
 
 TEST_F(RpyFloatingJointTest, SetVelocityAndAccelerationLimits) {

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -198,30 +198,33 @@ TEST_F(ScrewJointTest, AddInDampingForces) {
 
 TEST_F(ScrewJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
-  const auto& joint_clone = dynamic_cast<const ScrewJoint<AutoDiffXd>&>(
+  const auto& joint_clone1 = dynamic_cast<const ScrewJoint<AutoDiffXd>&>(
       model_clone->get_variant(*joint_));
 
-  EXPECT_EQ(joint_clone.name(), joint_->name());
-  EXPECT_EQ(joint_clone.frame_on_parent().index(),
-            joint_->frame_on_parent().index());
-  EXPECT_EQ(joint_clone.frame_on_child().index(),
-            joint_->frame_on_child().index());
-  EXPECT_EQ(joint_clone.position_lower_limits(),
-            joint_->position_lower_limits());
-  EXPECT_EQ(joint_clone.position_upper_limits(),
-            joint_->position_upper_limits());
-  EXPECT_EQ(joint_clone.velocity_lower_limits(),
-            joint_->velocity_lower_limits());
-  EXPECT_EQ(joint_clone.velocity_upper_limits(),
-            joint_->velocity_upper_limits());
-  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
-            joint_->acceleration_lower_limits());
-  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
-            joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.default_damping(), joint_->default_damping());
-  EXPECT_EQ(joint_clone.get_default_rotation(), joint_->get_default_rotation());
-  EXPECT_EQ(joint_clone.get_default_translation(),
-            joint_->get_default_translation());
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint_clone1.ShallowClone();
+  const auto& joint_clone2 =
+      dynamic_cast<const ScrewJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint_clone1, &joint_clone2}) {
+    EXPECT_EQ(clone->name(), joint_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint_->frame_on_child().index());
+    EXPECT_EQ(clone->position_lower_limits(), joint_->position_lower_limits());
+    EXPECT_EQ(clone->position_upper_limits(), joint_->position_upper_limits());
+    EXPECT_EQ(clone->velocity_lower_limits(), joint_->velocity_lower_limits());
+    EXPECT_EQ(clone->velocity_upper_limits(), joint_->velocity_upper_limits());
+    EXPECT_EQ(clone->acceleration_lower_limits(),
+              joint_->acceleration_lower_limits());
+    EXPECT_EQ(clone->acceleration_upper_limits(),
+              joint_->acceleration_upper_limits());
+    EXPECT_EQ(clone->default_damping(), joint_->default_damping());
+    EXPECT_EQ(clone->get_default_rotation(), joint_->get_default_rotation());
+    EXPECT_EQ(clone->get_default_translation(),
+              joint_->get_default_translation());
+  }
 }
 
 TEST_F(ScrewJointTest, CanRotateOrTranslate) {

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -185,28 +185,31 @@ TEST_F(UniversalJointTest, AddInDamping) {
 
 TEST_F(UniversalJointTest, Clone) {
   auto model_clone = tree().CloneToScalar<AutoDiffXd>();
-  const auto& joint_clone = dynamic_cast<const UniversalJoint<AutoDiffXd>&>(
+  const auto& joint_clone1 = dynamic_cast<const UniversalJoint<AutoDiffXd>&>(
       model_clone->get_variant(*joint_));
 
-  EXPECT_EQ(joint_clone.name(), joint_->name());
-  EXPECT_EQ(joint_clone.frame_on_parent().index(),
-            joint_->frame_on_parent().index());
-  EXPECT_EQ(joint_clone.frame_on_child().index(),
-            joint_->frame_on_child().index());
-  EXPECT_EQ(joint_clone.position_lower_limits(),
-            joint_->position_lower_limits());
-  EXPECT_EQ(joint_clone.position_upper_limits(),
-            joint_->position_upper_limits());
-  EXPECT_EQ(joint_clone.velocity_lower_limits(),
-            joint_->velocity_lower_limits());
-  EXPECT_EQ(joint_clone.velocity_upper_limits(),
-            joint_->velocity_upper_limits());
-  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
-            joint_->acceleration_lower_limits());
-  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
-            joint_->acceleration_upper_limits());
-  EXPECT_EQ(joint_clone.default_damping(), joint_->default_damping());
-  EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint_clone1.ShallowClone();
+  const auto& joint_clone2 =
+      dynamic_cast<const UniversalJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint_clone1, &joint_clone2}) {
+    EXPECT_EQ(clone->name(), joint_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint_->frame_on_child().index());
+    EXPECT_EQ(clone->position_lower_limits(), joint_->position_lower_limits());
+    EXPECT_EQ(clone->position_upper_limits(), joint_->position_upper_limits());
+    EXPECT_EQ(clone->velocity_lower_limits(), joint_->velocity_lower_limits());
+    EXPECT_EQ(clone->velocity_upper_limits(), joint_->velocity_upper_limits());
+    EXPECT_EQ(clone->acceleration_lower_limits(),
+              joint_->acceleration_lower_limits());
+    EXPECT_EQ(clone->acceleration_upper_limits(),
+              joint_->acceleration_upper_limits());
+    EXPECT_EQ(clone->default_damping(), joint_->default_damping());
+    EXPECT_EQ(clone->get_default_angles(), joint_->get_default_angles());
+  }
 }
 
 TEST_F(UniversalJointTest, SetVelocityAndAccelerationLimits) {

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -95,6 +95,26 @@ TEST_F(WeldJointTest, Damping) {
   EXPECT_EQ(joint_->default_damping_vector().size(), 0);
 }
 
+TEST_F(WeldJointTest, Clone) {
+  auto model_clone = tree().CloneToScalar<AutoDiffXd>();
+  const auto& joint_clone1 = dynamic_cast<const WeldJoint<AutoDiffXd>&>(
+      model_clone->get_variant(*joint_));
+
+  const std::unique_ptr<Joint<AutoDiffXd>> shallow =
+      joint_clone1.ShallowClone();
+  const auto& joint_clone2 =
+      dynamic_cast<const WeldJoint<AutoDiffXd>&>(*shallow);
+
+  for (const auto* clone : {&joint_clone1, &joint_clone2}) {
+    EXPECT_EQ(clone->name(), joint_->name());
+    EXPECT_EQ(clone->frame_on_parent().index(),
+              joint_->frame_on_parent().index());
+    EXPECT_EQ(clone->frame_on_child().index(),
+              joint_->frame_on_child().index());
+    EXPECT_TRUE(clone->X_FM().IsExactlyEqualTo(joint_->X_FM()));
+  }
+}
+
 TEST_F(WeldJointTest, JointLocking) {
   // Joint locking on a weld joint does nothing; still, invoking it should not
   // be an error.

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -227,6 +227,13 @@ UniformGravityFieldElement<T>::DoCloneToScalar(
       gravity_vector(), disabled_model_instances_);
 }
 
+template <typename T>
+std::unique_ptr<ForceElement<T>> UniformGravityFieldElement<T>::DoShallowClone()
+    const {
+  return std::make_unique<UniformGravityFieldElement<T>>(
+      gravity_vector(), disabled_model_instances_);
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/uniform_gravity_field_element.h
+++ b/multibody/tree/uniform_gravity_field_element.h
@@ -130,6 +130,8 @@ class UniformGravityFieldElement : public ForceElement<T> {
   std::unique_ptr<ForceElement<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<ForceElement<T>> DoShallowClone() const override;
+
  private:
   Vector3<double> g_W_;
   // Set of model instances for which gravity is disabled.

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -58,6 +58,13 @@ std::unique_ptr<Joint<symbolic::Expression>> UniversalJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> UniversalJoint<T>::DoShallowClone() const {
+  return std::make_unique<UniversalJoint<T>>(
+      this->name(), this->frame_on_parent(), this->frame_on_child(),
+      this->default_damping());
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -252,6 +252,8 @@ class UniversalJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>&) const override;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+
   // Make UniversalJoint templated on every other scalar type a friend of
   // UniversalJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of UniversalJoint<T>.

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -51,6 +51,12 @@ std::unique_ptr<Joint<symbolic::Expression>> WeldJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+template <typename T>
+std::unique_ptr<Joint<T>> WeldJoint<T>::DoShallowClone() const {
+  return std::make_unique<WeldJoint<T>>(this->name(), this->frame_on_parent(),
+                                        this->frame_on_child(), X_FM());
+}
+
 // N.B. Due to esoteric linking errors on Mac (see #9345) involving
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -110,6 +110,8 @@ class WeldJoint final : public Joint<T> {
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
       const internal::MultibodyTree<symbolic::Expression>& x) const override;
 
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+
   // Make WeldJoint templated on every other scalar type a friend of
   // WeldJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of WeldJoint<T>.


### PR DESCRIPTION
This reduces our reliance RLG/pybind11 custom unique_ptr semantics.  (Towards #21968.)  Python bindings cannot transfer exclusive ownership via `unique_ptr` arguments.  They must either copy the argument, or use `shared_ptr` ownership.  Here, we'll choose to copy.

Introduce a new DoShallowClone virtual function on Joint, Frame, and ForceElement. Downstream code that has implemented its own subclass of any of those bases and bound the subclass in Python must override the new virtual function.

Python code must no longer assume that the object passed AddJoint, AddFrame, or AddForceElement is what gets added to the plant. Instead, code should always capture the return value, i.e.,

  joint = plant.AddJoint(PrismaticJoint(...))

or

  joint = PrismaticJoint(...)
  joint = plant.AddJoint(joint)

are fine, but in this approach

  joint = PrismaticJoint(...)
  plant.AddJoint(joint)

the original 'joint' object will NOT necessarily be part of the plant, so would probably be a mistake to be used thereafter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22498)
<!-- Reviewable:end -->
