### PR TITLE
Fix doxygen error in obj_to_surface_mesh.h

### DIFF
--- a/geometry/proximity/obj_to_surface_mesh.h
+++ b/geometry/proximity/obj_to_surface_mesh.h
@@ -36,7 +36,7 @@ std::optional<TriangleSurfaceMesh<double>> DoReadObjToSurfaceMesh(
  the file format.
  @param filename
      A valid file name with absolute path or relative path.
- @param scale
+ @param scale3
      A scale to coordinates.
  @param on_warning
      An optional callback that will receive warning message(s) encountered


### PR DESCRIPTION
The parameter name in the doxygen didn't match the C++ parameter name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22786)
<!-- Reviewable:end -->
