### PR TITLE
[multibody] Fix crash on frame elements not added to a plant

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -401,30 +401,6 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_EQ(pendulum_frame_indices[3], pin_joint.frame_on_child().index());
   EXPECT_EQ(pendulum_frame_indices[4], weld_joint.frame_on_parent().index());
   EXPECT_EQ(pendulum_frame_indices[5], weld_joint.frame_on_child().index());
-
-  // At this point in this test, plant->Finalize() has already been called.
-  // Create another frame (which is not part of the plant). Ensure an exception
-  // is thrown if there is a query for information about this frame that needs
-  // the associated multibody tree. Herein we try various public methods.
-  multibody::FixedOffsetFrame<double> frame_not_in_multibody_tree(
-      "bad_frame", plant->world_frame(), RigidTransform<double>{});
-  std::unique_ptr<Context<double>> context = plant->CreateDefaultContext();
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      frame_not_in_multibody_tree.CalcPoseInWorld(*context),
-      ".*has_parent_tree.*failed.*");
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      frame_not_in_multibody_tree.CalcPose(*context, model_frame),
-      ".*has_parent_tree.*failed.*");
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      frame_not_in_multibody_tree.CalcRotationMatrix(*context, model_frame),
-      ".*has_parent_tree.*failed.*");
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      frame_not_in_multibody_tree.CalcRotationMatrixInWorld(*context),
-      ".*has_parent_tree.*failed.*");
 }
 
 GTEST_TEST(MultibodyPlantTest, AddJointActuator) {

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -401,6 +401,18 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_EQ(pendulum_frame_indices[3], pin_joint.frame_on_child().index());
   EXPECT_EQ(pendulum_frame_indices[4], weld_joint.frame_on_parent().index());
   EXPECT_EQ(pendulum_frame_indices[5], weld_joint.frame_on_child().index());
+
+  // After plant->Finalize(), create another frame. Ensure an exception is
+  // thrown if trying to query information (e.g., its pose in world) for
+  // this frame which is not part of the plant.
+  multibody::FixedOffsetFrame<double> fixed_offset_frame(
+      "bad_frame", plant->world_frame(), RigidTransform<double>{});
+  std::unique_ptr<Context<double>> context = plant->CreateDefaultContext();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      fixed_offset_frame.CalcPoseInWorld(*context),
+      "This multibody element was not added to a MultibodyTree.");
+  //      "Frame is not associated with its parent tree, possibly due to being "
+  //      "created after the plant method Finalize\\(\\) was called.");
 }
 
 GTEST_TEST(MultibodyPlantTest, AddJointActuator) {

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -405,12 +405,29 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   // At this point in this test, plant->Finalize() has already been called.
   // Create another frame (which is not part of the plant). Ensure an exception
   // is thrown if there is a query for information about this frame that needs
-  // the associated multibody tree. Herein we try calculating the frame's pose.
+  // the associated multibody tree. Herein we try various public methods.
   multibody::FixedOffsetFrame<double> fixed_offset_frame(
       "bad_frame", plant->world_frame(), RigidTransform<double>{});
   std::unique_ptr<Context<double>> context = plant->CreateDefaultContext();
+
   DRAKE_EXPECT_THROWS_MESSAGE(
       fixed_offset_frame.CalcPoseInWorld(*context),
+      "This multibody element was not added to a MultibodyTree.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      fixed_offset_frame.CalcPose(*context, model_frame),
+      "This multibody element was not added to a MultibodyTree.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      fixed_offset_frame.CalcRotationMatrix(*context, model_frame),
+      "This multibody element was not added to a MultibodyTree.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      fixed_offset_frame.CalcRotationMatrixInWorld(*context),
+      "This multibody element was not added to a MultibodyTree.");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      fixed_offset_frame.CalcRotationMatrixInWorld(*context),
       "This multibody element was not added to a MultibodyTree.");
 }
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -406,29 +406,25 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   // Create another frame (which is not part of the plant). Ensure an exception
   // is thrown if there is a query for information about this frame that needs
   // the associated multibody tree. Herein we try various public methods.
-  multibody::FixedOffsetFrame<double> fixed_offset_frame(
+  multibody::FixedOffsetFrame<double> frame_not_in_multibody_tree(
       "bad_frame", plant->world_frame(), RigidTransform<double>{});
   std::unique_ptr<Context<double>> context = plant->CreateDefaultContext();
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      fixed_offset_frame.CalcPoseInWorld(*context),
-      "This multibody element was not added to a MultibodyTree.");
+      frame_not_in_multibody_tree.CalcPoseInWorld(*context),
+      ".*has_parent_tree.*failed.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      fixed_offset_frame.CalcPose(*context, model_frame),
-      "This multibody element was not added to a MultibodyTree.");
+      frame_not_in_multibody_tree.CalcPose(*context, model_frame),
+      ".*has_parent_tree.*failed.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      fixed_offset_frame.CalcRotationMatrix(*context, model_frame),
-      "This multibody element was not added to a MultibodyTree.");
+      frame_not_in_multibody_tree.CalcRotationMatrix(*context, model_frame),
+      ".*has_parent_tree.*failed.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      fixed_offset_frame.CalcRotationMatrixInWorld(*context),
-      "This multibody element was not added to a MultibodyTree.");
-
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      fixed_offset_frame.CalcRotationMatrixInWorld(*context),
-      "This multibody element was not added to a MultibodyTree.");
+      frame_not_in_multibody_tree.CalcRotationMatrixInWorld(*context),
+      ".*has_parent_tree.*failed.*");
 }
 
 GTEST_TEST(MultibodyPlantTest, AddJointActuator) {

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -402,17 +402,16 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_EQ(pendulum_frame_indices[4], weld_joint.frame_on_parent().index());
   EXPECT_EQ(pendulum_frame_indices[5], weld_joint.frame_on_child().index());
 
-  // After plant->Finalize(), create another frame. Ensure an exception is
-  // thrown if trying to query information (e.g., its pose in world) for
-  // this frame which is not part of the plant.
+  // At this point in this test, plant->Finalize() has already been called.
+  // Create another frame (which is not part of the plant). Ensure an exception
+  // is thrown if there is a query for information about this frame that needs
+  // the associated multibody tree. Herein we try calculating the frame's pose.
   multibody::FixedOffsetFrame<double> fixed_offset_frame(
       "bad_frame", plant->world_frame(), RigidTransform<double>{});
   std::unique_ptr<Context<double>> context = plant->CreateDefaultContext();
   DRAKE_EXPECT_THROWS_MESSAGE(
       fixed_offset_frame.CalcPoseInWorld(*context),
       "This multibody element was not added to a MultibodyTree.");
-  //      "Frame is not associated with its parent tree, possibly due to being "
-  //      "created after the plant method Finalize\\(\\) was called.");
 }
 
 GTEST_TEST(MultibodyPlantTest, AddJointActuator) {

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -356,7 +356,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "frames_test",
-    deps = [":tree"],
+    deps = [
+        ":tree",
+        "//common/test_utilities:expect_throws_message",
+        ],
 )
 
 drake_cc_googletest(

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -359,7 +359,7 @@ drake_cc_googletest(
     deps = [
         ":tree",
         "//common/test_utilities:expect_throws_message",
-        ],
+    ],
 )
 
 drake_cc_googletest(

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -218,7 +218,8 @@ class Frame : public MultibodyElement<T> {
   /// the pose for a body frame.
   math::RigidTransform<T> CalcPoseInWorld(
       const systems::Context<T>& context) const {
-    const internal::MultibodyTree<T>& tree = this->GetParentTreeOrThrow();
+    DRAKE_THROW_UNLESS(this->has_parent_tree());
+    const internal::MultibodyTree<T>& tree = this->get_parent_tree();
     return tree.CalcRelativeTransform(context, tree.world_frame(), *this);
   }
 
@@ -227,23 +228,26 @@ class Frame : public MultibodyElement<T> {
   /// @see CalcPoseInWorld().
   math::RigidTransform<T> CalcPose(const systems::Context<T>& context,
                                    const Frame<T>& frame_M) const {
-    return this->GetParentTreeOrThrow().CalcRelativeTransform(context, frame_M,
-                                                              *this);
+    DRAKE_THROW_UNLESS(this->has_parent_tree());
+    return this->get_parent_tree().CalcRelativeTransform(context, frame_M,
+                                                         *this);
   }
 
   /// Calculates and returns the rotation matrix `R_MF` that relates `frame_M`
   /// and `this` frame F as a function of the state stored in `context`.
   math::RotationMatrix<T> CalcRotationMatrix(const systems::Context<T>& context,
                                              const Frame<T>& frame_M) const {
-    return this->GetParentTreeOrThrow().CalcRelativeRotationMatrix(
-        context, frame_M, *this);
+    DRAKE_THROW_UNLESS(this->has_parent_tree());
+    return this->get_parent_tree().CalcRelativeRotationMatrix(context, frame_M,
+                                                              *this);
   }
 
   /// Calculates and returns the rotation matrix `R_WF` that relates the world
   /// frame W and `this` frame F as a function of the state stored in `context`.
   math::RotationMatrix<T> CalcRotationMatrixInWorld(
       const systems::Context<T>& context) const {
-    const internal::MultibodyTree<T>& tree = this->GetParentTreeOrThrow();
+    DRAKE_THROW_UNLESS(this->has_parent_tree());
+    const internal::MultibodyTree<T>& tree = this->get_parent_tree();
     return tree.CalcRelativeRotationMatrix(context, tree.world_frame(), *this);
   }
 

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -218,8 +218,8 @@ class Frame : public MultibodyElement<T> {
   /// the pose for a body frame.
   math::RigidTransform<T> CalcPoseInWorld(
       const systems::Context<T>& context) const {
-    return this->get_parent_tree().CalcRelativeTransform(
-        context, this->get_parent_tree().world_frame(), *this);
+    const internal::MultibodyTree<T>& tree = this->GetParentTreeOrThrow();
+    return tree.CalcRelativeTransform(context, tree.world_frame(), *this);
   }
 
   /// Computes and returns the pose `X_MF` of `this` frame F in measured in
@@ -227,24 +227,24 @@ class Frame : public MultibodyElement<T> {
   /// @see CalcPoseInWorld().
   math::RigidTransform<T> CalcPose(const systems::Context<T>& context,
                                    const Frame<T>& frame_M) const {
-    return this->get_parent_tree().CalcRelativeTransform(context, frame_M,
-                                                         *this);
+    return this->GetParentTreeOrThrow().CalcRelativeTransform(context, frame_M,
+                                                              *this);
   }
 
   /// Calculates and returns the rotation matrix `R_MF` that relates `frame_M`
   /// and `this` frame F as a function of the state stored in `context`.
   math::RotationMatrix<T> CalcRotationMatrix(const systems::Context<T>& context,
                                              const Frame<T>& frame_M) const {
-    return this->get_parent_tree().CalcRelativeRotationMatrix(context, frame_M,
-                                                              *this);
+    return this->GetParentTreeOrThrow().CalcRelativeRotationMatrix(
+        context, frame_M, *this);
   }
 
   /// Calculates and returns the rotation matrix `R_WF` that relates the world
   /// frame W and `this` frame F as a function of the state stored in `context`.
   math::RotationMatrix<T> CalcRotationMatrixInWorld(
       const systems::Context<T>& context) const {
-    return this->get_parent_tree().CalcRelativeRotationMatrix(
-        context, this->get_parent_tree().world_frame(), *this);
+    const internal::MultibodyTree<T>& tree = this->GetParentTreeOrThrow();
+    return tree.CalcRelativeRotationMatrix(context, tree.world_frame(), *this);
   }
 
   /// Evaluates `this` frame F's angular velocity measured and expressed in the

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -107,8 +107,15 @@ class MultibodyElement {
 
   /// Returns a constant reference to the parent MultibodyTree that
   /// owns this element.
-  const internal::MultibodyTree<T>& get_parent_tree() const {
+  const internal::MultibodyTree<T>& GetParentTreeOrThrow() const {
     HasParentTreeOrThrow();
+    return get_parent_tree();
+  }
+
+  /// Returns a constant reference to the parent MultibodyTree that
+  /// owns this element.
+  const internal::MultibodyTree<T>& get_parent_tree() const {
+    DRAKE_ASSERT_VOID(HasParentTreeOrThrow());
     return *parent_tree_;
   }
 

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -107,6 +107,7 @@ class MultibodyElement {
 
   /// Returns a constant reference to the parent MultibodyTree that
   /// owns this element.
+  /// @throws std::exception in debug builds if has_parent_tree() is false.
   const internal::MultibodyTree<T>& get_parent_tree() const {
     DRAKE_ASSERT_VOID(HasParentTreeOrThrow());
     return *parent_tree_;
@@ -114,6 +115,7 @@ class MultibodyElement {
 
   /// Returns a constant reference to the parent MultibodyTreeSystem that
   /// owns the parent MultibodyTree that owns this element.
+  /// @throws std::exception in debug builds if has_parent_tree() is false.
   const internal::MultibodyTreeSystem<T>& GetParentTreeSystem() const {
     DRAKE_ASSERT_VOID(HasParentTreeOrThrow());
     return get_parent_tree().tree_system();
@@ -152,7 +154,6 @@ class MultibodyElement {
       internal::MultibodyTreeSystem<T>* tree_system,
       const AbstractValue& model_value);
 
- protected:
   /// Returns true if this multibody element has a parent tree, otherwise false.
   bool has_parent_tree() const { return parent_tree_ != nullptr; }
 

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -108,7 +108,7 @@ class MultibodyElement {
   /// Returns a constant reference to the parent MultibodyTree that
   /// owns this element.
   const internal::MultibodyTree<T>& get_parent_tree() const {
-    DRAKE_ASSERT_VOID(HasParentTreeOrThrow());
+    HasParentTreeOrThrow();
     return *parent_tree_;
   }
 

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -107,13 +107,6 @@ class MultibodyElement {
 
   /// Returns a constant reference to the parent MultibodyTree that
   /// owns this element.
-  const internal::MultibodyTree<T>& GetParentTreeOrThrow() const {
-    HasParentTreeOrThrow();
-    return get_parent_tree();
-  }
-
-  /// Returns a constant reference to the parent MultibodyTree that
-  /// owns this element.
   const internal::MultibodyTree<T>& get_parent_tree() const {
     DRAKE_ASSERT_VOID(HasParentTreeOrThrow());
     return *parent_tree_;
@@ -159,6 +152,10 @@ class MultibodyElement {
       internal::MultibodyTreeSystem<T>* tree_system,
       const AbstractValue& model_value);
 
+ protected:
+  /// Returns true if this multibody element has a parent tree, otherwise false.
+  bool has_parent_tree() const { return parent_tree_ != nullptr; }
+
  private:
   // MultibodyTree<T> is a natural friend of MultibodyElement objects and
   // therefore it can set the owning parent tree and unique index in that tree.
@@ -177,8 +174,6 @@ class MultibodyElement {
   void set_model_instance(ModelInstanceIndex model_instance) {
     model_instance_ = model_instance;
   }
-
-  bool has_parent_tree() const { return parent_tree_ != nullptr; }
 
   // Checks whether this MultibodyElement has been registered into
   // a MultibodyTree and throws an exception if not.

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -168,7 +168,7 @@ TEST_F(FrameTests, IsBodyFrameMethod) {
 // there is a query for information about this frame that needs the associated
 // multibody tree. Check that exceptions are thrown for common public methods.
 TEST_F(FrameTests, IsFrameMethodCalledWithNoMultibodyTree) {
-  multibody::FixedOffsetFrame<double> frame_not_in_multibody_tree(
+  FixedOffsetFrame<double> frame_not_in_multibody_tree(
       "bad_frame", *frameB_, math::RigidTransform<double>{});
 
   DRAKE_EXPECT_THROWS_MESSAGE(

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/tree/fixed_offset_frame.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
 #include "drake/multibody/tree/multibody_tree_system.h"
@@ -161,6 +162,31 @@ TEST_F(FrameTests, IsBodyFrameMethod) {
   EXPECT_TRUE(frame_W.is_body_frame());
   const Frame<double>& bodyB_frame = bodyB_->body_frame();
   EXPECT_TRUE(bodyB_frame.is_body_frame());
+}
+
+// Create a frame which is not part of a plant. Ensure an exception is thrown if
+// there is a query for information about this frame that needs the associated
+// multibody tree. Check that exceptions are thrown for common public methods.
+TEST_F(FrameTests, IsFrameMethodCalledWithNoMultibodyTree) {
+  multibody::FixedOffsetFrame<double> frame_not_in_multibody_tree(
+      "bad_frame", *frameB_, math::RigidTransform<double>{});
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      frame_not_in_multibody_tree.CalcPoseInWorld(*context_),
+      ".*has_parent_tree.*failed.*");
+
+  const Frame<double>& frame_W = tree().world_frame();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      frame_not_in_multibody_tree.CalcPose(*context_, frame_W),
+      ".*has_parent_tree.*failed.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      frame_not_in_multibody_tree.CalcRotationMatrixInWorld(*context_),
+      ".*has_parent_tree.*failed.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      frame_not_in_multibody_tree.CalcRotationMatrix(*context_, frame_W),
+      ".*has_parent_tree.*failed.*");
 }
 
 // Verifies the BodyFrame methods to compute poses in different frames.


### PR DESCRIPTION
Resolves #22804.

Fixes segmentation fault for a calculation involving a frame that was not added to a MultibodyTree.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22821)
<!-- Reviewable:end -->
