### PR TITLE
Support x'Nu term in discrete-time LQR

### DIFF
--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -315,11 +315,13 @@ PYBIND11_MODULE(controllers, m) {
       [](const Eigen::Ref<const Eigen::MatrixXd>& A,
           const Eigen::Ref<const Eigen::MatrixXd>& B,
           const Eigen::Ref<const Eigen::MatrixXd>& Q,
-          const Eigen::Ref<const Eigen::MatrixXd>& R) {
-        auto result = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
+          const Eigen::Ref<const Eigen::MatrixXd>& R,
+          const Eigen::Ref<const Eigen::MatrixXd>& N) {
+        auto result = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R, N);
         return std::make_pair(result.K, result.S);
       },
       py::arg("A"), py::arg("B"), py::arg("Q"), py::arg("R"),
+      py::arg("N") = Eigen::Matrix<double, 0, 0>::Zero(),
       doc.DiscreteTimeLinearQuadraticRegulator.doc);
 
   m.def("LinearQuadraticRegulator",

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -402,7 +402,12 @@ class TestControllers(unittest.TestCase):
         B = np.array([[0], [1]])
         Q = np.identity(2)
         R = np.identity(1)
+        N = np.array([[1], [0]])
         (K, S) = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R)
+        self.assertEqual(K.shape, (1, 2))
+        self.assertEqual(S.shape, (2, 2))
+        # Test with N.
+        (K, S) = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R, N)
         self.assertEqual(K.shape, (1, 2))
         self.assertEqual(S.shape, (2, 2))
 

--- a/systems/controllers/linear_quadratic_regulator.cc
+++ b/systems/controllers/linear_quadratic_regulator.cc
@@ -120,20 +120,37 @@ LinearQuadraticRegulatorResult DiscreteTimeLinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
     const Eigen::Ref<const Eigen::MatrixXd>& B,
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
-    const Eigen::Ref<const Eigen::MatrixXd>& R) {
+    const Eigen::Ref<const Eigen::MatrixXd>& R,
+    const Eigen::Ref<const Eigen::MatrixXd>& N) {
   Eigen::Index n = A.rows(), m = B.cols();
   DRAKE_DEMAND(n > 0 && m > 0);
   DRAKE_DEMAND(B.rows() == n && A.cols() == n);
   DRAKE_DEMAND(Q.rows() == n && Q.cols() == n);
   DRAKE_DEMAND(R.rows() == m && R.cols() == m);
   DRAKE_DEMAND(is_approx_equal_abstol(R, R.transpose(), 1e-10));
+  if (N.rows() != 0) {
+    DRAKE_DEMAND(N.rows() == n && N.cols() == m);
+  }
+
+  Eigen::LLT<Eigen::MatrixXd> R_cholesky(R);
+  if (R_cholesky.info() != Eigen::Success)
+    throw std::runtime_error("R must be positive definite");
 
   LinearQuadraticRegulatorResult ret;
 
-  ret.S = math::DiscreteAlgebraicRiccatiEquation(A, B, Q, R);
+  if (N.rows() != 0) {
+    Eigen::MatrixXd A1 = A - B * R_cholesky.solve(N.transpose());
+    Eigen::MatrixXd Q1 = Q - N * R_cholesky.solve(N.transpose());
+    ret.S = math::DiscreteAlgebraicRiccatiEquation(A1, B, Q1, R);
 
-  Eigen::MatrixXd tmp = B.transpose() * ret.S * B + R;
-  ret.K = tmp.llt().solve(B.transpose() * ret.S * A);
+    Eigen::MatrixXd tmp = B.transpose() * ret.S * B + R;
+    ret.K = tmp.llt().solve(B.transpose() * ret.S * A + N.transpose());
+  } else {
+    ret.S = math::DiscreteAlgebraicRiccatiEquation(A, B, Q, R);
+
+    Eigen::MatrixXd tmp = B.transpose() * ret.S * B + R;
+    ret.K = tmp.llt().solve(B.transpose() * ret.S * A);
+  }
 
   return ret;
 }
@@ -143,15 +160,13 @@ std::unique_ptr<systems::LinearSystem<double>> LinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::MatrixXd>& R,
     const Eigen::Ref<const Eigen::MatrixXd>& N) {
-  // DiscreteTimeLinearQuadraticRegulator does not support N yet.
-  DRAKE_DEMAND(system.time_period() == 0.0 || N.rows() == 0);
-
   const int num_states = system.B().rows(), num_inputs = system.B().cols();
 
   LinearQuadraticRegulatorResult lqr_result =
       (system.time_period() == 0.0)
           ? LinearQuadraticRegulator(system.A(), system.B(), Q, R, N)
-          : DiscreteTimeLinearQuadraticRegulator(system.A(), system.B(), Q, R);
+          : DiscreteTimeLinearQuadraticRegulator(system.A(), system.B(), Q, R,
+                                                 N);
 
   // Return the controller: u = -Kx.
   return std::make_unique<systems::LinearSystem<double>>(
@@ -184,15 +199,12 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
       Linearize(system, context, InputPortIndex{input_port_index},
                 OutputPortSelection::kNoOutput);
 
-  // DiscreteTimeLinearQuadraticRegulator does not support N yet.
-  DRAKE_DEMAND(linear_system->time_period() == 0.0 || N.rows() == 0);
-
   LinearQuadraticRegulatorResult lqr_result =
       (linear_system->time_period() == 0.0)
           ? LinearQuadraticRegulator(linear_system->A(), linear_system->B(), Q,
                                      R, N)
           : DiscreteTimeLinearQuadraticRegulator(linear_system->A(),
-                                                 linear_system->B(), Q, R);
+                                                 linear_system->B(), Q, R, N);
 
   const Eigen::VectorXd& x0 =
       (linear_system->time_period() == 0.0)

--- a/systems/controllers/linear_quadratic_regulator.h
+++ b/systems/controllers/linear_quadratic_regulator.h
@@ -50,13 +50,11 @@ LinearQuadraticRegulatorResult LinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& F =
         Eigen::Matrix<double, 0, 0>::Zero());
 
-// TODO(russt): Consider implementing the optional N argument as in the
-// continuous-time formulation.
 /// Computes the optimal feedback controller, u=-Kx, and the optimal
 /// cost-to-go J = x'Sx for the problem:
 ///
 ///   @f[ x[n+1] = Ax[n] + Bu[n] @f]
-///   @f[ \min_u \sum_0^\infty x'Qx + u'Ru @f]
+///   @f[ \min_u \sum_0^\infty x'Qx + u'Ru + 2x'Nu @f]
 ///
 /// @param A The state-space dynamics matrix of size num_states x num_states.
 /// @param B The state-space input matrix of size num_states x num_inputs.
@@ -64,16 +62,21 @@ LinearQuadraticRegulatorResult LinearQuadraticRegulator(
 /// num_states.
 /// @param R A symmetric positive definite cost matrix of size num_inputs x
 /// num_inputs.
+/// @param N A cost matrix of size num_states x num_inputs. If N.rows() == 0, N
+/// will be treated as a num_states x num_inputs zero matrix.
 /// @returns A structure that contains the optimal feedback gain K and the
 /// quadratic cost term S. The optimal feedback control is u = -Kx;
 ///
-/// @throws std::exception if R is not positive definite.
+/// @throws std::exception if R is not positive definite or if [Q N; N' R] is
+/// not positive semi-definite.
 /// @ingroup control
 LinearQuadraticRegulatorResult DiscreteTimeLinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
     const Eigen::Ref<const Eigen::MatrixXd>& B,
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
-    const Eigen::Ref<const Eigen::MatrixXd>& R);
+    const Eigen::Ref<const Eigen::MatrixXd>& R,
+    const Eigen::Ref<const Eigen::MatrixXd>& N =
+        Eigen::Matrix<double, 0, 0>::Zero());
 
 /// Creates a system that implements the optimal time-invariant linear quadratic
 /// regulator (LQR).  If @p system is a continuous-time system, then solves

--- a/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
@@ -178,7 +178,6 @@ GTEST_TEST(FiniteHorizonLQRTest, DoubleIntegratorWithNonZeroGoal) {
 
   Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
   Vector1d R = Vector1d(4.12);
-  Eigen::Vector2d N(2.2, 1.3);
 
   LinearQuadraticRegulatorResult lqr_result =
       LinearQuadraticRegulator(A, B, Q, R);
@@ -378,15 +377,17 @@ GTEST_TEST(DiscreteTimeFiniteHorizonLQRTest, InfiniteHorizonTest) {
 
   Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
   Vector1d R = Vector1d(4.12);
+  Eigen::Vector2d N(0.2, 1.3);
 
   LinearQuadraticRegulatorResult lqr_result =
-      DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
+      DiscreteTimeLinearQuadraticRegulator(A, B, Q, R, N);
 
   const double t0 = 0;
   const double tf = 40.0;
   FiniteHorizonLinearQuadraticRegulatorOptions options;
   auto context = sys.CreateDefaultContext();
   sys.get_input_port().FixValue(context.get(), 0.0);
+  options.N = N;
 
   // Test that it converges towards the fixed point from zero final cost.
   FiniteHorizonLinearQuadraticRegulatorResult result =
@@ -514,12 +515,14 @@ GTEST_TEST(DiscreteTimeFiniteHorizonLQRTest, AffineSystemTest) {
 
   Eigen::Matrix2d Q;
   Eigen::Matrix2d R;
+  Eigen::Matrix2d N;
   Q << 0.8, 0.7, 0.7, 0.9;
   R << 1.4, 0.2, 0.2, 1.2;
+  N << 0.1, 0.2, 0.3, 0.4;
 
   // Solve it again with the other interface to get access to S.
   LinearQuadraticRegulatorResult lqr_result =
-      DiscreteTimeLinearQuadraticRegulator(A, B, Q, R);
+      DiscreteTimeLinearQuadraticRegulator(A, B, Q, R, N);
 
   const double t0 = 0;
   const double tf = 70.0;
@@ -530,6 +533,7 @@ GTEST_TEST(DiscreteTimeFiniteHorizonLQRTest, AffineSystemTest) {
   const Eigen::Vector2d udv = -B.inverse() * c;
   trajectories::PiecewisePolynomial<double> ud_traj(udv);
   options.ud = &ud_traj;
+  options.N = N;
   options.Qf = lqr_result.S;
 
   FiniteHorizonLinearQuadraticRegulatorResult result =

--- a/systems/controllers/test/linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/linear_quadratic_regulator_test.cc
@@ -291,6 +291,26 @@ GTEST_TEST(TestLqr, DiscreteDoubleIntegrator) {
 
   // Test AffineSystem version of the LQR
   TestLqrAffineSystemAgainstKnownSolution(tol, sys, K, Q, R);
+
+  // A different cost function with the same Q and R, and an extra N = [1; 0].
+  Eigen::Vector2d N(1, 0);
+  // Solution from dlqr in Matlab.
+  K << 0.427961322156271, 1.06165953563278;
+
+  // clang-format off
+  S << 2.48073711494216, 1.33665975925470,
+       1.33665975925470, 4.45997883052027;
+  // clang-format on
+
+  result = DiscreteTimeLinearQuadraticRegulator(A, B, Q, R, N);
+  EXPECT_TRUE(CompareMatrices(result.K, K, tol));
+  EXPECT_TRUE(CompareMatrices(result.S, S, tol));
+
+  // Test LinearSystem version of the LQR
+  TestLqrLinearSystemAgainstKnownSolution(tol, sys, K, Q, R, N);
+
+  // Test AffineSystem version of the LQR
+  TestLqrAffineSystemAgainstKnownSolution(tol, sys, K, Q, R, N);
 }
 
 // Adds test coverage for calling LQR from a LeafSystem and from a


### PR DESCRIPTION
The current discrete-time LQR implementation only supports minimizing  

$$ \sum_{n=0}^\infty x^\top Q x + u^\top R u. $$  

This PR completes the TODOs in the code and extends support for minimizing  

$$ \sum_{n=0}^\infty x^\top Q x + u^\top R u + 2 x^\top N u. $$

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22686)
<!-- Reviewable:end -->
