### PR TITLE
Check RotationalInertia moments/products with IsFinite() instead of IsNaN(). 

### DIFF
--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -342,8 +342,9 @@ std::optional<std::string> RotationalInertia<T>::CreateInvalidityReport()
     const {
   // Default return value is an empty string (this RotationalInertia is valid).
   std::string error_message;
-  if (IsNaN()) {
-    error_message = fmt::format("\nNaN detected in RotationalInertia.");
+  if (!IsFinite()) {
+    error_message = fmt::format("\nNon-finite moment or product of inertia "
+                                "detected in RotationalInertia.");
   } else if constexpr (scalar_predicate<T>::is_bool) {
     if (!AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality()) {
       const Vector3<double> p = CalcPrincipalMomentsOfInertia();

--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -343,8 +343,9 @@ std::optional<std::string> RotationalInertia<T>::CreateInvalidityReport()
   // Default return value is an empty string (this RotationalInertia is valid).
   std::string error_message;
   if (!IsFinite()) {
-    error_message = fmt::format("\nNon-finite moment or product of inertia "
-                                "detected in RotationalInertia.");
+    error_message = fmt::format(
+        "\nNon-finite moment or product of inertia "
+        "detected in RotationalInertia.");
   } else if constexpr (scalar_predicate<T>::is_bool) {
     if (!AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality()) {
       const Vector3<double> p = CalcPrincipalMomentsOfInertia();

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -496,6 +496,23 @@ class RotationalInertia {
     I_SP_E_.template triangularView<Eigen::Lower>() = Matrix3<T>::Zero();
   }
 
+  /// Returns true if all moments and products in `this` rotational inertia are
+  /// finite (e.g., no NaNs or infinities), otherwise returns false.
+  boolean<T> IsFinite() const {
+    using std::isfinite;
+    // Only check the lower-triangular part of this symmetric matrix for NaN.
+    // The three upper off-diagonal products of inertia should be/remain NaN.
+    static_assert(is_lower_triangular_order(0, 0), "Invalid indices");
+    static_assert(is_lower_triangular_order(1, 0), "Invalid indices");
+    static_assert(is_lower_triangular_order(2, 0), "Invalid indices");
+    static_assert(is_lower_triangular_order(1, 1), "Invalid indices");
+    static_assert(is_lower_triangular_order(2, 1), "Invalid indices");
+    static_assert(is_lower_triangular_order(2, 2), "Invalid indices");
+    return isfinite(I_SP_E_(0, 0)) && isfinite(I_SP_E_(1, 0)) &&
+           isfinite(I_SP_E_(1, 1)) && isfinite(I_SP_E_(2, 0)) &&
+           isfinite(I_SP_E_(2, 1)) && isfinite(I_SP_E_(2, 2));
+  }
+
   /// Returns `true` if any moment/product in `this` rotational inertia is NaN.
   /// Otherwise returns `false`.
   boolean<T> IsNaN() const {

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -131,8 +131,9 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
 
   // Check for a thrown exception with proper error message when creating a
   // rotational inertia with a non-finite moment or product of inertia.
-  std::string expected_message = "[^]*Non-finite moment or product of inertia "
-                                 "detected in RotationalInertia\\.";
+  std::string expected_message =
+      "[^]*Non-finite moment or product of inertia "
+      "detected in RotationalInertia\\.";
   constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
   DRAKE_EXPECT_THROWS_MESSAGE(
       RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -130,12 +130,20 @@ GTEST_TEST(RotationalInertia, MakeFromMomentsAndProductsOfInertia) {
   EXPECT_FALSE(I.CouldBePhysicallyValid());
 
   // Check for a thrown exception with proper error message when creating a
-  // rotational inertia with NaN moments/products of inertia.
-  std::string expected_message = "[^]*NaN detected in RotationalInertia\\.";
-  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+  // rotational inertia with a non-finite moment or product of inertia.
+  std::string expected_message = "[^]*Non-finite moment or product of inertia "
+                                 "detected in RotationalInertia\\.";
+  constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
   DRAKE_EXPECT_THROWS_MESSAGE(
       RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
-          nan, Iyy, Izz, /* Ixy = */ 0, /* Ixz = */ 0, /* Iyz = */ 0,
+          kNaN, Iyy, Izz, /* Ixy = */ 0, /* Ixz = */ 0, /* Iyz = */ 0,
+          /* skip_validity_check = */ false),
+      expected_message);
+
+  constexpr double kInfinity = std::numeric_limits<double>::infinity();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      RotationalInertia<double>::MakeFromMomentsAndProductsOfInertia(
+          kInfinity, Iyy, Izz, /* Ixy = */ 0, /* Ixz = */ 0, /* Iyz = */ 0,
           /* skip_validity_check = */ false),
       expected_message);
 


### PR DESCRIPTION
Check moments/products of inertia with IsFinite() instead of IsNan() and add missing test of infinity -- which somehow used to pass IsPhysicallyValid().  This is work towards issue #22651.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22642)
<!-- Reviewable:end -->
