### PR TITLE
Move DiscreteTimeApproximation function to //systems/analysis

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -113,6 +113,7 @@ drake_pybind_library(
     py_deps = [
         ":framework_py",
         ":module_py",
+        ":primitives_py",
         "//bindings/pydrake:trajectories_py",
         "//bindings/pydrake/solvers",
     ],

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -7,6 +7,7 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/scope_exit.h"
 #include "drake/systems/analysis/batch_eval.h"
+#include "drake/systems/analysis/discrete_time_approximation.h"
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/monte_carlo.h"
 #include "drake/systems/analysis/region_of_attraction.h"
@@ -43,6 +44,7 @@ PYBIND11_MODULE(analysis, m) {
   m.doc() = "Bindings for the analysis portion of the Systems framework.";
 
   py::module::import("pydrake.systems.framework");
+  py::module::import("pydrake.systems.primitives");
   py::module::import("pydrake.solvers");
   py::module::import("pydrake.trajectories");
 
@@ -227,6 +229,18 @@ PYBIND11_MODULE(analysis, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `context` alive.
             py::keep_alive<1, 4>(), doc.RungeKutta2Integrator.ctor.doc);
+
+    m.def("DiscreteTimeApproximation",
+        overload_cast_explicit<std::unique_ptr<LinearSystem<T>>,
+            const LinearSystem<T>&, double>(&DiscreteTimeApproximation),
+        py::arg("system"), py::arg("time_period"),
+        doc.DiscreteTimeApproximation.doc_linearsystem);
+
+    m.def("DiscreteTimeApproximation",
+        overload_cast_explicit<std::unique_ptr<AffineSystem<T>>,
+            const AffineSystem<T>&, double>(&DiscreteTimeApproximation),
+        py::arg("system"), py::arg("time_period"),
+        doc.DiscreteTimeApproximation.doc_affinesystem);
   };
   type_visit(bind_scalar_types, CommonScalarPack{});
 

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -880,18 +880,6 @@ PYBIND11_MODULE(primitives, m) {
 
   m.def("IsDetectable", &IsDetectable, py::arg("sys"),
       py::arg("threshold") = std::nullopt, doc.IsDetectable.doc);
-
-  m.def("DiscreteTimeApproximation",
-      overload_cast_explicit<std::unique_ptr<LinearSystem<double>>,
-          const LinearSystem<double>&, double>(&DiscreteTimeApproximation),
-      py::arg("system"), py::arg("time_period"),
-      doc.DiscreteTimeApproximation.doc_linearsystem);
-
-  m.def("DiscreteTimeApproximation",
-      overload_cast_explicit<std::unique_ptr<AffineSystem<double>>,
-          const AffineSystem<double>&, double>(&DiscreteTimeApproximation),
-      py::arg("system"), py::arg("time_period"),
-      doc.DiscreteTimeApproximation.doc_affinesystem);
 }  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -31,7 +31,6 @@ from pydrake.systems.primitives import (
     ConstantValueSource, ConstantValueSource_,
     ConstantVectorSource, ConstantVectorSource_,
     ControllabilityMatrix,
-    DiscreteTimeApproximation,
     Demultiplexer, Demultiplexer_,
     DiscreteDerivative, DiscreteDerivative_,
     DiscreteTimeDelay, DiscreteTimeDelay_,
@@ -1062,40 +1061,3 @@ class TestGeneral(unittest.TestCase):
         self.assertTrue(
             all(logger.GetLog(logger_context) == logger.FindLog(context)
                 for logger, logger_context in loggers_and_contexts))
-
-    def test_discrete_time_approximation(self):
-        A = np.array([[0, 1], [0, 0]])
-        B = np.array([0, 1])
-        f0 = np.array([2, 1])
-        C = np.array([[1, 0]])
-        D = np.array([0])
-        y0 = np.array([0])
-
-        h = 0.031415926
-        Ad = np.array([[1, h], [0, 1]])
-        Bd = np.array([0.5*h**2, h])
-        f0d = np.array([2*h+0.5*h**2, h])
-        Cd = C
-        Dd = D
-        y0d = y0
-
-        def assert_array_close(x, y): np.testing.assert_allclose(
-            np.squeeze(x), np.squeeze(y), atol=1e-10)
-
-        continuous_system = LinearSystem(A, B, C, D)
-        discrete_system = DiscreteTimeApproximation(
-            system=continuous_system, time_period=h)
-        assert_array_close(discrete_system.A(), Ad)
-        assert_array_close(discrete_system.B(), Bd)
-        assert_array_close(discrete_system.C(), Cd)
-        assert_array_close(discrete_system.D(), Dd)
-
-        continuous_system = AffineSystem(A, B, f0, C, D, y0)
-        discrete_system = DiscreteTimeApproximation(
-            system=continuous_system, time_period=h)
-        assert_array_close(discrete_system.A(),  Ad)
-        assert_array_close(discrete_system.B(),  Bd)
-        assert_array_close(discrete_system.f0(), f0d)
-        assert_array_close(discrete_system.C(),  Cd)
-        assert_array_close(discrete_system.D(),  Dd)
-        assert_array_close(discrete_system.y0(), y0d)

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_package_library(
         ":batch_eval",
         ":bogacki_shampine3_integrator",
         ":dense_output",
+        ":discrete_time_approximation",
         ":explicit_euler_integrator",
         ":hermitian_dense_output",
         ":implicit_euler_integrator",
@@ -118,6 +119,16 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
         "@fmt",
+    ],
+)
+
+drake_cc_library(
+    name = "discrete_time_approximation",
+    srcs = ["discrete_time_approximation.cc"],
+    hdrs = ["discrete_time_approximation.h"],
+    deps = [
+        "//systems/primitives:affine_system",
+        "//systems/primitives:linear_system",
     ],
 )
 
@@ -586,6 +597,14 @@ drake_cc_googletest(
         "//math:geometric_transform",
         "//multibody/plant",
         "//systems/analysis/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "discrete_time_approximation_test",
+    deps = [
+        ":discrete_time_approximation",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/systems/analysis/discrete_time_approximation.cc
+++ b/systems/analysis/discrete_time_approximation.cc
@@ -1,0 +1,70 @@
+#include "drake/systems/analysis/discrete_time_approximation.h"
+
+#include <memory>
+
+#include <unsupported/Eigen/MatrixFunctions>
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+std::unique_ptr<LinearSystem<T>> DiscreteTimeApproximation(
+    const LinearSystem<T>& system, double time_period) {
+  // Check that the original system is continuous.
+  DRAKE_THROW_UNLESS(system.IsDifferentialEquationSystem());
+  // Check that the discrete time_period is greater than zero.
+  DRAKE_THROW_UNLESS(time_period > 0);
+
+  const int ns = system.num_states();
+  const int ni = system.num_inputs();
+
+  Eigen::MatrixXd M(ns + ni, ns + ni);
+  M << system.A(), system.B(), Eigen::MatrixXd::Zero(ni, ns + ni);
+
+  Eigen::MatrixXd Md = (M * time_period).exp();
+
+  auto Ad = Md.block(0, 0, ns, ns);
+  auto Bd = Md.block(0, ns, ns, ni);
+  auto& Cd = system.C();
+  auto& Dd = system.D();
+
+  return std::make_unique<LinearSystem<T>>(Ad, Bd, Cd, Dd, time_period);
+}
+
+template <typename T>
+std::unique_ptr<AffineSystem<T>> DiscreteTimeApproximation(
+    const AffineSystem<T>& system, double time_period) {
+  // Check that the original system is continuous.
+  DRAKE_THROW_UNLESS(system.IsDifferentialEquationSystem());
+  // Check that the discrete time_period is greater than zero.
+  DRAKE_THROW_UNLESS(time_period > 0);
+
+  const int ns = system.num_states();
+  const int ni = system.num_inputs();
+
+  Eigen::MatrixXd M(ns + ni + 1, ns + ni + 1);
+  M << system.A(), system.B(), system.f0(),
+      Eigen::MatrixXd::Zero(ni + 1, ns + ni + 1);
+
+  Eigen::MatrixXd Md = (M * time_period).exp();
+
+  auto Ad = Md.block(0, 0, ns, ns);
+  auto Bd = Md.block(0, ns, ns, ni);
+  auto f0d = Md.block(0, ns + ni, ns, 1);
+  auto& Cd = system.C();
+  auto& Dd = system.D();
+  auto& y0d = system.y0();
+
+  return std::make_unique<AffineSystem<T>>(Ad, Bd, f0d, Cd, Dd, y0d,
+                                           time_period);
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+  static_cast<std::unique_ptr<LinearSystem<T>> (*)(
+      const LinearSystem<T>&, double)>(&DiscreteTimeApproximation<T>),
+  static_cast<std::unique_ptr<AffineSystem<T>> (*)(
+      const AffineSystem<T>&, double)>(&DiscreteTimeApproximation<T>)
+));
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/discrete_time_approximation.h
+++ b/systems/analysis/discrete_time_approximation.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/systems/primitives/affine_system.h"
+#include "drake/systems/primitives/linear_system.h"
+
+namespace drake {
+namespace systems {
+
+/// Converts a continuous-time linear system to a discrete-time linear system
+/// using the zero-order hold (ZOH) method.
+///
+/// @param system The continuous-time LinearSystem.
+/// @param time_period The discrete time period.
+/// @returns A discrete-time LinearSystem.
+/// @pre @p system must be a continuous-time system. @p time_period must be
+/// greater than zero.
+///
+/// @tparam_default_scalar
+/// @ingroup analysis
+/// @pydrake_mkdoc_identifier{linearsystem}
+template <typename T>
+std::unique_ptr<LinearSystem<T>> DiscreteTimeApproximation(
+    const LinearSystem<T>& system, double time_period);
+
+/// Converts a continuous-time affine system to a discrete-time affine system
+/// using the zero-order hold (ZOH) method.
+///
+/// @param system The continuous-time AffineSystem.
+/// @param time_period The discrete time period.
+/// @returns A discrete-time AffineSystem.
+/// @pre @p system must be a continuous-time system. @p time_period must be
+/// greater than zero.
+///
+/// @tparam_default_scalar
+/// @ingroup analysis
+/// @pydrake_mkdoc_identifier{affinesystem}
+template <typename T>
+std::unique_ptr<AffineSystem<T>> DiscreteTimeApproximation(
+    const AffineSystem<T>& system, double time_period);
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/test/discrete_time_approximation_test.cc
+++ b/systems/analysis/test/discrete_time_approximation_test.cc
@@ -1,0 +1,67 @@
+#include "drake/systems/analysis/discrete_time_approximation.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(DiscreteTimeApproximation, AffineSystemTest) {
+  Eigen::Matrix<double, 2, 2> A;
+  Eigen::Matrix<double, 2, 1> B;
+  Eigen::Vector<double, 2> f0;
+  Eigen::Matrix<double, 1, 2> C;
+  Eigen::Matrix<double, 1, 1> D;
+  Eigen::Vector<double, 1> y0;
+  A << 0, 1, 0, 0;
+  B << 0, 1;
+  f0 << 2, 1;
+  C << 1, 0;
+  D << 1;
+  y0 << 1;
+
+  // Reject discrete system as argument.
+  EXPECT_ANY_THROW(DiscreteTimeApproximation<double>(
+      AffineSystem<double>(A, B, f0, C, D, y0, 0.1), 0.1));
+
+  const double h = 0.031415926;
+
+  Eigen::Matrix<double, 2, 2> Ad;
+  Eigen::Matrix<double, 2, 1> Bd;
+  Eigen::Vector<double, 2> f0d;
+  Eigen::Matrix<double, 1, 2> Cd = C;
+  Eigen::Matrix<double, 1, 1> Dd = D;
+  Eigen::Vector<double, 1> y0d = y0;
+  Ad << 1, h, 0, 1;
+  Bd << 0.5 * h * h, h;
+  f0d << 2 * h + 0.5 * h * h, h;
+
+  AffineSystem<double> continuous_affine_sys(A, B, f0, C, D, y0);
+  auto discrete_affine_sys =
+      DiscreteTimeApproximation<double>(continuous_affine_sys, h);
+
+  const double kCompTolerance = 1e-14;
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->A(), Ad, kCompTolerance));
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->B(), Bd, kCompTolerance));
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->f0(), f0d, kCompTolerance));
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->C(), Cd));
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->D(), Dd));
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->y0(), y0d));
+
+  LinearSystem<double> continuous_linear_sys(A, B, C, D);
+  auto discrete_linear_sys =
+      DiscreteTimeApproximation<double>(continuous_affine_sys, h);
+
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->A(), Ad, kCompTolerance));
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->B(), Bd, kCompTolerance));
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->C(), Cd));
+  EXPECT_TRUE(CompareMatrices(discrete_affine_sys->D(), Dd));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -6,7 +6,6 @@
 #include <Eigen/Dense>
 #include <Eigen/LU>
 #include <fmt/format.h>
-#include <unsupported/Eigen/MatrixFunctions>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
@@ -283,58 +282,6 @@ bool IsDetectable(const LinearSystem<double>& sys,
   return internal::IsDetectable(sys.A(), sys.C(), continuous_time, threshold);
 }
 
-template <typename T>
-std::unique_ptr<LinearSystem<T>> DiscreteTimeApproximation(
-    const LinearSystem<T>& system, double time_period) {
-  // Check that the original system is continuous.
-  DRAKE_THROW_UNLESS(system.IsDifferentialEquationSystem());
-  // Check that the discrete time_period is greater than zero.
-  DRAKE_THROW_UNLESS(time_period > 0);
-
-  const int ns = system.num_states();
-  const int ni = system.num_inputs();
-
-  Eigen::MatrixXd M(ns + ni, ns + ni);
-  M << system.A(), system.B(), Eigen::MatrixXd::Zero(ni, ns + ni);
-
-  Eigen::MatrixXd Md = (M * time_period).exp();
-
-  auto Ad = Md.block(0, 0, ns, ns);
-  auto Bd = Md.block(0, ns, ns, ni);
-  auto& Cd = system.C();
-  auto& Dd = system.D();
-
-  return std::make_unique<LinearSystem<T>>(Ad, Bd, Cd, Dd, time_period);
-}
-
-template <typename T>
-std::unique_ptr<AffineSystem<T>> DiscreteTimeApproximation(
-    const AffineSystem<T>& system, double time_period) {
-  // Check that the original system is continuous.
-  DRAKE_THROW_UNLESS(system.IsDifferentialEquationSystem());
-  // Check that the discrete time_period is greater than zero.
-  DRAKE_THROW_UNLESS(time_period > 0);
-
-  const int ns = system.num_states();
-  const int ni = system.num_inputs();
-
-  Eigen::MatrixXd M(ns + ni + 1, ns + ni + 1);
-  M << system.A(), system.B(), system.f0(),
-      Eigen::MatrixXd::Zero(ni + 1, ns + ni + 1);
-
-  Eigen::MatrixXd Md = (M * time_period).exp();
-
-  auto Ad = Md.block(0, 0, ns, ns);
-  auto Bd = Md.block(0, ns, ns, ni);
-  auto f0d = Md.block(0, ns + ni, ns, 1);
-  auto& Cd = system.C();
-  auto& Dd = system.D();
-  auto& y0d = system.y0();
-
-  return std::make_unique<AffineSystem<T>>(Ad, Bd, f0d, Cd, Dd, y0d,
-                                           time_period);
-}
-
 }  // namespace systems
 }  // namespace drake
 
@@ -343,11 +290,3 @@ DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::TimeVaryingLinearSystem);
-
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    (static_cast<std::unique_ptr<::drake::systems::LinearSystem<T>> (*)(
-         const ::drake::systems::LinearSystem<T>&, double)>(
-         &::drake::systems::DiscreteTimeApproximation<T>),
-     static_cast<std::unique_ptr<::drake::systems::AffineSystem<T>> (*)(
-         const ::drake::systems::AffineSystem<T>&, double)>(
-         &::drake::systems::DiscreteTimeApproximation<T>)));

--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -285,33 +285,5 @@ bool IsStabilizable(const LinearSystem<double>& sys,
 bool IsDetectable(const LinearSystem<double>& sys,
                   std::optional<double> threshold = std::nullopt);
 
-/// Converts a continuous-time linear system to a discrete-time linear system
-/// using the zero-order hold (ZOH) method.
-///
-/// @param system The continuous-time LinearSystem.
-/// @param time_period The sampling time period.
-/// @returns A discrete-time LinearSystem.
-/// @throws if the @p system is not continuous or @p time_period <= 0.
-/// @tparam_default_scalar
-/// @ingroup primitive_systems
-/// @pydrake_mkdoc_identifier{linearsystem}
-template <typename T>
-std::unique_ptr<LinearSystem<T>> DiscreteTimeApproximation(
-    const LinearSystem<T>& system, double time_period);
-
-/// Converts a continuous-time affine system to a discrete-time affine system
-/// using the zero-order hold (ZOH) method.
-///
-/// @param system The continuous-time AffineSystem.
-/// @param time_period The sampling time period.
-/// @returns A discrete-time AffineSystem.
-/// @throws if the @p system is not continuous or @p time_period <= 0.
-/// @tparam_default_scalar
-/// @ingroup primitive_systems
-/// @pydrake_mkdoc_identifier{affinesystem}
-template <typename T>
-std::unique_ptr<AffineSystem<T>> DiscreteTimeApproximation(
-    const AffineSystem<T>& system, double time_period);
-
 }  // namespace systems
 }  // namespace drake

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -984,58 +984,6 @@ GTEST_TEST(LinearSystemBespokeTest, NonSymbolicFeedthrough) {
   EXPECT_FALSE(dut2.HasAnyDirectFeedthrough());
 }
 
-GTEST_TEST(DiscreteTimeApproximation, test) {
-  Eigen::Matrix<double, 2, 2> A;
-  Eigen::Matrix<double, 2, 1> B;
-  Eigen::Vector<double, 2> f0;
-  Eigen::Matrix<double, 1, 2> C;
-  Eigen::Matrix<double, 1, 1> D;
-  Eigen::Vector<double, 1> y0;
-  A << 0, 1, 0, 0;
-  B << 0, 1;
-  f0 << 2, 1;
-  C << 1, 0;
-  D << 1;
-  y0 << 1;
-
-  // Reject discrete system as argument.
-  EXPECT_ANY_THROW(DiscreteTimeApproximation<double>(
-      AffineSystem<double>(A, B, f0, C, D, y0, 0.1), 0.1));
-
-  const double h = 0.031415926;
-
-  Eigen::Matrix<double, 2, 2> Ad;
-  Eigen::Matrix<double, 2, 1> Bd;
-  Eigen::Vector<double, 2> f0d;
-  Eigen::Matrix<double, 1, 2> Cd = C;
-  Eigen::Matrix<double, 1, 1> Dd = D;
-  Eigen::Vector<double, 1> y0d = y0;
-  Ad << 1, h, 0, 1;
-  Bd << 0.5 * h * h, h;
-  f0d << 2 * h + 0.5 * h * h, h;
-
-  AffineSystem<double> continuous_affine_sys(A, B, f0, C, D, y0);
-  auto discrete_affine_sys =
-      DiscreteTimeApproximation<double>(continuous_affine_sys, h);
-
-  const double kEpsilon = 1e-10;
-  EXPECT_TRUE(discrete_affine_sys->A().isApprox(Ad, kEpsilon));
-  EXPECT_TRUE(discrete_affine_sys->B().isApprox(Bd, kEpsilon));
-  EXPECT_TRUE(discrete_affine_sys->f0().isApprox(f0d, kEpsilon));
-  EXPECT_TRUE(discrete_affine_sys->C().isApprox(Cd, kEpsilon));
-  EXPECT_TRUE(discrete_affine_sys->D().isApprox(Dd, kEpsilon));
-  EXPECT_TRUE(discrete_affine_sys->y0().isApprox(y0d, kEpsilon));
-
-  LinearSystem<double> continuous_linear_sys(A, B, C, D);
-  auto discrete_linear_sys =
-      DiscreteTimeApproximation<double>(continuous_affine_sys, h);
-
-  EXPECT_TRUE(discrete_linear_sys->A().isApprox(Ad, kEpsilon));
-  EXPECT_TRUE(discrete_linear_sys->B().isApprox(Bd, kEpsilon));
-  EXPECT_TRUE(discrete_linear_sys->C().isApprox(Cd, kEpsilon));
-  EXPECT_TRUE(discrete_linear_sys->D().isApprox(Dd, kEpsilon));
-}
-
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
This PR aims to move the function `DiscreteTimeApproximation` from */systems/primitives* to */systems/analysis* before the next release. This is in regard to https://github.com/RobotLocomotion/drake/pull/22652#pullrequestreview-2629078976, https://github.com/RobotLocomotion/drake/pull/22652#pullrequestreview-2629569074, and https://github.com/RobotLocomotion/drake/pull/22652#issuecomment-2671691156 (quoted below).

> I have also moved the `LinearSystem` and `AffineSystem` version to /system/analysis. Otherwise, `from pydrake.all import DiscreteTimeApproximation` will only import a subset of the overloads.

> Yes. This is a bit unfortunate. Even though these methods are brand new, it happened that we just had a monthly release the other day. So they were published in their original location; that might mean we need a deprecation shim.

> > Any new API will have these requirements waived for the first version where that API appears. (In other words, the second release of the API is the one where the Stable guarantees come into effect.) However, we will make a best effort to adhere to these guidelines as we resolve any issues with the new API, even in the first release.
> 
> -- [drake.mit.edu/stable.html#exemptions](https://drake.mit.edu/stable.html#exemptions)
> 
> Given that the change for the user is just fixing an `#include` or `import` statement, I don't think we need to provide a deprecated forwarding alias.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22755)
<!-- Reviewable:end -->
