### PR TITLE
Implement create IntegratorBase from integration scheme

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -470,6 +470,7 @@ drake_cc_googletest(
         ":simulator_config_functions",
         "//common:nice_type_name",
         "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
         "//common/yaml",
         "//systems/framework:leaf_system",
         "//systems/primitives:constant_vector_source",

--- a/systems/analysis/simulator_config_functions.h
+++ b/systems/analysis/simulator_config_functions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -7,6 +8,7 @@
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_config.h"
+#include "drake/systems/framework/system.h"
 
 namespace drake {
 namespace systems {
@@ -70,6 +72,25 @@ the integrator's scalar type's extra information such as gradients.
 template <typename T>
 SimulatorConfig ExtractSimulatorConfig(
     const drake::systems::Simulator<T>& simulator);
+
+/** Create an integrator according to the given configuration.
+
+@param system A pointer to the System to be integrated; the integrator will
+  maintain a reference to the system in perpetuity, so the integrator must not
+  outlive the system.
+@param integrator_config Configuration to be used. Only values relevant to the
+  integrator (integration_scheme, max_step_size, use_error_control, accuracy)
+  are applied.
+@pre `system != nullptr`.
+@throw std::exception if the integration scheme does not match any of
+  GetIntegrationSchemes(), or if the integration scheme does not support the
+  scalar type T.
+@tparam_default_scalar
+
+@ingroup simulator_configuration */
+template <typename T>
+std::unique_ptr<IntegratorBase<T>> CreateIntegratorFromConfig(
+    const System<T>* system, const SimulatorConfig& integrator_config);
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -26,8 +26,8 @@ DEFINE_bool(simulator_publish_every_time_step,
 
 // === Integrator's parameters ===
 
-// N.B. The list here must be kept in sync with GetSupportedIntegrators() in
-// simulator_config_functions.cc.
+// N.B. The list here must be kept in sync with
+// GetAllNamedConfigureIntegratorFuncs() in simulator_config_functions.cc.
 DEFINE_string(simulator_integration_scheme,
               drake::systems::SimulatorConfig{}.integration_scheme,
               "[Integrator flag] Integration scheme to be used. Available "


### PR DESCRIPTION
Adds a factory function `std::unique_ptr<IntegratorBase<T>> CreateIntegratorFromFlags(const System<T>& system, const SimulatorConfig& config)` as required [here](https://reviewable.io/reviews/RobotLocomotion/drake/22652#-OMbihXP4FvHphI2nDQZ).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22838)
<!-- Reviewable:end -->
