### PR TITLE
Suppress benign eXIf warnings from libpng 1.6.47

### DIFF
--- a/tools/workspace/libpng_internal/png_drake_vendor.h
+++ b/tools/workspace/libpng_internal/png_drake_vendor.h
@@ -4,3 +4,6 @@
 
 /* Always use the macros, never the slow out-of-line functions. */
 #undef PNG_READ_INT_FUNCTIONS_SUPPORTED
+
+/* Suppress benign eXIf warnings, as they produce unnecessary test output. */
+#undef PNG_READ_eXIf_SUPPORTED

--- a/tools/workspace/libpng_internal/repository.bzl
+++ b/tools/workspace/libpng_internal/repository.bzl
@@ -6,8 +6,8 @@ def libpng_internal_repository(
     github_archive(
         name = name,
         repository = "glennrp/libpng",
-        commit = "v1.6.46",
-        sha256 = "767b01936f9620d4ab4cdf6ec348f6526f861f825648b610b1d604167dc738d2",  # noqa
+        commit = "v1.6.47",
+        sha256 = "631a4c58ea6c10c81f160c4b21fa8495b715d251698ebc2552077e8450f30454",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Closes #22728, unblocks #22862, and towards #22836

Modifies list of custom, drake-specific adjustments to libpng to disable eXIf read support. Disabling this option effectively suppresses the `libpng warning: eXIf: invalid` output that we would observe running the drake vtk rendering tests on Linux. As eXIf chunks are optional and tend to contain image metadata (particularly metadata relevant to images taken with physical cameras, e.g. aperture and shutter speed), reads for these kinds of chunks can be safely disabled for the rendered test images used for this test suite.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22861)
<!-- Reviewable:end -->
