### PR TITLE
[estimators] Deprecate one overload of SteadyStateKalmanFilter

### DIFF
--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -72,7 +72,8 @@ int do_main() {
       0.1 * Eigen::Matrix2d::Identity();  // Position measurements are clean.
   auto observer =
       builder.AddSystem(systems::estimators::SteadyStateKalmanFilter(
-          std::move(observer_acrobot), std::move(observer_context), W, V));
+          std::move(observer_acrobot), *observer_context, W, V));
+  observer_context.reset();
   observer->set_name("observer");
   builder.Connect(acrobot_w_encoder->get_output_port(0),
                   observer->get_input_port(0));

--- a/systems/estimators/kalman_filter.h
+++ b/systems/estimators/kalman_filter.h
@@ -4,6 +4,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/systems/estimators/luenberger_observer.h"
 #include "drake/systems/primitives/linear_system.h"
 
@@ -88,9 +89,11 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     const Eigen::Ref<const Eigen::MatrixXd>& W,
     const Eigen::Ref<const Eigen::MatrixXd>& V);
 
-// TODO(jwnimmer-tri) Add deprecation marker on or about 2025-02-01.
-/// (To be deprecated) An overload that accepts `context` by unique_ptr.
-/// @exclude_from_pydrake_mkdoc{This is not bound.}
+DRAKE_DEPRECATED(
+    "2025-06-01",
+    "This overload is deprecated for removal. Instead, use the other overload "
+    "by passing a const-ref to the context. (Add an asterisk at the call site "
+    "to de-reference the context.)")
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::unique_ptr<System<double>> system,
     std::unique_ptr<Context<double>> context,

--- a/systems/estimators/test/kalman_filter_test.cc
+++ b/systems/estimators/test/kalman_filter_test.cc
@@ -51,13 +51,16 @@ GTEST_TEST(TestKalman, DoubleIntegrator) {
   context.reset();
   EXPECT_TRUE(CompareMatrices(filter->L(), L, tol));
 
-  // Also check the to-be-deprecated overload that accepts a unique_ptr context.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // Also check the 2025-06-01 deprecated overload that accepts a unique_ptr.
   auto owned = std::make_unique<LinearSystem<double>>(A, B, C, D);
   context = owned->CreateDefaultContext();
   owned->get_input_port().FixValue(context.get(), 0.0);
   context->SetContinuousState(Eigen::Vector2d::Zero());
-  filter = SteadyStateKalmanFilter(std::move(owned), std::move(context), W, V);
+  filter = SteadyStateKalmanFilter(std::move(owned), *context, W, V);
   EXPECT_TRUE(CompareMatrices(filter->L(), L, tol));
+#pragma GCC diagnostic pop
 }
 
 }  // namespace


### PR DESCRIPTION
Follow-up from #22351.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22563)
<!-- Reviewable:end -->
