### PR TITLE
[workspace] Upgrade vtk_internal to latest commit

### DIFF
--- a/tools/workspace/vtk_internal/gen/vtkRenderingOpenGL2ObjectFactory.cxx
+++ b/tools/workspace/vtk_internal/gen/vtkRenderingOpenGL2ObjectFactory.cxx
@@ -34,7 +34,7 @@
 #include "vtkOpenGLTextMapper.h"
 #include "vtkOpenGLTexture.h"
 // Removed the next lines for Drake.
-// #include "vtkCocoaRenderWindow.h"
+// #include "vtkOpenGLHyperTreeGridMapper.h"
 // #include "vtkOpenGLRenderWindow.h"
 
 
@@ -68,8 +68,9 @@ VTK_CREATE_CREATE_FUNCTION(vtkOpenGLTextActor3D)
 VTK_CREATE_CREATE_FUNCTION(vtkOpenGLTextMapper)
 VTK_CREATE_CREATE_FUNCTION(vtkOpenGLTexture)
 // Removed the next lines for Drake.
-// VTK_CREATE_CREATE_FUNCTION(vtkCocoaRenderWindow)
+// VTK_CREATE_CREATE_FUNCTION(vtkOpenGLHyperTreeGridMapper)
 // VTK_CREATE_CREATE_FUNCTION(vtkOpenGLRenderWindow)
+
 
 vtkRenderingOpenGL2ObjectFactory::vtkRenderingOpenGL2ObjectFactory()
 {
@@ -97,13 +98,13 @@ this->RegisterOverride("vtkTextActor", "vtkOpenGLTextActor", "Override for VTK::
 this->RegisterOverride("vtkTextActor3D", "vtkOpenGLTextActor3D", "Override for VTK::RenderingOpenGL2 module", 1, vtkObjectFactoryCreatevtkOpenGLTextActor3D);
 this->RegisterOverride("vtkTextMapper", "vtkOpenGLTextMapper", "Override for VTK::RenderingOpenGL2 module", 1, vtkObjectFactoryCreatevtkOpenGLTextMapper);
 this->RegisterOverride("vtkTexture", "vtkOpenGLTexture", "Override for VTK::RenderingOpenGL2 module", 1, vtkObjectFactoryCreatevtkOpenGLTexture);
-// Removed the next line for Drake.
-// this->RegisterOverride("vtkRenderWindow", "vtkCocoaRenderWindow", "Override for VTK::RenderingOpenGL2 module", 1, vtkObjectFactoryCreatevtkCocoaRenderWindow);
+// Removed the next lines for Drake.
+// this->RegisterOverride("vtkHyperTreeGridMapper", "vtkOpenGLHyperTreeGridMapper", "Override for VTK::RenderingOpenGL2 module", 1, vtkObjectFactoryCreatevtkOpenGLHyperTreeGridMapper);
 // this->RegisterOverride("vtkRenderWindow", "vtkOpenGLRenderWindow", "Override for VTK::RenderingOpenGL2 module", 1, vtkObjectFactoryCreatevtkOpenGLRenderWindow);
 
 }
 
-const char * vtkRenderingOpenGL2ObjectFactory::GetVTKSourceVersion()
+const char * vtkRenderingOpenGL2ObjectFactory::GetVTKSourceVersion() VTK_FUTURE_CONST
 {
   return VTK_SOURCE_VERSION;
 }

--- a/tools/workspace/vtk_internal/gen/vtkRenderingOpenGL2ObjectFactory.h
+++ b/tools/workspace/vtk_internal/gen/vtkRenderingOpenGL2ObjectFactory.h
@@ -15,9 +15,9 @@ public:
   static vtkRenderingOpenGL2ObjectFactory * New();
   vtkTypeMacro(vtkRenderingOpenGL2ObjectFactory, vtkObjectFactory);
 
-  const char * GetDescription() override { return "vtkRenderingOpenGL2 factory overrides."; }
+  const char * GetDescription() VTK_FUTURE_CONST override { return "vtkRenderingOpenGL2 factory overrides."; }
 
-  const char * GetVTKSourceVersion() override;
+  const char * GetVTKSourceVersion() VTK_FUTURE_CONST override;
 
   void PrintSelf(ostream &os, vtkIndent indent) override;
 

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -184,8 +184,8 @@ def vtk_internal_repository(
         # TODO(jwnimmer-tri) Once there's a tagged release with support for
         # VTK_ABI_NAMESPACE, we should switch to an official version number
         # here. That probably means waiting for the VTK 10 release.
-        commit = "d236d27dde52f1f14eb919adacf0d355af6a440a",
-        sha256 = "349aa9da6b2be0b21d522695af116219c0fd43fe62902508f21eb59251303185",  # noqa
+        commit = "4200a02757df119c8c4ca8a66f1e52729522b1f5",
+        sha256 = "8e2c070127586d5e9d0c3cdd33ca87b08a7dd5b21237922576cb1d1f4d0e7631",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             # Drake's conventions for VTK patches are:


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/22836

This commit had problematic output in local testing and caused CI jobs to fail. Most recent CI run passed locally, but will await Jenkins ci builds for confirmation.

It would appear these upgrades are indeed problematic: [linux-jammy-clang-bazel-experimental-everything-release](https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-experimental-everything-release/7901/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22857)
<!-- Reviewable:end -->
