### PR TITLE
SceneGraph protects itself from non-finite values on its inputs

### DIFF
--- a/geometry/kinematics_vector.h
+++ b/geometry/kinematics_vector.h
@@ -140,6 +140,9 @@ class KinematicsVector {
    */
   std::vector<Id> ids() const;
 
+  /** Reports if *all* values are finite. */
+  bool IsFinite() const;
+
  private:
   void CheckInvariants() const;
 

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -677,6 +677,13 @@ void SceneGraph<T>::CalcPoseUpdate(const Context<T>& context, int*) const {
         }
         const auto& poses =
             pose_port.template Eval<FramePoseVector<T>>(context);
+        if (!poses.IsFinite()) {
+          throw std::runtime_error(fmt::format(
+              "SceneGraph encountered a non-finite value (e.g., NaN or "
+              "infinity) on a pose input port. It came from the input "
+              "associated with source id {} and name '{}'.",
+              fmt_streamed(source_id), state.GetName(source_id)));
+        }
         state.SetFramePoses(source_id, poses, &kinematics_data);
       }
     }
@@ -715,6 +722,13 @@ void SceneGraph<T>::CalcConfigurationUpdate(const Context<T>& context,
         const auto& configs =
             configuration_port.template Eval<GeometryConfigurationVector<T>>(
                 context);
+        if (!configs.IsFinite()) {
+          throw std::runtime_error(fmt::format(
+              "SceneGraph encountered a non-finite value (e.g., Nan or "
+              "infinity) on a deformable configuration input port. It came "
+              "from the input associated with source id {} and name '{}'.",
+              fmt_streamed(source_id), state.GetName(source_id)));
+        }
         state.SetGeometryConfiguration(source_id, configs, &kinematics_data);
       }
     }

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -971,6 +971,53 @@ GTEST_TEST(SceneGraphConnectionTest, FullPoseUpdateDisconnected) {
           source_system->registered_source_name()));
 }
 
+GTEST_TEST(SceneGraphConnectionTest, NanInPoseInputs) {
+  SceneGraph<double> sg;
+  const SourceId s_id = sg.RegisterSource("nan_port");
+  const FrameId f_id = sg.RegisterFrame(s_id, GeometryFrame("frame"));
+  std::unique_ptr<Context<double>> context = sg.CreateDefaultContext();
+
+  FramePoseVector<double> poses;
+  RigidTransformd nan_pose(
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()));
+  poses.set_value(f_id, nan_pose);
+
+  sg.get_source_pose_port(s_id).FixValue(context.get(), poses);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SceneGraphTester::FullPoseUpdate(sg, *context),
+      ".*non-finite value .* on a pose input port.*'nan_port'.*");
+}
+
+GTEST_TEST(SceneGraphConnectionTest, NanInConfigInputs) {
+  SceneGraph<double> sg;
+  const SourceId s_id = sg.RegisterSource("nan_port");
+
+  // Sphere tessellated as an octahedron.
+  GeometryId deformable_id = sg.RegisterDeformableGeometry(
+      s_id, sg.world_frame_id(), make_sphere_instance(), 2.0);
+
+  std::unique_ptr<Context<double>> context = sg.CreateDefaultContext();
+
+  const SceneGraphInspector<double>& inspector = sg.model_inspector();
+  const VolumeMesh<double>* mesh_ptr =
+      inspector.GetReferenceMesh(deformable_id);
+  DRAKE_DEMAND(mesh_ptr != nullptr);
+
+  GeometryConfigurationVector<double> configs;
+  Eigen::VectorX<double> qs =
+      Eigen::VectorX<double>::Zero(mesh_ptr->num_vertices() * 3);
+  qs[1] = std::numeric_limits<double>::quiet_NaN();
+  configs.set_value(deformable_id, qs);
+
+  sg.get_source_configuration_port(s_id).FixValue(context.get(), configs);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      SceneGraphTester::FullConfigurationUpdate(sg, *context),
+      ".*non-finite value .* on a deformable configuration input "
+      "port.*'nan_port'.*");
+}
+
 // Confirms that the SceneGraph can be instantiated on AutoDiff type.
 GTEST_TEST(SceneGraphAutoDiffTest, InstantiateAutoDiff) {
   SceneGraph<AutoDiffXd> scene_graph;


### PR DESCRIPTION
The various kinematics vectors (pose and deformable configuration) can now detect if they have been populated with any NaN values.

SceneGraph uses that functionality to detect if it's input has NaN values and throw exceptions attributing NaN to the appropriate input port.

Relates #22586.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22592)
<!-- Reviewable:end -->
