### PR TITLE
[build] Switch bzlmod clang-format to use_repo_rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,9 +77,12 @@ spdlog_repository(name = "pkgconfig_spdlog")
 
 bazel_dep(name = "toolchains_llvm", version = "1.3.0")
 
-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
-llvm.toolchain(llvm_version = "15.0.5")
-use_repo(llvm, "llvm_toolchain")
+llvm = use_repo_rule("@toolchains_llvm//toolchain:rules.bzl", "llvm")
+
+llvm(
+    name = "llvm",
+    llvm_version = "15.0.5",
+)
 
 # Load dependencies which are "public", i.e., made available to downstream
 # projects.

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -50,7 +50,7 @@ drake_py_library(
     srcs = ["clang_format.py"],
     data = [
         "//:.clang-format",
-        "@llvm_toolchain//:clang-format",
+        "@llvm//:bin/clang-format",
     ],
     deps = [
         ":module_py",

--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -10,7 +10,7 @@ from python import runfiles
 
 def get_clang_format_path():
     manifest = runfiles.Create()
-    path = Path(manifest.Rlocation("llvm_toolchain/clang-format"))
+    path = Path(manifest.Rlocation("llvm/bin/clang-format"))
     if not path.is_file():
         raise RuntimeError(f"Could not find required clang-format at {path}")
     return path


### PR DESCRIPTION
Apparently only the use_repo_rule form (not the use_extension form) can be inherited by downstream projects.

Amends #22504.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22555)
<!-- Reviewable:end -->
