### PR TITLE
[build] Hotfix zlib repository rule when in legacy WORKSPACE mode

### DIFF
--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -487,7 +487,7 @@ def _drake_dep_repositories_impl(module_ctx):
     snopt_repository(name = "snopt")
     styleguide_repository(name = "styleguide", mirrors = mirrors)
     x11_repository(name = "x11")
-    zlib_repository(name = "zlib")
+    zlib_repository(name = "zlib", _legacy_workspace = False)
     for name in ["eigen", "fmt", "spdlog"]:
         alias_repository(
             name = name,

--- a/tools/workspace/zlib/BUILD.bazel
+++ b/tools/workspace/zlib/BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
     name = "hardcoded",
     linkopts = ["-lz"],
     tags = ["manual"],
+    visibility = ["@zlib//:__subpackages__"],
 )
 
 config_setting(

--- a/tools/workspace/zlib/repository.bzl
+++ b/tools/workspace/zlib/repository.bzl
@@ -1,7 +1,10 @@
 load("//tools/workspace:alias.bzl", "alias_repository")
 
-def zlib_repository(name):
+def zlib_repository(name, _legacy_workspace = True):
+    actual = "@drake//tools/workspace/zlib"
+    if _legacy_workspace:
+        actual += ":hardcoded"
     alias_repository(
         name = name,
-        aliases = {"zlib": "@drake//tools/workspace/zlib"},
+        aliases = {"zlib": actual},
     )


### PR DESCRIPTION
In legacy mode, we should not obey the zlib internal/external flag, we should always just use the hardcoded legacy flavor.