### PR TITLE
Revert "[py sensors] ApplyCameraConfig overloaded on LcmInterfaceSystem (#22811)"

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -194,7 +194,6 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":framework_py",
-        ":lcm_py",
         ":module_py",
         "//bindings/pydrake/geometry",
     ],

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -12,7 +12,6 @@ PYBIND11_MODULE(sensors, m) {
   py::module::import("pydrake.common.schema");
   py::module::import("pydrake.geometry");
   py::module::import("pydrake.systems.framework");
-  py::module::import("pydrake.systems.lcm");
 
   internal::DefineSensorsImage(m);
   internal::DefineSensorsImageIo(m);

--- a/bindings/pydrake/systems/sensors_py_camera_config.cc
+++ b/bindings/pydrake/systems/sensors_py_camera_config.cc
@@ -1,8 +1,6 @@
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/systems/sensors_py.h"
-#include "drake/common/overloaded.h"
-#include "drake/systems/lcm/lcm_interface_system.h"
 #include "drake/systems/sensors/camera_config_functions.h"
 
 namespace drake {
@@ -64,25 +62,12 @@ void DefineSensorsCameraConfig(py::module m) {
     DefCopyAndDeepCopy(&config_cls);
   }
 
-  m.def(
-      "ApplyCameraConfig",
-      [](const CameraConfig& config, DiagramBuilder<double>* builder,
-          const systems::lcm::LcmBuses* lcm_buses,
-          const multibody::MultibodyPlant<double>* plant,
-          geometry::SceneGraph<double>* scene_graph,
-          std::variant<drake::lcm::DrakeLcmInterface*,
-              drake::systems::lcm::LcmInterfaceSystem*>
-              lcm) {
-        // See kLcmInterfaceSystemClassWarning in pydrake/systems/lcm_py.cc; we
-        // need to accept two distinct types in the python signature and upcast
-        // inside the C++ implementation here.
-        std::visit(
-            [&](auto* unboxed_lcm) {
-              ApplyCameraConfig(
-                  config, builder, lcm_buses, plant, scene_graph, unboxed_lcm);
-            },
-            lcm);
-      },
+  m.def("ApplyCameraConfig",
+      py::overload_cast<const CameraConfig&, DiagramBuilder<double>*,
+          const systems::lcm::LcmBuses*,
+          const multibody::MultibodyPlant<double>*,
+          geometry::SceneGraph<double>*, drake::lcm::DrakeLcmInterface*>(
+          &ApplyCameraConfig),
       py::arg("config"), py::arg("builder"), py::arg("lcm_buses") = nullptr,
       py::arg("plant") = nullptr, py::arg("scene_graph") = nullptr,
       py::arg("lcm") = nullptr,

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -32,7 +32,7 @@ from pydrake.systems.framework import (
     InputPort,
     OutputPort,
     )
-from pydrake.systems.lcm import LcmBuses, LcmInterfaceSystem, _Serializer_
+from pydrake.systems.lcm import LcmBuses, _Serializer_
 from drake import (
     lcmt_image,
     lcmt_image_array,
@@ -256,7 +256,6 @@ class TestSensors(unittest.TestCase):
         self.assertGreater(len(builder.GetSystems()), system_count)
 
     def test_camera_config_lcm_buses(self):
-        """Calls ApplyCameraConfig using LcmBuses."""
         builder = DiagramBuilder()
         plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
         system_count = len(builder.GetSystems())
@@ -269,16 +268,6 @@ class TestSensors(unittest.TestCase):
                               lcm_buses=lcm_buses)
 
         # Check that systems were added.
-        self.assertGreater(len(builder.GetSystems()), system_count)
-
-    def test_camera_config_lcm_interface_system(self):
-        """Calls ApplyCameraConfig using LcmInterfaceSystem."""
-        builder = DiagramBuilder()
-        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
-        lcm = builder.AddSystem(LcmInterfaceSystem(lcm=DrakeLcm()))
-        config = mut.CameraConfig()
-        system_count = len(builder.GetSystems())
-        mut.ApplyCameraConfig(config=config, builder=builder, lcm=lcm)
         self.assertGreater(len(builder.GetSystems()), system_count)
 
     def test_camera_info(self):


### PR DESCRIPTION
 Dear @jwnimmer-tri,

 The on-call build cop, Aiden McCormack (@Aiden2244), believes that your PR 22811 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-continuous-everything-release/1547/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22812)
<!-- Reviewable:end -->
