### PR TITLE
Fix py_env_runner

### DIFF
--- a/tools/skylark/py_env_runner.py
+++ b/tools/skylark/py_env_runner.py
@@ -6,8 +6,12 @@ Python libraries using an environment established by Bazel.
 # TODO(eric.cousineau): See if there is a way to do this in pure C++, such
 # that it is easier to debug.
 
+import os
 import subprocess
 import sys
 
+env = os.environ.copy()
+env['PYTHONPATH'] = ':'.join([p for p in sys.path if p])
+
 assert len(sys.argv) >= 2
-subprocess.check_call(sys.argv[1:])
+subprocess.check_call(sys.argv[1:], env=env)


### PR DESCRIPTION
Modify py_env_runner to export the PYTHONPATH. This is needed to ensure that CPython can find everything the Python interpreter in use can find (particularly when using a virtual environment).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22549)
<!-- Reviewable:end -->
