### PR TITLE
Revert "[workspace] Upgrade libpng_internal to latest release v1.6.47"

### DIFF
--- a/tools/workspace/libpng_internal/repository.bzl
+++ b/tools/workspace/libpng_internal/repository.bzl
@@ -6,8 +6,8 @@ def libpng_internal_repository(
     github_archive(
         name = name,
         repository = "glennrp/libpng",
-        commit = "v1.6.47",
-        sha256 = "631a4c58ea6c10c81f160c4b21fa8495b715d251698ebc2552077e8450f30454",  # noqa
+        commit = "v1.6.46",
+        sha256 = "767b01936f9620d4ab4cdf6ec348f6526f861f825648b610b1d604167dc738d2",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
This reverts commit 4ed4d749a8d82fb16515f8755161f8cd69e4b6e5.

---

The upgrade caused our tests (e.g., `bazel test //geometry/render_vtk:internal_render_engine_vtk_test --test_output=streamed`) spam the console with png warnings:

```
[==========] Running 28 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 28 tests from RenderEngineVtkTest
[ RUN      ] RenderEngineVtkTest.NoBodyTest
[       OK ] RenderEngineVtkTest.NoBodyTest (488 ms)
[ RUN      ] RenderEngineVtkTest.ControlBackgroundColor
[       OK ] RenderEngineVtkTest.ControlBackgroundColor (607 ms)
[ RUN      ] RenderEngineVtkTest.MeshTest
[2025-03-04 16:28:18.685] [console] [warning] warning: The mesh /mnt/nobackup/cache/bazel/_bazel_jwnimmer/10ee8aea36b37b216ef85df1451b64ad/execroot/_main/bazel-out/k8-opt/bin/geometry/render_vtk/internal_render_engine_vtk_test.runfiles/_main/geometry/render/test/meshes/box.obj has its own materials, but material properties have been defined as well. They will be ignored: ('phong', 'diffuse') = 0.8980392156862745 0.8980392156862745 0.8980392156862745                  1
[       OK ] RenderEngineVtkTest.MeshTest (339 ms)
[ RUN      ] RenderEngineVtkTest.InMemoryMesh
libpng warning: eXIf: invalid
libpng warning: eXIf: invalid
libpng warning: eXIf: invalid
libpng warning: eXIf: invalid
libpng warning: eXIf: invalid
libpng warning: eXIf: invalid
libpng warning: eXIf: invalid
libpng warning: eXIf: invalid
[       OK ] RenderEngineVtkTest.InMemoryMesh (358 ms)
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22727)
<!-- Reviewable:end -->
