### PR TITLE
[Meshcat] Set object from JavaScript code

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -282,6 +282,11 @@ void DefineMeshcat(py::module m) {
             py::arg("wireframe") = false, py::arg("wireframe_line_width") = 1.0,
             py::arg("side") = Meshcat::SideOfFaceToRender::kDoubleSide,
             cls_doc.SetObject.doc_triangle_surface_mesh)
+        .def("SetObjectFromThreeJsCode",
+            py::overload_cast<std::string_view, std::string_view>(
+                &Class::SetObjectFromThreeJsCode),
+            py::arg("path"), py::arg("three_js_lambda"),
+            cls_doc.SetObjectFromThreeJsCode.doc)
         .def("SetLine", &Class::SetLine, py::arg("path"), py::arg("vertices"),
             py::arg("line_width") = 1.0,
             py::arg("rgba") = Rgba(0.1, 0.1, 0.1, 1.0), cls_doc.SetLine.doc)

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -228,6 +228,21 @@ class Meshcat {
                  bool wireframe = false, double wireframe_line_width = 1.0,
                  SideOfFaceToRender side = kDoubleSide);
 
+  /** Sets the "object" at a given `path` in the scene tree by executing native
+  THREE.js JavaScript code. The code snippet is expected to be a JavaScript
+  lambda function that returns a THREE.Object3D. This object is then set at
+  the specified `path`. See @ref meshcat_path. Any objects previously set at
+  this `path` will be replaced.
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
+  @param three_js_lambda a string containing JavaScript code that returns a
+                         THREE.Object3D instance. The code should be a lambda
+                         function,
+                         e.g. "() => { ...; return new THREE.Mesh(...); }".
+  */
+  void SetObjectFromThreeJsCode(std::string_view path,
+                                std::string_view three_js_lambda);
+
   /** Sets the "object" at `path` in the scene tree to a piecewise-linear
   interpolation between the `vertices`.
 

--- a/geometry/meshcat_types_internal.h
+++ b/geometry/meshcat_types_internal.h
@@ -395,6 +395,13 @@ struct SetObjectData {
   MSGPACK_DEFINE_MAP(type, path, object);
 };
 
+struct SetObjectFromThreeJsCodeData {
+  std::string type{"set_object_from_code"};
+  std::string path;
+  std::string code;
+  MSGPACK_DEFINE_MAP(type, path, code);
+};
+
 template <typename CameraData>
 struct LumpedCameraData {
   CameraData object;

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -270,7 +270,7 @@ int do_main() {
   {
     std::string javascript = R"""(() => {
       // Create a plane geometry to serve as the canvas for our text
-      const geometry = new THREE.PlaneGeometry(1, 1, 1, 1);
+      const geometry = new THREE.PlaneGeometry(0.5, 0.5, 1, 1);
 
       // Create a canvas to draw the text
       const canvas = document.createElement('canvas');
@@ -283,16 +283,16 @@ int do_main() {
       context.fillRect(0, 0, canvas.width, canvas.height);
 
       // Draw the text
-      context.font = '320px sans-serif';
+      context.font = '380px sans-serif';
       context.fillStyle = 'red';
       context.textAlign = 'center';
       context.textBaseline = 'middle';
 
       // Draw "Hello" slightly above the center
-      context.fillText('Hello,', canvas.width / 2, canvas.height / 2 - 140);
+      context.fillText('Hello,', canvas.width / 2, canvas.height / 2 - 180);
 
       // Draw "world!" slightly below the center
-      context.fillText('world!', canvas.width / 2, canvas.height / 2 + 140);
+      context.fillText('world!', canvas.width / 2, canvas.height / 2 + 180);
 
       // Create a texture from the canvas
       const texture = new THREE.CanvasTexture(canvas);
@@ -309,10 +309,10 @@ int do_main() {
     })""";
     meshcat->SetObjectFromThreeJsCode("text", javascript);
 
-    x += 2;  // the previous surface occupies 2 spots.
+    x += 1.5;  // the previous surface occupies 1 meter.
     meshcat->SetTransform("text", RigidTransformd(
         RotationMatrixd::MakeXRotation(M_PI/2),  // Rotate 90° around X axis
-        Vector3d{x, 0, 0.4}));
+        Vector3d{x, 0, 0.25}));
   }
 
   std::cout << "\nDo *not* open up your browser to the URL above. Instead use "

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -103,7 +103,7 @@ int do_main() {
   // For every items we add to the initial array, decrement start_x by one half
   // to keep things centered.
   // Use ++x as the x-position of new items.
-  const double start_x = -8.5;
+  const double start_x = -9.5;
   double x = start_x;
 
   Vector3d sphere_home{++x, 0, 0};
@@ -264,6 +264,55 @@ int do_main() {
     meshcat->PlotSurface("plot_surface", X, Y, Z, Rgba(0, 0, 0.9, 1.0), true);
     meshcat->SetTransform("plot_surface",
                           RigidTransformd(Vector3d{++x, -0.25, 0}));
+  }
+
+  // Text using SetObjectFromThreeJsCode.
+  {
+    std::string javascript = R"""(() => {
+      // Create a plane geometry to serve as the canvas for our text
+      const geometry = new THREE.PlaneGeometry(1, 1, 1, 1);
+
+      // Create a canvas to draw the text
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+      canvas.width = 1024;
+      canvas.height = 1024;
+
+      // Set up the canvas with a transparent background
+      context.fillStyle = 'rgba(0, 0, 0, 0)';
+      context.fillRect(0, 0, canvas.width, canvas.height);
+
+      // Draw the text
+      context.font = '320px sans-serif';
+      context.fillStyle = 'red';
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+
+      // Draw "Hello" slightly above the center
+      context.fillText('Hello,', canvas.width / 2, canvas.height / 2 - 140);
+
+      // Draw "world!" slightly below the center
+      context.fillText('world!', canvas.width / 2, canvas.height / 2 + 140);
+
+      // Create a texture from the canvas
+      const texture = new THREE.CanvasTexture(canvas);
+
+      // Create a material using the texture
+      const material = new THREE.MeshPhongMaterial({
+        map: texture,
+        transparent: true,
+        side: THREE.DoubleSide
+      });
+
+      // Create and return the mesh
+      return new THREE.Mesh(geometry, material);
+    })""";
+    meshcat->SetObjectFromThreeJsCode("text", javascript);
+
+    x += 2;  // the previous surface occupies 2 spots.
+    meshcat->SetTransform("text", RigidTransformd(
+        RotationMatrixd::MakeXRotation(M_PI/2),  // Rotate 90° around X axis
+        Vector3d{x, 0, 0.4}));
   }
 
   std::cout << "\nDo *not* open up your browser to the URL above. Instead use "

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -380,6 +380,7 @@ Ignore those for now; we'll need to circle back and fix them later.
   - the same purple triangle mesh drawn as a wireframe.
   - the same triangle mesh drawn in multicolor.
   - a blue mesh plot of the function z = y*sin(5*x).
+  - floating text that says "Hello, world!".
 )""");
   MaybePauseForUser();
 

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -10,8 +10,8 @@ def meshcat_repository(
         Updating this commit requires local testing; see
         drake/tools/workspace/meshcat/README.md for details.
         """,
-        commit = "14f683e4bcd5bb34b435b4c74309e0e50d54bc9a",
-        sha256 = "dae769f555fc7281b8a30795a9a5978faef3ec85ceafb809c332575dbe0b52d7",  # noqa
+        commit = "10a4338776fc8792df29c25a5e8a6b42bfd6879a",
+        sha256 = "635a79485826f496a351aad0f266b212753ffed33a5c9d1107540ad9d033d959",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -10,8 +10,8 @@ def meshcat_repository(
         Updating this commit requires local testing; see
         drake/tools/workspace/meshcat/README.md for details.
         """,
-        commit = "10a4338776fc8792df29c25a5e8a6b42bfd6879a",
-        sha256 = "635a79485826f496a351aad0f266b212753ffed33a5c9d1107540ad9d033d959",  # noqa
+        commit = "d48277939b7654fd1f1cf62f6630d8f79e5f0faa",
+        sha256 = "adeeeb4f41be94862a2946014ee0d475489689fa03d491460b07aa43916b2722",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -5,13 +5,13 @@ def meshcat_repository(
         mirrors = None):
     github_archive(
         name = name,
-        repository = "meshcat-dev/meshcat",
+        repository = "siddancha/meshcat",
         upgrade_advice = """
         Updating this commit requires local testing; see
         drake/tools/workspace/meshcat/README.md for details.
         """,
-        commit = "df31f9c357ba37121dc38d463ac94780204a3e37",
-        sha256 = "b0d8210e11495c1c6011927a9b0a76b1940e8d97e44044124333f1d19cb4aecd",  # noqa
+        commit = "14f683e4bcd5bb34b435b4c74309e0e50d54bc9a",
+        sha256 = "dae769f555fc7281b8a30795a9a5978faef3ec85ceafb809c332575dbe0b52d7",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
## Description

This PR implements:
```c++
Meshcat::SetObjectFromThreeJsCode(std::string_view path, std::string_view three_js_lambda)
```
that lets the user invoke Meshcat's `set_object_from_code` command (https://github.com/meshcat-dev/meshcat/pull/188) by sending a string of native JavaScript/THREE.js code. The code string contains a JavaScript lambda function that creates a `THREE.Object3D` instance; this object is then set at `path`. An example command is:

```c++
meshcat.SetObjectFromThreeJsCode(
    "/meshcat/my_object",
    R"""(() => {
        const geometry = new THREE.PlaneGeometry(...);
        const material = new THREE.MeshPhongMaterial(...);
        return new THREE.Mesh(geometry, material);
    })"""
);
```

## Motivation

Currently, the only way to set objects in Meshcat is via `SetObject()` calls that support a specific set of object types (like `Shape`, `PointCloud` etc.). By letting the user create objects via native JavaScript/THREE.js code, Drake's Meschat API can support _**all**_ THREE.js object types.

## Relation to https://github.com/RobotLocomotion/drake/issues/20941
https://github.com/RobotLocomotion/drake/issues/20941 proposes something like `void SetObjectRaw(std::string_view path, std::string_view threejs_object_json)` i.e. passing a `THREE.Object3D`'s serialized JSON. In my view the following are the pros/cons of sending THREE.js code instead.

### Pros
1. Not all THREE.js can be serialized. For example, I want to use the `Reflector` object [[1](https://threejs.org/examples/?q=reflec#webgl_mirror), [2](https://github.com/mrdoob/three.js/blob/56a1d6dcb2f47fa5786e57daf9b6da0a628b63ad/examples/jsm/objects/Reflector.js#L15)] to create a reflective floor, [as shown in this demo](https://www.mit.edu/~sancha/meshcat-mujoco-theme.html). However, `Reflector` cannot be serialized because it uses ShaderMaterial [[3](https://threejs.org/docs/#api/en/materials/ShaderMaterial)], which in turn uses dynamic textures that are computed at runtime and cannot be serialized. When I try to serialize by calling `Reflector.toJSON()`, I get the following warning:
    ```bash
    THREE.Texture: Unable to serialize Texture.
    ```
    By letting the user create objects via native JavaScript/THREE.js code, Meschat can support _**all**_ THREE.js object types, whether they can be serialized or not.
2. It is often easier to write THREE.js code to create objects than its serialized JSON. The serialization of object types are not well-document, and I have often needed to write native THREE.js code anyway and call the `.toJSON()` function to understand what the serialization format looks like.

### Cons

1. Specifying the JSON is more efficient if the object's JSON involves large `TypedArrays` (e.g. `Float32Array`). For example, setting a `PointCloud` usually requires specifying a large `positions` array. Msgpack can efficiently pack float arrays. On the other hand, embedding the floating values into a string might make the string unnecessarily bulky.

In conclusion, this PR might **not_resolve** https://github.com/RobotLocomotion/drake/issues/20941, but it can handle most uses cases well. For example, the proposed use case of setting text in Meshcat (https://github.com/RobotLocomotion/drake/issues/20884) is easily handled by this approach, as demonstrated in the test (see below).

## Test example

This PR also adds an example to `//geometry:meshcat_manual_test` that creates a floating text mesh using `Meshcat::SetObjectFromThreeJsCode`, as desired by https://github.com/RobotLocomotion/drake/issues/20884. On running
```bash
bazel run //geometry:meshcat_manual_test
```
we see

![image](https://github.com/user-attachments/assets/c493b42b-d8fd-40c0-91ec-57c25b5e15ae)

Resolves https://github.com/RobotLocomotion/drake/issues/20884

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22683)
<!-- Reviewable:end -->
