### PR TITLE
[build] Use clang-format from bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,6 +73,14 @@ spdlog_repository = use_repo_rule(
 
 spdlog_repository(name = "pkgconfig_spdlog")
 
+# Add additional modules we use as tools (not runtime dependencies).
+
+bazel_dep(name = "toolchains_llvm", version = "1.3.0")
+
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(llvm_version = "15.0.5")
+use_repo(llvm, "llvm_toolchain")
+
 # Load dependencies which are "public", i.e., made available to downstream
 # projects.
 #

--- a/doc/_pages/clion.md
+++ b/doc/_pages/clion.md
@@ -169,9 +169,6 @@ CLion such that the modification may not be immediately apparent. When in doubt,
 select away from the target file and back; this will cause the file to refresh
 and you can confirm that the file has been modified as expected.
 
-First, make sure you have installed ``clang-format-15``
-(see [Tools for Code Style Compliance](/code_style_tools.html)).
-
 ### Clang format selected file
 
 Open the ``Edit Tool`` for external tools as outlined above and enter the
@@ -179,8 +176,8 @@ following values for the fields:
 
 * **Name:** ``Clang Format Full File``
 * **Description:** ``Apply clang-format to the active file``
-* **Program:** ``clang-format-15``
-* **Arguments:** ``-i $FileName$``
+* **Program:** ``bazel``
+* **Arguments:** ``run //tools/lint:clang-format -- -i $FileName$``
 * **Working directory:** ``$FileDir$``
 * **Advanced Options:** Uncheck ``Open console for tool output``
 
@@ -193,8 +190,8 @@ following values for the fields:
 
 * **Name:** ``Clang Format Selected Lines``
 * **Description:** ``Apply clang-format to the selected lines``
-* **Program:** ``clang-format-15``
-* **Arguments:** ``-lines $SelectionStartLine$:$SelectionEndLine$ -i $FileName$``
+* **Program:** ``bazel``
+* **Arguments:** ``run //tools/lint:clang-format -- -lines $SelectionStartLine$:$SelectionEndLine$ -i $FileName$``
 * **Working directory:** ``$FileDir$``
 * **Advanced Options:** Uncheck ``Open console for tool output``
 

--- a/doc/_pages/code_style_tools.md
+++ b/doc/_pages/code_style_tools.md
@@ -41,14 +41,11 @@ User manuals for the style-checking tools are as follows:
 
 ## C/C++: Clang-Format
 
-The [Mandatory platform-specific instructions](/from_source.html#mandatory-platform-specific-instructions)
-install Drake's required version of ``clang-format``, depending on the platform
-(macOS or Ubuntu).
-
 To run ``clang-format``:
 
 ```
-clang-format-15 -i -style=file [file name]
+cd drake
+bazel run //tools/lint:clang-format -- -i -style=file [file name]
 ```
 
 Using ``clang-format`` will modify the entire file that is specified. As an
@@ -56,17 +53,15 @@ alternative, you can use ``git clang-format`` on Ubuntu to change only the
 portions of a file that you have modified. To run ``git clang-format``:
 
 ```
+# Make sure the clang-format program exists at the path we want to use.
+bazel build //tools/lint/...
+
 # For development on Ubuntu: format a file that has been staged in git
-git clang-format-15 --binary=/usr/bin/clang-format-15 -- [file name]
+git clang-format --binary=/path/to/drake/bazel-bin/tools/lint/clang-format -- [file name]
 
 # For development on Ubuntu: format a file that has been modified but not staged
-git clang-format-15 --binary=/usr/bin/clang-format-15 -f -- [file name]
+git clang-format --binary=/path/to/drake/bazel-bin/tools/lint/clang-format -f -- [file name]
 ```
-
-On macOS, the command to use is
-``/opt/homebrew/opt/llvm@15/bin/clang-format``.
-Note in particular that ``15`` is part of the directory name, not a suffix on
-the program name.
 
 ### IDE integration
 

--- a/doc/_pages/emacs.md
+++ b/doc/_pages/emacs.md
@@ -26,6 +26,7 @@ On Ubuntu ``sudo apt install elpa-magit``.
 
 Use ``(require 'clang-format)`` to enable the ``M-x clang-format-...`` family of
 functions. Also check that the customize variable ``clang-format-executable`` is
-set to Drake's preferred value ``clang-format-15``.
+set to Drake's preferred value
+``/path/to/drake/bazel-bin/tools/lint/clang-format``.
 
 <!--- TODO(jwnimmer-tri) Explain 'google-c-style from the styleguide. -->

--- a/doc/_pages/vscode.md
+++ b/doc/_pages/vscode.md
@@ -29,4 +29,4 @@ on code formatting work well. Take note of "Format Document",
 
 In the VS Code Options configuration, check that the option for
 ``C_Cpp: Clang_format_path`` is set to Drake's preferred value
-``clang-format-15``.
+``/path/to/drake/bazel-bin/tools/lint/clang-format``.

--- a/setup/BUILD.bazel
+++ b/setup/BUILD.bazel
@@ -8,8 +8,6 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
     "mac/binary_distribution/Brewfile",
     "mac/source_distribution/Brewfile",
-    "mac/source_distribution/Brewfile-doc-only",
-    "mac/source_distribution/Brewfile-maintainer-only",
     "python/pdm.lock",
     "python/pyproject.toml",
     "python/requirements.txt",

--- a/setup/mac/source_distribution/Brewfile-test-only
+++ b/setup/mac/source_distribution/Brewfile-test-only
@@ -1,4 +1,0 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-
-brew 'llvm@15'

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -7,18 +7,13 @@
 
 set -euxo pipefail
 
-with_test_only=1
-
 while [ "${1:-}" != "" ]; do
   case "$1" in
     --developer)
       with_test_only=1
       ;;
-    # Do NOT install prerequisites that are only needed to build and/or run
-    # unit tests, i.e., those prerequisites that are not dependencies of
-    # bazel { build, run } //:install.
     --without-test-only)
-      with_test_only=0
+      # Ignored for backwards compatibility.
       ;;
     *)
       echo 'Invalid command line argument' >&2
@@ -38,7 +33,3 @@ if ! command -v brew &>/dev/null; then
 fi
 
 brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock
-
-if [[ "${with_test_only}" -eq 1 ]]; then
-  brew bundle --file="${BASH_SOURCE%/*}/Brewfile-test-only" --no-lock
-fi

--- a/setup/ubuntu/source_distribution/packages-jammy-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy-test-only.txt
@@ -1,4 +1,3 @@
-clang-format-15
 curl
 kcov
 libstdc++6-10-dbg

--- a/setup/ubuntu/source_distribution/packages-noble-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-noble-test-only.txt
@@ -1,4 +1,3 @@
-clang-format-15
 curl
 libstdc++6-10-dbg
 python3-dateutil

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -48,9 +48,22 @@ drake_py_library(
     name = "clang_format",
     testonly = 1,
     srcs = ["clang_format.py"],
-    data = ["//:.clang-format"],
+    data = [
+        "//:.clang-format",
+        "@llvm_toolchain//:clang-format",
+    ],
     deps = [
         ":module_py",
+        "@rules_python//python/runfiles",
+    ],
+)
+
+drake_py_binary(
+    name = "clang-format",
+    testonly = 1,
+    srcs = ["clang_format.py"],
+    deps = [
+        ":clang_format",
     ],
 )
 

--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -2,23 +2,24 @@
 """
 
 import os
-import platform
+from pathlib import Path
+import sys
+
+from python import runfiles
 
 
-def get_clang_format_path(version=None):
-    """Call with version=None to use Drake's default version.
-    Otherwise, pass the desired major version as an int.
-    """
-    if version is None:
-        version = 15
-    if platform.system() == "Darwin":
-        if platform.machine() == "arm64":
-            homebrew = "/opt/homebrew"
-        else:
-            homebrew = "/usr/local"
-        path = f"{homebrew}/opt/llvm@{version}/bin/clang-format"
-    else:
-        path = f"/usr/bin/clang-format-{version}"
-    if os.path.isfile(path):
-        return path
-    raise RuntimeError("Could not find required clang-format at " + path)
+def get_clang_format_path():
+    manifest = runfiles.Create()
+    path = Path(manifest.Rlocation("llvm_toolchain/clang-format"))
+    if not path.is_file():
+        raise RuntimeError(f"Could not find required clang-format at {path}")
+    return path
+
+
+def _main():
+    exe = get_clang_format_path()
+    os.execvp(exe, [exe] + sys.argv[1:])
+
+
+if __name__ == "__main__":
+    _main()

--- a/tools/lint/clang_format_lint.py
+++ b/tools/lint/clang_format_lint.py
@@ -31,7 +31,10 @@ def _check_clang_format_idempotence(filename):
     if not changes:
         return 0
     print("ERROR: {} needs clang-format".format(filename))
-    print("note: fix via {} -style=file -i {}".format(clang_format, filename))
+    print("note: fix via {} -style=file -i {}".format(
+        "bazel-bin/tools/lint/clang-format", filename))
+    print("note: if that program does not exist, you might need to compile it "
+          "first: bazel build //tools/lint/...")
     return 1
 
 

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -418,6 +418,7 @@ REPOS_ALREADY_PROVIDED_BY_BAZEL_MODULES = [
     "rules_rust",
     "rules_shell",
     "spdlog",
+    "toolchains_llvm",
 ]
 
 # This is the list of repositories that Drake provides as a module extension

--- a/tools/workspace/workspace_bzlmod_sync_test.py
+++ b/tools/workspace/workspace_bzlmod_sync_test.py
@@ -68,6 +68,7 @@ class TestWorkspaceBzlmodSync(unittest.TestCase):
 
         # Don't check modules that are known to be module-only.
         del modules["bazel_features"]
+        del modules["toolchains_llvm"]
 
         # Don't check modules whose repository rule twin is pkgconfig (and thus
         # doesn't have a github pinned version that we need to keep in sync).


### PR DESCRIPTION
Towards #20731 and #21714 and #14967 and #4843.

For now, the clang-format remains pinned to 15 (no change).  In a future PR, I'll aim to upgrade that to the latest and greatest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22504)
<!-- Reviewable:end -->
