### PR TITLE
Always build Python for wheels

### DIFF
--- a/tools/wheel/image/build-python.sh
+++ b/tools/wheel/image/build-python.sh
@@ -7,13 +7,7 @@ set -eu -o pipefail
 
 readonly VERSION=$1
 readonly PREFIX=$2
-readonly SHA=$3
-
-apt-get -y update
-apt-get -y install --no-install-recommends \
-    build-essential \
-    libc6-dev \
-    libssl-dev
+readonly EXPECTED_SHA=$3
 
 readonly ARCHIVE=Python-$VERSION.tar.xz
 readonly URL=https://www.python.org/ftp/python/$VERSION/$ARCHIVE
@@ -22,8 +16,12 @@ readonly SRC_DIR=/opt/drake-wheel-build/python
 mkdir -p $SRC_DIR
 cd $SRC_DIR
 
-wget $URL
-echo "$SHA  $ARCHIVE" | sha256sum -c
+wget --no-verbose $URL
+
+readonly ACTUAL_SHA=$(sha256sum $ARCHIVE | cut -d' ' -f1)
+echo "    Actual SHA: $ACTUAL_SHA"
+echo "  Expected SHA: $EXPECTED_SHA"
+test $ACTUAL_SHA == $EXPECTED_SHA
 
 tar --strip-components=1 -xf $ARCHIVE
 rm $ARCHIVE

--- a/tools/wheel/image/packages-jammy
+++ b/tools/wheel/image/packages-jammy
@@ -4,18 +4,27 @@ g++
 gfortran
 libgfortran-11-dev
 nasm
+
 # Clang (for mkdoc).
 libclang-15-dev
+
 # Other code tools.
 cmake
 make
 pkg-config
+
 # Other general tools.
 ca-certificates
 file
 patch
 patchelf
 wget
+
 # Build dependencies (general).
 libglib2.0-dev
 libxt-dev
+
+# Build dependencies (Python).
+xz-utils
+libc6-dev
+libssl-dev

--- a/tools/wheel/image/provision-base.sh
+++ b/tools/wheel/image/provision-base.sh
@@ -14,6 +14,6 @@ apt-get -y install lsb-release
 # Install prerequisites.
 readonly DISTRO=$(lsb_release -sc)
 
-mapfile -t PACKAGES < <(sed -e '/^#/d' < /image/packages-${DISTRO})
+mapfile -t PACKAGES < <(sed -r -e '/^(#|$)/d' < /image/packages-${DISTRO})
 
 apt-get -y install --no-install-recommends ${PACKAGES[@]}

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -38,16 +38,18 @@ targets = (
     Target(
         build_platform=Platform('ubuntu', '22.04', 'jammy'),
         test_platform=None,
-        python_version_tuple=(3, 10)),
+        python_version_tuple=(3, 10, 16),
+        python_sha='bfb249609990220491a1b92850a07135ed0831e41738cf681d63cf01b2a8fbd1'),  # noqa
     Target(
         build_platform=Platform('ubuntu', '22.04', 'jammy'),
         test_platform=None,
-        python_version_tuple=(3, 11)),
+        python_version_tuple=(3, 11, 11),
+        python_sha='2a9920c7a0cd236de33644ed980a13cbbc21058bfdc528febb6081575ed73be3'),  # noqa
     Target(
         build_platform=Platform('ubuntu', '22.04', 'jammy'),
         test_platform=Platform('ubuntu', '24.04', 'noble'),
-        python_version_tuple=(3, 12, 0),
-        python_sha='795c34f44df45a0e9b9710c8c71c15c671871524cd412ca14def212e8ccb155d'),  # noqa
+        python_version_tuple=(3, 12, 8),
+        python_sha='c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e'),  # noqa
 )
 glibc_versions = {
     'jammy': '2_35',


### PR DESCRIPTION
Change wheel builds to always build Python from source. This provides better insulation against what Python versions are or are not packaged by the build host. Move dependencies for building Python to the base package list, which allows us to remove logic to install them from `build-python.sh`. Improve reporting if the Python source tarball doesn't match the expected hash. Tweak `provision-base.sh` to "allow" blank lines in the package list. (In practice, it seems they were harmless anyway, but we now explicitly ignore them, as well as comments.)

This does not, however, remove support for using the distro-provided Python, as we may or may not stick with "always build our own".

Toward #22403.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22745)
<!-- Reviewable:end -->
