### PR TITLE
Patch brittle `visualization_install_tests` for macOS

### DIFF
--- a/bindings/pydrake/visualization/test/visualization_install_tests.py
+++ b/bindings/pydrake/visualization/test/visualization_install_tests.py
@@ -7,8 +7,6 @@ import install_test_helper
 
 class TestVisualizationInstalled(unittest.TestCase):
 
-    # TODO(#21023) This test is a bit too tricky in CI.
-    @unittest.skipIf(sys.platform == "darwin", "Skipped for tricky macOS CI")
     def test_meldis_help(self):
         """Ensures we can call `./bin/meldis --help` from install."""
         # Get install directory.
@@ -16,11 +14,13 @@ class TestVisualizationInstalled(unittest.TestCase):
         # N.B. Do not update PYTHONPATH, as the script should handle that
         # itself.
         bin_path = join(install_dir, "bin", "meldis")
-        text = install_test_helper.check_output([bin_path, "--help"])
+        text = install_test_helper.check_output([
+            install_test_helper.get_python_executable(),
+            bin_path,
+            "--help"
+        ])
         self.assertIn("usage: meldis ", text)
 
-    # TODO(#21023) This test is a bit too tricky in CI.
-    @unittest.skipIf(sys.platform == "darwin", "Skipped for tricky macOS CI")
     def test_model_visualizer_help(self):
         """Ensures we can call `./bin/model_visualizer --help` from install."""
         # Get install directory.
@@ -28,17 +28,20 @@ class TestVisualizationInstalled(unittest.TestCase):
         # N.B. Do not update PYTHONPATH, as the script should handle that
         # itself.
         bin_path = join(install_dir, "bin", "model_visualizer")
-        text = install_test_helper.check_output([bin_path, "--help"])
+        text = install_test_helper.check_output([
+            install_test_helper.get_python_executable(),
+            bin_path,
+            "--help"
+        ])
         self.assertIn("usage: model_visualizer ", text)
 
-    # TODO(#21023) This test is a bit too tricky in CI.
-    @unittest.skipIf(sys.platform == "darwin", "Skipped for tricky macOS CI")
     def test_drake_models_meshes(self):
         """Ensures that the package://drake_models/... can be found by testing
         a model that uses a meshfile from that location.
         """
         install_dir = install_test_helper.get_install_dir()
         install_test_helper.check_call([
+            install_test_helper.get_python_executable(),
             join(install_dir, "bin", "model_visualizer"),
             "--loop_once",
             "package://drake_models/"


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake/issues/21023.

The shebangs present in `run_installed_meldis.py` and `run_installed_model_visualizer.py` were causing these tests to use two different interpreters on macOS. When the `visualiztion_install_tests` would dispatch subprocesses to execute the installed binaries of `meldis` and `model_visualizer` , the subprocess would select the interpreter to run the two aforementioned python files based on the shebang in the executable file. This would make it so the installation portion of the test would use the python interpreter in Drake’s `venv` (which is the desired behavior), but the actual handling of the executable would be kicked to the mac’s globally installed python interpreter. This misalignment is what caused the three install tests to fail, and this problem happens exclusively on macOS. 

The fix here is rather straightforward. By adding the `sys.executable` variable in the `args` arrays passed to the `subprocess` wrapper functions in `visualizaton_install_tests.py`, we can explicitly specify the path of the interpreter to use for the executable files *before* dispatching a subprocess. This allows the tests to run successfully on macOS as well as linux.

I attempted to use `execve` to dispatch the process instead of importing the module in `run_installed_meldis`. Due to the aforementioned shebang issue, this did not work on macOS, as `sys.executable` would resolve to my Mac’s global interpreter inside of this file, and there didn’t seem like there was a non-hacky way to introduce the proper context for the venv path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22787)
<!-- Reviewable:end -->
