### PR TITLE
[pydrake] Stop using PYBIND11_NUMPY_OBJECT_DTYPE

### DIFF
--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -177,5 +177,11 @@ std::shared_ptr<T> make_shared_ptr_from_py_object(py::object py_object) {
 }  // namespace pydrake
 }  // namespace drake
 
-#define DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(Type) \
-  PYBIND11_NUMPY_OBJECT_DTYPE(Type)
+#define DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(Type)     \
+  namespace pybind11 {                              \
+  namespace detail {                                \
+  template <>                                       \
+  struct npy_format_descriptor<Type>                \
+      : public npy_format_descriptor<PyObject*> {}; \
+  } /* namespace detail */                          \
+  } /* namespace pybind11 */


### PR DESCRIPTION
The PYBIND11_... spelling is an RLG-specific addition atop pybind11. We're moving to use upstream pybind11, so we can't rely on the RLG macro anymore.

Towards #21968.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22576)
<!-- Reviewable:end -->
