### PR TITLE
MapQDDotToAcceleration() and MapAccelerationToQDDot() for simple mobilizers

### DIFF
--- a/multibody/tree/mobilizer.cc
+++ b/multibody/tree/mobilizer.cc
@@ -18,10 +18,10 @@ std::pair<Eigen::Quaternion<T>, Vector3<T>> Mobilizer<T>::GetPosePair(
 }
 
 template <typename T>
-void Mobilizer<T>::MapVelocityDotToQDDot(const systems::Context<T>&,
-                                         const Eigen::Ref<const VectorX<T>>&,
-                                         EigenPtr<VectorX<T>>) const {
-  // TODO(Mitiguy) remove this function when Mobilizer::MapVelocityDotToQDDot()
+void Mobilizer<T>::MapAccelerationToQDDot(const systems::Context<T>&,
+                                          const Eigen::Ref<const VectorX<T>>&,
+                                          EigenPtr<VectorX<T>>) const {
+  // TODO(Mitiguy) remove this function when Mobilizer::MapAccelerationToQDDot()
   //  is changed to a pure virtual function that requires override.
   const std::string error_message = fmt::format(
       "The function {}() has not been implemented for this "
@@ -31,10 +31,10 @@ void Mobilizer<T>::MapVelocityDotToQDDot(const systems::Context<T>&,
 }
 
 template <typename T>
-void Mobilizer<T>::MapQDDotToVelocityDot(const systems::Context<T>&,
-                                         const Eigen::Ref<const VectorX<T>>&,
-                                         EigenPtr<VectorX<T>>) const {
-  // TODO(Mitiguy) remove this function when Mobilizer::MapVelocityDotToQDDot()
+void Mobilizer<T>::MapQDDotToAcceleration(const systems::Context<T>&,
+                                          const Eigen::Ref<const VectorX<T>>&,
+                                          EigenPtr<VectorX<T>>) const {
+  // TODO(Mitiguy) remove this function when Mobilizer::MapAccelerationToQDDot()
   //  is changed to a pure virtual function that requires override.
   const std::string error_message = fmt::format(
       "The function {}() has not been implemented for this "

--- a/multibody/tree/mobilizer.cc
+++ b/multibody/tree/mobilizer.cc
@@ -17,6 +17,32 @@ std::pair<Eigen::Quaternion<T>, Vector3<T>> Mobilizer<T>::GetPosePair(
   return std::pair(X_FM.rotation().ToQuaternion(), X_FM.translation());
 }
 
+template <typename T>
+void Mobilizer<T>::MapVelocityDotToQDDot(const systems::Context<T>&,
+                                         const Eigen::Ref<const VectorX<T>>&,
+                                         EigenPtr<VectorX<T>>) const {
+  // TODO(Mitiguy) remove this function when Mobilizer::MapVelocityDotToQDDot()
+  //  is changed to a pure virtual function that requires override.
+  const std::string error_message = fmt::format(
+      "The function {}() has not been implemented for this "
+      "mobilizer.",
+      __func__);
+  throw std::logic_error(error_message);
+}
+
+template <typename T>
+void Mobilizer<T>::MapQDDotToVelocityDot(const systems::Context<T>&,
+                                         const Eigen::Ref<const VectorX<T>>&,
+                                         EigenPtr<VectorX<T>>) const {
+  // TODO(Mitiguy) remove this function when Mobilizer::MapVelocityDotToQDDot()
+  //  is changed to a pure virtual function that requires override.
+  const std::string error_message = fmt::format(
+      "The function {}() has not been implemented for this "
+      "mobilizer.",
+      __func__);
+  throw std::logic_error(error_message);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -622,9 +622,9 @@ class Mobilizer : public MultibodyElement<T> {
   // Note: Generalized positions and velocities are stored in `context`.
   // TODO(Mitiguy) change this function to a pure virtual function when it has
   //  been overridden in all subclasses.
-  virtual void MapVelocityDotToQDDot(const systems::Context<T>& context,
-                                     const Eigen::Ref<const VectorX<T>>& vdot,
-                                     EigenPtr<VectorX<T>> qddot) const;
+  virtual void MapAccelerationToQDDot(const systems::Context<T>& context,
+                                      const Eigen::Ref<const VectorX<T>>& vdot,
+                                      EigenPtr<VectorX<T>> qddot) const;
 
   // Uses the kinematic mapping `v̇ = N(q)⋅q̈` to calculate v̇ from q̈.
   // @param[in] qddot 2ⁿᵈ time derivatives of the generalized positions (q̈).
@@ -632,9 +632,9 @@ class Mobilizer : public MultibodyElement<T> {
   // Note: Generalized positions and velocities are stored in `context`.
   // TODO(Mitiguy) change this function to a pure virtual function when it has
   //  been overridden in all subclasses.
-  virtual void MapQDDotToVelocityDot(const systems::Context<T>& context,
-                                     const Eigen::Ref<const VectorX<T>>& qddot,
-                                     EigenPtr<VectorX<T>> v) const;
+  virtual void MapQDDotToAcceleration(const systems::Context<T>& context,
+                                      const Eigen::Ref<const VectorX<T>>& qddot,
+                                      EigenPtr<VectorX<T>> v) const;
   // @}
 
   // Returns a const Eigen expression of the vector of generalized positions

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -616,7 +616,7 @@ class Mobilizer : public MultibodyElement<T> {
                                  const Eigen::Ref<const VectorX<T>>& qdot,
                                  EigenPtr<VectorX<T>> v) const = 0;
 
-  // Calculates q̈ from v̇ and v using q̈ = N(q)⋅v̇ + Ṅ(q,v)⋅v.
+  // Calculates q̈ from v̇, v, q using q̈ = N(q)⋅v̇ + Ṅ(q,v)⋅v.
   // @param[in] context stores generalized positions q and velocities v.
   // @param[in] vdot (v̇) 1ˢᵗ time derivatives of generalized velocities.
   // @param[out] qddot (q̈) 2ⁿᵈ time derivatives of the generalized positions.
@@ -626,7 +626,7 @@ class Mobilizer : public MultibodyElement<T> {
                                       const Eigen::Ref<const VectorX<T>>& vdot,
                                       EigenPtr<VectorX<T>> qddot) const;
 
-  // Calculates v̇ from q̈ and v using v̇ = N⁺(q)⋅q̈ + Ṅ⁺(q,v)⋅q̇ where q̇ = N(q)⋅v.
+  // Calculates v̇ from q̈, v, q using v̇ = N⁺(q)⋅q̈ + Ṅ⁺(q,v)⋅q̇ where q̇ = N(q)⋅v.
   // @param[in] context stores generalized positions q and velocities v.
   // @param[in] qddot (q̈) 2ⁿᵈ time derivatives of the generalized positions.
   // @param[out] vdot (v̇) 1ˢᵗ time derivatives of generalized velocities.

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -620,6 +620,8 @@ class Mobilizer : public MultibodyElement<T> {
   // @param[in] vdot 1ˢᵗ time derivatives of generalized velocities (v̇).
   // @param[out] qddot 2ⁿᵈ time derivatives of the generalized positions (q̈).
   // Note: Generalized positions and velocities are stored in `context`.
+  // TODO(Mitiguy) change this function to a pure virtual function when it has
+  //  been overridden in all subclasses.
   virtual void MapVelocityDotToQDDot(const systems::Context<T>& context,
                                      const Eigen::Ref<const VectorX<T>>& vdot,
                                      EigenPtr<VectorX<T>> qddot) const;
@@ -628,6 +630,8 @@ class Mobilizer : public MultibodyElement<T> {
   // @param[in] qddot 2ⁿᵈ time derivatives of the generalized positions (q̈).
   // @param[out] vdot 1ˢᵗ time derivatives of generalized velocities (v̇).
   // Note: Generalized positions and velocities are stored in `context`.
+  // TODO(Mitiguy) change this function to a pure virtual function when it has
+  //  been overridden in all subclasses.
   virtual void MapQDDotToVelocityDot(const systems::Context<T>& context,
                                      const Eigen::Ref<const VectorX<T>>& qddot,
                                      EigenPtr<VectorX<T>> v) const;

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -615,6 +615,22 @@ class Mobilizer : public MultibodyElement<T> {
   virtual void MapQDotToVelocity(const systems::Context<T>& context,
                                  const Eigen::Ref<const VectorX<T>>& qdot,
                                  EigenPtr<VectorX<T>> v) const = 0;
+
+  // Uses the kinematic mapping `q̈ = N(q)⋅v̇` to calculate q̈ from v̇.
+  // @param[in] vdot 1ˢᵗ time derivatives of generalized velocities (v̇).
+  // @param[out] qddot 2ⁿᵈ time derivatives of the generalized positions (q̈).
+  // Note: Generalized positions and velocities are stored in `context`.
+  virtual void MapVelocityDotToQDDot(const systems::Context<T>& context,
+                                     const Eigen::Ref<const VectorX<T>>& vdot,
+                                     EigenPtr<VectorX<T>> qddot) const;
+
+  // Uses the kinematic mapping `v̇ = N(q)⋅q̈` to calculate v̇ from q̈.
+  // @param[in] qddot 2ⁿᵈ time derivatives of the generalized positions (q̈).
+  // @param[out] vdot 1ˢᵗ time derivatives of generalized velocities (v̇).
+  // Note: Generalized positions and velocities are stored in `context`.
+  virtual void MapQDDotToVelocityDot(const systems::Context<T>& context,
+                                     const Eigen::Ref<const VectorX<T>>& qddot,
+                                     EigenPtr<VectorX<T>> v) const;
   // @}
 
   // Returns a const Eigen expression of the vector of generalized positions

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -616,25 +616,25 @@ class Mobilizer : public MultibodyElement<T> {
                                  const Eigen::Ref<const VectorX<T>>& qdot,
                                  EigenPtr<VectorX<T>> v) const = 0;
 
-  // Uses the kinematic mapping `q̈ = N(q)⋅v̇` to calculate q̈ from v̇.
-  // @param[in] vdot 1ˢᵗ time derivatives of generalized velocities (v̇).
-  // @param[out] qddot 2ⁿᵈ time derivatives of the generalized positions (q̈).
-  // Note: Generalized positions and velocities are stored in `context`.
+  // Calculates q̈ from v̇ and v using q̈ = N(q)⋅v̇ + Ṅ(q,v)⋅v.
+  // @param[in] context stores generalized positions q and velocities v.
+  // @param[in] vdot (v̇) 1ˢᵗ time derivatives of generalized velocities.
+  // @param[out] qddot (q̈) 2ⁿᵈ time derivatives of the generalized positions.
   // TODO(Mitiguy) change this function to a pure virtual function when it has
   //  been overridden in all subclasses.
   virtual void MapAccelerationToQDDot(const systems::Context<T>& context,
                                       const Eigen::Ref<const VectorX<T>>& vdot,
                                       EigenPtr<VectorX<T>> qddot) const;
 
-  // Uses the kinematic mapping `v̇ = N(q)⋅q̈` to calculate v̇ from q̈.
-  // @param[in] qddot 2ⁿᵈ time derivatives of the generalized positions (q̈).
-  // @param[out] vdot 1ˢᵗ time derivatives of generalized velocities (v̇).
-  // Note: Generalized positions and velocities are stored in `context`.
+  // Calculates v̇ from q̈ and v using v̇ = N⁺(q)⋅q̈ + Ṅ⁺(q,v)⋅q̇ where q̇ = N(q)⋅v.
+  // @param[in] context stores generalized positions q and velocities v.
+  // @param[in] qddot (q̈) 2ⁿᵈ time derivatives of the generalized positions.
+  // @param[out] vdot (v̇) 1ˢᵗ time derivatives of generalized velocities.
   // TODO(Mitiguy) change this function to a pure virtual function when it has
   //  been overridden in all subclasses.
   virtual void MapQDDotToAcceleration(const systems::Context<T>& context,
                                       const Eigen::Ref<const VectorX<T>>& qddot,
-                                      EigenPtr<VectorX<T>> v) const;
+                                      EigenPtr<VectorX<T>> vdot) const;
   // @}
 
   // Returns a const Eigen expression of the vector of generalized positions

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -186,6 +186,26 @@ void PlanarMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
+void PlanarMobilizer<T>::MapAccelerationToQDDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
+    EigenPtr<VectorX<T>> qddot) const {
+  DRAKE_ASSERT(vdot.size() == kNv);
+  DRAKE_ASSERT(qddot != nullptr);
+  DRAKE_ASSERT(qddot->size() == kNq);
+  *qddot = vdot;
+}
+
+template <typename T>
+void PlanarMobilizer<T>::MapQDDotToAcceleration(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
+    EigenPtr<VectorX<T>> vdot) const {
+  DRAKE_ASSERT(qddot.size() == kNq);
+  DRAKE_ASSERT(vdot != nullptr);
+  DRAKE_ASSERT(vdot->size() == kNv);
+  *vdot = qddot;
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Mobilizer<ToScalar>>
 PlanarMobilizer<T>::TemplatedDoCloneToScalar(

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -210,17 +210,25 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  /* Performs the identity mapping from v to qdot since, for this mobilizer,
-   v = q̇. */
+  // Maps v to qdot, which for this mobilizer is q̇ = v̇.
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const override;
+                         EigenPtr<VectorX<T>> qdot) const final;
 
-  /* Performs the identity mapping from qdot to v since, for this mobilizer,
-   v = q̇. */
+  // Maps qdot to v, which for this mobilizer is v = q̇.
   void MapQDotToVelocity(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const override;
+                         EigenPtr<VectorX<T>> v) const final;
+
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void MapAccelerationToQDDot(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& vdot,
+                              EigenPtr<VectorX<T>> qddot) const final;
+
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const final;
 
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -210,7 +210,7 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v̇.
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
                          EigenPtr<VectorX<T>> qdot) const final;

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -139,6 +139,26 @@ void PrismaticMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
+void PrismaticMobilizer<T>::MapAccelerationToQDDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
+    EigenPtr<VectorX<T>> qddot) const {
+  DRAKE_ASSERT(vdot.size() == kNv);
+  DRAKE_ASSERT(qddot != nullptr);
+  DRAKE_ASSERT(qddot->size() == kNq);
+  *qddot = vdot;
+}
+
+template <typename T>
+void PrismaticMobilizer<T>::MapQDDotToAcceleration(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
+    EigenPtr<VectorX<T>> vdot) const {
+  DRAKE_ASSERT(qddot.size() == kNq);
+  DRAKE_ASSERT(vdot != nullptr);
+  DRAKE_ASSERT(vdot->size() == kNv);
+  *vdot = qddot;
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Mobilizer<ToScalar>>
 PrismaticMobilizer<T>::TemplatedDoCloneToScalar(

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -180,14 +180,12 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // Computes the kinematic mapping from generalized velocities v to time
-  // derivatives of the generalized positions `q̇`. For this mobilizer `q̇ = v`.
+  // Maps v to qdot, which for this mobilizer is q̇ = v̇.
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
                          EigenPtr<VectorX<T>> qdot) const final;
 
-  // Computes the kinematic mapping from time derivatives of the generalized
-  // positions `q̇` to generalized velocities v. For this mobilizer `v = q̇`.
+  // Maps qdot to v, which for this mobilizer is v = q̇.
   void MapQDotToVelocity(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -192,6 +192,16 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
 
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void MapAccelerationToQDDot(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& vdot,
+                              EigenPtr<VectorX<T>> qddot) const final;
+
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const final;
+
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -180,7 +180,7 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v̇.
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
                          EigenPtr<VectorX<T>> qdot) const final;

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -138,6 +138,26 @@ void RevoluteMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
+void RevoluteMobilizer<T>::MapVelocityDotToQDDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
+    EigenPtr<VectorX<T>> qddot) const {
+  DRAKE_ASSERT(vdot.size() == kNv);
+  DRAKE_ASSERT(qddot != nullptr);
+  DRAKE_ASSERT(qddot->size() == kNq);
+  *qddot = vdot;
+}
+
+template <typename T>
+void RevoluteMobilizer<T>::MapQDDotToVelocityDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
+    EigenPtr<VectorX<T>> vdot) const {
+  DRAKE_ASSERT(qddot.size() == kNq);
+  DRAKE_ASSERT(vdot != nullptr);
+  DRAKE_ASSERT(vdot->size() == kNv);
+  *vdot = qddot;
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Mobilizer<ToScalar>>
 RevoluteMobilizer<T>::TemplatedDoCloneToScalar(

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -138,7 +138,7 @@ void RevoluteMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::MapVelocityDotToQDDot(
+void RevoluteMobilizer<T>::MapAccelerationToQDDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
     EigenPtr<VectorX<T>> qddot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
@@ -148,7 +148,7 @@ void RevoluteMobilizer<T>::MapVelocityDotToQDDot(
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::MapQDDotToVelocityDot(
+void RevoluteMobilizer<T>::MapQDDotToAcceleration(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
     EigenPtr<VectorX<T>> vdot) const {
   DRAKE_ASSERT(qddot.size() == kNq);

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -184,7 +184,7 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v̇.
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
                          EigenPtr<VectorX<T>> qdot) const final;

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -184,10 +184,12 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
+  // Maps v to qdot, which for this mobilizer is q̇ = v̇.
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
                          EigenPtr<VectorX<T>> qdot) const final;
 
+  // Maps qdot to v, which for this mobilizer is v = q̇.
   void MapQDotToVelocity(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -186,19 +186,21 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const override;
+                         EigenPtr<VectorX<T>> qdot) const final;
 
   void MapQDotToVelocity(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const override;
+                         EigenPtr<VectorX<T>> v) const final;
 
-  void MapVelocityDotToQDDot(const systems::Context<T>& context,
-                             const Eigen::Ref<const VectorX<T>>& vdot,
-                             EigenPtr<VectorX<T>> qddot) const override;
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void MapAccelerationToQDDot(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& vdot,
+                              EigenPtr<VectorX<T>> qddot) const final;
 
-  void MapQDDotToVelocityDot(const systems::Context<T>& context,
-                             const Eigen::Ref<const VectorX<T>>& qddot,
-                             EigenPtr<VectorX<T>> vdot) const override;
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const final;
 
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -192,6 +192,14 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const override;
 
+  void MapVelocityDotToQDDot(const systems::Context<T>& context,
+                             const Eigen::Ref<const VectorX<T>>& vdot,
+                             EigenPtr<VectorX<T>> qddot) const override;
+
+  void MapQDDotToVelocityDot(const systems::Context<T>& context,
+                             const Eigen::Ref<const VectorX<T>>& qddot,
+                             EigenPtr<VectorX<T>> vdot) const override;
+
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -183,6 +183,26 @@ void ScrewMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
+void ScrewMobilizer<T>::MapAccelerationToQDDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
+    EigenPtr<VectorX<T>> qddot) const {
+  DRAKE_ASSERT(vdot.size() == kNv);
+  DRAKE_ASSERT(qddot != nullptr);
+  DRAKE_ASSERT(qddot->size() == kNq);
+  *qddot = vdot;
+}
+
+template <typename T>
+void ScrewMobilizer<T>::MapQDDotToAcceleration(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
+    EigenPtr<VectorX<T>> vdot) const {
+  DRAKE_ASSERT(qddot.size() == kNq);
+  DRAKE_ASSERT(vdot != nullptr);
+  DRAKE_ASSERT(vdot->size() == kNv);
+  *vdot = qddot;
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Mobilizer<ToScalar>>
 ScrewMobilizer<T>::TemplatedDoCloneToScalar(

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -264,7 +264,7 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v̇.
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
                          EigenPtr<VectorX<T>> qdot) const final;

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -264,17 +264,25 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  /* Performs the identity mapping from v to qdot since, for this mobilizer,
-   v = q̇. */
+  // Maps v to qdot, which for this mobilizer is q̇ = v̇.
   void MapVelocityToQDot(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& v,
                          EigenPtr<VectorX<T>> qdot) const final;
 
-  /* Performs the identity mapping from qdot to v since, for this mobilizer,
-   v = q̇. */
+  // Maps qdot to v, which for this mobilizer is v = q̇.
   void MapQDotToVelocity(const systems::Context<T>& context,
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
+
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void MapAccelerationToQDDot(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& vdot,
+                              EigenPtr<VectorX<T>> qddot) const final;
+
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const final;
 
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -262,6 +262,19 @@ TEST_F(PlanarMobilizerTest, MapVelocityToQDotAndBack) {
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
   EXPECT_TRUE(
       CompareMatrices(v, qdot, kTolerance, MatrixCompareType::relative));
+
+  // Test relationship between q̈ (2ⁿᵈ time derivatives of generalized positions)
+  // and v̇ (1ˢᵗ time derivatives of generalized velocities) and vice-versa.
+  Vector3d vdot(1.23, 4.56, 7.89);
+  Vector3d qddot;
+  mobilizer_->MapAccelerationToQDDot(*context_, vdot, &qddot);
+  EXPECT_TRUE(
+      CompareMatrices(qddot, vdot, kTolerance, MatrixCompareType::relative));
+
+  qddot = Vector3d(-std::sqrt(5), 9.87, 6.54);
+  mobilizer_->MapQDDotToAcceleration(*context_, qddot, &vdot);
+  EXPECT_TRUE(
+      CompareMatrices(vdot, qddot, kTolerance, MatrixCompareType::relative));
 }
 
 TEST_F(PlanarMobilizerTest, KinematicMapping) {

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -157,6 +157,17 @@ TEST_F(PrismaticMobilizerTest, MapVelocityToQDotAndBack) {
   qdot(0) = -std::sqrt(2);
   slider_->MapQDotToVelocity(*context_, qdot, &v);
   EXPECT_NEAR(v(0), qdot(0), kTolerance);
+
+  // Test relationship between q̈ (2ⁿᵈ time derivatives of generalized positions)
+  // and v̇ (1ˢᵗ time derivatives of generalized velocities) and vice-versa.
+  Vector1d vdot(1.2345);
+  Vector1d qddot;
+  slider_->MapAccelerationToQDDot(*context_, vdot, &qddot);
+  EXPECT_NEAR(qddot(0), vdot(0), kTolerance);
+
+  qddot(0) = -std::sqrt(5);
+  slider_->MapQDDotToAcceleration(*context_, qddot, &vdot);
+  EXPECT_NEAR(vdot(0), qddot(0), kTolerance);
 }
 
 TEST_F(PrismaticMobilizerTest, KinematicMapping) {

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -205,13 +205,15 @@ TEST_F(RevoluteMobilizerTest, MapVelocityToQDotAndBack) {
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
   EXPECT_NEAR(v(0), qdot(0), kTolerance);
 
+  // Test relationship between q̈ (2ⁿᵈ time derivatives of generalized positions)
+  // and v̇ (1ˢᵗ time derivatives of generalized velocities) and vice-versa.
   Vector1d vdot(1.2345);
   Vector1d qddot;
-  mobilizer_->MapVelocityDotToQDDot(*context_, vdot, &qddot);
+  mobilizer_->MapAccelerationToQDDot(*context_, vdot, &qddot);
   EXPECT_NEAR(qddot(0), vdot(0), kTolerance);
 
   qddot(0) = -std::sqrt(5);
-  mobilizer_->MapQDotToVelocity(*context_, qddot, &vdot);
+  mobilizer_->MapQDDotToAcceleration(*context_, qddot, &vdot);
   EXPECT_NEAR(vdot(0), qddot(0), kTolerance);
 }
 

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -204,6 +204,15 @@ TEST_F(RevoluteMobilizerTest, MapVelocityToQDotAndBack) {
   qdot(0) = -std::sqrt(2);
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
   EXPECT_NEAR(v(0), qdot(0), kTolerance);
+
+  Vector1d vdot(1.2345);
+  Vector1d qddot;
+  mobilizer_->MapVelocityDotToQDDot(*context_, vdot, &qddot);
+  EXPECT_NEAR(qddot(0), vdot(0), kTolerance);
+
+  qddot(0) = -std::sqrt(5);
+  mobilizer_->MapQDotToVelocity(*context_, qddot, &vdot);
+  EXPECT_NEAR(vdot(0), qddot(0), kTolerance);
 }
 
 TEST_F(RevoluteMobilizerTest, KinematicMapping) {

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -286,6 +286,17 @@ TEST_F(ScrewMobilizerTest, MapVelocityToQDotAndBack) {
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
   EXPECT_TRUE(
       CompareMatrices(v, qdot, kTolerance, MatrixCompareType::relative));
+
+  // Test relationship between q̈ (2ⁿᵈ time derivatives of generalized positions)
+  // and v̇ (1ˢᵗ time derivatives of generalized velocities) and vice-versa.
+  Vector1d vdot(1.2345);
+  Vector1d qddot;
+  mobilizer_->MapAccelerationToQDDot(*context_, vdot, &qddot);
+  EXPECT_NEAR(qddot(0), vdot(0), kTolerance);
+
+  qddot(0) = -std::sqrt(5);
+  mobilizer_->MapQDDotToAcceleration(*context_, qddot, &vdot);
+  EXPECT_NEAR(vdot(0), qddot(0), kTolerance);
 }
 
 TEST_F(ScrewMobilizerTest, KinematicMapping) {

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -72,7 +72,7 @@ void WeldMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
-void WeldMobilizer<T>::MapVelocityDotToQDDot(
+void WeldMobilizer<T>::MapAccelerationToQDDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
     EigenPtr<VectorX<T>> qddot) const {
   DRAKE_ASSERT(vdot.size() == kNv);
@@ -81,7 +81,7 @@ void WeldMobilizer<T>::MapVelocityDotToQDDot(
 }
 
 template <typename T>
-void WeldMobilizer<T>::MapQDDotToVelocityDot(
+void WeldMobilizer<T>::MapQDDotToAcceleration(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
     EigenPtr<VectorX<T>> vdot) const {
   DRAKE_ASSERT(qddot.size() == kNq);

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -72,6 +72,24 @@ void WeldMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
+void WeldMobilizer<T>::MapVelocityDotToQDDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
+    EigenPtr<VectorX<T>> qddot) const {
+  DRAKE_ASSERT(vdot.size() == kNv);
+  DRAKE_ASSERT(qddot != nullptr);
+  DRAKE_ASSERT(qddot->size() == kNq);
+}
+
+template <typename T>
+void WeldMobilizer<T>::MapQDDotToVelocityDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
+    EigenPtr<VectorX<T>> vdot) const {
+  DRAKE_ASSERT(qddot.size() == kNq);
+  DRAKE_ASSERT(vdot != nullptr);
+  DRAKE_ASSERT(vdot->size() == kNv);
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Mobilizer<ToScalar>> WeldMobilizer<T>::TemplatedDoCloneToScalar(
     const MultibodyTree<ToScalar>& tree_clone) const {

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -104,15 +104,15 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
 
   // This override is a no-op since this mobilizer has no generalized
   // velocities associated with it.
-  void MapVelocityDotToQDDot(const systems::Context<T>& context,
-                             const Eigen::Ref<const VectorX<T>>& vdot,
-                             EigenPtr<VectorX<T>> qddot) const final;
+  void MapAccelerationToQDDot(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& vdot,
+                              EigenPtr<VectorX<T>> qddot) const final;
 
   // This override is a no-op since this mobilizer has no generalized
   // velocities associated with it.
-  void MapQDDotToVelocityDot(const systems::Context<T>& context,
-                             const Eigen::Ref<const VectorX<T>>& qddot,
-                             EigenPtr<VectorX<T>> vdot) const final;
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const final;
 
   bool can_rotate() const final { return false; }
   bool can_translate() const final { return false; }

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -102,6 +102,18 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
 
+  // This override is a no-op since this mobilizer has no generalized
+  // velocities associated with it.
+  void MapVelocityDotToQDDot(const systems::Context<T>& context,
+                             const Eigen::Ref<const VectorX<T>>& vdot,
+                             EigenPtr<VectorX<T>> qddot) const final;
+
+  // This override is a no-op since this mobilizer has no generalized
+  // velocities associated with it.
+  void MapQDDotToVelocityDot(const systems::Context<T>& context,
+                             const Eigen::Ref<const VectorX<T>>& qddot,
+                             EigenPtr<VectorX<T>> vdot) const final;
+
   bool can_rotate() const final { return false; }
   bool can_translate() const final { return false; }
 


### PR DESCRIPTION
This is the first PR of several to help address issue #22630.  It creates MapQDDotToAcceleration() and MapAccelerationToQDDot() for simple mobilizers.  

Subsequent PRs will create helper methods for more complex mobilizers (e.g., rpy_ball_mobilizer, curvilinear_mobilizer, quaternion_floating_mobilizer, etc.) to consolidate creation of the N(q) and  N⁺(q) matrices that is shared between MapQDotToVelocity() and MapQDDotToAcceleration()  as well as MapVelocityToQDDot() and MapAccelerationToQDDot().

In conjunction with each of the subsequent PRs, each more complex mobilizer will implement its functions MapQDDotToAcceleration() and MapAccelerationToQDDot().

FYI: Since mobilizers are Drake internal classes, after the internal mobilizer work is complete, there will be PRs (code and testing) for the public API in MultibodyPlant to address issue #22630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22698)
<!-- Reviewable:end -->
