### PR TITLE
Don't fail wheel build if symlink exists

### DIFF
--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -153,6 +153,9 @@ def build(options):
 
     # Build the wheel(s).
     for python_target in targets_to_build:
+        if os.path.islink(wheel_root):
+            os.unlink(wheel_root)
+
         wheel_versioned_root = os.path.join(
             build_root, f'python{python_target.version}', 'wheel')
         os.symlink(wheel_versioned_root, wheel_root)


### PR DESCRIPTION
Towards #22848 
Unblocks drake-ci [#320](https://github.com/RobotLocomotion/drake-ci/pull/320)

This is a small change that prevents the wheel builds from failing if one of the paths that it attempts to remove is a symlink. The desired condition for the wheel builder path removal is for the path to not exist at all in any form, but if it exists as a symlink it was likely left over from a previous build and/or doesn't contain any data itself and can be safely removed. We only want the builds to fail if the path exists and it is NOT a symlink, as the directory may not be safe to remove automatically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22904)
<!-- Reviewable:end -->
