### PR TITLE
 Overload `ExtractValue` and `ExtractGradient` to allow preallocated output matrix

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -329,6 +329,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 


### PR DESCRIPTION
Currently, the functions `ExtractValue` and `ExtractGradient` **returns** the value and gradient part of a `Eigen::MatrixX<AutoDiffXd>`. This PR adds overloads accepting an additional argument `Eigen::MatrixXd*`, giving users the ability to preallocate the output matrices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22895)
<!-- Reviewable:end -->
