### PR TITLE
[workspace] Tweak glob in pybind11 rules

### DIFF
--- a/tools/workspace/pybind11/package.BUILD.bazel
+++ b/tools/workspace/pybind11/package.BUILD.bazel
@@ -51,7 +51,7 @@ _HDRS = [
 check_lists_consistency(
     files = _HDRS,
     glob_include = [
-        "include/**",
+        "include/**/*.h",
     ],
 )
 


### PR DESCRIPTION
If our repository rules patch leaves behind an *.orig file, then the check_lists_consistency would (spuriously) fail. Avoid that by only globbing the files we care about (i.e., headers).

Amends #22450.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22506)
<!-- Reviewable:end -->
