### PR TITLE
[analysis] Avoid unique_ptr in simulator context bindings

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -18,8 +18,6 @@
 #include "drake/systems/analysis/simulator_print_stats.h"
 #include "drake/systems/analysis/simulator_python_internal.h"
 
-using std::unique_ptr;
-
 namespace drake {
 namespace pydrake {
 
@@ -240,12 +238,14 @@ PYBIND11_MODULE(analysis, m) {
     auto cls = DefineTemplateClassWithDefault<Simulator<T>>(
         m, "Simulator", GetPyParam<T>(), doc.Simulator.doc);
     cls  // BR
-        .def(py::init<const System<T>&, unique_ptr<Context<T>>>(),
+        .def(py::init([](const System<T>& system, Context<T>* context) {
+          auto py_context = py::cast(context);
+          return Simulator<T>::MakeWithSharedContext(
+              system, make_shared_ptr_from_py_object<Context<T>>(py_context));
+        }),
             py::arg("system"), py::arg("context") = nullptr,
             // Keep alive, reference: `self` keeps `system` alive.
-            py::keep_alive<1, 2>(),
-            // Keep alive, ownership: `context` keeps `self` alive.
-            py::keep_alive<3, 1>(), doc.Simulator.ctor.doc)
+            py::keep_alive<1, 2>())
         .def("Initialize", &Simulator<T>::Initialize,
             doc.Simulator.Initialize.doc,
             py::arg("params") = InitializeParams{})
@@ -310,11 +310,14 @@ Parameter ``interruptible``:
             py_rvp::reference_internal, doc.Simulator.get_mutable_context.doc)
         .def("has_context", &Simulator<T>::has_context,
             doc.Simulator.has_context.doc)
-        .def("reset_context", &Simulator<T>::reset_context, py::arg("context"),
-            // Keep alive, ownership: `context` keeps `self` alive.
-            py::keep_alive<2, 1>(), doc.Simulator.reset_context.doc)
-        // TODO(eric.cousineau): Bind `release_context` once some form of the
-        // PR RobotLocomotion/pybind11#33 lands. Presently, it fails.
+        .def(
+            "reset_context",
+            [](Simulator<T>* self, Context<T>* context) {
+              auto py_context = py::cast(context);
+              self->reset_context_from_shared(
+                  make_shared_ptr_from_py_object<Context<T>>(py_context));
+            },
+            py::arg("context"), doc.Simulator.reset_context.doc)
         .def("set_publish_every_time_step",
             &Simulator<T>::set_publish_every_time_step, py::arg("publish"),
             doc.Simulator.set_publish_every_time_step.doc)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -640,8 +640,6 @@ class TestGeneral(unittest.TestCase):
         # WARNING: Once we call `simulator.reset_context()`, it will delete the
         # context it currently owns, which is `context_default` in this case.
         # BE CAREFUL IN SITUATIONS LIKE THIS!
-        # TODO(eric.cousineau): Bind `release_context()`, or migrate context
-        # usage to use `shared_ptr`.
         context = system.CreateDefaultContext()
         simulator.reset_context(context)
         self.assertIs(context, simulator.get_mutable_context())

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -826,6 +826,46 @@ GTEST_TEST(SimulatorTest, SecondConstructor) {
   EXPECT_EQ(simulator.get_context().get_time(), 3.0);
 }
 
+// Tests the internal use (for Python) factory method that takes the context via
+// shared pointer.
+GTEST_TEST(SimulatorTest, SharedContextFactoryMethod) {
+  // Create the spring-mass system and context.
+  analysis_test::MySpringMassSystem<double> spring_mass(1.0, 1.0, 0.0);
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Mark the context with an arbitrary value.
+  context->SetTime(7.0);
+  std::shared_ptr<Context<double>> shared_context(std::move(context));
+
+  // Construct the simulator with the created context.
+  auto simulator = Simulator<double>::MakeWithSharedContext(
+      spring_mass, std::move(shared_context));
+
+  // Verify that context values are equivalent.
+  EXPECT_EQ(simulator->get_context().get_time(), 7.0);
+}
+
+// Tests the internal use (for Python) method that resets the context via
+// shared pointer.
+GTEST_TEST(SimulatorTest, ResetFromShared) {
+  // Create the spring-mass system and context.
+  analysis_test::MySpringMassSystem<double> spring_mass(1.0, 1.0, 0.0);
+  auto context = spring_mass.CreateDefaultContext();
+
+  // Mark the context with an arbitrary value.
+  context->SetTime(11.0);
+  std::shared_ptr<Context<double>> shared_context(std::move(context));
+
+  // Construct the simulator with a default context.
+  Simulator<double> simulator(spring_mass);
+
+  // Change to the marked context.
+  simulator.reset_context_from_shared(std::move(shared_context));
+
+  // Verify that context values are equivalent.
+  EXPECT_EQ(simulator.get_context().get_time(), 11.0);
+}
+
 GTEST_TEST(SimulatorTest, MiscAPI) {
   analysis_test::MySpringMassSystem<double> spring_mass(1.0, 1.0, 0.0);
   Simulator<double> simulator(spring_mass);  // Use default Context.
@@ -865,10 +905,13 @@ GTEST_TEST(SimulatorTest, ContextAccess) {
   simulator.get_mutable_context().SetTime(3.0);
   EXPECT_EQ(simulator.get_context().get_time(), 3.0);
   EXPECT_TRUE(simulator.has_context());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   simulator.release_context();
   EXPECT_FALSE(simulator.has_context());
   DRAKE_EXPECT_THROWS_MESSAGE(simulator.Initialize(),
       ".*Initialize.*Context.*not.*set.*");
+#pragma GCC diagnostic pop
 
   // Create another context.
   auto ucontext = spring_mass.CreateDefaultContext();


### PR DESCRIPTION
Towards #21968.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22511)
<!-- Reviewable:end -->
