### PR TITLE
Extend Mesh/Convex to include non-uniform scale

### DIFF
--- a/bindings/pydrake/geometry/_geometry_extra.py
+++ b/bindings/pydrake/geometry/_geometry_extra.py
@@ -105,8 +105,9 @@ def _add_extraneous_repr_functions():
             data_param = f"filename={repr(str(mesh.source().path()))}"
         else:
             data_param = f"mesh_data={repr(mesh.source().in_memory())}"
+        # Convert array to list to ease converting repr to mesh type.
         return (
-            f"{type_name}({data_param}, scale={repr(mesh.scale())})"
+            f"{type_name}({data_param}, scale3={repr(list(mesh.scale3()))})"
         )
     Mesh.__repr__ = lambda x: mesh_or_convex_repr(x, "Mesh")
     Convex.__repr__ = lambda x: mesh_or_convex_repr(x, "Convex")

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -495,29 +495,51 @@ void DefineShapes(py::module m) {
               return Capsule(dims.first, dims.second);
             }));
 
+    // Note: meshes used to get pickled with a single scale value (representing
+    // uniform scale). While we now allow for non-uniform scaling, we still
+    // need to depickle the old representation. So, we need to handle both
+    // scale representations.
+    using ScaleVariant = std::variant<double, Vector3<double>>;
+
     py::class_<Convex, Shape> convex_cls(m, "Convex", doc.Convex.doc);
     convex_cls
         .def(py::init<std::filesystem::path, double>(), py::arg("filename"),
             py::arg("scale") = 1.0, doc.Convex.ctor.doc_2args_filename_scale)
+        .def(py::init<std::filesystem::path, const Vector3<double>&>(),
+            py::arg("filename"), py::arg("scale3"),
+            doc.Convex.ctor.doc_2args_filename_scale3)
         .def(py::init<InMemoryMesh, double>(), py::arg("mesh_data"),
             py::arg("scale") = 1.0, doc.Convex.ctor.doc_2args_mesh_data_scale)
+        .def(py::init<InMemoryMesh, const Vector3<double>&>(),
+            py::arg("mesh_data"), py::arg("scale3"),
+            doc.Convex.ctor.doc_2args_mesh_data_scale3)
         .def(py::init<MeshSource, double>(), py::arg("source"),
             py::arg("scale") = 1.0, doc.Convex.ctor.doc_2args_source_scale)
+        .def(py::init<MeshSource, const Vector3<double>&>(), py::arg("source"),
+            py::arg("scale3"), doc.Convex.ctor.doc_2args_source_scale3)
         .def(py::init<const Eigen::Matrix3X<double>&, const std::string&,
                  double>(),
             py::arg("points"), py::arg("label"), py::arg("scale") = 1.0,
             doc.Convex.ctor.doc_3args_points_label_scale)
+        .def(py::init<const Eigen::Matrix3X<double>&, const std::string&,
+                 const Vector3<double>&>(),
+            py::arg("points"), py::arg("label"), py::arg("scale3"),
+            doc.Convex.ctor.doc_3args_points_label_scale3)
         .def("source", &Convex::source, doc.Convex.source.doc)
         .def("extension", &Convex::extension, doc.Convex.extension.doc)
         .def("scale", &Convex::scale, doc.Convex.scale.doc)
+        .def("scale3", &Convex::scale3, doc.Convex.scale3.doc)
         .def("GetConvexHull", &Convex::GetConvexHull,
             doc.Convex.GetConvexHull.doc)
         .def(py::pickle(
             [](const Convex& self) {
-              return std::make_pair(self.source(), self.scale());
+              return std::make_pair(self.source(), ScaleVariant(self.scale3()));
             },
-            [](std::pair<MeshSource, double> info) {
-              return Convex(std::move(info.first), info.second);
+            [](std::pair<MeshSource, ScaleVariant> info) {
+              return std::visit<Convex>(overloaded{[&info](auto&& scale) {
+                return Convex(std::move(info.first), scale);
+              }},
+                  info.second);
             }));
     // Note: Convex.__repr__ is redefined in _geometry_extra.py;
     // Shape::to_string() does not properly condition strings for python.
@@ -570,22 +592,34 @@ void DefineShapes(py::module m) {
     mesh_cls
         .def(py::init<std::filesystem::path, double>(), py::arg("filename"),
             py::arg("scale") = 1.0, doc.Mesh.ctor.doc_2args_filename_scale)
+        .def(py::init<std::filesystem::path, const Vector3<double>&>(),
+            py::arg("filename"), py::arg("scale3"),
+            doc.Mesh.ctor.doc_2args_filename_scale3)
         .def(py::init<InMemoryMesh, double>(), py::arg("mesh_data"),
             py::arg("scale") = 1.0, doc.Mesh.ctor.doc_2args_mesh_data_scale)
+        .def(py::init<InMemoryMesh, const Vector3<double>&>(),
+            py::arg("mesh_data"), py::arg("scale3"),
+            doc.Mesh.ctor.doc_2args_mesh_data_scale3)
         .def(py::init<MeshSource, double>(), py::arg("source"),
             py::arg("scale") = 1.0, doc.Mesh.ctor.doc_2args_source_scale)
+        .def(py::init<MeshSource, const Vector3<double>&>(), py::arg("source"),
+            py::arg("scale3"), doc.Mesh.ctor.doc_2args_source_scale3)
         .def("source", &Mesh::source, doc.Mesh.source.doc)
         .def("extension", &Mesh::extension, doc.Mesh.extension.doc)
         .def("scale", &Mesh::scale, doc.Mesh.scale.doc)
+        .def("scale3", &Mesh::scale3, doc.Mesh.scale3.doc)
         .def("GetConvexHull", &Mesh::GetConvexHull, doc.Mesh.GetConvexHull.doc)
         .def(py::pickle(
             [](const Mesh& self) {
-              return std::make_pair(self.source(), self.scale());
+              return std::make_pair(self.source(), ScaleVariant(self.scale3()));
             },
-            [](std::pair<MeshSource, double> info) {
-              return Mesh(std::move(info.first), info.second);
+            [](std::pair<MeshSource, ScaleVariant> info) {
+              return std::visit<Mesh>(overloaded{[&info](auto&& scale) {
+                return Mesh(std::move(info.first), scale);
+              }},
+                  info.second);
             }));
-    // Note: Convex.__repr__ is redefined in _geometry_extra.py;
+    // Note: Mesh.__repr__ is redefined in _geometry_extra.py;
     // Shape::to_string() does not properly condition strings for python.
 
 #pragma GCC diagnostic push

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -1420,6 +1420,7 @@ drake_cc_googletest(
     deps = [
         ":make_convex_hull_mesh",
         "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/geometry/proximity/make_convex_hull_mesh.cc
+++ b/geometry/proximity/make_convex_hull_mesh.cc
@@ -27,13 +27,11 @@ class Hullifier final : public ShapeReifier {
   using ShapeReifier::ImplementGeometry;
 
   void ImplementGeometry(const Mesh& mesh, void*) final {
-    hull_ =
-        MakeConvexHull(mesh.source(), Eigen::Vector3d::Constant(mesh.scale()));
+    hull_ = MakeConvexHull(mesh.source(), mesh.scale3());
   }
 
   void ImplementGeometry(const Convex& convex, void*) final {
-    hull_ = MakeConvexHull(convex.source(),
-                           Eigen::Vector3d::Constant(convex.scale()));
+    hull_ = MakeConvexHull(convex.source(), convex.scale3());
   }
 
   PolygonSurfaceMesh<double> hull_;

--- a/geometry/proximity/test/make_convex_hull_mesh_test.cc
+++ b/geometry/proximity/test/make_convex_hull_mesh_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
@@ -33,8 +34,16 @@ GTEST_TEST(MakeConvexHullMeshTest, ShapeSupport) {
   /* Supported shapes. */
   const std::string mesh_file =
       FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj");
-  EXPECT_NO_THROW(MakeConvexHull(Convex(mesh_file)));
-  EXPECT_NO_THROW(MakeConvexHull(Mesh(mesh_file)));
+
+  const Eigen::Vector3d scale(2, 3, 4);
+  auto validate_hull = [&scale](auto&& shape) {
+    SCOPED_TRACE(shape.type_name());
+    PolygonSurfaceMesh<double> hull = MakeConvexHull(shape);
+    const auto& [_, size] = hull.CalcBoundingBox();
+    EXPECT_TRUE(CompareMatrices(size, 2 * scale));
+  };
+  validate_hull(Convex(mesh_file, scale));
+  validate_hull(Mesh(mesh_file, scale));
 }
 
 }  // namespace

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -42,15 +42,14 @@ namespace {
 // shape_specification_thread_test.cc.
 void ComputeConvexHullAsNecessary(
     std::shared_ptr<PolygonSurfaceMesh<double>>* hull_ptr,
-    const MeshSource& mesh_source, double scale) {
+    const MeshSource& mesh_source, const Vector3<double>& scale) {
   std::shared_ptr<PolygonSurfaceMesh<double>> check =
       std::atomic_load(hull_ptr);
   if (check == nullptr) {
     // Note: This approach means that multiple threads *may* redundantly compute
     // the convex hull; but only the first one will set the hull.
-    auto new_hull =
-        std::make_shared<PolygonSurfaceMesh<double>>(internal::MakeConvexHull(
-            mesh_source, Vector3<double>::Constant(scale)));
+    auto new_hull = std::make_shared<PolygonSurfaceMesh<double>>(
+        internal::MakeConvexHull(mesh_source, scale));
     std::atomic_compare_exchange_strong(hull_ptr, &check, new_hull);
   }
 }
@@ -59,7 +58,7 @@ void ComputeConvexHullAsNecessary(
 // converting the MeshSource into the appropriate parameter name and value
 // representation and then packages it into the full Mesh string representation.
 std::string MeshToString(std::string_view class_name, const MeshSource& source,
-                         double scale) {
+                         const Vector3<double>& scale) {
   const std::string mesh_parameter = [&source]() {
     if (source.is_path()) {
       return fmt::format("filename='{}'", source.path().string());
@@ -67,13 +66,15 @@ std::string MeshToString(std::string_view class_name, const MeshSource& source,
       return fmt::format("mesh_data={}", source.in_memory());
     }
   }();
-  return fmt::format("{}({}, scale={})", class_name, mesh_parameter, scale);
+  return fmt::format("{}({}, scale=[{}])", class_name, mesh_parameter,
+                     fmt_eigen(scale.transpose()));
 }
 
-void ThrowForBadScale(double scale, std::string_view source) {
-  if (std::abs(scale) < 1e-8) {
+void ThrowForBadScale(const Vector3<double>& scale, std::string_view source) {
+  if ((scale.array().abs() < 1e-8).any()) {
     throw std::logic_error(
-        fmt::format("{} |scale| cannot be < 1e-8, given {}.", source, scale));
+        fmt::format("{} |scale| cannot be < 1e-8 on any axis, given [{}].",
+                    source, fmt_eigen(scale.transpose())));
   }
 }
 
@@ -134,23 +135,37 @@ std::string Capsule::do_to_string() const {
 }
 
 Convex::Convex(const std::filesystem::path& filename, double scale)
-    : Convex(MeshSource(std::filesystem::absolute(filename)), scale) {}
+    : Convex(filename, Vector3<double>::Constant(scale)) {}
+
+Convex::Convex(const std::filesystem::path& filename,
+               const Vector3<double>& scale3)
+    : Convex(MeshSource(std::filesystem::absolute(filename)), scale3) {}
 
 Convex::Convex(InMemoryMesh mesh_data, double scale)
-    : Convex(MeshSource(std::move(mesh_data)), scale) {}
+    : Convex(std::move(mesh_data), Vector3<double>::Constant(scale)) {}
+
+Convex::Convex(InMemoryMesh mesh_data, const Vector3<double>& scale3)
+    : Convex(MeshSource(std::move(mesh_data)), scale3) {}
 
 Convex::Convex(MeshSource source, double scale)
-    : source_(std::move(source)), scale_(scale) {
+    : Convex(std::move(source), Vector3<double>::Constant(scale)) {}
+
+Convex::Convex(MeshSource source, const Vector3<double>& scale3)
+    : source_(std::move(source)), scale_(scale3) {
   // Note: We don't validate extensions because there's a possibility that a
   // mesh of unsupported type is used, but only processed by client code.
-  ThrowForBadScale(scale, "Convex");
+  ThrowForBadScale(scale_, "Convex");
 }
 
 Convex::Convex(const Eigen::Matrix3X<double>& points, const std::string& label,
                double scale)
+    : Convex(points, label, Vector3<double>::Constant(scale)) {}
+
+Convex::Convex(const Eigen::Matrix3X<double>& points, const std::string& label,
+               const Vector3<double>& scale3)
     : Convex(InMemoryMesh{.mesh_file = MemoryFile(PointsToObjString(points),
                                                   ".obj", label)},
-             scale) {}
+             scale3) {}
 
 std::string Convex::filename() const {
   if (source_.is_path()) {
@@ -163,13 +178,23 @@ std::string Convex::filename() const {
                   source_.in_memory().mesh_file.filename_hint()));
 }
 
+double Convex::scale() const {
+  if ((scale_.array() != scale_[0]).any()) {
+    throw std::runtime_error(
+        fmt::format("Convex::scale() can only be called for uniform scaling. "
+                    "This mesh has scale [{}]. Use Convex::scale3() instead.",
+                    fmt_eigen(scale_.transpose())));
+  }
+  return scale_[0];
+}
+
 const PolygonSurfaceMesh<double>& Convex::GetConvexHull() const {
   ComputeConvexHullAsNecessary(&hull_, source_, scale_);
   return *hull_;
 }
 
 std::string Convex::do_to_string() const {
-  return MeshToString(type_name(), source(), scale());
+  return MeshToString(type_name(), source(), scale_);
 }
 
 Cylinder::Cylinder(double radius, double length)
@@ -243,16 +268,25 @@ std::string HalfSpace::do_to_string() const {
 }
 
 Mesh::Mesh(const std::filesystem::path& filename, double scale)
-    : Mesh(MeshSource(std::filesystem::absolute(filename)), scale) {}
+    : Mesh(filename, Vector3<double>::Constant(scale)) {}
+
+Mesh::Mesh(const std::filesystem::path& filename, const Vector3<double>& scale3)
+    : Mesh(MeshSource(std::filesystem::absolute(filename)), scale3) {}
 
 Mesh::Mesh(InMemoryMesh mesh_data, double scale)
-    : Mesh(MeshSource(std::move(mesh_data)), scale) {}
+    : Mesh(std::move(mesh_data), Vector3<double>::Constant(scale)) {}
+
+Mesh::Mesh(InMemoryMesh mesh_data, const Vector3<double>& scale3)
+    : Mesh(MeshSource(std::move(mesh_data)), scale3) {}
 
 Mesh::Mesh(MeshSource source, double scale)
-    : source_(std::move(source)), scale_(scale) {
+    : Mesh(std::move(source), Vector3<double>::Constant(scale)) {}
+
+Mesh::Mesh(MeshSource source, const Vector3<double>& scale3)
+    : source_(std::move(source)), scale_(scale3) {
   // Note: We don't validate extensions because there's a possibility that a
   // mesh of unsupported type is used, but only processed by client code.
-  ThrowForBadScale(scale, "Mesh");
+  ThrowForBadScale(scale_, "Mesh");
 }
 
 std::string Mesh::filename() const {
@@ -266,13 +300,23 @@ std::string Mesh::filename() const {
                   source_.in_memory().mesh_file.filename_hint()));
 }
 
+double Mesh::scale() const {
+  if ((scale_.array() != scale_[0]).any()) {
+    throw std::runtime_error(
+        fmt::format("Mesh::scale() can only be called for uniform scaling. "
+                    "This mesh has scale [{}]. Use Mesh::scale3() instead.",
+                    fmt_eigen(scale_.transpose())));
+  }
+  return scale_[0];
+}
+
 const PolygonSurfaceMesh<double>& Mesh::GetConvexHull() const {
   ComputeConvexHullAsNecessary(&hull_, source_, scale_);
   return *hull_;
 }
 
 std::string Mesh::do_to_string() const {
-  return MeshToString(type_name(), source(), scale());
+  return MeshToString(type_name(), source(), scale_);
 }
 
 MeshcatCone::MeshcatCone(double height, double a, double b)
@@ -362,7 +406,7 @@ double CalcMeshVolume(const Mesh& mesh) {
         mesh_source.description()));
   }
   TriangleSurfaceMesh<double> surface_mesh =
-      ReadObjToTriangleSurfaceMesh(mesh_source, mesh.scale());
+      ReadObjToTriangleSurfaceMesh(mesh_source, mesh.scale3());
   return internal::CalcEnclosedVolume(surface_mesh);
 }
 

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -249,9 +249,6 @@ class Convex final : public Shape {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Convex);
 
-  // TODO(SeanCurtis-TRI): WHen scale is Vector3, make it clear that mirroring
-  // meshes can reverse winding, leading to a permutation of per-face ordering.
-
   /** Constructs a convex shape specification from the file located at the
    given file path. Optionally uniformly scaled by the given scale factor.
 
@@ -269,6 +266,9 @@ class Convex final : public Shape {
                                 considering revisiting the model itself. */
   explicit Convex(const std::filesystem::path& filename, double scale = 1.0);
 
+  /** File variant that allows for specification of non-uniform scale. */
+  Convex(const std::filesystem::path& filename, const Vector3<double>& scale3);
+
   /** Constructs a convex shape specification from the contents of a
    Drake-supported mesh file type.
 
@@ -283,11 +283,19 @@ class Convex final : public Shape {
    @param scale       An optional scale to coordinates. */
   explicit Convex(InMemoryMesh mesh_data, double scale = 1.0);
 
+  /** Mesh-contents variant that allows for specification of non-uniform scale.
+   */
+  Convex(InMemoryMesh mesh_data, const Vector3<double>& scale3);
+
   /** Constructs a convex shape specification from the given `source`.
 
    @param source   The source for the mesh data.
    @param scale    An optional scale to coordinates. */
   explicit Convex(MeshSource source, double scale = 1.0);
+
+  /** Mesh-source variant that allows for specification of non-uniform scale.
+   */
+  Convex(MeshSource source, const Vector3<double>& scale3);
 
   /** Constructs an in-memory convex shape specification from the given points.
 
@@ -303,8 +311,12 @@ class Convex final : public Shape {
 
    @throws std::exception       if label contains newlines.
    @throws std::exception       if |scale| < 1e-8. */
-  explicit Convex(const Eigen::Matrix3X<double>& points,
-                  const std::string& label, double scale = 1.0);
+  Convex(const Eigen::Matrix3X<double>& points, const std::string& label,
+         double scale = 1.0);
+
+  /** Point variant that allows for specification of non-uniform scale. */
+  Convex(const Eigen::Matrix3X<double>& points, const std::string& label,
+         const Vector3<double>& scale3);
 
   ~Convex() final;
 
@@ -335,7 +347,13 @@ class Convex final : public Shape {
    of the MemoryFile passed to the constructor. */
   const std::string& extension() const { return source_.extension(); }
 
-  double scale() const { return scale_; }
+  /** Returns a single scale representing the _uniform_ scale factor.
+   @throws if the scale is not uniform in all directions. */
+  double scale() const;
+
+  /** Returns general scale factors for this mesh. */
+  const Vector3<double>& scale3() const { return scale_; }
+
 
   /** Reports the convex hull of the named mesh.
 
@@ -356,7 +374,7 @@ class Convex final : public Shape {
   VariantShapeConstPtr get_variant_this() const final;
 
   MeshSource source_;
-  double scale_{};
+  Vector3<double> scale_;
   // Allows the deferred computation of the hull on an otherwise const Convex.
   mutable std::shared_ptr<PolygonSurfaceMesh<double>> hull_{nullptr};
 };
@@ -503,7 +521,21 @@ class HalfSpace final : public Shape {
 
  The mesh is defined in a canonical frame C, implicit in the file parsed. Upon
  loading it in SceneGraph it can be scaled around the origin of C by a given
- `scale` amount. */
+ `scale` amount.
+
+ Note: a negative scale can be applied. This can be useful in mirroring the
+ geometry (e.g., using a right hand mesh for a left hand). Mirroring the
+ geometry will typically change the "winding" of the mesh elements. By
+ convention, Drake looks at the _ordering_ of the vertices that form mesh
+ elements (triangles and tetrahedra) and derives the notion of "inside" and
+ "outside" relative to that element. In order to preserve the input mesh's
+ definition of "inside" and "outside", when the mesh gets mirrored Drake may
+ perturb the ordering of the vertex indices. For example, a triangle originally
+ referencing vertices `[0 1 2]`, when mirrored may change to `[2 1 0]`, so don't
+ be surprised if you introspect the details of the loaded mesh if you see such
+ a change. An analogous change can affect the vertex ordering of tetrahedra in
+ a volume mesh (i.e., a perturbation of the original vertex index list
+ `[0 1 2 3]` to `[2 1 0 3]`). */
 class Mesh final : public Shape {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Mesh);
@@ -527,6 +559,9 @@ class Mesh final : public Shape {
                                 considering revisiting the model itself. */
   explicit Mesh(const std::filesystem::path& filename, double scale = 1.0);
 
+  /** Mesh-file variant that allows for specification of non-uniform scale. */
+  Mesh(const std::filesystem::path& filename, const Vector3<double>& scale3);
+
   /** Constructs a mesh shape specification from the contents of a
    Drake-supported mesh file type.
 
@@ -540,11 +575,19 @@ class Mesh final : public Shape {
    @param scale       An optional scale to coordinates. */
   explicit Mesh(InMemoryMesh mesh_data, double scale = 1.0);
 
+  /** Mesh-contents variant that allows for specification of non-uniform scale.
+   */
+  Mesh(InMemoryMesh mesh_data, const Vector3<double>& scale3);
+
   /** Constructs a mesh shape specification from the given `source`.
 
    @param source   The source for the mesh data.
    @param scale    An optional scale to coordinates. */
   explicit Mesh(MeshSource source, double scale = 1.0);
+
+  /** Mesh-source variant that allows for specification of non-uniform scale.
+   */
+  Mesh(MeshSource source, const Vector3<double>& scale3);
 
   ~Mesh() final;
 
@@ -571,7 +614,12 @@ class Mesh final : public Shape {
    of the MemoryFile passed to the constructor. */
   const std::string& extension() const { return source_.extension(); }
 
-  double scale() const { return scale_; }
+  /** Returns a single scale representing the _uniform_ scale factor.
+   @throws if the scale is not uniform in all directions. */
+  double scale() const;
+
+  /** Returns general scale factors for this mesh.*/
+  const Vector3<double>& scale3() const { return scale_; }
 
   /** Reports the convex hull of the named mesh.
 
@@ -593,7 +641,7 @@ class Mesh final : public Shape {
 
   // NOTE: Cannot be const to support default copy/move semantics.
   MeshSource source_;
-  double scale_{};
+  Vector3<double> scale_;
   // Allows the deferred computation of the hull on an otherwise const Mesh.
   mutable std::shared_ptr<PolygonSurfaceMesh<double>> hull_{nullptr};
 };


### PR DESCRIPTION
Note: while this adds the APIs, the non-uniform scale is not used in most places. Configuring a non-uniform scale and then exercising those domains will throw an exception.

Currently, the computation of convex hulls from non-uniform scale is the only supported operation.

NOTE TO RELEASE ENGINEER:

This is one of multiple PRs that enable non-uniform scaling (see also #22772).  For the release, they should all be lumped together. The total feature description is:

Enable non-uniform scaling for Mesh and Convex geometries.

Relates https://github.com/RobotLocomotion/drake/issues/22046.