### PR TITLE
[geometry/proximity] Rigid hydro geometries can be defined in-memory

### DIFF
--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -379,14 +379,8 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 
   const std::string extension = mesh_spec.extension();
   if (extension == ".obj") {
-    if (!mesh_spec.source().is_path()) {
-      throw std::runtime_error(
-          "In-memory meshes are still in development. Rigid hydroelastic "
-          "meshes from .obj must still be named with a file path.");
-    }
-    mesh =
-        make_unique<TriangleSurfaceMesh<double>>(ReadObjToTriangleSurfaceMesh(
-            mesh_spec.source().path(), mesh_spec.scale()));
+    mesh = make_unique<TriangleSurfaceMesh<double>>(
+        ReadObjToTriangleSurfaceMesh(mesh_spec.source(), mesh_spec.scale()));
   } else if (extension == ".vtk") {
     mesh = make_unique<TriangleSurfaceMesh<double>>(
         ConvertVolumeToSurfaceMesh(MakeVolumeMeshFromVtk<double>(mesh_spec)));

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -760,6 +760,10 @@ TEST_F(HydroelasticRigidGeometryTest, Mesh) {
     TestRigidMeshCube(Mesh(obj_path, kScale));
   }
   {
+    SCOPED_TRACE("Rigid Mesh, in-memory obj");
+    TestRigidMeshCube(Mesh(InMemoryMesh{MemoryFile::Make(obj_path)}, kScale));
+  }
+  {
     SCOPED_TRACE("Rigid Mesh, on-disk vtk");
     TestRigidMeshCube(Mesh(vtk_path, kScale));
   }


### PR DESCRIPTION
There was a legacy exception if an in-memory obj was provided as a rigid hydroelastic object. The rest of the code is sufficient for reading the mesh from in-memory, so we simply remove the limitation.

The limitation was introduced early in the PR train for in-memory meshes but never got cleaned up at the end of the train.