### PR TITLE
[multibody] Allow reversed revolute joints

### DIFF
--- a/doc/_pages/troubleshooting.md
+++ b/doc/_pages/troubleshooting.md
@@ -74,6 +74,27 @@ The connection can be reported as missing for several reasons:
       xdot = plant.EvalTimeDerivatives(context=plant_context)
     ```
 
+## Loops in the body-joint graph {#mbp-loops-in-graph}
+
+Currently Drake does not support automatic modeling of systems for which the
+bodies and joints form one or more loops in the system graph. However, there
+are several ways you can model these systems in Drake:
+
+  - Break each loop at a joint and replace the joint by an equivalent constraint
+    or by using a `LinearBushingRollPitchYaw`
+    ([C++][c_LinearBushingRollPitchYaw],
+    [Python][p_LinearBushingRollPitchYaw]) force element.
+  - Break each loop by cutting one of the bodies involved in the loop. This
+    introduces a new "shadow" body that will follow the "primary" body. For best
+    numerical behavior, distribute the mass and inertia 1/2 to each of the
+    two bodies. Use a Weld constraint to attach the shadow to its primary. This
+    method has the advantage that joints remain uniformly treated and the
+    joint coordinates are unchanged.
+
+It is also possible to introduce loops by accident. If you didn't intend to
+do so, check your system description to see whether some joint may have been
+connected to the wrong body.
+
 # System Framework
 
 ## Context-System mismatch {#framework-context-system-mismatch}
@@ -285,6 +306,8 @@ sudo route -nv add -net 224.0.0.0/4 -interface lo0
 <!-- drake/multibody/plant -->
 [c_AddMultibodyPlantSceneGraph]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html#aac66563a5f3eb9e2041bd4fa8d438827
 [p_AddMultibodyPlantSceneGraph]: https://drake.mit.edu/pydrake/pydrake.multibody.plant.html#pydrake.multibody.plant.AddMultibodyPlantSceneGraph
+[c_LinearBushingRollPitchYaw]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_linear_bushing_roll_pitch_yaw.html
+[p_LinearBushingRollPitchYaw]: https://drake.mit.edu/pydrake/pydrake.multibody.tree.html#pydrake.multibody.tree.LinearBushingRollPitchYaw
 [c_MultibodyPlant]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html
 [p_MultibodyPlant]: https://drake.mit.edu/pydrake/pydrake.multibody.plant.html#pydrake.multibody.plant.MultibodyPlant
 

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -58,7 +58,6 @@ using std::set;
 using std::unique_ptr;
 
 // Tests the basic MultibodyTree API to add bodies and joints.
-// Tests we cannot create graph loops.
 GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
   auto model = std::make_unique<MultibodyTree<double>>();
 
@@ -140,7 +139,7 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
 }
 
 // Tests the basic MultibodyTree API to add bodies and joints.
-// Tests we cannot create graph loops. See previous test for notes.
+// Tests we cannot currently create graph loops. See previous test for notes.
 GTEST_TEST(MultibodyTree, TopologicalLoopDisallowed) {
   auto model = std::make_unique<MultibodyTree<double>>();
   const RigidBody<double>& world_body = model->world_body();
@@ -155,7 +154,7 @@ GTEST_TEST(MultibodyTree, TopologicalLoopDisallowed) {
   EXPECT_EQ(model->num_bodies(), 3);
   EXPECT_EQ(model->num_joints(), 2);
 
-  // Attempts to create a loop. Verify we gen an exception at Finalize().
+  // Attempts to create a loop. Verify we get an exception at Finalize().
   model->AddJoint<RevoluteJoint>("joint2", pendulum, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
@@ -164,8 +163,9 @@ GTEST_TEST(MultibodyTree, TopologicalLoopDisallowed) {
 
   // Topology is invalid before MultibodyTree::Finalize(), and after fail.
   EXPECT_FALSE(model->topology_is_valid());
-  DRAKE_EXPECT_THROWS_MESSAGE(model->Finalize(),
-                              ".*kinematic loop using joints.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model->Finalize(),
+      "The bodies and joints of this system form one or more loops.*");
   EXPECT_FALSE(model->topology_is_valid());
 }
 


### PR DESCRIPTION
PR #22873 implemented reverse revolute joints as a side effect of choosing optimal F & M frames for revolute mobilizers but did not enable the feature. This PR enables reverse revolute joints and adds test cases to show that they are working.

This is half of issue #22212; prismatic joints still remain to be reversed.

This also adds a missing error message for systems whose links and joints form topological loops since we don't have automatic support for those yet. This prevents issuing a confusing "this joint can't be reversed" error message when the cause of the reversal was the presence of a loop. A short troubleshooting section on how to model systems with loops is added also.

Unit tests are provided for (a) loop detection, (b) reversed revolute functionality, and (c) rejection of unsupported reverse joints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22883)
<!-- Reviewable:end -->
