### PR TITLE
Implement discrete-time finite-horizon LQR

### DIFF
--- a/doc/_pages/credits.md
+++ b/doc/_pages/credits.md
@@ -8,7 +8,7 @@ and the [Robotics Division](https://www.tri.global/our-work/robotics/) at
 Toyota Research Institute.  Many other people have since contributed their
 talents to help make Drake successful.  Here's an alphabetical list: (note to contributors: *do add yourself*)
 
-{% comment %} 
+{% comment %}
 this is modeled directly, and shamelessly, on: http://eigen.tuxfamily.org/index.php?title=Main_Page#Credits
 {% endcomment %}
 
@@ -47,6 +47,7 @@ this is modeled directly, and shamelessly, on: http://eigen.tuxfamily.org/index.
 * Naveen Kuppuswamy
 * Benoit Landry
 * Dominic Liao-McPherson
+* Wei-Chen Li
 * Lucas Manuelli
 * Matt Marjanovic
 * Pat Marion

--- a/systems/controllers/finite_horizon_linear_quadratic_regulator.cc
+++ b/systems/controllers/finite_horizon_linear_quadratic_regulator.cc
@@ -8,6 +8,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/is_approx_equal_abstol.h"
+#include "drake/common/trajectories/discrete_time_trajectory.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/matrix_util.h"
@@ -20,6 +21,7 @@ namespace drake {
 namespace systems {
 namespace controllers {
 
+using trajectories::DiscreteTimeTrajectory;
 using trajectories::PiecewisePolynomial;
 using trajectories::Trajectory;
 
@@ -142,8 +144,8 @@ class RiccatiSystem : public LeafSystem<double> {
     } else {
       Sxx = Eigen::Map<const Eigen::MatrixXd>(S_vectorized.data(), num_states_,
                                               num_states_);
-      Eigen::Map<Eigen::MatrixXd> minus_Sxxdot(
-          minus_Sdot_vectorized.data(), num_states_, num_states_);
+      Eigen::Map<Eigen::MatrixXd> minus_Sxxdot(minus_Sdot_vectorized.data(),
+                                               num_states_, num_states_);
       minus_Sxxdot = Sxx * A + A.transpose() * Sxx -
                      (N_ + Sxx * B) * Rinv_ * (N_ + Sxx * B).transpose() + Q_;
     }
@@ -283,10 +285,8 @@ class RiccatiSystem : public LeafSystem<double> {
   const FiniteHorizonLinearQuadraticRegulatorOptions& options_;
 };
 
-}  // namespace
-
 FiniteHorizonLinearQuadraticRegulatorResult
-FiniteHorizonLinearQuadraticRegulator(
+ContinuousTimeFiniteHorizonLinearQuadraticRegulator(
     const System<double>& system, const Context<double>& context, double t0,
     double tf, const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::MatrixXd>& R,
@@ -294,6 +294,7 @@ FiniteHorizonLinearQuadraticRegulator(
   // Most argument consistency checks are handled by RiccatiSystem, but that
   // System doesn't need to understand the time range, so we perform (only)
   // those checks here.
+  DRAKE_DEMAND(system.IsDifferentialEquationSystem());
   system.ValidateContext(context);
   DRAKE_DEMAND(system.num_input_ports() > 0);
   DRAKE_DEMAND(tf > t0);
@@ -400,6 +401,219 @@ FiniteHorizonLinearQuadraticRegulator(
   riccati.MakeKTrajectories(&result);
 
   return result;
+}
+
+FiniteHorizonLinearQuadraticRegulatorResult
+DiscreteTimeFiniteHorizonLinearQuadraticRegulator(
+    const System<double>& system, const Context<double>& context, double t0,
+    double tf, const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::MatrixXd>& R,
+    const FiniteHorizonLinearQuadraticRegulatorOptions& options) {
+  DRAKE_DEMAND(system.IsDifferenceEquationSystem());
+  system.ValidateContext(context);
+  DRAKE_THROW_UNLESS(system.num_input_ports() > 0);
+  DRAKE_THROW_UNLESS(tf > t0);
+
+  if (options.use_square_root_method) {
+    // TODO(wei-chen): Find if possible and implement square root method.
+    throw std::logic_error(
+        "Discrete-time finite-horizon LQR does not yet support the square root "
+        "method.");
+  }
+
+  const Trajectory<double>* x0_traj;
+  PiecewisePolynomial<double> x0_constant_traj;
+  if (options.x0 != nullptr) {
+    DRAKE_THROW_UNLESS(options.x0->start_time() <= t0);
+    DRAKE_THROW_UNLESS(options.x0->end_time() >= tf);
+    x0_traj = options.x0;
+  } else {
+    // Make a constant trajectory with the state from context.
+    x0_constant_traj = PiecewisePolynomial<double>(
+        context.get_discrete_state_vector().CopyToVector());
+    x0_traj = &x0_constant_traj;
+  }
+
+  const Trajectory<double>* u0_traj;
+  PiecewisePolynomial<double> u0_constant_traj;
+  if (options.u0 != nullptr) {
+    DRAKE_THROW_UNLESS(options.u0->start_time() <= t0);
+    DRAKE_THROW_UNLESS(options.u0->end_time() >= tf);
+    u0_traj = options.u0;
+  } else {
+    // Make a constant trajectory with the input from context.
+    const InputPort<double>* input_port =
+        system.get_input_port_selection(options.input_port_index);
+    DRAKE_THROW_UNLESS(input_port != nullptr);
+    u0_constant_traj = PiecewisePolynomial<double>(input_port->Eval(context));
+    u0_traj = &u0_constant_traj;
+  }
+
+  // Create an autodiff version of the system.
+  std::unique_ptr<System<AutoDiffXd>> autodiff_system =
+      drake::systems::System<double>::ToAutoDiffXd(system);
+
+  const InputPort<AutoDiffXd>* input_port =
+      autodiff_system->get_input_port_selection(options.input_port_index);
+  DRAKE_THROW_UNLESS(input_port != nullptr);
+
+  // Initialize autodiff.
+  std::unique_ptr<Context<AutoDiffXd>> autodiff_context =
+      autodiff_system->CreateDefaultContext();
+  autodiff_context->SetTimeStateAndParametersFrom(context);
+  autodiff_system->FixInputPortsFrom(system, context, autodiff_context.get());
+
+  const int num_states = autodiff_context->num_total_states();
+  const int num_inputs = input_port->size();
+
+  // Check arguments.
+  if (input_port->get_data_type() == PortDataType::kAbstractValued) {
+    throw std::logic_error(
+        "The specified input port is abstract-valued, but "
+        "FiniteHorizonLinearQuadraticRegulator only supports vector-valued "
+        "input ports.  Did you perhaps forget to pass a non-default "
+        "`input_port_index` argument?");
+  }
+  DRAKE_THROW_UNLESS(input_port->get_data_type() ==
+                     PortDataType::kVectorValued);
+
+  DRAKE_THROW_UNLESS(num_states > 0);
+  DRAKE_THROW_UNLESS(num_inputs > 0);
+
+  const double kSymmetryTolerance = 1e-8;
+  DRAKE_THROW_UNLESS(Q.rows() == num_states && Q.cols() == num_states);
+  DRAKE_THROW_UNLESS(math::IsPositiveDefinite(Q, 0.0, kSymmetryTolerance));
+
+  DRAKE_THROW_UNLESS(R.rows() == num_inputs && R.cols() == num_inputs);
+  DRAKE_THROW_UNLESS(math::IsPositiveDefinite(
+      R, std::numeric_limits<double>::epsilon(), kSymmetryTolerance));
+
+  const Eigen::MatrixXd Qf =
+      options.Qf.value_or(Eigen::MatrixXd::Zero(num_states, num_states));
+  DRAKE_THROW_UNLESS(Qf.rows() == num_states && Qf.cols() == num_states);
+  DRAKE_THROW_UNLESS(math::IsPositiveDefinite(Q, 0.0, kSymmetryTolerance));
+
+  const Eigen::MatrixXd N =
+      options.N.value_or(Eigen::MatrixXd::Zero(num_states, num_inputs));
+  DRAKE_THROW_UNLESS(N.rows() == num_states && N.cols() == num_inputs);
+
+  // Compute the discrete times.
+  const double kTimeCompTolerance = 1e-10;
+  std::vector<double> times;
+  DRAKE_THROW_UNLESS(
+      system.GetUniquePeriodicDiscreteUpdateAttribute().has_value());
+  auto discrete = system.GetUniquePeriodicDiscreteUpdateAttribute().value();
+  DRAKE_THROW_UNLESS(std::abs(std::remainder(t0 - discrete.offset_sec(),
+                                             discrete.period_sec())) <=
+                     kTimeCompTolerance);
+  DRAKE_THROW_UNLESS(std::abs(std::remainder(tf - discrete.offset_sec(),
+                                             discrete.period_sec())) <=
+                     kTimeCompTolerance);
+  times.resize(std::round((tf - t0) / discrete.period_sec() + 1));
+  for (int n = 0; n < ssize(times); ++n) {
+    times[n] = t0 + discrete.period_sec() * n;
+  }
+
+  // Compute discrete-time finite horizon LQR,
+  // K[n], k0[n] depends on S[n+1], sx[n+1], s0[n+1].
+  std::vector<Eigen::MatrixXd> K(times.size() - 1), k0(times.size() - 1),
+      S(times.size()), sx(times.size()), s0(times.size());
+
+  Eigen::MatrixXd xd0f =
+      (options.xd != nullptr)
+          ? (options.xd->value(tf) - x0_traj->value(tf)).eval()
+          : Eigen::VectorXd::Zero(num_states);
+  S.back() = Qf;
+  sx.back() = -Qf * xd0f;
+  s0.back() = xd0f.transpose() * Qf * xd0f;
+
+  for (int n = ssize(times) - 2; n >= 0; --n) {
+    double t = times[n];
+
+    Eigen::MatrixXd x0 = x0_traj->value(t);
+    Eigen::MatrixXd u0 = u0_traj->value(t);
+
+    Eigen::MatrixXd x0_next = x0_traj->value(times[n + 1]);
+
+    // Desired trajectories relative to the nominal.
+    Eigen::MatrixXd xd0 =
+        ((options.xd != nullptr) ? options.xd->value(t) : x0) - x0;
+    Eigen::MatrixXd ud0 =
+        ((options.ud != nullptr) ? options.ud->value(t) : u0) - u0;
+
+    auto autodiff_args = math::InitializeAutoDiffTuple(x0, u0);
+
+    input_port->FixValue(autodiff_context.get(), std::get<1>(autodiff_args));
+
+    autodiff_context->SetTime(t);
+    autodiff_context->SetDiscreteState(std::get<0>(autodiff_args));
+
+    auto autodiff_x0_next =
+        autodiff_system->EvalUniquePeriodicDiscreteUpdate(*autodiff_context)
+            .value();
+
+    const Eigen::MatrixXd AB = math::ExtractGradient(autodiff_x0_next);
+
+    Eigen::MatrixXd A = AB.leftCols(num_states);
+    Eigen::MatrixXd B = AB.rightCols(num_inputs);
+    Eigen::MatrixXd c = math::ExtractValue(autodiff_x0_next) - x0_next;
+
+    Eigen::MatrixXd qx = -Q * xd0 - N * ud0;
+    Eigen::MatrixXd q0 =
+        xd0.transpose() * Q * xd0 + 2 * xd0.transpose() * N * ud0;
+    Eigen::MatrixXd ru = -R * ud0 - N.transpose() * xd0;
+    Eigen::MatrixXd r0 = ud0.transpose() * R * ud0;
+
+    Eigen::MatrixXd R_BSB_inv = (R + B.transpose() * S[n + 1] * B).inverse();
+    Eigen::MatrixXd N_BSA = N.transpose() + B.transpose() * S[n + 1] * A;
+    Eigen::MatrixXd ru_BSc_Bsx =
+        ru + B.transpose() * S[n + 1] * c + B.transpose() * sx[n + 1];
+
+    K[n] = R_BSB_inv * N_BSA;
+    k0[n] = R_BSB_inv * ru_BSc_Bsx;
+
+    S[n] = Q + A.transpose() * S[n + 1] * A -
+           N_BSA.transpose() * R_BSB_inv * N_BSA;
+    sx[n] = qx + A.transpose() * S[n + 1] * c + A.transpose() * sx[n + 1] -
+            N_BSA.transpose() * R_BSB_inv * ru_BSc_Bsx;
+    s0[n] = c.transpose() * S[n + 1] * c + 2 * c.transpose() * sx[n + 1] +
+            s0[n + 1] + q0 + r0 -
+            ru_BSc_Bsx.transpose() * R_BSB_inv * ru_BSc_Bsx;
+  }  // for loop
+
+  FiniteHorizonLinearQuadraticRegulatorResult result;
+  result.x0 = x0_traj->Clone();
+  result.u0 = u0_traj->Clone();
+  result.S = DiscreteTimeTrajectory(times, std::move(S));
+  result.sx = DiscreteTimeTrajectory(times, std::move(sx));
+  result.s0 = DiscreteTimeTrajectory(times, std::move(s0));
+  times.pop_back();
+  result.K = DiscreteTimeTrajectory(times, std::move(K));
+  result.k0 = DiscreteTimeTrajectory(times, std::move(k0));
+
+  return result;
+}
+
+}  // namespace
+
+FiniteHorizonLinearQuadraticRegulatorResult
+FiniteHorizonLinearQuadraticRegulator(
+    const System<double>& system, const Context<double>& context, double t0,
+    double tf, const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::MatrixXd>& R,
+    const FiniteHorizonLinearQuadraticRegulatorOptions& options) {
+  if (system.IsDifferentialEquationSystem()) {
+    return ContinuousTimeFiniteHorizonLinearQuadraticRegulator(
+        system, context, t0, tf, Q, R, options);
+  } else if (system.IsDifferenceEquationSystem()) {
+    return DiscreteTimeFiniteHorizonLinearQuadraticRegulator(
+        system, context, t0, tf, Q, R, options);
+  } else {
+    throw std::logic_error(
+        "FiniteHorizonLinearQuadraticRegulator only supports system where "
+        "either system.IsDifferentialEquationSystem() or "
+        "system.IsDifferenceEquationSystem() is true");
+  }
 }
 
 namespace {

--- a/systems/controllers/finite_horizon_linear_quadratic_regulator.h
+++ b/systems/controllers/finite_horizon_linear_quadratic_regulator.h
@@ -34,17 +34,19 @@ struct FiniteHorizonLinearQuadraticRegulatorOptions {
 
   /**
   A nominal state trajectory.  The system is linearized about this trajectory.
-  x0 must be defined over the entire interval [t0, tf].  If null, then x0 is
-  taken to be a constant trajectory (whose value is specified by the context
-  passed into the LQR method).
+  x0 must be defined over the entire interval [t0, tf] for the continuous-time
+  case, or at least over the sample times for the discrete-time case. If null,
+  then x0 is taken to be a constant trajectory (whose value is specified by the
+  context passed into the LQR method).
   */
   const trajectories::Trajectory<double>* x0{nullptr};
 
   /**
   A nominal input trajectory.  The system is linearized about this trajectory.
-  u0 must be defined over the entire interval, [t0, tf].  If null, then u0 is
-  taken to be a constant trajectory (whose value is specified by the context
-  passed into the LQR method).
+  u0 must be defined over the entire interval [t0, tf] for the continuous-time
+  case, or at least over the sample times for the discrete-time case.  If null,
+  then u0 is taken to be a constant trajectory (whose value is specified by the
+  context passed into the LQR method).
   */
   const trajectories::Trajectory<double>* u0{nullptr};
 
@@ -78,18 +80,26 @@ struct FiniteHorizonLinearQuadraticRegulatorOptions {
   bool use_square_root_method{false};
 
   /**
-  For continuous-time dynamical systems, the Riccati equation is solved by the
-  Simulator (running backwards in time). Use this parameter to configure the
-  simulator (e.g. choose non-default integrator or integrator parameters). */
+  For continuous-time finite-horizon LQR, the Riccati differential equation is
+  solved by the Simulator (running backwards in time). Use this parameter to
+  configure the simulator (e.g. choose non-default integrator or integrator
+  parameters). */
   SimulatorConfig simulator_config{};
 };
 
 /**
 A structure that contains the basic FiniteHorizonLinearQuadraticRegulator
-results. The finite-horizon cost-to-go is given by (x-x0(t))'*S(t)*(x-x0(t)) +
-2*(x-x₀(t))'sₓ(t) + s₀(t) and the optimal controller is given by u-u0(t) =
--K(t)*(x-x₀(t)) - k₀(t).  Please don't overlook the factor of 2 in front of the
-sₓ(t) term.
+results.
+
+The continuous-time finite-horizon cost-to-go is given by
+(x-x₀(t))'*S(t)*(x-x₀(t)) + 2(x-x₀(t))'sₓ(t) + s₀(t) and the optimal controller
+is given by u-u₀(t) = -K(t) (x-x₀(t)) - k₀(t). Please don't overlook the factor
+of 2 in front of the sₓ(t) term.
+
+The discrete-time finite-horizon cost-to-go is given by
+(x−x₀[n])'*S[n]*(x−x₀[n])) + 2(x−x₀[n])'sₓ[n] + s₀[n] and the optimal controller
+is given by u−u₀[n] = −K[n] (x−x₀[n]) − k₀[n]. Please don't overlook the factor
+of 2 in front of the sₓ[n] term.
 */
 struct FiniteHorizonLinearQuadraticRegulatorResult {
   copyable_unique_ptr<trajectories::Trajectory<double>> x0;
@@ -106,16 +116,15 @@ struct FiniteHorizonLinearQuadraticRegulatorResult {
   copyable_unique_ptr<trajectories::Trajectory<double>> s0;
 };
 
-// TODO(russt): Add support for difference-equation systems.
-
 // TODO(russt): Add variants for specifying the cost with Q and/or R
 // trajectories, full quadratic forms, and perhaps even symbolic and/or
 // std::function cost l(t,x,u) whose's Hessian is evaluated via autodiff to give
 // the terms.
 
 /**
-Solves the differential Riccati equation to compute the optimal controller and
-optimal cost-to-go for the finite-horizon linear quadratic regulator:
+If @p system is a continuous-time system, then solves the differential Riccati
+equation to compute the optimal controller and optimal cost-to-go for the
+continuous-time finite-horizon linear quadratic regulator:
 
 @f[\min_u (x(t_f)-x_d(t_f))'Q_f(x(t_f)-x_d(t_f)) + \int_{t_0}^{t_f}
   (x(t)-x_d(t))'Q(x(t)-x_d(t)) dt + \int_{t_0}^{t_f}
@@ -125,11 +134,32 @@ optimal cost-to-go for the finite-horizon linear quadratic regulator:
 u_0(t)) + c(t)
 @f]
 
-where A(t), B(t), and c(t) are taken from the gradients of the continuous-time
-dynamics ẋ = f(t,x,u), as A(t) = dfdx(t, x0(t), u0(t)), B(t) = dfdu(t, x0(t),
-u0(t)), and c(t) = f(t, x0(t), u0(t)) - ẋ0(t).  x0(t) and u0(t) can be
-specified in @p options, otherwise are taken to be constant trajectories with
-values given by @p context.
+where @f$ A(t) @f$, @f$ B(t) @f$, and @f$ c(t) @f$ are taken from the gradients
+of the continuous-time dynamics @f$ \dot{x} = f(t,x,u) @f$, where @f$ A(t) =
+\frac{\partial f}{\partial x}(t, x_0(t), u_0(t)) @f$, @f$ B(t) = \frac{\partial
+f}{\partial u}(t, x_0(t), u_0(t)) @f$, and @f$ c(t) = f(t, x_0(t), u_0(t)) -
+\dot{x}_0(t) @f$. @f$ x_0(t) @f$ and @f$ u_0(t) @f$ can be specified in @p
+options, otherwise are taken to be constant trajectories with values given by @p
+context.
+
+If @p system is a discrete-time system, then solves the Riccati difference
+equation to compute the optimal controller and optimal cost-to-go for the
+doscrete-time finite-horizon linear quadratic regulator:
+
+@f[\min_u (x[N]-x_d[N])'Q_f(x[N]-x_d[N]) + \sum_{n=0}^{N-1}
+  (x[n]-x_d[n])'Q(x[n]-x_d[n])+ \sum_{n=0}^{N-1}
+  (u[n]-u_d[n])'R(u[n]-u_d[n]) + \sum_{n=0}^{N-1}
+  2(x[n]-x_d[n])'N(u[n]-u_d[n]) \\
+  \text{s.t. } x[n+1] - x_0[n+1] = A[n](x[n] - x_0[n]) + B[n](u[n] -
+u_0[n]) + c[n]
+@f]
+
+where @f$ A[n] @f$, @f$ B[n] @f$, and @f$ c[n] @f$ are taken from the gradients
+of the discrete-time dynamics @f$ x[n+1] = f_d(n,x[n],u[n]) @f$, where @f$ A[n]
+=\frac{\partial f_d}{\partial x}(x_0[n], u_0[n]), B[n] = \frac{\partial
+f_d}{\partial u}(n,x_0[n], u_0[n]) @f$, and @f$ c[n] = f_d(n,x_0[n],u_0[n]) -
+x_0[n+1] @f$. @f$ x_0[n] @f$ and @f$ u_0[n] @f$ can be specified in @p options,
+otherwise are taken to be constant trajectories with values given by @p context.
 
 @param system a System<double> representing the plant.
 @param context a Context<double> used to pass the default input, state, and
@@ -141,12 +171,14 @@ values given by @p context.
 @param R is mxm positive definite.
 @param options is the optional FiniteHorizonLinearQuadraticRegulatorOptions.
 
-@pre @p system must be a System<double> with (only) n continuous state variables
-and m inputs.  It must be convertible to System<AutoDiffXd>.
+@return FiniteHorizonLinearQuadraticRegulatorResult representing a
+continuous-time or a discrete-time finite-horizon LQR.
 
-@note Support for difference-equation systems (@see
-System<T>::IsDifferenceEquationSystem()) by solving the differential Riccati
-equation and richer specification of the objective are anticipated (they are
+@pre @p system must be a System<double> with n continuous state variables and m
+inputs, or a System<double> with n discrete state variables and m inputs.  It
+must be convertible to System<AutoDiffXd>.
+
+@note Richer specification of the objective is anticipated (they are
 listed in the code as TODOs).
 
 @ingroup control
@@ -165,6 +197,13 @@ implementing the regulator (controller) as a System, with a single
 output for the regulator control output.
 
 @see FiniteHorizonLinearQuadraticRegulator for details on the arguments.
+
+@note To control a continuous-time plant using a discrete-time finite-horizon
+LQR controller, first convert the plant using DiscreteTimeApproximation and
+pass it to the function. After obtaining the discrete-time controller, be sure
+to connect a ZeroOrderHold system to its output. For more details, refer to the
+DiscreteTimeTrajectory documentation.
+
 @ingroup control_systems
 */
 std::unique_ptr<System<double>> MakeFiniteHorizonLinearQuadraticRegulator(

--- a/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/trajectories/discrete_time_trajectory.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/primitives/linear_system.h"
@@ -70,7 +71,7 @@ GTEST_TEST(FiniteHorizonLQRTest, InfiniteHorizonTest) {
       MakeFiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
                                                 options);
   auto regulator_context = regulator->CreateDefaultContext();
-  const Eigen::Vector2d x(.1, -.3);
+  const Eigen::Vector2d x(0.1, -0.3);
   regulator->get_input_port(0).FixValue(regulator_context.get(), x);
   EXPECT_EQ(regulator->get_input_port(0).size(), 2);
   EXPECT_EQ(regulator->get_output_port(0).size(), 1);
@@ -210,7 +211,7 @@ GTEST_TEST(FiniteHorizonLQRTest, DoubleIntegratorWithNonZeroGoal) {
       MakeFiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
                                                 options);
   auto regulator_context = regulator->CreateDefaultContext();
-  const Eigen::Vector2d x(.1, -.3);
+  const Eigen::Vector2d x(0.1, -0.3);
   regulator->get_input_port(0).FixValue(regulator_context.get(), x);
   EXPECT_TRUE(
       CompareMatrices(regulator->get_output_port(0).Eval(*regulator_context),
@@ -220,10 +221,10 @@ GTEST_TEST(FiniteHorizonLQRTest, DoubleIntegratorWithNonZeroGoal) {
 // Tests the affine terms by solving LQR from a different coordinate system.
 // Given an affine system: xdot = Ax + Bu + c, with B invertible, we have a
 // fixed point at x0=0, B*u0 = -c.  Normally, we would stabilize as a linear
-// system in relative to x0, u0 using LQR.  Here we will leave the coordinate
-// system alone (x0=0, u0=0), but set B*ud = -c.  The steady-state solution to
-// the finite-horizon LQR problem will contain non-zero affine terms in order
-// to get back to the offset form of this LQR controller.
+// system in relative to x0, u0 using LQR.  Here set the coordinate system to
+// (x0=0, u0=1), and set B*ud = -c.  The steady-state solution to the
+// finite-horizon LQR problem will contain non-zero affine terms in order to get
+// back to the offset form of this LQR controller.
 GTEST_TEST(FiniteHorizonLQRTest, AffineSystemTest) {
   Eigen::Matrix2d A;
   Eigen::Matrix2d B;
@@ -251,7 +252,8 @@ GTEST_TEST(FiniteHorizonLQRTest, AffineSystemTest) {
   const double tf = 70.0;
   FiniteHorizonLinearQuadraticRegulatorOptions options;
   auto context = sys.CreateDefaultContext();
-  sys.get_input_port().FixValue(context.get(), Eigen::Vector2d::Zero());
+  const Eigen::Vector2d u0v = Eigen::Vector2d::Ones();
+  sys.get_input_port().FixValue(context.get(), u0v);
   const Eigen::Vector2d udv = -B.inverse() * c;
   trajectories::PiecewisePolynomial<double> ud_traj(udv);
   options.ud = &ud_traj;
@@ -262,22 +264,23 @@ GTEST_TEST(FiniteHorizonLQRTest, AffineSystemTest) {
       FiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
                                             options);
   // The LQR x'Sx is the correct solution, because this is equivalent to solving
-  // the in linear system in xbar=(x-x0), ubar=(u-0); and the LQR solution is
+  // the linear system in xbar=(x-x0), ubar=(u-0); and the LQR solution is
   // xbar'Sxbar, with x0=0.  However, in the finite-horizon version, all of the
   // affine terms must be correct to cancel each other out.
   EXPECT_TRUE(CompareMatrices(result.S->value(t0), lqr_result.S, 3.8e-5));
   EXPECT_TRUE(result.sx->value(t0).isZero(1e-5));
   EXPECT_TRUE(result.s0->value(t0).isZero(1e-5));
-  // The LQR controller would be u0 - Kx, so Kx = lqr.K, k0 = -u0.
+  // The LQR controller would be u = ud - Kx or u - u0 = -K(x-x0) - k0,
+  // so Kx = lqr.K, k0 = -ud + u0.
   EXPECT_TRUE(CompareMatrices(result.K->value(t0), lqr_result.K, 4e-4));
-  EXPECT_TRUE(CompareMatrices(result.k0->value(t0), -udv, 1e-5));
+  EXPECT_TRUE(CompareMatrices(result.k0->value(t0), -udv + u0v, 1e-5));
 
   // Test that the System version also works.
   const std::unique_ptr<System<double>> regulator =
       MakeFiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
                                                 options);
   auto regulator_context = regulator->CreateDefaultContext();
-  const Eigen::Vector2d x(.1, -.3);
+  const Eigen::Vector2d x(0.1, -0.3);
   regulator->get_input_port(0).FixValue(regulator_context.get(), x);
   EXPECT_TRUE(
       CompareMatrices(regulator->get_output_port(0).Eval(*regulator_context),
@@ -291,7 +294,7 @@ GTEST_TEST(FiniteHorizonLQRTest, AffineSystemTest) {
   EXPECT_TRUE(result.sx->value(t0).isZero(1e-5));
   EXPECT_TRUE(result.s0->value(t0).isZero(1e-5));
   EXPECT_TRUE(CompareMatrices(result.K->value(t0), lqr_result.K, 1e-4));
-  EXPECT_TRUE(CompareMatrices(result.k0->value(t0), -udv, 1e-4));
+  EXPECT_TRUE(CompareMatrices(result.k0->value(t0), -udv + u0v, 1e-4));
 }
 
 // Ensures that we can scalar convert the System version of the regulator.
@@ -358,6 +361,231 @@ GTEST_TEST(FiniteHorizonLQRTest, SimulatorConfig) {
       result.S.get());
   ASSERT_NE(S, nullptr);
   EXPECT_EQ(S->get_number_of_segments(), 15);
+}
+
+// For a time-invariant system and cost, the
+// DiscreteTimeLinearQuadraticRegulator should be a stable fixed-point for the
+// discrete-time finite-horizon solution.
+GTEST_TEST(DiscreteTimeFiniteHorizonLQRTest, InfiniteHorizonTest) {
+  const double h = 0.1;
+  // Discrete-time double integrator dynamics
+  Eigen::Matrix2d A;
+  Eigen::Vector2d B;
+  A << 1, h, 0, 1;
+  B << 0.5 * h * h, h;
+  LinearSystem<double> sys(A, B, Eigen::Matrix<double, 0, 2>::Zero(),
+                           Eigen::Matrix<double, 0, 1>::Zero(), h);
+
+  Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
+  Vector1d R = Vector1d(4.12);
+
+  LinearQuadraticRegulatorResult lqr_result =
+      DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
+
+  const double t0 = 0;
+  const double tf = 40.0;
+  FiniteHorizonLinearQuadraticRegulatorOptions options;
+  auto context = sys.CreateDefaultContext();
+  sys.get_input_port().FixValue(context.get(), 0.0);
+
+  // Test that it converges towards the fixed point from zero final cost.
+  FiniteHorizonLinearQuadraticRegulatorResult result =
+      FiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
+                                            options);
+  EXPECT_EQ(result.S->start_time(), t0);
+  EXPECT_EQ(result.S->end_time(), tf);
+  EXPECT_EQ(result.sx->start_time(), t0);
+  EXPECT_EQ(result.sx->end_time(), tf);
+  EXPECT_EQ(result.s0->start_time(), t0);
+  EXPECT_EQ(result.s0->end_time(), tf);
+  // Confirm that it's initialized to zero.
+  EXPECT_TRUE(result.S->value(tf).isZero(1e-12));
+  EXPECT_TRUE(result.sx->value(tf).isZero(1e-12));
+  EXPECT_TRUE(result.s0->value(tf).isZero(1e-12));
+  // Confirm that it converges to the infinite-horizon solution.
+  EXPECT_TRUE(CompareMatrices(result.S->value(t0), lqr_result.S, 1e-5));
+  EXPECT_TRUE(result.sx->value(t0).isZero(1e-12));
+  EXPECT_TRUE(result.s0->value(t0).isZero(1e-12));
+  EXPECT_EQ(result.K->start_time(), t0);
+  EXPECT_DOUBLE_EQ(result.K->end_time(), tf - h);
+  EXPECT_TRUE(CompareMatrices(result.K->value(t0), lqr_result.K, 1e-5));
+  EXPECT_TRUE(result.k0->value(t0).isZero(1e-12));
+  EXPECT_TRUE(CompareMatrices(result.x0->value(t0), Eigen::Vector2d::Zero()));
+  EXPECT_TRUE(CompareMatrices(result.x0->value(tf), Eigen::Vector2d::Zero()));
+  EXPECT_TRUE(CompareMatrices(result.u0->value(t0), Vector1d::Zero()));
+  EXPECT_TRUE(CompareMatrices(result.u0->value(tf), Vector1d::Zero()));
+
+  // Test that the System version also works.
+  const std::unique_ptr<System<double>> regulator =
+      MakeFiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
+                                                options);
+  auto regulator_context = regulator->CreateDefaultContext();
+  const Eigen::Vector2d x(0.1, -0.3);
+  regulator->get_input_port(0).FixValue(regulator_context.get(), x);
+  EXPECT_EQ(regulator->get_input_port(0).size(), 2);
+  EXPECT_EQ(regulator->get_output_port(0).size(), 1);
+  EXPECT_TRUE(
+      CompareMatrices(regulator->get_output_port(0).Eval(*regulator_context),
+                      -lqr_result.K * x, 1e-5));
+
+  // Test that it stays at the fixed-point if initialized at the fixed point.
+  options.Qf = lqr_result.S;
+  result = FiniteHorizonLinearQuadraticRegulator(sys, *context, t0, t0 + 2.0, Q,
+                                                 R, options);
+  EXPECT_TRUE(CompareMatrices(result.S->value(t0), lqr_result.S, 1e-12));
+  EXPECT_TRUE(CompareMatrices(result.K->value(t0), lqr_result.K, 1e-12));
+  // Already confirmed above that sx, s0, and k0 stay zero.
+}
+
+// Tests the affine terms by setting options.xd != options.x0.  We can stabilize
+// the double integrator away from the origin, and the resulting solution should
+// be match the quadratic form from LQR, but shifted to the new desired fixed
+// point.
+GTEST_TEST(DiscreteTimeFiniteHorizonLQRTest,
+           DiscreteTimeDoubleIntegratorWithNonZeroGoal) {
+  const double h = 0.1;
+  Eigen::Matrix2d A;
+  Eigen::Vector2d B;
+  A << 1, h, 0, 1;
+  B << 0.5 * h * h, h;
+  LinearSystem<double> sys(A, B, Eigen::Matrix<double, 0, 2>::Zero(),
+                           Eigen::Matrix<double, 0, 1>::Zero(), h);
+
+  Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
+  Vector1d R = Vector1d(4.12);
+
+  LinearQuadraticRegulatorResult lqr_result =
+      DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
+
+  const double t0 = 0;
+  const double tf = 20.0;
+  FiniteHorizonLinearQuadraticRegulatorOptions options;
+  auto context = sys.CreateDefaultContext();
+  sys.get_input_port().FixValue(context.get(), 0.0);
+  const Eigen::Vector2d xdv(2.87, 0);
+  trajectories::PiecewisePolynomial<double> xd_traj(xdv);
+  options.xd = &xd_traj;
+
+  FiniteHorizonLinearQuadraticRegulatorResult result =
+      FiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
+                                            options);
+  // Confirm that it converges to the solution (the same quadratic form, but
+  // shifted to the new origin): Sxx = lqr.S, sx = -Sxx*xd, s0 = xd'*Sxx*xd.
+  EXPECT_TRUE(CompareMatrices(result.S->value(t0), lqr_result.S, 1e-5));
+  EXPECT_TRUE(CompareMatrices(result.sx->value(t0), -lqr_result.S * xdv, 1e-5));
+  EXPECT_TRUE(CompareMatrices(result.s0->value(t0),
+                              xdv.transpose() * lqr_result.S * xdv, 1e-5));
+  // The controller should be the same linear controller, but also shifted to
+  // the new origin: Kx = lqr.K, k0 = -Kx*xdv.
+  EXPECT_TRUE(CompareMatrices(result.K->value(t0), lqr_result.K, 1e-5));
+  EXPECT_TRUE(CompareMatrices(result.k0->value(t0), -lqr_result.K * xdv, 1e-5));
+
+  // Test that the System version also works.
+  const std::unique_ptr<System<double>> regulator =
+      MakeFiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
+                                                options);
+  auto regulator_context = regulator->CreateDefaultContext();
+  const Eigen::Vector2d x(0.1, -0.3);
+  regulator->get_input_port(0).FixValue(regulator_context.get(), x);
+  EXPECT_TRUE(
+      CompareMatrices(regulator->get_output_port(0).Eval(*regulator_context),
+                      -lqr_result.K * (x - xdv), 1e-5));
+}
+
+// Tests the affine terms by solving LQR from a different coordinate system.
+// Given an affine system: x[n+1] = Ax[n] + Bu + c, with B invertible, we have a
+// fixed point at x0=0, B*u0 = -c.  Normally, we would stabilize as a linear
+// system in relative to x0, u0 using LQR.  Here set the coordinate system to
+// (x0=0, u0=1), and set B*ud = -c.  The steady-state solution to the
+// finite-horizon LQR problem will contain non-zero affine terms in order to get
+// back to the offset form of this LQR controller.
+GTEST_TEST(DiscreteTimeFiniteHorizonLQRTest, AffineSystemTest) {
+  const double time_period = 0.1;
+  Eigen::Matrix2d A;
+  Eigen::Matrix2d B;
+  Eigen::Vector2d c;
+  A << 0, 1, 0, 0;
+  B << 5, 6, 7, 8;
+  c << 9, 10;
+
+  AffineSystem<double> sys(A, B, c, Eigen::Matrix<double, 0, 2>(),
+                           Eigen::Matrix<double, 0, 2>(),
+                           Eigen::Matrix<double, 0, 1>(), time_period);
+
+  Eigen::Matrix2d Q;
+  Eigen::Matrix2d R;
+  Q << 0.8, 0.7, 0.7, 0.9;
+  R << 1.4, 0.2, 0.2, 1.2;
+
+  // Solve it again with the other interface to get access to S.
+  LinearQuadraticRegulatorResult lqr_result =
+      DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
+
+  const double t0 = 0;
+  const double tf = 70.0;
+  FiniteHorizonLinearQuadraticRegulatorOptions options;
+  auto context = sys.CreateDefaultContext();
+  const Eigen::Vector2d u0v = Eigen::Vector2d::Ones();
+  sys.get_input_port().FixValue(context.get(), u0v);
+  const Eigen::Vector2d udv = -B.inverse() * c;
+  trajectories::PiecewisePolynomial<double> ud_traj(udv);
+  options.ud = &ud_traj;
+  options.Qf = lqr_result.S;
+
+  FiniteHorizonLinearQuadraticRegulatorResult result =
+      FiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
+                                            options);
+  // The LQR x'Sx is the correct solution, because this is equivalent to solving
+  // the linear system in xbar=(x-x0), ubar=(u-u0); and the LQR solution is
+  // xbar'Sxbar, with x0=0.  However, in the finite-horizon version, all of the
+  // affine terms must be correct to cancel each other out.
+  EXPECT_TRUE(CompareMatrices(result.S->value(t0), lqr_result.S, 3.8e-5));
+  EXPECT_TRUE(result.sx->value(t0).isZero(1e-5));
+  EXPECT_TRUE(result.s0->value(t0).isZero(1e-5));
+  // The LQR controller would be u = ud - Kx or u - u0 = -K(x-x0) - k0,
+  // so Kx = lqr.K, k0 = -ud + u0.
+  EXPECT_TRUE(CompareMatrices(result.K->value(t0), lqr_result.K, 4e-4));
+  EXPECT_TRUE(CompareMatrices(result.k0->value(t0), -udv + u0v, 1e-5));
+
+  // Test that the System version also works.
+  const std::unique_ptr<System<double>> regulator =
+      MakeFiniteHorizonLinearQuadraticRegulator(sys, *context, t0, tf, Q, R,
+                                                options);
+  auto regulator_context = regulator->CreateDefaultContext();
+  const Eigen::Vector2d x(0.1, -0.3);
+  regulator->get_input_port(0).FixValue(regulator_context.get(), x);
+  EXPECT_TRUE(
+      CompareMatrices(regulator->get_output_port(0).Eval(*regulator_context),
+                      udv - lqr_result.K * x, 7.5e-5));
+}
+
+// Ensures that we can scalar convert the System version of the regulator.
+GTEST_TEST(DiscreteTimeFiniteHorizonLQRTest, ResultSystemIsScalarConvertible) {
+  const double h = 0.1;
+  Eigen::Matrix2d A;
+  Eigen::Vector2d B;
+  A << 1, h, 0, 1;
+  B << 0.5 * h * h, h;
+  LinearSystem<double> sys(A, B, Eigen::Matrix<double, 0, 2>::Zero(),
+                           Eigen::Matrix<double, 0, 1>::Zero(), h);
+  auto context = sys.CreateDefaultContext();
+  sys.get_input_port().FixValue(context.get(), 0.0);
+  const double t0 = 0.0;
+  Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
+  Vector1d R = Vector1d(1.0);
+
+  const std::unique_ptr<System<double>> regulator =
+      MakeFiniteHorizonLinearQuadraticRegulator(sys, *context, t0, t0 + 0.1, Q,
+                                                R);
+
+  EXPECT_TRUE(is_autodiffxd_convertible(*regulator, [&](const auto& converted) {
+    EXPECT_EQ(converted.num_input_ports(), 1);
+    EXPECT_EQ(converted.num_total_inputs(), 2);
+    EXPECT_EQ(converted.num_output_ports(), 1);
+    EXPECT_EQ(converted.num_total_outputs(), 1);
+  }));
+
+  EXPECT_TRUE(is_symbolic_convertible(*regulator));
 }
 
 }  // namespace


### PR DESCRIPTION
In the implementation, calling `FiniteHorizonLinearQuadraticRegulator(system, contex, t0, tf, Q, R, options)` will invoke discrete-time finite-horizon LQR if

1. `system` is a difference equation system, or
2. `system` is continuous and `options.x0`/`options.u0` is of type `DiscreteTimeTrajectory`. 

The second case is useful when we have a trajectory for a continuous-time system, e.g., cart-pole swing-up, but we want to track the (sampled) trajectory using a discrete-time controller.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22609)
<!-- Reviewable:end -->
