### PR TITLE
[build] CMake installs eigen,fmt,spdlog when not user-supplied

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,8 @@ endfunction()
 macro(override_module NAME)
   set(local_path "${CMAKE_CURRENT_BINARY_DIR}/external/workspace/${NAME}")
   string(APPEND BAZEL_REPO_ENV " --override_module=${NAME}=${local_path}")
+  string(APPEND BAZEL_REPO_ENV
+      " --@drake//tools/workspace/${NAME}:with_user_${NAME}=True")
   file(GENERATE OUTPUT "${local_path}/MODULE.bazel"
     INPUT "${CMAKE_CURRENT_SOURCE_DIR}/cmake/external/workspace/${NAME}/MODULE.bazel.in")
   file(GENERATE OUTPUT "${local_path}/BUILD.bazel"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -255,6 +255,4 @@ use_repo(
 # TODO(#20731) More improvements are still needed to our MODULE organization:
 # - Provide better configuration options for choosing dependencies.
 # - Adjust the wheel build to build more dependencies as Bazel modules.
-# - Update the maintainer docs in tools/workspace/README.
-# - Investigate any impact on S3 mirroring.
 # - Deprecate non-bzlmod use of Drake downstream.

--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -15,9 +15,6 @@ common --announce_rc
 # the module path to refer to what the user provided.
 common --@drake//tools/flags:public_repo_default=module
 
-# TODO(jwnimmer-tri) Ideally this would be automatically inferred.
-common --@drake//tools/install/libdrake:spdlog_dynamic=True
-
 # Flags that tweak repository rules (if any).
 common @BAZEL_REPO_ENV@
 

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -79,13 +79,13 @@ of the CMake GUIs.
 
 Adjusting open-source dependencies:
 
-* WITH_USER_EIGEN (default OFF). When ON, uses `find_package(Eigen3)`
+* WITH_USER_EIGEN (default ON). When ON, uses `find_package(Eigen3)`
   to locate a user-provided `Eigen3::Eigen` library
   instead of hard-coding to the operating system version.
-* WITH_USER_FMT (default OFF). When ON, uses `find_package(fmt)`
+* WITH_USER_FMT (default ON). When ON, uses `find_package(fmt)`
   to locate a user-provided `fmt::fmt` library
   instead of hard-coding to the operating system version.
-* WITH_USER_SPDLOG (default OFF). When ON, uses `find_package(spdlog)`
+* WITH_USER_SPDLOG (default ON). When ON, uses `find_package(spdlog)`
   to locate a user-provided `spdlog::spdlog` library
   instead of hard-coding to the operating system version.
 

--- a/tools/install/install.bzl
+++ b/tools/install/install.bzl
@@ -90,7 +90,12 @@ def _output_path(ctx, input_file, strip_prefix = [], ignore_errors = False):
     return input_file.basename
 
 #------------------------------------------------------------------------------
-def _guess_files(target, candidates, scope, attr_name):
+def _guess_files(
+        target,
+        candidates,
+        scope,
+        attr_name,
+        allowed_externals = None):
     if scope == "EVERYTHING":
         return candidates
 
@@ -107,6 +112,17 @@ def _guess_files(target, candidates, scope, attr_name):
             for f in _depset_to_list(candidates)
             if (target.label.workspace_root == f.owner.workspace_root and
                 target.label.package == f.owner.package)
+        ]
+
+    elif scope == "ALLOWED_EXTERNALS" and allowed_externals != None:
+        return [
+            f
+            for f in _depset_to_list(candidates)
+            if f.is_source and any([
+                allowed.label.workspace_root == f.owner.workspace_root and
+                allowed.label.package == f.owner.package
+                for allowed in allowed_externals
+            ])
         ]
 
     else:
@@ -256,6 +272,7 @@ def _install_cc_actions(ctx, target):
             target[CcInfo].compilation_context.headers,
             ctx.attr.guess_hdrs,
             "guess_hdrs",
+            getattr(ctx.attr, "allowed_externals"),
         )
         actions += _install_actions(
             ctx,
@@ -668,6 +685,9 @@ Note:
       target and owned by a target in the same package.
     * ``WORKSPACE``: For each target, install those files which are used by the
       target and owned by a target in the same workspace.
+    * ``ALLOWED_EXTERNALS``: (For guess_hdrs only) for each target, install
+      source files which are used by the target and owned by a target in the
+      at least one of the `allowed_externals = ...` list of labels.
     * ``EVERYTHING``: Install all headers/resources used by the target.
 
     The headers and resource files considered are *all* headers or resource

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load(
     "@drake//tools/workspace:cmake_configure_file.bzl",
@@ -14,7 +13,6 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:cc.bzl", "cc_binary", "cc_library")
 load(
     "//tools/skylark:drake_cc.bzl",
-    "cc_nolink_library",
     "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_test",
@@ -25,6 +23,7 @@ load(
     "drake_py_binary",
     "drake_py_unittest",
 )
+load("//tools/workspace:generate_file.bzl", "generate_file")
 load(":build_components.bzl", "LIBDRAKE_COMPONENTS")
 load(":header_lint.bzl", "cc_check_allowed_headers")
 
@@ -60,6 +59,42 @@ run_binary(
     tool = "parse_version",
 )
 
+generate_file(
+    name = "with_user_eigen.cmake",
+    content = select({
+        "//tools/workspace/eigen:is_external": (
+            "set(WITH_USER_EIGEN ON)"
+        ),
+        "//conditions:default": (
+            "set(WITH_USER_EIGEN OFF)"
+        ),
+    }),
+)
+
+generate_file(
+    name = "with_user_fmt.cmake",
+    content = select({
+        "//tools/workspace/fmt:is_external": (
+            "set(WITH_USER_FMT ON)"
+        ),
+        "//conditions:default": (
+            "set(WITH_USER_FMT OFF)"
+        ),
+    }),
+)
+
+generate_file(
+    name = "with_user_spdlog.cmake",
+    content = select({
+        "//tools/workspace/spdlog:is_external": (
+            "set(WITH_USER_SPDLOG ON)"
+        ),
+        "//conditions:default": (
+            "set(WITH_USER_SPDLOG OFF)"
+        ),
+    }),
+)
+
 cmake_configure_file(
     name = "drake_config_cmake_expand",
     src = "drake-config.cmake.in",
@@ -68,6 +103,9 @@ cmake_configure_file(
     cmakelists = [
         ":python_version.cmake",
         ":stamp_version.cmake",
+        ":with_user_eigen.cmake",
+        ":with_user_fmt.cmake",
+        ":with_user_spdlog.cmake",
     ],
 )
 
@@ -221,8 +259,7 @@ cc_library(
 #
 # TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
 # *.so files for us, without us having to know up-front here which dependencies
-# are coming from the WORKSPACE in the form of *.so. This leaks out into the
-# hacky ":is_spdlog_dynamic_true" immediately below.
+# are coming from the WORKSPACE in the form of *.so.
 cc_library(
     name = "libdrake_runtime_so_deps",
     deps = [
@@ -231,24 +268,10 @@ cc_library(
         ":usd_deps",
         ":x11_deps",
         "//common:drake_marker_shared_library",
+        "//tools/workspace/fmt:shared_library_maybe",
+        "//tools/workspace/spdlog:shared_library_maybe",
         "@lcm",
-    ] + select({
-        ":is_spdlog_dynamic_true": ["@spdlog"],
-        "//conditions:default": [],
-    }),
-)
-
-# TODO(jwnimmer-tri) This is a hack. Find a better solution.
-bool_flag(
-    name = "spdlog_dynamic",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "is_spdlog_dynamic_true",
-    flag_values = {
-        ":spdlog_dynamic": "True",
-    },
+    ],
 )
 
 # The list of depended-on header-only libraries that libdrake's header files
@@ -260,21 +283,11 @@ config_setting(
 cc_library(
     name = "libdrake_header_only_deps",
     deps = [
-        ":fmt_headers",
-        ":spdlog_headers",
         "//lcmtypes:lcmtypes_drake_cc",
+        "//tools/workspace/fmt:hdrs",
+        "//tools/workspace/spdlog:hdrs",
         "@eigen",
     ],
-)
-
-cc_nolink_library(
-    name = "fmt_headers",
-    deps = ["@fmt"],
-)
-
-cc_nolink_library(
-    name = "spdlog_headers",
-    deps = ["@spdlog"],
 )
 
 drake_cc_test(

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -21,10 +21,20 @@ if(${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX STREQUAL "/")
 endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules;${CMAKE_MODULE_PATH}")
-find_dependency(Eigen3 3.3.4 CONFIG)
-find_dependency(fmt 6.0 CONFIG HINTS "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/cmake/fmt")
+set(_drake_interface_libraries drake::drake-marker)
+if(@WITH_USER_EIGEN@)
+  find_dependency(Eigen3 CONFIG)
+  list(APPEND _drake_interface_libraries Eigen3::Eigen)
+endif()
+if (@WITH_USER_FMT@)
+  find_dependency(fmt CONFIG)
+  list(APPEND _drake_interface_libraries fmt::fmt)
+endif()
 find_dependency(lcm 1.4 CONFIG HINTS "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/cmake/lcm")
-find_dependency(spdlog 1.5 CONFIG HINTS "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/cmake/spdlog")
+if (@WITH_USER_SPDLOG@)
+  find_dependency(spdlog CONFIG)
+  list(APPEND _drake_interface_libraries spdlog::spdlog)
+endif()
 set(_expectedTargets drake::drake drake::drake-lcmtypes-cpp drake::drake-lcmtypes-java drake::drake-marker)
 
 set(_targetsDefined)
@@ -60,7 +70,7 @@ set_target_properties(drake::drake PROPERTIES
   IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/libdrake.so"
   IMPORTED_SONAME "${_apple_soname_prologue}libdrake.so"
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include"
-  INTERFACE_LINK_LIBRARIES "drake::drake-marker;Eigen3::Eigen;fmt::fmt-header-only;lcm::lcm;spdlog::spdlog"
+  INTERFACE_LINK_LIBRARIES "${_drake_interface_libraries}"
   INTERFACE_COMPILE_FEATURES "cxx_std_20"
   INTERFACE_COMPILE_DEFINITIONS "HAVE_SPDLOG"
 )

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -26,8 +26,6 @@ build --define=LCM_INSTALL_JAVA=OFF
 # TODO(jwnimmer-tri) Offer an official //tools/flags and CMake option to
 # disable Drake's Java support, and use it here.
 build --java_runtime_version=remotejdk_11
-# TODO(jwnimmer-tri) Ideally this would be automatically inferred.
-common --@drake//tools/install/libdrake:spdlog_dynamic=False
 EOF
 
 # Install Drake using our wheel-build-specific Python interpreter.

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -59,8 +59,6 @@ build --config=packaging
 build --define=LCM_INSTALL_JAVA=OFF
 # See tools/wheel/wheel_builder/macos.py for more on this env variable.
 build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
-# TODO(jwnimmer-tri) Ideally this would be automatically inferred.
-common --@drake//tools/install/libdrake:spdlog_dynamic=False
 EOF
 
 # Install Drake.

--- a/tools/workspace/eigen/BUILD.bazel
+++ b/tools/workspace/eigen/BUILD.bazel
@@ -1,6 +1,9 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("//tools/install:install.bzl", "install_license")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("//tools/install:install.bzl", "install", "install_license")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+# ---- Logic for choosing which eigen to use. ---
 
 config_setting(
     name = "flag_eigen_repo_pkgconfig",
@@ -48,8 +51,40 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# ---- Logic for installing eigen-related files. ---
+
+bool_flag(
+    name = "with_user_eigen",
+    # This is overridden by our CMakeLists.txt to match the CMake option.
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "is_with_user_true",
+    flag_values = {":with_user_eigen": "True"},
+)
+
+selects.config_setting_group(
+    name = "is_external",
+    match_any = [
+        ":is_with_user_true",
+        ":use_pkgconfig",
+    ],
+)
+
+install(
+    name = "install_hdrs",
+    targets = select({
+        ":is_external": [],
+        "//conditions:default": ["@module_eigen//:eigen"],
+    }),
+    hdr_dest = "include",
+    guess_hdrs = "PACKAGE",
+    allowed_externals = ["@module_eigen//:eigen"],
+)
+
 install_license(
-    name = "install",
+    name = "install_license",
     doc_dest = "share/doc/eigen",
     licenses = [
         "@module_eigen//:license.APACHE",
@@ -57,7 +92,15 @@ install_license(
         "@module_eigen//:license.MINPACK",
         "@module_eigen//:license.MPL2",
     ],
+)
+
+install(
+    name = "install",
     visibility = ["//tools/workspace:__pkg__"],
+    deps = [
+        ":install_hdrs",
+        ":install_license",
+    ],
 )
 
 add_lint_tests()

--- a/tools/workspace/fmt/BUILD.bazel
+++ b/tools/workspace/fmt/BUILD.bazel
@@ -1,6 +1,11 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("//tools/install:install.bzl", "install_license")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("//tools/install:install.bzl", "install", "install_license")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:cc.bzl", "cc_library")
+load("//tools/skylark:drake_cc.bzl", "cc_nolink_library")
+
+# ---- Logic for choosing which fmt to use. ---
 
 config_setting(
     name = "flag_fmt_repo_pkgconfig",
@@ -48,11 +53,67 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# ---- Logic for installing fmt-related files. ---
+
+bool_flag(
+    name = "with_user_fmt",
+    # This is overridden by our CMakeLists.txt to match the CMake option.
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "is_with_user_true",
+    flag_values = {":with_user_fmt": "True"},
+)
+
+selects.config_setting_group(
+    name = "is_external",
+    match_any = [
+        ":is_with_user_true",
+        ":use_pkgconfig",
+    ],
+)
+
+cc_nolink_library(
+    name = "hdrs",
+    visibility = ["//tools/install/libdrake:__pkg__"],
+    deps = ["@fmt"],
+)
+
+cc_library(
+    name = "shared_library_maybe",
+    visibility = ["//tools/install/libdrake:__pkg__"],
+    deps = select({
+        ":is_external": ["@fmt"],
+        "//conditions:default": [],
+    }),
+)
+
+install(
+    name = "install_hdrs",
+    targets = select({
+        ":is_external": [],
+        "//conditions:default": [":hdrs"],
+    }),
+    hdr_dest = "include",
+    hdr_strip_prefix = ["include"],
+    guess_hdrs = "ALLOWED_EXTERNALS",
+    allowed_externals = ["@module_fmt//:fmt"],
+)
+
 install_license(
-    name = "install",
+    name = "install_license",
     doc_dest = "share/doc/fmt",
     licenses = ["@module_fmt//:license"],
+)
+
+install(
+    name = "install",
     visibility = ["//tools/workspace:__pkg__"],
+    deps = [
+        ":install_hdrs",
+        ":install_license",
+    ],
 )
 
 add_lint_tests()

--- a/tools/workspace/spdlog/BUILD.bazel
+++ b/tools/workspace/spdlog/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("//tools/install:install.bzl", "install_license")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("//tools/install:install.bzl", "install", "install_license")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:cc.bzl", "cc_library")
+load("//tools/skylark:drake_cc.bzl", "cc_nolink_library")
+
+# ---- Logic for choosing which spdlog to use. ---
 
 config_setting(
     name = "flag_spdlog_repo_disabled",
@@ -62,11 +66,67 @@ cc_library(
     }),
 )
 
+# ---- Logic for installing spdlog-related files. ---
+
+bool_flag(
+    name = "with_user_spdlog",
+    # This is overridden by our CMakeLists.txt to match the CMake option.
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "is_with_user_true",
+    flag_values = {":with_user_spdlog": "True"},
+)
+
+selects.config_setting_group(
+    name = "is_external",
+    match_any = [
+        ":is_with_user_true",
+        ":use_pkgconfig",
+    ],
+)
+
+cc_nolink_library(
+    name = "hdrs",
+    visibility = ["//tools/install/libdrake:__pkg__"],
+    deps = ["@spdlog"],
+)
+
+cc_library(
+    name = "shared_library_maybe",
+    visibility = ["//tools/install/libdrake:__pkg__"],
+    deps = select({
+        ":is_external": ["@spdlog"],
+        "//conditions:default": [],
+    }),
+)
+
+install(
+    name = "install_hdrs",
+    targets = select({
+        ":is_external": [],
+        "//conditions:default": [":hdrs"],
+    }),
+    hdr_dest = "include",
+    hdr_strip_prefix = ["include"],
+    guess_hdrs = "ALLOWED_EXTERNALS",
+    allowed_externals = ["@module_spdlog//:spdlog"],
+)
+
 install_license(
-    name = "install",
+    name = "install_license",
     doc_dest = "share/doc/spdlog",
     licenses = ["@module_spdlog//:license"],
+)
+
+install(
+    name = "install",
     visibility = ["//tools/workspace:__pkg__"],
+    deps = [
+        ":install_hdrs",
+        ":install_license",
+    ],
 )
 
 add_lint_tests()


### PR DESCRIPTION
When installing from an internally vendored eigen, fmt, or spdlog, install their headers alongside Drake's headers and omit them from INTERFACE_LINK_LIBRARIES when Drake is consumed as a CMake external project.

Since #22432 landed, if the user explicitly sets `WITH_USER_...=OFF` when installing Drake, the installed copy would be unusable from C++ (if they didn't have the dep installed system-wide) or ODR-violating (if they did).  This is probably not a big deal since really only Python users should be setting that, but anyway it's fixed now.

Also remove some related cruft in drake-config.cmake when they are user-supplied -- cross-checking the version is not Drake's job, and the config hint is irrelevant since Drake doesn't install config scripts for them when user-supplied.

Amends #22432.  Towards #22159.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22520)
<!-- Reviewable:end -->
