### PR TITLE
Implements hydro box mesh with faces split into four triangles

### DIFF
--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -337,13 +337,8 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Box& box, const ProximityProperties&) {
-  PositiveDouble validator("Box", "rigid");
-  // Use the coarsest mesh for the box. The safety factor 1.1 guarantees the
-  // resolution-hint argument is larger than the box size, so the mesh
-  // will have only 8 vertices and 12 triangles.
   auto mesh = make_unique<TriangleSurfaceMesh<double>>(
-      MakeBoxSurfaceMesh<double>(box, 1.1 * box.size().maxCoeff()));
-
+      MakeBoxSurfaceMeshWithSymmetricTriangles<double>(box));
   return RigidGeometry(RigidMesh(std::move(mesh)));
 }
 
@@ -458,7 +453,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
 
   // First, create an inflated mesh.
   auto inflated_mesh = make_unique<VolumeMesh<double>>(
-      MakeBoxVolumeMeshWithMa<double>(inflated_box));
+      MakeBoxVolumeMeshWithMaAndSymmetricTriangles<double>(inflated_box));
 
   const double hydroelastic_modulus =
       PositiveDouble("Box", "soft").Extract(props, kHydroGroup, kElastic);

--- a/geometry/proximity/make_box_mesh.h
+++ b/geometry/proximity/make_box_mesh.h
@@ -156,6 +156,18 @@ namespace internal {
 template <typename T>
 VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box);
 
+/* Generates a tetrahedral volume mesh for a given box. The generated
+ tesselation:
+  - splits each rectangular face into four congruent triangles, and
+  - respects the medial axis.
+
+ @param[in] box
+     The box shape specification (see drake::geometry::Box).
+ @retval volume_mesh
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+VolumeMesh<T> MakeBoxVolumeMeshWithMaAndSymmetricTriangles(const Box& box);
+
 /*
  Generates a tetrahedral volume mesh of a given box by subdividing the box
  into _rectangular cells_ (volume bounded by six axis-aligned faces) and
@@ -220,6 +232,15 @@ TriangleSurfaceMesh<T> MakeBoxSurfaceMesh(const Box& box,
   // TODO(SeanCurtis-TRI): Consider putting an upper limit - as with the sphere.
   return ConvertVolumeToSurfaceMesh<T>(
       MakeBoxVolumeMesh<T>(box, resolution_hint));
+}
+
+template <typename T>
+TriangleSurfaceMesh<T> MakeBoxSurfaceMeshWithSymmetricTriangles(
+    const Box& box) {
+  // TODO(amcastro-tri): Consider an implementation with hardcoded mesh
+  // connectivities.
+  return ConvertVolumeToSurfaceMesh<T>(
+      MakeBoxVolumeMeshWithMaAndSymmetricTriangles<T>(box));
 }
 
 /* The functions below are only support functions for the main API above. They

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -582,11 +582,10 @@ TEST_F(HydroelasticRigidGeometryTest, Sphere) {
 // *right* representation.
 TEST_F(HydroelasticRigidGeometryTest, Box) {
   const double edge_len = 0.5;
-  // Pick a characteristic length *larger* than the box dimensions so that
-  // I only get 8 vertices - one at each corner. This is merely evidence that
-  // the box method is called -- we rely on tests of that functionality to
-  // create more elaborate meshes with smaller edge lengths.
-  ProximityProperties props = rigid_properties(1.5 * edge_len);
+  // Proximity properties can be empty. Currently rigid boxes do not need a
+  // resolution hint since we produce a coarse tesselation where each face is
+  // split into a fan of four triangles around the center of the face.
+  ProximityProperties props;  // empty.
 
   std::optional<RigidGeometry> box =
       MakeRigidRepresentation(Box(edge_len, edge_len, edge_len), props);
@@ -594,12 +593,17 @@ TEST_F(HydroelasticRigidGeometryTest, Box) {
   ASSERT_FALSE(box->is_half_space());
 
   const TriangleSurfaceMesh<double>& mesh = box->mesh();
-  EXPECT_EQ(mesh.num_vertices(), 8);
+  EXPECT_EQ(mesh.num_vertices(), 14);  // 8 corners + 6 face centers.
   // Because it is a cube centered at the origin, the distance from the origin
-  // to each vertex should be sqrt(3) * edge_len / 2.
-  const double expected_dist = std::sqrt(3) * edge_len / 2;
-  for (int v = 0; v < mesh.num_vertices(); ++v) {
-    ASSERT_NEAR(mesh.vertex(v).norm(), expected_dist, 1e-15);
+  // to each corner vertex should be sqrt(3) * edge_len / 2.
+  const double expected_corner_dist = std::sqrt(3) * edge_len / 2;
+  for (int v = 0; v < 8 /* only the first 8 */; ++v) {
+    ASSERT_NEAR(mesh.vertex(v).norm(), expected_corner_dist, 1e-15);
+  }
+
+  const double expected_face_dist = 0.25;
+  for (int v = 8; v < 14 /* only the face centers */; ++v) {
+    ASSERT_NEAR(mesh.vertex(v).norm(), expected_face_dist, 1e-15);
   }
 }
 
@@ -1146,7 +1150,7 @@ TEST_F(HydroelasticSoftGeometryTest, Box) {
 
   // Smoke test the mesh and the pressure field. It relies on unit tests for
   // the generators of the mesh and the pressure field.
-  const int expected_num_vertices = 12;
+  const int expected_num_vertices = 18;
   EXPECT_EQ(box->mesh().num_vertices(), expected_num_vertices);
   const double E = properties.GetPropertyOrDefault(kHydroGroup, kElastic, 1e8);
   for (int v = 0; v < box->mesh().num_vertices(); ++v) {

--- a/geometry/proximity/test/make_box_mesh_test.cc
+++ b/geometry/proximity/test/make_box_mesh_test.cc
@@ -64,8 +64,9 @@ bool IsTetrahedronRespectingMa(const VolumeElement& tetrahedron,
   return false;
 }
 
-// Verifies that a tetrahedral mesh of a box from MakeBoxVolumeMeshWithMa()
-// satisfies all these properties:
+// Verifies that a tetrahedral mesh of a box from MakeBoxVolumeMeshWithMa() or
+// MakeBoxVolumeMeshWithMaAndSymmetricTriangles() satisfies all these
+// properties:
 //
 //   A. The mesh is conforming.
 //   B. The mesh conforms to the box.
@@ -335,6 +336,58 @@ GTEST_TEST(MakeBoxVolumeMeshWithMaTest, ParameterValueCoverage) {
   }
 }
 
+GTEST_TEST(MakeBoxVolumeMeshWithMaAndSymmetricTriangles,
+           ParameterValueCoverage) {
+  // A box with a point MA (same three dimensions).
+  {
+    const Box box(2., 2., 2.);
+    const VolumeMesh<double> mesh =
+        MakeBoxVolumeMeshWithMaAndSymmetricTriangles<double>(box);
+    EXPECT_EQ(mesh.num_elements(), 24);
+    EXPECT_EQ(mesh.num_vertices(), 15);
+    EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+  }
+
+  // A box with a line MA (two dimensions are the same).
+  {
+    // Box lengths, with L1 < L2 for a MA line of length L2.
+    const double L1 = 2;
+    const double L2 = 4;
+    // We test the 3 distinct permutations.
+    for (const Box& box : {Box{L2, L1, L1}, Box{L1, L2, L1}, Box{L1, L1, L2}}) {
+      const VolumeMesh<double> mesh =
+          MakeBoxVolumeMeshWithMaAndSymmetricTriangles<double>(box);
+      EXPECT_EQ(mesh.num_elements(), 40);
+      EXPECT_EQ(mesh.num_vertices(), 17);
+      EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+    }
+  }
+
+  // A box with planar MA.
+  {
+    const double L1 = 2;
+    const double L2 = 4;
+    const double L3 = 6;
+    // We test the 6 distinct permutations.
+    for (const Box& box : {
+             // clang-format off
+             Box{L1, L2, L3},
+             Box{L1, L3, L2},
+             Box{L2, L1, L3},
+             Box{L2, L3, L1},
+             Box{L3, L1, L2},
+             Box{L3, L2, L1},
+             // clang-format on
+         }) {
+      const VolumeMesh<double> mesh =
+          MakeBoxVolumeMeshWithMaAndSymmetricTriangles<double>(box);
+      EXPECT_EQ(mesh.num_elements(), 44);
+      EXPECT_EQ(mesh.num_vertices(), 18);
+      EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+    }
+  }
+}
+
 GTEST_TEST(MakeBoxVolumeMeshTest, CalcSequentialIndex) {
   const Vector3<int> num_vertices(3, 2, 5);
   EXPECT_EQ(28, CalcSequentialIndex(2, 1, 3, num_vertices));
@@ -467,6 +520,19 @@ GTEST_TEST(MakeBoxSurfaceMeshTest, GenerateSurface) {
 
   const int expect_num_vertices = 114;
   EXPECT_EQ(expect_num_vertices, surface_mesh.num_vertices());
+}
+
+// Smoke test only. Assume correctness of
+// MakeBoxVolumeMeshWithMaAndSymmetricTriangles() and
+// ConvertVolumeToSurfaceMesh().
+GTEST_TEST(MakeBoxSurfaceMeshWithSymmetricTrianglesTest, GenerateSurface) {
+  const Box box(0.2, 0.4, 0.8);
+  TriangleSurfaceMesh<double> surface_mesh =
+      MakeBoxSurfaceMeshWithSymmetricTriangles<double>(box);
+  const int expect_num_vertices = 14;  // 8 corners + 6 face centers.
+  EXPECT_EQ(expect_num_vertices, surface_mesh.num_vertices());
+  const int expect_num_elements = 24;  // Triangles.
+  EXPECT_EQ(expect_num_elements, surface_mesh.num_elements());
 }
 
 }  // namespace

--- a/multibody/plant/test/deformable_integration_test.cc
+++ b/multibody/plant/test/deformable_integration_test.cc
@@ -165,7 +165,7 @@ namespace {
 TEST_F(DeformableIntegrationTest, SteadyState) {
   Simulator<double> simulator(*diagram_);
   /* Run simulation for long enough to reach steady state. */
-  simulator.AdvanceTo(2.5);
+  simulator.AdvanceTo(5.0);
 
   /* Verify the system has reached steady state. */
   const Context<double>& diagram_context = simulator.get_context();


### PR DESCRIPTION
Closes #22213.

As discussed in #22213, our hydro boxes customized to discretize the MA with a minimum number of tetrahedra do not play well with discrete schemes.
The solution proposed in #22213 is a custom box mesh that respects the MA, uses a coarse discretization of the box, but that it splits each face into four triangles for a more symmetric tesselation that more accurate predicts restoring moments in the discrete case.

**Note:**
I tried to reuse the already existing implementation. The current implementation is highly customized for the case of splitting each face into two triangles, and even though I could modify the code to do what I wanted, the solution ended up being a collection of hacks piled on top of each other. Even if we liked it, it'd be very hard to explain and document. Therefore I resorted to a much simpler appraoch (thanks @joemasterjohn for the idea!). There are three cases really, corresponding to when the MA is a point, line or plane. For each, I created a custom mesh that respects the MA and splits faces into four triangles. Then I use these "canonical" meshes in the code, scaled and rotated to match the original box. The resulting code is clean and very easy to understand. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22640)
<!-- Reviewable:end -->
