### PR TITLE
[hotfix] SpGrid reserves smaller memory span in tests

### DIFF
--- a/multibody/mpm/test/particle_sorter_test.cc
+++ b/multibody/mpm/test/particle_sorter_test.cc
@@ -15,6 +15,7 @@ namespace internal {
 namespace {
 
 using Eigen::Vector3i;
+const int kLog2MaxGridSize = 5;
 
 GTEST_TEST(ConvertToRangeVectorTest, ConvertToRangeVector) {
   std::vector<int> data = {1, 3, 6, 9};
@@ -54,7 +55,7 @@ bool OverlapOneRing(const Vector3i& a, const Vector3i& b) {
 }
 
 GTEST_TEST(ParticleSorterTest, Sort) {
-  using Grid = SpGrid<GridData<double>>;
+  using Grid = SpGrid<GridData<double>, kLog2MaxGridSize>;
   const Grid spgrid;
   const double dx = 0.2;
   const std::vector<Vector3<double>> particle_positions = SamplePoints(7);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22548)
<!-- Reviewable:end -->
