### PR TITLE
[primitives] Add Selector primitive system

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -86,6 +86,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:eigen_pybind",
+        "//bindings/pydrake/common:serialize_pybind",
     ],
     cc_srcs = ["primitives_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -1,6 +1,7 @@
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
+#include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/systems/primitives/adder.h"
@@ -24,6 +25,7 @@
 #include "drake/systems/primitives/port_switch.h"
 #include "drake/systems/primitives/random_source.h"
 #include "drake/systems/primitives/saturation.h"
+#include "drake/systems/primitives/selector.h"
 #include "drake/systems/primitives/shared_pointer_system.h"
 #include "drake/systems/primitives/sine.h"
 #include "drake/systems/primitives/sparse_matrix_gain.h"
@@ -63,6 +65,42 @@ PYBIND11_MODULE(primitives, m) {
           doc.PerceptronActivationType.kReLU.doc)
       .value("kTanh", PerceptronActivationType::kTanh,
           doc.PerceptronActivationType.kTanh.doc);
+
+  {
+    using Class = SelectorParams;
+    py::class_<Class> cls(m, "SelectorParams", doc.SelectorParams.doc);
+    {
+      using Nested = Class::InputPortParams;
+      py::class_<Nested> nested(
+          cls, "InputPortParams", doc.SelectorParams.InputPortParams.doc);
+      nested.def(ParamInit<Nested>());
+      DefAttributesUsingSerialize(&nested, doc.SelectorParams.InputPortParams);
+      DefReprUsingSerialize(&nested);
+      DefCopyAndDeepCopy(&nested);
+    }
+    {
+      using Nested = Class::OutputSelection;
+      py::class_<Nested> nested(
+          cls, "OutputSelection", doc.SelectorParams.OutputSelection.doc);
+      nested.def(ParamInit<Nested>());
+      DefAttributesUsingSerialize(&nested, doc.SelectorParams.OutputSelection);
+      DefReprUsingSerialize(&nested);
+      DefCopyAndDeepCopy(&nested);
+    }
+    {
+      using Nested = Class::OutputPortParams;
+      py::class_<Nested> nested(
+          cls, "OutputPortParams", doc.SelectorParams.OutputPortParams.doc);
+      nested.def(ParamInit<Nested>());
+      DefAttributesUsingSerialize(&nested, doc.SelectorParams.OutputPortParams);
+      DefReprUsingSerialize(&nested);
+      DefCopyAndDeepCopy(&nested);
+    }
+    cls.def(ParamInit<Class>());
+    DefAttributesUsingSerialize(&cls, doc.SelectorParams);
+    DefReprUsingSerialize(&cls);
+    DefCopyAndDeepCopy(&cls);
+  }
 
   // N.B. Capturing `&doc` should not be required; workaround per #9600.
   auto bind_common_scalar_types = [&m, &doc](auto dummy) {
@@ -210,6 +248,11 @@ PYBIND11_MODULE(primitives, m) {
             doc.Gain.ctor.doc_2args)
         .def(py::init<const Eigen::Ref<const VectorXd>&>(), py::arg("k"),
             doc.Gain.ctor.doc_1args);
+
+    DefineTemplateClassWithDefault<Selector<T>, LeafSystem<T>>(
+        m, "Selector", GetPyParam<T>(), doc.Selector.doc)
+        .def(py::init<SelectorParams>(), py::arg("params"),
+            doc.Selector.ctor.doc);
 
     DefineTemplateClassWithDefault<Sine<T>, LeafSystem<T>>(
         m, "Sine", GetPyParam<T>(), doc.Sine.doc)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -1,3 +1,4 @@
+import copy
 import gc
 import scipy.sparse
 import unittest
@@ -52,6 +53,7 @@ from pydrake.systems.primitives import (
     PortSwitch, PortSwitch_,
     RandomSource,
     Saturation, Saturation_,
+    Selector, Selector_, SelectorParams,
     SharedPointerSystem, SharedPointerSystem_,
     Sine, Sine_,
     SparseMatrixGain_,
@@ -106,6 +108,7 @@ class TestGeneral(unittest.TestCase):
         self._check_instantiations(PassThrough_)
         self._check_instantiations(PortSwitch_)
         self._check_instantiations(Saturation_)
+        self._check_instantiations(Selector_)
         self._check_instantiations(SharedPointerSystem_)
         self._check_instantiations(Sine_)
         self._check_instantiations(StateInterpolatorWithDiscreteDerivative_)
@@ -410,6 +413,65 @@ class TestGeneral(unittest.TestCase):
 
         mytest((-5., 5., 4.), (0., 2., 4.))
         mytest((.4, 0., 3.5), (.4, 0., 3.5))
+
+    def _make_selector_params(self):
+        def _select(i, j):
+            return SelectorParams.OutputSelection(
+                input_port_index=i,
+                input_offset=j,
+            )
+        return SelectorParams(
+            inputs=[
+                SelectorParams.InputPortParams(name="x", size=3),
+                SelectorParams.InputPortParams(name="y", size=2),
+                SelectorParams.InputPortParams(name="z", size=1),
+            ],
+            outputs=[
+                # a = <x[0], x[1]>
+                SelectorParams.OutputPortParams(
+                    name="a",
+                    selections=[_select(0, 0), _select(0, 1)],
+                ),
+                # b = <x[2], y[0]>
+                SelectorParams.OutputPortParams(
+                    name="b",
+                    selections=[_select(0, 2), _select(1, 0)],
+                ),
+                # c = <y[1], z[0]>
+                SelectorParams.OutputPortParams(
+                    name="c",
+                    selections=[_select(1, 1), _select(2, 0)]
+                ),
+            ],
+        )
+
+    def test_selector_params(self):
+        dut = self._make_selector_params()
+        self.assertEqual(len(dut.inputs), 3)
+        copy.deepcopy(dut)
+        self.maxDiff = None
+        self.assertEqual(
+            repr(dut),
+            "SelectorParams("
+            "inputs=["
+            "InputPortParams(name='x', size=3), "
+            "InputPortParams(name='y', size=2), "
+            "InputPortParams(name='z', size=1)], "
+            "outputs=["
+            "OutputPortParams(name='a', selections=["
+            "OutputSelection(input_port_index=0, input_offset=0), "
+            "OutputSelection(input_port_index=0, input_offset=1)]), "
+            "OutputPortParams(name='b', selections=["
+            "OutputSelection(input_port_index=0, input_offset=2), "
+            "OutputSelection(input_port_index=1, input_offset=0)]), "
+            "OutputPortParams(name='c', selections=["
+            "OutputSelection(input_port_index=1, input_offset=1), "
+            "OutputSelection(input_port_index=2, input_offset=0)])])")
+
+    @numpy_compare.check_all_types
+    def test_selector(self, T):
+        dut = Selector_[T](params=self._make_selector_params())
+        dut.CreateDefaultContext()
 
     def test_trajectory_source(self):
         ppt = PiecewisePolynomial.FirstOrderHold(

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -33,6 +33,7 @@ drake_cc_package_library(
         ":port_switch",
         ":random_source",
         ":saturation",
+        ":selector",
         ":shared_pointer_system",
         ":sine",
         ":sparse_matrix_gain",
@@ -275,6 +276,20 @@ drake_cc_library(
     srcs = ["saturation.cc"],
     hdrs = ["saturation.h"],
     deps = [
+        "//systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "selector",
+    srcs = ["selector.cc"],
+    hdrs = [
+        "selector.h",
+        "selector_internal.h",
+    ],
+    install_hdrs_exclude = ["selector_internal.h"],
+    deps = [
+        "//common:name_value",
         "//systems/framework",
     ],
 )
@@ -698,6 +713,15 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//systems/framework",
         "//systems/framework/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "selector_test",
+    deps = [
+        ":selector",
+        "//common/test_utilities:expect_throws_message",
+        "//systems/framework/test_utilities:scalar_conversion",
     ],
 )
 

--- a/systems/primitives/selector.cc
+++ b/systems/primitives/selector.cc
@@ -1,0 +1,177 @@
+#include "drake/systems/primitives/selector.h"
+
+#include <deque>
+
+#include "drake/systems/primitives/selector_internal.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using InputPortParams = SelectorParams::InputPortParams;
+using OutputPortParams = SelectorParams::OutputPortParams;
+using OutputSelection = SelectorParams::OutputSelection;
+using SelectorProgram = internal::SelectorProgram;
+
+/* Given a list of elements, merges elements as much as possible by replacing
+logically abutting elements with a single element that has a larger count. */
+void ConsolidateElements(std::vector<SelectorProgram::Element>* elements) {
+  using Element = SelectorProgram::Element;
+  DRAKE_DEMAND(elements != nullptr);
+
+  // Make a worklist of sorted elements.
+  std::sort(elements->begin(), elements->end());
+  std::deque<Element> worklist(elements->begin(), elements->end());
+
+  // Move elements from the worklist to the result, merging as possible.
+  std::vector<SelectorProgram::Element> result;
+  while (!worklist.empty()) {
+    const Element candidate = worklist.front();
+    worklist.pop_front();
+    if (!worklist.empty()) {
+      const Element next = worklist.front();
+      if ((candidate.input_start + candidate.count == next.input_start) &&
+          (candidate.output_start + candidate.count == next.output_start)) {
+        // The 'candidate' and 'next' are abutting, so we'll merge them.
+        Element replacement = candidate;
+        replacement.count += next.count;
+        // Overwrite 'next'. This is equivalent to popping 'next' and pushing
+        // 'replacement' back onto the front of the worklist.
+        worklist.front() = replacement;
+        continue;
+      }
+    }
+    // We couldn't merge the candidate, so it goes onto 'result' unchanged.
+    result.push_back(candidate);
+  }
+
+  // Write out the result.
+  *elements = std::move(result);
+}
+
+}  // namespace
+
+namespace internal {
+
+SelectorProgram::SelectorProgram(
+    const SelectorParams& params,
+    const std::vector<const InputPortBase*>& input_ports) {
+  DRAKE_DEMAND(params.inputs.size() == input_ports.size());
+  for (const OutputPortParams& output : params.outputs) {
+    // Group the output elements by the input port they come from.
+    std::map<InputPortIndex, std::vector<Element>> per_input;
+    int output_offset = 0;
+    for (const OutputSelection& selection : output.selections) {
+      const InputPortIndex input_port_index{selection.input_port_index};
+      per_input[input_port_index].push_back(Element{
+          .count = 1,
+          .input_start = selection.input_offset,
+          .output_start = output_offset,
+      });
+      ++output_offset;
+    }
+    // Consolidate each per-input recipe into as few elements as possible.
+    for (auto& [_, elements] : per_input) {
+      ConsolidateElements(&elements);
+    }
+    // Pack the recipe into a PerOutput helper struct. We'll pack a pre-fetched
+    // input port pointer so that CalcOutput doesn't need to perform all of the
+    // extra error checking during an inner loop.
+    PerOutput compiled_output(per_input.size());
+    int j = 0;
+    for (auto& [input_port_index, elements] : per_input) {
+      compiled_output[j].first = input_ports[input_port_index];
+      compiled_output[j].second = std::move(elements);
+      ++j;
+    }
+    outputs_.push_back(std::move(compiled_output));
+  }
+}
+
+}  // namespace internal
+
+namespace {
+
+// Returns the framework spelling of the given params port name.
+std::variant<std::string, UseDefaultName> ConvertPortName(
+    const std::optional<std::string>& name) {
+  if (name.has_value()) {
+    return name.value();
+  }
+  return kUseDefaultName;
+}
+
+}  // namespace
+
+template <typename T>
+Selector<T>::Selector(SelectorParams params)
+    : LeafSystem<T>(SystemTypeTag<Selector>{}), params_(std::move(params)) {
+  // Validate input parameters and declare input ports.
+  const int num_inputs = ssize(params_.inputs);
+  std::vector<const InputPortBase*> input_ports;
+  for (const InputPortParams& input : params_.inputs) {
+    DRAKE_THROW_UNLESS(input.size >= 0);
+    const InputPort<T>& port =
+        this->DeclareVectorInputPort(ConvertPortName(input.name), input.size);
+    input_ports.push_back(&port);
+  }
+
+  // Validate output parameters and declare output ports.
+  const int num_outputs = ssize(params_.outputs);
+  for (OutputPortIndex i{0}; i < num_outputs; ++i) {
+    const OutputPortParams& output = params_.outputs[i];
+    const int output_size = ssize(output.selections);
+    std::set<DependencyTicket> prerequisites_of_calc;
+    for (const auto& [input_port_index, input_offset] : output.selections) {
+      DRAKE_THROW_UNLESS(input_port_index >= 0);
+      DRAKE_THROW_UNLESS(input_port_index < num_inputs);
+      DRAKE_THROW_UNLESS(input_offset >= 0);
+      DRAKE_THROW_UNLESS(input_offset < params_.inputs[input_port_index].size);
+      prerequisites_of_calc.insert(
+          this->input_port_ticket(InputPortIndex{input_port_index}));
+    }
+    if (output_size == 0) {
+      prerequisites_of_calc.insert(this->nothing_ticket());
+    }
+    this->DeclareVectorOutputPort(
+        ConvertPortName(output.name), output_size,
+        [this, i](const Context<T>& context, BasicVector<T>* result) {
+          this->CalcOutput(context, i, result);
+        },
+        std::move(prerequisites_of_calc));
+  }
+
+  // Convert the params to a more suitable form for use by CalcOutput.
+  program_ = std::make_unique<SelectorProgram>(params_, input_ports);
+}
+
+template <typename T>
+template <typename U>
+Selector<T>::Selector(const Selector<U>& other) : Selector(other.params_) {}
+
+template <typename T>
+Selector<T>::~Selector() = default;
+
+template <typename T>
+void Selector<T>::CalcOutput(const Context<T>& context,
+                             OutputPortIndex output_port_index,
+                             BasicVector<T>* output) const {
+  Eigen::VectorBlock<VectorX<T>> output_block = output->get_mutable_value();
+  for (const auto& [input_port_base, elements] :
+       program_->get(output_port_index)) {
+    const InputPort<T>& input_port =
+        *static_cast<const InputPort<T>*>(input_port_base);
+    const VectorX<T>& input = input_port.Eval(context);
+    for (const SelectorProgram::Element& element : elements) {
+      for (int j = 0; j < element.count; ++j) {
+        output_block[element.output_start + j] = input[element.input_start + j];
+      }
+    }
+  }
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::Selector);

--- a/systems/primitives/selector.h
+++ b/systems/primitives/selector.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/name_value.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+#ifndef DRAKE_DOXYGEN_CXX
+namespace internal {
+class SelectorProgram;  // Declared in selector_internal.h.
+}  // namespace internal
+#endif
+
+/** The constructor arguments for a Selector. */
+struct SelectorParams {
+  /** Helper struct for `inputs`. */
+  struct InputPortParams {
+    /** Passes this object to an Archive.
+    Refer to @ref yaml_serialization "YAML Serialization" for background. */
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(name));
+      a->Visit(DRAKE_NVP(size));
+    }
+
+    /** (Optional) Specifies a name for the port. When given, the name must be a
+    valid port name. When unset, the port will use kDefaultName. */
+    std::optional<std::string> name;
+
+    /** Specifies the size of the port, which must be non-negative. */
+    int size{0};
+  };
+
+  /** Helper struct for `output_selections`. */
+  struct OutputSelection {
+    /** Passes this object to an Archive.
+    Refer to @ref yaml_serialization "YAML Serialization" for background. */
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(input_port_index));
+      a->Visit(DRAKE_NVP(input_offset));
+    }
+
+    /** The input port to use for this single output element. */
+    int input_port_index{};
+
+    /** The element offset within the given input port to use for this single
+    output element. */
+    int input_offset{};
+  };
+
+  /** Helper struct for `outputs`. */
+  struct OutputPortParams {
+    /** Passes this object to an Archive.
+    Refer to @ref yaml_serialization "YAML Serialization" for background. */
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(name));
+      a->Visit(DRAKE_NVP(selections));
+    }
+
+    /** (Optional) Specifies a name for the port. When given, the name must be a
+    valid port name. When unset, the port will use kDefaultName. */
+    std::optional<std::string> name;
+
+    /** Specifies the values for the output port elements, and by implication
+    the port's size. The port will have size `selections.size()`, and its i'th
+    output value will be determined by the (input_port_index, input_offset) pair
+    at `selections[i]`, i.e., for the m'th output port we have:
+    ```txt
+    n = selections[i].input_port_index
+    j = selections[i].input_offset
+    y_m[i] = u_n[j]
+    ```
+    Output elements always come from some input element; it is not possible to
+    directly set an output to a constant. (If a constant is necessary, connect
+    a ConstantVectorSource to an input port.) */
+    std::vector<OutputSelection> selections;
+  };
+
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(inputs));
+    a->Visit(DRAKE_NVP(outputs));
+  }
+
+  /** Specifies details of the input ports, and by implication the total number
+  of input ports. There will be `inputs.size()` ports in total. */
+  std::vector<InputPortParams> inputs;
+
+  /** Specifies details of the output ports, and by implication the total number
+  of output ports. There will be `outputs.size()` ports in total. */
+  std::vector<OutputPortParams> outputs;
+};
+
+/** This system combines multiple vector-valued inputs into multiple vector-
+valued outputs. It operates at the level of individual elements of the input and
+output vectors (i.e., an output port can provide a mixture of data from multiple
+input ports). The inputs to this system directly feed through to its outputs.
+Refer to SelectorParams to understand how the selection is specified.
+
+@system
+name: Selector
+input_ports:
+- u0
+- ...
+- u(N-1)
+output_ports:
+- y0
+- ...
+- y(M-1)
+@endsystem
+
+The port names shown in the figure above are the defaults. Custom names may be
+specified in the SelectorParams.
+
+@tparam_default_scalar
+@ingroup primitive_systems */
+template <typename T>
+class Selector final : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Selector);
+
+  /** Constructs a %Selector with the given parameters. */
+  explicit Selector(SelectorParams params);
+
+  // TODO(jwnimmer-tri) In addition to the params constructor, we could also
+  // imagine accepting a permutation matrix via SparseMatrix as a convenience.
+
+  /** Scalar-converting copy constructor. See @ref system_scalar_conversion. */
+  template <typename U>
+  explicit Selector(const Selector<U>&);
+
+  ~Selector() final;
+
+ private:
+  template <typename>
+  friend class Selector;
+
+  void CalcOutput(const Context<T>& context, OutputPortIndex output_port_index,
+                  BasicVector<T>* output) const;
+
+  const SelectorParams params_;
+  std::unique_ptr<internal::SelectorProgram> program_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/selector_internal.h
+++ b/systems/primitives/selector_internal.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/systems/framework/input_port_base.h"
+
+namespace drake {
+namespace systems {
+namespace internal {
+
+/* This class stores the selection recipe for all output ports in a way that's
+convenient and efficient for CalcOutput to use. Its implementation appears in
+selector.cc (not selector_internal.cc). */
+class SelectorProgram {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SelectorProgram);
+
+  /* Constructs a SelectorProgram from the (already-valiated) params. */
+  SelectorProgram(const SelectorParams& params,
+                  const std::vector<const InputPortBase*>& input_ports);
+
+  /* The recipe for a span of output elements. Which input port and output port
+  these ranges apply to is not stored here; rather, it is inferred from the
+  container(s) that store this element. */
+  struct Element {
+    auto operator<=>(const Element&) const = default;
+    int count{};
+    int input_start{};
+    int output_start{};
+    // TODO(jwnimmer-tri) If we find that selections often reflect a stride,
+    // we could also add an input_stride and output_stride here.
+  };
+
+  /* The group of all recipe elements for a single pair of input and output
+  ports. The input port is stored explicitly, but the output port is inferred
+  from the container that stores this element. */
+  using OutputFromInputs =
+      std::pair<const InputPortBase*, std::vector<Element>>;
+
+  /* The entire recipe for a single output port. */
+  using PerOutput = std::vector<OutputFromInputs>;
+
+  /* Returns the recipe for the given output port. */
+  const PerOutput& get(OutputPortIndex i) const { return outputs_[i]; }
+
+ private:
+  std::vector<PerOutput> outputs_;
+};
+
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/test/selector_test.cc
+++ b/systems/primitives/test/selector_test.cc
@@ -1,0 +1,401 @@
+#include "drake/systems/primitives/selector.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+#include "drake/systems/primitives/selector_internal.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+class SelectorTest : public ::testing::Test {
+ protected:
+  using InputPortParams = SelectorParams::InputPortParams;
+  using OutputPortParams = SelectorParams::OutputPortParams;
+  using OutputSelection = SelectorParams::OutputSelection;
+
+  void Initialize(
+      const SelectorParams& params = MakeTrivialPassthroughParams()) {
+    dut_ = std::make_unique<Selector<double>>(params);
+    context_ = dut_->CreateDefaultContext();
+  }
+
+  // This gives y0 = u0 where each port is a 1-element vector.
+  static SelectorParams MakeTrivialPassthroughParams() {
+    return SelectorParams{
+        .inputs{
+            InputPortParams{.size = 1},
+        },
+        .outputs{
+            OutputPortParams{
+                .selections{
+                    OutputSelection{
+                        .input_port_index = 0,
+                        .input_offset = 0,
+                    },
+                },
+            },
+        },
+    };
+  }
+
+  std::unique_ptr<System<double>> dut_;
+  std::unique_ptr<Context<double>> context_;
+};
+
+TEST_F(SelectorTest, Basic) {
+  Initialize();
+
+  // Check the shape.
+  EXPECT_TRUE(context_->is_stateless());
+  ASSERT_EQ(dut_->num_input_ports(), 1);
+  ASSERT_EQ(dut_->num_output_ports(), 1);
+  EXPECT_EQ(dut_->get_input_port().get_name(), "u0");
+  EXPECT_EQ(dut_->get_input_port().size(), 1);
+  EXPECT_EQ(dut_->get_output_port().get_name(), "y0");
+  EXPECT_EQ(dut_->get_output_port().size(), 1);
+
+  // Check the output.
+  const Vector1<double> input(22.0);
+  dut_->get_input_port().FixValue(context_.get(), input);
+  EXPECT_EQ(dut_->get_output_port().Eval(*context_), input);
+}
+
+TEST_F(SelectorTest, NoPorts) {
+  Initialize(SelectorParams{});
+  ASSERT_EQ(dut_->num_input_ports(), 0);
+  ASSERT_EQ(dut_->num_output_ports(), 0);
+}
+
+TEST_F(SelectorTest, NoOutputPort) {
+  SelectorParams params = MakeTrivialPassthroughParams();
+  params.outputs.clear();
+  Initialize(params);
+  ASSERT_EQ(dut_->num_input_ports(), 1);
+  ASSERT_EQ(dut_->num_output_ports(), 0);
+  EXPECT_EQ(dut_->get_input_port().size(), 1);
+}
+
+TEST_F(SelectorTest, ZeroSizedPorts) {
+  const SelectorParams params{
+      .inputs{InputPortParams{.size = 0}},
+      .outputs{OutputPortParams{.selections{}}},
+  };
+  Initialize(params);
+  ASSERT_EQ(dut_->num_input_ports(), 1);
+  ASSERT_EQ(dut_->num_output_ports(), 1);
+  EXPECT_EQ(dut_->get_input_port().size(), 0);
+  EXPECT_EQ(dut_->get_output_port().size(), 0);
+}
+
+TEST_F(SelectorTest, ComplicatedSelection) {
+  // Calculate the following selection recipe ...
+  //  y0 = <u0[0], u1[0]>
+  //  y1 = <u1[0], u1[2]>
+  //  y2 = <u1[1], u0[1]>
+  //  y3 = <u1[1], u1[0], u0[1], u0[0]>
+  //  y4 = <>  (i.e., empty)
+  // ... with u2 unused.
+  const SelectorParams params{
+      .inputs{
+          InputPortParams{.size = 2},
+          InputPortParams{.size = 3},
+          InputPortParams{.size = 1},
+      },
+      .outputs{
+          // y0 = <u0[0], u1[0]>
+          OutputPortParams{
+              .selections{
+                  OutputSelection{
+                      .input_port_index = 0,
+                      .input_offset = 0,
+                  },
+                  OutputSelection{
+                      .input_port_index = 1,
+                      .input_offset = 0,
+                  },
+              },
+          },
+          //  y1 = <u1[0], u1[2]>
+          OutputPortParams{
+              .selections{
+                  OutputSelection{
+                      .input_port_index = 1,
+                      .input_offset = 0,
+                  },
+                  OutputSelection{
+                      .input_port_index = 1,
+                      .input_offset = 2,
+                  },
+              },
+          },
+          // y2 = <u1[1], u0[1]>
+          OutputPortParams{
+              .selections{
+                  OutputSelection{
+                      .input_port_index = 1,
+                      .input_offset = 1,
+                  },
+                  OutputSelection{
+                      .input_port_index = 0,
+                      .input_offset = 1,
+                  },
+              },
+          },
+          // y3 = <u1[1], u1[0], u0[1], u0[0]>
+          OutputPortParams{
+              .selections{
+                  OutputSelection{
+                      .input_port_index = 1,
+                      .input_offset = 1,
+                  },
+                  OutputSelection{
+                      .input_port_index = 1,
+                      .input_offset = 0,
+                  },
+                  OutputSelection{
+                      .input_port_index = 0,
+                      .input_offset = 1,
+                  },
+                  OutputSelection{
+                      .input_port_index = 0,
+                      .input_offset = 0,
+                  },
+              },
+          },
+          // y4 = <>  (i.e., empty)
+          OutputPortParams{
+              .selections{},
+          },
+      },
+  };
+  Initialize(params);
+
+  // Check the shape.
+  ASSERT_EQ(dut_->num_input_ports(), 3);
+  ASSERT_EQ(dut_->num_output_ports(), 5);
+  EXPECT_EQ(dut_->get_input_port(0).get_name(), "u0");
+  EXPECT_EQ(dut_->get_input_port(0).size(), 2);
+  EXPECT_EQ(dut_->get_input_port(1).get_name(), "u1");
+  EXPECT_EQ(dut_->get_input_port(1).size(), 3);
+  EXPECT_EQ(dut_->get_input_port(2).get_name(), "u2");
+  EXPECT_EQ(dut_->get_input_port(2).size(), 1);
+  EXPECT_EQ(dut_->get_output_port(0).get_name(), "y0");
+  EXPECT_EQ(dut_->get_output_port(0).size(), 2);
+  EXPECT_EQ(dut_->get_output_port(1).get_name(), "y1");
+  EXPECT_EQ(dut_->get_output_port(1).size(), 2);
+  EXPECT_EQ(dut_->get_output_port(2).get_name(), "y2");
+  EXPECT_EQ(dut_->get_output_port(2).size(), 2);
+  EXPECT_EQ(dut_->get_output_port(3).get_name(), "y3");
+  EXPECT_EQ(dut_->get_output_port(3).size(), 4);
+  EXPECT_EQ(dut_->get_output_port(4).get_name(), "y4");
+  EXPECT_EQ(dut_->get_output_port(4).size(), 0);
+
+  // Check the output.
+  const Vector2<double> u0(0.0, 1.0);
+  const Vector3<double> u1(10.0, 11.0, 12.0);
+  const Vector1<double> u2(20.0);
+  dut_->get_input_port(0).FixValue(context_.get(), u0);
+  dut_->get_input_port(1).FixValue(context_.get(), u1);
+  dut_->get_input_port(2).FixValue(context_.get(), u2);
+  const Vector2<double> expected_y0(0.0, 10.0);
+  const Vector2<double> expected_y1(10.0, 12.0);
+  const Vector2<double> expected_y2(11.0, 1.0);
+  const Vector4<double> expected_y3(11.0, 10.0, 1.0, 0.0);
+  const VectorX<double> expected_y4;
+  EXPECT_EQ(dut_->get_output_port(0).Eval(*context_), expected_y0);
+  EXPECT_EQ(dut_->get_output_port(1).Eval(*context_), expected_y1);
+  EXPECT_EQ(dut_->get_output_port(2).Eval(*context_), expected_y2);
+  EXPECT_EQ(dut_->get_output_port(3).Eval(*context_), expected_y3);
+  EXPECT_EQ(dut_->get_output_port(4).Eval(*context_), expected_y4);
+}
+
+TEST_F(SelectorTest, CustomNames) {
+  SelectorParams params = MakeTrivialPassthroughParams();
+  params.inputs.at(0).name = "my_input";
+  params.outputs.at(0).name = "my_output";
+  Initialize(params);
+  ASSERT_EQ(dut_->num_input_ports(), 1);
+  ASSERT_EQ(dut_->num_output_ports(), 1);
+  EXPECT_EQ(dut_->get_input_port().get_name(), "my_input");
+  EXPECT_EQ(dut_->get_output_port().get_name(), "my_output");
+}
+
+TEST_F(SelectorTest, BadInputSize) {
+  // Try to request an invalid input size.
+  SelectorParams params = MakeTrivialPassthroughParams();
+  params.inputs.at(0).size = -1;
+  DRAKE_EXPECT_THROWS_MESSAGE(Selector<double>(params), ".*input.size.*");
+}
+
+TEST_F(SelectorTest, BadOutputInvalidInputPort) {
+  // Try to cite an input port that doesn't exist.
+  SelectorParams params = MakeTrivialPassthroughParams();
+  params.outputs.at(0).selections.at(0).input_port_index = 1;
+  DRAKE_EXPECT_THROWS_MESSAGE(Selector<double>(params), ".*input_port_index.*");
+  params.outputs.at(0).selections.at(0).input_port_index = -1;
+  DRAKE_EXPECT_THROWS_MESSAGE(Selector<double>(params), ".*input_port_index.*");
+}
+
+TEST_F(SelectorTest, BadOutputInvalidInputOffset) {
+  // Try to read beyond the extent of an input port.
+  SelectorParams params = MakeTrivialPassthroughParams();
+  params.outputs.at(0).selections.at(0).input_offset = 1;
+  DRAKE_EXPECT_THROWS_MESSAGE(Selector<double>(params), ".*input_offset.*");
+  params.outputs.at(0).selections.at(0).input_offset = -1;
+  DRAKE_EXPECT_THROWS_MESSAGE(Selector<double>(params), ".*input_offset.*");
+}
+
+TEST_F(SelectorTest, ToAutoDiff) {
+  Initialize();
+  EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
+    ASSERT_EQ(converted.num_input_ports(), 1);
+    ASSERT_EQ(converted.num_output_ports(), 1);
+  }));
+}
+
+TEST_F(SelectorTest, ToSymbolic) {
+  Initialize();
+  EXPECT_TRUE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
+    ASSERT_EQ(converted.num_input_ports(), 1);
+    ASSERT_EQ(converted.num_output_ports(), 1);
+  }));
+}
+
+TEST_F(SelectorTest, DependencyTickets) {
+  // Calculate the following selection recipe ...
+  //  y0 = <>  (i.e., empty)
+  //  y1 = <u0[0]>
+  //  y2 = <u1[0]>
+  //  y3 = <u0[0], u1[0]>
+  // ... with u2 unused.
+  const SelectorParams params{
+      .inputs{
+          InputPortParams{.size = 1},
+          InputPortParams{.size = 1},
+          InputPortParams{.size = 1},
+      },
+      .outputs{
+          //  y0 = <>  (i.e., empty)
+          OutputPortParams{.selections{}},
+          //  y1 = <u0[0]>
+          OutputPortParams{
+              .selections{
+                  OutputSelection{
+                      .input_port_index = 0,
+                      .input_offset = 0,
+                  },
+              },
+          },
+          //  y2 = <u1[0]>
+          OutputPortParams{
+              .selections{
+                  OutputSelection{
+                      .input_port_index = 1,
+                      .input_offset = 0,
+                  },
+              },
+          },
+          //  y3 = <u0[0], u1[0]>
+          OutputPortParams{
+              .selections{
+                  OutputSelection{
+                      .input_port_index = 0,
+                      .input_offset = 0,
+                  },
+                  OutputSelection{
+                      .input_port_index = 1,
+                      .input_offset = 0,
+                  },
+              },
+          },
+      },
+  };
+  Initialize(params);
+  ASSERT_EQ(dut_->num_input_ports(), 3);
+  ASSERT_EQ(dut_->num_output_ports(), 4);
+
+  // y0 depends on nothing.
+  EXPECT_FALSE(dut_->HasDirectFeedthrough(0, 0));
+  EXPECT_FALSE(dut_->HasDirectFeedthrough(1, 0));
+  EXPECT_FALSE(dut_->HasDirectFeedthrough(2, 0));
+
+  // y1 depends on u0.
+  EXPECT_TRUE(dut_->HasDirectFeedthrough(0, 1));
+  EXPECT_FALSE(dut_->HasDirectFeedthrough(1, 1));
+  EXPECT_FALSE(dut_->HasDirectFeedthrough(2, 1));
+
+  // y2 depends on u1.
+  EXPECT_FALSE(dut_->HasDirectFeedthrough(0, 2));
+  EXPECT_TRUE(dut_->HasDirectFeedthrough(1, 2));
+  EXPECT_FALSE(dut_->HasDirectFeedthrough(2, 2));
+
+  // y3 depends on u0,u1.
+  EXPECT_TRUE(dut_->HasDirectFeedthrough(0, 3));
+  EXPECT_TRUE(dut_->HasDirectFeedthrough(1, 3));
+  EXPECT_FALSE(dut_->HasDirectFeedthrough(2, 3));
+}
+
+TEST_F(SelectorTest, EfficientPacking) {
+  // Define the following selection recipe:
+  //  y0 = <u1[0], u1[1], u0[2], u0[3]>
+  const SelectorParams params{
+      .inputs{
+          InputPortParams{.size = 5},
+          InputPortParams{.size = 5},
+      },
+      .outputs{
+          //  y0 = <u1[1], u1[2], u0[3], u0[4]>
+          OutputPortParams{.selections{
+              OutputSelection{
+                  .input_port_index = 1,
+                  .input_offset = 1,
+              },
+              OutputSelection{
+                  .input_port_index = 1,
+                  .input_offset = 2,
+              },
+              OutputSelection{
+                  .input_port_index = 0,
+                  .input_offset = 3,
+              },
+              OutputSelection{
+                  .input_port_index = 0,
+                  .input_offset = 4,
+              },
+          }},
+      },
+  };
+  Initialize(params);
+
+  // Check that the packed form is as expected. For this, we'll recreate the
+  // program instead of fishing it out of the dut.
+  using internal::SelectorProgram;
+  const std::vector<const InputPortBase*> ports{&dut_->get_input_port(0),
+                                                &dut_->get_input_port(1)};
+  const SelectorProgram program(params, ports);
+  const SelectorProgram::PerOutput& y = program.get(OutputPortIndex{0});
+  // The output uses both input ports.
+  ASSERT_EQ(y.size(), 2);
+  EXPECT_EQ(y[0].first, ports[0]);
+  EXPECT_EQ(y[1].first, ports[1]);
+  // Each input port is used for a single contiguous span.
+  const std::vector<SelectorProgram::Element>& u0 = y[0].second;
+  const std::vector<SelectorProgram::Element>& u1 = y[1].second;
+  EXPECT_EQ(u0.size(), 1);
+  EXPECT_EQ(u0.at(0).input_start, 3);
+  EXPECT_EQ(u0.at(0).output_start, 2);
+  EXPECT_EQ(u0.at(0).count, 2);
+  EXPECT_EQ(u1.size(), 1);
+  EXPECT_EQ(u1.at(0).input_start, 1);
+  EXPECT_EQ(u1.at(0).output_start, 0);
+  EXPECT_EQ(u1.at(0).count, 2);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/tools/workspace/pybind11/mkdoc_comment.py
+++ b/tools/workspace/pybind11/mkdoc_comment.py
@@ -527,6 +527,7 @@ def reflow(s):
         "cpp": "c++",
         "python": "python",
         "py": "python",
+        "txt": "txt",
         "yaml": "yaml",
     }
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**

When wiring up all of the various MultibodyPlant input and output ports to controllers, it's often the case that we need to multiplex and/or split up the data on those ports.  Sometimes we need to stack per-model q, v, or x together (e.g., arm model + gripper model), sometimes we need to slice out actuated dofs from unactuated dofs, sometimes we need to interleave q with v, sometimes we need to switch between velocity-based indexing and actuator-based indexing, or any number of other permutations.

Each time this comes up, of course it's possible to write a custom LeafSystem to do the exact rearrangement that's needed, or put lots of Multiplexer and Demultiplexer systems in series, or use a SparseMatrixGain to formulate the selection as a matrix product (for each necessary output port, one at a time), but all of that is extremely awkward.

**Describe the solution you'd like**

We should offer a primitive system that can perform arbitrary vector slicing / selection, with multiple input ports, multiple output ports, and any element of any output port can be mapped to any element of any input port.

Note that we do not need _scaling_.  If there is scaling required, a Gain or MatrixGain or SparseMatrixGain system can be used in front of or behind the Selector.

With a bow to Simulink, we should call this system a `Selector`.

**Describe alternatives you've considered**

Writing copy-paste systems for the acute purpose every time (and binding them in Python, and testing them, and optimizing them for performance one by one, and etc.).

**Additional context**

Also, by making the constructor `...Params` a serializable first-class object, downstream users can still write customized and easily-tested recipes for preparing the selection recipe they need (only operating on the params object), and then later hand it off to Selector system for efficient execution at runtime.  This neatly separates the concerns of "carefully specify and choose the recipe" from "efficiently execute the recipe at runtime".  If we find ways to speed up the selection implementation down the road, all users will benefit without needing to copy-paste the fix into their custom code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22635)
<!-- Reviewable:end -->
