### PR TITLE
Update rendering to use non-uniform Convex/Mesh scale

### DIFF
--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -1233,6 +1233,117 @@ TEST_F(RenderEngineGlTest, MeshTest) {
   }
 }
 
+// Confirm that non-uniform scale is correctly applied. We'll render create
+// two renderings: one with a reference mesh and one with the mesh pre-scaled
+// (applying the inverse scale to the Shape). The two images should end up
+// identical.
+TEST_F(RenderEngineGlTest, NonUniformScaleTest) {
+  RenderEngineGl ref_engine;
+  RenderEngineGl scale_engine;
+
+  // The mesh we're rendering has faces that are *not* aligned to the mesh's
+  // frame. This is important to confirm that the normals are handled properly.
+  // So, our mesh will be a cube rotated away from canonical orientation.
+
+  Eigen::Matrix3Xd vertices(3, 8);
+  Eigen::Matrix3Xd normals(3, 6);
+  // clang-format off
+  vertices << -1, -1,  1,  1, -1, -1,  1,  1,
+              -1,  1, -1,  1, -1,  1, -1,  1,
+              -1, -1, -1, -1,  1,  1,  1,  1;
+  normals <<   1, -1,  0,  0,  0,  0,
+               0,  0,  1, -1,  0,  0,
+               0,  0,  0,  0,  1, -1;
+  // clang-format on
+  RotationMatrixd R_GB(math::RollPitchYawd(M_PI / 4, M_PI / 4, 0));
+  // const RotationMatrixd R_GB;
+  for (int c = 0; c < vertices.cols(); ++c) {
+    vertices.col(c) = R_GB * vertices.col(c);
+  }
+  for (int n = 0; n < normals.cols(); ++n) {
+    normals.col(n) = R_GB * normals.col(n);
+  }
+
+  // Makes a MeshSource scaled such that if the scale `s` is applied, it becomes
+  // a 2x2x2 cube.
+  auto make_cube_mesh_source = [&vertices, &normals](const Vector3d& s) {
+    const Vector3d s_inv = s.cwiseInverse();
+    std::string obj_contents = "mtllib test_cube.mtl";
+    for (int v = 0; v < vertices.cols(); ++v) {
+      const Vector3d scaled = vertices.col(v).cwiseProduct(s_inv);
+      obj_contents +=
+          fmt::format("\nv {} {} {}", scaled[0], scaled[1], scaled[2]);
+    }
+    for (int n = 0; n < normals.cols(); ++n) {
+      const Vector3d scaled = normals.col(n).cwiseProduct(s).normalized();
+      obj_contents +=
+          fmt::format("\nvn {} {} {}", scaled[0], scaled[1], scaled[2]);
+    }
+    obj_contents += R"""(
+    usemtl red
+    f 1//6 2//6 4//6 3//6
+    f 1//4 3//4 7//4 5//4
+    f 1//2 5//2 6//2 2//2
+    f 8//5 6//5 5//5 7//5
+    f 8//1 7//1 3//1 4//1
+    f 8//3 4//3 2//3 6//3
+    )""";
+    // fmt::print(obj_contents);
+    std::cout << obj_contents << "\n";
+    return InMemoryMesh{
+        .mesh_file = MemoryFile(std::move(obj_contents), ".obj", "cube.obj"),
+        .supporting_files = {
+            {"test_cube.mtl",
+             MemoryFile("newmtl red\nKd 0.8 0 0\n", ".mtl", "test mtl")}}};
+  };
+
+  const auto convex_id = GeometryId::get_new_id();
+  const auto mesh_id = GeometryId::get_new_id();
+  PerceptionProperties material;
+  material.AddProperty("label", "id", RenderLabel::kDontCare);
+
+  const Vector3d unit_scale(1, 1, 1);
+  ref_engine.RegisterVisual(
+      mesh_id, Mesh(make_cube_mesh_source(unit_scale), unit_scale), material,
+      RigidTransformd(Vector3d(-1.5, 0, 0)), /* needs_update =*/false);
+  ref_engine.RegisterVisual(
+      convex_id, Convex(make_cube_mesh_source(unit_scale), unit_scale),
+      material, RigidTransformd(Vector3d(1.5, 0, 0)), /* needs_update =*/false);
+
+  const Vector3d stretch(2, 4, 8);  // powers of two for perfect math.
+  scale_engine.RegisterVisual(
+      mesh_id, Mesh(make_cube_mesh_source(stretch), stretch), material,
+      RigidTransformd(Vector3d(-1.5, 0, 0)), /* needs_update =*/false);
+  scale_engine.RegisterVisual(
+      convex_id, Convex(make_cube_mesh_source(stretch), stretch), material,
+      RigidTransformd(Vector3d(1.5, 0, 0)), /* needs_update =*/false);
+
+  // The camera is above the Wz = 0 plane, looking generally down and in the
+  // +Wy direction.
+  const RigidTransformd X_WC(RotationMatrixd::MakeXRotation(-3.2 * M_PI / 4),
+                             Vector3d(0, -3, 4.4));
+  ref_engine.UpdateViewpoint(X_WC);
+  scale_engine.UpdateViewpoint(X_WC);
+
+  const ColorRenderCamera camera(depth_camera_.core(), FLAGS_show_window);
+  const int w = camera.core().intrinsics().width();
+  const int h = camera.core().intrinsics().height();
+  ImageRgba8U ref_color(w, h);
+  ImageRgba8U scale_color(w, h);
+  EXPECT_NO_THROW(ref_engine.RenderColorImage(camera, &ref_color));
+  EXPECT_NO_THROW(scale_engine.RenderColorImage(camera, &scale_color));
+
+  if (const char* dir = std::getenv("TEST_UNDECLARED_OUTPUTS_DIR")) {
+    const fs::path out_dir(dir);
+    const std::string file_prefix = "NonUniformScaleTest";
+    ImageIo{}.Save(ref_color,
+                   out_dir / fmt::format("{}_ref_color.png", file_prefix));
+    ImageIo{}.Save(scale_color,
+                   out_dir / fmt::format("{}_scale_color.png", file_prefix));
+  }
+  EXPECT_EQ(ref_color, scale_color);
+}
+
 // Repeats various mesh-based tests, but this time the meshes are loaded from
 // memory. We render the scene twice: once with the one mesh and once with the
 // other to confirm they are rendered the same.

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -239,7 +239,8 @@ std::map<int, Matrix4<double>> FindRootNodes(const nlohmann::json& gltf) {
                      properties from the targeted nodes. */
 void SetRootPoses(nlohmann::json* gltf,
                   const std::map<int, Matrix4<double>>& root_nodes,
-                  const math::RigidTransformd& X_WG, double scale, bool strip) {
+                  const math::RigidTransformd& X_WG,
+                  const Vector3<double>& scale, bool strip) {
   /* We have to do some extra work for poses. A *correct* glTF file is defined
    in the file's frame F as y up. Drake poses things in a geometry frame G which
    is z up. When VTK exports a glTF file, it doesn't rotate from F to G (y up
@@ -264,7 +265,11 @@ void SetRootPoses(nlohmann::json* gltf,
   // T_WF isn't truly T_WF at construction. We'll construct it piecemeal as
   // we concatenate transforms on its right side as indicated above.
   Matrix4<double> T_WF = X_WG.GetAsMatrix4();
-  T_WF.block<3, 3>(0, 0) *= scale;  // S_WG.
+  // S_WG is `scale` on the diagonal. Multiplication with X_WG has the effect of
+  // scaling the corresponding columns.
+  for (int i = 0; i < 3; ++i) {
+    T_WF.block<3, 1>(0, i) *= scale(i);
+  }
   const math::RigidTransformd X_GF(
       math::RotationMatrixd::MakeXRotation(M_PI / 2));
   T_WF *= X_GF.GetAsMatrix4();
@@ -637,14 +642,14 @@ bool RenderEngineGltfClient::ImplementGltf(
   // of materials.
 
   std::map<int, Matrix4<double>> root_nodes = FindRootNodes(mesh_data);
-  SetRootPoses(&mesh_data, root_nodes, data.X_WG, mesh.scale(), true);
+  SetRootPoses(&mesh_data, root_nodes, data.X_WG, mesh.scale3(), true);
 
   DRAKE_DEMAND(!gltfs_.contains(data.id));
   const MeshSource& mesh_source = mesh.source();
   const std::string gltf_name = mesh_source.description();
   gltfs_.insert({data.id,
                  {gltf_name, std::move(mesh_data), std::move(root_nodes),
-                  mesh.scale(), GetRenderLabelOrThrow(data.properties)}});
+                  mesh.scale3(), GetRenderLabelOrThrow(data.properties)}});
   return true;
 }
 

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.h
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.h
@@ -124,8 +124,8 @@ class DRAKE_NO_EXPORT RenderEngineGltfClient
     // file's frame F. Note this "pose" is not necessarily a RigidTransform. It
     // can include scale. It is the node matrix stored in the gltf.
     std::map<int, Matrix4<double>> root_nodes;
-    // The isotropic scale of the mesh.
-    double scale{};
+    // The anisotropic scale of the mesh.
+    Vector3<double> scale;
     // The render label associated with the geometry.
     render::RenderLabel label;
   };

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -249,7 +249,8 @@ void RenderEngineVtk::ImplementGeometry(const Convex& convex, void* user_data) {
   }
   // We don't use convex.scale() because it's already built in to the convex
   // hull.
-  ImplementRenderMesh(std::move(render_mesh), /* scale =*/1.0, data);
+  const Vector3<double> kUnitScale(1, 1, 1);
+  ImplementRenderMesh(std::move(render_mesh), kUnitScale, data);
 }
 
 void RenderEngineVtk::ImplementGeometry(const Cylinder& cylinder,
@@ -316,7 +317,7 @@ bool RenderEngineVtk::DoRegisterDeformableVisual(
   RegistrationData data{properties, RigidTransformd::Identity(), id};
   for (const RenderMesh& render_mesh : render_meshes) {
     auto copy = render_mesh;
-    ImplementRenderMesh(std::move(copy), /* scale = */ 1.0, data);
+    ImplementRenderMesh(std::move(copy), Vector3d(1, 1, 1), data);
   }
   return true;
 }
@@ -606,7 +607,8 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
   }
 }
 
-void RenderEngineVtk::ImplementRenderMesh(RenderMesh&& mesh, double scale,
+void RenderEngineVtk::ImplementRenderMesh(RenderMesh&& mesh,
+                                          const Vector3<double>& scale,
                                           const RegistrationData& data) {
   const RenderMaterial material = mesh.material.has_value()
                                       ? *mesh.material
@@ -615,14 +617,13 @@ void RenderEngineVtk::ImplementRenderMesh(RenderMesh&& mesh, double scale,
   vtkSmartPointer<vtkPolyDataAlgorithm> mesh_source =
       CreateVtkMesh(std::move(mesh));
 
-  if (scale == 1) {
+  if ((scale.array() == 1).all()) {
     ImplementPolyData(mesh_source.GetPointer(), material, data);
     return;
   }
 
   vtkNew<vtkTransform> transform;
-  // TODO(SeanCurtis-TRI): Should I be allowing only isotropic scale.
-  transform->Scale(scale, scale, scale);
+  transform->Scale(scale.x(), scale.y(), scale.z());
   vtkNew<vtkTransformPolyDataFilter> transform_filter;
   transform_filter->SetInputConnection(mesh_source->GetOutputPort());
   transform_filter->SetTransform(transform.GetPointer());
@@ -636,7 +637,7 @@ bool RenderEngineVtk::ImplementObj(const Mesh& mesh,
   std::vector<RenderMesh> meshes = LoadRenderMeshesFromObj(
       mesh.source(), data.properties, default_diffuse_, diagnostic_);
   for (auto& render_mesh : meshes) {
-    ImplementRenderMesh(std::move(render_mesh), mesh.scale(), data);
+    ImplementRenderMesh(std::move(render_mesh), mesh.scale3(), data);
   }
   return true;
 }
@@ -685,7 +686,7 @@ bool RenderEngineVtk::ImplementGltf(const Mesh& mesh,
   // This includes the rotation from y-up to z-up and the requested scale.
   const RigidTransformd X_GF(RotationMatrixd::MakeXRotation(M_PI / 2));
   vtkSmartPointer<vtkTransform> T_GF_transform =
-      ConvertToVtkTransform(X_GF, mesh.scale());
+      ConvertToVtkTransform(X_GF, mesh.scale3());
   vtkMatrix4x4* T_GF = T_GF_transform->GetMatrix();
 
   // Color.

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -212,7 +212,8 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
 
   // Helper function for mapping a RenderMesh instance into the appropriate VTK
   // polydata.
-  void ImplementRenderMesh(geometry::internal::RenderMesh&& mesh, double scale,
+  void ImplementRenderMesh(geometry::internal::RenderMesh&& mesh,
+                           const Vector3<double>& scale,
                            const RegistrationData& data);
 
   // Adds an .obj to the scene for the id currently being reified (data->id).

--- a/geometry/render_vtk/internal_vtk_util.cc
+++ b/geometry/render_vtk/internal_vtk_util.cc
@@ -29,12 +29,12 @@ vtkSmartPointer<vtkPlaneSource> CreateSquarePlane(double size) {
 }
 
 vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
-    const math::RigidTransformd& transform, double scale) {
+    const math::RigidTransformd& transform, const Vector3<double>& scale) {
   vtkNew<vtkMatrix4x4> vtk_mat;
   for (int i = 0; i < 3; ++i) {
     const auto& row = transform.rotation().row(i);
     for (int j = 0; j < 3; ++j) {
-      vtk_mat->SetElement(i, j, row(j) * scale);
+      vtk_mat->SetElement(i, j, row(j) * scale(j));
     }
     vtk_mat->SetElement(i, 3, transform.translation()(i));
   }

--- a/geometry/render_vtk/internal_vtk_util.h
+++ b/geometry/render_vtk/internal_vtk_util.h
@@ -40,7 +40,8 @@ vtkSmartPointer<vtkPlaneSource> CreateSquarePlane(double size);
 // matrix with `scale` on the diagonal). This is the standard transform matrix
 // for graphics.
 vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
-    const math::RigidTransformd& transform, double scale = 1.0);
+    const math::RigidTransformd& transform,
+    const Vector3<double>& scale = Vector3<double>::Ones());
 
 // Makes vtkPointerArray from one or multiple pointer(s) for VTK objects
 // wrapped by vtkNew.

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -786,6 +786,114 @@ TEST_F(RenderEngineVtkTest, MeshTest) {
   }
 }
 
+// Confirm that non-uniform scale is correctly applied. We'll render create
+// two renderings: one with a reference mesh and one with the mesh pre-scaled
+// (applying the inverse scale to the Shape). The two images should end up
+// identical.
+TEST_F(RenderEngineVtkTest, NonUniformScaleTest) {
+  RenderEngineVtk ref_engine;
+  RenderEngineVtk scale_engine;
+
+  // The mesh we're rendering has faces that are *not* aligned to the mesh's
+  // frame. This is important to confirm that the normals are handled properly.
+  // So, our mesh will be a cube rotated away from canonical orientation.
+
+  Eigen::Matrix3Xd vertices(3, 8);
+  Eigen::Matrix3Xd normals(3, 6);
+  // clang-format off
+  vertices << -1, -1,  1,  1, -1, -1,  1,  1,
+              -1,  1, -1,  1, -1,  1, -1,  1,
+              -1, -1, -1, -1,  1,  1,  1,  1;
+  normals <<   1, -1,  0,  0,  0,  0,
+               0,  0,  1, -1,  0,  0,
+               0,  0,  0,  0,  1, -1;
+  // clang-format on
+  RotationMatrixd R_GB(math::RollPitchYawd(M_PI / 4, M_PI / 4, 0));
+  // const RotationMatrixd R_GB;
+  for (int c = 0; c < vertices.cols(); ++c) {
+    vertices.col(c) = R_GB * vertices.col(c);
+  }
+  for (int n = 0; n < normals.cols(); ++n) {
+    normals.col(n) = R_GB * normals.col(n);
+  }
+
+  // Makes a MeshSource scaled such that if the scale `s` is applied, it becomes
+  // a 2x2x2 cube.
+  auto make_cube_mesh_source = [&vertices, &normals](const Vector3d& s) {
+    const Vector3d s_inv = s.cwiseInverse();
+    std::string obj_contents = "mtllib test_cube.mtl";
+    for (int v = 0; v < vertices.cols(); ++v) {
+      const Vector3d scaled = vertices.col(v).cwiseProduct(s_inv);
+      obj_contents +=
+          fmt::format("\nv {} {} {}", scaled[0], scaled[1], scaled[2]);
+    }
+    for (int n = 0; n < normals.cols(); ++n) {
+      const Vector3d scaled = normals.col(n).cwiseProduct(s).normalized();
+      obj_contents +=
+          fmt::format("\nvn {} {} {}", scaled[0], scaled[1], scaled[2]);
+    }
+    obj_contents += R"""(
+    usemtl red
+    f 1//6 2//6 4//6 3//6
+    f 1//4 3//4 7//4 5//4
+    f 1//2 5//2 6//2 2//2
+    f 8//5 6//5 5//5 7//5
+    f 8//1 7//1 3//1 4//1
+    f 8//3 4//3 2//3 6//3
+    )""";
+    // fmt::print(obj_contents);
+    std::cout << obj_contents << "\n";
+    return InMemoryMesh{
+        .mesh_file = MemoryFile(std::move(obj_contents), ".obj", "cube.obj"),
+        .supporting_files = {
+            {"test_cube.mtl",
+             MemoryFile("newmtl red\nKd 0.8 0 0\n", ".mtl", "test mtl")}}};
+  };
+
+  const auto convex_id = GeometryId::get_new_id();
+  const auto mesh_id = GeometryId::get_new_id();
+  PerceptionProperties material;
+  material.AddProperty("label", "id", RenderLabel::kDontCare);
+
+  const Vector3d unit_scale(1, 1, 1);
+  ref_engine.RegisterVisual(
+      mesh_id, Mesh(make_cube_mesh_source(unit_scale), unit_scale), material,
+      RigidTransformd(Vector3d(-1.5, 0, 0)), /* needs_update =*/false);
+  ref_engine.RegisterVisual(
+      convex_id, Convex(make_cube_mesh_source(unit_scale), unit_scale),
+      material, RigidTransformd(Vector3d(1.5, 0, 0)), /* needs_update =*/false);
+
+  const Vector3d stretch(2, 4, 8);  // powers of two for perfect math.
+  scale_engine.RegisterVisual(
+      mesh_id, Mesh(make_cube_mesh_source(stretch), stretch), material,
+      RigidTransformd(Vector3d(-1.5, 0, 0)), /* needs_update =*/false);
+  scale_engine.RegisterVisual(
+      convex_id, Convex(make_cube_mesh_source(stretch), stretch), material,
+      RigidTransformd(Vector3d(1.5, 0, 0)), /* needs_update =*/false);
+
+  // The camera is above the Wz = 0 plane, looking generally down and in the
+  // +Wy direction.
+  const RigidTransformd X_WC(RotationMatrixd::MakeXRotation(-3.2 * M_PI / 4),
+                             Vector3d(0, -3, 4.4));
+  ref_engine.UpdateViewpoint(X_WC);
+  scale_engine.UpdateViewpoint(X_WC);
+
+  const ColorRenderCamera camera(depth_camera_.core(), FLAGS_show_window);
+  const int w = camera.core().intrinsics().width();
+  const int h = camera.core().intrinsics().height();
+  ImageRgba8U ref_color(w, h);
+  ImageRgba8U scale_color(w, h);
+  EXPECT_NO_THROW(ref_engine.RenderColorImage(camera, &ref_color));
+  EXPECT_NO_THROW(scale_engine.RenderColorImage(camera, &scale_color));
+
+  const std::source_location& caller = std::source_location::current();
+  const std::string stem = fmt::format("line_{:0>4}", caller.line());
+  SaveTestOutputImage(ref_color, fmt::format("{0}_ref_color.png", stem));
+  SaveTestOutputImage(scale_color, fmt::format("{0}_scale_color.png", stem));
+
+  EXPECT_EQ(ref_color, scale_color);
+}
+
 // Repeats various mesh-based tests, but this time the meshes are loaded from
 // memory. We render the scene twice: once with the on-disk mesh and once with
 // the in-memory mesh to confirm they are rendered the same.

--- a/geometry/render_vtk/test/internal_vtk_util_test.cc
+++ b/geometry/render_vtk/test/internal_vtk_util_test.cc
@@ -67,10 +67,12 @@ GTEST_TEST(ConvertToVtkTransformTest, ConversionTest) {
     }
   }
 
-  const double scale = 1.5;
+  const Vector3<double> scale(2, 3, 4);
   auto dut_T_AB = ConvertToVtkTransform(X_AB, scale);
   Eigen::Matrix4d T_AB_expected = X_AB.GetAsMatrix4();
-  T_AB_expected.block<3, 3>(0, 0) *= scale;
+  T_AB_expected.block<3, 1>(0, 0) *= scale.x();
+  T_AB_expected.block<3, 1>(0, 1) *= scale.y();
+  T_AB_expected.block<3, 1>(0, 2) *= scale.z();
 
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {


### PR DESCRIPTION
Note: very little has to be done with the Convex as the scale is directly incorporated into the hull's polygonal mesh directly. Only the mesh requires particular effort.

NOTE TO RELEASE ENGINEER:

This is one of multiple PRs that enable non-uniform scaling (see also #22772).  For the release, they should all be lumped together. The total feature description is:

    Enable non-uniform scaling for Mesh and Convex geometries.

Relates https://github.com/RobotLocomotion/drake/issues/22046.