### PR TITLE
[WIP] Create mobilizer functions CalcNDotMatrix() and CalcNplusDotMatrix().

### DIFF
--- a/multibody/tree/mobilizer.cc
+++ b/multibody/tree/mobilizer.cc
@@ -43,6 +43,28 @@ void Mobilizer<T>::MapQDDotToAcceleration(const systems::Context<T>&,
   throw std::logic_error(error_message);
 }
 
+template <typename T>
+void Mobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                    EigenPtr<MatrixX<T>>) const {
+  // TODO(Mitiguy) remove this function when Mobilizer::CalcNDotMatrix()
+  //  is changed to a pure virtual function that requires override.
+  const std::string error_message = fmt::format(
+      "The function {}() has not been implemented for this mobilizer.",
+      __func__);
+  throw std::logic_error(error_message);
+}
+
+template <typename T>
+void Mobilizer<T>::DoCalcNplusDotMatrix(const systems::Context<T>&,
+                                        EigenPtr<MatrixX<T>>) const {
+  // TODO(Mitiguy) remove this function when Mobilizer::CalcNplusDotMatrix()
+  //  is changed to a pure virtual function that requires override.
+  const std::string error_message = fmt::format(
+      "The function {}() has not been implemented for this mobilizer.",
+      __func__);
+  throw std::logic_error(error_message);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -599,6 +599,38 @@ class Mobilizer : public MultibodyElement<T> {
     DoCalcNplusMatrix(context, Nplus);
   }
 
+  // Computes the matrix Ṅ(q,q̇) that helps relate q̈ (2ⁿᵈ time derivative of the
+  // generalized positions) to v̇ (1ˢᵗ time derivative of generalized velocities)
+  // via q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇, where N(q) is formed by CalcNMatrix().
+  // @param[in] context stores generalized positions q and velocities v.
+  // @param[out] Ndot The matrix Ṅ(q,q̇). On input Ndot must have size
+  //   `nq x nv` where nq is the number of generalized positions and
+  //   nv is the number of generalized velocities for this mobilizer.
+  // @see MapAccelerationToQDDot().
+  void CalcNDotMatrix(const systems::Context<T>& context,
+                      EigenPtr<MatrixX<T>> Ndot) const {
+    DRAKE_DEMAND(Ndot != nullptr);
+    DRAKE_DEMAND(Ndot->rows() == num_positions());
+    DRAKE_DEMAND(Ndot->cols() == num_velocities());
+    DoCalcNDotMatrix(context, Ndot);
+  }
+
+  // Computes the matrix Ṅ⁺(q,q̇) that helps relate v̇ (1ˢᵗ time derivative of
+  // generalized velocities) to q̈ (2ⁿᵈ time derivative of generalized positions)
+  // via v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈, where N⁺(q) is formed by CalcNPlusMatrix().
+  // @param[in] context stores generalized positions q and velocities v.
+  // @param[out] NplusDot The matrix Ṅ(q,q̇). On input NplusDot must have size
+  //   `nq x nv` where nq is the number of generalized positions and
+  //   nv is the number of generalized velocities for this mobilizer.
+  // @see MapQDDotToAcceleration().
+  void CalcNplusDotMatrix(const systems::Context<T>& context,
+                          EigenPtr<MatrixX<T>> NplusDot) const {
+    DRAKE_DEMAND(NplusDot != nullptr);
+    DRAKE_DEMAND(NplusDot->rows() == num_velocities());
+    DRAKE_DEMAND(NplusDot->cols() == num_positions());
+    DoCalcNplusDotMatrix(context, NplusDot);
+  }
+
   virtual bool is_velocity_equal_to_qdot() const = 0;
 
   // Computes the kinematic mapping `q̇ = N(q)⋅v` between generalized
@@ -757,6 +789,20 @@ class Mobilizer : public MultibodyElement<T> {
   // not the nullptr and that Nplus has the proper size.
   virtual void DoCalcNplusMatrix(const systems::Context<T>& context,
                                  EigenPtr<MatrixX<T>> Nplus) const = 0;
+
+  // NVI to CalcNDotMatrix(). Implementations can safely assume that Ndot is
+  // not the nullptr and that Ndot has the proper size.
+  // TODO(Mitiguy) change this function to a pure virtual function when it has
+  //  been overridden in all subclasses.
+  virtual void DoCalcNDotMatrix(const systems::Context<T>& context,
+                                EigenPtr<MatrixX<T>> Ndot) const;
+
+  // NVI to CalcNplusDotMatrix(). Implementations can safely assume that
+  // NplusDot is not the nullptr and that NplusDot has the proper size.
+  // TODO(Mitiguy) change this function to a pure virtual function when it has
+  //  been overridden in all subclasses.
+  virtual void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                                    EigenPtr<MatrixX<T>> NplusDot) const;
 
   // @name Methods to make a clone templated on different scalar types.
   //

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -131,6 +131,18 @@ void PrismaticMobilizer<T>::DoCalcNplusMatrix(
 }
 
 template <typename T>
+void PrismaticMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                             EigenPtr<MatrixX<T>> Ndot) const {
+  (*Ndot)(0, 0) = 0.0;
+}
+
+template <typename T>
+void PrismaticMobilizer<T>::DoCalcNplusDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> NplusDot) const {
+  (*NplusDot)(0, 0) = 0.0;
+}
+
+template <typename T>
 void PrismaticMobilizer<T>::MapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -17,49 +17,26 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-/* A Prismatic Mobilizer allows two frames to translate relative to one another
-along an axis that is constant when measured in either of the frames, while the
-frame coordinate axes remain aligned (that is, there is no rotation). The
-translation axis must be one of the coordinate axes x, y, or z. To fully specify
-this mobilizer we need an inboard ("fixed") frame F, an outboard ("mobilized")
-frame M and the coordinate axis along which frame M translates with respect to F
-(see PrismaticMobilizerAxial below). The axis vector can be considered axis_F
-(expressed in frame F) or axis_M (expressed in frame M) since the components are
-identical in either frame.
-
-The restriction to translating along a coordinate axis means that the transform
-X_FM has special structure that can be exploited for speed (it is an "axial
-translation transform" atX_FM; search for the Doxygen tag "special_xform_def" in
-drake/math/rigid_transform.h for a definition). Velocity and acceleration
-quantities are simplified also. In robotics, the prismatic joint is common
-so it is important that we handle its implementation efficiently.
-
-The single generalized coordinate q introduced by this mobilizer corresponds to
-the translation distance in meters of frame M with respect to frame F along the
-translation axis. When q = 0, frames F and M are coincident. The translation is
-defined to be positive in the direction of the translation axis.
-
-Notice that the components of the rotation axis as expressed in either frame F
-or M are constant. That is, axis_F and axis_M remain identical and unchanged
-w.r.t. both frames by this mobilizer's motion.
-
-H_FM_F₆ₓ₁=[0₃ axis_F]ᵀ     Hdot_FM_F₆ₓ₁ = 0₆
-H_FM_M₆ₓ₁=[0₃ axis_M]ᵀ     Hdot_FM_M₆ₓ₁ = 0₆
-   where axis_M == axis_F
-
-@tparam_default_scalar */
-
-// PrismaticMobilizer base class.
-// This is an abstract base class to provide high-level access to the common
-// features of the axial prismatic mobilizer concrete classes (defined below),
-// intended for use by the Joint and PrismaticJoint APIs. Internal algorithms,
-// however, should be templatized on the specific prismatic mobilizer instance
-// to permit inline access to performance-critical functions.
+// This Mobilizer allows two frames to translate relative to one another
+// along an axis whose direction is constant when measured in either this
+// mobilizer's inboard frame or its outboard frame. There is no relative
+// rotation between the inboard and outboard frames, just translation.
+// To fully specify this mobilizer, a user must provide the inboard frame F,
+// the outboard (or "mobilized") frame M and the axis `axis_F` (expressed in
+// frame F) along which frame M translates with respect to frame F.
+// The single generalized coordinate q introduced by this mobilizer
+// corresponds to the translation distance (in meters) of the origin `Mo` of
+// frame M with respect to frame F along `axis_F`. When `q = 0`, frames F and M
+// are coincident. The translation distance is defined to be positive in the
+// direction of `axis_F`.
+//
+// H_FM₆ₓ₁=[0₃, axis_F]ᵀ     Hdot_FM₆ₓ₁ = 0
+//
+// @tparam_default_scalar
 template <typename T>
-class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
+class PrismaticMobilizer final : public MobilizerImpl<T, 1, 1> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PrismaticMobilizer);
-
   using MobilizerBase = MobilizerImpl<T, 1, 1>;
   using MobilizerBase::kNq, MobilizerBase::kNv, MobilizerBase::kNx;
   template <typename U>
@@ -69,7 +46,30 @@ class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
   template <typename U>
   using HMatrix = typename MobilizerBase::template HMatrix<U>;
 
-  ~PrismaticMobilizer() override;
+  // Constructor for a %PrismaticMobilizer between the `inboard_frame_F` and
+  // `outboard_frame_M` granting a single translational degree of freedom along
+  // `axis_F`, expressed in the `inboard_frame_F`.
+  // @pre `axis_F` must be a non-zero vector with norm at least root square of
+  // machine epsilon. This vector can have any length (subject to the norm
+  // restriction above), only the direction is used.
+  // @throws std::exception if the L2 norm of `axis_F` is less than the square
+  // root of machine epsilon.
+  PrismaticMobilizer(const SpanningForest::Mobod& mobod,
+                     const Frame<T>& inboard_frame_F,
+                     const Frame<T>& outboard_frame_M,
+                     const Vector3<double>& axis_F)
+      : MobilizerBase(mobod, inboard_frame_F, outboard_frame_M),
+        axis_F_(axis_F) {
+    double kEpsilon = std::sqrt(std::numeric_limits<double>::epsilon());
+    DRAKE_DEMAND(!axis_F.isZero(kEpsilon));
+    axis_F_.normalize();
+  }
+
+  ~PrismaticMobilizer() final;
+
+  std::unique_ptr<BodyNode<T>> CreateBodyNode(
+      const BodyNode<T>* parent_node, const RigidBody<T>* body,
+      const Mobilizer<T>* mobilizer) const final;
 
   // Overloads to define the suffix names for the position and velocity
   // elements.
@@ -79,11 +79,9 @@ class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
   bool can_rotate() const final { return false; }
   bool can_translate() const final { return true; }
 
-  // @retval axis The translation axis as a unit vector expressed identically
-  // in both the F and M frames. This will be one of the coordinate axes,
-  // which will have been constructed to be aligned with the user's specified
-  // translation axis for the PrismaticJoint this is implementing.
-  const Vector3<double>& translation_axis() const { return axis_; }
+  // @retval axis_F The translation axis as a unit vector expressed in the
+  // inboard frame F.
+  const Vector3<double>& translation_axis() const { return axis_F_; }
 
   // Gets the translational distance for `this` mobilizer from `context`. See
   // class documentation for sign convention details.
@@ -122,66 +120,39 @@ class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
   const PrismaticMobilizer<T>& SetTranslationRate(
       systems::Context<T>* context, const T& translation_dot) const;
 
-  bool is_velocity_equal_to_qdot() const final { return true; }
+  // Computes the across-mobilizer transform `X_FM(q)` between the inboard
+  // frame F and the outboard frame M as a function of the translation distance
+  // along this mobilizer's axis (see translation_axis().)
+  math::RigidTransform<T> calc_X_FM(const T* q) const {
+    return math::RigidTransform<T>(q[0] * translation_axis());
+  }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
+  /* We're not yet attempting to optimize the X_FM update. */
+  // TODO(sherm1) Optimize this.
+  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
+    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
+    *X_FM = calc_X_FM(q);
+  }
 
-  // Maps qdot to v, which for this mobilizer is v = q̇.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
+  // Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame
+  // M measured and expressed in frame F as a function of the input
+  // translational velocity v along this mobilizer's axis (see
+  // translation_axis()).
+  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
+    return SpatialVelocity<T>(Vector3<T>::Zero(), v[0] * translation_axis());
+  }
 
-  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
-  void MapAccelerationToQDDot(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& vdot,
-                              EigenPtr<VectorX<T>> qddot) const final;
+  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
+    return SpatialAcceleration<T>(Vector3<T>::Zero(),
+                                  vdot[0] * translation_axis());
+  }
 
-  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
-  void MapQDDotToAcceleration(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& qddot,
-                              EigenPtr<VectorX<T>> vdot) const final;
-
- protected:
-  // Constructor for a PrismaticMobilizer between the inboard frame F and the
-  // outboard frame M, granting a single translational degree of freedom along
-  // a coordinate axis (axis=0, 1, or 2) common to both frames.
-  PrismaticMobilizer(const SpanningForest::Mobod& mobod,
-                     const Frame<T>& inboard_frame_F,
-                     const Frame<T>& outboard_frame_M, int axis);
-
-  void DoCalcNMatrix(const systems::Context<T>& context,
-                     EigenPtr<MatrixX<T>> N) const final;
-
-  void DoCalcNplusMatrix(const systems::Context<T>& context,
-                         EigenPtr<MatrixX<T>> Nplus) const final;
-
- private:
-  // Joint axis expressed identically in frames F and M. This must be one of
-  // the coordinate axes 100, 010, or 001.
-  Vector3<double> axis_;
-};
-
-// Prismatic mobilizer with translation axis aligned with one of the F and M
-// frame axes.
-template <typename T, int axis>
-  requires(0 <= axis && axis <= 2)
-class PrismaticMobilizerAxial final : public PrismaticMobilizer<T> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PrismaticMobilizerAxial);
-
-  PrismaticMobilizerAxial(const SpanningForest::Mobod& mobod,
-                          const Frame<T>& inboard_frame_F,
-                          const Frame<T>& outboard_frame_M)
-      : PrismaticMobilizer<T>(mobod, inboard_frame_F, outboard_frame_M, axis) {}
-
-  ~PrismaticMobilizerAxial() final;
-
-  std::unique_ptr<BodyNode<T>> CreateBodyNode(
-      const BodyNode<T>* parent_node, const RigidBody<T>* body,
-      const Mobilizer<T>* mobilizer) const final;
+  // Returns tau = H_FMᵀ⋅F, where H_FMᵀ = [0₃ᵀ axis_Fᵀ].
+  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
+    DRAKE_ASSERT(tau != nullptr);
+    const Vector3<T>& f_BMo_F = F_BMo_F.translational();
+    tau[0] = axis_F_.dot(f_BMo_F);
+  }
 
   math::RigidTransform<T> CalcAcrossMobilizerTransform(
       const systems::Context<T>& context) const final;
@@ -205,7 +176,7 @@ class PrismaticMobilizerAxial final : public PrismaticMobilizer<T> {
   // Projects the spatial force `F_Mo_F` on `this` mobilizer's outboard
   // frame M onto its translation axis (see translation_axis().)
   // Mathematically: <pre>
-  //    tau = F_Mo_F.translational().dot(axis)
+  //    tau = F_Mo_F.translational().dot(axis_F)
   // </pre>
   // Therefore, the result of this method is the scalar value of the linear
   // force along the axis of `this` mobilizer.
@@ -214,71 +185,43 @@ class PrismaticMobilizerAxial final : public PrismaticMobilizer<T> {
                            const SpatialForce<T>& F_Mo_F,
                            Eigen::Ref<VectorX<T>> tau) const final;
 
-  // Computes the across-mobilizer transform `X_FM(q)` between the inboard
-  // frame F and the outboard frame M as a function of the translation distance
-  // along this mobilizer's axis (see translation_axis().)
-  math::RigidTransform<T> calc_X_FM(const T* q) const {
-    DRAKE_ASSERT(q != nullptr);
-    Eigen::Vector3<T> p_FM;
-    p_FM[kX] = q[0];
-    p_FM[kY] = 0;
-    p_FM[kZ] = 0;
-    return math::RigidTransform<T>(p_FM);
-  }
+  bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // We only need to write q into the appropriate slot of X_FM to update. */
-  void update_X_FM(const T* q, math::RigidTransform<T>* X_FM) const {
-    DRAKE_ASSERT(q != nullptr && X_FM != nullptr);
-    math::RigidTransform<T>::template UpdateAxialTranslation<axis>(*q, X_FM);
-  }
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const final;
 
-  // Returns X_AM = X_AF * atX_FM, exploiting known structure of atX_FM.
-  math::RigidTransform<T> post_multiply_by_X_FM(
-      const math::RigidTransform<T>& X_AF,
-      const math::RigidTransform<T>& atX_FM) const {
-    math::RigidTransform<T> X_AM;
-    X_AF.template PostMultiplyByAxialTranslation<axis>(atX_FM, &X_AM);
-    return X_AM;
-  }
+  // Maps qdot to v, which for this mobilizer is v = q̇.
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const final;
 
-  // Returns X_FB = atX_FM * X_MB, exploiting known structure of atX_FM.
-  math::RigidTransform<T> pre_multiply_by_X_FM(
-      const math::RigidTransform<T>& atX_FM,
-      const math::RigidTransform<T>& X_MB) const {
-    math::RigidTransform<T> X_FB;
-    X_MB.template PreMultiplyByAxialTranslation<axis>(atX_FM, &X_FB);
-    return X_FB;
-  }
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void MapAccelerationToQDDot(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& vdot,
+                              EigenPtr<VectorX<T>> qddot) const final;
 
-  // Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame M
-  // measured and expressed in frame F as a function of the input translational
-  // velocity v along this mobilizer's axis (see translation_axis()).
-  SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
-    DRAKE_ASSERT(v != nullptr);
-    Eigen::Vector3<T> v_FM;
-    v_FM[kX] = v[0];
-    v_FM[kY] = 0;
-    v_FM[kZ] = 0;
-    return SpatialVelocity<T>(Vector3<T>::Zero(), v_FM);
-  }
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const final;
 
-  SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
-    DRAKE_ASSERT(vdot != nullptr);
-    Eigen::Vector3<T> a_FM;
-    a_FM[kX] = vdot[0];
-    a_FM[kY] = 0;
-    a_FM[kZ] = 0;
-    return SpatialAcceleration<T>(Vector3<T>::Zero(), a_FM);
-  }
+ protected:
+  void DoCalcNMatrix(const systems::Context<T>& context,
+                     EigenPtr<MatrixX<T>> N) const final;
 
-  // Returns tau = H_FM_Fᵀ⋅F, where H_FM_Fᵀ = [0₃ᵀ axis_Fᵀ].
-  void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
-    DRAKE_ASSERT(tau != nullptr);
-    const Vector3<T>& f_BMo_F = F_BMo_F.translational();
-    tau[0] = f_BMo_F[axis];
-  }
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const final;
 
- private:
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;
 
@@ -288,14 +231,14 @@ class PrismaticMobilizerAxial final : public PrismaticMobilizer<T> {
   std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
       const MultibodyTree<symbolic::Expression>& tree_clone) const final;
 
+ private:
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
       const MultibodyTree<ToScalar>& tree_clone) const;
 
-  // Write algorithms as though the axes were x, y, and z; modular arithmetic
-  // here ensures they will work correctly for axis=0, 1, or 2.
-  static constexpr int kX = axis, kY = (axis + 1) % 3, kZ = (axis + 2) % 3;
+  // Default axis expressed in the inboard frame F. It is a unit vector.
+  Vector3<double> axis_F_;
 };
 
 }  // namespace internal
@@ -304,17 +247,3 @@ class PrismaticMobilizerAxial final : public PrismaticMobilizer<T> {
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::PrismaticMobilizer);
-
-#define DRAKE_DECLARE_PRISMATIC_MOBILIZER(axis)                                \
-  extern template class ::drake::multibody::internal::PrismaticMobilizerAxial< \
-      double, axis>;                                                           \
-  extern template class ::drake::multibody::internal::PrismaticMobilizerAxial< \
-      ::drake::AutoDiffXd, axis>;                                              \
-  extern template class ::drake::multibody::internal::PrismaticMobilizerAxial< \
-      ::drake::symbolic::Expression, axis>
-
-DRAKE_DECLARE_PRISMATIC_MOBILIZER(0);
-DRAKE_DECLARE_PRISMATIC_MOBILIZER(1);
-DRAKE_DECLARE_PRISMATIC_MOBILIZER(2);
-
-#undef DRAKE_DECLARE_PRISMATIC_MOBILIZER

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -130,6 +130,18 @@ void RevoluteMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
 }
 
 template <typename T>
+void RevoluteMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                            EigenPtr<MatrixX<T>> Ndot) const {
+  (*Ndot)(0, 0) = 0.0;
+}
+
+template <typename T>
+void RevoluteMobilizer<T>::DoCalcNplusDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> NplusDot) const {
+  (*NplusDot)(0, 0) = 0.0;
+}
+
+template <typename T>
 void RevoluteMobilizer<T>::MapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -153,6 +153,14 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
  private:
   // Joint axis expressed identically in frames F and M. This must be one of
   // the coordinate axes 100, 010, or 001.

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -249,6 +249,16 @@ TEST_F(PrismaticMobilizerTest, KinematicMapping) {
   MatrixX<double> Nplus(1, 1);
   slider_->CalcNplusMatrix(*context_, &Nplus);
   EXPECT_EQ(Nplus(0, 0), 1.0);
+
+  // Ensure Ṅ(q,q̇) = [0].
+  MatrixX<double> NDot(1, 1);
+  slider_->CalcNDotMatrix(*context_, &NDot);
+  EXPECT_EQ(NDot(0, 0), 0.0);
+
+  // Ensure Ṅ⁺(q,q̇) = [0].
+  MatrixX<double> NplusDot(1, 1);
+  slider_->CalcNplusDotMatrix(*context_, &NplusDot);
+  EXPECT_EQ(NplusDot(0, 0), 0.0);
 }
 
 TEST_F(PrismaticMobilizerTest, MapUsesN) {

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -251,6 +251,16 @@ TEST_F(RevoluteMobilizerTest, KinematicMapping) {
   MatrixX<double> Nplus(1, 1);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
   EXPECT_EQ(Nplus(0, 0), 1.0);
+
+  // Ensure Ṅ(q,q̇) = [0].
+  MatrixX<double> NDot(1, 1);
+  mobilizer_->CalcNDotMatrix(*context_, &NDot);
+  EXPECT_EQ(NDot(0, 0), 0.0);
+
+  // Ensure Ṅ⁺(q,q̇) = [0].
+  MatrixX<double> NplusDot(1, 1);
+  mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot);
+  EXPECT_EQ(NplusDot(0, 0), 0.0);
 }
 
 TEST_F(RevoluteMobilizerTest, MapUsesN) {


### PR DESCRIPTION
This is one in a series of PRs to help address issue #22630. It creates CalcNDotMatrix(), CalcNplusDotMatrix() and DoCalcNDotMatrix(), DoCalcNplusDotMatrix() for a generic mobilizer and overrides DoCalcNDotMatrix(), DoCalcNplusDotMatrix() for two simple mobilizers (namely revolute and prismatic).

Subsequent PRs will create additional instances for others mobilizers (e.g., rpy_ball_mobilizer, curvilinear_mobilizer, quaternion_floating_mobilizer, etc.) to facilitate implementation of MapQDDotToAcceleration() and MapAccelerationToQDDot().

FYI: Since mobilizers are Drake internal classes, after the internal mobilizer work is complete, there will be PRs (code and testing) for the public API in MultibodyPlant to address issue #22630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22948)
<!-- Reviewable:end -->
