### PR TITLE
Clarify render engine backed and show_rgb

### DIFF
--- a/geometry/render_vtk/render_engine_vtk_params.h
+++ b/geometry/render_vtk/render_engine_vtk_params.h
@@ -247,7 +247,14 @@ struct RenderEngineVtkParams {
 
   If the option is set to one of the permissible values but the related graphics
   library has not been compiled into current build (e.g., "GLX" on macOS), then
-  the default choice (empty string) will be used instead, with a warning. */
+  the default choice (empty string) will be used instead, with a warning.
+
+  Note: %RenderEngineVtk's API allows callers to request an interactive display
+  of the current rendering (such as when
+  systems::sensors::CameraConfig::show_rgb is set to `true`). Whether or not the
+  debug window is displayed depends on the final backend configuration of the
+  %RenderEngineVtk instance (after resolving default values as documented
+  above). _Currently_, the EGL background does not support this display. */
   std::string backend;
 };
 

--- a/systems/sensors/camera_config.h
+++ b/systems/sensors/camera_config.h
@@ -412,7 +412,8 @@ struct CameraConfig {
    rendered). Because both RGB and label images are configured from the same
    `ColorRenderCamera`, this setting applies to both images. Even when set to
    true, whether or not the image is able to be displayed depends on the
-   specific render engine and its configuration.
+   specific render engine and its configuration (see e.g.,
+   geometry::RenderEngineVtkParams::backend).
 
    Note: This flag is intended for quick debug use during development instead of
    serving as an image viewer. Currently, there are known issues, e.g.,


### PR DESCRIPTION
Tweak the documentation to make the requirements for `show_rgb` to actually work clearer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22667)
<!-- Reviewable:end -->
