### PR TITLE
[multibody] Add GetScopedFrameByName overloads on scalar type

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -151,6 +151,7 @@ drake_pybind_library(
     name = "parsing_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:serialize_pybind",
         "//bindings/pydrake/common:sorted_pair_pybind",

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -1,3 +1,4 @@
+#include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/sorted_pair_pybind.h"
@@ -281,17 +282,29 @@ PYBIND11_MODULE(parsing, m) {
       py::arg("directives"), py::arg("plant"), py::arg("parser") = nullptr,
       doc.parsing.ProcessModelDirectives.doc_4args);
 
-  m.def("GetScopedFrameByName", &parsing::GetScopedFrameByName,
-      py::arg("plant"), py::arg("full_name"),
-      py::return_value_policy::reference,
-      py::keep_alive<0, 1>(),  // `return` keeps `plant` alive.
-      doc.parsing.GetScopedFrameByName.doc);
+  type_visit(
+      [&m]<typename T>(T) {
+        m.def("GetScopedFrameByName",
+            overload_cast_explicit<const Frame<T>&, const MultibodyPlant<T>&,
+                const std::string&>(&parsing::GetScopedFrameByName),
+            py::arg("plant"), py::arg("full_name"),
+            py::return_value_policy::reference,
+            py::keep_alive<0, 1>(),  // `return` keeps `plant` alive.
+            doc.parsing.GetScopedFrameByName.doc);
+      },
+      CommonScalarPack{});
 
-  m.def("GetScopedFrameByNameMaybe", &parsing::GetScopedFrameByNameMaybe,
-      py::arg("plant"), py::arg("full_name"),
-      py::return_value_policy::reference,
-      py::keep_alive<0, 1>(),  // `return` keeps `plant` alive.
-      doc.parsing.GetScopedFrameByNameMaybe.doc);
+  type_visit(
+      [&m]<typename T>(T) {
+        m.def("GetScopedFrameByNameMaybe",
+            overload_cast_explicit<const Frame<T>*, const MultibodyPlant<T>&,
+                const std::string&>(&parsing::GetScopedFrameByNameMaybe),
+            py::arg("plant"), py::arg("full_name"),
+            py::return_value_policy::reference,
+            py::keep_alive<0, 1>(),  // `return` keeps `plant` alive.
+            doc.parsing.GetScopedFrameByNameMaybe.doc);
+      },
+      CommonScalarPack{});
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -27,12 +27,14 @@ import re
 import unittest
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities import numpy_compare
 from pydrake.geometry import SceneGraph
 from pydrake.multibody.tree import (
     ModelInstanceIndex,
 )
 from pydrake.multibody.plant import (
     MultibodyPlant,
+    MultibodyPlant_,
 )
 
 
@@ -235,8 +237,9 @@ class TestParsing(unittest.TestCase):
         ModelInstanceInfo.X_PC
         ModelInstanceInfo.model_instance
 
-    def test_scoped_frame_names(self):
-        plant = MultibodyPlant(time_step=0.01)
+    @numpy_compare.check_all_types
+    def test_scoped_frame_names(self, T):
+        plant = MultibodyPlant_[T](time_step=0.01)
         GetScopedFrameByName(plant, "world")
         GetScopedFrameByNameMaybe(plant, "world")
 

--- a/multibody/parsing/scoped_names.cc
+++ b/multibody/parsing/scoped_names.cc
@@ -1,13 +1,15 @@
 #include "drake/multibody/parsing/scoped_names.h"
 
+#include "drake/common/default_scalars.h"
 #include "drake/multibody/tree/scoped_name.h"
 
 namespace drake {
 namespace multibody {
 namespace parsing {
 
-const drake::multibody::Frame<double>* GetScopedFrameByNameMaybe(
-    const drake::multibody::MultibodyPlant<double>& plant,
+template <typename T>
+const drake::multibody::Frame<T>* GetScopedFrameByNameMaybe(
+    const drake::multibody::MultibodyPlant<T>& plant,
     const std::string& full_name) {
   if (full_name == "world") {
     return &plant.world_frame();
@@ -26,8 +28,9 @@ const drake::multibody::Frame<double>* GetScopedFrameByNameMaybe(
   return nullptr;
 }
 
-const drake::multibody::Frame<double>& GetScopedFrameByName(
-    const drake::multibody::MultibodyPlant<double>& plant,
+template <typename T>
+const drake::multibody::Frame<T>& GetScopedFrameByName(
+    const drake::multibody::MultibodyPlant<T>& plant,
     const std::string& full_name) {
   if (full_name == "world") {
     return plant.world_frame();
@@ -40,6 +43,13 @@ const drake::multibody::Frame<double>& GetScopedFrameByName(
     return plant.GetFrameByName(scoped_name.get_element());
   }
 }
+
+// clang-format off
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &GetScopedFrameByNameMaybe<T>,
+    &GetScopedFrameByName<T>
+));
+// clang-format on
 
 }  // namespace parsing
 }  // namespace multibody

--- a/multibody/parsing/scoped_names.h
+++ b/multibody/parsing/scoped_names.h
@@ -12,14 +12,20 @@ namespace parsing {
 ///
 /// Returns `nullptr` if the frame is not found, as well as all the error
 /// cases of `MultibodyPlant::HasFrameByName(std::string)`.
-const drake::multibody::Frame<double>* GetScopedFrameByNameMaybe(
-    const drake::multibody::MultibodyPlant<double>& plant,
+///
+/// @tparam_default_scalar
+template <typename T>
+const drake::multibody::Frame<T>* GetScopedFrameByNameMaybe(
+    const drake::multibody::MultibodyPlant<T>& plant,
     const std::string& full_name);
 
 /// Equivalent to `GetScopedFrameByNameMaybe`, but throws if the frame
 /// is not found.
-const drake::multibody::Frame<double>& GetScopedFrameByName(
-    const drake::multibody::MultibodyPlant<double>& plant,
+///
+/// @tparam_default_scalar
+template <typename T>
+const drake::multibody::Frame<T>& GetScopedFrameByName(
+    const drake::multibody::MultibodyPlant<T>& plant,
     const std::string& full_name);
 
 }  // namespace parsing

--- a/multibody/parsing/test/scoped_names_test.cc
+++ b/multibody/parsing/test/scoped_names_test.cc
@@ -52,6 +52,18 @@ GTEST_TEST(ScopedNamesTest, GetScopedFrameByName) {
       ".*no.*bar_model.*instances are.*scoped_names_model.*");
 }
 
+GTEST_TEST(ScopedNamesTest, AutoDiffXd) {
+  MultibodyPlant<AutoDiffXd> plant(0.0);
+  EXPECT_NO_THROW(GetScopedFrameByName(plant, "world"));
+  EXPECT_NO_THROW(GetScopedFrameByNameMaybe(plant, "world"));
+}
+
+GTEST_TEST(ScopedNamesTest, Expression) {
+  MultibodyPlant<symbolic::Expression> plant(0.0);
+  EXPECT_NO_THROW(GetScopedFrameByName(plant, "world"));
+  EXPECT_NO_THROW(GetScopedFrameByNameMaybe(plant, "world"));
+}
+
 }  // namespace
 }  // namespace parsing
 }  // namespace multibody

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2085,7 +2085,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// See documentation of geometry::SceneGraphInspector on where to get an
   /// inspector.
   ///
-  /// <h4> %MultibodyPlant names vs. SceneGraph names
+  /// <h4>%MultibodyPlant names vs. SceneGraph names</h4>
   ///
   /// In %MultibodyPlant, frame names only have to be unique in a single
   /// model instance. However, SceneGraph knows nothing of model instances. So,


### PR DESCRIPTION
Closes #22590

Also fix related docs markup (closes #22622).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22644)
<!-- Reviewable:end -->
