### PR TITLE
[workspace] Disable monthly upgrades of rust_toolchain

### DIFF
--- a/tools/workspace/metadata.py
+++ b/tools/workspace/metadata.py
@@ -128,11 +128,5 @@ def read_repository_metadata(repositories=None):
         # Downloads are associated with individual "crate__..." repositories.
         "downloads": {},
     }
-    result["rust_toolchain"] = {
-        "repository_rule_type": "scripted",
-        "upgrade_script": "upgrade.py",
-        # Downloads are associated with individual "rust_..." repositories.
-        "downloads": {},
-    }
 
     return result

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -112,8 +112,6 @@ _COHORTS = (
     {"clarabel_cpp_internal", "crate_universe"},
     # mypy uses mypy_extensions; be sure to keep them aligned.
     {"mypy_internal", "mypy_extensions_internal"},
-    # rules_rust uses rust_toolchain; be sure to keep them aligned.
-    {"rules_rust", "rust_toolchain"},
     # sdformat depends on both gz libraries; be sure to keep them aligned.
     {"sdformat_internal", "gz_math_internal", "gz_utils_internal"},
     # uwebsockets depends on usockets; be sure to keep them aligned.


### PR DESCRIPTION
During the workspace-bzlmod transition, we do not want to upgrade the workspace's toolchain.

Closes #22684.

+@nicolecheetham for feature review, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22828)
<!-- Reviewable:end -->
