### PR TITLE
[primitives] Allow an initial value to be specified for Integrator

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -268,7 +268,14 @@ PYBIND11_MODULE(primitives, m) {
 
     DefineTemplateClassWithDefault<Integrator<T>, LeafSystem<T>>(
         m, "Integrator", GetPyParam<T>(), doc.Integrator.doc)
-        .def(py::init<int>(), doc.Integrator.ctor.doc)
+        .def(py::init<int>(), py::arg("size"),
+            doc.Integrator.ctor.doc_1args_size)
+        .def(py::init<const VectorXd&>(), py::arg("initial_value"),
+            doc.Integrator.ctor.doc_1args_initial_value)
+        .def("set_default_integral_value",
+            &Integrator<T>::set_default_integral_value,
+            py::arg("initial_value"),
+            doc.Integrator.set_default_integral_value.doc)
         .def("set_integral_value", &Integrator<T>::set_integral_value,
             py::arg("context"), py::arg("value"),
             doc.Integrator.set_integral_value.doc);

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -400,6 +400,30 @@ class TestGeneral(unittest.TestCase):
             test_input = np.arange(input_size)
             mytest(np.arange(input_size), k*np.arange(input_size))
 
+    def test_integrator(self):
+        n = 3
+        initial_value = np.array((1.0, 2.0, 3.0))
+        size_integrator = Integrator(size=n)
+        value_integrator = Integrator(initial_value=initial_value)
+        size_context = size_integrator.CreateDefaultContext()
+        value_context = value_integrator.CreateDefaultContext()
+        self.assertTrue(np.array_equal(
+            size_integrator.get_output_port(0).Eval(size_context),
+            (0.0, 0.0, 0.0)))
+        self.assertTrue(np.array_equal(
+            value_integrator.get_output_port(0).Eval(value_context),
+            initial_value))
+        value_integrator.set_default_integral_value(2 * initial_value)
+        value_context2 = value_integrator.CreateDefaultContext()
+        self.assertTrue(np.array_equal(
+            value_integrator.get_output_port(0).Eval(value_context2),
+            2 * initial_value))
+        size_integrator.set_integral_value(context=size_context,
+                                           value=initial_value)
+        self.assertTrue(np.array_equal(
+            size_integrator.get_output_port(0).Eval(size_context),
+            initial_value))
+
     def test_saturation(self):
         system = Saturation((0., -1., 3.), (1., 2., 4.))
         context = system.CreateDefaultContext()

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -94,12 +94,7 @@ class VectorSystem : public LeafSystem<T> {
         prerequisites_of_calc = {this->all_sources_ticket()};
       } else {
         // Depend on everything *except* for the inputs.
-        prerequisites_of_calc = {
-            this->time_ticket(),
-            this->accuracy_ticket(),
-            this->all_state_ticket(),
-            this->all_parameters_ticket(),
-        };
+        prerequisites_of_calc = {this->all_sources_except_input_ports_ticket()};
       }
       this->DeclareVectorOutputPort(kUseDefaultName, output_size,
                                     &VectorSystem::CalcVectorOutput,

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -559,6 +559,7 @@ drake_cc_googletest(
     deps = [
         ":integrator",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//systems/framework",
         "//systems/framework/test_utilities",
     ],

--- a/systems/primitives/integrator.h
+++ b/systems/primitives/integrator.h
@@ -24,9 +24,15 @@ class Integrator final : public VectorSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Integrator);
 
-  /// Constructs an %Integrator system.
+  /// Constructs an %Integrator system. The initial output value will be zero.
   /// @param size number of elements in the signal to be processed.
-  explicit Integrator(int size);
+  explicit Integrator(int size) : Integrator(VectorX<double>::Zero(size)) {}
+
+  /// Constructs an %Integrator system with a particular initial output value.
+  /// The size of both input and output are inferred from the given
+  /// `initial_value`.
+  /// @param initial_value the initial output value.
+  explicit Integrator(const VectorX<double>& initial_value);
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
@@ -34,12 +40,28 @@ class Integrator final : public VectorSystem<T> {
 
   ~Integrator() final;
 
+  /// Sets the initial value of the integral state variable that will be
+  /// present in a subsequently-created Context. Overrides any value that
+  /// was provided in the constructor or previous calls to this function.
+  /// However, the size of `value` must be the same as the size indicated at
+  /// construction.
+  /// @see set_integral_value() to set the initial value in an already-allocated
+  ///     Context.
+  /// @throws std::exception if an attempt is made to change the state size.
+  void set_default_integral_value(const VectorX<double>& initial_value);
+
   /// Sets the value of the integral modifying the state in the context.
-  /// @p value must be a column vector of the appropriate size.
+  /// `value` must be a column vector of the appropriate size.
+  /// @see set_default_integral_value() to set the initial value that will
+  ///   be present in a newly-allocated Context.
+  /// @throws std::exception if an attempt is made to change the state size.
   void set_integral_value(Context<T>* context,
                           const Eigen::Ref<const VectorX<T>>& value) const;
 
  private:
+  template <typename U>
+  friend class Integrator;
+
   // VectorSystem<T> override.
   void DoCalcVectorOutput(const Context<T>& context,
                           const Eigen::VectorBlock<const VectorX<T>>& input,
@@ -52,6 +74,12 @@ class Integrator final : public VectorSystem<T> {
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* derivatives) const final;
+
+  // System<T> override. Sets the initial state in a default Context to
+  // initial_value_.
+  void SetDefaultState(const Context<T>& context, State<T>* state) const final;
+
+  VectorX<double> initial_value_;
 };
 
 }  // namespace systems

--- a/systems/primitives/test/integrator_test.cc
+++ b/systems/primitives/test/integrator_test.cc
@@ -7,8 +7,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
-#include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/fixed_input_port_value.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
@@ -24,11 +23,11 @@ class IntegratorTest : public ::testing::Test {
     context_ = integrator_->CreateDefaultContext();
     derivatives_ = integrator_->AllocateTimeDerivatives();
 
-    // Set the state to zero initially.
+    // State will be zero initially.
     ContinuousState<double>& xc = continuous_state();
-    EXPECT_EQ(3, xc.size());
-    EXPECT_EQ(3, xc.get_misc_continuous_state().size());
-    xc.SetFromVector(Eigen::VectorXd::Zero(kLength));
+    EXPECT_EQ(xc.size(), 3);
+    EXPECT_EQ(xc.get_misc_continuous_state().size(), 3);
+    EXPECT_EQ(xc.CopyToVector(), Eigen::VectorXd::Zero(kLength));
   }
 
   ContinuousState<double>& continuous_state() {
@@ -59,12 +58,47 @@ TEST_F(IntegratorTest, Output) {
   integrator_->get_input_port(0).FixValue(context_.get(),
                                           Eigen::Vector3d{1.0, 2.0, 3.0});
 
+  // With no initial state specified, output should be zero initially.
   Eigen::Vector3d expected = Eigen::Vector3d::Zero();
   EXPECT_EQ(expected, integrator_->get_output_port(0).Eval(*context_));
 
   continuous_state().get_mutable_vector().SetAtIndex(1, 42.0);
   expected << 0.0, 42.0, 0.0;
   EXPECT_EQ(expected, integrator_->get_output_port(0).Eval(*context_));
+}
+
+GTEST_TEST(InitializedIntegratorTest, InitialValue) {
+  // We can set the initial value at construction.
+  const Eigen::Vector3d initial_value{1.0, 2.0, 3.0};
+  Integrator<double> integrator(initial_value);
+  auto context = integrator.CreateDefaultContext();
+  EXPECT_EQ(integrator.get_output_port(0).Eval(*context), initial_value);
+
+  // We can override the initial value post-construction.
+  integrator.set_default_integral_value(2 * initial_value);
+  auto context2 = integrator.CreateDefaultContext();
+  EXPECT_EQ(integrator.get_output_port(0).Eval(*context2), 2 * initial_value);
+
+  // We reject an attempt to change the size.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      integrator.set_default_integral_value(Eigen::Vector2d::Zero()),
+      ".*size.*");
+
+  // We can change the value in an existing context.
+  integrator.set_integral_value(context.get(), 4 * initial_value);
+  EXPECT_EQ(integrator.get_output_port(0).Eval(*context), 4 * initial_value);
+
+  // We reject an attempt to change the size in an existing context.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      integrator.set_integral_value(context.get(), Eigen::Vector2d::Zero()),
+      ".*size.*");
+
+  // Check that the default initial value is retained on scalar conversion.
+  auto integrator_ad = integrator.ToAutoDiffXd();
+  auto context_ad = integrator_ad->CreateDefaultContext();
+  EXPECT_EQ(
+      ExtractDoubleOrThrow(integrator_ad->get_output_port(0).Eval(*context_ad)),
+      2 * initial_value);
 }
 
 // Tests that the derivatives of an integrator's state are its input.


### PR DESCRIPTION
Adds a constructor and setter to the Integrator primitive that allows specification of a non-zero (but numerical) initial value.

Also adds missing tests and cleans up some error handling.

Resolves #22673

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22682)
<!-- Reviewable:end -->
