### PR TITLE
Fix Drake's ssize wrapper

### DIFF
--- a/common/ssize.h
+++ b/common/ssize.h
@@ -1,8 +1,9 @@
 #pragma once
 
-// Many C++20 std headers define ssize; pick one. This is needed even to
-// get the __cpp_lib_ssize define set.
-#include <vector>
+// Although many C++20 std headers define ssize, the standard specifies that
+// only <iterator> and <version> (the latter of which only exists in C++20 and
+// later) define the feature test macro.
+#include <iterator>
 
 #ifdef __cpp_lib_ssize
 namespace drake {


### PR DESCRIPTION
Use `<iterator>` instead of `<vector>` in Drake's `ssize` wrapper header. Of the several headers that provide `ssize`, only `<iterator>` is guaranteed to also provide the `__cpp_lib_ssize` feature test macro.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22767)
<!-- Reviewable:end -->
