### PR TITLE
Add HessianType::kZero to QuadraticConstraint.

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -388,7 +388,9 @@ void BindEvaluatorsAndBindings(py::module m) {
           QuadraticConstraint::HessianType::kNegativeSemidefinite,
           doc.QuadraticConstraint.HessianType.kNegativeSemidefinite.doc)
       .value("kIndefinite", QuadraticConstraint::HessianType::kIndefinite,
-          doc.QuadraticConstraint.HessianType.kIndefinite.doc);
+          doc.QuadraticConstraint.HessianType.kIndefinite.doc)
+      .value("kZero", QuadraticConstraint::HessianType::kZero,
+          doc.QuadraticConstraint.HessianType.kZero.doc);
 
   quadratic_constraint_cls
       .def(py::init([](const Eigen::Ref<const Eigen::MatrixXd>& Q0,

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -203,12 +203,13 @@ class QuadraticConstraint : public Constraint {
 
   /**
    Whether the Hessian matrix is positive semidefinite, negative semidefinite,
-   or indefinite.
+   indefinite or a zero-matrix.
    */
   enum class HessianType {
     kPositiveSemidefinite,
     kNegativeSemidefinite,
     kIndefinite,
+    kZero,
   };
 
   /**

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -360,6 +360,19 @@ GTEST_TEST(testConstraint, testQuadraticConstraintHessian) {
   // Construct a constraint with psd Hessian and lower bound being -inf.
   QuadraticConstraint constraint3(Eigen::Matrix2d::Identity(), b, -kInf, 1);
   EXPECT_TRUE(constraint3.is_convex());
+
+  // Construct a constraint with a zero Hessian
+  QuadraticConstraint constraint4(Eigen::Matrix2d::Zero(), b, 1, 1);
+  EXPECT_EQ(constraint4.hessian_type(),
+            QuadraticConstraint::HessianType::kZero);
+  EXPECT_TRUE(constraint4.is_convex());
+
+  // Construct a constraint with hessian trace being 0.
+  QuadraticConstraint constraint5((Eigen::Matrix2d() << 0, 1, 1, 0).finished(),
+                                  b, 1, 1);
+  EXPECT_EQ(constraint5.hessian_type(),
+            QuadraticConstraint::HessianType::kIndefinite);
+  EXPECT_FALSE(constraint5.is_convex());
 }
 
 GTEST_TEST(testConstraint, QudraticConstraintLDLtFailute) {

--- a/solvers/test/create_constraint_test.cc
+++ b/solvers/test/create_constraint_test.cc
@@ -92,6 +92,14 @@ TEST_F(ParseQuadraticConstraintTest, Test0) {
   CheckParseQuadraticConstraint(
       -x0_ * x0_ + 2 * x1_, -kInf, 3, std::nullopt,
       QuadraticConstraint::HessianType::kNegativeSemidefinite);
+
+  // Special case that the Hessian is a zero-matrix.
+  CheckParseQuadraticConstraint(-x0_ + 2 * x1_, -kInf, 3, std::nullopt,
+                                QuadraticConstraint::HessianType::kZero);
+
+  // Special case that the Hessian has trace 0.
+  CheckParseQuadraticConstraint(-x0_ * x1_ + 2 * x1_, -kInf, 3, std::nullopt,
+                                QuadraticConstraint::HessianType::kIndefinite);
 }
 
 void CheckParseLorentzConeConstraint(


### PR DESCRIPTION
Also when the trace of the Hessian is zero, we know the Hessian is indefinite.

Motivated from slack discussion https://drakedevelopers.slack.com/archives/C3L92BM2Q/p1739979166969959