### PR TITLE
Proxmity and Parsing use non-uniform scale

### DIFF
--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -380,7 +380,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
   const std::string extension = mesh_spec.extension();
   if (extension == ".obj") {
     mesh = make_unique<TriangleSurfaceMesh<double>>(
-        ReadObjToTriangleSurfaceMesh(mesh_spec.source(), mesh_spec.scale()));
+        ReadObjToTriangleSurfaceMesh(mesh_spec.source(), mesh_spec.scale3()));
   } else if (extension == ".vtk") {
     mesh = make_unique<TriangleSurfaceMesh<double>>(
         ConvertVolumeToSurfaceMesh(MakeVolumeMeshFromVtk<double>(mesh_spec)));
@@ -552,11 +552,9 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   // For zero margin, use the pre-computed convex hull for the shape.
   const TriangleSurfaceMesh<double> inflated_surface_mesh =
       MakeTriangleFromPolygonMesh(
-          margin > 0
-              ? MakeConvexHull(convex_spec.source(),
-                               Vector3<double>::Constant(convex_spec.scale()),
-                               margin)
-              : convex_spec.GetConvexHull());
+          margin > 0 ? MakeConvexHull(convex_spec.source(),
+                                      convex_spec.scale3(), margin)
+                     : convex_spec.GetConvexHull());
   auto inflated_mesh = make_unique<VolumeMesh<double>>(
       MakeConvexVolumeMesh<double>(inflated_surface_mesh));
 

--- a/geometry/proximity/make_mesh_from_vtk.cc
+++ b/geometry/proximity/make_mesh_from_vtk.cc
@@ -21,21 +21,20 @@ VolumeMesh<T> MakeVolumeMeshFromVtk(const Mesh& mesh) {
         mesh.extension(), mesh.source().description()));
   }
 
-  const double scale = mesh.scale();
+  const Eigen::Vector3d scale = mesh.scale3();
 
-  VolumeMesh<double> read_mesh =
-      ReadVtkToVolumeMesh(mesh.source(), Eigen::Vector3d::Constant(scale));
+  VolumeMesh<double> read_mesh = ReadVtkToVolumeMesh(mesh.source(), scale);
 
   for (int e = 0; e < read_mesh.num_elements(); ++e) {
     if (read_mesh.CalcTetrahedronVolume(e) <= 0.) {
       throw std::runtime_error(fmt::format(
-          "MakeVolumeMeshFromVtk('{}', {}): "
+          "MakeVolumeMeshFromVtk('{}') with scale [{}]: "
           "The {}-th tetrahedron (index start at 0) with "
           "vertices {}, {}, {}, {} has non-positive volume, "
           "so you might want to switch two consecutive vertices.",
-          mesh.source().description(), scale, e, read_mesh.element(e).vertex(0),
-          read_mesh.element(e).vertex(1), read_mesh.element(e).vertex(2),
-          read_mesh.element(e).vertex(3)));
+          mesh.source().description(), fmt_eigen(scale.transpose()), e,
+          read_mesh.element(e).vertex(0), read_mesh.element(e).vertex(1),
+          read_mesh.element(e).vertex(2), read_mesh.element(e).vertex(3)));
     }
   }
 

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -10,6 +10,7 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/make_sphere_field.h"
@@ -735,45 +736,48 @@ void TestRigidMeshCube(const Mesh& mesh) {
   EXPECT_EQ(surface_mesh.num_vertices(), 8);
   EXPECT_EQ(surface_mesh.num_triangles(), 12);
 
-  // The scale factor multiplies the measure of every vertex position, so
-  // the expected distance of the vertex to the origin should be:
-  // scale * sqrt(3) (because the original mesh was the unit sphere).
-  const double expected_dist = std::sqrt(3) * mesh.scale();
+  // The original mesh was the unit cube. The mesh will be scaled by scale3.
+  // Each vertex is the same distance from the origin. The expected distance is
+  // simply the distance of one "unit" corner with the scale applied.
+  const Vector3d p_GV(1, 1, 1);  // The position of a corner vertex.
+  const double expected_dist = mesh.scale3().cwiseProduct(p_GV).norm();
+  const double tolerance = mesh.scale3().norm() * kEps;
   for (int v = 0; v < surface_mesh.num_vertices(); ++v) {
     const double dist = surface_mesh.vertex(v).norm();
-    ASSERT_NEAR(dist, expected_dist, mesh.scale() * kEps)
-        << "for scale: " << mesh.scale() << " at vertex " << v;
+    ASSERT_NEAR(dist, expected_dist, tolerance)
+        << "for scale: " << fmt::to_string(fmt_eigen(mesh.scale3().transpose()))
+        << " at vertex " << v;
   }
 }
 
 // Confirm support for a rigid Mesh. Tests that a hydroelastic representation
 // is made.
 TEST_F(HydroelasticRigidGeometryTest, Mesh) {
-  // We just want a non-unit scale.
-  constexpr double kScale = 0.75;
+  // Non-unit, non-uniform scale.
+  const Vector3d kScale3(2, 3, 4);
   const std::string obj_path =
       FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
   const std::string vtk_path =
       FindResourceOrThrow("drake/geometry/test/cube_as_volume.vtk");
   {
     SCOPED_TRACE("Rigid Mesh, on-disk obj");
-    TestRigidMeshCube(Mesh(obj_path, kScale));
+    TestRigidMeshCube(Mesh(obj_path, kScale3));
   }
   {
     SCOPED_TRACE("Rigid Mesh, in-memory obj");
-    TestRigidMeshCube(Mesh(InMemoryMesh{MemoryFile::Make(obj_path)}, kScale));
+    TestRigidMeshCube(Mesh(InMemoryMesh{MemoryFile::Make(obj_path)}, kScale3));
   }
   {
     SCOPED_TRACE("Rigid Mesh, on-disk vtk");
-    TestRigidMeshCube(Mesh(vtk_path, kScale));
+    TestRigidMeshCube(Mesh(vtk_path, kScale3));
   }
   {
     SCOPED_TRACE("Rigid Mesh, in-memory vtk");
-    TestRigidMeshCube(Mesh(InMemoryMesh{MemoryFile::Make(vtk_path)}, kScale));
+    TestRigidMeshCube(Mesh(InMemoryMesh{MemoryFile::Make(vtk_path)}, kScale3));
   }
   {
     SCOPED_TRACE("Rigid Mesh, unsupported extension");
-    DRAKE_EXPECT_THROWS_MESSAGE(TestRigidMeshCube(Mesh("invalid.stl", kScale)),
+    DRAKE_EXPECT_THROWS_MESSAGE(TestRigidMeshCube(Mesh("invalid.stl", kScale3)),
                                 ".*Mesh shapes can only use .*invalid.stl");
   }
 }
@@ -782,7 +786,8 @@ TEST_F(HydroelasticRigidGeometryTest, Mesh) {
 // hull.
 TEST_F(HydroelasticRigidGeometryTest, Convex) {
   auto expect_convex_cube = [](const std::string& file) {
-    const Convex convex(file, 1.0);
+    const Vector3d kScale3(2, 3, 4);
+    const Convex convex(file, kScale3);
     // Empty properties since its contents do not matter.
     const std::optional<RigidGeometry> geometry =
         MakeRigidRepresentation(convex, ProximityProperties());
@@ -793,6 +798,9 @@ TEST_F(HydroelasticRigidGeometryTest, Convex) {
     const TriangleSurfaceMesh<double>& surface_mesh = geometry->mesh();
     EXPECT_EQ(surface_mesh.num_vertices(), 8);
     EXPECT_EQ(surface_mesh.num_triangles(), 12);
+    // The box is a 2x2x2 cube. We've scaled it up.
+    const auto& [_, size] = surface_mesh.CalcBoundingBox();
+    EXPECT_TRUE(CompareMatrices(size, 2 * kScale3));
   };
 
   {
@@ -1296,9 +1304,14 @@ TEST_F(HydroelasticSoftGeometryTest, Ellipsoid) {
 TEST_F(HydroelasticSoftGeometryTest, Convex) {
   // Construct off of a known convex mesh.
   std::string file = FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
-  const Convex convex_spec(file);
+  const Vector3d kScale3(2, 3, 4);
+  const Convex convex_spec(file, kScale3);
 
   ProximityProperties properties = soft_properties(0.16);
+  // We need a non-zero margin value to trigger the recomputation of the convex
+  // hull -- confirm it passes margin and scale.
+  const double margin_value = 0.0001;
+  properties.AddProperty(kHydroGroup, kMargin, margin_value);
   std::optional<SoftGeometry> convex =
       MakeSoftRepresentation(convex_spec, properties);
 
@@ -1307,11 +1320,23 @@ TEST_F(HydroelasticSoftGeometryTest, Convex) {
   const int expected_num_vertices = 9;
   EXPECT_EQ(convex->mesh().num_vertices(), expected_num_vertices);
   const double E = properties.GetPropertyOrDefault(kHydroGroup, kElastic, 1e8);
+  // We want the bound of the box to see if scale was applied.
+  Vector3d min_pt = Vector3d::Constant(std::numeric_limits<double>::infinity());
+  Vector3d max_pt = -min_pt;
   for (int v = 0; v < convex->mesh().num_vertices(); ++v) {
     const double pressure = convex->pressure_field().EvaluateAtVertex(v);
-    EXPECT_GE(pressure, 0);
+    // The non-zero margin gives us negative pressure on the boundary. The
+    // magnitude of that negative pressure is _essentially_:
+    //   margin_value / box_depth * E.
+    // Box depth is essentially one for `quad_cube.obj`.
+    EXPECT_GE(pressure, -margin_value * E);
     EXPECT_LE(pressure, E);
+    min_pt = min_pt.cwiseMin(convex->mesh().vertex(v));
+    max_pt = max_pt.cwiseMax(convex->mesh().vertex(v));
   }
+  EXPECT_TRUE(CompareMatrices(max_pt - min_pt,
+                              2 * (kScale3 + Vector3d::Constant(margin_value)),
+                              1e-14));
 }
 
 // Test construction of a compliant (generally non-convex) tetrahedral mesh.
@@ -1321,8 +1346,10 @@ TEST_F(HydroelasticSoftGeometryTest, Convex) {
 TEST_F(HydroelasticSoftGeometryTest, Mesh) {
   const std::string path =
       FindResourceOrThrow("drake/geometry/test/non_convex_mesh.vtk");
-  const std::vector<Mesh> meshes{Mesh(path),
-                                 Mesh(InMemoryMesh{MemoryFile::Make(path)})};
+  // Non-unit, non-uniform scale.
+  const Vector3d kScale3(2, 3, 4);
+  const std::vector<Mesh> meshes{
+      Mesh(path, kScale3), Mesh(InMemoryMesh{MemoryFile::Make(path)}, kScale3)};
   for (const Mesh& mesh_specification : meshes) {
     ProximityProperties properties = soft_properties();
     std::optional<SoftGeometry> compliant_geometry =
@@ -1334,12 +1361,19 @@ TEST_F(HydroelasticSoftGeometryTest, Mesh) {
     EXPECT_EQ(compliant_geometry->mesh().num_vertices(), expected_num_vertices);
     const double E =
         properties.GetPropertyOrDefault(kHydroGroup, kElastic, 1e8);
+    // We want the bound of the box to see if scale was applied.
+    Vector3d min_pt =
+        Vector3d::Constant(std::numeric_limits<double>::infinity());
+    Vector3d max_pt = -min_pt;
     for (int v = 0; v < compliant_geometry->mesh().num_vertices(); ++v) {
       const double pressure =
           compliant_geometry->pressure_field().EvaluateAtVertex(v);
       EXPECT_GE(pressure, 0);
       EXPECT_LE(pressure, E);
+      min_pt = min_pt.cwiseMin(compliant_geometry->mesh().vertex(v));
+      max_pt = max_pt.cwiseMax(compliant_geometry->mesh().vertex(v));
     }
+    EXPECT_TRUE(CompareMatrices(max_pt - min_pt, kScale3, 1e-14));
   }
 }
 

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -909,6 +909,15 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     return geometries_for_deformable_contact_;
   }
 
+  const TriangleSurfaceMesh<double>* mesh_distance_boundary(
+      GeometryId g_id) const {
+    const auto iter = mesh_sdf_data_.find(g_id);
+    if (iter == mesh_sdf_data_.end()) {
+      return nullptr;
+    }
+    return &iter->second.tri_mesh();
+  }
+
   bool IsFclConvexType(GeometryId id) const {
     auto iter = dynamic_objects_.find(id);
     if (iter == dynamic_objects_.end()) {
@@ -1117,7 +1126,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     } else if (mesh.extension() == ".obj") {
       mesh_sdf_data_.emplace(data.id,
                              MeshDistanceBoundary(ReadObjToTriangleSurfaceMesh(
-                                 mesh.source(), mesh.scale())));
+                                 mesh.source(), mesh.scale3())));
     }
     // Meshes are unsupported if we cannot compute a MeshDistanceBoundary.
     // point_distance::Callback() skips every Mesh that doesn't have an entry
@@ -1456,6 +1465,12 @@ template <typename T>
 const deformable::Geometries&
 ProximityEngine<T>::deformable_contact_geometries() const {
   return impl_->deformable_contact_geometries();
+}
+
+template <typename T>
+const TriangleSurfaceMesh<double>* ProximityEngine<T>::mesh_distance_boundary(
+    GeometryId g_id) const {
+  return impl_->mesh_distance_boundary(g_id);
 }
 
 template <typename T>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -296,6 +296,11 @@ class ProximityEngine {
    use for proximity queries for deformable contact. */
   const deformable::Geometries& deformable_contact_geometries() const;
 
+  /* Returns the mesh-distance boundary surface associated with the given
+   geometry id; if it exists (otherwise null). */
+  const TriangleSurfaceMesh<double>* mesh_distance_boundary(
+      GeometryId g_id) const;
+
  private:
   // Testing utilities:
   // These functions facilitate *limited* introspection into the engine state.

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -405,9 +405,12 @@ void ShapeMatcher<Mesh>::TestShapeParameters(const Mesh& test) {
     error() << "\nExpected description " << expected_.source().description()
             << ", received description " << test.source().description();
   }
-  if (test.scale() != expected_.scale()) {
-    error() << "\nExpected mesh scale " << expected_.scale()
-            << ", received mesh scale " << test.scale();
+  // Looking for *exact* match.
+  if (test.scale3() != expected_.scale3()) {
+    error() << "\nExpected mesh scale "
+            << fmt::to_string(fmt_eigen(expected_.scale3().transpose()))
+            << ", received mesh scale "
+            << fmt::to_string(fmt_eigen(test.scale3().transpose()));
   }
 }
 
@@ -418,9 +421,12 @@ void ShapeMatcher<Convex>::TestShapeParameters(const Convex& test) {
     error() << "\nExpected description " << expected_.source().description()
             << ", received description " << test.source().description();
   }
-  if (test.scale() != expected_.scale()) {
-    error() << "\nExpected convex scale " << expected_.scale()
-            << ", received convex scale " << test.scale();
+  // Looking for *exact* match.
+  if (test.scale3() != expected_.scale3()) {
+    error() << "\nExpected convex scale "
+            << fmt::to_string(fmt_eigen(expected_.scale3().transpose()))
+            << ", received convex scale "
+            << fmt::to_string(fmt_eigen(test.scale3().transpose()));
   }
 }
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -19,6 +19,7 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/deformable_contact_internal.h"
 #include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/mesh_distance_boundary.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/autodiff.h"
@@ -87,6 +88,12 @@ class ProximityEngineTester {
   static const internal::deformable::Geometries&
   get_deformable_contact_geometries(const ProximityEngine<T>& engine) {
     return engine.deformable_contact_geometries();
+  }
+
+  template <typename T>
+  static const TriangleSurfaceMesh<double>* get_mesh_distance_boundary(
+      const ProximityEngine<T>& engine, GeometryId id) {
+    return engine.mesh_distance_boundary(id);
   }
 };
 
@@ -536,6 +543,30 @@ GTEST_TEST(ProximityEngineTests, ProcessVtkConvexUndefHydro) {
     EXPECT_EQ(ProximityEngineTester::hydroelastic_type(convex_id, engine),
               HydroelasticType::kUndefined);
   }
+}
+
+// TODO(SeanCurtis-TRI): Confirm that SDF data gets computed for Mesh(vtk) and
+// all Convex().
+
+// Tests that the signed distance field (SDF) data computed for an obj correctly
+// accounts for its scale factor.
+GTEST_TEST(ProximityEngineTest, ProcessMeshSdfDataForObj) {
+  ProximityEngine<double> engine;
+
+  const GeometryId g_id = GeometryId::get_new_id();
+  const Vector3d scale(2, 3, 4);
+  const Mesh mesh(FindResourceOrThrow("drake/geometry/test/quad_cube.obj"),
+                  scale);
+  engine.AddAnchoredGeometry(mesh, {}, g_id);
+
+  const TriangleSurfaceMesh<double>* boundary_mesh =
+      ProximityEngineTester::get_mesh_distance_boundary(engine, g_id);
+
+  ASSERT_NE(boundary_mesh, nullptr);
+  // The cube is 2x2x2. The bounding box of the boundary mesh should be that,
+  // scaled by the given scale factors.
+  const auto& [_, size] = boundary_mesh->CalcBoundingBox();
+  EXPECT_TRUE(CompareMatrices(size, 2 * scale));
 }
 
 // Adds a single shape to the given engine with the indicated anchored/dynamic

--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -617,7 +617,7 @@ class MujocoParser {
           // As with mujoco, failure leads to using the convex hull.
           // https://github.com/google-deepmind/mujoco/blob/df7ea3ed3350164d0f111c12870e46bc59439a96/src/user/user_mesh.cc#L1379-L1382
           result = CalcSpatialInertiaImpl(
-              geometry::Convex(mesh.source().path(), mesh.scale()),
+              geometry::Convex(mesh.source().path(), mesh.scale3()),
               1.0 /* density */);
           if (std::holds_alternative<std::string>(result)) {
             policy_.Error(fmt::format(
@@ -1415,18 +1415,7 @@ class MujocoParser {
         }
 
         Vector3d scale{1, 1, 1};
-        if (ParseVectorAttribute(mesh_node, "scale", &scale)) {
-          if (scale[0] != scale[1] || scale[1] != scale[2]) {
-            Error(*node,
-                  fmt::format(
-                      "mesh {} was defined with a non-uniform scale; but Drake "
-                      "currently only supports uniform scaling. See "
-                      "https://drake.mit.edu/troubleshooting.html for "
-                      "additional resources.",
-                      name));
-            continue;
-          }
-        }
+        ParseVectorAttribute(mesh_node, "scale", &scale);
 
         std::filesystem::path filename(file);
 
@@ -1460,7 +1449,7 @@ class MujocoParser {
                          ::tolower);
           // TODO(russt): Support .vtk files.
           if (extension == ".obj") {
-            mesh_[name] = std::make_unique<geometry::Mesh>(filename, scale[0]);
+            mesh_[name] = std::make_unique<geometry::Mesh>(filename, scale);
           } else {
             Error(
                 *node,

--- a/multibody/parsing/detail_sdf_geometry.cc
+++ b/multibody/parsing/detail_sdf_geometry.cc
@@ -170,23 +170,13 @@ std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
       DRAKE_DEMAND(mesh_uri.has_value());
       if (!mesh_uri.has_value()) return nullptr;
       const std::string file_name = resolve_filename(diagnostic, *mesh_uri);
-      double scale = 1.0;
+      Vector3d scale(1, 1, 1);
       if (mesh_element->HasElement("scale")) {
-        std::optional<gz::math::Vector3d> scale_vector =
+        std::optional<gz::math::Vector3d> gz_scale =
             GetChildElementValue<gz::math::Vector3d>(diagnostic, mesh_element,
                                                      "scale");
-        if (!scale_vector.has_value()) return nullptr;
-        // geometry::Mesh only supports isotropic scaling and therefore we
-        // enforce it.
-        if (!(scale_vector->X() == scale_vector->Y() &&
-              scale_vector->X() == scale_vector->Z())) {
-          std::string message =
-              "Drake meshes only support isotropic scaling. Therefore all "
-              "three scaling factors must be exactly equal.";
-          diagnostic.Error(mesh_element, std::move(message));
-          return nullptr;
-        }
-        scale = scale_vector->X();
+        if (!gz_scale.has_value()) return nullptr;
+        scale = Vector3d(gz_scale->X(), gz_scale->Y(), gz_scale->Z());
       }
       // TODO(amcastro-tri): Fix the given path to be an absolute path.
       if (mesh_element->HasElement("drake:declare_convex")) {

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -299,22 +299,10 @@ std::unique_ptr<geometry::Shape> ParseMesh(const TinyXml2Diagnostic& diagnostic,
     return {};
   }
 
-  double scale = 1.0;
+  Vector3d scale(1, 1, 1);
   // Obtains the scale of the mesh if it exists.
   if (shape_node->Attribute("scale") != nullptr) {
-    Vector3d scale_vector;
-    ParseThreeVectorAttribute(shape_node, "scale", &scale_vector);
-    // geometry::Mesh only supports isotropic scaling and therefore we
-    // enforce it.
-    if (!(scale_vector(0) == scale_vector(1) &&
-          scale_vector(0) == scale_vector(2))) {
-      diagnostic.Error(*shape_node,
-                       "Drake meshes only support isotropic"
-                       " scaling. Therefore all three scaling factors must be"
-                       " exactly equal.");
-      return {};
-    }
-    scale = scale_vector(0);
+    ParseThreeVectorAttribute(shape_node, "scale", &scale);
   }
 
   // Rely on geometry::Shape to validate physical parameters.

--- a/multibody/parsing/detail_usd_geometry.cc
+++ b/multibody/parsing/detail_usd_geometry.cc
@@ -333,25 +333,6 @@ std::optional<Eigen::Vector2d> GetCapsuleDimension(
   return Eigen::Vector2d(capsule_radius, capsule_height);
 }
 
-std::optional<double> GetMeshScale(const pxr::UsdPrim& prim,
-                                   const DiagnosticPolicy& diagnostic) {
-  std::optional<Eigen::Vector3d> prim_scale_opt =
-      GetPrimScale(prim, diagnostic);
-  if (!prim_scale_opt.has_value()) {
-    return std::nullopt;
-  }
-  Eigen::Vector3d prim_scale = prim_scale_opt.value();
-
-  if (prim_scale[0] != prim_scale[1] || prim_scale[1] != prim_scale[2]) {
-    diagnostic.Error(fmt::format(
-        "The scaling of the mesh at {} is not isotropic. Non-isotropic scaling "
-        "of a mesh is not supported.",
-        prim.GetPath().GetString()));
-    return std::nullopt;
-  }
-  return prim_scale[0];
-}
-
 std::unique_ptr<geometry::Shape> CreateGeometryBox(
     const pxr::UsdPrim& prim, double meters_per_unit,
     const DiagnosticPolicy& diagnostic) {
@@ -417,7 +398,7 @@ std::unique_ptr<geometry::Shape> CreateGeometryMesh(
     return nullptr;
   }
 
-  std::optional<double> prim_scale = GetMeshScale(prim, diagnostic);
+  std::optional<Eigen::Vector3d> prim_scale = GetPrimScale(prim, diagnostic);
   if (!prim_scale.has_value()) {
     return nullptr;
   }

--- a/multibody/parsing/detail_usd_geometry.h
+++ b/multibody/parsing/detail_usd_geometry.h
@@ -39,10 +39,6 @@ std::optional<Eigen::Vector2d> GetCapsuleDimension(
     const pxr::UsdPrim& prim, double meters_per_unit,
     const pxr::TfToken& stage_up_axis, const DiagnosticPolicy& diagnostic);
 
-// Returns the scale factor of an UsdGeomMesh, or nullopt if an error occurs.
-std::optional<double> GetMeshScale(const pxr::UsdPrim& prim,
-                                   const DiagnosticPolicy& diagnostic);
-
 // Creates a geometry::Box with a dimension specified by the UsdGeomCube prim.
 // Returns nullptr if an error occurs.
 std::unique_ptr<geometry::Shape> CreateGeometryBox(

--- a/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
@@ -95,8 +95,6 @@ constexpr std::string_view kItWorks{""};
 constexpr std::string_view kTooSlow =  // #22412
     "skip me";
 namespace KnownErrors {
-constexpr std::string_view kNonUniformScale =  // #22046
-    ".*non-uniform scale.*";
 constexpr std::string_view kSizeFromMesh =  // #22372
     ".*size of the shape from the mesh.*";
 constexpr std::string_view kStlMesh =  // #19408
@@ -142,8 +140,6 @@ TEST_P(MujocoMenagerieTest, MujocoMenagerie) {
 // TODO(russt): Some of the tests are redundant (e.g. the scene models load the
 // main robot models.)
 const std::pair<const char*, std::string_view> mujoco_menagerie_models[] = {
-    {"agility_cassie/cassie", KnownErrors::kNonUniformScale},
-    {"agility_cassie/scene", KnownErrors::kNonUniformScale},
     {"aloha/aloha", KnownErrors::kStlMesh},
     {"aloha/scene", KnownErrors::kStlMesh},
     {"anybotics_anymal_b/anymal_b", kItWorks},
@@ -226,9 +222,7 @@ const std::pair<const char*, std::string_view> mujoco_menagerie_models[] = {
     {"shadow_dexee/scene", KnownErrors::kStlMesh},
     {"shadow_dexee/shadow_dexee", KnownErrors::kStlMesh},
     {"shadow_hand/keyframes", kItWorks},
-    {"shadow_hand/left_hand", KnownErrors::kNonUniformScale},
     {"shadow_hand/right_hand", kItWorks},
-    {"shadow_hand/scene_left", KnownErrors::kNonUniformScale},
     {"shadow_hand/scene_right", kItWorks},
     {"skydio_x2/scene", kItWorks},
     {"skydio_x2/x2", kItWorks},

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -427,35 +427,14 @@ TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometry) {
       "  <uri>" +
       absolute_file_path +
       "</uri>"
-      "  <scale> 3 3 3 </scale>"
+      "  <scale> 3 2 1 </scale>"
       "</mesh>");
   unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
   const Mesh* mesh = dynamic_cast<const Mesh*>(shape.get());
   ASSERT_NE(mesh, nullptr);
   ASSERT_TRUE(mesh->source().is_path());
   EXPECT_EQ(mesh->source().path(), absolute_file_path);
-  EXPECT_EQ(mesh->scale(), 3);
-}
-
-// Verify error when mesh scale is not isotropic.
-TEST_F(SceneGraphParserDetail, MakeMeshFromSdfGeometryIsotropicError) {
-  // TODO(amcastro-tri): Be warned, the result of this test might (should)
-  // change as we add support allowing to specify paths relative to the SDF file
-  // location.
-  const std::string absolute_file_path = "/path/to/some/mesh.obj";
-  unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
-      "<mesh>"
-      "  <uri>" +
-      absolute_file_path +
-      "</uri>"
-      "  <scale> 3 1 2 </scale>"
-      "</mesh>");
-  unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
-  EXPECT_EQ(shape, nullptr);
-  EXPECT_THAT(TakeError(),
-              ::testing::MatchesRegex(
-                  ".*Drake meshes only support isotropic scaling. Therefore"
-                  " all three scaling factors must be exactly equal."));
+  EXPECT_TRUE(CompareMatrices(mesh->scale3(), Vector3d(3, 2, 1)));
 }
 
 // Verify MakeShapeFromSdfGeometry can make a convex mesh from an sdf::Geometry.
@@ -467,14 +446,15 @@ TEST_F(SceneGraphParserDetail, MakeConvexFromSdfGeometry) {
       "  <uri>" +
       absolute_file_path +
       "</uri>"
-      "  <scale> 3 3 3 </scale>"
+      "  <scale> 3 2 1 </scale>"
       "</mesh>");
   unique_ptr<Shape> shape = MakeShapeFromSdfGeometry(*sdf_geometry);
   const Convex* convex = dynamic_cast<const Convex*>(shape.get());
   ASSERT_NE(convex, nullptr);
   EXPECT_TRUE(convex->source().is_path());
   EXPECT_EQ(convex->source().path(), absolute_file_path);
-  EXPECT_EQ(convex->scale(), 3);
+  // EXPECT_EQ(convex->scale(), 3);
+  EXPECT_TRUE(CompareMatrices(convex->scale3(), Vector3d(3, 2, 1)));
 }
 
 // Verify that MakeShapeFromSdfGeometry does nothing with a heightmap.

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -931,11 +931,27 @@ TEST_F(UrdfGeometryTest, TestBadMesh) {
 
   ParseUrdfGeometryString(fmt::format(base, "filename='/QQQ'"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*/QQQ.*invalid.*"));
+}
 
+TEST_F(UrdfGeometryTest, MeshNonUniformScale) {
+  constexpr const char* base = R"""(
+    <robot name='a'>
+      <link name='b'>
+        <collision>
+          <geometry>
+            <mesh {}/>
+          </geometry>
+        </collision>
+      </link>
+    </robot>)""";
   ParseUrdfGeometryString(fmt::format(base, R"""(
    filename='package://drake/multibody/parsing/test/tri_cube.obj' scale='1 2 3'
    )"""));
-  EXPECT_THAT(TakeError(), MatchesRegex(".*only.*isotropic scaling.*"));
+  ASSERT_EQ(collision_instances_.size(), 1);
+  const geometry::Shape& shape = collision_instances_[0].shape();
+  const auto* mesh = dynamic_cast<const geometry::Mesh*>(&shape);
+  ASSERT_NE(mesh, nullptr);
+  EXPECT_EQ(mesh->scale3(), Eigen::Vector3d(1, 2, 3));
 }
 
 TEST_F(UrdfGeometryTest, TestBadShapeCollision) {

--- a/multibody/tree/geometry_spatial_inertia.cc
+++ b/multibody/tree/geometry_spatial_inertia.cc
@@ -28,7 +28,7 @@ CalcSpatialInertiaResult CalcMeshSpatialInertia(const Mesh& mesh,
   const auto& extension = mesh.extension();
   if (extension == ".obj") {
     return internal::CalcSpatialInertiaImpl(
-        geometry::ReadObjToTriangleSurfaceMesh(mesh.source(), mesh.scale()),
+        geometry::ReadObjToTriangleSurfaceMesh(mesh.source(), mesh.scale3()),
         density);
   }
   if (extension == ".vtk") {

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -217,9 +217,13 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
   const std::string valid_vtk_path =
       FindResourceOrThrow("drake/geometry/test/one_tetrahedron.vtk");
   const MeshType unit_scale_obj(valid_obj_path, 1.0);
-  const MeshType double_scale_obj(valid_obj_path, 2.0);
+  // By creating a non-uniform scale, we're increasing the volume by a factor
+  // of sx * sy * sz.
+  const Vector3d scale3(2, 3, 4);
+  const double increase_factor = scale3.prod();
+  const MeshType double_scale_obj(valid_obj_path, scale3);
   const MeshType unit_scale_vtk(valid_vtk_path, 1.0);
-  const MeshType double_scale_vtk(valid_vtk_path, 2.0);
+  const MeshType double_scale_vtk(valid_vtk_path, scale3);
   const MeshType nonexistent("nonexistent.stl", 1.0);
 
   {
@@ -249,7 +253,7 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
     const SpatialInertia<double> M_SScm_S_obj_large =
         CalcSpatialInertia(double_scale_obj, kDensity);
     EXPECT_DOUBLE_EQ(M_SScm_S_obj_large.get_mass(),
-                     M_SScm_S_obj_small.get_mass() * 8);
+                     M_SScm_S_obj_small.get_mass() * increase_factor);
   }
 
   {
@@ -259,7 +263,7 @@ TYPED_TEST_P(MeshTypeSpatialInertaTest, Administrivia) {
     const SpatialInertia<double> M_SScm_S_vtk_large =
         CalcSpatialInertia(double_scale_vtk, kDensity);
     EXPECT_DOUBLE_EQ(M_SScm_S_vtk_large.get_mass(),
-                     M_SScm_S_vtk_small.get_mass() * 8);
+                     M_SScm_S_vtk_small.get_mass() * increase_factor);
   }
 
   {


### PR DESCRIPTION
NOTE TO RELEASE ENGINEER:

This is one of multiple PRs that enable non-uniform scaling (see also #22772, #22785, and others).  For the release, they should all be lumped together. The total feature description is:

    Enable non-uniform scaling for Mesh and Convex geometries.

Relates https://github.com/RobotLocomotion/drake/issues/22046.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22824)
<!-- Reviewable:end -->
