### PR TITLE
[doc] Add documentation for running drake-external-examples CI jobs on Drake PRs

### DIFF
--- a/doc/_pages/developers.md
+++ b/doc/_pages/developers.md
@@ -54,8 +54,7 @@ of artifacts distributed with this website.
 
 # Testing
 
-* [Detailed Notes on Drake's Unit Tests](/unit_testing_instructions.html)
-* [Downstream Testing (Drake as a Dependency)](/downstream_testing.html)
+Refer to [Detailed Notes on Drake's Unit Tests](/unit_testing_instructions.html).
 
 # Supported Configurations
 

--- a/doc/_pages/developers.md
+++ b/doc/_pages/developers.md
@@ -242,7 +242,7 @@ can look into the question.
 # Continuous Integration Notes
 
 * [CDash](https://drake-cdash.csail.mit.edu/index.php?project=Drake)
-* [GitHub PR Interaction with Jenkins](/jenkins.html)
+* [Continuous Integration with GitHub Pull Requests](/jenkins.html)
 * [Build Cop](/buildcop.html)
 
 # Programming Tools

--- a/doc/_pages/downstream_testing.md
+++ b/doc/_pages/downstream_testing.md
@@ -17,12 +17,15 @@ section.
 # Local Testing
 
 For CMake, see the
-[drake_cmake_installed](https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_cmake_installed#developer-testing)
+[drake_cmake_installed](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed#developer-testing)
 example.
 
 For Bazel, see the
-[drake_bazel_external](https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_bazel_external)
-example, and note the comment in
-[WORKSPACE](https://github.com/RobotLocomotion/drake-external-examples/blob/master/drake_bazel_external/WORKSPACE)
-which mentions using something like
-[local_repository](https://docs.bazel.build/versions/master/be/workspace.html#local_repository) to consume a local checkout of Drake.
+[drake_bazel_external](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_bazel_external)
+example, and note the comments in:
+
+* the [README](https://github.com/RobotLocomotion/drake-external-examples/blob/main/drake_bazel_external#using-a-local-checkout-of-Drake),
+which mentions using
+[`--override-module`](https://bazel.build/reference/command-line-reference#flag--override_module) to consume a local checkout of Drake
+* [`MODULE.bazel`](https://github.com/RobotLocomotion/drake-external-examples/blob/main/drake_bazel_external/MODULE.bazel),
+which can be modified to use a particular revision (commit or release) of Drake

--- a/doc/_pages/downstream_testing.md
+++ b/doc/_pages/downstream_testing.md
@@ -2,30 +2,4 @@
 title: Downstream Testing (Drake as a Dependency)
 ---
 
-# Introduction
-
-To ensure that Drake enables downstream consumption, there are downstream tests
-that show basic usage of Drake as a dependency. Those tests are located in
-the [drake-external-examples](https://github.com/RobotLocomotion/drake-external-examples)
-repository.
-
-# Continuous Integration
-
-Please see the drake-external-examples [Continuous Integration](https://github.com/RobotLocomotion/drake-external-examples#continuous-integration)
-section.
-
-# Local Testing
-
-For CMake, see the
-[drake_cmake_installed](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed#developer-testing)
-example.
-
-For Bazel, see the
-[drake_bazel_external](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_bazel_external)
-example, and note the comments in:
-
-* the [README](https://github.com/RobotLocomotion/drake-external-examples/blob/main/drake_bazel_external#using-a-local-checkout-of-Drake),
-which mentions using
-[`--override-module`](https://bazel.build/reference/command-line-reference#flag--override_module) to consume a local checkout of Drake
-* [`MODULE.bazel`](https://github.com/RobotLocomotion/drake-external-examples/blob/main/drake_bazel_external/MODULE.bazel),
-which can be modified to use a particular revision (commit or release) of Drake
+Content moved to [Continuous Integration with GitHub Pull Requests](/jenkins.html#testing-via-external-examples).

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub PR Interaction with Jenkins
+title: Continuous Integration with GitHub Pull Requests
 ---
 
 When a new pull request is opened in the project and the author of the pull
@@ -189,3 +189,46 @@ env/bin/pip install --upgrade pip
 env/bin/pip install <url-of-experimental-wheel>
 source env/bin/activate
 ```
+
+# Testing via External Examples
+
+The examples within Drake's
+[gallery of external examples](https://github.com/RobotLocomotion/drake-external-examples)
+provide continuous integration via both Jenkins and GitHub Actions. This provides
+downstream test coverage for Drake developers to ensure reliability in the
+build infrastructure. Additionally, the GitHub Actions provide a bonus benefit
+for end users, in that examples of lightweight, open-source builds using Drake
+on public CI servers are made easily accessible.
+
+When a new pull request is opened in Drake, members of the RobotLocomotion
+organization can utilize Jenkins and GitHub Actions to run custom builds.
+This is especially pertinent for pull requests which affect the build infrastructure.
+
+## Jenkins
+
+To test the examples which use Jenkins for CI with a PR branch of Drake,
+comment on an open pull request using the following command:
+
+* ``@drake-jenkins-bot linux-jammy-unprovisioned-external-examples please``
+
+or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
+to schedule a build of the
+[external examples job](https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-external-examples/).
+Note that this job provides parameters for branches of
+drake and drake-external-examples.
+
+## GitHub Actions
+
+You can schedule "experimental" builds of a [binary package](/from_binary.html),
+[debian package](/apt.html), and/or a [wheel package](/pip.html) by following the
+instructions [above](#building-packages-on-demand).
+Copy the download URL(s) obtained from the build as described.
+
+From the [GitHub Actions workflow](https://github.com/RobotLocomotion/drake-external-examples/actions/workflows/ci.yml)
+in drake-external-examples, notice the message "This workflow has a
+`workflow_dispatch` event trigger." Click "Run workflow" and input the
+download URL(s) copied from Jenkins in the drop-down menu.
+All parameters are optional, so you can ignore the package(s) and/or platform(s)
+that you don't need. (For those left blank, the default workflow will run using
+a more "stable" version of Drake, which is usually either source code from
+`master` or a nightly release depending on the example).

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -196,9 +196,16 @@ The examples within Drake's
 [gallery of external examples](https://github.com/RobotLocomotion/drake-external-examples)
 provide continuous integration via both Jenkins and GitHub Actions. This provides
 downstream test coverage for Drake developers to ensure reliability in the
-build infrastructure. Additionally, the GitHub Actions provide a bonus benefit
-for end users, in that examples of lightweight, open-source builds using Drake
-on public CI servers are made easily accessible.
+build infrastructure. Additionally, the GitHub Actions provide a benefit
+for end users, in that examples of CI pipelines on public servers for
+external projects using Drake installations are made easily accessible.
+
+See the external examples
+[continuous integration](https://github.com/RobotLocomotion/drake-external-examples#continuous-integration)
+for details on which examples use Jenkins or GitHub Actions. In general,
+GitHub Actions is used for the lightweight examples which use some
+installed version of Drake, while Jenkins is used for complete coverage
+on examples which pull in Drake externally and build it.
 
 When a new pull request is opened in Drake, members of the RobotLocomotion
 organization can utilize Jenkins and GitHub Actions to run custom builds.

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -239,3 +239,19 @@ All parameters are optional, so you can ignore the package(s) and/or platform(s)
 that you don't need. (For those left blank, the default workflow will run using
 a more "stable" version of Drake, which is usually either source code from
 `master` or a nightly release depending on the example).
+
+## Local Testing
+
+For CMake, see the
+[drake_cmake_installed](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed#developer-testing)
+example.
+
+For Bazel, see the
+[drake_bazel_external](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_bazel_external)
+example, and note the comments in:
+
+* the [README](https://github.com/RobotLocomotion/drake-external-examples/blob/main/drake_bazel_external#using-a-local-checkout-of-Drake),
+which mentions using
+[`--override-module`](https://bazel.build/reference/command-line-reference#flag--override_module) to consume a local checkout of Drake
+* [`MODULE.bazel`](https://github.com/RobotLocomotion/drake-external-examples/blob/main/drake_bazel_external/MODULE.bazel),
+which can be modified to use a particular revision (commit or release) of Drake


### PR DESCRIPTION
Towards #22574, associated with [#374](https://github.com/RobotLocomotion/drake-external-examples/pull/374) and [#376](https://github.com/RobotLocomotion/drake-external-examples/pull/376) on drake-external-examples.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22721)
<!-- Reviewable:end -->
