### PR TITLE
Add MpmModel and SolverState

### DIFF
--- a/multibody/mpm/BUILD.bazel
+++ b/multibody/mpm/BUILD.bazel
@@ -73,6 +73,7 @@ drake_cc_library_linux_only(
         ":particle_data",
         ":particle_sorter",
         ":spgrid",
+        "//multibody/contact_solvers/sap:partial_permutation",
     ],
 )
 
@@ -125,6 +126,27 @@ drake_cc_library_linux_only(
         ":particle_data",
         ":particle_sorter",
         ":spgrid",
+        "//multibody/contact_solvers/sap:partial_permutation",
+    ],
+)
+
+drake_cc_library_linux_only(
+    name = "mpm_model",
+    srcs = [
+        "mpm_model.cc",
+        "solver_state.cc",
+    ],
+    hdrs = [
+        "mpm_model.h",
+        "solver_state.h",
+    ],
+    deps = [
+        ":mock_sparse_grid",
+        ":particle_data",
+        ":sparse_grid",
+        ":transfer",
+        "//math:fourth_order_tensor",
+        "//multibody/contact_solvers/sap:partial_permutation",
     ],
 )
 
@@ -185,6 +207,14 @@ drake_cc_googletest(
     name = "grid_data_test",
     deps = [
         ":grid_data",
+    ],
+)
+
+drake_cc_googletest_linux_only(
+    name = "mpm_model_test",
+    deps = [
+        ":mpm_model",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/mpm/mock_sparse_grid.cc
+++ b/multibody/mpm/mock_sparse_grid.cc
@@ -135,6 +135,34 @@ void MockSparseGrid<T>::IterateGrid(
   }
 }
 
+template <typename T>
+void MockSparseGrid<T>::IterateConstGrid(
+    const std::function<void(const GridData<T>&)>& func) const {
+  for (const auto& [_, data] : grid_data_) {
+    func(data);
+  }
+}
+
+template <typename T>
+contact_solvers::internal::VertexPartialPermutation
+MockSparseGrid<T>::SetNodeIndices() {
+  std::vector<int> participating_nodes;
+  int node_index = 0;
+  int participating_node_index = 0;
+  for (auto& [_, data] : grid_data_) {
+    if (data.m > 0.0) {
+      if (data.index_or_flag.is_flag()) {
+        participating_nodes.push_back(participating_node_index++);
+      } else {
+        participating_nodes.push_back(-1);
+      }
+      data.index_or_flag.set_index(node_index++);
+    }
+  }
+  return contact_solvers::internal::VertexPartialPermutation(
+      std::move(participating_nodes));
+}
+
 }  // namespace internal
 }  // namespace mpm
 }  // namespace multibody

--- a/multibody/mpm/mock_sparse_grid.cc
+++ b/multibody/mpm/mock_sparse_grid.cc
@@ -136,7 +136,7 @@ void MockSparseGrid<T>::IterateGrid(
 }
 
 template <typename T>
-void MockSparseGrid<T>::IterateConstGrid(
+void MockSparseGrid<T>::IterateGrid(
     const std::function<void(const GridData<T>&)>& func) const {
   for (const auto& [_, data] : grid_data_) {
     func(data);

--- a/multibody/mpm/mock_sparse_grid.cc
+++ b/multibody/mpm/mock_sparse_grid.cc
@@ -149,16 +149,17 @@ MockSparseGrid<T>::SetNodeIndices() {
   std::vector<int> participating_nodes;
   int node_index = 0;
   int participating_node_index = 0;
-  for (auto& [_, data] : grid_data_) {
-    if (data.m > 0.0) {
-      if (data.index_or_flag.is_flag()) {
+  auto index_grid = [&](GridData<T>* data) {
+    if (data->m > 0.0) {
+      if (data->index_or_flag.is_flag()) {
         participating_nodes.push_back(participating_node_index++);
       } else {
         participating_nodes.push_back(-1);
       }
-      data.index_or_flag.set_index(node_index++);
+      data->index_or_flag.set_index(node_index++);
     }
-  }
+  };
+  IterateGrid(index_grid);
   return contact_solvers::internal::VertexPartialPermutation(
       std::move(participating_nodes));
 }

--- a/multibody/mpm/mock_sparse_grid.h
+++ b/multibody/mpm/mock_sparse_grid.h
@@ -105,8 +105,7 @@ class MockSparseGrid {
 
   void IterateGrid(const std::function<void(GridData<T>*)>& func);
 
-  void IterateConstGrid(
-      const std::function<void(const GridData<T>&)>& func) const;
+  void IterateGrid(const std::function<void(const GridData<T>&)>& func) const;
 
   contact_solvers::internal::VertexPartialPermutation SetNodeIndices();
 

--- a/multibody/mpm/mock_sparse_grid.h
+++ b/multibody/mpm/mock_sparse_grid.h
@@ -95,6 +95,14 @@ class MockSparseGrid {
     particle_sorter_.Iterate(this, &particle_data, kernel);
   }
 
+  void IterateParticleAndGrid(
+      const ParticleData<T>& particle_data,
+      const std::function<void(int, const Pad<Vector3<double>>&,
+                               const Pad<GridData<T>>&,
+                               const ParticleData<T>&)>& kernel) const {
+    particle_sorter_.Iterate(this, &particle_data, kernel);
+  }
+
   void IterateGrid(const std::function<void(GridData<T>*)>& func);
 
   void IterateConstGrid(

--- a/multibody/mpm/mock_sparse_grid.h
+++ b/multibody/mpm/mock_sparse_grid.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/sap/partial_permutation.h"
 #include "drake/multibody/mpm/grid_data.h"
 #include "drake/multibody/mpm/mass_and_momentum.h"
 #include "drake/multibody/mpm/particle_data.h"
@@ -95,6 +96,11 @@ class MockSparseGrid {
   }
 
   void IterateGrid(const std::function<void(GridData<T>*)>& func);
+
+  void IterateConstGrid(
+      const std::function<void(const GridData<T>&)>& func) const;
+
+  contact_solvers::internal::VertexPartialPermutation SetNodeIndices();
 
  private:
   double dx_{};

--- a/multibody/mpm/mpm_model.cc
+++ b/multibody/mpm/mpm_model.cc
@@ -1,0 +1,124 @@
+#include "drake/multibody/mpm/mpm_model.h"
+
+#include "drake/multibody/mpm/mock_sparse_grid.h"
+#include "drake/multibody/mpm/solver_state.h"
+
+namespace drake {
+namespace multibody {
+namespace mpm {
+namespace internal {
+
+template <typename T, typename Grid>
+MpmModel<T, Grid>::MpmModel(T dt, double dx, ParticleData<T> particle_data)
+    : dt_(dt),
+      dx_(dx),
+      particle_data_(std::move(particle_data)),
+      D_inverse_(4.0 / (dx_ * dx_)),
+      scratch_(particle_data_.deformation_gradient_data()) {
+  DRAKE_DEMAND(dt > 0);
+  DRAKE_DEMAND(dx > 0);
+}
+
+template <typename T, typename Grid>
+T MpmModel<T, Grid>::CalcCost(const SolverState<T, Grid>& solver_state) const {
+  const int kDim = 3;
+  const int num_dofs = solver_state.num_dofs();
+  const VectorX<T>& dv = solver_state.dv();
+  /* Potential energy from the particles. */
+  T total_energy =
+      particle_data_.ComputeTotalEnergy(solver_state.F(), &scratch_);
+  /* The 1/2*dv*M*dv term. */
+  solver_state.grid().IterateConstGrid([&](const GridData<T>& node) {
+    if (node.m > 0.0) {
+      DRAKE_ASSERT(node.index_or_flag.is_index());
+      const int index = node.index_or_flag.index();
+      DRAKE_ASSERT(index >= 0 && index * kDim < num_dofs);
+      total_energy +=
+          0.5 * node.m * dv.template segment<kDim>(index * kDim).squaredNorm();
+    }
+  });
+  return total_energy;
+}
+
+template <typename T, typename Grid>
+void MpmModel<T, Grid>::CalcResidual(const SolverState<T, Grid>& solver_state,
+                                     VectorX<T>* result) const {
+  DRAKE_ASSERT(result != nullptr);
+  result->resize(solver_state.num_dofs());
+  constexpr int kDim = 3;
+  /* We borrow the grid velocity memory to temporarily store the forces. We will
+   restore the grid velocity before leaving this function. */
+  auto& grid = const_cast<Grid&>(solver_state.grid());
+  /* Back up grid velocity and reset grid data to zero to prepare accumulation
+   of force. */
+  VectorX<T> backup_v = VectorX<T>::Zero(solver_state.num_dofs());
+  grid.IterateGrid([&](GridData<T>* node) {
+    if (node->m > 0.0) {
+      DRAKE_ASSERT(node->index_or_flag.is_index());
+      const int index = node->index_or_flag.index();
+      DRAKE_ASSERT(index >= 0 && index < backup_v.size() / 3);
+      backup_v.template segment<kDim>(index * kDim) = node->v;
+      node->v.setZero();
+    }
+  });
+
+  using U = typename Grid::NodeScalarType;
+  using PadNodeType = typename Grid::PadNodeType;
+  using PadDataType = typename Grid::PadDataType;
+  /* Splat temporary (negative) impulses to the grid data scratch and collect
+   them into the result. */
+  auto splat_force_kernel = [&](int p_index, const PadNodeType& grid_x,
+                                const ParticleData<T>& particle_data,
+                                PadDataType* grid_data) {
+    const Vector3<T>& x = particle_data.x()[p_index];
+    const BsplineWeights<U> bspline =
+        MakeBsplineWeights(x, static_cast<U>(dx_));
+    for (int a = 0; a < 3; ++a) {
+      for (int b = 0; b < 3; ++b) {
+        for (int c = 0; c < 3; ++c) {
+          const U& w_ip = bspline.weight(a, b, c);
+          const Vector3<U>& xi = grid_x[a][b][c];
+          /* Note that we take the stress from the scratch data here instead
+           directly from the particle because we are in the Newton loop. */
+          const Matrix3<T>& tau_volume = solver_state.tau_volume()[p_index];
+          /* For the elastic force from particles, we compute -∂E/∂xᵢ and
+           get
+
+             fᵢ = -∑ₚ Vₚ * Pₚ * Fₚⁿᵀ * D⁻¹ * (xᵢ − xₚ) * wᵢₚ
+
+           with Pₚ = ∂Ψ/∂Fₚ. Noting that Pₚ * Fₚⁿᵀ is the Kirchhoff stress,
+           we group Vₚ * Pₚ * Fₚⁿᵀ into a single term `tau_v0`. Rearranging
+           terms reveals that - fᵢdt is given by the equation in the code
+           below. */
+          (*grid_data)[a][b][c].v +=
+              tau_volume * (xi - x) * D_inverse_ * dt_ * w_ip;
+        }
+      }
+    }
+  };
+  grid.ApplyParticleToGridKernel(particle_data_, std::move(splat_force_kernel));
+  /* Collect from the scratch data, add in the M * dv term, and clear the
+   scratch data. */
+  const VectorX<T>& dv = solver_state.dv();
+  grid.IterateGrid([&](GridData<T>* node) {
+    if (node->m > 0.0) {
+      DRAKE_ASSERT(node->index_or_flag.is_index());
+      const int index = node->index_or_flag.index();
+      DRAKE_ASSERT(index >= 0 && index < result->size() / 3);
+      result->template segment<kDim>(index * kDim) =
+          node->m * dv.template segment<kDim>(index * kDim) + node->v;
+      node->v = backup_v.template segment<kDim>(index * kDim);
+    }
+  });
+}
+
+}  // namespace internal
+}  // namespace mpm
+}  // namespace multibody
+}  // namespace drake
+
+template class drake::multibody::mpm::internal::MpmModel<double>;
+template class drake::multibody::mpm::internal::MpmModel<float>;
+template class drake::multibody::mpm::internal::MpmModel<
+    drake::AutoDiffXd,
+    drake::multibody::mpm::internal::MockSparseGrid<drake::AutoDiffXd>>;

--- a/multibody/mpm/mpm_model.cc
+++ b/multibody/mpm/mpm_model.cc
@@ -26,7 +26,7 @@ T MpmModel<T, Grid>::CalcCost(const SolverState<T, Grid>& solver_state) const {
   /* Potential energy from the particles. */
   T total_energy = solver_state.elastic_energy();
   /* The 1/2*dv*M*dv term. */
-  solver_state.grid().IterateConstGrid([&](const GridData<T>& node) {
+  solver_state.grid().IterateGrid([&](const GridData<T>& node) {
     if (node.m > 0.0) {
       DRAKE_ASSERT(node.index_or_flag.is_index());
       const int index = node.index_or_flag.index();
@@ -86,7 +86,7 @@ void MpmModel<T, Grid>::CalcResidual(const SolverState<T, Grid>& solver_state,
   /* Collect from the scratch data, add in the M * dv term, and clear the
    scratch data. */
   const VectorX<T>& dv = solver_state.dv();
-  grid.IterateConstGrid([&](const GridData<T>& node) {
+  grid.IterateGrid([&](const GridData<T>& node) {
     if (node.m > 0.0) {
       DRAKE_ASSERT(node.index_or_flag.is_index());
       const int index = node.index_or_flag.index();

--- a/multibody/mpm/mpm_model.cc
+++ b/multibody/mpm/mpm_model.cc
@@ -30,7 +30,7 @@ T MpmModel<T, Grid>::CalcCost(const SolverState<T, Grid>& solver_state) const {
   const VectorX<T>& dv = solver_state.dv();
   /* Potential energy from the particles. */
   T total_energy = solver_state.elastic_energy();
-  /* The 1/2*dv*M*dv term. */
+  /* The 1/2*dv*M*dv kinetic energy term. */
   grid().IterateGrid([&](const GridData<T>& node) {
     if (node.m > 0.0) {
       DRAKE_ASSERT(node.index_or_flag.is_index());
@@ -87,8 +87,7 @@ void MpmModel<T, Grid>::CalcResidual(const SolverState<T, Grid>& solver_state,
     }
   };
   grid().IterateParticleAndGrid(particle_data_, splat_force_kernel);
-  /* Collect from the scratch data, add in the M * dv term, and clear the
-   scratch data. */
+  /* Add in the M * dv term. */
   const VectorX<T>& dv = solver_state.dv();
   grid().IterateGrid([&](const GridData<T>& node) {
     if (node.m > 0.0) {

--- a/multibody/mpm/mpm_model.h
+++ b/multibody/mpm/mpm_model.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/multibody/mpm/particle_data.h"
+#include "drake/multibody/mpm/sparse_grid.h"
+
+namespace drake {
+namespace multibody {
+namespace mpm {
+namespace internal {
+
+template <typename T, typename Grid>
+class SolverState;
+
+/* MpmModel provides information about an implicit (backward Euler) MPM system.
+ Given particle states, it models the objective function as a function of the
+ grid velocity change, `dv`. It works in conjunction with a Solver that
+ minimizes the objective function by solving non-linear system of equations and
+ a SolverState that holds the state that changes during the optimization
+ process.
+
+ Specifically, the cost function is given by
+
+  E(v) = ½ (v − vⁿ)ᵀ M (v − vⁿ) + ∑ₚ Ψ(Fₚ(v; Fₚⁿ)) ⋅ volₚ
+
+ Here, v is the grid velocity, vⁿ is the grid velocity at the previous time
+ step, M is the lumped mass matrix, Fₚ is the deformation gradient of the p-th
+ particle, volₚ is the volume of the p-th particle in the reference
+ configuration, Ψ is the strain energy density function. Note in particular that
+ the deformation gradient Fₚ(v; Fₚⁿ) is a function of the grid velocity v and
+ the previous deformation gradient Fₚⁿ, but Fₚⁿ is fixed in the optimization
+ process.
+
+ Differentiating E(v) with respect to v, we get the gradient(or "residual")
+ vector
+
+  M(v - vⁿ) - f(v; Fₚⁿ)dt,
+
+ where f(v; Fₚⁿ) is the grid force that depends implicitly on v. In practice, we
+ work with dv = v - vⁿ because it's slightly more convenient.
+
+ MpmModel stores the particle data evaluated at time step tⁿ (e.g Fₚⁿ) and those
+ that are constant (e.g. volₚ). The state that changes during the optimization
+ process, such as dv, Fₚ(v; Fₚⁿ), and stress [dΨ/dFₚ(Fₚ(v; Fₚⁿ))] are stored in
+ SolverState. MpmModel provides functions to compute the cost,
+ gradient(residual), and Hessian of the objective function by evaluating them at
+ a given solver state. Once the solver state that minimizes the objective has
+ been found, the state can be used to update the MpmModel (see
+ SolverState::UpdateModel). */
+template <typename T, typename Grid = SparseGrid<T>>
+class MpmModel {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MpmModel);
+
+  /* Creates a MpmModel derived from the given particles.
+   @param[in] dt         The time step used in this MpmModel (in seconds).
+   @param[in] dx         The grid spacing (in meters).
+   @param[in] particles  The particle data.
+   @pre dt > 0 and dx > 0.
+   @pre particles and grid are non-null. */
+  MpmModel(T dt, double dx, ParticleData<T> particles);
+
+  T dt() const { return dt_; }
+
+  double dx() const { return dx_; }
+
+  int num_particles() const { return particle_data_.num_particles(); }
+
+  /* Computes the energy at the given solver state using the formula
+   E(v) = ½ (v − vⁿ)ᵀ M (v − vⁿ) + ∑ₚ Ψ(Fₚ(v)) ⋅ volₚ. */
+  T CalcCost(const SolverState<T, Grid>& solver_state) const;
+
+  /* Computes the residual vector b = Mdv - f(v)dt. */
+  void CalcResidual(const SolverState<T, Grid>& solver_state,
+                    VectorX<T>* result) const;
+
+  const ParticleData<T>& particle_data() const { return particle_data_; }
+  ParticleData<T>& mutable_particle_data() { return particle_data_; }
+
+ private:
+  T dt_{};
+  double dx_{};
+  ParticleData<T> particle_data_{};
+  T D_inverse_{};
+  mutable std::vector<DeformationGradientDataVariant<T>> scratch_;
+};
+
+}  // namespace internal
+}  // namespace mpm
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/mpm/mpm_model.h
+++ b/multibody/mpm/mpm_model.h
@@ -18,10 +18,10 @@ class SolverState;
 
 /* MpmModel provides information about an implicit (backward Euler) MPM system.
  Given particle states, it models the objective function as a function of the
- grid velocity change, `dv`. It works in conjunction with a Solver that
- minimizes the objective function by solving non-linear system of equations and
- a SolverState that holds the state that changes during the optimization
- process.
+ grid velocity change, `dv`. It works in conjunction with a solver and
+ SolverState. The solver minimizes the objective function by solving a
+ non-linear system of equations, changing the SolverState during the
+ optimization process.
 
  Specifically, the cost function is given by
 
@@ -56,7 +56,7 @@ class MpmModel {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MpmModel);
 
-  /* Creates a MpmModel given the current state of particles.
+  /* Creates an MpmModel given the current state of particles.
    @param[in] dt         The time step used in this MpmModel (in seconds).
    @param[in] dx         The grid spacing (in meters).
    @param[in] particles  The particle data.
@@ -70,10 +70,10 @@ class MpmModel {
   int num_particles() const { return particle_data_.num_particles(); }
 
   /* Computes the energy at the given solver state using the formula
-   E(v) = ½ (v − vⁿ)ᵀ M (v − vⁿ) + ∑ₚ Ψ(Fₚ(v)) ⋅ volₚ. */
+   E(v) = ½ (v − vⁿ)ᵀ M (v − vⁿ) + ∑ₚ Ψ(Fₚ(v; Fₚⁿ)) ⋅ volₚ. */
   T CalcCost(const SolverState<T, Grid>& solver_state) const;
 
-  /* Computes the residual vector b = Mdv - f(v)dt. */
+  /* Computes the residual vector b = M(v - vⁿ) - f(v; Fₚⁿ)dt. */
   void CalcResidual(const SolverState<T, Grid>& solver_state,
                     VectorX<T>* result) const;
 

--- a/multibody/mpm/mpm_model.h
+++ b/multibody/mpm/mpm_model.h
@@ -41,24 +41,23 @@ class SolverState;
  work with dv = v - vⁿ because it's slightly more convenient.
 
  MpmModel stores the particle data evaluated at time step tⁿ (e.g Fₚⁿ) and those
- that are constant (e.g. volₚ). The state that changes during the optimization
- process, such as dv, Fₚ(v; Fₚⁿ), and stress [dΨ/dFₚ(Fₚ(v; Fₚⁿ))] are stored in
- SolverState. MpmModel provides functions to compute the cost,
- gradient(residual), and Hessian of the objective function by evaluating them at
- a given solver state. Once the solver state that minimizes the objective has
- been found, the state can be used to update the MpmModel (see
+ that are constant during the optimization process (e.g. volₚ). The state that
+ changes during the optimization process, such as dv, Fₚ(v; Fₚⁿ), and stress
+ [dΨ/dFₚ(Fₚ(v; Fₚⁿ))] are stored in SolverState. MpmModel provides functions to
+ compute the cost, gradient(residual), and Hessian of the objective function by
+ evaluating them at a given solver state. Once the solver state that minimizes
+ the objective has been found, the state can be used to update the MpmModel (see
  SolverState::UpdateModel). */
 template <typename T, typename Grid = SparseGrid<T>>
 class MpmModel {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MpmModel);
 
-  /* Creates a MpmModel derived from the given particles.
+  /* Creates a MpmModel given the current state of particles.
    @param[in] dt         The time step used in this MpmModel (in seconds).
    @param[in] dx         The grid spacing (in meters).
    @param[in] particles  The particle data.
-   @pre dt > 0 and dx > 0.
-   @pre particles and grid are non-null. */
+   @pre dt > 0 and dx > 0. */
   MpmModel(T dt, double dx, ParticleData<T> particles);
 
   T dt() const { return dt_; }
@@ -83,7 +82,6 @@ class MpmModel {
   double dx_{};
   ParticleData<T> particle_data_{};
   T D_inverse_{};
-  mutable std::vector<DeformationGradientDataVariant<T>> scratch_;
 };
 
 }  // namespace internal

--- a/multibody/mpm/particle_data.h
+++ b/multibody/mpm/particle_data.h
@@ -62,7 +62,7 @@ class ParticleData {
   /* Const accessors for state-dependent data. */
   const std::vector<int>& in_constraint() const { return in_constraint_; }
   const std::vector<DeformationGradientDataVariant<T>>&
-  deformation_gradient_data() {
+  deformation_gradient_data() const {
     return deformation_gradient_data_;
   }
   const std::vector<Matrix3<T>>& tau_volume() const { return tau_volume_; }

--- a/multibody/mpm/solver_state.cc
+++ b/multibody/mpm/solver_state.cc
@@ -9,26 +9,13 @@ namespace internal {
 
 template <typename T, typename Grid>
 SolverState<T, Grid>::SolverState(const MpmModel<T, Grid>& model)
-    : transfer_(model.dt(), model.dx()),
-      grid_(std::make_unique<Grid>(model.dx())) {
+    : D_inverse_(4.0 / (model.dx() * model.dx())) {
   Reset(model);
 }
 
 template <typename T, typename Grid>
 void SolverState<T, Grid>::Reset(const MpmModel<T, Grid>& model) {
-  DRAKE_DEMAND(model.dx() == grid_->dx());
   const ParticleData<T>& particle_data = model.particle_data();
-  grid_->Allocate(particle_data.x());
-  transfer_.ParticleToGrid(particle_data, grid_.get_mutable());
-  int num_dofs = 0;
-  /* Convert from grid momentum to grid velocity and count the number of dofs
-   in the system. */
-  grid_->IterateGrid([&](GridData<T>* node) {
-    if (node->m > 0.0) {
-      node->v /= node->m;
-      num_dofs += 3;
-    }
-  });
   F_ = particle_data.F();
   deformation_gradient_data_ = particle_data.deformation_gradient_data();
   tau_volume_ = particle_data.tau_volume();
@@ -36,32 +23,27 @@ void SolverState<T, Grid>::Reset(const MpmModel<T, Grid>& model) {
   particle_data.ComputePK1StressDerivatives(F_, &deformation_gradient_data_,
                                             &volume_scaled_stress_derivatives_);
 
-  index_permutation_ = grid_->SetNodeIndices();
-  dv_.resize(num_dofs);
+  dv_.resize(model.num_dofs());
   dv_.setZero();
-
-  is_valid_ = true;
 }
 
 template <typename T, typename Grid>
 void SolverState<T, Grid>::UpdateState(const VectorX<T>& ddv,
                                        const MpmModel<T, Grid>& model) {
   DRAKE_ASSERT(ddv.size() == num_dofs());
-  DRAKE_ASSERT(model.dx() == grid().dx());
-  DRAKE_ASSERT(is_valid_);
   constexpr int kDim = 3;
   const T dt = model.dt();
+  const double dx = model.dx();
   dv_ += ddv;
   using U = typename Grid::NodeScalarType;
   using PadNodeType = typename Grid::PadNodeType;
   using PadDataType = typename Grid::PadDataType;
-  auto update_F_kernel = [this, dt](int p_index, const PadNodeType& grid_x,
-                                    const PadDataType& grid_data,
-                                    const ParticleData<T>& particle_data) {
+  auto update_F_kernel = [this, dt, dx](int p_index, const PadNodeType& grid_x,
+                                        const PadDataType& grid_data,
+                                        const ParticleData<T>& particle_data) {
     const Vector3<T>& x = particle_data.x()[p_index];
     Matrix3<T> C = Matrix3<T>::Zero();
-    const BsplineWeights<U> bspline =
-        MakeBsplineWeights(x, static_cast<U>(grid_->dx()));
+    const BsplineWeights<U> bspline = MakeBsplineWeights(x, static_cast<U>(dx));
     for (int a = 0; a < 3; ++a) {
       for (int b = 0; b < 3; ++b) {
         for (int c = 0; c < 3; ++c) {
@@ -76,40 +58,22 @@ void SolverState<T, Grid>::UpdateState(const VectorX<T>& ddv,
         }
       }
     }
-    C *= transfer_.D_inverse();
+    C *= D_inverse_;
     const Matrix3<T>& F0 = particle_data.F()[p_index];
     F_[p_index] = F0 + C * dt * F0;
   };
   const auto& particle_data = model.particle_data();
-  grid_->IterateParticleAndGrid(particle_data, update_F_kernel);
+  model.grid().IterateParticleAndGrid(particle_data, update_F_kernel);
 
-  /* Then update stress and stress derivatives. */
+  // TODO(xuchenhan-tri): This can be grouped into a single function to reduce
+  // redundant computation.
+  /* Then update energy, stress, and stress derivatives. */
   elastic_energy_ =
       particle_data.ComputeTotalEnergy(F_, &deformation_gradient_data_);
   particle_data.ComputeKirchhoffStress(F_, &deformation_gradient_data_,
                                        &tau_volume_);
   particle_data.ComputePK1StressDerivatives(F_, &deformation_gradient_data_,
                                             &volume_scaled_stress_derivatives_);
-}
-
-template <typename T, typename Grid>
-void SolverState<T, Grid>::UpdateModel(MpmModel<T, Grid>* model) {
-  DRAKE_ASSERT(model != nullptr);
-  constexpr int kDim = 3;
-  auto update_grid_velocity = [&](GridData<T>* node) {
-    if (node->m > 0.0) {
-      DRAKE_ASSERT(node->index_or_flag.is_index());
-      node->v += dv_.template segment<kDim>(kDim * node->index_or_flag.index());
-    }
-  };
-  grid_->IterateGrid(update_grid_velocity);
-  ParticleData<T>& particle_data = model->mutable_particle_data();
-  transfer_.GridToParticle(*grid_, &particle_data);
-  particle_data.ComputeKirchhoffStress(
-      particle_data.F(), &particle_data.mutable_deformation_gradient_data(),
-      &particle_data.mutable_tau_volume());
-
-  is_valid_ = false;
 }
 
 }  // namespace internal

--- a/multibody/mpm/solver_state.cc
+++ b/multibody/mpm/solver_state.cc
@@ -30,10 +30,10 @@ void SolverState<T, Grid>::Reset(const MpmModel<T, Grid>& model) {
     }
   });
   F_ = particle_data.F();
-  scratch_ = particle_data.deformation_gradient_data();
+  deformation_gradient_data_ = particle_data.deformation_gradient_data();
   tau_volume_ = particle_data.tau_volume();
   volume_scaled_stress_derivatives_.resize(F_.size());
-  particle_data.ComputePK1StressDerivatives(F_, &scratch_,
+  particle_data.ComputePK1StressDerivatives(F_, &deformation_gradient_data_,
                                             &volume_scaled_stress_derivatives_);
 
   index_permutation_ = grid_->SetNodeIndices();
@@ -90,8 +90,11 @@ void SolverState<T, Grid>::UpdateState(const VectorX<T>& ddv,
   grid_->ApplyGridToParticleKernel(&mutable_particle_data, update_F_kernel);
 
   /* Then update stress and stress derivatives. */
-  particle_data.ComputeKirchhoffStress(F_, &scratch_, &tau_volume_);
-  particle_data.ComputePK1StressDerivatives(F_, &scratch_,
+  elastic_energy_ =
+      particle_data.ComputeTotalEnergy(F_, &deformation_gradient_data_);
+  particle_data.ComputeKirchhoffStress(F_, &deformation_gradient_data_,
+                                       &tau_volume_);
+  particle_data.ComputePK1StressDerivatives(F_, &deformation_gradient_data_,
                                             &volume_scaled_stress_derivatives_);
 }
 

--- a/multibody/mpm/solver_state.cc
+++ b/multibody/mpm/solver_state.cc
@@ -1,0 +1,127 @@
+#include "drake/multibody/mpm/solver_state.h"
+
+#include "drake/multibody/mpm/mock_sparse_grid.h"
+
+namespace drake {
+namespace multibody {
+namespace mpm {
+namespace internal {
+
+template <typename T, typename Grid>
+SolverState<T, Grid>::SolverState(const MpmModel<T, Grid>& model)
+    : transfer_(model.dt(), model.dx()),
+      grid_(std::make_unique<Grid>(model.dx())) {
+  Reset(model);
+}
+
+template <typename T, typename Grid>
+void SolverState<T, Grid>::Reset(const MpmModel<T, Grid>& model) {
+  DRAKE_DEMAND(model.dx() == grid_->dx());
+  const ParticleData<T>& particle_data = model.particle_data();
+  grid_->Allocate(particle_data.x());
+  transfer_.ParticleToGrid(particle_data, grid_.get_mutable());
+  int num_dofs = 0;
+  /* Convert from grid momentum to grid velocity and count the number of dofs
+   in the system. */
+  grid_->IterateGrid([&](GridData<T>* node) {
+    if (node->m > 0.0) {
+      node->v /= node->m;
+      num_dofs += 3;
+    }
+  });
+  F_ = particle_data.F();
+  scratch_ = particle_data.deformation_gradient_data();
+  tau_volume_ = particle_data.tau_volume();
+  volume_scaled_stress_derivatives_.resize(F_.size());
+  particle_data.ComputePK1StressDerivatives(F_, &scratch_,
+                                            &volume_scaled_stress_derivatives_);
+
+  index_permutation_ = grid_->SetNodeIndices();
+  dv_.resize(num_dofs);
+  dv_.setZero();
+
+  is_valid_ = true;
+}
+
+template <typename T, typename Grid>
+void SolverState<T, Grid>::UpdateState(const VectorX<T>& ddv,
+                                       const MpmModel<T, Grid>& model) {
+  DRAKE_ASSERT(ddv.size() == num_dofs());
+  DRAKE_ASSERT(model.dx() == grid().dx());
+  DRAKE_ASSERT(is_valid_);
+  constexpr int kDim = 3;
+  const T dt = model.dt();
+  dv_ += ddv;
+  using U = typename Grid::NodeScalarType;
+  using PadNodeType = typename Grid::PadNodeType;
+  using PadDataType = typename Grid::PadDataType;
+  auto update_F_kernel = [this, dt](int p_index, const PadNodeType& grid_x,
+                                    const PadDataType& grid_data,
+                                    ParticleData<T>* particle_data) {
+    const ParticleData<T>& const_particle_data = *particle_data;
+    const Vector3<T>& x = const_particle_data.x()[p_index];
+    Matrix3<T> C = Matrix3<T>::Zero();
+    const BsplineWeights<U> bspline =
+        MakeBsplineWeights(x, static_cast<U>(grid_->dx()));
+    for (int a = 0; a < 3; ++a) {
+      for (int b = 0; b < 3; ++b) {
+        for (int c = 0; c < 3; ++c) {
+          if (grid_data[a][b][c].m == 0.0) continue;
+          DRAKE_ASSERT(grid_data[a][b][c].index_or_flag.is_index());
+          const int grid_index = grid_data[a][b][c].index_or_flag.index();
+          const Vector3<T>& vi = grid_data[a][b][c].v +
+                                 dv_.template segment<kDim>(kDim * grid_index);
+          const Vector3<U>& xi = grid_x[a][b][c];
+          const U w = bspline.weight(a, b, c);
+          C += (w * vi) * (xi - x).transpose();
+        }
+      }
+    }
+    C *= transfer_.D_inverse();
+    const Matrix3<T>& F0 = const_particle_data.F()[p_index];
+    F_[p_index] = F0 + C * dt * F0;
+  };
+  const auto& particle_data = model.particle_data();
+  /* We const cast the particle data to satisfy the signature of G2P, but we
+   don't actually modify the content of the particle data as seen in the
+   kernel above; instead, we only make use of the side-effect of the transfer.
+  */
+  auto& mutable_particle_data = const_cast<ParticleData<T>&>(particle_data);
+  grid_->ApplyGridToParticleKernel(&mutable_particle_data, update_F_kernel);
+
+  /* Then update stress and stress derivatives. */
+  particle_data.ComputeKirchhoffStress(F_, &scratch_, &tau_volume_);
+  particle_data.ComputePK1StressDerivatives(F_, &scratch_,
+                                            &volume_scaled_stress_derivatives_);
+}
+
+template <typename T, typename Grid>
+void SolverState<T, Grid>::UpdateModel(MpmModel<T, Grid>* model) {
+  DRAKE_ASSERT(model != nullptr);
+  constexpr int kDim = 3;
+  auto update_grid_velocity = [&](GridData<T>* node) {
+    if (node->m > 0.0) {
+      DRAKE_ASSERT(node->index_or_flag.is_index());
+      node->v += dv_.template segment<kDim>(kDim * node->index_or_flag.index());
+    }
+  };
+  grid_->IterateGrid(update_grid_velocity);
+  ParticleData<T>& particle_data = model->mutable_particle_data();
+  transfer_.GridToParticle(*grid_, &particle_data);
+  particle_data.ComputeKirchhoffStress(
+      particle_data.F(), &particle_data.mutable_deformation_gradient_data(),
+      &particle_data.mutable_tau_volume());
+
+  is_valid_ = false;
+}
+
+}  // namespace internal
+}  // namespace mpm
+}  // namespace multibody
+}  // namespace drake
+
+template class drake::multibody::mpm::internal::SolverState<double>;
+template class drake::multibody::mpm::internal::SolverState<float>;
+template class drake::multibody::mpm::internal::SolverState<
+    drake::AutoDiffXd,
+    drake::multibody::mpm::internal::MockSparseGrid<drake::AutoDiffXd>>;

--- a/multibody/mpm/solver_state.cc
+++ b/multibody/mpm/solver_state.cc
@@ -47,12 +47,13 @@ void SolverState<T, Grid>::UpdateState(const VectorX<T>& ddv,
     for (int a = 0; a < 3; ++a) {
       for (int b = 0; b < 3; ++b) {
         for (int c = 0; c < 3; ++c) {
-          if (grid_data[a][b][c].m == 0.0) continue;
-          DRAKE_ASSERT(grid_data[a][b][c].index_or_flag.is_index());
-          const int grid_index = grid_data[a][b][c].index_or_flag.index();
-          const Vector3<T>& vi = grid_data[a][b][c].v +
-                                 dv_.template segment<kDim>(kDim * grid_index);
+          const GridData<T>& data_i = grid_data[a][b][c];
+          if (data_i.m == 0.0) continue;
           const Vector3<U>& xi = grid_x[a][b][c];
+          DRAKE_ASSERT(data_i.index_or_flag.is_index());
+          const int grid_index = data_i.index_or_flag.index();
+          const Vector3<T>& vi =
+              data_i.v + dv_.template segment<kDim>(kDim * grid_index);
           const U w = bspline.weight(a, b, c);
           C += (w * vi) * (xi - x).transpose();
         }

--- a/multibody/mpm/solver_state.h
+++ b/multibody/mpm/solver_state.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/math/fourth_order_tensor.h"
+#include "drake/multibody/contact_solvers/sap/partial_permutation.h"
+#include "drake/multibody/mpm/mpm_model.h"
+#include "drake/multibody/mpm/particle_data.h"
+#include "drake/multibody/mpm/sparse_grid.h"
+#include "drake/multibody/mpm/transfer.h"
+
+namespace drake {
+namespace multibody {
+namespace mpm {
+namespace internal {
+
+/* The SolverState class works closely with ModelModel and stores the state of
+ the MPM system during the optimization process (see MpmModel). It holds the
+ grid velocity change, `dv`, and other quantities that depend on `dv`
+ optimization process. */
+template <typename T, typename Grid = SparseGrid<T>>
+class SolverState {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SolverState)
+
+  /* Constructs a SolverState object that's compatible with the given MpmModel.
+   The grid mass and velocity are transferred from the particles in MpmModel.
+   The difference between the grid velocity and the previous grid velocity,
+   `dv`, is initialized to zero. The deformation gradient, stress, and stress
+   derivatives are also initialized to be their values at the previous time
+   step. */
+  explicit SolverState(const MpmModel<T, Grid>& model);
+
+  /* Resets the SolverState to be compatible with the given MpmModel.
+   @pre  model.dx() == grid().dx().
+   @post `this` SolverState is as if it was just constructed with the given
+   MpmModel. */
+  void Reset(const MpmModel<T, Grid>& model);
+
+  /* Returns the number of degrees of freedom (DoFs) in the system), which is
+   the 3 times the number of supported grid nodes. */
+  int num_dofs() const {
+    DRAKE_ASSERT(is_valid_);
+    return dv_.size();
+  }
+
+  /* Returns the MPM grid used in the optimization process. */
+  const Grid& grid() const {
+    DRAKE_ASSERT(is_valid_);
+    return *grid_;
+  }
+
+  /* Returns the change in the grid velocity dv = v - vn, ordered using grid
+   node indices. */
+  const VectorX<T>& dv() const {
+    DRAKE_ASSERT(is_valid_);
+    return dv_;
+  }
+
+  /* Returns the partial permutation that maps participating vertices/dofs to
+   their indices in the SAP contact problem. */
+  const contact_solvers::internal::VertexPartialPermutation& index_permutation()
+      const {
+    DRAKE_ASSERT(is_valid_);
+    return index_permutation_;
+  }
+
+  const std::vector<Matrix3<T>>& F() const {
+    DRAKE_ASSERT(is_valid_);
+    return F_;
+  }
+
+  const std::vector<Matrix3<T>>& tau_volume() const {
+    DRAKE_ASSERT(is_valid_);
+    return tau_volume_;
+  }
+
+  /* Given the change in `dv`, `ddv`, and the MpmModel associated with `this`
+   SolverState, updates the internal state of `this` SolverState.
+   @pre ddv.size() == num_dofs().
+   @pre `this` SolverState is constructed with the given `model` or is reset
+   from the given `model`. */
+  void UpdateState(const VectorX<T>& ddv, const MpmModel<T, Grid>& model);
+
+  /* Uses `this` SolverState to update the given MpmModel to the next time
+   step's state. Calls to this function invalidates the SolverState; the
+   SolverState needs to be reset before being used again (see Reset()). */
+  void UpdateModel(MpmModel<T, Grid>* model);
+
+ private:
+  Transfer<Grid> transfer_;
+  copyable_unique_ptr<Grid> grid_;
+  VectorX<T> dv_;
+  contact_solvers::internal::VertexPartialPermutation index_permutation_;
+  std::vector<Matrix3<T>> F_;
+  std::vector<DeformationGradientDataVariant<T>> scratch_;
+  std::vector<Matrix3<T>> tau_volume_;
+  std::vector<math::internal::FourthOrderTensor<T>>
+      volume_scaled_stress_derivatives_;
+  bool is_valid_{false};
+};
+
+}  // namespace internal
+}  // namespace mpm
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/mpm/solver_state.h
+++ b/multibody/mpm/solver_state.h
@@ -29,8 +29,7 @@ class SolverState {
    step. */
   explicit SolverState(const MpmModel<T, Grid>& model);
 
-  /* Resets the SolverState to be compatible with the given MpmModel. Makes this
-   @pre  model.dx() == grid().dx().
+  /* Resets the SolverState to be compatible with the given MpmModel.
    @post `this` SolverState is as if it was just constructed with the given
    MpmModel. */
   void Reset(const MpmModel<T, Grid>& model);

--- a/multibody/mpm/sparse_grid.cc
+++ b/multibody/mpm/sparse_grid.cc
@@ -54,7 +54,7 @@ template <typename T>
 std::vector<std::pair<Vector3<int>, GridData<T>>> SparseGrid<T>::GetGridData()
     const {
   std::vector<std::pair<Vector3<int>, GridData<T>>> result;
-  spgrid_.IterateConstGridWithOffset(
+  spgrid_.IterateGridWithOffset(
       [&](uint64_t offset, const GridData<T>& node_data) {
         if (node_data.m > 0.0) {
           const Vector3<int> coordinate = spgrid_.OffsetToCoordinate(offset);
@@ -67,7 +67,7 @@ std::vector<std::pair<Vector3<int>, GridData<T>>> SparseGrid<T>::GetGridData()
 template <typename T>
 MassAndMomentum<T> SparseGrid<T>::ComputeTotalMassAndMomentum() const {
   MassAndMomentum<T> result;
-  spgrid_.IterateConstGridWithOffset(
+  spgrid_.IterateGridWithOffset(
       [&](uint64_t offset, const GridData<T>& node_data) {
         if (node_data.m > 0.0) {
           const Vector3<T>& xi =

--- a/multibody/mpm/sparse_grid.cc
+++ b/multibody/mpm/sparse_grid.cc
@@ -81,6 +81,26 @@ MassAndMomentum<T> SparseGrid<T>::ComputeTotalMassAndMomentum() const {
   return result;
 }
 
+template <typename T>
+contact_solvers::internal::VertexPartialPermutation
+SparseGrid<T>::SetNodeIndices() {
+  std::vector<int> participating_nodes;
+  int node_index = 0;
+  int participating_node_index = 0;
+  spgrid_.IterateGrid([&](GridData<T>* node_data) {
+    if (node_data->m > 0.0) {
+      if (node_data->index_or_flag.is_flag()) {
+        participating_nodes.push_back(participating_node_index++);
+      } else {
+        participating_nodes.push_back(-1);
+      }
+      node_data->index_or_flag.set_index(node_index++);
+    }
+  });
+  return contact_solvers::internal::VertexPartialPermutation(
+      std::move(participating_nodes));
+}
+
 }  // namespace internal
 }  // namespace mpm
 }  // namespace multibody

--- a/multibody/mpm/sparse_grid.h
+++ b/multibody/mpm/sparse_grid.h
@@ -152,6 +152,37 @@ class SparseGrid {
     particle_sorter_.Iterate(this, particle_data, kernel);
   }
 
+  /* Iterates over all particles and the grid nodes supported by them, applying
+   the given kernel.
+
+   This method traverses every particle in the provided ParticleData instance.
+   For each particle, it:
+     - Retrieves the pad of grid nodes and grid data that the particle supports.
+     - Invokes the provided kernel function with:
+       - The index of the current particle.
+       - A const reference to the positions of the pad of grid nodes supported
+         by the particle.
+       - A const reference to the pad of grid data.
+       - A const reference to the particle data.
+   Note that this kernel should only read the particle data with the given
+   particle index, and it should not assume an ordering of how the particles are
+   iterated.
+
+   @param[in] particle_data  Pointer to the particle data to iterate over. It
+                             provides the particle position to locate the
+                             relevant grid pad as well as the current particle
+                             state to be used in the kernel.
+   @param[in] kernel         The grid-to-particle kernel to apply.
+   @pre The grid's Allocate() method must have been called with the positions
+   contained in the given particle_data. */
+  void IterateParticleAndGrid(
+      const ParticleData<T>& particle_data,
+      const std::function<void(int, const Pad<Vector3<T>>&,
+                               const Pad<GridData<T>>&,
+                               const ParticleData<T>&)>& kernel) const {
+    particle_sorter_.Iterate(this, &particle_data, kernel);
+  }
+
   /* Iterates over all particles and the grid nodes supported by them,
    applying the given kernel, and writes back the updated grid data.
 

--- a/multibody/mpm/sparse_grid.h
+++ b/multibody/mpm/sparse_grid.h
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/multibody/contact_solvers/sap/partial_permutation.h"
 #include "drake/multibody/mpm/grid_data.h"
 #include "drake/multibody/mpm/mass_and_momentum.h"
 #include "drake/multibody/mpm/particle_data.h"
@@ -193,6 +194,20 @@ class SparseGrid {
   void IterateGrid(const std::function<void(GridData<T>*)>& func) {
     spgrid_.IterateGrid(func);
   }
+
+  /* Iterates over all grid nodes in the grid and applies the given function
+   `func` to each grid node. */
+  void IterateConstGrid(
+      const std::function<void(const GridData<T>&)>& func) const {
+    spgrid_.IterateConstGrid(func);
+  }
+
+  /* Sets the indices of all active nodes in the grid and returns a
+   VertexPartialPermutation that maps the grid indices/dofs to the permuted grid
+   indices/dofs. With the permuted grid indices, grid nodes/dofs participating
+   in constraints come before nodes those don't participate in any constraint.
+  */
+  contact_solvers::internal::VertexPartialPermutation SetNodeIndices();
 
  private:
   /* Grid spacing (in meters). */

--- a/multibody/mpm/sparse_grid.h
+++ b/multibody/mpm/sparse_grid.h
@@ -228,9 +228,8 @@ class SparseGrid {
 
   /* Iterates over all grid nodes in the grid and applies the given function
    `func` to each grid node. */
-  void IterateConstGrid(
-      const std::function<void(const GridData<T>&)>& func) const {
-    spgrid_.IterateConstGrid(func);
+  void IterateGrid(const std::function<void(const GridData<T>&)>& func) const {
+    spgrid_.IterateGrid(func);
   }
 
   /* Sets the indices of all active nodes in the grid and returns a

--- a/multibody/mpm/sparse_grid.h
+++ b/multibody/mpm/sparse_grid.h
@@ -238,7 +238,7 @@ class SparseGrid {
    in constraints come before nodes those don't participate in any constraint.
    Nodes are marked as "participating" during P2G in Transfer::ParticleToGrid().
    A node is marked as participating whenever it is in the support of a particle
-   particpating in a constraint. Refer to Transfer::ParticleToGrid() for
+   participating in a constraint. Refer to Transfer::ParticleToGrid() for
    details. */
   contact_solvers::internal::VertexPartialPermutation SetNodeIndices();
 

--- a/multibody/mpm/sparse_grid.h
+++ b/multibody/mpm/sparse_grid.h
@@ -236,7 +236,10 @@ class SparseGrid {
    VertexPartialPermutation that maps the grid indices/dofs to the permuted grid
    indices/dofs. With the permuted grid indices, grid nodes/dofs participating
    in constraints come before nodes those don't participate in any constraint.
-  */
+   Nodes are marked as "participating" during P2G in Transfer::ParticleToGrid().
+   A node is marked as participating whenever it is in the support of a particle
+   particpating in a constraint. Refer to Transfer::ParticleToGrid() for
+   details. */
   contact_solvers::internal::VertexPartialPermutation SetNodeIndices();
 
  private:

--- a/multibody/mpm/spgrid.h
+++ b/multibody/mpm/spgrid.h
@@ -267,8 +267,7 @@ class SpGrid {
 
   /* Iterates over all grid nodes in the grid and applies the given function
    `func` to each grid node. */
-  void IterateConstGrid(
-      const std::function<void(const GridData&)>& func) const {
+  void IterateGrid(const std::function<void(const GridData&)>& func) const {
     const uint64_t data_size = 1 << kDataBits;
     ConstArray grid_data = allocator_.Get_Array();
     auto [block_offsets, num_blocks] = blocks_.Get_Blocks();
@@ -313,7 +312,7 @@ class SpGrid {
 
   /* Iterates over all grid nodes in the grid and applies the given function
    `func` to each grid node's offset and data. */
-  void IterateConstGridWithOffset(
+  void IterateGridWithOffset(
       const std::function<void(Offset, const GridData&)>& func) const {
     const uint64_t data_size = 1 << kDataBits;
     ConstArray grid_data = allocator_.Get_Array();

--- a/multibody/mpm/spgrid.h
+++ b/multibody/mpm/spgrid.h
@@ -266,6 +266,29 @@ class SpGrid {
   }
 
   /* Iterates over all grid nodes in the grid and applies the given function
+   `func` to each grid node. */
+  void IterateConstGrid(
+      const std::function<void(const GridData&)>& func) const {
+    const uint64_t data_size = 1 << kDataBits;
+    ConstArray grid_data = allocator_.Get_Array();
+    auto [block_offsets, num_blocks] = blocks_.Get_Blocks();
+    for (int b = 0; b < static_cast<int>(num_blocks); ++b) {
+      const uint64_t block_offset = block_offsets[b];
+      uint64_t node_offset = block_offset;
+      /* The coordinate of the origin of this block. */
+      for (int i = 0; i < kNumNodesInBlockX; ++i) {
+        for (int j = 0; j < kNumNodesInBlockY; ++j) {
+          for (int k = 0; k < kNumNodesInBlockZ; ++k) {
+            const GridData& node_data = grid_data(node_offset);
+            func(node_data);
+            node_offset += data_size;
+          }
+        }
+      }
+    }
+  }
+
+  /* Iterates over all grid nodes in the grid and applies the given function
    `func` to each grid node's offset and data. */
   void IterateGridWithOffset(
       const std::function<void(Offset, GridData*)>& func) {

--- a/multibody/mpm/test/mpm_model_test.cc
+++ b/multibody/mpm/test/mpm_model_test.cc
@@ -1,0 +1,300 @@
+#include "drake/multibody/mpm/mpm_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff.h"
+#include "drake/multibody/mpm/mock_sparse_grid.h"
+#include "drake/multibody/mpm/solver_state.h"
+
+namespace drake {
+namespace multibody {
+namespace mpm {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+using Eigen::Vector3i;
+using Eigen::VectorXd;
+
+template <typename Grid>
+class MpmModelTest : public ::testing::Test {};
+
+using MyTypes = ::testing::Types<SparseGrid<double>, SparseGrid<float>>;
+TYPED_TEST_SUITE(MpmModelTest, MyTypes);
+
+/* Tests the constructors of MpmModel and SolverState. */
+TYPED_TEST(MpmModelTest, Constructor) {
+  using Grid = TypeParam;
+  using T = typename Grid::Scalar;
+
+  const double dx = 0.01;
+  ParticleData<T> particle_data;
+  /* Add a particle so that all grid nodes touched by this particle are in a
+   single grid block. */
+  const Vector3d x0(dx, dx, dx);
+  particle_data.AddParticles({x0}, 1.0,
+                             multibody::fem::DeformableBodyConfig<double>());
+  const T dt = 0.02;
+
+  MpmModel<T> model(dt, dx, std::move(particle_data));
+  SolverState<T> state(model);
+
+  EXPECT_EQ(model.dt(), dt);
+  EXPECT_EQ(model.dx(), dx);
+  EXPECT_EQ(model.num_particles(), 1);
+  EXPECT_EQ(state.num_dofs(), 27 * 3);
+  EXPECT_EQ(state.grid().dx(), dx);
+  EXPECT_TRUE(CompareMatrices(state.dv(), VectorX<T>::Zero(27 * 3)));
+  const contact_solvers::internal::PartialPermutation& vertex_permutation =
+      state.index_permutation().vertex();
+  EXPECT_EQ(vertex_permutation.domain_size(), 27);
+  EXPECT_EQ(vertex_permutation.permuted_domain_size(), 0);
+  EXPECT_EQ(state.F().size(), 1);
+  EXPECT_EQ(state.tau_volume().size(), 1);
+}
+
+TYPED_TEST(MpmModelTest, UpdateModelAndReset) {
+  using Grid = TypeParam;
+  using T = typename Grid::Scalar;
+
+  const double dx = 0.01;
+  ParticleData<T> particle_data;
+  /* Add a particle so that all grid nodes touched by this particle are in a
+   single grid block. */
+  const Vector3d x0(dx, dx, dx);
+  /* Set the config such that the scale of the result is close to 1.0. */
+  multibody::fem::DeformableBodyConfig<double> config;
+  config.set_youngs_modulus(1.0);
+  config.set_poissons_ratio(0.1);
+  config.set_mass_density(1.0);
+  particle_data.AddParticles({x0}, 1.0, config);
+  const T dt = 0.01;
+
+  MpmModel<T> model(dt, dx, std::move(particle_data));
+  SolverState<T> state(model);
+
+  /* Give the grid a uniform velocity field of (1, 0, 0). */
+  VectorX<T> ddv = VectorX<T>::Zero(state.num_dofs());
+  for (int i = 0; i < state.num_dofs(); ++i) {
+    if (i % 3 == 0) {
+      ddv[i] = 1.0;
+    }
+  }
+  state.UpdateState(ddv, model);
+  EXPECT_EQ(state.dv(), ddv);
+  /* Write the change in the state back to the model. Now the particle should be
+   moved to (0.02, 0.01, 0.01), with no deformation. */
+  state.UpdateModel(&model);
+  constexpr T kTol = 4.0 * std::numeric_limits<T>::epsilon();
+  EXPECT_TRUE(CompareMatrices(model.particle_data().x()[0],
+                              Vector3<T>(0.02, 0.01, 0.01), kTol));
+  EXPECT_TRUE(CompareMatrices(model.particle_data().F()[0],
+                              Matrix3<T>::Identity(), kTol));
+  /* Reset the state, now the grid should reflect that the particle is at the
+   new location. */
+  state.Reset(model);
+  struct Vector3iLess {
+    bool operator()(const Vector3i& a, const Vector3i& b) const {
+      return std::lexicographical_compare(a.data(), a.data() + 3, b.data(),
+                                          b.data() + 3);
+    }
+  };
+  std::set<Vector3i, Vector3iLess> expected_active_nodes;
+  for (int a = -1; a <= 1; ++a) {
+    for (int b = -1; b <= 1; ++b) {
+      for (int c = -1; c <= 1; ++c) {
+        expected_active_nodes.insert(Vector3i(2 + a, 1 + b, 1 + c));
+      }
+    }
+  }
+  const std::vector<std::pair<Vector3i, GridData<T>>> grid_data =
+      state.grid().GetGridData();
+  EXPECT_EQ(grid_data.size(), expected_active_nodes.size());
+  for (const auto& [node, node_data] : grid_data) {
+    EXPECT_TRUE(expected_active_nodes.contains(node));
+    EXPECT_TRUE(CompareMatrices(node_data.v, Vector3<T>(1.0, 0.0, 0.0), kTol));
+  }
+}
+
+TYPED_TEST(MpmModelTest, CalcCost) {
+  using Grid = TypeParam;
+  using T = typename Grid::Scalar;
+
+  const double dx = 0.01;
+  ParticleData<T> particle_data;
+  const Vector3d x0(dx, dx, dx);
+
+  multibody::fem::DeformableBodyConfig<double> config;
+  config.set_youngs_modulus(1.0);
+  config.set_poissons_ratio(0.1);
+  config.set_mass_density(1.0);
+
+  particle_data.AddParticles({x0}, 1.0, config);
+  const T dt = 0.02;
+  constexpr T kTol = 4.0 * std::numeric_limits<T>::epsilon();
+
+  MpmModel<T> model(dt, dx, particle_data);
+  SolverState<T> state(model);
+  T energy = model.CalcCost(state);
+  EXPECT_EQ(energy, 0.0);
+
+  /* A single particle activates 27 grid ndoes. */
+  constexpr int num_dofs = 27 * 3;
+  ASSERT_EQ(state.num_dofs(), num_dofs);
+  /* Arbitrary velocity field. */
+  VectorX<T> ddv = VectorX<T>::LinSpaced(num_dofs, 0.0, 1.0);
+  state.UpdateState(ddv, model);
+  energy = model.CalcCost(state);
+
+  auto scratch = particle_data.deformation_gradient_data();
+  /* This is tested in the ParticleData class. */
+  const T elastic_energy =
+      particle_data.ComputeTotalEnergy(state.F(), &scratch);
+
+  double kinetic_energy = 0.0;
+  const std::vector<std::pair<Vector3i, GridData<T>>> grid_data =
+      state.grid().GetGridData();
+  for (const auto& [node, node_data] : grid_data) {
+    const int a = node[0];
+    const int b = node[1];
+    const int c = node[2];
+    /* We make use of the fact that SpGrid follows lexicographical order
+     within a block.*/
+    const int node_index = a * 9 + b * 3 + c;
+    kinetic_energy +=
+        0.5 * node_data.m *
+        state.dv().template segment<3>(node_index * 3).squaredNorm();
+  }
+  EXPECT_NEAR(energy, kinetic_energy + elastic_energy, kTol);
+}
+
+TYPED_TEST(MpmModelTest, CalcResidual) {
+  using Grid = TypeParam;
+  using T = typename Grid::Scalar;
+
+  const double dx = 0.01;
+  ParticleData<T> particle_data;
+  const Vector3d x0(dx, dx, dx);
+
+  /* Set the config such that the scale of the result is close to 1.0. */
+  multibody::fem::DeformableBodyConfig<double> config;
+  config.set_youngs_modulus(1.0);
+  config.set_poissons_ratio(0.1);
+  config.set_mass_density(1.0);
+
+  particle_data.AddParticles({x0}, 1.0, config);
+  const T dt = 0.02;
+  constexpr T kTol = 4.0 * std::numeric_limits<T>::epsilon();
+
+  MpmModel<T> model(dt, dx, particle_data);
+  SolverState<T> state(model);
+  const int num_dofs = state.num_dofs();
+
+  /* We set b to be an arbitrary value with an arbitrary size to test that the
+   function does not crash. */
+  VectorX<T> residual = VectorX<T>::LinSpaced(42, 0, 1);
+  model.CalcResidual(state, &residual);
+  EXPECT_TRUE(CompareMatrices(residual, VectorX<T>::Zero(num_dofs)));
+
+  /* Give the grid a constant velocity field so that it doesn't induce any
+   deformation on the particle. Consequently, the only residual comes from the
+   M * dv term. */
+  VectorX<T> ddv = VectorX<T>::Ones(num_dofs);
+  state.UpdateState(ddv, model);
+  EXPECT_TRUE(CompareMatrices(state.dv(), ddv));
+  model.CalcResidual(state, &residual);
+  /* Get the Bspline weights between the only particle and the pad it
+   * supports.
+   */
+  const BsplineWeights<T> weights(particle_data.x()[0], static_cast<T>(dx));
+  for (int a = 0; a < 3; ++a) {
+    for (int b = 0; b < 3; ++b) {
+      for (int c = 0; c < 3; ++c) {
+        const T weight = weights.weight(a, b, c);
+        /* We make use of the fact that SpGrid follows lexicographical order
+         within a block.*/
+        const int node_index = a * 9 + b * 3 + c;
+        EXPECT_TRUE(CompareMatrices(
+            residual.template segment<3>(node_index * 3),
+            weight * ddv.template segment<3>(node_index * 3), kTol));
+      }
+    }
+  }
+
+  /* Reset dv to zero. */
+  state.UpdateState(-ddv, model);
+  EXPECT_TRUE(CompareMatrices(state.dv(), VectorX<T>::Zero(num_dofs), kTol));
+  model.CalcResidual(state, &residual);
+  EXPECT_TRUE(CompareMatrices(residual, VectorX<T>::Zero(num_dofs), kTol));
+
+  /* Add a non-constant velocity field and confirm that the residual is no
+   longer equal to M * dv, except for the center node; The center node is
+   right on top of the particle and because of the xᵢ − xₚ term in computing
+   the residual, the contribution to the residual from the particle
+   deformation at this node is zero. */
+  ddv = VectorX<T>::LinSpaced(num_dofs, 0, 1);
+  state.UpdateState(ddv, model);
+  model.CalcResidual(state, &residual);
+  for (int a = 0; a < 3; ++a) {
+    for (int b = 0; b < 3; ++b) {
+      for (int c = 0; c < 3; ++c) {
+        const double weight = weights.weight(a, b, c);
+        /* We make use of the fact that SpGrid follows lexicographical order
+         within a block.*/
+        const int node_index = a * 9 + b * 3 + c;
+        if (a == 1 && b == 1 && c == 1) {
+          EXPECT_TRUE(CompareMatrices(
+              residual.template segment<3>(node_index * 3),
+              weight * ddv.template segment<3>(node_index * 3), kTol));
+        } else {
+          EXPECT_FALSE(CompareMatrices(
+              residual.template segment<3>(node_index * 3),
+              weight * ddv.template segment<3>(node_index * 3), 1e-4));
+        }
+      }
+    }
+  }
+}
+
+GTEST_TEST(MpmModelTest, ResidualIsDerivativeOfEnergy) {
+  const double dx = 0.01;
+  const Vector3d x0(dx, dx, dx);
+  const Vector3d x1(1.1 * dx, 1.2 * dx, 1.3 * dx);
+  /* Set the config such that the scale of the result is close to 1.0. */
+  multibody::fem::DeformableBodyConfig<double> config;
+  config.set_youngs_modulus(1.0);
+  config.set_poissons_ratio(0.1);
+  config.set_mass_density(1.0);
+
+  ParticleData<AutoDiffXd> particle_data;
+  particle_data.AddParticles({x0, x1}, 1.0, config);
+
+  const double dt = 0.02;
+  MpmModel<AutoDiffXd, MockSparseGrid<AutoDiffXd>> model(dt, dx, particle_data);
+  SolverState<AutoDiffXd, MockSparseGrid<AutoDiffXd>> state(model);
+
+  const int num_dofs = state.num_dofs();
+  ASSERT_EQ(num_dofs, 27 * 3);
+
+  VectorX<double> ddv = VectorX<double>::LinSpaced(num_dofs, 0.0, 1.0);
+  VectorX<AutoDiffXd> ddv_ad;
+  ddv_ad.resize(num_dofs);
+  math::InitializeAutoDiff(ddv, &ddv_ad);
+  state.UpdateState(ddv_ad, model);
+
+  const AutoDiffXd energy = model.CalcCost(state);
+  VectorX<AutoDiffXd> residual;
+  model.CalcResidual(state, &residual);
+  const double kTol = 4.0 * std::numeric_limits<double>::epsilon();
+  EXPECT_TRUE(CompareMatrices(energy.derivatives(),
+                              math::DiscardGradient(residual), kTol));
+  EXPECT_FALSE(
+      CompareMatrices(energy.derivatives(), VectorXd::Zero(num_dofs), 0.1));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace mpm
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/mpm/test/mpm_model_test.cc
+++ b/multibody/mpm/test/mpm_model_test.cc
@@ -253,6 +253,8 @@ TYPED_TEST(MpmModelTest, CalcResidual) {
               weight * particle_mass * ddv.template segment<3>(node_index * 3),
               kTol));
         } else {
+          /* Even if we allow a lot of slop, these things aren't even nearly the
+           same. */
           EXPECT_FALSE(CompareMatrices(
               residual.template segment<3>(node_index * 3),
               weight * particle_mass * ddv.template segment<3>(node_index * 3),

--- a/multibody/mpm/test/particle_sorter_test.cc
+++ b/multibody/mpm/test/particle_sorter_test.cc
@@ -132,7 +132,7 @@ GTEST_TEST(ParticleSorterTest, Sort) {
     allocated_offsets.insert(offset);
   };
 
-  another_grid.IterateConstGridWithOffset(callback);
+  another_grid.IterateGridWithOffset(callback);
   for (uint64_t offset : base_node_offsets) {
     const Vector3i coord = another_grid.OffsetToCoordinate(offset);
     /* Get the offsets of nodes in the one-ring of the base node. */

--- a/multibody/mpm/test/sparse_grid_test.cc
+++ b/multibody/mpm/test/sparse_grid_test.cc
@@ -383,7 +383,8 @@ TYPED_TEST(SparseGridTest, SetNodeIndices) {
   std::vector<Vector3<double>> q_WPs = {q_WP0, q_WP1};
   ParticleData<T> particle_data;
   particle_data.AddParticles(q_WPs, 1.0, fem::DeformableBodyConfig<double>());
-  /* The first particle is not in constraint while the second is. */
+  /* The first particle is not participating in a constraint while the second
+   is. */
   particle_data.mutable_in_constraint() = {0, 1};
 
   grid.Allocate(particle_data.x());

--- a/multibody/mpm/test/sparse_grid_test.cc
+++ b/multibody/mpm/test/sparse_grid_test.cc
@@ -46,7 +46,7 @@ TYPED_TEST(SparseGridTest, Allocate) {
   auto count_active_nodes = [&num_active_nodes](uint64_t, const GridData<U>&) {
     ++num_active_nodes;
   };
-  grid.spgrid().IterateConstGridWithOffset(count_active_nodes);
+  grid.spgrid().IterateGridWithOffset(count_active_nodes);
 
   const int block_size = std::is_same_v<U, double> ? 64 : 128;
   /* We allocate the block B that contains the particle and the one ring of
@@ -286,7 +286,7 @@ TYPED_TEST(SparseGridTest, ApplyGridToParticleKernel) {
   grid.ApplyGridToParticleKernel(&particle_data, g2p_kernel);
 }
 
-/* Tests both IterateGrid and IterateConstGrid. */
+/* Tests both IterateGrid and IterateGrid. */
 TYPED_TEST(SparseGridTest, IterateGrid) {
   using Grid = TypeParam;
   using T = typename Grid::Scalar;
@@ -318,7 +318,7 @@ TYPED_TEST(SparseGridTest, IterateGrid) {
   auto count_total_mass = [&total_mass](const GridData<T>& data) {
     total_mass += data.m;
   };
-  grid.IterateConstGrid(count_total_mass);
+  grid.IterateGrid(count_total_mass);
   EXPECT_EQ(total_mass, expected_total_mass);
 }
 

--- a/multibody/mpm/test/spgrid_test.cc
+++ b/multibody/mpm/test/spgrid_test.cc
@@ -178,8 +178,8 @@ GTEST_TEST(SpGridTest, IterateGridWithOffset) {
     TripleLoop(func);
   }
 
-  // Use IterateConstGridWithOffset to ensure const access does not modify data
-  grid.IterateConstGridWithOffset([](Offset offset, const GridData& node_data) {
+  // Use IterateGridWithOffset to ensure const access does not modify data
+  grid.IterateGridWithOffset([](Offset offset, const GridData& node_data) {
     Vector4d expected_value(offset * 1.0, offset * 2.0, offset * 3.0,
                             offset * 4.0);
     EXPECT_EQ(node_data.data, expected_value);

--- a/multibody/mpm/transfer.h
+++ b/multibody/mpm/transfer.h
@@ -43,8 +43,8 @@ class Transfer {
 
   /* The Particle to grid transfer (P2G). After the call to P2G, the grid stores
    the mass and momentum transfered from the particles using APIC. In the
-   process, also mark the grid nodes that are in support of any particle in
-   constraint with the "participating" flag.
+   process, also mark the grid nodes that are in support of any particle that is
+   participating in a constraint with the "participating" flag.
    @note The `v` attribute of the grid data at the end of the operation stores
    the momentum, not velocity, of the grid node. */
   void ParticleToGrid(const ParticleData<T>& particle, Grid* grid);

--- a/multibody/mpm/transfer.h
+++ b/multibody/mpm/transfer.h
@@ -31,7 +31,7 @@ namespace internal {
 template <typename Grid = SparseGrid<double>>
 class Transfer {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Transfer);
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Transfer);
 
   /* The scalar type for the grid and particle data. */
   using T = typename Grid::Scalar;
@@ -52,6 +52,8 @@ class Transfer {
    @pre the grid stores mass and velocity (not momentum). Hence, the velocity
    from the grid needs to be processed after P2G and before G2P. */
   void GridToParticle(const Grid& grid, ParticleData<T>* particle);
+
+  T D_inverse() const { return D_inverse_; }
 
  private:
   T dt_{};

--- a/multibody/mpm/transfer.h
+++ b/multibody/mpm/transfer.h
@@ -42,7 +42,9 @@ class Transfer {
   Transfer(T dt, double dx);
 
   /* The Particle to grid transfer (P2G). After the call to P2G, the grid stores
-   the mass and momentum transfered from the particles using APIC.
+   the mass and momentum transfered from the particles using APIC. In the
+   process, also mark the grid nodes that are in support of any particle in
+   constraint with the "participating" flag.
    @note The `v` attribute of the grid data at the end of the operation stores
    the momentum, not velocity, of the grid node. */
   void ParticleToGrid(const ParticleData<T>& particle, Grid* grid);


### PR DESCRIPTION
In support of these two new classes and their tests, also add SparseGrid::IterateConstGrid(), MockSparseGrid::IterateConstGrid(), SparseGrid::SetNodeIndices(), MockSparseGrid::SetNodeIndices().

Make Transfer class copyable.

Add a missing const in ParticleData.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22882)
<!-- Reviewable:end -->
