### PR TITLE
[build] Document the new "spdlog disabled" flag as experimental

### DIFF
--- a/tools/flags/BUILD.bazel
+++ b/tools/flags/BUILD.bazel
@@ -121,6 +121,11 @@ string_flag(
 # `@drake//tools/workspace/spdlog` library into a no-op and Drake will be built
 # without any text_logging infrastructure; all log messages will be discarded.
 #
+# WARNING: The "disabled" feature should be considered experimental (no promise
+# of stability in future releases); in the future, we anticipate respelling the
+# flag so that "how to find spdlog" and "what should text_logging be doing" are
+# configured separately.
+#
 # Note that fmt is typically a dependency of spdlog, so be careful to configure
 # them in a sensible pairing; setting one to module and the other to pkgconfig
 # is probably a mistake.
@@ -129,9 +134,10 @@ string_flag(
     build_setting_default = "default",
     values = [
         "default",
-        "disabled",
         "module",
         "pkgconfig",
+        # N.B. See warning above about our stability promise for 'disabled'.
+        "disabled",
     ],
 )
 


### PR DESCRIPTION
Amends #22432.

While working with this flag in WIP branches lately, I'm not sure we should keep this option.  I anticipate adding a new "how should logging behave" flag, separate from this one which is more about choosing a version.  This would become Stable API in the next release, so we should mark it experimental for now.

+@xuchenhan-tri for both reviews (Monday), please.  No rush.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22577)
<!-- Reviewable:end -->
