### PR TITLE
Fix CMake dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,10 +663,10 @@ add_custom_target(drake_version ALL
 
 add_custom_target(drake_cxx_python ALL
   COMMAND "${Bazel_EXECUTABLE}" build ${BAZEL_INSTALL_TARGET}
-  DEPENDS "${PROJECT_BINARY_DIR}/VERSION.TXT"
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/drake_build_cwd"
   USES_TERMINAL
 )
+add_dependencies(drake_cxx_python drake_version)
 
 install(CODE
   "execute_process(


### PR DESCRIPTION
Add an explicit dependency on the drake_version target to the drake_cxx_python target. Previously, the latter depended on the generated version script, but that isn't understood as an output of the drake_version target, which would sometimes lead to build errors due to the file not existing and the tool not knowing how to build it. (This is more likely to be a problem with build parallelism enabled, and especially was hitting Ninja builds.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22766)
<!-- Reviewable:end -->
