### PR TITLE
Create mobilizer functions CalcNDotMatrix() and CalcNplusDotMatrix().

### DIFF
--- a/multibody/tree/mobilizer.cc
+++ b/multibody/tree/mobilizer.cc
@@ -43,6 +43,28 @@ void Mobilizer<T>::MapQDDotToAcceleration(const systems::Context<T>&,
   throw std::logic_error(error_message);
 }
 
+template <typename T>
+void Mobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                    EigenPtr<MatrixX<T>>) const {
+  // TODO(Mitiguy) remove this function when Mobilizer::CalcNDotMatrix()
+  //  is changed to a pure virtual function that requires override.
+  const std::string error_message = fmt::format(
+      "The function {}() has not been implemented for this mobilizer.",
+      __func__);
+  throw std::logic_error(error_message);
+}
+
+template <typename T>
+void Mobilizer<T>::DoCalcNplusDotMatrix(const systems::Context<T>&,
+                                        EigenPtr<MatrixX<T>>) const {
+  // TODO(Mitiguy) remove this function when Mobilizer::CalcNplusDotMatrix()
+  //  is changed to a pure virtual function that requires override.
+  const std::string error_message = fmt::format(
+      "The function {}() has not been implemented for this mobilizer.",
+      __func__);
+  throw std::logic_error(error_message);
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -599,6 +599,36 @@ class Mobilizer : public MultibodyElement<T> {
     DoCalcNplusMatrix(context, Nplus);
   }
 
+  // Computes the matrix Ṅ(q,q̇) that helps relate q̈ (2ⁿᵈ time derivative of the
+  // generalized positions) to v̇ (1ˢᵗ time derivative of generalized velocities)
+  // via q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇, where N(q) is formed by CalcNMatrix().
+  // @param[in] context stores generalized positions q and velocities v.
+  // @param[out] Ndot The matrix Ṅ(q,q̇). On input Ndot must have size
+  //   `nq x nv` where nq is the number of generalized positions and
+  //   nv is the number of generalized velocities for this mobilizer.
+  void CalcNDotMatrix(const systems::Context<T>& context,
+                      EigenPtr<MatrixX<T>> Ndot) const {
+    DRAKE_DEMAND(Ndot != nullptr);
+    DRAKE_DEMAND(Ndot->rows() == num_positions());
+    DRAKE_DEMAND(Ndot->cols() == num_velocities());
+    DoCalcNDotMatrix(context, Ndot);
+  }
+
+  // Computes the matrix Ṅ⁺(q,q̇) that helps relate v̇ (1ˢᵗ time derivative of
+  // generalized velocities) to q̈ (2ⁿᵈ time derivative of generalized positions)
+  // via v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈, where N⁺(q) is formed by CalcNPlusMatrix().
+  // @param[in] context stores generalized positions q and velocities v.
+  // @param[out] NplusDot The matrix Ṅ(q,q̇). On input NplusDot must have size
+  //   `nq x nv` where nq is the number of generalized positions and
+  //   nv is the number of generalized velocities for this mobilizer.
+  void CalcNplusDotMatrix(const systems::Context<T>& context,
+                          EigenPtr<MatrixX<T>> NplusDot) const {
+    DRAKE_DEMAND(NplusDot != nullptr);
+    DRAKE_DEMAND(NplusDot->rows() == num_velocities());
+    DRAKE_DEMAND(NplusDot->cols() == num_positions());
+    DoCalcNplusDotMatrix(context, NplusDot);
+  }
+
   virtual bool is_velocity_equal_to_qdot() const = 0;
 
   // Computes the kinematic mapping `q̇ = N(q)⋅v` between generalized
@@ -757,6 +787,20 @@ class Mobilizer : public MultibodyElement<T> {
   // not the nullptr and that Nplus has the proper size.
   virtual void DoCalcNplusMatrix(const systems::Context<T>& context,
                                  EigenPtr<MatrixX<T>> Nplus) const = 0;
+
+  // NVI to CalcNDotMatrix(). Implementations can safely assume that Ndot is
+  // not the nullptr and that Ndot has the proper size.
+  // TODO(Mitiguy) change this function to a pure virtual function when it has
+  //  been overridden in all subclasses.
+  virtual void DoCalcNDotMatrix(const systems::Context<T>& context,
+                                EigenPtr<MatrixX<T>> Ndot) const;
+
+  // NVI to CalcNplusDotMatrix(). Implementations can safely assume that
+  // NplusDot is not the nullptr and that NplusDot has the proper size.
+  // TODO(Mitiguy) change this function to a pure virtual function when it has
+  //  been overridden in all subclasses.
+  virtual void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                                    EigenPtr<MatrixX<T>> NplusDot) const;
 
   // @name Methods to make a clone templated on different scalar types.
   //

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -604,7 +604,7 @@ class Mobilizer : public MultibodyElement<T> {
   // via q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇, where N(q) is formed by CalcNMatrix().
   // @param[in] context stores generalized positions q and velocities v.
   // @param[out] Ndot The matrix Ṅ(q,q̇). On input Ndot must have size
-  //   `nq x nv` where nq is the number of generalized positions and
+  //   nq x nv where nq is the number of generalized positions and
   //   nv is the number of generalized velocities for this mobilizer.
   void CalcNDotMatrix(const systems::Context<T>& context,
                       EigenPtr<MatrixX<T>> Ndot) const {
@@ -619,8 +619,8 @@ class Mobilizer : public MultibodyElement<T> {
   // via v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈, where N⁺(q) is formed by CalcNPlusMatrix().
   // @param[in] context stores generalized positions q and velocities v.
   // @param[out] NplusDot The matrix Ṅ(q,q̇). On input NplusDot must have size
-  //   `nq x nv` where nq is the number of generalized positions and
-  //   nv is the number of generalized velocities for this mobilizer.
+  //   nv x nq where nv is the number of generalized velocities and
+  //   nq is the number of generalized positions for this mobilizer.
   void CalcNplusDotMatrix(const systems::Context<T>& context,
                           EigenPtr<MatrixX<T>> NplusDot) const {
     DRAKE_DEMAND(NplusDot != nullptr);

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -131,6 +131,18 @@ void PrismaticMobilizer<T>::DoCalcNplusMatrix(
 }
 
 template <typename T>
+void PrismaticMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                             EigenPtr<MatrixX<T>> Ndot) const {
+  (*Ndot)(0, 0) = 0.0;
+}
+
+template <typename T>
+void PrismaticMobilizer<T>::DoCalcNplusDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> NplusDot) const {
+  (*NplusDot)(0, 0) = 0.0;
+}
+
+template <typename T>
 void PrismaticMobilizer<T>::MapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -158,6 +158,14 @@ class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
  private:
   // Joint axis expressed identically in frames F and M. This must be one of
   // the coordinate axes 100, 010, or 001.

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -130,6 +130,18 @@ void RevoluteMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
 }
 
 template <typename T>
+void RevoluteMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                            EigenPtr<MatrixX<T>> Ndot) const {
+  (*Ndot)(0, 0) = 0.0;
+}
+
+template <typename T>
+void RevoluteMobilizer<T>::DoCalcNplusDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> NplusDot) const {
+  (*NplusDot)(0, 0) = 0.0;
+}
+
+template <typename T>
 void RevoluteMobilizer<T>::MapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -153,6 +153,14 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
  private:
   // Joint axis expressed identically in frames F and M. This must be one of
   // the coordinate axes 100, 010, or 001.

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -249,6 +249,16 @@ TEST_F(PrismaticMobilizerTest, KinematicMapping) {
   MatrixX<double> Nplus(1, 1);
   slider_->CalcNplusMatrix(*context_, &Nplus);
   EXPECT_EQ(Nplus(0, 0), 1.0);
+
+  // Ensure Ṅ(q,q̇) = [0].
+  MatrixX<double> NDot(1, 1);
+  slider_->CalcNDotMatrix(*context_, &NDot);
+  EXPECT_EQ(NDot(0, 0), 0.0);
+
+  // Ensure Ṅ⁺(q,q̇) = [0].
+  MatrixX<double> NplusDot(1, 1);
+  slider_->CalcNplusDotMatrix(*context_, &NplusDot);
+  EXPECT_EQ(NplusDot(0, 0), 0.0);
 }
 
 TEST_F(PrismaticMobilizerTest, MapUsesN) {

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -251,6 +251,16 @@ TEST_F(RevoluteMobilizerTest, KinematicMapping) {
   MatrixX<double> Nplus(1, 1);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
   EXPECT_EQ(Nplus(0, 0), 1.0);
+
+  // Ensure Ṅ(q,q̇) = [0].
+  MatrixX<double> NDot(1, 1);
+  mobilizer_->CalcNDotMatrix(*context_, &NDot);
+  EXPECT_EQ(NDot(0, 0), 0.0);
+
+  // Ensure Ṅ⁺(q,q̇) = [0].
+  MatrixX<double> NplusDot(1, 1);
+  mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot);
+  EXPECT_EQ(NplusDot(0, 0), 0.0);
 }
 
 TEST_F(RevoluteMobilizerTest, MapUsesN) {


### PR DESCRIPTION
This is one in a series of PRs to help address issue  #22630. It creates CalcNDotMatrix(), CalcNplusDotMatrix() and DoCalcNDotMatrix(), DoCalcNplusDotMatrix() for a generic mobilizer and overrides DoCalcNDotMatrix(), DoCalcNplusDotMatrix() for two simple mobilizers (namely revolute and prismatic).

Subsequent PRs will create additional instances for others mobilizers (e.g., rpy_ball_mobilizer, curvilinear_mobilizer, quaternion_floating_mobilizer, etc.) to facilitate implementation of MapQDDotToAcceleration() and MapAccelerationToQDDot().

FYI: Since mobilizers are Drake internal classes, after the internal mobilizer work is complete, there will be PRs (code and testing) for the public API in MultibodyPlant to address issue #22630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22950)
<!-- Reviewable:end -->
