### PR TITLE
Hotfix for 22526

### DIFF
--- a/bindings/pydrake/systems/drawing.py
+++ b/bindings/pydrake/systems/drawing.py
@@ -3,8 +3,6 @@ Provides general visualization utilities. This is NOT related to `rendering`.
 """
 
 from tempfile import NamedTemporaryFile
-from IPython import get_ipython
-from IPython.display import SVG, display
 
 from pydrake.common import temp_directory
 
@@ -15,9 +13,16 @@ from pydrake.common import temp_directory
 # Use a global variable here because some calls to IPython will actually cause
 # an interpreter to be created.  This file needs to be imported BEFORE that
 # happens.
-running_as_notebook = (
-    get_ipython() and hasattr(get_ipython(), "kernel")
-)
+try:
+    # IPython module may not be available; in which case, we're definitely
+    # *not* running as a notebook.
+    from IPython import get_ipython
+    from IPython.display import SVG, display
+    running_as_notebook = (
+        get_ipython() and hasattr(get_ipython(), "kernel")
+    )
+except ModuleNotFoundError:
+    running_as_notebook = False
 
 
 def _plt():


### PR DESCRIPTION
Protect the drawing import from actually depending on IPython.

The dependency is only there to indicate if we're part of a notebook. If the module is not available, we're definitely not in a notebook.

FIxes #22526

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22546)
<!-- Reviewable:end -->
