### PR TITLE
[py visualization] Avoid writing to const contexts

### DIFF
--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -404,7 +404,8 @@ class ModelVisualizer:
         if position is not None and len(position) > 0:
             self._raise_if_invalid_positions(position)
             self._diagram.plant().SetPositions(
-                self._diagram.plant().GetMyContextFromRoot(self._context),
+                self._diagram.plant().GetMyMutableContextFromRoot(
+                    self._context),
                 position)
             self._sliders.SetPositions(position)
 
@@ -495,7 +496,8 @@ class ModelVisualizer:
 
         frame = self._diagram.plant().GetFrameByName("$rgbd_sensor_offset")
         frame.SetPoseInParentFrame(
-            context=self._diagram.plant().GetMyContextFromRoot(self._context),
+            context=self._diagram.plant().GetMyMutableContextFromRoot(
+                self._context),
             X_PF=X_WC)
         self._diagram.GetOutputPort("preview_image").Eval(self._context)
 
@@ -521,7 +523,8 @@ class ModelVisualizer:
             if position is not None and len(position) > 0:
                 self._raise_if_invalid_positions(position)
                 self._diagram.plant().SetPositions(
-                    self._diagram.plant().GetMyContextFromRoot(self._context),
+                    self._diagram.plant().GetMyMutableContextFromRoot(
+                        self._context),
                     position)
                 self._sliders.SetPositions(position)
                 self._diagram.ForcedPublish(self._context)
@@ -569,7 +572,8 @@ class ModelVisualizer:
                 q = self._sliders.get_output_port().Eval(
                     self._sliders.GetMyContextFromRoot(self._context))
                 self._diagram.plant().SetPositions(
-                    self._diagram.plant().GetMyContextFromRoot(self._context),
+                    self._diagram.plant().GetMyMutableContextFromRoot(
+                        self._context),
                     q)
                 self._diagram.ForcedPublish(self._context)
                 if loop_once or has_clicks(stop_button_name):


### PR DESCRIPTION
We are currently lucky that this doesn't hurt anything, but best not to tempt fate or provide bad examples to our users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22550)
<!-- Reviewable:end -->
