### PR TITLE
[analysis] Use shared_ptr for MonteCarlo simulator factory

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -39,6 +39,8 @@ void ThrowIfPythonHasPendingSignals() {
 PYBIND11_MODULE(analysis, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::systems;
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::systems::analysis;
 
   m.doc() = "Bindings for the analysis portion of the Systems framework.";
 
@@ -395,17 +397,49 @@ Parameter ``interruptible``:
 
   // Monte Carlo Testing
   {
-    // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-    using namespace drake::systems::analysis;
     constexpr auto& doc = pydrake_doc.drake.systems.analysis;
 
-    m.def("RandomSimulation",
-        WrapCallbacks([](const SimulatorFactory make_simulator,
-                          const ScalarSystemFunction& output, double final_time,
-                          RandomGenerator* generator) -> double {
+    // Like RandomSimulatorFactory but returning a Python object instead of C++.
+    using PyRandomSimulatorFactory =
+        std::function<py::object(RandomGenerator*)>;
+    auto make_cpp_compatible_factory =
+        [](PyRandomSimulatorFactory factory_py) -> RandomSimulatorFactory {
+      return [factory_py = std::move(factory_py)](RandomGenerator* generator) {
+        py::gil_scoped_acquire guard;
+        py::object make_simulator_result = factory_py(generator);
+        DRAKE_THROW_UNLESS(!make_simulator_result.is_none());
+        return make_shared_ptr_from_py_object<Simulator<double>>(
+            std::move(make_simulator_result));
+      };
+    };
+
+    // Like ScalarSystemFunction but with optional<> added to the return type.
+    // (This leads to better error messages in case the user forgot to return.)
+    using PyScalarSystemFunction = std::function<std::optional<double>(
+        const System<double>* system, const Context<double>* context)>;
+    auto make_cpp_compatible_output =
+        [](PyScalarSystemFunction output_py) -> ScalarSystemFunction {
+      return [output_py = std::move(output_py)](
+                 const System<double>& system, const Context<double>& context) {
+        py::gil_scoped_acquire guard;
+        std::optional<double> scalar_system_function_output =
+            output_py(&system, &context);
+        DRAKE_THROW_UNLESS(scalar_system_function_output.has_value());
+        return *scalar_system_function_output;
+      };
+    };
+
+    m.def(
+        "RandomSimulation",
+        [&make_cpp_compatible_factory, &make_cpp_compatible_output](
+            PyRandomSimulatorFactory make_simulator,
+            PyScalarSystemFunction output, double final_time,
+            RandomGenerator* generator) -> double {
           return RandomSimulation(
-              make_simulator, output, final_time, generator);
-        }),
+              make_cpp_compatible_factory(std::move(make_simulator)),
+              make_cpp_compatible_output(std::move(output)), final_time,
+              generator);
+        },
         py::arg("make_simulator"), py::arg("output"), py::arg("final_time"),
         py::arg("generator"), doc.RandomSimulation.doc);
 
@@ -421,47 +455,51 @@ Parameter ``interruptible``:
     // of Python systems on multiple threads was thought to be unsupported. It's
     // possible that with `py::call_guard<py::gil_scoped_release>` it would
     // actually be fine, so we could revisit that decision at some point.
-    m.def("MonteCarloSimulation",
-        WrapCallbacks([](const SimulatorFactory make_simulator,
-                          const ScalarSystemFunction& output, double final_time,
-                          int num_samples, RandomGenerator* generator)
-                          -> std::vector<RandomSimulationResult> {
-          return MonteCarloSimulation(make_simulator, output, final_time,
+    m.def(
+        "MonteCarloSimulation",
+        [&make_cpp_compatible_factory, &make_cpp_compatible_output](
+            PyRandomSimulatorFactory make_simulator,
+            PyScalarSystemFunction output, double final_time, int num_samples,
+            RandomGenerator* generator) -> std::vector<RandomSimulationResult> {
+          return MonteCarloSimulation(
+              make_cpp_compatible_factory(std::move(make_simulator)),
+              make_cpp_compatible_output(std::move(output)), final_time,
               num_samples, generator, /* parallelism = */ Parallelism::None());
-        }),
+        },
         py::arg("make_simulator"), py::arg("output"), py::arg("final_time"),
         py::arg("num_samples"), py::arg("generator"),
         doc.MonteCarloSimulation.doc);
+  }
 
-    {
-      using Class = RegionOfAttractionOptions;
-      constexpr auto& cls_doc = doc.RegionOfAttractionOptions;
-      py::class_<Class, std::shared_ptr<Class>> cls(
-          m, "RegionOfAttractionOptions", cls_doc.doc);
-      cls.def(py::init<>(), cls_doc.ctor.doc)
-          // TODO(jeremy.nimmer): replace the def_readwrite with
-          // DefAttributesUsingSerialize when we fix binding a
-          // VectorX<symbolic::Variable> state_variables to a numpy array of
-          // objects.
-          .def_readwrite("lyapunov_candidate",
-              &RegionOfAttractionOptions::lyapunov_candidate,
-              doc.RegionOfAttractionOptions.lyapunov_candidate.doc)
-          .def_readwrite("state_variables",
-              &RegionOfAttractionOptions::state_variables,
-              // dtype = object arrays must be copied, and cannot be referenced.
-              py_rvp::copy, doc.RegionOfAttractionOptions.state_variables.doc)
-          .def_readwrite("use_implicit_dynamics",
-              &RegionOfAttractionOptions::use_implicit_dynamics,
-              doc.RegionOfAttractionOptions.use_implicit_dynamics.doc)
-          .def_readwrite("solver_id", &RegionOfAttractionOptions::solver_id,
-              doc.RegionOfAttractionOptions.solver_id.doc)
-          .def_readwrite("solver_options",
-              &RegionOfAttractionOptions::solver_options,
-              doc.RegionOfAttractionOptions.solver_options.doc);
+  {
+    constexpr auto& doc = pydrake_doc.drake.systems.analysis;
 
-      DefReprUsingSerialize(&cls);
-      DefCopyAndDeepCopy(&cls);
-    }
+    using Class = RegionOfAttractionOptions;
+    constexpr auto& cls_doc = doc.RegionOfAttractionOptions;
+    py::class_<Class, std::shared_ptr<Class>> cls(
+        m, "RegionOfAttractionOptions", cls_doc.doc);
+    cls.def(py::init<>(), cls_doc.ctor.doc)
+        // TODO(jeremy.nimmer): replace the def_readwrite with
+        // DefAttributesUsingSerialize when we fix binding a
+        // VectorX<symbolic::Variable> state_variables to a numpy array of
+        // objects.
+        .def_readwrite("lyapunov_candidate",
+            &RegionOfAttractionOptions::lyapunov_candidate,
+            doc.RegionOfAttractionOptions.lyapunov_candidate.doc)
+        .def_readwrite("state_variables",
+            &RegionOfAttractionOptions::state_variables,
+            // dtype = object arrays must be copied, and cannot be referenced.
+            py_rvp::copy, doc.RegionOfAttractionOptions.state_variables.doc)
+        .def_readwrite("use_implicit_dynamics",
+            &RegionOfAttractionOptions::use_implicit_dynamics,
+            doc.RegionOfAttractionOptions.use_implicit_dynamics.doc)
+        .def_readwrite("solver_id", &RegionOfAttractionOptions::solver_id,
+            doc.RegionOfAttractionOptions.solver_id.doc)
+        .def_readwrite("solver_options",
+            &RegionOfAttractionOptions::solver_options,
+            doc.RegionOfAttractionOptions.solver_options.doc);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
 
     m.def("RegionOfAttraction", &RegionOfAttraction, py::arg("system"),
         py::arg("context"), py::arg("options") = RegionOfAttractionOptions(),

--- a/systems/analysis/monte_carlo.cc
+++ b/systems/analysis/monte_carlo.cc
@@ -12,9 +12,10 @@ namespace drake {
 namespace systems {
 namespace analysis {
 
-double RandomSimulation(
-    const SimulatorFactory& make_simulator, const ScalarSystemFunction& output,
-    const double final_time, RandomGenerator* const generator) {
+double RandomSimulation(const RandomSimulatorFactory& make_simulator,
+                        const ScalarSystemFunction& output,
+                        const double final_time,
+                        RandomGenerator* const generator) {
   auto simulator = make_simulator(generator);
 
   const System<double>& system = simulator->get_system();
@@ -29,9 +30,9 @@ namespace {
 
 // Serial (single-threaded) implementation of MonteCarloSimulation.
 std::vector<RandomSimulationResult> MonteCarloSimulationSerial(
-    const SimulatorFactory& make_simulator, const ScalarSystemFunction& output,
-    const double final_time, const int num_samples,
-    RandomGenerator* const generator) {
+    const RandomSimulatorFactory& make_simulator,
+    const ScalarSystemFunction& output, const double final_time,
+    const int num_samples, RandomGenerator* const generator) {
   std::vector<RandomSimulationResult> simulation_results;
   simulation_results.reserve(num_samples);
 
@@ -57,9 +58,10 @@ bool IsFutureReady(const std::future<T>& future) {
 
 // Parallel (multi-threaded) implementation of MonteCarloSimulation.
 std::vector<RandomSimulationResult> MonteCarloSimulationParallel(
-    const SimulatorFactory& make_simulator, const ScalarSystemFunction& output,
-    const double final_time, const int num_samples,
-    RandomGenerator* const generator, const int num_threads) {
+    const RandomSimulatorFactory& make_simulator,
+    const ScalarSystemFunction& output, const double final_time,
+    const int num_samples, RandomGenerator* const generator,
+    const int num_threads) {
   // Initialize storage for all simulation results. The full vector must be
   // constructed up front (i.e. we can't use reserve()) to avoid a race
   // condition on checking the size of the vector when the worker threads write
@@ -129,8 +131,9 @@ std::vector<RandomSimulationResult> MonteCarloSimulationParallel(
 }  // namespace
 
 std::vector<RandomSimulationResult> MonteCarloSimulation(
-    const SimulatorFactory& make_simulator, const ScalarSystemFunction& output,
-    const double final_time, const int num_samples, RandomGenerator* generator,
+    const RandomSimulatorFactory& make_simulator,
+    const ScalarSystemFunction& output, const double final_time,
+    const int num_samples, RandomGenerator* generator,
     const Parallelism parallelism) {
   // Create a generator if the user didn't provide one.
   std::unique_ptr<RandomGenerator> owned_generator;

--- a/systems/analysis/monte_carlo.h
+++ b/systems/analysis/monte_carlo.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/parallelism.h"
 #include "drake/systems/analysis/simulator.h"
 
@@ -16,8 +17,8 @@ namespace analysis {
  * Defines a factory method that constructs a Simulator (with an owned System)
  * using the supplied RandomGenerator as the only source of randomness.
  *
- * Note that in many interesting cases, the SimulatorFactory may simply ignore
- * the RandomGenerator argument and return the Simulator object
+ * Note that in many interesting cases, the RandomSimulatorFactory may simply
+ * ignore the RandomGenerator argument and return the Simulator object
  * deterministically, because randomness may also be introduced *inside* the
  * simulation (by SetRandomContext and/or random input ports).
  *
@@ -26,9 +27,14 @@ namespace analysis {
  * Having the Simulator own the System (by calling the unique_ptr version of
  * the constructor) is one convenient solution.
  */
-typedef std::function<std::unique_ptr<Simulator<double>>(
-    RandomGenerator* generator)>
-    SimulatorFactory;
+using RandomSimulatorFactory = std::function<std::shared_ptr<Simulator<double>>(
+    RandomGenerator* generator)>;
+
+/** (Deprecated.) */
+using SimulatorFactory DRAKE_DEPRECATED("2025-05-01",
+                                        "Use RandomSimulatorFactory instead.") =
+    std::function<
+        std::unique_ptr<Simulator<double>>(RandomGenerator* generator)>;
 
 /***
  * Defines an arbitrary scalar function of the Context.  This is used in the
@@ -83,7 +89,7 @@ typedef std::function<double(const System<double>& system,
  *
  * @ingroup analysis
  */
-double RandomSimulation(const SimulatorFactory& make_simulator,
+double RandomSimulation(const RandomSimulatorFactory& make_simulator,
                         const ScalarSystemFunction& output, double final_time,
                         RandomGenerator* generator);
 
@@ -163,9 +169,9 @@ struct RandomSimulationResult {
 // TODO(russt): Consider generalizing this with options (e.g. setting the
 // number of simulators, number of samples per simulator, ...).
 std::vector<RandomSimulationResult> MonteCarloSimulation(
-    const SimulatorFactory& make_simulator, const ScalarSystemFunction& output,
-    double final_time, int num_samples, RandomGenerator* generator = nullptr,
-    Parallelism parallelism = false);
+    const RandomSimulatorFactory& make_simulator,
+    const ScalarSystemFunction& output, double final_time, int num_samples,
+    RandomGenerator* generator = nullptr, Parallelism parallelism = false);
 
 // The below functions are exposed for unit testing only.
 namespace internal {


### PR DESCRIPTION
Deprecate the previous typedef that used unique_ptr.

Adjust pydrake bindings to use the shared_ptr callback, and fix wrong grouping scope for unrelated classes.

Towards #21968.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22528)
<!-- Reviewable:end -->
