### PR TITLE
Change location of Python used to build wheels

### DIFF
--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -40,5 +40,5 @@ cmake ../drake \
     -DDRAKE_VERSION_OVERRIDE="${DRAKE_VERSION}" \
     -DDRAKE_GIT_SHA_OVERRIDE="${DRAKE_GIT_SHA}" \
     -DCMAKE_INSTALL_PREFIX=/opt/drake \
-    -DPython_EXECUTABLE=/usr/local/bin/python
+    -DPython_EXECUTABLE=/opt/drake-python/bin/python
 make install

--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -5,35 +5,41 @@
 
 set -eu -o pipefail
 
+readonly PREFIX=/opt/drake-python
+
 # The Python version is either e.g. '3.10' or 'build:3.10.0' (or is not
 # specified). The 'build:3.x.y' form indicates that we should build our own
 # Python rather than using system packages, and requires a complete version
 # (needed to download the sources). Otherwise, the version should be a valid
 # suffix of 'python'. Unspecified is treated as '3'.
 if [[ "${1%:*}" == "build" ]]; then
-    readonly PREFIX=/opt/drake-python
+    readonly SRC=${PREFIX}
     readonly PYTHON=python$(echo ${1#*:} | cut -d. -f1-2)
 
     cd "$(dirname "${BASH_SOURCE}")"
-    ./build-python.sh ${1#*:} ${PREFIX} $2
+    ./build-python.sh ${1#*:} ${SRC} $2
+
+    ln -s ${SRC}/bin/python3 ${PREFIX}/bin/python
 else
-    readonly PREFIX=/usr
+    readonly SRC=/usr
     readonly PYTHON=python${1:-3}
 
     # Set up Python environment and install Python prerequisites.
     apt-get -y update
     apt-get -y install --no-install-recommends \
         ${PYTHON}-dev lib${PYTHON}-dev ${PYTHON}-venv
+
+    mkdir ${PREFIX}
+    ${SRC}/bin/${PYTHON} -m venv ${PREFIX}
+
+    # Python 3.11 venv creates an empty directory here, which prevents us
+    # creating a symlink to the real directory, so remove it if present.
+    rmdir ${PREFIX}/include/${PYTHON} || true
+
+    ln -s ${SRC}/bin/${PYTHON}-config ${PREFIX}/bin/python3-config
+    ln -s ${SRC}/include/${PYTHON} ${PREFIX}/include/
+    ln -s ${SRC}/include/${PYTHON}m ${PREFIX}/include/
 fi
 
-${PREFIX}/bin/${PYTHON} -m venv /usr/local
-
-# Python 3.11 venv creates an empty directory here, which prevents us creating
-# a symlink to the real directory, so remove it if present.
-rmdir /usr/local/include/${PYTHON} || true
-
-ln -s ${PREFIX}/bin/${PYTHON}-config /usr/bin/python3-config
-ln -s ${PREFIX}/bin/${PYTHON}-config /usr/local/bin/python-config
-ln -s ${PREFIX}/include/${PYTHON} /usr/local/include/
-ln -s ${PREFIX}/include/${PYTHON}m /usr/local/include/
-ln -s /usr/local/bin/python /usr/bin/python
+ln -s ${SRC}/bin/${PYTHON}-config ${PREFIX}/bin/python-config
+ln -s ${PREFIX}/bin/python3 /usr/bin/python


### PR DESCRIPTION
Modify how we build wheels to use Python from `/opt/drake-python` instead of `/usr/local`. While the latter works fine on Ubuntu (which correctly doesn't put its own stuff in /usr/local), manylinux unfortunately litters `/usr/local` with a bunch of Python interpreters that are missing the bits to build C/C++ code against them.

Toward #22403.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22754)
<!-- Reviewable:end -->
