### PR TITLE
[multibody] MakeMobilizerForJoint() can now create Frames

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3897,8 +3897,8 @@ void MultibodyPlant<T>::CalcReactionForces(
   // for the discrete solvers we have today, though it might change for future
   // solvers that prefer an implicit evaluation of these terms.
   // TODO(amcastro-tri): Consider having a
-  // DiscreteUpdateManager::EvalReactionForces() to ensure the manager performs
-  // this computation consistently with its discrete update.
+  //  DiscreteUpdateManager::EvalReactionForces() to ensure the manager performs
+  //  this computation consistently with its discrete update.
   const VectorX<T>& vdot = this->EvalForwardDynamics(context).get_vdot();
   std::vector<SpatialAcceleration<T>> A_WB_vector(num_bodies());
   std::vector<SpatialForce<T>> F_BMo_W_vector(num_bodies());
@@ -3910,9 +3910,9 @@ void MultibodyPlant<T>::CalcReactionForces(
   // Since vdot is the result of Fapplied and tau_applied we expect the result
   // from inverse dynamics to be zero.
   // TODO(amcastro-tri): find a better estimation for this bound. For instance,
-  // we can make an estimation based on the trace of the mass matrix (Jain 2011,
-  // Eq. 4.21). For now we only ASSERT though with a better estimation we could
-  // promote this to a DEMAND.
+  //  we can make an estimation based on the trace of the mass matrix (Jain
+  //  2011, Eq. 4.21). For now we only ASSERT though with a better estimation we
+  //  could promote this to a DEMAND.
   // TODO(amcastro-tri) Uncomment this line once issue #12473 is resolved.
   // DRAKE_ASSERT(tau_id.norm() <
   //              100 * num_velocities() *
@@ -3926,61 +3926,49 @@ void MultibodyPlant<T>::CalcReactionForces(
         internal_tree().get_joint_mobilizer(joint_index);
     const internal::Mobilizer<T>& mobilizer =
         internal_tree().get_mobilizer(mobilizer_index);
-    const internal::MobodIndex mobod_index = mobilizer.mobod().index();
+
+    // Reversed means the joint's parent(child) body is the outboard(inboard)
+    // body for the mobilizer.
+    const bool is_reversed = mobilizer.mobod().is_reversed();
 
     // F_BMo_W is the mobilizer reaction force on mobilized body B at the origin
     // Mo of the mobilizer's outboard frame M, expressed in the world frame W.
-    const SpatialForce<T>& F_BMo_W = F_BMo_W_vector[mobod_index];
+    const SpatialForce<T>& F_BMo_W = F_BMo_W_vector[mobilizer_index];
+
+    // But the quantity of interest, F_CJc_Jc, is the joint's reaction force on
+    // the joint's child body C at the joint's child frame Jc, expressed in Jc.
+    SpatialForce<T>& F_CJc_Jc = output->at(joint.ordinal());
 
     // Frames of interest:
-    const Frame<T>& frame_Jp = joint.frame_on_parent();
     const Frame<T>& frame_Jc = joint.frame_on_child();
-    const FrameIndex F_index = mobilizer.inboard_frame().index();
-    const FrameIndex M_index = mobilizer.outboard_frame().index();
-    const FrameIndex Jp_index = frame_Jp.index();
-    const FrameIndex Jc_index = frame_Jc.index();
-
-    // In Drake we must have either:
-    //  - Jp == F and Jc == M (typical case)
-    //  - Jp == M and Jc == F (mobilizer is reversed from joint)
-    DRAKE_DEMAND((Jp_index == F_index && Jc_index == M_index) ||
-                 (Jp_index == M_index && Jc_index == F_index));
-
-    // Mobilizer is reversed if the joint's parent frame Jp is the mobilizer's
-    // outboard frame M.
-    const bool is_reversed = (Jp_index == M_index);
+    const Frame<T>& frame_M = mobilizer.outboard_frame();
 
     // We'll need this in both cases below since we're required to report
     // the reaction force expressed in the joint's child frame Jc.
     const RotationMatrix<T> R_JcW =
         frame_Jc.CalcRotationMatrixInWorld(context).inverse();
 
-    // The quantity of interest, F_CJc_Jc, is the joint's reaction force on the
-    // joint's child body C at the joint's child frame Jc, expressed in Jc.
-    SpatialForce<T>& F_CJc_Jc = output->at(joint.ordinal());
-    if (!is_reversed) {
-      F_CJc_Jc = R_JcW * F_BMo_W;  // The typical case: Mo==Jc and B==C.
-    } else {
-      // For this reversed case, F_BMo_W is the reaction on the joint's _parent_
-      // body at Jp, expressed in W.
-      const SpatialForce<T>& F_PJp_W = F_BMo_W;  // Reversed: Mo==Jp and B==P.
-
-      // Newton's 3ʳᵈ law (action/reaction) (and knowing Drake's joints are
-      // massless) says the force on the child _at Jp_ is equal and opposite to
-      // the force on the parent at Jp.
-      const SpatialForce<T> F_CJp_W = -F_PJp_W;
-      const SpatialForce<T> F_CJp_Jc = R_JcW * F_CJp_W;  // Reexpress in Jc.
-
-      // However, the reaction force we want to report on the child is at Jc,
-      // not Jp. We need to shift the application point from Jp to Jc.
-
-      // Find the shift vector p_JpJc_Jc (= -p_JcJp_Jc).
-      const RigidTransform<T> X_JcJp = frame_Jp.CalcPose(context, frame_Jc);
-      const Vector3<T> p_JpJc_Jc = -X_JcJp.translation();
-
-      // Perform  the Jp->Jc shift.
-      F_CJc_Jc = F_CJp_Jc.Shift(p_JpJc_Jc);
+    if (&frame_M == &frame_Jc) {
+      // This is the easy case. Just need to re-express.
+      F_CJc_Jc = R_JcW * F_BMo_W;
+      continue;
     }
+
+    // If the mobilizer is reversed, Newton's 3ʳᵈ law (action/reaction) (and
+    // knowing Drake's joints are massless) says the force on the child at M
+    // is equal and opposite to the force on the parent at M.
+    const SpatialForce<T> F_CMo_W = is_reversed ? -F_BMo_W : F_BMo_W;
+    const SpatialForce<T> F_CMo_Jc = R_JcW * F_CMo_W;  // Reexpress in Jc.
+
+    // However, the reaction force we want to report on the child is at Jc,
+    // not M. We need to shift the application point from Mo to Jco.
+
+    // Find the shift vector p_MoJco_Jc (= -p_JcoMo_Jc).
+    const RigidTransform<T> X_JcM = frame_M.CalcPose(context, frame_Jc);
+    const Vector3<T> p_MoJco_Jc = -X_JcM.translation();
+
+    // Perform  the M->Jc shift.
+    F_CJc_Jc = F_CMo_Jc.Shift(p_MoJco_Jc);
   }
 }
 

--- a/multibody/plant/test/sap_driver_multidof_joints_test.cc
+++ b/multibody/plant/test/sap_driver_multidof_joints_test.cc
@@ -92,13 +92,15 @@ class MultiDofJointWithLimits final : public Joint<T> {
   int do_get_position_start() const override { return 0; }
 
   std::unique_ptr<Mobilizer<T>> MakeMobilizerForJoint(
-      const SpanningForest::Mobod& mobod) const override {
+      const SpanningForest::Mobod& mobod,
+      MultibodyTree<T>* tree) const override {
+    DRAKE_DEMAND(tree != nullptr);  // Just a sanity check; we don't need it.
     const auto [inboard_frame, outboard_frame] =
         this->tree_frames(mobod.is_reversed());
     // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
-    // The only restriction here relevant for these tests is that we provide a
-    // mobilizer with kNumDofs positions and velocities, so that indexes are
-    // consistent during MultibodyPlant::Finalize().
+    //  The only restriction here relevant for these tests is that we provide a
+    //  mobilizer with kNumDofs positions and velocities, so that indexes are
+    //  consistent during MultibodyPlant::Finalize().
     auto revolute_mobilizer = std::make_unique<internal::RpyBallMobilizer<T>>(
         mobod, *inboard_frame, *outboard_frame);
     return revolute_mobilizer;

--- a/multibody/rational/rational_forward_kinematics.cc
+++ b/multibody/rational/rational_forward_kinematics.cc
@@ -179,10 +179,11 @@ RationalForwardKinematics::Pose<T> RationalForwardKinematics::
 template <typename T>
 RationalForwardKinematics::Pose<T>
 RationalForwardKinematics::CalcWeldJointChildBodyPose(
-    const math::RigidTransformd& X_FM, const math::RigidTransformd& X_PF,
-    const math::RigidTransformd& X_MC, const Pose<T>& X_AP) const {
-  const Matrix3<double> R_FM = X_FM.rotation().matrix();
-  const Vector3<double> p_FM = X_FM.translation();
+    const math::RigidTransformd& X_PF, const math::RigidTransformd& X_MC,
+    const Pose<T>& X_AP) const {
+  // X_FM is always identity for a Weld mobilizer.
+  const Matrix3<double> R_FM = Matrix3<double>::Identity();
+  const Vector3<double> p_FM = Vector3<double>::Zero();
   const Matrix3<T>& R_AP = X_AP.rotation;
   const Vector3<T>& p_AP = X_AP.position;
   return CalcChildPose(R_AP, p_AP, X_PF, X_MC, R_FM, p_FM);
@@ -287,17 +288,9 @@ RationalForwardKinematics::CalcChildBodyPoseAsMultilinearPolynomial(
     return CalcPrismaticJointChildLinkPose(axis_F, X_PF, X_MC, X_AP,
                                            q_star(s_index), s_[s_index]);
   } else if (IsWeld(*mobilizer)) {
-    const internal::WeldMobilizer<double>* weld_mobilizer =
-        static_cast<const internal::WeldMobilizer<double>*>(mobilizer);
-    math::RigidTransformd X_FM;
-    if (!is_order_reversed) {
-      X_FM = weld_mobilizer->get_X_FM();
-    } else {
-      X_FM = weld_mobilizer->get_X_FM().inverse();
-    }
-    return CalcWeldJointChildBodyPose(X_FM, X_PF, X_MC, X_AP);
+    return CalcWeldJointChildBodyPose(X_PF, X_MC, X_AP);
   }
-  // Successful construction guarantess that all supported mobilizers are
+  // Successful construction guarantees that all supported mobilizers are
   // handled.
   DRAKE_UNREACHABLE();
 }

--- a/multibody/rational/rational_forward_kinematics.h
+++ b/multibody/rational/rational_forward_kinematics.h
@@ -233,8 +233,7 @@ class RationalForwardKinematics {
   // Computes the pose of the body, connected to its parent body through a
   // weld joint.
   template <typename T>
-  Pose<T> CalcWeldJointChildBodyPose(const math::RigidTransformd& X_FM,
-                                     const math::RigidTransformd& X_PF,
+  Pose<T> CalcWeldJointChildBodyPose(const math::RigidTransformd& X_PF,
                                      const math::RigidTransformd& X_MC,
                                      const Pose<T>& X_AP) const;
 

--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -71,7 +71,8 @@ std::unique_ptr<Joint<T>> BallRpyJoint<T>::DoShallowClone() const {
 // in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> BallRpyJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod) const {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>*) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -71,9 +71,9 @@ class BallRpyJoint final : public Joint<T> {
     DRAKE_THROW_UNLESS(damping >= 0);
   }
 
-  ~BallRpyJoint() override;
+  ~BallRpyJoint() final;
 
-  const std::string& type_name() const override;
+  const std::string& type_name() const final;
 
   /// Returns `this` joint's default damping constant in N⋅m⋅s. The damping
   /// torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with
@@ -191,7 +191,7 @@ class BallRpyJoint final : public Joint<T> {
   /// Adding forces per-dof makes no physical sense. Therefore, this method
   /// throws an exception if invoked.
   void DoAddInOneForce(const systems::Context<T>&, int, const T&,
-                       MultibodyForces<T>*) const override {
+                       MultibodyForces<T>*) const final {
     throw std::logic_error(
         "Ball RPY joints do not allow applying forces to individual degrees of "
         "freedom.");
@@ -203,7 +203,7 @@ class BallRpyJoint final : public Joint<T> {
   /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
   /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const override {
+                      MultibodyForces<T>* forces) const final {
     Eigen::Ref<VectorX<T>> t_BMo_F =
         get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
@@ -212,28 +212,28 @@ class BallRpyJoint final : public Joint<T> {
   }
 
  private:
-  int do_get_velocity_start() const override {
+  int do_get_velocity_start() const final {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 3; }
+  int do_get_num_velocities() const final { return 3; }
 
-  int do_get_position_start() const override {
+  int do_get_position_start() const final {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 3; }
+  int do_get_num_positions() const final { return 3; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) override {
+      const VectorX<double>& default_positions) final {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
@@ -241,18 +241,19 @@ class BallRpyJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const override;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const override;
+      const internal::MultibodyTree<double>& tree_clone) const final;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const override;
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
 
   // Make BallRpyJoint templated on every other scalar type a friend of
   // BallRpyJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/curvilinear_joint.cc
+++ b/multibody/tree/curvilinear_joint.cc
@@ -101,7 +101,8 @@ std::unique_ptr<Joint<T>> CurvilinearJoint<T>::DoShallowClone() const {
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>>
 CurvilinearJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod) const {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>*) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/curvilinear_joint.h
+++ b/multibody/tree/curvilinear_joint.h
@@ -121,9 +121,9 @@ class CurvilinearJoint final : public Joint<T> {
           curvilinear_path,
       double pos_lower_limit, double pos_upper_limit, double damping = 0);
 
-  ~CurvilinearJoint() override;
+  ~CurvilinearJoint() final;
 
-  const std::string& type_name() const override;
+  const std::string& type_name() const final;
 
   /** Returns `this` joint's default damping constant in N⋅s/m. */
   double default_damping() const { return this->default_damping_vector()[0]; }
@@ -269,7 +269,7 @@ class CurvilinearJoint final : public Joint<T> {
    @see The public NVI AddInOneForce() for details. */
   void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
                        const T& joint_tau,
-                       MultibodyForces<T>* forces) const override {
+                       MultibodyForces<T>* forces) const final {
     DRAKE_DEMAND(joint_dof == 0);
     Eigen::Ref<VectorX<T>> tau_mob =
         get_mobilizer().get_mutable_generalized_forces_from_array(
@@ -288,62 +288,63 @@ class CurvilinearJoint final : public Joint<T> {
    @param[out] forces The MultibodyForces object to which the damping force is
    added. */
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const override {
+                      MultibodyForces<T>* forces) const final {
     const T damping_force =
         -this->GetDamping(context) * get_tangential_velocity(context);
     AddInForce(context, damping_force, forces);
   }
 
  private:
-  int do_get_velocity_start() const override {
+  int do_get_velocity_start() const final {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 1; }
+  int do_get_num_velocities() const final { return 1; }
 
-  int do_get_position_start() const override {
+  int do_get_position_start() const final {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 1; }
+  int do_get_num_positions() const final { return 1; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) override {
+      const VectorX<double>& default_positions) final {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
-  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
+  const T& DoGetOnePosition(const systems::Context<T>& context) const final {
     return get_distance(context);
   }
 
-  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const final {
     return get_tangential_velocity(context);
   }
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const override;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const override;
+      const internal::MultibodyTree<double>& tree_clone) const final;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const override;
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
 
   // Make CurvilinearJoint templated on every other scalar type a friend of
   // CurvilinearJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/joint.cc
+++ b/multibody/tree/joint.cc
@@ -73,9 +73,11 @@ Eigen::Ref<const VectorX<T>> Joint<T>::GetVelocities(
 
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> Joint<T>::Build(
-    const internal::SpanningForest::Mobod& mobod) {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>* tree) {
+  DRAKE_DEMAND(tree != nullptr);
   std::unique_ptr<internal::Mobilizer<T>> owned_mobilizer =
-      MakeMobilizerForJoint(mobod);
+      MakeMobilizerForJoint(mobod, tree);
   mobilizer_ = owned_mobilizer.get();
   return owned_mobilizer;
 }

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -99,8 +99,8 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
   // to this tree. This is a pathological case, but in theory nothing
   // (but this test) stops a user from adding frames to a tree1 and attempting
   // later to define mobilizers between those frames in a second tree2.
-  mobilizer->inboard_frame().HasThisParentTreeOrThrow(this);
-  mobilizer->outboard_frame().HasThisParentTreeOrThrow(this);
+  mobilizer->inboard_frame().HasThisParentTreeOrThrow(this);   // F frame
+  mobilizer->outboard_frame().HasThisParentTreeOrThrow(this);  // M frame
   MobodIndex mobilizer_index = topology_.add_mobilizer(
       mobilizer->mobod(), mobilizer->inboard_frame().index(),
       mobilizer->outboard_frame().index());
@@ -239,9 +239,9 @@ template <typename T>
 template <template <typename> class JointType, typename... Args>
 const JointType<T>& MultibodyTree<T>::AddJoint(
     const std::string& name, const RigidBody<T>& parent,
-    const std::optional<math::RigidTransform<double>>& X_PF,
+    const std::optional<math::RigidTransform<double>>& X_PJp,
     const RigidBody<T>& child,
-    const std::optional<math::RigidTransform<double>>& X_BM, Args&&... args) {
+    const std::optional<math::RigidTransform<double>>& X_CJc, Args&&... args) {
   static_assert(std::is_base_of_v<Joint<T>, JointType<T>>,
                 "JointType<T> must be a sub-class of Joint<T>.");
 
@@ -259,9 +259,9 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
   // model instance when creating any offset frames needed for the joint.
   const ModelInstanceIndex joint_instance = child.model_instance();
   const Frame<T>& frame_on_parent =
-      this->AddOrGetJointFrame(parent, X_PF, joint_instance, name, "parent");
+      this->AddOrGetJointFrame(parent, X_PJp, joint_instance, name, "parent");
   const Frame<T>& frame_on_child =
-      this->AddOrGetJointFrame(child, X_BM, joint_instance, name, "child");
+      this->AddOrGetJointFrame(child, X_CJc, joint_instance, name, "child");
   const JointType<T>& result = AddJoint(std::make_unique<JointType<T>>(
       name, frame_on_parent, frame_on_child, std::forward<Args>(args)...));
   DRAKE_DEMAND(result.model_instance() == joint_instance);

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -758,7 +758,7 @@ void MultibodyTree<T>::CreateJointImplementations() {
       // Mobods, BodyNodes, and Mobilizers have identical numbering.
       topology_.add_world_mobilizer(mobod, world_body().body_frame().index());
       auto dummy_weld = std::make_unique<internal::WeldMobilizer<T>>(
-          mobod, world_frame(), world_frame(), RigidTransform<double>());
+          mobod, world_frame(), world_frame());
       dummy_weld->set_model_instance(world_model_instance());
       dummy_weld->set_parent_tree(this, MobodIndex(0));
       mobilizers_.push_back(std::move(dummy_weld));
@@ -783,7 +783,7 @@ void MultibodyTree<T>::CreateJointImplementations() {
           GetModelInstanceName(joint.model_instance())));
     }
 
-    std::unique_ptr<Mobilizer<T>> owned_mobilizer = joint.Build(mobod);
+    std::unique_ptr<Mobilizer<T>> owned_mobilizer = joint.Build(mobod, this);
     Mobilizer<T>* mobilizer = owned_mobilizer.get();
     AddMobilizer(std::move(owned_mobilizer));  // ownership->tree
     mobilizer->set_model_instance(joint.model_instance());

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -387,10 +387,13 @@ class MultibodyTree {
   // _parent_ body is made inboard and the _child_ outboard in the tree.
   //
   // As explained in the Joint class's documentation, in Drake we define a
-  // frame F attached to the parent body P with pose `X_PF` and a frame M
-  // attached to the child body B with pose `X_BM`. This method helps create
-  // a joint between two bodies with fixed poses `X_PF` and `X_BM`.
-  // Refer to the Joint class's documentation for more details.
+  // frame Jp attached to the parent body P with pose `X_PJp` and a frame Jc
+  // attached to the child body C with pose `X_CJc`. This method helps create
+  // a joint between two bodies with fixed poses `X_PJp` and `X_CJc`.
+  // Refer to the Joint class's documentation for more details. (We have
+  // sometimes used F for Jp and M for Jc in documentation; don't confuse
+  // those with the implementing Mobilizer's inboard F frame and outboard M
+  // frame which in general are not the same.)
   //
   // The arguments to this method `args` are forwarded to `JointType`'s
   // constructor. The newly created `JointType` object will be specialized on
@@ -400,43 +403,45 @@ class MultibodyTree {
   //   The name of the joint.
   // @param[in] parent
   //   The parent body connected by the new joint.
-  // @param[in] X_PF
-  //   The fixed pose of frame F attached to the parent body, measured in
-  //   the frame P of that body. `X_PF` is an optional parameter; empty curly
-  //   braces `{}` imply that frame F **is** the same body frame P. If instead
-  //   your intention is to make a frame F with pose `X_PF`, provide
-  //   `RigidTransform<double>::Identity()` as your input.
+  // @param[in] X_PJp
+  //   The fixed pose of frame Jp attached to the parent body, measured in
+  //   the frame P of that body. X_PJp is an optional parameter; empty curly
+  //   braces {} imply that frame Jp **is** the same body frame P. If instead
+  //   your intention is to make a separate frame Jp that is coincident
+  //   (by default at least) with P, provide
+  //   X_PJp = RigidTransform<double>::Identity() as your input.
   // @param[in] child
   //   The child body connected by the new joint.
-  // @param[in] X_BM
-  //   The fixed pose of frame M attached to the child body, measured in
-  //   the frame B of that body. `X_BM` is an optional parameter; empty curly
-  //   braces `{}` imply that frame M **is** the same body frame B. If instead
-  //   your intention is to make a frame F with pose `X_PF`, provide
-  //   `RigidTransform<double>::Identity()` as your input.
+  // @param[in] X_CJc
+  //   The fixed pose of frame Jc attached to the child body, measured in
+  //   the frame C of that body. X_CJc is an optional parameter; empty curly
+  //   braces {} imply that frame Jc **is** the same body frame C. If instead
+  //   your intention is to make a separate frame Jc that is coincident
+  //   (by default at least) with C, provide
+  //   X_CJc = RigidTransform<double>::Identity() as your input.
   // @tparam JointType
   //   The type of the new joint to add, which must be a subclass of Joint<T>.
-  // @returns A constant reference to the new joint just added, of type
-  //   `JointType<T>` specialized on the scalar type T of `this`
+  // @returns A const reference to the new joint just added, of type
+  //   JointType<T> specialized on the scalar type T of `this`
   //   %MultibodyTree. It will remain valid for the lifetime of `this`
   //   %MultibodyTree.
   //
   // Example of usage:
   // @code
   //   MultibodyTree<T> model;
-  //   // ... Code to define a parent body P and a child body B.
+  //   // ... Code to define a parent body P and a child body C.
   //   const RigidBody<double>& parent_body =
   //     model.AddRigidBody(parent_name, SpatialInertia<double>(...));
   //   const RigidBody<double>& child_body =
   //     model.AddRigidBody(child_name, SpatialInertia<double>(...));
-  //   // Define the pose X_BM of a frame M rigidly attached to child body B.
+  //   // Define the pose X_CJc of a frame Jc rigidly attached to child body C.
   //   const RevoluteJoint<double>& elbow =
   //     model.AddJoint<RevoluteJoint>(
   //       "Elbow",                /* joint name */
   //       model.world_body(),     /* parent body */
-  //       {},                     /* frame F IS the parent body frame P */
+  //       {},                     /* frame Jp IS the parent body frame P */
   //       pendulum,               /* child body, the pendulum */
-  //       X_BM,                   /* pose of frame M in the body frame B */
+  //       X_CJc,                  /* pose of frame Jc in child body frame C */
   //       Vector3d::UnitZ());     /* revolute axis in this case */
   // @endcode
   //
@@ -449,17 +454,16 @@ class MultibodyTree {
   template <template <typename> class JointType, typename... Args>
   const JointType<T>& AddJoint(
       const std::string& name, const RigidBody<T>& parent,
-      const std::optional<math::RigidTransform<double>>& X_PF,
+      const std::optional<math::RigidTransform<double>>& X_PJp,
       const RigidBody<T>& child,
-      const std::optional<math::RigidTransform<double>>& X_BM, Args&&... args);
+      const std::optional<math::RigidTransform<double>>& X_CJc, Args&&... args);
 
   // See MultibodyPlant documentation.
   void RemoveJoint(const Joint<T>& joint);
 
   // Creates and adds a JointActuator model for an actuator acting on a given
-  // `joint`.
-  // This method returns a constant reference to the actuator just added, which
-  // will remain valid for the lifetime of `this` %MultibodyTree.
+  // `joint`. This method returns a const reference to the actuator just added,
+  // which will remain valid for the lifetime of `this` %MultibodyTree.
   //
   // @param[in] name
   //   A string that identifies the new actuator to be added to `this`

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -70,7 +70,8 @@ std::unique_ptr<Joint<T>> PlanarJoint<T>::DoShallowClone() const {
 // in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> PlanarJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod) const {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>*) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -305,11 +305,11 @@ class PlanarJoint final : public Joint<T> {
 
   int do_get_num_positions() const final { return 3; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
@@ -322,7 +322,8 @@ class PlanarJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const final;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -71,9 +71,9 @@ class PrismaticJoint final : public Joint<T> {
       double pos_upper_limit = std::numeric_limits<double>::infinity(),
       double damping = 0);
 
-  ~PrismaticJoint() override;
+  ~PrismaticJoint() final;
 
-  const std::string& type_name() const override;
+  const std::string& type_name() const final;
 
   /// Returns the axis of translation for `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
@@ -255,51 +255,52 @@ class PrismaticJoint final : public Joint<T> {
   /// viscous law `f = -d⋅v`, with d the damping coefficient (see
   /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const override {
+                      MultibodyForces<T>* forces) const final {
     const T damping_force =
         -this->GetDamping(context) * get_translation_rate(context);
     AddInForce(context, damping_force, forces);
   }
 
  private:
-  int do_get_velocity_start() const override {
+  int do_get_velocity_start() const final {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 1; }
+  int do_get_num_velocities() const final { return 1; }
 
-  int do_get_position_start() const override {
+  int do_get_position_start() const final {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 1; }
+  int do_get_num_positions() const final { return 1; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) override {
+      const VectorX<double>& default_positions) final {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
-  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
+  const T& DoGetOnePosition(const systems::Context<T>& context) const final {
     return get_translation(context);
   }
 
-  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const final {
     return get_translation_rate(context);
   }
 
   // Joint<T> finals:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const final {
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>*) const final {
     const auto [inboard_frame, outboard_frame] =
         this->tree_frames(mobod.is_reversed());
     // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/quaternion_floating_joint.cc
+++ b/multibody/tree/quaternion_floating_joint.cc
@@ -68,7 +68,8 @@ std::unique_ptr<Joint<T>> QuaternionFloatingJoint<T>::DoShallowClone() const {
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>>
 QuaternionFloatingJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod) const {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>*) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -97,10 +97,10 @@ class QuaternionFloatingJoint final : public Joint<T> {
     this->set_default_quaternion(Quaternion<double>::Identity());
   }
 
-  ~QuaternionFloatingJoint() override;
+  ~QuaternionFloatingJoint() final;
 
   /// Returns the name of this joint type: "quaternion_floating"
-  const std::string& type_name() const override {
+  const std::string& type_name() const final {
     static const never_destroyed<std::string> name{kTypeName};
     return name.access();
   }
@@ -361,7 +361,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// Adding forces per-dof makes no physical sense. Therefore, this method
   /// throws an exception if invoked.
   void DoAddInOneForce(const systems::Context<T>&, int, const T&,
-                       MultibodyForces<T>*) const override;
+                       MultibodyForces<T>*) const final;
 
   /// Joint<T> override called through public NVI, Joint::AddInDamping().
   /// Therefore arguments were already checked to be valid.
@@ -372,31 +372,31 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// dissipative torque according to the viscous law `τ = -d⋅ω`, with d the
   /// damping coefficient (see default_angular_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const override;
+                      MultibodyForces<T>* forces) const final;
 
  private:
-  int do_get_velocity_start() const override {
+  int do_get_velocity_start() const final {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 6; }
+  int do_get_num_velocities() const final { return 6; }
 
-  int do_get_position_start() const override {
+  int do_get_position_start() const final {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 7; }
+  int do_get_num_positions() const final { return 7; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) override {
+      const VectorX<double>& default_positions) final {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
@@ -418,18 +418,19 @@ class QuaternionFloatingJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const override;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const override;
+      const internal::MultibodyTree<double>& tree_clone) const final;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const override;
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
 
   // Make QuaternionFloatingJoint templated on every other scalar type a friend
   // of QuaternionFloatingJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -97,12 +97,10 @@ std::unique_ptr<Joint<T>> RevoluteJoint<T>::DoShallowClone() const {
       this->position_upper_limit(), this->default_damping());
 }
 
-// N.B. Due to esoteric linking errors on Mac (see #9345) involving
-// `MobilizerImpl`, we must place this implementation in the source file, not
-// in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> RevoluteJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod) const {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>*) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -104,9 +104,9 @@ class RevoluteJoint final : public Joint<T> {
                 double pos_lower_limit, double pos_upper_limit,
                 double damping = 0);
 
-  ~RevoluteJoint() override;
+  ~RevoluteJoint() final;
 
-  const std::string& type_name() const override;
+  const std::string& type_name() const final;
 
   /// Returns the axis of revolution of `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
@@ -271,7 +271,7 @@ class RevoluteJoint final : public Joint<T> {
   /// around the joint's axis.
   void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
                        const T& joint_tau,
-                       MultibodyForces<T>* forces) const override {
+                       MultibodyForces<T>* forces) const final {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
     DRAKE_DEMAND(joint_dof == 0);
@@ -287,62 +287,63 @@ class RevoluteJoint final : public Joint<T> {
   /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
   /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const override {
+                      MultibodyForces<T>* forces) const final {
     const T damping_torque =
         -this->GetDamping(context) * get_angular_rate(context);
     AddInTorque(context, damping_torque, forces);
   }
 
  private:
-  int do_get_velocity_start() const override {
+  int do_get_velocity_start() const final {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 1; }
+  int do_get_num_velocities() const final { return 1; }
 
-  int do_get_position_start() const override {
+  int do_get_position_start() const final {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 1; }
+  int do_get_num_positions() const final { return 1; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) override {
+      const VectorX<double>& default_positions) final {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
-  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
+  const T& DoGetOnePosition(const systems::Context<T>& context) const final {
     return get_angle(context);
   }
 
-  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const final {
     return get_angular_rate(context);
   }
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const override;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const override;
+      const internal::MultibodyTree<double>& tree_clone) const final;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const override;
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
 
   // Make RevoluteJoint templated on every other scalar type a friend of
   // RevoluteJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/rpy_floating_joint.cc
+++ b/multibody/tree/rpy_floating_joint.cc
@@ -73,7 +73,8 @@ std::unique_ptr<Joint<T>> RpyFloatingJoint<T>::DoShallowClone() const {
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>>
 RpyFloatingJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod) const {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>*) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -428,7 +428,8 @@ class RpyFloatingJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const final;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -101,7 +101,8 @@ std::unique_ptr<Joint<T>> ScrewJoint<T>::DoShallowClone() const {
 // in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> ScrewJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod) const {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>*) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -325,11 +325,11 @@ class ScrewJoint final : public Joint<T> {
 
   int do_get_num_positions() const final { return 1; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
@@ -340,17 +340,18 @@ class ScrewJoint final : public Joint<T> {
     }
   }
 
-  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
+  const T& DoGetOnePosition(const systems::Context<T>& context) const final {
     return get_rotation(context);
   }
 
-  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const final {
     return get_angular_velocity(context);
   }
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const final;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -71,7 +71,8 @@ std::unique_ptr<Joint<T>> UniversalJoint<T>::DoShallowClone() const {
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>>
 UniversalJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod) const {
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>*) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -87,9 +87,9 @@ class UniversalJoint final : public Joint<T> {
     DRAKE_THROW_UNLESS(damping >= 0);
   }
 
-  ~UniversalJoint() override;
+  ~UniversalJoint() final;
 
-  const std::string& type_name() const override;
+  const std::string& type_name() const final;
 
   /// Returns `this` joint's default damping constant in N⋅m⋅s. The damping
   /// torque (in N⋅m) is modeled as `τᵢ = -damping⋅ωᵢ, i = 1, 2` i.e. opposing
@@ -189,7 +189,7 @@ class UniversalJoint final : public Joint<T> {
   /// acceleration (of the child body frame).
   void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
                        const T& joint_tau,
-                       MultibodyForces<T>* forces) const override {
+                       MultibodyForces<T>* forces) const final {
     DRAKE_DEMAND(joint_dof < 2);
     Eigen::Ref<VectorX<T>> tau_mob =
         get_mobilizer().get_mutable_generalized_forces_from_array(
@@ -203,7 +203,7 @@ class UniversalJoint final : public Joint<T> {
   /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
   /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const override {
+                      MultibodyForces<T>* forces) const final {
     Eigen::Ref<VectorX<T>> tau =
         get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
@@ -212,28 +212,28 @@ class UniversalJoint final : public Joint<T> {
   }
 
  private:
-  int do_get_velocity_start() const override {
+  int do_get_velocity_start() const final {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 2; }
+  int do_get_num_velocities() const final { return 2; }
 
-  int do_get_position_start() const override {
+  int do_get_position_start() const final {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 2; }
+  int do_get_num_positions() const final { return 2; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) override {
+      const VectorX<double>& default_positions) final {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
@@ -241,18 +241,19 @@ class UniversalJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const override;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const override;
+      const internal::MultibodyTree<double>& tree_clone) const final;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const override;
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
 
   // Make UniversalJoint templated on every other scalar type a friend of
   // UniversalJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -50,9 +50,9 @@ class WeldJoint final : public Joint<T> {
                  VectorX<double>() /* no acc upper limits */),
         X_JpJc_(X_FM) {}
 
-  ~WeldJoint() override;
+  ~WeldJoint() final;
 
-  const std::string& type_name() const override;
+  const std::string& type_name() const final;
 
   // See note above. We're returning X_JpJc here.
   /// Returns the pose X_FM of frame M in F.
@@ -64,53 +64,54 @@ class WeldJoint final : public Joint<T> {
   /// apply forces between them. Therefore this method throws an exception if
   /// invoked.
   void DoAddInOneForce(const systems::Context<T>&, int, const T&,
-                       MultibodyForces<T>*) const override {
+                       MultibodyForces<T>*) const final {
     throw std::logic_error("Weld joints do not allow applying forces.");
   }
 
  private:
-  int do_get_velocity_start() const override {
+  int do_get_velocity_start() const final {
     // Since WeldJoint has no state, the start index has no meaning. However,
     // we let its decide the return value for this case (this has to do with
     // allowing zero sized Eigen blocks).
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 0; }
+  int do_get_num_velocities() const final { return 0; }
 
-  int do_get_position_start() const override {
+  int do_get_position_start() const final {
     // Since WeldJoint has no state, the start index has no meaning. However,
     // we let it decide the return value for this case (this has to do with
     // allowing zero sized Eigen blocks).
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 0; }
+  int do_get_num_positions() const final { return 0; }
 
-  std::string do_get_position_suffix(int index) const override {
+  std::string do_get_position_suffix(int index) const final {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const override {
+  std::string do_get_velocity_suffix(int index) const final {
     return get_mobilizer().velocity_suffix(index);
   }
 
-  void do_set_default_positions(const VectorX<double>&) override { return; }
+  void do_set_default_positions(const VectorX<double>&) final { return; }
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod) const override;
+      const internal::SpanningForest::Mobod& mobod,
+      internal::MultibodyTree<T>* tree) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const override;
+      const internal::MultibodyTree<double>& tree_clone) const final;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>& x) const override;
+      const internal::MultibodyTree<symbolic::Expression>& x) const final;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const override;
+  std::unique_ptr<Joint<T>> DoShallowClone() const final;
 
   // Make WeldJoint templated on every other scalar type a friend of
   // WeldJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -23,7 +23,7 @@ std::unique_ptr<internal::BodyNode<T>> WeldMobilizer<T>::CreateBodyNode(
 template <typename T>
 math::RigidTransform<T> WeldMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>&) const {
-  return X_FM_.cast<T>();
+  return math::RigidTransform<T>();  // Identity
 }
 
 template <typename T>
@@ -81,7 +81,7 @@ std::unique_ptr<Mobilizer<ToScalar>> WeldMobilizer<T>::TemplatedDoCloneToScalar(
       tree_clone.get_variant(this->outboard_frame());
   return std::make_unique<WeldMobilizer<ToScalar>>(
       tree_clone.get_mobod(this->mobod().index()), inboard_frame_clone,
-      outboard_frame_clone, this->get_X_FM());
+      outboard_frame_clone);
 }
 
 template <typename T>

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -16,8 +16,8 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// This mobilizer fixes the relative pose `X_FM` of an outboard frame M in an
-// inboard frame F as if "welding" them together at this fixed relative pose.
+// This mobilizer fixes the relative pose of an outboard frame M to be
+// coincident with an inboard frame F as if "welding" them together.
 // Therefore, this mobilizer has no associated state with it.
 //
 // @tparam_default_scalar
@@ -35,13 +35,11 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   using HMatrix = typename MobilizerBase::template HMatrix<U>;
 
   // Constructor for a %WeldMobilizer between the `inboard_frame_F` and
-  // `outboard_frame_M`.
-  // @param[in] X_FM Pose of `outboard_frame_M` in the `inboard_frame_F`.
+  // `outboard_frame_M`. The frames will be held coincident forever.
   WeldMobilizer(const SpanningForest::Mobod& mobod,
                 const Frame<T>& inboard_frame_F,
-                const Frame<T>& outboard_frame_M,
-                const math::RigidTransform<double>& X_FM)
-      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M), X_FM_(X_FM) {}
+                const Frame<T>& outboard_frame_M)
+      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
 
   ~WeldMobilizer() final;
 
@@ -49,12 +47,16 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
       const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
 
-  // @retval X_FM The pose of the outboard frame M in the inboard frame F.
-  const math::RigidTransform<double>& get_X_FM() const { return X_FM_; }
+  // TODO(sherm1) Replace this method with operators like
+  //  compose_with_X_FM(X_WF) and apply_X_FM(v) so that we can take advantage
+  //  of the mobilizer's knowledge of its kinematic structure (part of
+  //  performance epic #18442).
 
   // Computes the across-mobilizer transform `X_FM`, which for this mobilizer
-  // is independent of the state stored in `context`.
-  math::RigidTransform<T> calc_X_FM(const T*) const { return X_FM_.cast<T>(); }
+  // is always the identity transform since F==M by construction.
+  math::RigidTransform<T> calc_X_FM(const T*) const {
+    return math::RigidTransform<T>();
+  }
 
   // Computes the across-mobilizer velocity V_FM which for this mobilizer is
   // always zero since the outboard frame M is fixed to the inboard frame F.
@@ -126,9 +128,6 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
       const MultibodyTree<ToScalar>& tree_clone) const;
-
-  // Pose of the outboard frame M in the inboard frame F.
-  math::RigidTransform<double> X_FM_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
Allows a joint to choose mobilizer F and M frames that are distinct from the joint's parent and child frames Jp and Jc. Demonstrates the capability by moving the Weld mobilizer F frame to be coincident with the M frame, even if Jp and Jc are not coincident, and strips the Weld mobilizer of its ability to model the F≠M case. Requires reaction force computation to understand whether Jc and M are the same because if not the reaction force must be shifted from the origin Mo of M to the origin Jco of Jc. Reverse welds must also be accommodated.

Existing tests in multibody_plant_test.cc already look at reaction forces for a variety of welds, reversed and with a general X_JpJc. New tests verify that we choose optimal F and M frames for Welds. 

This does _not_ include
- modifications to other mobilizer types
- changes to algorithms that permit taking advantage of the available speedup
- any of the M-frame work in #22253 (that is orthogonal to moving the frame around)

This is the first PR in a series leading to MultibodyPlant taking advantage of optimal mobilizer frame choice for faster kinematics.

### Notes for Release engineer
This is a change to the `protected` Joint API (added a parameter to pure virtual `MakeMobilizerForJoint()`). That only affects people who have written new Joint & Mobilizer types. If there are any non-Drake Joint extensions, they will need to add that parameter to the signature, although it can be ignored. Per our policy as stated in the Joint class header, the Joint `protected` API is subject to change without deprecation. However, we promise to note when changes have been made.

Resolves #22648

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22649)
<!-- Reviewable:end -->
