### PR TITLE
New deformable contact

### DIFF
--- a/examples/multibody/deformable/bubble_gripper.cc
+++ b/examples/multibody/deformable/bubble_gripper.cc
@@ -83,7 +83,9 @@ int do_main() {
    deformable bodies.
    1. A valid Coulomb friction coefficient, and
    2. A resolution hint. (Rigid bodies need to be tessellated so that collision
-   queries can be performed against deformable geometries.) */
+   queries can be performed against deformable geometries.)
+   3. A hydroelastic modulus (which is added by default through scene graph
+   config). */
   ProximityProperties rigid_proximity_props;
   const CoulombFriction<double> surface_friction(1.0, 1.0);
   const double resolution_hint = 0.01;

--- a/examples/multibody/deformable/deformable_torus.cc
+++ b/examples/multibody/deformable/deformable_torus.cc
@@ -116,29 +116,15 @@ ModelInstanceIndex AddSuctionGripper(
   return model_instance;
 }
 
-/* Adds a parallel gripper to the given MultibodyPlant and assign
- `proximity_props` to all the registered collision geometries. Returns the
+/* Adds a parallel gripper to the given MultibodyPlant. Returns the
  ModelInstanceIndex of the gripper model. */
-ModelInstanceIndex AddParallelGripper(
-    MultibodyPlant<double>* plant, const ProximityProperties& proximity_props) {
+ModelInstanceIndex AddParallelGripper(MultibodyPlant<double>* plant) {
   // TODO(xuchenhan-tri): Consider using a schunk gripper from the manipulation
   // station instead.
   Parser parser(plant);
   ModelInstanceIndex model_instance = parser.AddModelsFromUrl(
       "package://drake/examples/multibody/deformable/models/simple_gripper.sdf")
                                           [0];
-  /* Add collision geometries. */
-  const RigidTransformd X_BG =
-      RigidTransformd(math::RollPitchYawd(M_PI_2, 0, 0), Vector3d::Zero());
-  const RigidBody<double>& left_finger = plant->GetBodyByName("left_finger");
-  const RigidBody<double>& right_finger = plant->GetBodyByName("right_finger");
-  /* The size of the fingers is set to match the visual geometries in
-   simple_gripper.sdf. */
-  Capsule capsule(0.01, 0.08);
-  plant->RegisterCollisionGeometry(left_finger, X_BG, capsule,
-                                   "left_finger_collision", proximity_props);
-  plant->RegisterCollisionGeometry(right_finger, X_BG, capsule,
-                                   "right_finger_collision", proximity_props);
   /* Get joints so that we can set initial conditions. */
   PrismaticJoint<double>& left_slider =
       plant->GetMutableJointByName<PrismaticJoint>("left_slider");
@@ -180,7 +166,7 @@ int do_main() {
   const bool use_suction = FLAGS_gripper == "suction";
   ModelInstanceIndex gripper_instance =
       use_suction ? AddSuctionGripper(&plant, rigid_proximity_props)
-                  : AddParallelGripper(&plant, rigid_proximity_props);
+                  : AddParallelGripper(&plant);
 
   /* Set up a deformable torus. */
   DeformableBodyConfig<double> deformable_config;

--- a/examples/multibody/deformable/models/simple_gripper.sdf
+++ b/examples/multibody/deformable/models/simple_gripper.sdf
@@ -9,8 +9,7 @@
 
        The frame of the gripper, G, has its x-axis pointing to the right
        of the gripper, its y-axis pointing "forward" (towards the fingers
-       side) and, the z-axis pointing upwards. This file only defines visual
-       geometry but not contact geometry.
+       side) and, the z-axis pointing upwards.
   -->
   <model name="simple_gripper">
     <pose>0 0.06 0.08 -1.57 0 1.57</pose>
@@ -63,17 +62,29 @@
         </inertia>
       </inertial>
       <visual name="visual">
-        <pose>0 0.0 0.0 1.57 0 0</pose>
         <geometry>
-          <capsule>
-            <radius>0.01</radius>
-            <length>0.08</length>
-          </capsule>
+          <box>
+            <size>0.007 0.081 0.028</size>
+          </box>
         </geometry>
         <material>
           <diffuse>0.3 0.3 0.3 0.9</diffuse>
         </material>
       </visual>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.007 0.081 0.028</size>
+          </box>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_dynamic>1.5</drake:mu_dynamic>
+          <drake:mu_static>1.5</drake:mu_static>
+          <drake:hydroelastic_modulus>1e6</drake:hydroelastic_modulus>
+          <drake:hunt_crossley_dissipation>5</drake:hunt_crossley_dissipation>
+          <drake:compliant_hydroelastic/>
+        </drake:proximity_properties>
+      </collision>
     </link>
     <link name="right_finger">
       <!-- Each finger is positioned along the x-axis such that at q=0 the pads
@@ -92,17 +103,29 @@
         </inertia>
       </inertial>
       <visual name="visual">
-        <pose>0 0.0 0.0 1.57 0 0</pose>
         <geometry>
-          <capsule>
-            <radius>0.01</radius>
-            <length>0.08</length>
-          </capsule>
+          <box>
+            <size>0.007 0.081 0.028</size>
+          </box>
         </geometry>
         <material>
           <diffuse>0.3 0.3 0.3 0.9</diffuse>
         </material>
       </visual>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.007 0.081 0.028</size>
+          </box>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_dynamic>1.5</drake:mu_dynamic>
+          <drake:mu_static>1.5</drake:mu_static>
+          <drake:hydroelastic_modulus>1e6</drake:hydroelastic_modulus>
+          <drake:hunt_crossley_dissipation>5</drake:hunt_crossley_dissipation>
+          <drake:compliant_hydroelastic/>
+        </drake:proximity_properties>
+      </collision>
     </link>
     <joint name="left_slider" type="prismatic">
       <parent>body</parent>

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -70,6 +70,7 @@ drake_cc_library(
         ":geometry_ids",
         ":geometry_roles",
         ":internal_geometry",
+        ":mesh_deformation_interpolator",
         ":shape_specification",
         "//common:default_scalars",
         "//common:sorted_pair",
@@ -934,6 +935,7 @@ drake_cc_googletest(
         ":test_vtk_files",
     ],
     deps = [
+        ":geometry_state",
         ":proximity_engine",
         ":shape_specification",
         "//common/test_utilities:eigen_matrix_compare",

--- a/geometry/deformable_mesh_with_bvh.cc
+++ b/geometry/deformable_mesh_with_bvh.cc
@@ -13,6 +13,8 @@ void DeformableMeshWithBvh<MeshType>::UpdateVertexPositions(
 
 template class DeformableMeshWithBvh<VolumeMesh<double>>;
 template class DeformableMeshWithBvh<VolumeMesh<AutoDiffXd>>;
+template class DeformableMeshWithBvh<TriangleSurfaceMesh<double>>;
+template class DeformableMeshWithBvh<TriangleSurfaceMesh<AutoDiffXd>>;
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/deformable_mesh_with_bvh.h
+++ b/geometry/deformable_mesh_with_bvh.h
@@ -4,6 +4,7 @@
 
 #include "drake/geometry/proximity/bvh.h"
 #include "drake/geometry/proximity/bvh_updater.h"
+#include "drake/geometry/proximity/triangle_surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 
 namespace drake {
@@ -110,6 +111,9 @@ class DeformableMeshWithBvh {
 
 template <typename T>
 using DeformableVolumeMeshWithBvh = DeformableMeshWithBvh<VolumeMesh<T>>;
+template <typename T>
+using DeformableSurfaceMeshWithBvh =
+    DeformableMeshWithBvh<TriangleSurfaceMesh<T>>;
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -29,6 +29,7 @@ namespace drake {
 namespace geometry {
 
 using internal::convert_to_double;
+using internal::ConvertVolumeToSurfaceMeshWithBoundaryVertices;
 using internal::DrivenTriangleMesh;
 using internal::FrameNameSet;
 using internal::HydroelasticType;
@@ -48,6 +49,7 @@ using internal::kSlabThickness;
 using internal::MakeRenderMeshFromTriangleSurfaceMesh;
 using internal::ProximityEngine;
 using internal::RenderMesh;
+using internal::VertexSampler;
 using math::RigidTransform;
 using math::RigidTransformd;
 using render::ColorRenderCamera;
@@ -87,13 +89,9 @@ void DrivenMeshData::SetControlMeshPositions(
 }
 
 void DrivenMeshData::SetMeshes(GeometryId id,
-                               std::vector<DrivenTriangleMesh> driven_meshes,
-                               std::vector<RenderMesh> render_meshes) {
+                               std::vector<DrivenTriangleMesh> driven_meshes) {
   DRAKE_DEMAND(!driven_meshes.empty());
-  DRAKE_DEMAND(!render_meshes.empty());
-  DRAKE_DEMAND(driven_meshes.size() == render_meshes.size());
   driven_meshes_.emplace(id, std::move(driven_meshes));
-  render_meshes_.emplace(id, std::move(render_meshes));
 }
 
 }  // namespace internal
@@ -182,15 +180,17 @@ GeometryState<T>::GeometryState()
   frame_index_to_id_map_.push_back(world);
   kinematics_data_.X_WFs.push_back(RigidTransform<T>::Identity());
   kinematics_data_.X_PFs.push_back(RigidTransform<T>::Identity());
+  kinematics_data_.driven_mesh_data[Role::kPerception] = {};
+  kinematics_data_.driven_mesh_data[Role::kIllustration] = {};
+  kinematics_data_.driven_mesh_data[Role::kProximity] = {};
+  deformable_render_meshes_[Role::kPerception] = {};
+  deformable_render_meshes_[Role::kIllustration] = {};
+  deformable_render_meshes_[Role::kProximity] = {};
 
   source_frame_id_map_[self_source_] = {world};
   source_deformable_geometry_id_map_[self_source_] = {};
   source_frame_name_map_[self_source_] = {"world"};
   source_root_frame_map_[self_source_] = {world};
-
-  driven_mesh_data_[Role::kPerception] = {};
-  driven_mesh_data_[Role::kIllustration] = {};
-  driven_mesh_data_[Role::kProximity] = {};
 }
 
 namespace {
@@ -286,7 +286,7 @@ GeometryState<T>::GeometryState(const GeometryState<U>& source)
       frames_(source.frames_),
       geometries_(source.geometries_),
       frame_index_to_id_map_(source.frame_index_to_id_map_),
-      driven_mesh_data_(source.driven_mesh_data_),
+      deformable_render_meshes_(source.deformable_render_meshes_),
       geometry_engine_(
           std::move(source.geometry_engine_->template ToScalarType<T>())),
       render_engines_(source.render_engines_),
@@ -747,7 +747,7 @@ const std::vector<RenderMesh>& GeometryState<T>::GetDrivenRenderMeshes(
                     "geometry with specified role {}",
                     id, role));
   }
-  return driven_mesh_data_.at(role).render_meshes(id);
+  return deformable_render_meshes_.at(role).at(id);
 }
 
 template <typename T>
@@ -913,7 +913,7 @@ std::vector<VectorX<T>> GeometryState<T>::GetDrivenMeshConfigurationsInWorld(
     return result;
   };
 
-  return calc_configuration(driven_mesh_data_.at(role));
+  return calc_configuration(kinematics_data_.driven_mesh_data.at(role));
 }
 
 template <typename T>
@@ -1224,8 +1224,19 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
       geometry.SetRole(std::move(properties));
       if (geometry.is_deformable()) {
         DRAKE_DEMAND(geometry.reference_mesh() != nullptr);
-        geometry_engine_->AddDeformableGeometry(*geometry.reference_mesh(),
-                                                geometry_id);
+        const VolumeMesh<double>& reference_mesh = *geometry.reference_mesh();
+        std::vector<int> surface_vertices;
+        TriangleSurfaceMesh<double> surface_mesh =
+            ConvertVolumeToSurfaceMeshWithBoundaryVertices(reference_mesh,
+                                                           &surface_vertices);
+        geometry_engine_->AddDeformableGeometry(reference_mesh, surface_mesh,
+                                                surface_vertices, geometry_id);
+        VertexSampler vertex_sampler(std::move(surface_vertices),
+                                     reference_mesh);
+        std::vector<DrivenTriangleMesh> driven_meshes;
+        driven_meshes.emplace_back(vertex_sampler, surface_mesh);
+        kinematics_data_.driven_mesh_data[Role::kProximity].SetMeshes(
+            geometry_id, std::move(driven_meshes));
       } else if (geometry.is_dynamic()) {
         // Pass the geometry to the engine.
         const RigidTransformd& X_WG =
@@ -1483,7 +1494,7 @@ void GeometryState<T>::AddRenderer(
         const GeometryId id = id_geo_pair.first;
         if (geometry.is_deformable()) {
           accepted |= render_engine->RegisterDeformableVisual(
-              id, driven_mesh_data_.at(Role::kPerception).render_meshes(id),
+              id, deformable_render_meshes_.at(Role::kPerception).at(id),
               *properties);
         } else {
           accepted |= render_engine->RegisterVisual(
@@ -1740,11 +1751,15 @@ void GeometryState<T>::FinalizePoseUpdate(
 template <typename T>
 void GeometryState<T>::FinalizeConfigurationUpdate(
     const internal::KinematicsData<T>& kinematics_data,
-    const internal::DrivenMeshData& driven_meshes,
     internal::ProximityEngine<T>* proximity_engine,
     std::vector<render::RenderEngine*> render_engines) const {
-  proximity_engine->UpdateDeformableVertexPositions(kinematics_data.q_WGs);
-  for (const auto& [id, meshes] : driven_meshes.driven_meshes()) {
+  const internal::DrivenMeshData& proximity_driven_mesh_data =
+      kinematics_data.driven_mesh_data.at(Role::kProximity);
+  proximity_engine->UpdateDeformableVertexPositions(
+      kinematics_data.q_WGs, proximity_driven_mesh_data.driven_meshes());
+  const internal::DrivenMeshData& perception_driven_mesh_data =
+      kinematics_data.driven_mesh_data.at(Role::kPerception);
+  for (const auto& [id, meshes] : perception_driven_mesh_data.driven_meshes()) {
     // Vertex positions of driven meshes.
     std::vector<VectorX<double>> q_WDs(meshes.size());
     // Vertex normals of driven meshes.
@@ -1935,8 +1950,18 @@ void GeometryState<T>::AddToProximityEngineUnchecked(
   const GeometryId geometry_id = geometry.id();
   if (geometry.is_deformable()) {
     DRAKE_DEMAND(geometry.reference_mesh() != nullptr);
-    geometry_engine_->AddDeformableGeometry(*geometry.reference_mesh(),
-                                            geometry_id);
+    const VolumeMesh<double>& reference_mesh = *geometry.reference_mesh();
+    std::vector<int> surface_vertices;
+    TriangleSurfaceMesh<double> surface_mesh =
+        ConvertVolumeToSurfaceMeshWithBoundaryVertices(reference_mesh,
+                                                       &surface_vertices);
+    geometry_engine_->AddDeformableGeometry(reference_mesh, surface_mesh,
+                                            surface_vertices, geometry_id);
+    VertexSampler vertex_sampler(std::move(surface_vertices), reference_mesh);
+    std::vector<DrivenTriangleMesh> driven_meshes;
+    driven_meshes.emplace_back(vertex_sampler, surface_mesh);
+    kinematics_data_.driven_mesh_data[Role::kProximity].SetMeshes(
+        geometry_id, driven_meshes);
   } else if (geometry.is_dynamic()) {
     // Pass the geometry to the engine.
     const RigidTransformd& X_WG =
@@ -2032,7 +2057,7 @@ bool GeometryState<T>::AddDeformableToCompatibleRenderersUnchecked(
   for (auto& engine : *candidate_renderers) {
     added_to_renderer =
         engine->RegisterDeformableVisual(
-            id, driven_mesh_data_.at(Role::kPerception).render_meshes(id),
+            id, deformable_render_meshes_.at(Role::kPerception).at(id),
             properties) ||
         added_to_renderer;
   }
@@ -2067,18 +2092,20 @@ void GeometryState<T>::RegisterDrivenMesh(GeometryId geometry_id, Role role) {
         driven_meshes.emplace_back(MakeTriangleSurfaceMesh(render_mesh),
                                    control_mesh);
       }
-      driven_mesh_data_[Role::kPerception].SetMeshes(
-          geometry_id, std::move(driven_meshes), std::move(render_meshes));
+      kinematics_data_.driven_mesh_data[Role::kPerception].SetMeshes(
+          geometry_id, std::move(driven_meshes));
+      deformable_render_meshes_[Role::kPerception][geometry_id] =
+          std::move(render_meshes);
       return;
     }
   }
 
   // Simply go with the surface mesh of the control mesh.
   driven_meshes.emplace_back(internal::MakeDrivenSurfaceMesh(control_mesh));
+  kinematics_data_.driven_mesh_data[role].SetMeshes(geometry_id, driven_meshes);
   render_meshes.emplace_back(MakeRenderMeshFromTriangleSurfaceMesh(
       driven_meshes.back().triangle_surface_mesh(), properties));
-  driven_mesh_data_[role].SetMeshes(geometry_id, std::move(driven_meshes),
-                                    std::move(render_meshes));
+  deformable_render_meshes_[role][geometry_id] = std::move(render_meshes);
 }
 
 template <typename T>
@@ -2132,7 +2159,8 @@ bool GeometryState<T>::RemovePerceptionRole(GeometryId geometry_id) {
   // perception meshes.
   RemoveFromAllRenderersUnchecked(geometry_id);
   if (IsDeformableGeometry(geometry_id)) {
-    driven_mesh_data_[Role::kPerception].Remove(geometry_id);
+    kinematics_data_.driven_mesh_data[Role::kPerception].Remove(geometry_id);
+    deformable_render_meshes_[Role::kPerception].erase(geometry_id);
   }
   geometry->RemovePerceptionRole();
   return true;

--- a/geometry/proximity/deformable_contact_geometries.cc
+++ b/geometry/proximity/deformable_contact_geometries.cc
@@ -56,26 +56,35 @@ DeformableGeometry& DeformableGeometry::operator=(
     const DeformableGeometry& other) {
   if (this == &other) return *this;
 
-  deformable_mesh_ = std::make_unique<DeformableVolumeMeshWithBvh<double>>(
-      *other.deformable_mesh_);
+  deformable_volume_ = std::make_unique<DeformableVolumeMeshWithBvh<double>>(
+      *other.deformable_volume_);
+  deformable_surface_ = std::make_unique<DeformableSurfaceMeshWithBvh<double>>(
+      *other.deformable_surface_);
+  surface_index_to_volume_index_ = other.surface_index_to_volume_index_;
   // We can't simply copy the field; the copy must contain a pointer to
   // the new mesh. So, we use CloneAndSetMesh() instead.
-  signed_distance_field_ =
-      other.signed_distance_field_->CloneAndSetMesh(&deformable_mesh_->mesh());
+  signed_distance_field_ = other.signed_distance_field_->CloneAndSetMesh(
+      &deformable_volume_->mesh());
   return *this;
 }
 
-DeformableGeometry::DeformableGeometry(VolumeMesh<double> mesh)
-    : deformable_mesh_(std::make_unique<DeformableVolumeMeshWithBvh<double>>(
-          std::move(mesh))),
+DeformableGeometry::DeformableGeometry(
+    VolumeMesh<double> volume_mesh, TriangleSurfaceMesh<double> surface_mesh,
+    std::vector<int> surface_index_to_volume_index)
+    : deformable_volume_(std::make_unique<DeformableVolumeMeshWithBvh<double>>(
+          std::move(volume_mesh))),
+      deformable_surface_(
+          std::make_unique<DeformableSurfaceMeshWithBvh<double>>(
+              std::move(surface_mesh))),
+      surface_index_to_volume_index_(std::move(surface_index_to_volume_index)),
       signed_distance_field_(
-          ApproximateSignedDistanceField(&deformable_mesh_->mesh())) {}
+          ApproximateSignedDistanceField(&deformable_volume_->mesh())) {}
 
 const VolumeMeshFieldLinear<double, double>&
 DeformableGeometry::CalcSignedDistanceField() const {
   std::vector<double> values = signed_distance_field_->values();
   *signed_distance_field_ = VolumeMeshFieldLinear<double, double>(
-      std::move(values), &deformable_mesh_->mesh());
+      std::move(values), &deformable_volume_->mesh());
   return *signed_distance_field_;
 }
 

--- a/geometry/proximity/deformable_contact_geometries.h
+++ b/geometry/proximity/deformable_contact_geometries.h
@@ -21,9 +21,11 @@ namespace deformable {
 
 // TODO(xuchenhan-tri): Consider supporting AutoDiffXd.
 /* Definition of a deformable geometry for contact evaluations. To be
- considered as deformable, a geometry must be associated with both:
-   - a deformable volume mesh, and
-   - an approximate signed distance field in the interior of the mesh. */
+ considered as deformable, a geometry must be associated with:
+   - a deformable volume mesh,
+   - an approximate signed distance field in the interior of the volume mesh,
+     and
+   - the surface triangle mesh of the volume mesh. */
 class DeformableGeometry {
  public:
   DeformableGeometry(const DeformableGeometry& other);
@@ -31,27 +33,58 @@ class DeformableGeometry {
   DeformableGeometry(DeformableGeometry&&) = default;
   DeformableGeometry& operator=(DeformableGeometry&&) = default;
 
-  /* Constructs a deformable geometry from the given mesh. Also computes an
-   approximate signed distance field for the mesh. */
-  explicit DeformableGeometry(VolumeMesh<double> mesh);
+  /* Constructs a deformable geometry from the given meshes. Also computes an
+   approximate signed distance field for the mesh.
+   @param[in] volume_mesh   The volume mesh representation of the geometry.
+   @param[in] surface_mesh  The surface of `volume_mesh`.
+   @param[in] surface_index_to_volume_index
+                            Mapping from surface index to volume index. The iᵗʰ
+                            entry is the index of the volume mesh vertex that
+                            corresponds to the iᵗʰ surface vertex. */
+  DeformableGeometry(VolumeMesh<double> volume_mesh,
+                     TriangleSurfaceMesh<double> surface_mesh,
+                     std::vector<int> surface_index_to_volume_index);
 
   // TODO(xuchenhan-tri): Consider adding another constructor that takes in both
   // a mesh and a precomputed (approximated) sign distance field.
 
   /* Returns the volume mesh representation of the deformable geometry at
    current configuration. */
-  const DeformableVolumeMeshWithBvh<double>& deformable_mesh() const {
-    return *deformable_mesh_;
+  const DeformableVolumeMeshWithBvh<double>& deformable_volume() const {
+    return *deformable_volume_;
   }
 
-  /* Updates the vertex positions of the underlying deformable mesh.
-  @param q  A vector of 3N values (where this mesh has N vertices). The iᵗʰ
-            vertex gets values <q(3i), q(3i + 1), q(3i + 2)>. Each vertex is
-            assumed to be measured and expressed in the mesh's frame M.
-  @pre q.size() == 3 * deformable_mesh().num_vertices(). */
-  void UpdateVertexPositions(const Eigen::Ref<const VectorX<double>>& q) {
-    DRAKE_DEMAND(q.size() == 3 * deformable_mesh().mesh().num_vertices());
-    deformable_mesh_->UpdateVertexPositions(q);
+  /* Returns the surface mesh representation of the deformable geometry at
+   current configuration. */
+  const DeformableSurfaceMeshWithBvh<double>& deformable_surface() const {
+    return *deformable_surface_;
+  }
+
+  /* Returns the mapping from surface index to volume index. The iᵗʰ entry is
+   the index of the volume mesh vertex that corresponds to the iᵗʰ surface
+   vertex. */
+  const std::vector<int>& surface_index_to_volume_index() const {
+    return surface_index_to_volume_index_;
+  }
+
+  /* Updates the vertex positions of the deformable geometry.
+  @param q_volume  A vector of 3N values (where the volume mesh has N vertices).
+                   The iᵗʰ vertex in the volume mesh gets values
+                   <q(3i), q(3i + 1), q(3i + 2)>. Each vertex is assumed to be
+                   measured and expressed in the mesh's frame M.
+  @param q_surface Similar to `q_volume`, but provides the vertex positions of
+                   the surface mesh.
+  @pre q_volume.size() == 3 * deformable_volume().mesh().num_vertices().
+  @pre q_surface.size() == 3 * deformable_surface().mesh(). num_vertices(). */
+  void UpdateVertexPositions(
+      const Eigen::Ref<const VectorX<double>>& q_volume,
+      const Eigen::Ref<const VectorX<double>>& q_surface) {
+    DRAKE_DEMAND(q_volume.size() ==
+                 3 * deformable_volume().mesh().num_vertices());
+    DRAKE_DEMAND(q_surface.size() ==
+                 3 * deformable_surface().mesh().num_vertices());
+    deformable_volume_->UpdateVertexPositions(q_volume);
+    deformable_surface_->UpdateVertexPositions(q_surface);
   }
 
   /* Returns the approximate signed distance field (sdf) for the deformable
@@ -66,7 +99,9 @@ class DeformableGeometry {
   const VolumeMeshFieldLinear<double, double>& CalcSignedDistanceField() const;
 
  private:
-  std::unique_ptr<DeformableVolumeMeshWithBvh<double>> deformable_mesh_;
+  std::unique_ptr<DeformableVolumeMeshWithBvh<double>> deformable_volume_;
+  std::unique_ptr<DeformableSurfaceMeshWithBvh<double>> deformable_surface_;
+  std::vector<int> surface_index_to_volume_index_;
   /* Note: we don't provide an accessor to `signed_distance_field_` as it may be
    invalidated by calls to `UpdateVertexPositions()`. Instead, we provide
    `CalcSignedDistanceField()` that guarantees to return the up-to-date mesh
@@ -74,21 +109,22 @@ class DeformableGeometry {
   std::unique_ptr<VolumeMeshFieldLinear<double, double>> signed_distance_field_;
 };
 
-/* Defines a rigid geometry -- a rigid hydroelastic mesh repurposed to compute
- deformable vs. rigid contact, along with local data to keep track of the pose
- of the mesh. We need to locally store the pose of the mesh because right now we
- aren't relying on FCL's broadphase. */
+// TODO(xuchenhan-tri): Rename this class to NonDeformableGeometry. The name
+//  "rigid" is too overloaded.
+/* Defines a non-deformable geometry -- a compliant hydroelastic mesh repurposed
+ to compute deformable vs. non-deformable contact, along with local data to keep
+ track of the pose of the mesh. We need to locally store the pose of the mesh
+ because right now we aren't relying on FCL's broadphase. */
 class RigidGeometry {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RigidGeometry);
 
-  explicit RigidGeometry(
-      std::unique_ptr<internal::hydroelastic::RigidMesh> rigid_mesh)
-      : rigid_mesh_(std::move(rigid_mesh)) {}
+  explicit RigidGeometry(std::unique_ptr<internal::hydroelastic::SoftMesh> mesh)
+      : mesh_(std::move(mesh)) {}
 
-  const internal::hydroelastic::RigidMesh& rigid_mesh() const {
-    DRAKE_DEMAND(rigid_mesh_ != nullptr);
-    return *rigid_mesh_;
+  const internal::hydroelastic::SoftMesh& mesh() const {
+    DRAKE_DEMAND(mesh_ != nullptr);
+    return *mesh_;
   }
 
   /* Updates the pose of the geometry in the world frame to the given pose. */
@@ -100,26 +136,35 @@ class RigidGeometry {
   const math::RigidTransform<double>& pose_in_world() const { return X_WG_; }
 
  private:
-  copyable_unique_ptr<internal::hydroelastic::RigidMesh> rigid_mesh_;
+  copyable_unique_ptr<internal::hydroelastic::SoftMesh> mesh_;
   math::RigidTransform<double> X_WG_;
 };
 
 /* Generic interface for handling rigid Shapes. By default, we support all
- shapes that are supported by rigid hydroelastic. Unsupported shapes (e.g. half
- space) can choose to opt out. Geometries not supported by rigid hydroelastics
- will return a std::nullopt. The rigid mesh created upon a successful creation
- of RigidGeometry will be the same mesh as used for rigid hydroelastics. */
+ shapes that are supported by compliant hydroelastic. Unsupported shapes (e.g.
+ half space) can choose to opt out. Geometries not supported by compliant
+ hydroelastics will return a std::nullopt. The mesh created upon a successful
+ creation of RigidGeometry will be the same mesh as used for compliant
+ hydroelastics. */
 template <typename Shape>
-std::optional<RigidGeometry> MakeRigidRepresentation(
+std::optional<RigidGeometry> MakeMeshRepresentation(
     const Shape& shape, const ProximityProperties& props) {
-  std::optional<internal::hydroelastic::RigidGeometry> hydro_rigid_geometry =
-      internal::hydroelastic::MakeRigidRepresentation(shape, props);
-  if (!hydro_rigid_geometry || hydro_rigid_geometry->is_half_space()) {
+  std::optional<internal::hydroelastic::SoftGeometry> compliant_hydro_geometry =
+      internal::hydroelastic::MakeSoftRepresentation(shape, props);
+  // TODO(xuchenhan-tri): Support half space.
+  if (!compliant_hydro_geometry || compliant_hydro_geometry->is_half_space()) {
     return {};
   }
-  /* RigidGeometry is documented as having a mesh or having a half space. We've
-   excluded the latter, so we know we have a mesh. */
-  return RigidGeometry(hydro_rigid_geometry->release_mesh());
+  /* hydroelastic::SoftGeometry is documented as having a mesh or having a half
+   space. We've excluded the latter, so we know we have a mesh. */
+  // TODO(xuchenhan-tri): consider allowing SoftMesh to release its mesh to
+  // prevent copying here.
+  auto mesh =
+      std::make_unique<VolumeMesh<double>>(compliant_hydro_geometry->mesh());
+  std::unique_ptr<VolumeMeshFieldLinear<double, double>> field =
+      compliant_hydro_geometry->pressure_field().CloneAndSetMesh(mesh.get());
+  return RigidGeometry(std::make_unique<internal::hydroelastic::SoftMesh>(
+      std::move(mesh), std::move(field)));
 }
 
 }  // namespace deformable

--- a/geometry/proximity/deformable_contact_internal.cc
+++ b/geometry/proximity/deformable_contact_internal.cc
@@ -34,7 +34,8 @@ void Geometries::MaybeAddRigidGeometry(
   // and deformable contact. Consider reorganizing the proximity properties to
   // make this sharing more explicit. We should also avoid having two copies of
   // the same rigid geometry for both hydro and deformable contact.
-  if (props.HasProperty(kHydroGroup, kRezHint)) {
+  if (props.HasProperty(kHydroGroup, kRezHint) &&
+      props.HasProperty(kHydroGroup, kElastic)) {
     ReifyData data{id, props};
     shape.Reify(this, &data);
     UpdateRigidWorldPose(id, X_WG);
@@ -54,15 +55,21 @@ void Geometries::UpdateRigidWorldPose(
   }
 }
 
-void Geometries::AddDeformableGeometry(GeometryId id, VolumeMesh<double> mesh) {
-  deformable_geometries_.insert({id, DeformableGeometry(std::move(mesh))});
+void Geometries::AddDeformableGeometry(
+    GeometryId id, VolumeMesh<double> volume_mesh,
+    TriangleSurfaceMesh<double> surface_mesh,
+    std::vector<int> surface_index_to_volume_index) {
+  deformable_geometries_.insert(
+      {id, DeformableGeometry(std::move(volume_mesh), std::move(surface_mesh),
+                              std::move(surface_index_to_volume_index))});
   FlushPendingRigidGeometry();
 }
 
 void Geometries::UpdateDeformableVertexPositions(
-    GeometryId id, const Eigen::Ref<const VectorX<double>>& q_WG) {
+    GeometryId id, const Eigen::Ref<const VectorX<double>>& q_WV,
+    const Eigen::Ref<const VectorX<double>>& q_WS) {
   if (is_deformable(id)) {
-    deformable_geometries_.at(id).UpdateVertexPositions(q_WG);
+    deformable_geometries_.at(id).UpdateVertexPositions(q_WV, q_WS);
   }
 }
 
@@ -88,7 +95,7 @@ DeformableContact<double> Geometries::ComputeDeformableContact(
         &deformable_geometry.CalcSignedDistanceField();
     result.RegisterDeformableGeometry(
         deformable_id,
-        deformable_geometry.deformable_mesh().mesh().num_vertices());
+        deformable_geometry.deformable_volume().mesh().num_vertices());
   }
 
   // Add deformable-rigid contacts.
@@ -100,12 +107,14 @@ DeformableContact<double> Geometries::ComputeDeformableContact(
       if (collision_filter.CanCollideWith(deformable_id, rigid_id)) {
         const math::RigidTransform<double>& X_WR =
             rigid_geometry.pose_in_world();
-        const auto& rigid_bvh = rigid_geometry.rigid_mesh().bvh();
-        const auto& rigid_tri_mesh = rigid_geometry.rigid_mesh().mesh();
+        const auto& rigid_bvh = rigid_geometry.mesh().bvh();
+        const auto& pressure_field_R = rigid_geometry.mesh().pressure();
+        // Deformable geometry is in the world frame.
+        const auto X_RD = X_WR.inverse();
         AddDeformableRigidContactSurface(
-            *signed_distance_fields.at(deformable_id),
-            deformable_geometry.deformable_mesh(), deformable_id, rigid_id,
-            rigid_tri_mesh, rigid_bvh, X_WR, &result);
+            deformable_geometry.deformable_surface(),
+            deformable_geometry.surface_index_to_volume_index(), deformable_id,
+            rigid_id, pressure_field_R, rigid_bvh, X_RD, &result);
       }
     }
   }
@@ -133,15 +142,15 @@ DeformableContact<double> Geometries::ComputeDeformableContact(
         if (deformable1_id < deformable0_id) {
           AddDeformableDeformableContactSurface(
               *signed_distance_fields.at(deformable0_id),
-              it0->second.deformable_mesh(), deformable0_id,
+              it0->second.deformable_volume(), deformable0_id,
               *signed_distance_fields.at(deformable1_id),
-              it1->second.deformable_mesh(), deformable1_id, &result);
+              it1->second.deformable_volume(), deformable1_id, &result);
         } else {
           AddDeformableDeformableContactSurface(
               *signed_distance_fields.at(deformable1_id),
-              it1->second.deformable_mesh(), deformable1_id,
+              it1->second.deformable_volume(), deformable1_id,
               *signed_distance_fields.at(deformable0_id),
-              it0->second.deformable_mesh(), deformable0_id, &result);
+              it0->second.deformable_volume(), deformable0_id, &result);
         }
       }
     }
@@ -203,7 +212,7 @@ void Geometries::AddRigidGeometry(const ShapeType& shape,
     return;
   }
   std::optional<RigidGeometry> rigid_geometry =
-      internal::deformable::MakeRigidRepresentation(shape, data.properties);
+      internal::deformable::MakeMeshRepresentation(shape, data.properties);
   if (rigid_geometry) {
     rigid_geometries_.insert({data.id, std::move(*rigid_geometry)});
   }

--- a/geometry/proximity/deformable_contact_internal.h
+++ b/geometry/proximity/deformable_contact_internal.h
@@ -63,26 +63,33 @@ class Geometries final : public ShapeReifier {
   void RemoveGeometry(GeometryId id);
 
   // TODO(xuchenhan-tri): Currently we rely on the resolution_hint property to
-  // determine whether a rigid geometry participates in deformable contact. This
-  // is very much an ad-hoc measure to quickly enable deformable contact of some
-  // sort. In the future, we need to decouple the ability of a rigid geometry to
-  // participate in *deformable contact* from its *hydroelastic* properties.
+  // determine whether a non-deformable geometry participates in deformable
+  // contact. This is very much an ad-hoc measure to quickly enable deformable
+  // contact of some sort. In the future, we need to decouple the ability of a
+  // non-deformable geometry to participate in *deformable contact* from its
+  // *hydroelastic* properties.
+  // TODO(xuchenhan-tri): A resolution hint isn't really necessary for convex
+  // and mesh shapes to instantiate a non-deformable representation. We
+  // shouldn't unnecessarily require it.
 
-  /* Examines the given shape and properties, adding a rigid geometry
-   representation if
+  /* Examines the given shape that has been declared as non-deformable and add a
+   deformable::RigidGeometry if
    1. `props` specifies the resolution hint for the mesh representation of the
-      rigid geometry.
-   2. The `shape` type is supported for rigid representation for deformable
-      contact. The set of supported geometries is the set of all supported hydro
-      rigid geometries minus half space. We use the same implementation that the
-      hydro-rigid reifier is using for supported shapes.
-   This function is a no-op if the resolution_hint property is not specified and
-   logs a one-time warning if the shape is not supported for deformable contact.
+      geometry and a valid hydroelastic modulus.
+   2. The `shape` type is supported for non-deformable representation for
+      deformable contact. The set of supported geometries is the set of all
+      supported hydroelastic compliant geometries minus half space. We use the
+      same implementation that the compliant hydroelastic reifier is using for
+      supported shapes.
+
+   This function is a no-op if the resolution_hint or the hydroelastic modulus
+   property is not specified and logs a one-time warning if the shape is not
+   supported for deformable contact.
 
    @param shape         The shape to possibly represent.
    @param id            The unique identifier for the geometry.
    @param properties    The proximity properties that specifies the properties
-                        of the rigid representation.
+                        of the non-deformable representation.
    @param X_WG          The pose of the geometry in the world frame.
    @throws std::exception if resolution hint <= 0 for the following shapes: Box,
            Sphere, Cylinder, Capsule, and Ellipsoid. Note that Mesh and Convex
@@ -97,24 +104,33 @@ class Geometries final : public ShapeReifier {
   void UpdateRigidWorldPose(GeometryId id,
                             const math::RigidTransform<double>& X_WG);
 
-  /* Adds a deformable geometry whose contact mesh representation is given by
-   `mesh`.
+  /* Adds a deformable geometry whose contact mesh representations are given by
+   `mesh` and `surface_mesh`.
 
-   @param id     The unique identifier for the geometry.
-   @param mesh   The volume mesh representation of the deformable geometry.
+   @param id             The unique identifier for the geometry.
+   @param mesh           The volume mesh representation of the deformable
+                         geometry.
+   @param surface_mesh   The surface mesh of `mesh`.
+   @param surface_index_to_volume_index
+                         A mapping from the index of a vertex in the surface
+                         mesh to the index of the corresponding vertex in the
+                         volume mesh.
    @pre There is no previous representation associated with id. */
-  void AddDeformableGeometry(GeometryId id, VolumeMesh<double> mesh);
+  void AddDeformableGeometry(GeometryId id, VolumeMesh<double> mesh,
+                             TriangleSurfaceMesh<double> surface_mesh,
+                             std::vector<int> surface_index_to_volume_index);
 
   /* If a deformable geometry with `id` exists, updates the vertex positions
-   of the geometry (in the world frame) to `q_WG`. */
+   of the volume mesh (in the world frame) to `q_WV` and the vertex positions
+   of the surface mesh (in the world frame) to `q_WS`. */
   void UpdateDeformableVertexPositions(
-      GeometryId id, const Eigen::Ref<const VectorX<double>>& q_WG);
+      GeometryId id, const Eigen::Ref<const VectorX<double>>& q_WV,
+      const Eigen::Ref<const VectorX<double>>& q_WS);
 
   /* For each registered deformable geometry, computes the contact data of it
    with respect to all registered rigid geometries and all other deformable
    geometries. Assumes the vertex positions and poses of all registered
-   deformable and rigid geometries are up to date.
-  */
+   deformable and rigid geometries are up to date. */
   DeformableContact<double> ComputeDeformableContact(
       const CollisionFilter& collision_filter) const;
 
@@ -125,7 +141,7 @@ class Geometries final : public ShapeReifier {
    parameter in the ImplementGeometry API. */
   struct ReifyData {
     GeometryId id;
-    const ProximityProperties& properties;
+    ProximityProperties properties;
   };
 
   void ImplementGeometry(const Box& box, void* user_data) override;

--- a/geometry/proximity/deformable_mesh_intersection.cc
+++ b/geometry/proximity/deformable_mesh_intersection.cc
@@ -16,20 +16,20 @@ namespace internal {
 //  file to test it directly and for future code re-use.
 
 class DeformableSurfaceVolumeIntersector
-    : public SurfaceVolumeIntersector<PolyMeshBuilder<double>, Aabb> {
+    : public SurfaceVolumeIntersector<PolyMeshBuilder<double>, Obb, Aabb> {
  public:
   // N.B. If this class declaration moves to the header, don't inline this dtor.
   ~DeformableSurfaceVolumeIntersector() = default;
 
-  /* Returns the indices of tetrahedra containing the contact polygons.
+  /* Returns the indices of triangles containing the contact polygons.
    @pre Call it after SampleVolumeFieldOnSurface() finishes.  */
-  std::vector<int>& mutable_tetrahedron_index_of_polygons() {
-    return tetrahedron_index_of_polygons_;
+  std::vector<int>& mutable_triangle_index_of_polygons() {
+    return triangle_index_of_polygons_;
   }
 
   /* Returns barycentric coordinates of the centroids of the contact polygons.
    @pre Call it after SampleVolumeFieldOnSurface() finishes.  */
-  std::vector<VolumeMesh<double>::Barycentric<double>>&
+  std::vector<TriangleSurfaceMesh<double>::Barycentric<double>>&
   mutable_barycentric_centroids() {
     return barycentric_centroids_;
   }
@@ -38,108 +38,133 @@ class DeformableSurfaceVolumeIntersector
   /* Override the parent class's virtual function to store additional
    data for deformables. */
   void CalcContactPolygon(
-      const VolumeMeshFieldLinear<double, double>& volume_field_D,
-      const TriangleSurfaceMesh<double>& surface_R,
-      const math::RigidTransform<T>& X_DR,
-      const math::RigidTransform<double>& X_DR_d,
-      PolyMeshBuilder<double>* builder_D,
+      const VolumeMeshFieldLinear<double, double>& volume_field_R,
+      const TriangleSurfaceMesh<double>& surface_D,
+      const math::RigidTransform<T>& X_RD,
+      const math::RigidTransform<double>& X_RD_d,
+      PolyMeshBuilder<double>* builder_R,
       bool filter_face_normal_along_field_gradient, int tet_index,
       int tri_index) override {
-    const int num_vertices_before = builder_D->num_vertices();
+    const int num_vertices_before = builder_R->num_vertices();
     // N.B. we must invoke the base implementation before recording any new
     // data.
-    SurfaceVolumeIntersector<PolyMeshBuilder<double>, Aabb>::CalcContactPolygon(
-        volume_field_D, surface_R, X_DR, X_DR_d, builder_D,
-        filter_face_normal_along_field_gradient, tet_index, tri_index);
-    const int num_vertices_after = builder_D->num_vertices();
+    SurfaceVolumeIntersector<PolyMeshBuilder<double>, Obb, Aabb>::
+        CalcContactPolygon(volume_field_R, surface_D, X_RD, X_RD_d, builder_R,
+                           filter_face_normal_along_field_gradient, tet_index,
+                           tri_index);
+    const int num_vertices_after = builder_R->num_vertices();
     const int num_new_vertices = num_vertices_after - num_vertices_before;
     if (num_new_vertices == 0) {
       return;
     }
-    tetrahedron_index_of_polygons_.push_back(tet_index);
+    triangle_index_of_polygons_.push_back(tri_index);
 
     // TODO(xuchenhan-tri): Consider accessing the newly added polygon from
     //  the builder. Here we assume internal knowledge how the function
     //  SurfaceVolumeIntersector::CalcContactPolygon works, i.e., the list of
     //  new vertices form the new polygon in that order.
-    std::vector<int> polygon(num_vertices_after - num_vertices_before);
+    std::vector<int> polygon(num_new_vertices);
     std::iota(polygon.begin(), polygon.end(), num_vertices_before);
 
-    barycentric_centroids_.push_back(volume_field_D.mesh().CalcBarycentric(
-        CalcPolygonCentroid(
-            polygon, X_DR_d.rotation() * surface_R.face_normal(tri_index),
-            builder_D->vertices()),
-        tet_index));
+    const Vector3<double> n_R =
+        X_RD_d.rotation() * -surface_D.face_normal(tri_index);
+    const Vector3<double> p_RC =
+        CalcPolygonCentroid(polygon, n_R, builder_R->vertices());
+    const auto X_DR_d = X_RD_d.inverse();
+    // Our convention is that the deformable body quantities are always measured
+    // and expressed in the world frame.
+    const Vector3<double> p_WC_W = X_DR_d * p_RC;
+    const Vector3<double> barycentric_centroid =
+        surface_D.CalcBarycentric(p_WC_W, tri_index);
+    barycentric_centroids_.push_back(barycentric_centroid);
   }
 
  private:
-  std::vector<int> tetrahedron_index_of_polygons_{};
-  std::vector<VolumeMesh<double>::Barycentric<double>> barycentric_centroids_{};
+  std::vector<int> triangle_index_of_polygons_{};
+  std::vector<TriangleSurfaceMesh<double>::Barycentric<double>>
+      barycentric_centroids_{};
 };
 
 void AddDeformableRigidContactSurface(
-    const VolumeMeshFieldLinear<double, double>& deformable_sdf,
-    const DeformableVolumeMeshWithBvh<double>& deformable_mesh,
+    const DeformableSurfaceMeshWithBvh<double>& deformable_mesh_D,
+    const std::vector<int>& surface_index_to_volume_index,
     const GeometryId deformable_id, const GeometryId rigid_id,
-    const TriangleSurfaceMesh<double>& rigid_mesh_R,
-    const Bvh<Obb, TriangleSurfaceMesh<double>>& rigid_bvh_R,
-    const math::RigidTransform<double>& X_DR,
+    const VolumeMeshFieldLinear<double, double>& pressure_field_R,
+    const Bvh<Obb, VolumeMesh<double>>& rigid_bvh_R,
+    const math::RigidTransform<double>& X_RD,
     DeformableContact<double>* deformable_contact) {
   DRAKE_DEMAND(deformable_contact != nullptr);
-
   DeformableSurfaceVolumeIntersector intersect;
   intersect.SampleVolumeFieldOnSurface(
-      deformable_sdf, deformable_mesh.bvh(), rigid_mesh_R, rigid_bvh_R, X_DR,
-      false /* don't filter face normal along field gradient */);
+      pressure_field_R, rigid_bvh_R, deformable_mesh_D.mesh(),
+      deformable_mesh_D.bvh(), X_RD,
+      true /* Filter face normal along field gradient */);
 
   if (intersect.has_intersection()) {
-    std::unique_ptr<PolygonSurfaceMesh<double>> contact_mesh_W =
+    std::unique_ptr<PolygonSurfaceMesh<double>> contact_mesh_R =
         intersect.release_mesh();
-    const PolygonSurfaceMeshFieldLinear<double, double>& signed_distance_field =
-        intersect.mutable_field();
-    const int num_faces = contact_mesh_W->num_faces();
-    /* Compute the penetration distance at the centroid of each contact polygon
-     using the signed distance field. */
-    std::vector<double> penetration_distances(num_faces);
+    const PolygonSurfaceMeshFieldLinear<double, double>&
+        surface_pressure_field_R = intersect.mutable_field();
+    const int num_faces = contact_mesh_R->num_faces();
+    /* Compute the pressure values at the centroid of each contact polygon. */
+    std::vector<double> pressures(num_faces);
     for (int i = 0; i < num_faces; ++i) {
-      const Vector3<double>& contact_points_W =
-          contact_mesh_W->element_centroid(i);
-      /* `signed_distance_field` has a gradient, therefore `EvaluateCartesian()`
-       should be cheap. */
-      penetration_distances[i] =
-          signed_distance_field.EvaluateCartesian(i, contact_points_W);
+      const Vector3<double>& contact_points_R =
+          contact_mesh_R->element_centroid(i);
+      /* `surface_pressure_field_R` has a gradient, therefore
+       `EvaluateCartesian()` should be cheap. */
+      pressures[i] =
+          surface_pressure_field_R.EvaluateCartesian(i, contact_points_R);
     }
 
-    const VolumeMesh<double>& mesh = deformable_mesh.mesh();
-    // Each contact polygon generates one "participating tetrahedron". Hence
-    // `participating_tetrahedra` contains duplicated entries when a tetrahedron
-    // covers multiple contact polygons.
-    const std::vector<int>& participating_tetrahedra =
-        intersect.mutable_tetrahedron_index_of_polygons();
-    DRAKE_DEMAND(static_cast<int>(participating_tetrahedra.size()) ==
-                 num_faces);
+    // Transform the contact mesh from the rigid frame R to the deformable frame
+    // (which is aligned with the world frame).
+    const math::RigidTransform<double> X_WR = X_RD.inverse();
+    contact_mesh_R->TransformVertices(X_WR);
+    std::unique_ptr<PolygonSurfaceMesh<double>> contact_mesh_W =
+        std::move(contact_mesh_R);
 
-    std::unordered_set<int> participating_vertices;
-    std::vector<Vector4<int>> contact_vertex_indexes;
-    // Each contact point generates 4 participating vertices. We overestimate by
-    // ignoring duplications caused by the possibility of one tet containing
-    // more than one contact point.
-    participating_vertices.reserve(4 * num_faces);
-    contact_vertex_indexes.reserve(num_faces);
-    for (int e : participating_tetrahedra) {
-      Vector4<int> tetrahedron_vertex_indexes;
-      for (int v = 0; v < VolumeMesh<double>::kVertexPerElement; ++v) {
-        const int index = mesh.element(e).vertex(v);
-        tetrahedron_vertex_indexes(v) = index;
-        participating_vertices.insert(index);
+    const TriangleSurfaceMesh<double>& mesh = deformable_mesh_D.mesh();
+    // Each contact polygon generates one "participating triangle". Hence
+    // `participating_triangles` contains duplicated entries when a triangle
+    // covers multiple contact polygons.
+    const std::vector<int>& participating_triangles =
+        intersect.mutable_triangle_index_of_polygons();
+    DRAKE_DEMAND(static_cast<int>(participating_triangles.size()) == num_faces);
+
+    // The set of all indices of the tet vertices of the deformable body that
+    // are participating in contact.
+    std::unordered_set<int> participating_tri_vertices;
+    // contact_tet_vertex_indices[i] stores the _tet_ indices of the vertices
+    // incident to the i-th triangle in contact.
+    std::vector<Vector3<int>> contact_tet_vertex_indices;
+    // Each contact point generates 3 participating vertices. We overestimate by
+    // ignoring potential duplications.
+    participating_tri_vertices.reserve(3 * num_faces);
+    contact_tet_vertex_indices.reserve(num_faces);
+    const std::vector<Vector3<double>>& pressure_gradient_R =
+        intersect.mutable_grad_eM_M();
+    DRAKE_DEMAND(ssize(pressure_gradient_R) == num_faces);
+    std::vector<Vector3<double>> pressure_gradient_W(num_faces);
+    for (int e : participating_triangles) {
+      Vector3<int> triangle_vertex_tet_indices;
+      for (int v = 0; v < TriangleSurfaceMesh<double>::kVertexPerElement; ++v) {
+        // Map from the surface mesh's vertex index to the volume mesh's vertex
+        const int index =
+            surface_index_to_volume_index[mesh.element(e).vertex(v)];
+        triangle_vertex_tet_indices(v) = index;
+        participating_tri_vertices.insert(index);
       }
-      contact_vertex_indexes.push_back(tetrahedron_vertex_indexes);
+      contact_tet_vertex_indices.push_back(triangle_vertex_tet_indices);
+    }
+    for (int e = 0; e < num_faces; ++e) {
+      pressure_gradient_W[e] = X_WR * pressure_gradient_R[e];
     }
 
     deformable_contact->AddDeformableRigidContactSurface(
-        deformable_id, rigid_id, participating_vertices,
-        std::move(*contact_mesh_W), std::move(penetration_distances),
-        std::move(contact_vertex_indexes),
+        deformable_id, rigid_id, participating_tri_vertices,
+        std::move(*contact_mesh_W), std::move(pressures),
+        std::move(pressure_gradient_W), std::move(contact_tet_vertex_indices),
         std::move(intersect.mutable_barycentric_centroids()));
   }
 }

--- a/geometry/proximity/deformable_mesh_intersection.h
+++ b/geometry/proximity/deformable_mesh_intersection.h
@@ -14,36 +14,49 @@ namespace geometry {
 namespace internal {
 
 /* Computes the contact surface between a deformable geometry and a rigid
- geometry and appends it to existing data.
- @param[in] deformable_sdf_D
-     The approximated signed distance field for the deformable geometry in the
-     deformable geometry's frame D.
+ geometry and appends it to existing data. The resulting contact surface lies on
+ the surface of the deformable geometry (possibly with additional subdivisions
+ due to the intersection with the volume of the rigid geometry). This choice of
+ contact surface representation (as opposed to making the contact surface lie on
+ the surface of the rigid geometry) is made because:
+
+ 1. it often in practice reduces the number of contact points and the number of
+    participating vertices (i.e. the vertices incident to the deformable
+    tetrahedra containing at least one contact point),
+ 2. it prevents contact constraints that only involve internal deformable
+    vertices, and
+ 3. It mitigates the “sticking” artifact we observe when a deformable body
+    is in contact a rigid shape with sharp features (i.e., discontinuous
+    normals), preventing unintended adhesion and ensuring the two bodies cleanly
+    separate.
+
  @param[in] deformable_mesh_D
-     The deformable geometry's mesh expressed in the deformable geometry's frame
-     D.
+     The deformable geometry's surface mesh expressed in the deformable
+     geometry's frame D. We assume that triangles are oriented outward.
+ @param[in] surface_index_to_volume_index
+     A mapping from the deformable surface mesh's vertex index to the deformable
+     volume mesh's vertex index.
  @param[in] deformable_id
      Id of the deformable geometry.
  @param[in] rigid_id
      Id of the rigid geometry.
- @param[in] rigid_mesh_R
-     The rigid geometry is represented as a surface mesh, whose vertices are
-     measusured and expressed in frame R. We assume that triangles are oriented
-     outward.
+ @param[in] pressure_field_R
+     The pressure field in the rigid geometry's frame R.
  @param[in] rigid_bvh_R
      A bounding volume hierarchy built on the geometry contained in
      rigid_mesh_R.
- @param[in] X_DR
-     The pose of the rigid geometry's frame R in deformable geometry's frame D.
+ @param[in] X_RD
+     The pose of the deformable geometry's frame D in rigid geometry's frame R.
  @param[in, out] deformable_contact
      The deformable contact data to be appended to.
  @pre deformable_contact != nullptr. */
 void AddDeformableRigidContactSurface(
-    const VolumeMeshFieldLinear<double, double>& deformable_sdf,
-    const DeformableVolumeMeshWithBvh<double>& deformable_mesh,
+    const DeformableSurfaceMeshWithBvh<double>& deformable_mesh_D,
+    const std::vector<int>& surface_index_to_volume_index,
     GeometryId deformable_id, GeometryId rigid_id,
-    const TriangleSurfaceMesh<double>& rigid_mesh_R,
-    const Bvh<Obb, TriangleSurfaceMesh<double>>& rigid_bvh_R,
-    const math::RigidTransform<double>& X_DR,
+    const VolumeMeshFieldLinear<double, double>& pressure_field_R,
+    const Bvh<Obb, VolumeMesh<double>>& rigid_bvh_R,
+    const math::RigidTransform<double>& X_RD,
     DeformableContact<double>* deformable_contact);
 
 }  // namespace internal

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -106,10 +106,12 @@ class SurfaceVolumeIntersectorTester;
    surface. It can be TriMeshBuilder<T> or PolyMeshBuilder<T> for T = double
    or AutoDiffXd.
 
- @tparam BvType  The type of bounding volumes for the tetrahedra in the
+ @tparam TetBvType  The type of bounding volumes for the tetrahedra in the
    volume mesh. It can be Obb for hydroelastics or Aabb for deformables.
- */
-template <typename MeshBuilder, typename BvType>
+
+ @tparam TriBvType  The type of bounding volumes for the triangles in the
+   surface mesh. It can be Obb for hydroelastics or Aabb for deformables. */
+template <typename MeshBuilder, typename TetBvType, typename TriBvType = Obb>
 class SurfaceVolumeIntersector {
  public:
   using MeshType = typename MeshBuilder::MeshType;
@@ -160,9 +162,9 @@ class SurfaceVolumeIntersector {
    */
   void SampleVolumeFieldOnSurface(
       const VolumeMeshFieldLinear<double, double>& volume_field_M,
-      const Bvh<BvType, VolumeMesh<double>>& bvh_M,
+      const Bvh<TetBvType, VolumeMesh<double>>& bvh_M,
       const TriangleSurfaceMesh<double>& surface_N,
-      const Bvh<Obb, TriangleSurfaceMesh<double>>& bvh_N,
+      const Bvh<TriBvType, TriangleSurfaceMesh<double>>& bvh_N,
       const math::RigidTransform<T>& X_MN,
       bool filter_face_normal_along_field_gradient = true);
 

--- a/geometry/proximity/test/deformable_contact_geometries_test.cc
+++ b/geometry/proximity/test/deformable_contact_geometries_test.cc
@@ -5,6 +5,7 @@
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/make_sphere_field.h"
 #include "drake/geometry/proximity/make_sphere_mesh.h"
 #include "drake/geometry/proximity_properties.h"
 
@@ -54,7 +55,12 @@ GTEST_TEST(DeformableGeometryTest, Constructor) {
   ASSERT_EQ(num_vertices, 7);
   const int kCenterVertexIndex = 0;
 
-  DeformableGeometry deformable_geometry(mesh_W);
+  std::vector<int> surface_vertices;
+  TriangleSurfaceMesh<double> surface_mesh_W =
+      ConvertVolumeToSurfaceMeshWithBoundaryVertices(mesh_W, &surface_vertices);
+  const int num_surface_vertices = surface_mesh_W.num_vertices();
+  DeformableGeometry deformable_geometry(mesh_W, surface_mesh_W,
+                                         surface_vertices);
 
   auto verify_sdf = [num_vertices](const DeformableGeometry& geometry) {
     const VolumeMeshFieldLinear<double, double>& sdf =
@@ -71,11 +77,15 @@ GTEST_TEST(DeformableGeometryTest, Constructor) {
 
   // Verify that the distance field is unaffected by deformation of the mesh.
   VectorXd q(3 * num_vertices);
+  VectorXd q_surface(3 * num_surface_vertices);
   const double scale = 1.23;
   for (int v = 0; v < num_vertices; ++v) {
     q.segment<3>(3 * v) = scale * mesh_W.vertex(v);
   }
-  deformable_geometry.UpdateVertexPositions(q);
+  for (int v = 0; v < num_surface_vertices; ++v) {
+    q_surface.segment<3>(3 * v) = scale * surface_mesh_W.vertex(v);
+  }
+  deformable_geometry.UpdateVertexPositions(q, q_surface);
   verify_sdf(deformable_geometry);
 }
 
@@ -84,30 +94,48 @@ GTEST_TEST(DeformableGeometryTest, TestCopyAndMoveSemantics) {
   const Box box = Box::MakeCube(kEdgeLength);
   const double kRezHint = 0.5;
   VolumeMesh<double> mesh = MakeBoxVolumeMesh<double>(box, kRezHint);
-  DeformableGeometry original(mesh);
+  std::vector<int> surface_vertices;
+  TriangleSurfaceMesh<double> surface_mesh =
+      ConvertVolumeToSurfaceMeshWithBoundaryVertices(mesh, &surface_vertices);
+
+  DeformableGeometry original(mesh, surface_mesh, surface_vertices);
 
   std::vector<Vector3d> dummy_vertices = {Vector3d(0, 0, 0), Vector3d(1, 0, 0),
                                           Vector3d(0, 1, 0), Vector3d(0, 0, 1)};
   std::vector<VolumeElement> dummy_elements = {VolumeElement(0, 1, 2, 3)};
   VolumeMesh dummy_mesh(std::move(dummy_elements), std::move(dummy_vertices));
+  dummy_vertices = {Vector3d(0, 0, 0), Vector3d(1, 0, 0), Vector3d(0, 1, 0)};
+  std::vector<SurfaceTriangle> dummy_triangles = {SurfaceTriangle(0, 1, 2)};
+  TriangleSurfaceMesh dummy_surface_mesh(std::move(dummy_triangles),
+                                         std::move(dummy_vertices));
+  std::vector<int> dummy_surface_vertices = {0, 1, 2};
 
   // Test copy-assignment operator.
   {
-    DeformableGeometry copy(dummy_mesh);
-    EXPECT_FALSE(
-        copy.deformable_mesh().mesh().Equal(original.deformable_mesh().mesh()));
+    DeformableGeometry copy(dummy_mesh, dummy_surface_mesh,
+                            dummy_surface_vertices);
+    EXPECT_FALSE(copy.deformable_volume().mesh().Equal(
+        original.deformable_volume().mesh()));
+    EXPECT_FALSE(copy.deformable_surface().mesh().Equal(
+        original.deformable_surface().mesh()));
     copy = original;
 
     // Test for uniqueness.
-    EXPECT_NE(&original.deformable_mesh(), &copy.deformable_mesh());
-    EXPECT_NE(&original.deformable_mesh().mesh(),
-              &copy.deformable_mesh().mesh());
-    EXPECT_NE(&copy.deformable_mesh().bvh(), &original.deformable_mesh().bvh());
+    EXPECT_NE(&original.deformable_volume(), &copy.deformable_volume());
+    EXPECT_NE(&original.deformable_volume().mesh(),
+              &copy.deformable_volume().mesh());
+    EXPECT_NE(&copy.deformable_volume().bvh(),
+              &original.deformable_volume().bvh());
+    EXPECT_NE(&original.deformable_surface(), &copy.deformable_surface());
 
-    EXPECT_TRUE(
-        copy.deformable_mesh().mesh().Equal(original.deformable_mesh().mesh()));
-    EXPECT_TRUE(
-        copy.deformable_mesh().bvh().Equal(original.deformable_mesh().bvh()));
+    EXPECT_TRUE(copy.deformable_volume().mesh().Equal(
+        original.deformable_volume().mesh()));
+    EXPECT_TRUE(copy.deformable_volume().bvh().Equal(
+        original.deformable_volume().bvh()));
+    EXPECT_TRUE(copy.deformable_surface().mesh().Equal(
+        original.deformable_surface().mesh()));
+    EXPECT_TRUE(copy.deformable_surface().bvh().Equal(
+        original.deformable_surface().bvh()));
 
     const VolumeMeshFieldLinear<double, double>& copy_sdf =
         copy.CalcSignedDistanceField();
@@ -121,15 +149,21 @@ GTEST_TEST(DeformableGeometryTest, TestCopyAndMoveSemantics) {
     DeformableGeometry copy(original);
 
     // Test for uniqueness.
-    EXPECT_NE(&original.deformable_mesh(), &copy.deformable_mesh());
-    EXPECT_NE(&original.deformable_mesh().mesh(),
-              &copy.deformable_mesh().mesh());
-    EXPECT_NE(&copy.deformable_mesh().bvh(), &original.deformable_mesh().bvh());
+    EXPECT_NE(&original.deformable_volume(), &copy.deformable_volume());
+    EXPECT_NE(&original.deformable_volume().mesh(),
+              &copy.deformable_volume().mesh());
+    EXPECT_NE(&copy.deformable_volume().bvh(),
+              &original.deformable_volume().bvh());
+    EXPECT_NE(&original.deformable_surface(), &copy.deformable_surface());
 
-    EXPECT_TRUE(
-        copy.deformable_mesh().mesh().Equal(original.deformable_mesh().mesh()));
-    EXPECT_TRUE(
-        copy.deformable_mesh().bvh().Equal(original.deformable_mesh().bvh()));
+    EXPECT_TRUE(copy.deformable_volume().mesh().Equal(
+        original.deformable_volume().mesh()));
+    EXPECT_TRUE(copy.deformable_volume().bvh().Equal(
+        original.deformable_volume().bvh()));
+    EXPECT_TRUE(copy.deformable_surface().mesh().Equal(
+        original.deformable_surface().mesh()));
+    EXPECT_TRUE(copy.deformable_surface().bvh().Equal(
+        original.deformable_surface().bvh()));
 
     const VolumeMeshFieldLinear<double, double>& copy_sdf =
         copy.CalcSignedDistanceField();
@@ -149,16 +183,21 @@ GTEST_TEST(DeformableGeometryTest, TestCopyAndMoveSemantics) {
     // Grab raw pointers so we can determine that their ownership changes due to
     // move semantics.
     const DeformableVolumeMeshWithBvh<double>* const mesh_ptr =
-        &start.deformable_mesh();
+        &start.deformable_volume();
+    const DeformableSurfaceMeshWithBvh<double>* const surface_mesh_ptr =
+        &start.deformable_surface();
 
     // Test move constructor.
     DeformableGeometry move_constructed(std::move(start));
-    EXPECT_EQ(&move_constructed.deformable_mesh(), mesh_ptr);
+    EXPECT_EQ(&move_constructed.deformable_volume(), mesh_ptr);
+    EXPECT_EQ(&move_constructed.deformable_surface(), surface_mesh_ptr);
 
     // Test move-assignment operator.
-    DeformableGeometry move_assigned(dummy_mesh);
+    DeformableGeometry move_assigned(dummy_mesh, dummy_surface_mesh,
+                                     dummy_surface_vertices);
     move_assigned = std::move(move_constructed);
-    EXPECT_EQ(&move_assigned.deformable_mesh(), mesh_ptr);
+    EXPECT_EQ(&move_assigned.deformable_volume(), mesh_ptr);
+    EXPECT_EQ(&move_assigned.deformable_surface(), surface_mesh_ptr);
   }
 }
 
@@ -167,14 +206,29 @@ GTEST_TEST(DeformableGeometryTest, UpdateVertexPositions) {
   VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(
       sphere, 0.5, TessellationStrategy::kDenseInteriorVertices);
   const int num_vertices = mesh.num_vertices();
-  DeformableGeometry deformable_geometry(std::move(mesh));
+  std::vector<int> surface_vertices;
+  TriangleSurfaceMesh<double> surface_mesh =
+      ConvertVolumeToSurfaceMeshWithBoundaryVertices(mesh, &surface_vertices);
+  const int num_surface_vertices = surface_mesh.num_vertices();
+
+  DeformableGeometry deformable_geometry(
+      std::move(mesh), std::move(surface_mesh), std::move(surface_vertices));
   const VectorXd q = VectorXd::LinSpaced(3 * num_vertices, 0.0, 1.0);
-  deformable_geometry.UpdateVertexPositions(q);
-  const VolumeMesh<double> deformed_mesh =
-      deformable_geometry.deformable_mesh().mesh();
+  const VectorXd q_surface =
+      VectorXd::LinSpaced(3 * num_surface_vertices, 0.0, 1.0);
+  deformable_geometry.UpdateVertexPositions(q, q_surface);
+  const VolumeMesh<double>& deformed_mesh =
+      deformable_geometry.deformable_volume().mesh();
+  const TriangleSurfaceMesh<double>& deformed_surface_mesh =
+      deformable_geometry.deformable_surface().mesh();
   for (int i = 0; i < num_vertices; ++i) {
     const Vector3d& q_MV = deformed_mesh.vertex(i);
     const Vector3d& expected_q_MV = q.segment<3>(3 * i);
+    EXPECT_EQ(q_MV, expected_q_MV);
+  }
+  for (int i = 0; i < num_surface_vertices; ++i) {
+    const Vector3d& q_MV = deformed_surface_mesh.vertex(i);
+    const Vector3d& expected_q_MV = q_surface.segment<3>(3 * i);
     EXPECT_EQ(q_MV, expected_q_MV);
   }
 }
@@ -182,28 +236,34 @@ GTEST_TEST(DeformableGeometryTest, UpdateVertexPositions) {
 GTEST_TEST(RigidGeometryTest, Pose) {
   const Sphere sphere(1.0);
   const double resolution_hint = 0.5;
-  auto mesh = make_unique<TriangleSurfaceMesh<double>>(
-      MakeSphereSurfaceMesh<double>(sphere, resolution_hint));
-  auto rigid_mesh = make_unique<hydroelastic::RigidMesh>(std::move(mesh));
-  RigidGeometry rigid_geometry(std::move(rigid_mesh));
+  auto mesh = std::make_unique<VolumeMesh<double>>(MakeSphereVolumeMesh<double>(
+      sphere, resolution_hint, TessellationStrategy::kSingleInteriorVertex));
+  const double hydroelastic_modulus = 1234.5;
+  auto mesh_field = make_unique<VolumeMeshFieldLinear<double, double>>(
+      MakeSpherePressureField<double>(sphere, mesh.get(),
+                                      hydroelastic_modulus));
+  auto soft_hydro_mesh = make_unique<hydroelastic::SoftMesh>(
+      std::move(mesh), std::move(mesh_field));
+  RigidGeometry rigid_geometry(std::move(soft_hydro_mesh));
   const math::RigidTransform<double> X_WG(
       math::RollPitchYaw<double>(-1.57, 0, 3), Vector3d(-0.3, -0.55, 0.36));
   rigid_geometry.set_pose_in_world(X_WG);
   EXPECT_TRUE(X_WG.IsExactlyEqualTo(rigid_geometry.pose_in_world()));
 }
 
-GTEST_TEST(RigidGeometryTest, MakeRigidRepresentation) {
+GTEST_TEST(RigidGeometryTest, MakeMeshRepresentation) {
   const Sphere sphere(1.0);
   ProximityProperties props;
   const double resolution_hint = 0.5;
-  AddRigidHydroelasticProperties(resolution_hint, &props);
-  EXPECT_TRUE(MakeRigidRepresentation(sphere, props).has_value());
+  AddCompliantHydroelasticProperties(resolution_hint, 1234.5, &props);
+  EXPECT_TRUE(MakeMeshRepresentation(sphere, props).has_value());
 
   const MeshcatCone cone(1.0, 2.0, 3.0);
-  EXPECT_FALSE(MakeRigidRepresentation(cone, props).has_value());
+  EXPECT_FALSE(MakeMeshRepresentation(cone, props).has_value());
 
+  props.AddProperty("hydroelastic", "slab_thickness", 0.1);
   const HalfSpace half_space;
-  EXPECT_FALSE(MakeRigidRepresentation(half_space, props).has_value());
+  EXPECT_FALSE(MakeMeshRepresentation(half_space, props).has_value());
 }
 
 }  // namespace

--- a/geometry/proximity/test/deformable_contact_internal_test.cc
+++ b/geometry/proximity/test/deformable_contact_internal_test.cc
@@ -76,12 +76,25 @@ VolumeMesh<double> MakeVolumeMesh() {
       sphere, kRezHint, TessellationStrategy::kDenseInteriorVertices);
 }
 
+void AddDeformableGeometry(GeometryId id, VolumeMesh<double> mesh,
+                           Geometries* geometries) {
+  std::vector<int> surface_vertices;
+  TriangleSurfaceMesh<double> surface_mesh =
+      ConvertVolumeToSurfaceMeshWithBoundaryVertices(mesh, &surface_vertices);
+  geometries->AddDeformableGeometry(id, std::move(mesh),
+                                    std::move(surface_mesh),
+                                    std::move(surface_vertices));
+}
+
 /* Makes a ProximityProperties with a resolution hint property in the hydro
  group.
  @pre resolution_hint > 0. */
-ProximityProperties MakeProximityPropsWithRezHint(double resolution_hint) {
+ProximityProperties MakeCompliantHydroProps(double resolution_hint,
+                                            double hydroelastic_modulus = 1e5) {
   ProximityProperties props;
-  props.AddProperty(internal::kHydroGroup, internal::kRezHint, resolution_hint);
+  AddCompliantHydroelasticProperties(resolution_hint, hydroelastic_modulus,
+                                     &props);
+  props.AddProperty("hydroelastic", "slab_thickness", 0.1);
   return props;
 }
 
@@ -105,7 +118,7 @@ GTEST_TEST(GeometriesTest, AddRigidGeometry) {
   /* Add a rigid geometry with resolution hint property. */
   constexpr double kRadius = 0.5;
   constexpr double kRezHint = 0.5;
-  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  ProximityProperties props = MakeCompliantHydroProps(kRezHint);
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id, props,
                                    default_pose());
 
@@ -131,10 +144,10 @@ GTEST_TEST(GeometriesTest, AddRigidGeometry) {
 }
 
 /* Test coverage for all unsupported shapes as rigid geometries: MeshcatCone and
- * HalfSpace. */
+ HalfSpace. */
 GTEST_TEST(GeometriesTest, UnsupportedRigidShapes) {
   constexpr double kRezHint = 0.5;
-  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  ProximityProperties props = MakeCompliantHydroProps(kRezHint);
   Geometries geometries;
 
   /* Unsupported shapes: MeshcatCone, HalfSpace. */
@@ -161,7 +174,7 @@ GTEST_TEST(GeometriesTest, UnsupportedRigidShapes) {
  Cylinder, Capsule, Ellipsoid, Mesh, Convex. */
 GTEST_TEST(GeometriesTest, SupportedRigidShapes) {
   constexpr double kRezHint = 0.5;
-  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  ProximityProperties props = MakeCompliantHydroProps(kRezHint);
   Geometries geometries;
 
   /* Box */
@@ -233,7 +246,7 @@ GTEST_TEST(GeometriesTest, UpdateRigidWorldPose) {
   GeometryId rigid_id = GeometryId::get_new_id();
   constexpr double kRadius = 0.5;
   constexpr double kRezHint = 0.5;
-  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  ProximityProperties props = MakeCompliantHydroProps(kRezHint);
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id, props,
                                    default_pose());
 
@@ -262,7 +275,7 @@ GTEST_TEST(GeometriesTest, AddDeformableGeometry) {
   EXPECT_FALSE(geometries.is_deformable(deformable_id));
 
   /* Add a deformable geometry. */
-  geometries.AddDeformableGeometry(deformable_id, MakeVolumeMesh());
+  AddDeformableGeometry(deformable_id, MakeVolumeMesh(), &geometries);
   EXPECT_FALSE(geometries.is_rigid(deformable_id));
   EXPECT_TRUE(geometries.is_deformable(deformable_id));
 }
@@ -272,15 +285,15 @@ GTEST_TEST(GeometriesTest, RemoveGeometry) {
   /* Add a couple of deformable geometries. */
   GeometryId deformable_id0 = GeometryId::get_new_id();
   GeometryId deformable_id1 = GeometryId::get_new_id();
-  geometries.AddDeformableGeometry(deformable_id0, MakeVolumeMesh());
-  geometries.AddDeformableGeometry(deformable_id1, MakeVolumeMesh());
+  AddDeformableGeometry(deformable_id0, MakeVolumeMesh(), &geometries);
+  AddDeformableGeometry(deformable_id1, MakeVolumeMesh(), &geometries);
 
   /* Add a couple of rigid geometries. */
   GeometryId rigid_id0 = GeometryId::get_new_id();
   GeometryId rigid_id1 = GeometryId::get_new_id();
   constexpr double kRadius = 0.5;
   constexpr double kRezHint = 0.5;
-  ProximityProperties props = MakeProximityPropsWithRezHint(kRezHint);
+  ProximityProperties props = MakeCompliantHydroProps(kRezHint);
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id0, props,
                                    default_pose());
   geometries.MaybeAddRigidGeometry(Sphere(kRadius), rigid_id1, props,
@@ -321,27 +334,42 @@ GTEST_TEST(GeometriesTest, UpdateDeformableVertexPositions) {
   /* Add a deformable geometry. */
   GeometryId deformable_id = GeometryId::get_new_id();
   const VolumeMesh<double> input_mesh = MakeVolumeMesh();
-  geometries.AddDeformableGeometry(deformable_id, input_mesh);
+  const TriangleSurfaceMesh<double> input_surface_mesh =
+      ConvertVolumeToSurfaceMeshWithBoundaryVertices(input_mesh);
+
+  AddDeformableGeometry(deformable_id, input_mesh, &geometries);
   const int num_vertices = input_mesh.num_vertices();
+  const int num_surface_vertices = input_surface_mesh.num_vertices();
 
   /* Initially the vertex positions is the same as the registered mesh. */
   {
     ASSERT_TRUE(geometries.is_deformable(deformable_id));
     const DeformableGeometry& geometry =
         GeometriesTester::get_deformable_geometry(geometries, deformable_id);
-    EXPECT_TRUE(geometry.deformable_mesh().mesh().Equal(input_mesh));
+    EXPECT_TRUE(geometry.deformable_volume().mesh().Equal(input_mesh));
   }
   /* Update the vertex positions to some arbitrary value. */
   const VectorXd q = VectorXd::LinSpaced(3 * num_vertices, 0.0, 1.0);
-  geometries.UpdateDeformableVertexPositions(deformable_id, q);
+  const VectorXd q_surface =
+      VectorXd::LinSpaced(3 * num_surface_vertices, 0.0, 1.0);
+  geometries.UpdateDeformableVertexPositions(deformable_id, q, q_surface);
   {
     const DeformableGeometry& geometry =
         GeometriesTester::get_deformable_geometry(geometries, deformable_id);
-    const VolumeMesh<double>& mesh = geometry.deformable_mesh().mesh();
+    const VolumeMesh<double>& mesh = geometry.deformable_volume().mesh();
     for (int i = 0; i < num_vertices; ++i) {
       const Vector3d& q_MV = mesh.vertex(i);
       const Vector3d& reference_q_MV = input_mesh.vertex(i);
       const Vector3d& expected_q_MV = q.segment<3>(3 * i);
+      EXPECT_EQ(q_MV, expected_q_MV);
+      EXPECT_NE(q_MV, reference_q_MV);
+    }
+    const TriangleSurfaceMesh<double>& surface_mesh =
+        geometry.deformable_surface().mesh();
+    for (int i = 0; i < num_surface_vertices; ++i) {
+      const Vector3d& q_MV = surface_mesh.vertex(i);
+      const Vector3d& reference_q_MV = input_surface_mesh.vertex(i);
+      const Vector3d& expected_q_MV = q_surface.segment<3>(3 * i);
       EXPECT_EQ(q_MV, expected_q_MV);
       EXPECT_NE(q_MV, reference_q_MV);
     }
@@ -363,7 +391,7 @@ GTEST_TEST(GeometriesTest, ComputeDeformableContact_DeformableRigid) {
   VolumeMesh<double> deformable_mesh =
       MakeBoxVolumeMesh<double>(Box::MakeCube(1.0), 1.0);
   const int num_vertices = deformable_mesh.num_vertices();
-  geometries.AddDeformableGeometry(deformable_id, std::move(deformable_mesh));
+  AddDeformableGeometry(deformable_id, std::move(deformable_mesh), &geometries);
   collision_filter.AddGeometry(deformable_id);
 
   /* There is no geometry to collide with the deformable geometry yet. */
@@ -371,7 +399,7 @@ GTEST_TEST(GeometriesTest, ComputeDeformableContact_DeformableRigid) {
   ASSERT_EQ(contact_data.contact_surfaces().size(), 0);
   /* Add a rigid unit cube. */
   GeometryId rigid_id = GeometryId::get_new_id();
-  ProximityProperties rigid_properties = MakeProximityPropsWithRezHint(1.0);
+  ProximityProperties rigid_properties = MakeCompliantHydroProps(1.0);
   math::RigidTransform<double> X_WR(Vector3d(0, -2.0, 0));
   geometries.MaybeAddRigidGeometry(Box::MakeCube(1.0), rigid_id,
                                    rigid_properties, X_WR);
@@ -387,11 +415,11 @@ GTEST_TEST(GeometriesTest, ComputeDeformableContact_DeformableRigid) {
                                    |
              rigid box             |      deformable box
                    ----------+--+--+-------
-                   |         |  ●  |      |
                    |         |  |  |      |
+                   |         ●  |  |      |
             -Y-----+---------+--+--+------+-------+Y
                    |         |  |  |      |
-                   |         |  ●  |      |
+                   |         ●  |  |      |
                    ----------+--+--+-------
                                    |
                                    |
@@ -408,17 +436,20 @@ GTEST_TEST(GeometriesTest, ComputeDeformableContact_DeformableRigid) {
   /* Verify that the contact surface is as expected. */
   const auto& X_DR =
       X_WR;  // The deformable mesh frame is always the world frame.
+  const auto X_RD = X_DR.inverse();
   const DeformableGeometry& deformable_geometry =
       GeometriesTester::get_deformable_geometry(geometries, deformable_id);
   const RigidGeometry& rigid_geometry =
       GeometriesTester::get_rigid_geometry(geometries, rigid_id);
+  const VolumeMeshFieldLinear<double, double>& pressure_field =
+      rigid_geometry.mesh().pressure();
   DeformableContact<double> expected_contact_data;
   expected_contact_data.RegisterDeformableGeometry(deformable_id, num_vertices);
   AddDeformableRigidContactSurface(
-      deformable_geometry.CalcSignedDistanceField(),
-      deformable_geometry.deformable_mesh(), deformable_id, rigid_id,
-      rigid_geometry.rigid_mesh().mesh(), rigid_geometry.rigid_mesh().bvh(),
-      X_DR, &expected_contact_data);
+      deformable_geometry.deformable_surface(),
+      deformable_geometry.surface_index_to_volume_index(), deformable_id,
+      rigid_id, pressure_field, rigid_geometry.mesh().bvh(), X_RD,
+      &expected_contact_data);
 
   /* Verify that the contact data is the same as expected by checking a subset
    of all data fields. */
@@ -479,8 +510,8 @@ class DeformableDeformableContactTest : public ::testing::Test {
     VolumeMesh<double> mesh1 =
         MakeBoxVolumeMeshWithMa<double>(Box(0.01, 0.01, 0.3));
 
-    geometries_.AddDeformableGeometry(deformable0_id_, std::move(mesh0));
-    geometries_.AddDeformableGeometry(deformable1_id_, std::move(mesh1));
+    AddDeformableGeometry(deformable0_id_, std::move(mesh0), &geometries_);
+    AddDeformableGeometry(deformable1_id_, std::move(mesh1), &geometries_);
   }
 
   const GeometryId deformable0_id_{GeometryId::get_new_id()};
@@ -503,15 +534,15 @@ TEST_F(DeformableDeformableContactTest, OneContactPair) {
       GeometriesTester::get_deformable_geometry(geometries_, deformable1_id_);
   expected.RegisterDeformableGeometry(
       deformable0_id_,
-      deformable0_geometry.deformable_mesh().mesh().num_vertices());
+      deformable0_geometry.deformable_volume().mesh().num_vertices());
   expected.RegisterDeformableGeometry(
       deformable1_id_,
-      deformable1_geometry.deformable_mesh().mesh().num_vertices());
+      deformable1_geometry.deformable_volume().mesh().num_vertices());
   AddDeformableDeformableContactSurface(
       deformable1_geometry.CalcSignedDistanceField(),
-      deformable1_geometry.deformable_mesh(), deformable1_id_,
+      deformable1_geometry.deformable_volume(), deformable1_id_,
       deformable0_geometry.CalcSignedDistanceField(),
-      deformable0_geometry.deformable_mesh(), deformable0_id_, &expected);
+      deformable0_geometry.deformable_volume(), deformable0_id_, &expected);
   ASSERT_EQ(expected.contact_surfaces().size(), 1);
 
   ASSERT_TRUE(contact_data.contact_surfaces().at(0).id_A() == deformable0_id_ &&
@@ -554,7 +585,7 @@ TEST_F(DeformableDeformableContactTest, MultipleContactPairs) {
     collision_filter_.AddGeometry(deformable2_id);
     VolumeMesh<double> mesh2 =
         MakeBoxVolumeMeshWithMa<double>(Box(0.01, 0.3, 0.01));
-    geometries_.AddDeformableGeometry(deformable2_id, std::move(mesh2));
+    AddDeformableGeometry(deformable2_id, std::move(mesh2), &geometries_);
   }
   ASSERT_EQ(GeometriesTester::deformable_geometries(geometries_).size(), 3);
   auto it = GeometriesTester::deformable_geometries(geometries_).begin();

--- a/geometry/proximity/test/deformable_field_intersection_test.cc
+++ b/geometry/proximity/test/deformable_field_intersection_test.cc
@@ -152,10 +152,10 @@ TEST_F(AddDeformableDeformableContactSurfaceTest, HaveContact) {
     EXPECT_EQ(
         contact_surface.signed_distances().at(0),
         sdf1_W.EvaluateCartesian(0, contact_surface.contact_points_W().at(0)));
-    EXPECT_EQ(contact_surface.barycentric_coordinates_A().at(0),
+    EXPECT_EQ(contact_surface.tet_barycentric_coordinates_A().at(0),
               deform0_W_.mesh().CalcBarycentric(
                   contact_surface.contact_points_W().at(0), 0));
-    EXPECT_EQ(contact_surface.contact_vertex_indexes_A().at(0),
+    EXPECT_EQ(contact_surface.tet_contact_vertex_indexes_A().at(0),
               Vector4<int>(0, 1, 2, 3));
     EXPECT_EQ(contact_surface.barycentric_coordinates_B().at(0),
               deform1_W_.mesh().CalcBarycentric(

--- a/geometry/proximity/test/deformable_mesh_intersection_test.cc
+++ b/geometry/proximity/test/deformable_mesh_intersection_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/geometry/proximity/deformable_contact_geometries.h"
+#include "drake/geometry/proximity/make_box_field.h"
 #include "drake/geometry/proximity/make_box_mesh.h"
 #include "drake/geometry/proximity/make_sphere_mesh.h"
 #include "drake/geometry/shape_specification.h"
@@ -15,19 +16,30 @@ namespace geometry {
 namespace internal {
 namespace {
 
+const deformable::DeformableGeometry MakeDeformableGeometry(
+    const VolumeMesh<double>& mesh) {
+  std::vector<int> surface_vertices;
+  TriangleSurfaceMesh<double> surface_mesh =
+      ConvertVolumeToSurfaceMeshWithBoundaryVertices(mesh, &surface_vertices);
+  return deformable::DeformableGeometry(mesh, std::move(surface_mesh),
+                                        std::move(surface_vertices));
+}
+
 GTEST_TEST(ComputeContactSurfaceDeformableRigid, NoContact) {
   const GeometryId deformable_id = GeometryId::get_new_id();
   const Sphere unit_sphere(1.0);
-  const deformable::DeformableGeometry deformable_W(
-      MakeSphereVolumeMesh<double>(
+  const deformable::DeformableGeometry deformable_W =
+      MakeDeformableGeometry(MakeSphereVolumeMesh<double>(
           unit_sphere, 10.0 /* very coarse resolution */,
           TessellationStrategy::kDenseInteriorVertices));
 
   const GeometryId rigid_id = GeometryId::get_new_id();
   // The cube of edge length 2.0 occupies the space [-1,1]x[-1,1]x[-1,1].
-  const TriangleSurfaceMesh<double> rigid_mesh_R = MakeBoxSurfaceMesh<double>(
-      Box::MakeCube(2.0), 10.0 /* very coarse resolution */);
-  const Bvh<Obb, TriangleSurfaceMesh<double>> rigid_bvh_R(rigid_mesh_R);
+  const VolumeMesh<double> rigid_mesh_R =
+      MakeBoxVolumeMeshWithMa<double>(Box::MakeCube(2.0));
+  const Bvh<Obb, VolumeMesh<double>> rigid_bvh_R(rigid_mesh_R);
+  const VolumeMeshFieldLinear<double, double> pressure_field_R =
+      MakeBoxPressureField<double>(Box::MakeCube(2.0), &rigid_mesh_R, 1e5);
 
   /* We use the knowledge that the coarsest sphere volume mesh is a octahedron
    to pose the rigid surface so that
@@ -51,7 +63,7 @@ GTEST_TEST(ComputeContactSurfaceDeformableRigid, NoContact) {
 
   // Verify that the two BVHs have indeed collided.
   bool bvhs_collide = false;
-  deformable_W.deformable_mesh().bvh().Collide(
+  deformable_W.deformable_surface().bvh().Collide(
       rigid_bvh_R, X_WR, [&bvhs_collide](int, int) {
         bvhs_collide = true;
         return BvttCallbackResult::Terminate;
@@ -60,10 +72,11 @@ GTEST_TEST(ComputeContactSurfaceDeformableRigid, NoContact) {
 
   DeformableContact<double> contact_data;
   contact_data.RegisterDeformableGeometry(
-      deformable_id, deformable_W.deformable_mesh().mesh().num_vertices());
-  AddDeformableRigidContactSurface(
-      deformable_W.CalcSignedDistanceField(), deformable_W.deformable_mesh(),
-      deformable_id, rigid_id, rigid_mesh_R, rigid_bvh_R, X_WR, &contact_data);
+      deformable_id, deformable_W.deformable_volume().mesh().num_vertices());
+  AddDeformableRigidContactSurface(deformable_W.deformable_surface(),
+                                   deformable_W.surface_index_to_volume_index(),
+                                   deformable_id, rigid_id, pressure_field_R,
+                                   rigid_bvh_R, X_WR.inverse(), &contact_data);
 
   // Zero contact points and no vertices in contact are good enough indication
   // that the contact data is empty.
@@ -72,7 +85,7 @@ GTEST_TEST(ComputeContactSurfaceDeformableRigid, NoContact) {
 
 // Note that the deformable rigid contact computation largely utilizes
 // previously tested code in mesh_intersection.cc. On top of that, it evaluates
-// signed distances, reports deformable vertices participating in contact, and
+// pressure, reports deformable vertices participating in contact, and
 // contact point barycentric coordinates. We test the correctness of these newly
 // added operations here in this test.
 GTEST_TEST(ComputeContactSurfaceDeformableRigid, OnePolygon) {
@@ -80,27 +93,33 @@ GTEST_TEST(ComputeContactSurfaceDeformableRigid, OnePolygon) {
   const VolumeMesh<double> single_tetrahedron_mesh_W(
       {{0, 1, 2, 3}}, {Vector3<double>::Zero(), Vector3<double>::UnitX(),
                        Vector3<double>::UnitY(), Vector3<double>::UnitZ()});
-  const deformable::DeformableGeometry deformable_W(
-      std::move(single_tetrahedron_mesh_W));
+  const deformable::DeformableGeometry deformable_W =
+      MakeDeformableGeometry(single_tetrahedron_mesh_W);
 
   const GeometryId rigid_id = GeometryId::get_new_id();
-  // Single-triangle surface mesh with the triangle large enough to intersect
-  // the tetrahedron well.
-  const TriangleSurfaceMesh<double> rigid_mesh_R(
-      {{0, 1, 2}}, {Vector3<double>(-1, -1, 0), Vector3<double>(3, -1, 0),
-                    Vector3<double>(-1, 3, 0)});
-  const Bvh<Obb, TriangleSurfaceMesh<double>> rigid_bvh_R(rigid_mesh_R);
+  // Single-tet rigid geometry.
+  const VolumeMesh<double> rigid_mesh_R(
+      {{0, 1, 2, 3}}, {Vector3<double>::Zero(), Vector3<double>::UnitX(),
+                       Vector3<double>::UnitY(), Vector3<double>::UnitZ()});
+  const Bvh<Obb, VolumeMesh<double>> rigid_bvh_R(rigid_mesh_R);
+  const double dummy_pressure = 123.0;
+  std::vector<double> pressure_values{dummy_pressure, dummy_pressure,
+                                      dummy_pressure, dummy_pressure};
+  const VolumeMeshFieldLinear<double, double> pressure_field(
+      std::move(pressure_values), &rigid_mesh_R);
 
-  // Pose the rigid surface at Wz=0.5 so that it intersects the deformable
-  // octahedron somewhere on that surface (since the triangle is parallel to the
-  // xy-plane).
-  const math::RigidTransform<double> X_WR(Vector3<double>{0, 0, 0.5});
+  // Pose the rigid tet so that it intersects the bottom face
+  // of the deformable tet. We choose a shift so that the intersection
+  // triangle's centroid comes out to have a nice number.
+  const math::RigidTransform<double> X_WR(
+      Vector3<double>{1.0 / 6.0, 1.0 / 6.0, -0.5});
 
   DeformableContact<double> contact_data;
   contact_data.RegisterDeformableGeometry(deformable_id, 4);
-  AddDeformableRigidContactSurface(
-      deformable_W.CalcSignedDistanceField(), deformable_W.deformable_mesh(),
-      deformable_id, rigid_id, rigid_mesh_R, rigid_bvh_R, X_WR, &contact_data);
+  AddDeformableRigidContactSurface(deformable_W.deformable_surface(),
+                                   deformable_W.surface_index_to_volume_index(),
+                                   deformable_id, rigid_id, pressure_field,
+                                   rigid_bvh_R, X_WR.inverse(), &contact_data);
   constexpr int kExpectedNumContactPoints = 1;
 
   ASSERT_EQ(contact_data.contact_surfaces().size(), 1);
@@ -108,39 +127,36 @@ GTEST_TEST(ComputeContactSurfaceDeformableRigid, OnePolygon) {
       contact_data.contact_surfaces()[0];
 
   ASSERT_EQ(contact_surface.num_contact_points(), kExpectedNumContactPoints);
-  // The approximated signed distance function is zero because all vertices of
-  // the tet mesh are on the boundary.
-  ASSERT_EQ(contact_surface.signed_distances().size(),
-            kExpectedNumContactPoints);
-  const double signed_distance_at_contact_point =
-      contact_surface.signed_distances()[0];
-  EXPECT_NEAR(signed_distance_at_contact_point, 0.0,
-              std::numeric_limits<double>::epsilon());
-  // The centroid is (1/6, 1/6, 1/2).
+  // The pressure value is equal to the dummy value because the interpolation is
+  // constant.
+  ASSERT_EQ(contact_surface.pressures().size(), kExpectedNumContactPoints);
+  const double pressure = contact_surface.pressures()[0];
+  EXPECT_NEAR(pressure, dummy_pressure, std::numeric_limits<double>::epsilon());
+  // The centroid of the contact triangle in the world frame is (1/3, 1/3, 0).
   const Vector3<double> contact_point_W = contact_surface.contact_points_W()[0];
   constexpr double kTol = 1e-14;
   EXPECT_TRUE(CompareMatrices(
-      contact_point_W, Vector3<double>(1.0 / 6, 1.0 / 6, 1.0 / 2), kTol));
-  // The indexes of vertices incident to the only tetrahedron containing the
-  // only contact point.
-  const Vector4<int> vertex_indexes =
-      contact_surface.contact_vertex_indexes_A()[0];
-  const Vector4<int> expected_vertex_indexes{0, 1, 2, 3};
+      contact_point_W, Vector3<double>(1.0 / 3.0, 1.0 / 3.0, 0.0), kTol));
+  // The indexes of vertices incident to the bottom face of the triangle
+  // containing the only contact point.
+  const Vector3<int> vertex_indexes =
+      contact_surface.tri_contact_vertex_indexes_A()[0];
+  const Vector3<int> expected_vertex_indexes{2, 1, 0};
   EXPECT_EQ(vertex_indexes, expected_vertex_indexes);
-  // The centroid is (1/6, 1/6, 1/2), and the vertex positions are (0, 0, 0),
-  // (1, 0, 0), (0, 1, 0), (0, 0, 1). The the barycentric weights is (1/6, 1/6,
-  // 1/6, 1/2).
-  ASSERT_EQ(contact_surface.barycentric_coordinates_A().size(),
+  // The centroid is (1/3, 1/3, 0), and the vertex positions are (1, 0, 0),
+  // (0, 1, 0), (0, 0, 0), (0, 0, 1). The the barycentric weights is (1/3, 1/3,
+  // 1/3).
+  ASSERT_EQ(contact_surface.tri_barycentric_coordinates_A().size(),
             kExpectedNumContactPoints);
-  EXPECT_TRUE(CompareMatrices(
-      contact_surface.barycentric_coordinates_A()[0],
-      Vector4<double>(1.0 / 6, 1.0 / 6, 1.0 / 6, 1.0 / 2), kTol));
+  EXPECT_TRUE(
+      CompareMatrices(contact_surface.tri_barycentric_coordinates_A()[0],
+                      Vector3<double>(1.0 / 3, 1.0 / 3, 1.0 / 3), kTol));
 
-  // Only on tetrahedron is participating in contact and there are 4 vertices
-  // incident to a tetrahedron.
+  // Only one face is participating in contact and there are 3 vertices
+  // incident to a triangle face.
   const ContactParticipation& contact_participation =
       contact_data.contact_participation(deformable_id);
-  EXPECT_EQ(contact_participation.num_vertices_in_contact(), 4);
+  EXPECT_EQ(contact_participation.num_vertices_in_contact(), 3);
 }
 
 /* Tests that the per-contact-point data depends only on the relative pose
@@ -152,15 +168,18 @@ GTEST_TEST(ComputeContactSurfaceDeformableRigid, OnePolygon) {
 GTEST_TEST(ComputeContactSurfaceDeformableRigid, OnlyRelativePoseMatters) {
   const GeometryId deformable_id = GeometryId::get_new_id();
   const Sphere unit_sphere(1.0);
-  deformable::DeformableGeometry deformable_W(MakeSphereVolumeMesh<double>(
-      unit_sphere, 10.0 /* very coarse resolution */,
-      TessellationStrategy::kDenseInteriorVertices));
+  deformable::DeformableGeometry deformable_W =
+      MakeDeformableGeometry(MakeSphereVolumeMesh<double>(
+          unit_sphere, 10.0 /* very coarse resolution */,
+          TessellationStrategy::kDenseInteriorVertices));
 
   const GeometryId rigid_id = GeometryId::get_new_id();
   // The cube of edge length 2.0 occupies the space [-1,1]x[-1,1]x[-1,1].
-  const TriangleSurfaceMesh<double> rigid_mesh_R = MakeBoxSurfaceMesh<double>(
-      Box::MakeCube(2.0), 10.0 /* very coarse resolution */);
-  const Bvh<Obb, TriangleSurfaceMesh<double>> rigid_bvh_R(rigid_mesh_R);
+  const VolumeMesh<double> rigid_mesh_R =
+      MakeBoxVolumeMeshWithMa<double>(Box::MakeCube(2.0));
+  const Bvh<Obb, VolumeMesh<double>> rigid_bvh_R(rigid_mesh_R);
+  const VolumeMeshFieldLinear<double, double> pressure_field_R =
+      MakeBoxPressureField<double>(Box::MakeCube(2.0), &rigid_mesh_R, 1e5);
   math::RigidTransform<double> X_WR(Vector3<double>{1.5, 0.0, 0.0});
 
   /* Projected to the xy-plane, the setup of the two geometries looks like
@@ -174,12 +193,13 @@ GTEST_TEST(ComputeContactSurfaceDeformableRigid, OnlyRelativePoseMatters) {
                           \|/|____________|                                 */
 
   /* Compute the first set of contact data. */
-  const VolumeMesh<double> mesh_W = deformable_W.deformable_mesh().mesh();
+  const VolumeMesh<double> mesh_W = deformable_W.deformable_volume().mesh();
   DeformableContact<double> contact_data;
   contact_data.RegisterDeformableGeometry(deformable_id, mesh_W.num_vertices());
-  AddDeformableRigidContactSurface(
-      deformable_W.CalcSignedDistanceField(), deformable_W.deformable_mesh(),
-      deformable_id, rigid_id, rigid_mesh_R, rigid_bvh_R, X_WR, &contact_data);
+  AddDeformableRigidContactSurface(deformable_W.deformable_surface(),
+                                   deformable_W.surface_index_to_volume_index(),
+                                   deformable_id, rigid_id, pressure_field_R,
+                                   rigid_bvh_R, X_WR.inverse(), &contact_data);
   ASSERT_EQ(contact_data.contact_surfaces().size(), 1);
   const DeformableContactSurface<double>& contact_surface =
       contact_data.contact_surfaces()[0];
@@ -194,41 +214,36 @@ GTEST_TEST(ComputeContactSurfaceDeformableRigid, OnlyRelativePoseMatters) {
   for (int v = 0; v < mesh_W.num_vertices(); ++v) {
     q_WD.segment<3>(3 * v) = arbitrary_transform * mesh_W.vertex(v);
   }
-  deformable_W.UpdateVertexPositions(q_WD);
+  const TriangleSurfaceMesh<double> surface_mesh_W =
+      deformable_W.deformable_surface().mesh();
+  VectorX<double> q_surface_WD(3 * surface_mesh_W.num_vertices());
+  for (int v = 0; v < surface_mesh_W.num_vertices(); ++v) {
+    q_surface_WD.segment<3>(3 * v) =
+        arbitrary_transform * surface_mesh_W.vertex(v);
+  }
+
+  deformable_W.UpdateVertexPositions(q_WD, q_surface_WD);
   X_WR = arbitrary_transform * X_WR;
   /* Compute the second set of contact data. */
   DeformableContact<double> contact_data2;
   contact_data2.RegisterDeformableGeometry(deformable_id,
                                            mesh_W.num_vertices());
-  AddDeformableRigidContactSurface(
-      deformable_W.CalcSignedDistanceField(), deformable_W.deformable_mesh(),
-      deformable_id, rigid_id, rigid_mesh_R, rigid_bvh_R, X_WR, &contact_data2);
+  AddDeformableRigidContactSurface(deformable_W.deformable_surface(),
+                                   deformable_W.surface_index_to_volume_index(),
+                                   deformable_id, rigid_id, pressure_field_R,
+                                   rigid_bvh_R, X_WR.inverse(), &contact_data2);
   ASSERT_EQ(contact_data2.contact_surfaces().size(), 1);
   const DeformableContactSurface<double>& contact_surface2 =
       contact_data2.contact_surfaces()[0];
 
   EXPECT_EQ(contact_surface.num_contact_points(),
             contact_surface2.num_contact_points());
-  /* Verify that penetration distances are not all equal simply because they are
+  /* Verify that pressure values are not all equal simply because they are
    all zero -- some meaningful values do exist. */
-  const auto has_negative_distance =
-      [](const DeformableContactSurface<double>& surface) {
-        const std::vector<double>& sdf = surface.signed_distances();
-        bool negative_distance_exists = false;
-        for (const double d : sdf) {
-          EXPECT_LE(d, 0.0);
-          if (d < 0.0) {
-            negative_distance_exists = true;
-          }
-        }
-        EXPECT_TRUE(negative_distance_exists);
-      };
-  has_negative_distance(contact_surface);
-  const std::vector<double>& sdf = contact_surface.signed_distances();
-  const std::vector<double>& sdf2 = contact_surface2.signed_distances();
-  for (int i = 0; i < contact_surface.num_contact_points(); ++i) {
-    EXPECT_NEAR(sdf[i], sdf2[i], 1e-14);
-  }
+  const auto [min_element, max_element] = std::minmax_element(
+      contact_surface.pressures().begin(), contact_surface.pressures().end());
+  EXPECT_GE(*min_element, 0.0);
+  EXPECT_GT(*max_element, 0.0);
 }
 
 }  // namespace

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -352,8 +352,13 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
                 &anchored_objects_);
   }
 
-  void AddDeformableGeometry(const VolumeMesh<double>& mesh_W, GeometryId id) {
-    geometries_for_deformable_contact_.AddDeformableGeometry(id, mesh_W);
+  void AddDeformableGeometry(const VolumeMesh<double>& mesh_W,
+                             TriangleSurfaceMesh<double> surface_mesh_W,
+                             std::vector<int> surface_index_to_volume_index,
+                             GeometryId id) {
+    geometries_for_deformable_contact_.AddDeformableGeometry(
+        id, mesh_W, std::move(surface_mesh_W),
+        std::move(surface_index_to_volume_index));
     // Currently, even though no collision filtering is done for deformable
     // geometries, the collision filter still needs to be aware of the existence
     // of deformable geometries. This is because collision filters implicitly
@@ -518,10 +523,19 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   void UpdateDeformableVertexPositions(
-      const std::unordered_map<GeometryId, VectorX<T>>& q_WGs) {
+      const std::unordered_map<GeometryId, VectorX<T>>& q_WGs,
+      const std::unordered_map<GeometryId, std::vector<DrivenTriangleMesh>>&
+          driven_meshes) {
     for (const auto& [id, q_WG] : q_WGs) {
+      if (!driven_meshes.contains(id)) {
+        continue;  // No driven meshes for this id because there's no proximity
+                   // role for this geometry.
+      }
+      DRAKE_DEMAND(driven_meshes.at(id).size() == 1);
+      const DrivenTriangleMesh& driven_mesh = driven_meshes.at(id)[0];
       geometries_for_deformable_contact_.UpdateDeformableVertexPositions(
-          id, ExtractDoubleOrThrow(q_WG));
+          id, ExtractDoubleOrThrow(q_WG),
+          driven_mesh.GetDrivenVertexPositions());
     }
   }
 
@@ -1291,9 +1305,11 @@ void ProximityEngine<T>::AddAnchoredGeometry(const Shape& shape,
 }
 
 template <typename T>
-void ProximityEngine<T>::AddDeformableGeometry(const VolumeMesh<double>& mesh,
-                                               GeometryId id) {
-  impl_->AddDeformableGeometry(mesh, id);
+void ProximityEngine<T>::AddDeformableGeometry(
+    const VolumeMesh<double>& mesh, TriangleSurfaceMesh<double> surface_mesh,
+    std::vector<int> surface_index_to_volume_index, GeometryId id) {
+  impl_->AddDeformableGeometry(mesh, std::move(surface_mesh),
+                               std::move(surface_index_to_volume_index), id);
 }
 
 template <typename T>
@@ -1363,8 +1379,10 @@ void ProximityEngine<T>::UpdateWorldPoses(
 
 template <typename T>
 void ProximityEngine<T>::UpdateDeformableVertexPositions(
-    const std::unordered_map<GeometryId, VectorX<T>>& q_WGs) {
-  impl_->UpdateDeformableVertexPositions(q_WGs);
+    const std::unordered_map<GeometryId, VectorX<T>>& q_WGs,
+    const std::unordered_map<GeometryId, std::vector<DrivenTriangleMesh>>&
+        driven_meshes) {
+  impl_->UpdateDeformableVertexPositions(q_WGs, driven_meshes);
 }
 
 template <typename T>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -13,6 +13,7 @@
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/internal_geometry.h"
+#include "drake/geometry/mesh_deformation_interpolator.h"
 #include "drake/geometry/proximity/collision_filter.h"
 #include "drake/geometry/proximity/deformable_contact_internal.h"
 #include "drake/geometry/proximity/hydroelastic_internal.h"
@@ -114,9 +115,19 @@ class ProximityEngine {
    @param mesh_W  The volume mesh representation of the deformable geometry
                   represented in the world frame, including initial positions of
                   the vertices.
+   @param surface_mesh_W
+                  The surface mesh representation of the deformable geometry
+                  represented in the world frame. This is the surface of the
+                  volume mesh `mesh_W`.
+   @param surface_index_to_volume_index
+                  A mapping from the index of a vertex in the surface mesh to
+                  the index of the corresponding vertex in the volume mesh.
    @param id      The id of the geometry in SceneGraph to which this mesh
                   belongs. */
-  void AddDeformableGeometry(const VolumeMesh<double>& mesh_W, GeometryId id);
+  void AddDeformableGeometry(const VolumeMesh<double>& mesh_W,
+                             TriangleSurfaceMesh<double> surface_mesh_W,
+                             std::vector<int> surface_index_to_volume_index,
+                             GeometryId id);
 
   /* Reports if the engine requires a convex hull for the given geometry. */
   bool NeedsConvexHull(const InternalGeometry& geometry) const;
@@ -195,10 +206,17 @@ class ProximityEngine {
                  world frame `W`. If a deformable geometry with the given `id`
                  is registered in the engine (and hasn't been removed), its
                  vertex position is updated to the value in the given map.
+   @param driven_meshes
+                 The mapping from GeometryId `id` to driven triangle meshes for
+                 proximity roles.
    @pre if a deformable geometry with the given `id` is registered, its number
-   of dofs matches the size of the value in the corresponding q_WG. */
+   of dofs matches the size of the value in the corresponding q_WG.
+   @pre if a deformable geometry with the given `id` is registered with a
+   proximity role, driven_mesh.at(id) has size 1. */
   void UpdateDeformableVertexPositions(
-      const std::unordered_map<GeometryId, VectorX<T>>& q_WGs);
+      const std::unordered_map<GeometryId, VectorX<T>>& q_WGs,
+      const std::unordered_map<GeometryId, std::vector<DrivenTriangleMesh>>&
+          driven_meshes);
 
   // ----------------------------------------------------------------------
   /* @name              Signed Distance Queries

--- a/geometry/query_results/deformable_contact.cc
+++ b/geometry/query_results/deformable_contact.cc
@@ -40,11 +40,44 @@ VertexPartialPermutation ContactParticipation::CalcPartialPermutation() const {
 template <typename T>
 DeformableContactSurface<T>::DeformableContactSurface(
     GeometryId id_A, GeometryId id_B, PolygonSurfaceMesh<T> contact_mesh_W,
+    std::vector<T> pressures, std::vector<Vector3<T>> pressure_gradients_W,
+    std::vector<Vector3<int>> contact_vertex_indexes_A,
+    std::vector<Vector3<T>> barycentric_coordinates_A)
+    : id_A_(id_A),
+      id_B_(id_B),
+      contact_mesh_W_(std::move(contact_mesh_W)),
+      pressures_(std::move(pressures)),
+      pressure_gradients_W_(std::move(pressure_gradients_W)),
+      contact_vertex_indexes_A_(std::move(contact_vertex_indexes_A)),
+      barycentric_coordinates_A_(std::move(barycentric_coordinates_A)) {
+  const int num_contact_points = contact_mesh_W_.num_faces();
+  DRAKE_DEMAND(num_contact_points == ssize(*pressures_));
+  DRAKE_DEMAND(num_contact_points == ssize(std::get<std::vector<Vector3<T>>>(
+                                         barycentric_coordinates_A_)));
+  DRAKE_DEMAND(num_contact_points == ssize(std::get<std::vector<Vector3<int>>>(
+                                         contact_vertex_indexes_A_)));
+  nhats_W_.reserve(num_contact_points);
+  contact_points_W_.reserve(num_contact_points);
+  R_WCs_.reserve(num_contact_points);
+  const int kZAxis = 2;
+  for (int i = 0; i < num_contact_points; ++i) {
+    /* Ensure that in rigid deformable contact, the normal is pointing from
+     rigid to deformable (i.e. from B into A). */
+    nhats_W_.emplace_back(-contact_mesh_W_.face_normal(i));
+    contact_points_W_.emplace_back(contact_mesh_W_.element_centroid(i));
+    R_WCs_.emplace_back(
+        math::RotationMatrix<T>::MakeFromOneUnitVector(-nhats_W_[i], kZAxis));
+  }
+}
+
+template <typename T>
+DeformableContactSurface<T>::DeformableContactSurface(
+    GeometryId id_A, GeometryId id_B, PolygonSurfaceMesh<T> contact_mesh_W,
     std::vector<T> signed_distances,
     std::vector<Vector4<int>> contact_vertex_indexes_A,
     std::vector<Vector4<T>> barycentric_coordinates_A,
-    std::optional<std::vector<Vector4<int>>> contact_vertex_indexes_B,
-    std::optional<std::vector<Vector4<T>>> barycentric_coordinates_B)
+    std::vector<Vector4<int>> contact_vertex_indexes_B,
+    std::vector<Vector4<T>> barycentric_coordinates_B)
     : id_A_(id_A),
       id_B_(id_B),
       contact_mesh_W_(std::move(contact_mesh_W)),
@@ -54,21 +87,14 @@ DeformableContactSurface<T>::DeformableContactSurface(
       contact_vertex_indexes_B_(std::move(contact_vertex_indexes_B)),
       barycentric_coordinates_B_(std::move(barycentric_coordinates_B)) {
   const int num_contact_points = contact_mesh_W_.num_faces();
-  DRAKE_DEMAND(num_contact_points ==
-               static_cast<int>(signed_distances_.size()));
-  DRAKE_DEMAND(num_contact_points ==
-               static_cast<int>(barycentric_coordinates_A_.size()));
-  DRAKE_DEMAND(num_contact_points ==
-               static_cast<int>(contact_vertex_indexes_A_.size()));
-  DRAKE_DEMAND(contact_vertex_indexes_B_.has_value() ==
-               barycentric_coordinates_B_.has_value());
-  if (contact_vertex_indexes_B_.has_value()) {
-    DRAKE_DEMAND(num_contact_points ==
-                 static_cast<int>(barycentric_coordinates_B_->size()));
-    DRAKE_DEMAND(num_contact_points ==
-                 static_cast<int>(contact_vertex_indexes_B_->size()));
-    DRAKE_DEMAND(id_A < id_B);
-  }
+  DRAKE_DEMAND(num_contact_points == ssize(*signed_distances_));
+  DRAKE_DEMAND(num_contact_points == ssize(std::get<std::vector<Vector4<int>>>(
+                                         contact_vertex_indexes_A_)));
+  DRAKE_DEMAND(num_contact_points == ssize(std::get<std::vector<Vector4<T>>>(
+                                         barycentric_coordinates_A_)));
+  DRAKE_DEMAND(num_contact_points == ssize(*barycentric_coordinates_B_));
+  DRAKE_DEMAND(num_contact_points == ssize(*contact_vertex_indexes_B_));
+  DRAKE_DEMAND(id_A < id_B);
   nhats_W_.reserve(num_contact_points);
   contact_points_W_.reserve(num_contact_points);
   R_WCs_.reserve(num_contact_points);
@@ -91,12 +117,15 @@ template <typename T>
 void DeformableContact<T>::AddDeformableRigidContactSurface(
     GeometryId deformable_id, GeometryId rigid_id,
     const std::unordered_set<int>& participating_vertices,
-    PolygonSurfaceMesh<T> contact_mesh_W, std::vector<T> signed_distances,
-    std::vector<Vector4<int>> contact_vertex_indexes,
-    std::vector<Vector4<T>> barycentric_coordinates) {
+    PolygonSurfaceMesh<T> contact_mesh_W, std::vector<T> pressures,
+    std::vector<Vector3<T>> pressure_gradients_W,
+    std::vector<Vector3<int>> contact_vertex_indexes,
+    std::vector<Vector3<T>> barycentric_coordinates) {
   const auto iter = contact_participations_.find(deformable_id);
   DRAKE_THROW_UNLESS(iter != contact_participations_.end());
-  DRAKE_DEMAND(static_cast<int>(signed_distances.size()) ==
+  DRAKE_DEMAND(static_cast<int>(pressures.size()) ==
+               contact_mesh_W.num_faces());
+  DRAKE_DEMAND(static_cast<int>(pressure_gradients_W.size()) ==
                contact_mesh_W.num_faces());
   DRAKE_DEMAND(static_cast<int>(contact_vertex_indexes.size()) ==
                contact_mesh_W.num_faces());
@@ -104,9 +133,9 @@ void DeformableContact<T>::AddDeformableRigidContactSurface(
                contact_mesh_W.num_faces());
   iter->second.Participate(participating_vertices);
   contact_surfaces_.emplace_back(
-      deformable_id, rigid_id, std::move(contact_mesh_W),
-      std::move(signed_distances), std::move(contact_vertex_indexes),
-      std::move(barycentric_coordinates), std::nullopt, std::nullopt);
+      deformable_id, rigid_id, std::move(contact_mesh_W), std::move(pressures),
+      std::move(pressure_gradients_W), std::move(contact_vertex_indexes),
+      std::move(barycentric_coordinates));
 }
 
 template <typename T>

--- a/geometry/query_results/deformable_contact.h
+++ b/geometry/query_results/deformable_contact.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include "drake/geometry/geometry_ids.h"
@@ -106,11 +107,45 @@ class DeformableContactSurface {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformableContactSurface);
 
-  /* Constructs a deformable contact surface with the given data.
+  /* Constructs a deformable contact surface between a deformable geometry and a
+   rigid geometry with the given data.
    @param[in] id_A
       The GeometryId of the deformable geometry A.
    @param[in] id_B
-      The GeometryId of the geometry B that may be deformable.
+      The GeometryId of the rigid geometry B.
+   @param[in] contact_mesh_W
+      The contact surface mesh expressed in the world frame. The normals of the
+      mesh point out of B into A.
+   @param[in] pressures
+      The hydroelastic pressure sampled on `contact_mesh_W`. These values are
+      non-negative. Note that there is one pressure value per contact point and
+      the i-th pressure corresponds to the i-th element in the contact mesh.
+   @param[in] pressure_gradients_W
+      The pressure gradient at the contact points expressed in the world frame,
+      with the same index semantics as pressure.
+   @param[in] contact_vertex_indexes_A
+      Vector of three vertex indexes of the triangle in the surface mesh of
+      geometry A containing each contact point with the same index semantics as
+      `pressure`.
+   @param[in] barycentric_coordinates_A
+      Barycentric coordinates of centroids of contact polygons with respect to
+      their containing triangle in mesh A with the same index semantics as
+      `pressure`.
+   @pre contact_mesh_W.num_faces() == pressure.size().
+   @pre contact_mesh_W.num_faces() == contact_vertex_indexes_A.size().
+   @pre contact_mesh_W.num_faces() == barycentric_coordinates_A.size(). */
+  DeformableContactSurface(GeometryId id_A, GeometryId id_B,
+                           PolygonSurfaceMesh<T> contact_mesh_W,
+                           std::vector<T> pressures,
+                           std::vector<Vector3<T>> pressure_gradients_W,
+                           std::vector<Vector3<int>> contact_vertex_indexes_A,
+                           std::vector<Vector3<T>> barycentric_coordinates_A);
+
+  /* Constructs a deformable-deformable contact surface with the given data.
+   @param[in] id_A
+      The GeometryId of the deformable geometry A.
+   @param[in] id_B
+      The GeometryId of the deformable geometry B.
    @param[in] contact_mesh_W
       The contact surface mesh expressed in the world frame. The normals of the
       mesh point out of B into A.
@@ -130,25 +165,23 @@ class DeformableContactSurface {
    @param[in] contact_vertex_indexes_B
       Vector of four vertex indexes of the tetrahedra in the mesh of geometry B
       containing each contact point with the same index semantics as
-      `signed_distances` if B is deformable. std::nullopt otherwise.
+      `signed_distances`.
    @param[in] barycentric_coordinates_B
       Barycentric coordinates of centroids of contact polygons with respect to
-      their containing tetrahedra in mesh B if B is deformable. std::nullopt
-      otherwise.
-   @pre id_A < id_B if both geometries are deformable.
+      their containing tetrahedra in mesh B.
+   @pre id_A < id_B.
    @pre contact_mesh_W.num_faces() == signed_distances.size().
    @pre contact_mesh_W.num_faces() == contact_vertex_indexes_A.size().
    @pre contact_mesh_W.num_faces() == barycentric_coordinates_A.size().
-   @pre contact_vertex_indexes_B and barycentric_coordinates_B are both
-        std::nullopts when geometry B is rigid and both have values with size
-        equal to contact_mesh_W.num_faces() when geometry B is deformable. */
-  DeformableContactSurface(
-      GeometryId id_A, GeometryId id_B, PolygonSurfaceMesh<T> contact_mesh_W,
-      std::vector<T> signed_distances,
-      std::vector<Vector4<int>> contact_vertex_indexes_A,
-      std::vector<Vector4<T>> barycentric_coordinates_A,
-      std::optional<std::vector<Vector4<int>>> contact_vertex_indexes_B,
-      std::optional<std::vector<Vector4<T>>> barycentric_coordinates_B);
+   @pre contact_mesh_W.num_faces() == contact_vertex_indexes_B.size().
+   @pre contact_mesh_W.num_faces() == barycentric_coordinates_B.size(). */
+  DeformableContactSurface(GeometryId id_A, GeometryId id_B,
+                           PolygonSurfaceMesh<T> contact_mesh_W,
+                           std::vector<T> signed_distances,
+                           std::vector<Vector4<int>> contact_vertex_indexes_A,
+                           std::vector<Vector4<T>> barycentric_coordinates_A,
+                           std::vector<Vector4<int>> contact_vertex_indexes_B,
+                           std::vector<Vector4<T>> barycentric_coordinates_B);
 
   ~DeformableContactSurface();
 
@@ -165,50 +198,100 @@ class DeformableContactSurface {
   }
 
   /* Returns the total number of contact points on this contact surface. */
-  int num_contact_points() const { return signed_distances_.size(); }
+  int num_contact_points() const { return contact_mesh_W_.num_faces(); }
 
-  /* Returns the *approximations* of signed distances at all contact points. The
-     approximate signed distance values have the following properties:
+  /* Returns the *approximations* of signed distances at all contact points if
+   `this` is a deformable-deformable contact surface. The approximate signed
+   distance values have the following properties:
      1. Contact points on the surface of a deformable geometry will report
         with zero distances.
-     2. The signed distance values for all contact points are non-positive. */
-  const std::vector<T>& signed_distances() const { return signed_distances_; }
+     2. The signed distance values for all contact points are non-positive.
+   @pre is_B_deformable() is true. */
+  const std::vector<T>& signed_distances() const {
+    DRAKE_THROW_UNLESS(is_B_deformable());
+    return *signed_distances_;
+  }
+
+  /* Returns the pressure values at all contact points if `this` is a
+   deformable-rigid contact surface.
+   @pre is_B_deformable() is false. */
+  const std::vector<T>& pressures() const {
+    DRAKE_THROW_UNLESS(!is_B_deformable());
+    return *pressures_;
+  }
+
+  /* Returns the pressure gradients (in the world frame) at all contact points
+   if `this` is a deformable-rigid contact surface.
+   @pre is_B_deformable() is false. */
+  const std::vector<Vector3<T>>& pressure_gradients_W() const {
+    DRAKE_THROW_UNLESS(!is_B_deformable());
+    return *pressure_gradients_W_;
+  }
 
   /* Returns the world frame positions of the contact_points. The ordering of
-   contact points is the same as that in `signed_distances()`.*/
+   contact points is the same as that in `signed_distances()` or `pressures()`.
+  */
   const std::vector<Vector3<T>>& contact_points_W() const {
     return contact_points_W_;
   }
 
-  /* Returns the barycentric coordinates of each contact point in its containing
-   tetrahedron in the deformable geometry A's mesh. The ordering of barycentric
-   coordinates is the same as that in `signed_distances()`. */
-  const std::vector<Vector4<T>>& barycentric_coordinates_A() const {
-    return barycentric_coordinates_A_;
+  /* If `this` is a deformable-rigid contact surface, returns the
+   barycentric coordinates of each contact point within the triangle in
+   deformable geometry A's mesh that contains the contact point. The ordering of
+   barycentric coordinates is the same as that in `pressures()`.
+   @pre is_B_deformable() is false. */
+  const std::vector<Vector3<T>>& tri_barycentric_coordinates_A() const {
+    DRAKE_THROW_UNLESS(!is_B_deformable());
+    return std::get<std::vector<Vector3<T>>>(barycentric_coordinates_A_);
   }
 
-  /* Returns the indexes of the 4 vertices forming the tetrahedra containing the
-   contact points in the deformable geometry A's mesh. The ordering of contact
-   vertex indexes is the same as that in `signed_distances()`. */
-  const std::vector<Vector4<int>>& contact_vertex_indexes_A() const {
-    return contact_vertex_indexes_A_;
+  /* If `this` is a deformable-rigid contact surface, returns the volume mesh
+   indexes of the 3 vertices forming the triangle (in arbitrary order)
+   containing the contact points in the deformable geometry A's mesh. The
+   ordering of contact vertex indexes is the same as that in `pressures()`.
+   @pre is_B_deformable() is false  */
+  const std::vector<Vector3<int>>& tri_contact_vertex_indexes_A() const {
+    DRAKE_THROW_UNLESS(!is_B_deformable());
+    return std::get<std::vector<Vector3<int>>>(contact_vertex_indexes_A_);
   }
 
-  /* If geometry B is deformable, returns the barycentric coordinates of each
-   contact point in its containing tetrahedron in the deformable geometry A's
-   mesh. The ordering of barycentric coordinates is the same as that in
+  /* If `this` is a deformable-deformable contact surface, returns the
+   barycentric coordinates of each contact point within the tetrahedron in the
+   deformable geometry A's mesh that contains the contact point. The ordering of
+   barycentric coordinates is the same as that in `signed_distances()`.
+   @pre is_B_deformable() is true. */
+  const std::vector<Vector4<T>>& tet_barycentric_coordinates_A() const {
+    DRAKE_THROW_UNLESS(is_B_deformable());
+    return std::get<std::vector<Vector4<T>>>(barycentric_coordinates_A_);
+  }
+
+  /* If `this` is a deformable-deformable contact surface, returns the volume
+   mesh indexes of the 4 vertices forming the tetrahedron (in arbitrary order)
+   containing the contact points in the deformable geometry A's mesh. The
+   ordering of contact vertex indexes is the same as that in
    `signed_distances()`.
-   @throws std::exception if geometry B is not deformable. */
+   @pre is_B_deformable() is true.  */
+  const std::vector<Vector4<int>>& tet_contact_vertex_indexes_A() const {
+    DRAKE_THROW_UNLESS(is_B_deformable());
+    return std::get<std::vector<Vector4<int>>>(contact_vertex_indexes_A_);
+  }
+
+  /* If `this` is a deformable-deformable contact surface, returns the
+   tetrahedral barycentric coordinates of each contact point in its containing
+   in the deformable geometry B's mesh. The ordering of barycentric coordinates
+   is the same as that in `signed_distances()`.
+   @pre is_B_deformable() is true. */
   const std::vector<Vector4<T>>& barycentric_coordinates_B() const {
     DRAKE_THROW_UNLESS(is_B_deformable());
     return *barycentric_coordinates_B_;
   }
 
-  /* If geometry B is deformable, returns the indexes of the 4 vertices forming
-   the tetrahedra containing the contact points in the deformable geometry A's
-   mesh. The ordering of contact vertex indexes is the same as that in
+  /* If `this` is a deformable-deformable contact surface, returns the volume
+   mesh indexes of the 4 vertices forming the tetrahedron (in arbitrary order)
+   containing the contact points in the deformable geometry B's mesh. The
+   ordering of contact vertex indexes is the same as that in
    `signed_distances()`.
-   @throws std::exception if geometry B is not deformable. */
+   @pre is_B_deformable() is true.  */
   const std::vector<Vector4<int>>& contact_vertex_indexes_B() const {
     DRAKE_THROW_UNLESS(is_B_deformable());
     return *contact_vertex_indexes_B_;
@@ -216,15 +299,15 @@ class DeformableContactSurface {
 
   /* Returns the world frame contact normals pointing from geometry B into
    geometry A. The ordering of contact normals is the same as that in
-   `signed_distances()`.*/
+   `signed_distances()` or `pressures`. */
   const std::vector<Vector3<T>>& nhats_W() const { return nhats_W_; }
 
   /* Returns rotation matrices that transform the basis of frame W into the
    basis of an arbitrary frame C. In this transformation, the z-axis of frame,
    Cz, is aligned with the vector n̂. The vector n̂ represents the normal as
-   reported in `nhats_W()`. Cx and Cy are arbitrary but sufficient to form the
-   right-handed basis. The ordering of rotation matrices is the same as that in
-   `signed_distances()`. */
+   opposite to the one reported in `nhats_W()`. Cx and Cy are arbitrary but
+   sufficient to form the right-handed basis. The ordering of rotation matrices
+   is the same as that in `signed_distances()` or `pressures()`. */
   const std::vector<math::RotationMatrix<T>>& R_WCs() const { return R_WCs_; }
 
   bool is_B_deformable() const { return contact_vertex_indexes_B_.has_value(); }
@@ -235,9 +318,13 @@ class DeformableContactSurface {
   PolygonSurfaceMesh<T> contact_mesh_W_;
   /* per-contact point data. */
   std::vector<Vector3<T>> contact_points_W_;
-  std::vector<T> signed_distances_;
-  std::vector<Vector4<int>> contact_vertex_indexes_A_;
-  std::vector<Vector4<T>> barycentric_coordinates_A_;
+  std::optional<std::vector<T>> pressures_;
+  std::optional<std::vector<T>> signed_distances_;
+  std::optional<std::vector<Vector3<T>>> pressure_gradients_W_;
+  std::variant<std::vector<Vector3<int>>, std::vector<Vector4<int>>>
+      contact_vertex_indexes_A_;
+  std::variant<std::vector<Vector3<T>>, std::vector<Vector4<T>>>
+      barycentric_coordinates_A_;
   std::optional<std::vector<Vector4<int>>> contact_vertex_indexes_B_;
   std::optional<std::vector<Vector4<T>>> barycentric_coordinates_B_;
   std::vector<Vector3<T>> nhats_W_;
@@ -280,35 +367,43 @@ class DeformableContact {
      The GeometryId of the rigid geometry.
   @param[in] participating_vertices
      Each contact polygon in `contact_mesh_W` is completely contained within
-     one tetrahedron of the deformable mesh. `participating_vertices` contains
-     the indexes of vertices incident to all such tetrahedra.
+     one triangle of the deformable surface mesh. `participating_vertices`
+     contains the _volume mesh_ indexes of vertices into the full deformable
+     _volume_ mesh.
   @param[in] contact_mesh_W
      The contact surface mesh expressed in the world frame. The normals of the
      mesh point out of the rigid geometry.
-  @param[in] signed_distances
-     _Approximate_ signed distances of penetration sampled on `contact_mesh_W`.
-     These values are non-positive. Note that there is one signed distance
-     value per contact point and the i-th signed distance corresponds to the
-     i-th element in the contact mesh.
+  @param[in] pressures
+     Hydroelastic pressure of the rigid body sampled on `contact_mesh_W`.
+     These values are non-negative. Note that there is one pressure value per
+     contact point and the i-th signed distance corresponds to the i-th element
+     in the contact mesh.
+  @param[in] pressure_gradients_W
+     Hydroelastic pressure gradients of the rigid body sampled on
+     `contact_mesh_W`, expressed in the world frame.
   @param[in] contact_vertex_indexes
-     Vector of four vertex indexes of the tetrahedra in the mesh of the
-     deformable geometry containing each contact point with the same index
-     semantics as `signed_distances`.
+     Vector of three vertex indexes of the triangle in contact. Note that the
+     indexes are the indexes into the volume mesh's vertices. The ordering of
+     contact vertex indexes is the same as that in `pressure`.
   @param[in] barycentric_coordinates
      Barycentric coordinates of centroids of contact polygons with respect to
-     their containing tetrahedra in the mesh of the deformable geometry with
-     the same index semantics as `signed_distances`.
+     their containing triangle in the surface mesh of the deformable geometry.
+     This has the ordering semantics as `pressure`.
   @pre A deformable geometry with the given `deformable_id` has been registered
      via `RegisterDeformableGeometry()`.
-  @pre contact_mesh_W.num_faces() == signed_distances.size().
+  @pre contact_mesh_W.num_faces() == pressures.size().
+  @pre contact_mesh_W.num_faces() == pressure_gradients_W.size().
   @pre contact_mesh_W.num_faces() == contact_vertex_indexes.size().
   @pre contact_mesh_W.num_faces() == barycentric_coordinates.size(). */
   void AddDeformableRigidContactSurface(
       GeometryId deformable_id, GeometryId rigid_id,
       const std::unordered_set<int>& participating_vertices,
-      PolygonSurfaceMesh<T> contact_mesh_W, std::vector<T> signed_distances,
-      std::vector<Vector4<int>> contact_vertex_indexes,
-      std::vector<Vector4<T>> barycentric_coordinates);
+      // TODO(xuchenhan-tri): The sign of the has been flipped from changing
+      // from sign-distance to pressure. Confirm the implications.
+      PolygonSurfaceMesh<T> contact_mesh_W, std::vector<T> pressures,
+      std::vector<Vector3<T>> pressure_gradients_W,
+      std::vector<Vector3<int>> contact_vertex_indexes,
+      std::vector<Vector3<T>> barycentric_coordinates);
 
   /* Adds a contact surface between two deformable geometries.
   @param[in] id0

--- a/geometry/query_results/test/deformable_contact_test.cc
+++ b/geometry/query_results/test/deformable_contact_test.cc
@@ -62,19 +62,40 @@ GTEST_TEST(ContactParticipation, SomeVerticesAreParticipating) {
   EXPECT_EQ(dof.permutation(), kExpectedDofPermutation);
 }
 
-/* Tests the constructor constructs an empty DeformableContactSurface. */
+/* Tests the constructor constructs an empty (deformable vs. rigid)
+ DeformableContactSurface. */
 GTEST_TEST(DeformableContactSurface, EmptySurface) {
+  /* Deformable rigid surface constructor. */
+  DeformableContactSurface<double> dut(kIdA, kIdB, {}, {}, {}, {}, {});
+  EXPECT_EQ(dut.id_A(), kIdA);
+  EXPECT_EQ(dut.id_B(), kIdB);
+  EXPECT_EQ(dut.num_contact_points(), 0);
+  EXPECT_EQ(dut.contact_points_W().size(), 0);
+  EXPECT_EQ(dut.pressures().size(), 0);
+  EXPECT_EQ(dut.pressure_gradients_W().size(), 0);
+  EXPECT_EQ(dut.tri_barycentric_coordinates_A().size(), 0);
+  EXPECT_EQ(dut.tri_contact_vertex_indexes_A().size(), 0);
+  EXPECT_EQ(dut.nhats_W().size(), 0);
+  EXPECT_EQ(dut.R_WCs().size(), 0);
+  EXPECT_FALSE(dut.is_B_deformable());
+}
+
+/* Tests the constructor constructs an empty (deformable vs. deformable)
+ DeformableContactSurface. */
+GTEST_TEST(DeformableContactSurface, EmptySurface2) {
   DeformableContactSurface<double> dut(kIdA, kIdB, {}, {}, {}, {}, {}, {});
   EXPECT_EQ(dut.id_A(), kIdA);
   EXPECT_EQ(dut.id_B(), kIdB);
   EXPECT_EQ(dut.num_contact_points(), 0);
   EXPECT_EQ(dut.contact_points_W().size(), 0);
   EXPECT_EQ(dut.signed_distances().size(), 0);
-  EXPECT_EQ(dut.barycentric_coordinates_A().size(), 0);
-  EXPECT_EQ(dut.contact_vertex_indexes_A().size(), 0);
+  EXPECT_EQ(dut.tet_barycentric_coordinates_A().size(), 0);
+  EXPECT_EQ(dut.tet_contact_vertex_indexes_A().size(), 0);
+  EXPECT_EQ(dut.barycentric_coordinates_B().size(), 0);
+  EXPECT_EQ(dut.contact_vertex_indexes_B().size(), 0);
   EXPECT_EQ(dut.nhats_W().size(), 0);
   EXPECT_EQ(dut.R_WCs().size(), 0);
-  EXPECT_FALSE(dut.is_B_deformable());
+  EXPECT_TRUE(dut.is_B_deformable());
 }
 
 GTEST_TEST(DeformableContactSurface, Getters) {
@@ -104,9 +125,9 @@ GTEST_TEST(DeformableContactSurface, Getters) {
   EXPECT_EQ(dut.num_contact_points(), 1);
   EXPECT_EQ(dut.contact_points_W(), contact_points_W);
   EXPECT_EQ(dut.signed_distances(), signed_distances);
-  EXPECT_EQ(dut.contact_vertex_indexes_A(), vertex_indexes_A);
+  EXPECT_EQ(dut.tet_contact_vertex_indexes_A(), vertex_indexes_A);
   EXPECT_EQ(dut.contact_vertex_indexes_B(), vertex_indexes_B);
-  EXPECT_EQ(dut.barycentric_coordinates_A(), barycentric_centroids_A);
+  EXPECT_EQ(dut.tet_barycentric_coordinates_A(), barycentric_centroids_A);
   EXPECT_EQ(dut.barycentric_coordinates_B(), barycentric_centroids_B);
   EXPECT_EQ(dut.nhats_W(), nhats_W);
   EXPECT_EQ(dut.R_WCs().size(), dut.nhats_W().size());
@@ -145,14 +166,15 @@ GTEST_TEST(DeformableContact, AddDeformableRigidContactSurface) {
       });
   const std::vector<Vector3<double>> contact_points_W = {
       {1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0}};
-  const std::vector<double> signed_distances = {-0.25};
-  const std::vector<Vector4<int>> contact_vertex_indexes = {{0, 3, 2, 5}};
-  const std::vector<Vector4<double>> barycentric_centroids = {
-      {0.1, 0.2, 0.3, 0.4}};
+  const std::vector<double> pressures = {0.25};
+  const std::vector<Vector3<double>> pressure_gradients = {
+      Vector3<double>(0.25, 0.26, 0.27)};
+  const std::vector<Vector3<int>> contact_vertex_indexes = {{0, 3, 2}};
+  const std::vector<Vector3<double>> barycentric_centroids = {{0.2, 0.3, 0.5}};
 
-  dut.AddDeformableRigidContactSurface(kIdA, kIdB, {0, 3, 2, 5}, contact_mesh_W,
-                                       signed_distances, contact_vertex_indexes,
-                                       barycentric_centroids);
+  dut.AddDeformableRigidContactSurface(
+      kIdA, kIdB, {0, 3, 2}, contact_mesh_W, pressures, pressure_gradients,
+      contact_vertex_indexes, barycentric_centroids);
   /* Verify that the contact surface is as expected. */
   const std::vector<DeformableContactSurface<double>>& surfaces =
       dut.contact_surfaces();
@@ -162,12 +184,12 @@ GTEST_TEST(DeformableContact, AddDeformableRigidContactSurface) {
   EXPECT_EQ(s.id_B(), kIdB);
   EXPECT_EQ(s.num_contact_points(), 1);
   EXPECT_EQ(s.contact_points_W(), contact_points_W);
-  EXPECT_EQ(s.signed_distances(), signed_distances);
-  EXPECT_EQ(s.contact_vertex_indexes_A(), contact_vertex_indexes);
-  EXPECT_EQ(s.barycentric_coordinates_A(), barycentric_centroids);
+  EXPECT_EQ(s.pressures(), pressures);
+  EXPECT_EQ(s.tri_contact_vertex_indexes_A(), contact_vertex_indexes);
+  EXPECT_EQ(s.tri_barycentric_coordinates_A(), barycentric_centroids);
   EXPECT_FALSE(s.is_B_deformable());
   /* Verify that contact participation is as expected. */
-  EXPECT_EQ(dut.contact_participation(kIdA).num_vertices_in_contact(), 4);
+  EXPECT_EQ(dut.contact_participation(kIdA).num_vertices_in_contact(), 3);
 }
 
 GTEST_TEST(DeformableContact, Participate) {
@@ -226,8 +248,8 @@ GTEST_TEST(DeformableContact, AddDeformableDeformableContactSurface) {
   EXPECT_EQ(s.num_contact_points(), 1);
   EXPECT_EQ(s.signed_distances(), signed_distances);
   EXPECT_EQ(s.contact_points_W(), contact_points_W);
-  EXPECT_EQ(s.barycentric_coordinates_A(), barycentric_centroids_A);
-  EXPECT_EQ(s.contact_vertex_indexes_A(), contact_vertex_indexes_A);
+  EXPECT_EQ(s.tet_barycentric_coordinates_A(), barycentric_centroids_A);
+  EXPECT_EQ(s.tet_contact_vertex_indexes_A(), contact_vertex_indexes_A);
   EXPECT_EQ(s.barycentric_coordinates_B(), barycentric_centroids_B);
   EXPECT_EQ(s.contact_vertex_indexes_B(), contact_vertex_indexes_B);
   EXPECT_EQ(s.nhats_W().size(), 1);

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -748,12 +748,12 @@ void SceneGraph<T>::CalcConfigurationUpdate(const Context<T>& context,
 
   for (const auto role : std::vector<Role>{
            Role::kIllustration, Role::kPerception, Role::kProximity}) {
-    state.mutable_driven_mesh_data(role).SetControlMeshPositions(
+    kinematics_data.driven_mesh_data[role].SetControlMeshPositions(
         kinematics_data.q_WGs);
   }
-  state.FinalizeConfigurationUpdate(
-      kinematics_data, state.mutable_driven_mesh_data(Role::kPerception),
-      &state.mutable_proximity_engine(), state.GetMutableRenderEngines());
+  state.FinalizeConfigurationUpdate(kinematics_data,
+                                    &state.mutable_proximity_engine(),
+                                    state.GetMutableRenderEngines());
 }
 
 template <typename T>

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -407,7 +407,7 @@ class SceneGraphInspector {
                            acquired.
    @throws std::exception  if `geometry_id` does not map to a registered
                            deformable geometry with the given `role` or if
-                           `role` is Role::kUnassigned.
+                           `role` is undefined.
    @experimental */
   const std::vector<internal::RenderMesh>& GetDrivenRenderMeshes(
       GeometryId geometry_id, Role role) const;

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -17,6 +17,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/geometry_state.h"
 #include "drake/geometry/proximity/deformable_contact_internal.h"
 #include "drake/geometry/proximity/make_sphere_mesh.h"
 #include "drake/geometry/proximity/mesh_distance_boundary.h"
@@ -4655,10 +4656,14 @@ class ProximityEngineDeformableContactTest : public testing::Test {
         const_cast<internal::deformable::Geometries*>(&geometries));
   }
 
-  ProximityProperties MakeProximityPropsWithRezHint(double resolution_hint) {
+  // Makes proximity properties that allows a geometry to be registered as a
+  // rigid geometry for deformable contact.
+  ProximityProperties MakeProximityPropsForRigidGeometry(
+      double resolution_hint) {
     ProximityProperties props;
     props.AddProperty(internal::kHydroGroup, internal::kRezHint,
                       resolution_hint);
+    props.AddProperty(internal::kHydroGroup, internal::kElastic, 1e6);
     return props;
   }
 
@@ -4683,15 +4688,30 @@ class ProximityEngineDeformableContactTest : public testing::Test {
         deformable_contact_geometries(), id);
   }
 
-  // Registers a deformable sphere with the proximity engine. Returns the id of
-  // the newly registered geometry.
+  // Given the volume mesh of a deformable geometry, registers it with the
+  // proximity engine and stores the driven mesh data in the testing class.
+  void AddDeformableGeometry(const VolumeMesh<double>& mesh, GeometryId id) {
+    std::vector<int> surface_vertices;
+    TriangleSurfaceMesh<double> surface_mesh =
+        ConvertVolumeToSurfaceMeshWithBoundaryVertices(mesh, &surface_vertices);
+    engine_.AddDeformableGeometry(mesh, surface_mesh, surface_vertices, id);
+
+    VertexSampler vertex_sampler(std::move(surface_vertices), mesh);
+    std::vector<DrivenTriangleMesh> driven_meshes;
+    driven_meshes.emplace_back(vertex_sampler, surface_mesh);
+    driven_mesh_data_.SetMeshes(id, std::move(driven_meshes));
+  }
+
+  // Registers a deformable sphere with the proximity engine and stores the
+  // driven mesh data in the testing class. Returns the id of the
+  // newly registered geometry.
   GeometryId AddDeformableSphere() {
     constexpr double kResolutionHint = 0.5;
     Sphere sphere(kSphereRadius);
     const VolumeMesh<double> input_mesh = MakeSphereVolumeMesh<double>(
         sphere, kResolutionHint, TessellationStrategy::kDenseInteriorVertices);
     const GeometryId id = GeometryId::get_new_id();
-    engine_.AddDeformableGeometry(input_mesh, id);
+    AddDeformableGeometry(input_mesh, id);
     return id;
   }
 
@@ -4750,6 +4770,7 @@ class ProximityEngineDeformableContactTest : public testing::Test {
   }
 
   ProximityEngine<double> engine_;
+  internal::DrivenMeshData driven_mesh_data_;
 };
 
 // Tests that registration of supported rigid (non-deformable) geometries make
@@ -4757,7 +4778,7 @@ class ProximityEngineDeformableContactTest : public testing::Test {
 // Also verifies that no geometry is added if the resolution hint property is
 // missing.
 TEST_F(ProximityEngineDeformableContactTest, AddSupportedRigidGeometries) {
-  ProximityProperties valid_props = MakeProximityPropsWithRezHint(1.0);
+  ProximityProperties valid_props = MakeProximityPropsForRigidGeometry(1.0);
   ProximityProperties empty_props;
   {
     Sphere sphere(0.5);
@@ -4800,7 +4821,7 @@ TEST_F(ProximityEngineDeformableContactTest, AddSupportedRigidGeometries) {
 // Tests that registration of geometries supported by ProximityEngine but not
 // supported by deforamble contact (aka HalfSpace) doesn't throw.
 TEST_F(ProximityEngineDeformableContactTest, AddUnsupportedRigidGeometries) {
-  ProximityProperties valid_props = MakeProximityPropsWithRezHint(1.0);
+  ProximityProperties valid_props = MakeProximityPropsForRigidGeometry(1.0);
   HalfSpace half_space;
   EXPECT_NO_THROW(
       TestRigidRegistrationAndRemoval(half_space, valid_props, false));
@@ -4838,7 +4859,7 @@ TEST_F(ProximityEngineDeformableContactTest, ReplacePropertiesRigid) {
   // Case: The new properties have resolution hint while the old do not; this
   // should add a new deformable contact rigid representation.
   {
-    ProximityProperties props = MakeProximityPropsWithRezHint(1.0);
+    ProximityProperties props = MakeProximityPropsForRigidGeometry(1.0);
     DRAKE_EXPECT_NO_THROW(
         engine_.UpdateRepresentationForNewProperties(sphere, props));
     EXPECT_TRUE(deformable_contact_geometries().is_rigid(sphere.id()));
@@ -4852,18 +4873,16 @@ TEST_F(ProximityEngineDeformableContactTest, ReplacePropertiesRigid) {
         deformable::GeometriesTester::get_rigid_geometry(
             deformable_contact_geometries(), sphere.id());
     const RigidTransformd X_WG_old = geometry_old.pose_in_world();
-    const int num_vertices_old =
-        geometry_old.rigid_mesh().mesh().num_vertices();
+    const int num_vertices_old = geometry_old.mesh().mesh().num_vertices();
 
-    ProximityProperties props = MakeProximityPropsWithRezHint(0.5);
+    ProximityProperties props = MakeProximityPropsForRigidGeometry(0.5);
     engine_.UpdateRepresentationForNewProperties(sphere, props);
 
     const deformable::RigidGeometry geometry_new =
         deformable::GeometriesTester::get_rigid_geometry(
             deformable_contact_geometries(), sphere.id());
     const RigidTransformd X_WG_new = geometry_new.pose_in_world();
-    const int num_vertices_new =
-        geometry_new.rigid_mesh().mesh().num_vertices();
+    const int num_vertices_new = geometry_new.mesh().mesh().num_vertices();
 
     EXPECT_TRUE(deformable_contact_geometries().is_rigid(sphere.id()));
     EXPECT_TRUE(X_WG_new.IsExactlyEqualTo(X_WG_old));
@@ -4899,7 +4918,7 @@ TEST_F(ProximityEngineDeformableContactTest, ReplacePropertiesDeformable) {
   // Case: The new and old properties are both valid proximity properties. The
   // update is a no-op in this case.
   ProximityProperties props;
-  engine_.AddDeformableGeometry(*sphere.reference_mesh(), sphere.id());
+  AddDeformableGeometry(*sphere.reference_mesh(), sphere.id());
   EXPECT_TRUE(deformable_contact_geometries().is_deformable(sphere.id()));
   const internal::deformable::DeformableGeometry& old_geometry =
       deformable_geometry(sphere.id());
@@ -4909,17 +4928,17 @@ TEST_F(ProximityEngineDeformableContactTest, ReplacePropertiesDeformable) {
   const internal::deformable::DeformableGeometry& new_geometry =
       deformable_geometry(sphere.id());
   // Verify that the content didn't change.
-  EXPECT_TRUE(old_geometry.deformable_mesh().mesh().Equal(
-      new_geometry.deformable_mesh().mesh()));
-  EXPECT_TRUE(old_geometry.deformable_mesh().bvh().Equal(
-      new_geometry.deformable_mesh().bvh()));
+  EXPECT_TRUE(old_geometry.deformable_volume().mesh().Equal(
+      new_geometry.deformable_volume().mesh()));
+  EXPECT_TRUE(old_geometry.deformable_volume().bvh().Equal(
+      new_geometry.deformable_volume().bvh()));
   EXPECT_TRUE(old_geometry.CalcSignedDistanceField().Equal(
       new_geometry.CalcSignedDistanceField()));
   // Verify that the address didn't change either; so it's indeed an no-op.
-  EXPECT_EQ(&old_geometry.deformable_mesh().mesh(),
-            &new_geometry.deformable_mesh().mesh());
-  EXPECT_EQ(&old_geometry.deformable_mesh().bvh(),
-            &new_geometry.deformable_mesh().bvh());
+  EXPECT_EQ(&old_geometry.deformable_volume().mesh(),
+            &new_geometry.deformable_volume().mesh());
+  EXPECT_EQ(&old_geometry.deformable_volume().bvh(),
+            &new_geometry.deformable_volume().bvh());
 }
 
 TEST_F(ProximityEngineDeformableContactTest, AddAndRemoveDeformableGeometry) {
@@ -4932,7 +4951,7 @@ TEST_F(ProximityEngineDeformableContactTest, AddAndRemoveDeformableGeometry) {
 }
 
 TEST_F(ProximityEngineDeformableContactTest, UpdatePose) {
-  ProximityProperties props = MakeProximityPropsWithRezHint(1.0);
+  ProximityProperties props = MakeProximityPropsForRigidGeometry(1.0);
   const GeometryId id = GeometryId::get_new_id();
   // Arbitrary initial pose of the rigid geometry.
   RollPitchYawd rpy(1, 2, 3);
@@ -4946,20 +4965,19 @@ TEST_F(ProximityEngineDeformableContactTest, UpdatePose) {
 }
 
 TEST_F(ProximityEngineDeformableContactTest, UpdateDeformablePositions) {
-  constexpr double kRezHint = 0.5;
-  Sphere sphere(kSphereRadius);
-  const VolumeMesh<double> input_mesh = MakeSphereVolumeMesh<double>(
-      sphere, kRezHint, TessellationStrategy::kDenseInteriorVertices);
-  const GeometryId id = GeometryId::get_new_id();
-  engine_.AddDeformableGeometry(input_mesh, id);
+  const GeometryId id = AddDeformableSphere();
+  const VolumeMesh<double>& mesh =
+      deformable_geometry(id).deformable_volume().mesh();
+  const int num_vertices = mesh.num_vertices();
   /* Update the vertex positions to some arbitrary value. */
   const VectorX<double> q =
-      VectorX<double>::LinSpaced(3 * input_mesh.num_vertices(), 0.0, 1.0);
-  engine_.UpdateDeformableVertexPositions({{id, q}});
-  const VolumeMesh<double>& mesh =
-      deformable_geometry(id).deformable_mesh().mesh();
-  for (int i = 0; i < input_mesh.num_vertices(); ++i) {
-    const Vector3d& q_MV = mesh.vertex(i);
+      VectorX<double>::LinSpaced(3 * num_vertices, 0.0, 1.0);
+  engine_.UpdateDeformableVertexPositions({{id, q}},
+                                          driven_mesh_data_.driven_meshes());
+  const VolumeMesh<double>& deformed_mesh =
+      deformable_geometry(id).deformable_volume().mesh();
+  for (int i = 0; i < num_vertices; ++i) {
+    const Vector3d& q_MV = deformed_mesh.vertex(i);
     const Vector3d& expected_q_MV = q.segment<3>(3 * i);
     EXPECT_EQ(q_MV, expected_q_MV);
   }
@@ -4972,8 +4990,10 @@ TEST_F(ProximityEngineDeformableContactTest, ComputeDeformableContact) {
 
   // Add a rigid sphere partially overlapping the deformable sphere.
   const GeometryId rigid_id = GeometryId::get_new_id();
-  ProximityProperties props = MakeProximityPropsWithRezHint(1.0);
-  engine_.AddDynamicGeometry(Sphere(kSphereRadius), {}, rigid_id, props);
+  ProximityProperties props = MakeProximityPropsForRigidGeometry(1.0);
+  const Vector3d p_WR = Vector3d(kSphereRadius, 0, 0);
+  engine_.AddDynamicGeometry(Sphere(kSphereRadius), RigidTransformd(p_WR),
+                             rigid_id, props);
 
   // Verify the two spheres are in contact.
   DeformableContact<double> contact_data;
@@ -4988,19 +5008,24 @@ TEST_F(ProximityEngineDeformableContactTest, ComputeDeformableContact) {
   // in contact.
   const Vector3d offset_W(10, 0, 0);
   const VolumeMesh<double>& mesh =
-      deformable_geometry(deformable_id).deformable_mesh().mesh();
+      deformable_geometry(deformable_id).deformable_volume().mesh();
   Eigen::VectorXd q_WD(3 * mesh.num_vertices());
   for (int i = 0; i < mesh.num_vertices(); ++i) {
     q_WD.segment<3>(3 * i) = mesh.vertex(i) + offset_W;
   }
-  engine_.UpdateDeformableVertexPositions({{deformable_id, q_WD}});
+  std::unordered_map<GeometryId, Eigen::VectorXd> geometry_id_to_q_WD;
+  geometry_id_to_q_WD.insert({deformable_id, q_WD});
+  driven_mesh_data_.SetControlMeshPositions(geometry_id_to_q_WD);
+  engine_.UpdateDeformableVertexPositions(geometry_id_to_q_WD,
+                                          driven_mesh_data_.driven_meshes());
   engine_.ComputeDeformableContact(&contact_data);
   ASSERT_EQ(contact_data.contact_surfaces().size(), 0);
 
   // Shift the rigid geometry by the same offset and they are again in
   // contact.
   std::unordered_map<GeometryId, RigidTransformd> geometry_id_to_world_poses;
-  geometry_id_to_world_poses.insert({rigid_id, RigidTransformd(offset_W)});
+  geometry_id_to_world_poses.insert(
+      {rigid_id, RigidTransformd(p_WR + offset_W)});
   engine_.UpdateWorldPoses(geometry_id_to_world_poses);
   engine_.ComputeDeformableContact(&contact_data);
   ASSERT_EQ(contact_data.contact_surfaces().size(), 1);

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -1022,6 +1022,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "deformable_driver_contact_test",
+    data = ["test/box.vtk"],
     deps = [
         ":multibody_plant_core",
         "//common/test_utilities:eigen_matrix_compare",
@@ -1031,6 +1032,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "deformable_driver_contact_kinematics_test",
+    data = ["test/box.vtk"],
     deps = [
         ":multibody_plant_config_functions",
         ":multibody_plant_core",

--- a/multibody/plant/deformable_driver.cc
+++ b/multibody/plant/deformable_driver.cc
@@ -281,6 +281,7 @@ DeformableDriver<T>::ComputeContactDataForDeformable(
    blocks. */
   std::vector<typename Block3x3SparseMatrix<T>::Triplet> triplets;
   triplets.reserve(4);
+  bool is_deformable_rigid = !surface.is_B_deformable();
   for (int i = 0; i < surface.num_contact_points(); ++i) {
     /* The contact Jacobian (w.r.t. v) of the velocity of the point affixed to
      the geometry that coincides with the contact point C in the world frame,
@@ -290,14 +291,27 @@ DeformableDriver<T>::ComputeContactDataForDeformable(
     Block3x3SparseMatrix<T> scaled_Jv_v_WGc_C(
         /* block rows */ 1,
         /* block columns */ participation.num_vertices_in_contact());
-    const Vector4<int>& participating_vertices =
-        is_A ? surface.contact_vertex_indexes_A()[i]
-             : surface.contact_vertex_indexes_B()[i];
-    const Vector4<T>& b = is_A ? surface.barycentric_coordinates_A()[i]
-                               : surface.barycentric_coordinates_B()[i];
+    Vector4<int> participating_vertices = Vector4<int>::Constant(-1);
+    Vector4<T> barycentric_weights = Vector4<T>::Zero();
+    if (is_deformable_rigid) {
+      DRAKE_DEMAND(is_A);
+      participating_vertices.head<3>() =
+          surface.tri_contact_vertex_indexes_A()[i];
+      barycentric_weights.template head<3>() =
+          surface.tri_barycentric_coordinates_A()[i];
+    } else {
+      participating_vertices = is_A ? surface.tet_contact_vertex_indexes_A()[i]
+                                    : surface.contact_vertex_indexes_B()[i];
+      barycentric_weights = is_A ? surface.tet_barycentric_coordinates_A()[i]
+                                 : surface.barycentric_coordinates_B()[i];
+    }
     Vector3<T> v_WGc = Vector3<T>::Zero();
     triplets.clear();
     for (int v = 0; v < 4; ++v) {
+      if (participating_vertices(v) < 0) {
+        DRAKE_DEMAND(barycentric_weights(v) == 0.0);
+        continue;
+      }
       const bool vertex_under_bc = num_bcs[participating_vertices(v)] > 0;
       /* Map indexes to the permuted domain. */
       const int permuted_vertex =
@@ -307,10 +321,10 @@ DeformableDriver<T>::ComputeContactDataForDeformable(
          v₃ are the velocities of the vertices forming the tetrahedron
          containing the contact point and the b's are their corresponding
          barycentric weights. */
-        triplets.emplace_back(
-            0, permuted_vertex,
-            scale * b(v) * surface.R_WCs()[i].matrix().transpose());
-        v_WGc += b(v) *
+        triplets.emplace_back(0, permuted_vertex,
+                              scale * barycentric_weights(v) *
+                                  surface.R_WCs()[i].matrix().transpose());
+        v_WGc += barycentric_weights(v) *
                  body_participating_v0.template segment<3>(3 * permuted_vertex);
       }
       /* If the vertex is under bc, the corresponding jacobian block is zero
@@ -477,19 +491,50 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
        k * ϕ where ϕ is the penetration distance. The contact force balances
        gravity and we have
 
-         kϕ  = CL²ϕ = gρL³,
+         kϕ  = CL²ϕ = GρL³,
 
-       which gives ϕ = gρL / C.
+       which gives ϕ = GρL / C.
        We choose a large C = 1e8 Pa/m so that for ρ = 1000 kg/m³ and
-       g = 10 m/s², we get ϕ = 1e-4 * L, or 0.01 mm for a 10 cm cube with
+       G = 10 m/s², we get ϕ = 1e-4 * L, or 0.01 mm for a 10 cm cube with
        density of water, a reasonably small penetration. */
-      const T kA = surface.contact_mesh_W().area(i) * 1e8;
-      const T default_rigid_k = std::numeric_limits<T>::infinity();
-      const T kB = surface.is_B_deformable() ? kA : default_rigid_k;
-      /* Combine stiffnesses k₁ (of geometry A) and k₂ (of geometry B) to get k
-       according to the rule: 1/k = 1/k₁ + 1/k₂. */
-      const T k = GetCombinedPointContactStiffness(kA, kB);
+      const Vector3<T>& nhat_BA_W = surface.nhats_W()[i];
+      const T Ae = surface.contact_mesh_W().area(i);
+      /* Geometry A is always deformable, so this is deformable vs. deformable
+       contact iff geometry B is deformable. */
+      const bool is_deformable_vs_deformable = surface.is_B_deformable();
+      /* One dimensional pressure gradient (in Pa/m), only used in deformable
+       vs. rigid contact, following the notation in [Masterjohn, 2022].
+       [Masterjohn, 2022] Velocity Level Approximation of Pressure Field
+       Contact Patches. */
+      std::optional<T> g;
+      /* Filter out negative directional pressure derivatives (separating
+       contact) and tiny contact polygons (to avoid numerical issues). */
+      if (!is_deformable_vs_deformable) {
+        /* Unlike [Masterjohn, 2022], the pressure gradient is positive in the
+         direction "into" the rigid body. Therefore, we need a negative sign. */
+        g = -surface.pressure_gradients_W()[i].dot(nhat_BA_W);
+        if (g.value() < 1e-14 || Ae < 1e-14) {
+          continue;
+        }
+      }
 
+      const auto [k, phi0, fn0] = [&]() {
+        if (is_deformable_vs_deformable) {
+          const T deformable_k = Ae * 1e8;
+          const T deformable_phi0 = surface.signed_distances()[i];
+          const T deformable_fn0 = -deformable_k * deformable_phi0;
+          return std::make_tuple(deformable_k, deformable_phi0, deformable_fn0);
+        } else {
+          DRAKE_ASSERT(g.has_value());
+          const T rigid_k = Ae * g.value();
+          const T rigid_phi0 = -surface.pressures()[i] / g.value();
+          const T rigid_fn0 = Ae * surface.pressures()[i];
+          return std::make_tuple(rigid_k, rigid_phi0, rigid_fn0);
+        }
+      }();
+
+      // TODO(xuchenhan-tri): Use the real H&C dissipation for rigid vs.
+      //  deformable.
       /* While in Drake we provide constraints to model Hunt & Crossley or
       linear Kelvin–Voigt dissipation, for deformable objects all we want is to
       enforce the non-penetration constraint. We do this using the high
@@ -509,14 +554,12 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
       const double mu =
           GetCombinedDynamicCoulombFriction(id_A, id_B, inspector);
 
-      const T& phi0 = surface.signed_distances()[i];
-      const T fn0 = -k * phi0;
-      /* The normal (scalar) component of the contact velocity in the contact
-       frame. */
       /* Contact solver assumes the normal points from A to B whereas the
        surface's normal points from B to A. */
       const Vector3<T> nhat_AB_W = -surface.nhats_W()[i];
       const math::RotationMatrix<T>& R_WC = surface.R_WCs()[i];
+      /* The normal (scalar) component of the contact velocity in the contact
+       frame. */
       const T v_AcBc_Cz = nhat_AB_W.dot(v_WBc - v_WAc);
       DiscreteContactPair<T> contact_pair{
           .jacobian = std::move(jacobian_blocks),
@@ -528,7 +571,7 @@ void DeformableDriver<T>::AppendDiscreteContactPairs(
           .p_WC = p_WC,
           .p_ApC_W = p_AC_W,
           .p_BqC_W = p_BC_W,
-          .nhat_BA_W = -nhat_AB_W,
+          .nhat_BA_W = nhat_BA_W,
           .phi0 = phi0,
           .vn0 = v_AcBc_Cz,
           .fn0 = fn0,

--- a/multibody/plant/test/box.vtk
+++ b/multibody/plant/test/box.vtk
@@ -1,0 +1,25 @@
+# vtk DataFile Version 3.0
+Unit Cube Tet Mesh
+ASCII
+DATASET UNSTRUCTURED_GRID
+POINTS 8 double
+-0.5 -0.5 -0.5
+ 0.5 -0.5 -0.5
+ 0.5  0.5 -0.5
+-0.5  0.5 -0.5
+-0.5 -0.5  0.5
+ 0.5 -0.5  0.5
+ 0.5  0.5  0.5
+-0.5  0.5  0.5
+CELLS 5 25
+4 0 1 3 4
+4 1 2 3 6
+4 1 4 5 6
+4 3 4 6 7
+4 1 3 4 6
+CELL_TYPES 5
+10
+10
+10
+10
+10

--- a/multibody/plant/test/deformable_integration_test.cc
+++ b/multibody/plant/test/deformable_integration_test.cc
@@ -226,13 +226,16 @@ TEST_F(DeformableIntegrationTest, SteadyState) {
   const int num_vertices = vertex_positions.size() / 3;
   /* The deformable mesh is an octahedron and the only stable configuration on a
    plane is with one face lying on the plane. In that configuration, all
-   vertices are participating in contact and thus we expect the number of
-   participating dofs to be equal to the total number of dofs in the deformable
-   model. In that case, the participating dofs (in contact solver results) and
-   the full model (i.e data in `vertex_positions`) share the same indexing. */
-  ASSERT_EQ(contact_solver_results.v_next.size(), 3 * num_vertices);
-  for (int i = 0; i < num_vertices; ++i) {
-    const Vector3d& p_WV = vertex_positions.segment<3>(3 * i);
+   vertices except the center vertex are participating in contact and thus we
+   expect the number of participating dofs to be equal to the total number of
+   dofs in the deformable model minus 3. We know that the internal vertex is
+   vertex zero. The the permutation is the mapping
+   (1, 2, 3, 4, 5, 6) -> (0, 1, 2, 3, 4, 5), i.e., we can get the position of
+   the i-th vertex *after* the permutation by looking at the i+1-th vertex
+   position *before* the permutation.  */
+  ASSERT_EQ(contact_solver_results.v_next.size(), 3 * (num_vertices - 1));
+  for (int i = 0; i < num_vertices - 1; ++i) {
+    const Vector3d& p_WV = vertex_positions.segment<3>(3 * (i + 1));
     const Vector3d p_VC_W = p_WC - p_WV;
     F_Ac_W_expected +=
         SpatialForce<double>(Vector3d::Zero(), f_C_W.segment<3>(3 * i))


### PR DESCRIPTION
When registering contact points between a rigid geometry and a deformable geometry, use the rigid geometry's volume mesh (inherited from compliant hydroelastics) to clip the surface of the deformable mesh (instead of using the rigid geometry's surface mesh to clip the volume mesh of the deformable geometry prior to this PR).

This has the advantage of introducing significantly smaller number of contact points and avoids the "sitcking" artifact often seen when the rigid geometry in contact has sharp features.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22917)
<!-- Reviewable:end -->
