### PR TITLE
Desired state input ports are no longer required to be connected

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
         ":contact_results",
         ":coulomb_friction",
         ":deformable_ids",
+        ":desired_state_input",
         ":discrete_contact_data",
         ":discrete_contact_pair",
         ":externally_applied_spatial_force",
@@ -128,6 +129,7 @@ drake_cc_library(
         ":contact_results",
         ":coulomb_friction",
         ":deformable_ids",
+        ":desired_state_input",
         ":discrete_contact_data",
         ":discrete_contact_pair",
         ":externally_applied_spatial_force",
@@ -281,6 +283,20 @@ drake_cc_library(
     ],
     deps = [
         "//common:identifier",
+    ],
+)
+
+drake_cc_library(
+    name = "desired_state_input",
+    srcs = [
+        "desired_state_input.cc",
+    ],
+    hdrs = [
+        "desired_state_input.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//multibody/tree:multibody_tree_indexes",
     ],
 )
 

--- a/multibody/plant/desired_state_input.cc
+++ b/multibody/plant/desired_state_input.cc
@@ -1,0 +1,36 @@
+#include "drake/multibody/plant/desired_state_input.h"
+
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+DesiredStateInput<T>::DesiredStateInput(int num_model_instances) {
+  DRAKE_DEMAND(num_model_instances > 0);
+  positions_.resize(num_model_instances);
+  velocities_.resize(num_model_instances);
+}
+
+template <typename T>
+DesiredStateInput<T>::~DesiredStateInput() = default;
+
+template <typename T>
+void DesiredStateInput<T>::SetModelInstanceDesiredStates(
+    ModelInstanceIndex model_instance, const Eigen::Ref<const VectorX<T>>& qd,
+    const Eigen::Ref<const VectorX<T>>& vd) {
+  DRAKE_DEMAND(model_instance < num_model_instances());
+  DRAKE_DEMAND(qd.size() == vd.size());
+  positions_[model_instance] = qd;
+  velocities_[model_instance] = vd;
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::DesiredStateInput);

--- a/multibody/plant/desired_state_input.h
+++ b/multibody/plant/desired_state_input.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* This class stores the desired state inputs for all model instances.
+
+ Desired states for a given model instance are stored with calls to
+ SetModelInstanceDesiredStates(). Model instances with desired states are marked
+ as "armed", see is_armed().
+
+ This class is the result of MultibodyPlant::AssembleDesiredStateInput().
+ See also @ref pd_controllers_and_ports for further details.
+
+ @tparam_default_scalar */
+template <typename T>
+class DesiredStateInput {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DesiredStateInput);
+
+  /* Constructor for the desired states of `num_model_instances`. */
+  explicit DesiredStateInput(int num_model_instances);
+
+  ~DesiredStateInput();
+
+  int num_model_instances() const { return positions_.size(); }
+
+  /* Sets `this` class to store the desired positions `qd` and velocities `vd`
+   for the given `model_instance`. Subsequent calls to is_armed() for the given
+   model instance will return `true`.
+   @pre model_instance < num_model_instances()
+   @pre qd and vd have size equal to the number of actuators in
+   `model_instance`. MultibodyPlant::AssembleDesiredStateInput() will evaluate
+   the desired state input state ports for each model instance and store the
+   result for each model instance in a DesiredStateInput. */
+  void SetModelInstanceDesiredStates(ModelInstanceIndex model_instance,
+                                     const Eigen::Ref<const VectorX<T>>& qd,
+                                     const Eigen::Ref<const VectorX<T>>& vd);
+
+  /* Returns `true` if `model_instance` is armed.
+   @pre model_instance < num_model_instances() */
+  bool is_armed(ModelInstanceIndex model_instance) const {
+    DRAKE_DEMAND(model_instance < num_model_instances());
+    return positions_[model_instance].has_value();
+  }
+
+  /* Returns the desired positions for `model_instance`.
+   @pre is_armed(model_instance) is `true`. */
+  const VectorX<T>& positions(ModelInstanceIndex model_instance) const {
+    DRAKE_DEMAND(is_armed(model_instance));
+    return *positions_[model_instance];
+  }
+
+  /* Returns the desired velocities for `model_instance`.
+   @pre is_armed(model_instance) is `true`. */
+  const VectorX<T>& velocities(ModelInstanceIndex model_instance) const {
+    DRAKE_DEMAND(is_armed(model_instance));
+    return *velocities_[model_instance];
+  }
+
+ private:
+  std::vector<std::optional<VectorX<T>>> positions_;
+  std::vector<std::optional<VectorX<T>>> velocities_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::DesiredStateInput);

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -280,7 +280,7 @@ VectorX<T> DiscreteUpdateManager<T>::AssembleActuationInput(
 }
 
 template <typename T>
-VectorX<T> DiscreteUpdateManager<T>::AssembleDesiredStateInput(
+DesiredStateInput<T> DiscreteUpdateManager<T>::AssembleDesiredStateInput(
     const systems::Context<T>& context) const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<
       T>::AssembleDesiredStateInput(plant(), context);

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -17,6 +17,7 @@
 #include "drake/multibody/plant/coulomb_friction.h"
 #include "drake/multibody/plant/deformable_driver.h"
 #include "drake/multibody/plant/deformable_model.h"
+#include "drake/multibody/plant/desired_state_input.h"
 #include "drake/multibody/plant/discrete_contact_data.h"
 #include "drake/multibody/plant/discrete_contact_pair.h"
 #include "drake/multibody/plant/discrete_step_memory.h"
@@ -313,7 +314,7 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
   VectorX<T> AssembleActuationInput(const systems::Context<T>& context) const;
 
-  VectorX<T> AssembleDesiredStateInput(
+  DesiredStateInput<T> AssembleDesiredStateInput(
       const systems::Context<T>& context) const;
 
   const std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -278,22 +278,6 @@ bool AnyActuatorHasPdControl(const MultibodyPlant<T>& plant) {
   return false;
 }
 
-// Helper that computes the number of PD controlled actuators in a given model
-// instance.
-template <typename T>
-int NumOfPdControlledActuators(const MultibodyPlant<T>& plant,
-                               ModelInstanceIndex model_instance) {
-  int num_actuators = 0;
-  for (JointActuatorIndex a : plant.GetJointActuatorIndices()) {
-    const JointActuator<T>& actuator = plant.get_joint_actuator(a);
-    if (actuator.model_instance() == model_instance &&
-        actuator.has_controller()) {
-      ++num_actuators;
-    }
-  }
-  return num_actuators;
-}
-
 // Retrieves the DiscreteStepMemory pointer from state in the given `context`.
 // If there is no memory (e.g., has never been updated by a step), returns null.
 // @pre The context is from a plant with use_sampled_output_ports() == true.
@@ -2695,63 +2679,61 @@ void MultibodyPlant<T>::CalcInstanceNetActuationOutput(
 }
 
 template <typename T>
-VectorX<T> MultibodyPlant<T>::AssembleDesiredStateInput(
+internal::DesiredStateInput<T> MultibodyPlant<T>::AssembleDesiredStateInput(
     const systems::Context<T>& context) const {
   this->ValidateContext(context);
 
+  // Checks if desired state x for model_instance has NaNs. Only entries
+  // corresponding to PD-controlled actuators on non-locked joints are checked
+  // and otherwise ignored.
+  auto has_nans_unless_ignored = [&](ModelInstanceIndex model_instance,
+                                     const VectorX<T>& x) -> bool {
+    using std::isnan;
+    const int nu = num_actuators(model_instance);
+    DRAKE_DEMAND(x.size() == 2 * nu);
+    const auto q = x.head(nu);
+    const auto v = x.tail(nu);
+    int a = 0;  // Actuator index local to its model-instance.
+    for (JointActuatorIndex actuator_index :
+         GetJointActuatorIndices(model_instance)) {
+      const JointActuator<T>& actuator = get_joint_actuator(actuator_index);
+      const bool is_locked = actuator.joint().is_locked(context);
+      if (actuator.has_controller() && !is_locked) {
+        if (isnan(q[a]) || isnan(v[a])) return true;
+      }
+      ++a;
+    }
+    return false;
+  };
+
   // Assemble the vector from the model instance input ports.
   // TODO(amcastro-tri): Heap allocation here. Get rid of it. Make it EvalFoo().
-  // Desired states of size 2 * num_actuators() for the full model packed as xd
-  // = [qd, vd].
-  VectorX<T> xd = VectorX<T>::Zero(2 * num_actuated_dofs());
-  auto qd = xd.head(num_actuated_dofs());
-  auto vd = xd.tail(num_actuated_dofs());
+  internal::DesiredStateInput<T> desired_states(num_model_instances());
 
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     // Ignore the port if the model instance has no actuated DoFs.
     const int instance_num_u = num_actuated_dofs(model_instance_index);
-    const int instance_num_xd = 2 * instance_num_u;
-    if (instance_num_xd == 0) continue;
+    if (instance_num_u == 0) continue;
 
     const auto& xd_input_port =
         this->get_desired_state_input_port(model_instance_index);
-
-    const int num_pd_controlled_actuators =
-        NumOfPdControlledActuators(*this, model_instance_index);
-    DRAKE_DEMAND(num_pd_controlled_actuators <= instance_num_u);
-
-    // Desired states input port is ignored for models without PD controllers.
-    if (num_pd_controlled_actuators == instance_num_u) {
-      if (xd_input_port.HasValue(context)) {
-        const auto& xd_instance = xd_input_port.Eval(context);
-        if (xd_instance.hasNaN()) {
-          throw std::runtime_error(
-              fmt::format("Desired state input port for model "
-                          "instance {} contains NaN.",
-                          GetModelInstanceName(model_instance_index)));
-        }
-        const auto qd_instance = xd_instance.head(instance_num_u);
-        SetActuationInArray(model_instance_index, qd_instance, &qd);
-        const auto vd_instance = xd_instance.tail(instance_num_u);
-        SetActuationInArray(model_instance_index, vd_instance, &vd);
-      } else {
+    if (xd_input_port.HasValue(context)) {
+      const auto& xd_instance = xd_input_port.Eval(context);
+      if (has_nans_unless_ignored(model_instance_index, xd_instance)) {
         throw std::runtime_error(
             fmt::format("Desired state input port for model "
-                        "instance {} not connected.",
+                        "instance {} contains NaN.",
                         GetModelInstanceName(model_instance_index)));
       }
-    } else if (0 < num_pd_controlled_actuators &&
-               num_pd_controlled_actuators < instance_num_u) {
-      // Partially controlled model. Not supported.
-      throw std::runtime_error(fmt::format(
-          "Model {} is partially PD controlled. For PD controlling a model "
-          "instance, all of its actuators must have gains defined.",
-          GetModelInstanceName(model_instance_index)));
+      const auto qd = xd_instance.head(instance_num_u);
+      const auto vd = xd_instance.tail(instance_num_u);
+      desired_states.SetModelInstanceDesiredStates(model_instance_index, qd,
+                                                   vd);
     }
   }
 
-  return xd;
+  return desired_states;
 }
 
 template <typename T>
@@ -3260,7 +3242,7 @@ void MultibodyPlant<T>::DeclareInputPorts() {
     // Input "{model_instance_name}_actuation".
     // Actuators can only be defined on single-dof joints. Therefore the number
     // of desired states per instance is twice the number of actuators.
-    const int instance_num_xd = 2 * NumOfPdControlledActuators(*this, i);
+    const int instance_num_xd = 2 * num_actuators(i);
     input_port_indices_.instance[i].desired_state =
         this->DeclareVectorInputPort(
                 fmt::format("{}_desired_state", model_instance_name),

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -83,7 +83,7 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.AssembleActuationInput(context);
   }
 
-  static VectorX<T> AssembleDesiredStateInput(
+  static DesiredStateInput<T> AssembleDesiredStateInput(
       const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
     return plant.AssembleDesiredStateInput(context);
   }

--- a/multibody/plant/test/actuated_models_test.cc
+++ b/multibody/plant/test/actuated_models_test.cc
@@ -33,8 +33,8 @@ class MultibodyPlantTester {
     return plant.AssembleActuationInput(context);
   }
 
-  static VectorXd AssembleDesiredStateInput(const MultibodyPlant<double>& plant,
-                                            const Context<double>& context) {
+  static internal::DesiredStateInput<double> AssembleDesiredStateInput(
+      const MultibodyPlant<double>& plant, const Context<double>& context) {
     return plant.AssembleDesiredStateInput(context);
   }
 };
@@ -46,13 +46,18 @@ namespace {
 class ActuatedIiwaArmTest : public ::testing::Test {
  public:
   // Enum to control the PD model for ther kuka arm and its gripper.
+  // Unless otherwise stated, the gripper has PD control.
   // This does not affect the acrobot model, which has no PD controllers.
   enum class ModelConfiguration {
     // None of the models have PD controllers.
     kNoPdControl,
+    // Arm is fully PD controlled.
     kArmIsControlled,
+    // Arm has no PD control.
     kArmIsNotControlled,
+    // Arm has PD control in only two of its joints.
     kArmIsPartiallyControlled,
+    // Both arm and gripper have zero gains controllers.
     kModelWithZeroGains,
   };
 
@@ -341,6 +346,7 @@ TEST_F(ActuatedIiwaArmTest, JointActuatorApis) {
   }
 }
 
+// We verify basic port size invariants.
 TEST_F(ActuatedIiwaArmTest, GetActuationInputPort) {
   SetUpModel();
 
@@ -359,19 +365,45 @@ TEST_F(ActuatedIiwaArmTest, GetActuationInputPort) {
       "num_model_instances\\(\\)' failed.");
 }
 
+/* Unit tests internal:: class to store desired states. */
+GTEST_TEST(DesiredStateInput, DesiredStateInputTest) {
+  internal::DesiredStateInput<double> xd(5);
+  const Vector3<double> q1(1.0, 2.0, 3.0);
+  const Vector3<double> v1(4.0, 5.0, 6.0);
+  xd.SetModelInstanceDesiredStates(ModelInstanceIndex(1), q1, v1);
+
+  const Vector2<double> q3(1.0, 2.0);
+  const Vector2<double> v3(3.0, 4.0);
+  xd.SetModelInstanceDesiredStates(ModelInstanceIndex(3), q3, v3);
+
+  EXPECT_EQ(xd.num_model_instances(), 5);
+  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(0)));
+  EXPECT_TRUE(xd.is_armed(ModelInstanceIndex(1)));
+  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(2)));
+  EXPECT_TRUE(xd.is_armed(ModelInstanceIndex(3)));
+  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(4)));
+
+  EXPECT_EQ(xd.positions(ModelInstanceIndex(1)), q1);
+  EXPECT_EQ(xd.velocities(ModelInstanceIndex(1)), v1);
+  EXPECT_EQ(xd.positions(ModelInstanceIndex(3)), q3);
+  EXPECT_EQ(xd.velocities(ModelInstanceIndex(3)), v3);
+}
+
+// We verify basic port size invariants for a model in which only a subset of
+// the arm's actuators are PD controlled.
 TEST_F(ActuatedIiwaArmTest, GetDesiredStatePort) {
-  SetUpModel(ModelConfiguration::kArmIsNotControlled);
+  SetUpModel(ModelConfiguration::kArmIsPartiallyControlled);
 
-  EXPECT_NO_THROW(plant_->get_desired_state_input_port(arm_model_));
-  EXPECT_NO_THROW(plant_->get_desired_state_input_port(gripper_model_));
-
-  // For consistency with actuation input ports, all model instances have a
-  // desired state input port. If the model instance has no PD controllers, this
-  // port will have zero size.
+  // Whether PD-controlled or not, all desired state input ports have size
+  // num_actuators(model_instance).
   EXPECT_EQ(plant_->get_desired_state_input_port(arm_model_).size(),
-            0);  // The arm is not PD controlled.
+            2 * plant_->num_actuators(arm_model_));
+  EXPECT_EQ(plant_->get_desired_state_input_port(gripper_model_).size(),
+            2 * plant_->num_actuators(gripper_model_));
+  EXPECT_EQ(plant_->get_desired_state_input_port(acrobot_model_).size(),
+            2 * plant_->num_actuators(acrobot_model_));
   EXPECT_EQ(plant_->get_desired_state_input_port(box_model_).size(),
-            0);  // The free floating box has no actuators.
+            2 * plant_->num_actuators(box_model_));
 
   // Invalid model index throws.
   const ModelInstanceIndex invalid_index(plant_->num_model_instances() + 10);
@@ -415,34 +447,27 @@ TEST_F(ActuatedIiwaArmTest, AssembleActuationInput) {
   EXPECT_EQ(full_u, expected_u);
 }
 
-// Verify that MultibodyPlant::AssembleDesiredStateInput() throws an exception
-// when not all actuators in a model instance are PD controlled. Once a PD
-// controller is defined in a model instance, all actuators must use PD control.
+// We build an a model containing a fully PD-actuated gripper and an iiwa arm
+// with only a subset of its joints PD-controlled.
 TEST_F(ActuatedIiwaArmTest,
-       AssembleDesiredStateInput_ThrowsIfPartiallyPDControlled) {
+       AssembleDesiredStateInput_PartiallyPdControlledModelsAreAllowed) {
+  // We build an IIWA model with only a subset of actuators having PD control.
   SetUpModel(ModelConfiguration::kArmIsPartiallyControlled);
 
-  // The gripper has controllers in all of its actuators and thus it is required
-  // to be connected.
-  plant_->get_desired_state_input_port(gripper_model_)
-      .FixValue(context_.get(), VectorXd::Zero(2 * kGripperNumPositions_));
+  // Desired state for the arm.
+  const VectorXd arm_xd =
+      VectorXd::LinSpaced(2 * kKukaNumPositions_, 1.0, 14.0);
+  plant_->get_desired_state_input_port(arm_model_)
+      .FixValue(context_.get(), arm_xd);
 
-  // We now verify AssembleDesiredStateInput() throws for the right reason.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_),
-      "Model iiwa7 is partially PD controlled. .*");
-}
-
-TEST_F(ActuatedIiwaArmTest,
-       AssembleDesiredStateInput_ThrowsIfDesiredStateNotConnected) {
-  SetUpModel();
-
-  // The input port for desired states for the gripper is required to be
-  // connected.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_),
-      "Desired state input port for model instance Schunk_Gripper not "
-      "connected.");
+  // Verify input assembly.
+  const internal::DesiredStateInput<double> input =
+      MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_);
+  EXPECT_EQ(input.num_model_instances(), plant_->num_model_instances());
+  EXPECT_TRUE(input.is_armed(arm_model_));
+  EXPECT_FALSE(input.is_armed(gripper_model_));
+  EXPECT_EQ(input.positions(arm_model_), arm_xd.head(kKukaNumPositions_));
+  EXPECT_EQ(input.velocities(arm_model_), arm_xd.tail(kKukaNumPositions_));
 }
 
 // Verify the assembly of desired states for a plant with a single PD controlled
@@ -454,31 +479,19 @@ TEST_F(ActuatedIiwaArmTest,
   const VectorXd gripper_xd = (VectorXd(4) << 1.0, 2.0, 3.0, 4.0).finished();
   plant_->get_desired_state_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_xd);
-  const VectorXd full_xd =
+  const internal::DesiredStateInput<double> input =
       MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_);
 
-  const int nu = plant_->num_actuated_dofs();
-  // AssembleDesiredStateInput will always return a vector of size 2 * nu. It
-  // fills in values for those models with PD control and set all other entries
-  // to zero. In this case, entries corresponding to the arm are expected to be
-  // zero. All qd values go first, followed by vd values.
-  const int arm_nu = plant_->num_actuated_dofs(arm_model_);
-  // clang-format off
-  VectorXd expected_xd =
-      (VectorXd(2 * nu) <<
-        // Desired positions.
-        VectorXd::Zero(arm_nu),
-        0.0, /* Acrobot shoulder */
-        gripper_xd.head<2>(),
-        0.0, /* Acrobot elbow */
-        // Desired velocities.
-        VectorXd::Zero(arm_nu),
-        0.0, /* Acrobot shoulder */
-        gripper_xd.tail<2>(),
-        0.0 /* Acrobot elbow */).finished();
-  // clang-format on
+  // Only the gripper model is "armed".
+  EXPECT_EQ(input.num_model_instances(), plant_->num_model_instances());
+  EXPECT_FALSE(input.is_armed(acrobot_model_));
+  EXPECT_FALSE(input.is_armed(arm_model_));
+  EXPECT_TRUE(input.is_armed(gripper_model_));
+  EXPECT_FALSE(input.is_armed(box_model_));
 
-  EXPECT_EQ(full_xd, expected_xd);
+  // Verify desired states for the only model that is armed.
+  EXPECT_EQ(input.positions(gripper_model_), gripper_xd.head(2));
+  EXPECT_EQ(input.velocities(gripper_model_), gripper_xd.tail(2));
 }
 
 // Verify the assembly of desired states for a plant with two PD controlled
@@ -487,37 +500,106 @@ TEST_F(ActuatedIiwaArmTest,
        AssembleDesiredStateInput_VerifyAssemblyWithTwoModels) {
   SetUpModel(ModelConfiguration::kArmIsControlled);
 
-  // Fixed desired state input ports to known values.
-  // Both arm and gripper are required to be connected.
+  // Fixed desired state for the gripper.
   const VectorXd gripper_xd = (VectorXd(4) << 1.0, 2.0, 3.0, 4.0).finished();
   plant_->get_desired_state_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_xd);
+
+  // We provided no desired state for the arm, and it is therefore "disarmed".
+  {
+    const internal::DesiredStateInput<double> input =
+        MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_);
+
+    EXPECT_EQ(input.num_model_instances(), plant_->num_model_instances());
+    EXPECT_FALSE(input.is_armed(acrobot_model_));
+    EXPECT_FALSE(input.is_armed(arm_model_));
+    EXPECT_TRUE(input.is_armed(gripper_model_));
+    EXPECT_FALSE(input.is_armed(box_model_));
+    EXPECT_EQ(input.positions(gripper_model_), gripper_xd.head(2));
+    EXPECT_EQ(input.velocities(gripper_model_), gripper_xd.tail(2));
+  }
+
+  // We now do provide desired state for the arm.
   const VectorXd arm_xd = VectorXd::LinSpaced(14, 1.0, 14.0);
   plant_->get_desired_state_input_port(arm_model_)
       .FixValue(context_.get(), arm_xd);
 
-  const VectorXd full_xd =
-      MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_);
-  // Desired states must be assembled according to model instance order,
-  // therefore in this case arm first followed by gripper. All qd values go
-  // first, followed by vd values.
-  const int nu = plant_->num_actuated_dofs();
-  // clang-format off
-  const VectorXd expected_xd =
-      (VectorXd(2 * nu) <<
-        // Desired positions.
-        arm_xd.head<7>(),
-        0.0, /* Acrobot shoulder */
-        gripper_xd.head<2>(),
-        0.0, /* Acrobot elbow */
-        // Desired velocities.
-        arm_xd.tail<7>(),
-        0.0, /* Acrobot shoulder */
-        gripper_xd.tail<2>(),
-        0.0 /* Acrobot elbow */).finished();
-  // clang-format on
+  // We verify the arm is no longer disarmed and the input assembly.
+  {
+    const internal::DesiredStateInput<double> input =
+        MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_);
 
-  EXPECT_EQ(full_xd, expected_xd);
+    // Verify desired states for the models that are armed.
+    EXPECT_FALSE(input.is_armed(acrobot_model_));
+    EXPECT_TRUE(input.is_armed(arm_model_));
+    EXPECT_TRUE(input.is_armed(gripper_model_));
+    EXPECT_FALSE(input.is_armed(box_model_));
+    EXPECT_EQ(input.positions(gripper_model_), gripper_xd.head(2));
+    EXPECT_EQ(input.velocities(gripper_model_), gripper_xd.tail(2));
+    EXPECT_EQ(input.positions(arm_model_), arm_xd.head(7));
+    EXPECT_EQ(input.velocities(arm_model_), arm_xd.tail(7));
+  }
+}
+
+// Verify that an exception is thrown if there are NaNs in the desired state
+// input port, only for states corresponding to PD-controlled actuators. Desired
+// states for non PD-controlled actuators are ignored.
+TEST_F(ActuatedIiwaArmTest, AssembleDesiredStateInput_RejectNansUnlessIgnored) {
+  // We build an IIWA model with only a subset of actuators having PD control.
+  SetUpModel(ModelConfiguration::kArmIsPartiallyControlled);
+
+  // Purposely inject NaN values for actuators with no PD. These should not
+  // trigger an exception since they are ignored.
+  {
+    VectorXd arm_xd = VectorXd::LinSpaced(2 * kKukaNumPositions_, 1.0, 14.0);
+    // First actuator does not have PD-control.
+    const int first_actuator_index = 0;
+    const JointActuator<double>& actuator = plant_->get_joint_actuator(
+        plant_->GetJointActuatorIndices(arm_model_)[first_actuator_index]);
+    ASSERT_FALSE(actuator.has_controller());
+    arm_xd[first_actuator_index] = NAN;
+    arm_xd[kKukaNumPositions_ + first_actuator_index] = NAN;
+    plant_->get_desired_state_input_port(arm_model_)
+        .FixValue(context_.get(), arm_xd);
+    EXPECT_NO_THROW(
+        MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_));
+  }
+
+  // NaN values for PD-controlled actuators do trigger an exception, unless the
+  // actuated joint is locked.
+  {
+    VectorXd arm_xd = VectorXd::LinSpaced(2 * kKukaNumPositions_, 1.0, 14.0);
+    // Second actuator does have PD-control.
+    const JointActuatorIndex pd_actuator(1);
+    const auto& actuator = plant_->get_joint_actuator(pd_actuator);
+
+    // NaN qd, valid vd.
+    arm_xd[pd_actuator] = NAN;
+    arm_xd[kKukaNumPositions_ + pd_actuator] = 0.0;
+    plant_->get_desired_state_input_port(arm_model_)
+        .FixValue(context_.get(), arm_xd);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_),
+        "Desired state input port for model instance iiwa7 contains NaN.");
+    // The NaN should be ignored if the actuated joint is locked.
+    actuator.joint().Lock(context_.get());
+    EXPECT_NO_THROW(
+        MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_));
+
+    // Valid qd, NaN vd.
+    arm_xd[pd_actuator] = 0.0;
+    arm_xd[kKukaNumPositions_ + pd_actuator] = NAN;
+    actuator.joint().Unlock(context_.get());
+    plant_->get_desired_state_input_port(arm_model_)
+        .FixValue(context_.get(), arm_xd);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_),
+        "Desired state input port for model instance iiwa7 contains NaN.");
+    // The NaN should be ignored if the actuated joint is locked.
+    actuator.joint().Lock(context_.get());
+    EXPECT_NO_THROW(
+        MultibodyPlantTester::AssembleDesiredStateInput(*plant_, *context_));
+  }
 }
 
 TEST_F(ActuatedIiwaArmTest,

--- a/multibody/plant/test/sap_driver_pd_controller_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_pd_controller_constraints_test.cc
@@ -77,8 +77,8 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
     plant_->WeldFrames(plant_->world_frame(), base_body.body_frame());
     plant_->WeldFrames(end_effector.body_frame(), gripper_body.body_frame());
 
-    // Set PD controllers for the gripper.
-    SetGripperModel();
+    SetPdGainsForGripperModel();
+    SetPdGainsForArmModel();
 
     plant_->Finalize();
 
@@ -92,13 +92,30 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
     context_ = plant_->CreateDefaultContext();
   }
 
-  void SetGripperModel() {
+  // Sets both actuators to have PD control.
+  void SetPdGainsForGripperModel() {
     for (JointActuatorIndex actuator_index :
          plant_->GetJointActuatorIndices()) {
       JointActuator<double>& actuator =
           plant_->get_mutable_joint_actuator(actuator_index);
       if (actuator.model_instance() == gripper_model_) {
-        actuator.set_controller_gains({kProportionalGain_, kDerivativeGain_});
+        actuator.set_controller_gains(
+            {kGripperProportionalGain_, kGripperDerivativeGain_});
+      }
+    }
+  }
+
+  // Sets only joints 2 and 4 of the arm to have PD control, even though all
+  // joints have (feed-forward) actuation.
+  void SetPdGainsForArmModel() {
+    for (JointActuatorIndex actuator_index :
+         plant_->GetJointActuatorIndices()) {
+      JointActuator<double>& actuator =
+          plant_->get_mutable_joint_actuator(actuator_index);
+      if (actuator.joint().name() == "iiwa_joint_2" ||
+          actuator.joint().name() == "iiwa_joint_4") {
+        actuator.set_controller_gains(
+            {kArmProportionalGain_, kArmDerivativeGain_});
       }
     }
   }
@@ -110,9 +127,14 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
  protected:
   const int kKukaNumPositions_{7};
   const int kGripperNumPositions_{2};
-  const double kProportionalGain_{10000.0};
-  const double kDerivativeGain_{100.0};
-  const double kEffortLimit_{80.0};  // Defined in schunk_wsg_50.sdf
+  const double kGripperProportionalGain_{10000.0};
+  const double kGripperDerivativeGain_{100.0};
+  const double kGripperEffortLimit_{80.0};  // Defined in schunk_wsg_50.sdf
+  const double kArmProportionalGain_{15000.0};
+  const double kArmDerivativeGain_{300.0};
+  // Efforts for second and fourth joints defined in iiwa14_no_collision.sdf
+  const double kArmEffortLimit2_{320.0};
+  const double kArmEffortLimit4_{176.0};
   std::unique_ptr<MultibodyPlant<double>> plant_;
   ModelInstanceIndex arm_model_;
   ModelInstanceIndex gripper_model_;
@@ -121,74 +143,97 @@ class ActuatedIiiwaArmTest : public ::testing::Test {
 };
 
 // We verify that the SAP driver properly defined constraints to model the PD
-// controllers in the gripper fingers.
+// controllers in the gripper fingers. We build a model in which only a subset
+// of non-consecutive joints in the arm have PD control. We do this to stress
+// test the proper assembly of the resulting SAP problem.
 TEST_F(ActuatedIiiwaArmTest, VerifyConstraints) {
   // We expect each of the 1-DOF joints to be actuated.
   EXPECT_EQ(plant_->num_actuators(), plant_->num_velocities());
 
-  // Sanity check we only defined PD controllers for the grippers DOFs.
-  int num_controlled_actuators = 0;
-  for (JointActuatorIndex a : plant_->GetJointActuatorIndices()) {
-    const JointActuator<double>& actuator = plant_->get_joint_actuator(a);
-    if (actuator.has_controller()) ++num_controlled_actuators;
-  }
-  EXPECT_EQ(num_controlled_actuators, 2);
+  // Sanity check the number of actuators.
+  EXPECT_EQ(plant_->num_actuators(gripper_model_), 2);
+  EXPECT_EQ(plant_->num_actuators(arm_model_), 7);
 
-  // The actuation input port for the arm is required to be connected.
-  const VectorXd arm_u =
-      VectorXd::LinSpaced(kKukaNumPositions_, 1.0, kKukaNumPositions_);
-  plant_->get_actuation_input_port(arm_model_).FixValue(context_.get(), arm_u);
+  // We must provide desired state values for all actuators, whether they have
+  // PD control or not.
+  // Values for non-controlled actuators are ignored. We fill those in with NaNs
+  // and verify they do not propagate below.
+  VectorXd plant_qd = VectorXd::LinSpaced(9, 1.0, 9.0);
+  VectorXd plant_vd = VectorXd::LinSpaced(9, 10.0, 18.0);
+  // The first actuator in the arm is not PD-controlled.
+  plant_qd[0] = NAN;
+  plant_vd[0] = NAN;
 
-  // Since the gripper has controllers, the desired state input port must be
-  // connected.
-  const VectorXd gripper_xd = (VectorXd(4) << 1., 2., 3, 4.).finished();
+  // Plant feed-forward actuation, arm (7) + gripper (2)
+  const VectorXd plant_uff = VectorXd::LinSpaced(9, 7.0, 13.0);
+
+  // Desired state for the gripper.
+  const VectorXd gripper_xd = (VectorXd(2 * kGripperNumPositions_)
+                                   << plant_qd.tail(kGripperNumPositions_),
+                               plant_vd.tail(kGripperNumPositions_))
+                                  .finished();
   plant_->get_desired_state_input_port(gripper_model_)
       .FixValue(context_.get(), gripper_xd);
 
-  // Arbitrary feed-forward term for testing.
-  const VectorXd gripper_ff = (VectorXd(2) << 5., 6.).finished();
+  // Feed-forward actuation for the gripper.
+  const VectorXd gripper_uff = plant_uff.tail(kGripperNumPositions_);
   plant_->get_actuation_input_port(gripper_model_)
-      .FixValue(context_.get(), gripper_ff);
+      .FixValue(context_.get(), gripper_uff);
 
+  // Desired state for the arm.
+  const VectorXd arm_xd =
+      (VectorXd(2 * kKukaNumPositions_) << plant_qd.head(kKukaNumPositions_),
+       plant_vd.head(kKukaNumPositions_))
+          .finished();
+  plant_->get_desired_state_input_port(arm_model_)
+      .FixValue(context_.get(), arm_xd);
+
+  // Feed-forward actuation for the arm.
+  const VectorXd arm_uff = plant_uff.head(kKukaNumPositions_);
+  plant_->get_actuation_input_port(arm_model_)
+      .FixValue(context_.get(), arm_uff);
+
+  // Evaluate the contact problem so that we can verify it has the expected
+  // constraints.
   const ContactProblemCache<double>& problem_cache =
       SapDriverTest::EvalContactProblemCache(sap_driver(), *context_);
   const SapContactProblem<double>& problem = *problem_cache.sap_problem;
 
-  // We should at least have two constraints to model the controllers.
+  // We should at least have four constraints to model the PD controllers.
   // Additional constraints will correspond to joint limits.
-  EXPECT_GE(problem.num_constraints(), 2);
-  EXPECT_GE(problem.num_constraint_equations(), 2);
+  EXPECT_GE(problem.num_constraints(), 4);
+  EXPECT_GE(problem.num_constraint_equations(), 4);
 
-  auto make_finger_config = [&](const std::string& name) {
-    const int dof = plant_->GetJointByName(name).velocity_start();
-    const int gripper_dof = dof - kKukaNumPositions_;
+  auto make_config = [&](int dof) {
     const int clique = 0;  // Only one kinematic tree in this model.
     const int clique_dof = dof;
-    const int clique_nv = 9;  // 7 Kuka DOFs + 2 gripper DOFs.
+    const int clique_nv = kKukaNumPositions_ + kGripperNumPositions_;
     const VectorXd q = plant_->GetPositions(*context_);
     const double q0 = q[dof];  // For this model nq = nv.
-    const double qd = gripper_xd(gripper_dof);
-    const double vd = gripper_xd(2 + gripper_dof);
-    const double u_ff = gripper_ff(gripper_dof);
+    const double qd = plant_qd(dof);
+    const double vd = plant_vd(dof);
+    const double u_ff = plant_uff(dof);
     SapPdControllerConstraint<double>::Configuration config{
         clique, clique_dof, clique_nv, q0, qd, vd, u_ff};
     return config;
   };
-
-  const SapPdControllerConstraint<double>::Configuration left_finger_config =
-      make_finger_config("left_finger_sliding_joint");
-  const SapPdControllerConstraint<double>::Configuration right_finger_config =
-      make_finger_config("right_finger_sliding_joint");
 
   for (int k = 0; k < problem.num_constraints(); ++k) {
     const auto* constraint =
         dynamic_cast<const SapPdControllerConstraint<double>*>(
             &problem.get_constraint(k));
     if (constraint != nullptr) {
-      const auto& p = constraint->parameters();
-      EXPECT_EQ(p.Kp(), kProportionalGain_);
-      EXPECT_EQ(p.Kd(), kDerivativeGain_);
-      EXPECT_EQ(p.effort_limit(), kEffortLimit_);
+      const auto& c = constraint->configuration();
+      // Verify that NaN desired states for non-controlled actuators do not
+      // propagate into any constraint.
+      using std::isnan;
+      EXPECT_FALSE(isnan(c.qd));
+      EXPECT_FALSE(isnan(c.vd));
+
+      // Verify expected values.
+      const SapPdControllerConstraint<double>::Configuration expected_config =
+          make_config(c.clique_dof);
+      EXPECT_EQ(c, expected_config);
 
       // Always one clique for PD controllers.
       EXPECT_EQ(constraint->num_cliques(), 1);
@@ -197,16 +242,17 @@ TEST_F(ActuatedIiiwaArmTest, VerifyConstraints) {
       EXPECT_EQ(constraint->first_clique(), 0);
       EXPECT_THROW(constraint->second_clique(), std::exception);
 
-      const auto& c = constraint->configuration();
-      EXPECT_EQ(c.clique, 0);  // There is only one clique.
-      // Either of the two gripper DOFs.
-      EXPECT_TRUE(c.clique_dof == 7 || c.clique_dof == 8);
-      EXPECT_EQ(c.clique_nv, 9);  // 7 Kuka DOFs + 2 gripper DOFs.
-
-      if (c.clique_dof == left_finger_config.clique_dof) {
-        EXPECT_EQ(c, left_finger_config);
-      } else {
-        EXPECT_EQ(c, right_finger_config);
+      const auto& p = constraint->parameters();
+      if (c.clique_dof >= 7) {  // Gripper
+        EXPECT_EQ(p.Kp(), kGripperProportionalGain_);
+        EXPECT_EQ(p.Kd(), kGripperDerivativeGain_);
+        EXPECT_EQ(p.effort_limit(), kGripperEffortLimit_);
+      } else {  // Arm
+        EXPECT_EQ(p.Kp(), kArmProportionalGain_);
+        EXPECT_EQ(p.Kd(), kArmDerivativeGain_);
+        const double expected_limit =
+            c.clique_dof == 1 ? kArmEffortLimit2_ : kArmEffortLimit4_;
+        EXPECT_EQ(p.effort_limit(), expected_limit);
       }
     }
   }

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -304,6 +304,13 @@ class JointActuator final : public MultibodyElement<T> {
 
   /// Returns `true` if controller gains have been specified with a call to
   /// set_controller_gains().
+  ///
+  /// @note A controller for a given model instance can be _disarmed_ if the
+  /// desired state input port for its model instance is not connected. When a
+  /// PD controller is disarmed, it has no effect on the MultibodyPlant's
+  /// dynamics, as if there was no PD controller (still, this method returns
+  /// `true` whenever controller gains were set with set_controller_gains().)
+  /// See @ref pd_controllers_and_ports for further details.
   bool has_controller() const { return pd_controller_gains_.has_value(); }
 
   /// Returns a reference to the controller gains for this actuator.


### PR DESCRIPTION
Closes #22444.

Per discussion in #22444, we allow the desired state input ports for a model instance to be disconneted. This "disarms" PD control for such model instance, meaning that this controller won't have any effect on the dynamics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22542)
<!-- Reviewable:end -->
