### PR TITLE
Use @python to provide Linux wheel dependencies

### DIFF
--- a/setup/python/pdm.lock
+++ b/setup/python/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "test", "wheel"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:6e0102fe5ea6c29e8888d56dfc6686fb1c73a2070f8dbff0e62ced5adb76a886"
+content_hash = "sha256:5675c5bbfb85cb016da1228ab88e99c1eb08625a3c9374558a60844705872724"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -15,6 +15,7 @@ name = "altgraph"
 version = "0.17.4"
 summary = "Python graph (network) package"
 groups = ["wheel"]
+marker = "sys_platform == \"darwin\""
 files = [
     {file = "altgraph-0.17.4-py2.py3-none-any.whl", hash = "sha256:642743b4750de17e655e6711601b077bc6598dbfa3ba5fa2b2a35ce12b508dff"},
     {file = "altgraph-0.17.4.tar.gz", hash = "sha256:1b5afbb98f6c4dcadb2e2ae6ab9fa994bbb8c1d75f4fa96d340f9437ae454406"},
@@ -139,6 +140,22 @@ files = [
 ]
 
 [[package]]
+name = "auditwheel"
+version = "6.2.0"
+requires_python = ">=3.9"
+summary = "Cross-distribution Linux wheels"
+groups = ["wheel"]
+marker = "sys_platform == \"linux\""
+dependencies = [
+    "packaging>=20.9",
+    "pyelftools>=0.24",
+]
+files = [
+    {file = "auditwheel-6.2.0-py3-none-any.whl", hash = "sha256:927e0fc9ab5b6040c1240c81dd7f50924c99c3ca876a776d52e042ba374f6604"},
+    {file = "auditwheel-6.2.0.tar.gz", hash = "sha256:4fc9f778cd81dac56820e8cdee9842dc44b8f435f8783606dabd4964d4638b30"},
+]
+
+[[package]]
 name = "babel"
 version = "2.16.0"
 requires_python = ">=3.8"
@@ -164,20 +181,6 @@ dependencies = [
 files = [
     {file = "beautifulsoup4-4.12.3-py3-none-any.whl", hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"},
     {file = "beautifulsoup4-4.12.3.tar.gz", hash = "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"},
-]
-
-[[package]]
-name = "bindepend"
-version = "0.1"
-summary = "Binary depedency analysis"
-groups = ["wheel"]
-marker = "sys_platform == \"win32\""
-dependencies = [
-    "pefile",
-]
-files = [
-    {file = "bindepend-0.1-py3-none-any.whl", hash = "sha256:8c3017b8d25b18c3865f55137656338312d06999b93b798b5be1a1d0176e6493"},
-    {file = "bindepend-0.1.tar.gz", hash = "sha256:4a376a4a81d4812e85be9cf1b9b49c78bcf76a3278b94a9b080c22ac9c3ad1fd"},
 ]
 
 [[package]]
@@ -527,6 +530,7 @@ version = "0.12.0"
 requires_python = ">=3.7"
 summary = "Move macOS dynamic libraries into package"
 groups = ["wheel"]
+marker = "sys_platform == \"darwin\""
 dependencies = [
     "bindepend; sys_platform == \"win32\"",
     "macholib",
@@ -1187,26 +1191,13 @@ name = "macholib"
 version = "1.16.3"
 summary = "Mach-O header analysis and editing"
 groups = ["wheel"]
+marker = "sys_platform == \"darwin\""
 dependencies = [
     "altgraph>=0.17",
 ]
 files = [
     {file = "macholib-1.16.3-py2.py3-none-any.whl", hash = "sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c"},
     {file = "macholib-1.16.3.tar.gz", hash = "sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30"},
-]
-
-[[package]]
-name = "machomachomangler"
-version = "0.0.1"
-summary = "Tools for mangling Mach-O and PE binaries"
-groups = ["wheel"]
-marker = "sys_platform == \"win32\""
-dependencies = [
-    "attrs",
-]
-files = [
-    {file = "machomachomangler-0.0.1-py3-none-any.whl", hash = "sha256:4fa66b8b65959399874f05a4d93abe1e49db46f71bef66a68a93e060d9ba0cb3"},
-    {file = "machomachomangler-0.0.1.tar.gz", hash = "sha256:2acbad5bd465c5f386e5ceac8a8a1939a9789f503dd84f491e046292cf6e54a6"},
 ]
 
 [[package]]
@@ -1568,18 +1559,6 @@ files = [
 ]
 
 [[package]]
-name = "pefile"
-version = "2024.8.26"
-requires_python = ">=3.6.0"
-summary = "Python PE parsing module"
-groups = ["wheel"]
-marker = "sys_platform == \"win32\""
-files = [
-    {file = "pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f"},
-    {file = "pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632"},
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 summary = "Pexpect allows easy control of interactive console applications."
@@ -1759,6 +1738,17 @@ dependencies = [
 files = [
     {file = "pydot-3.0.4-py3-none-any.whl", hash = "sha256:bfa9c3fc0c44ba1d132adce131802d7df00429d1a79cc0346b0a5cd374dbe9c6"},
     {file = "pydot-3.0.4.tar.gz", hash = "sha256:3ce88b2558f3808b0376f22bfa6c263909e1c3981e2a7b629b65b451eee4a25d"},
+]
+
+[[package]]
+name = "pyelftools"
+version = "0.31"
+summary = "Library for analyzing ELF files and DWARF debugging information"
+groups = ["wheel"]
+marker = "sys_platform == \"linux\""
+files = [
+    {file = "pyelftools-0.31-py3-none-any.whl", hash = "sha256:f52de7b3c7e8c64c8abc04a79a1cf37ac5fb0b8a49809827130b858944840607"},
+    {file = "pyelftools-0.31.tar.gz", hash = "sha256:c774416b10310156879443b81187d182d8d9ee499660380e645918b50bc88f99"},
 ]
 
 [[package]]
@@ -2303,6 +2293,7 @@ version = "4.12.2"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
 groups = ["default", "wheel"]
+marker = "sys_platform == \"darwin\" or python_version < \"3.13\""
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},

--- a/setup/python/pyproject.toml
+++ b/setup/python/pyproject.toml
@@ -37,7 +37,8 @@ test = [
 ]
 # (Additional) dependencies needed to build a Drake wheel.
 wheel = [
-    "delocate",
+    "auditwheel; sys_platform == 'linux'",
+    "delocate; sys_platform == 'darwin'",
     "setuptools",
     "wheel",
 ]

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -39,6 +39,10 @@ chrpath()
 
 ###############################################################################
 
+# Activate Drake's virtual environment, which provides some of the tools that
+# we need to build the wheels.
+. /opt/drake-wheel-build/drake/venv/bin/activate
+
 readonly WHEEL_DIR=/opt/drake-wheel-build/wheel
 readonly WHEEL_SHARE_DIR=${WHEEL_DIR}/pydrake/share
 

--- a/tools/wheel/image/packages-jammy
+++ b/tools/wheel/image/packages-jammy
@@ -22,6 +22,7 @@ pkg-config
 ca-certificates
 file
 patch
+patchelf
 wget
 unzip
 zip

--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -37,15 +37,3 @@ ln -s ${PREFIX}/bin/${PYTHON}-config /usr/local/bin/python-config
 ln -s ${PREFIX}/include/${PYTHON} /usr/local/include/
 ln -s ${PREFIX}/include/${PYTHON}m /usr/local/include/
 ln -s /usr/local/bin/python /usr/bin/python
-
-# TODO(jwnimmer-tri): Should these be version-pinned? What's the process for
-# keeping them up to date if they are?
-pip install \
-    matplotlib \
-    numpy \
-    pyyaml \
-    semantic-version \
-    setuptools \
-    wheel \
-    auditwheel \
-    patchelf

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -82,17 +82,12 @@ ln -s "$(bazel info bazel-bin)" "$build_root"/bazel-bin
 find "$build_root" -type d -print0 | xargs -0 chmod u+w
 
 # -----------------------------------------------------------------------------
-# Obtain and activate Drake's Python virtual environment.
-# -----------------------------------------------------------------------------
-
-readonly drake_python="$(bazel info output_base).drake_python"
-readonly venv_drake="$drake_python/venv.drake"
-
-. "$venv_drake/bin/activate"
-
-# -----------------------------------------------------------------------------
 # "Install" additional tools to build the wheel.
 # -----------------------------------------------------------------------------
+
+ln -nsf "$git_root" "/opt/drake-wheel-build/drake"
+
+readonly venv_drake="/opt/drake-wheel-build/drake/venv"
 
 ln -s \
     "$build_root/bazel-bin/external/drake+/tools/wheel/strip_rpath" \

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -118,9 +118,9 @@ def _get_linkopts(repo_ctx, python_config):
     return linkopts
 
 def _prepare_venv(repo_ctx, python):
-    # Only macOS uses a venv at the moment.
+    # Only macOS and wheel builds use a venv at the moment.
     os_name = repo_ctx.os.name  # "linux" or "mac os x"
-    if os_name != "mac os x":
+    if os_name != "mac os x" and not is_wheel_build(repo_ctx):
         return python
 
     # Locate lock files and mark them to be monitored for changes.
@@ -144,14 +144,16 @@ def _prepare_venv(repo_ctx, python):
     # doesn't exist at all yet.
     sync_label = Label("@drake//tools/workspace/python:venv_sync")
     sync = repo_ctx.path(sync_label).realpath
-    repo_ctx.report_progress("Running venv_sync")
-    execute_or_fail(repo_ctx, [
-        sync,
+    sync_args = [
         "--python",
         python,
         "--repository",
         repo_ctx.path("").realpath,
-    ])
+    ]
+    if is_wheel_build:
+        sync_args.append("--symlink")
+    repo_ctx.report_progress("Running venv_sync")
+    execute_or_fail(repo_ctx, [sync] + sync_args)
     repo_ctx.watch(sync)
 
     # Read the path to the venv's python3. (This file is created by venv_sync.)

--- a/tools/workspace/python/venv_sync
+++ b/tools/workspace/python/venv_sync
@@ -10,6 +10,7 @@ set -eux -o pipefail
 # Globals (will be set from command line arguments).
 python=
 repository=
+symlink=
 
 # Create virtual environment at specified path (if it doesn't exist).
 mkvenv() {
@@ -34,6 +35,13 @@ while [ "${1:-}" != "" ]; do
             # location, containing the path to our venv.drake/bin/python3.
             readonly repository="$2"
             shift
+            ;;
+        --symlink)
+            # Create a symlink to the virtual environment in the Drake source
+            # tree. This is intended to be used by wheel builds, which may,
+            # outside of the Bazel build, need access to tools installed in the
+            # virtual environment.
+            readonly symlink="venv"
             ;;
         *)
             echo 'Invalid command line argument' >&2
@@ -107,11 +115,16 @@ if [[ -z "${checksum}" ]]; then
     exit 1
 fi
 
-# Symlink our venv bin path for the repository.bzl to use. We'll salt it with
-# the requirements checksum so that Bazel will invalidate all Python targets
-# when the checksum changes.
-mkdir -p "${repository}/${checksum}"
-ln -nsf "${venv_drake}/bin" "${repository}/${checksum}/bin"
+# Symlink our venv path for the repository.bzl to use. It's directory name
+# inside of our repository is a hash of the requirements file so that Bazel
+# will invalidate all Python targets when the checksum changes.
+ln -nsf "${venv_drake}" "${repository}/${checksum}"
 
 # Tell repository.bzl which path to use.
 echo -n "${checksum}/bin/python3" > "${repository}/venv_python3.txt"
+
+# Symlink our venv path for wheel builds to use (if requested; see
+# documentation of --symlink, above).
+if [[ -n "${symlink}" ]]; then
+    ln -nsf "${venv_drake}" "${drake_root}/${symlink}"
+fi


### PR DESCRIPTION
Use the managed virtual environment to provide Python dependencies for Linux wheel builds. This allows Linux wheels to version-pin their dependencies the same way we're already doing for macOS.

This includes several additional changes:

- Modify `venv_sync` to make the virtual environment available in a known location for wheel builds.

- Use `patchelf` from Ubuntu's repositories rather than PyPI. We originally needed a newer version to avoid problems with auditwheel (n.b. https://github.com/pypa/auditwheel/issues/103), but this is no longer necessary.

- When making the virtual environment available to Bazel, symlink the root, not just the `bin` subdirectory. The latter seems to be sufficient on macOS, but not on Linux.

Fixes #22042.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22505)
<!-- Reviewable:end -->
