### PR TITLE
Add discrete-time steady-state Kalman filter

### DIFF
--- a/bindings/pydrake/systems/estimators_py.cc
+++ b/bindings/pydrake/systems/estimators_py.cc
@@ -55,6 +55,11 @@ PYBIND11_MODULE(estimators, m) {
         py::arg("A"), py::arg("C"), py::arg("W"), py::arg("V"),
         doc.SteadyStateKalmanFilter.doc_ACWV);
 
+    m.def("DiscreteTimeSteadyStateKalmanFilter",
+        &DiscreteTimeSteadyStateKalmanFilter, py::arg("A"), py::arg("C"),
+        py::arg("W"), py::arg("V"),
+        doc.DiscreteTimeSteadyStateKalmanFilter.doc);
+
     m.def(
         "SteadyStateKalmanFilter",
         [](const LinearSystem<double>& system,

--- a/bindings/pydrake/systems/test/estimators_test.py
+++ b/bindings/pydrake/systems/test/estimators_test.py
@@ -35,6 +35,9 @@ class TestEstimators(unittest.TestCase):
         L = mut.SteadyStateKalmanFilter(A=A, C=C, W=W, V=V)
         self.assertEqual(L.shape, (2, 2))
 
+        L = mut.DiscreteTimeSteadyStateKalmanFilter(A=A, C=C, W=W, V=V)
+        self.assertEqual(L.shape, (2, 2))
+
         plant = LinearSystem(A=A, C=C)
         filter = mut.SteadyStateKalmanFilter(system=plant, W=W, V=V)
         self.assertIsInstance(filter, mut.LuenbergerObserver)

--- a/systems/estimators/BUILD.bazel
+++ b/systems/estimators/BUILD.bazel
@@ -23,7 +23,8 @@ drake_cc_library(
     hdrs = ["kalman_filter.h"],
     deps = [
         ":luenberger_observer",
-        "//systems/controllers:linear_quadratic_regulator",
+        "//math:continuous_algebraic_riccati_equation",
+        "//math:discrete_algebraic_riccati_equation",
         "//systems/framework",
         "//systems/primitives:linear_system",
     ],

--- a/systems/estimators/kalman_filter.cc
+++ b/systems/estimators/kalman_filter.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/math/continuous_algebraic_riccati_equation.h"
+#include "drake/math/discrete_algebraic_riccati_equation.h"
 #include "drake/systems/estimators/luenberger_observer.h"
 #include "drake/systems/primitives/linear_system.h"
 
@@ -16,18 +17,40 @@ Eigen::MatrixXd SteadyStateKalmanFilter(
     const Eigen::Ref<const Eigen::MatrixXd>& C,
     const Eigen::Ref<const Eigen::MatrixXd>& W,
     const Eigen::Ref<const Eigen::MatrixXd>& V) {
-  const auto& P =
-      math::ContinuousAlgebraicRiccatiEquation(
-          A.transpose(), C.transpose(), W, V);
+  const auto& P = math::ContinuousAlgebraicRiccatiEquation(A.transpose(),
+                                                           C.transpose(), W, V);
   return P * C.transpose() * V.inverse();
+}
+
+Eigen::MatrixXd DiscreteTimeSteadyStateKalmanFilter(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::MatrixXd>& C,
+    const Eigen::Ref<const Eigen::MatrixXd>& W,
+    const Eigen::Ref<const Eigen::MatrixXd>& V) {
+  // Kalman filter dynamics:
+  // K = P̂C'(CP̂C' + V)⁻¹
+  // x̂[n|n] = x̂[n|n-1] + K(y - ŷ)
+  // x̂[n+1|n] = Ax̂[n|n] + Bu[n]
+  // Steady state dynamics:
+  // x̂[n+1|n] = Ax̂[n|n-1] + Bu[n] + L(y - ŷ)
+  // Therefore, L = AK = APC'(CPC' + V)⁻¹
+  const auto& P = math::DiscreteAlgebraicRiccatiEquation(A.transpose(),
+                                                         C.transpose(), W, V);
+  return (C * P * C.transpose() + V)
+      .llt()
+      .solve(C * P * A.transpose())
+      .transpose();
 }
 
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::shared_ptr<const LinearSystem<double>> system,
     const Eigen::Ref<const Eigen::MatrixXd>& W,
     const Eigen::Ref<const Eigen::MatrixXd>& V) {
+  const bool is_continuous = system->IsDifferentialEquationSystem();
   const Eigen::MatrixXd L =
-      SteadyStateKalmanFilter(system->A(), system->C(), W, V);
+      is_continuous
+          ? SteadyStateKalmanFilter(system->A(), system->C(), W, V)
+          : DiscreteTimeSteadyStateKalmanFilter(system->A(), system->C(), W, V);
 
   return std::make_unique<LuenbergerObserver<double>>(
       std::move(system), *system->CreateDefaultContext(), L);
@@ -35,22 +58,25 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
 
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::shared_ptr<const System<double>> system,
-    const Context<double>& context,
-    const Eigen::Ref<const Eigen::MatrixXd>& W,
+    const Context<double>& context, const Eigen::Ref<const Eigen::MatrixXd>& W,
     const Eigen::Ref<const Eigen::MatrixXd>& V) {
-  DRAKE_DEMAND(context.get_continuous_state_vector().size() >
-               0);  // Otherwise, I don't need an estimator.
+  const bool is_continuous = system->IsDifferentialEquationSystem();
+  DRAKE_DEMAND((is_continuous ? context.get_continuous_state_vector()
+                              : context.get_discrete_state_vector())
+                   .size() > 0);  // Otherwise, I don't need an estimator.
   DRAKE_DEMAND(system->num_output_ports() ==
                1);  // Need measurements to estimate state.
 
   // TODO(russt): Demand time-invariant once we can.
-  // TODO(russt): Check continuous-time (only).
 
   std::unique_ptr<LinearSystem<double>> linear_system =
       Linearize(*system, context);
 
   const Eigen::MatrixXd L =
-      SteadyStateKalmanFilter(linear_system->A(), linear_system->C(), W, V);
+      is_continuous ? SteadyStateKalmanFilter(linear_system->A(),
+                                              linear_system->C(), W, V)
+                    : DiscreteTimeSteadyStateKalmanFilter(
+                          linear_system->A(), linear_system->C(), W, V);
 
   return std::make_unique<LuenbergerObserver<double>>(std::move(system),
                                                       context, L);

--- a/systems/estimators/kalman_filter.h
+++ b/systems/estimators/kalman_filter.h
@@ -12,7 +12,8 @@ namespace drake {
 namespace systems {
 namespace estimators {
 
-/// Computes the optimal observer gain, L, for the linear system defined by
+/// Computes the optimal observer gain, L, for the continuous-time linear system
+/// defined by
 ///   @f[ \dot{x} = Ax + Bu + w, @f]
 ///   @f[ y = Cx + Du + v. @f]
 /// The resulting observer is of the form
@@ -28,12 +29,13 @@ namespace estimators {
 /// @param C The state-space output matrix of size num_outputs x num_states.
 /// @param W The process noise covariance matrix, E[ww'], of size num_states x
 /// num_states.
-/// @param V The measurement noise covariance matrix, E[vv'], of size num_.
+/// @param V The measurement noise covariance matrix, E[vv'], of size
+/// num_outputs x num_outputs.
 /// @returns The steady-state observer gain matrix of size num_states x
 /// num_outputs.
 ///
 /// @throws std::exception if V is not positive definite.
-/// @ingroup estimator_systems
+/// @ingroup estimation
 /// @pydrake_mkdoc_identifier{ACWV}
 ///
 Eigen::MatrixXd SteadyStateKalmanFilter(
@@ -42,13 +44,47 @@ Eigen::MatrixXd SteadyStateKalmanFilter(
     const Eigen::Ref<const Eigen::MatrixXd>& W,
     const Eigen::Ref<const Eigen::MatrixXd>& V);
 
+/// Computes the optimal observer gain, L, for the discrete-time linear system
+/// defined by
+///   @f[ x[n+1] = Ax[n] + Bu[n] + w, @f]
+///   @f[ y[n] = Cx[n] + Du[n] + v. @f]
+/// The resulting observer is of the form
+///   @f[ \hat{x}[n+1] = A\hat{x}[n] + Bu[n] + L(y - C\hat{x}[n] - Du[n]). @f]
+/// The process noise, w, and the measurement noise, v, are assumed to be iid
+/// mean-zero Gaussian.
+///
+/// This is a simplified form of the full Kalman filter obtained by assuming
+/// that the state-covariance matrix has already converged to its steady-state
+/// solution P, and the observer gain L = APC'(CPC' + V)⁻¹.
+///
+/// @param A The state-space dynamics matrix of size num_states x num_states.
+/// @param C The state-space output matrix of size num_outputs x num_states.
+/// @param W The process noise covariance matrix, E[ww'], of size num_states x
+/// num_states.
+/// @param V The measurement noise covariance matrix, E[vv'], of size
+/// num_outputs x num_outputs.
+/// @returns The steady-state observer gain matrix of size num_states x
+/// num_outputs.
+///
+/// @throws std::exception if W is not positive semi-definite or if V is not
+/// positive definite.
+/// @ingroup estimation
+///
+Eigen::MatrixXd DiscreteTimeSteadyStateKalmanFilter(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::MatrixXd>& C,
+    const Eigen::Ref<const Eigen::MatrixXd>& W,
+    const Eigen::Ref<const Eigen::MatrixXd>& V);
+
 /// Creates a Luenberger observer system using the optimal steady-state Kalman
-/// filter gain matrix, L, as described above.
+/// filter gain matrix, L, as described in @ref SteadyStateKalmanFilter and @ref
+/// DiscreteTimeSteadyStateKalmanFilter.
 ///
 /// @param system The LinearSystem describing the system to be observed.
 /// @param W The process noise covariance matrix, E[ww'], of size num_states x
 /// num_states.
-/// @param V The measurement noise covariance matrix, E[vv'], of size num_.
+/// @param V The measurement noise covariance matrix, E[vv'], of size
+/// num_outputs x num_outputs.
 /// @returns The constructed observer system.
 ///
 /// @throws std::exception if V is not positive definite.
@@ -62,22 +98,27 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
 /// Creates a Luenberger observer system using the steady-state Kalman filter
 /// observer gain.
 ///
-/// Assuming @p system has the (continuous-time) dynamics:
-///   dx/dt = f(x,u),
-/// and the output:
-///   y = g(x,u),
-/// then the resulting observer will have the form
-///   dx̂/dt = f(x̂,u) + L(y - g(x̂,u)),
-/// where x̂ is the estimated state and the gain matrix, L, is designed
-/// as a steady-state Kalman filter using a linearization of f(x,u) at
-/// `context` as described above.
+/// If @p system has continuous-time dynamics: ẋ = f(x,u), and the output: y =
+/// g(x,u), then the resulting observer will have the form
+/// dx̂/dt = f(x̂,u) + L(y − g(x̂,u)),
+/// where x̂ is the estimated state and the gain matrix, L, is designed as a
+/// steady-state Kalman filter using a linearization of f(x,u) at @p
+/// context as described above.
+///
+/// If @p system has discrete-time dynamics: x[n+1] = f(x[n],u[n]), and the
+/// output: y[n] = g(x[n],u[n]), then the resulting observer will have the form
+/// x̂[n+1] = f(x̂[n],u[n]) + L(y − g(x̂[n],u[n])),
+/// where x̂[n+1] is the estimated state and the gain matrix, L, is designed as
+/// a steady-state Kalman filter using a linearization of f(x,u) at @p context
+/// as described above.
 ///
 /// @param system The System describing the system to be observed.
 /// @param context The context describing a fixed-point of the system (plus any
 /// additional parameters).
 /// @param W The process noise covariance matrix, E[ww'], of size num_states x
 /// num_states.
-/// @param V The measurement noise covariance matrix, E[vv'], of size num_.
+/// @param V The measurement noise covariance matrix, E[vv'], of size
+/// num_outputs x num_outputs.
 /// @returns The constructed observer system.
 ///
 /// @throws std::exception if V is not positive definite.
@@ -85,8 +126,7 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
 /// @pydrake_mkdoc_identifier{system}
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::shared_ptr<const System<double>> system,
-    const Context<double>& context,
-    const Eigen::Ref<const Eigen::MatrixXd>& W,
+    const Context<double>& context, const Eigen::Ref<const Eigen::MatrixXd>& W,
     const Eigen::Ref<const Eigen::MatrixXd>& V);
 
 DRAKE_DEPRECATED(

--- a/systems/estimators/luenberger_observer.h
+++ b/systems/estimators/luenberger_observer.h
@@ -13,19 +13,26 @@ namespace drake {
 namespace systems {
 namespace estimators {
 
-/// A simple state observer for a dynamical system of the form:
-/// @f[\dot{x} = f(x,u) @f]
-/// @f[y = g(x,u) @f]
+/// A simple state observer for a continuous-time dynamical system of the form:
+///  @f[ \dot{x} = f(x,u) @f]
+///  @f[ y = g(x,u) @f]
 /// the observer dynamics takes the form
-/// @f[\dot{\hat{x}} = f(\hat{x},u) + L(y - g(\hat{x},u)) @f]
-/// where @f$\hat{x}@f$ is the estimated state of the original system.
+///  @f[ \dot{\hat{x}} = f(\hat{x},u) + L(y - g(\hat{x},u)) @f]
+/// where @f$\hat{x}@f$ is the estimated state of the original system. The
+/// output of the observer system is @f$\hat{x}@f$.
 ///
-/// The output of the observer system is @f$\hat{x}@f$.
+/// Or a simple state observer for a discrete-time dynamical system of the form:
+///  @f[ x[n+1] = f_d(x[n],u[n]) @f]
+///  @f[ y[n] = g(x[n],u[n]) @f]
+/// the observer dynamics takes the form
+///  @f[ \hat{x}[n+1] = f(\hat{x}[n],u[n]) + L(y - g(\hat{x}[n],u[n])) @f]
+/// where @f$\hat{x}@f$ is the estimated state of the original system.
+/// The output of the observer system is @f$\hat{x}[n+1]@f$.
 ///
 /// @system
 /// name: LuenbergerObserver
 /// input_ports:
-/// - observed system input
+/// - observed_system_input
 /// - observed_system_output
 /// output_ports:
 /// - estimated_state
@@ -34,7 +41,7 @@ namespace estimators {
 /// @ingroup estimator_systems
 /// @tparam_default_scalar
 template <typename T>
-class LuenbergerObserver final: public LeafSystem<T> {
+class LuenbergerObserver final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LuenbergerObserver);
 
@@ -88,13 +95,12 @@ class LuenbergerObserver final: public LeafSystem<T> {
 
  private:
   // Advance the state estimate using forward dynamics and the observer
-  // gains.
+  // gains. Continuous-time version.
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override;
-
-  // Outputs the estimated state.
-  void CalcEstimatedState(const Context<T>& context,
-                          BasicVector<T>* output) const;
+  // Discrete-time version.
+  void DiscreteUpdate(const Context<T>& context,
+                      DiscreteValues<T>* x_estimate) const;
 
   void UpdateObservedSystemContext(const Context<T>& context,
                                    Context<T>* observed_system_context) const;

--- a/systems/estimators/test/kalman_filter_test.cc
+++ b/systems/estimators/test/kalman_filter_test.cc
@@ -11,7 +11,7 @@ namespace estimators {
 
 namespace {
 
-GTEST_TEST(TestKalman, DoubleIntegrator) {
+GTEST_TEST(TestContinuousTimeKalman, DoubleIntegrator) {
   // Double integrator dynamics: qddot = u, where q is the position coordinate.
   Eigen::Matrix2d A;
   Eigen::Vector2d B;
@@ -61,6 +61,48 @@ GTEST_TEST(TestKalman, DoubleIntegrator) {
   filter = SteadyStateKalmanFilter(std::move(owned), *context, W, V);
   EXPECT_TRUE(CompareMatrices(filter->L(), L, tol));
 #pragma GCC diagnostic pop
+}
+
+GTEST_TEST(TestDiscreteTimeKalman, DoubleIntegrator) {
+  const double h = 0.01;
+  Eigen::Matrix2d A;
+  Eigen::Vector2d B;
+  Eigen::Matrix<double, 1, 2> C;
+  Vector1d D;
+  A << 1, h, 0, 1;
+  B << 0.5 * h * h, h;
+  C << 1, 0;
+  D << 0;
+
+  // Specify simple noise covariance matrices.
+  Eigen::Matrix2d W;
+  Vector1d V;
+  W << h, 0, 0, h;
+  V << 1 / h;
+
+  // Solution using the matlab command A*dlqe(A,eye(2),C,W,V).
+  Eigen::Matrix<double, 2, 1> L;
+  L << 0.0172705080770414, 0.00991377137943259;
+
+  double tol = 1e-13;
+
+  // Test the matrix-only version.
+  EXPECT_TRUE(
+      CompareMatrices(DiscreteTimeSteadyStateKalmanFilter(A, C, W, V), L, tol));
+
+  // Test LinearSystem version of the Kalman filter.
+  auto sys = std::make_shared<const LinearSystem<double>>(A, B, C, D, h);
+  auto linear_filter = SteadyStateKalmanFilter(sys, W, V);
+  EXPECT_TRUE(CompareMatrices(linear_filter->L(), L, tol));
+
+  // Call it as a generic System (by passing in a Context).
+  // Should get the same result, but as an affine system.
+  auto context = sys->CreateDefaultContext();
+  sys->get_input_port().FixValue(context.get(), 0.0);
+  context->SetDiscreteState(Eigen::Vector2d::Zero());
+  auto filter = SteadyStateKalmanFilter(sys, *context, W, V);
+  context.reset();
+  EXPECT_TRUE(CompareMatrices(filter->L(), L, tol));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR implements the discrete-time steady-state Kalman filter and Luenberger observer.

For reference, the Kalman filter dynamics is given by:

$$
K = \hat{P} C^\top (C \hat{P} C^\top+ V)^{-1}
$$
$$
\hat{x}[n|n] = \hat{x}[n|n-1] + K(y - \hat{y})
$$
$$
\hat{x}[n+1|n] = A \hat{x}[n|n] + B u[n]
$$

At steady-state, the dynamics is given by:

$$
\hat{x}[n+1|n] = A \hat{x}[n|n-1] + B u[n] + L(y - \hat{y})
$$

Thus, the observer gain is:

$$
L = A \hat{P} C^\top (C \hat{P} C^\top + V)^{-1}
$$

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22687)
<!-- Reviewable:end -->
