### PR TITLE
[workspace] Upgrade bzlmod eigen to 3.4.0.bcr.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,7 +48,7 @@ use_repo(cc_configure, "local_config_cc")
 # For first-party Bazel builds (by Drake Developers), the pkgconfig flavor is
 # used by default but can be changed using the Bazel flags.
 
-bazel_dep(name = "eigen", version = "3.4.0.bcr.2", repo_name = "module_eigen")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3", repo_name = "module_eigen")
 bazel_dep(name = "fmt", version = "11.0.2.bcr.1", repo_name = "module_fmt")
 bazel_dep(name = "spdlog", version = "1.15.0.bcr.4", repo_name = "module_spdlog")  # noqa
 


### PR DESCRIPTION
This works around a problem with GitLab-hosted archives changing out from under us (see https://github.com/bazelbuild/bazel-central-registry/issues/4355). Only the hosting URL is changed (not the code).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22918)
<!-- Reviewable:end -->
