### PR TITLE
Return non-existent file paths

### DIFF
--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -135,7 +135,7 @@ void ParseModelDirectivesImpl(
           ScopedName::Join(model_namespace, model.name).to_string();
       drake::log()->debug("  add_model: {}\n    {}", name, model.file);
       const std::string file =
-          ResolveUri(diagnostic, model.file, package_map, {});
+          std::get<0>(ResolveUri(diagnostic, model.file, package_map, {}));
       std::optional<ModelInstanceIndex> child_model_instance_id =
           parser_selector(diagnostic, file).AddModel(
               {DataSource::kFilename, &file},
@@ -256,7 +256,8 @@ void ParseModelDirectivesImpl(
             "Namespace '{}' does not exist as model instance",
             new_model_namespace));
       }
-      std::string filename = ResolveUri(diagnostic, sub.file, package_map, {});
+      std::string filename =
+        std::get<0>(ResolveUri(diagnostic, sub.file, package_map, {}));
       auto sub_directives =
           LoadModelDirectives({DataSource::kFilename, &filename});
       ParseModelDirectivesImpl(sub_directives, new_model_namespace, workspace,

--- a/multibody/parsing/detail_path_utils.h
+++ b/multibody/parsing/detail_path_utils.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
+#include <tuple>
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/multibody/parsing/package_map.h"
@@ -14,10 +16,10 @@ namespace internal {
 // Otherwise, iff a root_dir was provided then @p uri is appended to the end
 // of @p root_dir (if it's not already an absolute path) and checked for
 // existence.  If the file does not exist or is not found, an error is posted
-// to @p diagnostic and an empty string is returned. The returned path
-// will be lexically normalized. In other words, a path like
-// `/some//path/to/ignored/../file.txt` (with duplicate slashes, directory
-// changes, etc.) would be boiled down to `/some/path/to/file.txt`.
+// to @p diagnostic. The returned path will be lexically normalized. In other
+// words, a path like `/some//path/to/ignored/../file.txt` (with duplicate
+// slashes, directory changes, etc.) would be boiled down to
+// `/some/path/to/file.txt`.
 //
 // @param diagnostic The error-reporting channel.
 //
@@ -31,9 +33,10 @@ namespace internal {
 // @p filename does not start with "package:".  Can be empty when only URIs
 // (not relative paths) should be allowed for @p uri.
 //
-// @return The file's full path, lexically normalized, or an empty string if
-// the file is not found or does not exist.
-std::string ResolveUri(const drake::internal::DiagnosticPolicy& diagnostic,
+// @return The file's full path, lexically normalized, and whether the file
+// exists.
+std::tuple<std::string, bool> ResolveUri(
+                       const drake::internal::DiagnosticPolicy& diagnostic,
                        const std::string& uri,
                        const PackageMap& package_map,
                        const std::string& root_dir);

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -166,7 +166,8 @@ std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
       // parsing should handle the case of this missing.
       DRAKE_DEMAND(mesh_uri.has_value());
       if (!mesh_uri.has_value()) return nullptr;
-      const std::string file_name = resolve_filename(diagnostic, *mesh_uri);
+      const std::string file_name =
+        std::get<0>(resolve_filename(diagnostic, *mesh_uri));
       double scale = 1.0;
       if (mesh_element->HasElement("scale")) {
         std::optional<gz::math::Vector3d> scale_vector =
@@ -416,13 +417,12 @@ VisualProperties MakeVisualPropertiesFromSdfVisual(
       auto [texture_name, has_value] =
           material_element->Get<std::string>("drake:diffuse_map", {});
       if (has_value) {
-        const std::string resolved_path =
+        auto [resolved_path, file_exists] =
             resolve_filename(diagnostic, texture_name);
-        if (resolved_path.empty()) {
+        if (!file_exists) {
           std::string message = std::string(fmt::format(
               "Unable to locate the texture file: {}", texture_name));
           diagnostic.Error(visual_element, std::move(message));
-          return {std::nullopt, std::nullopt};
         }
         properties->AddProperty("phong", "diffuse_map", resolved_path);
       }

--- a/multibody/parsing/detail_sdf_geometry.h
+++ b/multibody/parsing/detail_sdf_geometry.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include <sdf/Collision.hh>
@@ -29,7 +30,7 @@ namespace internal {
 constexpr char kIsDrakeNamespaceAttr[] = "drake-namespaced";
 
 /* Used for resolving URIs / filenames.  */
-using ResolveFilename = std::function<std::string (
+using ResolveFilename = std::function<std::tuple<std::string, bool> (
     const SDFormatDiagnostic&, std::string)>;
 
 /* Given an sdf::Geometry object representing a <geometry> element from an SDF

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -2113,7 +2113,12 @@ sdf::ParserConfig MakeSdfParserConfig(const ParsingWorkspace& workspace) {
     debug_log.SetActionForErrors([](const DiagnosticDetail& detail) {
       drake::log()->debug(detail.FormatError());
     });
-    return ResolveUri(debug_log, _input, workspace.package_map, ".");
+    auto [result, exists] =
+        ResolveUri(debug_log, _input, workspace.package_map, ".");
+    if (!exists) {
+      return std::string{};
+    }
+    return result;
   });
 
   parser_config.RegisterCustomModelParser(

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -148,16 +148,13 @@ UrdfMaterial ParseMaterial(const TinyXml2Diagnostic& diagnostic,
   std::optional<std::string> texture_path;
   const XMLElement* texture_node = node->FirstChildElement("texture");
   if (texture_node) {
-    // TODO(rpoyner-tri): error for empty texture tag?
     std::string texture_name;
     if (ParseStringAttribute(texture_node, "filename", &texture_name) &&
         !texture_name.empty()) {
-      texture_path = ResolveUri(diagnostic.MakePolicyForNode(texture_node),
-                                texture_name, package_map, root_dir);
-      if (texture_path->empty()) {
-        // ResolveUri already emitted an error message.
-        return {};
-      }
+      // ResolveUri will emit an error message.
+      texture_path = std::get<0>(
+        ResolveUri(diagnostic.MakePolicyForNode(texture_node), texture_name,
+                    package_map, root_dir));
     }
   }
 
@@ -292,13 +289,9 @@ std::unique_ptr<geometry::Shape> ParseMesh(const TinyXml2Diagnostic& diagnostic,
     return {};
   }
 
-  const std::string resolved_filename = ResolveUri(
+  const std::string resolved_filename = std::get<0>(ResolveUri(
       diagnostic.MakePolicyForNode(shape_node), filename, package_map,
-      root_dir);
-  if (resolved_filename.empty()) {
-    // ResolveUri already emitted an error message.
-    return {};
-  }
+      root_dir));
 
   double scale = 1.0;
   // Obtains the scale of the mesh if it exists.

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -766,7 +766,7 @@ const std::string& PackageMap::GetPath(
 
 std::string PackageMap::ResolveUrl(const std::string& url) const {
   drake::internal::DiagnosticPolicy diagnostic_policy;
-  return internal::ResolveUri(diagnostic_policy, url, *this, {});
+  return std::get<0>(internal::ResolveUri(diagnostic_policy, url, *this, {}));
 }
 
 void PackageMap::PopulateFromFolder(const std::string& path) {

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -96,9 +96,9 @@ std::vector<ModelInstanceIndex> Parser::AddModels(
 
 std::vector<ModelInstanceIndex> Parser::AddModelsFromUrl(
     const std::string& url) {
-  const std::string file_name = internal::ResolveUri(
+  auto [file_name, file_exists] = internal::ResolveUri(
       diagnostic_policy_, url, package_map_, {});
-  if (file_name.empty()) {
+  if (!file_exists) {
     return {};
   }
   return AddModels(file_name);

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -164,7 +164,8 @@ void FlattenModelDirectivesInternal(const ModelDirectives& directives,
 std::string ResolveModelDirectiveUri(const std::string& uri,
                                      const PackageMap& package_map) {
   ::drake::internal::DiagnosticPolicy policy;
-  return ::drake::multibody::internal::ResolveUri(policy, uri, package_map, "");
+  return std::get<0>(
+    ::drake::multibody::internal::ResolveUri(policy, uri, package_map, ""));
 }
 
 void ProcessModelDirectives(const ModelDirectives& directives,


### PR DESCRIPTION
This is towards adding mesh geometries to the `SceneGraph` even if the files are not found.

Note that I wasn't sure where the root directory is getting added, hence for that case I also returned the uri.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22510)
<!-- Reviewable:end -->
