### PR TITLE
Fix improper use of QDLDL by SCS

### DIFF
--- a/tools/workspace/scs_internal/patches/upstream/fix_arg.patch
+++ b/tools/workspace/scs_internal/patches/upstream/fix_arg.patch
@@ -1,0 +1,27 @@
+[scs] Fix argument type of 'bwork', passed to QDLDL_factor.
+
+https://github.com/cvxgrp/scs/issues/310
+
+--- linsys/cpu/direct/private.c
++++ linsys/cpu/direct/private.c
+@@ -51,7 +51,7 @@ static scs_int ldl_prepare(ScsLinSysWork *p) {
+   L->i = (scs_int *)scs_calloc(nzmax, sizeof(scs_int));
+   p->Dinv = (scs_float *)scs_calloc(n, sizeof(scs_float));
+   p->D = (scs_float *)scs_calloc(n, sizeof(scs_float));
+-  p->bwork = (scs_int *)scs_calloc(n, sizeof(scs_int));
++  p->bwork = (QDLDL_bool *)scs_calloc(n, sizeof(QDLDL_bool));
+   p->fwork = (scs_float *)scs_calloc(n, sizeof(scs_float));
+   return nzmax;
+ }
+--- linsys/cpu/direct/private.h
++++ linsys/cpu/direct/private.h
+@@ -22,7 +22,8 @@ struct SCS_LIN_SYS_WORK {
+   scs_int factorizations;
+   /* ldl factorization workspace */
+   scs_float *D, *fwork;
+-  scs_int *etree, *iwork, *Lnz, *bwork;
++  scs_int *etree, *iwork, *Lnz;
++  QDLDL_bool *bwork;
+   scs_float *diag_p;
+ };
+

--- a/tools/workspace/scs_internal/repository.bzl
+++ b/tools/workspace/scs_internal/repository.bzl
@@ -13,6 +13,7 @@ def scs_internal_repository(
         sha256 = "bc8211cfd213f3117676ceb7842f4ed8a3bc7ed9625c4238cc7d83f666e22cc9",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
+            ":patches/upstream/fix_arg.patch",
             ":patches/upstream/include_paths.patch",
         ],
         mirrors = mirrors,


### PR DESCRIPTION
Patch SCS passing an incorrect argument type to QDLDL_factor. For some reason, this causes a warning (which gets treated as an error) about the incompatible argument type on manylinux, but apparently not on Ubuntu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22771)
<!-- Reviewable:end -->
