### PR TITLE
[inverse_kinematics] Fix plant lifetime in AddMultibodyPlantConstraints

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -167,8 +167,17 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             py_rvp::reference_internal, cls_doc.get_mutable_context.doc);
   }
 
-  m.def("AddMultibodyPlantConstraints", &AddMultibodyPlantConstraints,
-      py::arg("plant"), py::arg("q"), py::arg("prog"), py::arg("plant_context"),
+  m.def(
+      "AddMultibodyPlantConstraints",
+      [](py::object plant, const solvers::VectorXDecisionVariable& q,
+          solvers::MathematicalProgram* prog,
+          systems::Context<double>* plant_context) {
+        return AddMultibodyPlantConstraints(
+            make_shared_ptr_from_py_object<MultibodyPlant<double>>(plant), q,
+            prog, plant_context);
+      },
+      py::arg("plant"), py::arg("q"), py::arg("prog"),
+      py::arg("plant_context") = py::none(),
       doc.AddMultibodyPlantConstraints.doc);
 
   {

--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
@@ -1,7 +1,5 @@
 #include "drake/multibody/inverse_kinematics/add_multibody_plant_constraints.h"
 
-#include <memory>
-
 #include "drake/multibody/inverse_kinematics/orientation_constraint.h"
 #include "drake/multibody/inverse_kinematics/point_to_point_distance_constraint.h"
 #include "drake/multibody/inverse_kinematics/position_constraint.h"
@@ -13,21 +11,54 @@ namespace multibody {
 using solvers::Binding;
 using solvers::Constraint;
 
+namespace {
+// Given a binding that requires the plant to be kept alive, modifies the
+// binding to incorporate a shared_ptr to the given plant.
+// TODO(jwnimmer-tri) Ideally the constraints themselves would accept a
+// shared_ptr to the plant instead of a raw pointer.
+void AddPlantLifetimeToBinding(
+    const std::shared_ptr<const MultibodyPlant<double>>& plant,
+    Binding<Constraint>* binding) {
+  DRAKE_DEMAND(binding != nullptr);
+  // Obtain the binding's constraint as it exists now.
+  const std::shared_ptr<Constraint> old_constraint_shared =
+      binding->evaluator();
+  Constraint* old_constraint_raw = old_constraint_shared.get();
+  // For the binding to remain valid, we need to ensure that both the MbP and
+  // the constraint live at least as long as the binding. We can accomplish that
+  // by keeping each of their shared_ptrs alive (as a pair, for convenience).
+  std::shared_ptr<void> keep_alives =
+      std::make_shared<std::pair<std::shared_ptr<const MultibodyPlant<double>>,
+                                 std::shared_ptr<Constraint>>>(
+          plant, old_constraint_shared);
+  // Create a shared_ptr whose `get()` still points to the constraint, but whose
+  // control block now keeps alive *both* the the plant and the constraint.
+  std::shared_ptr<Constraint> new_constraint_shared(
+      /* managed object = */ std::move(keep_alives),
+      /* stored pointer = */ old_constraint_raw);
+  // Replace the binding's constraint with our new, fatter one.
+  *binding = Binding<Constraint>(std::move(new_constraint_shared),
+                                 binding->variables());
+}
+}  // namespace
+
 std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
-    const MultibodyPlant<double>& plant,
+    const std::shared_ptr<const MultibodyPlant<double>>& plant,
     const solvers::VectorXDecisionVariable& q,
     solvers::MathematicalProgram* prog,
     systems::Context<double>* plant_context) {
+  DRAKE_THROW_UNLESS(plant != nullptr);
   DRAKE_THROW_UNLESS(prog != nullptr);
+  const MultibodyPlant<double>& plant_ref = *plant;
   if (plant_context) {
-    plant.ValidateContext(*plant_context);
+    plant_ref.ValidateContext(*plant_context);
   }
   // AddMultibodyPlantConstraints only supports coupler, ball, distance, and
   // weld.
   int num_supported_constraints =
-      plant.num_coupler_constraints() + plant.num_ball_constraints() +
-      plant.num_distance_constraints() + plant.num_weld_constraints();
-  if (num_supported_constraints != plant.num_constraints()) {
+      plant_ref.num_coupler_constraints() + plant_ref.num_ball_constraints() +
+      plant_ref.num_distance_constraints() + plant_ref.num_weld_constraints();
+  if (num_supported_constraints != plant_ref.num_constraints()) {
     // TODO(russt): It would be better to say something specific about the
     // unidentified constraint here, but the constraint API for MultibodyPlant
     // does not have that surface area (yet).
@@ -37,22 +68,22 @@ std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
         "Distance, Ball, and Weld multibody constraints. If you're seeing "
         "this, MultibodyPlant must have gained a new constraint type that is "
         "not supported here yet (but likely should be)",
-        plant.num_constraints(), num_supported_constraints));
+        plant_ref.num_constraints(), num_supported_constraints));
   }
   std::vector<Binding<Constraint>> bindings;
 
   // Joint limits.
-  const int nq = plant.num_positions();
-  Eigen::VectorXd lb = plant.GetPositionLowerLimits();
-  Eigen::VectorXd ub = plant.GetPositionUpperLimits();
+  const int nq = plant_ref.num_positions();
+  Eigen::VectorXd lb = plant_ref.GetPositionLowerLimits();
+  Eigen::VectorXd ub = plant_ref.GetPositionUpperLimits();
 
   // Joint locking.
   VectorX<bool> is_locked = VectorX<bool>::Constant(nq, false);
   Eigen::VectorXd current_positions(nq);
   if (plant_context) {
-    current_positions = plant.GetPositions(*plant_context);
-    for (JointIndex i : plant.GetJointIndices()) {
-      const Joint<double>& joint = plant.get_joint(i);
+    current_positions = plant_ref.GetPositions(*plant_context);
+    for (JointIndex i : plant_ref.GetJointIndices()) {
+      const Joint<double>& joint = plant_ref.get_joint(i);
       if (joint.is_locked(*plant_context)) {
         const int start = joint.position_start();
         const int size = joint.num_positions();
@@ -64,8 +95,8 @@ std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
   }
 
   // Add the unit quaternion constraints.
-  for (BodyIndex i{0}; i < plant.num_bodies(); ++i) {
-    const RigidBody<double>& body = plant.get_body(i);
+  for (BodyIndex i{0}; i < plant_ref.num_bodies(); ++i) {
+    const RigidBody<double>& body = plant_ref.get_body(i);
     if (body.has_quaternion_dofs()) {
       const int start = body.floating_positions_start();
       constexpr int kSize = 4;
@@ -100,9 +131,11 @@ std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
       .evaluator()
       ->set_description("Joint limits");
 
-  for (const auto& [id, spec] : plant.get_coupler_constraint_specs()) {
-    const int q0_index = plant.get_joint(spec.joint0_index).position_start();
-    const int q1_index = plant.get_joint(spec.joint1_index).position_start();
+  for (const auto& [id, spec] : plant_ref.get_coupler_constraint_specs()) {
+    const int q0_index =
+        plant_ref.get_joint(spec.joint0_index).position_start();
+    const int q1_index =
+        plant_ref.get_joint(spec.joint1_index).position_start();
     bindings
         .emplace_back(prog->AddLinearEqualityConstraint(
             q[q0_index] == spec.gear_ratio * q[q1_index] + spec.offset))
@@ -111,61 +144,67 @@ std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
             fmt::format("Coupler constraint for joint {} and joint {}",
                         spec.joint0_index, spec.joint1_index));
   }
-  for (const auto& [id, spec] : plant.get_distance_constraint_specs()) {
+  for (const auto& [id, spec] : plant_ref.get_distance_constraint_specs()) {
     DRAKE_THROW_UNLESS(plant_context != nullptr);
     // d(q) == d₀.
     bindings
         .emplace_back(prog->AddConstraint(
             std::make_shared<PointToPointDistanceConstraint>(
-                &plant, plant.get_body(spec.body_A).body_frame(), spec.p_AP,
-                plant.get_body(spec.body_B).body_frame(), spec.p_BQ,
-                spec.distance, spec.distance, plant_context),
+                &plant_ref, plant_ref.get_body(spec.body_A).body_frame(),
+                spec.p_AP, plant_ref.get_body(spec.body_B).body_frame(),
+                spec.p_BQ, spec.distance, spec.distance, plant_context),
             q))
         .evaluator()
         ->set_description(
             fmt::format("Distance constraint between body {} and body {}",
                         spec.body_A, spec.body_B));
+    AddPlantLifetimeToBinding(plant, &bindings.back());
   }
-  for (const auto& [id, spec] : plant.get_ball_constraint_specs()) {
+  for (const auto& [id, spec] : plant_ref.get_ball_constraint_specs()) {
     DRAKE_THROW_UNLESS(plant_context != nullptr);
     bindings
         .emplace_back(prog->AddConstraint(
             std::make_shared<PositionConstraint>(
-                &plant, plant.get_body(spec.body_A).body_frame(), spec.p_AP,
-                spec.p_AP, plant.get_body(spec.body_B).body_frame(), *spec.p_BQ,
+                &plant_ref, plant_ref.get_body(spec.body_A).body_frame(),
+                spec.p_AP, spec.p_AP,
+                plant_ref.get_body(spec.body_B).body_frame(), *spec.p_BQ,
                 plant_context),
             q))
         .evaluator()
         ->set_description(
             fmt::format("Ball constraint between body {} and body {}",
                         spec.body_A, spec.body_B));
+    AddPlantLifetimeToBinding(plant, &bindings.back());
   }
-  for (const auto& [id, spec] : plant.get_weld_constraint_specs()) {
+  for (const auto& [id, spec] : plant_ref.get_weld_constraint_specs()) {
     DRAKE_THROW_UNLESS(plant_context != nullptr);
     // TODO(russt): Consider implementing a WeldConstraint.
     bindings
         .emplace_back(prog->AddConstraint(
             std::make_shared<PositionConstraint>(
-                &plant, plant.get_body(spec.body_A).body_frame(),
+                &plant_ref, plant_ref.get_body(spec.body_A).body_frame(),
                 spec.X_AP.translation(), spec.X_AP.translation(),
-                plant.get_body(spec.body_B).body_frame(),
+                plant_ref.get_body(spec.body_B).body_frame(),
                 spec.X_BQ.translation(), plant_context),
             q))
         .evaluator()
         ->set_description(
             fmt::format("Weld position constraint between body {} and body {}",
                         spec.body_A, spec.body_B));
+    AddPlantLifetimeToBinding(plant, &bindings.back());
     bindings
         .emplace_back(prog->AddConstraint(
             std::make_shared<OrientationConstraint>(
-                &plant, plant.get_body(spec.body_A).body_frame(),
-                spec.X_AP.rotation(), plant.get_body(spec.body_B).body_frame(),
+                &plant_ref, plant_ref.get_body(spec.body_A).body_frame(),
+                spec.X_AP.rotation(),
+                plant_ref.get_body(spec.body_B).body_frame(),
                 spec.X_BQ.rotation(), 0.0, plant_context),
             q))
         .evaluator()
         ->set_description(fmt::format(
             "Weld orientation constraint between body {} and body {}",
             spec.body_A, spec.body_B));
+    AddPlantLifetimeToBinding(plant, &bindings.back());
   }
   return bindings;
 }

--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.h
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "drake/multibody/plant/multibody_plant.h"
@@ -31,7 +32,7 @@ MultibodyPlant constraints requires it. (unit quaternion constraints and coupler
 constraints do not).
 */
 std::vector<solvers::Binding<solvers::Constraint>> AddMultibodyPlantConstraints(
-    const MultibodyPlant<double>& plant,
+    const std::shared_ptr<const MultibodyPlant<double>>& plant,
     const solvers::VectorXDecisionVariable& q,
     solvers::MathematicalProgram* prog,
     systems::Context<double>* plant_context = nullptr);

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -50,7 +50,11 @@ InverseKinematics::InverseKinematics(
   }
   DRAKE_DEMAND(context_ != nullptr);  // Sanity check.
 
-  AddMultibodyPlantConstraints(plant, q_, prog_.get(), context_);
+  AddMultibodyPlantConstraints(
+      std::shared_ptr<const MultibodyPlant<double>>(
+          /* managed object = */ std::shared_ptr<void>{},
+          /* stored pointer = */ &plant_),
+      q_, prog_.get(), context_);
 
   if (!with_joint_limits) {
     // Remove only the joint limit constraint.

--- a/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
+++ b/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
@@ -25,41 +25,41 @@ bool SnoptSolverUnavailable() {
 class AddMultibodyPlantConstraintsTest : public ::testing::Test {
  public:
   void SetUp() override {
-    plant_.set_discrete_contact_approximation(
+    plant_->set_discrete_contact_approximation(
         DiscreteContactApproximation::kSap);
-    plant_.SetUseSampledOutputPorts(false);
+    plant_->SetUseSampledOutputPorts(false);
 
-    body_A_ = &plant_.AddRigidBody(
+    body_A_ = &plant_->AddRigidBody(
         "body_A", SpatialInertia<double>::SolidBoxWithMass(1, 1, 1, 1));
-    body_B_ = &plant_.AddRigidBody(
+    body_B_ = &plant_->AddRigidBody(
         "body_B", SpatialInertia<double>::SolidBoxWithMass(1, 1, 1, 1));
-    world_A_ = &plant_.AddJoint<RevoluteJoint>(
-        "world_A", plant_.world_body(), RigidTransformd(Vector3d(-1, 0, 0)),
+    world_A_ = &plant_->AddJoint<RevoluteJoint>(
+        "world_A", plant_->world_body(), RigidTransformd(Vector3d(-1, 0, 0)),
         *body_A_, RigidTransformd(), Vector3d::UnitZ());
     // Add and then immediately remove a joint so that the joint indices do not
     // correspond to the position indices.
-    plant_.RemoveJoint(plant_.AddJoint<RevoluteJoint>(
+    plant_->RemoveJoint(plant_->AddJoint<RevoluteJoint>(
         "temp", *body_A_, RigidTransformd(Vector3d(1, 0, 0)), *body_B_,
         RigidTransformd(), Vector3d::UnitZ()));
-    A_B_ = &plant_.AddJoint<RevoluteJoint>(
+    A_B_ = &plant_->AddJoint<RevoluteJoint>(
         "A_B", *body_A_, RigidTransformd(Vector3d(1, 0, 0)), *body_B_,
         RigidTransformd(), Vector3d::UnitZ());
   }
 
   void CheckConstraints(int expected_num_constraints = 2, double tol = 1e-6) {
-    if (!plant_.is_finalized()) {
-      plant_.Finalize();
+    if (!plant_->is_finalized()) {
+      plant_->Finalize();
     }
-    plant_context_ = plant_.CreateDefaultContext();
+    plant_context_ = plant_->CreateDefaultContext();
 
     // First demonstrate that these constraints work with MathematicalProgram,
     // and use them to find a valid initial condition.
     solvers::MathematicalProgram prog;
-    auto q = prog.NewContinuousVariables(plant_.num_positions());
-    VectorXd q0 = VectorXd::LinSpaced(plant_.num_positions(), 0, 1);
+    auto q = prog.NewContinuousVariables(plant_->num_positions());
+    VectorXd q0 = VectorXd::LinSpaced(plant_->num_positions(), 0, 1);
     prog.AddQuadraticErrorCost(
-        MatrixXd::Identity(plant_.num_positions(), plant_.num_positions()), q0,
-        q);
+        MatrixXd::Identity(plant_->num_positions(), plant_->num_positions()),
+        q0, q);
 
     auto constraints =
         AddMultibodyPlantConstraints(plant_, q, &prog, plant_context_.get());
@@ -69,17 +69,18 @@ class AddMultibodyPlantConstraintsTest : public ::testing::Test {
 
     // Now step the dynamics forward and verify that the constraint stays
     // satisfied.
-    plant_.SetPositions(plant_context_.get(), result.GetSolution(q));
-    VectorXd qn = plant_.EvalUniquePeriodicDiscreteUpdate(*plant_context_)
+    plant_->SetPositions(plant_context_.get(), result.GetSolution(q));
+    VectorXd qn = plant_->EvalUniquePeriodicDiscreteUpdate(*plant_context_)
                       .value()
-                      .head(plant_.num_positions());
+                      .head(plant_->num_positions());
 
     prog.SetInitialGuessForAllVariables(qn);
     EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
   }
 
  protected:
-  MultibodyPlant<double> plant_{0.1};
+  std::shared_ptr<MultibodyPlant<double>> plant_{
+      std::make_shared<MultibodyPlant<double>>(0.1)};
   std::unique_ptr<systems::Context<double>> plant_context_{};
   const RigidBody<double>* body_A_{nullptr};
   const RigidBody<double>* body_B_{nullptr};
@@ -88,24 +89,24 @@ class AddMultibodyPlantConstraintsTest : public ::testing::Test {
 };
 
 TEST_F(AddMultibodyPlantConstraintsTest, CouplerConstraint) {
-  plant_.AddCouplerConstraint(*world_A_, *A_B_, 2.3);
+  plant_->AddCouplerConstraint(*world_A_, *A_B_, 2.3);
   CheckConstraints();
 
   // Confirm that I also could have called the method with plant_context ==
   // nullptr.
   solvers::MathematicalProgram prog;
-  auto q = prog.NewContinuousVariables(plant_.num_positions());
+  auto q = prog.NewContinuousVariables(plant_->num_positions());
   EXPECT_NO_THROW(AddMultibodyPlantConstraints(plant_, q, &prog));
 }
 
 TEST_F(AddMultibodyPlantConstraintsTest, DistanceConstraint) {
-  plant_.AddDistanceConstraint(*body_A_, Vector3d(0.0, 1.0, 0.0), *body_B_,
-                               Vector3d(0.0, 1.0, 0.0), 1.5);
+  plant_->AddDistanceConstraint(*body_A_, Vector3d(0.0, 1.0, 0.0), *body_B_,
+                                Vector3d(0.0, 1.0, 0.0), 1.5);
   CheckConstraints();
 }
 
 TEST_F(AddMultibodyPlantConstraintsTest, BallConstraint) {
-  plant_.AddBallConstraint(*body_A_, Vector3d(0.0, 2.0, 0.0), *body_B_);
+  plant_->AddBallConstraint(*body_A_, Vector3d(0.0, 2.0, 0.0), *body_B_);
   if (SnoptSolverUnavailable()) {
     // IPOPT is flakey on this test.
     return;
@@ -114,10 +115,10 @@ TEST_F(AddMultibodyPlantConstraintsTest, BallConstraint) {
 }
 
 TEST_F(AddMultibodyPlantConstraintsTest, WeldConstraint) {
-  const RigidBody<double>& body_C = plant_.AddRigidBody(
+  const RigidBody<double>& body_C = plant_->AddRigidBody(
       "body_C", SpatialInertia<double>::SolidBoxWithMass(1, 1, 1, 1));
-  plant_.AddWeldConstraint(*body_A_, RigidTransformd(Vector3d(1, 2, 3)), body_C,
-                           RigidTransformd(Vector3d(4, 5, 6)));
+  plant_->AddWeldConstraint(*body_A_, RigidTransformd(Vector3d(1, 2, 3)),
+                            body_C, RigidTransformd(Vector3d(4, 5, 6)));
   if (SnoptSolverUnavailable()) {
     // IPOPT is flakey on this test.
     return;
@@ -128,15 +129,15 @@ TEST_F(AddMultibodyPlantConstraintsTest, WeldConstraint) {
 }
 
 GTEST_TEST(AdditionalTests, QuaternionsAndJointLimitsAndLocks) {
-  MultibodyPlant<double> plant(0);
+  auto plant = std::make_shared<MultibodyPlant<double>>(0);
 
   // Create a plant with four bodies.
-  const auto& world = plant.world_body();
+  const auto& world = plant->world_body();
   const auto M = SpatialInertia<double>::SolidCubeWithMass(1.0, 0.1);
-  const auto& body1 = plant.AddRigidBody("body1", M);
-  const auto& body2 = plant.AddRigidBody("body2", M);
-  const auto& body3 = plant.AddRigidBody("body3", M);
-  const auto& body4 = plant.AddRigidBody("body4", M);
+  const auto& body1 = plant->AddRigidBody("body1", M);
+  const auto& body2 = plant->AddRigidBody("body2", M);
+  const auto& body3 = plant->AddRigidBody("body3", M);
+  const auto& body4 = plant->AddRigidBody("body4", M);
 
   // Attach a specific joint to each body:
   // (1) A quaternion floating joint that will not be locked.
@@ -146,15 +147,15 @@ GTEST_TEST(AdditionalTests, QuaternionsAndJointLimitsAndLocks) {
   math::RigidTransform<double> I;
   Eigen::Vector3d X = Eigen::Vector3d::UnitX();
   const auto& joint1 =
-      plant.AddJoint<QuaternionFloatingJoint>("joint1", world, I, body1, I);
+      plant->AddJoint<QuaternionFloatingJoint>("joint1", world, I, body1, I);
   const auto& joint2 =
-      plant.AddJoint<QuaternionFloatingJoint>("joint2", world, I, body2, I);
+      plant->AddJoint<QuaternionFloatingJoint>("joint2", world, I, body2, I);
   const auto& joint3 =
-      plant.AddJoint<RevoluteJoint>("joint3", world, I, body3, I, X);
+      plant->AddJoint<RevoluteJoint>("joint3", world, I, body3, I, X);
   const auto& joint4 =
-      plant.AddJoint<RevoluteJoint>("joint4", world, I, body4, I, X);
-  plant.Finalize();
-  auto context = plant.CreateDefaultContext();
+      plant->AddJoint<RevoluteJoint>("joint4", world, I, body4, I, X);
+  plant->Finalize();
+  auto context = plant->CreateDefaultContext();
 
   // Leave joint1 unlocked.
 
@@ -163,17 +164,17 @@ GTEST_TEST(AdditionalTests, QuaternionsAndJointLimitsAndLocks) {
   joint2.Lock(&*context);
 
   // Set limits on joint3, but do not lock it.
-  dynamic_cast<RevoluteJoint<double>&>(plant.get_mutable_joint(joint3.index()))
+  dynamic_cast<RevoluteJoint<double>&>(plant->get_mutable_joint(joint3.index()))
       .set_position_limits(Vector1d{-0.5}, Vector1d{0.5});
 
   // Lock body4's revolute joint beyond its limit.
-  dynamic_cast<RevoluteJoint<double>&>(plant.get_mutable_joint(joint4.index()))
+  dynamic_cast<RevoluteJoint<double>&>(plant->get_mutable_joint(joint4.index()))
       .set_position_limits(Vector1d{-1}, Vector1d{1});
   joint4.set_angle(&*context, 1.1);
   joint4.Lock(&*context);
 
   solvers::MathematicalProgram prog;
-  auto q = prog.NewContinuousVariables(plant.num_positions());
+  auto q = prog.NewContinuousVariables(plant->num_positions());
   AddMultibodyPlantConstraints(plant, q, &prog, context.get());
 
   // The initial guess is set for the two quaternion floating joints.
@@ -226,7 +227,7 @@ GTEST_TEST(AdditionalTests, QuaternionsAndJointLimitsAndLocks) {
 
   // If we don't pass in the context, then we will not get the locked joints.
   solvers::MathematicalProgram prog2;
-  auto q2 = prog2.NewContinuousVariables(plant.num_positions());
+  auto q2 = prog2.NewContinuousVariables(plant->num_positions());
   AddMultibodyPlantConstraints(plant, q2, &prog2);
   EXPECT_EQ(prog2.linear_equality_constraints().size(), 0);
 }


### PR DESCRIPTION
Amends #22327.

- [x] Requires #22478 to land first.

(Not breaking Stable API because this function has only be published in 1 release so far.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22502)
<!-- Reviewable:end -->
