### PR TITLE
Re-enable hardware_sim test on macOS Sequoia and add documentation

### DIFF
--- a/doc/_pages/troubleshooting.md
+++ b/doc/_pages/troubleshooting.md
@@ -238,6 +238,36 @@ Note that the concurrency level passed to `make` (e.g., `make -j 2`) does not
 propagate through to affect the concurrency of most of Drake's build steps; you
 need to configure the dotfile in order to control the build concurrency.
 
+# Network Configuration
+
+## LCM on macOS {#lcm-macos}
+
+When building and testing Drake from source on macOS 15 (Sequoia), you may
+encounter issues with [LCM](https://lcm-proj.github.io/lcm/index.html).
+In particular, an error message that can arise is: "LCM self test failed!!
+Check your routing tables and firewall settings." LCM relies on
+[UDP Multicast](https://lcm-proj.github.io/lcm/content/multicast-setup.html)
+over loopback, so multicast traffic must be enabled over the loopback
+interface on your computer in order for it to work.
+
+Sometimes this is not explicitly enabled on macOS. If you see this error,
+check the routing table by running `netstat -nr`. The following entry in the
+IPv4 table is correct:
+
+```
+Internet:
+Destination        Gateway            Flags               Netif Expire
+...
+224.0.0/4          lo0                UmS                   lo0
+```
+
+If you see a different interface for this address, such as `en0`, then
+run the following to change it to loopback (`lo0`):
+
+```
+sudo route -nv delete 224.0.0.0/4
+sudo route -nv add -net 224.0.0.0/4 -interface lo0
+```
 
 <!-- Links to the various Drake doxygen pages.
      Order determined by directory structure first and names second.

--- a/examples/hardware_sim/test/hardware_sim_test_common.py
+++ b/examples/hardware_sim/test/hardware_sim_test_common.py
@@ -9,24 +9,14 @@ hardware_sim_py_test to actually run it.
 
 import copy
 import os.path
-import platform
 import re
 import shlex
 import subprocess
 import sys
-import unittest
 
 import yaml
 
 from python.runfiles import Create as CreateRunfiles
-
-
-def _is_macos_sequoia() -> bool:
-    if sys.platform == "darwin":
-        ver_str = platform.mac_ver()[0]
-        major = int(ver_str.split(".")[0])
-        return major == 15
-    return False
 
 
 class HardwareSimTest:
@@ -91,7 +81,6 @@ class HardwareSimTest:
         """Tests the OneOfEverything test scenario."""
         self._run(self._test_scenarios, "OneOfEverything")
 
-    @unittest.skipIf(_is_macos_sequoia(), "LCM problems cause a segfault")
     def test_Demo(self):
         """Tests the Demo example."""
         self._run(self._example_scenarios, "Demo")

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -17,6 +17,9 @@ namespace lcm {
  *
  * See \ref allow_network "DRAKE_ALLOW_NETWORK" for an environment variable
  * option to disable LCM network traffic (i.e., only allowing `memq://` URLs).
+ *
+ * For network issues on macOS, see
+ * https://drake.mit.edu/troubleshooting.html#lcm-macos.
  */
 class DrakeLcm : public DrakeLcmInterface {
  public:


### PR DESCRIPTION
Addresses #22322 and re-enables the unit test that was failing. See [here](https://github.com/RobotLocomotion/drake/issues/22322#issuecomment-2619688764) for a description of the network config fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22572)
<!-- Reviewable:end -->
