### PR TITLE
[tools] Push an official source code archive to GitHub releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/POST_RELEASE_ACTIONS.yml
+++ b/.github/ISSUE_TEMPLATE/POST_RELEASE_ACTIONS.yml
@@ -34,7 +34,9 @@ body:
         "These two steps must be completed in order. Check each box after
         completion."
       options:
-        - label: "Run script to push Docker images and mirror the artifacts to S3"
+        - label: >
+            Run script to push Docker images, mirror the artifacts to S3, and
+            push the source archive to GitHub
           required: false
         - label: "Run script for Apt repository updates"
           required: false

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -8,6 +8,18 @@ For first-time users, we strongly suggest using one of the pre-compiled binaries
 described on our [installation](/installation.html) page. This page explains how
 to build Drake from source, which is somewhat more challenging.
 
+# Obtaining the Source Code
+
+Drake's source code is available on [GitHub](https://github.com/RobotLocomotion/drake).
+
+In addition to the code on `master`, the source code archives
+are published for each release at
+`https://github.com/RobotLocomotion/drake/releases/download/drake-<version>-src.tar.gz`
+with corresponding .sha256 and .sha512 checksums.
+This mirrors GitHub's source code archive available at
+`https://github.com/RobotLocomotion/drake/archive/refs/tags/v<version>.tar.gz`,
+but checksums are provided for additional stability.
+
 # Supported Configurations
 
 The following table shows the configurations and platforms that Drake

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -103,10 +103,10 @@ the main body of the document:
 ## Cutting the release
 
 1. Find a plausible nightly build to use:
-   1. Make sure <https://drake-jenkins.csail.mit.edu/view/Production/> is clean
+   1. Make sure <https://drake-jenkins.csail.mit.edu/view/Production/> is clean.
    2. Make sure <https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/>
       has nothing still running (modulo the ``*-coverage`` builds, which we can
-      ignore)
+      ignore).
    3. Open the latest builds from the following builds:
       1. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-jammy-unprovisioned-gcc-cmake-nightly-packaging/>
       2. <https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-noble-unprovisioned-gcc-cmake-nightly-packaging/>
@@ -119,7 +119,7 @@ the main body of the document:
    5. Use the
       ``tools/release_engineering/download_release_candidate`` tool with the
       ``--find-git-sha`` option to download and verify that all the nightlies
-      are built from the same commit.  (It's usage instructions are atop its
+      are built from the same commit.  (Its usage instructions are atop its
       source code:
       [download_release_candidate.py](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/download_release_candidate.py).)
 2. Launch the staging builds for that git commit sha:
@@ -149,10 +149,10 @@ the main body of the document:
 5. Wait for the wheel builds to complete, and then download release artifacts:
    1. Use the
       ``tools/release_engineering/download_release_candidate`` tool with the
-      ``--version`` option to download and verify all binaries.  (It's usage
+      ``--version`` option to download and verify all binaries.  (Its usage
       instructions are atop its source code:
       [download_release_candidate.py](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/download_release_candidate.py).)
-6. Merge the release notes PR
+6. Merge the release notes PR.
    1. Take care when squashing not to accept github's auto-generated commit message if it is not appropriate.
    2. After merge, go to <https://drake-jenkins.csail.mit.edu/view/Documentation/job/linux-jammy-unprovisioned-gcc-bazel-nightly-documentation/> and push "Build now".
       * If you don't have "Build now" click "Log in" first in upper right.
@@ -183,7 +183,7 @@ the main body of the document:
 8. Once the documentation build finishes, release!
    1. Check that the link to drake.mit.edu docs from the GitHub release draft
       page actually works.
-   2. Click "Publish release"
+   2. Click "Publish release".
    3. Create a new GitHub issue on the [drake](https://github.com/RobotLocomotion/drake/issues/new/choose)
       repository and select the "Post-Release Actions" template.
    4. Create a GitHub issue on the [drake-ros](https://github.com/RobotLocomotion/drake-ros/issues)

--- a/tools/release_engineering/dev/README.md
+++ b/tools/release_engineering/dev/README.md
@@ -65,7 +65,10 @@ Clone the drake repository:
     git clone https://github.com/RobotLocomotion/drake.git
     cd drake
 
-## Run script to push docker images and mirror the .tar/.deb artifacts to S3
+## Run script for Docker / S3 / GitHub
+
+The next step is to push docker images, mirror the .tar/.deb artifacts to S3,
+and push the official source code archive to GitHub.
 
 Once your machine is set-up, run the `push_release` script as described below:
 


### PR DESCRIPTION
Closes #19734. Drake's release process currently relies on GitHub's automated source archival, for which the creation and checksums aren't necessarily stable over time. This PR introduces an additional step in the post-release process to download GitHub's source code archive, calculate sha256 and sha512 checksums, and re-upload those three files as `drake-<version>-src.tar.gz(.sha256|.sha512)`.

* Factors out some common logic from `push_archive`
* Adds a push of the source code archive to GitHub using the `github3` API in `_push_archive`
* Adds some clarification to existing comments about binary vs. source artifacts

Other incidental changes:

* Documents everything in the post-release actions issue template, release README, and `doc/_pages/from_source.md`
* Adds a check to `options.push_docker` inside `_State` so that the API is not instantiated if not using that option
* Fixes some grammar in the release playbook

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22923)
<!-- Reviewable:end -->
