### PR TITLE
Tweak some yaml serialization documentation

### DIFF
--- a/common/memory_file.h
+++ b/common/memory_file.h
@@ -85,16 +85,18 @@ class MemoryFile final {
    Serializing the %MemoryFile will produce such a string. Writing a yaml file
    by hand will be more challenging.
 
-   The following yaml would produce a %MemoryFile with contents equal to:
+   For this yaml:
 
-       This is an example of memory file test contents.
-
-   ```yaml
+   @code{yaml}
    contents: !!binary VGhpcyBpcyBhbiBleGFtcGxlIG9mIG1
            lbW9yeSBmaWxlIHRlc3QgY29udGVudHMu
    extension: .txt
    filename_hint: payload.txt
-   ```
+   @endcode
+
+   we would produce a %MemoryFile with contents equal to:
+
+       This is an example of memory file test contents.
    */
   template <typename Archive>
   void Serialize(Archive* a) {

--- a/geometry/rgba.h
+++ b/geometry/rgba.h
@@ -93,8 +93,8 @@ class Rgba {
 
   /** Passes this object to an Archive.
 
-   In YAML, an %Rgba is represented by an array-like list of three or four
-   numbers. E.g.,
+   In YAML, an %Rgba is represented by a mapping of the symbol `rgba` to
+   an array-like list of three or four numbers. E.g.,
 
         rgba: [0.5, 0.5, 1.0]
 
@@ -104,6 +104,29 @@ class Rgba {
 
    such that the first three values are red, green, and blue, respectively. If
    no fourth value is provided, alpha is defined a 1.0.
+
+   When another struct has an %Rgba-valued member (e.g.,
+   systems::sensors::CameraConfig::background), remember to include the full
+   mapping. For example, imagine the struct:
+
+   ```{cpp}
+   struct Foo {
+     Rgba color1;
+     Rgba color2;
+   };
+   ```
+
+   The correct yaml representation of this would be:
+
+   ```yaml
+   color1:
+     rgba: [0.5, 0.5, 1.0]
+   color2:
+     rgba: [1.0, 0.0, 0.0, 0.5]
+   ```
+
+   The *values* of `color1` and `color2` are the mapping from `rgba` to the
+   desired color tuples.
 
    Refer to @ref yaml_serialization "YAML Serialization" for background. */
   template <typename Archive>


### PR DESCRIPTION
1. MemoryFile's documentation choked doxygen. There was no documentation rendered for Serialize(). The minimum fix led to really ugly layout. (Code block immediately followed indented block.) So, we shuffled the rhetoric so the layout looked better.
2. Rgba suffered from a similar layout problem. Furthermore, it wasn't clear that it had particularly weird yaml semantics. The documentation has been extended to help that become clearer.

closes #22582

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22584)
<!-- Reviewable:end -->
