### PR TITLE
Correct parsing for multiple materials

### DIFF
--- a/tools/workspace/tinyobjloader_internal/patches/upstream/reset_default_kd.patch
+++ b/tools/workspace/tinyobjloader_internal/patches/upstream/reset_default_kd.patch
@@ -1,0 +1,18 @@
+Every material should default to a white material for Kd if none is specified
+but a map_Kd *is* specified. However, tinyobj forgot to reset the test for
+whether or not Kd had been set with each new material.
+
+This patch is tested in render_mesh_test.cc as
+GTEST_TEST(TinyObjReaderRegression, DefaultDiffuseIsWhiteWithMap)
+That test can probably be removed when this gets upstreamed.
+
+--- tiny_obj_loader.h
++++ tiny_obj_loader.h
+@@ -2134,6 +2134,7 @@ void LoadMtl(std::map<std::string, int> *material_map,
+ 
+       has_d = false;
+       has_tr = false;
++      has_kd = false;
+ 
+       // set new mtl name
+       token += 7;

--- a/tools/workspace/tinyobjloader_internal/repository.bzl
+++ b/tools/workspace/tinyobjloader_internal/repository.bzl
@@ -12,6 +12,7 @@ def tinyobjloader_internal_repository(
         mirrors = mirrors,
         patches = [
             ":patches/upstream/in_memory_parsing_support.patch",
+            ":patches/upstream/reset_default_kd.patch",
             ":patches/upstream/silence_materials.patch",
             ":patches/faster_float_parsing.patch",
             ":patches/default_texture_color.patch",


### PR DESCRIPTION
If a material specifies a diffuse map (map_Kd) but doesn't specify a Kd value, it *should* default to white. However, for multiple materials in the file, the parser makes an error. It attempts to track whether the material has specified Kd. But it never resets that record. So, as soon as any material specifies Kd, all subsequent material definitions are classified as *also* having provided one -- even if they haven't. This leads to the correctly reset diffuse color of black being used with diffuse textures (producing black meshes).

This simply resets the `has_kd` flag every time a new material definition starts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22524)
<!-- Reviewable:end -->
