### PR TITLE
[pydrake] Avoid lifetime hazards with port references

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -364,6 +364,7 @@ drake_py_unittest(
         ":test_util_py",
         "//bindings/pydrake/common/test_utilities",
         "//bindings/pydrake/examples",
+        "//bindings/pydrake/systems/test_utilities:framework_test_util_py",
     ],
 )
 

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -802,8 +802,8 @@ void DoDefineFrameworkDiagramBuilder(py::module m) {
 // should split it up into smaller pieces.
 template <typename T>
 void DefineRemainingScalarDependentDefinitions(py::module m) {
-  DefineTemplateClassWithDefault<OutputPort<T>>(
-      m, "OutputPort", GetPyParam<T>(), doc.OutputPort.doc)
+  DefineTemplateClassWithDefault<OutputPort<T>>(m, "OutputPort",
+      GetPyParam<T>(), doc.OutputPort.doc, std::nullopt, py::dynamic_attr())
       .def("size", &OutputPort<T>::size, doc.PortBase.size.doc)
       .def("get_data_type", &OutputPort<T>::get_data_type,
           doc.PortBase.get_data_type.doc)
@@ -873,8 +873,8 @@ void DefineRemainingScalarDependentDefinitions(py::module m) {
       .def("get_vector_data", &SystemOutput<T>::get_vector_data,
           py_rvp::reference_internal, doc.SystemOutput.get_vector_data.doc);
 
-  DefineTemplateClassWithDefault<InputPort<T>>(
-      m, "InputPort", GetPyParam<T>(), doc.InputPort.doc)
+  DefineTemplateClassWithDefault<InputPort<T>>(m, "InputPort", GetPyParam<T>(),
+      doc.InputPort.doc, std::nullopt, py::dynamic_attr())
       .def("get_name", &InputPort<T>::get_name, doc.PortBase.get_name.doc)
       .def("GetFullDescription", &InputPort<T>::GetFullDescription,
           doc.PortBase.GetFullDescription.doc)

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -6,6 +6,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
+#include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -468,35 +469,39 @@ Note: The above is for the C++ documentation. For Python, use
             py::arg("root_context"), py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), doc.System.GetMyMutableContextFromRoot.doc)
-        // Utility methods.
+        // Port access methods. All returned port references use a ref_cycle
+        // (rather than the implicit keep-alive of reference_internal) to avoid
+        // immortality hazards like #22515.
         .def("get_input_port",
             overload_cast_explicit<const InputPort<T>&, int, bool>(
                 &System<T>::get_input_port),
-            py_rvp::reference_internal, py::arg("port_index"),
-            py::arg("warn_deprecated") = true,
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
+            py::arg("port_index"), py::arg("warn_deprecated") = true,
             doc.System.get_input_port.doc_2args)
         .def("get_input_port",
             overload_cast_explicit<const InputPort<T>&>(
                 &System<T>::get_input_port),
-            py_rvp::reference_internal, doc.System.get_input_port.doc_0args)
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
+            doc.System.get_input_port.doc_0args)
         .def("GetInputPort", &System<T>::GetInputPort,
-            py_rvp::reference_internal, py::arg("port_name"),
-            doc.System.GetInputPort.doc)
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
+            py::arg("port_name"), doc.System.GetInputPort.doc)
         .def("HasInputPort", &System<T>::HasInputPort, py::arg("port_name"),
             doc.System.HasInputPort.doc)
         .def("get_output_port",
             overload_cast_explicit<const OutputPort<T>&, int, bool>(
                 &System<T>::get_output_port),
-            py_rvp::reference_internal, py::arg("port_index"),
-            py::arg("warn_deprecated") = true,
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
+            py::arg("port_index"), py::arg("warn_deprecated") = true,
             doc.System.get_output_port.doc_2args)
         .def("get_output_port",
             overload_cast_explicit<const OutputPort<T>&>(
                 &System<T>::get_output_port),
-            py_rvp::reference_internal, doc.System.get_output_port.doc_0args)
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
+            doc.System.get_output_port.doc_0args)
         .def("GetOutputPort", &System<T>::GetOutputPort,
-            py_rvp::reference_internal, py::arg("port_name"),
-            doc.System.GetOutputPort.doc)
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
+            py::arg("port_name"), doc.System.GetOutputPort.doc)
         .def("HasOutputPort", &System<T>::HasOutputPort, py::arg("port_name"),
             doc.System.HasOutputPort.doc)
         // Witness functions.
@@ -517,8 +522,11 @@ Note: The above is for the C++ documentation. For Python, use
             overload_cast_explicit<InputPort<T>&,
                 std::variant<std::string, UseDefaultName>, PortDataType, int,
                 std::optional<RandomDistribution>>(&PySystem::DeclareInputPort),
-            py_rvp::reference_internal, py::arg("name"), py::arg("type"),
-            py::arg("size"), py::arg("random_type") = std::nullopt,
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
+            py::arg("type"), py::arg("size"),
+            py::arg("random_type") = std::nullopt,
             doc.System.DeclareInputPort.doc)
         // Not part of System; SystemBase method promoted in bindings.
         .def(
@@ -610,8 +618,10 @@ Note: The above is for the C++ documentation. For Python, use
                 const AbstractValue& model_value) -> const InputPort<T>& {
               return self->DeclareAbstractInputPort(name, model_value);
             },
-            py_rvp::reference_internal, py::arg("name"), py::arg("model_value"),
-            doc.LeafSystem.DeclareAbstractInputPort.doc)
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
+            py::arg("model_value"), doc.LeafSystem.DeclareAbstractInputPort.doc)
         .def("DeclareAbstractParameter",
             &PyLeafSystem::DeclareAbstractParameter, py::arg("model_value"),
             doc.LeafSystem.DeclareAbstractParameter.doc)
@@ -628,8 +638,10 @@ Note: The above is for the C++ documentation. For Python, use
                   MakeCppCompatibleCalcCallback(std::move(calc)),
                   prerequisites_of_calc);
             },
-            py_rvp::reference_internal, py::arg("name"), py::arg("alloc"),
-            py::arg("calc"),
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
+            py::arg("alloc"), py::arg("calc"),
             py::arg("prerequisites_of_calc") =
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
             doc.LeafSystem.DeclareAbstractOutputPort
@@ -643,7 +655,9 @@ Note: The above is for the C++ documentation. For Python, use
               return self->DeclareVectorInputPort(
                   name, model_vector, random_type);
             },
-            py_rvp::reference_internal, py::arg("name"),
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
             py::arg("model_vector"), py::arg("random_type") = std::nullopt,
             doc.LeafSystem.DeclareVectorInputPort.doc_3args_model_vector)
         .def(
@@ -653,8 +667,10 @@ Note: The above is for the C++ documentation. For Python, use
                 -> InputPort<T>& {
               return self->DeclareVectorInputPort(name, size, random_type);
             },
-            py_rvp::reference_internal, py::arg("name"), py::arg("size"),
-            py::arg("random_type") = std::nullopt,
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
+            py::arg("size"), py::arg("random_type") = std::nullopt,
             doc.LeafSystem.DeclareVectorInputPort.doc_3args_size)
         .def("DeclareVectorOutputPort",
             WrapCallbacks(
@@ -664,8 +680,10 @@ Note: The above is for the C++ documentation. For Python, use
                     -> const OutputPort<T>& {
                   return self->DeclareVectorOutputPort(name, arg1, arg2, arg3);
                 }),
-            py_rvp::reference_internal, py::arg("name"), py::arg("model_value"),
-            py::arg("calc"),
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
+            py::arg("model_value"), py::arg("calc"),
             py::arg("prerequisites_of_calc") =
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
             doc.LeafSystem.DeclareVectorOutputPort.doc_4args_model_vector)
@@ -678,8 +696,10 @@ Note: The above is for the C++ documentation. For Python, use
                   return self->DeclareVectorOutputPort(
                       name, size, calc, prerequisites_of_calc);
                 }),
-            py_rvp::reference_internal, py::arg("name"), py::arg("size"),
-            py::arg("calc"),
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
+            py::arg("size"), py::arg("calc"),
             py::arg("prerequisites_of_calc") =
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
             doc.LeafSystem.DeclareVectorOutputPort.doc_4args_size)
@@ -687,17 +707,26 @@ Note: The above is for the C++ documentation. For Python, use
             py::overload_cast<std::variant<std::string, UseDefaultName>,
                 ContinuousStateIndex>(
                 &LeafSystemPublic::DeclareStateOutputPort),
-            py::arg("name"), py::arg("state_index"), py_rvp::reference_internal,
+            py::arg("name"), py::arg("state_index"),
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
             doc.LeafSystem.DeclareStateOutputPort.doc_continuous)
         .def("DeclareStateOutputPort",
             py::overload_cast<std::variant<std::string, UseDefaultName>,
                 DiscreteStateIndex>(&LeafSystemPublic::DeclareStateOutputPort),
-            py::arg("name"), py::arg("state_index"), py_rvp::reference_internal,
+            py::arg("name"), py::arg("state_index"),
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
             doc.LeafSystem.DeclareStateOutputPort.doc_discrete)
         .def("DeclareStateOutputPort",
             py::overload_cast<std::variant<std::string, UseDefaultName>,
                 AbstractStateIndex>(&LeafSystemPublic::DeclareStateOutputPort),
-            py::arg("name"), py::arg("state_index"), py_rvp::reference_internal,
+            py::arg("name"), py::arg("state_index"),
+            // Use a ref_cycle (rather than the implicit keep-alive of
+            // reference_internal) to avoid immortality hazards like #22515.
+            internal::ref_cycle<0, 1>(), py_rvp::reference,
             doc.LeafSystem.DeclareStateOutputPort.doc_abstract)
         // TODO(russt): Implement the std::function variant of
         // LeafSystem::Declare*Event sugar methods if they are ever needed,

--- a/bindings/pydrake/systems/test_utilities/BUILD.bazel
+++ b/bindings/pydrake/systems/test_utilities/BUILD.bazel
@@ -1,0 +1,35 @@
+load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
+load(
+    "//tools/skylark:drake_py.bzl",
+    "drake_py_library",
+)
+load(
+    "//tools/skylark:pybind.bzl",
+    "get_pybind_package_info",
+)
+
+package(default_visibility = ["//bindings/pydrake:__subpackages__"])
+
+# This determines how `PYTHONPATH` is configured.
+PACKAGE_INFO = get_pybind_package_info("//bindings")
+
+drake_py_library(
+    name = "module_py",
+    testonly = 1,
+    srcs = ["__init__.py"],
+    imports = PACKAGE_INFO.py_imports,
+    deps = [
+        "//bindings/pydrake/systems:module_py",
+    ],
+)
+
+drake_py_library(
+    name = "framework_test_util_py",
+    testonly = True,
+    srcs = ["framework_test_util.py"],
+    deps = [
+        ":module_py",
+    ],
+)
+
+add_lint_tests_pydrake()

--- a/bindings/pydrake/systems/test_utilities/__init__.py
+++ b/bindings/pydrake/systems/test_utilities/__init__.py
@@ -1,0 +1,3 @@
+"""
+Utilities for unit testing.
+"""

--- a/bindings/pydrake/systems/test_utilities/framework_test_util.py
+++ b/bindings/pydrake/systems/test_utilities/framework_test_util.py
@@ -1,0 +1,69 @@
+import copy
+import dataclasses
+import gc
+import unittest
+import weakref
+
+from pydrake.systems.framework import DiagramBuilder, System
+
+
+@dataclasses.dataclass
+class PortMonitor:
+    """Mock-up of some bespoke user code that would monitor ports during a
+    simulation."""
+    system: System | None = None
+    ports: list | None = None
+
+
+def _create_port_monitor_diagram(system, ports):
+    """Prepares a diagram to provoke a lifetime hazard like #22515."""
+    port_monitor = PortMonitor(system, ports)
+    builder = DiagramBuilder()
+    builder.AddSystem(system)
+    diagram = builder.Build()
+    diagram.port_monitor = port_monitor
+    return diagram
+
+
+def check_ports_lifetime_hazard(
+        test: unittest.TestCase,
+        dut: list[System],
+        ports: list):
+    """Checks that the list of 'ports', when stored as metadata associated with
+    a Diagram, does not interfere with garbage collection.
+
+    The `test` is used to report pass/fail.
+
+    The `dut` must be *list* containing a single System. (We need to pass it as
+    a list so that we can clear the caller's local variable reference to it.)
+
+    The `ports` is a list of one or more input or output ports from the `dut`.
+    """
+    # Take ownership of `dut` (now named `system`).
+    assert isinstance(dut, list)
+    (system,) = dut
+    assert isinstance(system, System)
+    dut[:] = []
+
+    # Take ownership of `ports` (now named `my_ports`).
+    assert isinstance(ports, list)
+    assert len(ports) > 0
+    my_ports = copy.copy(ports)
+    ports[:] = []
+
+    # Spy on the lifetime of `system`.
+    system_spy = weakref.finalize(system, lambda: None)
+
+    # Add `system` to a diagram, pushing ownership of the list of `system` and
+    # `my_ports` down into the diagram.
+    diagram = _create_port_monitor_diagram(system, my_ports)
+    del system, my_ports
+
+    # Sanity check that the system is still alive.
+    gc.collect()
+    test.assertTrue(system_spy.alive)
+
+    # Releasing the diagram should be enough to release the system and ports.
+    del diagram
+    gc.collect()
+    test.assertFalse(system_spy.alive)

--- a/bindings/pydrake/test/memory_leak_test.py
+++ b/bindings/pydrake/test/memory_leak_test.py
@@ -338,6 +338,4 @@ class TestMemoryLeaks(unittest.TestCase):
         self.do_test(dut=_dut_full_example, count=1)
 
     def test_mypyleafsystem(self):
-        # TODO(#22515): Fix this family of leaks.
-        self.do_test(dut=_dut_mypyleafsystem, count=1, leaks_allowed=1,
-                     leaks_required=1)
+        self.do_test(dut=_dut_mypyleafsystem, count=1)


### PR DESCRIPTION
Stop using keep_alive with returned port references; use ref_cycle instead. The most common place where this problem can arise is when writing leaf systems in Python. However, since systems have dynamic_attr() now, it can be induced anywhere. So, to avoid immortality problems across the board, re-annotate all APIs that return port references.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22775)
<!-- Reviewable:end -->
