### PR TITLE
Support `x'Nu` term in discrete-time LQR

### DIFF
--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -315,11 +315,13 @@ PYBIND11_MODULE(controllers, m) {
       [](const Eigen::Ref<const Eigen::MatrixXd>& A,
           const Eigen::Ref<const Eigen::MatrixXd>& B,
           const Eigen::Ref<const Eigen::MatrixXd>& Q,
-          const Eigen::Ref<const Eigen::MatrixXd>& R) {
+          const Eigen::Ref<const Eigen::MatrixXd>& R,
+          const Eigen::Ref<const Eigen::MatrixXd>& N) {
         auto result = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
         return std::make_pair(result.K, result.S);
       },
       py::arg("A"), py::arg("B"), py::arg("Q"), py::arg("R"),
+      py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
       doc.DiscreteTimeLinearQuadraticRegulator.doc);
 
   m.def("LinearQuadraticRegulator",

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -402,7 +402,12 @@ class TestControllers(unittest.TestCase):
         B = np.array([[0], [1]])
         Q = np.identity(2)
         R = np.identity(1)
+        N = np.array([[1], [0]])
         (K, S) = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R)
+        self.assertEqual(K.shape, (1, 2))
+        self.assertEqual(S.shape, (2, 2))
+        # Test with N.
+        (K, S) = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R, N)
         self.assertEqual(K.shape, (1, 2))
         self.assertEqual(S.shape, (2, 2))
 

--- a/systems/controllers/linear_quadratic_regulator.h
+++ b/systems/controllers/linear_quadratic_regulator.h
@@ -50,13 +50,11 @@ LinearQuadraticRegulatorResult LinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& F =
         Eigen::Matrix<double, 0, 0>::Zero());
 
-// TODO(russt): Consider implementing the optional N argument as in the
-// continuous-time formulation.
 /// Computes the optimal feedback controller, u=-Kx, and the optimal
 /// cost-to-go J = x'Sx for the problem:
 ///
 ///   @f[ x[n+1] = Ax[n] + Bu[n] @f]
-///   @f[ \min_u \sum_0^\infty x'Qx + u'Ru @f]
+///   @f[ \min_u \sum_0^\infty x'Qx + u'Ru + 2x'Nu @f]
 ///
 /// @param A The state-space dynamics matrix of size num_states x num_states.
 /// @param B The state-space input matrix of size num_states x num_inputs.
@@ -64,6 +62,8 @@ LinearQuadraticRegulatorResult LinearQuadraticRegulator(
 /// num_states.
 /// @param R A symmetric positive definite cost matrix of size num_inputs x
 /// num_inputs.
+/// @param N A cost matrix of size num_states x num_inputs. If N.rows() == 0, N
+/// will be treated as a num_states x num_inputs zero matrix.
 /// @returns A structure that contains the optimal feedback gain K and the
 /// quadratic cost term S. The optimal feedback control is u = -Kx;
 ///
@@ -73,7 +73,9 @@ LinearQuadraticRegulatorResult DiscreteTimeLinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
     const Eigen::Ref<const Eigen::MatrixXd>& B,
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
-    const Eigen::Ref<const Eigen::MatrixXd>& R);
+    const Eigen::Ref<const Eigen::MatrixXd>& R,
+    const Eigen::Ref<const Eigen::MatrixXd>& N =
+        Eigen::Matrix<double, 0, 0>::Zero());
 
 /// Creates a system that implements the optimal time-invariant linear quadratic
 /// regulator (LQR).  If @p system is a continuous-time system, then solves

--- a/systems/controllers/test/linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/linear_quadratic_regulator_test.cc
@@ -29,10 +29,12 @@ GTEST_TEST(TestLqr, TestException) {
   DRAKE_EXPECT_NO_THROW(LinearQuadraticRegulator(A, B, Q, R));
 
   // R is not positive definite, should throw exception.
-  EXPECT_THROW(LinearQuadraticRegulator(
-        A, B, Q, Eigen::Matrix<double, 1, 1>::Zero()), std::runtime_error);
-  EXPECT_THROW(LinearQuadraticRegulator(
-        A, B, Q, Eigen::Matrix<double, 1, 1>::Zero(), N), std::runtime_error);
+  EXPECT_THROW(
+      LinearQuadraticRegulator(A, B, Q, Eigen::Matrix<double, 1, 1>::Zero()),
+      std::runtime_error);
+  EXPECT_THROW(
+      LinearQuadraticRegulator(A, B, Q, Eigen::Matrix<double, 1, 1>::Zero(), N),
+      std::runtime_error);
 }
 
 void TestLqrAgainstKnownSolution(
@@ -47,9 +49,9 @@ void TestLqrAgainstKnownSolution(
   LinearQuadraticRegulatorResult result =
       LinearQuadraticRegulator(A, B, Q, R, N);
   EXPECT_TRUE(CompareMatrices(K_known, result.K, tolerance,
-        MatrixCompareType::absolute));
+                              MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(S_known, result.S, tolerance,
-        MatrixCompareType::absolute));
+                              MatrixCompareType::absolute));
 }
 
 void TestLqrLinearSystemAgainstKnownSolution(
@@ -67,12 +69,10 @@ void TestLqrLinearSystemAgainstKnownSolution(
   EXPECT_TRUE(CompareMatrices(linear_lqr->A(),
                               Eigen::Matrix<double, 0, 0>::Zero(), tolerance,
                               MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(linear_lqr->B(),
-                              Eigen::MatrixXd::Zero(0, n), tolerance,
-                              MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(linear_lqr->C(),
-                              Eigen::MatrixXd::Zero(m, 0), tolerance,
-                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(linear_lqr->B(), Eigen::MatrixXd::Zero(0, n),
+                              tolerance, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(linear_lqr->C(), Eigen::MatrixXd::Zero(m, 0),
+                              tolerance, MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(linear_lqr->D(), -K_known, tolerance,
                               MatrixCompareType::absolute));
   EXPECT_EQ(linear_lqr->time_period(), sys.time_period());
@@ -103,16 +103,16 @@ void TestLqrAffineSystemAgainstKnownSolution(
 
   EXPECT_TRUE(CompareMatrices(lqr->A(), Eigen::Matrix<double, 0, 0>::Zero(),
                               tolerance, MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(lqr->B(), Eigen::MatrixXd::Zero(0, n),
-                              tolerance, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(lqr->B(), Eigen::MatrixXd::Zero(0, n), tolerance,
+                              MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(lqr->f0(), Eigen::Matrix<double, 0, 1>::Zero(),
                               tolerance, MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(lqr->C(), Eigen::MatrixXd::Zero(m, 0),
-                              tolerance, MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(lqr->D(), -K_known,
-                              tolerance, MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(lqr->y0(), u0 + K_known * x0,
-                              tolerance, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(lqr->C(), Eigen::MatrixXd::Zero(m, 0), tolerance,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(lqr->D(), -K_known, tolerance,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(lqr->y0(), u0 + K_known * x0, tolerance,
+                              MatrixCompareType::absolute));
   EXPECT_EQ(lqr->time_period(), sys.time_period());
 }
 
@@ -291,6 +291,26 @@ GTEST_TEST(TestLqr, DiscreteDoubleIntegrator) {
 
   // Test AffineSystem version of the LQR
   TestLqrAffineSystemAgainstKnownSolution(tol, sys, K, Q, R);
+
+  // A different cost function with the same Q and R, and an extra N = [1; 0].
+  Eigen::Vector2d N(1, 0);
+  // Solution from dlqr in Matlab.
+  K << 0.427961322156271, 1.06165953563278;
+
+  // clang-format off
+  S << 2.48073711494216, 1.33665975925470,
+       1.33665975925470, 4.45997883052027;
+  // clang-format on
+
+  result = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R, N);
+  EXPECT_TRUE(CompareMatrices(result.K, K, tol));
+  EXPECT_TRUE(CompareMatrices(result.S, S, tol));
+
+  // Test LinearSystem version of the LQR
+  TestLqrLinearSystemAgainstKnownSolution(tol, sys, K, Q, R, N);
+
+  // Test AffineSystem version of the LQR
+  TestLqrAffineSystemAgainstKnownSolution(tol, sys, K, Q, R, N);
 }
 
 // Adds test coverage for calling LQR from a LeafSystem and from a
@@ -315,8 +335,8 @@ GTEST_TEST(TestLqr, AcrobotTest) {
 
   // Confirm that I get the same result by linearizing explicitly.
   const auto linear_system = Linearize(plant, *context);
-  const auto lqr_result = LinearQuadraticRegulator(
-          linear_system->A(), linear_system->B(), Q, R);
+  const auto lqr_result =
+      LinearQuadraticRegulator(linear_system->A(), linear_system->B(), Q, R);
   EXPECT_TRUE(CompareMatrices(-lqr_result.K, controller->D(), 1e-12));
 
   // Confirm that I get the same result via MultibodyPlant.


### PR DESCRIPTION
Currently, discrete-time LQR only support the cost function

$$
J(\boldsymbol{x}) = \sum_{n=0}^\infty \boldsymbol{x}^\top \mathbf{Q} \boldsymbol{x} + \boldsymbol{u}^\top \mathbf{R} \boldsymbol{u}  .
$$

This pull request implements the cost function

$$
J(\boldsymbol{x}) = \sum_{n=0}^\infty \boldsymbol{x}^\top \mathbf{Q} \boldsymbol{x} + \boldsymbol{u}^\top \mathbf{R} \boldsymbol{u} + 2  \boldsymbol{x}^\top \mathbf{N} \boldsymbol{u}   .
$$

---


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22623)
<!-- Reviewable:end -->
