### PR TITLE
[multibody] Fix and unit test Clone functions for Frames

### DIFF
--- a/multibody/tree/fixed_offset_frame.cc
+++ b/multibody/tree/fixed_offset_frame.cc
@@ -54,7 +54,7 @@ std::unique_ptr<Frame<ToScalar>> FixedOffsetFrame<T>::TemplatedDoCloneToScalar(
   const Frame<ToScalar>& parent_frame_clone =
       tree_clone.get_variant(parent_frame_);
   return std::make_unique<FixedOffsetFrame<ToScalar>>(
-      this->name(), parent_frame_clone, X_PF_);
+      this->name(), parent_frame_clone, X_PF_, this->model_instance());
 }
 
 template <typename T>
@@ -79,7 +79,7 @@ FixedOffsetFrame<T>::DoCloneToScalar(
 template <typename T>
 std::unique_ptr<Frame<T>> FixedOffsetFrame<T>::DoShallowClone() const {
   return std::make_unique<FixedOffsetFrame<T>>(this->name(), parent_frame_,
-                                               X_PF_);
+                                               X_PF_, this->model_instance());
 }
 
 template <typename T>

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -50,7 +50,7 @@ class FixedOffsetFrame final : public Frame<T> {
   ///   value (as a RigidTransform<double>) is provided.
   /// @param[in] model_instance
   ///   The model instance to which this frame belongs to. If unspecified, will
-  ///   use P.body().model_instance().
+  ///   use P.model_instance().
   FixedOffsetFrame(const std::string& name, const Frame<T>& P,
                    const math::RigidTransform<double>& X_PF,
                    std::optional<ModelInstanceIndex> model_instance = {});


### PR DESCRIPTION
Makes ShallowClone() and CloneToScalar() preserve the model instance for a FixedOffsetFrame.

Also corrects a class comment for FixedOffsetFrame (model instance has always been inherited from the parent frame's model instance, not the parent frame's _body's_ model instance)

Adds missing test cases in frames_test.cc.

Resolves #22695

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22696)
<!-- Reviewable:end -->
