### PR TITLE
Adds M-frame methods for curvilinear mobilizer.

### DIFF
--- a/common/trajectories/piecewise_constant_curvature_trajectory.cc
+++ b/common/trajectories/piecewise_constant_curvature_trajectory.cc
@@ -45,61 +45,75 @@ math::RigidTransform<T> PiecewiseConstantCurvatureTrajectory<T>::CalcPose(
     const T& s) const {
   const T w = maybe_wrap(s);
   int segment_index = this->get_segment_index(w);
-  const math::RigidTransform<T> X_FiF =
+  const math::RigidTransform<T> X_MiM =
       CalcRelativePoseInSegment(segment_turning_rates_[segment_index],
                                 w - this->start_time(segment_index));
-  return segment_start_poses_[segment_index] * X_FiF;
+  return segment_start_poses_[segment_index] * X_MiM;  // = X_AM
 }
 
 template <typename T>
 multibody::SpatialVelocity<T>
 PiecewiseConstantCurvatureTrajectory<T>::CalcSpatialVelocity(
     const T& s, const T& s_dot) const {
-  const T w = maybe_wrap(s);
-  const math::RotationMatrix<T> R_AF = CalcPose(w).rotation();
-  const T& rho_i = segment_turning_rates_[this->get_segment_index(w)];
+  const math::RotationMatrix<T> R_AM = CalcPose(s).rotation();
+  return R_AM * CalcSpatialVelocityInM(s, s_dot);  // V_AM_A
+}
+
+template <typename T>
+multibody::SpatialVelocity<T>
+PiecewiseConstantCurvatureTrajectory<T>::CalcSpatialVelocityInM(
+    const T& s, const T& s_dot) const {
+  const T& rho_i = curvature(s);
 
   multibody::SpatialVelocity<T> spatial_velocity;
   // From Frenet–Serret analysis and the class doc for
   // PiecewiseConstantCurvatureTrajectory, the rotational velocity is equal to
-  // the Darboux vector times the tangential velocity: ρ⋅Fz⋅ds/dt.
-  spatial_velocity.rotational() = rho_i * R_AF.col(kPlaneNormalIndex) * s_dot;
+  // the Darboux vector (plane normal p̂ (= Mz)) times the tangential velocity:
+  // ρ⋅Mz⋅ds/dt. But Mz expressed in M is just [0 0 1].
+  spatial_velocity.rotational() = Vector3<T>(0, 0, rho_i * s_dot);
 
   // The translational velocity is equal to the tangent direction times the
-  // tangential velocity: dr(s)/dt = t̂(s)⋅ds/dt = Fx(s)⋅ds/dt.
-  spatial_velocity.translational() = R_AF.col(kCurveTangentIndex) * s_dot;
+  // tangential velocity: dr(s)/dt = t̂(s)⋅ds/dt = Mx(s)⋅ds/dt. But Mx
+  // expressed in M is just [1 0 0].
+  spatial_velocity.translational() = Vector3<T>(s_dot, 0, 0);
 
-  return spatial_velocity;
+  return spatial_velocity;  // V_AM_M
 }
 
 template <typename T>
 multibody::SpatialAcceleration<T>
 PiecewiseConstantCurvatureTrajectory<T>::CalcSpatialAcceleration(
     const T& s, const T& s_dot, const T& s_ddot) const {
-  const T w = maybe_wrap(s);
-  const math::RotationMatrix<T> R_AF = CalcPose(w).rotation();
-  const T& rho_i = segment_turning_rates_[this->get_segment_index(w)];
+  const math::RotationMatrix<T> R_AM = CalcPose(s).rotation();
+  return R_AM * CalcSpatialAccelerationInM(s, s_dot, s_ddot);
+}
+
+template <typename T>
+multibody::SpatialAcceleration<T>
+PiecewiseConstantCurvatureTrajectory<T>::CalcSpatialAccelerationInM(
+    const T& s, const T& s_dot, const T& s_ddot) const {
+  const T& rho_i = curvature(s);
 
   // The spatial acceleration is the time derivative of the spatial velocity.
   // We compute the acceleration by applying the chain rule to the formulas
   // in CalcSpatialVelocity.
   multibody::SpatialAcceleration<T> spatial_acceleration;
 
-  // The angular velocity is ρᵢ⋅Fz⋅ds/dt. As Fz and ρᵢ are constant
-  // everywhere except the breaks, the angular acceleration is then equal to
-  // ρᵢ⋅Fz⋅d²s/dt².
-  spatial_acceleration.rotational() =
-      rho_i * R_AF.col(kPlaneNormalIndex) * s_ddot;
+  // The angular velocity is ρᵢ⋅Mz⋅ds/dt. As Mz is constant everywhere, and ρᵢ
+  // constant everywhere except the breaks, the angular acceleration is then
+  // equal to ρᵢ⋅Mz⋅d²s/dt². But Mz expressed in M is just [0 0 1].
+  spatial_acceleration.rotational() = Vector3<T>(0, 0, rho_i * s_ddot);
 
-  // The translational velocity is dr(s)/dt = Fx(s)⋅ds/dt. Thus by product and
+  // The translational velocity is dr(s)/dt = Mx(s)⋅ds/dt. Thus by product and
   // chain rule, the translational acceleration is:
-  //    a(s) = d²r(s)/ds² = dFx(s)/ds⋅(ds/dt)² + Fx⋅d²s/dt².
-  // From the class doc, we know dFx/ds = ρᵢ⋅Fy.
-  // Thus the translational acceleration is a(s) = ρᵢ⋅Fy⋅(ds/dt)² + Fx⋅d²s/dt².
+  //    a(s) = d²r(s)/ds² = dMx(s)/ds⋅(ds/dt)² + Mx⋅d²s/dt².
+  // From the class doc, we know dMx/ds = ρᵢ⋅My.
+  // Thus the translational acceleration is a(s) = ρᵢ⋅My⋅(ds/dt)² + Mx⋅d²s/dt².
+  // But expressed in M, Mx=[1 0 0] and My=[0 1 0].
   spatial_acceleration.translational() =
-      rho_i * R_AF.col(kCurveNormalIndex) * s_dot * s_dot +
-      R_AF.col(kCurveTangentIndex) * s_ddot;
-  return spatial_acceleration;
+      Vector3<T>(s_ddot, rho_i * s_dot * s_dot, 0);
+
+  return spatial_acceleration;  // A_AM_M
 }
 
 template <typename T>
@@ -123,23 +137,23 @@ template <typename T>
 math::RigidTransform<T>
 PiecewiseConstantCurvatureTrajectory<T>::CalcRelativePoseInSegment(
     const T& rho_i, const T& ds) {
-  Vector3<T> p_FioFo_Fi = Vector3<T>::Zero();
+  Vector3<T> p_MioMo_Mi = Vector3<T>::Zero();
   // Calculate rotation angle.
   const T theta = ds * rho_i;
-  math::RotationMatrix<T> R_FiF = math::RotationMatrix<T>::MakeZRotation(theta);
+  math::RotationMatrix<T> R_MiM = math::RotationMatrix<T>::MakeZRotation(theta);
   if (rho_i == T(0)) {
     // Case 1: zero curvature (straight line)
     //
-    // The tangent axis is constant, thus the displacement p_FioFo_Fi is just
+    // The tangent axis is constant, thus the displacement p_MioMo_Mi is just
     // t̂_Fi⋅Δs.
-    p_FioFo_Fi(kCurveTangentIndex) = ds;
+    p_MioMo_Mi(kCurveTangentIndex) = ds;
   } else {
     // Case 2: non-zero curvature (circular arc)
     //
-    // The entire trajectory lies in a plane with normal Fiz, and thus
-    // the arc is embedded in the Fix-Fiy plane.
+    // The entire trajectory lies in a plane with normal Miz, and thus
+    // the arc is embedded in the Mix-Miy plane.
     //
-    //     Fiy
+    //     Miy
     //      ↑
     //    C o             x
     //      │\            x
@@ -148,19 +162,19 @@ PiecewiseConstantCurvatureTrajectory<T>::CalcRelativePoseInSegment(
     //      │   \       x
     //      │    \     x
     //      │     \  xx
-    //      │ p_Fo ox
+    //      │ p_Mo ox
     //      │   xxx
-    //      └xxx───────────────→ Fix
-    //     p_Fio
+    //      └xxx───────────────→ Mix
+    //     p_Mio
     //
-    // The circular arc's centerpoint C is located at p_FioC = (1/ρᵢ)⋅Fiy,
-    // with initial direction Fix and radius abs(1/ρᵢ). Thus the angle traveled
+    // The circular arc's centerpoint C is located at p_MioC = (1/ρᵢ)⋅Miy,
+    // with initial direction Mix and radius abs(1/ρᵢ). Thus the angle traveled
     // along the arc is θ = ρᵢ⋅Δs, with the sign of ρᵢ handling the
     // clockwise/counterclockwise direction. The ρᵢ > 0 case is shown above.
-    p_FioFo_Fi(kCurveNormalIndex) = (T(1) - cos(theta)) / rho_i;
-    p_FioFo_Fi(kCurveTangentIndex) = sin(theta) / rho_i;
+    p_MioMo_Mi(kCurveNormalIndex) = (T(1) - cos(theta)) / rho_i;
+    p_MioMo_Mi(kCurveTangentIndex) = sin(theta) / rho_i;
   }
-  return math::RigidTransform<T>(R_FiF, p_FioFo_Fi);
+  return math::RigidTransform<T>(R_MiM, p_MioMo_Mi);
 }
 
 template <typename T>
@@ -168,11 +182,11 @@ math::RigidTransform<T>
 PiecewiseConstantCurvatureTrajectory<T>::MakeInitialPose(
     const Vector3<T>& initial_curve_tangent, const Vector3<T>& plane_normal,
     const Vector3<T>& initial_position) {
-  const Vector3<T> initial_Fy_A = plane_normal.cross(initial_curve_tangent);
-  const auto R_WF = math::RotationMatrix<T>::MakeFromOrthonormalColumns(
-      initial_curve_tangent.normalized(), initial_Fy_A.normalized(),
+  const Vector3<T> initial_My_A = plane_normal.cross(initial_curve_tangent);
+  const auto R_AM = math::RotationMatrix<T>::MakeFromOrthonormalColumns(
+      initial_curve_tangent.normalized(), initial_My_A.normalized(),
       plane_normal.normalized());
-  return math::RigidTransform<T>(R_WF, initial_position);
+  return math::RigidTransform<T>(R_AM, initial_position);  // X_AM
 }
 
 template <typename T>
@@ -192,12 +206,13 @@ PiecewiseConstantCurvatureTrajectory<T>::MakeSegmentStartPoses(
   // Build frames for the start of each segment.
   std::vector<math::RigidTransform<T>> segment_start_poses;
   segment_start_poses.reserve(num_segments);
-  segment_start_poses.push_back(initial_pose);
+  segment_start_poses.push_back(initial_pose);  // X_AM(0)
 
-  for (size_t i = 0; i < (num_segments - 1); i++) {
-    math::RigidTransform<T> X_FiFip1 =
+  for (size_t i = 0; i < (num_segments - 1); ++i) {
+    math::RigidTransform<T> X_MiMip1 =
         CalcRelativePoseInSegment(turning_rates[i], segment_durations[i]);
-    segment_start_poses.push_back(segment_start_poses.back() * X_FiFip1);
+    // X_AM(i+1)
+    segment_start_poses.push_back(segment_start_poses.back() * X_MiMip1);
   }
 
   return segment_start_poses;

--- a/common/trajectories/piecewise_constant_curvature_trajectory.h
+++ b/common/trajectories/piecewise_constant_curvature_trajectory.h
@@ -15,8 +15,8 @@
 namespace drake {
 namespace trajectories {
 
-/** A piecewise constant curvature trajectory within an arbitrary
- three-dimensional plane.
+/** A piecewise constant curvature trajectory in a plane, where the plane is
+ posed arbitrarily in three dimensions.
 
  The trajectory is defined by the position vector r(s): ℝ → ℝ³, parameterized by
  arclength s, and lies in a plane with normal vector p̂. The parameterization is
@@ -31,15 +31,15 @@ namespace trajectories {
 
  Given the tangent vector t̂(s) = dr(s)/ds and the plane's normal p̂, we define
  the _normal_ vector along the curve as n̂(s) = p̂ × t̂(s). These three vectors
- are used to define a frame F along the curve with basis vectors Fx, Fy, Fz
- coincident with vectors t̂, n̂, p̂, respectively.
+ are used to define a moving frame M along the curve with basis vectors
+ Mx, My, Mz coincident with vectors t̂, n̂, p̂, respectively.
 
- A trajectory is said to be periodic if the pose X_AF of frame F is a periodic
- function of arclength, i.e. X_AF(s) = X_AF(s + k⋅L) ∀ k ∈ ℤ, where L is the
+ A trajectory is said to be periodic if the pose X_AM of frame M is a periodic
+ function of arclength, i.e. X_AM(s) = X_AM(s + k⋅L) ∀ k ∈ ℤ, where L is the
  length of a single cycle along the trajectory. Periodicity is determined
  at construction.
 
- @note Though similar, frame F is distinct from the Frenet–Serret frame defined
+ @note Though similar, frame M is distinct from the Frenet–Serret frame defined
  by the tangent-normal-binormal vectors T̂, N̂, B̂ See <a
  href="https://en.wikipedia.org/wiki/Frenet%E2%80%93Serret_formulas">Frenet–Serret
  formulas</a> for further reading.
@@ -47,18 +47,20 @@ namespace trajectories {
  For constant curvature paths on a plane, the <a
  href="https://en.wikipedia.org/wiki/Frenet%E2%80%93Serret_formulas">Frenet–Serret
  formulas</a> simplify and we can write: <pre>
-     dFx/ds(s) =  ρ(s)⋅Fy(s)
-     dFy/ds(s) = -ρ(s)⋅Fx(s)
-     dFz/ds(s) =  0
+     dMx/ds(s) =  ρ(s)⋅My(s)
+     dMy/ds(s) = -ρ(s)⋅Mx(s)
+     dMz/ds(s) =  0
  </pre>
  for the entire trajectory.
 
  The spatial orientation of the curve is defined by the plane's normal p̂ and
  the initial tangent vector t̂₀ at s = 0. At construction, these are provided
- in a reference frame A, defining the pose X_AF₀ at s = 0. This class provides
- functions to compute the curve's kinematics given by its position vector
- r(s) = p_AoFo_A(s), pose X_AF(s), spatial velocity V_AF(s) and spatial
- acceleration A_AF(s).
+ in a reference frame A, defining the pose X_AM₀ at s = 0. This class provides
+ functions to compute the curve's kinematics given by its pose X_AM (comprising
+ position vector r(s) = p_AoMo_A(s) and orientation R_AM(s)), spatial velocity
+ V_AM_A(s) and spatial acceleration A_AM_A(s). We also provide functions to
+ return these quantities in the M frame (where they are much simpler), i.e.
+ V_AM_M(s) and A_AM_M(s).
 
  @warning Note that this class models a curve parameterized by arclength,
  rather than time as the Trajectory class and many of its inheriting types
@@ -66,7 +68,9 @@ namespace trajectories {
  for externally provided values of velocity ṡ and acceleration s̈ along the
  curve.
 
-  @tparam_default_scalar */
+ @see multibody::CurvilinearJoint
+
+ @tparam_default_scalar */
 template <typename T>
 class PiecewiseConstantCurvatureTrajectory final
     : public PiecewiseTrajectory<T> {
@@ -92,24 +96,24 @@ class PiecewiseConstantCurvatureTrajectory final
    the same reference frame A.
 
    The `initial_curve_tangent` t̂₀ and the `plane_normal` p̂, along with the
-   inital curve's normal n̂₀ = p̂ × t̂₀, define the initial orientation R_AF₀ of
-   frame F at s = 0.
+   initial curve's normal n̂₀ = p̂ × t̂₀, define the initial orientation R_AM₀ of
+   frame M at s = 0.
 
    @param breaks A vector of n break values sᵢ between segments. The parent
    class, PiecewiseTrajectory, enforces that the breaks increase by at least
    PiecewiseTrajectory::kEpsilonTime.
    @param turning_rates A vector of n-1 turning rates ρᵢ for each segment.
    @param initial_curve_tangent The initial tangent of the curve expressed in
-   the parent frame, t̂_A(s₀).
+   the parent frame, t̂_A(s₀) = Mx_A(s₀).
    @param plane_normal The normal axis of the 2D plane in which the curve
-   lies, expressed in the parent frame, p̂_A.
+   lies, expressed in the parent frame, p̂_A = Mz_A (constant).
    @param initial_position The initial position of the curve expressed in
-   the parent frame, p_AoFo_A(s₀).
+   the parent frame, p_AoMo_A(s₀).
    @param periodicity_tolerance Tolerance used to determine if the resulting
    trajectory is periodic, according to the metric defined by
    IsNearlyPeriodic(). If IsNearlyPeriodic(periodicity_tolerance) is true, then
    the newly constructed trajectory will be periodic. That is,
-   X_AF(s) = X_AF(s + k⋅L) ∀ k ∈ ℤ, where L equals length(). Subsequent calls to
+   X_AM(s) = X_AM(s + k⋅L) ∀ k ∈ ℤ, where L equals length(). Subsequent calls to
    is_periodic() will return `true`.
 
    @throws std::exception if the number of turning rates does not match
@@ -147,20 +151,20 @@ class PiecewiseConstantCurvatureTrajectory final
   /** @returns the total arclength of the curve in meters. */
   T length() const { return this->end_time(); }
 
-  /* Returns `true` if `this` trajectory is periodic.
-   That is, X_AF(s) = X_AF(s + k⋅L) ∀ k ∈ ℤ, where L equals length(). */
+  /** Returns `true` if `this` trajectory is periodic.
+   That is, X_AM(s) = X_AM(s + k⋅L) ∀ k ∈ ℤ, where L equals length(). */
   boolean<T> is_periodic() const { return is_periodic_; }
 
-  /** Calculates the trajectory's pose X_AF(s) at the given arclength s.
+  /** Calculates the trajectory's pose X_AM(s) at the given arclength s.
 
    @note For s < 0 and s > length() the pose is extrapolated as if the curve
    continued with the curvature of the corresponding end segment.
 
    @param s The query arclength in meters.
-   @returns the pose X_AF(s). */
+   @returns the pose X_AM(s). */
   math::RigidTransform<T> CalcPose(const T& s) const;
 
-  /** Computes r(s), the trajectory's position p_AoFo_A(s) expressed in
+  /** Computes r(s), the trajectory's position p_AoMo_A(s) expressed in
    reference frame A, at the given arclength s.
 
    @param s The query arclength in meters.
@@ -170,8 +174,17 @@ class PiecewiseConstantCurvatureTrajectory final
     return PiecewiseTrajectory<T>::value(s);
   }
 
-  /** Computes the spatial velocity V_AF_A(s) of frame F measured and expressed
-   in the reference frame A. See the class's documentation for frame
+  /** Returns the signed curvature ρ(s).
+
+   @param s The query arclength in meters.
+   @returns curvature ρ(s) */
+  const T& curvature(const T& s) const {
+    const T w = maybe_wrap(s);
+    return segment_turning_rates_[this->get_segment_index(w)];
+  }
+
+  /** Computes the spatial velocity V_AM_A(s,ṡ) of frame M measured and
+   expressed in the reference frame A. See the class's documentation for frame
    definitions.
 
    In frame invariant notation, the angular velocity ω(s) and translational
@@ -184,12 +197,26 @@ class PiecewiseConstantCurvatureTrajectory final
 
    @param s The query arclength, in meters.
    @param s_dot The magnitude ṡ of the tangential velocity along the curve, in
-   meters per second.
-   @returns The spatial velocity V_AF_A(s) at s. */
+     meters per second.
+   @retval V_AM_A The spatial velocity of M in A, expressed in A. */
   multibody::SpatialVelocity<T> CalcSpatialVelocity(const T& s,
                                                     const T& s_dot) const;
 
-  /** Returns the spatial acceleration A_AF_A(s) of frame F measured and
+  /** Computes the spatial velocity V_AM_M(s,ṡ) of frame M measured in frame A
+   but expressed in frame M.
+
+   See CalcSpatialVelocity() for details. Note that when expressed in frame M,
+   both p̂ and t̂ are constant, with p̂_M = [0 0 1]ᵀ and t̂_M = [1 0 0]ᵀ so the
+   returned spatial velocity is just `V_AM_M = [0 0 ṡ⋅ρ(s) ṡ 0 0]ᵀ`.
+
+   @param s The query arclength, in meters.
+   @param s_dot The magnitude ṡ of the tangential velocity along the curve, in
+     meters per second.
+   @retval V_AM_M The spatial velocity of M in A, expressed in M. */
+  multibody::SpatialVelocity<T> CalcSpatialVelocityInM(const T& s,
+                                                       const T& s_dot) const;
+
+  /** Computes the spatial acceleration A_AM_A(s,ṡ,s̈) of frame M measured and
    expressed in the reference frame A. See the class's documentation for frame
    definitions.
 
@@ -208,18 +235,36 @@ class PiecewiseConstantCurvatureTrajectory final
 
    @param s The query arclength, in meters.
    @param s_dot The magnitude ṡ of the tangential velocity along the curve, in
-   meters per second.
+     meters per second.
    @param s_ddot The magnitude s̈ of the tangential acceleration along the
-   curve, in meters per second squared.
+     curve, in meters per second squared.
 
-   @returns The spatial acceleration A_AF_A(s) at s. */
+   @retval A_AM_A The spatial acceleration of M in A, expressed in A. */
   multibody::SpatialAcceleration<T> CalcSpatialAcceleration(
+      const T& s, const T& s_dot, const T& s_ddot) const;
+
+  /** Computes the spatial acceleration A_AM_M(s,ṡ,s̈) of frame M measured in
+   frame A but expressed in frame M.
+
+   See CalcSpatialAcceleration() for details. Note that when expressed in frame
+   M, the vectors p̂, t̂, and n̂ are constant, with p̂_M = [0 0 1]ᵀ, t̂_M = [1 0 0]ᵀ,
+   and n̂_M = [0 1 0]ᵀ so the returned spatial acceleration is just
+   `A_AM_M = [0 0 s̈⋅ρ(s) s̈ ṡ²⋅ρ(s) 0]ᵀ`.
+
+   @param s The query arclength, in meters.
+   @param s_dot The magnitude ṡ of the tangential velocity along the curve, in
+     meters per second.
+   @param s_ddot The magnitude s̈ of the tangential acceleration along the
+     curve, in meters per second squared.
+
+   @retval A_AM_M The spatial acceleration of M in A, expressed in M. */
+  multibody::SpatialAcceleration<T> CalcSpatialAccelerationInM(
       const T& s, const T& s_dot, const T& s_ddot) const;
 
   /** @returns `true` if the trajectory is periodic within a given `tolerance`.
 
-   Periodicity is defined as the beginning and end poses X_AF(s₀) and
-   X_AF(sₙ) being equal up to the same tolerance, checked via
+   Periodicity is defined as the beginning and end poses X_AM(s₀) and
+   X_AM(sₙ) being equal up to the same tolerance, checked via
    RigidTransform::IsNearlyEqualTo() using `tolerance`.
 
    @param tolerance The tolerance for periodicity check. */
@@ -257,58 +302,58 @@ class PiecewiseConstantCurvatureTrajectory final
     return is_periodic_ ? math::wrap_to(s, T(0.), length()) : s;
   }
 
-  /* Calculates pose X_FiF of the frame F at distance ds from the start of the
-   i-th segment, relative to frame Fi at the start of the segment.
+  /* Calculates pose X_MiM of the frame M at distance ds from the start of the
+   i-th segment, relative to frame Mi at the start of the segment.
 
-   That is, X_FiF = X_AFi⁻¹ * X_AF(sᵢ + ds). As X_AF(s) defines the normal of
-   the plane as the z axis of F, this pose consists of a circular arc or line
+   That is, X_MiM = X_AMi⁻¹ * X_AM(sᵢ + ds). As X_AM(s) defines the normal of
+   the plane as the z axis of M, this pose consists of a circular arc or line
    segment in the x-y plane, and a corresponding z-axis rotation.
 
    @param rho_i The turning rate of the segment.
    @param ds The length within the segment.
-   @returns X_FiF. */
+   @retval X_MiM. */
   static math::RigidTransform<T> CalcRelativePoseInSegment(const T& rho_i,
                                                            const T& ds);
 
-  /* Builds the initial pose, X_AF₀, from the given tangent and plane axes,
+  /* Builds the initial pose, X_AM₀, from the given tangent and plane axes,
    expressed in a same reference frame A.
 
-   p_AoFo_A(s₀) is given by `initial_position`, and R_AF₀ is
-   calculated as follows: The plane normal p̂ is defined as the z axis Fz; the
-   initial heading is the x axis Fx; and the y axis is determined by cross
-   product. R_AF is constructed by passing normalized versions of these
+   p_AoMo_A(s₀) is given by `initial_position`, and R_AM₀ is
+   calculated as follows: The plane normal p̂ is defined as the z axis Mz; the
+   initial heading is the x axis Mx; and the y axis is determined by cross
+   product. R_AM is constructed by passing normalized versions of these
    vectors to RotationMatrix::MakeFromOrthonormalColumns, which may fail if
    the provided axes are not unit norm and orthogonal.
 
    @param initial_curve_tangent The tangent of the curve at arclength s₀ = 0.
    @param plane_normal The normal axis of the plane.
-   @param initial_position The initial position of the curve, p_AoFo_A(s₀).
+   @param initial_position The initial position of the curve, p_AoMo_A(s₀).
 
    @pre Norm of initial_curve_tangent is not zero.
    @pre Norm of plane_normal is not zero.
    @pre initial_curve_tangent is orthogonal to plane_normal.
 
-   @returns The initial pose X_AF. */
+   @returns The initial pose X_AM. */
   static math::RigidTransform<T> MakeInitialPose(
       const Vector3<T>& initial_curve_tangent, const Vector3<T>& plane_normal,
       const Vector3<T>& initial_position);
 
-  /* Calculates pose X_AF at the beginning of each segment.
+  /* Calculates pose X_AM at the beginning of each segment.
 
    For each segment i, the returned vector's i-th element contains the
-   relative transform X_AFi = X_AF(sᵢ), for 0 <= i < to turning_rates.size().
+   relative transform X_AMi = X_AM(sᵢ), for 0 <= i < to turning_rates.size().
 
    @param initial_pose The initial pose of the trajectory (at s₀ = 0).
    @param breaks The vector of break points sᵢ between segments.
    @param turning_rates The vector of turning rates ρᵢ for each segment.
 
    @returns A vector with as many entries as segments, storing at element i the
-   pose X_AFi at the beginning of the i-th segment. */
+            pose X_AMi at the beginning of the i-th segment. */
   static std::vector<math::RigidTransform<T>> MakeSegmentStartPoses(
       const math::RigidTransform<T>& initial_pose, const std::vector<T>& breaks,
       const std::vector<T>& turning_rates);
 
-  /** @returns the initial pose X_AF₀ at s = 0.
+  /* @returns the initial pose X_AM₀ at s = 0.
 
    @pre Trajectory must not be empty.
   */

--- a/common/trajectories/test/piecewise_constant_curvature_trajectory_test.cc
+++ b/common/trajectories/test/piecewise_constant_curvature_trajectory_test.cc
@@ -96,22 +96,35 @@ GTEST_TEST(TestPiecewiseConstantCurvatureTrajectory, TestAnalytical) {
     const Vector3d expected_tangent =
         RotationMatrixd::MakeZRotation(-M_PI / 2) * expected_normal;
 
-    const SpatialVelocity<double> expected_velocity(
+    const SpatialVelocity<double> expected_velocity_A(
         s_dot * kappa * Vector3d::UnitZ(), s_dot * expected_tangent);
 
-    const SpatialAcceleration<double> expected_acceleration(
+    const SpatialVelocity<double> expected_velocity_M(
+        Vector3d(0, 0, s_dot * kappa), Vector3d(s_dot, 0, 0));
+
+    const SpatialAcceleration<double> expected_acceleration_A(
         s_ddot * kappa * Vector3d::UnitZ(),
-        s_ddot * expected_tangent + s_dot * s_dot * expected_normal / r);
+        s_ddot * expected_tangent + s_dot * s_dot * kappa * expected_normal);
+
+    const SpatialAcceleration<double> expected_acceleration_M(
+        Vector3d(0, 0, s_ddot * kappa),
+        Vector3d(s_ddot, s_dot * s_dot * kappa, 0));
 
     const RigidTransformd pose = trajectory.CalcPose(s);
-    const SpatialVelocity<double> velocity =
+    const SpatialVelocity<double> velocity_A =
         trajectory.CalcSpatialVelocity(s, s_dot);
-    const SpatialAcceleration<double> acceleration =
+    const SpatialVelocity<double> velocity_M =
+        trajectory.CalcSpatialVelocityInM(s, s_dot);
+    const SpatialAcceleration<double> acceleration_A =
         trajectory.CalcSpatialAcceleration(s, s_dot, s_ddot);
+    const SpatialAcceleration<double> acceleration_M =
+        trajectory.CalcSpatialAccelerationInM(s, s_dot, s_ddot);
 
     EXPECT_TRUE(pose.IsNearlyEqualTo(expected_pose, kTolerance));
-    EXPECT_TRUE(velocity.IsApprox(expected_velocity, kTolerance));
-    EXPECT_TRUE(acceleration.IsApprox(expected_acceleration, kTolerance));
+    EXPECT_TRUE(velocity_A.IsApprox(expected_velocity_A, kTolerance));
+    EXPECT_TRUE(velocity_M.IsApprox(expected_velocity_M, kTolerance));
+    EXPECT_TRUE(acceleration_A.IsApprox(expected_acceleration_A, kTolerance));
+    EXPECT_TRUE(acceleration_M.IsApprox(expected_acceleration_M, kTolerance));
   }
 }
 
@@ -153,6 +166,13 @@ GTEST_TEST(TestPiecewiseConstantCurvatureTrajectory, TestRandomizedTrajectory) {
   const PiecewiseConstantCurvatureTrajectory<double> trajectory(
       breaks, turning_rates, initial_curve_tangent, initial_plane_normal,
       Vector3d::Zero());
+
+  // Check that curvatures are reported properly.
+  for (int i = 0; i < num_segments; ++i) {
+    const double s = (breaks[i + 1] + breaks[i]) / 2;  // middle of segment
+    EXPECT_EQ(trajectory.curvature(s), turning_rates[i]);
+  }
+
   const Vector3d initial_position =
       trajectory.CalcPose(breaks.front()).translation();
   // Check dense interpolated quaternions.
@@ -245,6 +265,15 @@ GTEST_TEST(TestPiecewiseConstantCurvatureTrajectory, TestPeriodicity) {
       periodic_trajectory.CalcPose(s + 3.0 * length);
   EXPECT_TRUE(X_AF_s0.IsNearlyEqualTo(X_AF_s1, kTolerance));
   EXPECT_TRUE(X_AF_s0.IsNearlyEqualTo(X_AF_s3, kTolerance));
+
+  // Check that curvature for periodic trajectory is properly wrapped.
+  for (int i = 0; i < num_segments; ++i) {
+    // Should be at the middle of each segment after wrapping.
+    const double s2 =
+        2 * length +
+        (segment_breaks_periodic[i + 1] + segment_breaks_periodic[i]) / 2;
+    EXPECT_EQ(periodic_trajectory.curvature(s2), turning_rates[i]);
+  }
 }
 
 GTEST_TEST(TestPiecewiseConstantCurvatureTrajectory, TestScalarConversion) {

--- a/multibody/tree/curvilinear_joint.h
+++ b/multibody/tree/curvilinear_joint.h
@@ -39,6 +39,8 @@ namespace multibody {
  By default, the joint position limits are the endpoints for aperiodic paths,
  and (-∞, ∞) for periodic paths.
 
+ @see trajectories::PiecewiseConstantCurvatureTrajectory
+
  @tparam_default_scalar */
 template <typename T>
 class CurvilinearJoint final : public Joint<T> {

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -31,24 +31,26 @@ dynamic memory allocations.
 Every concrete Mobilizer derived from MobilizerImpl must implement the
 following (ideally inline) methods.
 
+@note The coordinate pointers q and v are guaranteed to point to the kNq or kNv
+state variables for the particular mobilizer. They are only 8-byte aligned so be
+careful when interpreting them as Eigen vectors for computation purposes.
+
   // Returns X_FM(q)
   math::RigidTransform<T> calc_X_FM(const T* q) const;
 
-  // Returns H_FM(q)⋅v
+  // Returns V_FM_F = H_FM_F(q)⋅v
   SpatialVelocity<T> calc_V_FM(const T* q,
                                const T* v) const;
 
-  // Returns H_FM(q)⋅vdot + Hdot_FM(q,v)⋅v
+  // Returns A_FM_F = H_FM_F(q)⋅vdot + Hdot_FM_F(q,v)⋅v
   SpatialAcceleration<T> calc_A_FM(const T* q,
                                    const T* v,
                                    const T* vdot) const;
 
-  // Returns tau = H_FMᵀ(q)⋅F_BMo_F
+  // Returns tau = H_FM_Fᵀ(q)⋅F_BMo_F
   void calc_tau(const T* q, const SpatialForce<T>& F_BMo_F, T* tau) const;
 
-The coordinate pointers are guaranteed to point to the kNq or kNv state
-variables for the particular mobilizer. They are only 8-byte aligned so
-be careful when interpreting them as Eigen vectors for computation purposes.
+  // TODO(sherm1) More to come (see #22253)
 
 MobilizerImpl also provides a number of size specific methods to retrieve
 multibody quantities of interest from caching structures. These are common


### PR DESCRIPTION
This is a yak shave for the upcoming M-frame inverse dynamics PR (see #22253).

The new Curvilinear mobilizer (and its underlying PiecewiseConstantCurvatureTrajectory) provide velocity, acceleration, and force projection in the "fixed" frame rather than the moving M frame. Additional methods required for M frame support are added here. Incidentally, everything is much nicer in M for this mobilizer.

There was a terminology conflict between the trajectory which used frames A (fixed) and F (moving) and the mobilizer -- all mobilizers use frames F (fixed) and M (moving). I renamed the moving frame in the trajectory to M to avoid the inevitable disaster of using "F" for opposite meanings!

All code here is internal so there is no release note needed.

cc @mshalm

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22514)
<!-- Reviewable:end -->
