### PR TITLE
[framework] Introduce BusCreator, BusSelector, BusValue

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -7,6 +7,8 @@
 #include "drake/systems/primitives/adder.h"
 #include "drake/systems/primitives/affine_system.h"
 #include "drake/systems/primitives/barycentric_system.h"
+#include "drake/systems/primitives/bus_creator.h"
+#include "drake/systems/primitives/bus_selector.h"
 #include "drake/systems/primitives/constant_value_source.h"
 #include "drake/systems/primitives/constant_vector_source.h"
 #include "drake/systems/primitives/demultiplexer.h"
@@ -162,6 +164,33 @@ PYBIND11_MODULE(primitives, m) {
             &TimeVaryingAffineSystem<T>::configure_random_state,
             py::arg("covariance"),
             doc.TimeVaryingAffineSystem.configure_random_state.doc);
+
+    DefineTemplateClassWithDefault<BusCreator<T>, LeafSystem<T>>(
+        m, "BusCreator", GetPyParam<T>(), doc.BusCreator.doc)
+        .def(py::init<std::variant<std::string, UseDefaultName>>(),
+            py::arg("output_port_name") = kUseDefaultName,
+            doc.BusCreator.ctor.doc)
+        .def("DeclareVectorInputPort", &BusCreator<T>::DeclareVectorInputPort,
+            py::arg("name"), py::arg("size"), py_rvp::reference_internal,
+            doc.BusCreator.DeclareVectorInputPort.doc)
+        .def("DeclareAbstractInputPort",
+            &BusCreator<T>::DeclareAbstractInputPort, py::arg("name"),
+            py::arg("model_value"), py_rvp::reference_internal,
+            doc.BusCreator.DeclareAbstractInputPort.doc);
+
+    DefineTemplateClassWithDefault<BusSelector<T>, LeafSystem<T>>(
+        m, "BusSelector", GetPyParam<T>(), doc.BusSelector.doc)
+        .def(py::init<std::variant<std::string, UseDefaultName>>(),
+            py::arg("input_port_name") = kUseDefaultName,
+            doc.BusSelector.ctor.doc)
+        .def("DeclareVectorOutputPort",
+            &BusSelector<T>::DeclareVectorOutputPort, py::arg("name"),
+            py::arg("size"), py_rvp::reference_internal,
+            doc.BusSelector.DeclareVectorOutputPort.doc)
+        .def("DeclareAbstractOutputPort",
+            &BusSelector<T>::DeclareAbstractOutputPort, py::arg("name"),
+            py::arg("model_value"), py_rvp::reference_internal,
+            doc.BusSelector.DeclareAbstractOutputPort.doc);
 
     DefineTemplateClassWithDefault<ConstantValueSource<T>, LeafSystem<T>>(
         m, "ConstantValueSource", GetPyParam<T>(), doc.ConstantValueSource.doc)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -10,12 +10,14 @@ from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.value import Value
 from pydrake.symbolic import Expression, Variable
 from pydrake.systems.framework import (
-    BasicVector,
+    BasicVector, BasicVector_,
+    BusValue,
     DiagramBuilder,
     DiagramBuilder_,
     InputPort,
     TriggerType,
     VectorBase,
+    kUseDefaultName,
 )
 from pydrake.systems.test.test_util import (
     MyVector2,
@@ -24,6 +26,8 @@ from pydrake.systems.primitives import (
     Adder, Adder_,
     AddRandomInputs,
     AffineSystem, AffineSystem_,
+    BusCreator, BusCreator_,
+    BusSelector, BusSelector_,
     ConstantValueSource, ConstantValueSource_,
     ConstantVectorSource, ConstantVectorSource_,
     ControllabilityMatrix,
@@ -92,6 +96,8 @@ class TestGeneral(unittest.TestCase):
         # resolved for dtype=object, or dtype=custom is used.
         self._check_instantiations(Adder_)
         self._check_instantiations(AffineSystem_)
+        self._check_instantiations(BusCreator_)
+        self._check_instantiations(BusSelector_)
         self._check_instantiations(ConstantValueSource_)
         self._check_instantiations(ConstantVectorSource_)
         self._check_instantiations(Demultiplexer_)
@@ -329,6 +335,53 @@ class TestGeneral(unittest.TestCase):
 
         self.assertEqual(dut.get_output_port_w_out().size(), 3)
         self.assertEqual(dut.get_output_port_w_out_density().size(), 1)
+
+    @numpy_compare.check_all_types
+    def test_bus_creator(self, T):
+        dut = BusCreator_[T](output_port_name="foo")
+        dut.DeclareVectorInputPort(name="vec", size=2)
+        dut.DeclareVectorInputPort(name=kUseDefaultName, size=2)
+        dut.DeclareAbstractInputPort(name="abst", model_value=Value[str]())
+        dut.DeclareAbstractInputPort(name=kUseDefaultName,
+                                     model_value=Value[object]())
+        # Check exactly what types show up on the output bus.
+        context = dut.CreateDefaultContext()
+        dut.GetInputPort("vec").FixValue(context, value=np.ones(2))
+        dut.GetInputPort("u1").FixValue(context, value=np.zeros(2))
+        dut.GetInputPort("abst").FixValue(context, value="hello")
+        dut.GetInputPort("u3").FixValue(context, value=tuple([1, 2, 3]))
+        output = dut.get_output_port().Eval(context)
+        self.assertIsInstance(output.Find("vec"), BasicVector_[T])
+        self.assertIsInstance(output.Find("u1"), BasicVector_[T])
+        self.assertIsInstance(output.Find("abst"), str)
+        self.assertIsInstance(output.Find("u3"), tuple)
+
+    @numpy_compare.check_all_types
+    def test_bus_selector(self, T):
+        dut = BusSelector_[T](input_port_name="bar")
+        dut.DeclareVectorOutputPort(name="vec", size=2)
+        dut.DeclareVectorOutputPort(name=kUseDefaultName, size=2)
+        dut.DeclareAbstractOutputPort(name="abst", model_value=Value[str]())
+        dut.DeclareAbstractOutputPort(name=kUseDefaultName,
+                                      model_value=Value[object]())
+        # Make sure we know exactly how to populate a bus-valued input port.
+        input_bus = BusValue()
+        vec = np.ones(2)
+        y1 = np.zeros(2)
+        abst = "hello"
+        y3 = tuple([1, 2, 3])
+        input_bus.Set("vec", Value(BasicVector_[T](vec)))
+        input_bus.Set("y1", Value(BasicVector_[T](y1)))
+        input_bus.Set("abst", Value("hello"))
+        input_bus.Set("y3", Value(y3))
+        context = dut.CreateDefaultContext()
+        dut.get_input_port().FixValue(context, input_bus)
+        numpy_compare.assert_float_equal(
+            dut.GetOutputPort("vec").Eval(context), vec)
+        numpy_compare.assert_float_equal(
+            dut.GetOutputPort("y1").Eval(context), y1)
+        self.assertEqual(dut.GetOutputPort("abst").Eval(context), abst)
+        self.assertEqual(dut.GetOutputPort("y3").Eval(context), y3)
 
     def test_vector_pass_through(self):
         model_value = BasicVector([1., 2, 3])

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -11,9 +11,10 @@ from pydrake.common.test_utilities import numpy_compare
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import (
     BasicVector, BasicVector_,
+    BusValue,
     Parameters,
     VectorBase,
-    )
+)
 
 
 def pass_through(x):
@@ -148,6 +149,7 @@ class TestValue(unittest.TestCase):
     @numpy_compare.check_all_types
     def test_value_registration(self, T):
         Value[BasicVector_[T]]
+        Value[BusValue]
 
     def test_parameters_api(self):
 
@@ -191,3 +193,36 @@ class TestValue(unittest.TestCase):
             Parameters(vec=model_numeric.Clone()),
             Parameters(value=model_abstract.Clone()),
             ]
+
+    def test_bus_value(self):
+        dut = BusValue()
+        dut.Set("foo", Value[str]("Hello"))
+        dut.Set("bar", Value[str]("World"))
+        self.assertEqual(dut.Find("foo"), "Hello")
+        self.assertEqual(dut.Find("bar"), "World")
+        self.assertIsNone(dut.Find("quux"))
+
+        # Iterating a non-empty BusValue.
+        found_something = False
+        for i, name in enumerate(dut):
+            found_something = True,
+            if i == 0:
+                self.assertEqual(name, "foo")
+                self.assertEqual(dut[name], "Hello")
+            elif i == 1:
+                self.assertEqual(name, "bar")
+                self.assertEqual(dut[name], "World")
+            else:
+                self.fail(f"i should not be {i}")
+        self.assertTrue(found_something)
+
+        # Iterating an empty BusValue.
+        dut.Clear()
+        for name in dut:
+            self.fail(f"wrong iteration for {name}")
+
+        # Calling __getitem__ on a missing key.
+        with self.assertRaisesRegex(KeyError, "no_such_key"):
+            dut["no_such_key"]
+
+        copy.copy(dut)

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1166,6 +1166,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called before Finalize().
   const systems::InputPort<T>& get_applied_generalized_force_input_port() const;
 
+  // TODO(jwnimmer-tri) This input port should use BusValue instead of vector<>,
+  // so that the ExternallyAppliedSpatialForceMultiplexer hassle is unnecessary.
+  // Add the new port with a different name (maybe "applied_spatial_force_bus")
+  // and deprecate this port and that force mux for removal.
   /// Returns a constant reference to the input port for applying spatial
   /// forces to bodies in the plant. The data type for the port is an
   /// std::vector of ExternallyAppliedSpatialForce; any number of spatial forces

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
     deps = [
         ":abstract_value_cloner",
         ":abstract_values",
+        ":bus_value",
         ":cache_and_dependency_tracker",
         ":cache_entry",
         ":context",
@@ -129,6 +130,19 @@ drake_cc_library(
         ":framework_common",
         "//common:essential",
         "//common:value",
+    ],
+)
+
+drake_cc_library(
+    name = "bus_value",
+    srcs = ["bus_value.cc"],
+    hdrs = ["bus_value.h"],
+    deps = [
+        "//common:value",
+    ],
+    implementation_deps = [
+        "//common:drake_export",
+        "@abseil_cpp_internal//absl/container:flat_hash_map",
     ],
 )
 
@@ -740,6 +754,14 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities:my_vector",
+    ],
+)
+
+drake_cc_googletest(
+    name = "bus_value_test",
+    deps = [
+        ":bus_value",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/systems/framework/bus_value.cc
+++ b/systems/framework/bus_value.cc
@@ -1,0 +1,239 @@
+#include "drake/systems/framework/bus_value.h"
+
+#include "absl/container/flat_hash_map.h"
+
+#include "drake/common/drake_export.h"
+
+namespace drake {
+namespace systems {
+
+// This class holds the data for (and implements most of the the logic for) both
+// BusValue and BusValue::Iterator. We aim to use a storage representation that
+// is efficient for the following repeated cycle of operations:
+//
+// - Clear()                  # cycle begins
+// - Set(key_1,   value_1)
+// - Set(key_..., value_...)
+// - Set(key_N,   value_N)
+// - Begin(...)
+// - Advance(...)
+// - Advance(...)
+// - Clear()                  # cycle repeats
+// - Set(key_1, ...) ...
+//
+// Sometimes the accesses will happen using Find instead of Begin/Advance, but
+// the pattern remains: clear, batch write, batch read; clear, (repeat).
+//
+// To that end, in Clear() we just mark the slots with an invalid bit without
+// de-allocating anything. That leaves the memory allocated and warmed up for
+// the next cycle. To avoid a potential packrat problem, we free any unused
+// slots across the copy constructor. In the future, if we do find an access
+// pattern where memory grows without bound, we could keep a tally of how many
+// times an invalid slot has been cleared, and evict it after being empty for
+// too many clears in a row.
+class DRAKE_NO_EXPORT BusValue::Impl {
+ public:
+  Impl();
+
+  // We are copyable (and thus technically "moveable") but nothing else.
+  Impl(const Impl& other);
+  Impl& operator=(const Impl& other) = delete;
+
+  // These methods are forwarded to us from the BusValue outer class (or its
+  // nested Iterator helper class).
+  BusValue::Iterator IterBegin() const;
+  void IterAdvance(BusValue::Iterator* iterator) const;
+  BusValue::Iterator::value_type IterGet(size_t index) const;
+  const AbstractValue* Find(std::string_view name) const;
+  void Clear();
+  void Set(std::string_view name, const AbstractValue& value);
+
+ private:
+  // The storage for a single signal value. When valid is false, we must treat
+  // the slot like it's empty. (We don't delete unused slots because they are
+  // likely to become populated again.)
+  struct Slot {
+    std::string name;
+    copyable_unique_ptr<AbstractValue> datum;
+    bool valid{false};
+  };
+
+  // Fills index_ with a map of all names in data_.
+  // @pre index_.empty()
+  void RecomputeIndex();
+
+  // The storage for a BusValue.
+  std::vector<Slot> data_;
+
+  // It's likely that BusValue::Find() will be called from inner loops, so we
+  // want it to be O(1) not O(lg N) or O(N). Therefore, we'll maintain a hash
+  // map from a Slot::name to that slot's index in data_. To avoid unnecessary
+  // updates as slot validity changes, this indexes all slots in data_, even the
+  // invalid ones.
+  absl::flat_hash_map<std::string_view, size_t> index_;
+};
+
+BusValue::Impl::Impl() {
+  // Avoid re-indexing for small sizes.
+  data_.reserve(8);
+  index_.reserve(8);
+}
+
+BusValue::Impl::Impl(const Impl& other) : Impl() {
+  // We'll use the copy constructor as our signal to garbage collect unused
+  // names, by only copying valid slots.
+  for (const auto& slot : other.data_) {
+    if (slot.valid) {
+      data_.push_back(slot);
+    }
+  }
+  RecomputeIndex();
+}
+
+BusValue::Iterator BusValue::Impl::IterBegin() const {
+  for (size_t i = 0; i < data_.size(); ++i) {
+    if (data_[i].valid) {
+      Iterator result;
+      result.index_ = i;
+      result.impl_ = this;
+      return result;
+    }
+  }
+  // We don't have any data; return the BusValue::end() sentinel.
+  return BusValue::Iterator{};
+}
+
+void BusValue::Impl::IterAdvance(BusValue::Iterator* iterator) const {
+  for (size_t i = iterator->index_ + 1; i < data_.size(); ++i) {
+    if (data_[i].valid) {
+      iterator->index_ = i;
+      return;
+    }
+  }
+  // No more data; output the BusValue::end() sentinel.
+  *iterator = BusValue::Iterator{};
+}
+
+BusValue::Iterator::value_type BusValue::Impl::IterGet(size_t index) const {
+  const Slot& slot = data_.at(index);
+  DRAKE_THROW_UNLESS(slot.valid);
+  DRAKE_ASSERT(slot.datum != nullptr);
+  return {slot.name, *slot.datum};
+}
+
+const AbstractValue* BusValue::Impl::Find(std::string_view name) const {
+  auto iter = index_.find(name);
+  if (iter == index_.end()) {
+    return nullptr;
+  }
+  const size_t position = iter->second;
+  const Slot& slot = data_.at(position);
+  if (!slot.valid) {
+    return nullptr;
+  }
+  const AbstractValue* result = slot.datum.get();
+  DRAKE_ASSERT(result != nullptr);
+  return result;
+}
+
+void BusValue::Impl::Clear() {
+  for (auto& slot : data_) {
+    slot.valid = false;
+  }
+}
+
+void BusValue::Impl::Set(std::string_view name, const AbstractValue& value) {
+  auto iter = index_.find(name);
+  if (iter == index_.end()) {
+    Slot slot{.name = std::string{name}};
+    slot.datum = value.Clone();
+    slot.valid = true;
+    const size_t position = data_.size();
+    if (position < data_.capacity()) {
+      // The push_back will NOT re-allocate the data_, which means that the
+      // borrowed `string_view`s in the index_ map will all remain valid.
+      data_.push_back(std::move(slot));
+      index_.emplace(data_.back().name, position);
+    } else {
+      // The push_back WILL re-allocate the data_, which means that the
+      // borrowed `string_view`s in the index_ map all need to be replaced.
+      data_.push_back(std::move(slot));
+      index_.clear();
+      RecomputeIndex();
+    }
+  } else {
+    const size_t position = iter->second;
+    Slot& slot = data_.at(position);
+    slot.datum->SetFrom(value);
+    slot.valid = true;
+  }
+}
+
+void BusValue::Impl::RecomputeIndex() {
+  DRAKE_DEMAND(index_.empty());
+  for (size_t i = 0; i < data_.size(); ++i) {
+    index_.emplace(data_[i].name, i);
+  }
+}
+
+// This is cheap enough to be inline in the header, but due to the forward
+// declaration of our Impl class, it can't actually be defined there.
+BusValue::BusValue() = default;
+
+BusValue::BusValue(const BusValue&) = default;
+
+BusValue& BusValue::operator=(const BusValue&) = default;
+
+BusValue::BusValue(BusValue&&) = default;
+
+BusValue& BusValue::operator=(BusValue&&) = default;
+
+BusValue::~BusValue() = default;
+
+BusValue::Iterator BusValue::begin() const {
+  if (impl_ == nullptr) {
+    return end();
+  }
+  return impl_->IterBegin();
+}
+
+const AbstractValue* BusValue::Find(std::string_view name) const {
+  if (impl_ == nullptr) {
+    return nullptr;
+  }
+  return impl_->Find(name);
+}
+
+void BusValue::Clear() {
+  if (impl_ == nullptr) {
+    return;
+  }
+  return impl_->Clear();
+}
+
+void BusValue::Set(std::string_view name, const AbstractValue& value) {
+  if (impl_ == nullptr) {
+    impl_ = std::make_unique<Impl>();
+  }
+  return impl_->Set(name, value);
+}
+
+BusValue::Iterator::value_type BusValue::Iterator::operator*() const {
+  DRAKE_THROW_UNLESS(impl_ != nullptr);  // Cannot dereference end().
+  return static_cast<const BusValue::Impl*>(impl_)->IterGet(index_);
+}
+
+BusValue::Iterator& BusValue::Iterator::operator++() {
+  DRAKE_THROW_UNLESS(impl_ != nullptr);  // Cannot increment end().
+  static_cast<const BusValue::Impl*>(impl_)->IterAdvance(this);
+  return *this;
+}
+
+BusValue::Iterator BusValue::Iterator::operator++(int) {
+  Iterator result = *this;
+  ++(*this);
+  return result;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/bus_value.h
+++ b/systems/framework/bus_value.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cstddef>
+#include <string_view>
+#include <utility>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/value.h"
+
+namespace drake {
+namespace systems {
+
+/** %BusValue is a value type used on input ports and output ports to group
+labeled signals into a single port. Each signal is referred to by a unique
+name and stored using an AbstractValue.
+
+In some cases the signal names are used only for human-readable logging or
+debugging, so can be anything. In other cases, the systems using the signals
+will require the signals to use specific names per some convention (e.g.,
+for a BusSelector the signal names must match the output port names).
+
+@see BusCreator, BusSelector */
+class BusValue final {
+ public:
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(BusValue);
+
+  /** Constructs an empty %BusValue. */
+  BusValue();
+
+  ~BusValue();
+
+  /** @name Iterators
+  The iteration order is deterministic but unspecified. */
+  /** @{ */
+#ifndef DRAKE_DOXYGEN_CXX
+  class Iterator;
+#endif
+  Iterator begin() const;
+  Iterator end() const;
+  /** @} */
+
+  /** @name Container-like type aliases */
+  /** @{ */
+  using const_iterator = Iterator;
+  using value_type = std::pair<const std::string_view, const AbstractValue&>;
+  /** @} */
+
+  /** Gets one signal value. Returns nullptr if not found.
+  Does not invalidate any iterators, but the return value is invalidated by a
+  call to any non-const method on this. */
+  const AbstractValue* Find(std::string_view name) const;
+
+  /** Removes all signals from this. Invalidates all iterators. */
+  void Clear();
+
+  /** Sets one signal value. Invalidates all iterators. The `name` can be any
+  string without restriction, although we encourage valid UTF-8.
+
+  @warning Within a group of BusValue objects that are expected to inter-operate
+  (i.e., to be copied or assigned to each other), the type of the `value` for a
+  given `name` is expected to be consistent (i.e., homogenous) across the entire
+  group of objects. After setting a `name` to some value the first time, every
+  subsequent call to Set on the same BusValue object for that same `name` must
+  provide a value of the same type, even if the object has since been cleared or
+  copied onto another object. The only way to reset the hysteresis for the
+  "presumed type" of a name is to construct a new BusValue object. Failure to
+  keep the types consistent may result in an exception at runtime. However, we
+  might relax this restriction in the future, so don't count on it for error
+  handling. */
+  void Set(std::string_view name, const AbstractValue& value);
+
+ private:
+  class Impl;
+
+  // N.B. This is allowed to be nullptr (when the bus is empty).
+  // TODO(#13591) For efficiency this should probably be copy-on-write?
+  copyable_unique_ptr<Impl> impl_;
+};
+
+/** Provides a forward_iterator over BusValue signals.
+The iteration order is deterministic but unspecified. */
+class BusValue::Iterator {
+ public:
+  using difference_type = std::ptrdiff_t;
+  using value_type = typename BusValue::value_type;
+
+  Iterator() = default;
+  value_type operator*() const;
+  Iterator& operator++();
+  Iterator operator++(int);
+  bool operator==(const Iterator& other) const {
+    return index_ == other.index_;
+  }
+
+ private:
+  friend class BusValue;
+
+  // These default values denote the end() sentinel value.
+  size_t index_{~size_t{0}};
+  const void* impl_{nullptr};
+};
+
+// We define this function the header file for performance, but we can't do it
+// inside the BusValue class definition because Iterator is a nested class, so
+// we need to place the definition down here after both class definitions.
+inline BusValue::Iterator BusValue::end() const {
+  return BusValue::Iterator{};
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/test/bus_value_test.cc
+++ b/systems/framework/test/bus_value_test.cc
@@ -1,0 +1,174 @@
+#include "drake/systems/framework/bus_value.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+// N.B. In several of the tests below, we assume a specific iteration order to
+// make the tests simpler to write and understand, even though the API does not
+// promise one. If the implementation changes, we'll need to revisit the tests.
+
+std::optional<std::string> AsString(const AbstractValue* abstract) {
+  if (abstract == nullptr) {
+    return std::nullopt;
+  }
+  return abstract->template get_value<std::string>();
+}
+
+std::string AsString(const AbstractValue& abstract) {
+  return abstract.template get_value<std::string>();
+}
+
+GTEST_TEST(BusValueTest, Empty) {
+  const BusValue dut;
+  EXPECT_EQ(AsString(dut.Find("foo")), std::nullopt);
+  EXPECT_EQ(dut.begin(), dut.end());
+
+  BusValue dut_mutable;
+  EXPECT_NO_THROW(dut_mutable.Clear());
+}
+
+GTEST_TEST(BusValueTest, Operations) {
+  BusValue dut;
+
+  dut.Set("foo", Value<std::string>("foo_value"));
+  dut.Set("bar", Value<std::string>("bar_value"));
+  EXPECT_EQ(AsString(dut.Find("foo")), "foo_value");
+  EXPECT_EQ(AsString(dut.Find("bar")), "bar_value");
+  EXPECT_EQ(AsString(dut.Find("quux")), std::nullopt);
+  int i = 0;
+  for (const auto&& [name, abstract] : dut) {
+    const std::string expected = (i == 0) ? "foo" : "bar";
+    EXPECT_EQ(name, expected);
+    EXPECT_EQ(abstract.template get_value<std::string>(), expected + "_value");
+    ++i;
+  }
+  EXPECT_EQ(i, 2);
+
+  dut.Clear();
+  EXPECT_EQ(AsString(dut.Find("foo")), std::nullopt);
+  EXPECT_EQ(AsString(dut.Find("bar")), std::nullopt);
+  EXPECT_EQ(dut.begin(), dut.end());
+
+  dut.Set("bar", Value<std::string>("bar_value"));
+  dut.Set("quux", Value<std::string>("quux_value"));
+  EXPECT_EQ(AsString(dut.Find("foo")), std::nullopt);
+  EXPECT_EQ(AsString(dut.Find("bar")), "bar_value");
+  EXPECT_EQ(AsString(dut.Find("quux")), "quux_value");
+  i = 0;
+  for (const auto&& [name, abstract] : dut) {
+    EXPECT_LT(i, 2);
+    const std::string expected = (i == 0) ? "bar" : "quux";
+    EXPECT_EQ(name, expected);
+    EXPECT_EQ(AsString(abstract), expected + "_value");
+    ++i;
+  }
+
+  dut.Clear();
+  EXPECT_EQ(AsString(dut.Find("foo")), std::nullopt);
+  EXPECT_EQ(AsString(dut.Find("bar")), std::nullopt);
+  EXPECT_EQ(AsString(dut.Find("quux")), std::nullopt);
+  EXPECT_EQ(dut.begin(), dut.end());
+}
+
+GTEST_TEST(BusValueTest, DispreferredIterator) {
+  BusValue dut;
+  dut.Set("foo", Value<std::string>("foo_value"));
+  dut.Set("bar", Value<std::string>("bar_value"));
+  auto iter = dut.begin();
+  iter++;  // GSG says not to do this, but we need to test this overload.
+  EXPECT_EQ((*iter).first, "bar");
+}
+
+GTEST_TEST(BusValueTest, Copy) {
+  BusValue dut;
+  dut.Set("foo", Value<std::string>("foo_value"));
+  dut.Set("bar", Value<std::string>("bar_value"));
+
+  BusValue copy(dut);
+  dut.Clear();
+  EXPECT_EQ(AsString(copy.Find("foo")), "foo_value");
+  EXPECT_EQ(AsString(copy.Find("bar")), "bar_value");
+
+  BusValue empty(dut);
+  EXPECT_EQ(AsString(empty.Find("foo")), std::nullopt);
+  EXPECT_EQ(AsString(empty.Find("bar")), std::nullopt);
+  EXPECT_EQ(empty.begin(), empty.end());
+}
+
+GTEST_TEST(BusValueTest, CopyMoveAssignExist) {
+  // Given test coverage already provided by the Copy test immediately above,
+  // we'll rely on how copyable_unique_ptr works to conclude that the only extra
+  // testing we need for the other standard methods are to make sure they exist
+  // at all.
+
+  BusValue dut;
+  const BusValue ctor_copy{dut};
+  const BusValue ctor_move{std::move(dut)};
+  BusValue ctor_copy_assign;
+  ctor_copy_assign = dut;
+  BusValue ctor_move_assign;
+  ctor_move_assign = std::move(dut);
+}
+
+GTEST_TEST(BusValueTest, Reindexing) {
+  BusValue dut;
+
+  // Trigger the capacity overflow condition inside Set().
+  for (int i = 0; i < 100; ++i) {
+    const std::string x = std::to_string(i);
+    dut.Set(x, Value<std::string>(x + "_value"));
+  }
+
+  // Check that everything survived.
+  auto iter = dut.begin();
+  for (int i = 0; i < 100; ++i) {
+    SCOPED_TRACE(fmt::format("i = {}", i));
+    EXPECT_NE(iter, dut.end());
+    const auto& [name, abstract] = *iter;
+    const std::string x = std::to_string(i);
+    EXPECT_EQ(name, x);
+    EXPECT_EQ(AsString(abstract), x + "_value");
+    EXPECT_EQ(AsString(dut.Find(x)), x + "_value");
+    ++iter;
+  }
+}
+
+// This test demonstrates our current behavior for mismatched types. In the
+// future it would be okay to soften what's here, but at least this shows us
+// the starting point and will help us notice when things change.
+GTEST_TEST(BusValueTest, MismatchedTypes) {
+  const Value<int> indigo{22};
+  const Value<std::string> sierra{"sierra"};
+
+  // The current type of "x" will be "int".
+  BusValue dut;
+  dut.Set("x", indigo);
+
+  // Even after clearing, the presumed type remains.
+  dut.Clear();
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.Set("x", sierra), ".*cast.*int.*string.*");
+
+  // A default-constructed object is empty (and so, resets the presumed type).
+  dut = BusValue{};
+  EXPECT_NO_THROW(dut.Set("x", sierra));
+
+  // Start fresh, set the presumed type to "int" again.
+  dut = BusValue{};
+  dut.Set("x", indigo);
+  dut.Clear();
+
+  // The presumed type follows the move; the donor dut is truly empty now.
+  BusValue moved_to{std::move(dut)};
+  EXPECT_NO_THROW(dut.Set("x", sierra));
+  DRAKE_EXPECT_THROWS_MESSAGE(moved_to.Set("x", sierra),
+                              ".*cast.*int.*string.*");
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -15,6 +15,8 @@ drake_cc_package_library(
         ":adder",
         ":affine_system",
         ":barycentric_system",
+        ":bus_creator",
+        ":bus_selector",
         ":constant_value_source",
         ":constant_vector_source",
         ":demultiplexer",
@@ -78,6 +80,24 @@ drake_cc_library(
     deps = [
         "//math:barycentric",
         "//systems/framework:vector_system",
+    ],
+)
+
+drake_cc_library(
+    name = "bus_creator",
+    srcs = ["bus_creator.cc"],
+    hdrs = ["bus_creator.h"],
+    deps = [
+        "//systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "bus_selector",
+    srcs = ["bus_selector.cc"],
+    hdrs = ["bus_selector.h"],
+    deps = [
+        "//systems/framework",
     ],
 )
 
@@ -458,6 +478,23 @@ drake_cc_googletest(
         ":matrix_gain",
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/framework",
+    ],
+)
+
+drake_cc_googletest(
+    name = "bus_creator_test",
+    deps = [
+        ":bus_creator",
+        "//systems/framework/test_utilities:scalar_conversion",
+    ],
+)
+
+drake_cc_googletest(
+    name = "bus_selector_test",
+    deps = [
+        ":bus_selector",
+        "//common/test_utilities:expect_throws_message",
+        "//systems/framework/test_utilities:scalar_conversion",
     ],
 )
 

--- a/systems/primitives/bus_creator.cc
+++ b/systems/primitives/bus_creator.cc
@@ -1,0 +1,70 @@
+#include "drake/systems/primitives/bus_creator.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+BusCreator<T>::BusCreator(
+    std::variant<std::string, UseDefaultName> output_port_name)
+    : LeafSystem<T>(SystemTypeTag<BusCreator>{}) {
+  LeafSystem<T>::DeclareAbstractOutputPort(
+      std::move(output_port_name), BusValue{}, &BusCreator<T>::CalcOutput,
+      {this->all_input_ports_ticket()});
+}
+
+template <typename T>
+template <typename U>
+BusCreator<T>::BusCreator(const BusCreator<U>& other)
+    : BusCreator(other.get_output_port().get_name()) {
+  for (InputPortIndex i{0}; i < other.num_input_ports(); ++i) {
+    const auto& port = other.get_input_port(i, /* warn_deprecated = */ false);
+    switch (port.get_data_type()) {
+      case kAbstractValued: {
+        BusCreator<T>::DeclareAbstractInputPort(port.get_name(),
+                                                *port.Allocate());
+        break;
+      }
+      case kVectorValued: {
+        BusCreator<T>::DeclareVectorInputPort(port.get_name(), port.size());
+        break;
+      }
+    }
+  }
+}
+
+template <typename T>
+BusCreator<T>::~BusCreator() = default;
+
+template <typename T>
+InputPort<T>& BusCreator<T>::DeclareVectorInputPort(
+    std::variant<std::string, UseDefaultName> name, int size) {
+  return LeafSystem<T>::DeclareVectorInputPort(std::move(name), size);
+}
+
+template <typename T>
+InputPort<T>& BusCreator<T>::DeclareAbstractInputPort(
+    std::variant<std::string, UseDefaultName> name,
+    const AbstractValue& model_value) {
+  return LeafSystem<T>::DeclareAbstractInputPort(std::move(name), model_value);
+}
+
+template <typename T>
+void BusCreator<T>::CalcOutput(const Context<T>& context,
+                               BusValue* output) const {
+  output->Clear();
+  for (InputPortIndex i{0}; i < this->num_input_ports(); ++i) {
+    const auto& port = this->get_input_port(i, /* warn_deprecated = */ false);
+    if (port.HasValue(context)) {
+      const AbstractValue& value = port.template Eval<AbstractValue>(context);
+      output->Set(port.get_name(), value);
+    }
+  }
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::BusCreator);

--- a/systems/primitives/bus_creator.h
+++ b/systems/primitives/bus_creator.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <string>
+#include <variant>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/bus_value.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/** This system packs values from heterogeneous input ports into a single output
+port of type BusValue.
+
+@system
+name: BusCreator
+input_ports:
+- u0
+- ...
+- u(N-1)
+output_ports:
+- y0
+@endsystem
+
+The port names shown in the figure above are the defaults. Custom names may be
+specified when setting up the %BusCreator.
+
+When an input port is not connected, it is not an error; its value will simply
+not appear as part of the BusValue on the output port.
+
+@sa BusSelector, BusValue
+@tparam_default_scalar
+@ingroup primitive_systems */
+template <typename T>
+class BusCreator final : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BusCreator);
+
+  /** Constructs a %BusCreator with no inputs, and the given output port name.
+  Use DeclareAbstractInputPort() and DeclareVectorInputPort() to add ports. */
+  explicit BusCreator(std::variant<std::string, UseDefaultName>
+                          output_port_name = kUseDefaultName);
+
+  /** Scalar-converting copy constructor. See @ref system_scalar_conversion. */
+  template <typename U>
+  explicit BusCreator(const BusCreator<U>&);
+
+  ~BusCreator() final;
+
+  /** Declares a vector input port with the given attributes. The port name
+  will also be used as the name of this signal in the BusValue output port.
+  The type of the signal on the output bus will be `BasicVector<T>`. */
+  InputPort<T>& DeclareVectorInputPort(
+      std::variant<std::string, UseDefaultName> name, int size);
+
+  /** Declares an abstract input port with the given attributes. The port name
+  will also be used as the name of this signal in the BusValue output port. */
+  InputPort<T>& DeclareAbstractInputPort(
+      std::variant<std::string, UseDefaultName> name,
+      const AbstractValue& model_value);
+
+ private:
+  template <typename>
+  friend class BusCreator;
+
+  void CalcOutput(const Context<T>& context, BusValue* output) const;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/bus_selector.cc
+++ b/systems/primitives/bus_selector.cc
@@ -1,0 +1,113 @@
+#include "drake/systems/primitives/bus_selector.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+BusSelector<T>::BusSelector(
+    std::variant<std::string, UseDefaultName> input_port_name)
+    : LeafSystem<T>(SystemTypeTag<BusSelector>{}) {
+  LeafSystem<T>::DeclareAbstractInputPort(std::move(input_port_name),
+                                          Value<BusValue>{});
+}
+
+template <typename T>
+template <typename U>
+BusSelector<T>::BusSelector(const BusSelector<U>& other)
+    : BusSelector(other.get_input_port().get_name()) {
+  for (OutputPortIndex i{0}; i < other.num_output_ports(); ++i) {
+    const auto& port = other.get_output_port(i, /* warn_deprecated = */ false);
+    switch (port.get_data_type()) {
+      case kAbstractValued: {
+        BusSelector<T>::DeclareAbstractOutputPort(port.get_name(),
+                                                  *port.Allocate());
+        break;
+      }
+      case kVectorValued: {
+        BusSelector<T>::DeclareVectorOutputPort(port.get_name(), port.size());
+        break;
+      }
+    }
+  }
+}
+
+template <typename T>
+BusSelector<T>::~BusSelector() = default;
+
+template <typename T>
+OutputPort<T>& BusSelector<T>::DeclareVectorOutputPort(
+    std::variant<std::string, UseDefaultName> name, int size) {
+  const OutputPortIndex index{this->num_output_ports()};
+  OutputPort<T>& result = LeafSystem<T>::DeclareVectorOutputPort(
+      std::move(name), size,
+      [this, index](const Context<T>& context, BasicVector<T>* output) {
+        return this->CalcVectorOutput(context, index, output);
+      },
+      {this->all_input_ports_ticket()});
+  DRAKE_DEMAND(result.get_index() == index);
+  return result;
+}
+
+template <typename T>
+OutputPort<T>& BusSelector<T>::DeclareAbstractOutputPort(
+    std::variant<std::string, UseDefaultName> name,
+    const AbstractValue& model_value) {
+  const OutputPortIndex index{this->num_output_ports()};
+  OutputPort<T>& result = LeafSystem<T>::DeclareAbstractOutputPort(
+      std::move(name),
+      [model = copyable_unique_ptr<AbstractValue>(model_value.Clone())]() {
+        return model->Clone();
+      },
+      [this, index](const Context<T>& context, AbstractValue* output) {
+        this->CalcAbstractOutput(context, index, output);
+      },
+      {this->all_input_ports_ticket()});
+  DRAKE_DEMAND(result.get_index() == index);
+  return result;
+}
+
+template <typename T>
+void BusSelector<T>::CalcVectorOutput(const Context<T>& context,
+                                      OutputPortIndex index,
+                                      BasicVector<T>* output) const {
+  const BusValue& input =
+      this->get_input_port().template Eval<BusValue>(context);
+  const std::string& name = this->get_output_port(index).get_name();
+  const AbstractValue* value = input.Find(name);
+  if (value == nullptr) {
+    throw std::logic_error(
+        fmt::format("Missing value for input signal {} on {}", name,
+                    this->GetSystemPathname()));
+  }
+  const BasicVector<T>* vector = value->maybe_get_value<BasicVector<T>>();
+  if (vector == nullptr) {
+    throw std::logic_error(
+        fmt::format("Wrong type (non-vector) for input signal {} on {}", name,
+                    this->GetSystemPathname()));
+  }
+  output->SetFrom(*vector);
+}
+
+template <typename T>
+void BusSelector<T>::CalcAbstractOutput(const Context<T>& context,
+                                        OutputPortIndex index,
+                                        AbstractValue* output) const {
+  const BusValue& input =
+      this->get_input_port().template Eval<BusValue>(context);
+  const std::string& name = this->get_output_port(index).get_name();
+  const AbstractValue* value = input.Find(name);
+  if (value == nullptr) {
+    throw std::logic_error(
+        fmt::format("Missing value for input signal {} on {}", name,
+                    this->GetSystemPathname()));
+  }
+  output->SetFrom(*value);
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::BusSelector);

--- a/systems/primitives/bus_selector.h
+++ b/systems/primitives/bus_selector.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <string>
+#include <variant>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/bus_value.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/** This system unpacks values from a single input port of type BusValue onto
+heterogeneous output ports, where each output port's value comes from the same-
+named signal on the bus.
+
+The value on input port may contain additional bus value entries which are not
+selected (because there is no output port with that name); this is not an error.
+
+@system
+name: BusSelector
+input_ports:
+- u0
+output_ports:
+- y0
+- ...
+- y(N-1)
+@endsystem
+
+The port names shown in the figure above are the defaults. Custom names may be
+specified when setting up the %BusSelector.
+
+When an output port is evaluated but the input port's bus doesn't contain that
+signal name, it is an error.
+
+Because of the all-encompassing nature of AbstractValue, a vector-valued bus
+signal can be output on an abstract-valued port. Of course, the vector value can
+still be retrieved from the %AbstractValue. However, we recommend declaring
+output ports as vector-valued when the corresponding input signal is known to be
+vector-valued to maximize utility and minimize surprise.
+
+@sa BusCreator, BusValue
+@tparam_default_scalar
+@ingroup primitive_systems */
+template <typename T>
+class BusSelector final : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BusSelector);
+
+  /** Constructs a %BusSelector with the given input port name, and no outputs.
+  Use DeclareVectorOutputPort() and DeclareAbstractOutputPort() to add ports. */
+  explicit BusSelector(std::variant<std::string, UseDefaultName>
+                           input_port_name = kUseDefaultName);
+
+  /** Scalar-converting copy constructor. See @ref system_scalar_conversion. */
+  template <typename U>
+  explicit BusSelector(const BusSelector<U>&);
+
+  ~BusSelector() final;
+
+  /** Declares a vector output port with the given attributes. The port name
+  will also be used as the name of the signal to find in the BusValue input
+  port.  The type of the signal on the input bus must be `BasicVector<T>`. */
+  OutputPort<T>& DeclareVectorOutputPort(
+      std::variant<std::string, UseDefaultName> name, int size);
+
+  /** Declares an abstract output port with the given attributes. The port name
+  will also be used as the name of the signal to find in the BusValue input
+  port. */
+  OutputPort<T>& DeclareAbstractOutputPort(
+      std::variant<std::string, UseDefaultName> name,
+      const AbstractValue& model_value);
+
+ private:
+  template <typename>
+  friend class BusSelector;
+
+  void CalcVectorOutput(const Context<T>& context, OutputPortIndex index,
+                        BasicVector<T>* output) const;
+
+  void CalcAbstractOutput(const Context<T>& context, OutputPortIndex index,
+                          AbstractValue* output) const;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/test/bus_creator_test.cc
+++ b/systems/primitives/test/bus_creator_test.cc
@@ -1,0 +1,127 @@
+#include "drake/systems/primitives/bus_creator.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(BusCreatorTest, EmptyDefault) {
+  const BusCreator<double> dut;
+  EXPECT_EQ(dut.num_input_ports(), 0);
+  EXPECT_EQ(dut.num_output_ports(), 1);
+  EXPECT_EQ(dut.get_output_port().get_name(), "y0");
+  auto context = dut.CreateDefaultContext();
+  const auto& bus_value =
+      dut.get_output_port().template Eval<BusValue>(*context);
+  EXPECT_TRUE(bus_value.begin() == bus_value.end());
+}
+
+GTEST_TEST(BusCreatorTest, EmptyWithOutputName) {
+  const BusCreator<double> dut("bus");
+  EXPECT_EQ(dut.num_input_ports(), 0);
+  EXPECT_EQ(dut.num_output_ports(), 1);
+  EXPECT_EQ(dut.get_output_port().get_name(), "bus");
+}
+
+GTEST_TEST(BusCreatorTest, VariousPorts) {
+  BusCreator<double> dut("bus");
+  dut.DeclareVectorInputPort(kUseDefaultName, 2);
+  dut.DeclareVectorInputPort("in1", 3);
+  dut.DeclareAbstractInputPort(kUseDefaultName, Value<int>());
+  dut.DeclareAbstractInputPort("in3", Value<double>());
+
+  EXPECT_EQ(dut.num_input_ports(), 4);
+  EXPECT_EQ(dut.get_input_port(0).get_name(), "u0");
+  EXPECT_EQ(dut.get_input_port(1).get_name(), "in1");
+  EXPECT_EQ(dut.get_input_port(2).get_name(), "u2");
+  EXPECT_EQ(dut.get_input_port(3).get_name(), "in3");
+
+  // Create some sugar to dump the output port to a map<string, string>.
+  auto context = dut.CreateDefaultContext();
+  const auto& output = dut.get_output_port();
+  using Map = std::map<std::string, std::string>;
+  auto eval_output = [&output, &context]() -> Map {
+    Map result;
+    const auto& bus_value = output.template Eval<BusValue>(*context);
+    for (const auto&& [name, value] : bus_value) {
+      std::string value_str;
+      if ((name == "u0") || (name == "in1")) {
+        const auto& datum = value.template get_value<BasicVector<double>>();
+        value_str = fmt::to_string(fmt_eigen(datum.get_value()));
+      } else if (name == "u2") {
+        const auto& datum = value.template get_value<int>();
+        value_str = fmt::to_string(datum);
+      } else if (name == "in3") {
+        const auto& datum = value.template get_value<double>();
+        value_str = fmt::to_string(datum);
+      } else {
+        value_str = "error: unknown port name cannot be downcast";
+      }
+      result.emplace(name, std::move(value_str));
+    }
+    return result;
+  };
+
+  // The bus starts out empty.
+  Map expected;
+  EXPECT_EQ(eval_output(), expected);
+
+  // Add inputs one by one and make sure they come through.
+  const BasicVector<double> u0{12.0, 11.0};
+  const BasicVector<double> in1{3.0, 2.0, 1.0};
+  const int u2{11};
+  const double in3{22.2};
+  dut.get_input_port(3).FixValue(context.get(), Value{in3});
+  expected.emplace("in3", "22.2");
+  EXPECT_EQ(eval_output(), expected);
+  dut.get_input_port(2).FixValue(context.get(), Value{u2});
+  expected.emplace("u2", "11");
+  EXPECT_EQ(eval_output(), expected);
+  dut.get_input_port(1).FixValue(context.get(), Value{in1});
+  expected.emplace("in1", "3\n2\n1");
+  EXPECT_EQ(eval_output(), expected);
+  dut.get_input_port(0).FixValue(context.get(), Value{u0});
+  expected.emplace("u0", "12\n11");
+  EXPECT_EQ(eval_output(), expected);
+
+  // Change inputs and make sure the changes come through.
+  dut.get_input_port(0).FixValue(context.get(),
+                                 Value{BasicVector<double>{1.0, 2.0}});
+  expected["u0"] = "1\n2";
+  dut.get_input_port(2).FixValue(context.get(), Value{33});
+  expected["u2"] = "33";
+  EXPECT_EQ(eval_output(), expected);
+}
+
+GTEST_TEST(BusCreatorTest, ConvertScalarType) {
+  BusCreator<double> dut("bus");
+  dut.DeclareVectorInputPort(kUseDefaultName, 2);
+  dut.DeclareVectorInputPort("in1", 3);
+  dut.DeclareAbstractInputPort(kUseDefaultName, Value<int>());
+  dut.DeclareAbstractInputPort("in3", Value<double>());
+  EXPECT_TRUE(is_autodiffxd_convertible(dut, [&](const auto& converted) {
+    EXPECT_EQ(converted.num_input_ports(), 4);
+    EXPECT_EQ(converted.get_input_port(0).get_name(), "u0");
+    EXPECT_EQ(converted.get_input_port(1).get_name(), "in1");
+    EXPECT_EQ(converted.get_input_port(2).get_name(), "u2");
+    EXPECT_EQ(converted.get_input_port(3).get_name(), "in3");
+    EXPECT_EQ(converted.num_output_ports(), 1);
+    EXPECT_EQ(converted.get_output_port().get_name(), "bus");
+  }));
+  EXPECT_TRUE(is_symbolic_convertible(dut, [&](const auto& converted) {
+    EXPECT_EQ(converted.num_input_ports(), 4);
+    EXPECT_EQ(converted.get_input_port(0).get_name(), "u0");
+    EXPECT_EQ(converted.get_input_port(1).get_name(), "in1");
+    EXPECT_EQ(converted.get_input_port(2).get_name(), "u2");
+    EXPECT_EQ(converted.get_input_port(3).get_name(), "in3");
+    EXPECT_EQ(converted.num_output_ports(), 1);
+    EXPECT_EQ(converted.get_output_port().get_name(), "bus");
+  }));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/test/bus_selector_test.cc
+++ b/systems/primitives/test/bus_selector_test.cc
@@ -1,0 +1,111 @@
+#include "drake/systems/primitives/bus_selector.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(BusSelectorTest, EmptyDefault) {
+  const BusSelector<double> dut;
+  EXPECT_EQ(dut.num_input_ports(), 1);
+  EXPECT_EQ(dut.get_input_port().get_name(), "u0");
+  EXPECT_EQ(dut.num_output_ports(), 0);
+}
+
+GTEST_TEST(BusSelectorTest, EmptyWithInputName) {
+  const BusSelector<double> dut("bus");
+  EXPECT_EQ(dut.num_input_ports(), 1);
+  EXPECT_EQ(dut.get_input_port().get_name(), "bus");
+  EXPECT_EQ(dut.num_output_ports(), 0);
+}
+
+GTEST_TEST(BusSelectorTest, VariousPorts) {
+  BusSelector<double> dut("bus");
+  dut.DeclareVectorOutputPort(kUseDefaultName, 2);
+  dut.DeclareVectorOutputPort("out1", 3);
+  dut.DeclareAbstractOutputPort(kUseDefaultName, Value<int>());
+  dut.DeclareAbstractOutputPort("out3", Value<double>());
+
+  EXPECT_EQ(dut.num_output_ports(), 4);
+  EXPECT_EQ(dut.get_output_port(0).get_name(), "y0");
+  EXPECT_EQ(dut.get_output_port(1).get_name(), "out1");
+  EXPECT_EQ(dut.get_output_port(2).get_name(), "y2");
+  EXPECT_EQ(dut.get_output_port(3).get_name(), "out3");
+
+  // When input port(s) are missing, evaluating the output will throw.
+  auto context = dut.CreateDefaultContext();
+  BusValue bus;
+  auto& fixed_input = dut.get_input_port().FixValue(context.get(), bus);
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.get_output_port(0).Eval(*context),
+                              ".*Missing.*input.*y0.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.get_output_port(2).Eval(*context),
+                              ".*Missing.*input.*y2.*");
+
+  // When the value for a vector output port is wrongly typed, we throw.
+  bus.Set("y0", Value{0.5});
+  fixed_input.GetMutableData()->set_value(bus);
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.get_output_port(0).Eval(*context),
+                              ".*type.*non-vector.*y0.*");
+  bus = BusValue{};
+
+  // Prepare a context with the inputs set to a bus value with all data.
+  // Check that it all makes it through to the output.
+  const BasicVector<double> y0{12.0, 11.0};
+  const BasicVector<double> out1{3.0, 2.0, 1.0};
+  const int y2{11};
+  const double out3{22.2};
+  bus.Set("y0", Value{y0});
+  bus.Set("out1", Value{out1});
+  bus.Set("y2", Value{y2});
+  bus.Set("out3", Value{out3});
+  fixed_input.GetMutableData()->set_value(bus);
+  EXPECT_EQ(dut.get_output_port(0).Eval(*context), y0.get_value());
+  EXPECT_EQ(dut.get_output_port(1).Eval(*context), out1.get_value());
+  EXPECT_EQ(dut.get_output_port(2).template Eval<int>(*context), y2);
+  EXPECT_EQ(dut.get_output_port(3).template Eval<double>(*context), out3);
+
+  // Change the input and make sure the output updates.
+  const BasicVector<double> new_y0{1.0, 2.0};
+  const int new_y2{33};
+  bus.Set("y0", Value{new_y0});
+  bus.Set("y2", Value{new_y2});
+  fixed_input.GetMutableData()->set_value(bus);
+  EXPECT_EQ(dut.get_output_port(0).Eval(*context), new_y0.get_value());
+  EXPECT_EQ(dut.get_output_port(1).Eval(*context), out1.get_value());
+  EXPECT_EQ(dut.get_output_port(2).template Eval<int>(*context), new_y2);
+  EXPECT_EQ(dut.get_output_port(3).template Eval<double>(*context), out3);
+}
+
+GTEST_TEST(BusSelectorTest, ConvertScalarType) {
+  BusSelector<double> dut("bus");
+  dut.DeclareVectorOutputPort(kUseDefaultName, 2);
+  dut.DeclareVectorOutputPort("out1", 3);
+  dut.DeclareAbstractOutputPort(kUseDefaultName, Value<int>());
+  dut.DeclareAbstractOutputPort("out3", Value<double>());
+  EXPECT_TRUE(is_autodiffxd_convertible(dut, [&](const auto& converted) {
+    EXPECT_EQ(converted.num_input_ports(), 1);
+    EXPECT_EQ(converted.get_input_port().get_name(), "bus");
+    EXPECT_EQ(converted.num_output_ports(), 4);
+    EXPECT_EQ(converted.get_output_port(0).get_name(), "y0");
+    EXPECT_EQ(converted.get_output_port(1).get_name(), "out1");
+    EXPECT_EQ(converted.get_output_port(2).get_name(), "y2");
+    EXPECT_EQ(converted.get_output_port(3).get_name(), "out3");
+  }));
+  EXPECT_TRUE(is_symbolic_convertible(dut, [&](const auto& converted) {
+    EXPECT_EQ(converted.num_input_ports(), 1);
+    EXPECT_EQ(converted.get_input_port().get_name(), "bus");
+    EXPECT_EQ(converted.num_output_ports(), 4);
+    EXPECT_EQ(converted.get_output_port(0).get_name(), "y0");
+    EXPECT_EQ(converted.get_output_port(1).get_name(), "out1");
+    EXPECT_EQ(converted.get_output_port(2).get_name(), "y2");
+    EXPECT_EQ(converted.get_output_port(3).get_name(), "out3");
+  }));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**

It is not uncommon for a set of signals form a logical group, where they are always routed together (e.g., in and out of a diagram with a single port instead of one port per signal).

Consider the case of a controller system, which takes commanded RigidTransform poses as input.  Each pose has a name, perhaps `X_WL` and `X_WR` for the left and right hand pose.  Sometimes there might be more or fewer hands, or the poses willl have different names.  Even if we added "X_WL_input" and  "X_WR_input" ports to the controller, now we need to connect them to some sources, which might not be in the diagram so we'd need to export a bunch of specific ports and connect those elsewhere.  Even more troublesome, the set of poses being commanded could either _change_ over time, or at least not be known ahead of time during diagram building.  By mapping poses into ports, it severely limits what kind of information flows can be denoted by a Diagram.

**Describe the solution you'd like**

Introduce the concept of a "bus" to Drake's ports.  A bus will carry multiple independent signals, each with a string name.  In many cases, the set of signals will be known ahead of time but we also should allow it to be dynamic.  Each signal will be an abstract value.  So in other words, this is a way of gathering multiple ports up into a single port.

Add a primitive system to package scalar signals (one abstract value per input port, one bus-valued output port) and a system to unpackage them (one bus-valued input port, multiple scalar output ports).

Eventually we should add a system that merges buses, but I don't need that yet.

**Describe alternatives you've considered**

Users can hand-roll a solution, e.g., by creating a port of type `Value<std::map<std::string, RigidTransformd>>` and carefully operating and connecting that.  However, that is awkward -- the type eraser hasher in Value doesn't like deeply nested templates, the C++ / Python boundary can't handle this generically (we need to pybind each possible map instantiation separately, and make copies all over the place).

We already have a problem with [ExternallyAppliedSpatialForceMultiplexer](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_externally_applied_spatial_force_multiplexer.html) special case.  Having a general bus feature would allow us to just add a bus-valued input on MbP and no more need for purpose-built multiplexers.  The generic bus multiplexer (or compositor, etc) can do all of the lifting.

Additionally, all of the MbP output ports with per-body details (like `body_poses` and `body_spatial_velocities` etc.) could / should be phrased as a bus instead of a vector indexed by BodyIndex.  Once we add `MbP::RemoveBody` API, the body indices will no longer be contiguous.  Furthermore, it is much easier to debug / inspect using names vs indices.  It also would let us remove the weird `vector<SpatialThing>` bindings from pydrake.

**Additional context**

See also:
- https://www.mathworks.com/help/simulink/slref/buscreator.html
- https://www.mathworks.com/help/simulink/slref/busselector.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22679)
<!-- Reviewable:end -->
