### PR TITLE
[workspace] Upgrade googlebenchmark to latest release v1.9.2

### DIFF
--- a/tools/workspace/googlebenchmark/patches/console_allocs.patch
+++ b/tools/workspace/googlebenchmark/patches/console_allocs.patch
@@ -5,11 +5,11 @@ reworking the patch and tests to be suitable.
 
 --- src/console_reporter.cc
 +++ src/console_reporter.cc
-@@ -53,9 +53,11 @@ bool ConsoleReporter::ReportContext(const Context& context) {
- }
+@@ -59,9 +59,11 @@ bool ConsoleReporter::ReportContext(const Context& context) {
  
+ BENCHMARK_EXPORT
  void ConsoleReporter::PrintHeader(const Run& run) {
-+  const bool show_allocs = (run.memory_result != nullptr);
++  const bool show_allocs = (run.memory_result.memory_iterations > 0);
    std::string str =
 -      FormatString("%-*s %13s %15s %12s", static_cast<int>(name_field_width_),
 -                   "Benchmark", "Time", "CPU", "Iterations");
@@ -17,13 +17,13 @@ reworking the patch and tests to be suitable.
 +                   "Benchmark", "Time", "CPU", show_allocs ? 10 : 0,
 +                   show_allocs ? "Allocs " : "", "Iterations");
    if (!run.counters.empty()) {
-     if (output_options_ & OO_Tabular) {
+     if ((output_options_ & OO_Tabular) != 0) {
        for (auto const& c : run.counters) {
-@@ -163,6 +165,11 @@ void ConsoleReporter::PrintRunData(const Run& result) {
+@@ -176,6 +178,11 @@ void ConsoleReporter::PrintRunData(const Run& result) {
    }
  
    if (!result.report_big_o && !result.report_rms) {
-+    const bool show_allocs = (result.memory_result != nullptr);
++    const bool show_allocs = (result.memory_result.memory_iterations > 0);
 +    if (show_allocs) {
 +      const std::string s = HumanReadableNumber(result.allocs_per_iter, Counter::kIs1000);
 +      printer(Out, COLOR_YELLOW, "%7s   ", s.c_str());

--- a/tools/workspace/googlebenchmark/repository.bzl
+++ b/tools/workspace/googlebenchmark/repository.bzl
@@ -6,8 +6,8 @@ def googlebenchmark_repository(
     github_archive(
         name = name,
         repository = "google/benchmark",
-        commit = "v1.9.1",
-        sha256 = "32131c08ee31eeff2c8968d7e874f3cb648034377dfc32a4c377fa8796d84981",  # noqa
+        commit = "v1.9.2",
+        sha256 = "409075176168dc46bbb81b74c1b4b6900385b5d16bfc181d678afb060d928bd3",  # noqa
         mirrors = mirrors,
         patches = [
             ":patches/console_allocs.patch",


### PR DESCRIPTION
Towards #22836 

This commit had problematic output in local testing and caused CI jobs to fail. Most recent CI run passed locally, but will await Jenkins ci builds for confirmation.

It would appear these upgrades are indeed problematic: [linux-jammy-clang-bazel-experimental-everything-release](https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-experimental-everything-release/7899/)
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22854)
<!-- Reviewable:end -->
