### PR TITLE
[multibody] Eliminate unneeded BluePrint class

### DIFF
--- a/multibody/plant/test/sap_driver_multidof_joints_test.cc
+++ b/multibody/plant/test/sap_driver_multidof_joints_test.cc
@@ -91,9 +91,8 @@ class MultiDofJointWithLimits final : public Joint<T> {
   int do_get_velocity_start() const override { return 0; }
   int do_get_position_start() const override { return 0; }
 
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<Mobilizer<T>> MakeMobilizerForJoint(
       const SpanningForest::Mobod& mobod) const override {
-    auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
     const auto [inboard_frame, outboard_frame] =
         this->tree_frames(mobod.is_reversed());
     // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
@@ -102,8 +101,7 @@ class MultiDofJointWithLimits final : public Joint<T> {
     // consistent during MultibodyPlant::Finalize().
     auto revolute_mobilizer = std::make_unique<internal::RpyBallMobilizer<T>>(
         mobod, *inboard_frame, *outboard_frame);
-    blue_print->mobilizer = std::move(revolute_mobilizer);
-    return blue_print;
+    return revolute_mobilizer;
   }
 
   // We do not need an implementation for the methods below since the unit tests

--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -70,18 +70,15 @@ std::unique_ptr<Joint<T>> BallRpyJoint<T>::DoShallowClone() const {
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-BallRpyJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>> BallRpyJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
   auto ballrpy_mobilizer = std::make_unique<internal::RpyBallMobilizer<T>>(
       mobod, *inboard_frame, *outboard_frame);
   ballrpy_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizer = std::move(ballrpy_mobilizer);
-  return blue_print;
+  return ballrpy_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -240,7 +240,7 @@ class BallRpyJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/curvilinear_joint.cc
+++ b/multibody/tree/curvilinear_joint.cc
@@ -99,10 +99,9 @@ std::unique_ptr<Joint<T>> CurvilinearJoint<T>::DoShallowClone() const {
 }
 
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-CurvilinearJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>>
+CurvilinearJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
@@ -110,8 +109,7 @@ CurvilinearJoint<T>::MakeImplementationBlueprint(
       std::make_unique<internal::CurvilinearMobilizer<T>>(
           mobod, *inboard_frame, *outboard_frame, curvilinear_path_);
   curvilinear_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizer = std::move(curvilinear_mobilizer);
-  return blue_print;
+  return curvilinear_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/curvilinear_joint.h
+++ b/multibody/tree/curvilinear_joint.h
@@ -331,7 +331,7 @@ class CurvilinearJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -54,20 +54,17 @@ class JointImplementationBuilder {
 
   static Mobilizer<T>* Build(const SpanningForest::Mobod& mobod,
                              Joint<T>* joint, MultibodyTree<T>* tree) {
-    std::unique_ptr<JointBluePrint> blue_print =
-        joint->MakeImplementationBlueprint(mobod);
-    auto implementation = std::make_unique<JointImplementation>(*blue_print);
+    std::unique_ptr<Mobilizer<T>> owned_mobilizer =
+        joint->MakeMobilizerForJoint(mobod);
+    Mobilizer<T>* mobilizer = owned_mobilizer.get();
+    auto implementation =
+        std::make_unique<typename Joint<T>::JointImplementation>(mobilizer);
     DRAKE_DEMAND(implementation->has_mobilizer());
-    Mobilizer<T>* mobilizer = blue_print->mobilizer.get();
-    tree->AddMobilizer(std::move(blue_print->mobilizer));
+    tree->AddMobilizer(std::move(owned_mobilizer));  // ownership->tree
     // TODO(amcastro-tri): add force elements, bodies, constraints, etc.
     joint->OwnImplementation(std::move(implementation));
     return mobilizer;
   }
-
- private:
-  typedef typename Joint<T>::BluePrint JointBluePrint;
-  typedef typename Joint<T>::JointImplementation JointImplementation;
 };
 
 template <typename T>

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -69,18 +69,15 @@ std::unique_ptr<Joint<T>> PlanarJoint<T>::DoShallowClone() const {
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-PlanarJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>> PlanarJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
   auto planar_mobilizer = std::make_unique<internal::PlanarMobilizer<T>>(
       mobod, *inboard_frame, *outboard_frame);
   planar_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizer = std::move(planar_mobilizer);
-  return blue_print;
+  return planar_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -321,7 +321,7 @@ class PlanarJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -298,9 +298,8 @@ class PrismaticJoint final : public Joint<T> {
   }
 
   // Joint<T> finals:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const final {
-    auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
     const auto [inboard_frame, outboard_frame] =
         this->tree_frames(mobod.is_reversed());
     // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
@@ -308,8 +307,7 @@ class PrismaticJoint final : public Joint<T> {
         std::make_unique<internal::PrismaticMobilizer<T>>(
             mobod, *inboard_frame, *outboard_frame, axis_);
     prismatic_mobilizer->set_default_position(this->default_positions());
-    blue_print->mobilizer = std::move(prismatic_mobilizer);
-    return blue_print;
+    return prismatic_mobilizer;
   }
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/quaternion_floating_joint.cc
+++ b/multibody/tree/quaternion_floating_joint.cc
@@ -66,10 +66,9 @@ std::unique_ptr<Joint<T>> QuaternionFloatingJoint<T>::DoShallowClone() const {
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-QuaternionFloatingJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>>
+QuaternionFloatingJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
@@ -78,8 +77,7 @@ QuaternionFloatingJoint<T>::MakeImplementationBlueprint(
           mobod, *inboard_frame, *outboard_frame);
   quaternion_floating_mobilizer->set_default_position(
       this->default_positions());
-  blue_print->mobilizer = std::move(quaternion_floating_mobilizer);
-  return blue_print;
+  return quaternion_floating_mobilizer;
 }
 
 template <typename T>

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -417,7 +417,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -101,18 +101,15 @@ std::unique_ptr<Joint<T>> RevoluteJoint<T>::DoShallowClone() const {
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-RevoluteJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>> RevoluteJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
   auto revolute_mobilizer = std::make_unique<internal::RevoluteMobilizer<T>>(
       mobod, *inboard_frame, *outboard_frame, axis_);
   revolute_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizer = std::move(revolute_mobilizer);
-  return blue_print;
+  return revolute_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -330,7 +330,7 @@ class RevoluteJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/rpy_floating_joint.cc
+++ b/multibody/tree/rpy_floating_joint.cc
@@ -71,10 +71,9 @@ std::unique_ptr<Joint<T>> RpyFloatingJoint<T>::DoShallowClone() const {
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-RpyFloatingJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>>
+RpyFloatingJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
@@ -82,8 +81,7 @@ RpyFloatingJoint<T>::MakeImplementationBlueprint(
       std::make_unique<internal::RpyFloatingMobilizer<T>>(mobod, *inboard_frame,
                                                           *outboard_frame);
   rpy_floating_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizer = std::move(rpy_floating_mobilizer);
-  return blue_print;
+  return rpy_floating_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -427,7 +427,7 @@ class RpyFloatingJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -100,18 +100,15 @@ std::unique_ptr<Joint<T>> ScrewJoint<T>::DoShallowClone() const {
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-ScrewJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>> ScrewJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
   auto screw_mobilizer = std::make_unique<internal::ScrewMobilizer<T>>(
       mobod, *inboard_frame, *outboard_frame, this->screw_axis(), screw_pitch_);
   screw_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizer = std::move(screw_mobilizer);
-  return blue_print;
+  return screw_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -349,7 +349,7 @@ class ScrewJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -69,18 +69,16 @@ std::unique_ptr<Joint<T>> UniversalJoint<T>::DoShallowClone() const {
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-UniversalJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>>
+UniversalJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
-  auto univeral_mobilizer = std::make_unique<internal::UniversalMobilizer<T>>(
+  auto universal_mobilizer = std::make_unique<internal::UniversalMobilizer<T>>(
       mobod, *inboard_frame, *outboard_frame);
-  univeral_mobilizer->set_default_position(this->default_positions());
-  blue_print->mobilizer = std::move(univeral_mobilizer);
-  return blue_print;
+  universal_mobilizer->set_default_position(this->default_positions());
+  return universal_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -240,7 +240,7 @@ class UniversalJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -61,10 +61,8 @@ std::unique_ptr<Joint<T>> WeldJoint<T>::DoShallowClone() const {
 // `MobilizerImpl`, we must place this implementation in the source file, not
 // in the header file.
 template <typename T>
-std::unique_ptr<typename Joint<T>::BluePrint>
-WeldJoint<T>::MakeImplementationBlueprint(
+std::unique_ptr<internal::Mobilizer<T>> WeldJoint<T>::MakeMobilizerForJoint(
     const internal::SpanningForest::Mobod& mobod) const {
-  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
 
@@ -77,9 +75,9 @@ WeldJoint<T>::MakeImplementationBlueprint(
   // the mobilizer's inboard body rather than the usual outboard reaction.
   // That's handled when reporting (see MultibodyPlant::CalcReactionForces()),
   // not locally by the mobilizer.
-  blue_print->mobilizer = std::make_unique<internal::WeldMobilizer<T>>(
+  auto weld_mobilizer = std::make_unique<internal::WeldMobilizer<T>>(
       mobod, *inboard_frame, *outboard_frame, X_FM);
-  return blue_print;
+  return weld_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -98,7 +98,7 @@ class WeldJoint final : public Joint<T> {
   void do_set_default_positions(const VectorX<double>&) override { return; }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint(
+  std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(


### PR DESCRIPTION
MultibodyPlant's Joint implementation code has an unneeded intermediate "Blueprint" class. This PR nukes that to somewhat simplify MbP's baroque construction of a Joint's internal implementation. This is a yak shave for some upcoming changes to joint modeling.

All changes are internal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22608)
<!-- Reviewable:end -->
