### PR TITLE
[Meshcat] Fix custom packer's `type` field to BufferAttribute types

### DIFF
--- a/geometry/meshcat_types_internal.h
+++ b/geometry/meshcat_types_internal.h
@@ -593,15 +593,15 @@ struct pack<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
     // Based on pack_numpy_array method in meshcat-python geometry.py. See also
     // https://github.com/msgpack/msgpack/blob/master/spec.md#extension-types
     if (std::is_floating_point_v<Scalar>) {
-      o.pack("Float32Array");
+      o.pack("Float32BufferAttribute");
       ext = 0x17;
     } else if (std::is_same_v<std::remove_cv<Scalar>, uint8_t>) {
-      o.pack("Uint8Array");
+      o.pack("Uint8BufferAttribute");
       ext = 0x12;
     } else if (std::is_same_v<Scalar, uint32_t>) {
       // TODO(russt): Using std::remove_cv<Scalar> did not work here (it failed
       // to match).  Need to understand and resolve this.
-      o.pack("Uint32Array");
+      o.pack("Uint32BufferAttribute");
       ext = 0x16;
     } else {
       throw std::runtime_error("Unsupported Scalar " +


### PR DESCRIPTION
Currently, Drake's [custom packer](https://github.com/RobotLocomotion/drake/blob/9b777703db33d12f5ae01efbbfc6929d124d2522/geometry/meshcat_types_internal.h#L577-L627) transcribes Eigen matrices into Three.js object JSONs whose `type` field is set to Javascript's native [typed arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Typed_arrays) (`Float32Array`, `Uint8Array`, `Uint32Array`). However, it should be set to Three.js' [BufferAttribute types](https://threejs.org/docs/#api/en/core/bufferAttributeTypes/BufferAttributeTypes) (`Float32BufferAttribute`, `Uint8BufferAttribute`, `Uint32BufferAttribute`) that are wrappers around the typed arrays.

A few reasons to see why:
1. Fields set by the custom packer such as `itemSize` and `normalized` are present in the [BufferAttribute](https://threejs.org/docs/#api/en/core/BufferAttribute) base class, but not present in [typed arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Typed_arrays).
2. The type of the `array` field in the transcribed JSON is a typed array. So the higher level object must not be a typed array.
3. The Meshcat API creates objects for classes defined in Three.js (e.g. `THREE.BufferAttribute`), not native Javascript types.

I think this bug was propagated from `meshcat-python`'s [threejs_type()](https://github.com/meshcat-dev/meshcat-python/blob/785bc9d5ba6f8a8bb79ee8b25f523805946c1fbd/src/meshcat/geometry.py#L387-L397) function which (incorrectly) sets the `type` field in the transcribed JSON as typed arrays.

I think this bug did not break anything; it seems Meshcat interprets the objects as BufferAttributes regardless of what the `type` field says. But this PR fixes the semantics of the objects being transcribed to.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22605)
<!-- Reviewable:end -->
