### PR TITLE
Use separate venv for installation PDM

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -68,9 +68,11 @@ fi
 
 if [[ "${with_python_dependencies}" -eq 1 ]]; then
   readonly setup="${BASH_SOURCE%/*}"
-  readonly venv_root="$(cd "${setup}/../../.." && pwd)"
-  python3.12 -m venv "${venv_root}"
-  "${venv_root}/bin/pip3" install -U -r "${setup}/requirements.txt"
-  "${venv_root}/bin/pdm" use -p "${setup}" -f "${venv_root}"
-  "${venv_root}/bin/pdm" sync -p "${setup}" --prod
+  readonly venv_pdm="${setup}"
+  readonly venv_drake="$(cd "${setup}/../../.." && pwd)"
+  python3.12 -m venv "${venv_pdm}"
+  "${venv_pdm}/bin/pip3" install -U -r "${setup}/requirements.txt"
+  "${venv_pdm}/bin/python3" -m venv "${venv_drake}"
+  "${venv_pdm}/bin/pdm" use -p "${setup}" -f "${venv_drake}"
+  "${venv_pdm}/bin/pdm" sync -p "${setup}" --prod
 fi


### PR DESCRIPTION
Modify how we set up the virtual environment for macOS installs to keep PDM in a separate environment. This avoids PDM modifying its own environment (which appears to have possible race conditions).

Amends #22477.
Closes #22040.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22607)
<!-- Reviewable:end -->
