### PR TITLE
More verbose error message in DiagramBuilder::GetSystemByName()

### DIFF
--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -165,9 +165,14 @@ const System<T>& DiagramBuilder<T>::GetSubsystemByName(
   if (result != nullptr) {
     return *result;
   }
-  throw std::logic_error(fmt::format(
-      "DiagramBuilder does not contain a subsystem named {}",
-      name));
+  std::vector<std::string> valid_subsystems;
+  for (const auto& child : registered_systems_) {
+    valid_subsystems.push_back(child->get_name());
+  }
+  throw std::logic_error(
+      fmt::format("DiagramBuilder does not contain a subsystem named {}. Valid "
+                  "subsystems are {}.",
+                  name, fmt::join(valid_subsystems, ", ")));
 }
 
 template <typename T>

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -867,16 +867,16 @@ GTEST_TEST(DiagramBuilderTest, GetByName) {
   // Error: no such name.
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder.GetSubsystemByName("not_a_subsystem"),
-      ".*not_a_subsystem.*");
+      ".*not_a_subsystem.*Valid subsystems are.*adder.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder.GetMutableSubsystemByName("not_a_subsystem"),
-      ".*not_a_subsystem.*");
+      ".*not_a_subsystem.*Valid subsystems are.*adder.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder.GetDowncastSubsystemByName<Adder>("not_a_subsystem"),
-      ".*not_a_subsystem.*");
+      ".*not_a_subsystem.*Valid subsystems are.*adder.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       builder.GetMutableDowncastSubsystemByName<Adder>("not_a_subsystem"),
-      ".*not_a_subsystem.*");
+      ".*not_a_subsystem.*Valid subsystems are.*adder.*");
 
   // Error: wrong type.
   DRAKE_EXPECT_THROWS_MESSAGE(


### PR DESCRIPTION
Now it displays the valid subsystem names.

+@sherm1 for both reviews, please.