### PR TITLE
Growing IRIS-ZO Regions Along a Parametrized Subspace

### DIFF
--- a/planning/iris/iris_zo.cc
+++ b/planning/iris/iris_zo.cc
@@ -112,6 +112,16 @@ HPolyhedron IrisZo(const planning::CollisionChecker& checker,
   DRAKE_THROW_UNLESS(domain.IsBounded());
   DRAKE_THROW_UNLESS(domain.PointInSet(current_ellipsoid_center));
 
+  const int computed_ambient_dimension =
+      options.parametrization(starting_ellipsoid_center).size();
+  if (computed_ambient_dimension != ambient_dimension) {
+    throw std::runtime_error(
+        fmt::format("The plant has {} positions, but the given parametrization "
+                    "returned a point with the wrong dimension (its size was "
+                    "{}) when called on the center of the starting ellipsoid.",
+                    ambient_dimension, computed_ambient_dimension));
+  }
+
   int current_num_faces = domain.A().rows();
 
   if (options.max_iterations_separating_planes <= 0) {

--- a/planning/iris/iris_zo.cc
+++ b/planning/iris/iris_zo.cc
@@ -325,7 +325,8 @@ HPolyhedron IrisZo(const planning::CollisionChecker& checker,
         // Update current point using a fixed number of bisection steps.
         Eigen::VectorXd current_point_ambient =
             options.parametrization(curr_pt_lower);
-        DRAKE_ASSERT(current_point_ambient.size() == ambient_dimension);
+        DRAKE_ASSERT(current_point_ambient.size() ==
+                     checker.plant().num_positions());
         if (!checker.CheckConfigCollisionFree(current_point_ambient,
                                               thread_num)) {
           current_point = curr_pt_lower;
@@ -334,7 +335,8 @@ HPolyhedron IrisZo(const planning::CollisionChecker& checker,
           for (int i = 0; i < options.bisection_steps; ++i) {
             Eigen::VectorXd query = 0.5 * (curr_pt_upper + curr_pt_lower);
             Eigen::VectorXd query_ambient = options.parametrization(query);
-            DRAKE_ASSERT(query_ambient.size() == ambient_dimension);
+            DRAKE_ASSERT(query_ambient.size() ==
+                         checker.plant().num_positions());
             if (checker.CheckConfigCollisionFree(query_ambient, thread_num)) {
               curr_pt_lower = query;
             } else {

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -25,6 +25,8 @@ namespace planning {
  **/
 class IrisZoOptions {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IrisZoOptions);
+
   /** Passes this object to an Archive.
   Refer to @ref yaml_serialization "YAML Serialization" for background.
   Note: This only serializes options that are YAML built-in types. */
@@ -152,14 +154,26 @@ class IrisZoOptions {
     parameterization_dimension_ = parameterization_dimension;
   }
 
+  /** Get the parameterization function.
+   * @note If the user has not specified this with `set_parameterization()`,
+   * then the default value of `parameterization_` is the identity function,
+   * indicating that the regions should be grown in the full configuration space
+   * (in the standard coordinate system). */
   const ParameterizationFunction& get_parameterization() const {
     return parameterization_;
   }
 
+  /** Returns whether or not the parameterization is threadsafe.
+   * @note The default `parameterization_` is the identity function, which is
+   * threadsafe. */
   bool get_parameterization_is_threadsafe() const {
     return parameterization_is_threadsafe_;
   }
 
+  /** Returns the input dimension for the parameterization function, or
+   * std::nullopt if it has not been set. A std::nullopt value indicates that
+   * IrisZo should use the ambient configuration space dimension as the input
+   * dimension to the parameterization. */
   std::optional<int> get_parameterization_dimension() const {
     return parameterization_dimension_;
   }
@@ -167,14 +181,8 @@ class IrisZoOptions {
  private:
   bool parameterization_is_threadsafe_{true};
 
-  /* By default, this is not specified, and the full dimension of the
-   * configuration space is determined when IrisZo is called, and that value is
-   * used. */
   std::optional<int> parameterization_dimension_{std::nullopt};
 
-  /* By default, we just use the identity function, indicating that the regions
-   * should be grown in the full configuration space (in the standard coordinate
-   * system). */
   std::function<Eigen::VectorXd(const Eigen::VectorXd&)> parameterization_{
       [](const Eigen::VectorXd& q) -> Eigen::VectorXd {
         return q;

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -163,15 +163,17 @@ class IrisZoOptions {
     return parameterization_;
   }
 
-  /** Returns whether or not the parameterization is threadsafe.
+  /** Returns whether or not the user has specified the parameterization to be
+   * threadsafe.
    * @note The default `parameterization_` is the identity function, which is
    * threadsafe. */
   bool get_parameterization_is_threadsafe() const {
     return parameterization_is_threadsafe_;
   }
 
-  /** Returns the input dimension for the parameterization function, or
-   * std::nullopt if it has not been set. A std::nullopt value indicates that
+  /** Returns what the user has specified as the input dimension for the
+   * parameterization function, or std::nullopt if it has not been set. A
+   * std::nullopt value indicates that
    * IrisZo should use the ambient configuration space dimension as the input
    * dimension to the parameterization. */
   std::optional<int> get_parameterization_dimension() const {

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -135,6 +135,15 @@ class IrisZoOptions {
   typedef std::function<Eigen::VectorXd(const Eigen::VectorXd&)>
       ParameterizationFunction;
 
+  /** Ordinarily, IRIS-ZO grows collision free regions in the robot's
+   * configuration space C. This allows the user to specify a function f:Q→C ,
+   * and grow the region in Q instead. The function should be a map R^m to
+   * R^n, where n is the dimension of the plant configuration space, determined
+   * via `checker.plant().num_positions()` and m is `parameterization_dimension`
+   * if specified. The user must provide `parameterization`, which is the
+   * function f, `parameterization_is_threadsafe`, which is whether or not
+   * `parametrization` can be called concurrently, and
+   * `parameterization_dimension`, the dimension of the input space Q. */
   void set_parameterization(const ParameterizationFunction& parameterization,
                             bool parameterization_is_threadsafe,
                             int parameterization_dimension) {
@@ -156,27 +165,16 @@ class IrisZoOptions {
   }
 
  private:
-  /** Whether or not parameterization() is thread-safe. If the user specifies
-   * that the function is not threadsafe, then `parallelism` will be overridden
-   * and only one thread will be used.
-   * @warning If the user sets a new `parameterization` and it is not
-   * threadsafe, then parameterization_is_threadsafe must be set to false. */
   bool parameterization_is_threadsafe_{true};
 
-  /** The dimension of the parameterized subspace (and therefore, the input to
-   * the parameterization function). If not specified, the full dimension of the
-   * configuration space is used. */
+  /* By default, this is not specified, and the full dimension of the
+   * configuration space is determined when IrisZo is called, and that value is
+   * used. */
   std::optional<int> parameterization_dimension_{std::nullopt};
 
-  /** A function describing a parameterized subspace of the full configuration
-   * space, along which to grow the region. The function should be a map R^m to
-   * R^n, where n is the dimension of the plant configuration space, determined
-   * via `checker.plant().num_positions()` and m is `parameterization_dimension`
-   * if specified. The default value is just the identity function, indicating
-   * that the regions should be grow in the full configuration space (in the
-   * standard coordinate system).
-   * @warning If the user sets a new `parameterization` and it is not
-   * threadsafe, then parameterization_is_threadsafe must be set to false. */
+  /* By default, we just use the identity function, indicating that the regions
+   * should be grown in the full configuration space (in the standard coordinate
+   * system). */
   std::function<Eigen::VectorXd(const Eigen::VectorXd&)> parameterization_{
       [](const Eigen::VectorXd& q) -> Eigen::VectorXd {
         return q;

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -124,6 +125,23 @@ struct IrisZoOptions {
   /** Number of mixing steps used for hit-and-run sampling. */
   int mixing_steps{50};
 
+  /** Whether or not the parametrization function is thread-safe. */
+  bool parametrization_is_threadsafe{true};
+
+  /** The dimension of the parametrized subspace (and therefore, the input to
+   * the parametrization function). If not specified, the full dimension of the
+   * configuration space is used. */
+  std::optional<int> parametrization_dimension{std::nullopt};
+
+  /** A function describing a parametrized subspace of the full configuration
+   * space, along which to grow the region. Default value is just the identity
+   * function, indicating that the regions should be grow in the full
+   * configuration space (in the standard coordinate system). */
+  std::function<Eigen::VectorXd(const Eigen::VectorXd&)> parametrization{
+      [](const Eigen::VectorXd& q) -> Eigen::VectorXd {
+        return q;
+      }};
+
   /** Passing a meshcat instance may enable debugging visualizations; this
   currently and when the
   configuration space is <= 3 dimensional.*/
@@ -160,7 +178,9 @@ box representing joint limits (e.g. from HPolyhedron::MakeBox).
 fraction, confidence level, and various algorithmic settings.
 
 The @p starting_ellipsoid and @p domain must describe elements in the same
-ambient dimension as the configuration space of the robot.
+ambient dimension as the configuration space of the robot, unless a
+parametrization is specified (in which case, they must match
+`options.parametrization_dimension`).
 @return A HPolyhedron representing the computed collision-free region in
 configuration space.
 @ingroup robot_planning

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -125,7 +125,9 @@ struct IrisZoOptions {
   /** Number of mixing steps used for hit-and-run sampling. */
   int mixing_steps{50};
 
-  /** Whether or not the parametrization function is thread-safe. */
+  /** Whether or not the parametrization function is thread-safe. If the user
+   * specifies that the function is not threadsafe, then `parallelism` will be
+   * overridden and only one thread will be used. */
   bool parametrization_is_threadsafe{true};
 
   /** The dimension of the parametrized subspace (and therefore, the input to
@@ -134,8 +136,10 @@ struct IrisZoOptions {
   std::optional<int> parametrization_dimension{std::nullopt};
 
   /** A function describing a parametrized subspace of the full configuration
-   * space, along which to grow the region. Default value is just the identity
-   * function, indicating that the regions should be grow in the full
+   * space, along which to grow the region. The function should be a map R^m to
+   * R^n, where n is the dimension of the plant configuration space, determined
+   * via `checker.plant().num_positions()`. The default value is just the
+   * identity function, indicating that the regions should be grow in the full
    * configuration space (in the standard coordinate system). */
   std::function<Eigen::VectorXd(const Eigen::VectorXd&)> parametrization{
       [](const Eigen::VectorXd& q) -> Eigen::VectorXd {

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -238,7 +238,7 @@ GTEST_TEST(IrisZoTest, DoublePendulum) {
         3, n_points_per_edge * vregion.vertices().cols() + 1);
     int next_point_index = 0;
 
-    // Order vertices in counterclockwise order. Thanks claude.ai for the help.
+    // Order vertices in counterclockwise order.
     Vector2d centroid = vregion.vertices().rowwise().mean();
     Eigen::Matrix2Xd centered = vregion.vertices().colwise() - centroid;
     VectorXd angles = centered.row(1).array().binaryExpr(
@@ -283,6 +283,16 @@ GTEST_TEST(IrisZoTest, DoublePendulum) {
 
     MaybePauseForUser();
   }
+
+  // Verify that we fail gracefully if the parametrization has the wrong output
+  // dimension.
+  options.parametrization = [](const VectorXd& q) -> VectorXd {
+    return Vector1d(0.0);
+  };
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      IrisZoFromUrdf(double_pendulum_urdf, starting_ellipsoid, options,
+                     &domain),
+      ".*wrong dimension.*");
 }
 
 const char block_urdf[] = R"(

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -204,16 +204,16 @@ GTEST_TEST(IrisZoTest, DoublePendulum) {
     MaybePauseForUser();
   }
 
-  // We now test an example of a region grown along a parametrization of the
-  // space. We use the rational parametrization s=tan(θ/2), so our
-  // parametrization function is θ=2arctan(s).
-  options.parametrization_is_threadsafe = true;
-  options.parametrization = [](const VectorXd& q) -> VectorXd {
+  // We now test an example of a region grown along a parameterization of the
+  // space. We use the rational parameterization s=tan(θ/2), so our
+  // parameterization function is θ=2arctan(s).
+  options.parameterization_is_threadsafe = true;
+  options.parameterization = [](const VectorXd& q) -> VectorXd {
     return (2 * q.array().atan()).matrix();
   };
   options.configuration_space_margin = 1e-4;
-  // Note that we don't specify the parametrization dimension. This is unneeded,
-  // since it will just match the ambient dimension.
+  // Note that we don't specify the parameterization dimension. This is
+  // unneeded, since it will just match the ambient dimension.
   const Vector2d sample2{0.0, 0.0};
   starting_ellipsoid = Hyperellipsoid::MakeHypersphere(1e-2, sample2);
   // This domain matches the joint limits under the transformation.
@@ -264,19 +264,19 @@ GTEST_TEST(IrisZoTest, DoublePendulum) {
         double t =
             static_cast<double>(j) / static_cast<double>(n_points_per_edge);
         Vector2d q = t * q2 + (1 - t) * q1;
-        points.col(next_point_index).head(2) = options.parametrization(q);
+        points.col(next_point_index).head(2) = options.parameterization(q);
         ++next_point_index;
       }
     }
     points.topRightCorner(2, 1) =
-        options.parametrization(sorted_vertices.col(0));
+        options.parameterization(sorted_vertices.col(0));
     points.bottomRows<1>().setZero();
     meshcat->SetLine("IRIS Region", points, 2.0, Rgba(0, 1, 0));
 
     meshcat->SetObject("Test point", Sphere(0.03), Rgba(1, 0, 0));
 
     Vector2d ambient_query_point =
-        options.parametrization(region_query_point_1);
+        options.parameterization(region_query_point_1);
     meshcat->SetTransform(
         "Test point", math::RigidTransform(Eigen::Vector3d(
                           ambient_query_point[0], ambient_query_point[1], 0)));
@@ -284,9 +284,9 @@ GTEST_TEST(IrisZoTest, DoublePendulum) {
     MaybePauseForUser();
   }
 
-  // Verify that we fail gracefully if the parametrization has the wrong output
+  // Verify that we fail gracefully if the parameterization has the wrong output
   // dimension.
-  options.parametrization = [](const VectorXd& q) -> VectorXd {
+  options.parameterization = [](const VectorXd& q) -> VectorXd {
     return Vector1d(0.0);
   };
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -495,9 +495,9 @@ GTEST_TEST(IrisZoTest, ConvexConfigurationSpace) {
   }
 
   // We now test an example of a region grown along a subspace.
-  options.parametrization_is_threadsafe = true;
-  options.parametrization_dimension = 1;
-  options.parametrization = [](const Vector1d& q) -> Vector2d {
+  options.parameterization_is_threadsafe = true;
+  options.parameterization_dimension = 1;
+  options.parameterization = [](const Vector1d& q) -> Vector2d {
     return Vector2d{q[0], 2 * q[0] + 1};
   };
   const Vector1d sample2{-0.5};
@@ -517,7 +517,7 @@ GTEST_TEST(IrisZoTest, ConvexConfigurationSpace) {
     VPolytope vregion = VPolytope(region).GetMinimalRepresentation();
     points.resize(3, vregion.vertices().cols() + 1);
     for (int i = 0; i < vregion.vertices().cols(); ++i) {
-      Vector2d point = options.parametrization(vregion.vertices().col(i));
+      Vector2d point = options.parameterization(vregion.vertices().col(i));
       points.col(i).head(2) = point;
       if (i == 0) {
         points.topRightCorner(2, 1) = point;
@@ -529,7 +529,7 @@ GTEST_TEST(IrisZoTest, ConvexConfigurationSpace) {
     meshcat->SetObject("Test point", Sphere(0.03), Rgba(1, 0, 0));
 
     Vector2d ambient_query_point =
-        options.parametrization(region_query_point_1);
+        options.parameterization(region_query_point_1);
     meshcat->SetTransform(
         "Test point", math::RigidTransform(Eigen::Vector3d(
                           ambient_query_point[0], ambient_query_point[1], 0)));

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -239,9 +239,9 @@ GTEST_TEST(IrisZoTest, DoublePendulum) {
     int next_point_index = 0;
 
     // Order vertices in counterclockwise order. Thanks claude.ai for the help.
-    Eigen::Vector2d centroid = vregion.vertices().rowwise().mean();
+    Vector2d centroid = vregion.vertices().rowwise().mean();
     Eigen::Matrix2Xd centered = vregion.vertices().colwise() - centroid;
-    Eigen::VectorXd angles = centered.row(1).array().binaryExpr(
+    VectorXd angles = centered.row(1).array().binaryExpr(
         centered.row(0).array(), [](double y, double x) {
           return std::atan2(y, x);
         });

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -82,6 +82,31 @@ GTEST_TEST(IrisZoTest, JointLimits) {
       Hyperellipsoid::MakeHypersphere(1e-2, sample);
   IrisZoOptions options;
   options.verbose = true;
+
+  options.set_parameterization(
+      [](const VectorXd& q) -> VectorXd {
+        return q;
+      },
+      /* parameterization_is_threadsafe */ false,
+      /* parameterization_dimension */ 1);
+
+  // Check that the parameterization was set correctly. (Note the non-default
+  // value for parameterization_is_threadsafe.)
+  EXPECT_EQ(options.get_parameterization_is_threadsafe(), false);
+  ASSERT_TRUE(options.get_parameterization_dimension().has_value());
+  EXPECT_EQ(options.get_parameterization_dimension().value(), 1);
+  const Vector1d output = options.get_parameterization()(Vector1d(3.0));
+  EXPECT_NEAR(output[0], 3.0, 1e-15);
+
+  // Now set the parameterization with parameterization_is_threadsafe set to
+  // true.
+  options.set_parameterization(
+      [](const VectorXd& q) -> VectorXd {
+        return q;
+      },
+      /* parameterization_is_threadsafe */ true,
+      /* parameterization_dimension */ 1);
+
   HPolyhedron region = IrisZoFromUrdf(limits_urdf, starting_ellipsoid, options);
 
   EXPECT_EQ(region.ambient_dimension(), 1);
@@ -213,6 +238,15 @@ GTEST_TEST(IrisZoTest, DoublePendulum) {
       },
       /* parameterization_is_threadsafe */ true,
       /* parameterization_dimension */ 2);
+
+  // Check that the parameterization was set correctly.
+  EXPECT_EQ(options.get_parameterization_is_threadsafe(), true);
+  ASSERT_TRUE(options.get_parameterization_dimension().has_value());
+  EXPECT_EQ(options.get_parameterization_dimension().value(), 2);
+  const Vector2d output = options.get_parameterization()(Vector2d(0.0, 0.0));
+  EXPECT_NEAR(output[0], 0.0, 1e-15);
+  EXPECT_NEAR(output[1], 0.0, 1e-15);
+
   options.configuration_space_margin = 1e-4;
   const Vector2d sample2{0.0, 0.0};
   starting_ellipsoid = Hyperellipsoid::MakeHypersphere(1e-2, sample2);


### PR DESCRIPTION
Ordinarily, IRIS-ZO grows collision free regions in the robot's configuration space $\mathcal C$. This allows the user to specify a function $f:\mathcal Q\to\mathcal C$, and grow the region in $\mathcal Q$ instead. This has the following use cases:

- Supporting mimic joints (@sadraddini enjoy)
- [Growing regions in tangent-configuration space](https://journals.sagepub.com/doi/full/10.1177/02783649231201437) ([so that trajectories can be certified](https://ieeexplore.ieee.org/abstract/document/10611296))
- [Growing regions along the manifold of constraint-satisfying configurations for bimanual manipulation](https://ieeexplore.ieee.org/abstract/document/10610675) (although this still requires support for additional arbitrary user-specified constraints)

@wernerpe: I've currently implemented this where everything uses the parametrization machinery, and the default is to just use the identity function. I think this only adds a small overhead, since we occasionally do an extra copy, and it's a lot more readable than having switching logic in a ton of places. But I can go through and do the switching logic if you think that'll make a speed difference. We can also always go back and do that later if you notice it causing a problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22558)
<!-- Reviewable:end -->
