### PR TITLE
Initialize uninitialized matrices in continuous-to-discrete coversion

### DIFF
--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -995,6 +995,8 @@ GTEST_TEST(DiscreteTimeApproximation, test) {
   B << 0, 1;
   f0 << 2, 1;
   C << 1, 0;
+  D << 1;
+  y0 << 1;
 
   // Reject discrete system as argument.
   EXPECT_ANY_THROW(DiscreteTimeApproximation<double>(


### PR DESCRIPTION
Patches #22601 

The test had uninitialized matrices.

Replaces #22627

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22628)
<!-- Reviewable:end -->
