### PR TITLE
[examples] Disable test case on macOS

### DIFF
--- a/examples/allegro_hand/joint_control/test/run_twisting_mug_test.py
+++ b/examples/allegro_hand/joint_control/test/run_twisting_mug_test.py
@@ -48,6 +48,7 @@ class TestRunTwistingMug(unittest.TestCase):
     @unittest.skipIf(
         "--compilation_mode=dbg" in sys.argv,
         "This test is prohibitively slow in Debug builds.")
+    @unittest.skipIf(sys.platform == "darwin", "Not supported on macOS")
     def test_sim_and_control(self):
         # Run both the simulator and controller.
         sim_process = subprocess.Popen([


### PR DESCRIPTION
Closes #22815. As it's a relatively non-important test, we're just going to disable on macOS -- any *actual* LCM multicast errors would be reported via `//examples/hardware_sim:py/hardware_sim_py_test`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22859)
<!-- Reviewable:end -->
