### PR TITLE
[examples] Enable clang-format for some demos

### DIFF
--- a/examples/allegro_hand/BUILD.bazel
+++ b/examples/allegro_hand/BUILD.bazel
@@ -73,4 +73,4 @@ drake_cc_googletest(
     ],
 )
 
-add_lint_tests(enable_clang_format_lint = False)
+add_lint_tests()

--- a/examples/allegro_hand/allegro_common.cc
+++ b/examples/allegro_hand/allegro_common.cc
@@ -68,9 +68,8 @@ std::vector<std::string> GetPreferredJointOrdering() {
   return joint_name_mapping;
 }
 
-void GetControlPortMapping(
-    const MultibodyPlant<double>& plant,
-    MatrixX<double>* Sx, MatrixX<double>* Sy) {
+void GetControlPortMapping(const MultibodyPlant<double>& plant,
+                           MatrixX<double>* Sx, MatrixX<double>* Sy) {
   // Retrieve the list of finger joints in a user-defined ordering.
   const std::vector<std::string> joints_in_preferred_order =
       GetPreferredJointOrdering();

--- a/examples/allegro_hand/allegro_common.h
+++ b/examples/allegro_hand/allegro_common.h
@@ -33,9 +33,8 @@ void SetPositionControlledGains(double pid_frequency, double Ieff,
 /// of the finger joints in the desired order.
 /// @param Sy the matrix to match the output torque for the hand joint
 /// actuators in the desired order into the input actuation of the plant.
-void GetControlPortMapping(
-    const multibody::MultibodyPlant<double>& plant,
-    MatrixX<double>* Sx, MatrixX<double>* Sy);
+void GetControlPortMapping(const multibody::MultibodyPlant<double>& plant,
+                           MatrixX<double>* Sx, MatrixX<double>* Sy);
 
 /// Defines the desired ordering of the finger joints by name. The fingers are
 /// ordered as [thumb, index, middle, ring] and the joints of each finger are

--- a/examples/allegro_hand/allegro_lcm.cc
+++ b/examples/allegro_hand/allegro_lcm.cc
@@ -11,16 +11,15 @@ namespace allegro_hand {
 
 using systems::BasicVector;
 using systems::Context;
-using systems::DiscreteValues;
 using systems::DiscreteUpdateEvent;
+using systems::DiscreteValues;
 
 AllegroCommandReceiver::AllegroCommandReceiver(int num_joints,
                                                double lcm_period)
     : num_joints_(num_joints), lcm_period_(lcm_period) {
   DRAKE_THROW_UNLESS(lcm_period > 0);
-  this->DeclareAbstractInputPort(
-      systems::kUseDefaultName,
-      Value<lcmt_allegro_command>{});
+  this->DeclareAbstractInputPort(systems::kUseDefaultName,
+                                 Value<lcmt_allegro_command>{});
   state_output_port_ =
       this->DeclareVectorOutputPort(
               systems::kUseDefaultName, num_joints_ * 2,
@@ -94,16 +93,19 @@ void AllegroCommandReceiver::CopyStateToOutput(
 AllegroStatusSender::AllegroStatusSender(int num_joints)
     : num_joints_(num_joints) {
   // Commanded state.
-  command_input_port_ = this->DeclareInputPort(
-      systems::kUseDefaultName, systems::kVectorValued, num_joints_ * 2)
+  command_input_port_ =
+      this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued,
+                             num_joints_ * 2)
           .get_index();
   // Measured state.
-  state_input_port_ = this->DeclareInputPort(
-      systems::kUseDefaultName, systems::kVectorValued, num_joints_ * 2)
+  state_input_port_ =
+      this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued,
+                             num_joints_ * 2)
           .get_index();
   // Commanded torque.
-  command_torque_input_port_ = this->DeclareInputPort(
-      systems::kUseDefaultName, systems::kVectorValued, num_joints_)
+  command_torque_input_port_ =
+      this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued,
+                             num_joints_)
           .get_index();
 
   this->DeclareAbstractOutputPort(systems::kUseDefaultName,

--- a/examples/allegro_hand/allegro_lcm.h
+++ b/examples/allegro_hand/allegro_lcm.h
@@ -61,9 +61,7 @@ class AllegroCommandReceiver : public systems::LeafSystem<double> {
     return this->get_output_port(torque_output_port_);
   }
 
-  double lcm_period() const {
-    return lcm_period_;
-  }
+  double lcm_period() const { return lcm_period_; }
 
  private:
   void CopyStateToOutput(const systems::Context<double>& context, int start_idx,

--- a/examples/allegro_hand/joint_control/BUILD.bazel
+++ b/examples/allegro_hand/joint_control/BUILD.bazel
@@ -69,4 +69,4 @@ drake_py_unittest(
     ],
 )
 
-add_lint_tests(enable_clang_format_lint = False)
+add_lint_tests()

--- a/examples/allegro_hand/joint_control/run_twisting_mug.cc
+++ b/examples/allegro_hand/joint_control/run_twisting_mug.cc
@@ -34,8 +34,7 @@ const char* const kLcmCommandChannel = "ALLEGRO_COMMAND";
 class PositionCommander {
  public:
   PositionCommander() {
-    lcm_.subscribe(kLcmStatusChannel, &PositionCommander::HandleStatus,
-                   this);
+    lcm_.subscribe(kLcmStatusChannel, &PositionCommander::HandleStatus, this);
   }
 
   void Run() {
@@ -81,8 +80,7 @@ class PositionCommander {
       // position. Eigen::Vector3d(1, 1, 0.5) is a number based on experience
       // to keep the finger position, and 0.1 is the coefficient related to
       // the extra force to apply.
-      target_joint_position.segment<3>(9) +=
-          (0.1 * Eigen::Vector3d(1, 1, 0.5));
+      target_joint_position.segment<3>(9) += (0.1 * Eigen::Vector3d(1, 1, 0.5));
       // The thumb works as another pivot finger, and is expected to exert a
       // large force in order to keep stabilization.
       target_joint_position.segment<4>(0) =
@@ -95,8 +93,7 @@ class PositionCommander {
       MovetoPositionUntilStuck(target_joint_position);
 
       target_joint_position = close_hand_joint_position;
-      target_joint_position.segment<3>(9) +=
-          (0.1 * Eigen::Vector3d(1, 1, 0.5));
+      target_joint_position.segment<3>(9) += (0.1 * Eigen::Vector3d(1, 1, 0.5));
       target_joint_position.segment<4>(0) =
           hand_state_.FingerGraspJointPosition(0);
       // The ring finger works as the actuating finger now to rotate the mug in
@@ -108,15 +105,13 @@ class PositionCommander {
   }
 
  private:
-  void PublishPositionCommand(
-      const Eigen::VectorXd& target_joint_position) {
+  void PublishPositionCommand(const Eigen::VectorXd& target_joint_position) {
     Eigen::VectorXd::Map(&allegro_command_.joint_position[0],
                          kAllegroNumJoints) = target_joint_position;
     lcm_.publish(kLcmCommandChannel, &allegro_command_);
   }
 
-  void MovetoPositionUntilStuck(
-      const Eigen::VectorXd& target_joint_position) {
+  void MovetoPositionUntilStuck(const Eigen::VectorXd& target_joint_position) {
     PublishPositionCommand(target_joint_position);
     // A time delay at the initial moving stage so that the noisy data from the
     // hand motion is filtered.

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -28,7 +28,8 @@ namespace {
 
 using drake::multibody::MultibodyPlant;
 
-DEFINE_double(constant_load, 0, "the constant load on each joint, Unit [Nm]."
+DEFINE_double(constant_load, 0,
+              "the constant load on each joint, Unit [Nm]."
               "Suggested load is in the order of 0.01 Nm. When input value"
               "equals to 0 (default), the program runs a passive simulation.");
 
@@ -41,8 +42,9 @@ DEFINE_bool(use_right_hand, true,
 DEFINE_double(max_time_step, 1.0e-4,
               "Simulation time step used for integrator.");
 
-DEFINE_bool(add_gravity, true, "Indicator for whether terrestrial gravity"
-                                " (9.81 m/s²) is included or not.");
+DEFINE_bool(add_gravity, true,
+            "Indicator for whether terrestrial gravity"
+            " (9.81 m/s²) is included or not.");
 
 DEFINE_double(target_realtime_rate, 1,
               "Desired rate relative to real time.  See documentation for "
@@ -58,23 +60,24 @@ void DoMain() {
 
   std::string hand_url;
   if (FLAGS_use_right_hand) {
-    hand_url = "package://drake_models/"
-      "allegro_hand_description/sdf/allegro_hand_description_right.sdf";
+    hand_url =
+        "package://drake_models/"
+        "allegro_hand_description/sdf/allegro_hand_description_right.sdf";
   } else {
-    hand_url = "package://drake_models/"
-      "allegro_hand_description/sdf/allegro_hand_description_left.sdf";
+    hand_url =
+        "package://drake_models/"
+        "allegro_hand_description/sdf/allegro_hand_description_left.sdf";
   }
   multibody::Parser(&plant).AddModelsFromUrl(hand_url);
 
   // Weld the hand to the world frame
   const auto& joint_hand_root = plant.GetBodyByName("hand_root");
-  plant.AddJoint<multibody::WeldJoint>("weld_hand", plant.world_body(),
-      std::nullopt, joint_hand_root, std::nullopt,
-      math::RigidTransformd::Identity());
+  plant.AddJoint<multibody::WeldJoint>(
+      "weld_hand", plant.world_body(), std::nullopt, joint_hand_root,
+      std::nullopt, math::RigidTransformd::Identity());
 
   if (!FLAGS_add_gravity) {
-    plant.mutable_gravity_field().set_gravity_vector(
-        Eigen::Vector3d::Zero());
+    plant.mutable_gravity_field().set_gravity_vector(Eigen::Vector3d::Zero());
   }
 
   // Now the model is complete.
@@ -84,11 +87,11 @@ void DoMain() {
   DRAKE_DEMAND(plant.num_actuated_dofs() == 16);
 
   // constant force input
-  VectorX<double> constant_load_value = VectorX<double>::Ones(
-      plant.num_actuators()) * FLAGS_constant_load;
+  VectorX<double> constant_load_value =
+      VectorX<double>::Ones(plant.num_actuators()) * FLAGS_constant_load;
   auto constant_source =
-     builder.AddSystem<systems::ConstantVectorSource<double>>(
-      constant_load_value);
+      builder.AddSystem<systems::ConstantVectorSource<double>>(
+          constant_load_value);
   constant_source->set_name("constant_source");
   builder.Connect(constant_source->get_output_port(),
                   plant.get_actuation_input_port());

--- a/examples/allegro_hand/test/allegro_lcm_test.cc
+++ b/examples/allegro_hand/test/allegro_lcm_test.cc
@@ -17,35 +17,32 @@ GTEST_TEST(AllegroLcmTest, AllegroCommandReceiver) {
   AllegroCommandReceiver dut;
   std::unique_ptr<systems::Context<double>> context =
       dut.CreateDefaultContext();
-  std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput();
+  std::unique_ptr<systems::SystemOutput<double>> output = dut.AllocateOutput();
 
   // Check that the commanded pose starts out at zero, and that we can
   // set a different initial position.
   Eigen::VectorXd expected = Eigen::VectorXd::Zero(kAllegroNumJoints * 2);
   dut.CalcOutput(*context, output.get());
   const double tol = 1e-5;
-  EXPECT_TRUE(CompareMatrices(
-      expected, output->get_vector_data(0)->value(),
-      tol, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(expected, output->get_vector_data(0)->value(),
+                              tol, MatrixCompareType::absolute));
 
   Eigen::VectorXd position(kAllegroNumJoints);
-  position << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1,
-              1.2, 1.3, 1.4, 1.5, 1.6;
+  position << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3,
+      1.4, 1.5, 1.6;
   dut.set_initial_position(context.get(), position);
   dut.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(
-      position, output->get_vector_data(0)->value()
-      .head(kAllegroNumJoints),
+      position, output->get_vector_data(0)->value().head(kAllegroNumJoints),
       tol, MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(
       expected.tail(kAllegroNumJoints),
-      output->get_vector_data(0)->value().tail(kAllegroNumJoints),
-      tol, MatrixCompareType::absolute));
+      output->get_vector_data(0)->value().tail(kAllegroNumJoints), tol,
+      MatrixCompareType::absolute));
 
   Eigen::VectorXd delta(kAllegroNumJoints);
-  delta << 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009,
-           0.010, 0.011, 0.012, 0.013, 0.014, 0.015, 0.016;
+  delta << 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.010,
+      0.011, 0.012, 0.013, 0.014, 0.015, 0.016;
 
   lcmt_allegro_command command{};
   command.num_joints = kAllegroNumJoints;
@@ -62,28 +59,26 @@ GTEST_TEST(AllegroLcmTest, AllegroCommandReceiver) {
   dut.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(
       position + delta,
-      output->get_vector_data(0)->value().head(kAllegroNumJoints),
-      tol, MatrixCompareType::absolute));
+      output->get_vector_data(0)->value().head(kAllegroNumJoints), tol,
+      MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(
       VectorX<double>::Zero(kAllegroNumJoints),
-      output->get_vector_data(0)->value().tail(kAllegroNumJoints),
-      tol, MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(
-      VectorX<double>::Zero(kAllegroNumJoints),
-      output->get_vector_data(1)->value(),
-      tol, MatrixCompareType::absolute));
+      output->get_vector_data(0)->value().tail(kAllegroNumJoints), tol,
+      MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(VectorX<double>::Zero(kAllegroNumJoints),
+                              output->get_vector_data(1)->value(), tol,
+                              MatrixCompareType::absolute));
 }
 
 GTEST_TEST(AllegroLcmTest, AllegroStatusSenderTest) {
   AllegroStatusSender dut;
-  std::unique_ptr<systems::Context<double>>
-      context = dut.CreateDefaultContext();
-  std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput();
+  std::unique_ptr<systems::Context<double>> context =
+      dut.CreateDefaultContext();
+  std::unique_ptr<systems::SystemOutput<double>> output = dut.AllocateOutput();
 
   Eigen::VectorXd position(kAllegroNumJoints);
-  position << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1,
-              1.2, 1.3, 1.4, 1.5, 1.6;
+  position << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3,
+      1.4, 1.5, 1.6;
 
   Eigen::VectorXd command = Eigen::VectorXd::Zero(kAllegroNumJoints * 2);
   command.head(kAllegroNumJoints) = position * 0.5;
@@ -92,12 +87,12 @@ GTEST_TEST(AllegroLcmTest, AllegroStatusSenderTest) {
   Eigen::VectorXd state = Eigen::VectorXd::Zero(kAllegroNumJoints * 2);
   state.head(kAllegroNumJoints) = position;
   state.tail(kAllegroNumJoints) << 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 0.9, 0.8,
-                                   0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1;
+      0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1;
   dut.get_state_input_port().FixValue(context.get(), state);
 
   Eigen::VectorXd torque = Eigen::VectorXd::Zero(kAllegroNumJoints);
-  torque << 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1,
-            2.2, 2.3, 2.4, 2.5, 2.6;;
+  torque << 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3,
+      2.4, 2.5, 2.6;
   dut.get_commanded_torque_input_port().FixValue(context.get(), torque);
 
   dut.CalcOutput(*context, output.get());
@@ -107,8 +102,7 @@ GTEST_TEST(AllegroLcmTest, AllegroStatusSenderTest) {
   for (int i = 0; i < kAllegroNumJoints; i++) {
     EXPECT_EQ(status.joint_position_commanded[i], command(i));
     EXPECT_EQ(status.joint_position_measured[i], state(i));
-    EXPECT_EQ(status.joint_velocity_estimated[i], state(
-                                                  i + kAllegroNumJoints));
+    EXPECT_EQ(status.joint_velocity_estimated[i], state(i + kAllegroNumJoints));
     EXPECT_EQ(status.joint_torque_commanded[i], torque(i));
   }
 }

--- a/examples/allegro_hand/test/parse_test.cc
+++ b/examples/allegro_hand/test/parse_test.cc
@@ -19,14 +19,14 @@ class ParseTest : public testing::TestWithParam<std::string> {};
 
 TEST_P(ParseTest, Quantities) {
   const std::string file_extension = GetParam();
-  const std::string url_right =
-      fmt::format("package://drake_models/allegro_hand_description/{}/"
-                  "allegro_hand_description_right.{}",
-                  file_extension, file_extension);
-  const std::string url_left =
-      fmt::format("package://drake_models/allegro_hand_description/{}/"
-                  "allegro_hand_description_left.{}",
-                  file_extension, file_extension);
+  const std::string url_right = fmt::format(
+      "package://drake_models/allegro_hand_description/{}/"
+      "allegro_hand_description_right.{}",
+      file_extension, file_extension);
+  const std::string url_left = fmt::format(
+      "package://drake_models/allegro_hand_description/{}/"
+      "allegro_hand_description_left.{}",
+      file_extension, file_extension);
 
   MultibodyPlant<double> plant(0.0);
   Parser parser(&plant);

--- a/examples/kinova_jaco_arm/BUILD.bazel
+++ b/examples/kinova_jaco_arm/BUILD.bazel
@@ -71,4 +71,4 @@ drake_cc_binary(
     ],
 )
 
-add_lint_tests(enable_clang_format_lint = False)
+add_lint_tests()

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -38,14 +38,14 @@ using drake::geometry::SceneGraph;
 using drake::lcm::DrakeLcm;
 using drake::manipulation::kinova_jaco::JacoCommandReceiver;
 using drake::manipulation::kinova_jaco::JacoStatusSender;
-using drake::manipulation::kinova_jaco::kJacoDefaultArmNumJoints;
 using drake::manipulation::kinova_jaco::kJacoDefaultArmNumFingers;
+using drake::manipulation::kinova_jaco::kJacoDefaultArmNumJoints;
 using drake::manipulation::kinova_jaco::kJacoLcmStatusPeriod;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::Parser;
 using drake::multibody::RigidBody;
-using drake::systems::controllers::InverseDynamicsController;
 using drake::systems::Demultiplexer;
+using drake::systems::controllers::InverseDynamicsController;
 using drake::visualization::AddDefaultVisualization;
 
 namespace drake {
@@ -95,7 +95,7 @@ int DoMain() {
 
   auto mux = builder.AddSystem<systems::Multiplexer>(
       std::vector<int>({kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers,
-              kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers}));
+                        kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers}));
   builder.Connect(command_receiver->get_commanded_position_output_port(),
                   mux->get_input_port(0));
   builder.Connect(command_receiver->get_commanded_velocity_output_port(),
@@ -105,9 +105,8 @@ int DoMain() {
   builder.Connect(jaco_controller->get_output_port_control(),
                   jaco_plant.get_actuation_input_port(jaco_id));
 
-  auto status_pub =
-      builder.AddSystem(
-          systems::lcm::LcmPublisherSystem::Make<drake::lcmt_jaco_status>(
+  auto status_pub = builder.AddSystem(
+      systems::lcm::LcmPublisherSystem::Make<drake::lcmt_jaco_status>(
           "KINOVA_JACO_STATUS", lcm, kJacoLcmStatusPeriod));
   // TODO(sammy-tri) populate joint torque (and external torques).  External
   // torques might want to wait until after #12631 is fixed or it could slow
@@ -115,7 +114,7 @@ int DoMain() {
   auto status_sender = builder.AddSystem<JacoStatusSender>();
   auto demux = builder.AddSystem<systems::Demultiplexer>(
       std::vector<int>({kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers,
-              kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers}));
+                        kJacoDefaultArmNumJoints + kJacoDefaultArmNumFingers}));
   builder.Connect(jaco_plant.get_state_output_port(jaco_id),
                   demux->get_input_port());
   builder.Connect(demux->get_output_port(0),

--- a/examples/kinova_jaco_arm/move_jaco_ee.cc
+++ b/examples/kinova_jaco_arm/move_jaco_ee.cc
@@ -78,7 +78,8 @@ int DoMain() {
         }
       });
 
-  while (lc.handle() >= 0) { }
+  while (lc.handle() >= 0) {
+  }
   return 0;
 }
 

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -184,4 +184,4 @@ drake_sh_test(
     tags = ["no_kcov"],
 )
 
-add_lint_tests(enable_clang_format_lint = False)
+add_lint_tests()

--- a/examples/kuka_iiwa_arm/iiwa_common.cc
+++ b/examples/kuka_iiwa_arm/iiwa_common.cc
@@ -6,8 +6,7 @@ namespace drake {
 namespace examples {
 namespace kuka_iiwa_arm {
 
-void SetPositionControlledIiwaGains(Eigen::VectorXd* Kp,
-                                    Eigen::VectorXd* Ki,
+void SetPositionControlledIiwaGains(Eigen::VectorXd* Kp, Eigen::VectorXd* Ki,
                                     Eigen::VectorXd* Kd) {
   // All the gains are for acceleration, not directly responsible for generating
   // torques. These are set to high values to ensure good tracking. These gains
@@ -26,7 +25,7 @@ void SetTorqueControlledIiwaGains(Eigen::VectorXd* stiffness,
                                   Eigen::VectorXd* damping_ratio) {
   // All the gains are for directly generating torques. These gains are set
   // according to the values in the drake-iiwa-driver repository:
-  // https://github.com/RobotLocomotion/drake-iiwa-driver/blob/master/kuka-driver/sunrise_1.11/DrakeFRITorqueDriver.java NOLINT
+  // https://github.com/RobotLocomotion/drake-iiwa-driver/blob/master/kuka-driver/sunrise_1.11/DrakeFRITorqueDriver.java
 
   // The spring stiffness in Nm/rad.
   stiffness->resize(7);

--- a/examples/kuka_iiwa_arm/iiwa_common.h
+++ b/examples/kuka_iiwa_arm/iiwa_common.h
@@ -9,12 +9,11 @@ namespace kuka_iiwa_arm {
 
 // These details have moved to files under drake/manipulation/kuka_iiwa.
 // These forwarding aliases are placed here for compatibility purposes.
-using manipulation::kuka_iiwa::kIiwaArmNumJoints;
 using manipulation::kuka_iiwa::get_iiwa_max_joint_velocities;
+using manipulation::kuka_iiwa::kIiwaArmNumJoints;
 
 /// Used to set the feedback gains for the simulated position controlled KUKA.
-void SetPositionControlledIiwaGains(Eigen::VectorXd* Kp,
-                                    Eigen::VectorXd* Ki,
+void SetPositionControlledIiwaGains(Eigen::VectorXd* Kp, Eigen::VectorXd* Ki,
                                     Eigen::VectorXd* Kd);
 
 /// Used to set the feedback gains for the simulated torque controlled KUKA.

--- a/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -25,12 +25,12 @@
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
-using Eigen::MatrixXd;
-using Eigen::VectorXd;
-using Eigen::VectorXi;
 using drake::Vector1d;
+using Eigen::MatrixXd;
 using Eigen::Vector2d;
 using Eigen::Vector3d;
+using Eigen::VectorXd;
+using Eigen::VectorXi;
 
 namespace drake {
 namespace examples {
@@ -53,12 +53,9 @@ class RobotPlanRunner {
   /// plant is aliased
   explicit RobotPlanRunner(const multibody::MultibodyPlant<double>& plant)
       : plant_(plant), plan_number_(0) {
-    lcm_.subscribe(kLcmStatusChannel,
-                    &RobotPlanRunner::HandleStatus, this);
-    lcm_.subscribe(kLcmPlanChannel,
-                    &RobotPlanRunner::HandlePlan, this);
-    lcm_.subscribe(kLcmStopChannel,
-                    &RobotPlanRunner::HandleStop, this);
+    lcm_.subscribe(kLcmStatusChannel, &RobotPlanRunner::HandleStatus, this);
+    lcm_.subscribe(kLcmPlanChannel, &RobotPlanRunner::HandlePlan, this);
+    lcm_.subscribe(kLcmStopChannel, &RobotPlanRunner::HandleStop, this);
   }
 
   void Run() {
@@ -79,7 +76,8 @@ class RobotPlanRunner {
     while (true) {
       // Call lcm handle until at least one status message is
       // processed.
-      while (0 == lcm_.handleTimeout(10) || iiwa_status_.utime == -1) { }
+      while (0 == lcm_.handleTimeout(10) || iiwa_status_.utime == -1) {
+      }
 
       cur_time_us = iiwa_status_.utime;
 
@@ -196,7 +194,6 @@ int do_main() {
 }  // namespace kuka_iiwa_arm
 }  // namespace examples
 }  // namespace drake
-
 
 int main() {
   return drake::examples::kuka_iiwa_arm::do_main();

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -49,8 +49,8 @@ using multibody::MultibodyPlant;
 using multibody::PackageMap;
 using systems::Context;
 using systems::Demultiplexer;
-using systems::StateInterpolatorWithDiscreteDerivative;
 using systems::Simulator;
+using systems::StateInterpolatorWithDiscreteDerivative;
 using systems::controllers::InverseDynamicsController;
 using systems::controllers::StateFeedbackControllerInterface;
 
@@ -58,8 +58,8 @@ int DoMain() {
   systems::DiagramBuilder<double> builder;
 
   // Adds a plant.
-  auto [plant, scene_graph] = multibody::AddMultibodyPlantSceneGraph(
-      &builder, FLAGS_sim_dt);
+  auto [plant, scene_graph] =
+      multibody::AddMultibodyPlantSceneGraph(&builder, FLAGS_sim_dt);
   const char* kModelUrl =
       "package://drake_models/iiwa_description/"
       "urdf/iiwa14_polytope_collision.urdf";
@@ -108,14 +108,13 @@ int DoMain() {
       systems::lcm::LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>(
           "IIWA_COMMAND", lcm));
   command_sub->set_name("command_subscriber");
-  auto command_receiver =
-      builder.AddSystem<IiwaCommandReceiver>(num_joints);
+  auto command_receiver = builder.AddSystem<IiwaCommandReceiver>(num_joints);
   command_receiver->set_name("command_receiver");
-  auto plant_state_demux = builder.AddSystem<Demultiplexer>(
-      2 * num_joints, num_joints);
+  auto plant_state_demux =
+      builder.AddSystem<Demultiplexer>(2 * num_joints, num_joints);
   plant_state_demux->set_name("plant_state_demux");
-  auto desired_state_from_position = builder.AddSystem<
-      StateInterpolatorWithDiscreteDerivative>(
+  auto desired_state_from_position =
+      builder.AddSystem<StateInterpolatorWithDiscreteDerivative>(
           num_joints, kIiwaLcmStatusPeriod,
           true /* suppress_initial_transient */);
   desired_state_from_position->set_name("desired_state_from_position");

--- a/examples/kuka_iiwa_arm/kuka_torque_controller.cc
+++ b/examples/kuka_iiwa_arm/kuka_torque_controller.cc
@@ -13,11 +13,11 @@ namespace examples {
 namespace kuka_iiwa_arm {
 namespace {
 
-using drake::systems::kVectorValued;
 using drake::systems::Adder;
 using drake::systems::BasicVector;
 using drake::systems::Context;
 using drake::systems::DiagramBuilder;
+using drake::systems::kVectorValued;
 using drake::systems::LeafSystem;
 using drake::systems::controllers::PidController;
 
@@ -68,8 +68,7 @@ class StateDependentDamper : public LeafSystem<T> {
 
     // Compute critical damping gains and scale by damping ratio. Use Eigen
     // arrays (rather than matrices) for elementwise multiplication.
-    Eigen::ArrayXd temp =
-        H.diagonal().array() * stiffness_.array();
+    Eigen::ArrayXd temp = H.diagonal().array() * stiffness_.array();
     Eigen::ArrayXd damping_gains = 2 * temp.sqrt();
     damping_gains *= damping_ratio_.array();
 
@@ -83,11 +82,9 @@ class StateDependentDamper : public LeafSystem<T> {
 
 template <typename T>
 KukaTorqueController<T>::KukaTorqueController(
-    const multibody::MultibodyPlant<T>& plant,
-    const VectorX<double>& stiffness,
+    const multibody::MultibodyPlant<T>& plant, const VectorX<double>& stiffness,
     const VectorX<double>& damping)
     : plant_(plant) {
-
   DiagramBuilder<T> builder;
   DRAKE_DEMAND(plant_.num_positions() == stiffness.size());
   DRAKE_DEMAND(plant_.num_positions() == damping.size());
@@ -107,9 +104,8 @@ KukaTorqueController<T>::KukaTorqueController(
 
   // Adds gravity compensator.
   using drake::systems::controllers::InverseDynamics;
-  auto gravity_comp =
-      builder.template AddSystem<InverseDynamics<T>>(
-          &plant_, InverseDynamics<T>::kGravityCompensation);
+  auto gravity_comp = builder.template AddSystem<InverseDynamics<T>>(
+      &plant_, InverseDynamics<T>::kGravityCompensation);
 
   // Adds virtual springs.
   Eigen::VectorXd kd(dim);
@@ -153,8 +149,8 @@ KukaTorqueController<T>::KukaTorqueController(
       builder.ExportInput(adder->get_input_port(0), "commanded_torque");
 
   // Exposes controller output.
-  output_port_index_control_ = builder.ExportOutput(
-      adder->get_output_port(), "control");
+  output_port_index_control_ =
+      builder.ExportOutput(adder->get_output_port(), "control");
 
   builder.BuildInto(this);
 }

--- a/examples/kuka_iiwa_arm/kuka_torque_controller.h
+++ b/examples/kuka_iiwa_arm/kuka_torque_controller.h
@@ -42,10 +42,9 @@ class KukaTorqueController
 
   /// @p plant is aliased and must remain valid for the lifetime of the
   /// controller.
-  KukaTorqueController(
-      const multibody::MultibodyPlant<T>& plant,
-      const VectorX<double>& stiffness,
-      const VectorX<double>& damping);
+  KukaTorqueController(const multibody::MultibodyPlant<T>& plant,
+                       const VectorX<double>& stiffness,
+                       const VectorX<double>& damping);
 
   const systems::InputPort<T>& get_input_port_commanded_torque() const {
     return systems::Diagram<T>::get_input_port(

--- a/examples/kuka_iiwa_arm/lcm_plan_interpolator.cc
+++ b/examples/kuka_iiwa_arm/lcm_plan_interpolator.cc
@@ -60,7 +60,7 @@ void LcmPlanInterpolator::Initialize(double plan_start_time,
   robot_plan_interpolator_->Initialize(
       plan_start_time, q0,
       &this->GetMutableSubsystemContext(*robot_plan_interpolator_, context)
-          .get_mutable_state());
+           .get_mutable_state());
 }
 
 }  // namespace kuka_iiwa_arm

--- a/examples/kuka_iiwa_arm/lcm_plan_interpolator.h
+++ b/examples/kuka_iiwa_arm/lcm_plan_interpolator.h
@@ -25,12 +25,10 @@ namespace kuka_iiwa_arm {
  */
 class LcmPlanInterpolator : public systems::Diagram<double> {
  public:
-  LcmPlanInterpolator(
-      const std::string& model_path,
-      manipulation::util::InterpolatorType interpolator_type);
+  LcmPlanInterpolator(const std::string& model_path,
+                      manipulation::util::InterpolatorType interpolator_type);
 
-  const systems::InputPort<double>& get_input_port_iiwa_status()
-      const {
+  const systems::InputPort<double>& get_input_port_iiwa_status() const {
     return get_input_port(input_port_iiwa_status_);
   }
 

--- a/examples/kuka_iiwa_arm/move_iiwa_ee.cc
+++ b/examples/kuka_iiwa_arm/move_iiwa_ee.cc
@@ -70,7 +70,8 @@ int DoMain() {
         }
       });
 
-  while (lc.handle() >= 0) { }
+  while (lc.handle() >= 0) {
+  }
   return 0;
 }
 

--- a/examples/kuka_iiwa_arm/test/kuka_torque_controller_test.cc
+++ b/examples/kuka_iiwa_arm/test/kuka_torque_controller_test.cc
@@ -15,10 +15,8 @@ using drake::systems::BasicVector;
 
 namespace {
 Eigen::VectorXd CalcGravityCompensationTorque(
-    const multibody::MultibodyPlant<double>& plant,
-    const Eigen::VectorXd& q,
+    const multibody::MultibodyPlant<double>& plant, const Eigen::VectorXd& q,
     Eigen::MatrixXd* H = nullptr) {
-
   // Compute gravity compensation torque.
   std::unique_ptr<systems::Context<double>> plant_context =
       plant.CreateDefaultContext();
@@ -88,14 +86,13 @@ GTEST_TEST(KukaTorqueControllerTest, GravityCompensationTest) {
   controller.get_input_port_commanded_torque().FixValue(context.get(),
                                                         desired_torque_input);
 
-  Eigen::VectorXd expected_torque =
-      CalcGravityCompensationTorque(plant, q);
+  Eigen::VectorXd expected_torque = CalcGravityCompensationTorque(plant, q);
 
   // Check output.
   controller.CalcOutput(*context, output.get());
   const BasicVector<double>* output_vector = output->get_vector_data(0);
-  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(),
-                              1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(), 1e-10,
+                              MatrixCompareType::absolute));
 }
 
 GTEST_TEST(KukaTorqueControllerTest, SpringTorqueTest) {
@@ -149,8 +146,7 @@ GTEST_TEST(KukaTorqueControllerTest, SpringTorqueTest) {
                                                         desired_torque_input);
 
   // Compute gravity compensation torque.
-  Eigen::VectorXd expected_torque =
-      CalcGravityCompensationTorque(plant, q);
+  Eigen::VectorXd expected_torque = CalcGravityCompensationTorque(plant, q);
 
   // Compute spring torque.
   expected_torque += -((q - q_des).array() * stiffness.array()).matrix();
@@ -158,8 +154,8 @@ GTEST_TEST(KukaTorqueControllerTest, SpringTorqueTest) {
   // Check output.
   controller.CalcOutput(*context, output.get());
   const BasicVector<double>* output_vector = output->get_vector_data(0);
-  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(),
-                              1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(), 1e-10,
+                              MatrixCompareType::absolute));
 }
 
 GTEST_TEST(KukaTorqueControllerTest, DampingTorqueTest) {
@@ -214,8 +210,7 @@ GTEST_TEST(KukaTorqueControllerTest, DampingTorqueTest) {
 
   // Compute gravity compensation torque and mass matrix.
   Eigen::MatrixXd H(kIiwaArmNumJoints, kIiwaArmNumJoints);
-  Eigen::VectorXd expected_torque =
-      CalcGravityCompensationTorque(plant, q, &H);
+  Eigen::VectorXd expected_torque = CalcGravityCompensationTorque(plant, q, &H);
 
   // Compute spring torque.
   expected_torque += -((q - q_des).array() * stiffness.array()).matrix();
@@ -231,8 +226,8 @@ GTEST_TEST(KukaTorqueControllerTest, DampingTorqueTest) {
   // Check output.
   controller.CalcOutput(*context, output.get());
   const BasicVector<double>* output_vector = output->get_vector_data(0);
-  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(),
-                              1e-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(expected_torque, output_vector->value(), 1e-10,
+                              MatrixCompareType::absolute));
 }
 
 }  // namespace kuka_iiwa_arm


### PR DESCRIPTION
I'll be doing surgery on these demos soon to port them from `lcm-cpp.hpp` to `drake_lcm.h`.  In preparation for that, I need to get the formatting under control.

Towards #4843.