### PR TITLE
[parsing] Enhance ResolveUri to return non-existent paths

### DIFF
--- a/multibody/parsing/detail_path_utils.cc
+++ b/multibody/parsing/detail_path_utils.cc
@@ -20,8 +20,13 @@ namespace fs = std::filesystem;
 using drake::internal::DiagnosticPolicy;
 using std::string;
 
-string ResolveUri(const DiagnosticPolicy& diagnostic, const string& uri,
-                  const PackageMap& package_map, const string& root_dir) {
+std::string ResolveUriResult::GetStringPathIfExists() const {
+  return exists ? full_path.string() : std::string{};
+}
+
+ResolveUriResult ResolveUri(const DiagnosticPolicy& diagnostic,
+                            const string& uri, const PackageMap& package_map,
+                            const string& root_dir) {
   fs::path result;
 
   // Parse the given URI into pieces.
@@ -76,16 +81,15 @@ string ResolveUri(const DiagnosticPolicy& diagnostic, const string& uri,
     }
   }
 
-  result = result.lexically_normal();
-
-  if (!fs::exists(result)) {
+  ResolveUriResult compound_result;
+  compound_result.full_path = result.lexically_normal();
+  compound_result.exists = fs::exists(compound_result.full_path);
+  if (!compound_result.exists) {
     diagnostic.Error(
         fmt::format("URI '{}' resolved to '{}' which does not exist.", uri,
                     result.string()));
-    return {};
   }
-
-  return result.string();
+  return compound_result;
 }
 
 }  // namespace internal

--- a/multibody/parsing/detail_path_utils.h
+++ b/multibody/parsing/detail_path_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 #include "drake/common/diagnostic_policy.h"
@@ -9,33 +10,46 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// Resolves the full path of a URI. If @p uri starts with "package:" or
-// "model:", the ROS packages specified in @p package_map are searched.
-// Otherwise, iff a root_dir was provided then @p uri is appended to the end
-// of @p root_dir (if it's not already an absolute path) and checked for
-// existence.  If the file does not exist or is not found, an error is posted
-// to @p diagnostic and an empty string is returned. The returned path
-// will be lexically normalized. In other words, a path like
-// `/some//path/to/ignored/../file.txt` (with duplicate slashes, directory
-// changes, etc.) would be boiled down to `/some/path/to/file.txt`.
+// The return type of ResolveUri().
+struct ResolveUriResult {
+  // When `exists` is true, returns `full_path` as a string.
+  // When `exists` is false, returns an empty string.
+  std::string GetStringPathIfExists() const;
+
+  std::filesystem::path full_path;
+  bool exists{};
+};
+
+// Resolves the full path of a URI. If `uri` starts with "package:" or "model:",
+// the ROS packages specified in `package_map` are searched. Otherwise, iff a
+// root_dir was provided then `uri` is appended to the end of `root_dir` (if
+// it's not already an absolute path).
+//
+// The `result.full_path` will be lexically normalized. In other words, a path
+// like `/some//path/to/ignored/../file.txt` (with duplicate slashes, directory
+// changes, etc.) would be boiled down to `/some/path/to/file.txt`. The path
+// will be returned even when the file does not exist.
+//
+// If the file does not exist, an error will be posted to `diagnostic` and
+// `result.exists` will be `false`.
 //
 // @param diagnostic The error-reporting channel.
 //
 // @param[in] uri The name of the resource to find.
 //
 // @param[in] package_map A map where the keys are ROS package names and the
-// values are the paths to the packages. This is only used if @p filename
+// values are the paths to the packages. This is only used if `filename`,
 // starts with "package:"or "model:".
 //
 // @param[in] root_dir The root directory to look in. This is only used when
-// @p filename does not start with "package:".  Can be empty when only URIs
-// (not relative paths) should be allowed for @p uri.
+// `filename` does not start with "package:".  Can be empty when only URIs
+// (not relative paths) should be allowed for `uri`.
 //
-// @return The file's full path, lexically normalized, or an empty string if
-// the file is not found or does not exist.
-std::string ResolveUri(const drake::internal::DiagnosticPolicy& diagnostic,
-                       const std::string& uri, const PackageMap& package_map,
-                       const std::string& root_dir);
+// @return The file's full path, lexically normalized, and whether it exists.
+ResolveUriResult ResolveUri(const drake::internal::DiagnosticPolicy& diagnostic,
+                            const std::string& uri,
+                            const PackageMap& package_map,
+                            const std::string& root_dir);
 
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1125,8 +1125,10 @@ std::optional<std::vector<LinkInfo>> AddLinksFromSpecification(
       ResolveFilename resolve_filename =
           [&package_map, &root_dir, &link_element](
               const SDFormatDiagnostic& inner_diagnostic, std::string uri) {
-            return ResolveUri(inner_diagnostic.MakePolicyForNode(*link_element),
-                              uri, package_map, root_dir);
+            const ResolveUriResult resolved =
+                ResolveUri(inner_diagnostic.MakePolicyForNode(*link_element),
+                           uri, package_map, root_dir);
+            return resolved.GetStringPathIfExists();
           };
 
       for (uint64_t visual_index = 0; visual_index < link.VisualCount();
@@ -2268,7 +2270,9 @@ sdf::ParserConfig MakeSdfParserConfig(const ParsingWorkspace& workspace) {
     debug_log.SetActionForErrors([](const DiagnosticDetail& detail) {
       drake::log()->debug(detail.FormatError());
     });
-    return ResolveUri(debug_log, _input, workspace.package_map, ".");
+    const ResolveUriResult resolved =
+        ResolveUri(debug_log, _input, workspace.package_map, ".");
+    return resolved.GetStringPathIfExists();
   });
 
   parser_config.RegisterCustomModelParser(

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -151,9 +151,12 @@ UrdfMaterial ParseMaterial(const TinyXml2Diagnostic& diagnostic,
     std::string texture_name;
     if (ParseStringAttribute(texture_node, "filename", &texture_name) &&
         !texture_name.empty()) {
-      texture_path = ResolveUri(diagnostic.MakePolicyForNode(texture_node),
-                                texture_name, package_map, root_dir);
-      if (texture_path->empty()) {
+      const ResolveUriResult resolved =
+          ResolveUri(diagnostic.MakePolicyForNode(texture_node), texture_name,
+                     package_map, root_dir);
+      if (resolved.exists) {
+        texture_path = resolved.full_path.string();
+      } else {
         // ResolveUri already emitted an error message.
         return {};
       }
@@ -288,10 +291,10 @@ std::unique_ptr<geometry::Shape> ParseMesh(const TinyXml2Diagnostic& diagnostic,
     return {};
   }
 
-  const std::string resolved_filename =
+  const ResolveUriResult resolved =
       ResolveUri(diagnostic.MakePolicyForNode(shape_node), filename,
                  package_map, root_dir);
-  if (resolved_filename.empty()) {
+  if (!resolved.exists) {
     // ResolveUri already emitted an error message.
     return {};
   }
@@ -316,9 +319,9 @@ std::unique_ptr<geometry::Shape> ParseMesh(const TinyXml2Diagnostic& diagnostic,
 
   // Rely on geometry::Shape to validate physical parameters.
   if (shape_node->FirstChildElement("drake:declare_convex")) {
-    return std::make_unique<geometry::Convex>(resolved_filename, scale);
+    return std::make_unique<geometry::Convex>(resolved.full_path, scale);
   } else {
-    return std::make_unique<geometry::Mesh>(resolved_filename, scale);
+    return std::make_unique<geometry::Mesh>(resolved.full_path, scale);
   }
 }
 

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -766,7 +766,9 @@ const std::string& PackageMap::GetPath(
 
 std::string PackageMap::ResolveUrl(const std::string& url) const {
   drake::internal::DiagnosticPolicy diagnostic_policy;
-  return internal::ResolveUri(diagnostic_policy, url, *this, {});
+  const internal::ResolveUriResult resolved =
+      internal::ResolveUri(diagnostic_policy, url, *this, {});
+  return resolved.GetStringPathIfExists();
 }
 
 void PackageMap::PopulateFromFolder(const std::string& path) {

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -95,12 +95,12 @@ std::vector<ModelInstanceIndex> Parser::AddModels(
 
 std::vector<ModelInstanceIndex> Parser::AddModelsFromUrl(
     const std::string& url) {
-  const std::string file_name =
+  const internal::ResolveUriResult resolved =
       internal::ResolveUri(diagnostic_policy_, url, package_map_, {});
-  if (file_name.empty()) {
+  if (!resolved.exists) {
     return {};
   }
-  return AddModels(file_name);
+  return AddModels(resolved.full_path);
 }
 
 std::vector<ModelInstanceIndex> Parser::AddModelsFromString(

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -163,7 +163,9 @@ void FlattenModelDirectivesInternal(const ModelDirectives& directives,
 std::string ResolveModelDirectiveUri(const std::string& uri,
                                      const PackageMap& package_map) {
   ::drake::internal::DiagnosticPolicy policy;
-  return ::drake::multibody::internal::ResolveUri(policy, uri, package_map, "");
+  const auto resolved =
+      ::drake::multibody::internal::ResolveUri(policy, uri, package_map, "");
+  return resolved.GetStringPathIfExists();
 }
 
 void ProcessModelDirectives(const ModelDirectives& directives,

--- a/multibody/parsing/test/detail_path_utils_test.cc
+++ b/multibody/parsing/test/detail_path_utils_test.cc
@@ -29,10 +29,10 @@ std::string ResolveGoodUri(
   // Don't let warnings leak into spdlog; tests should always specifically
   // handle any warnings that appear.
   diagnostic.SetActionForWarnings(&DiagnosticPolicy::ErrorDefaultAction);
-  const std::string result = ResolveUri(
+  const ResolveUriResult result = ResolveUri(
       diagnostic, uri, package_map, root_dir);
-  EXPECT_NE(result, "");
-  return result;
+  EXPECT_TRUE(result.exists);
+  return result.full_path.string();
 }
 
 // This wraps the "ResolveUri()" device under test to return the error message
@@ -49,10 +49,30 @@ std::string ResolveBadUri(
   // Don't let warnings leak into spdlog; tests should always specifically
   // handle any warnings that appear.
   diagnostic.SetActionForWarnings(&DiagnosticPolicy::ErrorDefaultAction);
-  const std::string result = ResolveUri(
+  const ResolveUriResult result = ResolveUri(
       diagnostic, uri, package_map, root_dir);
-  EXPECT_EQ(result, "");
+  EXPECT_FALSE(result.exists);
   return error.FormatError();
+}
+
+// This wraps the "ResolveUri()" device under test to expect a well-formed
+// URI but pointing to a file that does not exist. Returns the expected path.
+std::string ResolveMissingUri(const std::string& uri,
+                              const PackageMap& package_map,
+                              const std::string& root_dir) {
+  DiagnosticPolicy diagnostic;
+  DiagnosticDetail error;
+  diagnostic.SetActionForErrors([&error](const DiagnosticDetail& detail) {
+    error = detail;
+  });
+  // Don't let warnings leak into spdlog; tests should always specifically
+  // handle any warnings that appear.
+  diagnostic.SetActionForWarnings(&DiagnosticPolicy::ErrorDefaultAction);
+  const ResolveUriResult result =
+      ResolveUri(diagnostic, uri, package_map, root_dir);
+  EXPECT_FALSE(result.exists);
+  EXPECT_THAT(error.message, ::testing::MatchesRegex(".*does not exist.*"));
+  return result.full_path.string();
 }
 
 // Verifies that the path returned is a normalized path. This is not an
@@ -84,6 +104,10 @@ GTEST_TEST(ResolveUriUncheckedTest, NormalizedPath) {
   // Case: Redundant directory dividers.
   EXPECT_EQ(ResolveGoodUri(".//test_model.sdf", package_map, root_dir),
             target_file);
+
+  // Case: Well-formed URL, but pointing to non-existent file.
+  EXPECT_EQ(ResolveMissingUri("./test_model.sdf2", package_map, root_dir),
+            target_file + "2");
 }
 
 // Verifies that ResolveUri() resolves the proper file using the scheme
@@ -215,9 +239,9 @@ GTEST_TEST(ResolveUriTest, DeprecatedPackage) {
   });
 
   // Check that we get a detailed warning.
-  std::string result = ResolveUri(
+  ResolveUriResult result = ResolveUri(
       diagnostic, "package://foo/multibody", package_map, "");
-  EXPECT_EQ(result, "multibody");
+  EXPECT_EQ(result.full_path.string(), "multibody");
   EXPECT_THAT(warning.message, ::testing::MatchesRegex(
       ".*package://foo/multibody.*is deprecated.*Stop using foo.*"));
 
@@ -225,9 +249,18 @@ GTEST_TEST(ResolveUriTest, DeprecatedPackage) {
   warning = {};
   result = ResolveUri(
       diagnostic, "package://bar/multibody", package_map, "");
-  EXPECT_EQ(result, "multibody");
+  EXPECT_EQ(result.full_path.string(), "multibody");
   EXPECT_THAT(warning.message, ::testing::MatchesRegex(
       ".*package://bar/multibody.*is deprecated.*"));
+}
+
+GTEST_TEST(ResolveUriResultTest, SugarGetter) {
+  ResolveUriResult dut;
+  dut.full_path = std::filesystem::path("/tmp");
+  dut.exists = true;
+  EXPECT_EQ(dut.GetStringPathIfExists(), "/tmp");
+  dut.exists = false;
+  EXPECT_EQ(dut.GetStringPathIfExists(), "");
 }
 
 }  // namespace


### PR DESCRIPTION
This is in anticipation of adding speculative meshes to SceneGraph (#22510).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22600)
<!-- Reviewable:end -->
