### PR TITLE
Compare RenderEngineParams with existing RenderEngine instances

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -109,6 +109,10 @@ class PyRenderEngine : public RenderEngine {
         void, Base, DoRenderLabelImage, camera, label_image_out);
   }
 
+  std::string DoGetParameterYaml() const override {
+    PYBIND11_OVERLOAD(std::string, Base, DoGetParameterYaml);
+  }
+
   void SetDefaultLightPosition(Vector3d const& X_DL) override {
     PYBIND11_OVERLOAD(void, Base, SetDefaultLightPosition, X_DL);
   }
@@ -316,6 +320,10 @@ void DoScalarIndependentDefinitions(py::module m) {
             static_cast<RenderLabel (Class::*)() const>(
                 &Class::default_render_label),
             cls_doc.default_render_label.doc)
+        .def("GetParameterYaml",
+            static_cast<std::string (Class::*)() const>(
+                &Class::GetParameterYaml),
+            cls_doc.GetParameterYaml.doc)
         // N.B. We're binding against the trampoline class PyRenderEngine,
         // rather than the direct class RenderEngine, solely for protected
         // helper methods and non-pure virtual functions because we want them

--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -338,6 +338,15 @@ void DefineSceneGraph(py::module m, T) {
                 const std::string&>(&Class::GetRendererTypeName),
             py::arg("context"), py::arg("name"),
             cls_doc.GetRendererTypeName.doc_2args)
+        .def("GetRendererParameterYaml",
+            overload_cast_explicit<std::string, const std::string&>(
+                &Class::GetRendererParameterYaml),
+            py::arg("name"), cls_doc.GetRendererParameterYaml.doc_1args)
+        .def("GetRendererParameterYaml",
+            overload_cast_explicit<std::string, const systems::Context<T>&,
+                const std::string&>(&Class::GetRendererParameterYaml),
+            py::arg("context"), py::arg("name"),
+            cls_doc.GetRendererParameterYaml.doc_2args)
         // - Begin: AssignRole Overloads.
         // - - Proximity.
         .def(

--- a/bindings/pydrake/geometry/test/render_test.py
+++ b/bindings/pydrake/geometry/test/render_test.py
@@ -298,6 +298,9 @@ class TestGeometryRender(unittest.TestCase):
                 self.label_count += 1
                 self.label_camera = camera
 
+            def DoGetParameterYaml(self):
+                return "PyDummyRenderEngine: {}"
+
         engine = DummyRenderEngine()
         self.assertIsInstance(engine, mut.RenderEngine)
         self.assertIsInstance(engine.Clone(), DummyRenderEngine)
@@ -342,6 +345,9 @@ class TestGeometryRender(unittest.TestCase):
         image = sensor.label_image_output_port().Eval(sensor_context)
         self.assertIsInstance(image, ImageLabel16I)
         self.assertEqual(current_engine.label_count, 1)
+
+        param_yaml = engine.GetParameterYaml()
+        self.assertEqual(param_yaml, "PyDummyRenderEngine: {}")
 
         # TODO(eric, duy): Test more properties.
 

--- a/bindings/pydrake/geometry/test/scene_graph_test.py
+++ b/bindings/pydrake/geometry/test/scene_graph_test.py
@@ -86,6 +86,11 @@ class TestGeometrySceneGraph(unittest.TestCase):
         self.assertEqual(scene_graph.RendererCount(), 1)
         renderer_type_name = scene_graph.GetRendererTypeName(
             name=renderer_name)
+        self.assertTrue(renderer_type_name.endswith("RenderEngineVtk"))
+
+        param_yaml = scene_graph.GetRendererParameterYaml(
+            name=renderer_name)
+        self.assertTrue(param_yaml.startswith("RenderEngineVtkParams:"))
 
         scene_graph.RemoveRenderer(renderer_name)
         self.assertFalse(scene_graph.HasRenderer(renderer_name))
@@ -386,10 +391,14 @@ class TestGeometrySceneGraph(unittest.TestCase):
         self.assertEqual(scene_graph.RendererCount(context=context), 1)
         self.assertTrue(
             scene_graph.HasRenderer(context=context, name=renderer_name))
-        scene_graph.RemoveRenderer(context=context, name=renderer_name)
-        self.assertEqual(scene_graph.RendererCount(context=context), 0)
         renderer_type_name = scene_graph.GetRendererTypeName(
             context=context, name=renderer_name)
+        self.assertTrue(renderer_type_name.endswith("RenderEngineVtk"))
+        param_yaml = scene_graph.GetRendererParameterYaml(
+            context=context, name=renderer_name)
+        self.assertTrue(param_yaml.startswith("RenderEngineVtkParams:"))
+        scene_graph.RemoveRenderer(context=context, name=renderer_name)
+        self.assertEqual(scene_graph.RendererCount(context=context), 0)
 
     @numpy_compare.check_all_types
     def test_scene_graph_register_geometry(self, T):

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -184,6 +184,10 @@ void RenderEngine::DoRenderLabelImage(const ColorRenderCamera&,
 
 void RenderEngine::SetDefaultLightPosition(const Vector3<double>&) {}
 
+std::string RenderEngine::DoGetParameterYaml() const {
+  return "UnknownRenderEngine: {}";
+}
+
 }  // namespace render
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -299,6 +300,10 @@ class RenderEngine {
    use.  */
   RenderLabel default_render_label() const { return default_render_label_; }
 
+  /** Produces a yaml string that can be deserialized into this *particular*
+   RenderEngine's type. */
+  std::string GetParameterYaml() const { return DoGetParameterYaml(); }
+
  protected:
   // Allow derived classes to implement Cloning via copy-construction.
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderEngine);
@@ -472,6 +477,10 @@ class RenderEngine {
           intrinsics.height()));
     }
   }
+
+  /** The NVI-function for GetParameterYaml(). Derived classes must implement
+   this in order to support engine comparisons. */
+  virtual std::string DoGetParameterYaml() const;
 
  private:
   friend class RenderEngineTester;

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -96,6 +96,7 @@ drake_cc_library_linux_only(
         ":render_engine_gl_params",
         "//common:diagnostic_policy",
         "//common:string_container",
+        "//common/yaml:yaml_io",
         "//geometry/proximity:polygon_to_triangle_mesh",
         "//geometry/render:render_engine",
         "//geometry/render:render_mesh",

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -17,6 +17,7 @@
 #include "drake/common/string_map.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
+#include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
 
 namespace drake {
@@ -1238,6 +1239,10 @@ void RenderEngineGl::DoRenderLabelImage(const ColorRenderCamera& camera,
   // the underlying RenderLabel value). Doing so would allow us to render labels
   // directly and eliminate this additional pass.
   GetLabelImage(label_image_out, render_target);
+}
+
+std::string RenderEngineGl::DoGetParameterYaml() const {
+  return yaml::SaveYamlString(parameters_, "RenderEngineGlParams");
 }
 
 void RenderEngineGl::AddGeometryInstance(int geometry_index, void* user_data,

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -193,6 +193,9 @@ class RenderEngineGl final : public render::RenderEngine, private ShapeReifier {
       const render::ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const final;
 
+  // @see RenderEngine::DoGetParameterYaml().
+  std::string DoGetParameterYaml() const final;
+
   // Copy constructor used for cloning.
   // Do *not* call this copy constructor directly. The resulting RenderEngineGl
   // is not complete -- it will render nothing except the background color.

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -21,6 +21,7 @@
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/read_gltf_to_memory.h"
@@ -615,6 +616,21 @@ class RenderEngineGlTest : public ::testing::Test {
 
   fs::path temp_dir_;
 };
+
+TEST_F(RenderEngineGlTest, ParameterMatching) {
+  auto make_yaml = [](const RenderEngineGlParams& params) {
+    return yaml::SaveYamlString(params, "RenderEngineGlParams");
+  };
+  const RenderEngineGlParams params1{
+      .lights = {LightParameter{.type = "spot"}}};
+  const RenderEngineGlParams params2;
+
+  const RenderEngineGl engine(params1);
+  const std::string from_engine = engine.GetParameterYaml();
+
+  EXPECT_EQ(from_engine, make_yaml(params1));
+  EXPECT_NE(from_engine, make_yaml(params2));
+}
 
 // Tests an empty image -- confirms that it clears to the "empty" color -- no
 // use of "inlier" or "outlier" pixel locations.

--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -118,6 +118,7 @@ drake_cc_library(
         ":internal_render_client",
         "//common:essential",
         "//common:find_resource",
+        "//common/yaml:yaml_io",
         "//geometry/render:render_camera",
         "//geometry/render_vtk:internal_render_engine_vtk",
         "//systems/sensors:image",

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -22,6 +22,7 @@
 #include "drake/common/overloaded.h"
 #include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
+#include "drake/common/yaml/yaml_io.h"
 
 namespace drake {
 namespace geometry {
@@ -474,6 +475,10 @@ void RenderEngineGltfClient::DoRenderLabelImage(
   if (get_params().cleanup) {
     CleanupFrame(scene_path, image_path, get_params().verbose);
   }
+}
+
+std::string RenderEngineGltfClient::DoGetParameterYaml() const {
+  return yaml::SaveYamlString(get_params(), "RenderEngineGltfClientParams");
 }
 
 void RenderEngineGltfClient::ExportScene(const std::string& export_path,

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.h
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.h
@@ -85,6 +85,9 @@ class DRAKE_NO_EXPORT RenderEngineGltfClient
       const render::ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const override;
 
+  // @see RenderEngine::DoGetParameterYaml().
+  std::string DoGetParameterYaml() const override;
+
   /* Exports the `RenderEngineVtk::pipelines_[image_type]` VTK scene to a
    glTF file given `export_path`. */
   void ExportScene(const std::string& export_path,

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -21,6 +21,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/render_gltf_client/internal_http_service.h"
 #include "drake/geometry/render_gltf_client/internal_merge_gltf.h"
 #include "drake/geometry/render_gltf_client/render_engine_gltf_client_params.h"
@@ -100,6 +101,20 @@ class RenderEngineGltfClientTest : public ::testing::Test {
   const ColorRenderCamera color_camera_;
   const DepthRenderCamera depth_camera_;
 };
+
+TEST_F(RenderEngineGltfClientTest, ParameterMatching) {
+  auto make_yaml = [](const RenderEngineGltfClientParams& params) {
+    return yaml::SaveYamlString(params, "RenderEngineGltfClientParams");
+  };
+  const RenderEngineGltfClientParams params1{.verbose = true};
+  const RenderEngineGltfClientParams params2{.verbose = false};
+
+  const RenderEngineGltfClient engine(params1);
+  const std::string from_engine = engine.GetParameterYaml();
+
+  EXPECT_EQ(from_engine, make_yaml(params1));
+  EXPECT_NE(from_engine, make_yaml(params2));
+}
 
 TEST_F(RenderEngineGltfClientTest, Constructor) {
   // Reference values of default parameters; we'll use this to make sure that

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -80,6 +80,7 @@ drake_cc_library(
         ":internal_render_engine_vtk_base",
         ":internal_vtk_util",
         "//common",
+        "//common/yaml:yaml_io",
         "//geometry:vtk_gltf_uri_loader",
         "//geometry/proximity:polygon_to_triangle_mesh",
         "//geometry/render:render_engine",

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -45,6 +45,7 @@
 #include "drake/common/never_destroyed.h"
 #include "drake/common/overloaded.h"
 #include "drake/common/text_logging.h"
+#include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
 #include "drake/geometry/render/shaders/depth_shaders.h"
 #include "drake/geometry/render_vtk/internal_make_render_window.h"
@@ -606,6 +607,10 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
     copy_cameras(other.pipelines_.at(p)->renderer.Get(),
                  pipelines_.at(p)->renderer.Get());
   }
+}
+
+std::string RenderEngineVtk::DoGetParameterYaml() const {
+  return yaml::SaveYamlString(parameters_, "RenderEngineVtkParams");
 }
 
 void RenderEngineVtk::ImplementRenderMesh(RenderMesh&& mesh,

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -210,6 +210,9 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
       const render::ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const override;
 
+  // @see RenderEngine::DoGetParameterYaml().
+  std::string DoGetParameterYaml() const override;
+
   // Helper function for mapping a RenderMesh instance into the appropriate VTK
   // polydata.
   void ImplementRenderMesh(geometry::internal::RenderMesh&& mesh,

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -28,6 +28,7 @@
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/text_logging.h"
+#include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/read_gltf_to_memory.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
@@ -718,6 +719,21 @@ class RenderEngineVtkTest : public ::testing::Test {
 
   unique_ptr<RenderEngineVtk> renderer_;
 };
+
+TEST_F(RenderEngineVtkTest, ParameterMatching) {
+  auto make_yaml = [](const RenderEngineVtkParams& params) {
+    return yaml::SaveYamlString(params, "RenderEngineVtkParams");
+  };
+  const RenderEngineVtkParams params1{
+      .lights = {LightParameter{.type = "spot"}}};
+  const RenderEngineVtkParams params2;
+
+  const RenderEngineVtk engine(params1);
+  const std::string from_engine = engine.GetParameterYaml();
+
+  EXPECT_EQ(from_engine, make_yaml(params1));
+  EXPECT_NE(from_engine, make_yaml(params2));
+}
 
 // Tests an empty image -- confirms that it clears to the "empty" color -- no
 // use of "inlier" or "outlier" pixel locations.

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -451,6 +451,27 @@ std::string SceneGraph<T>::GetRendererTypeName(const Context<T>& context,
 }
 
 template <typename T>
+std::string SceneGraph<T>::GetRendererParameterYaml(
+    const std::string& name) const {
+  const render::RenderEngine* engine = hub_.model().GetRenderEngineByName(name);
+  if (engine == nullptr) {
+    return {};
+  }
+  return engine->GetParameterYaml();
+}
+
+template <typename T>
+std::string SceneGraph<T>::GetRendererParameterYaml(
+    const Context<T>& context, const std::string& name) const {
+  const auto& g_state = geometry_state(context);
+  const render::RenderEngine* engine = g_state.GetRenderEngineByName(name);
+  if (engine == nullptr) {
+    return {};
+  }
+  return engine->GetParameterYaml();
+}
+
+template <typename T>
 int SceneGraph<T>::RendererCount() const {
   return hub_.model().RendererCount();
 }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -775,6 +775,23 @@ class SceneGraph final : public systems::LeafSystem<T> {
   std::string GetRendererTypeName(const systems::Context<T>& context,
                                   const std::string& name) const;
 
+  /** Creates a Yaml-formatted string representing the named engine's
+   parameters. The YAML will be prefixed with the paramater type's name, e.g:
+
+       RenderEngineVtkParams:
+         default_diffuse: [1, 1, 1]
+         ...
+
+   If no registered engine has the given `name`, the returned string is empty.
+   */
+  std::string GetRendererParameterYaml(const std::string& name) const;
+
+  /** systems::Context-query variant of GetRendererParameterYaml(). Rather than
+   querying %SceneGraph's model, it queries the copy of the model stored in the
+   provided context.  */
+  std::string GetRendererParameterYaml(const systems::Context<T>& context,
+                                       const std::string& name) const;
+
   /** Reports the number of renderers registered to this %SceneGraph.  */
   int RendererCount() const;
 

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -695,6 +695,28 @@ TEST_F(SceneGraphTest, GetRendererTypeName) {
             NiceTypeName::Get<DummyRenderEngine>());
 }
 
+TEST_F(SceneGraphTest, GetRendererParameterYaml) {
+  const std::string kRendererName1 = "bob";
+  const std::string kRendererName2 = "alice";
+
+  CreateDefaultContext();
+  DRAKE_EXPECT_NO_THROW(scene_graph_.AddRenderer(
+      kRendererName1, make_unique<DummyRenderEngine>()));
+  DRAKE_EXPECT_NO_THROW(scene_graph_.AddRenderer(
+      context_.get(), kRendererName2, make_unique<DummyRenderEngine>()));
+
+  // If no renderer has the name, the parameter string is empty.
+  EXPECT_EQ(scene_graph_.GetRendererParameterYaml("non-existent"), "");
+  EXPECT_EQ(scene_graph_.GetRendererParameterYaml(*context_, "non-existent"),
+            "");
+
+  // Confirm that the string is *not* empty for valid names. We won't worry
+  // about the string contents; it has been tested elsewhere.
+  EXPECT_FALSE(scene_graph_.GetRendererParameterYaml(kRendererName1).empty());
+  EXPECT_FALSE(
+      scene_graph_.GetRendererParameterYaml(*context_, kRendererName2).empty());
+}
+
 TEST_F(SceneGraphTest, RemoveRenderer) {
   const std::string kRendererName = "bob";
 

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -245,6 +245,11 @@ class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
     label_camera_ = camera;
   }
 
+  /* Implementation of RenderEngine::DoGetParameterYaml().  */
+  std::string DoGetParameterYaml() const override {
+    return "DummyRenderEngineParams: {}";
+  }
+
  private:
   // If true, the engine will accept all geometries.
   bool force_accept_{};

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -115,6 +115,7 @@ drake_cc_library(
         ":rgbd_sensor_async",
         ":sim_rgbd_sensor",
         "//common:overloaded",
+        "//common/yaml:yaml_io",
         "//geometry/render_gl",
         "//geometry/render_gltf_client",
         "//geometry/render_vtk",


### PR DESCRIPTION
This provides the ability to ask a RenderEngine instance if a set of parameters describes the engine.

We apply this new ability when processing CameraConfig instances. It makes the process more forgiving as multiple CameraConfig can reference otherwise equivalent RenderEngine instances (whereas before, it was more brittle and inclined to throw).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22871)
<!-- Reviewable:end -->
