### PR TITLE
Add explicit requirement for diffutils

### DIFF
--- a/setup/ubuntu/source_distribution/packages-jammy.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy.txt
@@ -1,4 +1,5 @@
 default-jdk
+diffutils
 file
 gfortran
 libclang-15-dev

--- a/setup/ubuntu/source_distribution/packages-noble.txt
+++ b/setup/ubuntu/source_distribution/packages-noble.txt
@@ -1,4 +1,5 @@
 default-jdk
+diffutils
 file
 gfortran
 libclang-15-dev

--- a/tools/wheel/image/packages-almalinux
+++ b/tools/wheel/image/packages-almalinux
@@ -13,6 +13,7 @@ make
 pkgconf-pkg-config
 
 # Other general tools.
+diffutils
 file
 patch
 patchelf


### PR DESCRIPTION
Our patch-applying process somewhere appears to rely on `diff` (normally provided on Linux via the GNU diffutils package). Previously, we have taken it for granted that this was available, but AlmaLinux appears to have "trimmed" their Docker image recently to omit it, resulting in build failures. Add the providing package to our various dependency lists to ensure it is available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22903)
<!-- Reviewable:end -->
