### PR TITLE
Prepare wheel builder scripts for macOS AWS transition

### DIFF
--- a/tools/wheel/README.rst
+++ b/tools/wheel/README.rst
@@ -14,10 +14,13 @@ environment setup required. However, it is recommended to run the script on the
 most recent version of Ubuntu LTS that is supported by Drake.
 
 On macOS, Drake's dependencies must be installed already (i.e. by preparing an
-environment as one would to build Drake normally). There are a small number of
-additional dependencies that will be installed by the builder, so the builder
-must be able to run ``brew``. The builder must also be able to write to
-``/opt``, as this is where the build is performed.
+environment as one would to build Drake normally).
+
+There are a small number of dependencies for the the builder scripts to work
+that Drake itself does not require. In order to install these additional
+packages, run the ``setup/install_prereqs`` script with the ``--developer``
+flag. The builder must also be able to write to ``/opt``, as this is where the
+build is performed.
 
 The script takes a single, required positional argument, which is used to
 specify the version with which the wheels should be tagged. The version number
@@ -137,7 +140,10 @@ located at ``/opt/drake``. Since multiple builds may be present, a temporary
 symlink is created at this path to the actual, Python-version-specific
 installation while building the wheel. Therefore, this path must be available.
 
-After performing wheel-specific provisioning using ``brew``, the builder
-invokes ``macos/build-wheel.sh``, optionally (and if the build succeeded)
-followed by ``macos/test-wheel.sh``. These scripts approximately replicate what
-would happen in Docker, and heavily reuse the same lower level scripts.
+Starting from a provisioned wheel building environment (installed via
+``setup/install_prereqs --developer``), the builder invokes
+``macos/build-wheel.sh``, optionally (and if the build succeeded) followed by
+a series of test scripts (namely ``macos/provision-test-python.sh``,
+``test/install-wheel.sh``, and ``test/test-wheel.sh``, in that order. These
+scripts approximately replicate what would happen in Docker, and heavily reuse
+the same lower level scripts.

--- a/tools/wheel/test/install-wheel.sh
+++ b/tools/wheel/test/install-wheel.sh
@@ -2,12 +2,12 @@
 
 # This shell script installs a Drake wheel. It must be run inside a container
 # (Ubuntu) or environment (macOS) which has been properly provisioned, e.g. by
-# the accompanying Dockerfile (Ubuntu) or by macos/test-wheel.sh (macOS). In
-# particular, /opt/drake-wheel-test/python must contain a Python virtual
-# environment which will be used to run the tests. The path to the wheel to be
-# installed must be given as an argument to the script. On Ubuntu, the wheel
-# must be accessible to the container, and the path must be the container's
-# path to the wheel (rather than the host's path).
+# the accompanying Dockerfile (Ubuntu) or by macos/provision-test-python.sh
+# (macOS). In particular, /opt/drake-wheel-test/python must contain a Python
+# virtual environment which will be used to run the tests. The path to the
+# wheel to be installed must be given as an argument to the script. On Ubuntu,
+# the wheel must be accessible to the container, and the path must be the
+# container's path to the wheel (rather than the host's path).
 #
 # In general, it is not recommended to attempt to run this script directly;
 # use //tools/wheel:builder instead.

--- a/tools/wheel/test/test-wheel.sh
+++ b/tools/wheel/test/test-wheel.sh
@@ -3,8 +3,9 @@
 # This shell script runs a test on a Drake wheel. It must be run inside of a
 # container (Ubuntu) or environment (macOS) which has been properly
 # provisioned, e.g. by the accompanying Dockerfile (Ubuntu) or by
-# macos/test-wheel.sh (macOS), and which already has the wheel installed. The
-# path to the test script must be given as an argument to the script.
+# macos/provision-wheel-python.sh (macOS), and which already has the wheel
+# installed. The path to the test script must be given as an argument to the
+# script.
 #
 # In general, it is not recommended to attempt to run this script directly;
 # use //tools/wheel:builder instead.

--- a/tools/wheel/wheel_builder/common.py
+++ b/tools/wheel/wheel_builder/common.py
@@ -19,6 +19,9 @@ build_root = '/opt/drake-wheel-build'
 # Location where testing of the wheel will take place.
 test_root = '/opt/drake-wheel-test'
 
+# Location of the Drake installation used to build the wheel.
+drake_install_root = '/opt/drake-dist'
+
 # Location where the wheel will be produced.
 wheel_root = os.path.join(build_root, 'wheel')
 wheelhouse = os.path.join(wheel_root, 'wheelhouse')
@@ -216,6 +219,7 @@ def do_main(args, platform):
 
     # Parse arguments.
     options = parser.parse_args(args)
+    print(f'DEBUG: options = {options}')
     if platform is not None:
         platform.fixup_options(options)
 


### PR DESCRIPTION
Closes #22848 

**Pending tasks**
- [x] Remove _provision() function and associated logic from wheel_builder/macos.py (blocked until Drake release 1.40.0).
- [x] Implement error handling logic to ensure build cleanup logic runs in the event of unsuccessful builds.
- [x] Remove references to macos/test-wheel.sh in documentation and comments.
- [x] Update README.rst to reflect the fact that macOS provisioning no longer occurs as part of the wheel builder process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22887)
<!-- Reviewable:end -->
