### PR TITLE
[examples] Port to always use DrakeLcm API

### DIFF
--- a/examples/allegro_hand/joint_control/BUILD.bazel
+++ b/examples/allegro_hand/joint_control/BUILD.bazel
@@ -45,9 +45,9 @@ drake_cc_binary(
     deps = [
         "//examples/allegro_hand:allegro_common",
         "//examples/allegro_hand:allegro_lcm",
+        "//lcm:drake_lcm",
         "//lcmtypes:allegro",
         "@gflags",
-        "@lcm",
     ],
 )
 

--- a/examples/allegro_hand/joint_control/run_twisting_mug.cc
+++ b/examples/allegro_hand/joint_control/run_twisting_mug.cc
@@ -12,12 +12,12 @@
 
 #include <iostream>
 
-#include "lcm/lcm-cpp.hpp"
 #include <Eigen/Dense>
 #include <gflags/gflags.h>
 
 #include "drake/examples/allegro_hand/allegro_common.h"
 #include "drake/examples/allegro_hand/allegro_lcm.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_allegro_command.hpp"
 #include "drake/lcmt_allegro_status.hpp"
 
@@ -28,14 +28,15 @@ namespace examples {
 namespace allegro_hand {
 namespace {
 
+using lcm::DrakeLcm;
+using lcm::Subscriber;
+
 const char* const kLcmStatusChannel = "ALLEGRO_STATUS";
 const char* const kLcmCommandChannel = "ALLEGRO_COMMAND";
 
 class PositionCommander {
  public:
-  PositionCommander() {
-    lcm_.subscribe(kLcmStatusChannel, &PositionCommander::HandleStatus, this);
-  }
+  PositionCommander() : lcm_{}, allegro_status_{&lcm_, kLcmStatusChannel} {}
 
   void Run() {
     allegro_command_.num_joints = kAllegroNumJoints;
@@ -43,7 +44,7 @@ class PositionCommander {
     allegro_command_.num_torques = 0;
     allegro_command_.joint_torque.resize(0);
 
-    flag_moving = true;
+    flag_moving_ = true;
     Eigen::VectorXd target_joint_position(kAllegroNumJoints);
     target_joint_position.setZero();
     MovetoPositionUntilStuck(target_joint_position);
@@ -64,13 +65,13 @@ class PositionCommander {
         hand_state_.FingerGraspJointPosition(3);
     MovetoPositionUntilStuck(target_joint_position);
     std::cout << "Hand is closed. \n";
-    while (0 == lcm_.handleTimeout(10)) {
-    }
+    WaitForStatus();
 
     // Record the joint position q when the fingers are close and gripping the
     // object
     Eigen::VectorXd close_hand_joint_position = Eigen::Map<Eigen::VectorXd>(
-        &(allegro_status_.joint_position_measured[0]), kAllegroNumJoints);
+        &(allegro_status_.message().joint_position_measured[0]),
+        kAllegroNumJoints);
     // twisting the cup repeatedly
     for (int cycle = 0; cycle < FLAGS_max_cycles; ++cycle) {
       target_joint_position = close_hand_joint_position;
@@ -108,37 +109,35 @@ class PositionCommander {
   void PublishPositionCommand(const Eigen::VectorXd& target_joint_position) {
     Eigen::VectorXd::Map(&allegro_command_.joint_position[0],
                          kAllegroNumJoints) = target_joint_position;
-    lcm_.publish(kLcmCommandChannel, &allegro_command_);
+    Publish(&lcm_, kLcmCommandChannel, allegro_command_);
   }
 
   void MovetoPositionUntilStuck(const Eigen::VectorXd& target_joint_position) {
     PublishPositionCommand(target_joint_position);
     // A time delay at the initial moving stage so that the noisy data from the
     // hand motion is filtered.
-    for (int i = 0; i < 60; i++) {
-      while (0 == lcm_.handleTimeout(10) || allegro_status_.utime == -1) {
-      }
-    }
-    // wait until the fingers are stuck, or stop moving.
-    while (flag_moving) {
-      while (0 == lcm_.handleTimeout(10) || allegro_status_.utime == -1) {
-      }
+    WaitForStatus(/* count = */ 60);
+    // Wait until the fingers are stuck, or stop moving.
+    while (flag_moving_) {
+      WaitForStatus();
     }
   }
 
-  void HandleStatus(const ::lcm::ReceiveBuffer*, const std::string&,
-                    const lcmt_allegro_status* status) {
-    allegro_status_ = *status;
-    hand_state_.Update(allegro_status_);
-    flag_moving = !hand_state_.IsAllFingersStuck();
+  void WaitForStatus(int count = 1) {
+    allegro_status_.clear();
+    while (allegro_status_.count() < count) {
+      lcm_.HandleSubscriptions(10);
+    }
+    hand_state_.Update(allegro_status_.message());
+    flag_moving_ = !hand_state_.IsAllFingersStuck();
   }
 
-  ::lcm::LCM lcm_;
-  lcmt_allegro_status allegro_status_;
+  DrakeLcm lcm_;
+  Subscriber<lcmt_allegro_status> allegro_status_;
   lcmt_allegro_command allegro_command_;
   AllegroHandMotionState hand_state_;
 
-  bool flag_moving = true;
+  bool flag_moving_ = true;
 };
 
 int do_main() {

--- a/examples/kinova_jaco_arm/BUILD.bazel
+++ b/examples/kinova_jaco_arm/BUILD.bazel
@@ -63,11 +63,11 @@ drake_cc_binary(
     ],
     deps = [
         "//common:add_text_logging_gflags",
+        "//lcm:drake_lcm",
         "//lcmtypes:jaco",
         "//manipulation/kinova_jaco:jaco_constants",
         "//manipulation/util:move_ik_demo_base",
         "//math:geometric_transform",
-        "@lcm",
     ],
 )
 

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -93,7 +93,7 @@ drake_cc_binary(
         ":iiwa_lcm",
         ":kuka_torque_controller",
         "//common:add_text_logging_gflags",
-        "//lcm",
+        "//lcm:drake_lcm",
         "//multibody/parsing",
         "//multibody/plant",
         "//systems/analysis:simulator",
@@ -115,11 +115,11 @@ drake_cc_binary(
     ],
     deps = [
         "//common/trajectories:piecewise_polynomial",
+        "//lcm:drake_lcm",
         "//lcmtypes:iiwa",
         "//lcmtypes:robot_plan",
         "//multibody/parsing",
         "//multibody/plant",
-        "@lcm",
     ],
 )
 
@@ -133,10 +133,10 @@ drake_cc_binary(
     deps = [
         ":iiwa_common",
         "//common:add_text_logging_gflags",
+        "//lcm:drake_lcm",
         "//lcmtypes:iiwa",
         "//manipulation/util:move_ik_demo_base",
         "//math:geometric_transform",
-        "@lcm",
     ],
 )
 


### PR DESCRIPTION
Towards #17231.  This is the last piece of Drake (other than `DrakeLcm` itself) that still directly uses the upstream API.

+@sammy-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22724)
<!-- Reviewable:end -->
