### PR TITLE
[workspace] Upgrade osqp and qdldl to latest versions

### DIFF
--- a/tools/workspace/osqp_internal/repository.bzl
+++ b/tools/workspace/osqp_internal/repository.bzl
@@ -9,8 +9,8 @@ def osqp_internal_repository(
         upgrade_advice = """
         When updating this commit, see drake/tools/workspace/qdldl/README.md.
         """,
-        commit = "v0.6.3",
-        sha256 = "a6b4148019001f87489c27232e2bdbac37c94f38fa37c1b4ee11eaa5654756d2",  # noqa
+        commit = "v1.0.0",
+        sha256 = "dd6a1c2e7e921485697d5e7cdeeb043c712526c395b3700601f51d472a7d8e48",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/qdldl_internal/repository.bzl
+++ b/tools/workspace/qdldl_internal/repository.bzl
@@ -9,8 +9,8 @@ def qdldl_internal_repository(
         upgrade_advice = """
         When updating this commit, see drake/tools/workspace/qdldl/README.md.
         """,
-        commit = "v0.1.7",
-        sha256 = "631ae65f367859fa1efade1656e4ba22b7da789c06e010cceb8b29656bf65757",  # noqa
+        commit = "v0.1.8",
+        sha256 = "ecf113fd6ad8714f16289eb4d5f4d8b27842b6775b978c39def5913f983f6daa",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Towards #22836 

These upgrades produced build failures in local testing. Furthermore, there have been changes regarding how the `osqp` upstream keeps track of its targeted version of `qdldl` that render our current documentation regarding this upgrade obsolete. Namely, `osqp` had a major version release since this time last month, and it would now appear that it handles its integration with `qdldl` in a more robust manner, appearing to [point to a stable release](https://github.com/osqp/osqp/blob/v1.0.0/algebra/_common/lin_sys/qdldl/qdldl.cmake) rather than a specific commit hash. Furthermore, the stable release of `qdldl` that `osqp v1.0.0` points to is `0.18`, which happens to be the same version that Drake wanted to upgrade to. There is a chance we may no longer need to keep track of these dependencies separately anymore and may be able to rely on the auto-update tool. What is known for certain is that the path referenced in `tools/workspace/qdldl_internal/README.md` no longer exists as a result of repository refactoring changes in the latest version of `osqp`, so at a minimum that reference will have to be removed once these upgrades land.

Problematic everything release job: [linux-jammy-clang-bazel-experimental-everything-release](https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-experimental-everything-release/7900/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22855)
<!-- Reviewable:end -->
