### PR TITLE
[build] macOS binary packages no longer use brew eigen/fmt/spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,15 @@ macro(override_module NAME)
     SYMBOLIC)
 endmacro()
 
-option(WITH_USER_EIGEN "Use user-provided Eigen3" ON)
+if(APPLE AND DRAKE_CI_ENABLE_PACKAGING)
+  # When building a macOS *.tar.gz binary release, never use Homebrew for C++
+  # dependencies, because it offers absolutely no version stability.
+  set(DEFAULT_WITH_USER_LIBS OFF)
+else()
+  set(DEFAULT_WITH_USER_LIBS ON)
+endif()
+
+option(WITH_USER_EIGEN "Use user-provided Eigen3" ${DEFAULT_WITH_USER_LIBS})
 
 if(WITH_USER_EIGEN)
   find_package(Eigen3 CONFIG REQUIRED)
@@ -367,7 +375,7 @@ if(WITH_USER_EIGEN)
   override_module(eigen)
 endif()
 
-option(WITH_USER_FMT "Use user-provided fmt" ON)
+option(WITH_USER_FMT "Use user-provided fmt" ${DEFAULT_WITH_USER_LIBS})
 
 if(WITH_USER_FMT)
   find_package(fmt CONFIG REQUIRED)
@@ -376,7 +384,7 @@ if(WITH_USER_FMT)
   override_module(fmt)
 endif()
 
-option(WITH_USER_SPDLOG "Use user-provided spdlog" ON)
+option(WITH_USER_SPDLOG "Use user-provided spdlog" ${DEFAULT_WITH_USER_LIBS})
 
 if(WITH_USER_SPDLOG)
   if(NOT WITH_USER_FMT)

--- a/setup/mac/binary_distribution/Brewfile
+++ b/setup/mac/binary_distribution/Brewfile
@@ -3,13 +3,9 @@
 
 cask 'temurin'
 
-brew 'eigen'
 brew 'gcc'
-brew 'fmt'
 brew 'glib'
 brew 'graphviz'
-brew 'pkg-config'
 brew 'python@3.12'
-brew 'spdlog'
 
 mas 'Xcode', id: 497799835 unless File.exist? '/Applications/Xcode.app'

--- a/setup/mac/source_distribution/Brewfile
+++ b/setup/mac/source_distribution/Brewfile
@@ -3,4 +3,8 @@
 
 brew 'bazelisk'
 brew 'cmake'
+brew 'eigen'
+brew 'fmt'
 brew 'nasm'
+brew 'pkg-config'
+brew 'spdlog'


### PR DESCRIPTION
When making a `*.tar.gz` binary release, don't use Homebrew for C++ dependencies (eigen, fmt, spdlog), because it offers absolutely no version stability.

Instead, our packages incorporate fmt and spdlog inside libdrake.so and install the eigen,fmt,spdlog headers alongside Drake's headers.

Also demote pkg-config to source_distribution; it hasn't been needed in binary_distribution since 78eaea83.

Closes #21714.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22519)
<!-- Reviewable:end -->
