### PR TITLE
[meshcat] Add `GetButtonNames()`

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -373,6 +373,8 @@ void DefineMeshcat(py::module m) {
             py::arg("keycode") = "", cls_doc.AddButton.doc)
         .def("GetButtonClicks", &Class::GetButtonClicks, py::arg("name"),
             cls_doc.GetButtonClicks.doc)
+        .def("GetButtonNames", &Class::GetButtonNames,
+            cls_doc.GetButtonNames.doc)
         .def("DeleteButton", &Class::DeleteButton, py::arg("name"),
             py::arg("strict") = true, cls_doc.DeleteButton.doc)
         .def("AddSlider", &Class::AddSlider, py::arg("name"), py::arg("min"),

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -262,6 +262,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         meshcat.SetCameraPose(camera_in_world=[3, 4, 5],
                               target_in_world=[1, 1, 1])
         meshcat.AddButton(name="alice", keycode="KeyB")
+        self.assertEqual(meshcat.GetButtonNames(), ["alice"])
         self.assertEqual(meshcat.GetButtonClicks(name="alice"), 0)
         meshcat._InjectWebsocketMessage(message=umsgpack.packb({
             "type": "button",

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1587,7 +1587,12 @@ class Meshcat::Impl {
       DRAKE_DEMAND(app_ != nullptr);
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
-      app_->publish("all", message_stream.str(), uWS::OpCode::BINARY, false);
+      std::string message = message_stream.str();
+      app_->publish("all", message, uWS::OpCode::BINARY, false);
+      const auto scene_tree_element_id =
+        "button_" + uuid_generator_.GenerateRandom();
+      SceneTreeElement& e = scene_tree_root_[scene_tree_element_id];
+      e.object().emplace() = std::move(message);
     });
   }
 
@@ -1681,7 +1686,12 @@ class Meshcat::Impl {
       DRAKE_DEMAND(app_ != nullptr);
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
-      app_->publish("all", message_stream.str(), uWS::OpCode::BINARY, false);
+      std::string message = message_stream.str();
+      app_->publish("all", message, uWS::OpCode::BINARY, false);
+      const auto scene_tree_element_id =
+        "slider_" + uuid_generator_.GenerateRandom();
+      SceneTreeElement& e = scene_tree_root_[scene_tree_element_id];
+      e.object().emplace() = std::move(message);
     });
     return value;
   }

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1587,12 +1587,7 @@ class Meshcat::Impl {
       DRAKE_DEMAND(app_ != nullptr);
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
-      std::string message = message_stream.str();
-      app_->publish("all", message, uWS::OpCode::BINARY, false);
-      const auto scene_tree_element_id =
-        "button_" + uuid_generator_.GenerateRandom();
-      SceneTreeElement& e = scene_tree_root_[scene_tree_element_id];
-      e.object().emplace() = std::move(message);
+      app_->publish("all", message_stream.str(), uWS::OpCode::BINARY, false);
     });
   }
 
@@ -1699,12 +1694,7 @@ class Meshcat::Impl {
       DRAKE_DEMAND(app_ != nullptr);
       std::stringstream message_stream;
       msgpack::pack(message_stream, data);
-      std::string message = message_stream.str();
-      app_->publish("all", message, uWS::OpCode::BINARY, false);
-      const auto scene_tree_element_id =
-        "slider_" + uuid_generator_.GenerateRandom();
-      SceneTreeElement& e = scene_tree_root_[scene_tree_element_id];
-      e.object().emplace() = std::move(message);
+      app_->publish("all", message_stream.str(), uWS::OpCode::BINARY, false);
     });
     return value;
   }

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1606,6 +1606,18 @@ class Meshcat::Impl {
     return iter->second.num_clicks;
   }
 
+  std::vector<std::string> GetButtonNames() const {
+    DRAKE_DEMAND(IsThread(main_thread_id_));
+
+    std::lock_guard<std::mutex> lock(controls_mutex_);
+    std::vector<std::string> names;
+    names.reserve(buttons_.size());
+    for (const auto& [name, _] : buttons_) {
+      names.push_back(name);
+    }
+    return names;
+  }
+
   // This function is public via the PIMPL.
   bool DeleteButton(std::string name, bool strict) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
@@ -2789,6 +2801,10 @@ void Meshcat::AddButton(std::string name, std::string keycode) {
 
 int Meshcat::GetButtonClicks(std::string_view name) const {
   return impl().GetButtonClicks(name);
+}
+
+std::vector<std::string> Meshcat::GetButtonNames() const {
+  return impl().GetButtonNames();
 }
 
 bool Meshcat::DeleteButton(std::string name, bool strict) {

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -1606,6 +1606,7 @@ class Meshcat::Impl {
     return iter->second.num_clicks;
   }
 
+  // This function is public via the PIMPL.
   std::vector<std::string> GetButtonNames() const {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
@@ -1752,6 +1753,7 @@ class Meshcat::Impl {
     return iter->second.value;
   }
 
+  // This function is public via the PIMPL.
   std::vector<std::string> GetSliderNames() const {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -766,6 +766,9 @@ class Meshcat {
    @throws std::exception if `name` is not a registered button. */
   int GetButtonClicks(std::string_view name) const;
 
+  /** Returns the names of all buttons. */
+  std::vector<std::string> GetButtonNames() const;
+
   /** Removes the button `name` from the GUI.
    @returns true iff the button was removed.
    @throws std::exception if `strict` is true and `name` is not a registered

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -873,6 +873,7 @@ GTEST_TEST(MeshcatTest, Buttons) {
 
   // A new button starts out unclicked.
   meshcat.AddButton("alice");
+  EXPECT_THAT(meshcat.GetButtonNames(), ElementsAre("alice"));
   EXPECT_EQ(meshcat.GetButtonClicks("alice"), 0);
 
   auto click = [&meshcat]() {
@@ -898,6 +899,7 @@ GTEST_TEST(MeshcatTest, Buttons) {
 
   // Removing the button then asking for clicks is an error.
   EXPECT_TRUE(meshcat.DeleteButton("alice"));
+  EXPECT_EQ(meshcat.GetButtonNames().size(), 0);
   DRAKE_EXPECT_THROWS_MESSAGE(meshcat.GetButtonClicks("alice"),
                               "Meshcat does not have any button named alice.*");
 
@@ -912,11 +914,13 @@ GTEST_TEST(MeshcatTest, Buttons) {
 
   // Buttons are removed when deleting all controls.
   meshcat.AddButton("bob");
+  EXPECT_THAT(meshcat.GetButtonNames(), ElementsAre("alice", "bob"));
   meshcat.DeleteAddedControls();
   DRAKE_EXPECT_THROWS_MESSAGE(meshcat.GetButtonClicks("alice"),
                               "Meshcat does not have any button named alice.*");
   DRAKE_EXPECT_THROWS_MESSAGE(meshcat.GetButtonClicks("bob"),
                               "Meshcat does not have any button named bob.*");
+  EXPECT_EQ(meshcat.GetButtonNames().size(), 0);
 
   // Adding a button with the keycode.
   meshcat.AddButton("alice", "KeyT");


### PR DESCRIPTION
This PR adds and binds a `Meshcat::GetButtonNames()` function, similar to `Meshcat::GetSliderNames()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22806)
<!-- Reviewable:end -->
