### PR TITLE
[lcm_gen] Optimize encoding and decoding of arrays

### DIFF
--- a/tools/lcm_gen/__init__.py
+++ b/tools/lcm_gen/__init__.py
@@ -461,6 +461,53 @@ class @@STRUCT_NAME@@ {
     }
   }
 
+  // Returns true iff T has a "slab" layout in memory, where all of its data
+  // lives in one block of contiguous memory. The template arguments are the
+  // same as _encode_field().
+  template <typename T, int ndims>
+  static constexpr bool _is_slab() {
+    if constexpr (ndims == 0) {
+      return false;
+    } else {
+      using Element = typename T::value_type;
+      if constexpr (!std::is_trivial_v<Element>) {
+        return false;
+      } else if constexpr (ndims == 1) {
+        return std::is_fundamental_v<Element>;
+      } else {
+        return _is_slab<Element, ndims - 1>();
+      }
+    }
+  }
+
+  // Returns the size of the ndims'th element type of the given containter T.
+  // (This tells us how big of a byteswap we'll need while copying T's slab.)
+  template <typename T, int ndims>
+  static constexpr size_t _get_slab_step() {
+    if constexpr (ndims > 0) {
+      return _get_slab_step<typename T::value_type, ndims - 1>();
+    }
+    return sizeof(T);
+  }
+
+  // Copies _bytes amount of data from _src to _dst. While copying, each group
+  // of N bytes is byteswapped. The number of _bytes must be a multiple of N.
+  template <size_t N>
+  static void _memcpy_byteswap(void* _dst, const void* _src, size_t _bytes) {
+    if constexpr (N == 1) {
+      if (_bytes > 0) [[likely]] {
+        std::memcpy(_dst, _src, _bytes);
+      }
+    } else {
+      for (size_t _i = 0; _i < _bytes; _i += N) {
+        auto _swapped = _byteswap<N>(_src);
+        std::memcpy(_dst, &_swapped, N);
+        _dst = static_cast<uint8_t*>(_dst) + N;
+        _src = static_cast<const uint8_t*>(_src) + N;
+      }
+    }
+  }
+
   // The dimensions of an array, for use during encoding / decoding, e.g., for
   // a message field `int8_t image[6][4]` we'd use `ArrayDims<2>{6, 4}`.
   template <size_t ndims>
@@ -522,10 +569,21 @@ class @@STRUCT_NAME@@ {
       if (static_cast<int64_t>(_input.size()) != _dims[0]) {
         return false;
       }
-      // Encode each sub-item in turn, forwarding all the _dims but the first.
-      for (const auto& _child : _input) {
-        if (!_encode_field(_child, _cursor, _end, _cdr(_dims))) {
+      if constexpr (_is_slab<T, ndims>()){
+        // Encode a slab of POD memory.
+        const size_t _raw_size = _input.size() * sizeof(_input[0]);
+        if ((*_cursor + _raw_size) > _end) {
           return false;
+        }
+        constexpr size_t N = _get_slab_step<T, ndims>();
+        _memcpy_byteswap<N>(*_cursor, _input.data(), _raw_size);
+        *_cursor += _raw_size;
+      } else {
+        // Encode each sub-item in turn, forwarding all _dims but the first.
+        for (const auto& _child : _input) {
+          if (!_encode_field(_child, _cursor, _end, _cdr(_dims))) {
+            return false;
+          }
         }
       }
       return true;
@@ -573,10 +631,21 @@ class @@STRUCT_NAME@@ {
       if constexpr (std::is_same_v<T, std::vector<typename T::value_type>>) {
         _output->resize(_dims[0]);
       }
-      // Decode each sub-item in turn.
-      for (auto& _child : *_output) {
-        if (!_decode_field(&_child, _cursor, _end, _cdr(_dims))) {
+      if constexpr (_is_slab<T, ndims>()) {
+        // Decode a slab of POD memory.
+        const size_t _raw_size = _dims[0] * sizeof((*_output)[0]);
+        if ((*_cursor + _raw_size) > _end) {
           return false;
+        }
+        constexpr size_t N = _get_slab_step<T, ndims>();
+        _memcpy_byteswap<N>(_output->data(), *_cursor, _raw_size);
+        *_cursor += _raw_size;
+      } else {
+        // Decode each sub-item in turn.
+        for (auto& _child : *_output) {
+          if (!_decode_field(&_child, _cursor, _end, _cdr(_dims))) {
+            return false;
+          }
         }
       }
       return true;

--- a/tools/lcm_gen/test/goal/mike.hpp
+++ b/tools/lcm_gen/test/goal/mike.hpp
@@ -192,6 +192,53 @@ class mike {
     }
   }
 
+  // Returns true iff T has a "slab" layout in memory, where all of its data
+  // lives in one block of contiguous memory. The template arguments are the
+  // same as _encode_field().
+  template <typename T, int ndims>
+  static constexpr bool _is_slab() {
+    if constexpr (ndims == 0) {
+      return false;
+    } else {
+      using Element = typename T::value_type;
+      if constexpr (!std::is_trivial_v<Element>) {
+        return false;
+      } else if constexpr (ndims == 1) {
+        return std::is_fundamental_v<Element>;
+      } else {
+        return _is_slab<Element, ndims - 1>();
+      }
+    }
+  }
+
+  // Returns the size of the ndims'th element type of the given containter T.
+  // (This tells us how big of a byteswap we'll need while copying T's slab.)
+  template <typename T, int ndims>
+  static constexpr size_t _get_slab_step() {
+    if constexpr (ndims > 0) {
+      return _get_slab_step<typename T::value_type, ndims - 1>();
+    }
+    return sizeof(T);
+  }
+
+  // Copies _bytes amount of data from _src to _dst. While copying, each group
+  // of N bytes is byteswapped. The number of _bytes must be a multiple of N.
+  template <size_t N>
+  static void _memcpy_byteswap(void* _dst, const void* _src, size_t _bytes) {
+    if constexpr (N == 1) {
+      if (_bytes > 0) [[likely]] {
+        std::memcpy(_dst, _src, _bytes);
+      }
+    } else {
+      for (size_t _i = 0; _i < _bytes; _i += N) {
+        auto _swapped = _byteswap<N>(_src);
+        std::memcpy(_dst, &_swapped, N);
+        _dst = static_cast<uint8_t*>(_dst) + N;
+        _src = static_cast<const uint8_t*>(_src) + N;
+      }
+    }
+  }
+
   // The dimensions of an array, for use during encoding / decoding, e.g., for
   // a message field `int8_t image[6][4]` we'd use `ArrayDims<2>{6, 4}`.
   template <size_t ndims>
@@ -253,10 +300,21 @@ class mike {
       if (static_cast<int64_t>(_input.size()) != _dims[0]) {
         return false;
       }
-      // Encode each sub-item in turn, forwarding all the _dims but the first.
-      for (const auto& _child : _input) {
-        if (!_encode_field(_child, _cursor, _end, _cdr(_dims))) {
+      if constexpr (_is_slab<T, ndims>()){
+        // Encode a slab of POD memory.
+        const size_t _raw_size = _input.size() * sizeof(_input[0]);
+        if ((*_cursor + _raw_size) > _end) {
           return false;
+        }
+        constexpr size_t N = _get_slab_step<T, ndims>();
+        _memcpy_byteswap<N>(*_cursor, _input.data(), _raw_size);
+        *_cursor += _raw_size;
+      } else {
+        // Encode each sub-item in turn, forwarding all _dims but the first.
+        for (const auto& _child : _input) {
+          if (!_encode_field(_child, _cursor, _end, _cdr(_dims))) {
+            return false;
+          }
         }
       }
       return true;
@@ -304,10 +362,21 @@ class mike {
       if constexpr (std::is_same_v<T, std::vector<typename T::value_type>>) {
         _output->resize(_dims[0]);
       }
-      // Decode each sub-item in turn.
-      for (auto& _child : *_output) {
-        if (!_decode_field(&_child, _cursor, _end, _cdr(_dims))) {
+      if constexpr (_is_slab<T, ndims>()) {
+        // Decode a slab of POD memory.
+        const size_t _raw_size = _dims[0] * sizeof((*_output)[0]);
+        if ((*_cursor + _raw_size) > _end) {
           return false;
+        }
+        constexpr size_t N = _get_slab_step<T, ndims>();
+        _memcpy_byteswap<N>(_output->data(), *_cursor, _raw_size);
+        *_cursor += _raw_size;
+      } else {
+        // Decode each sub-item in turn.
+        for (auto& _child : *_output) {
+          if (!_decode_field(&_child, _cursor, _end, _cdr(_dims))) {
+            return false;
+          }
         }
       }
       return true;

--- a/tools/lcm_gen/test/goal/november.hpp
+++ b/tools/lcm_gen/test/goal/november.hpp
@@ -132,6 +132,53 @@ class november {
     }
   }
 
+  // Returns true iff T has a "slab" layout in memory, where all of its data
+  // lives in one block of contiguous memory. The template arguments are the
+  // same as _encode_field().
+  template <typename T, int ndims>
+  static constexpr bool _is_slab() {
+    if constexpr (ndims == 0) {
+      return false;
+    } else {
+      using Element = typename T::value_type;
+      if constexpr (!std::is_trivial_v<Element>) {
+        return false;
+      } else if constexpr (ndims == 1) {
+        return std::is_fundamental_v<Element>;
+      } else {
+        return _is_slab<Element, ndims - 1>();
+      }
+    }
+  }
+
+  // Returns the size of the ndims'th element type of the given containter T.
+  // (This tells us how big of a byteswap we'll need while copying T's slab.)
+  template <typename T, int ndims>
+  static constexpr size_t _get_slab_step() {
+    if constexpr (ndims > 0) {
+      return _get_slab_step<typename T::value_type, ndims - 1>();
+    }
+    return sizeof(T);
+  }
+
+  // Copies _bytes amount of data from _src to _dst. While copying, each group
+  // of N bytes is byteswapped. The number of _bytes must be a multiple of N.
+  template <size_t N>
+  static void _memcpy_byteswap(void* _dst, const void* _src, size_t _bytes) {
+    if constexpr (N == 1) {
+      if (_bytes > 0) [[likely]] {
+        std::memcpy(_dst, _src, _bytes);
+      }
+    } else {
+      for (size_t _i = 0; _i < _bytes; _i += N) {
+        auto _swapped = _byteswap<N>(_src);
+        std::memcpy(_dst, &_swapped, N);
+        _dst = static_cast<uint8_t*>(_dst) + N;
+        _src = static_cast<const uint8_t*>(_src) + N;
+      }
+    }
+  }
+
   // The dimensions of an array, for use during encoding / decoding, e.g., for
   // a message field `int8_t image[6][4]` we'd use `ArrayDims<2>{6, 4}`.
   template <size_t ndims>
@@ -193,10 +240,21 @@ class november {
       if (static_cast<int64_t>(_input.size()) != _dims[0]) {
         return false;
       }
-      // Encode each sub-item in turn, forwarding all the _dims but the first.
-      for (const auto& _child : _input) {
-        if (!_encode_field(_child, _cursor, _end, _cdr(_dims))) {
+      if constexpr (_is_slab<T, ndims>()){
+        // Encode a slab of POD memory.
+        const size_t _raw_size = _input.size() * sizeof(_input[0]);
+        if ((*_cursor + _raw_size) > _end) {
           return false;
+        }
+        constexpr size_t N = _get_slab_step<T, ndims>();
+        _memcpy_byteswap<N>(*_cursor, _input.data(), _raw_size);
+        *_cursor += _raw_size;
+      } else {
+        // Encode each sub-item in turn, forwarding all _dims but the first.
+        for (const auto& _child : _input) {
+          if (!_encode_field(_child, _cursor, _end, _cdr(_dims))) {
+            return false;
+          }
         }
       }
       return true;
@@ -244,10 +302,21 @@ class november {
       if constexpr (std::is_same_v<T, std::vector<typename T::value_type>>) {
         _output->resize(_dims[0]);
       }
-      // Decode each sub-item in turn.
-      for (auto& _child : *_output) {
-        if (!_decode_field(&_child, _cursor, _end, _cdr(_dims))) {
+      if constexpr (_is_slab<T, ndims>()) {
+        // Decode a slab of POD memory.
+        const size_t _raw_size = _dims[0] * sizeof((*_output)[0]);
+        if ((*_cursor + _raw_size) > _end) {
           return false;
+        }
+        constexpr size_t N = _get_slab_step<T, ndims>();
+        _memcpy_byteswap<N>(_output->data(), *_cursor, _raw_size);
+        *_cursor += _raw_size;
+      } else {
+        // Decode each sub-item in turn.
+        for (auto& _child : *_output) {
+          if (!_decode_field(&_child, _cursor, _end, _cdr(_dims))) {
+            return false;
+          }
         }
       }
       return true;


### PR DESCRIPTION
As is turns out, the compiler doesn't inline recursive calls to encode or decode, even though the call graph and constexpr branches are known ahead of time. Instead, we'll directly check for the case of copying contiguous memory with a special case.

```
                     lcm-gen  lcm_gen  lcm_gen
                    upstream   before    after
ImageArrayEncode     77.9 us   975 us  78.3 us
ImageArrayDecode     80.0 us   979 us  81.3 us
PandaCommandEncode   29.3 ns  21.0 ns  20.9 ns
PandaCommandDecode   3.12 ns  3.08 ns  3.10 ns
PandaStatusEncode    69.2 ns  43.0 ns  34.9 ns
PandaStatusDecode    3.11 ns  3.08 ns  3.10 ns
ViewerDrawEncode     4.97 us  3.42 us  2.53 us
ViewerDrawDecode     3.11 ns  3.22 ns  3.09 ns
```

Note that by default all of our messages still use the lcm-gen (legacy upstream) message generator. This commit is just fixing performance prior to the switch-over.

---

Towards #20761.

The bottom line of the benchmark above is that this PR ("lcm_gen after") is on par with the performance of upstream's `lcm-gen` program.  (It's of course way better than our current on-master implementation "lcm_gen before".)

I have a few more micro-optimizations on deck after this, but this one alone is sufficient to unblock us from switching our default over to the new implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22525)
<!-- Reviewable:end -->
