### PR TITLE
Fix SceneGraph documentation on usage of query port

### DIFF
--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -96,16 +96,13 @@ class QueryObject;
 
  @section geom_sys_outputs Outputs
 
- %SceneGraph has two output ports:
+ %SceneGraph has one output port:
 
  __query port__: An abstract-valued port containing an instance of QueryObject.
- It provides a "ticket" for downstream LeafSystem instances to perform geometric
- queries on the %SceneGraph. To perform geometric queries, downstream
- LeafSystem instances acquire the QueryObject from %SceneGraph's output port
- and provide it as a parameter to one of %SceneGraph's query methods (e.g.,
- SceneGraph::ComputeContact()). This assumes that the querying system has
- access to a const pointer to the connected %SceneGraph instance. Use
- get_query_output_port() to acquire the output port for the query handle.
+ To perform geometric queries, downstream LeafSystem instances acquire the
+ QueryObject from %SceneGraph's output port and invoke the appropriate methods
+ on it. Use get_query_output_port() to acquire the output port for the query
+ handle.
 
  @section geom_sys_workflow Working with SceneGraph
 
@@ -125,9 +122,9 @@ class QueryObject;
 
  With those two requirements satisfied, a LeafSystem can perform geometry
  queries by:
-   1. evaluating the QueryObject input port, and
-   2. passing the returned query object into the appropriate query method on
-   SceneGraph (e.g., SceneGraph::ComputeContact()).
+   1. evaluating the QueryObject input port, retrieving a `const QueryObject&`
+   in return, and
+   2. invoking the appropriate method on the QueryObject.
 
  __Producer__
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22809)
<!-- Reviewable:end -->
