### PR TITLE
[multibody] Hotfix for PR 22649 duplicate frame name problem

### DIFF
--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -85,9 +85,8 @@ std::unique_ptr<internal::Mobilizer<T>> WeldJoint<T>::MakeMobilizerForJoint(
   // its model instance) and the name of the parent or child frame (not
   // necessarily unique). New frames go in the joint's model instance.
   auto F_frame_name = [this, tree](const Frame<T>& frame) -> std::string {
-    const std::string F_name =
-        fmt::format("{}_{}_F", this->name(), frame.name());
-    DRAKE_DEMAND(!tree->HasFrameNamed(F_name, this->model_instance()));
+    std::string F_name = fmt::format("{}_{}_F", this->name(), frame.name());
+    while (tree->HasFrameNamed(F_name, this->model_instance())) F_name += "_";
     return F_name;
   };
 


### PR DESCRIPTION
PR #22649 generated some internal frames with made-up names that turned out not always to be unique in practice. This hotfix ensures that the made-up names are always unique.

Once this merges we can close revert #22688

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22691)
<!-- Reviewable:end -->
