### PR TITLE
[visualization] Fix divide-by-zero in ColorizeDepthImage

### DIFF
--- a/visualization/colorize_depth_image.cc
+++ b/visualization/colorize_depth_image.cc
@@ -64,7 +64,9 @@ void ColorizeDepthImage<T>::Calc(const ImageDepth32F& input,
   };
 
   // Convert the depths to grayscale.
-  const double depth_scale = 1.0 / (*max_pixel - *min_pixel);
+  const double depth_scale = (*min_pixel == *max_pixel)
+                                 ? 1.0  // Avoid divide-by-zero.
+                                 : (1.0 / (*max_pixel - *min_pixel));
   for (int v = 0; v < output->height(); ++v) {
     for (int u = 0; u < output->width(); ++u) {
       const float pixel = input.at(u, v)[0];

--- a/visualization/test/colorize_depth_image_test.cc
+++ b/visualization/test/colorize_depth_image_test.cc
@@ -112,6 +112,18 @@ GTEST_TEST(ColorDepthImageTest, DefaultInvalidColor) {
   EXPECT_EQ(static_cast<int>(invalid.a() * 255), 255);
 }
 
+// Colorizes an image with valid, uniform depth across the board. The image
+// should be all white. This requires that the implementation take care when
+// scaling the depth range not to divide by zero.
+GTEST_TEST(ColorDepthImageTest, UniformDepth) {
+  const ImageDepth32F input(6, 2, 22.0f);
+  const ImageRgba8U expected(6, 2, uint8_t{255});
+  ColorizeDepthImage<double> dut;
+  ImageRgba8U actual;
+  dut.Calc(input, &actual);
+  EXPECT_EQ(actual, expected);
+}
+
 GTEST_TEST(ColorDepthImageTest, BadlyConnectedInputs) {
   ColorizeDepthImage<double> dut;
   auto context = dut.CreateDefaultContext();


### PR DESCRIPTION
+@xuchenhan-tri for both reviews, please.

This error is only detectable with UBSan.  Hotfix for #22740.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22765)
<!-- Reviewable:end -->
