### PR TITLE
Install macOS wheel builder deps with `--developer` flag

### DIFF
--- a/setup/mac/source_distribution/Brewfile-developer
+++ b/setup/mac/source_distribution/Brewfile-developer
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Additional packages needed to build wheels.
+brew 'bash'
+brew 'coreutils'
+
+# Python(s) for building wheels.  These should be kept in sync with
+# `python_targets` in `tools/wheel/wheel_builder/macos.py`.
+#
+# TODO(@aiden2244): As of writing, we still support 3.11, however, Drake 1.40
+# is slated to be the last version that supports 3.11, and also the last
+# release that does not use AWS. Since the builder is still responsible for
+# installing the requisite Python, this is okay. For AWS, however, we intend
+# to remove macOS provisioning from the builder, at which point this will
+# become the only "source of truth". Meanwhile, we are updating this file in
+# order to provide the expected needs for the AWS provisioned images (which we
+# don't expect to ever build 3.11 wheels). After 1.40 is released, we should
+# a) drop Python 3.11, b) remove macOS provisioning from the wheel builder,
+# and c) remove this TODO, in that order.
+brew 'python@3.12'
+brew 'python@3.13'

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -7,10 +7,12 @@
 
 set -euxo pipefail
 
+with_developer=0
+
 while [ "${1:-}" != "" ]; do
   case "$1" in
     --developer)
-      with_test_only=1
+      with_developer=1
       ;;
     --without-test-only)
       # Ignored for backwards compatibility.
@@ -33,3 +35,7 @@ if ! command -v brew &>/dev/null; then
 fi
 
 brew bundle --file="${BASH_SOURCE%/*}/Brewfile"
+
+if [[ "${with_developer}" -eq 1 ]]; then
+  brew bundle --file="${BASH_SOURCE%/*}/Brewfile-developer"
+fi


### PR DESCRIPTION
Towards #22848 

Installs additional `brew` dependencies for building drake wheels on macOS if the `setup/install_prereqs` script is run with the `--developer` flag passed to it. Eventually, the provisioning logic which previously installed these dependencies (contained within the wheel builder scripts themselves) will have to be removed in order to prevent build contamination between CI jobs on AWS Mac hosts.

Sample console output of this impl with the `--developer` flag set:
```Bash
++ command -v brew
++ brew bundle --file=/Users/aiden.mccormack/Code/tri/drake-build-local/drake/setup/mac/source_distribution/Brewfile
Using bazelisk
Using cmake
Using eigen
Using fmt
Using nasm
Using pkg-config
Using spdlog
`brew bundle` complete! 7 Brewfile dependencies now installed.
++ [[ 1 -eq 1 ]]
++ brew bundle --file=/Users/aiden.mccormack/Code/tri/drake-build-local/drake/setup/mac/source_distribution/developer/Brewfile
Using bash
Using coreutils
Using python@3.12
Using python@3.13
`brew bundle` complete! 4 Brewfile dependencies now installed.
```

Note: the rationale for creating the `developer/` subdirectory was to preserve the `Brewfile` naming convention, as opposed to creating a separate brew dependency list in the `source_distribution/` directory named something other than `Brewfile` (e.g. `Developer-Brewfile`). I am open to consider alternate approaches if this file structure is not preferred.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22875)
<!-- Reviewable:end -->
