### PR TITLE
[lcm_gen] Fix bounds checking in legacy API

### DIFF
--- a/tools/lcm_gen/__init__.py
+++ b/tools/lcm_gen/__init__.py
@@ -373,7 +373,7 @@ class @@STRUCT_NAME@@ {
   int64_t encode(void* buf, int64_t offset, int64_t maxlen) const {
     uint8_t* const _begin = static_cast<uint8_t*>(buf);
     uint8_t* const _start = _begin + offset;
-    uint8_t* const _end = _begin + maxlen;
+    uint8_t* const _end = _start + maxlen;
     uint8_t* _cursor = _start;
     return this->_encode<with_hash>(&_cursor, _end) ? (_cursor - _start) : -1;
   }
@@ -384,7 +384,7 @@ class @@STRUCT_NAME@@ {
   int64_t decode(const void* buf, int64_t offset, int64_t maxlen) {
     const uint8_t* const _begin = static_cast<const uint8_t*>(buf);
     const uint8_t* const _start = _begin + offset;
-    const uint8_t* const _end = _begin + maxlen;
+    const uint8_t* const _end = _start + maxlen;
     const uint8_t* _cursor = _start;
     return this->_decode<with_hash>(&_cursor, _end) ? (_cursor - _start) : -1;
   }

--- a/tools/lcm_gen/test/functional_test.cc
+++ b/tools/lcm_gen/test/functional_test.cc
@@ -123,6 +123,40 @@ GTEST_TEST(PapaTest, LimaRoundTrip) {
   EXPECT_EQ(send.encode(data.data(), 0, data.size()), -1);
 }
 
+// Check passing a non-zero offset to encode and decode.
+GTEST_TEST(PapaTest, LimaNonZeroOffset) {
+  papa::lima send{};
+  send.golf = true;
+  send.bravo = 22;
+  send.delta = 2.25;
+  send.foxtrot = 22.125;
+  send.india8 = 22;
+  send.india16 = 22222;
+  send.india32 = 22222222;
+  send.india64 = 222222222222222222;
+
+  // Encode, but starting at a non-zero offset into the destination buffer.
+  const int64_t num_bytes = send.getEncodedSize();
+  const int offset = 3;
+  std::vector<uint8_t> data(static_cast<size_t>(offset + num_bytes), uint8_t{});
+  const int64_t used_bytes = send.encode(data.data(), offset, num_bytes);
+  ASSERT_EQ(used_bytes, num_bytes);
+
+  // Decode, but starting from a non-zero offset the input buffer.
+  papa::lima receive{};
+  const int64_t read_bytes =
+      receive.decode(data.data(), offset, ssize(data) - offset);
+  ASSERT_EQ(read_bytes, num_bytes);
+  EXPECT_EQ(receive.golf, true);
+  EXPECT_EQ(receive.bravo, 22);
+  EXPECT_EQ(receive.delta, 2.25);
+  EXPECT_EQ(receive.foxtrot, 22.125);
+  EXPECT_EQ(receive.india8, 22);
+  EXPECT_EQ(receive.india16, 22222);
+  EXPECT_EQ(receive.india32, 22222222);
+  EXPECT_EQ(receive.india64, 222222222222222222);
+}
+
 // With the old lcm-gen, partially-fixed-size arrays are typed as std::vector so
 // need manual size bookkeeping.
 template <class T>

--- a/tools/lcm_gen/test/goal/lima.hpp
+++ b/tools/lcm_gen/test/goal/lima.hpp
@@ -50,7 +50,7 @@ class lima {
   int64_t encode(void* buf, int64_t offset, int64_t maxlen) const {
     uint8_t* const _begin = static_cast<uint8_t*>(buf);
     uint8_t* const _start = _begin + offset;
-    uint8_t* const _end = _begin + maxlen;
+    uint8_t* const _end = _start + maxlen;
     uint8_t* _cursor = _start;
     return this->_encode<with_hash>(&_cursor, _end) ? (_cursor - _start) : -1;
   }
@@ -61,7 +61,7 @@ class lima {
   int64_t decode(const void* buf, int64_t offset, int64_t maxlen) {
     const uint8_t* const _begin = static_cast<const uint8_t*>(buf);
     const uint8_t* const _start = _begin + offset;
-    const uint8_t* const _end = _begin + maxlen;
+    const uint8_t* const _end = _start + maxlen;
     const uint8_t* _cursor = _start;
     return this->_decode<with_hash>(&_cursor, _end) ? (_cursor - _start) : -1;
   }

--- a/tools/lcm_gen/test/goal/mike.hpp
+++ b/tools/lcm_gen/test/goal/mike.hpp
@@ -69,7 +69,7 @@ class mike {
   int64_t encode(void* buf, int64_t offset, int64_t maxlen) const {
     uint8_t* const _begin = static_cast<uint8_t*>(buf);
     uint8_t* const _start = _begin + offset;
-    uint8_t* const _end = _begin + maxlen;
+    uint8_t* const _end = _start + maxlen;
     uint8_t* _cursor = _start;
     return this->_encode<with_hash>(&_cursor, _end) ? (_cursor - _start) : -1;
   }
@@ -80,7 +80,7 @@ class mike {
   int64_t decode(const void* buf, int64_t offset, int64_t maxlen) {
     const uint8_t* const _begin = static_cast<const uint8_t*>(buf);
     const uint8_t* const _start = _begin + offset;
-    const uint8_t* const _end = _begin + maxlen;
+    const uint8_t* const _end = _start + maxlen;
     const uint8_t* _cursor = _start;
     return this->_decode<with_hash>(&_cursor, _end) ? (_cursor - _start) : -1;
   }

--- a/tools/lcm_gen/test/goal/november.hpp
+++ b/tools/lcm_gen/test/goal/november.hpp
@@ -35,7 +35,7 @@ class november {
   int64_t encode(void* buf, int64_t offset, int64_t maxlen) const {
     uint8_t* const _begin = static_cast<uint8_t*>(buf);
     uint8_t* const _start = _begin + offset;
-    uint8_t* const _end = _begin + maxlen;
+    uint8_t* const _end = _start + maxlen;
     uint8_t* _cursor = _start;
     return this->_encode<with_hash>(&_cursor, _end) ? (_cursor - _start) : -1;
   }
@@ -46,7 +46,7 @@ class november {
   int64_t decode(const void* buf, int64_t offset, int64_t maxlen) {
     const uint8_t* const _begin = static_cast<const uint8_t*>(buf);
     const uint8_t* const _start = _begin + offset;
-    const uint8_t* const _end = _begin + maxlen;
+    const uint8_t* const _end = _start + maxlen;
     const uint8_t* _cursor = _start;
     return this->_decode<with_hash>(&_cursor, _end) ? (_cursor - _start) : -1;
   }


### PR DESCRIPTION
The meaning of 'maxlen' is the number of bytes to read/write, not the overall number of bytes in the buffer.

Towards #20761.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22527)
<!-- Reviewable:end -->
