### PR TITLE
[pydrake] Bind DeformableContactInfo and ContactResults access

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -103,6 +103,28 @@ void DoScalarDependentDefinitions(py::module m, T) {
     AddValueInstantiation<Class>(m);
   }
 
+  // DeformableContactInfo
+  {
+    using Class = DeformableContactInfo<T>;
+    constexpr auto& cls_doc = doc.DeformableContactInfo;
+    auto cls = DefineTemplateClassWithDefault<Class>(
+        m, "DeformableContactInfo", param, cls_doc.doc);
+    if constexpr (!std::is_same_v<T, symbolic::Expression>) {
+      cls  // BR
+          .def(py::init<geometry::GeometryId, geometry::GeometryId,
+                   geometry::PolygonSurfaceMesh<T>, SpatialForce<T>>(),
+              py::arg("id_A"), py::arg("id_B"), py::arg("contact_mesh_W"),
+              py::arg("F_Ac_W"), cls_doc.ctor.doc)
+          .def("id_A", &Class::id_A, cls_doc.id_A.doc)
+          .def("id_B", &Class::id_B, cls_doc.id_B.doc)
+          .def("contact_mesh", &Class::contact_mesh, py_rvp::reference_internal,
+              cls_doc.contact_mesh.doc)
+          .def("F_Ac_W", &Class::F_Ac_W, cls_doc.F_Ac_W.doc);
+    }
+    DefCopyAndDeepCopy(&cls);
+    AddValueInstantiation<Class>(m);
+  }
+
   // ContactResults
   {
     using Class = ContactResults<T>;
@@ -119,6 +141,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.num_hydroelastic_contacts.doc)
         .def("hydroelastic_contact_info", &Class::hydroelastic_contact_info,
             py::arg("i"), cls_doc.hydroelastic_contact_info.doc)
+        .def("num_deformable_contacts", &Class::num_deformable_contacts,
+            cls_doc.num_deformable_contacts.doc)
+        .def("deformable_contact_info", &Class::deformable_contact_info,
+            py::arg("i"), py_rvp::reference_internal,
+            cls_doc.deformable_contact_info.doc)
         .def("plant", &Class::plant, py_rvp::reference, cls_doc.plant.doc)
         .def("SelectHydroelastic", &Class::SelectHydroelastic,
             py::arg("selector"), cls_doc.SelectHydroelastic.doc);

--- a/multibody/plant/deformable_contact_info.h
+++ b/multibody/plant/deformable_contact_info.h
@@ -74,6 +74,17 @@ class DeformableContactInfo {
   SpatialForce<T> F_Ac_W_;
 };
 
+#ifndef __MKDOC_PY__
+/** Full specialization of DeformableContactInfo for T = Expression, with
+ no member data. */
+template <>
+class DeformableContactInfo<symbolic::Expression> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformableContactInfo);
+  DeformableContactInfo() = default;
+};
+#endif
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/plant/test/deformable_contact_info_test.cc
+++ b/multibody/plant/test/deformable_contact_info_test.cc
@@ -27,6 +27,11 @@ GTEST_TEST(DeformableContactInfo, ConstructAndAccess) {
   EXPECT_EQ(dut.F_Ac_W().rotational(), F_Ac_W.rotational());
 }
 
+GTEST_TEST(DeformableContactInfo, EmptyForExpression) {
+  DeformableContactInfo<symbolic::Expression> dut;
+  EXPECT_EQ(sizeof(dut), 1);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22868)
<!-- Reviewable:end -->
