### PR TITLE
Implement continuous- to discrete-time conversion for linear systems

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -801,6 +801,18 @@ PYBIND11_MODULE(primitives, m) {
 
   m.def("IsDetectable", &IsDetectable, py::arg("sys"),
       py::arg("threshold") = std::nullopt, doc.IsDetectable.doc);
+
+  m.def("DiscreteTimeApproximation",
+      overload_cast_explicit<std::unique_ptr<LinearSystem<double>>,
+          const LinearSystem<double>&, double>(&DiscreteTimeApproximation),
+      py::arg("system"), py::arg("time_period"),
+      doc.DiscreteTimeApproximation.doc_linearsystem);
+
+  m.def("DiscreteTimeApproximation",
+      overload_cast_explicit<std::unique_ptr<AffineSystem<double>>,
+          const AffineSystem<double>&, double>(&DiscreteTimeApproximation),
+      py::arg("system"), py::arg("time_period"),
+      doc.DiscreteTimeApproximation.doc_affinesystem);
 }  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -26,6 +26,7 @@ from pydrake.systems.primitives import (
     ConstantValueSource, ConstantValueSource_,
     ConstantVectorSource, ConstantVectorSource_,
     ControllabilityMatrix,
+    DiscreteTimeApproximation,
     Demultiplexer, Demultiplexer_,
     DiscreteDerivative, DiscreteDerivative_,
     DiscreteTimeDelay, DiscreteTimeDelay_,
@@ -655,7 +656,7 @@ class TestGeneral(unittest.TestCase):
                                     activation_types=[
                                         PerceptronActivationType.kReLU,
                                         PerceptronActivationType.kTanh
-                                    ])
+        ])
         self.assertEqual(mlp2.activation_type(0),
                          PerceptronActivationType.kReLU)
         self.assertEqual(mlp2.activation_type(1),
@@ -674,7 +675,7 @@ class TestGeneral(unittest.TestCase):
                                    activation_types=[
                                        PerceptronActivationType.kReLU,
                                        PerceptronActivationType.kTanh
-                                   ])
+        ])
         self.assertEqual(mlp.get_input_port().size(), 2)
         np.testing.assert_array_equal(mlp.layers(), [3, 3, 2])
 
@@ -922,3 +923,40 @@ class TestGeneral(unittest.TestCase):
         self.assertTrue(
             all(logger.GetLog(logger_context) == logger.FindLog(context)
                 for logger, logger_context in loggers_and_contexts))
+
+    def test_discrete_time_approximation(self):
+        A = np.array([[0, 1], [0, 0]])
+        B = np.array([0, 1])
+        f0 = np.array([2, 1])
+        C = np.array([[1, 0]])
+        D = np.array([0])
+        y0 = np.array([0])
+
+        h = 0.031415926
+        Ad = np.array([[1, h], [0, 1]])
+        Bd = np.array([0.5*h**2, h])
+        f0d = np.array([2*h+0.5*h**2, h])
+        Cd = C
+        Dd = D
+        y0d = y0
+
+        def assert_array_close(x, y): np.testing.assert_allclose(
+            np.squeeze(x), np.squeeze(y), atol=1e-10)
+
+        continuous_system = LinearSystem(A, B, C, D)
+        discrete_system = DiscreteTimeApproximation(
+            system=continuous_system, time_period=h)
+        assert_array_close(discrete_system.A(), Ad)
+        assert_array_close(discrete_system.B(), Bd)
+        assert_array_close(discrete_system.C(), Cd)
+        assert_array_close(discrete_system.D(), Dd)
+
+        continuous_system = AffineSystem(A, B, f0, C, D, y0)
+        discrete_system = DiscreteTimeApproximation(
+            system=continuous_system, time_period=h)
+        assert_array_close(discrete_system.A(),  Ad)
+        assert_array_close(discrete_system.B(),  Bd)
+        assert_array_close(discrete_system.f0(), f0d)
+        assert_array_close(discrete_system.C(),  Cd)
+        assert_array_close(discrete_system.D(),  Dd)
+        assert_array_close(discrete_system.y0(), y0d)

--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -285,5 +285,33 @@ bool IsStabilizable(const LinearSystem<double>& sys,
 bool IsDetectable(const LinearSystem<double>& sys,
                   std::optional<double> threshold = std::nullopt);
 
+/// Converts a continuous-time linear system to a discrete-time linear system
+/// using the zero-order hold (ZOH) method.
+///
+/// @param system The continuous-time LinearSystem.
+/// @param time_period The sampling time period.
+/// @returns A discrete-time LinearSystem.
+/// @throws if the @p system is not continuous or @p time_period <= 0.
+/// @tparam_default_scalar
+/// @ingroup primitive_systems
+/// @pydrake_mkdoc_identifier{linearsystem}
+template <typename T>
+std::unique_ptr<LinearSystem<T>> DiscreteTimeApproximation(
+    const LinearSystem<T>& system, double time_period);
+
+/// Converts a continuous-time affine system to a discrete-time affine system
+/// using the zero-order hold (ZOH) method.
+///
+/// @param system The continuous-time AffineSystem.
+/// @param time_period The sampling time period.
+/// @returns A discrete-time AffineSystem.
+/// @throws if the @p system is not continuous or @p time_period <= 0.
+/// @tparam_default_scalar
+/// @ingroup primitive_systems
+/// @pydrake_mkdoc_identifier{affinesystem}
+template <typename T>
+std::unique_ptr<AffineSystem<T>> DiscreteTimeApproximation(
+    const AffineSystem<T>& system, double time_period);
+
 }  // namespace systems
 }  // namespace drake

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -984,6 +984,56 @@ GTEST_TEST(LinearSystemBespokeTest, NonSymbolicFeedthrough) {
   EXPECT_FALSE(dut2.HasAnyDirectFeedthrough());
 }
 
+GTEST_TEST(DiscreteTimeApproximation, test) {
+  Eigen::Matrix<double, 2, 2> A;
+  Eigen::Matrix<double, 2, 1> B;
+  Eigen::Vector<double, 2> f0;
+  Eigen::Matrix<double, 1, 2> C;
+  Eigen::Matrix<double, 1, 1> D;
+  Eigen::Vector<double, 1> y0;
+  A << 0, 1, 0, 0;
+  B << 0, 1;
+  f0 << 2, 1;
+  C << 1, 0;
+
+  // Reject discrete system as argument.
+  EXPECT_ANY_THROW(DiscreteTimeApproximation<double>(
+      AffineSystem<double>(A, B, f0, C, D, y0, 0.1), 0.1));
+
+  const double h = 0.031415926;
+
+  Eigen::Matrix<double, 2, 2> Ad;
+  Eigen::Matrix<double, 2, 1> Bd;
+  Eigen::Vector<double, 2> f0d;
+  Eigen::Matrix<double, 1, 2> Cd = C;
+  Eigen::Matrix<double, 1, 1> Dd = D;
+  Eigen::Vector<double, 1> y0d = y0;
+  Ad << 1, h, 0, 1;
+  Bd << 0.5 * h * h, h;
+  f0d << 2 * h + 0.5 * h * h, h;
+
+  AffineSystem<double> continuous_affine_sys(A, B, f0, C, D, y0);
+  auto discrete_affine_sys =
+      DiscreteTimeApproximation<double>(continuous_affine_sys, h);
+
+  const double kEpsilon = 1e-10;
+  EXPECT_TRUE(discrete_affine_sys->A().isApprox(Ad, kEpsilon));
+  EXPECT_TRUE(discrete_affine_sys->B().isApprox(Bd, kEpsilon));
+  EXPECT_TRUE(discrete_affine_sys->f0().isApprox(f0d, kEpsilon));
+  EXPECT_TRUE(discrete_affine_sys->C().isApprox(Cd, kEpsilon));
+  EXPECT_TRUE(discrete_affine_sys->D().isApprox(Dd, kEpsilon));
+  EXPECT_TRUE(discrete_affine_sys->y0().isApprox(y0d, kEpsilon));
+
+  LinearSystem<double> continuous_linear_sys(A, B, C, D);
+  auto discrete_linear_sys =
+      DiscreteTimeApproximation<double>(continuous_affine_sys, h);
+
+  EXPECT_TRUE(discrete_linear_sys->A().isApprox(Ad, kEpsilon));
+  EXPECT_TRUE(discrete_linear_sys->B().isApprox(Bd, kEpsilon));
+  EXPECT_TRUE(discrete_linear_sys->C().isApprox(Cd, kEpsilon));
+  EXPECT_TRUE(discrete_linear_sys->D().isApprox(Dd, kEpsilon));
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Added functionality for converting continuous-time LinearSystem and AffineSystem to discrete-time zero-order hold equivalents.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22601)
<!-- Reviewable:end -->
