### PR TITLE
Collision checker protects itself from user-provided NaN

### DIFF
--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -679,6 +679,10 @@ bool CollisionChecker::CheckContextEdgeCollisionFree(
   // There is also no need to special case checking q1, since it will be the
   // first configuration checked in the loop.
   if (!CheckContextConfigCollisionFree(model_context, q2)) {
+    // Checking q2 throws if q2 contains non-finite values.
+    // However, if q2 is all finite and in collision, we still should throw if
+    // q1 isn't finite; the return value is reserved for valid inputs.
+    DRAKE_THROW_UNLESS(q1.allFinite());
     return false;
   }
 
@@ -714,6 +718,10 @@ bool CollisionChecker::CheckEdgeCollisionFreeParallel(
     // failing fast on a colliding q2 helps reduce the work of checking
     // colliding edges.
     if (!CheckConfigCollisionFree(q2)) {
+      // Checking q2 throws if q2 contains non-finite values.
+      // However, if q2 is all finite and in collision, we still should throw if
+      // q1 isn't finite; the return value is reserved for valid inputs.
+      DRAKE_THROW_UNLESS(q1.allFinite());
       return false;
     }
     // Special case q1 as well, so it gets checked before parallel dispatch.

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -24,6 +24,13 @@
 namespace drake {
 namespace planning {
 
+/* Note to developers:
+
+ It is documented that when passing configurations, they must all have finite
+ values. However, CollisionChecker relies on other classes to do that validation
+ (e.g., MultibodyPlant and DistanceAndInterpolationProvider). This requirement
+ is tested in collision_checker_test against regression in those classes. */
+
 /** Interface for collision checkers to use.
 
  <!-- TODO(SeanCurtis-TRI): This documentation focuses on the context management
@@ -278,7 +285,8 @@ class CollisionChecker {
    The implicit context is either that specified by `context_number`, or when
    nullopt the context to be used with the current OpenMP thread.
    @param context_number Optional implicit context number.
-   @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
+   @see @ref ccb_implicit_contexts "Implicit Context Parallelism".
+   @throws if `q` contains non-finite values. */
   const systems::Context<double>& UpdatePositions(
       const Eigen::VectorXd& q,
       std::optional<int> context_number = std::nullopt) const {
@@ -287,6 +295,7 @@ class CollisionChecker {
 
   /** Explicit Context-based version of UpdatePositions().
    @throws std::exception if `model_context` is `nullptr`.
+   @throws if `q` contains non-finite values.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
   const systems::Context<double>& UpdateContextPositions(
       CollisionCheckerContext* model_context, const Eigen::VectorXd& q) const {
@@ -714,6 +723,7 @@ class CollisionChecker {
    @param q Configuration to check
    @param context_number Optional implicit context number.
    @returns true if collision free, false if in collision.
+   @throws if `q` contains non-finite values.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
   bool CheckConfigCollisionFree(
       const Eigen::VectorXd& q,
@@ -721,11 +731,11 @@ class CollisionChecker {
 
   /** Explicit Context-based version of CheckConfigCollisionFree().
    @throws std::exception if model_context is nullptr.
+   @throws if `q` contains non-finite values.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
   bool CheckContextConfigCollisionFree(CollisionCheckerContext* model_context,
                                        const Eigen::VectorXd& q) const;
 
-  // TODO(SeanCurtis-TRI): This isn't tested.
   /** Checks a vector of configurations for collision, evaluating in parallel
    when supported and enabled by `parallelize`. Parallelization in configuration
    collision checks is provided using OpenMP and is supported when both: (1) the
@@ -737,7 +747,8 @@ class CollisionChecker {
    @param configs     Configurations to check
    @param parallelize How much should collision checks be parallelized?
    @returns std::vector<uint8_t>, one for each configuration in configs. For
-   each configuration, 1 if collision free, 0 if in collision. */
+   each configuration, 1 if collision free, 0 if in collision.
+   @throws if `configs` contains non-finite values. */
   std::vector<uint8_t> CheckConfigsCollisionFree(
       const std::vector<Eigen::VectorXd>& configs,
       Parallelism parallelize = Parallelism::Max()) const;
@@ -890,7 +901,8 @@ class CollisionChecker {
 
   /** Computes configuration-space distance between the provided configurations
    `q1` and `q2`, using the distance function configured at construction-
-   time or via SetConfigurationDistanceFunction(). */
+   time or via SetConfigurationDistanceFunction().
+   @throws if `q1` or `q2` contain non-finite values. */
   double ComputeConfigurationDistance(const Eigen::VectorXd& q1,
                                       const Eigen::VectorXd& q2) const {
     return distance_and_interpolation_provider_->ComputeConfigurationDistance(
@@ -903,7 +915,8 @@ class CollisionChecker {
    ComputeConfigurationDistance().
    @warning do not pass this standalone function back into
    SetConfigurationDistanceFunction() function; doing so would create an
-   infinite loop. */
+   infinite loop.
+   @throws if `q1` or `q2` contain non-finite values. */
   ConfigurationDistanceFunction MakeStandaloneConfigurationDistanceFunction()
       const;
 
@@ -930,6 +943,7 @@ class CollisionChecker {
    @param ratio Interpolation ratio.
    @returns Interpolated configuration.
    @throws std::exception if ratio is not in range [0, 1].
+   @throws if `q1` or `q2` contain non-finite values.
    @see ConfigurationInterpolationFunction for more. */
   Eigen::VectorXd InterpolateBetweenConfigurations(const Eigen::VectorXd& q1,
                                                    const Eigen::VectorXd& q2,
@@ -964,12 +978,14 @@ class CollisionChecker {
    @param q2 End configuration for edge.
    @param context_number Optional implicit context number.
    @returns true if collision free, false if in collision.
+   @throws if `q1` or `q2` contain non-finite values.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
   bool CheckEdgeCollisionFree(
       const Eigen::VectorXd& q1, const Eigen::VectorXd& q2,
       std::optional<int> context_number = std::nullopt) const;
 
   /** Explicit Context-based version of CheckEdgeCollisionFree().
+   @throws if `q1` or `q2` contain non-finite values.
    @throws std::exception if `model_context` is nullptr.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
   bool CheckContextEdgeCollisionFree(CollisionCheckerContext* model_context,
@@ -983,7 +999,8 @@ class CollisionChecker {
    @param q1 Start configuration for edge.
    @param q2 End configuration for edge.
    @param parallelize How much should edge collision check be parallelized?
-   @returns true if collision free, false if in collision. */
+   @returns true if collision free, false if in collision.
+   @throws if `q1` or `q2` contain non-finite values. */
   bool CheckEdgeCollisionFreeParallel(
       const Eigen::VectorXd& q1, const Eigen::VectorXd& q2,
       Parallelism parallelize = Parallelism::Max()) const;
@@ -996,7 +1013,8 @@ class CollisionChecker {
    @param edges        Edges to check, each in the form of pair<q1, q2>.
    @param parallelize  How much should edge collision checks be parallelized?
    @returns std::vector<uint8_t>, one for each edge in edges. For each edge, 1
-   if collision free, 0 if in collision. */
+   if collision free, 0 if in collision.
+   @throws if any vector in `edges` contains non-finite values. */
   std::vector<uint8_t> CheckEdgesCollisionFree(
       const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
       Parallelism parallelize = Parallelism::Max()) const;
@@ -1007,6 +1025,7 @@ class CollisionChecker {
    @param q2 End configuration for edge.
    @param context_number Optional implicit context number.
    @returns A measure of how much of the edge is collision free.
+   @throws if `q1` or `q2` contain non-finite values.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
   EdgeMeasure MeasureEdgeCollisionFree(
       const Eigen::VectorXd& q1, const Eigen::VectorXd& q2,
@@ -1014,6 +1033,7 @@ class CollisionChecker {
 
   /** Explicit Context-based version of MeasureEdgeCollisionFree().
    @throws std::exception if `model_context` is nullptr.
+   @throws if `q1` or `q2` contain non-finite values.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
   EdgeMeasure MeasureContextEdgeCollisionFree(
       CollisionCheckerContext* model_context, const Eigen::VectorXd& q1,
@@ -1026,7 +1046,8 @@ class CollisionChecker {
    @param q1 Start configuration for edge.
    @param q2 End configuration for edge.
    @param parallelize How much should edge collision check be parallelized?
-   @returns A measure of how much of the edge is collision free. */
+   @returns A measure of how much of the edge is collision free.
+   @throws if `q1` or `q2` contain non-finite values. */
   EdgeMeasure MeasureEdgeCollisionFreeParallel(
       const Eigen::VectorXd& q1, const Eigen::VectorXd& q2,
       Parallelism parallelize = Parallelism::Max()) const;
@@ -1039,7 +1060,8 @@ class CollisionChecker {
    @param edges        Edges to check, each in the form of pair<q1, q2>.
    @param parallelize  How much should edge collision checks be parallelized?
    @returns A measure of how much of each edge is collision free. The iᵗʰ entry
-            is the result for the iᵗʰ edge. */
+            is the result for the iᵗʰ edge.
+   @throws if any vector in `edges` contains non-finite values. */
   std::vector<EdgeMeasure> MeasureEdgesCollisionFree(
       const std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& edges,
       Parallelism parallelize = Parallelism::Max()) const;
@@ -1076,6 +1098,7 @@ class CollisionChecker {
    @see RobotClearance for details on the quantities ϕ and Jqᵣ_ϕ (and other
    details).
    @param context_number Optional implicit context number.
+   @throws if `q` contains non-finite values.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
   RobotClearance CalcRobotClearance(
       const Eigen::VectorXd& q, double influence_distance,
@@ -1083,6 +1106,7 @@ class CollisionChecker {
 
   /** Explicit Context-based version of CalcRobotClearance().
    @throws std::exception if `model_context` is nullptr.
+   @throws if `q` contains non-finite values.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
   RobotClearance CalcContextRobotClearance(
       CollisionCheckerContext* model_context, const Eigen::VectorXd& q,
@@ -1109,6 +1133,7 @@ class CollisionChecker {
    entries for robot bodies are guaranteed to be valid; entries for
    environment bodies are populated with kNoCollision, regardless of their
    actual status.
+   @throws if `q` contains non-finite values.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
   std::vector<RobotCollisionType> ClassifyBodyCollisions(
       const Eigen::VectorXd& q,
@@ -1116,6 +1141,7 @@ class CollisionChecker {
 
   /** Explicit Context-based version of ClassifyBodyCollisions().
    @throws std::exception if `model_context` is nullptr.
+   @throws if `q` contains non-finite values.
    @see @ref ccb_explicit_contexts "Explicit Context Parallelism". */
   std::vector<RobotCollisionType> ClassifyContextBodyCollisions(
       CollisionCheckerContext* model_context, const Eigen::VectorXd& q) const;

--- a/planning/distance_and_interpolation_provider.cc
+++ b/planning/distance_and_interpolation_provider.cc
@@ -12,6 +12,7 @@ DistanceAndInterpolationProvider::~DistanceAndInterpolationProvider() = default;
 double DistanceAndInterpolationProvider::ComputeConfigurationDistance(
     const Eigen::VectorXd& from, const Eigen::VectorXd& to) const {
   DRAKE_THROW_UNLESS(from.size() == to.size());
+  DRAKE_THROW_UNLESS(from.allFinite() && to.allFinite());
   const double distance = DoComputeConfigurationDistance(from, to);
   DRAKE_THROW_UNLESS(distance >= 0.0);
   DRAKE_THROW_UNLESS(std::isfinite(distance));
@@ -25,6 +26,7 @@ DistanceAndInterpolationProvider::InterpolateBetweenConfigurations(
   DRAKE_THROW_UNLESS(from.size() == to.size());
   DRAKE_THROW_UNLESS(ratio >= 0.0);
   DRAKE_THROW_UNLESS(ratio <= 1.0);
+  DRAKE_THROW_UNLESS(from.allFinite() && to.allFinite());
   Eigen::VectorXd interpolated =
       DoInterpolateBetweenConfigurations(from, to, ratio);
   DRAKE_THROW_UNLESS(from.size() == interpolated.size());

--- a/planning/distance_and_interpolation_provider.h
+++ b/planning/distance_and_interpolation_provider.h
@@ -55,13 +55,15 @@ class DistanceAndInterpolationProvider {
   /** Computes the configuration distance from the provided configuration `from`
   to the provided configuration `to`. The returned distance will be strictly
   non-negative.
-  @pre from.size() == to.size() */
+  @pre from.size() == to.size().
+  @throws if `from` or `to` contain non-finite values. */
   double ComputeConfigurationDistance(const Eigen::VectorXd& from,
                                       const Eigen::VectorXd& to) const;
 
   /** Returns the interpolated configuration between `from` and `to` at `ratio`.
-  @pre from.size() == to.size()
-  @pre ratio in [0, 1] */
+  @pre from.size() == to.size().
+  @pre ratio in [0, 1].
+  @throws if `from` or `to` contain non-finite values. */
   Eigen::VectorXd InterpolateBetweenConfigurations(const Eigen::VectorXd& from,
                                                    const Eigen::VectorXd& to,
                                                    double ratio) const;
@@ -72,14 +74,18 @@ class DistanceAndInterpolationProvider {
   /** Derived distance and interpolation providers must implement distance
   computation. The returned distance must be non-negative.
   DistanceAndInterpolationProvider ensures that `from` and `to` are the same
-  size. */
+  size.
+
+  Base class guarantees that `from` and `to` contain only finite values. */
   virtual double DoComputeConfigurationDistance(
       const Eigen::VectorXd& from, const Eigen::VectorXd& to) const = 0;
 
   /** Derived distance and interpolation providers must implement interpolation.
   The returned configuration must be the same size as `from` and `to`.
   DistanceAndInterpolationProvider ensures that `from` and `to` are the same
-  size and that `ratio` is in [0, 1]. */
+  size and that `ratio` is in [0, 1].
+
+  Base class guarantees that `from` and `to` contain only finite values. */
   virtual Eigen::VectorXd DoInterpolateBetweenConfigurations(
       const Eigen::VectorXd& from, const Eigen::VectorXd& to,
       double ratio) const = 0;

--- a/planning/test/collision_checker_test.cc
+++ b/planning/test/collision_checker_test.cc
@@ -505,6 +505,7 @@ GTEST_TEST(CollisionCheckerTest, MutableSetupModel) {
 //
 //  - influence distance must be finite and positive
 //  - non-robot dofs must be zeroed out in the Jacobian.
+//  - confirm input only has finite values.
 //
 // Calling MaxNumDistance() simply defaults to the NVI implementation; we'll
 // confirm we get back the magic number: 13.
@@ -547,6 +548,11 @@ GTEST_TEST(CollisionCheckerTest, RobotClearance) {
   EXPECT_THROW(checker->CalcRobotClearance(q, -1), std::exception);
   constexpr double kInf = std::numeric_limits<double>::infinity();
   EXPECT_THROW(checker->CalcRobotClearance(q, kInf), std::exception);
+  // We're only testing against NaN as an indication that the upstream is
+  // validating at all.
+  const VectorXd nan =
+      VectorXd::Constant(q.size(), std::numeric_limits<double>::quiet_NaN());
+  EXPECT_THROW(checker->CalcRobotClearance(nan, 0), std::exception);
 }
 
 // Testing framework for the collision checker such that the model contains
@@ -915,6 +921,7 @@ TEST_F(TrivialCollisionCheckerTest, ReportParallelChecking) {
 //   2 Does the context get updated?
 //   3 Does the context get updated before DoUpdateContextPositions gets called?
 //   4 Does DoUpdateContextPositions get called with a non-null context?
+//   5 Do we check the inputs for non-finite values?
 TEST_F(TrivialCollisionCheckerTest, UpdatePositions) {
   VectorXd q = dut_->GetZeroConfiguration();
 
@@ -922,6 +929,11 @@ TEST_F(TrivialCollisionCheckerTest, UpdatePositions) {
   const Context<double>& model_plant_context = dut_->UpdatePositions(q);
   // Test for #3 and #4; it doesn't throw and the right positions were recorded.
   EXPECT_EQ(dut_->latest_positions()[0], 0.1);
+
+  // We're only testing against NaN as an indication that the upstream is
+  // validating at all.
+  q[0] = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(dut_->UpdatePositions(q), std::exception);
 
   q[0] = 0.2;
   std::shared_ptr<CollisionCheckerContext> collision_context =
@@ -934,6 +946,12 @@ TEST_F(TrivialCollisionCheckerTest, UpdatePositions) {
   // Test for #1 and #2; each context is observably updated as expected.
   EXPECT_EQ(dut_->plant().GetPositions(model_plant_context)[0], 0.1);
   EXPECT_EQ(dut_->plant().GetPositions(standalone_plant_context)[0], 0.2);
+
+  // We're only testing against NaN as an indication that the upstream is
+  // validating at all.
+  q[0] = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(dut_->UpdateContextPositions(collision_context.get(), q),
+               std::exception);
 }
 
 // Verify that positions get updated before the NVI method
@@ -948,6 +966,11 @@ TEST_F(TrivialCollisionCheckerTest, ClassifyBodyCollisions) {
   // Update got called before forwarding to a derived class.
   EXPECT_EQ(dut_->positions_for_classify()[0], 0.1);
 
+  // We're only testing against NaN as an indication that the upstream is
+  // validating at all.
+  q[0] = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(dut_->ClassifyBodyCollisions(q), std::exception);
+
   q[0] = 0.2;
   std::shared_ptr<CollisionCheckerContext> collision_context =
       dut_->MakeStandaloneModelContext();
@@ -956,10 +979,14 @@ TEST_F(TrivialCollisionCheckerTest, ClassifyBodyCollisions) {
   EXPECT_EQ(dut_->latest_positions()[0], 0.2);
   // Update got called before forwarding to a derived class.
   EXPECT_EQ(dut_->positions_for_classify()[0], 0.2);
+
+  q[0] = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(dut_->ClassifyContextBodyCollisions(collision_context.get(), q),
+               std::exception);
 }
 
-// Verify that positions get updated before the NVI method
-// DoCheckContextConfigCollisionFree gets called.
+// Verify that positions get checked for finite values and updated before the
+/// NVI method DoCheckContextConfigCollisionFree gets called.
 TEST_F(TrivialCollisionCheckerTest, CheckConfigCollisionFree) {
   VectorXd q = dut_->GetZeroConfiguration();
 
@@ -970,6 +997,11 @@ TEST_F(TrivialCollisionCheckerTest, CheckConfigCollisionFree) {
   // Update got called before forwarding to a derived class.
   EXPECT_EQ(dut_->positions_for_check()[0], 0.1);
 
+  // We're only testing against NaN as an indication that the upstream is
+  // validating at all.
+  q[0] = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(dut_->CheckConfigCollisionFree(q), std::exception);
+
   q[0] = 0.2;
   std::shared_ptr<CollisionCheckerContext> collision_context =
       dut_->MakeStandaloneModelContext();
@@ -978,6 +1010,13 @@ TEST_F(TrivialCollisionCheckerTest, CheckConfigCollisionFree) {
   EXPECT_EQ(dut_->latest_positions()[0], 0.2);
   // Update got called before forwarding to a derived class.
   EXPECT_EQ(dut_->positions_for_check()[0], 0.2);
+
+  q[0] = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(
+      dut_->CheckContextConfigCollisionFree(collision_context.get(), q),
+      std::exception);
+
+  EXPECT_THROW(dut_->CheckConfigsCollisionFree({q, q}), std::exception);
 }
 
 // Tests the ValidateFilteredCollisionMatrix() method by exercising
@@ -1454,6 +1493,8 @@ GTEST_TEST(EdgeCheckTest, Configuration) {
 
   const Eigen::VectorXd q1 = Eigen::VectorXd::Constant(q_size, 1);
   const Eigen::VectorXd q2 = Eigen::VectorXd::Zero(q_size);
+  const Eigen::VectorXd nan = Eigen::VectorXd::Constant(
+      q_size, std::numeric_limits<double>::quiet_NaN());
 
   {
     // Distance function.
@@ -1475,6 +1516,9 @@ GTEST_TEST(EdgeCheckTest, Configuration) {
     ASSERT_NE(dut.MakeStandaloneConfigurationDistanceFunction(), nullptr);
     EXPECT_EQ(dut.MakeStandaloneConfigurationDistanceFunction()(q1, q2),
               q1.norm());
+
+    EXPECT_THROW(dut.ComputeConfigurationDistance(q1, nan), std::exception);
+    EXPECT_THROW(dut.ComputeConfigurationDistance(nan, q2), std::exception);
   }
 
   {
@@ -1513,6 +1557,13 @@ GTEST_TEST(EdgeCheckTest, Configuration) {
     EXPECT_EQ(
         dut.MakeStandaloneConfigurationInterpolationFunction()(q1, q2, 0.5),
         0.5 * (q1 + q2));
+
+    // We're only testing against NaN as an indication that the upstream is
+    // validating at all.
+    EXPECT_THROW(dut.InterpolateBetweenConfigurations(q1, nan, 0.5),
+                 std::exception);
+    EXPECT_THROW(dut.InterpolateBetweenConfigurations(nan, q2, 0.5),
+                 std::exception);
   }
 }
 
@@ -1844,6 +1895,8 @@ TEST_P(ParameterizedEdgeCheckTest, MeasureEdgeCollisionFree) {
   // End configuration encodes failure based on the expected colliding range.
   const VectorXd q2 = dut.EncodeConfiguration(q_size, config.alpha,
                                               config.last_colliding_alpha);
+  const VectorXd nan =
+      VectorXd::Constant(q_size, std::numeric_limits<double>::quiet_NaN());
 
   const EdgeMeasure result = config.parallel
                                  ? dut.MeasureEdgeCollisionFreeParallel(q1, q2)
@@ -1864,6 +1917,16 @@ TEST_P(ParameterizedEdgeCheckTest, MeasureEdgeCollisionFree) {
   // Are things parallel as we expect?
   if (config.parallel) {
     EXPECT_GT(dut.thread_count(), 1);
+  }
+
+  // We're only testing against NaN as an indication that the upstream is
+  // validating at all.
+  if (config.parallel) {
+    EXPECT_THROW(dut.MeasureEdgeCollisionFree(q1, nan), std::exception);
+    EXPECT_THROW(dut.MeasureEdgeCollisionFree(nan, q2), std::exception);
+  } else {
+    EXPECT_THROW(dut.MeasureEdgeCollisionFreeParallel(q1, nan), std::exception);
+    EXPECT_THROW(dut.MeasureEdgeCollisionFreeParallel(nan, q2), std::exception);
   }
 }
 
@@ -1898,6 +1961,8 @@ TEST_P(ParameterizedEdgeCheckTest, CheckEdgeCollisionFree) {
   // End configuration encodes failure based on the expected colliding range.
   const VectorXd q2 = dut.EncodeConfiguration(q_size, config.alpha,
                                               config.last_colliding_alpha);
+  const VectorXd nan =
+      VectorXd::Constant(q_size, std::numeric_limits<double>::quiet_NaN());
 
   const bool result = config.parallel
                           ? dut.CheckEdgeCollisionFreeParallel(q1, q2)
@@ -1919,6 +1984,16 @@ TEST_P(ParameterizedEdgeCheckTest, CheckEdgeCollisionFree) {
       EXPECT_GT(dut.thread_count(), 1);
     }
   }
+
+  // We're only testing against NaN as an indication that the upstream is
+  // validating at all.
+  if (config.parallel) {
+    EXPECT_THROW(dut.CheckEdgeCollisionFree(q1, nan), std::exception);
+    EXPECT_THROW(dut.CheckEdgeCollisionFree(nan, q2), std::exception);
+  } else {
+    EXPECT_THROW(dut.CheckEdgeCollisionFreeParallel(q1, nan), std::exception);
+    EXPECT_THROW(dut.CheckEdgeCollisionFreeParallel(nan, q2), std::exception);
+  }
 }
 
 // The test for MeasureEdgesCollisionFree() (plural) uses
@@ -1935,6 +2010,9 @@ GTEST_TEST(EdgeCheckTest, MeasureMultipleEdges) {
   auto interp = MockEdgeChecker::MakeEdgeInterpolation();
 
   const int q_size = MockEdgeChecker::kQSize;
+
+  const VectorXd nan =
+      VectorXd::Constant(q_size, std::numeric_limits<double>::quiet_NaN());
 
   // Garbage start configuration; the values are ignored.
   const VectorXd q_start = VectorXd::Constant(q_size, 0.75);
@@ -1957,6 +2035,8 @@ GTEST_TEST(EdgeCheckTest, MeasureMultipleEdges) {
   // Three quarters free (collision at 1.0).
   edges.emplace_back(q_start,
                      MockEdgeChecker::EncodeConfiguration(q_size, 0.75, 1.25));
+  const VectorXd& q2 = edges[0].second;
+
   // The distance for all of the edges is the same.
   const double edge_dist = calc_dist(edges[0].first, edges[0].second);
   const vector<EdgeMeasure> expected_results{
@@ -1991,6 +2071,16 @@ GTEST_TEST(EdgeCheckTest, MeasureMultipleEdges) {
     } else {
       EXPECT_EQ(dut.thread_count(), 1);
     }
+    // We make sure there is one valid edge first so we know we catch the
+    // invalid edge, even if it isn't first.
+    // We're only testing against NaN as an indication that the upstream is
+    // validating at all.
+    EXPECT_THROW(dut.MeasureEdgesCollisionFree({{q_start, q2}, {q_start, nan}},
+                                               parallel),
+                 std::exception);
+    EXPECT_THROW(
+        dut.MeasureEdgesCollisionFree({{q_start, q2}, {nan, q2}}, parallel),
+        std::exception);
   }
 }
 
@@ -2002,6 +2092,9 @@ GTEST_TEST(EdgeCheckTest, CheckMultipleEdgesFree) {
   auto interp = MockEdgeChecker::MakeEdgeInterpolation();
 
   const int q_size = MockEdgeChecker::kQSize;
+
+  const VectorXd nan =
+      VectorXd::Constant(q_size, std::numeric_limits<double>::quiet_NaN());
 
   // Garbage start configuration; the values are ignored.
   const VectorXd q_start = VectorXd::Constant(q_size, 0.75);
@@ -2020,6 +2113,8 @@ GTEST_TEST(EdgeCheckTest, CheckMultipleEdgesFree) {
   // Later collision.
   edges.emplace_back(q_start,
                      MockEdgeChecker::EncodeConfiguration(q_size, 0.75, 1.25));
+  const VectorXd& q2 = edges[0].second;
+
   const vector<uint8_t> expected_results{edges[0].second(0) == 1.0,
                                          edges[1].second(0) == 1.0,
                                          edges[2].second(0) == 1.0};
@@ -2050,6 +2145,16 @@ GTEST_TEST(EdgeCheckTest, CheckMultipleEdgesFree) {
     } else {
       EXPECT_EQ(dut.thread_count(), 1);
     }
+    // We make sure there is one valid edge first so we know we catch the
+    // invalid edge, even if it isn't first.
+    // We're only testing against NaN as an indication that the upstream is
+    // validating at all.
+    EXPECT_THROW(
+        dut.CheckEdgesCollisionFree({{q_start, q2}, {q_start, nan}}, parallel),
+        std::exception);
+    EXPECT_THROW(
+        dut.CheckEdgesCollisionFree({{q_start, q2}, {nan, q2}}, parallel),
+        std::exception);
   }
 }
 


### PR DESCRIPTION
When users provide the configuration vector, we immediately test for NaNs.

Some context-variants of the public APIs are implicitly tested (as they were in the tests before this change).

Furthermore, the API CheckConfigsCollisionFree() wasn't tested before and still isn't tested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22593)
<!-- Reviewable:end -->
