### PR TITLE
[build] Move installed lcmtypes into the main Drake library

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -317,17 +317,10 @@ drake_transitive_installed_hdrs_filegroup(
     deps = LCMTYPES_CC,
 )
 
-# The drake-lcmtypes-cpp library is distinct from (but required by) the drake
-# library; refer to `tools/install/libdrake/drake.cps` for library structure.
-# Therefore, we install Drake's lcmtypes C++ headers to a different directory
-# than the drake library's include path; this ensures that downstream code is
-# using the correct include paths for the libraries they need.  The path to
-# `include/drake_lcmtypes` is provided to downstream code via `drake.cps` and
-# its generated cmake config `lib/cmake/drake/drake-config.cmake.
 install(
     name = "install_drake_cc_headers",
     hdrs = [":lcmtypes_drake_cc_headers"],
-    hdr_dest = "include/drake_lcmtypes",
+    hdr_dest = "include",
     visibility = ["//visibility:private"],
 )
 

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -60,14 +60,14 @@ set_target_properties(drake::drake PROPERTIES
   IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/libdrake.so"
   IMPORTED_SONAME "${_apple_soname_prologue}libdrake.so"
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include"
-  INTERFACE_LINK_LIBRARIES "drake::drake-lcmtypes-cpp;drake::drake-marker;Eigen3::Eigen;fmt::fmt-header-only;lcm::lcm;spdlog::spdlog"
+  INTERFACE_LINK_LIBRARIES "drake::drake-marker;Eigen3::Eigen;fmt::fmt-header-only;lcm::lcm;spdlog::spdlog"
   INTERFACE_COMPILE_FEATURES "cxx_std_20"
   INTERFACE_COMPILE_DEFINITIONS "HAVE_SPDLOG"
 )
 
 add_library(drake::drake-lcmtypes-cpp INTERFACE IMPORTED)
 set_target_properties(drake::drake-lcmtypes-cpp PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include/drake_lcmtypes"
+  INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include"
   INTERFACE_LINK_LIBRARIES "lcm::lcm-coretypes"
 )
 


### PR DESCRIPTION
We'll be happier without the added complexity of twisty include paths.

Using the nested path requires users to run CMake in order to discover the proper include directories.  This was plausible when we had a dozen external dependencies like TinyXML2 and Ipopt and all of that stuff, but now that our exposed dependencies are slim and getting slimmer, the extra path complexity seems like overkill.

Towards #20761 (so #17231).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22521)
<!-- Reviewable:end -->
