### PR TITLE
[geometry] Introduce 3D scale in mesh processing algorithms

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_meshes.cc
+++ b/bindings/pydrake/geometry/geometry_py_meshes.cc
@@ -199,6 +199,16 @@ void DoMeshDependentDefinitions(py::module m) {
       py::arg("filename"), py::arg("scale") = 1.0,
       // N.B. We have not bound the optional "on_warning" argument.
       doc.ReadObjToTriangleSurfaceMesh.doc_3args_filename_scale_on_warning);
+  m.def(
+      "ReadObjToTriangleSurfaceMesh",
+      [](const std::filesystem::path& filename, const Eigen::Vector3d& scale3) {
+        return geometry::ReadObjToTriangleSurfaceMesh(filename, scale3);
+      },
+      py::arg("filename"), py::arg("scale3"),
+      // N.B. We have not bound the optional "on_warning" argument.
+      doc.ReadObjToTriangleSurfaceMesh.doc_3args_filename_scale3_on_warning);
+  // Note: we're not binding the MeshSource variants to avoid having to resolve
+  // the binding dependency chain on MeshSource.
 }
 
 }  // namespace

--- a/bindings/pydrake/geometry/test/meshes_test.py
+++ b/bindings/pydrake/geometry/test/meshes_test.py
@@ -191,20 +191,34 @@ class TestGeometryMeshes(unittest.TestCase):
 
     def test_read_obj_to_surface_mesh(self):
         mesh_path = FindResourceOrThrow("drake/geometry/test/quad_cube.obj")
-        mesh = mut.ReadObjToTriangleSurfaceMesh(mesh_path)
-        vertices = mesh.vertices()
+        # Test default, uniform, and non-uniform scales.
+        for scale in [None, 2.0, [1.0, 2.0, 3.0]]:
+            if scale is None:
+                mesh = mut.ReadObjToTriangleSurfaceMesh(filename=mesh_path)
+                scale = [1.0, 1.0, 1.0]
+            elif isinstance(scale, float):
+                mesh = mut.ReadObjToTriangleSurfaceMesh(filename=mesh_path,
+                                                        scale=scale)
+                scale = [scale, scale, scale]
+            else:
+                mesh = mut.ReadObjToTriangleSurfaceMesh(filename=mesh_path,
+                                                        scale3=scale)
+            vertices = mesh.vertices()
 
-        # This test relies on the specific content of the file quad_cube.obj.
-        # These coordinates came from the first section of quad_cube.obj.
-        expected_vertices = [
-            [1.000000, -1.000000, -1.000000],
-            [1.000000, -1.000000,  1.000000],
-            [-1.000000, -1.000000,  1.000000],
-            [-1.000000, -1.000000, -1.000000],
-            [1.000000,  1.000000, -1.000000],
-            [1.000000,  1.000000,  1.000000],
-            [-1.000000,  1.000000,  1.000000],
-            [-1.000000,  1.000000, -1.000000],
-        ]
-        for i, expected in enumerate(expected_vertices):
-            self.assertListEqual(list(vertices[i]), expected)
+            # This test relies on the specific content of the file
+            # quad_cube.obj. These coordinates came from the first section of
+            # quad_cube.obj.
+            scale = np.array(scale)
+            scale.shape = (1, 3)
+            expected_vertices = np.array([
+                [1.000000, -1.000000, -1.000000],
+                [1.000000, -1.000000,  1.000000],
+                [-1.000000, -1.000000,  1.000000],
+                [-1.000000, -1.000000, -1.000000],
+                [1.000000,  1.000000, -1.000000],
+                [1.000000,  1.000000,  1.000000],
+                [-1.000000,  1.000000,  1.000000],
+                [-1.000000,  1.000000, -1.000000],
+            ]) * scale
+            for i, expected in enumerate(expected_vertices):
+                np.testing.assert_array_equal(vertices[i], expected)

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -552,9 +552,11 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   // For zero margin, use the pre-computed convex hull for the shape.
   const TriangleSurfaceMesh<double> inflated_surface_mesh =
       MakeTriangleFromPolygonMesh(
-          margin > 0 ? MakeConvexHull(convex_spec.source(), convex_spec.scale(),
-                                      margin)
-                     : convex_spec.GetConvexHull());
+          margin > 0
+              ? MakeConvexHull(convex_spec.source(),
+                               Vector3<double>::Constant(convex_spec.scale()),
+                               margin)
+              : convex_spec.GetConvexHull());
   auto inflated_mesh = make_unique<VolumeMesh<double>>(
       MakeConvexVolumeMesh<double>(inflated_surface_mesh));
 

--- a/geometry/proximity/make_convex_hull_mesh.cc
+++ b/geometry/proximity/make_convex_hull_mesh.cc
@@ -27,11 +27,13 @@ class Hullifier final : public ShapeReifier {
   using ShapeReifier::ImplementGeometry;
 
   void ImplementGeometry(const Mesh& mesh, void*) final {
-    hull_ = MakeConvexHull(mesh.source(), mesh.scale());
+    hull_ =
+        MakeConvexHull(mesh.source(), Eigen::Vector3d::Constant(mesh.scale()));
   }
 
   void ImplementGeometry(const Convex& convex, void*) final {
-    hull_ = MakeConvexHull(convex.source(), convex.scale());
+    hull_ = MakeConvexHull(convex.source(),
+                           Eigen::Vector3d::Constant(convex.scale()));
   }
 
   PolygonSurfaceMesh<double> hull_;

--- a/geometry/proximity/make_convex_hull_mesh_impl.h
+++ b/geometry/proximity/make_convex_hull_mesh_impl.h
@@ -46,10 +46,10 @@ namespace internal {
                            of the vertices lying on a plane is *not* degenerate.
  @throws std::exception if there is an unforeseen error in computing the convex
                            hull.
- @throws std::exception if `scale` is not strictly positive.
  @throws std::exception if `margin` is negative. */
 PolygonSurfaceMesh<double> MakeConvexHull(const MeshSource& mesh_source,
-                                          double scale, double margin = 0);
+                                          const Vector3<double>& scale,
+                                          double margin = 0);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_mesh_from_vtk.cc
+++ b/geometry/proximity/make_mesh_from_vtk.cc
@@ -23,7 +23,8 @@ VolumeMesh<T> MakeVolumeMeshFromVtk(const Mesh& mesh) {
 
   const double scale = mesh.scale();
 
-  VolumeMesh<double> read_mesh = ReadVtkToVolumeMesh(mesh.source(), scale);
+  VolumeMesh<double> read_mesh =
+      ReadVtkToVolumeMesh(mesh.source(), Eigen::Vector3d::Constant(scale));
 
   for (int e = 0; e < read_mesh.num_elements(); ++e) {
     if (read_mesh.CalcTetrahedronVolume(e) <= 0.) {

--- a/geometry/proximity/obj_to_surface_mesh.cc
+++ b/geometry/proximity/obj_to_surface_mesh.cc
@@ -18,11 +18,14 @@ using Eigen::Vector3d;
 namespace internal {
 
 std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
-    const MeshSource& mesh_source, double scale,
+    const MeshSource& mesh_source, const Vector3d& scale,
     const DiagnosticPolicy& diagnostic) {
   std::shared_ptr<std::vector<Eigen::Vector3d>> vertices;
   std::shared_ptr<std::vector<int>> face_data;
   int num_tris{};
+  // Note: we rely on ReadObj to do the "right" thing in case the scale factor
+  // would cause the mesh to get flipped inside out; we assume the mesh data
+  // returned has winding consistent with its inside and outside.
   std::tie(vertices, face_data, num_tris) =
       ReadObj(mesh_source, scale, /* triangulate = */ true,
               /* vertices_only = */ false, diagnostic);
@@ -52,13 +55,20 @@ std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
 }  // namespace internal
 
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
-    const std::filesystem::path& filename, const double scale,
+    const std::filesystem::path& filename, const Eigen::Vector3d& scale3,
     std::function<void(std::string_view)> on_warning) {
-  return ReadObjToTriangleSurfaceMesh(MeshSource(filename), scale, on_warning);
+  return ReadObjToTriangleSurfaceMesh(MeshSource(filename), scale3, on_warning);
 }
 
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
-    const MeshSource& mesh_source, double scale,
+    const std::filesystem::path& filename, const double scale,
+    std::function<void(std::string_view)> on_warning) {
+  return ReadObjToTriangleSurfaceMesh(
+      filename, Eigen::Vector3d::Constant(scale), on_warning);
+}
+
+TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
+    const MeshSource& mesh_source, const Eigen::Vector3d& scale3,
     std::function<void(std::string_view)> on_warning) {
   DiagnosticPolicy policy;
   if (on_warning != nullptr) {
@@ -67,7 +77,14 @@ TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
     });
   }
   // We will either throw or return a mesh here (courtesy of ReadObj).
-  return *internal::DoReadObjToSurfaceMesh(mesh_source, scale, policy);
+  return *internal::DoReadObjToSurfaceMesh(mesh_source, scale3, policy);
+}
+
+TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
+    const MeshSource& mesh_source, double scale,
+    std::function<void(std::string_view)> on_warning) {
+  return ReadObjToTriangleSurfaceMesh(
+      mesh_source, Eigen::Vector3d::Constant(scale), on_warning);
 }
 
 }  // namespace geometry

--- a/geometry/proximity/obj_to_surface_mesh.h
+++ b/geometry/proximity/obj_to_surface_mesh.h
@@ -24,7 +24,7 @@ namespace internal {
  configured to stop for errors, std::nullopt is returned.
  @pre `diagnostic` has both warning and error handlers defined. */
 std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
-    const MeshSource& source, double scale,
+    const MeshSource& source, const Eigen::Vector3d& scale,
     const drake::internal::DiagnosticPolicy& diagnostic);
 
 }  // namespace internal
@@ -37,18 +37,28 @@ std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
  @param filename
      A valid file name with absolute path or relative path.
  @param scale
-     An optional scale to coordinates.
+     A scale to coordinates.
  @param on_warning
      An optional callback that will receive warning message(s) encountered
      while reading the mesh.  When not provided, drake::log() will be used.
  @throws std::exception if there is an error reading the mesh data.
  @return surface mesh */
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
+    const std::filesystem::path& filename, const Eigen::Vector3d& scale3,
+    std::function<void(std::string_view)> on_warning = {});
+
+/** Variant that allows defining uniform scaling from a single scalar value. */
+TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
     const std::filesystem::path& filename, double scale = 1.0,
     std::function<void(std::string_view)> on_warning = {});
 
 /** Overload of @ref ReadObjToTriangleSurfaceMesh(const std::filesystem::path&,
  double) with the Wavefront .obj in a Mesh shape specification. */
+TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
+    const MeshSource& mesh_source, const Eigen::Vector3d& scale3,
+    std::function<void(std::string_view)> on_warning = {});
+
+/** Variant that allows defining uniform scaling from a single scalar value. */
 TriangleSurfaceMesh<double> ReadObjToTriangleSurfaceMesh(
     const MeshSource& mesh_source, double scale = 1.0,
     std::function<void(std::string_view)> on_warning = {});

--- a/geometry/proximity/vtk_to_volume_mesh.h
+++ b/geometry/proximity/vtk_to_volume_mesh.h
@@ -35,15 +35,28 @@ namespace internal {
  or per-tetrahedron velocity field are ignored.
 
  @param mesh_source      The source of mesh data to parse.
- @param scale            An optional scale to coordinates.
+ @param scale            An optional scale to coordinates. Negative scales can
+                         be used to mirror the geometry over axes. Zero scale
+                         is considered valid for this function, but will likely
+                         produce a degenerate mesh when used in Drake.
  @return tetrahedral volume mesh
+
+ @note Negative scales will cause the geometry to mirror itself over the scale
+ factor's corresponding axis. Depending on how many scale values are negative,
+ the "winding" of the tets would get reversed (so what was previously considered
+ inside is now outside). This function prevents this inside/outside inversion by
+ changing the ordering of the per-tet vertex ordering (maintaining the original
+ meshes definition of "inside" and "outside", even when the mesh has been
+ mirrored.) This means that the ordering of vertices within each tet may not
+ match the ordering of the input file; the index order will be permuted; indices
+ [0 1 2 3] would become [2 1 0 3].
 
  @note Error handling from parsing the file is performed by VTK library.
 
- @throw  std::exception if the file does not exist or unsupported.
-         std::exception for non-positive scale factors. */
+ @throw  std::exception if the file does not exist or unsupported. */
 VolumeMesh<double> ReadVtkToVolumeMesh(const MeshSource& mesh_source,
-                                       double scale = 1.0);
+                                       const Eigen::Vector3d& scale = {1, 1,
+                                                                       1});
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/read_obj.h
+++ b/geometry/read_obj.h
@@ -43,8 +43,8 @@ namespace internal {
  will throw in the face of errors. */
 std::tuple<std::shared_ptr<std::vector<Eigen::Vector3d>>,
            std::shared_ptr<std::vector<int>>, int>
-ReadObj(const MeshSource& mesh_source, double scale, bool triangulate,
-        bool vertices_only = false,
+ReadObj(const MeshSource& mesh_source, const Eigen::Vector3d& scale,
+        bool triangulate, bool vertices_only = false,
         const drake::internal::DiagnosticPolicy& diagnostic = {});
 
 }  // namespace internal

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -48,8 +48,9 @@ void ComputeConvexHullAsNecessary(
   if (check == nullptr) {
     // Note: This approach means that multiple threads *may* redundantly compute
     // the convex hull; but only the first one will set the hull.
-    auto new_hull = std::make_shared<PolygonSurfaceMesh<double>>(
-        internal::MakeConvexHull(mesh_source, scale));
+    auto new_hull =
+        std::make_shared<PolygonSurfaceMesh<double>>(internal::MakeConvexHull(
+            mesh_source, Vector3<double>::Constant(scale)));
     std::atomic_compare_exchange_strong(hull_ptr, &check, new_hull);
   }
 }

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -249,6 +249,9 @@ class Convex final : public Shape {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Convex);
 
+  // TODO(SeanCurtis-TRI): WHen scale is Vector3, make it clear that mirroring
+  // meshes can reverse winding, leading to a permutation of per-face ordering.
+
   /** Constructs a convex shape specification from the file located at the
    given file path. Optionally uniformly scaled by the given scale factor.
 

--- a/geometry/test/read_obj_test.cc
+++ b/geometry/test/read_obj_test.cc
@@ -6,7 +6,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/diagnostic_policy_test_base.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 
@@ -40,67 +42,71 @@ void CheckVertices(
 // on tinyobj to triangulate correctly. We'll just confirm that quads become
 // triangles upon request.
 GTEST_TEST(ReadObjTest, Triangulate) {
+  const Eigen::Vector3d scale(1, 2, 3);
   for (const bool triangulate : {true, false}) {
     const auto [vertices, faces, num_faces] =
         ReadObj(FindPathOrThrow("drake/geometry/test/quad_cube.obj"),
-                /* scale= */ 1, triangulate);
+                scale, triangulate);
     EXPECT_EQ(vertices->size(), 8);
     EXPECT_EQ(num_faces, triangulate ? 12 : 6);
   }
 }
 
-// Performs the test over multiple scales to make sure scale is included.
+// Confirm that the scale factor is included.
 GTEST_TEST(ReadObjTest, QuadCube) {
-  for (const double scale : {0.5, 1.5}) {
-    const auto [vertices, faces, num_faces] =
-        ReadObj(FindPathOrThrow("drake/geometry/test/quad_cube.obj"), scale,
-                /* triangulate= */ false);
-    EXPECT_EQ(vertices->size(), 8);
-    EXPECT_EQ(num_faces, 6);
-    Eigen::Matrix<double, 8, 3> vertices_expected;
-    // clang-format off
-    vertices_expected << -1, -1, -1,
-                         -1, -1, 1,
-                         -1, 1, 1,
-                         -1, 1, -1,
-                         1, 1, -1,
-                         1, -1, -1,
-                         1, -1, 1,
-                         1, 1, 1;
-    // clang-format on
-    vertices_expected *= scale;
-    CheckVertices(vertices, vertices_expected.transpose(), 0.);
-    // Each face has 4 vertices, hence the size of faces is num_faces * (1 + 4).
-    // The point on the same face will have one coordinate with the same value.
-    EXPECT_EQ(faces->size(), num_faces * 5);
-    for (int i = 0; i < num_faces; ++i) {
-      bool found_coord = false;
-      for (int coord = 0; coord < 3; ++coord) {
-        bool coord_same_value = true;
-        for (int vert = 2; vert <= 4; ++vert) {
-          if ((*vertices)[(*faces)[5 * i + vert]](coord) !=
-              (*vertices)[(*faces)[5 * i + 1]](coord)) {
-            coord_same_value = false;
-            break;
-          }
-        }
-        if (coord_same_value) {
-          found_coord = true;
+  const double sx = 2;
+  const double sy = 3;
+  const double sz = 4;
+  const Eigen::Vector3d scale(sx, sy, sz);
+  const auto [vertices, faces, num_faces] =
+      ReadObj(FindPathOrThrow("drake/geometry/test/quad_cube.obj"), scale,
+              /* triangulate= */ false);
+  EXPECT_EQ(vertices->size(), 8);
+  EXPECT_EQ(num_faces, 6);
+  Eigen::Matrix<double, 8, 3> vertices_expected;
+  // clang-format off
+  // The cube obj has +/- 1 in all vertex coordinates.
+  vertices_expected << -sx, -sy, -sz,
+                       -sx, -sy,  sz,
+                       -sx,  sy,  sz,
+                       -sx,  sy, -sz,
+                        sx,  sy, -sz,
+                        sx, -sy, -sz,
+                        sx, -sy,  sz,
+                        sx,  sy,  sz;
+  // clang-format on
+  CheckVertices(vertices, vertices_expected.transpose(), 0.);
+  // Each face has 4 vertices, hence the size of faces is num_faces * (1 + 4).
+  // The point on the same face will have one coordinate with the same value.
+  EXPECT_EQ(faces->size(), num_faces * 5);
+  for (int i = 0; i < num_faces; ++i) {
+    bool found_coord = false;
+    for (int coord = 0; coord < 3; ++coord) {
+      bool coord_same_value = true;
+      for (int vert = 2; vert <= 4; ++vert) {
+        if ((*vertices)[(*faces)[5 * i + vert]](coord) !=
+            (*vertices)[(*faces)[5 * i + 1]](coord)) {
+          coord_same_value = false;
           break;
         }
       }
-      EXPECT_TRUE(found_coord);
+      if (coord_same_value) {
+        found_coord = true;
+        break;
+      }
     }
+    EXPECT_TRUE(found_coord);
   }
 }
 
 // The octahedron.obj is comprised only of triangles; we should get the same
 // result regardless of whether triangulate is true or false.
 GTEST_TEST(ReadObjTest, TriangulatingNoop) {
+  const Eigen::Vector3d scale(1, 1, 1);
   for (const bool triangulate : {true, false}) {
     const auto [vertices, faces, num_faces] =
         ReadObj(FindPathOrThrow("drake/geometry/test/octahedron.obj"),
-                /* scale= */ 1.0, triangulate);
+                scale, triangulate);
     EXPECT_EQ(vertices->size(), 6u);
     Eigen::Matrix<double, 6, 3> vertices_expected;
     // clang-format off
@@ -121,8 +127,9 @@ GTEST_TEST(ReadObjTest, TriangulatingNoop) {
 // Simply tests that multiple objects are supported. Scale and triangulate have
 // been tested elsewhere.
 GTEST_TEST(ReadObjTest, MultipleObjects) {
+  const Eigen::Vector3d scale(1, 1, 1);
   const auto [vertices, faces, num_faces] = ReadObj(
-      FindPathOrThrow("drake/geometry/test/two_cube_objects.obj"), 1.0,
+      FindPathOrThrow("drake/geometry/test/two_cube_objects.obj"), scale,
       /* triangulate= */ false);
   Eigen::Matrix<double, 16, 3> vertices_expected;
   // clang-format off
@@ -174,6 +181,7 @@ GTEST_TEST(ReadObjTest, MultipleObjects) {
 // A quick reality check that we can successfully invoke with a MeshSource.
 // Previous tests have relied on implicit conversion from path to source.
 GTEST_TEST(ReadObjTest, MeshSourceRegression) {
+  const Eigen::Vector3d scale(2, 2, 2);
   // In-memory source.
   {
     const MeshSource source(InMemoryMesh{MemoryFile(R"""(v 0 0 0
@@ -184,7 +192,7 @@ GTEST_TEST(ReadObjTest, MeshSourceRegression) {
                                                        )""",
                                                     ".obj", "test")});
     const auto [vertices, faces, num_faces] =
-        ReadObj(source, 2.0, /* triangulate= */ true);
+        ReadObj(source, scale, /* triangulate= */ true);
     EXPECT_EQ(vertices->size(), 4);
     EXPECT_EQ(faces->size(), 8);  // Two encoded triangles, 4 ints per tri.
   }
@@ -194,7 +202,7 @@ GTEST_TEST(ReadObjTest, MeshSourceRegression) {
     const MeshSource source(
         FindPathOrThrow("drake/geometry/test/quad_cube.obj"));
     const auto [vertices, faces, num_faces] =
-        ReadObj(source, 2.0, /* triangulate= */ false);
+        ReadObj(source, scale, /* triangulate= */ false);
     EXPECT_EQ(vertices->size(), 8);
     EXPECT_EQ(faces->size(), 30);  // Six encoded quads, 5 ints per quad.
   }
@@ -204,23 +212,55 @@ GTEST_TEST(ReadObjTest, MeshSourceRegression) {
 // vertices from an obj that would ordinarily throw if we asked for the face
 // data (see ErrorModes, below).
 GTEST_TEST(ReadObjTest, VertexOnly) {
+  const Eigen::Vector3d scale(2, 2, 2);
   const MeshSource source(InMemoryMesh{MemoryFile(R"""(v 0 0 0
                                                        v 0 1 0
                                                        v 1 0 0
                                                        v 1 1 0
                                                      )""",
                                                   ".obj", "no_faces")});
-  const auto [vertices, faces, num_faces] =
-      ReadObj(source, 2.0, /* triangulate= */ true, /* vertices_only= */ true);
+  const auto [vertices, faces, num_faces] = ReadObj(
+      source, scale, /* triangulate= */ true, /* vertices_only= */ true);
   EXPECT_EQ(vertices->size(), 4);
   EXPECT_EQ(faces->size(), 0);
   EXPECT_EQ(num_faces, 0);
+}
+
+// When the non-uniform scale allows flipping, we want to make sure the faces
+// get rewound so that inside is still inside. We know the cube is centered
+// on the origin. That means the origin should be on the "inside" of every
+// triangle. We'll sample one triangle as evidence that winding got handled.
+GTEST_TEST(ReadObjTest, InverseScaleWinding) {
+  for (double sx : {-1.0, 1.0}) {
+    for (double sy : {-1.0, 1.0}) {
+      for (double sz : {-1.0, 1.0}) {
+        const Eigen::Vector3d scale(sx, sy, sz);
+        const auto [vertices, faces, num_faces] =
+            ReadObj(FindPathOrThrow("drake/geometry/test/quad_cube.obj"), scale,
+                    /* triangulate= */ true);
+        ASSERT_EQ(num_faces, 12);
+        // Remember: faces is encoded as [n0, v0_0, v0_1, v0_2, n1, ...].
+        const Eigen::Vector3d& p_GoA_G = vertices->at(faces->at(1));
+        const Eigen::Vector3d& p_GoB_G = vertices->at(faces->at(2));
+        const Eigen::Vector3d& p_GoC_G = vertices->at(faces->at(3));
+
+        const Eigen::Vector3d p_AB_G = p_GoB_G - p_GoA_G;
+        const Eigen::Vector3d p_AC_G = p_GoC_G - p_GoA_G;
+        const Eigen::Vector3d n_G = p_AB_G.cross(p_AC_G);
+        // The vector OA should point in basically the same direction as the
+        // normal.
+        SCOPED_TRACE(fmt::format("Scale [{}]", fmt_eigen(scale.transpose())));
+        EXPECT_GT(n_G.dot(p_GoA_G), 0);
+      }
+    }
+  }
 }
 
 class ReadObjDiagnosticsTest : public test::DiagnosticPolicyTestBase {};
 
 // Problems parsing the requested source.
 TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
+  const Eigen::Vector3d scale(2, 2, 2);
   // tinyobj errors broadcast as diagnostic errors. Without providing a
   // diagnostic policy, it throws.
   {
@@ -234,11 +274,11 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
     const MeshSource source(
         InMemoryMesh{MemoryFile(bad_index_obj, ".obj", "bad indices")});
     auto [verts, _1, _2] =
-        ReadObj(source, 2.0, /* triangulate= */ false,
+        ReadObj(source, scale, /* triangulate= */ false,
                 /* vertices_only= */ true, diagnostic_policy_);
     EXPECT_EQ(verts, nullptr);
     EXPECT_THAT(TakeError(), testing::HasSubstr("zero value for vertex"));
-    DRAKE_EXPECT_THROWS_MESSAGE(ReadObj(source, 2.0, /* triangulate= */ false,
+    DRAKE_EXPECT_THROWS_MESSAGE(ReadObj(source, scale, /* triangulate= */ false,
                                         /* vertices_only= */ true),
                                 "[^]*zero value for vertex[^]*");
   }
@@ -256,13 +296,13 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
     const MeshSource source(
         InMemoryMesh{MemoryFile(bad_index_obj, ".obj", "group")});
     auto [verts, _1, _2] =
-        ReadObj(source, 2.0, /* triangulate= */ false,
+        ReadObj(source, scale, /* triangulate= */ false,
                 /* vertices_only= */ true, diagnostic_policy_);
     EXPECT_EQ(verts->size(), 3);
     EXPECT_THAT(TakeWarning(),
                 testing::HasSubstr("Vertex indices out of bounds"));
     // This will write a warning to the console.
-    EXPECT_NO_THROW(ReadObj(source, 2.0, /* triangulate= */ false,
+    EXPECT_NO_THROW(ReadObj(source, scale, /* triangulate= */ false,
                             /* vertices_only= */ true));
   }
 
@@ -277,11 +317,11 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
     const MeshSource source(
         InMemoryMesh{MemoryFile(no_face_obj, ".obj", "no_faces")});
     auto [verts, _1, _2] =
-        ReadObj(source, 2.0, /* triangulate= */ false,
+        ReadObj(source, scale, /* triangulate= */ false,
                 /* vertices_only= */ false, diagnostic_policy_);
     EXPECT_EQ(verts, nullptr);
     EXPECT_THAT(TakeError(), testing::HasSubstr("no objects"));
-    DRAKE_EXPECT_THROWS_MESSAGE(ReadObj(source, 2.0, /* triangulate= */ false,
+    DRAKE_EXPECT_THROWS_MESSAGE(ReadObj(source, scale, /* triangulate= */ false,
                                         /* vertices_only= */ false),
                                 ".*no objects.*");
   }
@@ -291,11 +331,11 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
     const MeshSource source(
         InMemoryMesh{MemoryFile(no_face_obj, ".bad", "wrong_extension")});
     auto [verts, _1, _2] =
-        ReadObj(source, 2.0, /* triangulate= */ false,
+        ReadObj(source, scale, /* triangulate= */ false,
                 /* vertices_only= */ true, diagnostic_policy_);
     EXPECT_EQ(verts, nullptr);
     EXPECT_THAT(TakeError(), testing::HasSubstr("wrong extension: '.bad'"));
-    DRAKE_EXPECT_THROWS_MESSAGE(ReadObj(source, 2.0, /* triangulate= */ false,
+    DRAKE_EXPECT_THROWS_MESSAGE(ReadObj(source, scale, /* triangulate= */ false,
                                         /* vertices_only= */ false),
                                 ".*wrong extension.*");
   }
@@ -304,11 +344,11 @@ TEST_F(ReadObjDiagnosticsTest, ErrorModes) {
   {
     const MeshSource source("some_file.bad");
     auto [verts, _1, _2] =
-        ReadObj(source, 2.0, /* triangulate= */ false,
+        ReadObj(source, scale, /* triangulate= */ false,
                 /* vertices_only= */ true, diagnostic_policy_);
     EXPECT_EQ(verts, nullptr);
     EXPECT_THAT(TakeError(), testing::HasSubstr("wrong extension: '.bad'"));
-    DRAKE_EXPECT_THROWS_MESSAGE(ReadObj(source, 2.0, /* triangulate= */ false,
+    DRAKE_EXPECT_THROWS_MESSAGE(ReadObj(source, scale, /* triangulate= */ false,
                                         /* vertices_only= */ false),
                                 ".*wrong extension.*");
   }

--- a/multibody/parsing/detail_mesh_parser.cc
+++ b/multibody/parsing/detail_mesh_parser.cc
@@ -44,7 +44,7 @@ void CaptureName(void* storage, const char* parsed_name) {
 // value contains a null mesh.
 NamedMesh DoGetObjMesh(const DiagnosticPolicy& diagnostic,
                        const geometry::MeshSource& obj_source) {
-  const double kUnitScale = 1.0;
+  const Eigen::Vector3d kUnitScale(1, 1, 1);
   std::optional<TriangleSurfaceMesh<double>> mesh =
       geometry::internal::DoReadObjToSurfaceMesh(obj_source, kUnitScale,
                                                  diagnostic);


### PR DESCRIPTION
This includes parsing mesh into Drake constructs and computing convex hulls.

When parsing mesh files (e.g., obj, vtk, etc.) we explicitly handle the case where the scale includes mirroring which may cause the mesh windings to be wound incorrectly.

This also attempts to unify the internal APIs with regards to what scale factors are accepted. We accept any scale factor -- even zero. Because these are internal, if some limit needs to be placed by some application, we rely on the application to enforce that constraint.

Relates #22046.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22772)
<!-- Reviewable:end -->
