### PR TITLE
[build] Deprecate the HAVE_SPDLOG preprocessor definition

### DIFF
--- a/bindings/pydrake/common/text_logging_pybind.cc
+++ b/bindings/pydrake/common/text_logging_pybind.cc
@@ -10,7 +10,7 @@
 #include "drake/common/text_logging.h"
 // clang-format on
 
-#ifdef HAVE_SPDLOG
+#ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/stdout_sinks.h>
@@ -23,7 +23,7 @@ namespace drake {
 namespace pydrake {
 namespace internal {
 
-#ifdef HAVE_SPDLOG
+#ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
 namespace {
 class pylogging_sink final
     // We use null_mutex below because we'll use the GIL as our *only* mutex.

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -106,6 +106,14 @@ drake_cc_library(
         "ssize.h",
         "text_logging.h",
     ],
+    defines = select({
+        "//tools/workspace/spdlog:flag_spdlog_repo_disabled": [
+            # This is for internal use only by Drake. Downstream projects
+            # should not rely on it being defined.
+            "DRAKE_TEXT_LOGGING_NO_SPDLOG",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":fmt",
         "@eigen",
@@ -1184,8 +1192,8 @@ drake_cc_googletest(
     ],
 )
 
-# This version of text_logging_test is compiled with HAVE_SPDLOG enabled,
-# because that is what Drake's WORKSPACE provides for the @spdlog external.
+# This version of text_logging_test is compiled with the expectation that
+# spdlog is enabled.
 drake_cc_googletest(
     name = "text_logging_test",
     defines = [
@@ -1197,7 +1205,8 @@ drake_cc_googletest(
     ],
 )
 
-# Likewise (to the above test) for the ostream variation.
+# This version of text_logging_ostream_test is compiled with the expectation
+# that spdlog is enabled.
 drake_cc_googletest(
     name = "text_logging_ostream_test",
     defines = [
@@ -1210,7 +1219,7 @@ drake_cc_googletest(
 )
 
 # This version of text_logging_test re-compiles all source files without
-# defining HAVE_SPDLOG, to ensure that the no-op stubs behave as desired.
+# spdlog, to ensure that the no-op stubs behave as desired.
 drake_cc_googletest(
     name = "text_logging_no_spdlog_test",
     srcs = [
@@ -1222,6 +1231,7 @@ drake_cc_googletest(
         "text_logging.h",
     ],
     defines = [
+        "DRAKE_TEXT_LOGGING_NO_SPDLOG=1",
         "TEXT_LOGGING_TEST_SPDLOG=0",
     ],
     use_default_main = False,
@@ -1230,7 +1240,8 @@ drake_cc_googletest(
     ],
 )
 
-# Likewise (to the above test) for the ostream variation.
+# This version of text_logging_ostream_test re-compiles all source files
+# without spdlog, to ensure that the no-op stubs behave as desired.
 drake_cc_googletest(
     name = "text_logging_ostream_no_spdlog_test",
     srcs = [
@@ -1242,6 +1253,7 @@ drake_cc_googletest(
         "text_logging.h",
     ],
     defines = [
+        "DRAKE_TEXT_LOGGING_NO_SPDLOG=1",
         "TEXT_LOGGING_TEST_SPDLOG=0",
     ],
     use_default_main = False,

--- a/common/test/text_logging_ostream_test.cc
+++ b/common/test/text_logging_ostream_test.cc
@@ -14,21 +14,21 @@
 #error Missing a required definition to compile this test case.
 #endif
 
-// Check for the expected HAVE_SPDLOG value.
+// Check for the expected DRAKE_TEXT_LOGGING_NO_SPDLOG value.
 #if TEXT_LOGGING_TEST_SPDLOG
-  #ifndef HAVE_SPDLOG
-    #error Missing HAVE_SPDLOG.
+  #ifdef DRAKE_TEXT_LOGGING_NO_SPDLOG
+    #error Unwanted DRAKE_TEXT_LOGGING_NO_SPDLOG.
   #endif
 #else
-  #ifdef HAVE_SPDLOG
-    #error Unwanted HAVE_SPDLOG.
+  #ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
+    #error Missing DRAKE_TEXT_LOGGING_NO_SPDLOG.
   #endif
 #endif
 
-#ifdef HAVE_SPDLOG
+#ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
-#endif  // HAVE_SPDLOG
+#endif  // DRAKE_TEXT_LOGGING_NO_SPDLOG
 
 #include "drake/common/fmt_ostream.h"
 

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -12,14 +12,14 @@
 #error Missing a required definition to compile this test case.
 #endif
 
-// Check for the expected HAVE_SPDLOG value.
+// Check for the expected DRAKE_TEXT_LOGGING_NO_SPDLOG value.
 #if TEXT_LOGGING_TEST_SPDLOG
-  #ifndef HAVE_SPDLOG
-    #error Missing HAVE_SPDLOG.
+  #ifdef DRAKE_TEXT_LOGGING_NO_SPDLOG
+    #error Unwanted DRAKE_TEXT_LOGGING_NO_SPDLOG.
   #endif
 #else
-  #ifdef HAVE_SPDLOG
-    #error Unwanted HAVE_SPDLOG.
+  #ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
+    #error Missing DRAKE_TEXT_LOGGING_NO_SPDLOG.
   #endif
 #endif
 

--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -4,7 +4,7 @@
 #include <mutex>
 #include <utility>
 
-#ifdef HAVE_SPDLOG
+#ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/stdout_sinks.h>
 #endif
@@ -13,7 +13,7 @@
 
 namespace drake {
 
-#ifdef HAVE_SPDLOG
+#ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
 
 namespace {
 // Returns the default logger.  NOTE: This function assumes that it is mutexed,
@@ -121,7 +121,7 @@ const char* const logging::kSetLogPatternHelpMessage =
     "sets the spdlog pattern for formatting; for more information, see "
     "https://github.com/gabime/spdlog/wiki/3.-Custom-formatting";
 
-#else  // HAVE_SPDLOG
+#else  // DRAKE_TEXT_LOGGING_NO_SPDLOG
 
 logging::logger::logger() {}
 
@@ -151,7 +151,7 @@ void logging::set_log_pattern(const std::string&) {}
 const char* const logging::kSetLogPatternHelpMessage =
     "(Text logging is unavailable.)";
 
-#endif  // HAVE_SPDLOG
+#endif  // DRAKE_TEXT_LOGGING_NO_SPDLOG
 
 const char* const logging::kSetLogLevelUnchanged = "unchanged";
 

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -45,7 +45,7 @@ DRAKE_FORMATTER_AS(). Grep around in Drake's existing code to find examples. */
 #include "drake/common/fmt.h"
 
 #ifndef DRAKE_DOXYGEN_CXX
-#ifdef HAVE_SPDLOG
+#ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
 #ifndef NDEBUG
 
 // When in Debug builds, before including spdlog we set the compile-time
@@ -84,14 +84,17 @@ DRAKE_FORMATTER_AS(). Grep around in Drake's existing code to find examples. */
 
 #include <spdlog/spdlog.h>
 
-#endif  // HAVE_SPDLOG
+#endif  // DRAKE_TEXT_LOGGING_NO_SPDLOG
 #endif  // DRAKE_DOXYGEN_CXX
 
 #include "drake/common/drake_copyable.h"
 
 namespace drake {
 
-#ifdef HAVE_SPDLOG
+// N.B. The guard DRAKE_TEXT_LOGGING_NO_SPDLOG is for internal use only
+// by Drake. Downstream projects should not rely on it being defined.
+// Use drake::kHaveSpdlog, instead.
+#ifndef DRAKE_TEXT_LOGGING_NO_SPDLOG
 namespace logging {
 
 // If we have spdlog, just alias logger into our namespace.
@@ -108,7 +111,7 @@ constexpr bool kHaveSpdlog = true;
 
 }  // namespace logging
 
-#else  // HAVE_SPDLOG
+#else  // DRAKE_TEXT_LOGGING_NO_SPDLOG
 // If we don't have spdlog, we need to stub out logger.
 
 namespace logging {
@@ -149,7 +152,7 @@ class sink {
 #define DRAKE_LOGGER_TRACE(...)
 #define DRAKE_LOGGER_DEBUG(...)
 
-#endif  // HAVE_SPDLOG
+#endif  // DRAKE_TEXT_LOGGING_NO_SPDLOG
 
 /// Retrieve an instance of a logger to use for logging; for example:
 /// <pre>

--- a/doc/doxygen_cxx/Doxyfile_CXX.in
+++ b/doc/doxygen_cxx/Doxyfile_CXX.in
@@ -300,7 +300,7 @@ SEARCH_INCLUDES        = YES
 INCLUDE_PATH           =
 INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = DRAKE_DOXYGEN_CXX=1 \
-                         HAVE_SPDLOG=1
+                         DRAKE_TEXT_LOGGING_HAS_SPDLOG=1
 # =============================================================================
 # N.B. The spelling of the macro names between common/drake_copyable.h and this
 # file must be kept in sync!

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -72,6 +72,8 @@ set_target_properties(drake::drake PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include"
   INTERFACE_LINK_LIBRARIES "${_drake_interface_libraries}"
   INTERFACE_COMPILE_FEATURES "cxx_std_20"
+  # This definition is deprecated and will be removed from Drake on or after
+  # 2025-06-01.
   INTERFACE_COMPILE_DEFINITIONS "HAVE_SPDLOG"
 )
 

--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -24,10 +24,11 @@ _ALLOWED_DEFINES = [
     "EIGEN_MPL2_ONLY",
     "FMT_HEADER_ONLY=1",
     "FMT_NO_FMT_STRING_ALIAS=1",
-    "HAVE_SPDLOG",
     "SPDLOG_COMPILED_LIB",
     "SPDLOG_FMT_EXTERNAL",
     "SPDLOG_SHARED_LIB",
+    # Deprecated for removal on 2025-05-01.
+    "HAVE_SPDLOG",
 ]
 
 def _cc_check_allowed_headers_impl(ctx):

--- a/tools/workspace/spdlog/BUILD.bazel
+++ b/tools/workspace/spdlog/BUILD.bazel
@@ -55,7 +55,11 @@ cc_library(
     name = "spdlog",
     defines = select({
         ":flag_spdlog_repo_disabled": [],
-        "//conditions:default": ["HAVE_SPDLOG"],
+        "//conditions:default": [
+            # This definition is deprecated and will be removed from Drake on
+            # or after 2025-06-01.
+            "HAVE_SPDLOG",
+        ],
     }),
     tags = ["nolint"],
     visibility = ["//visibility:public"],

--- a/tools/workspace/spdlog/repository.bzl
+++ b/tools/workspace/spdlog/repository.bzl
@@ -13,7 +13,8 @@ spdlog_repository = repository_rule(
         "modname": attr.string(default = "spdlog"),
         # Offered for backwards compatibility, but ignored.
         "mirrors": attr.string_list_dict(),
-        # TODO(jwnimmer-tri) Remove this line when we drop WORKSPACE support.
+        # This definition is deprecated and will be removed from Drake on or
+        # after 2025-06-01.
         "extra_defines": attr.string_list(default = ["HAVE_SPDLOG"]),
     },
     local = True,


### PR DESCRIPTION
This definition is not properly drake-namespaced. Instead, we'll use a proper DRAKE_... prefix and switch the sense of the condition so that the default case is not to define anything.

Towards #20731.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22562)
<!-- Reviewable:end -->
