### PR TITLE
Support fixed step integration for a const IntegratorBase

### DIFF
--- a/systems/analysis/bogacki_shampine3_integrator.cc
+++ b/systems/analysis/bogacki_shampine3_integrator.cc
@@ -47,10 +47,10 @@ void BogackiShampine3Integrator<T>::DoInitialize() {
 }
 
 template <class T>
-bool BogackiShampine3Integrator<T>::DoStep(const T& h) {
+bool BogackiShampine3Integrator<T>::DoStepConst(Context<T>* context,
+                                                const T& h) const {
   using std::abs;
-  Context<T>& context = *this->get_mutable_context();
-  const T t0 = context.get_time();
+  const T t0 = context->get_time();
 
   // CAUTION: This is performance-sensitive inner loop code that uses dangerous
   // long-lived references into state and cache to avoid unnecessary copying and
@@ -67,11 +67,11 @@ bool BogackiShampine3Integrator<T>::DoStep(const T& h) {
   //              7/24 (d1)       1/4 (d2)     1/3 (d3)     1/8 (d4)
 
   // Save the continuous state at t₀.
-  context.get_continuous_state_vector().CopyToPreSizedVector(&save_xc0_);
+  context->get_continuous_state_vector().CopyToPreSizedVector(&save_xc0_);
 
   // Evaluate the derivative at t₀, xc₀.
   derivs1_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k1 = derivs1_->get_vector();
 
   // Cache: k1 references a *copy* of the derivative result so is immune
@@ -84,13 +84,13 @@ bool BogackiShampine3Integrator<T>::DoStep(const T& h) {
   // will require manual out-of-date notifications.
   const double c2 = 1.0 / 2;
   const double a21 = 1.0 / 2;
-  VectorBase<T>& xc = context.SetTimeAndGetMutableContinuousStateVector(
-      t0 + c2 * h);
+  VectorBase<T>& xc =
+      context->SetTimeAndGetMutableContinuousStateVector(t0 + c2 * h);
   xc.PlusEqScaled(a21 * h, k1);
 
   // Evaluate the derivative (denoted k2) at t₀ + c2 * h, xc₀ + a21 * h * k1.
   derivs2_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k2 = derivs2_->get_vector();  // xcdot⁽ᵃ⁾
 
   // Cache: k2 references a *copy* of the derivative result so is immune
@@ -103,7 +103,7 @@ bool BogackiShampine3Integrator<T>::DoStep(const T& h) {
   // This call marks t- and xc-dependent cache entries out of date, including
   // the derivative cache entry. (We already have the xc reference but must
   // issue the out-of-date notification here since we're about to change it.)
-  context.SetTimeAndNoteContinuousStateChange(t0 + c3 * h);
+  context->SetTimeAndNoteContinuousStateChange(t0 + c3 * h);
 
   // Evaluate the derivative (denoted k3) at t₀ + c3 * h,
   //   xc₀ + a31 * h * k1 + a32 * h * k2.
@@ -112,7 +112,7 @@ bool BogackiShampine3Integrator<T>::DoStep(const T& h) {
   xc.SetFromVector(save_xc0_);  // Restore xc ← xc₀.
   xc.PlusEqScaled({{a32 * h, k2}});
   derivs3_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k3 =  derivs3_->get_vector();
 
   // Compute the propagated solution (we're able to do this because b1 = a41,
@@ -124,14 +124,14 @@ bool BogackiShampine3Integrator<T>::DoStep(const T& h) {
   // This call marks t- and xc-dependent cache entries out of date, including
   // the derivative cache entry. (We already have the xc reference but must
   // issue the out-of-date notification here since we're about to change it.)
-  context.SetTimeAndNoteContinuousStateChange(t0 + c4 * h);
+  context->SetTimeAndNoteContinuousStateChange(t0 + c4 * h);
 
   // Evaluate the derivative (denoted k4) at t₀ + c4 * h, xc₀ + a41 * h * k1 +
   // a42 * h * k2 + a43 * h * k3. This will be used to compute the second
   // order solution.
   xc.SetFromVector(save_xc0_);  // Restore xc ← xc₀.
   xc.PlusEqScaled({{a41 * h, k1}, {a42 * h, k2}, {a43 * h, k3}});
-  const ContinuousState<T>& derivs4 = this->EvalTimeDerivatives(context);
+  const ContinuousState<T>& derivs4 = this->EvalTimeDerivatives(*context);
   const VectorBase<T>& k4 = derivs4.get_vector();
 
   // WARNING: k4 is a live reference into the cache. Be careful of adding

--- a/systems/analysis/bogacki_shampine3_integrator.h
+++ b/systems/analysis/bogacki_shampine3_integrator.h
@@ -59,18 +59,18 @@ class BogackiShampine3Integrator final : public IntegratorBase<T> {
 
  private:
   void DoInitialize() override;
-  bool DoStep(const T& h) override;
+  bool DoStepConst(Context<T>* context, const T& h) const override;
 
   // Vector used in error estimate calculations.
-  std::unique_ptr<BasicVector<T>> err_est_vec_;
+  mutable std::unique_ptr<BasicVector<T>> err_est_vec_;
 
   // Vector used to save initial value of xc.
-  VectorX<T> save_xc0_;
+  mutable VectorX<T> save_xc0_;
 
   // These are pre-allocated temporaries for use by integration. They store
   // the derivatives computed at various points within the integration
   // interval.
-  std::unique_ptr<ContinuousState<T>> derivs1_, derivs2_, derivs3_;
+  mutable std::unique_ptr<ContinuousState<T>> derivs1_, derivs2_, derivs3_;
 };
 
 }  // namespace systems

--- a/systems/analysis/explicit_euler_integrator.h
+++ b/systems/analysis/explicit_euler_integrator.h
@@ -52,7 +52,7 @@ class ExplicitEulerIntegrator final : public IntegratorBase<T> {
   int get_error_estimate_order() const override { return 0; }
 
  private:
-  bool DoStep(const T& h) override;
+  bool DoStepConst(Context<T>* context, const T& h) const override;
 };
 
 /**
@@ -60,16 +60,15 @@ class ExplicitEulerIntegrator final : public IntegratorBase<T> {
  * This value of h is determined by IntegratorBase::Step().
  */
 template <class T>
-bool ExplicitEulerIntegrator<T>::DoStep(const T& h) {
-  Context<T>& context = *this->get_mutable_context();
-
+bool ExplicitEulerIntegrator<T>::DoStepConst(Context<T>* context,
+                                             const T& h) const {
   // CAUTION: This is performance-sensitive inner loop code that uses dangerous
   // long-lived references into state and cache to avoid unnecessary copying and
   // cache invalidation. Be careful not to insert calls to methods that could
   // invalidate any of these references before they are used.
 
   // Evaluate derivative xcdot₀ ← xcdot(t₀, x(t₀), u(t₀)).
-  const ContinuousState<T>& xc_deriv = this->EvalTimeDerivatives(context);
+  const ContinuousState<T>& xc_deriv = this->EvalTimeDerivatives(*context);
   const VectorBase<T>& xcdot0 = xc_deriv.get_vector();
 
   // Cache: xcdot0 references the live derivative cache value, currently
@@ -78,8 +77,8 @@ bool ExplicitEulerIntegrator<T>::DoStep(const T& h) {
 
   // Update continuous state and time. This call marks t- and xc-dependent
   // cache entries out of date, including xcdot0.
-  VectorBase<T>& xc = context.SetTimeAndGetMutableContinuousStateVector(
-      context.get_time() + h);  // t ← t₀ + h
+  VectorBase<T>& xc = context->SetTimeAndGetMutableContinuousStateVector(
+      context->get_time() + h);  // t ← t₀ + h
 
   // Cache: xcdot0 still references the derivative cache value, which is
   // unchanged, although it is marked out of date.

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -399,6 +399,8 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   void DoInitialize() final;
 
   // Steps both implicit Euler and implicit trapezoid forward by h, if possible.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the integration step size to attempt.
   // @param xt0 the continuous state at t0.
@@ -407,14 +409,17 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param [out] xtplus_hie contains the half-sized step solution (i.e.,
   //              `x(t0+h)`) on return, or the implicit Trapezoid solution.
   // @returns `true` if the step of size `h` was successful.
-  bool AttemptStepPaired(const T& t0, const T& h, const VectorX<T>& xt0,
-      VectorX<T>* xtplus_ie, VectorX<T>* xtplus_hie);
+  bool AttemptStepPaired(Context<T>* context, const T& t0, const T& h,
+                         const VectorX<T>& xt0, VectorX<T>* xtplus_ie,
+                         VectorX<T>* xtplus_hie) const;
 
   // Performs the bulk of the stepping computation for both implicit Euler and
   // implicit trapezoid method; all those methods need to do is provide a
   // residual function (`g`) and an iteration matrix computation and
   // factorization function (`compute_and_factor_iteration_matrix`) specific to
   // the particular integrator scheme and this method does the rest.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the integration step size (> 0) to attempt.
   // @param xt0 the continuous state at t0.
@@ -437,25 +442,28 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   //       exit.
   // TODO(edrumwri) Explicitly test this method's fallback logic (i.e., how it
   //                calls MaybeFreshenMatrices()) in a unit test).
-  bool StepAbstract(const T& t0, const T& h, const VectorX<T>& xt0,
-                    const std::function<VectorX<T>()>& g,
-                    const std::function<
-                        void(const MatrixX<T>&, const T&,
-                             typename ImplicitIntegrator<T>::IterationMatrix*)>&
-                        compute_and_factor_iteration_matrix,
-                    const VectorX<T>& xtplus_guess,
-                    typename ImplicitIntegrator<T>::IterationMatrix*
-                    iteration_matrix, VectorX<T>* xtplus, int trial = 1);
+  bool StepAbstract(
+      Context<T>* context, const T& t0, const T& h, const VectorX<T>& xt0,
+      const std::function<VectorX<T>()>& g,
+      const std::function<
+          void(const MatrixX<T>&, const T&,
+               typename ImplicitIntegrator<T>::IterationMatrix*)>&
+          compute_and_factor_iteration_matrix,
+      const VectorX<T>& xtplus_guess,
+      typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix,
+      VectorX<T>* xtplus, int trial = 1) const;
 
   // Takes a given step of the requested size, if possible.
   // @returns `true` if successful; on `true`, the time and continuous state
   //          will be advanced in the context (e.g., from t0 to t0 + h). On a
   //          `false` return, the time and continuous state in the context will
   //          be restored to its original value (at t0).
-  bool DoImplicitIntegratorStep(const T& h) final;
+  bool DoImplicitIntegratorStep(Context<T>* context, const T& h) const final;
 
   // Steps the system forward by a single step of at most h using the implicit
   // Euler method.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the maximum time increment to step forward.
   // @param xt0 the continuous state at t0.
@@ -463,11 +471,13 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @returns `true` if the step of size `h` was successful.
   // @post The time and continuous state in the context are indeterminate upon
   //       exit.
-  bool StepImplicitEuler(const T& t0, const T& h, const VectorX<T>& xt0,
-      VectorX<T>* xtplus);
+  bool StepImplicitEuler(Context<T>* context, const T& t0, const T& h,
+                         const VectorX<T>& xt0, VectorX<T>* xtplus) const;
 
   // Steps the system forward by a single step of at most h using the implicit
   // Euler method, starting with a guess for the state xtplus.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the maximum time increment to step forward.
   // @param xt0 the continuous state at t0.
@@ -476,12 +486,15 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @returns `true` if the step of size `h` was successful.
   // @post The time and continuous state in the context are indeterminate upon
   //       exit.
-  bool StepImplicitEulerWithGuess(const T& t0, const T& h,
-      const VectorX<T>& xt0, const VectorX<T>& xtplus_guess,
-      VectorX<T>* xtplus);
+  bool StepImplicitEulerWithGuess(Context<T>* context, const T& t0, const T& h,
+                                  const VectorX<T>& xt0,
+                                  const VectorX<T>& xtplus_guess,
+                                  VectorX<T>* xtplus) const;
 
   // Steps forward by two steps of `h/2` using the implicit Euler
   // method, if possible.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the maximum time increment to step forward.
   // @param xt0 the continuous state at t0.
@@ -491,11 +504,15 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @returns `true` if the step was successful.
   // @post The time and continuous state in the context are indeterminate upon
   //       exit.
-  bool StepHalfSizedImplicitEulers(const T& t0, const T& h,
-      const VectorX<T>& xt0, const VectorX<T>& xtplus_ie, VectorX<T>* xtplus);
+  bool StepHalfSizedImplicitEulers(Context<T>* context, const T& t0, const T& h,
+                                   const VectorX<T>& xt0,
+                                   const VectorX<T>& xtplus_ie,
+                                   VectorX<T>* xtplus) const;
 
   // Steps forward by a single step of `h` using the implicit trapezoid
   // method, if possible.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the maximum time increment to step forward.
   // @param xt0 the continuous state at t0.
@@ -506,24 +523,26 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @returns `true` if the step was successful.
   // @post The time and continuous state in the context are indeterminate upon
   //       exit.
-  bool StepImplicitTrapezoid(const T& t0, const T& h, const VectorX<T>& xt0,
-      const VectorX<T>& dx0, const VectorX<T>& xtplus_ie, VectorX<T>* xtplus);
+  bool StepImplicitTrapezoid(Context<T>* context, const T& t0, const T& h,
+                             const VectorX<T>& xt0, const VectorX<T>& dx0,
+                             const VectorX<T>& xtplus_ie,
+                             VectorX<T>* xtplus) const;
 
   // The last computed iteration matrix and factorization for implicit Euler.
-  typename ImplicitIntegrator<T>::IterationMatrix ie_iteration_matrix_;
+  mutable typename ImplicitIntegrator<T>::IterationMatrix ie_iteration_matrix_;
 
   // The last computed iteration matrix and factorization for implicit
   // trapezoid.
-  typename ImplicitIntegrator<T>::IterationMatrix itr_iteration_matrix_;
+  mutable typename ImplicitIntegrator<T>::IterationMatrix itr_iteration_matrix_;
 
   // Vector used in error estimate calculations.
-  VectorX<T> err_est_vec_;
+  mutable VectorX<T> err_est_vec_;
 
   // The continuous state update vector used during Newton-Raphson.
-  std::unique_ptr<ContinuousState<T>> dx_state_;
+  mutable std::unique_ptr<ContinuousState<T>> dx_state_;
 
   // Variables to avoid heap allocations.
-  VectorX<T> xt0_, xdot_, xtplus_ie_, xtplus_hie_;
+  mutable VectorX<T> xt0_, xdot_, xtplus_ie_, xtplus_hie_;
 
   // Second order Runge-Kutta method for estimating the integration error when
   // the requested step size lies below the working step size.
@@ -535,14 +554,14 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // or the half-sized implicit Eulers. This is used in ImplicitIntegrator::
   // get_num_newton_raphson_iterations(). Other statistics integers for the
   // total are defined in ImplicitIntegrator.
-  int64_t num_nr_iterations_{0};
+  mutable int64_t num_nr_iterations_{0};
 
   // These track statistics specific to implicit trapezoid or the two half-
   // sized steps. Only one of the following two will be used at a time, the
   // other one will remain at 0 as long as
   // use_implicit_trapezoid_error_estimation_ does not change.
-  Statistics itr_statistics_;
-  Statistics hie_statistics_;
+  mutable Statistics itr_statistics_;
+  mutable Statistics hie_statistics_;
 
   // Since this integrator computes two small steps for its solution and
   // simultaneously computes a large step to estimate the error, this is a
@@ -553,7 +572,7 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // will not attempt to compute a Jacobian. This flag tells the next step that
   // the Jacobian is still not "fresh", or computed from (t0,x0) at the
   // beginning of the step, even after the step has failed.
-  bool failed_jacobian_is_from_second_small_step_{false};
+  mutable bool failed_jacobian_is_from_second_small_step_{false};
 
   // If set to true, the integrator uses implicit trapezoid instead of two
   // half-sized steps for error estimation.

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -29,9 +29,11 @@ void ImplicitIntegrator<T>::DoReset() {
 }
 
 template <class T>
-void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
-    const System<T>& system, const T& t, const VectorX<T>& xt,
-    const Context<T>& context, MatrixX<T>* J) {
+void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(const System<T>& system,
+                                                    const Context<T>& context,
+                                                    const T& t,
+                                                    const VectorX<T>& xt,
+                                                    MatrixX<T>* J) const {
   DRAKE_LOGGER_DEBUG("  ImplicitIntegrator Compute Autodiff Jacobian t={}", t);
   // TODO(antequ): Investigate how to refactor this method to use
   // math::jacobian(), if possible.
@@ -74,9 +76,11 @@ void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
 }
 
 template <class T>
-void ImplicitIntegrator<T>::ComputeForwardDiffJacobian(
-    const System<T>&, const T& t, const VectorX<T>& xt, Context<T>* context,
-    MatrixX<T>* J) {
+void ImplicitIntegrator<T>::ComputeForwardDiffJacobian(const System<T>&,
+                                                       Context<T>* context,
+                                                       const T& t,
+                                                       const VectorX<T>& xt,
+                                                       MatrixX<T>* J) const {
   using std::abs;
 
   // Set epsilon to the square root of machine precision.
@@ -134,9 +138,11 @@ void ImplicitIntegrator<T>::ComputeForwardDiffJacobian(
 }
 
 template <class T>
-void ImplicitIntegrator<T>::ComputeCentralDiffJacobian(
-    const System<T>&, const T& t, const VectorX<T>& xt, Context<T>* context,
-    MatrixX<T>* J) {
+void ImplicitIntegrator<T>::ComputeCentralDiffJacobian(const System<T>&,
+                                                       Context<T>* context,
+                                                       const T& t,
+                                                       const VectorX<T>& xt,
+                                                       MatrixX<T>* J) const {
   using std::abs;
 
   // Cube root of machine precision (indicated by theory) seems a bit coarse.
@@ -277,10 +283,9 @@ bool ImplicitIntegrator<T>::IsBadJacobian(const MatrixX<T>& J) const {
 }
 
 template <class T>
-const MatrixX<T>& ImplicitIntegrator<T>::CalcJacobian(const T& t,
-    const VectorX<T>& x) {
+const MatrixX<T>& ImplicitIntegrator<T>::CalcJacobian(
+    Context<T>* context, const T& t, const VectorX<T>& x) const {
   // We change the context but will change it back.
-  Context<T>* context = this->get_mutable_context();
 
   // Get the current time and state.
   const T t_current = context->get_time();
@@ -301,15 +306,15 @@ const MatrixX<T>& ImplicitIntegrator<T>::CalcJacobian(const T& t,
   [this, context, &system, &t, &x]() {
     switch (jacobian_scheme_) {
       case JacobianComputationScheme::kForwardDifference:
-        ComputeForwardDiffJacobian(system, t, x, &*context, &J_);
+        ComputeForwardDiffJacobian(system, context, t, x, &J_);
         break;
 
       case JacobianComputationScheme::kCentralDifference:
-        ComputeCentralDiffJacobian(system, t, x, &*context, &J_);
+        ComputeCentralDiffJacobian(system, context, t, x, &J_);
         break;
 
       case JacobianComputationScheme::kAutomatic:
-        ComputeAutoDiffJacobian(system, t, x, *context, &J_);
+        ComputeAutoDiffJacobian(system, *context, t, x, &J_);
         break;
     }
   }();
@@ -331,11 +336,11 @@ const MatrixX<T>& ImplicitIntegrator<T>::CalcJacobian(const T& t,
 
 template <class T>
 void ImplicitIntegrator<T>::FreshenMatricesIfFullNewton(
-    const T& t, const VectorX<T>& xt, const T& h,
+    Context<T>* context, const T& t, const VectorX<T>& xt, const T& h,
     const std::function<void(const MatrixX<T>&, const T&,
-        typename ImplicitIntegrator<T>::IterationMatrix*)>&
+                             typename ImplicitIntegrator<T>::IterationMatrix*)>&
         compute_and_factor_iteration_matrix,
-    typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix) {
+    typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix) const {
   DRAKE_DEMAND(iteration_matrix != nullptr);
 
   // Return immediately if full-Newton is not in use.
@@ -343,23 +348,24 @@ void ImplicitIntegrator<T>::FreshenMatricesIfFullNewton(
 
   // Compute the initial Jacobian and iteration matrices and factor them.
   MatrixX<T>& J = get_mutable_jacobian();
-  J = CalcJacobian(t, xt);
+  J = CalcJacobian(context, t, xt);
   ++num_iter_factorizations_;
   compute_and_factor_iteration_matrix(J, h, iteration_matrix);
 }
 
 template <class T>
 bool ImplicitIntegrator<T>::MaybeFreshenMatrices(
-    const T& t, const VectorX<T>& xt, const T& h, int trial,
+    Context<T>* context, const T& t, const VectorX<T>& xt, const T& h,
+    int trial,
     const std::function<void(const MatrixX<T>&, const T&,
-        typename ImplicitIntegrator<T>::IterationMatrix*)>&
+                             typename ImplicitIntegrator<T>::IterationMatrix*)>&
         compute_and_factor_iteration_matrix,
-    typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix) {
+    typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix) const {
   // Compute the initial Jacobian and iteration matrices and factor them, if
   // necessary.
   MatrixX<T>& J = get_mutable_jacobian();
   if (!get_reuse() || J.rows() == 0 || IsBadJacobian(J)) {
-    J = CalcJacobian(t, xt);
+    J = CalcJacobian(context, t, xt);
     ++num_iter_factorizations_;
     compute_and_factor_iteration_matrix(J, h, iteration_matrix);
     return true;  // Indicate success.
@@ -431,7 +437,7 @@ bool ImplicitIntegrator<T>::MaybeFreshenMatrices(
 
       // Otherwise, we can reform the Jacobian matrix and refactor the
       // iteration matrix.
-      J = CalcJacobian(t, xt);
+      J = CalcJacobian(context, t, xt);
       ++num_iter_factorizations_;
       compute_and_factor_iteration_matrix(J, h, iteration_matrix);
       return true;

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -263,6 +263,8 @@ class ImplicitIntegrator : public IntegratorBase<T> {
   /// Note that the sophisticated logic above only applies when the Jacobian
   /// reuse is activated (default, see get_reuse()).
   ///
+  /// @param context the Context of the system, at time and continuous state
+  /// unknown.
   /// @param t the time at which to compute the Jacobian.
   /// @param xt the continuous state at which the Jacobian is computed.
   /// @param h the integration step size (for computing iteration matrices).
@@ -277,16 +279,20 @@ class ImplicitIntegrator : public IntegratorBase<T> {
   /// @pre 1 <= `trial` <= 4.
   /// @post the state in the internal context may or may not be altered on
   ///       return; if altered, it will be set to (t, xt).
-  bool MaybeFreshenMatrices(const T& t, const VectorX<T>& xt, const T& h,
+  bool MaybeFreshenMatrices(
+      Context<T>* context, const T& t, const VectorX<T>& xt, const T& h,
       int trial,
-      const std::function<void(const MatrixX<T>& J, const T& h,
-          typename ImplicitIntegrator<T>::IterationMatrix*)>&
-      compute_and_factor_iteration_matrix,
-      typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix);
+      const std::function<
+          void(const MatrixX<T>& J, const T& h,
+               typename ImplicitIntegrator<T>::IterationMatrix*)>&
+          compute_and_factor_iteration_matrix,
+      typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix) const;
 
   /// Computes necessary matrices (Jacobian and iteration matrix) for full
   /// Newton-Raphson (NR) iterations, if full Newton-Raphson method is activated
   /// (if it's not activated, this method is a no-op).
+  /// @param context the Context of the system, at time and continuous state
+  /// unknown.
   /// @param t the time at which to compute the Jacobian.
   /// @param xt the continuous state at which the Jacobian is computed.
   /// @param h the integration step size (for computing iteration matrices).
@@ -296,11 +302,13 @@ class ImplicitIntegrator : public IntegratorBase<T> {
   ///             return.
   /// @post the state in the internal context will be set to (t, xt) and this
   ///       will store the updated Jacobian matrix, on return.
-  void FreshenMatricesIfFullNewton(const T& t, const VectorX<T>& xt, const T& h,
-      const std::function<void(const MatrixX<T>& J, const T& h,
-          typename ImplicitIntegrator<T>::IterationMatrix*)>&
-      compute_and_factor_iteration_matrix,
-      typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix);
+  void FreshenMatricesIfFullNewton(
+      Context<T>* context, const T& t, const VectorX<T>& xt, const T& h,
+      const std::function<
+          void(const MatrixX<T>& J, const T& h,
+               typename ImplicitIntegrator<T>::IterationMatrix*)>&
+          compute_and_factor_iteration_matrix,
+      typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix) const;
 
   /// Checks whether a proposed update is effectively zero, indicating that the
   /// Newton-Raphson process converged.
@@ -400,82 +408,83 @@ class ImplicitIntegrator : public IntegratorBase<T> {
   virtual int64_t do_get_num_error_estimator_jacobian_evaluations() const = 0;
   virtual int64_t do_get_num_error_estimator_iteration_matrix_factorizations()
       const = 0;
-  MatrixX<T>& get_mutable_jacobian() { return J_; }
+  MatrixX<T>& get_mutable_jacobian() const { return J_; }
   void DoResetStatistics() override;
   void DoReset() final;
 
   // Compute the partial derivative of the ordinary differential equations with
   // respect to the state variables for a given x(t).
+  // @param context the Context of the system, at time and continuous state
+  //        unknown.
   // @param t the time around which to compute the Jacobian matrix.
   // @param x the continuous state around which to compute the Jacobian matrix.
   // @post the context's time and continuous state will be temporarily set
   //       during this call (and then reset to their original values) on return.
   //       Furthermore, the jacobian_is_fresh_ flag is set to "true", indicating
   //       that the Jacobian was computed from the most recent time t.
-  const MatrixX<T>& CalcJacobian(const T& t, const VectorX<T>& x);
+  const MatrixX<T>& CalcJacobian(Context<T>* context, const T& t,
+                                 const VectorX<T>& x) const;
 
   // Computes the Jacobian of the ordinary differential equations around time
   // and continuous state `(t, xt)` using a first-order forward difference
   // (i.e., numerical differentiation).
   // @param system The dynamical system.
-  // @param t the time around which to compute the Jacobian matrix.
-  // @param xt the continuous state around which to compute the Jacobian matrix.
   // @param context the Context of the system, at time and continuous state
   //        unknown.
+  // @param t the time around which to compute the Jacobian matrix.
+  // @param xt the continuous state around which to compute the Jacobian matrix.
   // @param[out] J the Jacobian matrix around time and state `(t, xt)`.
   // @post The continuous state will be indeterminate on return.
-  void ComputeForwardDiffJacobian(const System<T>& system, const T& t,
-      const VectorX<T>& xt, Context<T>* context, MatrixX<T>* J);
+  void ComputeForwardDiffJacobian(const System<T>& system, Context<T>* context,
+                                  const T& t, const VectorX<T>& xt,
+                                  MatrixX<T>* J) const;
 
   // Computes the Jacobian of the ordinary differential equations around time
   // and continuous state `(t, xt)` using a second-order central difference
   // (i.e., numerical differentiation).
   // @param system The dynamical system.
-  // @param t the time around which to compute the Jacobian matrix.
-  // @param xt the continuous state around which to compute the Jacobian matrix.
   // @param context the Context of the system, at time and continuous state
   //        unknown.
+  // @param t the time around which to compute the Jacobian matrix.
+  // @param xt the continuous state around which to compute the Jacobian matrix.
   // @param[out] J the Jacobian matrix around time and state `(t, xt)`.
   // @post The continuous state will be indeterminate on return.
-  void ComputeCentralDiffJacobian(const System<T>& system, const T& t,
-      const VectorX<T>& xt, Context<T>* context, MatrixX<T>* J);
+  void ComputeCentralDiffJacobian(const System<T>& system, Context<T>* context,
+                                  const T& t, const VectorX<T>& xt,
+                                  MatrixX<T>* J) const;
 
   // Computes the Jacobian of the ordinary differential equations around time
   // and continuous state `(t, xt)` using automatic differentiation.
   // @param system The dynamical system.
-  // @param t the time around which to compute the Jacobian matrix.
-  // @param xt the continuous state around which to compute the Jacobian matrix.
   // @param context the Context of the system, at time and continuous state
   //        unknown.
+  // @param t the time around which to compute the Jacobian matrix.
+  // @param xt the continuous state around which to compute the Jacobian matrix.
   // @param[out] J the Jacobian matrix around time and state `(t, xt)`.
   // @post The continuous state will be indeterminate on return.
-  void ComputeAutoDiffJacobian(const System<T>& system, const T& t,
-      const VectorX<T>& xt, const Context<T>& context, MatrixX<T>* J);
+  void ComputeAutoDiffJacobian(const System<T>& system,
+                               const Context<T>& context, const T& t,
+                               const VectorX<T>& xt, MatrixX<T>* J) const;
 
-  /// @copydoc IntegratorBase::DoStep()
-  virtual bool DoImplicitIntegratorStep(const T& h) = 0;
+  /// @copydoc IntegratorBase::DoStepConst()
+  virtual bool DoImplicitIntegratorStep(Context<T>* context,
+                                        const T& h) const = 0;
 
   // Methods for derived classes to increment the factorization and Jacobian
   // evaluation counts.
-  void increment_num_iter_factorizations() {
-    ++num_iter_factorizations_;
-  }
+  void increment_num_iter_factorizations() const { ++num_iter_factorizations_; }
 
-  void increment_jacobian_computation_derivative_evaluations(int count) {
+  void increment_jacobian_computation_derivative_evaluations(int count) const {
     num_jacobian_function_evaluations_ += count;
   }
 
-  void increment_jacobian_evaluations() {
-    ++num_jacobian_evaluations_;
-  }
+  void increment_jacobian_evaluations() const { ++num_jacobian_evaluations_; }
 
-  void set_jacobian_is_fresh(bool flag) {
-    jacobian_is_fresh_ = flag;
-  }
+  void set_jacobian_is_fresh(bool flag) const { jacobian_is_fresh_ = flag; }
 
  private:
-  bool DoStep(const T& h) final {
-    bool result = DoImplicitIntegratorStep(h);
+  bool DoStepConst(Context<T>* context, const T& h) const final {
+    bool result = DoImplicitIntegratorStep(context, h);
     // If the implicit step is successful (result is true), we need a new
     // Jacobian (fresh is false). Otherwise, a failed step (result is false)
     // means we can keep the Jacobian (fresh is true). Therefore fresh =
@@ -498,14 +507,14 @@ class ImplicitIntegrator : public IntegratorBase<T> {
       JacobianComputationScheme::kForwardDifference};
 
   // The last computed Jacobian matrix.
-  MatrixX<T> J_;
+  mutable MatrixX<T> J_;
 
   // Indicates whether the Jacobian matrix is fresh. We say the Jacobian is
   // "fresh" if it was last computed at a state (t0, x0) from the beginning of
   // the current step. This indicates to MaybeFreshenMatrices that it should
   // not recompute the Jacobian, but rather it should fail immediately. This
   // is only used when use_full_newton_ and reuse_ are set to false.
-  bool jacobian_is_fresh_{false};
+  mutable bool jacobian_is_fresh_{false};
 
   // If set to `false`, Jacobian matrices and iteration matrix factorizations
   // will not be reused.
@@ -517,9 +526,9 @@ class ImplicitIntegrator : public IntegratorBase<T> {
   bool use_full_newton_{false};
 
   // Various combined statistics.
-  int64_t num_iter_factorizations_{0};
-  int64_t num_jacobian_evaluations_{0};
-  int64_t num_jacobian_function_evaluations_{0};
+  mutable int64_t num_iter_factorizations_{0};
+  mutable int64_t num_jacobian_evaluations_{0};
+  mutable int64_t num_jacobian_function_evaluations_{0};
 };
 
 // We do not support computing the Jacobian matrix using automatic
@@ -527,12 +536,12 @@ class ImplicitIntegrator : public IntegratorBase<T> {
 // Note: must be declared inline because it's specialized and located in the
 // header file (to avoid multiple definition errors).
 template <>
-inline void ImplicitIntegrator<AutoDiffXd>::
-    ComputeAutoDiffJacobian(const System<AutoDiffXd>&,
-      const AutoDiffXd&, const VectorX<AutoDiffXd>&,
-      const Context<AutoDiffXd>&, MatrixX<AutoDiffXd>*) {
-        throw std::runtime_error("AutoDiff'd Jacobian not supported from "
-                                     "AutoDiff'd ImplicitIntegrator");
+inline void ImplicitIntegrator<AutoDiffXd>::ComputeAutoDiffJacobian(
+    const System<AutoDiffXd>&, const Context<AutoDiffXd>&, const AutoDiffXd&,
+    const VectorX<AutoDiffXd>&, MatrixX<AutoDiffXd>*) const {
+  throw std::runtime_error(
+      "AutoDiff'd Jacobian not supported from "
+      "AutoDiff'd ImplicitIntegrator");
 }
 
 // Factors a dense matrix (the iteration matrix). This

--- a/systems/analysis/radau_integrator.cc
+++ b/systems/analysis/radau_integrator.cc
@@ -125,8 +125,8 @@ void RadauIntegrator<T, num_stages>::DoInitialize() {
 
 template <typename T, int num_stages>
 const VectorX<T>& RadauIntegrator<T, num_stages>::ComputeFofZ(
-      const T& t0, const T& h, const VectorX<T>& xt0, const VectorX<T>& Z) {
-  Context<T>* context = this->get_mutable_context();
+    Context<T>* context, const T& t0, const T& h, const VectorX<T>& xt0,
+    const VectorX<T>& Z) const {
   const int state_dim = xt0.size();
 
   // Evaluate the derivative at each stage.
@@ -155,8 +155,11 @@ void RadauIntegrator<T, num_stages>::ComputeSolutionFromIterate(
 }
 
 template <typename T, int num_stages>
-bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
-    const VectorX<T>& xt0, VectorX<T>* xtplus, int trial) {
+bool RadauIntegrator<T, num_stages>::StepRadau(Context<T>* context, const T& t0,
+                                               const T& h,
+                                               const VectorX<T>& xt0,
+                                               VectorX<T>* xtplus,
+                                               int trial) const {
   using std::max;
   using std::min;
 
@@ -167,7 +170,6 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
   DRAKE_ASSERT(1 <= trial && trial <= 4);
 
   // Set the state.
-  Context<T>* context = this->get_mutable_context();
   context->SetTimeAndContinuousState(t0, xt0);
 
   const int state_dim = xt0.size();
@@ -202,8 +204,9 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
   //                complicate the logic, since the Jacobian would no longer
   //                (necessarily) be fresh upon fallback to a smaller step size.
   if (!this->get_use_full_newton() &&
-      !this->MaybeFreshenMatrices(t0, xt0, h, trial, construct_iteration_matrix,
-      &iteration_matrix_radau_)) {
+      !this->MaybeFreshenMatrices(context, t0, xt0, h, trial,
+                                  construct_iteration_matrix,
+                                  &iteration_matrix_radau_)) {
     return false;
   }
 
@@ -214,14 +217,15 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
   for (int iter = 0; iter < this->max_newton_raphson_iterations(); ++iter) {
     DRAKE_LOGGER_DEBUG("Newton-Raphson iteration {}", iter);
 
-    this->FreshenMatricesIfFullNewton(
-        tf, *xtplus, h, construct_iteration_matrix, &iteration_matrix_radau_);
+    this->FreshenMatricesIfFullNewton(context, tf, *xtplus, h,
+                                      construct_iteration_matrix,
+                                      &iteration_matrix_radau_);
 
     // Update the number of Newton-Raphson iterations.
     ++num_nr_iterations_;
 
     // Evaluate the derivatives using the current iterate.
-    const VectorX<T>& F_of_Z = ComputeFofZ(t0, h, xt0, Z_);
+    const VectorX<T>& F_of_Z = ComputeFofZ(context, t0, h, xt0, Z_);
 
     // Compute the state update using (IV.8.4) in [Hairer, 1996], p. 119, i.e.:
     // Solve (I − hA⊗J) ΔZᵏ = h (A⊗I) F(Zᵏ) - Zᵏ for ΔZᵏ, where:
@@ -289,13 +293,14 @@ bool RadauIntegrator<T, num_stages>::StepRadau(const T& t0, const T& h,
 
   // Try StepRadau again, freshening Jacobians and iteration matrix
   // factorizations as helpful.
-  return StepRadau(t0, h, xt0, xtplus, trial+1);
+  return StepRadau(context, t0, h, xt0, xtplus, trial + 1);
 }
 
 template <typename T, int num_stages>
-bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoid(const T& t0,
-    const T& h, const VectorX<T>& xt0, const VectorX<T>& dx0,
-    const VectorX<T>& radau_xtplus, VectorX<T>* xtplus) {
+bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoid(
+    Context<T>* context, const T& t0, const T& h, const VectorX<T>& xt0,
+    const VectorX<T>& dx0, const VectorX<T>& radau_xtplus,
+    VectorX<T>* xtplus) const {
   using std::abs;
 
   DRAKE_LOGGER_DEBUG("StepImplicitTrapezoid(h={}) t={}",
@@ -303,7 +308,6 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoid(const T& t0,
 
   // Define g(x(t+h)) ≡ x(t+h) - x(t) - h/2 (f(t,x(t)) + f(t+h,x(t+h)) and
   // evaluate it at the current x(t+h).
-  Context<T>* context = this->get_mutable_context();
   std::function<VectorX<T>()> g =
       [&xt0, h, &dx0, context, this]() {
         return (context->get_continuous_state().CopyToVector() - xt0 - h/2 *
@@ -324,8 +328,8 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoid(const T& t0,
   int stored_num_nr_iterations = this->get_num_newton_raphson_iterations();
 
   // Step.
-  bool success = StepImplicitTrapezoidDetail(
-      t0, h, xt0, g, radau_xtplus, xtplus);
+  bool success =
+      StepImplicitTrapezoidDetail(context, t0, h, xt0, g, radau_xtplus, xtplus);
 
   // Move statistics to implicit trapezoid-specific.
   num_err_est_jacobian_reforms_ +=
@@ -346,9 +350,9 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoid(const T& t0,
 
 template <typename T, int num_stages>
 bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
-    const T& t0, const T& h,
-    const VectorX<T>& xt0, const std::function<VectorX<T>()>& g,
-    const VectorX<T>& radau_xtplus, VectorX<T>* xtplus, int trial) {
+    Context<T>* context, const T& t0, const T& h, const VectorX<T>& xt0,
+    const std::function<VectorX<T>()>& g, const VectorX<T>& radau_xtplus,
+    VectorX<T>* xtplus, int trial) const {
   using std::max;
   using std::min;
 
@@ -356,7 +360,6 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
   DRAKE_ASSERT(trial >= 1 && trial <= 4);
 
   // Verify xtplus.
-  Context<T>* context = this->get_mutable_context();
   DRAKE_ASSERT(xtplus &&
                xtplus->size() == context->get_continuous_state_vector().size());
 
@@ -386,7 +389,7 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
   //                logic, since the Jacobian would no longer (necessarily) be
   //                fresh upon fallback to a smaller step size.
   if (!this->get_use_full_newton() &&
-      !this->MaybeFreshenMatrices(t0, xt0, h, trial,
+      !this->MaybeFreshenMatrices(context, t0, xt0, h, trial,
                                   ComputeImplicitTrapezoidIterationMatrix,
                                   &iteration_matrix_implicit_trapezoid_)) {
     return false;
@@ -396,10 +399,9 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
     DRAKE_LOGGER_DEBUG("Newton-Raphson iteration {}", iter);
     ++num_nr_iterations_;
 
-    this->FreshenMatricesIfFullNewton(tf, *xtplus, h,
+    this->FreshenMatricesIfFullNewton(context, tf, *xtplus, h,
                                       ComputeImplicitTrapezoidIterationMatrix,
                                       &iteration_matrix_implicit_trapezoid_);
-
 
     // Evaluate the residual error using the current x(t+h).
     VectorX<T> goutput = g();
@@ -447,13 +449,14 @@ bool RadauIntegrator<T, num_stages>::StepImplicitTrapezoidDetail(
 
   // Try the step again, freshening Jacobians and iteration matrix
   // factorizations as helpful.
-  return StepImplicitTrapezoidDetail(
-      t0, h, xt0, g, radau_xtplus, xtplus, trial + 1);
+  return StepImplicitTrapezoidDetail(context, t0, h, xt0, g, radau_xtplus,
+                                     xtplus, trial + 1);
 }
 
 template <typename T, int num_stages>
-bool RadauIntegrator<T, num_stages>::AttemptStepPaired(const T& t0, const T& h,
-    const VectorX<T>& xt0, VectorX<T>* xtplus_radau, VectorX<T>* xtplus_itr) {
+bool RadauIntegrator<T, num_stages>::AttemptStepPaired(
+    Context<T>* context, const T& t0, const T& h, const VectorX<T>& xt0,
+    VectorX<T>* xtplus_radau, VectorX<T>* xtplus_itr) const {
   using std::abs;
   DRAKE_ASSERT(xtplus_radau != nullptr);
   DRAKE_ASSERT(xtplus_itr != nullptr);
@@ -461,21 +464,20 @@ bool RadauIntegrator<T, num_stages>::AttemptStepPaired(const T& t0, const T& h,
   DRAKE_ASSERT(xtplus_itr->size() == xt0.size());
 
   // Set the time and state in the context.
-  this->get_mutable_context()->SetTimeAndContinuousState(t0, xt0);
+  context->SetTimeAndContinuousState(t0, xt0);
 
   // Compute the derivative at xt0. NOTE: the derivative is calculated at this
   // point (early on in the integration process) in order to reuse the
   // derivative evaluation, via the cache, from the last integration step (if
   // possible).
-  const VectorX<T> dx0 = this->EvalTimeDerivatives(
-      this->get_context()).CopyToVector();
+  const VectorX<T> dx0 = this->EvalTimeDerivatives(*context).CopyToVector();
 
   // Use the current state as the candidate value for the next state.
   // [Hairer 1996] validates this choice (p. 120).
   *xtplus_radau = xt0;
 
   // Do the Radau step.
-  if (!StepRadau(t0, h, xt0, xtplus_radau)) {
+  if (!StepRadau(context, t0, h, xt0, xtplus_radau)) {
     DRAKE_LOGGER_DEBUG("Radau approach did not converge for "
         "step size {}", h);
     return false;
@@ -511,10 +513,10 @@ bool RadauIntegrator<T, num_stages>::AttemptStepPaired(const T& t0, const T& h,
   // result is propagated in the 1st order method.
 
   // Attempt to compute the implicit trapezoid solution.
-  if (StepImplicitTrapezoid(t0, h, xt0, dx0, *xtplus_radau, xtplus_itr)) {
+  if (StepImplicitTrapezoid(context, t0, h, xt0, dx0, *xtplus_radau,
+                            xtplus_itr)) {
     // Reset the state to that computed by Radau3.
-    this->get_mutable_context()->SetTimeAndContinuousState(
-        t0 + h, *xtplus_radau);
+    context->SetTimeAndContinuousState(t0 + h, *xtplus_radau);
     return true;
   } else {
     DRAKE_LOGGER_DEBUG("Implicit trapezoid approach FAILED with a step"
@@ -527,7 +529,7 @@ bool RadauIntegrator<T, num_stages>::AttemptStepPaired(const T& t0, const T& h,
 
 template <typename T, int num_stages>
 void RadauIntegrator<T, num_stages>::ComputeAndSetErrorEstimate(
-    const VectorX<T>& xtplus_prop, const VectorX<T>& xtplus_embed) {
+    const VectorX<T>& xtplus_prop, const VectorX<T>& xtplus_embed) const {
   err_est_vec_ = xtplus_prop - xtplus_embed;
   err_est_vec_ = err_est_vec_.cwiseAbs();
 
@@ -538,9 +540,8 @@ void RadauIntegrator<T, num_stages>::ComputeAndSetErrorEstimate(
 }
 
 template <typename T, int num_stages>
-bool RadauIntegrator<T, num_stages>::DoImplicitIntegratorStep(const T& h) {
-  Context<T>* context = this->get_mutable_context();
-
+bool RadauIntegrator<T, num_stages>::DoImplicitIntegratorStep(
+    Context<T>* context, const T& h) const {
   // Save the current time and state.
   const T t0 = context->get_time();
   DRAKE_LOGGER_DEBUG("Radau DoStep(h={}) t={}", h, t0);
@@ -562,7 +563,7 @@ bool RadauIntegrator<T, num_stages>::DoImplicitIntegratorStep(const T& h) {
       // The BS3 integrator provides exactly the same order as 2-stage
       // Radau + embedded implicit trapezoid.
       const int evals_before_bs3 = bs3_->get_num_derivative_evaluations();
-      DRAKE_DEMAND(bs3_->IntegrateWithSingleFixedStepToTime(t0 + h));
+      DRAKE_DEMAND(bs3_->IntegrateWithSingleFixedStepToTime(context, t0 + h));
       const int evals_after_bs3 = bs3_->get_num_derivative_evaluations();
       this->get_mutable_error_estimate()->SetFrom(*bs3_->get_error_estimate());
       this->add_derivative_evaluations(evals_after_bs3 - evals_before_bs3);
@@ -577,7 +578,7 @@ bool RadauIntegrator<T, num_stages>::DoImplicitIntegratorStep(const T& h) {
 
       // Compute the RK2 step.
       const int evals_before_rk2 = rk2_->get_num_derivative_evaluations();
-      DRAKE_DEMAND(rk2_->IntegrateWithSingleFixedStepToTime(t0 + h));
+      DRAKE_DEMAND(rk2_->IntegrateWithSingleFixedStepToTime(context, t0 + h));
       const int evals_after_rk2 = rk2_->get_num_derivative_evaluations();
 
       // Update the error estimation ODE counts.
@@ -594,8 +595,8 @@ bool RadauIntegrator<T, num_stages>::DoImplicitIntegratorStep(const T& h) {
     }
   } else {
     // Try taking the requested step.
-    bool success = AttemptStepPaired(
-        t0, h, xt0_, &xtplus_prop_, &xtplus_embed_);
+    bool success =
+        AttemptStepPaired(context, t0, h, xt0_, &xtplus_prop_, &xtplus_embed_);
 
     // If the step was not successful, reset the time and state.
     if (!success) {

--- a/systems/analysis/runge_kutta2_integrator.h
+++ b/systems/analysis/runge_kutta2_integrator.h
@@ -48,10 +48,10 @@ class RungeKutta2Integrator final : public IntegratorBase<T> {
   int get_error_estimate_order() const override { return 0; }
 
  private:
-  bool DoStep(const T& h) override;
+  bool DoStepConst(Context<T>* context, const T& h) const override;
 
   // A pre-allocated temporary for use by integration.
-  std::unique_ptr<ContinuousState<T>> derivs0_;
+  mutable std::unique_ptr<ContinuousState<T>> derivs0_;
 };
 
 /**
@@ -67,9 +67,8 @@ class RungeKutta2Integrator final : public IntegratorBase<T> {
  * </pre>
  */
 template <class T>
-bool RungeKutta2Integrator<T>::DoStep(const T& h) {
-  Context<T>* const context = IntegratorBase<T>::get_mutable_context();
-
+bool RungeKutta2Integrator<T>::DoStepConst(Context<T>* context,
+                                           const T& h) const {
   // CAUTION: This is performance-sensitive inner loop code that uses dangerous
   // long-lived references into state and cache to avoid unnecessary copying and
   // cache invalidation. Be careful not to insert calls to methods that could

--- a/systems/analysis/runge_kutta3_integrator.h
+++ b/systems/analysis/runge_kutta3_integrator.h
@@ -76,18 +76,18 @@ class RungeKutta3Integrator final : public IntegratorBase<T> {
 
  private:
   void DoInitialize() override;
-  bool DoStep(const T& h) override;
+  bool DoStepConst(Context<T>* context, const T& h) const override;
 
   // Vector used in error estimate calculations.
-  VectorX<T> err_est_vec_;
+  mutable VectorX<T> err_est_vec_;
 
   // Vector used to save initial value of xc.
-  VectorX<T> save_xc0_;
+  mutable VectorX<T> save_xc0_;
 
   // These are pre-allocated temporaries for use by integration. They store
   // the derivatives computed at various points within the integration
   // interval.
-  std::unique_ptr<ContinuousState<T>> derivs0_, derivs1_;
+  mutable std::unique_ptr<ContinuousState<T>> derivs0_, derivs1_;
 };
 
 }  // namespace systems

--- a/systems/analysis/runge_kutta5_integrator.cc
+++ b/systems/analysis/runge_kutta5_integrator.cc
@@ -43,10 +43,10 @@ void RungeKutta5Integrator<T>::DoInitialize() {
 }
 
 template <typename T>
-bool RungeKutta5Integrator<T>::DoStep(const T& h) {
+bool RungeKutta5Integrator<T>::DoStepConst(Context<T>* context,
+                                           const T& h) const {
   using std::abs;
-  Context<T>& context = *this->get_mutable_context();
-  const T t0 = context.get_time();
+  const T t0 = context->get_time();
   const T t1 = t0 + h;
 
   // CAUTION: This is performance-sensitive inner loop code that uses dangerous
@@ -69,11 +69,11 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
   */
 
   // Save the continuous state at t₀.
-  context.get_continuous_state_vector().CopyToPreSizedVector(&save_xc0_);
+  context->get_continuous_state_vector().CopyToPreSizedVector(&save_xc0_);
 
   // Evaluate the derivative at t₀, xc₀ and copy the result into a temporary.
   derivs1_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k1 = derivs1_->get_vector();
 
   // Cache: k1 references a *copy* of the derivative result so is immune
@@ -87,12 +87,12 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
   const double c2 = 1.0 / 5;
   const double a21 = 1.0 / 5;
   VectorBase<T>& xc =
-      context.SetTimeAndGetMutableContinuousStateVector(t0 + c2 * h);
+      context->SetTimeAndGetMutableContinuousStateVector(t0 + c2 * h);
   xc.PlusEqScaled(a21 * h, k1);
 
   // Evaluate the derivative (denoted k2) at t₀ + c2 * h, xc₀ + a21 * h * k1.
   derivs2_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k2 = derivs2_->get_vector();
 
   // Cache: k2 references a *copy* of the derivative result so is immune
@@ -105,14 +105,14 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
   // This call marks t- and xc-dependent cache entries out of date, including
   // the derivative cache entry. (We already have the xc reference but must
   // issue the out-of-date notification here since we're about to change it.)
-  context.SetTimeAndNoteContinuousStateChange(t0 + c3 * h);
+  context->SetTimeAndNoteContinuousStateChange(t0 + c3 * h);
 
   // Evaluate the derivative (denoted k3) at t₀ + c3 * h,
   //   xc₀ + a31 * h * k1 + a32 * h * k2.
   xc.SetFromVector(save_xc0_);  // Restore xc ← xc₀.
   xc.PlusEqScaled({{a31 * h, k1}, {a32 * h, k2}});
   derivs3_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k3 = derivs3_->get_vector();
 
   // Compute the third intermediate state and derivative (i.e., Stage 4).
@@ -123,14 +123,14 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
   // This call marks t- and xc-dependent cache entries out of date, including
   // the derivative cache entry. (We already have the xc reference but must
   // issue the out-of-date notification here since we're about to change it.)
-  context.SetTimeAndNoteContinuousStateChange(t0 + c4 * h);
+  context->SetTimeAndNoteContinuousStateChange(t0 + c4 * h);
 
   // Evaluate the derivative (denoted k4) at t₀ + c4 * h,
   //   xc₀ + a41 * h * k1 + a42 * h * k2 + a43 * h * k3.
   xc.SetFromVector(save_xc0_);
   xc.PlusEqScaled({{a41 * h, k1}, {a42 * h, k2}, {a43 * h, k3}});
   derivs4_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k4 = derivs4_->get_vector();
 
   // Compute the fourth intermediate state and derivative (i.e., Stage 5).
@@ -142,14 +142,14 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
   // This call marks t- and xc-dependent cache entries out of date, including
   // the derivative cache entry. (We already have the xc reference but must
   // issue the out-of-date notification here since we're about to change it.)
-  context.SetTimeAndNoteContinuousStateChange(t0 + c5 * h);
+  context->SetTimeAndNoteContinuousStateChange(t0 + c5 * h);
 
   // Evaluate the derivative (denoted k5) at t₀ + c5 * h,
   //   xc₀ + a51 * h * k1 + a52 * h * k2 + a53 * h * k3 + a54 * h * k4.
   xc.SetFromVector(save_xc0_);  // Restore xc ← xc₀.
   xc.PlusEqScaled({{a51 * h, k1}, {a52 * h, k2}, {a53 * h, k3}, {a54 * h, k4}});
   derivs5_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k5 = derivs5_->get_vector();
 
   // Compute the fifth intermediate state and derivative (i.e., Stage 6).
@@ -161,7 +161,7 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
   // This call marks t- and xc-dependent cache entries out of date, including
   // the derivative cache entry. (We already have the xc reference but must
   // issue the out-of-date notification here since we're about to change it.)
-  context.SetTimeAndNoteContinuousStateChange(t1);
+  context->SetTimeAndNoteContinuousStateChange(t1);
 
   // Evaluate the derivative (denoted k6) at t₀ + c6 * h,
   //   xc₀ + a61 * h * k1 + a62 * h * k2 + a63 * h * k3 + a64 * h * k4 +
@@ -173,12 +173,12 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
                    {a64 * h, k4},
                    {a65 * h, k5}});
   derivs6_->get_mutable_vector().SetFrom(
-      this->EvalTimeDerivatives(context).get_vector());
+      this->EvalTimeDerivatives(*context).get_vector());
   const VectorBase<T>& k6 = derivs6_->get_vector();
 
   // Cache: we're about to write through the xc reference again, so need to
   // mark xc-dependent cache entries out of date; time doesn't change here.
-  context.NoteContinuousStateChange();
+  context->NoteContinuousStateChange();
 
   // Compute the propagated solution (we're able to do this because b1 = a71,
   // b2 = a72, b3 = a73, b4 = a74, b5 = a75, and b6 = a76).
@@ -192,7 +192,7 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
   // the derivative cache entry. (We already have the xc reference but must
   // issue the out-of-date notification here since we're about to change it.)
   // Note that we use the simplification t1 = t0 + h * c7 = t0 + h * 1.
-  context.SetTimeAndNoteContinuousStateChange(t1);
+  context->SetTimeAndNoteContinuousStateChange(t1);
 
   // Evaluate the derivative (denoted k7) at t₀ + c7 * h,
   //   xc₀ + a71 * h * k1 + a72 * h * k2 + a73 * h * k3 + a74 * h * k4 +
@@ -203,7 +203,7 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
                    {a74 * h, k4},
                    {a75 * h, k5},
                    {a76 * h, k6}});
-  const ContinuousState<T>& derivs7 = this->EvalTimeDerivatives(context);
+  const ContinuousState<T>& derivs7 = this->EvalTimeDerivatives(*context);
   const VectorBase<T>& k7 = derivs7.get_vector();
 
   // WARNING: k7 is a live reference into the cache. Be careful of adding

--- a/systems/analysis/runge_kutta5_integrator.h
+++ b/systems/analysis/runge_kutta5_integrator.h
@@ -73,19 +73,19 @@ class RungeKutta5Integrator final : public IntegratorBase<T> {
 
  private:
   void DoInitialize() override;
-  bool DoStep(const T& h) override;
+  bool DoStepConst(Context<T>* context, const T& h) const override;
 
   // Vector used in error estimate calculations.
-  std::unique_ptr<BasicVector<T>> err_est_vec_;
+  mutable std::unique_ptr<BasicVector<T>> err_est_vec_;
 
   // Vector used to save initial value of xc.
-  VectorX<T> save_xc0_;
+  mutable VectorX<T> save_xc0_;
 
   // These are pre-allocated temporaries for use by integration. They store
   // the derivatives computed at various points within the integration
   // interval.
-  std::unique_ptr<ContinuousState<T>> derivs1_, derivs2_, derivs3_, derivs4_,
-      derivs5_, derivs6_;
+  mutable std::unique_ptr<ContinuousState<T>> derivs1_, derivs2_, derivs3_,
+      derivs4_, derivs5_, derivs6_;
 };
 
 }  // namespace systems

--- a/systems/analysis/test/implicit_integrator_test.cc
+++ b/systems/analysis/test/implicit_integrator_test.cc
@@ -53,7 +53,8 @@ class DummyImplicitIntegrator final : public ImplicitIntegrator<double> {
     has_reset_cached_matrices_ = true;
   }
 
-  bool DoImplicitIntegratorStep(const double& h) override {
+  bool DoImplicitIntegratorStep(Context<double>* context,
+                                const double& h) const override {
     throw std::logic_error("Dummy integrator not meant to be stepped.");
   }
 

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -338,10 +338,12 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   void DoInitialize() final;
 
-  bool DoImplicitIntegratorStep(const T& h) final;
+  bool DoImplicitIntegratorStep(Context<T>* context, const T& h) const final;
 
   // Steps the system forward by a single step of h using the velocity-implicit
   // Euler method.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the time increment to step forward.
   // @param xn the continuous state at t0, which is xⁿ.
@@ -360,10 +362,10 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @note The time and continuous state in the context are indeterminate upon
   //       exit.
   bool StepVelocityImplicitEuler(
-      const T& t0, const T& h, const VectorX<T>& xn,
+      Context<T>* context, const T& t0, const T& h, const VectorX<T>& xn,
       const VectorX<T>& xtplus_guess, VectorX<T>* xtplus,
       typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix,
-      MatrixX<T>* Jy, int trial = 1);
+      MatrixX<T>* Jy, int trial = 1) const;
 
   // Steps the system forward by two half-sized steps of size h/2 using the
   // velocity-implicit Euler method, and keeps track of separate statistics
@@ -371,6 +373,8 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // recomputations during these half-sized steps. This method calls
   // StepVelocityImplicitEuler() up to twice to perform the
   // two half-sized steps.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the combined time increment to step forward.
   // @param xn the continuous state at t0, which is xⁿ.
@@ -384,13 +388,15 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @note The time and continuous state in the context are indeterminate upon
   //       exit.
   bool StepHalfVelocityImplicitEulers(
-      const T& t0, const T& h, const VectorX<T>& xn,
+      Context<T>* context, const T& t0, const T& h, const VectorX<T>& xn,
       const VectorX<T>& xtplus_guess, VectorX<T>* xtplus,
       typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix,
-      MatrixX<T>* Jy);
+      MatrixX<T>* Jy) const;
 
   // Takes a large velocity-implicit Euler step (of size h) and two half-sized
   // velocity-implicit Euler steps (of size h/2), if possible.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t0 the time at the left end of the integration interval.
   // @param h the integration step size to attempt.
   // @param [out] xtplus_vie contains the velocity-implicit Euler solution
@@ -400,8 +406,9 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   //              return.
   // @returns `true` if all three step attempts were successful, `false`
   //          otherwise.
-  bool AttemptStepPaired(const T& t0, const T& h, const VectorX<T>& xt0,
-                         VectorX<T>* xtplus_vie, VectorX<T>* xtplus_hvie);
+  bool AttemptStepPaired(Context<T>* context, const T& t0, const T& h,
+                         const VectorX<T>& xt0, VectorX<T>* xtplus_vie,
+                         VectorX<T>* xtplus_hvie) const;
 
   // Compute the partial derivatives of the ordinary differential equations with
   // respect to the y variables of a given x(t). In particular, we compute the
@@ -415,6 +422,8 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // difference, a second-order centered difference, or automatic
   // differentiation. See math::ComputeNumericalGradient() for more details on
   // the first two methods.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t refers to tⁿ⁺¹, the time used in the definition of ℓ(y)
   // @param h is the time-step size parameter, h, used in the definition of
   //        ℓ(y)
@@ -426,9 +435,9 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param [out] Jy is the Jacobian matrix, Jₗ(y).
   // @post The context's time will be set to t, and its continuous state will
   //       be indeterminate on return.
-  void CalcVelocityJacobian(const T& t, const T& h, const VectorX<T>& y,
-                            const VectorX<T>& qk, const VectorX<T>& qn,
-                            MatrixX<T>* Jy);
+  void CalcVelocityJacobian(Context<T>* context, const T& t, const T& h,
+                            const VectorX<T>& y, const VectorX<T>& qk,
+                            const VectorX<T>& qn, MatrixX<T>* Jy) const;
 
   // Uses automatic differentiation to compute the Jacobian, Jₗ(y), of the
   // function ℓ(y), used in this integrator's residual computation, with
@@ -452,7 +461,7 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
                                        const VectorX<T>& y,
                                        const VectorX<T>& qk,
                                        const VectorX<T>& qn,
-                                       MatrixX<T>* Jy);
+                                       MatrixX<T>* Jy) const;
 
   // Computes necessary matrices (Jacobian and iteration matrix) for
   // Newton-Raphson (NR) iterations, as necessary. This method is based off of
@@ -480,6 +489,8 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // These changes allow the velocity-implicit Euler method to use the smaller
   // specialized Jacobian Jₗ(y) in its Newton solves.
   //
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t is the time at which to compute the Jacobian.
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate Jₗ(y).
@@ -502,18 +513,20 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   //       altered, the time will be set to t and the continuous state will be
   //       indeterminate.
   bool MaybeFreshenVelocityMatrices(
-      const T& t, const VectorX<T>& y, const VectorX<T>& qk,
-      const VectorX<T>& qn, const T& h, int trial,
+      Context<T>* context, const T& t, const VectorX<T>& y,
+      const VectorX<T>& qk, const VectorX<T>& qn, const T& h, int trial,
       const std::function<
           void(const MatrixX<T>& J, const T& h,
                typename ImplicitIntegrator<T>::IterationMatrix*)>&
           compute_and_factor_iteration_matrix,
       typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix,
-      MatrixX<T>* Jy);
+      MatrixX<T>* Jy) const;
 
   // Computes necessary matrices (Jacobian and iteration matrix) for full
   // Newton-Raphson (NR) iterations, if full Newton-Raphson method is activated
   // (if it's not activated, this method is a no-op).
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t the time at which to compute the Jacobian.
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate Jₗ(y).
@@ -530,20 +543,22 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   //       altered, the time will be set to t and the continuous state will be
   //       indeterminate.
   void FreshenVelocityMatricesIfFullNewton(
-      const T& t, const VectorX<T>& y, const VectorX<T>& qk,
-      const VectorX<T>& qn, const T& h,
+      Context<T>* context, const T& t, const VectorX<T>& y,
+      const VectorX<T>& qk, const VectorX<T>& qn, const T& h,
       const std::function<
           void(const MatrixX<T>& J, const T& h,
                typename ImplicitIntegrator<T>::IterationMatrix*)>&
           compute_and_factor_iteration_matrix,
       typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix,
-      MatrixX<T>* Jy);
+      MatrixX<T>* Jy) const;
 
   // This helper method evaluates the Newton-Raphson residual R(y), defined as
   // the following:
   //     R(y)  = y - yⁿ - h ℓ(y),
   //     ℓ(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),          (7)
   // with tⁿ⁺¹, y = (v, z), qₖ, qⁿ, yⁿ, and h passed in.
+  // @param context the Context of the system, at time and continuous state
+  // unknown.
   // @param t refers to tⁿ⁺¹, the time at which to compute the residual R(y).
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate R(y).
@@ -558,14 +573,16 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   //        allocations. Its value is indeterminate upon return.
   // @param [out] result is set to R(y).
   // @post The context is set to (tⁿ⁺¹, qⁿ + h N(qₖ) v, y).
-  VectorX<T> ComputeResidualR(const T& t, const VectorX<T>& y,
-                              const VectorX<T>& qk, const VectorX<T>& qn,
-                              const VectorX<T>& yn, const T& h,
-                              BasicVector<T>* qdot);
+  VectorX<T> ComputeResidualR(Context<T>* context, const T& t,
+                              const VectorX<T>& y, const VectorX<T>& qk,
+                              const VectorX<T>& qn, const VectorX<T>& yn,
+                              const T& h, BasicVector<T>* qdot) const;
 
   // This helper method evaluates ℓ(y), defined as the following:
   //     ℓ(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),          (7)
   // with tⁿ⁺¹, y = (v, z), qₖ, qⁿ, yⁿ, and h passed in.
+  // @param [in, out] context to pass in the time and continuous states when
+  //        evaluating f_y().
   // @param t refers to tⁿ⁺¹, the time at which to compute the residual R(y).
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate ℓ(y).
@@ -578,11 +595,11 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   //        allocations. Its value is indeterminate upon return.
   // @param [out] result is set to ℓ(y).
   // @post The context is set to (tⁿ⁺¹, qⁿ + h N(qₖ) v, y).
-  VectorX<T> ComputeLOfY(const T& t, const VectorX<T>& y, const VectorX<T>& qk,
-                         const VectorX<T>& qn, const T& h,
-                         BasicVector<T>* qdot) {
-    return this->ComputeLOfY(t, y, qk, qn, h, qdot, this->get_system(),
-        this->get_mutable_context());
+  VectorX<T> ComputeLOfY(Context<T>* context, const T& t, const VectorX<T>& y,
+                         const VectorX<T>& qk, const VectorX<T>& qn, const T& h,
+                         BasicVector<T>* qdot) const {
+    return this->ComputeLOfY(this->get_system(), context, t, y, qk, qn, h,
+                             qdot);
   }
 
   // This helper method evaluates ℓ(y), defined as the following:
@@ -595,6 +612,10 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // evaluations, which is necessary when computing an AutoDiff'd velocity
   // Jacobian; in particular, this version is explicitly called with type
   // U=AutoDiffXd in ComputeAutoDiffVelocityJacobian().
+  // @param [in] system defines f_y() so that we can evaluate f_y() with the
+  //        U scalar type.
+  // @param [in, out] context to pass in the time and continuous states when
+  //        evaluating f_y(); its scalar type must also be U.
   // @param t refers to tⁿ⁺¹, the time at which to compute the residual R(y).
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate ℓ(y); it uses the scalar type U.
@@ -605,51 +626,47 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param [in, out] qdot is a temporary BasicVector<U> of the same size as qⁿ
   //        allocated by the caller so that this method avoids unnecessary heap
   //        allocations. Its value is indeterminate upon return.
-  // @param [in] system defines f_y() so that we can evaluate f_y() with the
-  //        U scalar type.
-  // @param [in, out] context to pass in the time and continuous states when
-  //        evaluating f_y(); its scalar type must also be U.
   // @param [out] result is set to ℓ(y).
   // @post context is set to (tⁿ⁺¹, qⁿ + h N(qₖ) v, y).
   template <typename U>
-  VectorX<U> ComputeLOfY(const T& t, const VectorX<U>& y, const VectorX<T>& qk,
+  VectorX<U> ComputeLOfY(const System<U>& system, Context<U>* context,
+                         const T& t, const VectorX<U>& y, const VectorX<T>& qk,
                          const VectorX<T>& qn, const T& h,
-                         BasicVector<U>* qdot, const System<U>& system,
-                         Context<U>* context);
+                         BasicVector<U>* qdot) const;
 
   // The last computed iteration matrix and factorization.
-  typename ImplicitIntegrator<T>::IterationMatrix iteration_matrix_vie_;
+  mutable typename ImplicitIntegrator<T>::IterationMatrix iteration_matrix_vie_;
 
   // Vector used in error estimate calculations. At the end of every step, we
   // set this to ε* = x̅ⁿ⁺¹ - x̃ⁿ⁺¹, which is our estimate for ε = x̃ⁿ⁺¹ - xⁿ⁺¹,
   // the error of the propagated half-sized steps.
-  VectorX<T> err_est_vec_;
+  mutable VectorX<T> err_est_vec_;
 
   // The continuous state update vector used during Newton-Raphson.
-  std::unique_ptr<ContinuousState<T>> dx_state_;
+  mutable std::unique_ptr<ContinuousState<T>> dx_state_;
 
   // Variables to avoid heap allocations.
-  VectorX<T> xn_, xdot_, xtplus_vie_, xtplus_hvie_;
-  std::unique_ptr<BasicVector<T>> qdot_;
+  mutable VectorX<T> xn_, xdot_, xtplus_vie_, xtplus_hvie_;
+  mutable std::unique_ptr<BasicVector<T>> qdot_;
   // The following will help avoid repeated heap allocations when computing a
   // velocity Jacobian using automatic differentiation.
-  std::unique_ptr<System<AutoDiffXd>>      system_ad_;
-  std::unique_ptr<Context<AutoDiffXd>>     context_ad_;
-  std::unique_ptr<BasicVector<AutoDiffXd>> qdot_ad_;
+  mutable std::unique_ptr<System<AutoDiffXd>> system_ad_;
+  mutable std::unique_ptr<Context<AutoDiffXd>> context_ad_;
+  mutable std::unique_ptr<BasicVector<AutoDiffXd>> qdot_ad_;
 
   // The last computed velocity+misc Jacobian matrix.
-  MatrixX<T> Jy_vie_;
+  mutable MatrixX<T> Jy_vie_;
 
   // Various statistics.
-  int64_t num_nr_iterations_{0};
+  mutable int64_t num_nr_iterations_{0};
 
   // Half-sized-step-specific statistics, only updated when taking the half-
   // sized steps.
-  int64_t num_half_vie_jacobian_reforms_{0};
-  int64_t num_half_vie_iter_factorizations_{0};
-  int64_t num_half_vie_function_evaluations_{0};
-  int64_t num_half_vie_jacobian_function_evaluations_{0};
-  int64_t num_half_vie_nr_iterations_{0};
+  mutable int64_t num_half_vie_jacobian_reforms_{0};
+  mutable int64_t num_half_vie_iter_factorizations_{0};
+  mutable int64_t num_half_vie_function_evaluations_{0};
+  mutable int64_t num_half_vie_jacobian_function_evaluations_{0};
+  mutable int64_t num_half_vie_nr_iterations_{0};
 };
 
 // We do not support computing the Velocity Jacobian matrix using automatic
@@ -657,12 +674,11 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 // Note: must be declared inline because it's specialized and located in the
 // header file (to avoid multiple definition errors).
 template <>
-inline void VelocityImplicitEulerIntegrator<AutoDiffXd>::
-    ComputeAutoDiffVelocityJacobian(const AutoDiffXd&, const AutoDiffXd&,
-                                    const VectorX<AutoDiffXd>&,
-                                    const VectorX<AutoDiffXd>&,
-                                    const VectorX<AutoDiffXd>&,
-                                    MatrixX<AutoDiffXd>*) {
+inline void
+VelocityImplicitEulerIntegrator<AutoDiffXd>::ComputeAutoDiffVelocityJacobian(
+    const AutoDiffXd&, const AutoDiffXd&, const VectorX<AutoDiffXd>&,
+    const VectorX<AutoDiffXd>&, const VectorX<AutoDiffXd>&,
+    MatrixX<AutoDiffXd>*) const {
   throw std::runtime_error("AutoDiff'd Jacobian not supported for "
                            "AutoDiff'd VelocityImplicitEulerIntegrator");
 }


### PR DESCRIPTION
Resolves #22665

The implementation follows the discussion to offer a new entry point: `IntegratorBase<T>::IntegrateWithSingleFixedStepToTime(const T& t_target, Context<T>* context) const` which:

1. updates the mutable context argument,
2. still writes to the error control estimate,
3. still writes to book-keeping statistics  -- by marking them as `mutable`,
4. still writes to scratch memory -- by marking them as `mutable`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22720)
<!-- Reviewable:end -->
