### PR TITLE
Make GetContinuousRevoluteJointIndices Include UniversalJoint and BallRpyJoint

### DIFF
--- a/planning/trajectory_optimization/gcs_trajectory_optimization.h
+++ b/planning/trajectory_optimization/gcs_trajectory_optimization.h
@@ -1364,8 +1364,8 @@ class GcsTrajectoryOptimization final {
 
 /** Returns a list of indices in the plant's generalized positions which
 correspond to a continuous revolute joint (a revolute joint with no joint
-limits). This includes the revolute component of PlanarJoint and
-RpyFloatingJoint. */
+limits). This includes UniversalJoint, and the revolute component of PlanarJoint
+and RpyFloatingJoint. */
 std::vector<int> GetContinuousRevoluteJointIndices(
     const multibody::MultibodyPlant<double>& plant);
 


### PR DESCRIPTION
These two joints internally have revolute components, so if there are no limits, we include them in the "continuous revolute joints" framework.

Not sure if changing the return values technically counts as a breaking change, but `GcsTrajectoryOptimization` is tagged as `@experimental`, so we're fine either way.

This removes the TODO introduced in #21861

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22585)
<!-- Reviewable:end -->
