### PR TITLE
Perform wheel builds in a unique directory

### DIFF
--- a/tools/wheel/Dockerfile
+++ b/tools/wheel/Dockerfile
@@ -13,6 +13,9 @@ ADD image/provision-base.sh /image/
 
 RUN /image/provision-base.sh
 
+ADD image/provision-build.sh /image/
+RUN /image/provision-build.sh
+
 # -----------------------------------------------------------------------------
 # Install Python.
 # -----------------------------------------------------------------------------
@@ -31,8 +34,8 @@ RUN /image/provision-python.sh ${PYTHON} ${PYTHON_SHA}
 # -----------------------------------------------------------------------------
 
 ADD image/build-drake.sh /image/
-ADD image/drake-src.tar /opt/drake-wheel-build/drake/
-COPY image/snopt.tar.gz /opt/drake-wheel-build/src/
+ADD image/drake-src.tar /tmp/drake-wheel-build/drake-src/
+COPY image/snopt.tar.gz /tmp/drake-wheel-build/snopt/
 
 # -----------------------------------------------------------------------------
 # Build the Drake wheel.
@@ -45,14 +48,14 @@ ARG DRAKE_GIT_SHA
 
 ENV DRAKE_VERSION=${DRAKE_VERSION}
 ENV DRAKE_GIT_SHA=${DRAKE_GIT_SHA}
-ENV SNOPT_PATH=/opt/drake-wheel-build/src/snopt.tar.gz
+ENV SNOPT_PATH=/tmp/drake-wheel-build/snopt/snopt.tar.gz
 
 RUN --mount=type=cache,target=/var/cache/bazel \
     /image/build-drake.sh
 
 ADD image/build-wheel.sh /image/
-ADD image/setup.py /opt/drake-wheel-build/wheel/
-ADD content /opt/drake-wheel-content
-ADD licenses /opt/drake-wheel-licenses
+ADD image/setup.py /tmp/drake-wheel-build/drake-wheel/
+ADD content /tmp/drake-wheel-build/drake-wheel-content
+ADD licenses /tmp/drake-wheel-build/drake-wheel-licenses
 
 RUN /image/build-wheel.sh

--- a/tools/wheel/README.rst
+++ b/tools/wheel/README.rst
@@ -19,8 +19,9 @@ environment as one would to build Drake normally).
 There are a small number of dependencies for the the builder scripts to work
 that Drake itself does not require. In order to install these additional
 packages, run the ``setup/install_prereqs`` script with the ``--developer``
-flag. The builder must also be able to write to ``/opt``, as this is where the
-build is performed.
+flag. The builder must also be able to write to ``${HOME}``, as this is where
+the build is performed, and to ``/tmp``, as a redirect is created here so that
+build artifacts can be referenced via a known path.
 
 The script takes a single, required positional argument, which is used to
 specify the version with which the wheels should be tagged. The version number
@@ -68,7 +69,8 @@ debugging purposes and should not be needed in ordinary use.
     system. (The Docker cache and tagged images may still be altered.)
 
     On macOS, if ``--keep-build`` is used, the wheel will still be accessible
-    via its build location in ``//opt/drake-wheel-build/wheel/wheelhouse``.
+    via its build location in
+    ``${HOME}/.drake-wheel-build/<unique>/drake-wheel/wheelhouse``.
 
     This option automatically implies ``--no-test``.
 
@@ -92,7 +94,8 @@ debugging purposes and should not be needed in ordinary use.
 
 ``-k``, ``--keep-containers`` (macOS only)
     Do not delete the various build trees and artifacts, which can be found in
-    various subdirectories under ``/opt``.
+    various subdirectories under ``${HOME}/.drake-wheel-build`` in a
+    unique, per-build subdirectory.
 
 Implementation Details
 ----------------------
@@ -126,19 +129,11 @@ was successfully installed.
 On macOS, wheels must be built on the host system. The following directories
 are used:
 
-- ``/opt/drake-wheel-build``:
-  Contains most intermediate artifacts.
+- ``/tmp/drake-wheel-build``:
+  Symlink to the per-build unique build root
 
-- ``/opt/drake-dist``:
-  Contains the Drake installation used to build the wheel.
-
-- ``/opt/drake-wheel-test``:
-  Contains a Python virtual environment used to test the wheel.
-
-In addition, the wheel creation script requires that the Drake installation is
-located at ``/opt/drake``. Since multiple builds may be present, a temporary
-symlink is created at this path to the actual, Python-version-specific
-installation while building the wheel. Therefore, this path must be available.
+- ``${HOME}/.drake-wheel-build
+  Contains the per-build unique build root
 
 Starting from a provisioned wheel building environment (installed via
 ``setup/install_prereqs --developer``), the builder invokes

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -5,15 +5,17 @@
 
 set -eu -o pipefail
 
-mkdir /opt/drake-wheel-build/drake-build
-cd /opt/drake-wheel-build/drake-build
+[ -d /tmp/drake-wheel-build/ ]
+
+mkdir /tmp/drake-wheel-build/drake-build
+cd /tmp/drake-wheel-build/drake-build
 
 # Store downloads in the build cache to speed up rebuilds.
 export BAZELISK_HOME=/var/cache/bazel/bazelisk
 
 # Add wheel-specific bazel options.
 # N.B. When you change anything here, also fix wheel/macos/build-wheel.sh.
-cat > /opt/drake-wheel-build/drake-build/drake.bazelrc << EOF
+cat > /tmp/drake-wheel-build/drake-build/drake.bazelrc << EOF
 build --disk_cache=/var/cache/bazel/disk_cache
 build --repository_cache=/var/cache/bazel/repository_cache
 build --repo_env=DRAKE_WHEEL=1
@@ -30,7 +32,7 @@ EOF
 
 # Install Drake using our wheel-build-specific Python interpreter.
 # N.B. When you change anything here, also fix wheel/macos/build-wheel.sh.
-cmake ../drake \
+cmake ../drake-src \
     -DWITH_USER_EIGEN=OFF \
     -DWITH_USER_FMT=OFF \
     -DWITH_USER_SPDLOG=OFF \
@@ -39,6 +41,6 @@ cmake ../drake \
     -DWITH_USER_ZLIB=OFF \
     -DDRAKE_VERSION_OVERRIDE="${DRAKE_VERSION}" \
     -DDRAKE_GIT_SHA_OVERRIDE="${DRAKE_GIT_SHA}" \
-    -DCMAKE_INSTALL_PREFIX=/opt/drake \
+    -DCMAKE_INSTALL_PREFIX=/tmp/drake-wheel-build/drake-dist \
     -DPython_EXECUTABLE=/usr/local/bin/python
 make install

--- a/tools/wheel/image/build-python.sh
+++ b/tools/wheel/image/build-python.sh
@@ -11,7 +11,7 @@ readonly EXPECTED_SHA=$3
 
 readonly ARCHIVE=Python-$VERSION.tar.xz
 readonly URL=https://www.python.org/ftp/python/$VERSION/$ARCHIVE
-readonly SRC_DIR=/opt/drake-wheel-build/python
+readonly SRC_DIR=/tmp/drake-wheel-build/python-src
 
 mkdir -p $SRC_DIR
 cd $SRC_DIR

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -43,16 +43,16 @@ copy_license()
     package_name=$1
     mkdir -p ${WHEEL_DIR}/pydrake/doc/${package_name}
     cp -t ${WHEEL_DIR}/pydrake/doc/${package_name}/ \
-        /opt/drake-wheel-licenses/${package_name}/copyright
+        /tmp/drake-wheel-build/drake-wheel-licenses/${package_name}/copyright
 }
 
 ###############################################################################
 
 # Activate Drake's virtual environment, which provides some of the tools that
 # we need to build the wheels.
-. /opt/drake-wheel-build/drake/venv/bin/activate
+. /tmp/drake-wheel-build/drake-src/venv/bin/activate
 
-readonly WHEEL_DIR=/opt/drake-wheel-build/wheel
+readonly WHEEL_DIR=/tmp/drake-wheel-build/drake-wheel
 readonly WHEEL_SHARE_DIR=${WHEEL_DIR}/pydrake/share
 
 # TODO(mwoehlke-kitware) Most of this should move to Bazel.
@@ -62,24 +62,25 @@ mkdir -p ${WHEEL_DIR}/pydrake/share/drake
 cd ${WHEEL_DIR}
 
 cp -r -t ${WHEEL_DIR}/drake \
-    /opt/drake/lib/python*/site-packages/drake/*
+    /tmp/drake-wheel-build/drake-dist/lib/python*/site-packages/drake/*
 
 cp -r -t ${WHEEL_DIR}/pydrake \
-    /opt/drake/share/doc \
-    /opt/drake/lib/python*/site-packages/pydrake/*
+    /tmp/drake-wheel-build/drake-dist/share/doc \
+    /tmp/drake-wheel-build/drake-dist/lib/python*/site-packages/pydrake/*
 
 cp -r -t ${WHEEL_DIR}/pydrake/lib \
-    /opt/drake/lib/libdrake*.so
+    /tmp/drake-wheel-build/drake-dist/lib/libdrake*.so
 
 # MOSEK is "sort of" third party, but is procured as part of Drake's build and
-# ends up in /opt/drake. It should end up in the same place as libdrake.so.
+# ends up in /tmp/drake-wheel-build/drake-dist/. It should end up in the same
+# place as libdrake.so.
 cp -r -t ${WHEEL_DIR}/pydrake/lib \
-    /opt/drake/lib/libmosek* \
-    /opt/drake/lib/libtbb*
+    /tmp/drake-wheel-build/drake-dist/lib/libmosek* \
+    /tmp/drake-wheel-build/drake-dist/lib/libtbb*
 
 if [[ "$(uname)" == "Linux" ]]; then
   cp -r -t ${WHEEL_DIR}/pydrake \
-      /opt/drake-wheel-content/*
+      /tmp/drake-wheel-build/drake-wheel-content/*
 fi
 
 # Copy the license files from third party dependencies we vendor.
@@ -91,17 +92,17 @@ if [[ "$(uname)" == "Linux" ]]; then
 fi
 
 cp -r -t ${WHEEL_SHARE_DIR}/drake \
-    /opt/drake/share/drake/.drake-find_resource-sentinel \
-    /opt/drake/share/drake/package.xml \
-    /opt/drake/share/drake/examples \
-    /opt/drake/share/drake/geometry \
-    /opt/drake/share/drake/multibody \
-    /opt/drake/share/drake/tutorials
+    /tmp/drake-wheel-build/drake-dist/share/drake/.drake-find_resource-sentinel \
+    /tmp/drake-wheel-build/drake-dist/share/drake/package.xml \
+    /tmp/drake-wheel-build/drake-dist/share/drake/examples \
+    /tmp/drake-wheel-build/drake-dist/share/drake/geometry \
+    /tmp/drake-wheel-build/drake-dist/share/drake/multibody \
+    /tmp/drake-wheel-build/drake-dist/share/drake/tutorials
 
 if [[ "$(uname)" == "Linux" ]]; then
     mkdir -p ${WHEEL_SHARE_DIR}/drake/setup
     cp -r -t ${WHEEL_SHARE_DIR}/drake/setup \
-        /opt/drake/share/drake/setup/deepnote
+        /tmp/drake-wheel-build/drake-dist/share/drake/setup/deepnote
 fi
 
 if [[ "$(uname)" == "Linux" ]]; then

--- a/tools/wheel/image/provision-build.sh
+++ b/tools/wheel/image/provision-build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Internal script to prepare the build location.
+#
+# This procedure first creates the super root of the wheel build at
+# ``$HOME/.drake-wheel-build``. Then, the script creates a unique temporary
+# build directory for each wheel built as a subdirectory of the super root.
+# Finally, the temporary directory is symlinked to ``/tmp/drake-wheel-build``
+# for consistent reference in later steps of the wheel building process.
+#
+# The script takes an optional command-line argument denoting the python
+# version of the wheel being built. This adds the specified version as a
+# prefix to the random build directory name. This way, if the ``--keep-build``
+# flag is set for a macOS build, the user can differentiate between wheel
+# builds by python version (this is not applicable to Ubuntu builds since
+# Linux wheels are built in Docker containers).
+
+set -eu -o pipefail
+
+mkdir -p ~/.drake-wheel-build
+readonly d="$(mktemp -d ~/.drake-wheel-build/${1:-}XXXXXXXXXX)"
+ln -nsf "${d}" /tmp/drake-wheel-build

--- a/tools/wheel/image/provision-python.sh
+++ b/tools/wheel/image/provision-python.sh
@@ -11,7 +11,7 @@ set -eu -o pipefail
 # (needed to download the sources). Otherwise, the version should be a valid
 # suffix of 'python'. Unspecified is treated as '3'.
 if [[ "${1%:*}" == "build" ]]; then
-    readonly PREFIX=/opt/drake-python
+    readonly PREFIX=/tmp/drake-wheel-build/python-dist
     readonly PYTHON=python$(echo ${1#*:} | cut -d. -f1-2)
 
     cd "$(dirname "${BASH_SOURCE}")"

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -27,23 +27,15 @@ readonly python_prefix="$(brew --prefix python@$python_version)"
 readonly python_executable="$python_prefix/bin/$python"
 
 # -----------------------------------------------------------------------------
-# Clean up from old builds.
-# -----------------------------------------------------------------------------
-
-rm -rf "/opt/drake-wheel-build/$python"
-rm -rf "/opt/drake-dist/$python"
-
-if [ -e "/opt/drake" ]; then
-    echo "Unable to proceed: /opt/drake exists" \
-         "(left over from a failed build?)" >&2
-    exit 1
-fi
-
-# -----------------------------------------------------------------------------
 # Build and "install" Drake.
 # -----------------------------------------------------------------------------
 
-readonly build_root="/opt/drake-wheel-build/$python/drake-build"
+# Create a unique space for the build. Because there may be multiple such
+# spaces if the user needs to inspect them (i.e. using --keep-build), prefix
+# the space with the Python version to aid in identifying the spaces.
+"$resource_root/image/provision-build.sh" "$python-"
+
+readonly build_root="/tmp/drake-wheel-build/drake-build"
 
 mkdir -p "$build_root"
 cd "$build_root"
@@ -71,7 +63,7 @@ cmake "$git_root" \
     -DWITH_USER_LAPACK=OFF \
     -DWITH_USER_ZLIB=OFF \
     -DDRAKE_VERSION_OVERRIDE="${DRAKE_VERSION}" \
-    -DCMAKE_INSTALL_PREFIX="/opt/drake-dist/$python" \
+    -DCMAKE_INSTALL_PREFIX="/tmp/drake-wheel-build/drake-dist" \
     -DPython_EXECUTABLE="$python_executable"
 make install
 
@@ -91,9 +83,9 @@ find "$build_root" -type d -print0 | xargs -0 chmod u+w
 # "Install" additional tools to build the wheel.
 # -----------------------------------------------------------------------------
 
-ln -nsf "$git_root" "/opt/drake-wheel-build/drake"
+ln -nsf "$git_root" "/tmp/drake-wheel-build/drake-src"
 
-readonly venv_drake="/opt/drake-wheel-build/drake/venv"
+readonly venv_drake="/tmp/drake-wheel-build/drake-src/venv"
 
 ln -s \
     "$build_root/bazel-bin/external/drake+/tools/wheel/strip_rpath" \
@@ -107,17 +99,12 @@ ln -s \
 # Build the Drake wheel.
 # -----------------------------------------------------------------------------
 
-mkdir -p "/opt/drake-wheel-build/$python/wheel"
-
-ln -s "/opt/drake-dist/$python" \
-      "/opt/drake"
+mkdir -p "/tmp/drake-wheel-build/drake-wheel"
 
 cp \
     "$resource_root/image/setup.py" \
-    "/opt/drake-wheel-build/wheel/setup.py"
+    "/tmp/drake-wheel-build/drake-wheel/setup.py"
 
 export DRAKE_VERSION="$1"
 
 "$resource_root/image/build-wheel.sh"
-
-rm "/opt/drake"

--- a/tools/wheel/macos/provision-test-python.sh
+++ b/tools/wheel/macos/provision-test-python.sh
@@ -12,11 +12,11 @@ if [[ $# -lt 1 ]]; then
 fi
 
 # Clean up from old tests.
-rm -rf /opt/drake-wheel-test
+rm -rf /tmp/drake-wheel-test
 
 # Prepare test environment.
-mkdir /opt/drake-wheel-test
+mkdir /tmp/drake-wheel-test
 
 # NOTE: Xcode ships python3, make sure to use the one from brew.
 $(brew --prefix python@$1)/bin/python$1 \
-    -m venv /opt/drake-wheel-test/python$1
+    -m venv /tmp/drake-wheel-test/python$1

--- a/tools/wheel/test/install-wheel.sh
+++ b/tools/wheel/test/install-wheel.sh
@@ -3,7 +3,7 @@
 # This shell script installs a Drake wheel. It must be run inside a container
 # (Ubuntu) or environment (macOS) which has been properly provisioned, e.g. by
 # the accompanying Dockerfile (Ubuntu) or by macos/provision-test-python.sh
-# (macOS). In particular, /opt/drake-wheel-test/python must contain a Python
+# (macOS). In particular, /tmp/drake-wheel-test/python must contain a Python
 # virtual environment which will be used to run the tests. The path to the
 # wheel to be installed must be given as an argument to the script. On Ubuntu,
 # the wheel must be accessible to the container, and the path must be the
@@ -19,6 +19,6 @@ if [[ -z "$1" ]]; then
     exit 1
 fi
 
-. /opt/drake-wheel-test/python/bin/activate
+. /tmp/drake-wheel-test/python/bin/activate
 
 pip install "$1"

--- a/tools/wheel/test/provision.sh
+++ b/tools/wheel/test/provision.sh
@@ -15,8 +15,8 @@ apt-get -y install --no-install-recommends \
     python3-venv \
     libx11-6 libsm6 libxt6 libglib2.0-0
 
-${PYTHON} -m venv /opt/drake-wheel-test/python
+${PYTHON} -m venv /tmp/drake-wheel-test/python
 
-. /opt/drake-wheel-test/python/bin/activate
+. /tmp/drake-wheel-test/python/bin/activate
 
 pip install --upgrade pip

--- a/tools/wheel/test/test-wheel.sh
+++ b/tools/wheel/test/test-wheel.sh
@@ -19,6 +19,6 @@ fi
 
 cd "$(dirname "${BASH_SOURCE}")"
 
-. /opt/drake-wheel-test/python/bin/activate
+. /tmp/drake-wheel-test/python/bin/activate
 
 exec "$@"

--- a/tools/wheel/test/tests/hermetic/import-error-test.sh
+++ b/tools/wheel/test/tests/hermetic/import-error-test.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 cd "$(mktemp -d)"
 
-root=/opt/drake-wheel-test/python/lib/python*/site-packages/pydrake
+root=/tmp/drake-wheel-test/python/lib/python*/site-packages/pydrake
 
 # Remove libdrake.so so imports will fail.
 # (Note: Because this test tampers with the test environment, it should only be

--- a/tools/wheel/wheel_builder/common.py
+++ b/tools/wheel/wheel_builder/common.py
@@ -13,14 +13,18 @@ import subprocess
 import sys
 import tarfile
 
-# Location where most of the build will take place.
-build_root = '/opt/drake-wheel-build'
+# Location where most of the build will take place. This is a symlink to the
+# actual build directory which a) is unique per build, and b) resides in the
+# user's home directory, where we can be confident that there is enough disk
+# space for a build (since /tmp might be on tmpfs).
+build_root = '/tmp/drake-wheel-build'
 
 # Location where testing of the wheel will take place.
-test_root = '/opt/drake-wheel-test'
+# TODO(Aiden2244) Also make this a redirecto on macOS.
+test_root = '/tmp/drake-wheel-test'
 
 # Location where the wheel will be produced.
-wheel_root = os.path.join(build_root, 'wheel')
+wheel_root = os.path.join(build_root, 'drake-wheel')
 wheelhouse = os.path.join(wheel_root, 'wheelhouse')
 
 # Location of various scripts and other artifacts used to complete the build.
@@ -83,6 +87,7 @@ def create_snopt_tgz(*, snopt_path, output):
     if snopt_path != 'git':
         shutil.copy(src=snopt_path, dst=output)
         return
+
     print('[-] Creating SNOPT archive...', flush=True)
     tar_buffer = io.BytesIO()
     tar_writer = tarfile.open(mode='w', fileobj=tar_buffer)

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -2,7 +2,6 @@
 # //tools/wheel:builder for the user interface.
 
 import atexit
-import io
 import os
 import pathlib
 import subprocess


### PR DESCRIPTION
Towards #22848 

Modify wheel builds to create a unique build directory for each build in
a unique temporary directory. This has two effects; first, builds no
longer rely on `/opt` being writable; and second, macOS builds (which
cannot be done inside a container) are better isolated.

Additionally, some directory names are changed to improve naming
consistency.

Co-Authored-By: Matthew Woehlke <matthew.woehlke@kitware.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22931)
<!-- Reviewable:end -->
