### PR TITLE
[build] Remove unnecessary install boilerplate

### DIFF
--- a/cmake/external/workspace/eigen/BUILD.bazel.in
+++ b/cmake/external/workspace/eigen/BUILD.bazel.in
@@ -1,38 +1,7 @@
 # -*- bazel -*-
 
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@rules_license//rules:license.bzl", "license")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(":conversion.bzl", "split_cmake_list")
-
-write_file(
-    name = "unknown_license",
-    out = "LICENSE",
-    content = ["Unknown license (Drake used CMake find_package).\n"],
-)
-
-license(
-    name = "license.APACHE",
-    license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
-    license_text = "LICENSE",
-)
-
-license(
-    name = "license.BSD",
-    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause"],
-    license_text = "LICENSE",
-)
-
-license(
-    name = "license.MINPACK",
-    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause-Attribution"],
-    license_text = "LICENSE",
-)
-
-license(
-    name = "license.MPL2",
-    license_kinds = ["@rules_license//licenses/spdx:MPL-2.0"],
-    license_text = "LICENSE",
-)
 
 EIGEN_DEFINES = split_cmake_list(
     "$<TARGET_PROPERTY:Eigen3::Eigen,INTERFACE_COMPILE_DEFINITIONS>",

--- a/cmake/external/workspace/eigen/MODULE.bazel.in
+++ b/cmake/external/workspace/eigen/MODULE.bazel.in
@@ -2,5 +2,4 @@ module(
     name = "eigen",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.0.3")
-bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/cmake/external/workspace/fmt/BUILD.bazel.in
+++ b/cmake/external/workspace/fmt/BUILD.bazel.in
@@ -1,20 +1,7 @@
 # -*- bazel -*-
 
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@rules_license//rules:license.bzl", "license")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(":conversion.bzl", "split_cmake_list")
-
-write_file(
-    name = "unknown_license",
-    out = "LICENSE",
-    content = ["Unknown license (Drake used CMake find_package).\n"],
-)
-
-license(
-    name = "license",
-    license_kinds = ["@rules_license//licenses/spdx:MIT"],
-    license_text = "LICENSE",
-)
 
 _DEFINES = split_cmake_list(
     "$<TARGET_PROPERTY:fmt::fmt,INTERFACE_COMPILE_DEFINITIONS>",

--- a/cmake/external/workspace/fmt/MODULE.bazel.in
+++ b/cmake/external/workspace/fmt/MODULE.bazel.in
@@ -2,5 +2,4 @@ module(
     name = "fmt",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.0.3")
-bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/cmake/external/workspace/spdlog/BUILD.bazel.in
+++ b/cmake/external/workspace/spdlog/BUILD.bazel.in
@@ -1,21 +1,8 @@
 # -*- bazel -*-
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@rules_license//rules:license.bzl", "license")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(":conversion.bzl", "split_cmake_list")
-
-write_file(
-    name = "unknown_license",
-    out = "LICENSE",
-    content = ["Unknown license (Drake used CMake find_package).\n"],
-)
-
-license(
-    name = "license",
-    license_kinds = ["@rules_license//licenses/spdx:MIT"],
-    license_text = "LICENSE",
-)
 
 _DEFINES = split_cmake_list(
     "$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_COMPILE_DEFINITIONS>",

--- a/cmake/external/workspace/spdlog/MODULE.bazel.in
+++ b/cmake/external/workspace/spdlog/MODULE.bazel.in
@@ -5,4 +5,4 @@ module(
 bazel_dep(name = "fmt")
 
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
-bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/tools/workspace/eigen/BUILD.bazel
+++ b/tools/workspace/eigen/BUILD.bazel
@@ -74,10 +74,7 @@ selects.config_setting_group(
 
 install(
     name = "install_hdrs",
-    targets = select({
-        ":is_external": [],
-        "//conditions:default": ["@module_eigen//:eigen"],
-    }),
+    targets = ["@module_eigen//:eigen"],
     hdr_dest = "include",
     guess_hdrs = "PACKAGE",
     allowed_externals = ["@module_eigen//:eigen"],
@@ -97,10 +94,13 @@ install_license(
 install(
     name = "install",
     visibility = ["//tools/workspace:__pkg__"],
-    deps = [
-        ":install_hdrs",
-        ":install_license",
-    ],
+    deps = select({
+        ":is_external": [],
+        "//conditions:default": [
+            ":install_hdrs",
+            ":install_license",
+        ],
+    }),
 )
 
 add_lint_tests()

--- a/tools/workspace/fmt/BUILD.bazel
+++ b/tools/workspace/fmt/BUILD.bazel
@@ -91,10 +91,7 @@ cc_library(
 
 install(
     name = "install_hdrs",
-    targets = select({
-        ":is_external": [],
-        "//conditions:default": [":hdrs"],
-    }),
+    targets = [":hdrs"],
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
     guess_hdrs = "ALLOWED_EXTERNALS",
@@ -110,10 +107,13 @@ install_license(
 install(
     name = "install",
     visibility = ["//tools/workspace:__pkg__"],
-    deps = [
-        ":install_hdrs",
-        ":install_license",
-    ],
+    deps = select({
+        ":is_external": [],
+        "//conditions:default": [
+            ":install_hdrs",
+            ":install_license",
+        ],
+    }),
 )
 
 add_lint_tests()

--- a/tools/workspace/spdlog/BUILD.bazel
+++ b/tools/workspace/spdlog/BUILD.bazel
@@ -104,10 +104,7 @@ cc_library(
 
 install(
     name = "install_hdrs",
-    targets = select({
-        ":is_external": [],
-        "//conditions:default": [":hdrs"],
-    }),
+    targets = [":hdrs"],
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
     guess_hdrs = "ALLOWED_EXTERNALS",
@@ -123,10 +120,13 @@ install_license(
 install(
     name = "install",
     visibility = ["//tools/workspace:__pkg__"],
-    deps = [
-        ":install_hdrs",
-        ":install_license",
-    ],
+    deps = select({
+        ":is_external": [],
+        "//conditions:default": [
+            ":install_hdrs",
+            ":install_license",
+        ],
+    }),
 )
 
 add_lint_tests()


### PR DESCRIPTION
As of #22520, I should have realized that we now can drop the install-a-dummy-license-file boilerplate, since we know for certain whether the dependency is external or internal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22569)
<!-- Reviewable:end -->
