### PR TITLE
Skip Bazel prefetch in prerequisite installation

### DIFF
--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -102,9 +102,9 @@ source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
 # Configure user environment, executing as user if we're under `sudo`.
 user_env_script="${BASH_SOURCE%/*}/source_distribution/install_prereqs_user_environment.sh"
 if [[ -n "${SUDO_USER:+D}" ]]; then
-    sudo -u "${SUDO_USER}" bash "${user_env_script}"
+    sudo -u "${SUDO_USER}" bash "${user_env_script}" "${source_distribution_args[@]}"
 else
-    source "${user_env_script}"
+    source "${user_env_script}" "${source_distribution_args[@]}"
 fi
 
 trap : EXIT  # Disable exit reporting.

--- a/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
@@ -5,6 +5,37 @@
 
 set -euo pipefail
 
+with_bazel=1
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    --developer)
+      with_bazel=1
+      ;;
+    # Install bazelisk from a deb package.
+    --with-bazel)
+      with_bazel=1
+      ;;
+    # Do NOT install bazelisk.
+    --without-bazel)
+      with_bazel=0
+      ;;
+    # Ignore other source distribution arguments.
+    --with-doc-only | \
+    --with-clang | \
+    --without-clang | \
+    --with-maintainer-only | \
+    --without-test-only | \
+    --without-update | \
+    -y)
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 3
+  esac
+  shift
+done
+
 # Check for existence of `SUDO_USER` so that this may be used in Docker
 # environments.
 if [[ "${EUID}" -eq 0 && -n "${SUDO_USER:+D}" ]]; then
@@ -24,4 +55,6 @@ EOF
 
 # Prefetch the bazelisk download of bazel.
 # This is especially helpful for the "Provisioned" images in CI.
-(cd "${workspace_dir}" && bazel version)
+if [[ "${with_bazel}" -eq 1 ]]; then
+  (cd "${workspace_dir}" && bazel version)
+fi

--- a/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
@@ -5,29 +5,13 @@
 
 set -euo pipefail
 
-with_bazel=1
+prefetch_bazel=0
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
-    --developer)
-      with_bazel=1
-      ;;
-    # Install bazelisk from a deb package.
-    --with-bazel)
-      with_bazel=1
-      ;;
-    # Do NOT install bazelisk.
-    --without-bazel)
-      with_bazel=0
-      ;;
-    # Ignore other source distribution arguments.
-    --with-doc-only | \
-    --with-clang | \
-    --without-clang | \
-    --with-maintainer-only | \
-    --without-test-only | \
-    --without-update | \
-    -y)
+    # Prefetch bazel, if installing bazel.
+    --prefetch-bazel)
+      prefetch_bazel=1
       ;;
     *)
       echo 'Invalid command line argument' >&2
@@ -55,6 +39,6 @@ EOF
 
 # Prefetch the bazelisk download of bazel.
 # This is especially helpful for the "Provisioned" images in CI.
-if [[ "${with_bazel}" -eq 1 ]]; then
+if [[ "${prefetch_bazel}" -eq 1 ]]; then
   (cd "${workspace_dir}" && bazel version)
 fi


### PR DESCRIPTION
This follows from #22461. When installing `--without-bazel`, we need to skip a step in `install_prereqs_user_environment` which does a prefetch of the bazelisk download of bazel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22575)
<!-- Reviewable:end -->
