### PR TITLE
[doc] Remove links & references to macOS unprovisioned jobs

### DIFF
--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -107,11 +107,14 @@ and ``new_release.py``). Again, it is expected that a given prerequisite will
 only appear in one of these lists.
 
 When updating prerequisites with these scripts, the normal experimental CI will
-most likely fail. To test new prerequisites, you should first request
-unprovisioned experimental builds, e.g.:
+most likely fail. To test new prerequisites on Linux, you should first request an
+unprovisioned experimental build, e.g.:
 
 * ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-release please``
-* ``@drake-jenkins-bot mac-arm-sonoma-unprovisioned-clang-bazel-experimental-release please``
+
+Testing changes to the source distribution prerequisites for macOS is a work
+in progress as there are no longer unprovisioned builds.
+Contact `@BetsyMcPhail` for guidance on testing these changes.
 
 After this has passed, go through normal review. Once normal review is done,
 add `@BetsyMcPhail` for review and request that the provisioned instances be
@@ -126,7 +129,7 @@ or [debian package](/apt.html), comment on an open pull request using one or
 more of these commands:
 
 * ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-packaging please``
-* ``@drake-jenkins-bot mac-arm-sonoma-unprovisioned-clang-bazel-experimental-packaging please``
+* ``@drake-jenkins-bot mac-arm-sonoma-clang-bazel-experimental-packaging please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
 to schedule a build of one of the [Packaging](https://drake-jenkins.csail.mit.edu/view/Packaging/)
@@ -150,7 +153,7 @@ To schedule an "experimental" build of a [wheel package](/pip.html),
 comment on an open pull request using one or more of these commands:
 
 * ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-wheel-experimental-release please``
-* ``@drake-jenkins-bot mac-arm-sonoma-unprovisioned-clang-wheel-experimental-release please``
+* ``@drake-jenkins-bot mac-arm-sonoma-clang-wheel-experimental-release please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
 to schedule a build of one of the [Wheel](https://drake-jenkins.csail.mit.edu/view/Wheel/)

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -126,7 +126,7 @@ the main body of the document:
    1. Open the following Jenkins jobs (e.g., each in its own
       new window, so you can copy-and-paste sha1 and version easily):
       - [Linux Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-wheel-staging-release/)
-      - [macOS arm Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-sonoma-unprovisioned-clang-wheel-staging-release/)
+      - [macOS arm Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-sonoma-clang-wheel-staging-release/)
       - [Jammy Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-cmake-staging-packaging/)
       - [Noble Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-noble-unprovisioned-gcc-cmake-staging-packaging/)
       - [macOS arm Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-sonoma-clang-cmake-staging-packaging/)


### PR DESCRIPTION
All macOS jobs are now provisioned, so these links should be updated accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22902)
<!-- Reviewable:end -->
