### PR TITLE
Added gh issue template for post-release actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/POST_RELEASE_ACTIONS.yml
+++ b/.github/ISSUE_TEMPLATE/POST_RELEASE_ACTIONS.yml
@@ -1,0 +1,40 @@
+name: Post-Release Actions
+title: Post-release actions for release <version>
+description:
+  Create a tracking issue for Docker image tagging, S3 upload, and Apt
+  repository updates for a new Drake release.
+labels: ["type: release"]
+assignees: BetsyMcPhail
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Release Version
+      description:
+        "Enter the release version number WITHOUT the 'v' prefix (e.g.,
+        1.N.0)"
+      placeholder: "1.N.0"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Post-Release Documentation
+      value: |
+
+        This issue tracks the required post-release actions that need to be completed after the Drake release has been published to GitHub.
+
+        For detailed instructions, refer to the [Docker / Apt / S3 Release Process](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/dev/README.md).
+
+        To see the build artifacts for the latest Drake release, visit the [Drake GitHub Releases page](https://github.com/RobotLocomotion/drake/releases/latest).
+  - type: checkboxes
+    id: tasks
+    attributes:
+      label: Post-Release Tasks
+      description:
+        "These two steps must be completed in order. Check each box after
+        completion."
+      options:
+        - label: "Run script to push Docker images and mirror the artifacts to S3"
+          required: false
+        - label: "Run script for Apt repository updates"
+          required: false

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -184,9 +184,8 @@ the main body of the document:
    1. Check that the link to drake.mit.edu docs from the GitHub release draft
       page actually works.
    2. Click "Publish release"
-   3. Notify `@BetsyMcPhail` by creating a GitHub issue asking her to manually
-      tag docker images and upload the releases to S3. Be sure to provide her
-      with the release tag in the same ping.
+   3. Create a new GitHub issue on the [drake](https://github.com/RobotLocomotion/drake/issues/new/choose)
+      repository and select the "Post-Release Actions" template.
    4. Create a GitHub issue on the [drake-ros](https://github.com/RobotLocomotion/drake-ros/issues)
       repository, requesting an update of the `DRAKE_SUGGESTED_VERSION`
       constant.


### PR DESCRIPTION
Closes #22774

These changes introduce a formal structure for creating and tracking post-release action issues. The new github issue template links to documentation explaining what actions are required for a new release and provides a user-friendly interface for keeping track of these tasks. These changes are reflected in the release playbook documentation, allowing contributors from TRI, kitware, and the open source community to follow this procedure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22796)
<!-- Reviewable:end -->
