### PR TITLE
[py yaml] Alphabetize imports

### DIFF
--- a/bindings/pydrake/common/yaml.py
+++ b/bindings/pydrake/common/yaml.py
@@ -1,12 +1,12 @@
 import collections.abc
 import copy
 import dataclasses
-import math
 import functools
+import math
+from pathlib import Path
 import types
 import typing
 import warnings
-from pathlib import Path
 
 import numpy as np
 import yaml


### PR DESCRIPTION
When porting this file for Anzu, its linter flagged the mistake here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22810)
<!-- Reviewable:end -->
