### PR TITLE
[multibody] Unambiguously identify ephemeral elements

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -580,6 +580,7 @@ class TestPlant(unittest.TestCase):
         cls = type(element)
         self.assertIsInstance(element.index(), get_index_class(cls, T))
         self.assertIsInstance(element.model_instance(), ModelInstanceIndex)
+        self.assertFalse(element.is_ephemeral())
         element.GetParentPlant()
 
     def _test_frame_api(self, T, frame):

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -76,6 +76,7 @@ void BindMultibodyElementMixin(PyClass* pcls) {
   cls  // BR
       .def("index", &Class::index)
       .def("model_instance", &Class::model_instance)
+      .def("is_ephemeral", &Class::is_ephemeral)
       .def("GetParentPlant",
           [](const Class& self) -> const multibody::MultibodyPlant<T>& {
             return self.GetParentPlant();

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -100,6 +100,7 @@ class BodyNode : public MultibodyElement<T> {
         body_(body),
         mobilizer_(mobilizer) {
     DRAKE_DEMAND(!(parent_node == nullptr && body->index() != world_index()));
+    this->set_is_ephemeral(true);  // BodyNodes are never added by users.
   }
 
   ~BodyNode() override;

--- a/multibody/tree/fixed_offset_frame.cc
+++ b/multibody/tree/fixed_offset_frame.cc
@@ -53,8 +53,10 @@ std::unique_ptr<Frame<ToScalar>> FixedOffsetFrame<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
   const Frame<ToScalar>& parent_frame_clone =
       tree_clone.get_variant(parent_frame_);
-  return std::make_unique<FixedOffsetFrame<ToScalar>>(
+  auto new_frame = std::make_unique<FixedOffsetFrame<ToScalar>>(
       this->name(), parent_frame_clone, X_PF_, this->model_instance());
+  new_frame->set_is_ephemeral(this->is_ephemeral());
+  return new_frame;
 }
 
 template <typename T>
@@ -78,8 +80,10 @@ FixedOffsetFrame<T>::DoCloneToScalar(
 
 template <typename T>
 std::unique_ptr<Frame<T>> FixedOffsetFrame<T>::DoShallowClone() const {
-  return std::make_unique<FixedOffsetFrame<T>>(this->name(), parent_frame_,
-                                               X_PF_, this->model_instance());
+  auto new_frame = std::make_unique<FixedOffsetFrame<T>>(
+      this->name(), parent_frame_, X_PF_, this->model_instance());
+  new_frame->set_is_ephemeral(this->is_ephemeral());
+  return new_frame;
 }
 
 template <typename T>

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -7,7 +7,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/frame.h"
-#include "drake/multibody/tree/multibody_tree_topology.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -264,6 +264,7 @@ class Mobilizer : public MultibodyElement<T> {
       throw std::runtime_error(
           "The provided inboard and outboard frames reference the same object");
     }
+    this->set_is_ephemeral(true);  // Mobilizers are never added by users.
   }
 
   ~Mobilizer() override;

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -26,6 +26,14 @@ class MultibodyPlant;
 /// BodyIndex index() const { return this->template index_impl<BodyIndex>(); }
 /// @endcode
 ///
+/// Some multibody elements are added during Finalize() and are not part of
+/// the user-specified model. These are called "ephemeral" elements and can
+/// be identified using the `is_ephemeral()` function here. Examples include
+///   - free joints added to connect lone bodies or free-floating trees
+///     to World
+///   - fixed offset frames added when joints are modeled by mobilizers
+///   - all mobilizers.
+///
 /// @tparam_default_scalar
 template <typename T>
 class MultibodyElement {
@@ -63,6 +71,15 @@ class MultibodyElement {
   /// @param[out] parameters A mutable collections of parameters in a context.
   /// @pre parameters != nullptr
   void SetDefaultParameters(systems::Parameters<T>* parameters) const;
+
+  /// Returns `true` if this %MultibodyElement was added during Finalize()
+  /// rather than something a user added. (See class comments.)
+  bool is_ephemeral() const { return is_ephemeral_; }
+
+  /// (Internal use only) Sets the `is_ephemeral` flag to the indicated value.
+  /// The default if this is never called is `false`. Any element that is added
+  /// during Finalize() should set this flag to `true`.
+  void set_is_ephemeral(bool is_ephemeral) { is_ephemeral_ = is_ephemeral; }
 
  protected:
   /// Default constructor made protected so that sub-classes can still declare
@@ -186,6 +203,8 @@ class MultibodyElement {
   // The default model instance id is *invalid*. This must be set to a
   // valid index value before the element is released to the wild.
   ModelInstanceIndex model_instance_;
+
+  bool is_ephemeral_{false};
 };
 
 }  // namespace multibody

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -927,7 +927,10 @@ void MultibodyTree<T>::Finalize() {
   elements" to provide a uniform interface to the additional elements that were
   required to build the model. Below, we will augment the MultibodyPlant
   elements to match, so that advanced users can use the familiar Plant API to
-  access and control these ephemeral elements. */
+  access and control these ephemeral elements. The process of modeling Joints
+  with available Mobilizers may introduce ephemeral Frames as well. All
+  ephemeral elements must be marked as such in the base MultibodyElement class;
+  public API element.is_ephemeral() is available to check. */
   link_joint_graph_.BuildForest();
   const LinkJointGraph& graph = link_joint_graph_;
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -205,6 +205,10 @@ class MultibodyTree {
   template <template <typename Scalar> class FrameType>
   const FrameType<T>& AddFrame(std::unique_ptr<FrameType<T>> frame);
 
+  // Same as above but sets the `is_ephemeral` bit.
+  template <template <typename Scalar> class FrameType>
+  const FrameType<T>& AddEphemeralFrame(std::unique_ptr<FrameType<T>> frame);
+
   // Constructs a new frame with type `FrameType` with the given `args`, and
   // adds it to `this` %MultibodyTree, which retains ownership. The `FrameType`
   // will be specialized on the scalar type T of this %MultibodyTree.
@@ -242,6 +246,10 @@ class MultibodyTree {
   //                   this %MultibodyTree.
   template <template <typename Scalar> class FrameType, typename... Args>
   const FrameType<T>& AddFrame(Args&&... args);
+
+  // Same as above but sets the `is_ephemeral` bit.
+  template <template <typename Scalar> class FrameType, typename... Args>
+  const FrameType<T>& AddEphemeralFrame(Args&&... args);
 
   // Takes ownership of `mobilizer` and adds it to `this` %MultibodyTree.
   // Returns a constant reference to the mobilizer just added, which will
@@ -977,14 +985,18 @@ class MultibodyTree {
     return forest().mobods(index);
   }
 
-  // This method must be called after all elements in the plant (joints, bodies,
-  // force elements, constraints) were added and before any computations are
-  // performed. It compiles all the necessary "topological information", i.e.
-  // how bodies, mobilizers, and any other elements connect with each other, and
-  // performs all the required pre-processing to permit efficient computations
-  // at a later stage.
+  // Finalize() must be called after all user-defined elements in the plant
+  // (joints, bodies, force elements, constraints, etc.) have been added and
+  // before any computations are performed. It compiles all the necessary
+  // topological information, i.e. how bodies, mobilizers, and any other
+  // elements connect with each other, and performs all the required
+  // pre-processing to permit efficient computations at a later stage. During
+  // this process, we may add additional elements (e.g. joints, frames,
+  // and constraints) to facilitate computation; we call those "ephemeral"
+  // elements and mark them as such in the base MultibodyElement class to
+  // distinguish them from user-defined elements.
   //
-  // If the finalize stage is successful, the topology of this MultibodyTree
+  // If the Finalize operation is successful, the topology of this MultibodyTree
   // is validated, meaning that the topology is up-to-date after this call.
   // No more multibody plant elements can be added after a call to Finalize().
   //

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -70,16 +70,19 @@ class FrameTests : public ::testing::Test {
     // Frame Q is rigidly attached to P with pose X_PQ.
     frameQ_ = &model->AddFrame<FixedOffsetFrame>("Q", *frameP_, X_PQ_);
 
-    // Frame R is arbitrary, but named.
+    // Frame R is arbitrary, but named and not ephemeral.
     frameR_ = &model->AddFrame<FixedOffsetFrame>(
         "R", *frameP_, math::RigidTransformd::Identity());
+    EXPECT_FALSE(frameR_->is_ephemeral());
 
-    // Frame S is arbitrary, but named and with a specific model instance.
+    // Frame S is arbitrary, but named, with a specific model instance, and
+    // ephemeral.
     X_WS_ = X_BP_;  // Any non-identity pose will do.
     extra_instance_ = model->AddModelInstance("extra_instance");
-    frameS_ = &model->AddFrame<FixedOffsetFrame>("S", model->world_frame(),
-                                                 X_WS_, extra_instance_);
+    frameS_ = &model->AddEphemeralFrame<FixedOffsetFrame>(
+        "S", model->world_frame(), X_WS_, extra_instance_);
     EXPECT_EQ(frameS_->scoped_name().get_full(), "extra_instance::S");
+    EXPECT_TRUE(frameS_->is_ephemeral());
 
     // Ensure that the model instance propagates implicitly.
     frameSChild_ = &model->AddFrame<FixedOffsetFrame>(
@@ -351,6 +354,7 @@ TEST_F(FrameTests, ShallowCloneTests) {
   EXPECT_NE(dynamic_cast<const RigidBodyFrame<double>*>(frameB_), nullptr);
   EXPECT_EQ(clone_of_frameB->name(), frameB_->name());
   EXPECT_EQ(clone_of_frameB->model_instance(), frameB_->model_instance());
+  EXPECT_FALSE(clone_of_frameB->is_ephemeral());
 
   // Make sure ShallowClone() preserves FixedOffsetFrame frameS's properties.
   const std::unique_ptr<Frame<double>> clone_of_frameS =
@@ -358,6 +362,7 @@ TEST_F(FrameTests, ShallowCloneTests) {
   EXPECT_NE(clone_of_frameS.get(), frameS_);
   EXPECT_EQ(clone_of_frameS->name(), frameS_->name());
   EXPECT_EQ(clone_of_frameS->model_instance(), frameS_->model_instance());
+  EXPECT_TRUE(clone_of_frameS->is_ephemeral());
   const auto& downcast_clone =
       dynamic_cast<const FixedOffsetFrame<double>&>(*clone_of_frameS);
   EXPECT_TRUE(downcast_clone.GetFixedPoseInBodyFrame().IsExactlyEqualTo(X_WS_));
@@ -373,12 +378,14 @@ TEST_F(FrameTests, DeepCloneTests) {
             nullptr);
   EXPECT_EQ(clone_of_frameB.name(), frameB_->name());
   EXPECT_EQ(clone_of_frameB.model_instance(), frameB_->model_instance());
+  EXPECT_FALSE(clone_of_frameB.is_ephemeral());
 
   // Make sure CloneToScalar() preserves FixedOffsetFrame frameS's properties.
   const Frame<AutoDiffXd>& clone_of_frameS =
       cloned_tree->get_frame(frameS_->index());
   EXPECT_EQ(clone_of_frameS.name(), frameS_->name());
   EXPECT_EQ(clone_of_frameS.model_instance(), frameS_->model_instance());
+  EXPECT_TRUE(clone_of_frameS.is_ephemeral());
   const auto& downcast_clone =
       dynamic_cast<const FixedOffsetFrame<AutoDiffXd>&>(clone_of_frameS);
   EXPECT_TRUE(downcast_clone.GetFixedPoseInBodyFrame().IsExactlyEqualTo(

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -34,6 +34,8 @@ class RevoluteMobilizerTest : public MobilizerTester {
         std::make_unique<RevoluteJoint<double>>(
             "joint0", tree().world_body().body_frame(), body_->body_frame(),
             axis_F_));
+    // Mobilizers are always ephemeral (i.e. not added by user).
+    EXPECT_TRUE(mobilizer_->is_ephemeral());
     mutable_mobilizer_ = const_cast<RevoluteMobilizer<double>*>(mobilizer_);
   }
 


### PR DESCRIPTION
### Background

Users populate a MultibodyPlant with "elements" (Bodies, Joints, Frames, etc.), with base class MultibodyElement that holds common information like name, index, and model instance. During Finalize(), additional "ephemeral" elements are added internally to facilitate later computation. Currently we add ephemeral Joints to World for anything that doesn't have one already. We are adding ephemeral Frames for better performance in #22649, and we will add ephemeral Constraints for closing topological loops.

Currently there is no way to check whether an element in an existing plant is user-defined or ephemeral. This causes trouble in applications that involve rummaging through existing plants to construct a new plant. If the ephemeral elements are copied over from source plants to the destination plant, finalizing the destination plant will add more ephemeral elements causing duplication, name collisions, and unnecessary computation.  For example, in Anzu the multibody_plant_subgraph utility has this problem.

### Proposal

This PR introduces the public API `element.is_ephemeral()`. This can be used when rummaging through an already-finalized plant to skip over the throw-away ephemeral elements that may be there. Internally we already had AddEphemeralJoint(), now we add AddEphemeralFrame(), and both methods set the `is_ephemeral` bit. (BodyNodes and Mobilizers are always marked ephemeral though those are internal.) Cloning of possibly-ephemeral elements copies the `is_ephemeral` bit. Unit tests ensure that the known ephemeral elements are still ephemeral after cloning. 

### Next steps
This PR is a yak shave for the multibody performance epic #18442, so that #22649 (better F and M frames) can land. Once the `is_ephemeral()` API is available, I will fix Anzu's multibody_plant_subgraph utility to use it to avoid copying ephemeral elements. At that point it will be save to re-submit #22649 which will add ephemeral frames that multibody_plant_subgraph will then ignore.