### PR TITLE
Parse cameras from mujoco

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -112,6 +112,12 @@ PYBIND11_MODULE(parsing, m) {
         .def(py::init<MultibodyPlant<double>*, std::string_view>(),
             py::arg("plant"), py::arg("model_name_prefix"),
             cls_doc.ctor.doc_2args_plant_model_name_prefix)
+        .def(py::init<systems::DiagramBuilder<double>*, MultibodyPlant<double>*,
+                 geometry::SceneGraph<double>*, std::string_view>(),
+            py::arg("builder"), py::arg("plant") = nullptr,
+            py::arg("scene_graph") = nullptr, py::arg("model_name_prefix") = "",
+            cls_doc.ctor.doc_4args_builder_plant_scene_graph_model_name_prefix)
+        .def("builder", &Class::builder, py_rvp::reference, cls_doc.builder.doc)
         .def("plant", &Class::plant, py_rvp::reference, cls_doc.plant.doc)
         .def("scene_graph", &Class::scene_graph, py_rvp::reference,
             cls_doc.scene_graph.doc)

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -32,8 +32,10 @@ from pydrake.multibody.tree import (
     ModelInstanceIndex,
 )
 from pydrake.multibody.plant import (
+    AddMultibodyPlantSceneGraph,
     MultibodyPlant,
 )
+from pydrake.systems.framework import DiagramBuilder
 
 
 class TestParsing(unittest.TestCase):
@@ -225,6 +227,16 @@ class TestParsing(unittest.TestCase):
         parser = Parser(plant=plant)
         groups = parser.GetCollisionFilterGroups()
         self.assertTrue(groups.empty())
+
+    def test_parser_diagram_builder(self):
+        builder = DiagramBuilder()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(
+            builder, time_step=0.0)
+        parser = Parser(builder=builder, plant=plant, scene_graph=scene_graph,
+                        model_name_prefix="prefix")
+        self.assertEqual(parser.builder(), builder)
+        self.assertEqual(parser.plant(), plant)
+        self.assertEqual(parser.scene_graph(), scene_graph)
 
     def test_model_instance_info(self):
         """Checks that ModelInstanceInfo bindings exist."""

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -323,7 +323,9 @@ drake_cc_library(
         ":detail_make_model_name",
         ":detail_misc",
         ":detail_parsing_workspace",
+        "//lcm",
         "//multibody/plant",
+        "//systems/sensors:camera_config_functions",
         "@fmt",
         "@tinyxml2_internal//:tinyxml2",
     ],
@@ -537,6 +539,7 @@ drake_cc_googletest(
         ":parser",
         "//common:find_resource",
         "//common/test_utilities",
+        "//planning:robot_diagram_builder",
     ],
 )
 
@@ -681,6 +684,7 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:maybe_pause_for_user",
         "//geometry/test_utilities:meshcat_environment",
+        "//systems/sensors:rgbd_sensor",
         "//visualization",
     ],
 )

--- a/multibody/parsing/detail_composite_parse.cc
+++ b/multibody/parsing/detail_composite_parse.cc
@@ -18,7 +18,8 @@ CompositeParse::CompositeParse(Parser* parser)
       resolver_(&parser->plant()),
       options_({parser->GetAutoRenaming()}),
       workspace_(options_, parser->package_map(), parser->diagnostic_policy_,
-                 &parser->plant(), &resolver_, SelectParser) {}
+                 parser->builder(), &parser->plant(), &resolver_,
+                 SelectParser) {}
 
 CompositeParse::~CompositeParse() = default;
 

--- a/multibody/parsing/detail_dmd_parser.cc
+++ b/multibody/parsing/detail_dmd_parser.cc
@@ -116,8 +116,8 @@ void ParseModelDirectivesImpl(const ModelDirectives& directives,
                               std::vector<ModelInstanceInfo>* added_models) {
   drake::log()->debug("ParseModelDirectivesImpl(MultibodyPlant)");
   DRAKE_DEMAND(added_models != nullptr);
-  auto& [options, package_map, diagnostic, plant, collision_resolver,
-         parser_selector] = workspace;
+  auto& [options, package_map, diagnostic, builder, plant, scene_graph,
+         collision_resolver, parser_selector] = workspace;
   DRAKE_DEMAND(plant != nullptr);
   auto get_scoped_frame = [_plant = plant, &model_namespace](
                               const std::string& name) -> const Frame<double>& {

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -18,6 +18,7 @@
 #include "drake/geometry/proximity/obb.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
 #include "drake/geometry/shape_specification.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/detail_make_model_name.h"
@@ -29,6 +30,7 @@
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/scoped_name.h"
 #include "drake/multibody/tree/weld_joint.h"
+#include "drake/systems/sensors/camera_config_functions.h"
 
 namespace drake {
 namespace multibody {
@@ -56,15 +58,15 @@ constexpr std::array kOrientationAttributes = {  // BR
 
 class MujocoParser {
  public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MujocoParser)
+
   explicit MujocoParser(const ParsingWorkspace& workspace,
                         const DataSource& data_source)
       : workspace_(workspace),
         diagnostic_(&workspace.diagnostic, &data_source),
-        plant_(workspace.plant) {
-    // Clang complains that the workspace_ field is unused. Nerf the warning
-    // for now; it will be used soon.
-    unused(workspace_);
-  }
+        builder_(workspace.builder),
+        plant_(workspace.plant),
+        scene_graph_(workspace.scene_graph) {}
 
   void ErrorIfMoreThanOneOrientation(const XMLElement& node) {
     int num_orientation_attrs = 0;
@@ -1038,6 +1040,93 @@ class MujocoParser {
     return geom;
   }
 
+  void ParseCamera(XMLElement* node, const RigidBody<double>& parent,
+                   const std::string& child_class = "") {
+    if (builder_ == nullptr || scene_graph_ == nullptr) {
+      Warning(*node,
+              "camera element ignored; to register cameras, you must pass a "
+              "DiagramBuilder to the Parser and the plant must be registered "
+              "with a scene graph.");
+      return;
+    }
+
+    std::string class_name;
+    if (!ParseStringAttribute(node, "class", &class_name)) {
+      class_name = child_class.empty() ? "main" : child_class;
+    }
+    ApplyDefaultAttributes("camera", class_name, node);
+
+    systems::sensors::CameraConfig config;
+
+    std::string name;
+    if (!ParseStringAttribute(node, "name", &name)) {
+      name = fmt::format("camera{}", num_cameras_);
+    }
+    // We add the model instance name as a prefix to the camera name.
+    config.name = fmt::format(
+        "{}/{}", plant_->GetModelInstanceName(model_instance_), name);
+
+    std::string mode;
+    if (ParseStringAttribute(node, "mode", &mode)) {
+      if (mode != "fixed") {
+        Warning(*node,
+                fmt::format("camera {} requested mode '{}', which is not "
+                            "supported yet. A fixed mode will be used instead.",
+                            config.name, mode));
+      }
+    }
+
+    std::string orthographic;
+    if (ParseStringAttribute(node, "orthographic", &orthographic)) {
+      if (orthographic == "true") {
+        Warning(
+            *node,
+            fmt::format(
+                "camera {} requested orthographic projection, which is not "
+                "supported yet. A perspective projection will be used instead.",
+                config.name));
+      }
+    }
+
+    config.X_PB = schema::Transform(ParseTransform(node));
+    config.X_PB.base_frame = parent.body_frame().scoped_name().get_full();
+
+    double fovy{45};
+    ParseScalarAttribute(node, "fovy", &fovy);
+    // MuJoCo's fovy is always in degrees; it does not follow the
+    // compiler/angle setting.
+    config.focal = systems::sensors::CameraConfig::FovDegrees{.y = fovy};
+
+    // MuJoCo's specified a default resolution of (1,1); but Drake doesn't
+    // support this (and it's a silly default). We'll use Drake's default
+    // resolution unless a resolution is specified explicitly.
+    Vector2d resolution;
+    if (ParseVectorAttribute(node, "resolution", &resolution)) {
+      config.width = resolution[0];
+      config.height = resolution[1];
+    }
+
+    // TODO(russt): Support drake-specific elements/attributes to e.g. set the
+    // renderer name and other Drake camera configurable parameters.
+
+    // Note: we're opting-out of LCM by passing lcm_buses = nullptr and a
+    // throw-away DrakeLcm instance.
+    lcm::DrakeLcm lcm(systems::lcm::LcmBuses::kLcmUrlMemqNull);
+    ApplyCameraConfig(config, builder_, nullptr, plant_, scene_graph_, &lcm);
+    ++num_cameras_;
+
+    // Unsupported elements are listed in the order from the MuJoCo docs:
+    // https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-camera
+    WarnUnsupportedAttribute(*node, "target");
+    WarnUnsupportedAttribute(*node, "focal");
+    WarnUnsupportedAttribute(*node, "focalpixel");
+    WarnUnsupportedAttribute(*node, "principal");
+    WarnUnsupportedAttribute(*node, "principalpixel");
+    WarnUnsupportedAttribute(*node, "sensorsize");
+    WarnUnsupportedAttribute(*node, "ipd");
+    WarnUnsupportedAttribute(*node, "user");
+  }
+
   void ParseBody(XMLElement* node, const RigidBody<double>& parent,
                  const RigidTransformd& X_WP,
                  const std::string& parent_class = "") {
@@ -1152,13 +1241,17 @@ class MujocoParser {
       }
     }
 
+    for (XMLElement* camera_node = node->FirstChildElement("camera");
+         camera_node; camera_node = camera_node->NextSiblingElement("camera")) {
+      ParseCamera(camera_node, body, child_class);
+    }
+
     // Unsupported attributes are listed in the order from the MuJoCo docs:
     // https://mujoco.readthedocs.io/en/stable/XMLreference.html#body
     WarnUnsupportedAttribute(*node, "mocap");
     WarnUnsupportedAttribute(*node, "gravcomp");
     WarnUnsupportedAttribute(*node, "user");
     WarnUnsupportedElement(*node, "site");
-    WarnUnsupportedElement(*node, "camera");
     WarnUnsupportedElement(*node, "light");
     WarnUnsupportedElement(*node, "composite");
     WarnUnsupportedElement(*node, "flexcomp");
@@ -1193,13 +1286,17 @@ class MujocoParser {
       }
     }
 
+    for (XMLElement* camera_node = node->FirstChildElement("camera");
+         camera_node; camera_node = camera_node->NextSiblingElement("camera")) {
+      ParseCamera(camera_node, plant_->world_body());
+    }
+
     // Unsupported attributes are listed in the order from the MuJoCo docs:
     // https://mujoco.readthedocs.io/en/stable/XMLreference.html#body
     WarnUnsupportedAttribute(*node, "mocap");
     WarnUnsupportedAttribute(*node, "gravcomp");
     WarnUnsupportedAttribute(*node, "user");
     WarnUnsupportedElement(*node, "site");
-    WarnUnsupportedElement(*node, "camera");
     WarnUnsupportedElement(*node, "light");
     WarnUnsupportedElement(*node, "composite");
     WarnUnsupportedElement(*node, "flexcomp");
@@ -1547,12 +1644,10 @@ class MujocoParser {
       return;
     }
 
-    geometry::SceneGraph<double>* scene_graph =
-        plant_->GetMutableSceneGraphPreFinalize();
     geometry::CollisionFilterManager manager =
-        scene_graph->collision_filter_manager();
+        scene_graph_->collision_filter_manager();
     const geometry::SceneGraphInspector<double>& inspector =
-        scene_graph->model_inspector();
+        scene_graph_->model_inspector();
     const auto geom_ids = inspector.GetGeometryIds(
         geometry::GeometrySet(inspector.GetAllGeometryIds()),
         geometry::Role::kProximity);
@@ -1997,7 +2092,9 @@ class MujocoParser {
  private:
   const ParsingWorkspace& workspace_;
   TinyXml2Diagnostic diagnostic_;
-  MultibodyPlant<double>* plant_;
+  systems::DiagramBuilder<double>* const builder_;
+  MultibodyPlant<double>* const plant_;
+  geometry::SceneGraph<double>* const scene_graph_;
   ModelInstanceIndex model_instance_{};
   std::filesystem::path main_mjcf_path_{};
   bool autolimits_{true};
@@ -2014,6 +2111,7 @@ class MujocoParser {
   // Spatial inertia of mesh assets assuming density = 1.
   std::map<std::string, SpatialInertia<double>> mesh_inertia_{};
   std::map<JointIndex, double> armature_{};
+  int num_cameras_{0};
 };
 
 std::pair<std::optional<ModelInstanceIndex>, std::string>

--- a/multibody/parsing/detail_parsing_workspace.h
+++ b/multibody/parsing/detail_parsing_workspace.h
@@ -136,13 +136,18 @@ struct ParsingWorkspace {
   ParsingWorkspace(
       const ParsingOptions& options_in, const PackageMap& package_map_in,
       const drake::internal::DiagnosticPolicy& diagnostic_in,
+      systems::DiagramBuilder<double>* builder_in,
       MultibodyPlant<double>* plant_in,
       internal::CollisionFilterGroupResolver* collision_resolver_in,
       ParserSelector parser_selector_in)
       : options(options_in),
         package_map(package_map_in),
         diagnostic(diagnostic_in),
+        builder(builder_in),
         plant(plant_in),
+        scene_graph(plant_in->geometry_source_is_registered()
+                        ? plant_in->GetMutableSceneGraphPreFinalize()
+                        : nullptr),
         collision_resolver(collision_resolver_in),
         parser_selector(parser_selector_in) {
     DRAKE_DEMAND(plant != nullptr);
@@ -153,7 +158,9 @@ struct ParsingWorkspace {
   const ParsingOptions& options;
   const PackageMap& package_map;
   const drake::internal::DiagnosticPolicy& diagnostic;
+  systems::DiagramBuilder<double>* const builder;
   MultibodyPlant<double>* const plant;
+  geometry::SceneGraph<double>* const scene_graph;
   internal::CollisionFilterGroupResolver* const collision_resolver;
   const ParserSelector parser_selector;
 };

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -2139,8 +2139,8 @@ sdf::InterfaceModelPtr ParseNestedInterfaceModel(
     const ParsingWorkspace& workspace, const sdf::NestedInclude& include,
     sdf::Errors* errors) {
   const sdf::ParserConfig parser_config = MakeSdfParserConfig(workspace);
-  auto& [options, package_map, diagnostic, plant, collision_resolver,
-         parser_selector] = workspace;
+  auto& [options, package_map, diagnostic, builder, plant, scene_graph,
+         collision_resolver, parser_selector] = workspace;
   const std::string resolved_filename{include.ResolvedFileName()};
 
   // Do not attempt to parse anything other than URDF and MuJoCo xml files.
@@ -2171,8 +2171,9 @@ sdf::InterfaceModelPtr ParseNestedInterfaceModel(
   const bool is_merge_include = include.IsMerge().value_or(false);
 
   InterfaceModelHelper interface_model_helper(*plant);
-  ParsingWorkspace subworkspace{options, package_map,        subdiagnostic,
-                                plant,   collision_resolver, parser_selector};
+  ParsingWorkspace subworkspace{options,        package_map, subdiagnostic,
+                                builder,        plant,       collision_resolver,
+                                parser_selector};
 
   std::string model_frame_name = "__model__";
   std::string model_name;

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -133,6 +133,25 @@ class Parser final {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Parser);
 
+  /// Create a Parser given a DiagramBuilder (and optionally plant and
+  /// scene_graph). If specified, the resulting parser will apply
+  /// `model_name_prefix` to the names of any models parsed. `builder` may be
+  /// nullptr, but then you must specify a `plant`.
+  ///
+  /// @pre Either the given `builder` contains a MultibodyPlant system named
+  ///   "plant" or else the provided `plant` is non-null.
+  /// @pre If both `builder` and `plant` are specified, then
+  ///   plant ∈ builder.GetSystems()
+  /// @param scene_graph A pointer to a mutable SceneGraph object used for
+  ///   geometry registration (either to model visual or contact geometry).
+  ///   May be nullptr.
+  /// @pre If both `builder` and `scene_graph` are specified, then
+  ///   scene_graph ∈ builder.GetSystems().
+  explicit Parser(systems::DiagramBuilder<double>* builder,
+                  MultibodyPlant<double>* plant = nullptr,
+                  geometry::SceneGraph<double>* scene_graph = nullptr,
+                  std::string_view model_name_prefix = {});
+
   /// Creates a Parser that adds models to the given plant and (optionally)
   /// scene_graph.
   ///
@@ -175,6 +194,10 @@ class Parser final {
   Parser(MultibodyPlant<double>* plant, std::string_view model_name_prefix);
 
   ~Parser();
+
+  /// Gets a mutable pointer to the DiagramBuilder that will be modified by
+  /// this parser, or nullptr if this parser does not have a DiagramBuilder.
+  systems::DiagramBuilder<double>* builder() { return builder_; }
 
   /// Gets a mutable reference to the plant that will be modified by this
   /// parser.
@@ -256,7 +279,8 @@ class Parser final {
   bool enable_auto_rename_{false};
   PackageMap package_map_;
   drake::internal::DiagnosticPolicy diagnostic_policy_;
-  MultibodyPlant<double>* const plant_;
+  systems::DiagramBuilder<double>* const builder_;
+  MultibodyPlant<double>* plant_;
   std::optional<std::string> model_name_prefix_;
   struct ParserInternalData;
   std::unique_ptr<ParserInternalData> data_;

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -34,6 +34,18 @@ for any unsupported MuJoCo XML elements or attributes at runtime.
 
 <!-- TODO(rpoyner-tri): document mujoco format support -->
 
+@subsection mjcf_camera MuJoCo camera support
+
+The MuJoCo camera element is supported (with any unsupported attributes
+emmitting the standard parser warnings). To parse cameras, you must register a
+DiagramBuilder with the Parser, and the MultibodyPlant must have a registered
+SceneGraph. The parser will call ApplyCameraConfig() to produce a camera named
+"{model_instance_name}/{mjcf_camera_name}", where a default {mjcf_camera_name}
+of "camera{i}" for the ith camera (starting from 0) will be provided if no name
+is specified in the xml. Note that calling
+`MultibodyPlant::RenameModelInstance` after parsing will not update the camera
+name.
+
 @subsection mjcf_ignored_silent Tags ignored silently
 
 The following attributes are specific to the MuJoCo solver (listed here in the

--- a/multibody/parsing/test/detail_dmd_parser_test.cc
+++ b/multibody/parsing/test/detail_dmd_parser_test.cc
@@ -52,8 +52,9 @@ class DmdParserTest : public test::DiagnosticPolicyTestBase {
   std::vector<ModelInstanceInfo> ParseModelDirectives(
       const ModelDirectives& directives) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    const ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                             &plant_,  &resolver,    TestingSelect};
+    const ParsingWorkspace w{options_,     package_map_, diagnostic_policy_,
+                             nullptr,      &plant_,      &resolver,
+                             TestingSelect};
     auto result =
         multibody::internal::ParseModelDirectives(directives, std::nullopt, w);
     resolver.Resolve(diagnostic_policy_);

--- a/multibody/parsing/test/detail_make_model_name_test.cc
+++ b/multibody/parsing/test/detail_make_model_name_test.cc
@@ -23,7 +23,7 @@ class MakeModelNameTest : public testing::Test {
   DiagnosticPolicy policy_;
   MultibodyPlant<double> plant_{0.0};
   CollisionFilterGroupResolver resolver_{&plant_};
-  ParsingWorkspace workspace_{options_, package_map_, policy_,
+  ParsingWorkspace workspace_{options_, package_map_, policy_, nullptr,
                               &plant_,  &resolver_,   NoSelect};
 };
 

--- a/multibody/parsing/test/detail_mesh_parser_test.cc
+++ b/multibody/parsing/test/detail_mesh_parser_test.cc
@@ -35,7 +35,7 @@ class MeshParserTest : public test::DiagnosticPolicyTestBase {
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, nullptr,
                        &plant_,  &resolver,    TestingSelect};
     // The wrapper simply delegates to AddModelFromMesh(), so we're testing
     // the underlying implementation *and* confirming that the wrapper delegates
@@ -51,7 +51,7 @@ class MeshParserTest : public test::DiagnosticPolicyTestBase {
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, nullptr,
                        &plant_,  &resolver,    TestingSelect};
     // The wrapper is responsible for building the vector from whatever a call
     // to AddModelFromMesh() does; this confirms invocation and successful
@@ -210,7 +210,7 @@ TEST_F(MeshParserTest, ErrorModes) {
     const std::string data("Just some text");
     const DataSource data_source{DataSource::kContents, &data};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, nullptr,
                        &plant_,  &resolver,    TestingSelect};
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddModelFromMesh(data_source, "", std::nullopt, w),

--- a/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
@@ -23,7 +23,8 @@ class MujocoParserExamplesTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_name, const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                       &plant_,  &resolver,    NoSelect};
+                       nullptr,  &plant_,      &resolver,
+                       NoSelect};
     auto result = wrapper_.AddModel({DataSource::kFilename, &file_name},
                                     model_name, {}, w);
     resolver.Resolve(diagnostic_policy_);

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -18,6 +18,7 @@
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/weld_joint.h"
+#include "drake/systems/sensors/rgbd_sensor.h"
 #include "drake/visualization/visualization_config_functions.h"
 
 namespace drake {
@@ -46,13 +47,25 @@ const double kInf = std::numeric_limits<double>::infinity();
 
 class MujocoParserTest : public test::DiagnosticPolicyTestBase {
  public:
-  MujocoParserTest() { plant_.RegisterAsSourceForSceneGraph(&scene_graph_); }
+  MujocoParserTest() {
+    std::tie(plant_, scene_graph_) =
+        AddMultibodyPlantSceneGraph(&builder_, 0.1);
+  }
+
+  void RemoveSceneGraph() {
+    builder_.RemoveSystem(*scene_graph_);
+    scene_graph_ = nullptr;
+    // Now recreate the plant (to unregister the scene graph).
+    builder_.RemoveSystem(*plant_);
+    plant_ = builder_.AddSystem<MultibodyPlant>(0.1);
+  }
 
   std::optional<ModelInstanceIndex> AddModelFromFile(
       const std::string& file_name, const std::string& model_name) {
-    internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                       &plant_,  &resolver,    NoSelect};
+    internal::CollisionFilterGroupResolver resolver{plant_};
+    ParsingWorkspace w{options_,  package_map_, diagnostic_policy_,
+                       &builder_, plant_,       &resolver,
+                       NoSelect};
     auto result = wrapper_.AddModel({DataSource::kFilename, &file_name},
                                     model_name, {}, w);
     resolver.Resolve(diagnostic_policy_);
@@ -61,9 +74,10 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
 
   std::optional<ModelInstanceIndex> AddModelFromString(
       const std::string& file_contents, const std::string& model_name) {
-    internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                       &plant_,  &resolver,    NoSelect};
+    internal::CollisionFilterGroupResolver resolver{plant_};
+    ParsingWorkspace w{options_,  package_map_, diagnostic_policy_,
+                       &builder_, plant_,       &resolver,
+                       NoSelect};
     auto result = wrapper_.AddModel({DataSource::kContents, &file_contents},
                                     model_name, {}, w);
     resolver.Resolve(diagnostic_policy_);
@@ -73,9 +87,10 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
   std::vector<ModelInstanceIndex> AddAllModelsFromFile(
       const std::string& file_name,
       const std::optional<std::string>& parent_model_name) {
-    internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                       &plant_,  &resolver,    NoSelect};
+    internal::CollisionFilterGroupResolver resolver{plant_};
+    ParsingWorkspace w{options_,  package_map_, diagnostic_policy_,
+                       &builder_, plant_,       &resolver,
+                       NoSelect};
     auto result = wrapper_.AddAllModels({DataSource::kFilename, &file_name},
                                         parent_model_name, w);
     resolver.Resolve(diagnostic_policy_);
@@ -85,9 +100,10 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
   std::vector<ModelInstanceIndex> AddAllModelsFromString(
       const std::string& file_contents,
       const std::optional<std::string>& parent_model_name) {
-    internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                       &plant_,  &resolver,    NoSelect};
+    internal::CollisionFilterGroupResolver resolver{plant_};
+    ParsingWorkspace w{options_,  package_map_, diagnostic_policy_,
+                       &builder_, plant_,       &resolver,
+                       NoSelect};
     auto result = wrapper_.AddAllModels({DataSource::kContents, &file_contents},
                                         parent_model_name, w);
     resolver.Resolve(diagnostic_policy_);
@@ -101,10 +117,11 @@ class MujocoParserTest : public test::DiagnosticPolicyTestBase {
   }
 
  protected:
+  systems::DiagramBuilder<double> builder_;
   ParsingOptions options_;
   PackageMap package_map_;
-  MultibodyPlant<double> plant_{0.1};
-  SceneGraph<double> scene_graph_;
+  MultibodyPlant<double>* plant_{};
+  SceneGraph<double>* scene_graph_{};
   MujocoParserWrapper wrapper_;
 
   std::string box_obj_{std::filesystem::canonical(FindResourceOrThrow(
@@ -132,6 +149,7 @@ GTEST_TEST(MujocoParserExtraTest, Visualize) {
       options,
       package_map,
       diagnostic_policy,
+      nullptr,
       &plant,
       &resolver,
       [](const drake::internal::DiagnosticPolicy&,
@@ -160,18 +178,18 @@ TEST_F(MujocoParserTest, CartPole) {
   // For this parse, ignore all warnings.
   warning_records_.clear();
 
-  plant_.Finalize();
+  plant_->Finalize();
   // Check the kinematics. Passing this test requires a correct parsing of
   // joint defaults.
-  auto context = plant_.CreateDefaultContext();
+  auto context = plant_->CreateDefaultContext();
   const double x = 0.1;
   const double theta = 0.2;
   const double l = 1.0;
   const double z_offset_from_model = 1.0;
-  plant_.SetPositions(context.get(), Vector2d(x, theta));
+  plant_->SetPositions(context.get(), Vector2d(x, theta));
   Vector3d p_WP;
-  plant_.CalcPointsPositions(*context, plant_.GetFrameByName("pole_1"),
-                             Vector3d{0, 0, l}, plant_.world_frame(), &p_WP);
+  plant_->CalcPointsPositions(*context, plant_->GetFrameByName("pole_1"),
+                              Vector3d{0, 0, l}, plant_->world_frame(), &p_WP);
   EXPECT_TRUE(CompareMatrices(
       p_WP,
       Vector3d{x + l * sin(theta), 0, z_offset_from_model + l * cos(theta)},
@@ -185,19 +203,19 @@ TEST_F(MujocoParserTest, Acrobot) {
   // For this parse, ignore all warnings.
   warning_records_.clear();
 
-  plant_.Finalize();
+  plant_->Finalize();
   // Check the kinematics. Passing this test requires a correct parsing of the
   // joint position being defined in the child body frame, not the parent
   // body frame.
-  auto context = plant_.CreateDefaultContext();
+  auto context = plant_->CreateDefaultContext();
   const Vector2d q = {0.1, 0.2};
   const double l1 = 1.0;
   const double l2 = 0.5;
   const double z_offset_from_model = 2.0;
-  plant_.SetPositions(context.get(), q);
+  plant_->SetPositions(context.get(), q);
   Vector3d p_WP;
-  plant_.CalcPointsPositions(*context, plant_.GetFrameByName("lower_arm"),
-                             Vector3d{0, 0, l2}, plant_.world_frame(), &p_WP);
+  plant_->CalcPointsPositions(*context, plant_->GetFrameByName("lower_arm"),
+                              Vector3d{0, 0, l2}, plant_->world_frame(), &p_WP);
   EXPECT_TRUE(CompareMatrices(
       p_WP,
       Vector3d{l1 * sin(q[0]) + l2 * sin(q[0] + q[1]), 0,
@@ -213,7 +231,7 @@ TEST_F(MujocoParserTest, Option) {
 )""";
 
   AddModelFromString(xml, "test");
-  EXPECT_TRUE(CompareMatrices(plant_.gravity_field().gravity_vector(),
+  EXPECT_TRUE(CompareMatrices(plant_->gravity_field().gravity_vector(),
                               Vector3d{0, -9.81, 0}));
 }
 
@@ -264,7 +282,8 @@ TEST_F(MujocoParserTest, GeometryTypes) {
 )""";
 
   AddModelFromString(xml, "test");
-  const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
+  const SceneGraphInspector<double>& inspector =
+      scene_graph_->model_inspector();
 
   auto CheckShape = [&inspector](const std::string& geometry_name,
                                  std::string_view shape_type) {
@@ -312,7 +331,8 @@ TEST_F(MujocoParserTest, UniqueGeometryNames) {
 )""";
 
   AddModelFromString(xml, "test");
-  const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
+  const SceneGraphInspector<double>& inspector =
+      scene_graph_->model_inspector();
   EXPECT_NO_THROW(inspector.GetGeometryIdByName(inspector.world_frame_id(),
                                                 Role::kProximity, "geom0"));
   EXPECT_NO_THROW(inspector.GetGeometryIdByName(inspector.world_frame_id(),
@@ -403,7 +423,8 @@ TEST_F(MujocoParserTest, GeometryPose) {
   AddModelFromString(radians_xml, "radians_test");
   AddModelFromString(degrees_xml, "degrees_test");
 
-  const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
+  const SceneGraphInspector<double>& inspector =
+      scene_graph_->model_inspector();
 
   auto CheckPose = [&inspector](const std::string& geometry_name,
                                 const RigidTransformd& X_FG) {
@@ -502,7 +523,8 @@ TEST_F(MujocoParserTest, GeometryProperties) {
 
   AddModelFromString(xml, "test");
 
-  const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
+  const SceneGraphInspector<double>& inspector =
+      scene_graph_->model_inspector();
 
   auto CheckProperties = [&inspector](const std::string& geometry_name,
                                       double mu, const Vector4d& rgba,
@@ -583,7 +605,7 @@ TEST_F(MujocoParserTest, GeometryProperties) {
 }
 
 TEST_F(MujocoParserTest, Include) {
-  EXPECT_EQ(plant_.num_model_instances(), 2);
+  EXPECT_EQ(plant_->num_model_instances(), 2);
   // This scene.xml defines a scene with two pendula, defined using <include>
   // (and a nested <include>).
   AddAllModelsFromFile(
@@ -591,15 +613,15 @@ TEST_F(MujocoParserTest, Include) {
           "drake/multibody/parsing/test/mujoco_parser_test/scene.xml"),
       {});
   FlushDiagnostics();
-  plant_.Finalize();
-  EXPECT_EQ(plant_.num_model_instances(), 3);
-  EXPECT_EQ(plant_.num_positions(), 2);
-  EXPECT_EQ(plant_.num_velocities(), 2);
+  plant_->Finalize();
+  EXPECT_EQ(plant_->num_model_instances(), 3);
+  EXPECT_EQ(plant_->num_positions(), 2);
+  EXPECT_EQ(plant_->num_velocities(), 2);
 
   // In order for the total mass to be correct, the geom from the nested
   // include inside pendulum.xml must have been processed.
-  auto context = plant_.CreateDefaultContext();
-  EXPECT_EQ(plant_.CalcTotalMass(*context), 2.0);
+  auto context = plant_->CreateDefaultContext();
+  EXPECT_EQ(plant_->CalcTotalMass(*context), 2.0);
 }
 
 class BoxMeshTest : public MujocoParserTest {
@@ -628,7 +650,7 @@ class BoxMeshTest : public MujocoParserTest {
     AddModelFromString(xml, "test");
 
     const SceneGraphInspector<double>& inspector =
-        scene_graph_.model_inspector();
+        scene_graph_->model_inspector();
     GeometryId geom_id = inspector.GetGeometryIdByName(
         inspector.world_frame_id(), Role::kProximity, "box_geom");
     auto* mesh =
@@ -794,7 +816,8 @@ TEST_F(MujocoParserTest, MeshFileRelativePathFromFile) {
 
   AddModelFromFile(file, "test");
 
-  const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
+  const SceneGraphInspector<double>& inspector =
+      scene_graph_->model_inspector();
   GeometryId geom_id = inspector.GetGeometryIdByName(
       inspector.world_frame_id(), Role::kProximity, "box_geom");
   auto* mesh =
@@ -947,14 +970,14 @@ TEST_F(MujocoParserTest, InertialFromGeometry) {
 
   AddModelFromString(xml, "test_false");
 
-  plant_.Finalize();
+  plant_->Finalize();
 
-  auto context = plant_.CreateDefaultContext();
+  auto context = plant_->CreateDefaultContext();
 
   auto check_body = [this, &context](const std::string& body_name,
                                      const UnitInertia<double>& unit_M_BBo_B) {
     SCOPED_TRACE(fmt::format("checking body {}", body_name));
-    const RigidBody<double>& body = plant_.GetBodyByName(body_name);
+    const RigidBody<double>& body = plant_->GetBodyByName(body_name);
     EXPECT_TRUE(CompareMatrices(
         body.CalcSpatialInertiaInBodyFrame(*context).CopyToFullMatrix6(),
         SpatialInertia<double>(2.53, Vector3d::Zero(), unit_M_BBo_B)
@@ -967,7 +990,7 @@ TEST_F(MujocoParserTest, InertialFromGeometry) {
                                 const SpatialInertia<double>& M_BBo_B,
                                 double tol = 1e-14) {
     SCOPED_TRACE(fmt::format("checking body {} (spatial)", body_name));
-    const RigidBody<double>& body = plant_.GetBodyByName(body_name);
+    const RigidBody<double>& body = plant_->GetBodyByName(body_name);
     EXPECT_TRUE(CompareMatrices(
         body.CalcSpatialInertiaInBodyFrame(*context).CopyToFullMatrix6(),
         M_BBo_B.CopyToFullMatrix6(), tol));
@@ -979,7 +1002,7 @@ TEST_F(MujocoParserTest, InertialFromGeometry) {
 
   // This line documents that the world body (which has "plane" geometry in this
   // example) has NaN inertia, and that's ok:
-  EXPECT_TRUE(plant_.world_body().default_spatial_inertia().IsNaN());
+  EXPECT_TRUE(plant_->world_body().default_spatial_inertia().IsNaN());
 
   check_body("default", UnitInertia<double>::SolidSphere(0.1));
   check_body_spatial("sphere", inertia_from_inertial_tag);
@@ -1202,9 +1225,9 @@ TEST_F(MujocoParserTest, Joint) {
 )""";
 
   AddModelFromString(xml, "test");
-  plant_.Finalize();
+  plant_->Finalize();
 
-  auto context = plant_.CreateDefaultContext();
+  auto context = plant_->CreateDefaultContext();
 
   RigidTransformd X_WB(RollPitchYawd{M_PI / 6.0, M_PI / 4.0, M_PI / 3.0},
                        Vector3d{1.0, 2.0, 3.0});
@@ -1212,32 +1235,32 @@ TEST_F(MujocoParserTest, Joint) {
 
   // Note: for free bodies Drake ignores the given Mujoco joint name and makes
   // its own floating joint named like the body.
-  const RigidBody<double>& freejoint_body = plant_.GetBodyByName("freejoint");
-  EXPECT_FALSE(plant_.HasJointNamed("xfreejoint"));
-  EXPECT_TRUE(plant_.HasJointNamed("freejoint"));
+  const RigidBody<double>& freejoint_body = plant_->GetBodyByName("freejoint");
+  EXPECT_FALSE(plant_->HasJointNamed("xfreejoint"));
+  EXPECT_TRUE(plant_->HasJointNamed("freejoint"));
   EXPECT_TRUE(freejoint_body.is_floating());
-  EXPECT_TRUE(plant_.GetFreeBodyPose(*context, freejoint_body)
+  EXPECT_TRUE(plant_->GetFreeBodyPose(*context, freejoint_body)
                   .IsNearlyEqualTo(X_WB, 1e-14));
 
-  const RigidBody<double>& free_body = plant_.GetBodyByName("free");
-  EXPECT_FALSE(plant_.HasJointNamed("xfree"));
-  EXPECT_TRUE(plant_.HasJointNamed("free"));
+  const RigidBody<double>& free_body = plant_->GetBodyByName("free");
+  EXPECT_FALSE(plant_->HasJointNamed("xfree"));
+  EXPECT_TRUE(plant_->HasJointNamed("free"));
   EXPECT_TRUE(free_body.is_floating());
-  EXPECT_TRUE(
-      plant_.GetFreeBodyPose(*context, free_body).IsNearlyEqualTo(X_WB, 1e-14));
+  EXPECT_TRUE(plant_->GetFreeBodyPose(*context, free_body)
+                  .IsNearlyEqualTo(X_WB, 1e-14));
 
   const BallRpyJoint<double>& ball_joint =
-      plant_.GetJointByName<BallRpyJoint>("ball");
+      plant_->GetJointByName<BallRpyJoint>("ball");
   EXPECT_EQ(ball_joint.default_damping(), 0.1);
   EXPECT_TRUE(
       ball_joint.frame_on_child().CalcPoseInBodyFrame(*context).IsNearlyEqualTo(
           RigidTransformd(pos), 1e-14));
   EXPECT_TRUE(
-      plant_.GetBodyByName("ball").EvalPoseInWorld(*context).IsNearlyEqualTo(
+      plant_->GetBodyByName("ball").EvalPoseInWorld(*context).IsNearlyEqualTo(
           X_WB, 1e-14));
 
   const PrismaticJoint<double>& slide_joint =
-      plant_.GetJointByName<PrismaticJoint>("slide");
+      plant_->GetJointByName<PrismaticJoint>("slide");
   EXPECT_EQ(slide_joint.default_damping(), 0.2);
   EXPECT_TRUE(slide_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)
@@ -1245,7 +1268,7 @@ TEST_F(MujocoParserTest, Joint) {
   EXPECT_TRUE(
       CompareMatrices(slide_joint.translation_axis(), Vector3d{1, 0, 0}));
   EXPECT_TRUE(
-      plant_.GetBodyByName("slide").EvalPoseInWorld(*context).IsNearlyEqualTo(
+      plant_->GetBodyByName("slide").EvalPoseInWorld(*context).IsNearlyEqualTo(
           X_WB, 1e-14));
   EXPECT_TRUE(
       CompareMatrices(slide_joint.position_lower_limits(), Vector1d{-2.0}));
@@ -1253,14 +1276,14 @@ TEST_F(MujocoParserTest, Joint) {
       CompareMatrices(slide_joint.position_upper_limits(), Vector1d{1.5}));
 
   const RevoluteJoint<double>& hinge_joint =
-      plant_.GetJointByName<RevoluteJoint>("hinge");
+      plant_->GetJointByName<RevoluteJoint>("hinge");
   EXPECT_EQ(hinge_joint.default_damping(), 0.3);
   EXPECT_TRUE(hinge_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyEqualTo(RigidTransformd(pos), 1e-14));
   EXPECT_TRUE(CompareMatrices(hinge_joint.revolute_axis(), Vector3d{0, 1, 0}));
   EXPECT_TRUE(
-      plant_.GetBodyByName("hinge").EvalPoseInWorld(*context).IsNearlyEqualTo(
+      plant_->GetBodyByName("hinge").EvalPoseInWorld(*context).IsNearlyEqualTo(
           X_WB, 1e-14));
   EXPECT_TRUE(CompareMatrices(hinge_joint.position_lower_limits(),
                               Vector1d{-M_PI / 6.0}, 1e-14));
@@ -1268,7 +1291,7 @@ TEST_F(MujocoParserTest, Joint) {
                               Vector1d{M_PI / 3.0}, 1e-14));
 
   const RevoluteJoint<double>& hinge_w_joint_defaults_joint =
-      plant_.GetJointByName<RevoluteJoint>("hinge_w_joint_defaults");
+      plant_->GetJointByName<RevoluteJoint>("hinge_w_joint_defaults");
   EXPECT_EQ(hinge_w_joint_defaults_joint.default_damping(), 0.24);
   EXPECT_TRUE(
       hinge_w_joint_defaults_joint.frame_on_child()
@@ -1276,26 +1299,26 @@ TEST_F(MujocoParserTest, Joint) {
           .IsNearlyEqualTo(RigidTransformd(Vector3d{-0.1, -0.2, -0.3}), 1e-14));
   EXPECT_TRUE(CompareMatrices(hinge_w_joint_defaults_joint.revolute_axis(),
                               Vector3d{1, 0, 0}));
-  EXPECT_TRUE(plant_.GetBodyByName("hinge_w_joint_defaults")
+  EXPECT_TRUE(plant_->GetBodyByName("hinge_w_joint_defaults")
                   .EvalPoseInWorld(*context)
                   .IsNearlyEqualTo(X_WB, 1e-14));
   EXPECT_TRUE(CompareMatrices(
-      plant_.GetJointByName("hinge_w_joint_defaults").position_lower_limits(),
+      plant_->GetJointByName("hinge_w_joint_defaults").position_lower_limits(),
       Vector1d{-M_PI / 6.0}, 1e-14));
   EXPECT_TRUE(CompareMatrices(
-      plant_.GetJointByName("hinge_w_joint_defaults").position_upper_limits(),
+      plant_->GetJointByName("hinge_w_joint_defaults").position_upper_limits(),
       Vector1d{M_PI / 3.0}, 1e-14));
 
   const RevoluteJoint<double>& hinge_w_ref_joint =
-      plant_.GetJointByName<RevoluteJoint>("hinge_w_ref");
+      plant_->GetJointByName<RevoluteJoint>("hinge_w_ref");
   const double hinge_ref = 15.0 * M_PI / 180.0;
   EXPECT_NEAR(hinge_w_ref_joint.get_default_angle(), hinge_ref, 1e-14);
-  EXPECT_TRUE(plant_.GetBodyByName("hinge_w_ref")
+  EXPECT_TRUE(plant_->GetBodyByName("hinge_w_ref")
                   .EvalPoseInWorld(*context)
                   .IsNearlyIdentity(1e-14));
   hinge_w_ref_joint.set_angle(context.get(), 0.0);
   EXPECT_TRUE(
-      CompareMatrices(plant_.GetBodyByName("hinge_w_ref")
+      CompareMatrices(plant_->GetBodyByName("hinge_w_ref")
                           .EvalPoseInWorld(*context)
                           .GetAsMatrix34(),
                       RigidTransformd(AngleAxisd(-hinge_ref, Vector3d{0, 0, 1}),
@@ -1304,58 +1327,58 @@ TEST_F(MujocoParserTest, Joint) {
                       1e-14));
 
   const PrismaticJoint<double>& slide_w_ref_joint =
-      plant_.GetJointByName<PrismaticJoint>("slide_w_ref");
+      plant_->GetJointByName<PrismaticJoint>("slide_w_ref");
   EXPECT_EQ(slide_w_ref_joint.get_default_translation(), 1.1);
-  EXPECT_TRUE(plant_.GetBodyByName("slide_w_ref")
+  EXPECT_TRUE(plant_->GetBodyByName("slide_w_ref")
                   .EvalPoseInWorld(*context)
                   .IsNearlyIdentity(1e-14));
   slide_w_ref_joint.set_translation(context.get(), 0.0);
-  EXPECT_TRUE(CompareMatrices(plant_.GetBodyByName("slide_w_ref")
+  EXPECT_TRUE(CompareMatrices(plant_->GetBodyByName("slide_w_ref")
                                   .EvalPoseInWorld(*context)
                                   .translation(),
                               Vector3d{0, 0, -1.1}, 1e-14));
 
   const RevoluteJoint<double>& default_joint =
-      plant_.GetJointByName<RevoluteJoint>("default");
+      plant_->GetJointByName<RevoluteJoint>("default");
   EXPECT_EQ(default_joint.default_damping(), 0.4);
   EXPECT_TRUE(default_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyIdentity(1e-14));
   EXPECT_TRUE(
       CompareMatrices(default_joint.revolute_axis(), Vector3d{0, 0, 1}));
+  EXPECT_TRUE(plant_->GetBodyByName("default")
+                  .EvalPoseInWorld(*context)
+                  .IsNearlyEqualTo(X_WB, 1e-14));
   EXPECT_TRUE(
-      plant_.GetBodyByName("default").EvalPoseInWorld(*context).IsNearlyEqualTo(
-          X_WB, 1e-14));
-  EXPECT_TRUE(
-      CompareMatrices(plant_.GetJointByName("default").position_lower_limits(),
+      CompareMatrices(plant_->GetJointByName("default").position_lower_limits(),
                       Vector1d{-M_PI / 9.0}));
   EXPECT_TRUE(
-      CompareMatrices(plant_.GetJointByName("default").position_upper_limits(),
+      CompareMatrices(plant_->GetJointByName("default").position_upper_limits(),
                       Vector1d{M_PI / 12.0}));
 
   const RevoluteJoint<double>& hinge1_joint =
-      plant_.GetJointByName<RevoluteJoint>("hinge1");
+      plant_->GetJointByName<RevoluteJoint>("hinge1");
   EXPECT_EQ(hinge1_joint.default_damping(), 0.5);
   EXPECT_TRUE(CompareMatrices(hinge1_joint.revolute_axis(), Vector3d{1, 0, 0}));
   EXPECT_TRUE(hinge1_joint.frame_on_parent()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyEqualTo(RigidTransformd(pos), 1e-14));
   const RevoluteJoint<double>& hinge2_joint =
-      plant_.GetJointByName<RevoluteJoint>("hinge2");
+      plant_->GetJointByName<RevoluteJoint>("hinge2");
   EXPECT_EQ(hinge2_joint.default_damping(), 0.6);
   EXPECT_TRUE(CompareMatrices(hinge2_joint.revolute_axis(), Vector3d{0, 1, 0}));
   EXPECT_TRUE(hinge2_joint.frame_on_child()
                   .CalcPoseInBodyFrame(*context)
                   .IsNearlyEqualTo(RigidTransformd(pos), 1e-14));
-  EXPECT_TRUE(plant_.GetBodyByName("two_hinges")
+  EXPECT_TRUE(plant_->GetBodyByName("two_hinges")
                   .EvalPoseInWorld(*context)
                   .IsNearlyEqualTo(X_WB, 1e-14));
 
   EXPECT_TRUE(
-      plant_.GetBodyByName("weld").EvalPoseInWorld(*context).IsNearlyEqualTo(
+      plant_->GetBodyByName("weld").EvalPoseInWorld(*context).IsNearlyEqualTo(
           X_WB, 1e-14));
   const WeldJoint<double>& weld_joint =
-      plant_.GetJointByName<WeldJoint>("world_welds_to_weld");
+      plant_->GetJointByName<WeldJoint>("world_welds_to_weld");
   EXPECT_TRUE(weld_joint.X_FM().IsNearlyEqualTo(X_WB, 1e-14));
 }
 
@@ -1417,19 +1440,19 @@ std::string MakeAutoLimitsXML(bool auto_limits,
 TEST_F(MujocoParserTest, AutoLimitsTrue) {
   const std::string kXml = MakeAutoLimitsXML(true, "ctrl");
   AddModelFromString(kXml, "test");
-  plant_.Finalize();
-  EXPECT_EQ(plant_.num_positions(), 6);
+  plant_->Finalize();
+  EXPECT_EQ(plant_->num_positions(), 6);
   VectorXd expected_limits(6);
   expected_limits << 0.0, 1.0, 2.0, 3.0, kInf, kInf;
   EXPECT_TRUE(
-      CompareMatrices(plant_.GetPositionLowerLimits(), -expected_limits));
+      CompareMatrices(plant_->GetPositionLowerLimits(), -expected_limits));
   EXPECT_TRUE(
-      CompareMatrices(plant_.GetPositionUpperLimits(), expected_limits));
+      CompareMatrices(plant_->GetPositionUpperLimits(), expected_limits));
   EXPECT_THAT(TakeError(),
               MatchesRegex(".*The 'limited' attribute must be one of.*"));
-  EXPECT_TRUE(CompareMatrices(plant_.GetEffortLowerLimits(),
+  EXPECT_TRUE(CompareMatrices(plant_->GetEffortLowerLimits(),
                               -expected_limits.tail<5>()));
-  EXPECT_TRUE(CompareMatrices(plant_.GetEffortUpperLimits(),
+  EXPECT_TRUE(CompareMatrices(plant_->GetEffortUpperLimits(),
                               expected_limits.tail<5>()));
   EXPECT_THAT(TakeError(),
               MatchesRegex(".*The 'ctrllimited' attribute must be one of.*"));
@@ -1438,14 +1461,14 @@ TEST_F(MujocoParserTest, AutoLimitsTrue) {
 TEST_F(MujocoParserTest, AutoLimitsFalse) {
   const std::string kXml = MakeAutoLimitsXML(false, "force");
   AddModelFromString(kXml, "test");
-  plant_.Finalize();
-  EXPECT_EQ(plant_.num_positions(), 6);
+  plant_->Finalize();
+  EXPECT_EQ(plant_->num_positions(), 6);
   VectorXd expected_limits(6);
   expected_limits << 0.0, kInf, kInf, 3.0, kInf, kInf;
   EXPECT_TRUE(
-      CompareMatrices(plant_.GetPositionLowerLimits(), -expected_limits));
+      CompareMatrices(plant_->GetPositionLowerLimits(), -expected_limits));
   EXPECT_TRUE(
-      CompareMatrices(plant_.GetPositionUpperLimits(), expected_limits));
+      CompareMatrices(plant_->GetPositionUpperLimits(), expected_limits));
   EXPECT_THAT(TakeError(),
               MatchesRegex(".*The 'range' attribute was specified.*but "
                            "'autolimits' is disabled."));
@@ -1454,9 +1477,9 @@ TEST_F(MujocoParserTest, AutoLimitsFalse) {
                            "'autolimits' is disabled."));
   EXPECT_THAT(TakeError(),
               MatchesRegex(".*The 'limited' attribute must be one of.*"));
-  EXPECT_TRUE(CompareMatrices(plant_.GetEffortLowerLimits(),
+  EXPECT_TRUE(CompareMatrices(plant_->GetEffortLowerLimits(),
                               -expected_limits.tail<5>()));
-  EXPECT_TRUE(CompareMatrices(plant_.GetEffortUpperLimits(),
+  EXPECT_TRUE(CompareMatrices(plant_->GetEffortUpperLimits(),
                               expected_limits.tail<5>()));
   EXPECT_THAT(TakeError(),
               MatchesRegex(".*The 'forcerange' attribute was specified.*but "
@@ -1506,7 +1529,7 @@ TEST_F(MujocoParserTest, GeomAutoName) {
 )""";
 
   AddModelFromString(xml, "test");
-  auto& inspector = scene_graph_.model_inspector();
+  auto& inspector = scene_graph_->model_inspector();
   auto geom_ids = inspector.GetAllGeometryIds();
   EXPECT_EQ(geom_ids.size(), 2);
   for (auto geom_id : geom_ids) {
@@ -1645,14 +1668,14 @@ TEST_F(MujocoParserTest, Motor) {
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*motor3.*forcerange.*"));
   EXPECT_THAT(TakeWarning(), MatchesRegex(".*1 value or 6 values.*gear.*"));
 
-  plant_.Finalize();
+  plant_->Finalize();
 
-  EXPECT_EQ(plant_.get_actuation_input_port().size(), 10);
+  EXPECT_EQ(plant_->get_actuation_input_port().size(), 10);
 
   JointActuatorIndex actuator_index{0};
 
   const JointActuator<double>& motor0 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(motor0.name(), "motor0");
   EXPECT_EQ(motor0.joint().name(), "hinge0");
   EXPECT_EQ(motor0.effort_limit(), std::numeric_limits<double>::infinity());
@@ -1661,25 +1684,25 @@ TEST_F(MujocoParserTest, Motor) {
   EXPECT_FALSE(motor0.has_controller());
 
   const JointActuator<double>& motor1 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(motor1.name(), "motor1");
   EXPECT_EQ(motor1.joint().name(), "hinge1");
   EXPECT_EQ(motor1.effort_limit(), 2);
 
   const JointActuator<double>& motor2 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(motor2.name(), "motor2");
   EXPECT_EQ(motor2.joint().name(), "hinge2");
   EXPECT_EQ(motor2.effort_limit(), .5);
 
   const JointActuator<double>& motor3 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(motor3.name(), "motor3");
   EXPECT_EQ(motor3.joint().name(), "hinge3");
   EXPECT_EQ(motor3.effort_limit(), std::numeric_limits<double>::infinity());
 
   const JointActuator<double>& motor4 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(motor4.name(), "motor4");
   EXPECT_EQ(motor4.joint().name(), "hinge4");
   EXPECT_EQ(motor4.effort_limit(), std::numeric_limits<double>::infinity());
@@ -1687,7 +1710,7 @@ TEST_F(MujocoParserTest, Motor) {
   EXPECT_NEAR(motor4.default_reflected_inertia(), 12, 1e-14);
 
   const JointActuator<double>& motor5 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(motor5.name(), "motor5");
   EXPECT_EQ(motor5.joint().name(), "hinge5");
   EXPECT_EQ(motor5.effort_limit(), std::numeric_limits<double>::infinity());
@@ -1698,7 +1721,7 @@ TEST_F(MujocoParserTest, Motor) {
   // parsed before all positions, despite the order in which they occur in the
   // XML.
   const JointActuator<double>& motor6 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(motor6.name(), "motor6");
   EXPECT_EQ(motor6.joint().name(), "hinge8");
   EXPECT_EQ(motor6.effort_limit(), 1);  // from the mymotors default.
@@ -1706,7 +1729,7 @@ TEST_F(MujocoParserTest, Motor) {
   // Verify that omitting kp and kd for position tag results in the MuJoCo
   // default controller gains.
   const JointActuator<double>& position0 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(position0.name(), "position0");
   EXPECT_EQ(position0.joint().name(), "hinge6");
   EXPECT_EQ(position0.effort_limit(), std::numeric_limits<double>::infinity());
@@ -1717,7 +1740,7 @@ TEST_F(MujocoParserTest, Motor) {
   // the mininum of the absolute value of the control range and the force
   // range).
   const JointActuator<double>& position1 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(position1.name(), "position1");
   EXPECT_EQ(position1.joint().name(), "hinge7");
   EXPECT_EQ(position1.effort_limit(), 0.4);
@@ -1726,11 +1749,108 @@ TEST_F(MujocoParserTest, Motor) {
 
   // Check default parsing for positions.
   const JointActuator<double>& position2 =
-      plant_.get_joint_actuator(actuator_index++);
+      plant_->get_joint_actuator(actuator_index++);
   EXPECT_EQ(position2.name(), "motor9");  // both positions and motors have
                                           // "motor{}" as the default name.
   EXPECT_EQ(position2.joint().name(), "hinge9");
   EXPECT_EQ(position2.effort_limit(), 2);  // from the mypositions default.
+}
+
+TEST_F(MujocoParserTest, Camera) {
+  std::string xml = R"""(
+<mujoco model="test">
+  <default>
+    <geom type="sphere" size="1"/>
+    <camera fovy="35"/>
+    <default class="mycameras">
+      <camera name="from_default" pos="1 2 3"/>
+    </default>
+  </default>
+  <worldbody>
+    <camera name="world_camera" fovy="30" resolution="100 100"/>
+    <body name="camera_body">
+      <camera name="body_camera" resolution="200 200"/>
+      <camera class="mycameras"/>
+      <camera/> <!-- all defaults -->
+    </body>
+  </worldbody>
+</mujoco>
+)""";
+
+  AddModelFromString(xml, "test");
+
+  auto& world_camera =
+      builder_.GetDowncastSubsystemByName<systems::sensors::RgbdSensor>(
+          "rgbd_sensor_test/world_camera");
+  systems::sensors::CameraInfo info =
+      world_camera.default_color_render_camera().core().intrinsics();
+  EXPECT_EQ(info.width(), 100);
+  EXPECT_EQ(info.height(), 100);
+  EXPECT_NEAR(info.fov_y(), 30 * M_PI / 180, 1e-14);
+
+  auto& body_camera =
+      builder_.GetDowncastSubsystemByName<systems::sensors::RgbdSensor>(
+          "rgbd_sensor_test/body_camera");
+  info = body_camera.default_color_render_camera().core().intrinsics();
+  EXPECT_EQ(info.width(), 200);
+  EXPECT_EQ(info.height(), 200);
+  EXPECT_NEAR(info.fov_y(), 35 * M_PI / 180, 1e-14);  // from "main" default.
+
+  auto& from_default =
+      builder_.GetDowncastSubsystemByName<systems::sensors::RgbdSensor>(
+          "rgbd_sensor_test/from_default");
+  info = from_default.default_color_render_camera().core().intrinsics();
+  EXPECT_EQ(info.width(), 640);
+  EXPECT_EQ(info.height(), 480);
+  const math::RigidTransformd& X_PB = from_default.default_X_PB();
+  EXPECT_EQ(X_PB.translation(), Vector3d(1, 2, 3));
+
+  // Check that camera{} naming works.
+  auto& camera3 =
+      builder_.GetDowncastSubsystemByName<systems::sensors::RgbdSensor>(
+          "rgbd_sensor_test/camera3");
+  info = camera3.default_color_render_camera().core().intrinsics();
+  EXPECT_NEAR(info.fov_y(), 35 * M_PI / 180, 1e-14);  // from "main" default.
+}
+
+// Test to make sure that the camera parsing only adds a single RgbdSensor to
+// the diagram.
+TEST_F(MujocoParserTest, OnlyOneCamera) {
+  std::string xml = R"""(
+<mujoco model="test">
+  <worldbody>
+    <camera name="world_camera" fovy="30" resolution="100 100"/>
+  </worldbody>
+</mujoco>
+)""";
+
+  AddModelFromString(xml, "test");
+
+  auto systems = builder_.GetSystems();
+  EXPECT_EQ(systems.size(), 3);
+  for (const auto& system : systems) {
+    EXPECT_THAT(system->get_name(),
+                testing::AnyOf("plant", "scene_graph",
+                               "rgbd_sensor_test/world_camera"));
+  }
+}
+
+TEST_F(MujocoParserTest, CameraWithoutSceneGraph) {
+  std::string xml = R"""(
+<mujoco model="test">
+  <default>
+    <geom type="sphere" size="1"/>
+  </default>
+  <worldbody>
+    <camera name="world_camera" fovy="30" resolution="100 100"/>
+  </worldbody>
+</mujoco>
+)""";
+
+  RemoveSceneGraph();
+  AddModelFromString(xml, "test");
+  EXPECT_THAT(TakeWarning(),
+              MatchesRegex(".*camera element ignored.*scene graph.*"));
 }
 
 class ContactTest : public MujocoParserTest,
@@ -1769,20 +1889,21 @@ TEST_P(ContactTest, Contact) {
   )""";
 
   std::string xml = fmt::format(xml_base, include_contact ? contact_node : "");
-  plant_.set_adjacent_bodies_collision_filters(
+  plant_->set_adjacent_bodies_collision_filters(
       adjacent_bodies_collision_filters);
   AddModelFromString(xml, "test");
-  plant_.Finalize();
+  plant_->Finalize();
 
-  const SceneGraphInspector<double>& inspector = scene_graph_.model_inspector();
+  const SceneGraphInspector<double>& inspector =
+      scene_graph_->model_inspector();
   GeometryId base_geom = inspector.GetGeometries(
-      plant_.GetBodyFrameIdOrThrow(plant_.GetBodyByName("base").index()),
+      plant_->GetBodyFrameIdOrThrow(plant_->GetBodyByName("base").index()),
       geometry::Role::kProximity)[0];
   GeometryId body1_geom = inspector.GetGeometries(
-      plant_.GetBodyFrameIdOrThrow(plant_.GetBodyByName("body1").index()),
+      plant_->GetBodyFrameIdOrThrow(plant_->GetBodyByName("body1").index()),
       geometry::Role::kProximity)[0];
   GeometryId body2_geom = inspector.GetGeometries(
-      plant_.GetBodyFrameIdOrThrow(plant_.GetBodyByName("body2").index()),
+      plant_->GetBodyFrameIdOrThrow(plant_->GetBodyByName("body2").index()),
       geometry::Role::kProximity)[0];
   if (include_contact) {
     if (adjacent_bodies_collision_filters) {
@@ -1905,19 +2026,20 @@ TEST_F(MujocoParserTest, EqualityTest) {
 </mujoco>
 )""";
 
-  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  plant_->set_discrete_contact_approximation(
+      DiscreteContactApproximation::kSap);
   AddModelFromString(xml, "test");
-  const auto constraint_ids = plant_.GetConstraintIds();
-  const auto& spec1 = plant_.get_ball_constraint_specs(constraint_ids[0]);
-  const auto& spec2 = plant_.get_ball_constraint_specs(constraint_ids[1]);
+  const auto constraint_ids = plant_->GetConstraintIds();
+  const auto& spec1 = plant_->get_ball_constraint_specs(constraint_ids[0]);
+  const auto& spec2 = plant_->get_ball_constraint_specs(constraint_ids[1]);
   EXPECT_EQ(constraint_ids.size(), 2);
   EXPECT_FALSE(spec1.p_BQ.has_value());
   EXPECT_FALSE(spec2.p_BQ.has_value());
 
-  plant_.Finalize();
+  plant_->Finalize();
 
-  EXPECT_EQ(spec1.body_A, plant_.GetBodyByName("body1").index());
-  EXPECT_EQ(spec1.body_B, plant_.GetBodyByName("body2").index());
+  EXPECT_EQ(spec1.body_A, plant_->GetBodyByName("body1").index());
+  EXPECT_EQ(spec1.body_B, plant_->GetBodyByName("body2").index());
   Vector3d p_AP(1, 2, 3);
   EXPECT_TRUE(CompareMatrices(spec1.p_AP, p_AP));
   RigidTransformd X_WA(Vector3d(-1, 0, 0)), X_WB(Vector3d(1, 0, 0));
@@ -1925,9 +2047,9 @@ TEST_F(MujocoParserTest, EqualityTest) {
   ASSERT_TRUE(spec1.p_BQ.has_value());
   EXPECT_TRUE(CompareMatrices(spec1.p_BQ.value(), p_BQ, 1e-14));
 
-  auto context = plant_.CreateDefaultContext();
-  EXPECT_EQ(spec2.body_A, plant_.GetBodyByName("body1").index());
-  EXPECT_EQ(spec2.body_B, plant_.world_body().index());
+  auto context = plant_->CreateDefaultContext();
+  EXPECT_EQ(spec2.body_A, plant_->GetBodyByName("body1").index());
+  EXPECT_EQ(spec2.body_B, plant_->world_body().index());
   p_AP = Vector3d(4, 5, 6);
   EXPECT_TRUE(CompareMatrices(spec2.p_AP, p_AP));
   Vector3d p_WQ = X_WA * p_AP;
@@ -1959,7 +2081,8 @@ TEST_F(MujocoParserTest, BadEqualityTest) {
 </mujoco>
 )""";
 
-  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  plant_->set_discrete_contact_approximation(
+      DiscreteContactApproximation::kSap);
   AddModelFromString(xml, "test");
   EXPECT_THAT(TakeError(), MatchesRegex(".*anchor.*"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*body1.*anchor.*site1.*site2.*"));
@@ -1967,7 +2090,7 @@ TEST_F(MujocoParserTest, BadEqualityTest) {
   EXPECT_THAT(TakeError(), MatchesRegex(".*body1.*site1.*"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*body1.*nonsense.*"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*body2.*nonsense.*"));
-  const auto constraint_ids = plant_.GetConstraintIds();
+  const auto constraint_ids = plant_->GetConstraintIds();
   EXPECT_EQ(constraint_ids.size(), 0);
 }
 

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -99,7 +99,7 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, nullptr,
                        &plant_,  &resolver,    TestingSelect};
     std::optional<ModelInstanceIndex> result =
         AddModelFromSdf(data_source, model_name, parent_model_name, w);
@@ -114,7 +114,7 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kFilename, &file_name};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, nullptr,
                        &plant_,  &resolver,    TestingSelect};
     auto result = AddModelsFromSdf(data_source, parent_model_name, w);
     last_parsed_groups_ = ConvertInstancedNamesToStrings(
@@ -127,7 +127,7 @@ class SdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::optional<std::string>& parent_model_name = {}) {
     const DataSource data_source{DataSource::kContents, &file_contents};
     internal::CollisionFilterGroupResolver resolver{&plant_};
-    ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+    ParsingWorkspace w{options_, package_map_, diagnostic_policy_, nullptr,
                        &plant_,  &resolver,    TestingSelect};
     auto result = AddModelsFromSdf(data_source, parent_model_name, w);
     last_parsed_groups_ = ConvertInstancedNamesToStrings(
@@ -1296,7 +1296,7 @@ TEST_F(SdfParserTest, AddModelFromSdfNoModelError) {
 
   const DataSource data_source{DataSource::kContents, &sdf_string};
   internal::CollisionFilterGroupResolver resolver{&plant_};
-  ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+  ParsingWorkspace w{options_, package_map_, diagnostic_policy_, nullptr,
                      &plant_,  &resolver,    TestingSelect};
   std::optional<ModelInstanceIndex> result =
       AddModelFromSdf(data_source, "", "", w);
@@ -3750,7 +3750,7 @@ TEST_F(SdfParserTest, TestSingleModelEnforcement) {
 
   const DataSource data_source{DataSource::kContents, &multi_models};
   internal::CollisionFilterGroupResolver resolver{&plant_};
-  ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
+  ParsingWorkspace w{options_, package_map_, diagnostic_policy_, nullptr,
                      &plant_,  &resolver,    TestingSelect};
   std::optional<ModelInstanceIndex> result =
       AddModelFromSdf(data_source, "", {}, w);

--- a/multibody/parsing/test/detail_select_parser_test.cc
+++ b/multibody/parsing/test/detail_select_parser_test.cc
@@ -17,7 +17,7 @@ class SelectParserTest : public test::DiagnosticPolicyTestBase {
   MultibodyPlant<double> plant_{0.0};
   CollisionFilterGroupResolver resolver_{&plant_};
   ParsingOptions options_;
-  ParsingWorkspace w_{options_, {},         diagnostic_policy_,
+  ParsingWorkspace w_{options_, {},         diagnostic_policy_, nullptr,
                       &plant_,  &resolver_, SelectParser};
 };
 

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -61,7 +61,8 @@ class UrdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_name, const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                       &plant_,  &resolver,    NoSelect};
+                       nullptr,  &plant_,      &resolver,
+                       NoSelect};
     auto result = AddModelFromUrdf({DataSource::kFilename, &file_name},
                                    model_name, {}, w);
     last_parsed_groups_ = ConvertInstancedNamesToStrings(
@@ -73,7 +74,8 @@ class UrdfParserTest : public test::DiagnosticPolicyTestBase {
       const std::string& file_contents, const std::string& model_name) {
     internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                       &plant_,  &resolver,    NoSelect};
+                       nullptr,  &plant_,      &resolver,
+                       NoSelect};
     auto result = AddModelFromUrdf({DataSource::kContents, &file_contents},
                                    model_name, {}, w);
     last_parsed_groups_ = ConvertInstancedNamesToStrings(

--- a/multibody/parsing/test/detail_usd_parser_test.cc
+++ b/multibody/parsing/test/detail_usd_parser_test.cc
@@ -24,7 +24,8 @@ class UsdParserTest : public test::DiagnosticPolicyTestBase {
     const std::optional<std::string> parent_model_name;
     internal::CollisionFilterGroupResolver resolver{&plant_};
     ParsingWorkspace w{options_, package_map_, diagnostic_policy_,
-                       &plant_,  &resolver,    NoSelect};
+                       nullptr,  &plant_,      &resolver,
+                       NoSelect};
     UsdParserWrapper dut;
     auto result = dut.AddAllModels(source, parent_model_name, w);
     resolver.Resolve(diagnostic_policy_);

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -9,6 +9,7 @@
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/plant/multibody_plant_config_functions.h"
+#include "drake/planning/robot_diagram_builder.h"
 
 namespace drake {
 namespace multibody {
@@ -34,6 +35,7 @@ GTEST_TEST(FileParserTest, BasicTest) {
     Parser dut(&plant);
     EXPECT_EQ(&dut.plant(), &plant);
     EXPECT_EQ(dut.scene_graph(), nullptr);
+    EXPECT_EQ(dut.builder(), nullptr);
     EXPECT_EQ(dut.AddModels(sdf_name).size(), 1);
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(sdf_name);
     EXPECT_EQ(prefix_ids.size(), 1);
@@ -48,6 +50,7 @@ GTEST_TEST(FileParserTest, BasicTest) {
     Parser dut(&plant, &scene_graph);
     EXPECT_EQ(&dut.plant(), &plant);
     EXPECT_EQ(dut.scene_graph(), &scene_graph);
+    EXPECT_EQ(dut.builder(), nullptr);
     EXPECT_EQ(dut.AddModels(urdf_name).size(), 1);
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(urdf_name);
     EXPECT_EQ(prefix_ids.size(), 1);
@@ -95,6 +98,73 @@ GTEST_TEST(FileParserTest, BasicTest) {
     const auto prefix_ids = Parser(&plant, "prefix").AddModels(obj_name);
     EXPECT_EQ(prefix_ids.size(), 1);
     EXPECT_EQ(plant.GetModelInstanceName(prefix_ids[0]), "prefix::box");
+  }
+}
+
+GTEST_TEST(FileParserTest, BuilderTest) {
+  const std::string sdf_name =
+      FindResourceOrThrow("drake/multibody/benchmarks/acrobot/acrobot.sdf");
+
+  {  // Pass the builder only (using RobotDiagramBuilder).
+    planning::RobotDiagramBuilder<double> builder(0.0);
+    Parser dut(&builder.builder());
+    EXPECT_EQ(dut.builder(), &builder.builder());
+    EXPECT_EQ(&dut.plant(), &builder.plant());
+    EXPECT_EQ(dut.scene_graph(), &builder.scene_graph());
+    auto ids = dut.AddModels(sdf_name);
+    EXPECT_EQ(ids.size(), 1);
+    EXPECT_EQ(builder.plant().GetModelInstanceName(ids[0]), "acrobot");
+  }
+
+  {  // Pass the builder only (the Diagram has only the plant).
+    systems::DiagramBuilder<double> builder;
+    auto plant = builder.AddSystem<MultibodyPlant<double>>(0.0);
+    plant->set_name("plant");
+    Parser dut(&builder);
+    EXPECT_EQ(dut.builder(), &builder);
+    EXPECT_EQ(&dut.plant(), plant);
+    EXPECT_EQ(dut.scene_graph(), nullptr);
+    auto ids = dut.AddModels(sdf_name);
+    EXPECT_EQ(ids.size(), 1);
+    EXPECT_EQ(plant->GetModelInstanceName(ids[0]), "acrobot");
+  }
+
+  {  // The Diagram has a plant named "random", but no SceneGraph. Passing just
+     // the builder fails but if we pass the plant pointer it succeeds.
+    systems::DiagramBuilder<double> builder;
+    auto plant = builder.AddSystem<MultibodyPlant<double>>(0.0);
+    plant->set_name("random");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Parser(&builder),
+        "DiagramBuilder does not contain a subsystem named plant.*");
+    Parser dut(&builder, plant);
+    EXPECT_EQ(dut.builder(), &builder);
+    EXPECT_EQ(&dut.plant(), plant);
+    EXPECT_EQ(dut.scene_graph(), nullptr);
+    auto ids = dut.AddModels(sdf_name);
+    EXPECT_EQ(ids.size(), 1);
+    EXPECT_EQ(plant->GetModelInstanceName(ids[0]), "acrobot");
+  }
+
+  {  // The Diagram has a plant and scene_graph with non-default names. Passing
+     // just the builder and scene_graph fails but if we pass the plant pointer
+     // it succeeds.
+    systems::DiagramBuilder<double> builder;
+    auto plant = builder.AddSystem<MultibodyPlant<double>>(0.0);
+    auto scene_graph = builder.AddSystem<geometry::SceneGraph<double>>();
+    plant->set_name("random");
+    scene_graph->set_name("arbitrary");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Parser(&builder, nullptr, scene_graph),
+        "DiagramBuilder does not contain a subsystem named plant.*");
+    Parser dut(&builder, plant, scene_graph);
+    EXPECT_EQ(dut.builder(), &builder);
+    EXPECT_EQ(&dut.plant(), plant);
+    EXPECT_EQ(dut.scene_graph(), scene_graph);
+    EXPECT_EQ(plant->geometry_source_is_registered(), true);
+    auto ids = dut.AddModels(sdf_name);
+    EXPECT_EQ(ids.size(), 1);
+    EXPECT_EQ(plant->GetModelInstanceName(ids[0]), "acrobot");
   }
 }
 


### PR DESCRIPTION
Generalizes Parser() to take a DiagramBuilder, and uses this in the mujoco parser to add an RgbdSensor.

@jwnimmer-tri , @rpoyner-tri -- here is one concrete proposal on how we can parse ≫ MultibodyPlant from mujoco.  It was cleaner than I thought it might be... it means multibody/parsing gets new dependencies on systems/sensors , but multibody already depends on systems (the order is reasonable). 

The alternative I had considered was having two parsing entry points, one for multibodyplant related elements, and the other for diagram-related elements. But I do think this is better.

WDYT?  Should I continue and clean it up?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22531)
<!-- Reviewable:end -->
