### PR TITLE
Add cloning functionality for IntegratorBase

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -212,7 +212,9 @@ PYBIND11_MODULE(analysis, m) {
           .def("get_mutable_context", &Class::get_mutable_context,
               // Keep alive, transitive: `return` keeps `self` alive.
               py::keep_alive<0, 1>(), cls_doc.get_mutable_context.doc)
-          .def("reset_context", &Class::reset_context, py::arg("context"),
+          .def("reset_context",
+              py::overload_cast<Context<T>*>(&Class::reset_context),
+              py::arg("context"),
               // Keep alive, reference: `context` keeps `self` alive.
               py::keep_alive<2, 1>(), cls_doc.reset_context.doc);
     }

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -621,6 +621,8 @@ drake_cc_googletest(
     name = "implicit_integrator_test",
     deps = [
         ":implicit_integrator",
+        ":simulator_config_functions",
+        "//common:pointer_cast",
         "//common/test_utilities:expect_no_throw",
         "//systems/analysis/test_utilities:spring_mass_system",
     ],
@@ -630,8 +632,11 @@ drake_cc_googletest(
     name = "integrator_base_test",
     deps = [
         ":integrator_base",
+        ":simulator_config_functions",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//systems/analysis/test_utilities:spring_mass_system",
+        "//systems/primitives:linear_system",
     ],
 )
 

--- a/systems/analysis/bogacki_shampine3_integrator.cc
+++ b/systems/analysis/bogacki_shampine3_integrator.cc
@@ -168,6 +168,12 @@ bool BogackiShampine3Integrator<T>::DoStep(const T& h) {
   return true;
 }
 
+template <class T>
+std::unique_ptr<IntegratorBase<T>> BogackiShampine3Integrator<T>::DoClone()
+    const {
+  return std::make_unique<BogackiShampine3Integrator>(this->get_system());
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/bogacki_shampine3_integrator.h
+++ b/systems/analysis/bogacki_shampine3_integrator.h
@@ -61,6 +61,8 @@ class BogackiShampine3Integrator final : public IntegratorBase<T> {
   void DoInitialize() override;
   bool DoStep(const T& h) override;
 
+  std::unique_ptr<IntegratorBase<T>> DoClone() const override;
+
   // Vector used in error estimate calculations.
   std::unique_ptr<BasicVector<T>> err_est_vec_;
 

--- a/systems/analysis/explicit_euler_integrator.cc
+++ b/systems/analysis/explicit_euler_integrator.cc
@@ -6,6 +6,12 @@ namespace systems {
 template <class T>
 ExplicitEulerIntegrator<T>::~ExplicitEulerIntegrator() = default;
 
+template <class T>
+std::unique_ptr<IntegratorBase<T>> ExplicitEulerIntegrator<T>::DoClone() const {
+  return std::make_unique<ExplicitEulerIntegrator>(
+      this->get_system(), this->get_maximum_step_size());
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/explicit_euler_integrator.h
+++ b/systems/analysis/explicit_euler_integrator.h
@@ -53,6 +53,8 @@ class ExplicitEulerIntegrator final : public IntegratorBase<T> {
 
  private:
   bool DoStep(const T& h) override;
+
+  std::unique_ptr<IntegratorBase<T>> DoClone() const override;
 };
 
 /**

--- a/systems/analysis/implicit_euler_integrator.cc
+++ b/systems/analysis/implicit_euler_integrator.cc
@@ -76,6 +76,12 @@ void ImplicitEulerIntegrator<T>::DoInitialize() {
 }
 
 template <class T>
+std::unique_ptr<ImplicitIntegrator<T>>
+ImplicitEulerIntegrator<T>::DoImplicitIntegratorClone() const {
+  return std::make_unique<ImplicitEulerIntegrator>(this->get_system());
+}
+
+template <class T>
 void ImplicitEulerIntegrator<T>::ComputeAndFactorImplicitEulerIterationMatrix(
     const MatrixX<T>& J, const T& h,
     typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix) {

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -398,6 +398,9 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   void DoInitialize() final;
 
+  std::unique_ptr<ImplicitIntegrator<T>> DoImplicitIntegratorClone()
+      const final;
+
   // Steps both implicit Euler and implicit trapezoid forward by h, if possible.
   // @param t0 the time at the left end of the integration interval.
   // @param h the integration step size to attempt.

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -450,6 +450,16 @@ bool ImplicitIntegrator<T>::MaybeFreshenMatrices(
   }
 }
 
+template <class T>
+std::unique_ptr<IntegratorBase<T>> ImplicitIntegrator<T>::DoClone() const {
+  auto cloned = DoImplicitIntegratorClone();
+  cloned->set_reuse(this->get_reuse());
+  cloned->set_use_full_newton(this->get_use_full_newton());
+  cloned->set_jacobian_computation_scheme(
+      this->get_jacobian_computation_scheme());
+  return cloned;
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -389,6 +389,10 @@ class ImplicitIntegrator : public IntegratorBase<T> {
   /// become "bad". This is an O(n²) operation, where n is the state dimension.
   bool IsBadJacobian(const MatrixX<T>& J) const;
 
+  /// @copydoc IntegratorBase::DoClone()
+  virtual std::unique_ptr<ImplicitIntegrator<T>> DoImplicitIntegratorClone()
+      const = 0;
+
   // TODO(edrumwri) Document the functions below.
   virtual int64_t do_get_num_newton_raphson_iterations() const = 0;
   virtual int64_t do_get_num_error_estimator_derivative_evaluations() const = 0;
@@ -491,6 +495,8 @@ class ImplicitIntegrator : public IntegratorBase<T> {
 
     return result;
   }
+
+  std::unique_ptr<IntegratorBase<T>> DoClone() const final;
 
   // The scheme to be used for computing the Jacobian matrix during the
   // nonlinear system solve process.

--- a/systems/analysis/radau_integrator.cc
+++ b/systems/analysis/radau_integrator.cc
@@ -127,6 +127,12 @@ void RadauIntegrator<T, num_stages>::DoInitialize() {
 }
 
 template <typename T, int num_stages>
+std::unique_ptr<ImplicitIntegrator<T>>
+RadauIntegrator<T, num_stages>::DoImplicitIntegratorClone() const {
+  return std::make_unique<RadauIntegrator>(this->get_system());
+}
+
+template <typename T, int num_stages>
 const VectorX<T>& RadauIntegrator<T, num_stages>::ComputeFofZ(
       const T& t0, const T& h, const VectorX<T>& xt0, const VectorX<T>& Z) {
   Context<T>* context = this->get_mutable_context();

--- a/systems/analysis/radau_integrator.h
+++ b/systems/analysis/radau_integrator.h
@@ -155,7 +155,12 @@ class RadauIntegrator final : public ImplicitIntegrator<T> {
   // @return a (state_dim * num_stages)-dimensional vector.
   const VectorX<T>& ComputeFofZ(
       const T& t0, const T& h, const VectorX<T>& xt0, const VectorX<T>& Z);
+
   void DoInitialize() final;
+
+  std::unique_ptr<ImplicitIntegrator<T>> DoImplicitIntegratorClone()
+      const final;
+
   void DoResetCachedJacobianRelatedMatrices() final {
       iteration_matrix_radau_ = {};
       iteration_matrix_implicit_trapezoid_ = {};

--- a/systems/analysis/runge_kutta2_integrator.cc
+++ b/systems/analysis/runge_kutta2_integrator.cc
@@ -6,6 +6,12 @@ namespace systems {
 template <class T>
 RungeKutta2Integrator<T>::~RungeKutta2Integrator() = default;
 
+template <class T>
+std::unique_ptr<IntegratorBase<T>> RungeKutta2Integrator<T>::DoClone() const {
+  return std::make_unique<RungeKutta2Integrator>(this->get_system(),
+                                                 this->get_maximum_step_size());
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/runge_kutta2_integrator.h
+++ b/systems/analysis/runge_kutta2_integrator.h
@@ -50,6 +50,8 @@ class RungeKutta2Integrator final : public IntegratorBase<T> {
  private:
   bool DoStep(const T& h) override;
 
+  std::unique_ptr<IntegratorBase<T>> DoClone() const override;
+
   // A pre-allocated temporary for use by integration.
   std::unique_ptr<ContinuousState<T>> derivs0_;
 };

--- a/systems/analysis/runge_kutta3_integrator.cc
+++ b/systems/analysis/runge_kutta3_integrator.cc
@@ -151,6 +151,11 @@ bool RungeKutta3Integrator<T>::DoStep(const T& h) {
   return true;
 }
 
+template <class T>
+std::unique_ptr<IntegratorBase<T>> RungeKutta3Integrator<T>::DoClone() const {
+  return std::make_unique<RungeKutta3Integrator>(this->get_system());
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/runge_kutta3_integrator.h
+++ b/systems/analysis/runge_kutta3_integrator.h
@@ -78,6 +78,8 @@ class RungeKutta3Integrator final : public IntegratorBase<T> {
   void DoInitialize() override;
   bool DoStep(const T& h) override;
 
+  std::unique_ptr<IntegratorBase<T>> DoClone() const override;
+
   // Vector used in error estimate calculations.
   VectorX<T> err_est_vec_;
 

--- a/systems/analysis/runge_kutta5_integrator.cc
+++ b/systems/analysis/runge_kutta5_integrator.cc
@@ -246,6 +246,11 @@ bool RungeKutta5Integrator<T>::DoStep(const T& h) {
   return true;
 }
 
+template <class T>
+std::unique_ptr<IntegratorBase<T>> RungeKutta5Integrator<T>::DoClone() const {
+  return std::make_unique<RungeKutta5Integrator>(this->get_system());
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/runge_kutta5_integrator.h
+++ b/systems/analysis/runge_kutta5_integrator.h
@@ -75,6 +75,8 @@ class RungeKutta5Integrator final : public IntegratorBase<T> {
   void DoInitialize() override;
   bool DoStep(const T& h) override;
 
+  std::unique_ptr<IntegratorBase<T>> DoClone() const override;
+
   // Vector used in error estimate calculations.
   std::unique_ptr<BasicVector<T>> err_est_vec_;
 

--- a/systems/analysis/semi_explicit_euler_integrator.cc
+++ b/systems/analysis/semi_explicit_euler_integrator.cc
@@ -6,6 +6,13 @@ namespace systems {
 template <class T>
 SemiExplicitEulerIntegrator<T>::~SemiExplicitEulerIntegrator() = default;
 
+template <class T>
+std::unique_ptr<IntegratorBase<T>> SemiExplicitEulerIntegrator<T>::DoClone()
+    const {
+  return std::make_unique<SemiExplicitEulerIntegrator>(
+      this->get_system(), this->get_maximum_step_size());
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/semi_explicit_euler_integrator.h
+++ b/systems/analysis/semi_explicit_euler_integrator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <utility>
 
 #include "drake/common/default_scalars.h"
@@ -106,6 +107,8 @@ class SemiExplicitEulerIntegrator final : public IntegratorBase<T> {
 
  private:
   bool DoStep(const T& h) override;
+
+  std::unique_ptr<IntegratorBase<T>> DoClone() const override;
 
   // This is a pre-allocated temporary for use by integration
   BasicVector<T> qdot_;

--- a/systems/analysis/test/implicit_integrator_test.cc
+++ b/systems/analysis/test/implicit_integrator_test.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/pointer_cast.h"
+#include "drake/systems/analysis/simulator_config_functions.h"
 #include "drake/systems/analysis/test_utilities/spring_mass_system.h"
 
 using Eigen::VectorXd;
@@ -55,6 +57,11 @@ class DummyImplicitIntegrator final : public ImplicitIntegrator<double> {
 
   bool DoImplicitIntegratorStep(const double& h) override {
     throw std::logic_error("Dummy integrator not meant to be stepped.");
+  }
+
+  std::unique_ptr<ImplicitIntegrator<double>> DoImplicitIntegratorClone()
+      const override {
+    throw std::logic_error("Dummy integrator not meant to be cloned.");
   }
 
   bool has_reset_cached_matrices_{false};
@@ -135,6 +142,33 @@ GTEST_TEST(ImplicitIntegratorTest, SetComputationSchemeResetsCachedMatrices) {
             ImplicitIntegrator<double>
             ::JacobianComputationScheme::kAutomatic);
 }
+
+GTEST_TEST(ImplicitIntegratorTest, Clone) {
+  const double mass = 1.0;
+  const double spring_k = 1.0;
+  SpringMassSystem<double> dummy_system(spring_k, mass, false /* unforced */);
+
+  for (auto& scheme : GetIntegrationSchemes()) {
+    // Create the original implicit integrator.
+    Simulator<double> tmp(dummy_system);
+    auto original = dynamic_cast<ImplicitIntegrator<double>*>(
+        &ResetIntegratorFromFlags(&tmp, scheme, 0.2));
+    if (original == nullptr) continue;
+
+    // Clone the integrator.
+    auto integrator =
+        dynamic_pointer_cast<ImplicitIntegrator<double>>(original->Clone());
+
+    // Compare configuration parameters.
+    EXPECT_EQ(&integrator->get_system(), &original->get_system());
+    EXPECT_EQ(integrator->get_reuse(), original->get_reuse());
+    EXPECT_EQ(integrator->get_use_full_newton(),
+              original->get_use_full_newton());
+    EXPECT_EQ(integrator->get_jacobian_computation_scheme(),
+              original->get_jacobian_computation_scheme());
+  }
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test/integrator_base_test.cc
+++ b/systems/analysis/test/integrator_base_test.cc
@@ -2,8 +2,11 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/analysis/simulator_config_functions.h"
 #include "drake/systems/analysis/test_utilities/spring_mass_system.h"
+#include "drake/systems/primitives/linear_system.h"
 
 namespace drake {
 namespace systems {
@@ -34,9 +37,9 @@ class DummyIntegrator : public IntegratorBase<T> {
   // We want the Step function to fail whenever the step size is greater than
   // or equal to unity (see FixedStepFailureIndicatesSubstepFailure).
   bool DoStep(const T& step_size) override {
-      Context<T>* context = this->get_mutable_context();
-      context->SetTime(context->get_time() + step_size);
-      return (step_size < 1.0);
+    Context<T>* context = this->get_mutable_context();
+    context->SetTime(context->get_time() + step_size);
+    return (step_size < 1.0);
   }
 };
 
@@ -264,6 +267,79 @@ GTEST_TEST(IntegratorBaseTest, DenseOutputTest) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       static_cast<void>(integrator.IntegrateWithSingleFixedStepToTime(0.3)),
       ".*ConcatenateInTime.*time_offset.*");
+}
+
+GTEST_TEST(IntegratorBaseTest, Clone) {
+  // Create a free mass system.
+  Eigen::Matrix2d A;
+  A << 0.0, 1.0, 0.0, 0.0;
+  LinearSystem<double> system(A);
+
+  for (auto& scheme : GetIntegrationSchemes()) {
+    // Create an original integrator corresponding to scheme.
+    Simulator<double> tmp(system);
+    auto& original = ResetIntegratorFromFlags(&tmp, scheme, 0.2);
+    original.reset_context(system.CreateDefaultContext());
+    original.set_fixed_step_mode(true);
+    if (original.supports_error_estimation()) {
+      original.set_target_accuracy(1e-10);
+    }
+    original.Initialize();
+
+    // Clone the integrator.
+    auto integrator = original.Clone();
+
+    // The context should be cloned.
+    EXPECT_NE(integrator->get_mutable_context(), nullptr);
+    EXPECT_NE(&integrator->get_context(), &original.get_context());
+
+    // Compare configuration parameters.
+    EXPECT_EQ(&integrator->get_system(), &original.get_system());
+    EXPECT_EQ(integrator->is_initialized(), original.is_initialized());
+    EXPECT_EQ(integrator->supports_error_estimation(),
+              original.supports_error_estimation());
+    if (integrator->supports_error_estimation()) {
+      EXPECT_EQ(integrator->get_target_accuracy(),
+                original.get_target_accuracy());
+    }
+    EXPECT_EQ(integrator->get_error_estimate_order(),
+              original.get_error_estimate_order());
+    EXPECT_EQ(integrator->get_fixed_step_mode(),
+              original.get_fixed_step_mode());
+    EXPECT_EQ(integrator->get_maximum_step_size(),
+              original.get_maximum_step_size());
+    EXPECT_EQ(integrator->get_stretch_factor(), original.get_stretch_factor());
+    EXPECT_EQ(integrator->get_requested_minimum_step_size(),
+              original.get_requested_minimum_step_size());
+    EXPECT_EQ(integrator->get_throw_on_minimum_step_size_violation(),
+              original.get_throw_on_minimum_step_size_violation());
+
+    // Integrate to h and compare to the known analytical solution.
+    const double h = 3.1415926;
+    Eigen::Vector2d x0 = Eigen::Vector2d::Ones();
+
+    Eigen::Vector2d xf;
+    xf << x0(0) + h * x0(1), x0(1);
+
+    // Check IntegrateWithSingleFixedStepToTime() works.
+    integrator->get_mutable_context()->SetTimeAndContinuousState(0.0, x0);
+    EXPECT_TRUE(integrator->IntegrateWithSingleFixedStepToTime(h));
+    EXPECT_TRUE(CompareMatrices(
+        integrator->get_context().get_continuous_state().CopyToVector(), xf,
+        1e-10));
+
+    // Check IntegrateWithMultipleStepsToTime() works.
+    integrator->get_mutable_context()->SetTimeAndContinuousState(0.0, x0);
+    integrator->IntegrateWithMultipleStepsToTime(h);
+    EXPECT_TRUE(CompareMatrices(
+        integrator->get_context().get_continuous_state().CopyToVector(), xf,
+        1e-10));
+
+    // Cloning an uninitialized integration should result in an uninitialized
+    // integrator.
+    original.reset_context(nullptr);
+    EXPECT_FALSE(original.Clone()->is_initialized());
+  }
 }
 
 }  // namespace

--- a/systems/analysis/velocity_implicit_euler_integrator.cc
+++ b/systems/analysis/velocity_implicit_euler_integrator.cc
@@ -647,6 +647,12 @@ bool VelocityImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
   return true;
 }
 
+template <class T>
+std::unique_ptr<ImplicitIntegrator<T>>
+VelocityImplicitEulerIntegrator<T>::DoImplicitIntegratorClone() const {
+  return std::make_unique<VelocityImplicitEulerIntegrator>(this->get_system());
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -340,6 +340,9 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   bool DoImplicitIntegratorStep(const T& h) final;
 
+  std::unique_ptr<ImplicitIntegrator<T>> DoImplicitIntegratorClone()
+      const final;
+
   // Steps the system forward by a single step of h using the velocity-implicit
   // Euler method.
   // @param t0 the time at the left end of the integration interval.


### PR DESCRIPTION
As per [slack](https://drakedevelopers.slack.com/archives/C2CHRT98E/p1740326203692399?thread_ts=1740326158.413159&cid=C2CHRT98E) discussion, this PR implements the `Clone()` method for `IntegratorBase` so it can be put in a cache entry. This is guaranteed to be a thread-safe method for using integrators inside a `LeafSystem`. 

Another approach #22720 where we tried to add an entry point `IntegratorBase<T>::IntegrateWithSingleFixedStepToTime(const T& t_target, Context<T>* context) const`, is not thread-safe due to the fact that the integrator preallocates memory and rerads/writes to them during the integration

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22773)
<!-- Reviewable:end -->
