### PR TITLE
Support symbolic scalar type integrators in DiscreteTimeApproximation

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -245,24 +245,22 @@ PYBIND11_MODULE(analysis, m) {
           py::arg("affine_system"), py::arg("time_period"),
           doc.DiscreteTimeApproximation.doc_2args_constAffineSystem_double);
 
-      if constexpr (!std::is_same_v<T, symbolic::Expression>) {
-        m.def(
-            "DiscreteTimeApproximation",
-            [](const System<T>& system, double time_period,
-                const SimulatorConfig& integrator_config) {
-              return DiscreteTimeApproximation(
-                  // The lifetime of `system` is managed by the keep_alive
-                  // below, not the C++ shared_ptr.
-                  make_unowned_shared_ptr_from_raw(&system), time_period,
-                  integrator_config);
-            },
-            py::arg("system"), py::arg("time_period"),
-            py::arg("integrator_config") = SimulatorConfig(),
-            // Keep alive, reference: `result` keeps `system` alive.
-            py::keep_alive<0, 1>(),
-            doc.DiscreteTimeApproximation
-                .doc_3args_constSystem_double_SimulatorConfig);
-      }
+      m.def(
+          "DiscreteTimeApproximation",
+          [](const System<T>& system, double time_period,
+              const SimulatorConfig& integrator_config) {
+            return DiscreteTimeApproximation(
+                // The lifetime of `system` is managed by the keep_alive
+                // below, not the C++ shared_ptr.
+                make_unowned_shared_ptr_from_raw(&system), time_period,
+                integrator_config);
+          },
+          py::arg("system"), py::arg("time_period"),
+          py::arg("integrator_config") = SimulatorConfig(),
+          // Keep alive, reference: `result` keeps `system` alive.
+          py::keep_alive<0, 1>(),
+          doc.DiscreteTimeApproximation
+              .doc_3args_constSystem_double_SimulatorConfig);
     }
   };
   type_visit(bind_scalar_types, CommonScalarPack{});

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -78,10 +78,10 @@ class TestAnalysis(unittest.TestCase):
         numpy_compare.assert_equal(discrete_system.D(),  Dd)
         numpy_compare.assert_equal(discrete_system.y0(), y0d)
 
-    @numpy_compare.check_nonsymbolic_types
+    @numpy_compare.check_all_types
     def test_discrete_time_approximation_system(self, T):
         size = 5
-        config = SimulatorConfig()
+        config = SimulatorConfig(integration_scheme="explicit_euler")
         continuous_system = Integrator_[T](size)
         discrete_system = DiscreteTimeApproximation(
             system=continuous_system,

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -128,6 +128,7 @@ drake_cc_library(
     hdrs = ["discrete_time_approximation.h"],
     deps = [
         ":simulator_config_functions",
+        "//common:nice_type_name",
         "//systems/framework",
         "//systems/primitives:affine_system",
         "//systems/primitives:linear_system",
@@ -611,6 +612,7 @@ drake_cc_googletest(
     deps = [
         ":discrete_time_approximation",
         ":simulator",
+        "//common:nice_type_name",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",

--- a/systems/analysis/discrete_time_approximation.h
+++ b/systems/analysis/discrete_time_approximation.h
@@ -56,8 +56,10 @@ std::unique_ptr<AffineSystem<T>> DiscreteTimeApproximation(
  * accuracy).
  * @returns A discrete-time System.
  * @throws if the @p system is not continuous or @p time_period <= 0.
+ * @throws std::exception if the integration scheme does not support the scalar
+ * type T.
  *
- * @tparam_nonsymbolic_scalar
+ * @tparam_default_scalar
  * @ingroup analysis
  * @pydrake_mkdoc_identifier{3args_constSystem_double_SimulatorConfig}
  */
@@ -71,7 +73,7 @@ std::unique_ptr<System<T>> DiscreteTimeApproximation(
  * @warning The @p system reference must remain valid for the lifetime of the
  * returned system.
  *
- * @tparam_nonsymbolic_scalar
+ * @tparam_default_scalar
  * @ingroup analysis
  * @exclude_from_pydrake_mkdoc{This function is not bound.}
  */

--- a/systems/analysis/simulator_config_functions.cc
+++ b/systems/analysis/simulator_config_functions.cc
@@ -277,13 +277,25 @@ std::unique_ptr<IntegratorBase<T>> CreateIntegratorFromConfig(
       fmt::format("Unknown integration scheme: {}", config.integration_scheme));
 }
 
+template <typename T>
+bool IsScalarTypeSupportedByIntegrator(std::string_view integration_scheme) {
+  const auto& name_func_pairs = GetAllNamedConfigureIntegratorFuncs<T>();
+  for (const auto& [one_name, one_func] : name_func_pairs) {
+    if (integration_scheme == one_name) {
+      return one_func != nullptr;
+    }
+  }
+  throw std::runtime_error(
+      fmt::format("Unknown integration scheme: {}", integration_scheme));
+}
+
 // We can't support T=symbolic::Expression because Simulator doesn't support it.
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     (&ResetIntegratorFromFlags<T>, &ApplySimulatorConfig<T>,
      &ExtractSimulatorConfig<T>));
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    (&CreateIntegratorFromConfig<T>));
+    (&CreateIntegratorFromConfig<T>, &IsScalarTypeSupportedByIntegrator<T>));
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/simulator_config_functions.h
+++ b/systems/analysis/simulator_config_functions.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "drake/common/default_scalars.h"
@@ -91,6 +92,17 @@ SimulatorConfig ExtractSimulatorConfig(
 template <typename T>
 std::unique_ptr<IntegratorBase<T>> CreateIntegratorFromConfig(
     const System<T>* system, const SimulatorConfig& integrator_config);
+
+/** Reports if an integration scheme supports the scalar type T.
+
+@param integration_scheme Integration scheme to be checked.
+@throw std::exception if the integration scheme does not match any of
+  GetIntegrationSchemes().
+@tparam_default_scalar
+
+@ingroup simulator_configuration */
+template <typename T>
+bool IsScalarTypeSupportedByIntegrator(std::string_view integration_scheme);
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test/simulator_config_functions_test.cc
+++ b/systems/analysis/test/simulator_config_functions_test.cc
@@ -168,6 +168,20 @@ TYPED_TEST(IntegratorConfigFunctionsTest, CreateIntegratorFromConfigTest) {
   }
 }
 
+TYPED_TEST(IntegratorConfigFunctionsTest,
+           IsScalarTypeSupportedByIntegratorTest) {
+  using T = TypeParam;
+  for (const auto& [scheme, type_name, support_symbolic] : this->suites_) {
+    if constexpr (std::is_same_v<T, symbolic::Expression>) {
+      EXPECT_EQ(IsScalarTypeSupportedByIntegrator<T>(scheme), support_symbolic);
+    } else {
+      EXPECT_TRUE(IsScalarTypeSupportedByIntegrator<T>(scheme));
+    }
+  }
+  DRAKE_EXPECT_THROWS_MESSAGE(IsScalarTypeSupportedByIntegrator<T>("abc"),
+                              "Unknown integration scheme.*");
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
The recently added function `DiscreteTimeApproximation<T>(const System<T>&, double, const SimulatorConfig&)` in #22652 only supports `T=double` and `T=AutoDiffXd`. This PR adds support for `T=symbolic::Expression`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22913)
<!-- Reviewable:end -->
