### PR TITLE
Adapt visualizers to non-uniform scale

### DIFF
--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -265,7 +265,7 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                             for suffix in known_suffixes:
                                 alt_path = source.path().with_suffix(suffix)
                                 if alt_path.exists():
-                                    convex = Convex(alt_path, shape.scale())
+                                    convex = Convex(alt_path, shape.scale3())
                                     convex_hull = convex.GetConvexHull()
                                     break
 

--- a/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
+++ b/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
@@ -1,8 +1,10 @@
 import unittest
 
 from python.runfiles import Create as CreateRunfiles
+import io
 import numpy as np
 import os
+from PIL import Image
 
 from pydrake.common import (
     FindResourceOrThrow,
@@ -14,7 +16,7 @@ from pydrake.geometry import (
     Mesh,
     MeshSource,
 )
-from pydrake.math import RigidTransform
+from pydrake.math import RigidTransform, RollPitchYaw
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph, CoulombFriction)
@@ -230,6 +232,66 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         self.assertIn("has an unsupported extension", str(cm.exception))
         self.assertNotIn("No supported alternative could be found.",
                          str(cm.exception))
+
+    def test_non_uniform_scale(self):
+        """
+        This test ensures that the visualizer handles non-uniform scale on
+        Mesh (and, by implication, Convex). We do this by creating three
+        visualizations:
+
+        1. Visualization of arbitrary mesh.
+        2. Visualization of reference mesh.
+        3. Visualization of scaled mesh, such when applying the scale factors,
+           it should appear the same as the reference mesh.
+
+        We confirm that the visualization of the arbitrary and reference meshes
+        are different. And then that the reference and scaled match.
+        """
+        def visualizer_with_mesh(mesh_contents: str, scale: list):
+            builder = DiagramBuilder()
+            mbp, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+            world_body = mbp.world_body()
+
+            mesh_body = mbp.AddRigidBody("mesh")
+            mbp.WeldFrames(world_body.body_frame(), mesh_body.body_frame(),
+                           RigidTransform())
+            mesh = Mesh(
+                InMemoryMesh(
+                    mesh_file=MemoryFile(contents=mesh_contents,
+                                         extension=".obj",
+                                         filename_hint="test.obj")),
+                scale3=scale)
+            X_BG = RigidTransform(rpy=RollPitchYaw(0.25, 0.25, 0.25),
+                                  p=[0, 0, 0])
+            mbp.RegisterVisualGeometry(mesh_body, X_BG, mesh, "mesh_vis",
+                                       np.array([0.5, 0.5, 0.5, 1.]))
+            mbp.Finalize()
+
+            viz = PlanarSceneGraphVisualizer(scene_graph)
+
+            # Now return the visualized image.
+            buf = io.BytesIO()
+            viz.fig.savefig(buf, format='png')
+            buf.seek(0)
+            image = Image.open(buf)
+            return np.array(image)
+
+        # The meshes below have no faces; they get replaced by their convex
+        # hulls so the faces aren't needed.
+        viz_arbitrary = visualizer_with_mesh(
+            mesh_contents="v -1 0 0\nv 0 0 0\nv -1 1 0\nv -1 0 1\n",
+            scale=[1, 1, 1])
+        viz_reference = visualizer_with_mesh(
+            mesh_contents="v 0 0 0\nv 1 0 0\nv 0 1 0\nv 0 0 1\n",
+            scale=[1, 1, 1])
+        # Scale the tet vertex positions by the inverse of the non-uniform
+        # scale.
+        viz_scaled = visualizer_with_mesh(
+            mesh_contents="v 0 0 0\nv 0.5 0 0\nv 0 0.25 0\nv 0 0 0.125\n",
+            scale=[2, 4, 8])
+
+        self.assertTrue(np.any(np.not_equal(viz_reference, viz_arbitrary)))
+        np.testing.assert_array_equal(viz_reference, viz_scaled)
 
     def testConnectPlanarSceneGraphVisualizer(self):
         """Cart-Pole with simple geometry."""

--- a/bindings/pydrake/visualization/_meldis.py
+++ b/bindings/pydrake/visualization/_meldis.py
@@ -450,18 +450,17 @@ class _ViewerApplet:
             (a, b, c) = geom.float_data
             shape = Ellipsoid(a=a, b=b, c=c)
         elif geom.type == lcmt_viewer_geometry_data.MESH and geom.string_data:
-            (scale_x, scale_y, scale_z) = geom.float_data
-            assert scale_x == scale_y and scale_y == scale_z
+            scale3 = geom.float_data
             if geom.string_data[0] == "{":
                 mesh_source = _make_mesh_source_from_json(geom.string_data)
                 if mesh_source is None:
                     # Warning has already been emitted by _make_mesh_source...
                     return (None, None, None)
-                shape = Mesh(source=mesh_source, scale=scale_x)
+                shape = Mesh(source=mesh_source, scale3=scale3)
             else:
                 # A mesh to be loaded from a file.
                 filename = geom.string_data
-                shape = Mesh(filename=filename, scale=scale_x)
+                shape = Mesh(filename=filename, scale3=scale3)
         elif geom.type == lcmt_viewer_geometry_data.MESH:
             assert not geom.string_data
             shape = self._make_triangle_mesh(geom.float_data)

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -371,9 +371,10 @@ class ShapeToLcm : public ShapeReifier {
     // No specific mesh beat out the mesh file, so we'll simply send that.
     geometry_data_.type = geometry_data_.MESH;
     geometry_data_.num_float_data = 3;
-    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
-    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
-    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    const Vector3<double>& scale = mesh.scale3();
+    geometry_data_.float_data.push_back(static_cast<float>(scale.x()));
+    geometry_data_.float_data.push_back(static_cast<float>(scale.y()));
+    geometry_data_.float_data.push_back(static_cast<float>(scale.z()));
     const MeshSource& mesh_source = mesh.source();
     if (mesh_source.is_path()) {
       geometry_data_.string_data = mesh_source.path().string();

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -548,15 +548,19 @@ class MeshcatShapeReifier : public ShapeReifier {
       lumped.object.emplace<internal::MeshData>();
     }
 
-    // Set the scale.
-    const double scale = mesh.scale();
+    // Set the scale. Note that if this were a general transform including a
+    // rotation we would have to _multiply_ the diagonal by the scale factors.
+    // In meshcat, rotation is applied to a different node, so we can safely
+    // treat the lumped_object's matrix as if it contained an identity rotation
+    // and safely directly _set_ the scale factors on the diagonal.
+    const Vector3<double>& scale = mesh.scale3();
     std::visit<void>(
         overloaded{[](std::monostate) {},
                    [scale](auto& lumped_object) {
                      Eigen::Map<Eigen::Matrix4d> matrix(lumped_object.matrix);
-                     matrix(0, 0) = scale;
-                     matrix(1, 1) = scale;
-                     matrix(2, 2) = scale;
+                     matrix(0, 0) = scale.x();
+                     matrix(1, 1) = scale.y();
+                     matrix(2, 2) = scale.z();
                    }},
         lumped.object);
   }

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -390,14 +390,16 @@ class DrakeVisualizerTest : public ::testing::Test {
     const std::string kSupportingPngAsMemory(
         "fully_textured_pyramid_normal.png");
 
+    // Apply a non-uniform scale, so we can observe it in the LCM message.
+    const Vector3d scale(2, 3, 4);
     if (in_memory) {
       InMemoryMesh mesh_data = ReadGltfToMemory(fs::path(gltf_path));
       mesh_data.supporting_files[kSupportingPngAsMemory] =
           MemoryFile::Make(std::get<fs::path>(
               mesh_data.supporting_files[kSupportingPngAsMemory]));
-      mesh = make_unique<MeshType>(std::move(mesh_data));
+      mesh = make_unique<MeshType>(std::move(mesh_data), scale);
     } else {
-      mesh = make_unique<MeshType>(gltf_path);
+      mesh = make_unique<MeshType>(gltf_path, scale);
     }
 
     SCOPED_TRACE(fmt::format("{} {} shape with {} role",
@@ -480,6 +482,10 @@ class DrakeVisualizerTest : public ::testing::Test {
       EXPECT_TRUE(CompareMatrices(X_PC.GetAsMatrix34(),
                                   X_PG_test.GetAsMatrix34(), 1e-7));
     } else {
+      EXPECT_FALSE(geo_message.float_data.empty());
+      EXPECT_EQ(geo_message.float_data[0], scale.x());
+      EXPECT_EQ(geo_message.float_data[1], scale.y());
+      EXPECT_EQ(geo_message.float_data[2], scale.z());
       if (in_memory) {
         EXPECT_FALSE(geo_message.string_data.empty());
         nlohmann::json json_root =

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -345,6 +345,14 @@ GTEST_TEST(MeshcatTest, NumActive) {
   EXPECT_EQ(meshcat.GetNumActiveConnections(), 0);
 }
 
+// Simple utility struct that will allow us to determine the msgpack encoding
+// of an arbitrary 4x4 transform matrix (see e.g., MeshData.matrix or
+// MeshfileObjectData.matrix). The default value is the zero matrix.
+struct JustMatrix {
+  double matrix[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MSGPACK_DEFINE_MAP(matrix);
+};
+
 // Note: The Mesh shape is special. It can reference on-disk or in-memory data
 // and they all need to be handled. This test runs through the various
 // permutations.
@@ -354,11 +362,13 @@ GTEST_TEST(MeshcatTest, SetObjectWithMesh) {
   using testing::HasSubstr;
   using testing::Not;
 
+  // Apply an arbitrary, non-uniform scale so we can detect its inclusion.
+  const Vector3d non_uniform_scale{2, 3, 4};
   // A .obj file with material library and image. The packed message should
   // encode the .obj, the .mtl file, and the image.
   const fs::path obj_path =
       FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.obj");
-  const Mesh disk_obj(obj_path, 0.25);
+  const Mesh disk_obj(obj_path, non_uniform_scale);
   const auto obj_file = MemoryFile::Make(obj_path);
   const auto mtl_file = MemoryFile::Make(
       FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.mtl"));
@@ -368,17 +378,38 @@ GTEST_TEST(MeshcatTest, SetObjectWithMesh) {
       InMemoryMesh{MemoryFile(obj_file.contents(), obj_file.extension(),
                               "a hint; *not* a path"),
                    {{"rainbow_box.mtl", MemoryFile(mtl_file)},
-                    {"rainbow_stripes.png", MemoryFile(png_file)}}});
+                    {"rainbow_stripes.png", MemoryFile(png_file)}}},
+      non_uniform_scale);
   // The "hetero" objs mix up the supporting files so that, in turn, one is
   // in memory, and one is on-disk.
-  const Mesh hetero_obj1(InMemoryMesh{
-      MemoryFile(obj_file.contents(), obj_file.extension(), "hetero1_obj"),
-      {{"rainbow_box.mtl", fs::path(mtl_file.filename_hint())},
-       {"rainbow_stripes.png", MemoryFile(png_file)}}});
-  const Mesh hetero_obj2(InMemoryMesh{
-      MemoryFile(obj_file.contents(), obj_file.extension(), "hetero2_obj"),
-      {{"rainbow_box.mtl", MemoryFile(mtl_file)},
-       {"rainbow_stripes.png", fs::path(png_file.filename_hint())}}});
+  const Mesh hetero_obj1(
+      InMemoryMesh{
+          MemoryFile(obj_file.contents(), obj_file.extension(), "hetero1_obj"),
+          {{"rainbow_box.mtl", fs::path(mtl_file.filename_hint())},
+           {"rainbow_stripes.png", MemoryFile(png_file)}}},
+      non_uniform_scale);
+  const Mesh hetero_obj2(
+      InMemoryMesh{
+          MemoryFile(obj_file.contents(), obj_file.extension(), "hetero2_obj"),
+          {{"rainbow_box.mtl", MemoryFile(mtl_file)},
+           {"rainbow_stripes.png", fs::path(png_file.filename_hint())}}},
+      non_uniform_scale);
+
+  // Get the msgpack encoding of the matrix field (leaving out all prefixes).
+  // We'll match the string with the contents below.
+  const std::string matrix_string = [&non_uniform_scale]() {
+    JustMatrix data;
+    data.matrix[0] = non_uniform_scale.x();
+    data.matrix[5] = non_uniform_scale.y();
+    data.matrix[10] = non_uniform_scale.z();
+    data.matrix[15] = 1;  // Homogeneous matrix.
+    std::stringstream matrix_stream;
+    msgpack::pack(matrix_stream, data);
+    const std::string full_string = matrix_stream.str();
+    return full_string.substr(full_string.find("matrix"));
+  }();
+  DRAKE_DEMAND(!matrix_string.empty());
+
   for (const auto* mesh_ptr :
        {&disk_obj, &memory_obj, &hetero_obj1, &hetero_obj2}) {
     const MeshSource& source = mesh_ptr->source();
@@ -395,6 +426,8 @@ GTEST_TEST(MeshcatTest, SetObjectWithMesh) {
     EXPECT_THAT(packed_obj, testing::HasSubstr("data:image/png;base64"));
     // Evidence that the material library got loaded.
     EXPECT_THAT(packed_obj, testing::HasSubstr("newmtl Rainbow_Stripes"));
+    // Evidence that the non-uniform scale was propagated.
+    EXPECT_THAT(packed_obj, testing::HasSubstr(matrix_string));
     meshcat.Delete("obj_path");
     ASSERT_TRUE(meshcat.GetPackedObject("obj_path").empty());
   }


### PR DESCRIPTION
NOTE TO RELEASE ENGINEER:

This is one of multiple PRs that enable non-uniform scaling (see also #22772, #22785, and others).  For the release, they should all be lumped together. The total feature description is:

    Enable non-uniform scaling for Mesh and Convex geometries.

Relates https://github.com/RobotLocomotion/drake/issues/22046.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22823)
<!-- Reviewable:end -->
