### PR TITLE
[build] Fix spgrid_internal compatibility with bzlmod

### DIFF
--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -89,7 +89,7 @@ load("//tools/workspace/scs_internal:repository.bzl", "scs_internal_repository")
 load("//tools/workspace/sdformat_internal:repository.bzl", "sdformat_internal_repository")  # noqa
 load("//tools/workspace/snopt:repository.bzl", "snopt_repository")
 load("//tools/workspace/spdlog:repository.bzl", "spdlog_repository")
-load("//tools/workspace/spgrid_internal:repository.bzl", "spgrid_internal_repository")  # noqa
+load("//tools/workspace/spgrid_internal:repository.bzl", "spgrid_module_extension_impl")  # noqa
 load("//tools/workspace/spral_internal:repository.bzl", "spral_internal_repository")  # noqa
 load("//tools/workspace/stable_baselines3_internal:repository.bzl", "stable_baselines3_internal_repository")  # noqa
 load("//tools/workspace/statsjs:repository.bzl", "statsjs_repository")
@@ -315,8 +315,6 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         snopt_repository(name = "snopt")
     if "spdlog" not in excludes:
         spdlog_repository(name = "spdlog", mirrors = mirrors)
-    if "spgrid_internal" not in excludes:
-        spgrid_internal_repository(name = "spgrid_internal")
     if "spral_internal" not in excludes:
         spral_internal_repository(name = "spral_internal", mirrors = mirrors)
     if "stable_baselines3_internal" not in excludes:
@@ -489,12 +487,16 @@ drake_dep_repositories = module_extension(
 )
 
 def _internal_repositories_impl(module_ctx):
+    # Add the repository rules (shared code with WORKSPACE mode).
     excludes = (
         REPOS_ALREADY_PROVIDED_BY_BAZEL_MODULES +
         REPOS_EXPORTED +
         ["crate_universe"]
     )
     add_default_repositories(excludes = excludes)
+
+    # Add the MODULE-only deps (not shared with WORKSPACE mode).
+    spgrid_module_extension_impl(module_ctx)
 
 internal_repositories = module_extension(
     implementation = _internal_repositories_impl,

--- a/tools/workspace/spgrid_internal/repository.bzl
+++ b/tools/workspace/spgrid_internal/repository.bzl
@@ -1,8 +1,13 @@
 load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 
-def spgrid_internal_repository(name):
+# This must be a module extension (instead of a respository rule) so that the
+# new_local_repository path resolves correctly w.r.t Drake's root.
+
+def spgrid_module_extension_impl(module_ctx):
+    license = Label("@drake//third_party:spgrid/LICENSE")
+    directory = module_ctx.path(license).dirname
     new_local_repository(
-        name = name,
-        path = "third_party/spgrid/",
+        name = "spgrid_internal",
+        path = str(directory),
         build_file = "//tools/workspace/spgrid_internal:package.BUILD.bazel",
     )


### PR DESCRIPTION
When consumed in a downstream workspace, new_local_repository does not work correctly with a relative path.

+@xuchenhan-tri for both reviews, please.

I've manually tested that both DEE `drake_bazel_external{,_legacy}` pass with this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22561)
<!-- Reviewable:end -->
