### PR TITLE
fix clion external tool instructions

### DIFF
--- a/doc/_pages/clion.md
+++ b/doc/_pages/clion.md
@@ -177,8 +177,8 @@ following values for the fields:
 * **Name:** ``Clang Format Full File``
 * **Description:** ``Apply clang-format to the active file``
 * **Program:** ``bazel``
-* **Arguments:** ``run //tools/lint:clang-format -- -i $FileName$``
-* **Working directory:** ``$FileDir$``
+* **Arguments:** ``run //tools/lint:clang-format -- -i $FilePath$``
+* **Working directory:** ``$Projectpath$``
 * **Advanced Options:** Uncheck ``Open console for tool output``
 
 Leave the checkbox options in their default state.
@@ -191,8 +191,8 @@ following values for the fields:
 * **Name:** ``Clang Format Selected Lines``
 * **Description:** ``Apply clang-format to the selected lines``
 * **Program:** ``bazel``
-* **Arguments:** ``run //tools/lint:clang-format -- -lines $SelectionStartLine$:$SelectionEndLine$ -i $FileName$``
-* **Working directory:** ``$FileDir$``
+* **Arguments:** ``run //tools/lint:clang-format -- -lines $SelectionStartLine$:$SelectionEndLine$ -i $FilePath$``
+* **Working directory:** ``$Projectpath$``
 * **Advanced Options:** Uncheck ``Open console for tool output``
 
 Leave the checkbox options in their default state.


### PR DESCRIPTION
The instructions for setting up clang-format External Tools in CLion didn't work when I tried them today in CLion 2024.3.2. The commands were unable to find the file name to be processed. Changing from FileName to FilePath fixes the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22559)
<!-- Reviewable:end -->
