### PR TITLE
Nuke unneeded JointImplementation & JointImplementationBuilder classes

### DIFF
--- a/multibody/tree/joint.cc
+++ b/multibody/tree/joint.cc
@@ -8,14 +8,14 @@ Joint<T>::~Joint() = default;
 
 template <typename T>
 bool Joint<T>::can_rotate() const {
-  DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-  return get_implementation().mobilizer->can_rotate();
+  DRAKE_DEMAND(has_implementation());
+  return mobilizer_->can_rotate();
 }
 
 template <typename T>
 bool Joint<T>::can_translate() const {
-  DRAKE_DEMAND(this->get_implementation().has_mobilizer());
-  return get_implementation().mobilizer->can_translate();
+  DRAKE_DEMAND(has_implementation());
+  return mobilizer_->can_translate();
 }
 
 template <typename T>
@@ -32,21 +32,20 @@ void Joint<T>::SetPositions(
   DRAKE_THROW_UNLESS(context != nullptr);
   DRAKE_THROW_UNLESS(positions.size() == num_positions());
   this->get_parent_tree().ThrowIfNotFinalized("Joint::SetPositions");
-  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  DRAKE_DEMAND(has_implementation());
   const Eigen::VectorBlock<VectorX<T>> all_q =
       this->get_parent_tree().GetMutablePositions(&*context);
-  get_implementation().mobilizer->get_mutable_positions_from_array(&all_q) =
-      positions;
+  mobilizer_->get_mutable_positions_from_array(&all_q) = positions;
 }
 
 template <typename T>
 Eigen::Ref<const VectorX<T>> Joint<T>::GetPositions(
     const systems::Context<T>& context) const {
   this->get_parent_tree().ThrowIfNotFinalized("Joint::GetPositions");
-  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  DRAKE_DEMAND(has_implementation());
   const Eigen::VectorBlock<const VectorX<T>> all_q =
       this->get_parent_tree().get_positions(context);
-  return get_implementation().mobilizer->get_positions_from_array(all_q);
+  return mobilizer_->get_positions_from_array(all_q);
 }
 
 template <typename T>
@@ -56,21 +55,20 @@ void Joint<T>::SetVelocities(
   DRAKE_THROW_UNLESS(context != nullptr);
   DRAKE_THROW_UNLESS(velocities.size() == num_velocities());
   this->get_parent_tree().ThrowIfNotFinalized("Joint::SetVelocities");
-  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  DRAKE_DEMAND(has_implementation());
   const Eigen::VectorBlock<VectorX<T>> all_v =
       this->get_parent_tree().GetMutableVelocities(&*context);
-  get_implementation().mobilizer->get_mutable_velocities_from_array(&all_v) =
-      velocities;
+  mobilizer_->get_mutable_velocities_from_array(&all_v) = velocities;
 }
 
 template <typename T>
 Eigen::Ref<const VectorX<T>> Joint<T>::GetVelocities(
     const systems::Context<T>& context) const {
   this->get_parent_tree().ThrowIfNotFinalized("Joint::GetVelocities");
-  DRAKE_DEMAND(get_implementation().has_mobilizer());
+  DRAKE_DEMAND(has_implementation());
   const Eigen::VectorBlock<const VectorX<T>> all_v =
       this->get_parent_tree().get_velocities(context);
-  return get_implementation().mobilizer->get_velocities_from_array(all_v);
+  return mobilizer_->get_velocities_from_array(all_v);
 }
 
 template <typename T>
@@ -100,9 +98,9 @@ void Joint<T>::SetSpatialVelocityImpl(systems::Context<T>* context,
                                       const char* func) const {
   DRAKE_THROW_UNLESS(context != nullptr);
   this->get_parent_tree().ThrowIfNotFinalized("Joint::SetSpatialVelocity");
-  DRAKE_DEMAND(get_implementation().has_mobilizer());
-  if (!get_implementation().mobilizer->SetSpatialVelocity(
-          *context, V_FM, &context->get_mutable_state())) {
+  DRAKE_DEMAND(has_implementation());
+  if (!mobilizer_->SetSpatialVelocity(*context, V_FM,
+                                      &context->get_mutable_state())) {
     throw std::logic_error(
         fmt::format("{}(): {} joint does not implement this function "
                     "(joint '{}')",
@@ -114,8 +112,8 @@ template <typename T>
 SpatialVelocity<T> Joint<T>::GetSpatialVelocity(
     const systems::Context<T>& context) const {
   this->get_parent_tree().ThrowIfNotFinalized("Joint::GetSpatialVelocity");
-  DRAKE_DEMAND(get_implementation().has_mobilizer());
-  return get_implementation().mobilizer->GetSpatialVelocity(context);
+  DRAKE_DEMAND(has_implementation());
+  return mobilizer_->GetSpatialVelocity(context);
 }
 
 template <typename T>
@@ -124,9 +122,9 @@ void Joint<T>::SetPosePairImpl(systems::Context<T>* context,
                                const Vector3<T>& p_FM, const char* func) const {
   DRAKE_THROW_UNLESS(context != nullptr);
   this->get_parent_tree().ThrowIfNotFinalized("Joint::SetPosePair");
-  DRAKE_DEMAND(get_implementation().has_mobilizer());
-  if (!get_implementation().mobilizer->SetPosePair(
-          *context, q_FM, p_FM, &context->get_mutable_state())) {
+  DRAKE_DEMAND(has_implementation());
+  if (!mobilizer_->SetPosePair(*context, q_FM, p_FM,
+                               &context->get_mutable_state())) {
     throw std::logic_error(
         fmt::format("{}(): {} joint does not implement this function "
                     "(joint '{}')",
@@ -138,8 +136,8 @@ template <typename T>
 std::pair<Eigen::Quaternion<T>, Vector3<T>> Joint<T>::GetPosePair(
     const systems::Context<T>& context) const {
   this->get_parent_tree().ThrowIfNotFinalized("Joint::GetPosePair");
-  DRAKE_DEMAND(get_implementation().has_mobilizer());
-  return get_implementation().mobilizer->GetPosePair(context);
+  DRAKE_DEMAND(has_implementation());
+  return mobilizer_->GetPosePair(context);
 }
 
 }  // namespace multibody

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -19,10 +19,6 @@ namespace drake {
 namespace multibody {
 
 namespace internal {
-// This is a class used by MultibodyTree internals to create the implementation
-// for a particular joint object.
-template <typename T>
-class JointImplementationBuilder;
 class MobilizerTester;
 }  // namespace internal
 
@@ -341,20 +337,20 @@ class Joint : public MultibodyElement<T> {
   /// Lock the joint. Its generalized velocities will be 0 until it is
   /// unlocked.
   void Lock(systems::Context<T>* context) const {
-    DRAKE_DEMAND(implementation_->has_mobilizer());
-    implementation_->mobilizer->Lock(context);
+    DRAKE_DEMAND(has_implementation());
+    mobilizer_->Lock(context);
   }
 
   /// Unlock the joint.
   void Unlock(systems::Context<T>* context) const {
-    DRAKE_DEMAND(implementation_->has_mobilizer());
-    implementation_->mobilizer->Unlock(context);
+    DRAKE_DEMAND(has_implementation());
+    mobilizer_->Unlock(context);
   }
 
   /// @return true if the joint is locked, false otherwise.
   bool is_locked(const systems::Context<T>& context) const {
-    DRAKE_DEMAND(implementation_->has_mobilizer());
-    return implementation_->mobilizer->is_locked(context);
+    DRAKE_DEMAND(has_implementation());
+    return mobilizer_->is_locked(context);
   }
 
   /// @name            Methods to get and set limits
@@ -746,6 +742,16 @@ class Joint : public MultibodyElement<T> {
 
   // Hide the following section from Doxygen.
 #ifndef DRAKE_DOXYGEN_CXX
+  // (Internal use only) Model this joint using the appropriate Mobilizer.
+  internal::Mobilizer<T>* Build(const internal::SpanningForest::Mobod& mobod,
+                                internal::MultibodyTree<T>* tree) {
+    std::unique_ptr<internal::Mobilizer<T>> owned_mobilizer =
+        MakeMobilizerForJoint(mobod);
+    mobilizer_ = owned_mobilizer.get();
+    tree->AddMobilizer(std::move(owned_mobilizer));  // ownership->tree
+    return mobilizer_;
+  }
+
   // NVI to DoCloneToScalar() templated on the scalar type of the new clone to
   // be created. This method is intended to be called by
   // MultibodyTree::CloneToScalar().
@@ -754,11 +760,9 @@ class Joint : public MultibodyElement<T> {
       internal::MultibodyTree<ToScalar>* tree_clone) const {
     std::unique_ptr<Joint<ToScalar>> joint_clone = DoCloneToScalar(*tree_clone);
 
-    std::unique_ptr<typename Joint<ToScalar>::JointImplementation>
-        implementation_clone =
-            this->get_implementation().template CloneToScalar<ToScalar>(
-                tree_clone);
-    joint_clone->OwnImplementation(std::move(implementation_clone));
+    internal::Mobilizer<ToScalar>* mobilizer_clone =
+        FindMobilizerToScalarClone<ToScalar>(tree_clone);
+    joint_clone->mobilizer_ = mobilizer_clone;
 
     return joint_clone;
   }
@@ -769,58 +773,14 @@ class Joint : public MultibodyElement<T> {
   std::unique_ptr<Joint<T>> ShallowClone() const;
 
   const internal::Mobilizer<T>& GetMobilizerInUse() const {
-    // Currently we model each joint with a mobilizer.
-    DRAKE_DEMAND(get_implementation().has_mobilizer());
-    return *get_implementation().mobilizer;
+    // We model each joint with a mobilizer.
+    DRAKE_DEMAND(has_implementation());
+    return *mobilizer_;
   }
 #endif
   // End of hidden Doxygen section.
 
  protected:
-  /// (Advanced) A Joint is implemented in terms of MultibodyTree elements,
-  /// typically a Mobilizer. However, some Joints may be better modeled with
-  /// constraints or force elements. This object contains the internal details
-  /// of the MultibodyTree implementation for a joint. The implementation does
-  /// not own the MbT elements, it just keeps references to them. This is
-  /// intentionally made a protected member so that derived classes have
-  /// access to its definition.
-  struct JointImplementation {
-    /// Default constructor to create an empty implementation. Used by
-    /// Joint::CloneToScalar().
-    JointImplementation() {}
-
-    /// This constructor creates an implementation for `this` joint from the
-    /// mobilizer provided. Ownership remains with the caller.
-    explicit JointImplementation(internal::Mobilizer<T>* mobilizer_in) {
-      DRAKE_DEMAND(mobilizer_in != nullptr);
-      mobilizer = mobilizer_in;
-    }
-
-    /// Returns `true` if the implementation of this Joint uses a Mobilizer.
-    bool has_mobilizer() const { return mobilizer != nullptr; }
-
-    // Hide the following section from Doxygen.
-#ifndef DRAKE_DOXYGEN_CXX
-    // Helper method to be called within Joint::CloneToScalar() to clone its
-    // implementation to the appropriate scalar type.
-    template <typename ToScalar>
-    std::unique_ptr<typename Joint<ToScalar>::JointImplementation>
-    CloneToScalar(internal::MultibodyTree<ToScalar>* tree_clone) const {
-      auto implementation_clone =
-          std::make_unique<typename Joint<ToScalar>::JointImplementation>();
-      internal::Mobilizer<ToScalar>* mobilizer_clone =
-          &tree_clone->get_mutable_variant(*mobilizer);
-      implementation_clone->mobilizer = mobilizer_clone;
-      return implementation_clone;
-    }
-#endif
-    // End of hidden Doxygen section.
-
-    /// Reference (raw pointer) to the mobilizer implementing this Joint.
-    internal::Mobilizer<T>* mobilizer{};
-    // TODO(sherm1): add constraints and force elements as needed.
-  };
-
   /// Implementation of the NVI velocity_start(), see velocity_start() for
   /// details. Note that this must be the offset within just the velocity
   /// vector, _not_ within the composite state vector.
@@ -966,21 +926,6 @@ class Joint : public MultibodyElement<T> {
   virtual std::unique_ptr<Joint<T>> DoShallowClone() const;
   /// @}
 
-  /// Returns a const reference to the internal implementation of `this` joint.
-  /// @warning The MultibodyTree model must have already been finalized, or
-  /// this method will abort.
-  const JointImplementation& get_implementation() const {
-    // The MultibodyTree must have been finalized for the implementation to be
-    // valid.
-    DRAKE_DEMAND(this->get_parent_tree().topology_is_valid());
-    return *implementation_;
-  }
-
-  /// Returns whether `this` joint owns a particular implementation.
-  /// If the MultibodyTree has been finalized, this will return true.
-  bool has_implementation() const { return implementation_ != nullptr; }
-
- protected:
   /// Utility for concrete joint implementations to use to select the
   /// inboard/outboard frames for a tree in the spanning forest, given
   /// whether they should be reversed from the parent/child frames that are
@@ -995,48 +940,46 @@ class Joint : public MultibodyElement<T> {
   /// (Internal use only) Returns the mobilizer implementing this joint,
   /// downcast to its specific type.
   ///
-  /// @pre get_implementation().has_mobilizer() is true
+  /// @pre A mobilizer has been created for this Joint.
   /// @pre ConcreteMobilizer must exactly match the dynamic type of the
   /// mobilizer associated with this Joint. This requirement is (only) checked
   /// in Debug builds.
   template <template <typename> class ConcreteMobilizer>
   const ConcreteMobilizer<T>& get_mobilizer_downcast() const {
-    const internal::Mobilizer<T>* result = this->get_implementation().mobilizer;
-    DRAKE_DEMAND(result != nullptr);
-    DRAKE_ASSERT(typeid(*result) == typeid(ConcreteMobilizer<T>));
-    return static_cast<const ConcreteMobilizer<T>&>(*result);
+    DRAKE_DEMAND(mobilizer_ != nullptr);
+    DRAKE_ASSERT(typeid(*mobilizer_) == typeid(ConcreteMobilizer<T>));
+    return static_cast<const ConcreteMobilizer<T>&>(*mobilizer_);
   }
 
   /// (Internal use only) Mutable flavor of get_mobilizer_downcast().
   template <template <typename> class ConcreteMobilizer>
   ConcreteMobilizer<T>& get_mutable_mobilizer_downcast() {
-    internal::Mobilizer<T>* result = this->get_implementation().mobilizer;
-    DRAKE_DEMAND(result != nullptr);
-    DRAKE_ASSERT(typeid(*result) == typeid(ConcreteMobilizer<T>));
-    return static_cast<ConcreteMobilizer<T>&>(*result);
+    DRAKE_DEMAND(mobilizer_ != nullptr);
+    DRAKE_ASSERT(typeid(*mobilizer_) == typeid(ConcreteMobilizer<T>));
+    return static_cast<ConcreteMobilizer<T>&>(*mobilizer_);
   }
 
+  bool has_implementation() const { return mobilizer_ != nullptr; }
+
  private:
-  // Make all other Joint<U> objects a friend of Joint<T> so they can make
-  // Joint<ToScalar>::JointImplementation from CloneToScalar<ToScalar>().
+  // Make all other Joint<U> objects a friend of Joint<T> so they can clone
+  // successfully.
   template <typename>
   friend class Joint;
 
-  // JointImplementationBuilder is a friend so that it can access the
-  // private method MakeMobilizerForJoint().
-  friend class internal::JointImplementationBuilder<T>;
-
   // This method must be implemented by derived Joint classes in order to
-  // provide JointImplementationBuilder a Mobilizer as the Joint's internal
-  // representation.
+  // create a Mobilizer as the Joint's internal representation.
   virtual std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod) const = 0;
 
-  // When an implementation is created, either by
-  // internal::JointImplementationBuilder or by Joint::CloneToScalar(), this
-  // method is called to pass ownership of an implementation to the Joint.
-  void OwnImplementation(std::unique_ptr<JointImplementation> implementation) {
-    implementation_ = std::move(implementation);
+  // Helper method to be called within Joint::CloneToScalar() to clone its
+  // implementing Mobilizer to the appropriate scalar type.
+  template <typename ToScalar>
+  internal::Mobilizer<ToScalar>* FindMobilizerToScalarClone(
+      internal::MultibodyTree<ToScalar>* tree_clone) const {
+    internal::Mobilizer<ToScalar>* mobilizer_clone =
+        &tree_clone->get_mutable_variant(*mobilizer_);
+    return mobilizer_clone;
   }
 
   // Implementation for MultibodyElement::DoDeclareParameters().
@@ -1087,7 +1030,7 @@ class Joint : public MultibodyElement<T> {
   VectorX<double> default_positions_;
 
   // The Joint<T> implementation:
-  std::unique_ptr<JointImplementation> implementation_;
+  internal::Mobilizer<T>* mobilizer_{};
 
   // System parameter indices.
   systems::NumericParameterIndex damping_parameter_index_;

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -48,26 +48,6 @@ using math::RotationMatrix;
 #define DRAKE_MBT_THROW_IF_NOT_FINALIZED() ThrowIfNotFinalized(__func__)
 
 template <typename T>
-class JointImplementationBuilder {
- public:
-  JointImplementationBuilder() = delete;
-
-  static Mobilizer<T>* Build(const SpanningForest::Mobod& mobod,
-                             Joint<T>* joint, MultibodyTree<T>* tree) {
-    std::unique_ptr<Mobilizer<T>> owned_mobilizer =
-        joint->MakeMobilizerForJoint(mobod);
-    Mobilizer<T>* mobilizer = owned_mobilizer.get();
-    auto implementation =
-        std::make_unique<typename Joint<T>::JointImplementation>(mobilizer);
-    DRAKE_DEMAND(implementation->has_mobilizer());
-    tree->AddMobilizer(std::move(owned_mobilizer));  // ownership->tree
-    // TODO(amcastro-tri): add force elements, bodies, constraints, etc.
-    joint->OwnImplementation(std::move(implementation));
-    return mobilizer;
-  }
-};
-
-template <typename T>
 MultibodyTree<T>::MultibodyTree() {
   // Adds a "world" body to MultibodyTree having a NaN SpatialInertia.
   ModelInstanceIndex world_instance = AddModelInstance("WorldModelInstance");
@@ -803,8 +783,7 @@ void MultibodyTree<T>::CreateJointImplementations() {
           GetModelInstanceName(joint.model_instance())));
     }
 
-    Mobilizer<T>* mobilizer =
-        internal::JointImplementationBuilder<T>::Build(mobod, &joint, this);
+    Mobilizer<T>* mobilizer = joint.Build(mobod, this);
     mobilizer->set_model_instance(joint.model_instance());
     DRAKE_DEMAND(mobilizer->index() == mobod.index());
     // Record the joint to mobilizer map.


### PR DESCRIPTION
Further simplifies the process of implementing a Joint with a Mobilizer. Removes two unnecessary classes.

All changes are internal.