### PR TITLE
Revert "[multibody] MakeMobilizerForJoint() can now create Frames"

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3895,8 +3895,8 @@ void MultibodyPlant<T>::CalcReactionForces(
   // for the discrete solvers we have today, though it might change for future
   // solvers that prefer an implicit evaluation of these terms.
   // TODO(amcastro-tri): Consider having a
-  //  DiscreteUpdateManager::EvalReactionForces() to ensure the manager performs
-  //  this computation consistently with its discrete update.
+  // DiscreteUpdateManager::EvalReactionForces() to ensure the manager performs
+  // this computation consistently with its discrete update.
   const VectorX<T>& vdot = this->EvalForwardDynamics(context).get_vdot();
   std::vector<SpatialAcceleration<T>> A_WB_vector(num_bodies());
   std::vector<SpatialForce<T>> F_BMo_W_vector(num_bodies());
@@ -3908,9 +3908,9 @@ void MultibodyPlant<T>::CalcReactionForces(
   // Since vdot is the result of Fapplied and tau_applied we expect the result
   // from inverse dynamics to be zero.
   // TODO(amcastro-tri): find a better estimation for this bound. For instance,
-  //  we can make an estimation based on the trace of the mass matrix (Jain
-  //  2011, Eq. 4.21). For now we only ASSERT though with a better estimation we
-  //  could promote this to a DEMAND.
+  // we can make an estimation based on the trace of the mass matrix (Jain 2011,
+  // Eq. 4.21). For now we only ASSERT though with a better estimation we could
+  // promote this to a DEMAND.
   // TODO(amcastro-tri) Uncomment this line once issue #12473 is resolved.
   // DRAKE_ASSERT(tau_id.norm() <
   //              100 * num_velocities() *
@@ -3924,49 +3924,61 @@ void MultibodyPlant<T>::CalcReactionForces(
         internal_tree().get_joint_mobilizer(joint_index);
     const internal::Mobilizer<T>& mobilizer =
         internal_tree().get_mobilizer(mobilizer_index);
-
-    // Reversed means the joint's parent(child) body is the outboard(inboard)
-    // body for the mobilizer.
-    const bool is_reversed = mobilizer.mobod().is_reversed();
+    const internal::MobodIndex mobod_index = mobilizer.mobod().index();
 
     // F_BMo_W is the mobilizer reaction force on mobilized body B at the origin
     // Mo of the mobilizer's outboard frame M, expressed in the world frame W.
-    const SpatialForce<T>& F_BMo_W = F_BMo_W_vector[mobilizer_index];
-
-    // But the quantity of interest, F_CJc_Jc, is the joint's reaction force on
-    // the joint's child body C at the joint's child frame Jc, expressed in Jc.
-    SpatialForce<T>& F_CJc_Jc = output->at(joint.ordinal());
+    const SpatialForce<T>& F_BMo_W = F_BMo_W_vector[mobod_index];
 
     // Frames of interest:
+    const Frame<T>& frame_Jp = joint.frame_on_parent();
     const Frame<T>& frame_Jc = joint.frame_on_child();
-    const Frame<T>& frame_M = mobilizer.outboard_frame();
+    const FrameIndex F_index = mobilizer.inboard_frame().index();
+    const FrameIndex M_index = mobilizer.outboard_frame().index();
+    const FrameIndex Jp_index = frame_Jp.index();
+    const FrameIndex Jc_index = frame_Jc.index();
+
+    // In Drake we must have either:
+    //  - Jp == F and Jc == M (typical case)
+    //  - Jp == M and Jc == F (mobilizer is reversed from joint)
+    DRAKE_DEMAND((Jp_index == F_index && Jc_index == M_index) ||
+                 (Jp_index == M_index && Jc_index == F_index));
+
+    // Mobilizer is reversed if the joint's parent frame Jp is the mobilizer's
+    // outboard frame M.
+    const bool is_reversed = (Jp_index == M_index);
 
     // We'll need this in both cases below since we're required to report
     // the reaction force expressed in the joint's child frame Jc.
     const RotationMatrix<T> R_JcW =
         frame_Jc.CalcRotationMatrixInWorld(context).inverse();
 
-    if (&frame_M == &frame_Jc) {
-      // This is the easy case. Just need to re-express.
-      F_CJc_Jc = R_JcW * F_BMo_W;
-      continue;
+    // The quantity of interest, F_CJc_Jc, is the joint's reaction force on the
+    // joint's child body C at the joint's child frame Jc, expressed in Jc.
+    SpatialForce<T>& F_CJc_Jc = output->at(joint.ordinal());
+    if (!is_reversed) {
+      F_CJc_Jc = R_JcW * F_BMo_W;  // The typical case: Mo==Jc and B==C.
+    } else {
+      // For this reversed case, F_BMo_W is the reaction on the joint's _parent_
+      // body at Jp, expressed in W.
+      const SpatialForce<T>& F_PJp_W = F_BMo_W;  // Reversed: Mo==Jp and B==P.
+
+      // Newton's 3ʳᵈ law (action/reaction) (and knowing Drake's joints are
+      // massless) says the force on the child _at Jp_ is equal and opposite to
+      // the force on the parent at Jp.
+      const SpatialForce<T> F_CJp_W = -F_PJp_W;
+      const SpatialForce<T> F_CJp_Jc = R_JcW * F_CJp_W;  // Reexpress in Jc.
+
+      // However, the reaction force we want to report on the child is at Jc,
+      // not Jp. We need to shift the application point from Jp to Jc.
+
+      // Find the shift vector p_JpJc_Jc (= -p_JcJp_Jc).
+      const RigidTransform<T> X_JcJp = frame_Jp.CalcPose(context, frame_Jc);
+      const Vector3<T> p_JpJc_Jc = -X_JcJp.translation();
+
+      // Perform  the Jp->Jc shift.
+      F_CJc_Jc = F_CJp_Jc.Shift(p_JpJc_Jc);
     }
-
-    // If the mobilizer is reversed, Newton's 3ʳᵈ law (action/reaction) (and
-    // knowing Drake's joints are massless) says the force on the child at M
-    // is equal and opposite to the force on the parent at M.
-    const SpatialForce<T> F_CMo_W = is_reversed ? -F_BMo_W : F_BMo_W;
-    const SpatialForce<T> F_CMo_Jc = R_JcW * F_CMo_W;  // Reexpress in Jc.
-
-    // However, the reaction force we want to report on the child is at Jc,
-    // not M. We need to shift the application point from Mo to Jco.
-
-    // Find the shift vector p_MoJco_Jc (= -p_JcoMo_Jc).
-    const RigidTransform<T> X_JcM = frame_M.CalcPose(context, frame_Jc);
-    const Vector3<T> p_MoJco_Jc = -X_JcM.translation();
-
-    // Perform  the M->Jc shift.
-    F_CJc_Jc = F_CMo_Jc.Shift(p_MoJco_Jc);
   }
 }
 

--- a/multibody/plant/test/sap_driver_multidof_joints_test.cc
+++ b/multibody/plant/test/sap_driver_multidof_joints_test.cc
@@ -92,15 +92,13 @@ class MultiDofJointWithLimits final : public Joint<T> {
   int do_get_position_start() const override { return 0; }
 
   std::unique_ptr<Mobilizer<T>> MakeMobilizerForJoint(
-      const SpanningForest::Mobod& mobod,
-      MultibodyTree<T>* tree) const override {
-    DRAKE_DEMAND(tree != nullptr);  // Just a sanity check; we don't need it.
+      const SpanningForest::Mobod& mobod) const override {
     const auto [inboard_frame, outboard_frame] =
         this->tree_frames(mobod.is_reversed());
     // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
-    //  The only restriction here relevant for these tests is that we provide a
-    //  mobilizer with kNumDofs positions and velocities, so that indexes are
-    //  consistent during MultibodyPlant::Finalize().
+    // The only restriction here relevant for these tests is that we provide a
+    // mobilizer with kNumDofs positions and velocities, so that indexes are
+    // consistent during MultibodyPlant::Finalize().
     auto revolute_mobilizer = std::make_unique<internal::RpyBallMobilizer<T>>(
         mobod, *inboard_frame, *outboard_frame);
     return revolute_mobilizer;

--- a/multibody/rational/rational_forward_kinematics.h
+++ b/multibody/rational/rational_forward_kinematics.h
@@ -233,7 +233,8 @@ class RationalForwardKinematics {
   // Computes the pose of the body, connected to its parent body through a
   // weld joint.
   template <typename T>
-  Pose<T> CalcWeldJointChildBodyPose(const math::RigidTransformd& X_PF,
+  Pose<T> CalcWeldJointChildBodyPose(const math::RigidTransformd& X_FM,
+                                     const math::RigidTransformd& X_PF,
                                      const math::RigidTransformd& X_MC,
                                      const Pose<T>& X_AP) const;
 

--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -71,8 +71,7 @@ std::unique_ptr<Joint<T>> BallRpyJoint<T>::DoShallowClone() const {
 // in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> BallRpyJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>*) const {
+    const internal::SpanningForest::Mobod& mobod) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -71,9 +71,9 @@ class BallRpyJoint final : public Joint<T> {
     DRAKE_THROW_UNLESS(damping >= 0);
   }
 
-  ~BallRpyJoint() final;
+  ~BallRpyJoint() override;
 
-  const std::string& type_name() const final;
+  const std::string& type_name() const override;
 
   /// Returns `this` joint's default damping constant in N⋅m⋅s. The damping
   /// torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with
@@ -191,7 +191,7 @@ class BallRpyJoint final : public Joint<T> {
   /// Adding forces per-dof makes no physical sense. Therefore, this method
   /// throws an exception if invoked.
   void DoAddInOneForce(const systems::Context<T>&, int, const T&,
-                       MultibodyForces<T>*) const final {
+                       MultibodyForces<T>*) const override {
     throw std::logic_error(
         "Ball RPY joints do not allow applying forces to individual degrees of "
         "freedom.");
@@ -203,7 +203,7 @@ class BallRpyJoint final : public Joint<T> {
   /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
   /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const final {
+                      MultibodyForces<T>* forces) const override {
     Eigen::Ref<VectorX<T>> t_BMo_F =
         get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
@@ -212,28 +212,28 @@ class BallRpyJoint final : public Joint<T> {
   }
 
  private:
-  int do_get_velocity_start() const final {
+  int do_get_velocity_start() const override {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const final { return 3; }
+  int do_get_num_velocities() const override { return 3; }
 
-  int do_get_position_start() const final {
+  int do_get_position_start() const override {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const final { return 3; }
+  int do_get_num_positions() const override { return 3; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) final {
+      const VectorX<double>& default_positions) override {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
@@ -241,19 +241,18 @@ class BallRpyJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const final;
+      const internal::MultibodyTree<double>& tree_clone) const override;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const final;
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
 
   // Make BallRpyJoint templated on every other scalar type a friend of
   // BallRpyJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/curvilinear_joint.cc
+++ b/multibody/tree/curvilinear_joint.cc
@@ -101,8 +101,7 @@ std::unique_ptr<Joint<T>> CurvilinearJoint<T>::DoShallowClone() const {
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>>
 CurvilinearJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>*) const {
+    const internal::SpanningForest::Mobod& mobod) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/curvilinear_joint.h
+++ b/multibody/tree/curvilinear_joint.h
@@ -121,9 +121,9 @@ class CurvilinearJoint final : public Joint<T> {
           curvilinear_path,
       double pos_lower_limit, double pos_upper_limit, double damping = 0);
 
-  ~CurvilinearJoint() final;
+  ~CurvilinearJoint() override;
 
-  const std::string& type_name() const final;
+  const std::string& type_name() const override;
 
   /** Returns `this` joint's default damping constant in N⋅s/m. */
   double default_damping() const { return this->default_damping_vector()[0]; }
@@ -269,7 +269,7 @@ class CurvilinearJoint final : public Joint<T> {
    @see The public NVI AddInOneForce() for details. */
   void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
                        const T& joint_tau,
-                       MultibodyForces<T>* forces) const final {
+                       MultibodyForces<T>* forces) const override {
     DRAKE_DEMAND(joint_dof == 0);
     Eigen::Ref<VectorX<T>> tau_mob =
         get_mobilizer().get_mutable_generalized_forces_from_array(
@@ -288,63 +288,62 @@ class CurvilinearJoint final : public Joint<T> {
    @param[out] forces The MultibodyForces object to which the damping force is
    added. */
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const final {
+                      MultibodyForces<T>* forces) const override {
     const T damping_force =
         -this->GetDamping(context) * get_tangential_velocity(context);
     AddInForce(context, damping_force, forces);
   }
 
  private:
-  int do_get_velocity_start() const final {
+  int do_get_velocity_start() const override {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const final { return 1; }
+  int do_get_num_velocities() const override { return 1; }
 
-  int do_get_position_start() const final {
+  int do_get_position_start() const override {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const final { return 1; }
+  int do_get_num_positions() const override { return 1; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) final {
+      const VectorX<double>& default_positions) override {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
-  const T& DoGetOnePosition(const systems::Context<T>& context) const final {
+  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
     return get_distance(context);
   }
 
-  const T& DoGetOneVelocity(const systems::Context<T>& context) const final {
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
     return get_tangential_velocity(context);
   }
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const final;
+      const internal::MultibodyTree<double>& tree_clone) const override;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const final;
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
 
   // Make CurvilinearJoint templated on every other scalar type a friend of
   // CurvilinearJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/joint.cc
+++ b/multibody/tree/joint.cc
@@ -73,11 +73,9 @@ Eigen::Ref<const VectorX<T>> Joint<T>::GetVelocities(
 
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> Joint<T>::Build(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>* tree) {
-  DRAKE_DEMAND(tree != nullptr);
+    const internal::SpanningForest::Mobod& mobod) {
   std::unique_ptr<internal::Mobilizer<T>> owned_mobilizer =
-      MakeMobilizerForJoint(mobod, tree);
+      MakeMobilizerForJoint(mobod);
   mobilizer_ = owned_mobilizer.get();
   return owned_mobilizer;
 }

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -753,10 +753,8 @@ class Joint : public MultibodyElement<T> {
   // Hide the following section from Doxygen.
 #ifndef DRAKE_DOXYGEN_CXX
   // (Internal use only) Model this joint using the appropriate Mobilizer.
-  // `tree` must be non-null.
   std::unique_ptr<internal::Mobilizer<T>> Build(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree);
+      const internal::SpanningForest::Mobod& mobod);
 
   // NVI to DoCloneToScalar() templated on the scalar type of the new clone to
   // be created. This method is intended to be called by
@@ -976,45 +974,10 @@ class Joint : public MultibodyElement<T> {
   template <typename>
   friend class Joint;
 
-  /* This method must be implemented by derived Joint classes in order to create
-  a Mobilizer as the Joint's internal representation. Starting with the
-  user's joint frames Jp (on parent) and Jc (on child) we must create an
-  inboard frame F and outboard frame M suitable for an available Mobilizer.
-  For example, if a revolute Mobilizer can only rotate around its z axis,
-  while the revolute Joint specifies an arbitrary axis â, we'll need to
-  calculate frames such that Fz and Mz are aligned with â, and the other
-  axes chosen so that the joint coordinate q has the same meaning as it would
-  when rotating about â. We also must decide whether inboard/outboard is
-  reversed from parent/child. Normally we need X_JpF and X_JcM but when reversed
-  we need X_JcF and X_JpM. (We're ignoring reversal in the discussion below.)
-
-  In the case of revolute, prismatic, and screw joints we have an axis â
-  whose measure numbers are the same in Jp and Jc. However, for maximum
-  speed, the available mobilizers are specialized to rotate only about the
-  +z axis.
-  TODO(sherm1) Make that happen.
-  Consequently, we want new frames F and M with Fz=Mz=â, Fo=Jpo, Mo=Jco. We
-  also want F==M when Jp==Jc, i.e. at the joint zero position so that the
-  coordinate q will mean the same thing using F and M as it would have using
-  Jp, Jc, and â. We need to calculate R_JpF and R_JcM so that we can create
-  appropriate offset frames:
-       R_JpF = MakeFromOneVector(â_Jp, 2)   ("2" means "z axis")
-       R_JcM = R_JcJp(0) * R_JpF * R_FM(0)  (at q=0)
-  But in the zero configurations we have R_JcJp(0)=I and we want R_FM(0)=I
-  also, so R_JcM = R_JpF.
-
-  For a weld joint, we have Jp, Jc, and a fixed X_JpJc. We want to pick F
-  and M so F=M at all times. We can choose M=Jc and create a new offset frame
-  for F that is colocated with Jp:
-       X_JpF = X_JpJc
-  This yields X_FM = X_FJc = X_JpF⁻¹ * X_JpJc = Identity.
-
-  In order to permit auxiliary frames to be created, we provide mutable
-  access to the MultibodyTree here. Don't use that to add anything other
-  than frames. We promise that tree will be non-null. */
+  // This method must be implemented by derived Joint classes in order to
+  // create a Mobilizer as the Joint's internal representation.
   virtual std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const = 0;
+      const internal::SpanningForest::Mobod& mobod) const = 0;
 
   // Helper method to be called within Joint::CloneToScalar() to locate the
   // cloned Mobilizer corresponding to this Joint's Mobilizer.
@@ -1050,8 +1013,8 @@ class Joint : public MultibodyElement<T> {
                               const char* func) const;
 
   std::string name_;
-  const Frame<T>& frame_on_parent_;  // Frame Jp.
-  const Frame<T>& frame_on_child_;   // Frame Jc.
+  const Frame<T>& frame_on_parent_;
+  const Frame<T>& frame_on_child_;
 
   VectorX<double> damping_;
 
@@ -1073,7 +1036,7 @@ class Joint : public MultibodyElement<T> {
   // Joint default position. This vector has zero size for joints with no state.
   VectorX<double> default_positions_;
 
-  // The Joint<T> implementation.
+  // The Joint<T> implementation:
   internal::Mobilizer<T>* mobilizer_{};
 
   // System parameter indices.

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -99,8 +99,8 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
   // to this tree. This is a pathological case, but in theory nothing
   // (but this test) stops a user from adding frames to a tree1 and attempting
   // later to define mobilizers between those frames in a second tree2.
-  mobilizer->inboard_frame().HasThisParentTreeOrThrow(this);   // F frame
-  mobilizer->outboard_frame().HasThisParentTreeOrThrow(this);  // M frame
+  mobilizer->inboard_frame().HasThisParentTreeOrThrow(this);
+  mobilizer->outboard_frame().HasThisParentTreeOrThrow(this);
   MobodIndex mobilizer_index = topology_.add_mobilizer(
       mobilizer->mobod(), mobilizer->inboard_frame().index(),
       mobilizer->outboard_frame().index());
@@ -239,9 +239,9 @@ template <typename T>
 template <template <typename> class JointType, typename... Args>
 const JointType<T>& MultibodyTree<T>::AddJoint(
     const std::string& name, const RigidBody<T>& parent,
-    const std::optional<math::RigidTransform<double>>& X_PJp,
+    const std::optional<math::RigidTransform<double>>& X_PF,
     const RigidBody<T>& child,
-    const std::optional<math::RigidTransform<double>>& X_CJc, Args&&... args) {
+    const std::optional<math::RigidTransform<double>>& X_BM, Args&&... args) {
   static_assert(std::is_base_of_v<Joint<T>, JointType<T>>,
                 "JointType<T> must be a sub-class of Joint<T>.");
 
@@ -259,9 +259,9 @@ const JointType<T>& MultibodyTree<T>::AddJoint(
   // model instance when creating any offset frames needed for the joint.
   const ModelInstanceIndex joint_instance = child.model_instance();
   const Frame<T>& frame_on_parent =
-      this->AddOrGetJointFrame(parent, X_PJp, joint_instance, name, "parent");
+      this->AddOrGetJointFrame(parent, X_PF, joint_instance, name, "parent");
   const Frame<T>& frame_on_child =
-      this->AddOrGetJointFrame(child, X_CJc, joint_instance, name, "child");
+      this->AddOrGetJointFrame(child, X_BM, joint_instance, name, "child");
   const JointType<T>& result = AddJoint(std::make_unique<JointType<T>>(
       name, frame_on_parent, frame_on_child, std::forward<Args>(args)...));
   DRAKE_DEMAND(result.model_instance() == joint_instance);

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -758,7 +758,7 @@ void MultibodyTree<T>::CreateJointImplementations() {
       // Mobods, BodyNodes, and Mobilizers have identical numbering.
       topology_.add_world_mobilizer(mobod, world_body().body_frame().index());
       auto dummy_weld = std::make_unique<internal::WeldMobilizer<T>>(
-          mobod, world_frame(), world_frame());
+          mobod, world_frame(), world_frame(), RigidTransform<double>());
       dummy_weld->set_model_instance(world_model_instance());
       dummy_weld->set_parent_tree(this, MobodIndex(0));
       mobilizers_.push_back(std::move(dummy_weld));
@@ -783,7 +783,7 @@ void MultibodyTree<T>::CreateJointImplementations() {
           GetModelInstanceName(joint.model_instance())));
     }
 
-    std::unique_ptr<Mobilizer<T>> owned_mobilizer = joint.Build(mobod, this);
+    std::unique_ptr<Mobilizer<T>> owned_mobilizer = joint.Build(mobod);
     Mobilizer<T>* mobilizer = owned_mobilizer.get();
     AddMobilizer(std::move(owned_mobilizer));  // ownership->tree
     mobilizer->set_model_instance(joint.model_instance());

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -387,13 +387,10 @@ class MultibodyTree {
   // _parent_ body is made inboard and the _child_ outboard in the tree.
   //
   // As explained in the Joint class's documentation, in Drake we define a
-  // frame Jp attached to the parent body P with pose `X_PJp` and a frame Jc
-  // attached to the child body C with pose `X_CJc`. This method helps create
-  // a joint between two bodies with fixed poses `X_PJp` and `X_CJc`.
-  // Refer to the Joint class's documentation for more details. (We have
-  // sometimes used F for Jp and M for Jc in documentation; don't confuse
-  // those with the implementing Mobilizer's inboard F frame and outboard M
-  // frame which in general are not the same.)
+  // frame F attached to the parent body P with pose `X_PF` and a frame M
+  // attached to the child body B with pose `X_BM`. This method helps create
+  // a joint between two bodies with fixed poses `X_PF` and `X_BM`.
+  // Refer to the Joint class's documentation for more details.
   //
   // The arguments to this method `args` are forwarded to `JointType`'s
   // constructor. The newly created `JointType` object will be specialized on
@@ -403,45 +400,43 @@ class MultibodyTree {
   //   The name of the joint.
   // @param[in] parent
   //   The parent body connected by the new joint.
-  // @param[in] X_PJp
-  //   The fixed pose of frame Jp attached to the parent body, measured in
-  //   the frame P of that body. X_PJp is an optional parameter; empty curly
-  //   braces {} imply that frame Jp **is** the same body frame P. If instead
-  //   your intention is to make a separate frame Jp that is coincident
-  //   (by default at least) with P, provide
-  //   X_PJp = RigidTransform<double>::Identity() as your input.
+  // @param[in] X_PF
+  //   The fixed pose of frame F attached to the parent body, measured in
+  //   the frame P of that body. `X_PF` is an optional parameter; empty curly
+  //   braces `{}` imply that frame F **is** the same body frame P. If instead
+  //   your intention is to make a frame F with pose `X_PF`, provide
+  //   `RigidTransform<double>::Identity()` as your input.
   // @param[in] child
   //   The child body connected by the new joint.
-  // @param[in] X_CJc
-  //   The fixed pose of frame Jc attached to the child body, measured in
-  //   the frame C of that body. X_CJc is an optional parameter; empty curly
-  //   braces {} imply that frame Jc **is** the same body frame C. If instead
-  //   your intention is to make a separate frame Jc that is coincident
-  //   (by default at least) with C, provide
-  //   X_CJc = RigidTransform<double>::Identity() as your input.
+  // @param[in] X_BM
+  //   The fixed pose of frame M attached to the child body, measured in
+  //   the frame B of that body. `X_BM` is an optional parameter; empty curly
+  //   braces `{}` imply that frame M **is** the same body frame B. If instead
+  //   your intention is to make a frame F with pose `X_PF`, provide
+  //   `RigidTransform<double>::Identity()` as your input.
   // @tparam JointType
   //   The type of the new joint to add, which must be a subclass of Joint<T>.
-  // @returns A const reference to the new joint just added, of type
-  //   JointType<T> specialized on the scalar type T of `this`
+  // @returns A constant reference to the new joint just added, of type
+  //   `JointType<T>` specialized on the scalar type T of `this`
   //   %MultibodyTree. It will remain valid for the lifetime of `this`
   //   %MultibodyTree.
   //
   // Example of usage:
   // @code
   //   MultibodyTree<T> model;
-  //   // ... Code to define a parent body P and a child body C.
+  //   // ... Code to define a parent body P and a child body B.
   //   const RigidBody<double>& parent_body =
   //     model.AddRigidBody(parent_name, SpatialInertia<double>(...));
   //   const RigidBody<double>& child_body =
   //     model.AddRigidBody(child_name, SpatialInertia<double>(...));
-  //   // Define the pose X_CJc of a frame Jc rigidly attached to child body C.
+  //   // Define the pose X_BM of a frame M rigidly attached to child body B.
   //   const RevoluteJoint<double>& elbow =
   //     model.AddJoint<RevoluteJoint>(
   //       "Elbow",                /* joint name */
   //       model.world_body(),     /* parent body */
-  //       {},                     /* frame Jp IS the parent body frame P */
+  //       {},                     /* frame F IS the parent body frame P */
   //       pendulum,               /* child body, the pendulum */
-  //       X_CJc,                  /* pose of frame Jc in child body frame C */
+  //       X_BM,                   /* pose of frame M in the body frame B */
   //       Vector3d::UnitZ());     /* revolute axis in this case */
   // @endcode
   //
@@ -454,16 +449,17 @@ class MultibodyTree {
   template <template <typename> class JointType, typename... Args>
   const JointType<T>& AddJoint(
       const std::string& name, const RigidBody<T>& parent,
-      const std::optional<math::RigidTransform<double>>& X_PJp,
+      const std::optional<math::RigidTransform<double>>& X_PF,
       const RigidBody<T>& child,
-      const std::optional<math::RigidTransform<double>>& X_CJc, Args&&... args);
+      const std::optional<math::RigidTransform<double>>& X_BM, Args&&... args);
 
   // See MultibodyPlant documentation.
   void RemoveJoint(const Joint<T>& joint);
 
   // Creates and adds a JointActuator model for an actuator acting on a given
-  // `joint`. This method returns a const reference to the actuator just added,
-  // which will remain valid for the lifetime of `this` %MultibodyTree.
+  // `joint`.
+  // This method returns a constant reference to the actuator just added, which
+  // will remain valid for the lifetime of `this` %MultibodyTree.
   //
   // @param[in] name
   //   A string that identifies the new actuator to be added to `this`

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -70,8 +70,7 @@ std::unique_ptr<Joint<T>> PlanarJoint<T>::DoShallowClone() const {
 // in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> PlanarJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>*) const {
+    const internal::SpanningForest::Mobod& mobod) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -305,11 +305,11 @@ class PlanarJoint final : public Joint<T> {
 
   int do_get_num_positions() const final { return 3; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
@@ -322,8 +322,7 @@ class PlanarJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -71,9 +71,9 @@ class PrismaticJoint final : public Joint<T> {
       double pos_upper_limit = std::numeric_limits<double>::infinity(),
       double damping = 0);
 
-  ~PrismaticJoint() final;
+  ~PrismaticJoint() override;
 
-  const std::string& type_name() const final;
+  const std::string& type_name() const override;
 
   /// Returns the axis of translation for `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
@@ -255,52 +255,51 @@ class PrismaticJoint final : public Joint<T> {
   /// viscous law `f = -d⋅v`, with d the damping coefficient (see
   /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const final {
+                      MultibodyForces<T>* forces) const override {
     const T damping_force =
         -this->GetDamping(context) * get_translation_rate(context);
     AddInForce(context, damping_force, forces);
   }
 
  private:
-  int do_get_velocity_start() const final {
+  int do_get_velocity_start() const override {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const final { return 1; }
+  int do_get_num_velocities() const override { return 1; }
 
-  int do_get_position_start() const final {
+  int do_get_position_start() const override {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const final { return 1; }
+  int do_get_num_positions() const override { return 1; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) final {
+      const VectorX<double>& default_positions) override {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
-  const T& DoGetOnePosition(const systems::Context<T>& context) const final {
+  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
     return get_translation(context);
   }
 
-  const T& DoGetOneVelocity(const systems::Context<T>& context) const final {
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
     return get_translation_rate(context);
   }
 
   // Joint<T> finals:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>*) const final {
+      const internal::SpanningForest::Mobod& mobod) const final {
     const auto [inboard_frame, outboard_frame] =
         this->tree_frames(mobod.is_reversed());
     // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/quaternion_floating_joint.cc
+++ b/multibody/tree/quaternion_floating_joint.cc
@@ -68,8 +68,7 @@ std::unique_ptr<Joint<T>> QuaternionFloatingJoint<T>::DoShallowClone() const {
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>>
 QuaternionFloatingJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>*) const {
+    const internal::SpanningForest::Mobod& mobod) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/quaternion_floating_joint.h
+++ b/multibody/tree/quaternion_floating_joint.h
@@ -97,10 +97,10 @@ class QuaternionFloatingJoint final : public Joint<T> {
     this->set_default_quaternion(Quaternion<double>::Identity());
   }
 
-  ~QuaternionFloatingJoint() final;
+  ~QuaternionFloatingJoint() override;
 
   /// Returns the name of this joint type: "quaternion_floating"
-  const std::string& type_name() const final {
+  const std::string& type_name() const override {
     static const never_destroyed<std::string> name{kTypeName};
     return name.access();
   }
@@ -361,7 +361,7 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// Adding forces per-dof makes no physical sense. Therefore, this method
   /// throws an exception if invoked.
   void DoAddInOneForce(const systems::Context<T>&, int, const T&,
-                       MultibodyForces<T>*) const final;
+                       MultibodyForces<T>*) const override;
 
   /// Joint<T> override called through public NVI, Joint::AddInDamping().
   /// Therefore arguments were already checked to be valid.
@@ -372,31 +372,31 @@ class QuaternionFloatingJoint final : public Joint<T> {
   /// dissipative torque according to the viscous law `τ = -d⋅ω`, with d the
   /// damping coefficient (see default_angular_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const final;
+                      MultibodyForces<T>* forces) const override;
 
  private:
-  int do_get_velocity_start() const final {
+  int do_get_velocity_start() const override {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const final { return 6; }
+  int do_get_num_velocities() const override { return 6; }
 
-  int do_get_position_start() const final {
+  int do_get_position_start() const override {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const final { return 7; }
+  int do_get_num_positions() const override { return 7; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) final {
+      const VectorX<double>& default_positions) override {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
@@ -418,19 +418,18 @@ class QuaternionFloatingJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const final;
+      const internal::MultibodyTree<double>& tree_clone) const override;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const final;
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
 
   // Make QuaternionFloatingJoint templated on every other scalar type a friend
   // of QuaternionFloatingJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -97,10 +97,12 @@ std::unique_ptr<Joint<T>> RevoluteJoint<T>::DoShallowClone() const {
       this->position_upper_limit(), this->default_damping());
 }
 
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> RevoluteJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>*) const {
+    const internal::SpanningForest::Mobod& mobod) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -104,9 +104,9 @@ class RevoluteJoint final : public Joint<T> {
                 double pos_lower_limit, double pos_upper_limit,
                 double damping = 0);
 
-  ~RevoluteJoint() final;
+  ~RevoluteJoint() override;
 
-  const std::string& type_name() const final;
+  const std::string& type_name() const override;
 
   /// Returns the axis of revolution of `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
@@ -271,7 +271,7 @@ class RevoluteJoint final : public Joint<T> {
   /// around the joint's axis.
   void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
                        const T& joint_tau,
-                       MultibodyForces<T>* forces) const final {
+                       MultibodyForces<T>* forces) const override {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
     DRAKE_DEMAND(joint_dof == 0);
@@ -287,63 +287,62 @@ class RevoluteJoint final : public Joint<T> {
   /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
   /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const final {
+                      MultibodyForces<T>* forces) const override {
     const T damping_torque =
         -this->GetDamping(context) * get_angular_rate(context);
     AddInTorque(context, damping_torque, forces);
   }
 
  private:
-  int do_get_velocity_start() const final {
+  int do_get_velocity_start() const override {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const final { return 1; }
+  int do_get_num_velocities() const override { return 1; }
 
-  int do_get_position_start() const final {
+  int do_get_position_start() const override {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const final { return 1; }
+  int do_get_num_positions() const override { return 1; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) final {
+      const VectorX<double>& default_positions) override {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
   }
 
-  const T& DoGetOnePosition(const systems::Context<T>& context) const final {
+  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
     return get_angle(context);
   }
 
-  const T& DoGetOneVelocity(const systems::Context<T>& context) const final {
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
     return get_angular_rate(context);
   }
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const final;
+      const internal::MultibodyTree<double>& tree_clone) const override;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const final;
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
 
   // Make RevoluteJoint templated on every other scalar type a friend of
   // RevoluteJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/rpy_floating_joint.cc
+++ b/multibody/tree/rpy_floating_joint.cc
@@ -73,8 +73,7 @@ std::unique_ptr<Joint<T>> RpyFloatingJoint<T>::DoShallowClone() const {
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>>
 RpyFloatingJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>*) const {
+    const internal::SpanningForest::Mobod& mobod) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/rpy_floating_joint.h
+++ b/multibody/tree/rpy_floating_joint.h
@@ -428,8 +428,7 @@ class RpyFloatingJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -101,8 +101,7 @@ std::unique_ptr<Joint<T>> ScrewJoint<T>::DoShallowClone() const {
 // in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> ScrewJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>*) const {
+    const internal::SpanningForest::Mobod& mobod) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -325,11 +325,11 @@ class ScrewJoint final : public Joint<T> {
 
   int do_get_num_positions() const final { return 1; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
@@ -340,18 +340,17 @@ class ScrewJoint final : public Joint<T> {
     }
   }
 
-  const T& DoGetOnePosition(const systems::Context<T>& context) const final {
+  const T& DoGetOnePosition(const systems::Context<T>& context) const override {
     return get_rotation(context);
   }
 
-  const T& DoGetOneVelocity(const systems::Context<T>& context) const final {
+  const T& DoGetOneVelocity(const systems::Context<T>& context) const override {
     return get_angular_velocity(context);
   }
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -29,18 +29,14 @@ class WeldJointTest : public ::testing::Test {
     // Create an empty model.
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
-    // Add bodies so we can add forward and reverse weld joints.
+    // Add a body so we can add a joint to it.
     body_ = &model->AddRigidBody("body", M_B);
-    rbody_ = &model->AddRigidBody("rbody", M_B);
 
-    joint_ = &model->AddJoint<WeldJoint>("Welder", model->world_body(), X_PJp_,
-                                         *body_, X_CJc_, X_JpJc_);
-    // This is reversed since we're using the outboard rbody as the parent.
-    rjoint_ = &model->AddJoint<WeldJoint>("RWelder", *rbody_, X_PJp_, *body_,
-                                          X_CJc_, X_JpJc_);
+    joint_ = &model->AddJoint<WeldJoint>("Welder", model->world_body(), X_PF_,
+                                         *body_, X_CM_, X_FM_);
 
     // We are done adding modeling elements. Transfer tree to system for
-    // computation. This finalizes the MultibodyTree.
+    // computation.
     system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
         std::move(model), true /* is_discrete */);
   }
@@ -54,11 +50,9 @@ class WeldJointTest : public ::testing::Test {
 
   const RigidBody<double>* body_{nullptr};
   const WeldJoint<double>* joint_{nullptr};
-  const RigidBody<double>* rbody_{nullptr};
-  const WeldJoint<double>* rjoint_{nullptr};
-  const Translation3d X_JpJc_{0, 0.5, 0};
-  const Translation3d X_PJp_{0.5, 0, 0};
-  const Translation3d X_CJc_{0, 0, 0.5};
+  const Translation3d X_FM_{0, 0.5, 0};
+  const Translation3d X_PF_{0.5, 0, 0};
+  const Translation3d X_CM_{0, 0, 0.5};
 };
 
 TEST_F(WeldJointTest, CanRotateOrTranslate) {
@@ -83,55 +77,9 @@ TEST_F(WeldJointTest, NumDOFs) {
   DRAKE_EXPECT_NO_THROW(joint_->velocity_start());
 }
 
-// Verify we can retrieve the frame poses and that the implementing mobilizer
-// uses the best inboard (F) and outboard (M) frames. Check both forward and
-// reverse cases with non-identity X_JpJc.
-TEST_F(WeldJointTest, CheckFramesForward) {
-  EXPECT_TRUE(joint_->X_FM().IsExactlyEqualTo(X_JpJc_));
-  const auto& Jp = joint_->frame_on_parent();
-  const auto& Jc = joint_->frame_on_child();
-  const math::RigidTransform<double>& X_PJp = Jp.GetFixedPoseInBodyFrame();
-  const math::RigidTransform<double>& X_CJc = Jc.GetFixedPoseInBodyFrame();
-  EXPECT_TRUE(X_PJp.IsExactlyEqualTo(X_PJp_));
-  EXPECT_TRUE(X_CJc.IsExactlyEqualTo(X_CJc_));
-
-  const auto& mobilizer = joint_->GetMobilizerInUse();
-  const auto& F = mobilizer.inboard_frame();
-  const auto& M = mobilizer.outboard_frame();
-
-  // F must always be inboard so must be on World, with M on body.
-  EXPECT_EQ(F.body().index(), BodyIndex(0));
-  EXPECT_EQ(M.body().index(), body_->index());
-
-  EXPECT_EQ(&M, &Jc);  // We don't move the M frame.
-  EXPECT_NE(&F, &Jp);  // But should have moved the F frame.
-
-  const math::RigidTransform<double>& X_PF = F.GetFixedPoseInBodyFrame();
-  EXPECT_TRUE(X_PF.IsNearlyEqualTo(X_PJp * X_JpJc_, 1e-14));
-}
-
-TEST_F(WeldJointTest, CheckFramesReverse) {
-  EXPECT_TRUE(rjoint_->X_FM().IsExactlyEqualTo(X_JpJc_));
-  const auto& Jp = rjoint_->frame_on_parent();
-  const auto& Jc = rjoint_->frame_on_child();
-  const math::RigidTransform<double>& X_PJp = Jp.GetFixedPoseInBodyFrame();
-  const math::RigidTransform<double>& X_CJc = Jc.GetFixedPoseInBodyFrame();
-  EXPECT_TRUE(X_PJp.IsExactlyEqualTo(X_PJp_));
-  EXPECT_TRUE(X_CJc.IsExactlyEqualTo(X_CJc_));
-
-  const auto& mobilizer = rjoint_->GetMobilizerInUse();
-  const auto& F = mobilizer.inboard_frame();
-  const auto& M = mobilizer.outboard_frame();
-
-  // F must always be inboard so must now be on body, with M on rbody.
-  EXPECT_EQ(F.body().index(), body_->index());
-  EXPECT_EQ(M.body().index(), rbody_->index());
-
-  EXPECT_EQ(&M, &Jp);  // Switch bodies, but don't move the M frame.
-  EXPECT_NE(&F, &Jc);  // F needs to be moved to be coincident with M.
-
-  const math::RigidTransform<double>& X_CF = F.GetFixedPoseInBodyFrame();
-  EXPECT_TRUE(X_CF.IsNearlyEqualTo(X_CJc * X_JpJc_.inverse(), 1e-14));
+// Verify we can retrieve the fixed posed between the welded frames.
+TEST_F(WeldJointTest, GetX_FM) {
+  EXPECT_TRUE(joint_->X_FM().IsExactlyEqualTo(X_FM_));
 }
 
 TEST_F(WeldJointTest, GetJointLimits) {

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -71,8 +71,7 @@ std::unique_ptr<Joint<T>> UniversalJoint<T>::DoShallowClone() const {
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>>
 UniversalJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>*) const {
+    const internal::SpanningForest::Mobod& mobod) const {
   const auto [inboard_frame, outboard_frame] =
       this->tree_frames(mobod.is_reversed());
   // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -87,9 +87,9 @@ class UniversalJoint final : public Joint<T> {
     DRAKE_THROW_UNLESS(damping >= 0);
   }
 
-  ~UniversalJoint() final;
+  ~UniversalJoint() override;
 
-  const std::string& type_name() const final;
+  const std::string& type_name() const override;
 
   /// Returns `this` joint's default damping constant in N⋅m⋅s. The damping
   /// torque (in N⋅m) is modeled as `τᵢ = -damping⋅ωᵢ, i = 1, 2` i.e. opposing
@@ -189,7 +189,7 @@ class UniversalJoint final : public Joint<T> {
   /// acceleration (of the child body frame).
   void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
                        const T& joint_tau,
-                       MultibodyForces<T>* forces) const final {
+                       MultibodyForces<T>* forces) const override {
     DRAKE_DEMAND(joint_dof < 2);
     Eigen::Ref<VectorX<T>> tau_mob =
         get_mobilizer().get_mutable_generalized_forces_from_array(
@@ -203,7 +203,7 @@ class UniversalJoint final : public Joint<T> {
   /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see
   /// default_damping()).
   void DoAddInDamping(const systems::Context<T>& context,
-                      MultibodyForces<T>* forces) const final {
+                      MultibodyForces<T>* forces) const override {
     Eigen::Ref<VectorX<T>> tau =
         get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
@@ -212,28 +212,28 @@ class UniversalJoint final : public Joint<T> {
   }
 
  private:
-  int do_get_velocity_start() const final {
+  int do_get_velocity_start() const override {
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const final { return 2; }
+  int do_get_num_velocities() const override { return 2; }
 
-  int do_get_position_start() const final {
+  int do_get_position_start() const override {
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const final { return 2; }
+  int do_get_num_positions() const override { return 2; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
   void do_set_default_positions(
-      const VectorX<double>& default_positions) final {
+      const VectorX<double>& default_positions) override {
     if (this->has_mobilizer()) {
       get_mutable_mobilizer().set_default_position(default_positions);
     }
@@ -241,19 +241,18 @@ class UniversalJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const final;
+      const internal::MultibodyTree<double>& tree_clone) const override;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>&) const final;
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
 
   // Make UniversalJoint templated on every other scalar type a friend of
   // UniversalJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -57,59 +57,26 @@ std::unique_ptr<Joint<T>> WeldJoint<T>::DoShallowClone() const {
                                         this->frame_on_child(), X_FM());
 }
 
-/* For a weld joint, we are given Jp on parent P, Jc on child C, and a fixed
-X_JpJc. For optimal performance, the underlying mobilizer expects coincident
-frames F (on the inboard body) and M (on the outboard body) so that we don't
-have to apply X_JpJc repeatedly at run time. We only need to move one of the
-frames, and because of the way we report reaction forces (at Jc) it is best
-to choose M=Jc and move F if necessary by creating a new offset frame from Jp
-that is coincident with Jc (and M):
-    X_JpF = X_JpJc
-This yields X_FM = X_FJc = (X_JpF)⁻¹ * X_JpJc = Identity as required.
-If the mobilizer's inboard/outboard direction is reversed from the joint's
-parent/child direction, we instead choose M=Jp and an offset from F
-    X_JcF = (X_JpJc)⁻¹
-so that X_FM = X_FJp = (X_JcF)⁻¹ (X_JpJc)⁻¹ = Identity.
-
-If X_JpJc is already Identity we just use the original frames for F and M. */
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
 template <typename T>
 std::unique_ptr<internal::Mobilizer<T>> WeldJoint<T>::MakeMobilizerForJoint(
-    const internal::SpanningForest::Mobod& mobod,
-    internal::MultibodyTree<T>* tree) const {
-  DRAKE_DEMAND(tree != nullptr);
-  const Frame<T>& Jp = this->frame_on_parent();
-  const Frame<T>& Jc = this->frame_on_child();
-  const bool X_JpJc_is_identity = X_JpJc_.IsExactlyIdentity();
+    const internal::SpanningForest::Mobod& mobod) const {
+  const auto [inboard_frame, outboard_frame] =
+      this->tree_frames(mobod.is_reversed());
 
-  // Create a unique frame name for F based on the joint name (unique within
-  // its model instance) and the name of the parent or child frame (not
-  // necessarily unique). New frames go in the joint's model instance.
-  auto F_frame_name = [this, tree](const Frame<T>& frame) -> std::string {
-    const std::string F_name =
-        fmt::format("{}_{}_F", this->name(), frame.name());
-    DRAKE_DEMAND(!tree->HasFrameNamed(F_name, this->model_instance()));
-    return F_name;
-  };
+  // This quirk is unique to Weld joints.
+  const math::RigidTransform<double> X_FM =
+      mobod.is_reversed() ? X_JpJc_.inverse() : X_JpJc_;
 
-  const Frame<T>* F{};
-  const Frame<T>* M{};
-  if (mobod.is_reversed()) {
-    M = &Jp;  // The reversed case: outboard==parent, inboard==child.
-    F = X_JpJc_is_identity
-            ? &Jc
-            : &tree->AddFrame(std::make_unique<FixedOffsetFrame<T>>(
-                  F_frame_name(Jc), Jc, X_JpJc_.inverse(),
-                  this->model_instance()));
-  } else {
-    M = &Jc;  // The normal case: outboard==child, inboard==parent.
-    F = X_JpJc_is_identity
-            ? &Jp
-            : &tree->AddFrame(std::make_unique<FixedOffsetFrame<T>>(
-                  F_frame_name(Jp), Jp, X_JpJc_, this->model_instance()));
-  }
-
-  auto weld_mobilizer =
-      std::make_unique<internal::WeldMobilizer<T>>(mobod, *F, *M);
+  // The only other requirement for a reversed weld is that the reported
+  // reaction forces (on the joint's child link) must be those acting on
+  // the mobilizer's inboard body rather than the usual outboard reaction.
+  // That's handled when reporting (see MultibodyPlant::CalcReactionForces()),
+  // not locally by the mobilizer.
+  auto weld_mobilizer = std::make_unique<internal::WeldMobilizer<T>>(
+      mobod, *inboard_frame, *outboard_frame, X_FM);
   return weld_mobilizer;
 }
 

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -50,9 +50,9 @@ class WeldJoint final : public Joint<T> {
                  VectorX<double>() /* no acc upper limits */),
         X_JpJc_(X_FM) {}
 
-  ~WeldJoint() final;
+  ~WeldJoint() override;
 
-  const std::string& type_name() const final;
+  const std::string& type_name() const override;
 
   // See note above. We're returning X_JpJc here.
   /// Returns the pose X_FM of frame M in F.
@@ -64,54 +64,53 @@ class WeldJoint final : public Joint<T> {
   /// apply forces between them. Therefore this method throws an exception if
   /// invoked.
   void DoAddInOneForce(const systems::Context<T>&, int, const T&,
-                       MultibodyForces<T>*) const final {
+                       MultibodyForces<T>*) const override {
     throw std::logic_error("Weld joints do not allow applying forces.");
   }
 
  private:
-  int do_get_velocity_start() const final {
+  int do_get_velocity_start() const override {
     // Since WeldJoint has no state, the start index has no meaning. However,
     // we let its decide the return value for this case (this has to do with
     // allowing zero sized Eigen blocks).
     return get_mobilizer().velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const final { return 0; }
+  int do_get_num_velocities() const override { return 0; }
 
-  int do_get_position_start() const final {
+  int do_get_position_start() const override {
     // Since WeldJoint has no state, the start index has no meaning. However,
     // we let it decide the return value for this case (this has to do with
     // allowing zero sized Eigen blocks).
     return get_mobilizer().position_start_in_q();
   }
 
-  int do_get_num_positions() const final { return 0; }
+  int do_get_num_positions() const override { return 0; }
 
-  std::string do_get_position_suffix(int index) const final {
+  std::string do_get_position_suffix(int index) const override {
     return get_mobilizer().position_suffix(index);
   }
 
-  std::string do_get_velocity_suffix(int index) const final {
+  std::string do_get_velocity_suffix(int index) const override {
     return get_mobilizer().velocity_suffix(index);
   }
 
-  void do_set_default_positions(const VectorX<double>&) final { return; }
+  void do_set_default_positions(const VectorX<double>&) override { return; }
 
   // Joint<T> overrides:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
-      const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>* tree) const final;
+      const internal::SpanningForest::Mobod& mobod) const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
-      const internal::MultibodyTree<double>& tree_clone) const final;
+      const internal::MultibodyTree<double>& tree_clone) const override;
 
   std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
-      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
 
   std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
-      const internal::MultibodyTree<symbolic::Expression>& x) const final;
+      const internal::MultibodyTree<symbolic::Expression>& x) const override;
 
-  std::unique_ptr<Joint<T>> DoShallowClone() const final;
+  std::unique_ptr<Joint<T>> DoShallowClone() const override;
 
   // Make WeldJoint templated on every other scalar type a friend of
   // WeldJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -23,7 +23,7 @@ std::unique_ptr<internal::BodyNode<T>> WeldMobilizer<T>::CreateBodyNode(
 template <typename T>
 math::RigidTransform<T> WeldMobilizer<T>::CalcAcrossMobilizerTransform(
     const systems::Context<T>&) const {
-  return math::RigidTransform<T>();  // Identity
+  return X_FM_.cast<T>();
 }
 
 template <typename T>
@@ -81,7 +81,7 @@ std::unique_ptr<Mobilizer<ToScalar>> WeldMobilizer<T>::TemplatedDoCloneToScalar(
       tree_clone.get_variant(this->outboard_frame());
   return std::make_unique<WeldMobilizer<ToScalar>>(
       tree_clone.get_mobod(this->mobod().index()), inboard_frame_clone,
-      outboard_frame_clone);
+      outboard_frame_clone, this->get_X_FM());
 }
 
 template <typename T>

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -16,8 +16,8 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// This mobilizer fixes the relative pose of an outboard frame M to be
-// coincident with an inboard frame F as if "welding" them together.
+// This mobilizer fixes the relative pose `X_FM` of an outboard frame M in an
+// inboard frame F as if "welding" them together at this fixed relative pose.
 // Therefore, this mobilizer has no associated state with it.
 //
 // @tparam_default_scalar
@@ -35,11 +35,13 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   using HMatrix = typename MobilizerBase::template HMatrix<U>;
 
   // Constructor for a %WeldMobilizer between the `inboard_frame_F` and
-  // `outboard_frame_M`. The frames will be held coincident forever.
+  // `outboard_frame_M`.
+  // @param[in] X_FM Pose of `outboard_frame_M` in the `inboard_frame_F`.
   WeldMobilizer(const SpanningForest::Mobod& mobod,
                 const Frame<T>& inboard_frame_F,
-                const Frame<T>& outboard_frame_M)
-      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
+                const Frame<T>& outboard_frame_M,
+                const math::RigidTransform<double>& X_FM)
+      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M), X_FM_(X_FM) {}
 
   ~WeldMobilizer() final;
 
@@ -47,16 +49,12 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
       const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
 
-  // TODO(sherm1) Replace this method with operators like
-  //  compose_with_X_FM(X_WF) and apply_X_FM(v) so that we can take advantage
-  //  of the mobilizer's knowledge of its kinematic structure (part of
-  //  performance epic #18442).
+  // @retval X_FM The pose of the outboard frame M in the inboard frame F.
+  const math::RigidTransform<double>& get_X_FM() const { return X_FM_; }
 
   // Computes the across-mobilizer transform `X_FM`, which for this mobilizer
-  // is always the identity transform since F==M by construction.
-  math::RigidTransform<T> calc_X_FM(const T*) const {
-    return math::RigidTransform<T>();
-  }
+  // is independent of the state stored in `context`.
+  math::RigidTransform<T> calc_X_FM(const T*) const { return X_FM_.cast<T>(); }
 
   // Computes the across-mobilizer velocity V_FM which for this mobilizer is
   // always zero since the outboard frame M is fixed to the inboard frame F.
@@ -128,6 +126,9 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
       const MultibodyTree<ToScalar>& tree_clone) const;
+
+  // Pose of the outboard frame M in the inboard frame F.
+  math::RigidTransform<double> X_FM_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
Reverts RobotLocomotion/drake#22649.  This is breaking end-user simulations:

> RuntimeError: Model instance 'WorldModelInstance' already contains a frame named 'world_welds_to_base_link_world_F'. Frame names must be unique within a given model.

or

> RuntimeError: Model instance 'manipuland_table' already contains a frame named 'origin_welds_to_origin_origin_F'. Frame names must be unique within a given model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22688)
<!-- Reviewable:end -->
