### PR TITLE
[parsing] Parsed mesh geometries use default proximity props

### DIFF
--- a/multibody/parsing/detail_mesh_parser.cc
+++ b/multibody/parsing/detail_mesh_parser.cc
@@ -176,8 +176,10 @@ std::optional<ModelInstanceIndex> AddModelFromMesh(
     // and some shenanigans to placate MbP.
     const auto X_BG = math::RigidTransformd::Identity();
     const geometry::Mesh mesh(filename);
+    // We don't know any better than providing an empty ProximityProperties
+    // and waiting for SceneGraph to backfill with the default values.
     plant.RegisterCollisionGeometry(body, X_BG, mesh, "collision",
-                                    CoulombFriction<double>());
+                                    geometry::ProximityProperties());
     // TODO(SeanCurtis-TRI): If there's a material applied to the object, use
     // the specified color.
     plant.RegisterVisualGeometry(body, X_BG, mesh, "visual");

--- a/multibody/parsing/test/detail_mesh_parser_test.cc
+++ b/multibody/parsing/test/detail_mesh_parser_test.cc
@@ -296,6 +296,18 @@ TEST_F(MeshParserTest, RegisteredGeometry) {
   EXPECT_EQ(inspector.NumGeometriesForFrameWithRole(*frame_id,
                                                     geometry::Role::kProximity),
             1);
+
+  // Confirm that geometries registered as meshes have empty proximity
+  // properties -- the only property group is the default property group.
+  const std::vector<geometry::GeometryId> proximity_geometries =
+      inspector.GetGeometries(*frame_id, geometry::Role::kProximity);
+  for (const geometry::GeometryId id : proximity_geometries) {
+    const geometry::ProximityProperties* properties =
+        inspector.GetProximityProperties(id);
+    ASSERT_NE(properties, nullptr);
+    EXPECT_THAT(properties->GetGroupNames(),
+                ::testing::ElementsAre(properties->default_group_name()));
+  }
 }
 
 }  // namespace

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -974,8 +974,6 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
     geometry::ProximityProperties properties) {
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_THROW_UNLESS(geometry_source_is_registered());
-  DRAKE_THROW_UNLESS(properties.HasProperty(geometry::internal::kMaterialGroup,
-                                            geometry::internal::kFriction));
 
   // TODO(amcastro-tri): Consider doing this after finalize so that we can
   // register geometry that has a fixed path to world to the world body (i.e.,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2226,14 +2226,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] X_BG
   ///   The fixed pose of the geometry frame G in the body frame B.
   /// @param[in] shape
-  ///   The geometry::Shape used for visualization. E.g.: geometry::Sphere,
-  ///   geometry::Cylinder, etc.
+  ///   The geometry::Shape used for collision and contact. E.g.:
+  ///   geometry::Sphere, geometry::Cylinder, etc.
   /// @param[in] properties
-  ///   The proximity properties associated with the collision geometry. They
-  ///   *must* include the (`material`, `coulomb_friction`) property of type
-  ///   CoulombFriction<double>.
-  /// @throws std::exception if called post-finalize or if the properties are
-  /// missing the coulomb friction property (or if it is of the wrong type).
+  ///   The proximity properties associated with the collision geometry.
+  /// @throws std::exception if called post-finalize.
   geometry::GeometryId RegisterCollisionGeometry(
       const RigidBody<T>& body, const math::RigidTransform<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,


### PR DESCRIPTION
Previously, a proximity property with zero friction is hardcoded, and it prevents the default proximity property being backfilled.
Downstream symptom was observed here: https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1739978811296609

In addition, nuke the necessary check in MbP::RegisterCollisionGeometry and fix a typo in its documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22674)
<!-- Reviewable:end -->
