### PR TITLE
IrisZo: Better Handle Cases when the Center of the Ellipsoid is In-Collision

### DIFF
--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -274,6 +274,9 @@ parameterization is specified (in which case, they must match
 configuration space.
 @ingroup robot_planning
 @experimental
+
+@throws if the center of `starting_ellipsoid` is in collision, or violates any
+of the user-specified constraints in `options.prog_with_additional_constraints`.
 */
 
 geometry::optimization::HPolyhedron IrisZo(

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -641,6 +641,20 @@ GTEST_TEST(IrisZoTest, ConvexConfigurationSpace) {
   options.prog_with_additional_constraints = &prog;
   options.max_iterations = 1;
   options.max_iterations_separating_planes = 1;
+
+  // Verify that we throw a reasonable error when the initial point is in
+  // collision, and when the initial point violates an additional constraint.
+  Hyperellipsoid ellipsoid_in_collision =
+      Hyperellipsoid::MakeHypersphere(1e-2, Eigen::Vector2d(-1.0, 1.0));
+  Hyperellipsoid ellipsoid_violates_constraint =
+      Hyperellipsoid::MakeHypersphere(1e-2, Eigen::Vector2d(-0.1, 0.0));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      IrisZoFromUrdf(convex_urdf, ellipsoid_in_collision, options),
+      ".*Starting ellipsoid center.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      IrisZoFromUrdf(convex_urdf, ellipsoid_violates_constraint, options),
+      ".*Starting ellipsoid center.*");
+
   region = IrisZoFromUrdf(convex_urdf, starting_ellipsoid, options);
 
   // Due to the configuration space margin, this point can never be in the


### PR DESCRIPTION
Closes #22714

Note that we make two changes here:

1. We throw an error if the user provides a seed point that is in-collision (or violates one of the additional constraints the user has provided)
2. If after the first iteration, the center of the ellipsoid moves to a configuration that's in-collision, we return the polytope from the previous iteration, and warn the user that this has occurred.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22737)
<!-- Reviewable:end -->
