### PR TITLE
[doc] Cleanup extraneous Doxygen files

### DIFF
--- a/doc/doxygen_cxx/build.py
+++ b/doc/doxygen_cxx/build.py
@@ -9,6 +9,7 @@ import os
 from os.path import join, relpath
 import shutil
 import sys
+from glob import glob
 
 from python import runfiles
 
@@ -290,6 +291,13 @@ def _build(*, out_dir, temp_dir, modules, quick):
     perl_cleanup_html_output(
         out_dir=out_dir,
         extra_perl_statements=extra_perl_statements)
+
+    # Remove extraneous Doxygen build files.
+    files_to_remove = glob(os.path.join(out_dir, "*.md5"))
+    files_to_remove += glob(os.path.join(out_dir, "*.map"))
+    for i in files_to_remove:
+        if os.path.exists(i):
+            os.remove(i)
 
     # The nominal pages to offer for preview.
     return ["", "classes.html", "modules.html"]

--- a/doc/doxygen_cxx/build.py
+++ b/doc/doxygen_cxx/build.py
@@ -5,11 +5,11 @@ For instructions, see https://drake.mit.edu/documentation_instructions.html.
 
 import argparse
 from fnmatch import fnmatch
+from glob import glob
 import os
 from os.path import join, relpath
 import shutil
 import sys
-from glob import glob
 
 from python import runfiles
 
@@ -293,11 +293,13 @@ def _build(*, out_dir, temp_dir, modules, quick):
         extra_perl_statements=extra_perl_statements)
 
     # Remove extraneous Doxygen build files.
-    files_to_remove = glob(os.path.join(out_dir, "*.md5"))
-    files_to_remove += glob(os.path.join(out_dir, "*.map"))
+    files_to_remove = glob(join(out_dir, "*.md5"))
+    files_to_remove += glob(join(out_dir, "*.map"))
     for i in files_to_remove:
-        if os.path.exists(i):
+        try:
             os.remove(i)
+        except IOError:
+            pass
 
     # The nominal pages to offer for preview.
     return ["", "classes.html", "modules.html"]


### PR DESCRIPTION
Addresses #18554. Doxygen generates `*.md5` and `*.map` files as part of its build process which can be used to speed up build regeneration. Currently, these are ignored and excluded from the [website publication in CI](https://github.com/RobotLocomotion/drake-ci/blob/70e4326ab22049db3ae5ac16ad59c9f48bcd5b9d/tools/publish_documentation.bash#L40). This PR moves this logic to `drake/doc` by inserting a post-build removal step. (Unfortunately, Doxygen doesn't provide any command-line option to never generate these files in the first place). 

Tested locally with the following cases. The website preview remains unchanged, and the files are removed from either the output or temp directory:

* `bazel run //doc:build -- --serve`
* `bazel run //doc:build -- --out_dir=...`
* `bazel run //doc/doxygen_cxx:build -- --out_dir=...`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22606)
<!-- Reviewable:end -->
