### PR TITLE
Switch non-test code to use Parser(builder)

### DIFF
--- a/bindings/pydrake/examples/gym/envs/cart_pole.py
+++ b/bindings/pydrake/examples/gym/envs/cart_pole.py
@@ -60,8 +60,8 @@ drake_contact_approximations = ['sap', 'tamsi', 'similar', 'lagged']
 contact_approximation = drake_contact_approximations[0]
 
 
-def AddAgent(plant):
-    parser = Parser(plant)
+def AddAgent(plant=None, builder=None):
+    parser = Parser(builder=builder, plant=plant)
     model_file = FindResourceOrThrow(
         "drake/bindings/pydrake/examples/gym/models/cartpole_BSA.sdf")
     agent, = parser.AddModels(model_file)
@@ -86,13 +86,13 @@ def make_sim(meshcat=None,
     plant, scene_graph = AddMultibodyPlant(multibody_plant_config, builder)
 
     # Add assets to the plant.
-    agent = AddAgent(plant)
+    agent = AddAgent(builder=builder)
     plant.Finalize()
     plant.set_name("plant")
 
     # Add assets to the controller plant.
     controller_plant = MultibodyPlant(time_step=controller_time_step)
-    AddAgent(controller_plant)
+    AddAgent(plant=controller_plant)
 
     if meshcat:
         MeshcatVisualizer.AddToBuilder(builder, scene_graph, meshcat)

--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -28,7 +28,7 @@ def main():
     builder = DiagramBuilder()
     cart_pole, scene_graph = AddMultibodyPlantSceneGraph(
         builder=builder, time_step=args.time_step)
-    Parser(plant=cart_pole).AddModelsFromUrl(
+    Parser(builder=builder).AddModelsFromUrl(
         url="package://drake/examples/multibody/cart_pole/cart_pole.sdf")
     cart_pole.Finalize()
 

--- a/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
+++ b/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
@@ -52,7 +52,7 @@ def main():
     # Assemble the Pendulum plant.
     builder = DiagramBuilder()
     pendulum = builder.AddSystem(MultibodyPlant(0.0))
-    Parser(pendulum).AddModelsFromUrl(
+    Parser(builder, plant=pendulum).AddModelsFromUrl(
         url="package://drake/examples/pendulum/Pendulum.urdf")
     pendulum.Finalize()
 

--- a/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
@@ -20,7 +20,7 @@ from pydrake.systems.planar_scenegraph_visualizer import (
 def run_pendulum_example(args):
     builder = DiagramBuilder()
     plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
-    parser = Parser(plant)
+    parser = Parser(builder)
     parser.AddModelsFromUrl(
         url="package://drake/examples/pendulum/Pendulum.urdf")
     plant.Finalize()

--- a/bindings/pydrake/multibody/examples/jupyter_widgets_examples.ipynb
+++ b/bindings/pydrake/multibody/examples/jupyter_widgets_examples.ipynb
@@ -43,10 +43,13 @@
    "outputs": [],
    "source": [
     "builder = DiagramBuilder()\n",
+    "\n",
+    "# Note: Don't use AddMultibodyPlantSceneGraph because we are only using\n",
+    "# MultibodyPlant for parsing, then wiring our sliders directly to SceneGraph.\n",
     "scene_graph = builder.AddSystem(SceneGraph())\n",
     "plant = MultibodyPlant(time_step=0.0)\n",
     "plant.RegisterAsSourceForSceneGraph(scene_graph)\n",
-    "Parser(plant, scene_graph).AddModelsFromUrl(\n",
+    "Parser(plant).AddModelsFromUrl(\n",
     "    url=\"package://drake_models/iiwa_description/sdf/iiwa7_no_collision.sdf\")\n",
     "plant.Finalize()\n",
     "\n",
@@ -100,7 +103,7 @@
    "source": [
     "builder = DiagramBuilder()\n",
     "plant, scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=0.0)\n",
-    "Parser(plant).AddModelsFromUrl(\n",
+    "Parser(builder).AddModelsFromUrl(\n",
     "    url=\"package://drake_models/iiwa_description/sdf/iiwa7_no_collision.sdf\")\n",
     "plant.Finalize()\n",
     "\n",

--- a/bindings/pydrake/systems/drawing_graphviz_example.py
+++ b/bindings/pydrake/systems/drawing_graphviz_example.py
@@ -29,7 +29,7 @@ for env_name in ['BUILD_WORKING_DIRECTORY', 'TEST_TMPDIR']:
 builder = DiagramBuilder()
 cart_pole, scene_graph = AddMultibodyPlantSceneGraph(
     builder=builder, time_step=0.0)
-Parser(plant=cart_pole).AddModelsFromUrl(
+Parser(builder=builder).AddModelsFromUrl(
     url="package://drake/examples/multibody/cart_pole/cart_pole.sdf")
 
 plt.figure(figsize=(11, 8.5), dpi=300)

--- a/bindings/pydrake/systems/jupyter_widgets_examples.ipynb
+++ b/bindings/pydrake/systems/jupyter_widgets_examples.ipynb
@@ -64,7 +64,7 @@
     "scene_graph = builder.AddSystem(SceneGraph())\n",
     "plant = MultibodyPlant(time_step=0.0)\n",
     "plant.RegisterAsSourceForSceneGraph(scene_graph)\n",
-    "Parser(plant, scene_graph).AddModelsFromUrl(\n",
+    "Parser(plant=plant).AddModelsFromUrl(\n",
     "    url=\"package://drake_models/ycb/006_mustard_bottle.sdf\")\n",
     "plant.Finalize()\n",
     "\n",

--- a/doc/_pages/python_bindings.md
+++ b/doc/_pages/python_bindings.md
@@ -71,7 +71,7 @@ from pydrake.systems.framework import DiagramBuilder
 
 builder = DiagramBuilder()
 plant, _ = AddMultibodyPlantSceneGraph(builder, 0.0)
-Parser(plant).AddModels(
+Parser(builder).AddModels(
     FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
 plant.Finalize()
 diagram = builder.Build()
@@ -96,7 +96,7 @@ from pydrake.all import (
 
 builder = DiagramBuilder()
 plant, _ = AddMultibodyPlantSceneGraph(builder, 0.0)
-Parser(plant).AddModels(
+Parser(builder).AddModels(
     FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
 plant.Finalize()
 diagram = builder.Build()
@@ -111,7 +111,7 @@ import pydrake.all
 
 builder = pydrake.systems.framework.DiagramBuilder()
 plant, _ = pydrake.multibody.plant.AddMultibodyPlantSceneGraph(builder, 0.0)
-pydrake.multibody.parsing.Parser(plant).AddModels(
+pydrake.multibody.parsing.Parser(builder).AddModels(
   pydrake.common.FindResourceOrThrow(
       "drake/examples/pendulum/Pendulum.urdf"))
 plant.Finalize()

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -107,7 +107,7 @@ void DoMain() {
 
   const std::string object_model_url =
       "package://drake/examples/allegro_hand/joint_control/simple_mug.sdf";
-  multibody::Parser parser(&plant);
+  multibody::Parser parser(&builder);
   parser.AddModelsFromUrl(hand_model_url);
   parser.AddModelsFromUrl(object_model_url);
 

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -68,7 +68,7 @@ void DoMain() {
         "package://drake_models/"
         "allegro_hand_description/sdf/allegro_hand_description_left.sdf";
   }
-  multibody::Parser(&plant).AddModelsFromUrl(hand_url);
+  multibody::Parser(&builder).AddModelsFromUrl(hand_url);
 
   // Weld the hand to the world frame
   const auto& joint_hand_root = plant.GetBodyByName("hand_root");

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -52,7 +52,7 @@ int do_main() {
   auto [plant, scene_graph] =
       multibody::AddMultibodyPlant(plant_config, &builder);
 
-  multibody::Parser(&plant).AddModelsFromUrl(
+  multibody::Parser(&builder).AddModelsFromUrl(
       "package://drake_models/atlas/atlas_convex_hull.urdf");
 
   // Add model of the ground.

--- a/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
+++ b/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
@@ -35,7 +35,7 @@ def make_ball_paddle(contact_model, contact_surface_representation,
     builder = DiagramBuilder()
     plant, scene_graph = AddMultibodyPlant(multibody_plant_config, builder)
 
-    parser = Parser(plant)
+    parser = Parser(builder)
     paddle_sdf_url = \
         "package://drake/examples/hydroelastic/python_ball_paddle/paddle.sdf"
     (paddle,) = parser.AddModels(url=paddle_sdf_url)

--- a/examples/hydroelastic/python_nonconvex_mesh/drop_pepper.py
+++ b/examples/hydroelastic/python_nonconvex_mesh/drop_pepper.py
@@ -31,7 +31,7 @@ def make_pepper_bowl_table(contact_model, time_step):
                              contact_surface_representation="polygon"),
                            builder)
 
-    parser = Parser(plant)
+    parser = Parser(builder)
     parser.AddModels(
         url="package://drake_models/veggies/"
             "yellow_bell_pepper_no_stem_low.sdf")

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -144,7 +144,7 @@ int DoMain() {
       multibody::AddMultibodyPlant(plant_config, &builder);
 
   // Parse the gripper and spatula models.
-  multibody::Parser parser(&plant, &scene_graph);
+  multibody::Parser parser(&builder);
   parser.AddModelsFromUrl(
       "package://drake_models/wsg_50_description/sdf/"
       "schunk_wsg_50_hydro_bubble.sdf");

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -64,7 +64,7 @@ int DoMain() {
       multibody::AddMultibodyPlantSceneGraph(&builder, FLAGS_time_step);
 
   const multibody::ModelInstanceIndex jaco_id =
-      Parser(&jaco_plant).AddModelsFromUrl(kUrdfUrl).at(0);
+      Parser(&builder).AddModelsFromUrl(kUrdfUrl).at(0);
   jaco_plant.WeldFrames(jaco_plant.world_frame(),
                         jaco_plant.GetFrameByName("base"));
   jaco_plant.Finalize();

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -65,8 +65,7 @@ int DoMain() {
       "urdf/iiwa14_polytope_collision.urdf";
   const std::string urdf =
       (!FLAGS_urdf.empty() ? FLAGS_urdf : PackageMap{}.ResolveUrl(kModelUrl));
-  auto iiwa_instance =
-      multibody::Parser(&plant, &scene_graph).AddModels(urdf).at(0);
+  auto iiwa_instance = multibody::Parser(&builder).AddModels(urdf).at(0);
   plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"));
   plant.Finalize();
 

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -99,7 +99,7 @@ int do_main() {
   // Make and add the acrobot model.
   const std::string acrobot_url =
       "package://drake/multibody/benchmarks/acrobot/acrobot.sdf";
-  Parser parser(&acrobot);
+  Parser parser(&builder);
   parser.AddModelsFromUrl(acrobot_url);
 
   // We are done defining the model.

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -47,7 +47,7 @@ int do_main() {
       AddMultibodyPlantSceneGraph(&builder, FLAGS_time_step);
   const std::string sdf_url =
       "package://drake/examples/multibody/cart_pole/cart_pole.sdf";
-  Parser(&cart_pole, &scene_graph).AddModelsFromUrl(sdf_url);
+  Parser(&builder).AddModelsFromUrl(sdf_url);
 
   // Now the model is complete.
   cart_pole.Finalize();

--- a/examples/multibody/deformable/bubble_gripper.cc
+++ b/examples/multibody/deformable/bubble_gripper.cc
@@ -111,7 +111,7 @@ int do_main() {
                                "ground_visual", illustration_props);
 
   /* Parse the gripper model (without the bubbles). */
-  Parser parser(&plant, &scene_graph);
+  Parser parser(&builder);
   ModelInstanceIndex gripper_instance = parser.AddModelsFromUrl(
       "package://drake_models/wsg_50_description/sdf/"
       "schunk_wsg_50_deformable_bubble.sdf")[0];

--- a/examples/multibody/four_bar/passive_simulation.cc
+++ b/examples/multibody/four_bar/passive_simulation.cc
@@ -78,7 +78,7 @@ int do_main() {
   // Make and add the four_bar model from an SDF model.
   const std::string sdf_url =
       "package://drake/examples/multibody/four_bar/four_bar.sdf";
-  Parser parser(&four_bar);
+  Parser parser(&builder);
   parser.AddModelsFromUrl(sdf_url);
 
   // Get the two frames that define the bushing, namely frame Bc that is

--- a/examples/multibody/strandbeest/run_with_motor.cc
+++ b/examples/multibody/strandbeest/run_with_motor.cc
@@ -130,7 +130,7 @@ int do_main() {
     strandbeest.set_discrete_contact_approximation(
         drake::multibody::DiscreteContactApproximation::kSap);
   }
-  Parser parser(&strandbeest);
+  Parser parser(&builder);
   parser.AddModelsFromUrl(urdf_url);
 
   // We are done defining the model. Finalize.

--- a/examples/planar_gripper/gripper_brick.cc
+++ b/examples/planar_gripper/gripper_brick.cc
@@ -57,7 +57,7 @@ std::unique_ptr<systems::Diagram<T>> ConstructDiagram(
       multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
   const std::string gripper_url =
       "package://drake/examples/planar_gripper/planar_gripper.sdf";
-  multibody::Parser parser(*plant, *scene_graph);
+  multibody::Parser parser(&builder);
   parser.AddModelsFromUrl(gripper_url);
   examples::planar_gripper::WeldGripperFrames(*plant);
   const std::string brick_url =

--- a/examples/planar_gripper/planar_gripper_simulation.cc
+++ b/examples/planar_gripper/planar_gripper_simulation.cc
@@ -242,13 +242,13 @@ int DoMain() {
   const std::string gripper_url =
       "package://drake/examples/planar_gripper/planar_gripper.sdf";
   const ModelInstanceIndex gripper_index =
-      Parser(&plant).AddModelsFromUrl(gripper_url).at(0);
+      Parser(&builder).AddModelsFromUrl(gripper_url).at(0);
   WeldGripperFrames<double>(&plant);
 
   // Adds the brick to be manipulated.
   const std::string brick_url =
       "package://drake/examples/planar_gripper/planar_brick.sdf";
-  Parser(&plant).AddModelsFromUrl(brick_url);
+  Parser(&builder).AddModelsFromUrl(brick_url);
 
   // When the planar-gripper is welded via WeldGripperFrames(), motion always
   // lies in the world Y-Z plane (because the planar-gripper frame is aligned

--- a/examples/quadrotor/run_quadrotor_dynamics.cc
+++ b/examples/quadrotor/run_quadrotor_dynamics.cc
@@ -35,7 +35,7 @@ class Quadrotor : public systems::Diagram<T> {
     systems::DiagramBuilder<T> builder;
     auto [plant, scene_graph] =
         multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
-    multibody::Parser parser(&plant);
+    multibody::Parser parser(&builder);
     parser.AddModelsFromUrl(
         "package://drake_models/skydio_2/quadrotor.urdf");
     parser.AddModelsFromUrl(

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -177,7 +177,7 @@ int do_main() {
   auto [plant, scene_graph] =
       multibody::AddMultibodyPlant(plant_config, scene_graph_config, &builder);
 
-  Parser parser(&plant);
+  Parser parser(&builder);
   parser.AddModelsFromUrl(
       "package://drake/examples/simple_gripper/simple_gripper.sdf");
   parser.AddModelsFromUrl(

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -62,7 +62,7 @@ class InverseKinematics {
    * systems::DiagramBuilder<double> builder;
    * auto items = AddMultibodyPlantSceneGraph(&builder, 0.0);
    * // 2. Add collision geometries to the plant
-   * Parser(&(items.plant)).AddModels("model.sdf");
+   * Parser(&builder).AddModels("model.sdf");
    * // 3. Construct the diagram
    * auto diagram = builder.Build();
    * // 4. Create diagram context.

--- a/multibody/test_utilities/robot_model.cc
+++ b/multibody/test_utilities/robot_model.cc
@@ -68,7 +68,7 @@ RobotModel<T>::RobotModel(const RobotModelConfig& config,
   auto items = AddMultibodyPlantSceneGraph(&builder, kTimeStep);
   plant_ = &items.plant;
 
-  Parser parser(plant_);
+  Parser parser(&builder);
   robot_model_instance_ = parser.AddModelsFromUrl(
       "package://drake_models/iiwa_description/sdf/iiwa7_no_collision.sdf")[0];
   parser.AddModelsFromUrl("package://drake_models/dishes/plate_8in.sdf");

--- a/planning/robot_diagram_builder.cc
+++ b/planning/robot_diagram_builder.cc
@@ -23,7 +23,7 @@ RobotDiagramBuilder<T>::RobotDiagramBuilder(double time_step)
       pair_(AddMultibodyPlantSceneGraph<T>(builder_.get(), time_step)),
       plant_(pair_.plant),
       scene_graph_(pair_.scene_graph),
-      parser_(&plant_) {}
+      parser_(builder_.get()) {}
 
 template <typename T>
 RobotDiagramBuilder<T>::~RobotDiagramBuilder() = default;

--- a/planning/test/robot_diagram_test.cc
+++ b/planning/test/robot_diagram_test.cc
@@ -58,6 +58,9 @@ GTEST_TEST(RobotDiagramBuilderTest, Getters) {
   SceneGraph<double>& mutable_scene_graph = dut->scene_graph();
   const SceneGraph<double>& scene_graph = const_dut->scene_graph();
 
+  // The parser has a reference to the builder.
+  EXPECT_EQ(mutable_parser.builder(), &mutable_builder);
+
   // The getters for mutable vs readonly are consistent.
   EXPECT_EQ(&mutable_builder, &builder);
   EXPECT_EQ(&mutable_parser, &parser);

--- a/tutorials/authoring_multibody_simulation.ipynb
+++ b/tutorials/authoring_multibody_simulation.ipynb
@@ -380,7 +380,7 @@
     "    builder = DiagramBuilder()\n",
     "    plant, scene_graph = AddMultibodyPlantSceneGraph(\n",
     "        builder, time_step=sim_time_step)\n",
-    "    parser = Parser(plant)\n",
+    "    parser = Parser(builder)\n",
     "\n",
     "    # Loading models.\n",
     "    # Load the table top and the cylinder we created.\n",

--- a/tutorials/hydroelastic_contact_basics.ipynb
+++ b/tutorials/hydroelastic_contact_basics.ipynb
@@ -489,7 +489,7 @@
     "            time_step=time_step,\n",
     "            discrete_contact_approximation=\"similar\"),\n",
     "        builder)\n",
-    "    parser = Parser(plant)\n",
+    "    parser = Parser(builder)\n",
     "\n",
     "    # Load the table top and the box we created.\n",
     "    parser.AddModelsFromString(compliant_box_sdf, \"sdf\")\n",

--- a/tutorials/hydroelastic_contact_nonconvex_mesh.ipynb
+++ b/tutorials/hydroelastic_contact_nonconvex_mesh.ipynb
@@ -217,7 +217,7 @@
     "            time_step=time_step,\n",
     "            discrete_contact_approximation=\"lagged\"),\n",
     "        builder)\n",
-    "    parser = Parser(plant)\n",
+    "    parser = Parser(builder)\n",
     "\n",
     "    # Load the assets that we created.\n",
     "    parser.AddModels(url=bell_pepper_url)\n",

--- a/tutorials/pyplot_animation_multibody_plant.ipynb
+++ b/tutorials/pyplot_animation_multibody_plant.ipynb
@@ -121,7 +121,7 @@
     "    \"\"\"\n",
     "    builder = DiagramBuilder()\n",
     "    plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.)\n",
-    "    parser = Parser(plant)\n",
+    "    parser = Parser(builder)\n",
     "    parser.AddModels(\n",
     "        url=\"package://drake/examples/pendulum/Pendulum.urdf\")\n",
     "    plant.Finalize()\n",

--- a/tutorials/rendering_multibody_plant.ipynb
+++ b/tutorials/rendering_multibody_plant.ipynb
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(left_iiwa,) = Parser(plant, \"left\").AddModels(url=iiwa_url)\n",
+    "(left_iiwa,) = Parser(builder, model_name_prefix=\"left\").AddModels(url=iiwa_url)\n",
     "plant.WeldFrames(\n",
     "    frame_on_parent_F=plant.world_frame(),\n",
     "    frame_on_child_M=plant.GetFrameByName(\"iiwa_link_0\", left_iiwa),\n",
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(right_iiwa,) = Parser(plant, \"right\").AddModels(url=iiwa_url)\n",
+    "(right_iiwa,) = Parser(builder, model_name_prefix=\"right\").AddModels(url=iiwa_url)\n",
     "plant.WeldFrames(\n",
     "    frame_on_parent_F=plant.world_frame(),\n",
     "    frame_on_child_M=plant.GetFrameByName(\"iiwa_link_0\", right_iiwa),\n",
@@ -201,7 +201,7 @@
     "# Add a mesh from https://github.com/RobotLocomotion/models/ directly, without\n",
     "# using the SDFormat wrapper file.\n",
     "sugar_box_url = \"package://drake_models/ycb/meshes/004_sugar_box_textured.obj\"\n",
-    "(sugar_box,) = Parser(plant).AddModels(url=sugar_box_url)\n",
+    "(sugar_box,) = Parser(builder).AddModels(url=sugar_box_url)\n",
     "sugar_box_body = plant.GetBodyByName(\"004_sugar_box_textured\", sugar_box)\n",
     "plant.SetDefaultFreeBodyPose(sugar_box_body, xyz_rpy_deg([0, 0, 0.5], [0, 0, 0]))"
    ]


### PR DESCRIPTION
PR #22531 significantly expanded the role of the Parser from just parsing into MultibodyPlant to (potentially) also parsing into a DiagramBuilder. Because it is strictly more general, calling `Parser(builder)` instead of `Parser(plant)` is now the preferred usage when the standard builder/plant combination are both available. This PR updates non-test (library and example) code to use it, in order to set a good example.

Resolves #22641.

+@jwnimmer-tri for feature (both?) reviews. 
Then we'll announce to the platform reviewers (on slack?).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22662)
<!-- Reviewable:end -->
