### PR TITLE
Remove brew and update documentation for wheel builder scripts

### DIFF
--- a/tools/wheel/README.rst
+++ b/tools/wheel/README.rst
@@ -14,10 +14,13 @@ environment setup required. However, it is recommended to run the script on the
 most recent version of Ubuntu LTS that is supported by Drake.
 
 On macOS, Drake's dependencies must be installed already (i.e. by preparing an
-environment as one would to build Drake normally). There are a small number of
-additional dependencies that will be installed by the builder, so the builder
-must be able to run ``brew``. The builder must also be able to write to
-``/opt``, as this is where the build is performed.
+environment as one would to build Drake normally).
+
+There are a small number of dependencies for the the builder scripts to work
+that Drake itself does not require. In order to install these additional
+packages, run the ``setup/install_prereqs`` script with the ``--developer``
+flag. The builder must also be able to write to ``/opt``, as this is where the
+build is performed.
 
 The script takes a single, required positional argument, which is used to
 specify the version with which the wheels should be tagged. The version number
@@ -137,7 +140,10 @@ located at ``/opt/drake``. Since multiple builds may be present, a temporary
 symlink is created at this path to the actual, Python-version-specific
 installation while building the wheel. Therefore, this path must be available.
 
-After performing wheel-specific provisioning using ``brew``, the builder
-invokes ``macos/build-wheel.sh``, optionally (and if the build succeeded)
-followed by ``macos/test-wheel.sh``. These scripts approximately replicate what
-would happen in Docker, and heavily reuse the same lower level scripts.
+Starting from a provisioned wheel building environment (installed via
+``setup/install_prereqs --developer``), the builder invokes
+``macos/build-wheel.sh``, optionally (and if the build succeeded) followed by
+a series of test scripts (namely ``macos/provision-test-python.sh``,
+``test/install-wheel.sh``, and ``test/test-wheel.sh``, in that order. These
+scripts approximately replicate what would happen in Docker, and heavily reuse
+the same lower level scripts.

--- a/tools/wheel/test/install-wheel.sh
+++ b/tools/wheel/test/install-wheel.sh
@@ -2,12 +2,12 @@
 
 # This shell script installs a Drake wheel. It must be run inside a container
 # (Ubuntu) or environment (macOS) which has been properly provisioned, e.g. by
-# the accompanying Dockerfile (Ubuntu) or by macos/test-wheel.sh (macOS). In
-# particular, /opt/drake-wheel-test/python must contain a Python virtual
-# environment which will be used to run the tests. The path to the wheel to be
-# installed must be given as an argument to the script. On Ubuntu, the wheel
-# must be accessible to the container, and the path must be the container's
-# path to the wheel (rather than the host's path).
+# the accompanying Dockerfile (Ubuntu) or by macos/provision-test-python.sh
+# (macOS). In particular, /opt/drake-wheel-test/python must contain a Python
+# virtual environment which will be used to run the tests. The path to the
+# wheel to be installed must be given as an argument to the script. On Ubuntu,
+# the wheel must be accessible to the container, and the path must be the
+# container's path to the wheel (rather than the host's path).
 #
 # In general, it is not recommended to attempt to run this script directly;
 # use //tools/wheel:builder instead.

--- a/tools/wheel/test/test-wheel.sh
+++ b/tools/wheel/test/test-wheel.sh
@@ -3,8 +3,9 @@
 # This shell script runs a test on a Drake wheel. It must be run inside of a
 # container (Ubuntu) or environment (macOS) which has been properly
 # provisioned, e.g. by the accompanying Dockerfile (Ubuntu) or by
-# macos/test-wheel.sh (macOS), and which already has the wheel installed. The
-# path to the test script must be given as an argument to the script.
+# macos/provision-wheel-python.sh (macOS), and which already has the wheel
+# installed. The path to the test script must be given as an argument to the
+# script.
 #
 # In general, it is not recommended to attempt to run this script directly;
 # use //tools/wheel:builder instead.

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -20,6 +20,9 @@ _files_to_remove = []
 # This is the complete set of defined targets (i.e. potential wheels). By
 # default, all targets are built, but the user may down-select from this set.
 # On macOS (unlike Linux), this is just the set of Python versions targeted.
+#
+# These should be kept in sync with
+# `setup/macos/source_distribution/Brewfile-developer`.
 python_targets = (
     PythonTarget(3, 12),
     PythonTarget(3, 13),
@@ -65,18 +68,6 @@ def _assert_isdir(path, name):
     """
     if not os.path.isdir(path):
         die(f'{name} \'{path}\' is not a valid directory')
-
-
-def _provision(python_targets):
-    """
-    Prepares wheel build environment.
-    """
-    packages_path = os.path.join(resource_root, 'image', 'packages-macos')
-    command = ['brew', 'bundle', f'--file={packages_path}']
-    subprocess.check_call(command)
-
-    for t in python_targets:
-        subprocess.check_call(['brew', 'install', f'python@{t.version}'])
 
 
 def _test_wheel(wheel, python_target, env):
@@ -126,8 +117,6 @@ def build(options):
 
     # Set up build environment.
     os.makedirs(build_root, exist_ok=True)
-    if options.provision:
-        _provision(targets_to_build)
 
     # Sanitize the build/test environment.
     environment = os.environ.copy()
@@ -202,10 +191,6 @@ def add_build_arguments(parser):
         '-k', '--keep-build', action='store_true',
         help='do not delete build/test trees on success '
              '(tree(s) are always retained on failure)')
-    parser.add_argument(
-        '--no-provision', dest='provision', action='store_false',
-        help='skip host provisioning '
-             '(requires already-povisioned host)')
 
 
 def add_selection_arguments(parser):


### PR DESCRIPTION
Towards #22848 

This is the first PR towards the wheel builder upgrades that addresses the macOS CI transition from MacStadium to AWS.

Summary of changes:
 - Remove _provision() function and associated logic from wheel_builder/macos.py (blocked until Drake release 1.40.0).
 - Remove references to macos/test-wheel.sh in documentation and comments.
 - Update README.rst to reflect the fact that macOS provisioning no longer occurs as part of the wheel builder process.
 - Rebase onto master and safely remove python 3.11 support.

Eventually, there will be a follow up to this pr which  implements error handling logic to ensure build cleanup logic runs in the event of unsuccessful builds.