### PR TITLE
[multibody] Allow reversed prismatic joints

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1981,8 +1981,7 @@ GTEST_TEST(MultibodyPlantTest, ReversedRevoluteJoint) {
   const RevoluteJoint<double>& revolute = plant.AddJoint<RevoluteJoint>(
       "revolute", plant.world_body(), {}, body, {}, Vector3d(1, 1, 1));
 
-  // Add a body with parent=reverse_body, child=world. This is only allowed
-  // for Weld and Revolute joints currently.
+  // Add a body with parent=reverse_body, child=world.
   const RigidBody<double>& reverse_body =
       plant.AddRigidBody("reverse_body", default_model_instance(),
                          SpatialInertia<double>::MakeUnitary());
@@ -2023,11 +2022,64 @@ GTEST_TEST(MultibodyPlantTest, ReversedRevoluteJoint) {
                               kTolerance, MatrixCompareType::relative));
 }
 
+GTEST_TEST(MultibodyPlantTest, ReversedPrismaticJoint) {
+  const double kTolerance = 4 * std::numeric_limits<double>::epsilon();
+  MultibodyPlant<double> plant(0.0);
+
+  // Add a normal body which we'll use as the child of a prismatic joint.
+  const RigidBody<double>& body = plant.AddRigidBody(
+      "body", default_model_instance(), SpatialInertia<double>::MakeUnitary());
+  const PrismaticJoint<double>& prismatic = plant.AddJoint<PrismaticJoint>(
+      "prismatic", plant.world_body(), {}, body, {}, Vector3d(1, 1, 1));
+
+  // Add a body ("reverse_body") and a joint ("reverse_prismatic") with
+  // parent=reverse_body, child=world.
+  const RigidBody<double>& reverse_body =
+      plant.AddRigidBody("reverse_body", default_model_instance(),
+                         SpatialInertia<double>::MakeUnitary());
+  const PrismaticJoint<double>& reverse_prismatic =
+      plant.AddJoint<PrismaticJoint>("reverse_prismatic", reverse_body, {},
+                                     plant.world_body(), {}, Vector3d(1, 1, 1));
+  EXPECT_NO_THROW(plant.Finalize());
+  auto context = plant.CreateDefaultContext();
+
+  for (int i = 0; i < 3; ++i) {
+    const double third = std::numbers::inv_sqrt3_v<double>;
+    EXPECT_NEAR(prismatic.translation_axis()[i], third, kTolerance);
+    EXPECT_NEAR(reverse_prismatic.translation_axis()[i], third, kTolerance);
+  }
+
+  // The forward and reverse joints should produce the same motion, but the
+  // meaning of the generalized coordinate q (translation) is reversed.
+  prismatic.set_translation(&*context, 0.125);
+  EXPECT_EQ(prismatic.get_translation(*context), 0.125);
+  reverse_prismatic.set_translation(&*context, -0.125);
+  EXPECT_EQ(reverse_prismatic.get_translation(*context), -0.125);
+
+  const RigidTransformd pose = body.EvalPoseInWorld(*context);
+  const RigidTransformd rpose = reverse_body.EvalPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(rpose.GetAsMatrix34(), pose.GetAsMatrix34(),
+                              kTolerance, MatrixCompareType::relative));
+
+  // Now check the velocities.
+  prismatic.set_translation_rate(&*context, 1.5);
+  EXPECT_EQ(prismatic.get_translation_rate(*context), 1.5);
+  reverse_prismatic.set_translation_rate(&*context, -1.5);
+  EXPECT_EQ(reverse_prismatic.get_translation_rate(*context), -1.5);
+  const SpatialVelocity<double>& velocity =
+      body.EvalSpatialVelocityInWorld(*context);
+  const SpatialVelocity<double>& rvelocity =
+      reverse_body.EvalSpatialVelocityInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(rvelocity.get_coeffs(), velocity.get_coeffs(),
+                              kTolerance, MatrixCompareType::relative));
+}
+
 GTEST_TEST(MultibodyPlantTest, UnsupportedReversedJoint) {
   MultibodyPlant<double> plant(0.0);
 
-  // Add a body with parent=reverse_body, child=world. This is only allowed
-  // for Weld and Revolute joints currently.
+  // Add a body ("reverse_body") and a joint ("reverse_universal") with
+  // parent=reverse_body, child=world. Reversal is allowed for a limited set of
+  // joints, and UniversalJoint is not currently among them.
   const RigidBody<double>& reverse_body =
       plant.AddRigidBody("reverse_body", default_model_instance(),
                          SpatialInertia<double>::MakeUnitary());
@@ -2042,7 +2094,7 @@ GTEST_TEST(MultibodyPlantTest, UnsupportedReversedJoint) {
       plant.Finalize(),
       ".*Finalize.*parent/child ordering.*universal joint reverse_universal"
       ".*reversed.*does not support.*universal.*can be reversed.*"
-      ".*revolute.*weld.*Reverse.*ordering.*");
+      ".*prismatic.*revolute.*weld.*Reverse.*ordering.*");
 }
 
 // Currently we don't support automatic modeling of systems where the links

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -19,6 +19,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/body_node_world.h"
 #include "drake/multibody/tree/multibody_tree-inl.h"
+#include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/quaternion_floating_joint.h"
 #include "drake/multibody/tree/quaternion_floating_mobilizer.h"
 #include "drake/multibody/tree/revolute_joint.h"
@@ -753,9 +754,9 @@ void MultibodyTree<T>::CreateJointImplementations() {
 
   // These are the Joint type names for the joints that are currently
   // reversible.
-  // TODO(sherm1) Add more.
-  const std::set<std::string> reversible{WeldJoint<double>::kTypeName,
-                                         RevoluteJoint<double>::kTypeName};
+  const std::set<std::string> reversible{PrismaticJoint<double>::kTypeName,
+                                         RevoluteJoint<double>::kTypeName,
+                                         WeldJoint<double>::kTypeName};
 
   // Mobods are in depth-first order, starting with World.
   for (const auto& mobod : forest().mobods()) {


### PR DESCRIPTION
PR #22925 modified prismatic joints to be reversible but did not enable the feature. This PR turns on that feature and adds a test to show that it works, similar to what PR #22883 did for revolute joints.

This completes milestone 4 in [this document](https://docs.google.com/document/d/1KT2hlRc1eeIPSZ_Oo4tqESy0MadteJeAhFINwTZqfFY).

This _may_ resolve issue #17429 (finally!) but I haven't tested that yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22949)
<!-- Reviewable:end -->
