### PR TITLE
[multibody] Optimize F & M frames for prismatic joint's mobilizer.

### DIFF
--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -874,12 +874,19 @@ GTEST_TEST(RigidTransform, SpecializedTransformOperators) {
   EXPECT_TRUE(X_BC_update.IsNearlyEqualTo(
       Xform::MakeAxialRotation<2>(4 * theta), kTol));
 
+  // Make an axial translation transform (this one is y-axial).
+  const Xform ytX_BC(Vector3d(0, -2, 0));  // d = -2
+
+  // Test UpdateAxialTranslation().
+  Xform ytX_BC_update = ytX_BC;
+  Xform::UpdateAxialTranslation<1>(5, &ytX_BC_update);  // d = 5
+  EXPECT_TRUE(ytX_BC_update.IsExactlyEqualTo(Xform(Vector3d(0, 5, 0))));
+
   // Make general, rotation-only, and translation-only transforms.
   const Xform X_AB(RollPitchYaw(1.0, 2.0, 3.0), Vector3d(1.5, 2.5, 3.5));
   const Xform rX_BC(RollPitchYaw(0.5, 1.5, -2.5), Vector3d::Zero());
   const Xform tX_BC(Vector3d(-1.0, 2.0, -3.0));
-  const Xform ytX_BC(Vector3d(0.0, -2.0, 0.0));  // y-axial translation
-  Xform X_AC;                                    // reusable result
+  Xform X_AC;  // reusable result
 
   // Test PostMultiplyByRotation() and PostMultiplyBy[Axial]Translation().
   X_AB.PostMultiplyByRotation(rX_BC, &X_AC);
@@ -899,7 +906,7 @@ GTEST_TEST(RigidTransform, SpecializedTransformOperators) {
   X_AB.PostMultiplyByAxialRotation<2>(zrX_BC, &X_AC);
   EXPECT_TRUE(X_AC.IsNearlyEqualTo(X_AB * zrX_BC, kTol));
 
-  // Test PreMultiplyByAxialRotation().
+  // Test PreMultiplyByAxialRotation(), PreMultiplyByAxialTranslation().
   const Xform X_CD(RollPitchYaw(1.0, 2.0, 3.0), Vector3d(1.5, 2.5, 3.5));
   Xform X_BD;  // reusable result
   X_CD.PreMultiplyByAxialRotation<0>(xrX_BC, &X_BD);
@@ -908,6 +915,8 @@ GTEST_TEST(RigidTransform, SpecializedTransformOperators) {
   EXPECT_TRUE(X_BD.IsNearlyEqualTo(yrX_BC * X_CD, kTol));
   X_CD.PreMultiplyByAxialRotation<2>(zrX_BC, &X_BD);
   EXPECT_TRUE(X_BD.IsNearlyEqualTo(zrX_BC * X_CD, kTol));
+  X_CD.PreMultiplyByAxialTranslation<1>(ytX_BC, &X_BD);
+  EXPECT_TRUE(X_BD.IsNearlyEqualTo(ytX_BC * X_CD, kTol));
 }
 
 GTEST_TEST(RigidTransform, TestMemoryLayoutOfRigidTransformDouble) {

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -935,7 +935,9 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcSpatialAccelerationBias(
 #define EXPLICITLY_INSTANTIATE_IMPLS(T)                           \
   template class BodyNodeImpl<T, CurvilinearMobilizer<T>>;        \
   template class BodyNodeImpl<T, PlanarMobilizer<T>>;             \
-  template class BodyNodeImpl<T, PrismaticMobilizer<T>>;          \
+  template class BodyNodeImpl<T, PrismaticMobilizerAxial<T, 0>>;  \
+  template class BodyNodeImpl<T, PrismaticMobilizerAxial<T, 1>>;  \
+  template class BodyNodeImpl<T, PrismaticMobilizerAxial<T, 2>>;  \
   template class BodyNodeImpl<T, QuaternionFloatingMobilizer<T>>; \
   template class BodyNodeImpl<T, RevoluteMobilizerAxial<T, 0>>;   \
   template class BodyNodeImpl<T, RevoluteMobilizerAxial<T, 1>>;   \

--- a/multibody/tree/body_node_impl_mass_matrix.cc
+++ b/multibody/tree/body_node_impl_mass_matrix.cc
@@ -142,7 +142,9 @@ DEFINE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(6)
 #define EXPLICITLY_INSTANTIATE_IMPLS(T)                           \
   template class BodyNodeImpl<T, CurvilinearMobilizer<T>>;        \
   template class BodyNodeImpl<T, PlanarMobilizer<T>>;             \
-  template class BodyNodeImpl<T, PrismaticMobilizer<T>>;          \
+  template class BodyNodeImpl<T, PrismaticMobilizerAxial<T, 0>>;  \
+  template class BodyNodeImpl<T, PrismaticMobilizerAxial<T, 1>>;  \
+  template class BodyNodeImpl<T, PrismaticMobilizerAxial<T, 2>>;  \
   template class BodyNodeImpl<T, QuaternionFloatingMobilizer<T>>; \
   template class BodyNodeImpl<T, RevoluteMobilizerAxial<T, 0>>;   \
   template class BodyNodeImpl<T, RevoluteMobilizerAxial<T, 1>>;   \

--- a/multibody/tree/joint.cc
+++ b/multibody/tree/joint.cc
@@ -116,6 +116,18 @@ std::unique_ptr<Joint<T>> Joint<T>::DoShallowClone() const {
 }
 
 template <typename T>
+std::string Joint<T>::MakeUniqueOffsetFrameName(
+    const Frame<T>& parent_frame, const std::string& suffix) const {
+  const internal::MultibodyTree<T>& tree = this->get_parent_tree();
+  std::string new_name =
+      fmt::format("{}_{}_{}", this->name(), parent_frame.name(), suffix);
+  while (tree.HasFrameNamed(new_name, this->model_instance())) {
+    new_name = "_" + new_name;
+  }
+  return new_name;
+}
+
+template <typename T>
 void Joint<T>::SetSpatialVelocityImpl(systems::Context<T>* context,
                                       const SpatialVelocity<T>& V_FM,
                                       const char* func) const {

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -779,6 +779,16 @@ class Joint : public MultibodyElement<T> {
     DRAKE_DEMAND(has_mobilizer());
     return *mobilizer_;
   }
+
+  // (Internal use only) This utility generates a unique name for an offset
+  // frame of the form jointname_parentframename_suffix. This is intended for
+  // creating F and M mobilizer frames that are offset from joint frames Jp and
+  // Jc. The name is guaranteed to be unique within this Joint's model instance.
+  // If necessary, leading underscores are prepended until uniqueness is
+  // achieved. Be sure to create the new frame in the _Joint's_ model instance
+  // to avoid name clashes.
+  std::string MakeUniqueOffsetFrameName(const Frame<T>& parent_frame,
+                                        const std::string& suffix) const;
 #endif
   // End of hidden Doxygen section.
 

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -29,7 +29,10 @@ Every concrete Mobilizer derived from MobilizerImpl must implement the
 following (ideally inline) methods (some have defaults; see below). Note that
 these are not virtual methods so we have to document them here in a comment
 rather than as declarations in the header file. The code won't compile if
-any mobilizer fails to implement the non-defaulted methods.
+any mobilizer fails to implement the non-defaulted methods. These are const
+member functions (rather than static members) so are permitted to depend on
+mobilizer-specific data members, though in many cases they don't require any
+such data.
 
 @note The coordinate pointers q and v are guaranteed to point to the kNq or kNv
 state variables for the particular mobilizer. They are only 8-byte aligned so be

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -3,7 +3,7 @@
 #include <memory>
 #include <stdexcept>
 
-#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/multibody/tree/multibody_tree-inl.h"
 
 namespace drake {
 namespace multibody {
@@ -30,8 +30,7 @@ PrismaticJoint<T>::PrismaticJoint(const std::string& name,
   const double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
   if (axis.isZero(kEpsilon)) {
     throw std::logic_error(
-        "Prismatic joint axis vector must have nonzero "
-        "length.");
+        "Prismatic joint axis vector must have nonzero length.");
   }
   if (damping < 0) {
     throw std::logic_error("Prismatic joint damping must be nonnegative.");
@@ -95,6 +94,94 @@ std::unique_ptr<Joint<T>> PrismaticJoint<T>::DoShallowClone() const {
       this->name(), this->frame_on_parent(), this->frame_on_child(),
       this->translation_axis(), this->position_lower_limit(),
       this->position_upper_limit(), this->default_damping());
+}
+
+/* For a prismatic joint, we are given Jp on parent P, Jc on child C, and a
+translation unit vector â whose components are identical in Jp and Jc. At q=0,
+Jp and Jc are coincident. At all times, the coordinate axes of Jp and Jc remain
+aligned, and vector â has constant and equal components when expressed in these
+frames. Jc translates with respect to Jp by a translation distance q meters
+along the translation vector â. The origins Jpo and Jco are thus separated by
+a vector q⋅â so that Jco = Jpo + q⋅â.
+
+We need to implement this joint with one of three available prismatic
+mobilizers. Every mobilizer has an inboard frame F, and an outboard frame M. The
+available prismatic mobilizers translate along one of the coordinate axes x, y,
+or z. If â happens already to be a coordinate axis of Jp (and Jc), we are golden
+and can use Jp and Jc as F and M. Otherwise we are going to have to create new
+frames F and M such that one of their coordinate axes is aligned with â.
+
+To create new frames, we use the MakeFromOneVector() function to create a
+RotationMatrix R_JpF (R_JcM) such that F(M)'s z axis is aligned with â (or -â if
+the mobilizer is reversed from the joint). That rotation matrix is what we need
+to create FixedOffsetFrame F from Jp (or Jc if reversed) and M from Jc (or Jp
+if reversed). Then we use the z-axial prismatic mobilizer to implement the
+joint. */
+template <typename T>
+std::unique_ptr<internal::Mobilizer<T>>
+PrismaticJoint<T>::MakeMobilizerForJoint(
+    const internal::SpanningForest::Mobod& mobod,
+    internal::MultibodyTree<T>* tree) const {
+  DRAKE_DEMAND(tree != nullptr);
+  const bool reverse = mobod.is_reversed();
+  // These are the joint's parent and child frames, but adjusted for
+  // reversal to locate them on the inboard and outboard bodies. We may also
+  // need to reverse the axis so that q will retain its expected sign.
+  const Frame<T>& Jin =
+      reverse ? this->frame_on_child() : this->frame_on_parent();
+  const Frame<T>& Jout =
+      reverse ? this->frame_on_parent() : this->frame_on_child();
+  const Eigen::Vector3d axis = reverse ? -axis_ : axis_;  // a unit vector
+
+  // Determine whether the axis is one of +x, +y, +z, or something else.
+  // In the latter case we'll change this to +z below.
+  std::optional<int> which_axis = [&axis]() -> std::optional<int> {
+    for (int i = 0; i < 3; ++i) {
+      if (axis[i] == 1.0) return i;  // exact match only
+    }
+    return {};
+  }();
+
+  const Frame<T>* F{};
+  const Frame<T>* M{};
+  if (!which_axis) {
+    which_axis = 2;  // Arbitrarily using the z axis mobilizer.
+    const math::RotationMatrixd R_JinF =  // Also R_JoutM, since Jp=Jc at q=0.
+        math::RotationMatrixd::MakeFromOneUnitVector(axis, *which_axis);
+    F = &tree->AddEphemeralFrame(std::make_unique<FixedOffsetFrame<T>>(
+        this->MakeUniqueOffsetFrameName(Jin, "F"), Jin,
+        math::RigidTransformd(R_JinF), this->model_instance()));
+    M = &tree->AddEphemeralFrame(std::make_unique<FixedOffsetFrame<T>>(
+        this->MakeUniqueOffsetFrameName(Jout, "M"), Jout,
+        math::RigidTransformd(R_JinF), this->model_instance()));
+  } else {
+    F = &Jin;
+    M = &Jout;
+  }
+
+  std::unique_ptr<internal::PrismaticMobilizer<T>> prismatic_mobilizer;
+
+  switch (*which_axis) {
+    case 0:
+      prismatic_mobilizer =
+          std::make_unique<internal::PrismaticMobilizerAxial<T, 0>>(mobod, *F,
+                                                                    *M);
+      break;
+    case 1:
+      prismatic_mobilizer =
+          std::make_unique<internal::PrismaticMobilizerAxial<T, 1>>(mobod, *F,
+                                                                    *M);
+      break;
+    case 2:
+      prismatic_mobilizer =
+          std::make_unique<internal::PrismaticMobilizerAxial<T, 2>>(mobod, *F,
+                                                                    *M);
+      break;
+  }
+
+  DRAKE_DEMAND(prismatic_mobilizer != nullptr);
+  prismatic_mobilizer->set_default_position(this->default_positions());
+  return prismatic_mobilizer;
 }
 
 }  // namespace multibody

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -16,13 +16,12 @@ namespace multibody {
 
 /// This Joint allows two bodies to translate relative to one another along a
 /// common axis.
-/// That is, given a frame F attached to the parent body P and a frame M
-/// attached to the child body B (see the Joint class's documentation),
-/// this Joint allows frames F and M to translate with respect to each other
+/// That is, given a frame Jp attached to the parent body P and a frame Jc
+/// attached to the child body C (see the Joint class's documentation),
+/// this Joint allows frames Jp and Jc to translate with respect to each other
 /// along an axis â. The translation distance is defined positive when child
-/// body B translates along the direction of â.
-/// Axis â is constant and has the same measures in both frames F and M, that
-/// is, `â_F = â_M`.
+/// body C translates along the direction of â. Axis vector â is constant and
+/// has the same components in both frames Jp and Jc, that is, `â_Jp = â_Jc`.
 ///
 /// @tparam_default_scalar
 template <typename T>
@@ -36,8 +35,8 @@ class PrismaticJoint final : public Joint<T> {
   static const char kTypeName[];
 
   /// Constructor to create a prismatic joint between two bodies so that
-  /// frame F attached to the parent body P and frame M attached to the child
-  /// body B, translate relatively to one another along a common axis. See this
+  /// frame Jp attached to the parent body P and frame Jc attached to the child
+  /// body C, translate relatively to one another along a common axis. See this
   /// class's documentation for further details on the definition of these
   /// frames and translation distance.
   /// The first three arguments to this constructor are those of the Joint class
@@ -45,10 +44,10 @@ class PrismaticJoint final : public Joint<T> {
   /// The additional parameter `axis` is:
   /// @param[in] axis
   ///   A vector in ℝ³ specifying the translation axis for this joint. Given
-  ///   that frame M only translates with respect to F and there is no relative
-  ///   rotation, the measures of `axis` in either frame F or M
-  ///   are exactly the same, that is, `axis_F = axis_M`.
-  ///   This vector can have any length, only the direction is used.
+  ///   that frame Jc only translates with respect to Jp and there is no
+  ///   relative rotation, the components of `axis` in either frame Jp or Jc
+  ///   are exactly the same, that is, `axis_Jp = axis_Jc`. This vector can have
+  ///   any length, only the direction is used.
   /// @param[in] pos_lower_limit
   ///   Lower position limit, in meters, for the translation coordinate
   ///   (see get_translation()).
@@ -76,9 +75,9 @@ class PrismaticJoint final : public Joint<T> {
   const std::string& type_name() const final;
 
   /// Returns the axis of translation for `this` joint as a unit vector.
-  /// Since the measures of this axis in either frame F or M are the same (see
-  /// this class's documentation for frame definitions) then,
-  /// `axis = axis_F = axis_M`.
+  /// Since the components of this axis in either frame Jp or Jc are the same
+  /// (see this class's documentation for frame definitions) then,
+  /// `axis = axis_Jp = axis_Jc`.
   const Vector3<double>& translation_axis() const { return axis_; }
 
   /// Returns `this` joint's default damping constant in N⋅s/m.
@@ -243,6 +242,7 @@ class PrismaticJoint final : public Joint<T> {
                        MultibodyForces<T>* forces) const final {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
+    DRAKE_DEMAND(joint_dof == 0);
     Eigen::Ref<VectorX<T>> tau_mob =
         get_mobilizer().get_mutable_generalized_forces_from_array(
             &forces->mutable_generalized_forces());
@@ -300,16 +300,7 @@ class PrismaticJoint final : public Joint<T> {
   // Joint<T> finals:
   std::unique_ptr<internal::Mobilizer<T>> MakeMobilizerForJoint(
       const internal::SpanningForest::Mobod& mobod,
-      internal::MultibodyTree<T>*) const final {
-    const auto [inboard_frame, outboard_frame] =
-        this->tree_frames(mobod.is_reversed());
-    // TODO(sherm1) The mobilizer needs to be reversed, not just the frames.
-    auto prismatic_mobilizer =
-        std::make_unique<internal::PrismaticMobilizer<T>>(
-            mobod, *inboard_frame, *outboard_frame, axis_);
-    prismatic_mobilizer->set_default_position(this->default_positions());
-    return prismatic_mobilizer;
-  }
+      internal::MultibodyTree<T>*) const final;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -12,15 +12,17 @@ namespace multibody {
 namespace internal {
 
 template <typename T>
-PrismaticMobilizer<T>::~PrismaticMobilizer() = default;
+PrismaticMobilizer<T>::PrismaticMobilizer(const SpanningForest::Mobod& mobod,
+                                          const Frame<T>& inboard_frame_F,
+                                          const Frame<T>& outboard_frame_M,
+                                          int axis)
+    : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {
+  DRAKE_DEMAND(0 <= axis && axis <= 2);
+  axis_ = Eigen::Vector3d::Unit(axis);
+}
 
 template <typename T>
-std::unique_ptr<BodyNode<T>> PrismaticMobilizer<T>::CreateBodyNode(
-    const BodyNode<T>* parent_node, const RigidBody<T>* body,
-    const Mobilizer<T>* mobilizer) const {
-  return std::make_unique<BodyNodeImpl<T, PrismaticMobilizer>>(parent_node,
-                                                               body, mobilizer);
-}
+PrismaticMobilizer<T>::~PrismaticMobilizer() = default;
 
 template <typename T>
 std::string PrismaticMobilizer<T>::position_suffix(
@@ -61,7 +63,7 @@ template <typename T>
 const T& PrismaticMobilizer<T>::get_translation_rate(
     const systems::Context<T>& context) const {
   const auto& v = this->get_velocities(context);
-  DRAKE_ASSERT(v.size() == kNv);
+  DRAKE_ASSERT(v.size() == this->kNv);
   return v.coeffRef(0);
 }
 
@@ -69,40 +71,50 @@ template <typename T>
 const PrismaticMobilizer<T>& PrismaticMobilizer<T>::SetTranslationRate(
     systems::Context<T>* context, const T& translation_dot) const {
   auto v = this->GetMutableVelocities(context);
-  DRAKE_ASSERT(v.size() == kNv);
+  DRAKE_ASSERT(v.size() == this->kNv);
   v[0] = translation_dot;
   return *this;
 }
 
-template <typename T>
-math::RigidTransform<T> PrismaticMobilizer<T>::CalcAcrossMobilizerTransform(
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+PrismaticMobilizerAxial<T, axis>::~PrismaticMobilizerAxial() = default;
+
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+math::RigidTransform<T>
+PrismaticMobilizerAxial<T, axis>::CalcAcrossMobilizerTransform(
     const systems::Context<T>& context) const {
   const auto& q = this->get_positions(context);
-  DRAKE_ASSERT(q.size() == kNq);
+  DRAKE_ASSERT(q.size() == this->kNq);
   return calc_X_FM(q.data());
 }
 
-template <typename T>
-SpatialVelocity<T> PrismaticMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+SpatialVelocity<T>
+PrismaticMobilizerAxial<T, axis>::CalcAcrossMobilizerSpatialVelocity(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
-  DRAKE_ASSERT(v.size() == kNv);
+  DRAKE_ASSERT(v.size() == this->kNv);
   return calc_V_FM(nullptr, v.data());
 }
 
-template <typename T>
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
 SpatialAcceleration<T>
-PrismaticMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
+PrismaticMobilizerAxial<T, axis>::CalcAcrossMobilizerSpatialAcceleration(
     const systems::Context<T>&,
     const Eigen::Ref<const VectorX<T>>& vdot) const {
-  DRAKE_ASSERT(vdot.size() == kNv);
+  DRAKE_ASSERT(vdot.size() == this->kNv);
   return calc_A_FM(nullptr, nullptr, vdot.data());
 }
 
-template <typename T>
-void PrismaticMobilizer<T>::ProjectSpatialForce(
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+void PrismaticMobilizerAxial<T, axis>::ProjectSpatialForce(
     const systems::Context<T>&, const SpatialForce<T>& F_BMo_F,
     Eigen::Ref<VectorX<T>> tau) const {
-  DRAKE_ASSERT(tau.size() == kNv);
+  DRAKE_ASSERT(tau.size() == this->kNv);
   calc_tau(nullptr, F_BMo_F, tau.data());
 }
 
@@ -158,37 +170,52 @@ void PrismaticMobilizer<T>::MapQDDotToAcceleration(
   *vdot = qddot;
 }
 
-template <typename T>
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
 template <typename ToScalar>
 std::unique_ptr<Mobilizer<ToScalar>>
-PrismaticMobilizer<T>::TemplatedDoCloneToScalar(
+PrismaticMobilizerAxial<T, axis>::TemplatedDoCloneToScalar(
     const MultibodyTree<ToScalar>& tree_clone) const {
   const Frame<ToScalar>& inboard_frame_clone =
       tree_clone.get_variant(this->inboard_frame());
   const Frame<ToScalar>& outboard_frame_clone =
       tree_clone.get_variant(this->outboard_frame());
-  return std::make_unique<PrismaticMobilizer<ToScalar>>(
+  return std::make_unique<PrismaticMobilizerAxial<ToScalar, axis>>(
       tree_clone.get_mobod(this->mobod().index()), inboard_frame_clone,
-      outboard_frame_clone, this->translation_axis());
+      outboard_frame_clone);
 }
 
-template <typename T>
-std::unique_ptr<Mobilizer<double>> PrismaticMobilizer<T>::DoCloneToScalar(
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+std::unique_ptr<Mobilizer<double>>
+PrismaticMobilizerAxial<T, axis>::DoCloneToScalar(
     const MultibodyTree<double>& tree_clone) const {
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-template <typename T>
-std::unique_ptr<Mobilizer<AutoDiffXd>> PrismaticMobilizer<T>::DoCloneToScalar(
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+std::unique_ptr<Mobilizer<AutoDiffXd>>
+PrismaticMobilizerAxial<T, axis>::DoCloneToScalar(
     const MultibodyTree<AutoDiffXd>& tree_clone) const {
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
-template <typename T>
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
 std::unique_ptr<Mobilizer<symbolic::Expression>>
-PrismaticMobilizer<T>::DoCloneToScalar(
+PrismaticMobilizerAxial<T, axis>::DoCloneToScalar(
     const MultibodyTree<symbolic::Expression>& tree_clone) const {
   return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+std::unique_ptr<BodyNode<T>> PrismaticMobilizerAxial<T, axis>::CreateBodyNode(
+    const BodyNode<T>* parent_node, const RigidBody<T>* body,
+    const Mobilizer<T>* mobilizer) const {
+  return std::make_unique<BodyNodeImpl<T, PrismaticMobilizerAxial>>(
+      parent_node, body, mobilizer);
 }
 
 }  // namespace internal
@@ -197,3 +224,17 @@ PrismaticMobilizer<T>::DoCloneToScalar(
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::PrismaticMobilizer);
+
+#define DRAKE_DEFINE_PRISMATIC_MOBILIZER(axis)                                 \
+  template class ::drake::multibody::internal::PrismaticMobilizerAxial<double, \
+                                                                       axis>;  \
+  template class ::drake::multibody::internal::PrismaticMobilizerAxial<        \
+      ::drake::AutoDiffXd, axis>;                                              \
+  template class ::drake::multibody::internal::PrismaticMobilizerAxial<        \
+      ::drake::symbolic::Expression, axis>
+
+DRAKE_DEFINE_PRISMATIC_MOBILIZER(0);
+DRAKE_DEFINE_PRISMATIC_MOBILIZER(1);
+DRAKE_DEFINE_PRISMATIC_MOBILIZER(2);
+
+#undef DRAKE_DEFINE_PRISMATIC_MOBILIZER

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -17,26 +17,49 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// This Mobilizer allows two frames to translate relative to one another
-// along an axis whose direction is constant when measured in either this
-// mobilizer's inboard frame or its outboard frame. There is no relative
-// rotation between the inboard and outboard frames, just translation.
-// To fully specify this mobilizer, a user must provide the inboard frame F,
-// the outboard (or "mobilized") frame M and the axis `axis_F` (expressed in
-// frame F) along which frame M translates with respect to frame F.
-// The single generalized coordinate q introduced by this mobilizer
-// corresponds to the translation distance (in meters) of the origin `Mo` of
-// frame M with respect to frame F along `axis_F`. When `q = 0`, frames F and M
-// are coincident. The translation distance is defined to be positive in the
-// direction of `axis_F`.
-//
-// H_FM₆ₓ₁=[0₃, axis_F]ᵀ     Hdot_FM₆ₓ₁ = 0
-//
-// @tparam_default_scalar
+/* A Prismatic Mobilizer allows two frames to translate relative to one another
+along an axis that is constant when measured in either of the frames, while the
+frame coordinate axes remain aligned (that is, there is no rotation). The
+translation axis must be one of the coordinate axes x, y, or z. To fully specify
+this mobilizer we need an inboard ("fixed") frame F, an outboard ("mobilized")
+frame M and the coordinate axis along which frame M translates with respect to F
+(see PrismaticMobilizerAxial below). The axis vector can be considered axis_F
+(expressed in frame F) or axis_M (expressed in frame M) since the components are
+identical in either frame.
+
+The restriction to translating along a coordinate axis means that the transform
+X_FM has special structure that can be exploited for speed (it is an "axial
+translation transform" atX_FM; search for the Doxygen tag "special_xform_def" in
+drake/math/rigid_transform.h for a definition). Velocity and acceleration
+quantities are simplified also. In robotics, the prismatic joint is common
+so it is important that we handle its implementation efficiently.
+
+The single generalized coordinate q introduced by this mobilizer corresponds to
+the translation distance in meters of frame M with respect to frame F along the
+translation axis. When q = 0, frames F and M are coincident. The translation is
+defined to be positive in the direction of the translation axis.
+
+Notice that the components of the rotation axis as expressed in either frame F
+or M are constant. That is, axis_F and axis_M remain identical and unchanged
+w.r.t. both frames by this mobilizer's motion.
+
+H_FM_F₆ₓ₁=[0₃ axis_F]ᵀ     Hdot_FM_F₆ₓ₁ = 0₆
+H_FM_M₆ₓ₁=[0₃ axis_M]ᵀ     Hdot_FM_M₆ₓ₁ = 0₆
+   where axis_M == axis_F
+
+@tparam_default_scalar */
+
+// PrismaticMobilizer base class.
+// This is an abstract base class to provide high-level access to the common
+// features of the axial prismatic mobilizer concrete classes (defined below),
+// intended for use by the Joint and PrismaticJoint APIs. Internal algorithms,
+// however, should be templatized on the specific prismatic mobilizer instance
+// to permit inline access to performance-critical functions.
 template <typename T>
-class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
+class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PrismaticMobilizer);
+
   using MobilizerBase = MobilizerImpl<T, 1, 1>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
   template <typename U>
@@ -46,30 +69,7 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   template <typename U>
   using HMatrix = typename MobilizerBase::template HMatrix<U>;
 
-  // Constructor for a %PrismaticMobilizer between the `inboard_frame_F` and
-  // `outboard_frame_M` granting a single translational degree of freedom along
-  // `axis_F`, expressed in the `inboard_frame_F`.
-  // @pre `axis_F` must be a non-zero vector with norm at least root square of
-  // machine epsilon. This vector can have any length (subject to the norm
-  // restriction above), only the direction is used.
-  // @throws std::exception if the L2 norm of `axis_F` is less than the square
-  // root of machine epsilon.
-  PrismaticMobilizer(const SpanningForest::Mobod& mobod,
-                     const Frame<T>& inboard_frame_F,
-                     const Frame<T>& outboard_frame_M,
-                     const Vector3<double>& axis_F)
-      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M),
-        axis_F_(axis_F) {
-    double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
-    DRAKE_DEMAND(!axis_F.isZero(kEpsilon));
-    axis_F_.normalize();
-  }
-
-  ~PrismaticMobilizer() final;
-
-  std::unique_ptr<BodyNode<T>> CreateBodyNode(
-      const BodyNode<T>* parent_node, const RigidBody<T>* body,
-      const Mobilizer<T>* mobilizer) const final;
+  ~PrismaticMobilizer() override;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
@@ -79,9 +79,11 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   bool can_rotate() const final { return false; }
   bool can_translate() const final { return true; }
 
-  // @retval axis_F The translation axis as a unit vector expressed in the
-  // inboard frame F.
-  const Vector3<double>& translation_axis() const { return axis_F_; }
+  // @retval axis The translation axis as a unit vector expressed identically
+  // in both the F and M frames. This will be one of the coordinate axes,
+  // which will have been constructed to be aligned with the user's specified
+  // translation axis for the PrismaticJoint this is implementing.
+  const Vector3<double>& translation_axis() const { return axis_; }
 
   // Gets the translational distance for `this` mobilizer from `context`. See
   // class documentation for sign convention details.
@@ -120,39 +122,66 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   const PrismaticMobilizer<T>& SetTranslationRate(
       systems::Context<T>* context, const T& translation_dot) const;
 
-  // Computes the across-mobilizer transform `X_FM(q)` between the inboard
-  // frame F and the outboard frame M as a function of the translation distance
-  // along this mobilizer's axis (see translation_axis().)
-  math::RigidTransform<T> calc_X_FM(const T* q) const {
-    return math::RigidTransform<T>(q[0] * translation_axis());
-  }
+  bool is_velocity_equal_to_qdot() const final { return true; }
 
-  /* We're not yet attempting to optimize the X_FM update. */
-  // TODO(sherm1) Optimize this.
-  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
-    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
-    *X_FM = calc_X_FM(q);
-  }
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const final;
 
-  // Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame
-  // M measured and expressed in frame F as a function of the input
-  // translational velocity v along this mobilizer's axis (see
-  // translation_axis()).
-  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
-    return SpatialVelocity<T>(Vector3<T>::Zero(), v[0] * translation_axis());
-  }
+  // Maps qdot to v, which for this mobilizer is v = q̇.
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const final;
 
-  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
-    return SpatialAcceleration<T>(Vector3<T>::Zero(),
-                                  vdot[0] * translation_axis());
-  }
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void MapAccelerationToQDDot(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& vdot,
+                              EigenPtr<VectorX<T>> qddot) const final;
 
-  // Returns tau = H_FMᵀ⋅F, where H_FMᵀ = [0₃ᵀ axis_Fᵀ].
-  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
-    DRAKE_ASSERT(tau != nullptr);
-    const Vector3<T>& f_BMo_F = F_BMo_F.translational();
-    tau[0] = axis_F_.dot(f_BMo_F);
-  }
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const final;
+
+ protected:
+  // Constructor for a PrismaticMobilizer between the inboard frame F and the
+  // outboard frame M, granting a single translational degree of freedom along
+  // a coordinate axis (axis=0, 1, or 2) common to both frames.
+  PrismaticMobilizer(const SpanningForest::Mobod& mobod,
+                     const Frame<T>& inboard_frame_F,
+                     const Frame<T>& outboard_frame_M, int axis);
+
+  void DoCalcNMatrix(const systems::Context<T>& context,
+                     EigenPtr<MatrixX<T>> N) const final;
+
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const final;
+
+ private:
+  // Joint axis expressed identically in frames F and M. This must be one of
+  // the coordinate axes 100, 010, or 001.
+  Vector3<double> axis_;
+};
+
+// Prismatic mobilizer with translation axis aligned with one of the F and M
+// frame axes.
+template <typename T, int axis>
+  requires(0 <= axis && axis <= 2)
+class PrismaticMobilizerAxial final : public PrismaticMobilizer<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PrismaticMobilizerAxial);
+
+  PrismaticMobilizerAxial(const SpanningForest::Mobod& mobod,
+                          const Frame<T>& inboard_frame_F,
+                          const Frame<T>& outboard_frame_M)
+      : PrismaticMobilizer<T>(mobod, inboard_frame_F, outboard_frame_M, axis) {}
+
+  ~PrismaticMobilizerAxial() final;
+
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(
       const systems::Context<T>& context) const final;
@@ -176,7 +205,7 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Projects the spatial force `F_Mo_F` on `this` mobilizer's outboard
   // frame M onto its translation axis (see translation_axis().)
   // Mathematically: <pre>
-  //    tau = F_Mo_F.translational().dot(axis_F)
+  //    tau = F_Mo_F.translational().dot(axis)
   // </pre>
   // Therefore, the result of this method is the scalar value of the linear
   // force along the axis of `this` mobilizer.
@@ -185,35 +214,71 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
                            const SpatialForce<T>& F_Mo_F,
                            Eigen::Ref<VectorX<T>> tau) const final;
 
-  bool is_velocity_equal_to_qdot() const override { return true; }
+  // Computes the across-mobilizer transform `X_FM(q)` between the inboard
+  // frame F and the outboard frame M as a function of the translation distance
+  // along this mobilizer's axis (see translation_axis().)
+  math::RigidTransform<T> calc_X_FM(const T* q) const {
+    DRAKE_ASSERT(q != nullptr);
+    Eigen::Vector3<T> p_FM;
+    p_FM[kX] = q[0];
+    p_FM[kY] = 0;
+    p_FM[kZ] = 0;
+    return math::RigidTransform<T>(p_FM);
+  }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
+  // We only need to write q into the appropriate slot of X_FM to update. */
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    math::RigidTransform<T>::template UpdateAxialTranslation<axis>(*q, X_FM);
+  }
 
-  // Maps qdot to v, which for this mobilizer is v = q̇.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
+  // Returns X_AM = X_AF * atX_FM, exploiting known structure of atX_FM.
+  math::RigidTransform<T> post_multiply_by_X_FM(
+      const math::RigidTransform<T>& X_AF,
+      const math::RigidTransform<T>& atX_FM) const {
+    math::RigidTransform<T> X_AM;
+    X_AF.template PostMultiplyByAxialTranslation<axis>(atX_FM, &X_AM);
+    return X_AM;
+  }
 
-  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
-  void MapAccelerationToQDDot(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& vdot,
-                              EigenPtr<VectorX<T>> qddot) const final;
+  // Returns X_FB = atX_FM * X_MB, exploiting known structure of atX_FM.
+  math::RigidTransform<T> pre_multiply_by_X_FM(
+      const math::RigidTransform<T>& atX_FM,
+      const math::RigidTransform<T>& X_MB) const {
+    math::RigidTransform<T> X_FB;
+    X_MB.template PreMultiplyByAxialTranslation<axis>(atX_FM, &X_FB);
+    return X_FB;
+  }
 
-  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
-  void MapQDDotToAcceleration(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& qddot,
-                              EigenPtr<VectorX<T>> vdot) const final;
+  // Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame M
+  // measured and expressed in frame F as a function of the input translational
+  // velocity v along this mobilizer's axis (see translation_axis()).
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
+    DRAKE_ASSERT(v != nullptr);
+    Eigen::Vector3<T> v_FM;
+    v_FM[kX] = v[0];
+    v_FM[kY] = 0;
+    v_FM[kZ] = 0;
+    return SpatialVelocity<T>(Vector3<T>::Zero(), v_FM);
+  }
 
- protected:
-  void DoCalcNMatrix(const systems::Context<T>& context,
-                     EigenPtr<MatrixX<T>> N) const final;
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    DRAKE_ASSERT(vdot != nullptr);
+    Eigen::Vector3<T> a_FM;
+    a_FM[kX] = vdot[0];
+    a_FM[kY] = 0;
+    a_FM[kZ] = 0;
+    return SpatialAcceleration<T>(Vector3<T>::Zero(), a_FM);
+  }
 
-  void DoCalcNplusMatrix(const systems::Context<T>& context,
-                         EigenPtr<MatrixX<T>> Nplus) const final;
+  // Returns tau = H_FM_Fᵀ⋅F, where H_FM_Fᵀ = [0₃ᵀ axis_Fᵀ].
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    const Vector3<T>& f_BMo_F = F_BMo_F.translational();
+    tau[0] = f_BMo_F[axis];
+  }
 
+ private:
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;
 
@@ -223,14 +288,14 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
   std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
       const MultibodyTree<symbolic::Expression>& tree_clone) const final;
 
- private:
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
       const MultibodyTree<ToScalar>& tree_clone) const;
 
-  // Default axis expressed in the inboard frame F. It is a unit vector.
-  Vector3<double> axis_F_;
+  // Write algorithms as though the axes were x, y, and z; modular arithmetic
+  // here ensures they will work correctly for axis=0, 1, or 2.
+  static constexpr int kX = axis, kY = (axis + 1) % 3, kZ = (axis + 2) % 3;
 };
 
 }  // namespace internal
@@ -239,3 +304,17 @@ class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::PrismaticMobilizer);
+
+#define DRAKE_DECLARE_PRISMATIC_MOBILIZER(axis)                                \
+  extern template class ::drake::multibody::internal::PrismaticMobilizerAxial< \
+      double, axis>;                                                           \
+  extern template class ::drake::multibody::internal::PrismaticMobilizerAxial< \
+      ::drake::AutoDiffXd, axis>;                                              \
+  extern template class ::drake::multibody::internal::PrismaticMobilizerAxial< \
+      ::drake::symbolic::Expression, axis>
+
+DRAKE_DECLARE_PRISMATIC_MOBILIZER(0);
+DRAKE_DECLARE_PRISMATIC_MOBILIZER(1);
+DRAKE_DECLARE_PRISMATIC_MOBILIZER(2);
+
+#undef DRAKE_DECLARE_PRISMATIC_MOBILIZER

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -16,14 +16,14 @@ namespace multibody {
 
 /// This Joint allows two bodies to rotate relatively to one another around a
 /// common axis.
-/// That is, given a frame F attached to the parent body P and a frame M
-/// attached to the child body B (see the Joint class's documentation),
-/// this Joint allows frames F and M to rotate with respect to each other about
-/// an axis â. The rotation angle's sign is defined such that child body B
-/// rotates about axis â according to the right hand rule, with thumb aligned in
-/// the axis direction.
-/// Axis â is constant and has the same measures in both frames F and M, that
-/// is, `â_F = â_M`.
+/// That is, given a frame Jp attached to the parent body P and a frame Jc
+/// attached to the child body C (see the Joint class's documentation),
+/// this Joint allows frames Jp and Jc to rotate with respect to each other
+/// about an axis â. The rotation angle's sign is defined such that child body
+/// C rotates about axis â according to the right hand rule, with thumb aligned
+/// in the axis direction.
+/// Axis vector â is constant and has the same components in both frames Jp and
+/// Jc, that is, `â_Jp = â_Jc`.
 ///
 /// @tparam_default_scalar
 template <typename T>
@@ -37,8 +37,8 @@ class RevoluteJoint final : public Joint<T> {
   static const char kTypeName[];
 
   /// Constructor to create a revolute joint between two bodies so that
-  /// frame F attached to the parent body P and frame M attached to the child
-  /// body B, rotate relatively to one another about a common axis. See this
+  /// frame Jp attached to the parent body P and frame Jc attached to the child
+  /// body C, rotate relatively to one another about a common axis. See this
   /// class's documentation for further details on the definition of these
   /// frames and rotation angle.
   /// This constructor signature creates a joint with no joint limits, i.e. the
@@ -48,13 +48,12 @@ class RevoluteJoint final : public Joint<T> {
   /// The additional parameters are:
   /// @param[in] axis
   ///   A vector in ℝ³ specifying the axis of revolution for this joint. Given
-  ///   that frame M only rotates with respect to F and their origins are
-  ///   coincident at all times, the measures of `axis` in either frame F or M
-  ///   are exactly the same, that is, `axis_F = axis_M`. In other words,
-  ///   `axis_F` (or `axis_M`) is the eigenvector of `R_FM` with eigenvalue
-  ///   equal to one.
-  ///   This vector can have any length, only the direction is used. This method
-  ///   aborts if `axis` is the zero vector.
+  ///   that frame Jc only rotates with respect to Jp and their origins are
+  ///   coincident at all times, the components of `axis` in either frame Jp or
+  ///   Jc are exactly the same, that is, `axis_Jp = axis_Jc`. In other words,
+  ///   `axis_Jp` (or `axis_Jc`) is the eigenvector of `R_JpJc` with eigenvalue
+  ///   equal to one. This vector can have any length, only the direction is
+  ///   used. This method aborts if `axis` is the zero vector.
   /// @param[in] damping
   ///   Viscous damping coefficient, in N⋅m⋅s, used to model losses within the
   ///   joint. The damping torque (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e.
@@ -69,8 +68,8 @@ class RevoluteJoint final : public Joint<T> {
                          std::numeric_limits<double>::infinity(), damping) {}
 
   /// Constructor to create a revolute joint between two bodies so that
-  /// frame F attached to the parent body P and frame M attached to the child
-  /// body B, rotate relatively to one another about a common axis. See this
+  /// frame Jp attached to the parent body P and frame Jc attached to the child
+  /// body C, rotate relatively to one another about a common axis. See this
   /// class's documentation for further details on the definition of these
   /// frames and rotation angle.
   /// The first three arguments to this constructor are those of the Joint class
@@ -78,12 +77,12 @@ class RevoluteJoint final : public Joint<T> {
   /// The additional parameters are:
   /// @param[in] axis
   ///   A vector in ℝ³ specifying the axis of revolution for this joint. Given
-  ///   that frame M only rotates with respect to F and their origins are
-  ///   coincident at all times, the measures of `axis` in either frame F or M
-  ///   are exactly the same, that is, `axis_F = axis_M`. In other words,
-  ///   `axis_F` (or `axis_M`) is the eigenvector of `R_FM` with eigenvalue
-  ///   equal to one.
-  ///   This vector can have any length, only the direction is used.
+  ///   that frame Jc only rotates with respect to Jp and their origins are
+  ///   coincident at all times, the components of `axis` in either frame Jp or
+  ///   Jc are exactly the same, that is, `axis_Jp = axis_Jc`. In other words,
+  ///   `axis_Jp` (or `axis_Jc`) is the eigenvector of `R_JpJc` with eigenvalue
+  ///   equal to one. This vector can have any length, only the direction is
+  ///   used.
   /// @param[in] pos_lower_limit
   ///   Lower position limit, in radians, for the rotation coordinate
   ///   (see get_angle()).
@@ -111,7 +110,7 @@ class RevoluteJoint final : public Joint<T> {
   /// Returns the axis of revolution of `this` joint as a unit vector.
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frame definitions) then,
-  /// `axis = axis_F = axis_M`.
+  /// `axis = axis_Jp = axis_Jc`.
   const Vector3<double>& revolute_axis() const { return axis_; }
 
   /// Returns `this` joint's default damping constant in N⋅m⋅s.

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -13,8 +13,12 @@ namespace internal {
 template <typename T>
 RevoluteMobilizer<T>::RevoluteMobilizer(const SpanningForest::Mobod& mobod,
                                         const Frame<T>& inboard_frame_F,
-                                        const Frame<T>& outboard_frame_M)
-    : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {}
+                                        const Frame<T>& outboard_frame_M,
+                                        int axis)
+    : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M) {
+  DRAKE_DEMAND(0 <= axis && axis <= 2);
+  axis_ = Eigen::Vector3d::Unit(axis);
+}
 
 template <typename T>
 RevoluteMobilizer<T>::~RevoluteMobilizer() = default;

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -21,12 +21,12 @@ around an axis that is constant when measured in either of the frames, while the
 frame origins remain coincident. The axis must be one of the coordinate axes
 x, y, or z. To fully specify this mobilizer we need an inboard ("fixed") frame
 F, an outboard ("mobilized") frame M and the coordinate axis about which frame M
-rotates with respect to F (templatized as 0, 1, or 2). The axis vector can be
-considered axis_F (expressed in frame F) or axis_M (expressed in frame M) since
-the components are identical in either frame.
+rotates with respect to F (see RevoluteMobilizerAxial below). The axis vector
+can be considered axis_F (expressed in frame F) or axis_M (expressed in frame M)
+since the components are identical in either frame.
 
 The restriction to rotating about a coordinate axis means that the transform
-X_FM has special structure that can be exploited for speed(it is an "axial
+X_FM has special structure that can be exploited for speed (it is an "axial
 rotation transform" arX_FM; search for the Doxygen tag "special_xform_def" in
 drake/math/rigid_transform.h for a definition). Velocity and acceleration
 quantities are simplified also. In robotics, the revolute joint is very common
@@ -36,7 +36,7 @@ The single generalized coordinate q introduced by this mobilizer corresponds to
 the rotation angle in radians of frame M with respect to frame F about the
 rotation axis. When q = 0, frames F and M are coincident. The rotation angle is
 defined to be positive according to the right-hand-rule with the thumb aligned
-in the direction of the axis.
+in the direction of the rotation axis.
 
 Notice that the components of the rotation axis as expressed in either frame F
 or M are constant. That is, axis_F and axis_M remain identical and unchanged
@@ -48,11 +48,12 @@ H_FM_M₆ₓ₁=[axis_M 0₃]ᵀ     Hdot_FM_M₆ₓ₁ = 0₆
 
 @tparam_default_scalar */
 
-// This is the base class for the three available revolute mobilizers. It
-// provides high-level access to the common features of a revolute mobilizer,
+// RevoluteMobilizer base class.
+// This is an abstract base class to provide high-level access to the common
+// features of the axial revolute mobilizer concrete classes (defined below),
 // intended for use by the Joint and RevoluteJoint APIs. Internal algorithms,
-// however, should be templatized on the specific revolute mobilizer instance
-// to permit inline access to performance-critical functions.
+// however, should be templatized on the specific revolute mobilizer instance to
+// permit inline access to performance-critical functions.
 template <typename T>
 class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
  public:
@@ -75,11 +76,11 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   bool can_rotate() const final { return true; }
   bool can_translate() const final { return false; }
 
-  // @retval axis_FM The rotation axis as a unit vector expressed in the inboard
-  // frame F and the outboard frame M. This will be one of the coordinate axes,
+  // @retval axis The rotation axis as a unit vector expressed identically in
+  // both the F and M frames. This will be one of the coordinate axes,
   // which will have been constructed to be aligned with the user's specified
   // rotation axis for the RevoluteJoint this is implementing.
-  const Vector3<double>& revolute_axis() const { return axis_FM(); }
+  const Vector3<double>& revolute_axis() const { return axis_; }
 
   // Gets the rotation angle q of `this` mobilizer from `context`. See class
   // documentation for sign convention.
@@ -116,7 +117,7 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   // @returns a constant reference to `this` mobilizer.
   const RevoluteMobilizer<T>& SetAngularRate(systems::Context<T>* context,
                                              const T& theta_dot) const;
-  bool is_velocity_equal_to_qdot() const override { return true; }
+  bool is_velocity_equal_to_qdot() const final { return true; }
 
   // Maps v to qdot, which for this mobilizer is q̇ = v.
   void MapVelocityToQDot(const systems::Context<T>& context,
@@ -140,16 +141,11 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
 
  protected:
   // Constructor for a RevoluteMobilizer between the inboard frame F and the
-  // outboard frame M, granting a single rotational degree of freedom about some
-  // axis common to both frames.
+  // outboard frame M, granting a single rotational degree of freedom about a
+  // coordinate axis (axis=0, 1, or 2) common to both frames.
   RevoluteMobilizer(const SpanningForest::Mobod& mobod,
                     const Frame<T>& inboard_frame_F,
-                    const Frame<T>& outboard_frame_M);
-
-  // @pre axis_FM is a unit vector.
-  void set_axis_FM(const Vector3<double>& axis_FM) { axis_FM_ = axis_FM; }
-
-  const Vector3<double>& axis_FM() const { return axis_FM_; }
+                    const Frame<T>& outboard_frame_M, int axis);
 
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
@@ -160,7 +156,7 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
  private:
   // Joint axis expressed identically in frames F and M. This must be one of
   // the coordinate axes 100, 010, or 001.
-  Vector3<double> axis_FM_;
+  Vector3<double> axis_;
 };
 
 // Revolute mobilizer with rotation axis aligned with one of the F and M frame
@@ -171,16 +167,10 @@ class RevoluteMobilizerAxial final : public RevoluteMobilizer<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RevoluteMobilizerAxial);
 
-  using RevoluteMobilizer<T>::axis_FM;
-
   RevoluteMobilizerAxial(const SpanningForest::Mobod& mobod,
                          const Frame<T>& inboard_frame_F,
                          const Frame<T>& outboard_frame_M)
-      : RevoluteMobilizer<T>(mobod, inboard_frame_F, outboard_frame_M) {
-    Vector3<double> rotation_axis = Vector3<double>::Zero();
-    rotation_axis[axis] = 1;
-    this->set_axis_FM(rotation_axis);
-  }
+      : RevoluteMobilizer<T>(mobod, inboard_frame_F, outboard_frame_M, axis) {}
 
   ~RevoluteMobilizerAxial() final;
 
@@ -229,7 +219,7 @@ class RevoluteMobilizerAxial final : public RevoluteMobilizer<T> {
   // it by exploiting its known structure.
   void update_X_FM(const T* q, math::RigidTransform<T>* arX_FM) const {
     DRAKE_ASSERT(q != nullptr && arX_FM != nullptr);
-    math::RigidTransform<T>::template UpdateAxialRotation<axis>(q[0], &*arX_FM);
+    math::RigidTransform<T>::template UpdateAxialRotation<axis>(q[0], arX_FM);
   }
 
   // Returns X_AM = X_AF * arX_FM, exploiting known structure of arX_FM.
@@ -250,22 +240,27 @@ class RevoluteMobilizerAxial final : public RevoluteMobilizer<T> {
     return X_FB;
   }
 
-  // TODO(sherm1) Velocity & acceleration APIs should be reworked to perform
-  //  only simplified updates.
-
   // Computes the across-mobilizer spatial velocity V_FM(q, v) of the outboard
   // frame M measured and expressed in frame F as a function of the input
   // angular velocity `v` about this mobilizer's axis (@see revolute_axis()).
   SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
-    return SpatialVelocity<T>(v[0] * axis_FM(),  // axis_F, 3 flops
-                              Vector3<T>::Zero());
+    DRAKE_ASSERT(v != nullptr);
+    Eigen::Vector3<T> w_FM;
+    w_FM[kX] = v[0];
+    w_FM[kY] = 0;
+    w_FM[kZ] = 0;
+    return SpatialVelocity<T>(w_FM, Vector3<T>::Zero());
   }
 
   // Here H_F₆ₓ₁=[axis_F, 0₃]ᵀ so Hdot_F = 0 and
   // A_FM_F = H_F⋅vdot + Hdot_F⋅v = [axis_F⋅vdot, 0₃]ᵀ
   SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
-    return SpatialAcceleration<T>(vdot[0] * axis_FM(),  // axis_F, 3 flops
-                                  Vector3<T>::Zero());
+    DRAKE_ASSERT(vdot != nullptr);
+    Eigen::Vector3<T> alpha_FM;
+    alpha_FM[kX] = vdot[0];
+    alpha_FM[kY] = 0;
+    alpha_FM[kZ] = 0;
+    return SpatialAcceleration<T>(alpha_FM, Vector3<T>::Zero());
   }
 
   // Returns tau = H_FM_Fᵀ⋅F_F, where H_FM_Fᵀ = [axis_Fᵀ 0₃ᵀ].
@@ -289,6 +284,10 @@ class RevoluteMobilizerAxial final : public RevoluteMobilizer<T> {
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
       const MultibodyTree<ToScalar>& tree_clone) const;
+
+  // Write algorithms as though the axes were x, y, and z; modular arithmetic
+  // here ensures they will work correctly for axis=0, 1, or 2.
+  static constexpr int kX = axis, kY = (axis + 1) % 3, kZ = (axis + 2) % 3;
 };
 
 }  // namespace internal

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -205,9 +205,8 @@ GTEST_TEST(BodyNodeTest, FactorArticulatedBodyHingeInertiaMatrixErrorMessages) {
 
   {
     // Translation only.
-    const PrismaticMobilizer<double> mobilizer(dummy_mobod, parent.body_frame(),
-                                               child.body_frame(),
-                                               Vector3d{0, 0, 1});
+    const PrismaticMobilizerAxial<double, 2> mobilizer(
+        dummy_mobod, parent.body_frame(), child.body_frame());
     const DummyBodyNode body_node(&parent_node, &child, &mobilizer);
     DRAKE_EXPECT_THROWS_MESSAGE(
         BodyNodeTester::CallLltFactorization(body_node, one_by_one),

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -29,18 +29,19 @@ constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 class PrismaticMobilizerTest : public MobilizerTester {
  public:
   void SetUp() override {
-    slider_ = &AddJointAndFinalize<PrismaticJoint, PrismaticMobilizer>(
-        std::make_unique<PrismaticJoint<double>>(
-            "joint0", tree().world_body().body_frame(), body_->body_frame(),
-            axis_F_));
+    // The axis is not one of the coordinate axes, so we'll expect to get
+    // new F & M frames that translate along their common z axis.
+    const PrismaticMobilizer<double>& const_slider =
+        AddJointAndFinalize<PrismaticJoint, PrismaticMobilizer>(
+            std::make_unique<PrismaticJoint<double>>(
+                "joint0", tree().world_body().body_frame(), body_->body_frame(),
+                axis_Jp_));
+    slider_ = const_cast<PrismaticMobilizer<double>*>(&const_slider);
   }
 
  protected:
-  const PrismaticMobilizer<double>* slider_{nullptr};
-  // Prismatic mobilizer axis, expressed in the inboard frame F.
-  // It's intentionally left non-normalized to verify the mobilizer properly
-  // normalizes it at construction.
-  const Vector3d axis_F_{1.0, 2.0, 3.0};
+  PrismaticMobilizer<double>* slider_{nullptr};
+  const Vector3d axis_Jp_{1.0, 2.0, 3.0};  // also axis_Jc
 };
 
 TEST_F(PrismaticMobilizerTest, CanRotateOrTranslate) {
@@ -48,10 +49,11 @@ TEST_F(PrismaticMobilizerTest, CanRotateOrTranslate) {
   EXPECT_TRUE(slider_->can_translate());
 }
 
-// Verify that PrismaticMobilizer normalizes its axis on construction.
+// Even though we started with a _joint_ axis vector with arbitrary components,
+// we expect that the mobilizer will have a unit vector axis, and in particular
+// that we chose the z axis. We expect exact integer components, no roundoff.
 TEST_F(PrismaticMobilizerTest, AxisIsNormalizedAtConstruction) {
-  EXPECT_TRUE(CompareMatrices(slider_->translation_axis(), axis_F_.normalized(),
-                              kTolerance, MatrixCompareType::relative));
+  EXPECT_EQ(slider_->translation_axis(), Vector3d(0, 0, 1));
 }
 
 // Verifies method to mutate and access the context.
@@ -88,14 +90,58 @@ TEST_F(PrismaticMobilizerTest, ZeroState) {
   EXPECT_EQ(slider_->get_translation_rate(*context_), 0);
 }
 
+TEST_F(PrismaticMobilizerTest, DefaultPosition) {
+  EXPECT_EQ(slider_->get_translation(*context_), 0);
+
+  slider_->set_default_position(Vector1d{.4});
+  slider_->set_default_state(*context_, &context_->get_mutable_state());
+
+  EXPECT_EQ(slider_->get_translation(*context_), .4);
+}
+
+TEST_F(PrismaticMobilizerTest, RandomState) {
+  RandomGenerator generator;
+  std::uniform_real_distribution<symbolic::Expression> uniform;
+
+  // Default behavior is to set to zero.
+  slider_->set_random_state(*context_, &context_->get_mutable_state(),
+                            &generator);
+  EXPECT_EQ(slider_->get_translation(*context_), 0);
+  EXPECT_EQ(slider_->get_translation_rate(*context_), 0);
+
+  // Set position to be random, but not velocity (yet).
+  slider_->set_random_position_distribution(
+      Vector1<symbolic::Expression>(uniform(generator) + 2.0));
+  slider_->set_random_state(*context_, &context_->get_mutable_state(),
+                            &generator);
+  EXPECT_GE(slider_->get_translation(*context_), 2.0);
+  EXPECT_EQ(slider_->get_translation_rate(*context_), 0);
+
+  // Set the velocity distribution.  Now both should be random.
+  slider_->set_random_velocity_distribution(
+      Vector1<symbolic::Expression>(uniform(generator) - 2.0));
+  slider_->set_random_state(*context_, &context_->get_mutable_state(),
+                            &generator);
+  EXPECT_GE(slider_->get_translation(*context_), 2.0);
+  EXPECT_LE(slider_->get_translation_rate(*context_), -1.0);
+
+  // Check that they change on a second draw from the distribution.
+  const double last_translation = slider_->get_translation(*context_);
+  const double last_translation_rate = slider_->get_translation_rate(*context_);
+  slider_->set_random_state(*context_, &context_->get_mutable_state(),
+                            &generator);
+  EXPECT_NE(slider_->get_translation(*context_), last_translation);
+  EXPECT_NE(slider_->get_translation_rate(*context_), last_translation_rate);
+}
+
 TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerTransform) {
   const double kTol = 4 * std::numeric_limits<double>::epsilon();
   const double translation = 1.5;
   slider_->SetTranslation(context_.get(), translation);
   math::RigidTransformd X_FM(slider_->CalcAcrossMobilizerTransform(*context_));
 
-  const math::RigidTransformd X_FM_expected(
-      Vector3d(axis_F_.normalized() * translation));
+  const math::RigidTransformd X_FM_expected(translation *
+                                            slider_->translation_axis());
 
   // Though checked below, we make it explicit here that this mobilizer should
   // introduce no rotations at all.
@@ -104,16 +150,20 @@ TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerTransform) {
                               X_FM_expected.GetAsMatrix34(), kTolerance,
                               MatrixCompareType::relative));
 
-  // Now check the fast inline methods.
-  RigidTransformd fast_X_FM = slider_->calc_X_FM(&translation);
+  // Now check the fast inline methods. Since we used a general axis above,
+  // this should have been modeled with a z-axial mobilizer.
+  auto slider_z =
+      dynamic_cast<const PrismaticMobilizerAxial<double, 2>*>(slider_);
+  ASSERT_NE(slider_z, nullptr);
+  RigidTransformd fast_X_FM = slider_z->calc_X_FM(&translation);
   EXPECT_TRUE(fast_X_FM.IsNearlyEqualTo(X_FM, kTol));
   const double new_translation = 3;
   slider_->SetTranslation(context_.get(), new_translation);
   X_FM = slider_->CalcAcrossMobilizerTransform(*context_);
-  slider_->update_X_FM(&new_translation, &fast_X_FM);
+  slider_z->update_X_FM(&new_translation, &fast_X_FM);
   EXPECT_TRUE(fast_X_FM.IsNearlyEqualTo(X_FM, kTol));
 
-  TestPrePostMultiplyByX_FM(X_FM, *slider_);
+  TestPrePostMultiplyByX_FM(X_FM, *slider_z);
 }
 
 TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
@@ -123,7 +173,7 @@ TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
                                                   Vector1d(translation_rate));
 
   const SpatialVelocity<double> V_FM_expected(
-      Vector3d::Zero(), axis_F_.normalized() * translation_rate);
+      Vector3d::Zero(), translation_rate * slider_->translation_axis());
 
   // Though checked below, we make it explicit here that this mobilizer should
   // introduce no rotations at all.
@@ -138,7 +188,8 @@ TEST_F(PrismaticMobilizerTest, CalcAcrossMobilizerSpatialAcceleration) {
           *context_, Vector1d(translational_acceleration));
 
   const SpatialAcceleration<double> A_FM_expected(
-      Vector3d::Zero(), axis_F_.normalized() * translational_acceleration);
+      Vector3d::Zero(),
+      translational_acceleration * slider_->translation_axis());
 
   // Though checked below, we make it explicit here that this mobilizer should
   // introduce no rotations at all.
@@ -154,7 +205,7 @@ TEST_F(PrismaticMobilizerTest, ProjectSpatialForce) {
   slider_->ProjectSpatialForce(*context_, F_Mo_F, tau);
 
   // Only the force along axis_F does work.
-  const double tau_expected = force_Mo_F.dot(axis_F_.normalized());
+  const double tau_expected = force_Mo_F.dot(slider_->translation_axis());
   EXPECT_NEAR(tau(0), tau_expected, kTolerance);
 }
 

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -32,19 +32,19 @@ class RevoluteMobilizerTest : public MobilizerTester {
   void SetUp() override {
     // The axis is not one of the coordinate axes, so we'll expect to get
     // new F & M frames that rotate around their common z axis.
-    mobilizer_ = &AddJointAndFinalize<RevoluteJoint, RevoluteMobilizer>(
-        std::make_unique<RevoluteJoint<double>>(
-            "joint0", tree().world_body().body_frame(), body_->body_frame(),
-            axis_F_));
+    const RevoluteMobilizer<double>& const_mobilizer =
+        AddJointAndFinalize<RevoluteJoint, RevoluteMobilizer>(
+            std::make_unique<RevoluteJoint<double>>(
+                "joint0", tree().world_body().body_frame(), body_->body_frame(),
+                axis_Jp_));
     // Mobilizers are always ephemeral (i.e. not added by user).
+    mobilizer_ = const_cast<RevoluteMobilizer<double>*>(&const_mobilizer);
     EXPECT_TRUE(mobilizer_->is_ephemeral());
-    mutable_mobilizer_ = const_cast<RevoluteMobilizer<double>*>(mobilizer_);
   }
 
  protected:
-  const RevoluteMobilizer<double>* mobilizer_{nullptr};
-  RevoluteMobilizer<double>* mutable_mobilizer_{nullptr};
-  const Vector3d axis_F_{1.0, 2.0, 3.0};
+  RevoluteMobilizer<double>* mobilizer_{nullptr};
+  const Vector3d axis_Jp_{1.0, 2.0, 3.0};  // also axis_Jc
 };
 
 TEST_F(RevoluteMobilizerTest, CanRotateOrTranslate) {
@@ -56,7 +56,6 @@ TEST_F(RevoluteMobilizerTest, CanRotateOrTranslate) {
 // we expect that the mobilizer will have a unit vector axis, and in particular
 // that we chose the z axis. We expect exact integer components, no roundoff.
 TEST_F(RevoluteMobilizerTest, AxisIsNormalizedAtConstruction) {
-  EXPECT_EQ(mobilizer_->revolute_axis().norm(), 1.0);
   EXPECT_EQ(mobilizer_->revolute_axis(), Vector3d(0, 0, 1));
 }
 
@@ -97,7 +96,7 @@ TEST_F(RevoluteMobilizerTest, ZeroState) {
 TEST_F(RevoluteMobilizerTest, DefaultPosition) {
   EXPECT_EQ(mobilizer_->get_angle(*context_), 0);
 
-  mutable_mobilizer_->set_default_position(Vector1d{.4});
+  mobilizer_->set_default_position(Vector1d{.4});
   mobilizer_->set_default_state(*context_, &context_->get_mutable_state());
 
   EXPECT_EQ(mobilizer_->get_angle(*context_), .4);
@@ -108,32 +107,32 @@ TEST_F(RevoluteMobilizerTest, RandomState) {
   std::uniform_real_distribution<symbolic::Expression> uniform;
 
   // Default behavior is to set to zero.
-  mutable_mobilizer_->set_random_state(
-      *context_, &context_->get_mutable_state(), &generator);
+  mobilizer_->set_random_state(*context_, &context_->get_mutable_state(),
+                               &generator);
   EXPECT_EQ(mobilizer_->get_angle(*context_), 0);
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), 0);
 
   // Set position to be random, but not velocity (yet).
-  mutable_mobilizer_->set_random_position_distribution(
+  mobilizer_->set_random_position_distribution(
       Vector1<symbolic::Expression>(uniform(generator) + 2.0));
-  mutable_mobilizer_->set_random_state(
-      *context_, &context_->get_mutable_state(), &generator);
+  mobilizer_->set_random_state(*context_, &context_->get_mutable_state(),
+                               &generator);
   EXPECT_GE(mobilizer_->get_angle(*context_), 2.0);
   EXPECT_EQ(mobilizer_->get_angular_rate(*context_), 0);
 
   // Set the velocity distribution.  Now both should be random.
-  mutable_mobilizer_->set_random_velocity_distribution(
+  mobilizer_->set_random_velocity_distribution(
       Vector1<symbolic::Expression>(uniform(generator) - 2.0));
-  mutable_mobilizer_->set_random_state(
-      *context_, &context_->get_mutable_state(), &generator);
+  mobilizer_->set_random_state(*context_, &context_->get_mutable_state(),
+                               &generator);
   EXPECT_GE(mobilizer_->get_angle(*context_), 2.0);
   EXPECT_LE(mobilizer_->get_angular_rate(*context_), -1.0);
 
   // Check that they change on a second draw from the distribution.
   const double last_angle = mobilizer_->get_angle(*context_);
   const double last_angular_rate = mobilizer_->get_angular_rate(*context_);
-  mutable_mobilizer_->set_random_state(
-      *context_, &context_->get_mutable_state(), &generator);
+  mobilizer_->set_random_state(*context_, &context_->get_mutable_state(),
+                               &generator);
   EXPECT_NE(mobilizer_->get_angle(*context_), last_angle);
   EXPECT_NE(mobilizer_->get_angular_rate(*context_), last_angular_rate);
 }
@@ -144,8 +143,8 @@ TEST_F(RevoluteMobilizerTest, CalcAcrossMobilizerTransform) {
   mobilizer_->SetAngle(context_.get(), angle);
   RigidTransformd X_FM(mobilizer_->CalcAcrossMobilizerTransform(*context_));
 
-  const RigidTransformd X_FM_expected(RotationMatrixd(
-      AngleAxisd(angle, mobilizer_->revolute_axis().normalized())));
+  const RigidTransformd X_FM_expected(
+      RotationMatrixd(AngleAxisd(angle, mobilizer_->revolute_axis())));
 
   // Though checked below, we make it explicit here that this mobilizer should
   // introduce no translations at all.


### PR DESCRIPTION
Following PR #22873 (optimal frames for revolute joints), this PR does the same for prismatic joints.

Makes some minor changes to bring revolute_mobilizer and prismatic_mobilizer into nicely-matching terminology, implementation, and tests. Adds two missing unit tests to prismatic_mobilizer_test.cc. Adds two more RigidTransform internal-use-only specialized methods & unit tests.

Does not yet permit reversal of prismatic joints. There will be a follow-on similar to #22883 (reverse revolute joint) for prismatics.

Completes milestone 3 of [this document](https://docs.google.com/document/d/1KT2hlRc1eeIPSZ_Oo4tqESy0MadteJeAhFINwTZqfFY).

All changes are internal so no release note is required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22925)
<!-- Reviewable:end -->
