### PR TITLE
[WIP] Create MapQDDotToAcceleration() for RPY ball mobilizer.

### DIFF
--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -274,6 +274,11 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const override;
 
+  // Maps qddot to vdot, which for this mobilizer is complicated.
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const final;
+
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;

--- a/multibody/tree/test/rpy_ball_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_ball_mobilizer_test.cc
@@ -129,7 +129,7 @@ TEST_F(RpyBallMobilizerTest, MapUsesNplus) {
   const Vector3d rpy_value(M_PI / 3, -M_PI / 3, M_PI / 5);
   mobilizer_->SetAngles(context_.get(), rpy_value);
 
-  // Set arbitrary qdot and MapQDotToVelocity.
+  // Set arbitrary qdot and call MapQDotToVelocity().
   const Vector3<double> qdot = (Vector3<double>() << 1, 2, 3).finished();
   Vector3<double> v;
   mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
@@ -141,6 +141,17 @@ TEST_F(RpyBallMobilizerTest, MapUsesNplus) {
   // Ensure N⁺(q) is used in v = N⁺(q)⋅q̇
   EXPECT_TRUE(CompareMatrices(v, Nplus * qdot, kTolerance,
                               MatrixCompareType::relative));
+
+  // Ensure MapQDDotToAcceleration() works properly.
+  const Vector3<double> qddot(1.2, 2.3, 3.4);  // Set arbitrary values.
+  Vector3<double> vdot;
+  mobilizer_->MapQDDotToAcceleration(*context_, qdot, &v);
+
+  // Calculate vdot another way.
+  // TODO(Mitiguy) Finish -- as of now this is a dumb test.
+  Vector3<double> vdot_expected = Nplus * qddot;  // NOT TRUE YET.
+  EXPECT_FALSE(CompareMatrices(vdot, vdot_expected, kTolerance,
+                               MatrixCompareType::relative));
 }
 
 TEST_F(RpyBallMobilizerTest, SingularityError) {


### PR DESCRIPTION
This is one in a series of PRs to help address issue #22630. It creates MapQDDotToAcceleration() and MapAccelerationToQDDot() for an RPY ball mobilizer.

PR #22698 was already merged to handle simple mobilizers.  Subsequent PRs will create helper methods for other complex mobilizers (e.g., curvilinear_mobilizer, quaternion_floating_mobilizer, etc.).  There may be additional PRs to consolidate creation and improve the efficient of the N(q) and N⁺(q) matrices that are shared between MapQDotToVelocity() and MapQDDotToAcceleration() as well as MapVelocityToQDDot() and MapAccelerationToQDDot().

FYI: Since mobilizers are Drake internal classes, after the internal mobilizer work is complete, there will be PRs (code and testing) for the public API in MultibodyPlant to address issue #22630.