### PR TITLE
[multibody] Use specialized transforms for revolute joint performance

### DIFF
--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -292,7 +292,7 @@ class RigidTransform {
     set(RotationMatrix<T>(pose.linear()), pose.translation());
   }
 
-  /// @name     (Internal use only)) methods for specialized transforms
+  /// @name     (Internal use only) methods for specialized transforms
   /// @anchor special_xform_def
   ///
   /// (Internal use only) If we have foreknowledge that a %RigidTransform has
@@ -351,7 +351,7 @@ class RigidTransform {
   /// the rest will be set to 0 or 1. This structure can be exploited for
   /// efficient updating and operating with this transform.
   /// @param[in] theta the rotation angle.
-  /// @retval aX_BC the axial transform (also known as X_BC(theta)).
+  /// @retval arX_BC the axial transform (also known as X_BC(theta)).
   /// @tparam axis 0, 1, or 2 corresponding to +x, +y, or +z rotation axis.
   /// @see @ref special_xform_def "Specialized transforms".
   template <int axis>
@@ -359,12 +359,8 @@ class RigidTransform {
     requires(0 <= axis && axis <= 2)
 #endif
   static RigidTransform<T> MakeAxialRotation(const T& theta) {
-    if constexpr (axis == 0)
-      return RigidTransform<T>(RotationMatrix<T>::MakeXRotation(theta));
-    if constexpr (axis == 1)
-      return RigidTransform<T>(RotationMatrix<T>::MakeYRotation(theta));
-    if constexpr (axis == 2)
-      return RigidTransform<T>(RotationMatrix<T>::MakeZRotation(theta));
+    return RigidTransform<T>(
+        RotationMatrix<T>::template MakeAxialRotation<axis>(theta));
   }
 
   /// (Internal use only) Given an axial rotation transform arX_BC (just an
@@ -434,23 +430,47 @@ class RigidTransform {
 
   /// (Internal use only) With `this` a general transform X_AB, and given an
   /// axial rotation transform arX_BC, efficiently calculates
-  /// `X_AC = X_AB * arX_BC`. This requires only 14 floating point operations.
+  /// `X_AC = X_AB * arX_BC`. This requires only 18 floating point operations.
   /// @param[in] arX_BC An axial rotation transform about the indicated `axis`.
-  /// @param[out] X_AC Preallocated space for the result. Must not overlap with
-  ///   arX_BC in memory.
+  /// @param[out] X_AC Preallocated space for the result, which will be a
+  ///   general transform. Must not overlap with `this` in memory.
   /// @tparam axis 0, 1, or 2 corresponding to +x, +y, or +z rotation axis.
   /// @pre arX_BC is an @ref special_xform_def "Axial rotation transform"
+  /// @pre X_AC does not overlap with `this` in memory.
   template <int axis>
 #ifndef DRAKE_DOXYGEN_CXX
     requires(0 <= axis && axis <= 2)
 #endif
-  void ComposeWithAxialRotation(const RigidTransform<T>& arX_BC,
-                                RigidTransform<T>* X_AC) const {
-    DRAKE_ASSERT(X_AC != nullptr);
+  void PostMultiplyByAxialRotation(const RigidTransform<T>& arX_BC,
+                                   RigidTransform<T>* X_AC) const {
+    DRAKE_ASSERT(X_AC != nullptr && X_AC != this);
     DRAKE_ASSERT_VOID(arX_BC.IsAxialRotationOnlyOrThrow<axis>());
-    rotation().template ComposeWithAxialRotation<axis>(arX_BC.rotation(),
-                                                       &X_AC->R_AB_);
+    rotation().template PostMultiplyByAxialRotation<axis>(arX_BC.rotation(),
+                                                          &X_AC->R_AB_);
     X_AC->set_translation(p_AoBo_A_);  // unchanged
+  }
+
+  /// (Internal use only) With `this` a general transform X_BC, and given an
+  /// axial rotation transform arX_AB, efficiently calculates
+  /// `X_AC = arX_AB * X_BC`. This requires only 24 floating point operations.
+  /// @param[in] arX_BC An axial rotation transform about the indicated `axis`.
+  /// @param[out] X_AC Preallocated space for the result, which will be a
+  ///   general transform. Must not overlap with arX_BC or `this` in memory.
+  /// @tparam axis 0, 1, or 2 corresponding to +x, +y, or +z rotation axis.
+  /// @pre arX_BC is an @ref special_xform_def "Axial rotation transform"
+  /// @pre X_AC does not overlap with arX_AB or `this` in memory.
+  template <int axis>
+#ifndef DRAKE_DOXYGEN_CXX
+    requires(0 <= axis && axis <= 2)
+#endif
+  void PreMultiplyByAxialRotation(const RigidTransform<T>& arX_AB,
+                                  RigidTransform<T>* X_AC) const {
+    DRAKE_ASSERT(X_AC != nullptr && X_AC != this && X_AC != &arX_AB);
+    DRAKE_ASSERT_VOID(arX_AB.IsAxialRotationOnlyOrThrow<axis>());
+    const RotationMatrix<T>& aR_AB = arX_AB.rotation();
+    rotation().template PreMultiplyByAxialRotation<axis>(aR_AB, &X_AC->R_AB_);
+    X_AC->p_AoBo_A_ = RotationMatrix<T>::template ApplyAxialRotation<axis>(
+        aR_AB, translation());
   }
 
   /// (Internal use only) Composes `this` general transform X_AB with a given
@@ -465,8 +485,8 @@ class RigidTransform {
 #ifndef DRAKE_DOXYGEN_CXX
     requires(0 <= axis && axis <= 2)
 #endif
-  void ComposeWithAxialTranslation(const RigidTransform<T>& atX_BC,
-                                   RigidTransform<T>* X_AC) const {
+  void PostMultiplyByAxialTranslation(const RigidTransform<T>& atX_BC,
+                                      RigidTransform<T>* X_AC) const {
     DRAKE_ASSERT(X_AC != nullptr);
     DRAKE_ASSERT_VOID(atX_BC.IsAxialTranslationOnlyOrThrow<axis>());
     const Eigen::Vector3<T>& p_BC = atX_BC.translation();
@@ -480,8 +500,8 @@ class RigidTransform {
   /// @param[in] rX_BC the rotation-only transform.
   /// @param[out] X_AC Preallocated space for the result.
   /// @pre rX_BC is a @ref special_xform_def "Rotation transform".
-  void ComposeWithRotation(const RigidTransform<T>& rX_BC,
-                           RigidTransform<T>* X_AC) const {
+  void PostMultiplyByRotation(const RigidTransform<T>& rX_BC,
+                              RigidTransform<T>* X_AC) const {
     DRAKE_ASSERT(X_AC != nullptr);
     DRAKE_ASSERT_VOID(rX_BC.IsRotationOnlyOrThrow());
     X_AC->set_rotation(R_AB_ * rX_BC.rotation());
@@ -494,8 +514,8 @@ class RigidTransform {
   /// @param[in] tX_BC the translation-only transform.
   /// @param[out] X_AC preallocated space for the result.
   /// @pre tX_BC is a @ref special_xform_def "Translation transform".
-  void ComposeWithTranslation(const RigidTransform<T>& tX_BC,
-                              RigidTransform<T>* X_AC) const {
+  void PostMultiplyByTranslation(const RigidTransform<T>& tX_BC,
+                                 RigidTransform<T>* X_AC) const {
     DRAKE_ASSERT(X_AC != nullptr);
     DRAKE_ASSERT_VOID(tX_BC.IsTranslationOnlyOrThrow());
     X_AC->set_rotation(R_AB_);  // unchanged

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -881,23 +881,33 @@ GTEST_TEST(RigidTransform, SpecializedTransformOperators) {
   const Xform ytX_BC(Vector3d(0.0, -2.0, 0.0));  // y-axial translation
   Xform X_AC;                                    // reusable result
 
-  // Test ComposeWithRotation() and ComposeWithTranslation().
-  X_AB.ComposeWithRotation(rX_BC, &X_AC);
+  // Test PostMultiplyByRotation() and PostMultiplyBy[Axial]Translation().
+  X_AB.PostMultiplyByRotation(rX_BC, &X_AC);
   EXPECT_TRUE(X_AC.IsNearlyEqualTo(X_AB * rX_BC, kTol));
 
-  X_AB.ComposeWithTranslation(tX_BC, &X_AC);
+  X_AB.PostMultiplyByTranslation(tX_BC, &X_AC);
   EXPECT_TRUE(X_AC.IsNearlyEqualTo(X_AB * tX_BC, kTol));
 
-  X_AB.ComposeWithAxialTranslation<1>(ytX_BC, &X_AC);
+  X_AB.PostMultiplyByAxialTranslation<1>(ytX_BC, &X_AC);
   EXPECT_TRUE(X_AC.IsNearlyEqualTo(X_AB * ytX_BC, kTol));
 
-  // Test ComposeWithAxialRotation().
-  X_AB.ComposeWithAxialRotation<0>(xrX_BC, &X_AC);
+  // Test PostMultiplyByAxialRotation().
+  X_AB.PostMultiplyByAxialRotation<0>(xrX_BC, &X_AC);
   EXPECT_TRUE(X_AC.IsNearlyEqualTo(X_AB * xrX_BC, kTol));
-  X_AB.ComposeWithAxialRotation<1>(yrX_BC, &X_AC);
+  X_AB.PostMultiplyByAxialRotation<1>(yrX_BC, &X_AC);
   EXPECT_TRUE(X_AC.IsNearlyEqualTo(X_AB * yrX_BC, kTol));
-  X_AB.ComposeWithAxialRotation<2>(zrX_BC, &X_AC);
+  X_AB.PostMultiplyByAxialRotation<2>(zrX_BC, &X_AC);
   EXPECT_TRUE(X_AC.IsNearlyEqualTo(X_AB * zrX_BC, kTol));
+
+  // Test PreMultiplyByAxialRotation().
+  const Xform X_CD(RollPitchYaw(1.0, 2.0, 3.0), Vector3d(1.5, 2.5, 3.5));
+  Xform X_BD;  // reusable result
+  X_CD.PreMultiplyByAxialRotation<0>(xrX_BC, &X_BD);
+  EXPECT_TRUE(X_BD.IsNearlyEqualTo(xrX_BC * X_CD, kTol));
+  X_CD.PreMultiplyByAxialRotation<1>(yrX_BC, &X_BD);
+  EXPECT_TRUE(X_BD.IsNearlyEqualTo(yrX_BC * X_CD, kTol));
+  X_CD.PreMultiplyByAxialRotation<2>(zrX_BC, &X_BD);
+  EXPECT_TRUE(X_BD.IsNearlyEqualTo(zrX_BC * X_CD, kTol));
 }
 
 GTEST_TEST(RigidTransform, TestMemoryLayoutOfRigidTransformDouble) {

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -748,15 +748,25 @@ GTEST_TEST(RotationMatrix, AxialRotationOperators) {
                  std::exception);
   }
 
-  // Test ComposeWithAxialRotation().
+  // Test PostMultiplyByAxialRotation().
   const Rmat R_AB(RollPitchYaw(1.0, 2.0, 3.0));
   Rmat R_AC;  // reusable result
-  R_AB.ComposeWithAxialRotation<0>(xR_BC, &R_AC);
+  R_AB.PostMultiplyByAxialRotation<0>(xR_BC, &R_AC);
   EXPECT_TRUE(R_AC.IsNearlyEqualTo(R_AB * xR_BC, kTol));
-  R_AB.ComposeWithAxialRotation<1>(yR_BC, &R_AC);
+  R_AB.PostMultiplyByAxialRotation<1>(yR_BC, &R_AC);
   EXPECT_TRUE(R_AC.IsNearlyEqualTo(R_AB * yR_BC, kTol));
-  R_AB.ComposeWithAxialRotation<2>(zR_BC, &R_AC);
+  R_AB.PostMultiplyByAxialRotation<2>(zR_BC, &R_AC);
   EXPECT_TRUE(R_AC.IsNearlyEqualTo(R_AB * zR_BC, kTol));
+
+  // Test PreMultiplyByAxialRotation().
+  const Rmat R_CD(RollPitchYaw(1.0, 2.0, 3.0));
+  Rmat R_BD;  // reusable result
+  R_CD.PreMultiplyByAxialRotation<0>(xR_BC, &R_BD);
+  EXPECT_TRUE(R_BD.IsNearlyEqualTo(xR_BC * R_CD, kTol));
+  R_CD.PreMultiplyByAxialRotation<1>(yR_BC, &R_BD);
+  EXPECT_TRUE(R_BD.IsNearlyEqualTo(yR_BC * R_CD, kTol));
+  R_CD.PreMultiplyByAxialRotation<2>(zR_BC, &R_BD);
+  EXPECT_TRUE(R_BD.IsNearlyEqualTo(zR_BC * R_CD, kTol));
 }
 
 // The axial rotation operators exist for performance reasons. For some of them
@@ -803,12 +813,12 @@ GTEST_TEST(RotationMatrix, AxialRotationOptimizations) {
     EXPECT_EQ(yR_BC_matrix(1, 2), 13);
     EXPECT_EQ(yR_BC_matrix(2, 1), 14);
 
-    // ComposeWithAxialRotation() should access only the active elements so
+    // PostMultiplyByAxialRotation() should access only the active elements so
     // should give the same result either with our mangled matrix or a clean
     // one.
     const Rmat R_AB(RollPitchYaw(1.0, 2.0, 3.0));
     Rmat R_AC;
-    R_AB.ComposeWithAxialRotation<1>(yR_BC_mangled, &R_AC);
+    R_AB.PostMultiplyByAxialRotation<1>(yR_BC_mangled, &R_AC);
     EXPECT_TRUE(
         R_AC.IsNearlyEqualTo(R_AB * Rmat::MakeYRotation(new_theta), kTol));
   }

--- a/multibody/tree/body_node.cc
+++ b/multibody/tree/body_node.cc
@@ -11,55 +11,6 @@ template <typename T>
 BodyNode<T>::~BodyNode() = default;
 
 template <typename T>
-void BodyNode<T>::CalcAcrossMobilizerBodyPoses_BaseToTip(
-    const FrameBodyPoseCache<T>& frame_body_pose_cache,
-    PositionKinematicsCache<T>* pc) const {
-  // RigidBody for this node.
-  const RigidBody<T>& body_B = body();
-
-  // RigidBody for this node's parent, or the parent body P.
-  const RigidBody<T>& body_P = parent_body();
-
-  // Inboard/Outboard frames of this node's mobilizer.
-  const Frame<T>& frame_F = inboard_frame();
-  DRAKE_ASSERT(frame_F.body().index() == body_P.index());
-  const Frame<T>& frame_M = outboard_frame();
-  DRAKE_ASSERT(frame_M.body().index() == body_B.index());
-
-  // Input (const):
-  // - X_PF
-  // - X_MB
-  // - X_FM(q_B)
-  // - X_WP(q(W:P)), where q(W:P) includes all positions in the kinematics
-  //                 path from parent body P to the world W.
-  const math::RigidTransform<T>& X_MB =
-      frame_M.get_X_FB(frame_body_pose_cache);  // F==M
-  const math::RigidTransform<T>& X_PF =
-      frame_F.get_X_BF(frame_body_pose_cache);  // B==P
-  const math::RigidTransform<T>& X_FM = pc->get_X_FM(mobod_index());
-  const math::RigidTransform<T>& X_WP = pc->get_X_WB(inboard_mobod_index());
-
-  // Output (updating a cache entry):
-  // - X_PB(q_B)
-  // - X_WB(q(W:P), q_B)
-  math::RigidTransform<T>& X_PB = pc->get_mutable_X_PB(mobod_index());
-  math::RigidTransform<T>& X_WB = pc->get_mutable_X_WB(mobod_index());
-  Vector3<T>& p_PoBo_W = pc->get_mutable_p_PoBo_W(mobod_index());
-
-  // TODO(amcastro-tri): Consider logic for the common case B = M.
-  //  In that case X_FB = X_FM as suggested by setting X_MB = Identity.
-  const math::RigidTransform<T> X_FB = X_FM * X_MB;
-
-  X_PB = X_PF * X_FB;
-  X_WB = X_WP * X_PB;
-
-  // Compute shift vector p_PoBo_W from the parent origin to the body origin.
-  const Vector3<T>& p_PoBo_P = X_PB.translation();
-  const math::RotationMatrix<T>& R_WP = X_WP.rotation();
-  p_PoBo_W = R_WP * p_PoBo_P;
-}
-
-template <typename T>
 void BodyNode<T>::CalcCompositeBodyInertia_TipToBase(
     const PositionKinematicsCache<T>& pc,
     const std::vector<SpatialInertia<T>>& M_B_W_all,

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -598,23 +598,6 @@ class BodyNode : public MultibodyElement<T> {
       const VelocityKinematicsCache<T>& vc,
       std::vector<SpatialAcceleration<T>>* Ab_WB_array) const = 0;
 
-  // Helper method to be called within a base-to-tip recursion that computes
-  // into the PositionKinematicsCache:
-  // - X_PB(q_B)
-  // - X_WB(q(W:P), q_B)
-  // - p_PoBo_W(q_B)
-  // where q_B is the generalized coordinates associated with this node's
-  // mobilizer. q(W:P) denotes all generalized positions in the kinematics path
-  // between the world and the parent body P. It assumes we are in a base-to-tip
-  // recursion and therefore `X_WP` has already been updated.
-  //
-  // This function doesn't depend on the particular Mobilizer type so we
-  // implement once here in the base class rather than in the templatized
-  // derived class.
-  void CalcAcrossMobilizerBodyPoses_BaseToTip(
-      const FrameBodyPoseCache<T>& frame_body_pose_cache,
-      PositionKinematicsCache<T>* pc) const;
-
   // This method is used by MultibodyTree within a tip-to-base loop to compute
   // the composite body inertia of each body in the system.
   //

--- a/multibody/tree/body_node_impl.h
+++ b/multibody/tree/body_node_impl.h
@@ -23,23 +23,26 @@ namespace internal {
 // (especially for the O(n²) mass matrix algorithm) the definitions are split
 // into two files to keep compilation times balanced: body_node_impl.cc and
 // body_node_impl_mass_matrix.cc.
-template <typename T, template <typename> class ConcreteMobilizer>
+template <typename T, class ConcreteMobilizer>
 class BodyNodeImpl final : public BodyNode<T> {
+  static_assert(std::is_same_v<typename ConcreteMobilizer::ScalarType, T>,
+                "BodyNode and Mobilizer must use the same scalar type.");
+
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BodyNodeImpl);
 
   // Inherit sizes from the concrete mobilizer.
   enum : int {
-    kNq = ConcreteMobilizer<T>::kNq,
-    kNv = ConcreteMobilizer<T>::kNv,
-    kNx = ConcreteMobilizer<T>::kNx
+    kNq = ConcreteMobilizer::kNq,
+    kNv = ConcreteMobilizer::kNv,
+    kNx = ConcreteMobilizer::kNx
   };
   template <typename U>
-  using QVector = typename ConcreteMobilizer<T>::template QVector<U>;
+  using QVector = typename ConcreteMobilizer::template QVector<U>;
   template <typename U>
-  using VVector = typename ConcreteMobilizer<T>::template VVector<U>;
+  using VVector = typename ConcreteMobilizer::template VVector<U>;
   template <typename U>
-  using HMatrix = typename ConcreteMobilizer<T>::template HMatrix<U>;
+  using HMatrix = typename ConcreteMobilizer::template HMatrix<U>;
 
   using BodyNode<T>::body;
   using BodyNode<T>::child_nodes;
@@ -200,7 +203,7 @@ class BodyNodeImpl final : public BodyNode<T> {
         (*H_cache)[mobilizer().velocity_start_in_v()].data());
   }
 
-  const ConcreteMobilizer<T>& mobilizer() const {
+  const ConcreteMobilizer& mobilizer() const {
     DRAKE_ASSERT(mobilizer_ != nullptr);
     return *mobilizer_;
   }
@@ -435,7 +438,7 @@ class BodyNodeImpl final : public BodyNode<T> {
     return aba_force_cache->get_mutable_e_B(mobod_index());
   }
 
-  const ConcreteMobilizer<T>* const mobilizer_;
+  const ConcreteMobilizer* const mobilizer_;
 };
 
 }  // namespace internal

--- a/multibody/tree/body_node_impl_mass_matrix.cc
+++ b/multibody/tree/body_node_impl_mass_matrix.cc
@@ -23,7 +23,7 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-template <typename T, template <typename> class ConcreteMobilizer>
+template <typename T, class ConcreteMobilizer>
 void BodyNodeImpl<T, ConcreteMobilizer>::CalcMassMatrixContribution_TipToBase(
     const PositionKinematicsCache<T>& pc,
     const std::vector<SpatialInertia<T>>& Mc_B_W_cache,
@@ -111,7 +111,7 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcMassMatrixContribution_TipToBase(
 // size of the outer-loop body node R's mobilizer, kNv is the size of the
 // current body B's ConcreteMobilizer encountered on R's inboard sweep.
 #define DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(Rnv)                             \
-  template <typename T, template <typename> class ConcreteMobilizer>           \
+  template <typename T, class ConcreteMobilizer>                               \
   void                                                                         \
       BodyNodeImpl<T, ConcreteMobilizer>::CalcMassMatrixOffDiagonalBlock##Rnv( \
           int R_start_in_v, const std::vector<Vector6<T>>& H_PB_W_cache,       \
@@ -139,17 +139,19 @@ DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(6)
 #undef DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK
 
 // Macro used to explicitly instantiate implementations for every mobilizer.
-#define EXPLICITLY_INSTANTIATE_IMPLS(T)                        \
-  template class BodyNodeImpl<T, CurvilinearMobilizer>;        \
-  template class BodyNodeImpl<T, PlanarMobilizer>;             \
-  template class BodyNodeImpl<T, PrismaticMobilizer>;          \
-  template class BodyNodeImpl<T, QuaternionFloatingMobilizer>; \
-  template class BodyNodeImpl<T, RevoluteMobilizer>;           \
-  template class BodyNodeImpl<T, RpyBallMobilizer>;            \
-  template class BodyNodeImpl<T, RpyFloatingMobilizer>;        \
-  template class BodyNodeImpl<T, ScrewMobilizer>;              \
-  template class BodyNodeImpl<T, UniversalMobilizer>;          \
-  template class BodyNodeImpl<T, WeldMobilizer>
+#define EXPLICITLY_INSTANTIATE_IMPLS(T)                           \
+  template class BodyNodeImpl<T, CurvilinearMobilizer<T>>;        \
+  template class BodyNodeImpl<T, PlanarMobilizer<T>>;             \
+  template class BodyNodeImpl<T, PrismaticMobilizer<T>>;          \
+  template class BodyNodeImpl<T, QuaternionFloatingMobilizer<T>>; \
+  template class BodyNodeImpl<T, RevoluteMobilizerAxial<T, 0>>;   \
+  template class BodyNodeImpl<T, RevoluteMobilizerAxial<T, 1>>;   \
+  template class BodyNodeImpl<T, RevoluteMobilizerAxial<T, 2>>;   \
+  template class BodyNodeImpl<T, RpyBallMobilizer<T>>;            \
+  template class BodyNodeImpl<T, RpyFloatingMobilizer<T>>;        \
+  template class BodyNodeImpl<T, ScrewMobilizer<T>>;              \
+  template class BodyNodeImpl<T, UniversalMobilizer<T>>;          \
+  template class BodyNodeImpl<T, WeldMobilizer<T>>
 
 // Explicitly instantiates on the supported scalar types.
 // These should be kept in sync with the list in default_scalars.h.

--- a/multibody/tree/curvilinear_mobilizer.h
+++ b/multibody/tree/curvilinear_mobilizer.h
@@ -137,6 +137,12 @@ class CurvilinearMobilizer final : public MobilizerImpl<T, 1, 1> {
    @returns The across-mobilizer transform X_FM(q). */
   math::RigidTransform<T> calc_X_FM(const T* q) const;
 
+  /* We're not attempting to optimize the X_FM update. */
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
+  }
+
   /* Computes the across-mobilizer spatial velocity V_FM(q, v) as a function of
    the distance traveled and tangential velocity along the mobilizer's path.
    @param q The distance traveled along the mobilizer's path in meters.

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -551,6 +551,17 @@ class Frame : public MultibodyElement<T> {
       const internal::FrameBodyPoseCache<T>& frame_body_poses) const {
     return frame_body_poses.get_X_FB(body_pose_index_in_cache_);
   }
+
+  /// (Internal use only) Given an already up-to-date frame body pose cache,
+  /// returns whether X_BF (and thus X_FB) is exactly identity. This is
+  /// precomputed in the cache so is very fast to check.
+  /// @note Be sure you have called MultibodyTreeSystem::EvalFrameBodyPoses()
+  ///       since the last parameter change; we can't check here.
+  /// @see get_X_BF()
+  bool is_X_BF_identity(
+      const internal::FrameBodyPoseCache<T>& frame_body_poses) const {
+    return frame_body_poses.is_X_BF_identity(body_pose_index_in_cache_);
+  }
   //@}
 
  protected:

--- a/multibody/tree/frame_body_pose_cache.h
+++ b/multibody/tree/frame_body_pose_cache.h
@@ -6,6 +6,8 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/multibody/tree/multibody_tree_indexes.h"
+#include "drake/multibody/tree/spatial_inertia.h"
 
 namespace drake {
 namespace multibody {
@@ -17,14 +19,16 @@ body poses are parameterized, and given with respect to a parent frame P which
 may itself be a parameterized FixedOffsetFrame, we need to precalculate X_BF
 once the parameters have been set so that we don't have to do that calculation
 repeatedly at runtime. We also precalculate the inverse X_FB since that
-is often needed as well.
+is often needed as well, and record whether X_BF (and of course X_FB) is the
+identity transform, for use in runtime optimizations.
 
-Every Frame is allocated one slot here and the index of that slot is stored in
-the Frame object for fast retrieval. Since RigidBodyFrames have identity poses
-by definition, they all share a single entry (the 0th) here to permit getting
-the body pose of any Frame efficiently in cases where you don't know what kind
-of Frame you have. Of course if you know you are working with RigidBodyFrames
-you don't have to use this cache.
+Every Frame is allocated one slot here and the index of that slot (which we
+refer to as `body_pose_index` in this class) is stored in the Frame object for
+fast retrieval (the indices are assigned in Finalize()). Since RigidBodyFrames
+have identity poses by definition, they all share a single entry (the 0th) here
+to permit getting the body pose of any Frame efficiently in cases where you
+don't know what kind of Frame you have. Of course if you know you are working
+with RigidBodyFrames you don't have to use this cache.
 @tparam_default_scalar */
 template <typename T>
 class FrameBodyPoseCache {
@@ -33,33 +37,59 @@ class FrameBodyPoseCache {
 
   explicit FrameBodyPoseCache(int num_frame_body_pose_slots_needed)
       : X_BF_pool_(num_frame_body_pose_slots_needed),
-        X_FB_pool_(num_frame_body_pose_slots_needed) {
+        X_FB_pool_(num_frame_body_pose_slots_needed),
+        is_X_BF_identity_(num_frame_body_pose_slots_needed) {
     DRAKE_DEMAND(num_frame_body_pose_slots_needed > 0);
 
     // All RigidBodyFrames share this body pose.
     X_BF_pool_[0] = X_FB_pool_[0] = math::RigidTransform<T>::Identity();
+    is_X_BF_identity_[0] = true;
   }
 
   const math::RigidTransform<T>& get_X_BF(int body_pose_index) const {
+    // This method must be very fast in Release.
     DRAKE_ASSERT(0 <= body_pose_index && body_pose_index < ssize(X_BF_pool_));
     return X_BF_pool_[body_pose_index];
   }
 
   const math::RigidTransform<T>& get_X_FB(int body_pose_index) const {
+    // This method must be very fast in Release.
     DRAKE_ASSERT(0 <= body_pose_index && body_pose_index < ssize(X_FB_pool_));
     return X_FB_pool_[body_pose_index];
   }
 
-  void set_X_BF(int body_pose_index, const math::RigidTransform<T>& X_BF) {
-    DRAKE_ASSERT(0 <= body_pose_index && body_pose_index < ssize(X_BF_pool_));
+  // Returns true if F is a body frame or is coincident with a body frame,
+  // unless T is symbolic, in which case we always return false. This should be
+  // used only for performance optimization, so that a false negative
+  // harmlessly leads to treating X_BF as a general transform.
+  bool is_X_BF_identity(int body_pose_index) const {
+    // This method must be very fast in Release.
+    DRAKE_ASSERT(0 <= body_pose_index &&
+                 body_pose_index < ssize(is_X_BF_identity_));
+    return static_cast<bool>(is_X_BF_identity_[body_pose_index]);
+  }
+
+  void SetX_BF(int body_pose_index, const math::RigidTransform<T>& X_BF) {
+    // This method is only called when parameters change.
+    DRAKE_DEMAND(0 <= body_pose_index && body_pose_index < ssize(X_BF_pool_));
+    // RigidBodyFrames use pose index 0; we already know X_BF is identity.
+    if (body_pose_index == 0) return;
     X_BF_pool_[body_pose_index] = X_BF;
     X_FB_pool_[body_pose_index] = X_BF.inverse();
+    if constexpr (scalar_predicate<T>::is_bool) {
+      is_X_BF_identity_[body_pose_index] = X_BF.IsExactlyIdentity();
+    } else {
+      is_X_BF_identity_[body_pose_index] = static_cast<uint8_t>(false);
+    }
   }
 
  private:
-  // Size is set on construction.
+  // Sizes are set on construction.
+
+  // These are indexed by Frame::get_body_pose_index_in_cache().
   std::vector<math::RigidTransform<T>> X_BF_pool_;
   std::vector<math::RigidTransform<T>> X_FB_pool_;
+  std::vector<uint8_t> is_X_BF_identity_;  // fast vector<bool> equivalent
 };
 
 }  // namespace internal

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <optional>
-#include <vector>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
@@ -12,8 +11,6 @@
 #include "drake/multibody/tree/frame.h"
 #include "drake/multibody/tree/mobilizer.h"
 #include "drake/multibody/tree/multibody_element.h"
-#include "drake/multibody/tree/multibody_tree_indexes.h"
-#include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -29,25 +26,48 @@ of dynamic-sized Eigen matrices that would otherwise lead to run-time
 dynamic memory allocations.
 
 Every concrete Mobilizer derived from MobilizerImpl must implement the
-following (ideally inline) methods.
+following (ideally inline) methods (some have defaults; see below). Note that
+these are not virtual methods so we have to document them here in a comment
+rather than as declarations in the header file. The code won't compile if
+any mobilizer fails to implement the non-defaulted methods.
 
 @note The coordinate pointers q and v are guaranteed to point to the kNq or kNv
 state variables for the particular mobilizer. They are only 8-byte aligned so be
 careful when interpreting them as Eigen vectors for computation purposes.
 
-  // Returns X_FM(q)
-  math::RigidTransform<T> calc_X_FM(const T* q) const;
+  // Computes every element of X_FM(q).
+  RigidTransform<T> calc_X_FM(const T* q) const;
 
-  // Returns V_FM_F = H_FM_F(q)⋅v
+  // Given current q and an X_FM that was initialized to the identity transform
+  // and then possibly updated by this same mobilizer (meaning it has the
+  // right structure), update to X_FM(q) by filling in only the
+  // potentially-changed elements. For example, a revolute mobilizer about
+  // one of the frame axes will update only the four sine & cosine entries.
+  // A prismatic mobilizer along the Z axis updates only the z shift element.
+  void update_X_FM(const T* q, RigidTransform<T>* X_FM) const;
+
+  // Compose X_AM = X_AF ⋅ X_FM, optimized for the known structure of X_FM.
+  // For example, a revolute mobilizer has only 4 significant entries in X_FM
+  // out of 12, and a prismatic along Z has only 1.
+  void post_multiply_by_X_FM(const RigidTransform<T>& X_AF,
+                             const RigidTransform<T>& X_FM,
+                             RigidTransform<T>* X_AM) const;
+
+  // Compose X_FB = X_FM ⋅ X_MB, optimized for the known structure of X_FM.
+  void pre_multiply_by_X_FM(const RigidTransform<T>& X_FM,
+                            const RigidTransform<T>& X_MB,
+                            RigidTransform<T>* X_FB) const;
+
+  // Returns V_FM_F = H_FM_F(q)⋅v.
   SpatialVelocity<T> calc_V_FM(const T* q,
                                const T* v) const;
 
-  // Returns A_FM_F = H_FM_F(q)⋅vdot + Hdot_FM_F(q,v)⋅v
+  // Returns A_FM_F = H_FM_F(q)⋅vdot + Hdot_FM_F(q,v)⋅v.
   SpatialAcceleration<T> calc_A_FM(const T* q,
                                    const T* v,
                                    const T* vdot) const;
 
-  // Returns tau = H_FM_Fᵀ(q)⋅F_BMo_F
+  // Returns tau = H_FM_Fᵀ(q)⋅F_BMo_F.
   void calc_tau(const T* q, const SpatialForce<T>& F_BMo_F, T* tau) const;
 
   // TODO(sherm1) More to come (see #22253)
@@ -64,6 +84,8 @@ template <typename T, int compile_time_num_positions,
 class MobilizerImpl : public Mobilizer<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MobilizerImpl);
+
+  using ScalarType = T;
 
   // Handy enum to grant specific implementations compile time sizes.
   // static constexpr int i = 42; discouraged.  See answer in:
@@ -148,6 +170,30 @@ class MobilizerImpl : public Mobilizer<T> {
     }
 
     random_state_distribution_->template tail<kNv>() = velocity;
+  }
+
+  // N.B. no default implementations possible for calc_X_FM() and update_X_FM()
+  // here. However, a minimal implementation for update_X_FM() in a concrete
+  // mobilizer is just *X_FM = calc_X_FM(q).
+
+  // Returns the composition X_AM = X_AF ⋅ X_FM. The default implementation
+  // treats X_FM as fully general and performs this in 63 flops. Mobilizers
+  // that know more about the structure of their X_FM should override.
+  math::RigidTransform<T> post_multiply_by_X_FM(
+      const math::RigidTransform<T>& X_AF,
+      const math::RigidTransform<T>& X_FM) const {
+    const math::RigidTransform<T> X_AM = X_AF * X_FM;
+    return X_AM;
+  }
+
+  // Returns the composition X_FB = X_FM ⋅ X_MB. The default implementation
+  // treats X_FM as fully general and performs this in 63 flops. Mobilizers
+  // that know more about the structure of their X_FM should override.
+  math::RigidTransform<T> pre_multiply_by_X_FM(
+      const math::RigidTransform<T>& X_FM,
+      const math::RigidTransform<T>& X_MB) const {
+    const math::RigidTransform<T> X_FB = X_FM * X_MB;
+    return X_FB;
   }
 
  protected:

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -49,14 +49,12 @@ careful when interpreting them as Eigen vectors for computation purposes.
   // Compose X_AM = X_AF ⋅ X_FM, optimized for the known structure of X_FM.
   // For example, a revolute mobilizer has only 4 significant entries in X_FM
   // out of 12, and a prismatic along Z has only 1.
-  void post_multiply_by_X_FM(const RigidTransform<T>& X_AF,
-                             const RigidTransform<T>& X_FM,
-                             RigidTransform<T>* X_AM) const;
+  RigidTransform<T> post_multiply_by_X_FM(const RigidTransform<T>& X_AF,
+                                          const RigidTransform<T>& X_FM) const;
 
   // Compose X_FB = X_FM ⋅ X_MB, optimized for the known structure of X_FM.
-  void pre_multiply_by_X_FM(const RigidTransform<T>& X_FM,
-                            const RigidTransform<T>& X_MB,
-                            RigidTransform<T>* X_FB) const;
+  RigidTransform<T> pre_multiply_by_X_FM(const RigidTransform<T>& X_FM,
+                                         const RigidTransform<T>& X_MB) const;
 
   // Returns V_FM_F = H_FM_F(q)⋅v.
   SpatialVelocity<T> calc_V_FM(const T* q,

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1436,8 +1436,8 @@ void MultibodyTree<T>::CalcFrameBodyPoses(
     //  the whole computation is done only when parameters change. But if
     //  there is a performance issue, consider doing this in topological
     //  order (or memoizing) so we don't have to recalculate.
-    frame_body_poses->set_X_BF(body_pose_index_in_cache,
-                               frame->CalcPoseInBodyFrame(context));
+    frame_body_poses->SetX_BF(body_pose_index_in_cache,
+                              frame->CalcPoseInBodyFrame(context));
   }
 }
 

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -16,11 +16,11 @@ template <typename T>
 PlanarMobilizer<T>::~PlanarMobilizer() = default;
 
 template <typename T>
-std::unique_ptr<internal::BodyNode<T>> PlanarMobilizer<T>::CreateBodyNode(
-    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+std::unique_ptr<BodyNode<T>> PlanarMobilizer<T>::CreateBodyNode(
+    const BodyNode<T>* parent_node, const RigidBody<T>* body,
     const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<internal::BodyNodeImpl<T, PlanarMobilizer>>(
-      parent_node, body, mobilizer);
+  return std::make_unique<BodyNodeImpl<T, PlanarMobilizer>>(parent_node, body,
+                                                            mobilizer);
 }
 
 template <typename T>

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -63,8 +63,8 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   ~PlanarMobilizer() final;
 
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
@@ -151,6 +151,12 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
   math::RigidTransform<T> calc_X_FM(const T* q) const {
     return math::RigidTransform<T>(math::RotationMatrix<T>::MakeZRotation(q[2]),
                                    Vector3<T>(q[0], q[1], 0.0));
+  }
+
+  /* We're not yet attempting to optimize the X_FM update, though we could. */
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
   }
 
   /* Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -15,11 +15,11 @@ template <typename T>
 PrismaticMobilizer<T>::~PrismaticMobilizer() = default;
 
 template <typename T>
-std::unique_ptr<internal::BodyNode<T>> PrismaticMobilizer<T>::CreateBodyNode(
-    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+std::unique_ptr<BodyNode<T>> PrismaticMobilizer<T>::CreateBodyNode(
+    const BodyNode<T>* parent_node, const RigidBody<T>* body,
     const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<internal::BodyNodeImpl<T, PrismaticMobilizer>>(
-      parent_node, body, mobilizer);
+  return std::make_unique<BodyNodeImpl<T, PrismaticMobilizer>>(parent_node,
+                                                               body, mobilizer);
 }
 
 template <typename T>

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -67,8 +67,8 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   ~PrismaticMobilizer() final;
 
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
@@ -125,6 +125,13 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   // along this mobilizer's axis (see translation_axis().)
   math::RigidTransform<T> calc_X_FM(const T* q) const {
     return math::RigidTransform<T>(q[0] * translation_axis());
+  }
+
+  /* We're not yet attempting to optimize the X_FM update. */
+  // TODO(sherm1) Optimize this.
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
   }
 
   // Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -220,6 +220,12 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
                                    Vector3<T>(q[4], q[5], q[6]));
   }
 
+  /* There's nothing to optimize for the X_FM update. */
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
+  }
+
   SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
     DRAKE_ASSERT(v != nullptr);
     const Eigen::Map<const VVector<T>> V_FM(v);

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -10,35 +10,54 @@
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/frame.h"
 #include "drake/multibody/tree/mobilizer_impl.h"
-#include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
 namespace multibody {
 namespace internal {
 
-// This Mobilizer allows two frames to rotate relatively to one another around
-// an axis that is constant when measured in either this mobilizer's inboard or
-// outboard frames, while the distance between the two frames does not vary.
-// To fully specify this mobilizer a user must provide the inboard frame F,
-// the outboard (or "mobilized") frame M and the axis `axis_F` (expressed in
-// frame F) about which frame M rotates with respect to F.
-// The single generalized coordinate q introduced by this mobilizer
-// corresponds to the rotation angle in radians of frame M with respect to
-// frame F about the rotation axis `axis_F`. When `q = 0`, frames F and M are
-// coincident. The rotation angle is defined to be positive according to the
-// right-hand-rule with the thumb aligned in the direction of the `axis_F`.
-// Notice that the components of the rotation axis as expressed in
-// either frame F or M are constant. That is, `axis_F` and `axis_M` remain
-// unchanged w.r.t. both frames by this mobilizer's motion.
-//
-// H_FM₆ₓ₁=[axis_F 0₃]ᵀ     Hdot_FM₆ₓ₁ = 0₆
-//
-// @tparam_default_scalar
+/* A Revolute Mobilizer allows two frames to rotate relative to one another
+around an axis that is constant when measured in either of the frames, while the
+frame origins remain coincident. The axis must be one of the coordinate axes
+x, y, or z. To fully specify this mobilizer we need an inboard ("fixed") frame
+F, an outboard ("mobilized") frame M and the coordinate axis about which frame M
+rotates with respect to F (templatized as 0, 1, or 2). The axis vector can be
+considered axis_F (expressed in frame F) or axis_M (expressed in frame M) since
+the components are identical in either frame.
+
+The restriction to rotating about a coordinate axis means that the transform
+X_FM has special structure that can be exploited for speed(it is an "axial
+rotation transform" arX_FM; search for the Doxygen tag "special_xform_def" in
+drake/math/rigid_transform.h for a definition). Velocity and acceleration
+quantities are simplified also. In robotics, the revolute joint is very common
+so it is important that we handle its implementation efficiently.
+
+The single generalized coordinate q introduced by this mobilizer corresponds to
+the rotation angle in radians of frame M with respect to frame F about the
+rotation axis. When q = 0, frames F and M are coincident. The rotation angle is
+defined to be positive according to the right-hand-rule with the thumb aligned
+in the direction of the axis.
+
+Notice that the components of the rotation axis as expressed in either frame F
+or M are constant. That is, axis_F and axis_M remain identical and unchanged
+w.r.t. both frames by this mobilizer's motion.
+
+H_FM_F₆ₓ₁=[axis_F 0₃]ᵀ     Hdot_FM_F₆ₓ₁ = 0₆
+H_FM_M₆ₓ₁=[axis_M 0₃]ᵀ     Hdot_FM_M₆ₓ₁ = 0₆
+   where axis_M == axis_F
+
+@tparam_default_scalar */
+
+// This is the base class for the three available revolute mobilizers. It
+// provides high-level access to the common features of a revolute mobilizer,
+// intended for use by the Joint and RevoluteJoint APIs. Internal algorithms,
+// however, should be templatized on the specific revolute mobilizer instance
+// to permit inline access to performance-critical functions.
 template <typename T>
-class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
+class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RevoluteMobilizer);
+
   using MobilizerBase = MobilizerImpl<T, 1, 1>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
   template <typename U>
@@ -48,51 +67,29 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   template <typename U>
   using HMatrix = typename MobilizerBase::template HMatrix<U>;
 
-  // Constructor for a %RevoluteMobilizer between the inboard frame F
-  // `inboard_frame_F` and the outboard frame M `outboard_frame_F` granting a
-  // single rotational degree of freedom about axis `axis_F` expressed in the
-  // inboard frame F.
-  // @pre `axis_F` must be a non-zero vector with norm at least root square of
-  // machine epsilon. This vector can have any length (subject to the norm
-  // restriction above), only the direction is used.
-  RevoluteMobilizer(const SpanningForest::Mobod& mobod,
-                    const Frame<T>& inboard_frame_F,
-                    const Frame<T>& outboard_frame_M,
-                    const Vector3<double>& axis_F)
-      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M),
-        axis_F_(axis_F) {
-    double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
-    DRAKE_DEMAND(!axis_F_.isZero(kEpsilon));
-    axis_F_.normalize();
-  }
+  ~RevoluteMobilizer() override;
 
-  ~RevoluteMobilizer() final;
-
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
-      const Mobilizer<T>* mobilizer) const final;
-
-  // Overloads to define the suffix names for the position and velocity
-  // elements.
   std::string position_suffix(int position_index_in_mobilizer) const final;
   std::string velocity_suffix(int velocity_index_in_mobilizer) const final;
 
   bool can_rotate() const final { return true; }
   bool can_translate() const final { return false; }
 
-  // @retval axis_F The rotation axis as a unit vector expressed in the inboard
-  //                frame F.
-  const Vector3<double>& revolute_axis() const { return axis_F_; }
+  // @retval axis_FM The rotation axis as a unit vector expressed in the inboard
+  // frame F and the outboard frame M. This will be one of the coordinate axes,
+  // which will have been constructed to be aligned with the user's specified
+  // rotation axis for the RevoluteJoint this is implementing.
+  const Vector3<double>& revolute_axis() const { return axis_FM(); }
 
-  // Gets the rotation angle of `this` mobilizer from `context`. See class
+  // Gets the rotation angle q of `this` mobilizer from `context`. See class
   // documentation for sign convention.
   // @param[in] context The context of the MultibodyTree this mobilizer
   //                    belongs to.
   // @returns The angle coordinate of `this` mobilizer in the `context`.
   const T& get_angle(const systems::Context<T>& context) const;
 
-  // Sets the `context` so that the generalized coordinate corresponding to the
-  // rotation angle of `this` mobilizer equals `angle`.
+  // Sets the `context` so that the generalized coordinate q corresponding to
+  // the rotation angle of `this` mobilizer equals `angle`.
   // @param[in] context The context of the MultibodyTree this mobilizer
   //                    belongs to.
   // @param[in] angle The desired angle in radians.
@@ -101,8 +98,8 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
                                        const T& angle) const;
 
   // Gets the rate of change, in radians per second, of `this` mobilizer's
-  // angle (see get_angle()) from `context`. See class documentation for the
-  // angle sign convention.
+  // angle (see get_angle()) from `context`. This is the generalized velocity v
+  // of this mobilizer. See class documentation for the angle sign convention.
   // @param[in] context The context of the MultibodyTree this mobilizer
   //                    belongs to.
   // @returns The rate of change of `this` mobilizer's angle in the `context`.
@@ -119,69 +116,6 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
   // @returns a constant reference to `this` mobilizer.
   const RevoluteMobilizer<T>& SetAngularRate(systems::Context<T>* context,
                                              const T& theta_dot) const;
-
-  // Computes the across-mobilizer transform `X_FM(q)` between the inboard
-  // frame F and the outboard frame M as a function of the rotation angle
-  // about this mobilizer's axis (@see revolute_axis().)
-  // The generalized coordinate q for `this` mobilizer (the rotation angle) is
-  // stored in `context`.
-  // This method aborts in Debug builds if `v.size()` is not one.
-  math::RigidTransform<T> calc_X_FM(const T* q) const {
-    return math::RigidTransform<T>(Eigen::AngleAxis<T>(q[0], axis_F_),
-                                   Vector3<T>::Zero());
-  }
-
-  // Computes the across-mobilizer spatial velocity V_FM(q, v) of the outboard
-  // frame M measured and expressed in frame F as a function of the input
-  // angular velocity `v` about this mobilizer's axis (@see revolute_axis()).
-  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
-    return SpatialVelocity<T>(v[0] * axis_F_, Vector3<T>::Zero());
-  }
-
-  // Here H₆ₓ₁=[axis, 0₃]ᵀ so Hdot = 0 and
-  // A_FM = H⋅vdot + Hdot⋅v = [axis⋅vdot, 0₃]ᵀ
-  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
-    return SpatialAcceleration<T>(vdot[0] * axis_F_, Vector3<T>::Zero());
-  }
-
-  // Returns tau = H_FMᵀ⋅F, where H_FMᵀ = [axis_Fᵀ 0₃ᵀ].
-  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
-    DRAKE_ASSERT(tau != nullptr);
-    const Vector3<T>& t_BMo_F = F_BMo_F.rotational();
-    tau[0] = axis_F_.dot(t_BMo_F);
-  }
-
-  math::RigidTransform<T> CalcAcrossMobilizerTransform(
-      const systems::Context<T>& context) const final;
-
-  SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& v) const final;
-
-  // Computes the across-mobilizer acceleration `A_FM(q, v, v̇)` of the
-  // outboard frame M in the inboard frame F.
-  // By definition `A_FM = d_F(V_FM)/dt = H_FM(q) * v̇ + Ḣ_FM * v`.
-  // The acceleration `A_FM` will be a function of the rotation angle q, its
-  // rate of change v for the current state in `context` and of the input
-  // generalized acceleration `v̇ = dv/dt`, the rate of change of v.
-  // See class documentation for the angle sign convention.
-  // This method aborts in Debug builds if `vdot.size()` is not one.
-  SpatialAcceleration<T> CalcAcrossMobilizerSpatialAcceleration(
-      const systems::Context<T>& context,
-      const Eigen::Ref<const VectorX<T>>& vdot) const override;
-
-  // Projects the spatial force `F_Mo_F` on `this` mobilizer's outboard
-  // frame M onto its rotation axis (@see revolute_axis().) Mathematically:
-  // <pre>
-  //    tau = F_Mo_F.rotational().dot(axis_F)
-  // </pre>
-  // Therefore, the result of this method is the scalar value of the torque at
-  // the axis of `this` mobilizer.
-  // This method aborts in Debug builds if `tau.size()` is not one.
-  void ProjectSpatialForce(const systems::Context<T>& context,
-                           const SpatialForce<T>& F_Mo_F,
-                           Eigen::Ref<VectorX<T>> tau) const override;
-
   bool is_velocity_equal_to_qdot() const override { return true; }
 
   // Maps v to qdot, which for this mobilizer is q̇ = v.
@@ -205,29 +139,156 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
                               EigenPtr<VectorX<T>> vdot) const final;
 
  protected:
+  // Constructor for a RevoluteMobilizer between the inboard frame F and the
+  // outboard frame M, granting a single rotational degree of freedom about some
+  // axis common to both frames.
+  RevoluteMobilizer(const SpanningForest::Mobod& mobod,
+                    const Frame<T>& inboard_frame_F,
+                    const Frame<T>& outboard_frame_M);
+
+  // @pre axis_FM is a unit vector.
+  void set_axis_FM(const Vector3<double>& axis_FM) { axis_FM_ = axis_FM; }
+
+  const Vector3<double>& axis_FM() const { return axis_FM_; }
+
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
 
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
-  std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
-      const MultibodyTree<double>& tree_clone) const override;
+ private:
+  // Joint axis expressed identically in frames F and M. This must be one of
+  // the coordinate axes 100, 010, or 001.
+  Vector3<double> axis_FM_;
+};
 
-  std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
-      const MultibodyTree<AutoDiffXd>& tree_clone) const override;
+// Revolute mobilizer with rotation axis aligned with one of the F and M frame
+// axes.
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+class RevoluteMobilizerAxial final : public RevoluteMobilizer<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RevoluteMobilizerAxial);
 
-  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
-      const MultibodyTree<symbolic::Expression>& tree_clone) const override;
+  using RevoluteMobilizer<T>::axis_FM;
+
+  RevoluteMobilizerAxial(const SpanningForest::Mobod& mobod,
+                         const Frame<T>& inboard_frame_F,
+                         const Frame<T>& outboard_frame_M)
+      : RevoluteMobilizer<T>(mobod, inboard_frame_F, outboard_frame_M) {
+    Vector3<double> rotation_axis = Vector3<double>::Zero();
+    rotation_axis[axis] = 1;
+    this->set_axis_FM(rotation_axis);
+  }
+
+  ~RevoluteMobilizerAxial() final;
+
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
+
+  math::RigidTransform<T> CalcAcrossMobilizerTransform(
+      const systems::Context<T>& context) const final;
+
+  SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
+      const systems::Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& v) const final;
+
+  // Computes the across-mobilizer acceleration `A_FM(q, v, v̇)` of the
+  // outboard frame M in the inboard frame F.
+  // By definition `A_FM = d_F(V_FM)/dt = H_FM(q) * v̇ + Ḣ_FM * v`.
+  // The acceleration `A_FM` will be a function of the rotation angle q, its
+  // rate of change v for the current state in `context` and of the input
+  // generalized acceleration `v̇ = dv/dt`, the rate of change of v.
+  // See class documentation for the angle sign convention.
+  // This method aborts in Debug builds if `vdot.size()` is not one.
+  SpatialAcceleration<T> CalcAcrossMobilizerSpatialAcceleration(
+      const systems::Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& vdot) const final;
+
+  // Projects the spatial force `F_Mo_F` on `this` mobilizer's outboard
+  // frame M onto its rotation axis (@see revolute_axis().) Mathematically:
+  //    tau = F_Mo_F.rotational().dot(axis_F)
+  // Therefore, the result of this method is the scalar value of the torque at
+  // the axis of `this` mobilizer.
+  // This method aborts in Debug builds if `tau.size()` is not one.
+  void ProjectSpatialForce(const systems::Context<T>& context,
+                           const SpatialForce<T>& F_Mo_F,
+                           Eigen::Ref<VectorX<T>> tau) const final;
+
+  // Computes the across-mobilizer transform X_FM(q) between the inboard
+  // frame F and the outboard frame M as a function of the rotation angle
+  // about this mobilizer's axis. This is an axial rotation transform arX_FM.
+  math::RigidTransform<T> calc_X_FM(const T* q) const {
+    DRAKE_ASSERT(q != nullptr);
+    return math::RigidTransform<T>::template MakeAxialRotation<axis>(q[0]);
+  }
+
+  // Given an axial rotation transform for this mobilizer, efficiently update
+  // it by exploiting its known structure.
+  void update_X_FM(const T* q, math::RigidTransform<T>* arX_FM) const {
+    DRAKE_ASSERT(q != nullptr && arX_FM != nullptr);
+    math::RigidTransform<T>::template UpdateAxialRotation<axis>(q[0], &*arX_FM);
+  }
+
+  // Returns X_AM = X_AF * arX_FM, exploiting known structure of arX_FM.
+  math::RigidTransform<T> post_multiply_by_X_FM(
+      const math::RigidTransform<T>& X_AF,
+      const math::RigidTransform<T>& arX_FM) const {
+    math::RigidTransform<T> X_AM;
+    X_AF.template PostMultiplyByAxialRotation<axis>(arX_FM, &X_AM);
+    return X_AM;
+  }
+
+  // Returns X_FB = arX_FM * X_MB, exploiting known structure of arX_FM.
+  math::RigidTransform<T> pre_multiply_by_X_FM(
+      const math::RigidTransform<T>& arX_FM,
+      const math::RigidTransform<T>& X_MB) const {
+    math::RigidTransform<T> X_FB;
+    X_MB.template PreMultiplyByAxialRotation<axis>(arX_FM, &X_FB);
+    return X_FB;
+  }
+
+  // TODO(sherm1) Velocity & acceleration APIs should be reworked to perform
+  //  only simplified updates.
+
+  // Computes the across-mobilizer spatial velocity V_FM(q, v) of the outboard
+  // frame M measured and expressed in frame F as a function of the input
+  // angular velocity `v` about this mobilizer's axis (@see revolute_axis()).
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
+    return SpatialVelocity<T>(v[0] * axis_FM(),  // axis_F, 3 flops
+                              Vector3<T>::Zero());
+  }
+
+  // Here H_F₆ₓ₁=[axis_F, 0₃]ᵀ so Hdot_F = 0 and
+  // A_FM_F = H_F⋅vdot + Hdot_F⋅v = [axis_F⋅vdot, 0₃]ᵀ
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    return SpatialAcceleration<T>(vdot[0] * axis_FM(),  // axis_F, 3 flops
+                                  Vector3<T>::Zero());
+  }
+
+  // Returns tau = H_FM_Fᵀ⋅F_F, where H_FM_Fᵀ = [axis_Fᵀ 0₃ᵀ].
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    const Vector3<T>& t_BMo_F = F_BMo_F.rotational();
+    tau[0] = t_BMo_F[axis];
+  }
 
  private:
+  std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
+      const MultibodyTree<double>& tree_clone) const final;
+
+  std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
+      const MultibodyTree<AutoDiffXd>& tree_clone) const final;
+
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const final;
+
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
       const MultibodyTree<ToScalar>& tree_clone) const;
-
-  // Default joint axis expressed in the inboard frame F.
-  Vector3<double> axis_F_;
 };
 
 }  // namespace internal
@@ -236,3 +297,17 @@ class RevoluteMobilizer final : public MobilizerImpl<T, 1, 1> {
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::RevoluteMobilizer);
+
+#define DRAKE_DECLARE_REVOLUTE_MOBILIZER(axis)                                \
+  extern template class ::drake::multibody::internal::RevoluteMobilizerAxial< \
+      double, axis>;                                                          \
+  extern template class ::drake::multibody::internal::RevoluteMobilizerAxial< \
+      ::drake::AutoDiffXd, axis>;                                             \
+  extern template class ::drake::multibody::internal::RevoluteMobilizerAxial< \
+      ::drake::symbolic::Expression, axis>
+
+DRAKE_DECLARE_REVOLUTE_MOBILIZER(0);
+DRAKE_DECLARE_REVOLUTE_MOBILIZER(1);
+DRAKE_DECLARE_REVOLUTE_MOBILIZER(2);
+
+#undef DRAKE_DECLARE_REVOLUTE_MOBILIZER

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -19,11 +19,11 @@ template <typename T>
 RpyBallMobilizer<T>::~RpyBallMobilizer() = default;
 
 template <typename T>
-std::unique_ptr<internal::BodyNode<T>> RpyBallMobilizer<T>::CreateBodyNode(
-    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+std::unique_ptr<BodyNode<T>> RpyBallMobilizer<T>::CreateBodyNode(
+    const BodyNode<T>* parent_node, const RigidBody<T>* body,
     const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<internal::BodyNodeImpl<T, RpyBallMobilizer>>(
-      parent_node, body, mobilizer);
+  return std::make_unique<BodyNodeImpl<T, RpyBallMobilizer>>(parent_node, body,
+                                                             mobilizer);
 }
 
 template <typename T>

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -85,8 +85,8 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   ~RpyBallMobilizer() final;
 
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
 
   bool has_quaternion_dofs() const final { return false; }
@@ -183,6 +183,13 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   math::RigidTransform<T> calc_X_FM(const T* q) const {
     return math::RigidTransform<T>(math::RollPitchYaw<T>(q[0], q[1], q[2]),
                                    Vector3<T>::Zero());
+  }
+
+  /* We're not attempting to optimize the update, but could improve slightly
+  since the translation never changes (always zero). */
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
   }
 
   // Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame

--- a/multibody/tree/rpy_floating_mobilizer.cc
+++ b/multibody/tree/rpy_floating_mobilizer.cc
@@ -20,10 +20,10 @@ template <typename T>
 RpyFloatingMobilizer<T>::~RpyFloatingMobilizer() = default;
 
 template <typename T>
-std::unique_ptr<internal::BodyNode<T>> RpyFloatingMobilizer<T>::CreateBodyNode(
-    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+std::unique_ptr<BodyNode<T>> RpyFloatingMobilizer<T>::CreateBodyNode(
+    const BodyNode<T>* parent_node, const RigidBody<T>* body,
     const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<internal::BodyNodeImpl<T, RpyFloatingMobilizer>>(
+  return std::make_unique<BodyNodeImpl<T, RpyFloatingMobilizer>>(
       parent_node, body, mobilizer);
 }
 

--- a/multibody/tree/rpy_floating_mobilizer.h
+++ b/multibody/tree/rpy_floating_mobilizer.h
@@ -9,7 +9,6 @@
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/tree/frame.h"
 #include "drake/multibody/tree/mobilizer_impl.h"
-#include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -84,8 +83,8 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
 
   ~RpyFloatingMobilizer() final;
 
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
 
   bool has_quaternion_dofs() const final { return false; }
@@ -232,6 +231,12 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   math::RigidTransform<T> calc_X_FM(const T* q) const {
     return math::RigidTransform<T>(math::RollPitchYaw<T>(q[0], q[1], q[2]),
                                    Vector3<T>(q[3], q[4], q[5]));
+  }
+
+  /* There's nothing to optimize for the X_FM update. */
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
   }
 
   // Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame M

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -13,11 +13,11 @@ template <typename T>
 ScrewMobilizer<T>::~ScrewMobilizer() = default;
 
 template <typename T>
-std::unique_ptr<internal::BodyNode<T>> ScrewMobilizer<T>::CreateBodyNode(
-    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+std::unique_ptr<BodyNode<T>> ScrewMobilizer<T>::CreateBodyNode(
+    const BodyNode<T>* parent_node, const RigidBody<T>* body,
     const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<internal::BodyNodeImpl<T, ScrewMobilizer>>(
-      parent_node, body, mobilizer);
+  return std::make_unique<BodyNodeImpl<T, ScrewMobilizer>>(parent_node, body,
+                                                           mobilizer);
 }
 
 template <typename T>

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -98,8 +98,8 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   ~ScrewMobilizer() final;
 
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
@@ -200,6 +200,13 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
     const Vector3<T> p_FM(axis_ *
                           GetScrewTranslationFromRotation(q[0], screw_pitch_));
     return math::RigidTransform<T>(Eigen::AngleAxis<T>(q[0], axis_), p_FM);
+  }
+
+  /* We're not yet attempting to optimize the X_FM update. */
+  // TODO(sherm1) Optimize this.
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
   }
 
   /* Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -191,9 +191,8 @@ GTEST_TEST(BodyNodeTest, FactorArticulatedBodyHingeInertiaMatrixErrorMessages) {
   const SpanningForest::Mobod dummy_mobod(MobodIndex(0), LinkOrdinal(0));
   {
     // Rotation only.
-    const RevoluteMobilizer<double> mobilizer(dummy_mobod, parent.body_frame(),
-                                              child.body_frame(),
-                                              Vector3d{0, 0, 1});
+    const RevoluteMobilizerAxial<double, 2> mobilizer(
+        dummy_mobod, parent.body_frame(), child.body_frame());
     const DummyBodyNode body_node(&parent_node, &child, &mobilizer);
     DRAKE_EXPECT_THROWS_MESSAGE(
         BodyNodeTester::CallLltFactorization(body_node, one_by_one),
@@ -251,8 +250,8 @@ GTEST_TEST(BodyNodeTest, FactorHingeMatrixThrows) {
   const DummyBody world("world", world_index());
   const DummyBody body("child", BodyIndex(1));
   const SpanningForest::Mobod dummy_mobod(MobodIndex(0), LinkOrdinal(0));
-  const RevoluteMobilizer<double> mobilizer(
-      dummy_mobod, world.body_frame(), body.body_frame(), Vector3d{0, 0, 1});
+  const RevoluteMobilizerAxial<double, 2> mobilizer(
+      dummy_mobod, world.body_frame(), body.body_frame());
   const DummyBodyNode world_node(nullptr, &world, nullptr);
   const DummyBodyNode body_node(&world_node, &body, &mobilizer);
 

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -176,12 +176,13 @@ TEST_F(PlanarMobilizerTest, RandomState) {
 }
 
 TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerTransform) {
-  const Vector2d translations(1, 0.5);
-  const double angle = 1.5;
+  const double kTol = 4 * std::numeric_limits<double>::epsilon();
+  const double q[] = {1.0, 0.5, 1.5};
+  const Vector2d translations(q[0], q[1]);
+  const double angle = q[2];
   mobilizer_->set_translations(context_.get(), translations);
   mobilizer_->SetAngle(context_.get(), angle);
-  const RigidTransformd X_FM(
-      mobilizer_->CalcAcrossMobilizerTransform(*context_));
+  RigidTransformd X_FM(mobilizer_->CalcAcrossMobilizerTransform(*context_));
 
   Vector3d X_FM_translation;
   X_FM_translation << translations[0], translations[1], 0.0;
@@ -191,6 +192,25 @@ TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerTransform) {
   EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(),
                               X_FM_expected.GetAsMatrix34(), kTolerance,
                               MatrixCompareType::relative));
+
+  // Now check the fast inline methods.
+  RigidTransformd fast_X_FM = mobilizer_->calc_X_FM(q);
+  EXPECT_TRUE(fast_X_FM.IsNearlyEqualTo(X_FM, kTol));
+  const double new_q[] = {2, 1, 3};
+  const Vector2d new_translations(new_q[0], new_q[1]);
+  const double new_angle = new_q[2];
+  mobilizer_->set_translations(context_.get(), new_translations);
+  mobilizer_->SetAngle(context_.get(), new_angle);
+  X_FM = mobilizer_->CalcAcrossMobilizerTransform(*context_);
+  mobilizer_->update_X_FM(new_q, &fast_X_FM);
+  EXPECT_TRUE(fast_X_FM.IsNearlyEqualTo(X_FM, kTol));
+
+  const RigidTransformd X_AF(math::RollPitchYawd(1, 2, 3), Vector3d(4, 5, 6));
+  const RigidTransformd X_MB = X_AF;  // arbitrary
+  const RigidTransformd X_AM = mobilizer_->post_multiply_by_X_FM(X_AF, X_FM);
+  const RigidTransformd X_FB = mobilizer_->pre_multiply_by_X_FM(X_FM, X_MB);
+  EXPECT_TRUE(X_AM.IsNearlyEqualTo(X_AF * X_FM, kTol));
+  EXPECT_TRUE(X_FB.IsNearlyEqualTo(X_FM * X_MB, kTol));
 }
 
 TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -30,6 +30,8 @@ constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 class RevoluteMobilizerTest : public MobilizerTester {
  public:
   void SetUp() override {
+    // The axis is not one of the coordinate axes, so we'll expect to get
+    // new F & M frames that rotate around their common z axis.
     mobilizer_ = &AddJointAndFinalize<RevoluteJoint, RevoluteMobilizer>(
         std::make_unique<RevoluteJoint<double>>(
             "joint0", tree().world_body().body_frame(), body_->body_frame(),
@@ -50,10 +52,12 @@ TEST_F(RevoluteMobilizerTest, CanRotateOrTranslate) {
   EXPECT_FALSE(mobilizer_->can_translate());
 }
 
-// Verify that RevoluteMobilizer normalizes its axis on construction.
+// Even though we started with a _joint_ axis vector with arbitrary components,
+// we expect that the mobilizer will have a unit vector axis, and in particular
+// that we chose the z axis. We expect exact integer components, no roundoff.
 TEST_F(RevoluteMobilizerTest, AxisIsNormalizedAtConstruction) {
-  EXPECT_TRUE(CompareMatrices(mobilizer_->revolute_axis(), axis_F_.normalized(),
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_EQ(mobilizer_->revolute_axis().norm(), 1.0);
+  EXPECT_EQ(mobilizer_->revolute_axis(), Vector3d(0, 0, 1));
 }
 
 // Verifies method to mutate and access the context.
@@ -140,8 +144,8 @@ TEST_F(RevoluteMobilizerTest, CalcAcrossMobilizerTransform) {
   const RigidTransformd X_FM(
       mobilizer_->CalcAcrossMobilizerTransform(*context_));
 
-  const RigidTransformd X_FM_expected(
-      RotationMatrixd(AngleAxisd(angle, axis_F_.normalized())));
+  const RigidTransformd X_FM_expected(RotationMatrixd(
+      AngleAxisd(angle, mobilizer_->revolute_axis().normalized())));
 
   // Though checked below, we make it explicit here that this mobilizer should
   // introduce no translations at all.
@@ -158,7 +162,7 @@ TEST_F(RevoluteMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
                                                      Vector1d(angular_rate));
 
   const SpatialVelocity<double> V_FM_expected(
-      axis_F_.normalized() * angular_rate, Vector3d::Zero());
+      mobilizer_->revolute_axis() * angular_rate, Vector3d::Zero());
 
   // Though checked below, we make it explicit here that this mobilizer should
   // introduce no translations at all.
@@ -173,7 +177,7 @@ TEST_F(RevoluteMobilizerTest, CalcAcrossMobilizerSpatialAcceleration) {
           *context_, Vector1d(angular_acceleration));
 
   const SpatialAcceleration<double> A_FM_expected(
-      axis_F_.normalized() * angular_acceleration, Vector3d::Zero());
+      mobilizer_->revolute_axis() * angular_acceleration, Vector3d::Zero());
 
   // Though checked below, we make it explicit here that this mobilizer should
   // introduce no translations at all.
@@ -189,7 +193,7 @@ TEST_F(RevoluteMobilizerTest, ProjectSpatialForce) {
   mobilizer_->ProjectSpatialForce(*context_, F_Mo_F, tau);
 
   // Only the torque along axis_F does work.
-  const double tau_expected = torque_Mo_F.dot(axis_F_.normalized());
+  const double tau_expected = torque_Mo_F.dot(mobilizer_->revolute_axis());
   EXPECT_NEAR(tau(0), tau_expected, kTolerance);
 }
 

--- a/multibody/tree/test/weld_mobilizer_test.cc
+++ b/multibody/tree/test/weld_mobilizer_test.cc
@@ -18,6 +18,7 @@ namespace {
 
 using Eigen::Vector3d;
 using Eigen::VectorXd;
+using math::RigidTransformd;
 using std::make_unique;
 using std::unique_ptr;
 using systems::Context;
@@ -51,10 +52,27 @@ TEST_F(WeldMobilizerTest, ZeroSizedState) {
 }
 
 TEST_F(WeldMobilizerTest, CalcAcrossMobilizerTransform) {
+  const double kTol = 4 * std::numeric_limits<double>::epsilon();
   const math::RigidTransformd X_FM(
       weld_body_to_world_->CalcAcrossMobilizerTransform(*context_));
   EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(), X_WB_.GetAsMatrix34(),
                               kTolerance, MatrixCompareType::relative));
+
+  // Now check the fast inline methods.
+  const double q_dummy{};
+  RigidTransformd fast_X_FM = weld_body_to_world_->calc_X_FM(&q_dummy);
+  EXPECT_TRUE(fast_X_FM.IsExactlyIdentity());
+  weld_body_to_world_->update_X_FM(&q_dummy, &fast_X_FM);
+  EXPECT_TRUE(fast_X_FM.IsExactlyIdentity());
+
+  const RigidTransformd X_AF(math::RollPitchYawd(1, 2, 3), Vector3d(4, 5, 6));
+  const RigidTransformd X_MB = X_AF;  // arbitrary
+  const RigidTransformd X_AM =
+      weld_body_to_world_->post_multiply_by_X_FM(X_AF, X_FM);
+  const RigidTransformd X_FB =
+      weld_body_to_world_->pre_multiply_by_X_FM(X_FM, X_MB);
+  EXPECT_TRUE(X_AM.IsNearlyEqualTo(X_AF * X_FM, kTol));
+  EXPECT_TRUE(X_FB.IsNearlyEqualTo(X_FM * X_MB, kTol));
 }
 
 TEST_F(WeldMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {

--- a/multibody/tree/universal_mobilizer.cc
+++ b/multibody/tree/universal_mobilizer.cc
@@ -19,11 +19,11 @@ template <typename T>
 UniversalMobilizer<T>::~UniversalMobilizer() = default;
 
 template <typename T>
-std::unique_ptr<internal::BodyNode<T>> UniversalMobilizer<T>::CreateBodyNode(
-    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+std::unique_ptr<BodyNode<T>> UniversalMobilizer<T>::CreateBodyNode(
+    const BodyNode<T>* parent_node, const RigidBody<T>* body,
     const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<internal::BodyNodeImpl<T, UniversalMobilizer>>(
-      parent_node, body, mobilizer);
+  return std::make_unique<BodyNodeImpl<T, UniversalMobilizer>>(parent_node,
+                                                               body, mobilizer);
 }
 
 template <typename T>

--- a/multibody/tree/universal_mobilizer.h
+++ b/multibody/tree/universal_mobilizer.h
@@ -76,8 +76,8 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
 
   ~UniversalMobilizer() final;
 
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
@@ -139,6 +139,13 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
     return math::RigidTransform<T>(
         math::RotationMatrix<T>::MakeUnchecked(R_FM_matrix),
         Vector3<T>::Zero());
+  }
+
+  /* We're not attempting to optimize the update, but could improve slightly
+  since the translation never changes (always zero). */
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
   }
 
   // Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -92,8 +92,9 @@ std::unique_ptr<internal::Mobilizer<T>> WeldJoint<T>::MakeMobilizerForJoint(
   //  when we have more instances.
   auto F_frame_name = [this, tree](const Frame<T>& frame) -> std::string {
     std::string F_name = fmt::format("{}_{}_F", this->name(), frame.name());
-    while (tree->HasFrameNamed(F_name, this->model_instance()))
+    while (tree->HasFrameNamed(F_name, this->model_instance())) {
       F_name = "_" + F_name;
+    }
     return F_name;
   };
 

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -13,11 +13,11 @@ template <typename T>
 WeldMobilizer<T>::~WeldMobilizer() = default;
 
 template <typename T>
-std::unique_ptr<internal::BodyNode<T>> WeldMobilizer<T>::CreateBodyNode(
-    const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+std::unique_ptr<BodyNode<T>> WeldMobilizer<T>::CreateBodyNode(
+    const BodyNode<T>* parent_node, const RigidBody<T>* body,
     const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<internal::BodyNodeImpl<T, WeldMobilizer>>(
-      parent_node, body, mobilizer);
+  return std::make_unique<BodyNodeImpl<T, WeldMobilizer>>(parent_node, body,
+                                                          mobilizer);
 }
 
 template <typename T>

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -43,19 +43,36 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
 
   ~WeldMobilizer() final;
 
-  std::unique_ptr<internal::BodyNode<T>> CreateBodyNode(
-      const internal::BodyNode<T>* parent_node, const RigidBody<T>* body,
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
       const Mobilizer<T>* mobilizer) const final;
-
-  // TODO(sherm1) Replace this method with operators like
-  //  compose_with_X_FM(X_WF) and apply_X_FM(v) so that we can take advantage
-  //  of the mobilizer's knowledge of its kinematic structure (part of
-  //  performance epic #18442).
 
   // Computes the across-mobilizer transform `X_FM`, which for this mobilizer
   // is always the identity transform since F==M by construction.
   math::RigidTransform<T> calc_X_FM(const T*) const {
     return math::RigidTransform<T>();
+  }
+
+  /* We should do exactly nothing to update X_FM since it remains identity
+  forever. */
+  void update_X_FM(const T*, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(X_FM != nullptr);
+    DRAKE_ASSERT(X_FM->IsExactlyIdentity());
+    // Do nothing.
+  }
+
+  /* Since X_FM is identity, X_AF * X_FM is just X_AF. */
+  math::RigidTransform<T> post_multiply_by_X_FM(
+      const math::RigidTransform<T>& X_AF,
+      const math::RigidTransform<T>&) const {
+    return X_AF;
+  }
+
+  /* Since X_FM is identity, X_FM * X_MB is just X_MB. */
+  math::RigidTransform<T> pre_multiply_by_X_FM(
+      const math::RigidTransform<T>&,
+      const math::RigidTransform<T>& X_MB) const {
+    return X_MB;
   }
 
   // Computes the across-mobilizer velocity V_FM which for this mobilizer is


### PR DESCRIPTION
This PR uses optimal F & M frames for revolute joints, per issue #22769, and makes use of the axial transform specializations from PR #22814 (with some additions). This change alone provides ~30% speedup of position kinematics as measured by Cassiebench (see below).

This requires reworking the revolute mobilizer so that it revolves around a coordinate axis, and calculating appropriate F and M frames so that they are always aligned with one of those axes. Because we have to report back to users in their own frames, it is better if F and M are coincident with the user's Jp and Jc (saves a transform composition), so we go to some effort to use the original frames if they were aligned with any of the joint axes +x, +y, +z. This requires the revolute mobilizer to be templated by axis, so there are actually 3 revolute mobilizer instantiations now and they share a base class. We can also take good advantage
if the joint's M frame is coincident with the body frame, as it always is in urdf files.

We treat -x, -y, and -z like any general axis; I didn't think it was worth having 6 revolute instantiations to optimize those. If a revolute joint requires a reversed mobilizer (not common), we negate the rotation axis to keep the meaning of q and v as the user expects; that can turn a +x to a -x etc. However, note that reversed revolutes are not yet enabled -- the infrastructure for it is embedded in the F & M choice but not exercised in this PR (I'll turn it on and add test cases in PR #22883).

All changes are internal and thus likely to change frequently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22873)
<!-- Reviewable:end -->
