### PR TITLE
Test Fixtures and Cleanup for IrisZo (Part 2)

### DIFF
--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -130,6 +130,7 @@ drake_cc_library(
         "//geometry/optimization:convex_set",
         "//geometry/test_utilities:meshcat_environment",
         "//multibody/plant",
+        "//multibody/rational:rational_forward_kinematics",
         "//planning:collision_checker",
         "//planning:robot_diagram_builder",
         "//planning:scene_graph_collision_checker",

--- a/planning/iris/test/iris_test_utilities.cc
+++ b/planning/iris/test/iris_test_utilities.cc
@@ -289,5 +289,197 @@ void BlockOnGround::PlotEnvironmentAndRegion(const HPolyhedron& region) {
   MaybePauseForUser();
 }
 
+ConvexConfigurationSpace::ConvexConfigurationSpace() {
+  urdf_ = fmt::format(
+      R"(
+<robot name="pendulum_on_vertical_track">
+  <link name="fixed">
+    <collision name="ground">
+      <origin rpy="0 0 0" xyz="0 0 -1"/>
+      <geometry><box size="10 10 2"/></geometry>
+    </collision>
+  </link>
+  <joint name="fixed_link_weld" type="fixed">
+    <parent link="world"/>
+    <child link="fixed"/>
+  </joint>
+  <link name="cart">
+  </link>
+  <joint name="track" type="prismatic">
+    <axis xyz="0 0 1"/>
+    <limit lower="-{l}" upper="0"/>
+    <parent link="world"/>
+    <child link="cart"/>
+  </joint>
+  <link name="pendulum">
+    <collision name="ball">
+      <origin rpy="0 0 0" xyz="0 0 {l}"/>
+      <geometry><sphere radius="{r}"/></geometry>
+    </collision>
+  </link>
+  <joint name="pendulum" type="revolute">
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57"/>
+    <parent link="cart"/>
+    <child link="pendulum"/>
+  </joint>
+</robot>
+)",
+      fmt::arg("l", physical_param_l_), fmt::arg("r", physical_param_r_));
+
+  SetUpEnvironment(urdf_);
+
+  meshcat_ = geometry::GetTestEnvironmentMeshcat();
+
+  Vector2d sample{-0.5, 0.0};
+  starting_ellipsoid_ = Hyperellipsoid::MakeHypersphere(1e-2, sample);
+  domain_ = HPolyhedron::MakeBox(plant_ptr_->GetPositionLowerLimits(),
+                                 plant_ptr_->GetPositionUpperLimits());
+}
+
+void ConvexConfigurationSpace::CheckRegion(const HPolyhedron& region) {
+  // Confirm that the pendulum is colliding with the wall with true kinematics:
+  EXPECT_LE(z_test_ + physical_param_l_ * std::cos(theta_test_),
+            physical_param_r_);
+
+  EXPECT_FALSE(region.PointInSet(Vector2d{z_test_, theta_test_}));
+
+  EXPECT_EQ(region.ambient_dimension(), 2);
+  EXPECT_GE(region.MaximumVolumeInscribedEllipsoid().Volume(), 0.5);
+}
+
+void ConvexConfigurationSpace::PlotEnvironment() {
+  meshcat_->Set2dRenderMode(math::RigidTransformd(Eigen::Vector3d{0, 0, 1}),
+                            -3.25, 3.25, -3.25, 3.25);
+  meshcat_->SetProperty("/Grid", "visible", true);
+  Eigen::RowVectorXd theta1s = Eigen::RowVectorXd::LinSpaced(100, -1.5, 1.5);
+  Eigen::Matrix3Xd points = Eigen::Matrix3Xd::Zero(3, 2 * theta1s.size());
+  for (int i = 0; i < theta1s.size(); ++i) {
+    points(0, i) = physical_param_r_ - physical_param_l_ * cos(theta1s[i]);
+    points(1, i) = theta1s[i];
+    points(0, points.cols() - i - 1) = 0;
+    points(1, points.cols() - i - 1) = theta1s[i];
+  }
+  meshcat_->SetLine("True C_free", points, 2.0, Rgba(0, 0, 1));
+}
+
+void ConvexConfigurationSpace::PlotRegion(const HPolyhedron& region) {
+  VPolytope vregion = VPolytope(region).GetMinimalRepresentation();
+  Eigen::Matrix3Xd points =
+      Eigen::Matrix3Xd::Zero(3, vregion.vertices().cols() + 1);
+  points.topLeftCorner(2, vregion.vertices().cols()) = vregion.vertices();
+  points.topRightCorner(2, 1) = vregion.vertices().col(0);
+  points.bottomRows<1>().setZero();
+  meshcat_->SetLine("IRIS Region", points, 2.0, Rgba(0, 1, 0));
+
+  meshcat_->SetObject("Test point", Sphere(0.03), Rgba(1, 0, 0));
+  meshcat_->SetTransform("Test point", math::RigidTransform(Eigen::Vector3d(
+                                           z_test_, theta_test_, 0)));
+
+  MaybePauseForUser();
+}
+
+void ConvexConfigurationSpace::PlotEnvironmentAndRegion(
+    const HPolyhedron& region) {
+  PlotEnvironment();
+  PlotRegion(region);
+}
+
+ConvexConfigurationSpaceWithThreadsafeConstraint::
+    ConvexConfigurationSpaceWithThreadsafeConstraint() {
+  // Create the MathematicalProgram with the additional constraint.
+  auto q = prog_.NewContinuousVariables(2, "q");
+  Eigen::RowVectorXd a(2);
+  a << 1, 0;
+  double lb = -std::numeric_limits<double>::infinity();
+  double ub = -0.3;
+  prog_.AddLinearConstraint(a, lb, ub, q);
+
+  // Due to the configuration space margin, this point can never be in the
+  // region.
+  query_point_in_set_ = Vector2d(-0.31, 0.0);
+  query_point_not_in_set_ = Vector2d(-0.29, 0.0);
+}
+
+void ConvexConfigurationSpaceWithThreadsafeConstraint::CheckRegion(
+    const HPolyhedron& region) {
+  EXPECT_FALSE(region.PointInSet(query_point_not_in_set_));
+  EXPECT_TRUE(region.PointInSet(query_point_in_set_));
+}
+
+namespace {
+struct IdentityConstraint {
+  static size_t numInputs() { return 2; }
+  static size_t numOutputs() { return 2; }
+  template <typename ScalarType>
+  void eval(const Eigen::Ref<const VectorX<ScalarType>>& x,
+            VectorX<ScalarType>* y) const {
+    (*y) = x;
+  }
+};
+}  // namespace
+
+ConvexConfigurationSpaceWithNotThreadsafeConstraint::
+    ConvexConfigurationSpaceWithNotThreadsafeConstraint() {
+  // Create the MathematicalProgram with the additional constraint.
+  Eigen::VectorXd simple_constraint_lb = Eigen::Vector2d(-2.0, -0.5);
+  Eigen::VectorXd simple_constraint_ub = Eigen::Vector2d(0.0, 1.5);
+  std::shared_ptr<solvers::Constraint> simple_constraint =
+      std::make_shared<solvers::EvaluatorConstraint<
+          solvers::FunctionEvaluator<IdentityConstraint>>>(
+          std::make_shared<solvers::FunctionEvaluator<IdentityConstraint>>(
+              IdentityConstraint{}),
+          simple_constraint_lb, simple_constraint_ub);
+  prog_.AddConstraint(simple_constraint, prog_.decision_variables());
+
+  query_point_in_set_ = Vector2d(-1.0, -0.45);
+  query_point_not_in_set_ = Vector2d(-1.0, -0.55);
+}
+
+ConvexConfigurationSubspace::ConvexConfigurationSubspace() {
+  const Vector1d sample2{-0.5};
+  starting_ellipsoid_ = Hyperellipsoid::MakeHypersphere(1e-2, sample2);
+  // This domain matches the "x" dimension of C-space, so the region generated
+  // will respect the joint limits.
+  domain_ = HPolyhedron::MakeBox(Vector1d(-1.5), Vector1d(0));
+
+  region_query_point_1_ = Vector1d(-0.75);
+  region_query_point_2_ = Vector1d(-0.1);
+}
+
+void ConvexConfigurationSubspace::CheckRegion(const HPolyhedron& region) {
+  EXPECT_EQ(region.ambient_dimension(), 1);
+  EXPECT_TRUE(region.PointInSet(region_query_point_1_));
+  EXPECT_TRUE(region.PointInSet(region_query_point_2_));
+}
+
+void ConvexConfigurationSubspace::PlotEnvironmentAndRegionSubspace(
+    const HPolyhedron& region,
+    const std::function<VectorXd(const VectorXd&)>& parameterization) {
+  PlotEnvironment();
+
+  VPolytope vregion = VPolytope(region).GetMinimalRepresentation();
+  Eigen::Matrix3Xd points =
+      Eigen::Matrix3Xd::Zero(3, vregion.vertices().cols() + 1);
+  for (int i = 0; i < vregion.vertices().cols(); ++i) {
+    Vector2d point = parameterization(vregion.vertices().col(i));
+    points.col(i).head(2) = point;
+    if (i == 0) {
+      points.topRightCorner(2, 1) = point;
+    }
+  }
+  points.bottomRows<1>().setZero();
+  meshcat_->SetLine("IRIS Region", points, 2.0, Rgba(0, 1, 0));
+
+  meshcat_->SetObject("Test point", Sphere(0.03), Rgba(1, 0, 0));
+
+  Vector2d ambient_query_point = parameterization(region_query_point_1_);
+  meshcat_->SetTransform(
+      "Test point", math::RigidTransform(Eigen::Vector3d(
+                        ambient_query_point[0], ambient_query_point[1], 0)));
+
+  MaybePauseForUser();
+}
+
 }  // namespace planning
 }  // namespace drake

--- a/planning/iris/test/iris_test_utilities.cc
+++ b/planning/iris/test/iris_test_utilities.cc
@@ -98,9 +98,9 @@ DoublePendulum::DoublePendulum() {
   </joint>
 </robot>
 )",
-      fmt::arg("w_plus_one_half", physical_param_w_ + .5),
-      fmt::arg("l1", physical_param_l1_), fmt::arg("l2", physical_param_l2_),
-      fmt::arg("r", physical_param_r_));
+      fmt::arg("w_plus_one_half", kPhysicalParamW + .5),
+      fmt::arg("l1", kPhysicalParamL1), fmt::arg("l2", kPhysicalParamL2),
+      fmt::arg("r", kPhysicalParamR));
 
   SetUpEnvironment(urdf_);
 
@@ -134,11 +134,10 @@ void DoublePendulum::PlotEnvironmentAndRegion(
   meshcat_->SetProperty("/Grid", "visible", true);
   Eigen::RowVectorXd theta2s = Eigen::RowVectorXd::LinSpaced(100, -1.57, 1.57);
   Eigen::Matrix3Xd points = Eigen::Matrix3Xd::Zero(3, 2 * theta2s.size() + 1);
-  const double c = -physical_param_w_ + physical_param_r_;
+  const double c = -kPhysicalParamW + kPhysicalParamR;
   for (int i = 0; i < theta2s.size(); ++i) {
-    const double a = physical_param_l1_ +
-                     physical_param_l2_ * std::cos(theta2s[i]),
-                 b = physical_param_l2_ * std::sin(theta2s[i]);
+    const double a = kPhysicalParamL1 + kPhysicalParamL2 * std::cos(theta2s[i]),
+                 b = kPhysicalParamL2 * std::sin(theta2s[i]);
     // wolfram solve a*sin(q) + b*cos(q) = c for q
     points(0, i) =
         2 * std::atan((std::sqrt(a * a + b * b - c * c) + a) / (b + c)) + M_PI;
@@ -325,7 +324,7 @@ ConvexConfigurationSpace::ConvexConfigurationSpace() {
   </joint>
 </robot>
 )",
-      fmt::arg("l", physical_param_l_), fmt::arg("r", physical_param_r_));
+      fmt::arg("l", kPhysicalParamL), fmt::arg("r", kPhysicalParamR));
 
   SetUpEnvironment(urdf_);
 
@@ -339,10 +338,9 @@ ConvexConfigurationSpace::ConvexConfigurationSpace() {
 
 void ConvexConfigurationSpace::CheckRegion(const HPolyhedron& region) {
   // Confirm that the pendulum is colliding with the wall with true kinematics:
-  EXPECT_LE(z_test_ + physical_param_l_ * std::cos(theta_test_),
-            physical_param_r_);
+  EXPECT_LE(kZTest + kPhysicalParamL * std::cos(kThetaTest), kPhysicalParamR);
 
-  EXPECT_FALSE(region.PointInSet(Vector2d{z_test_, theta_test_}));
+  EXPECT_FALSE(region.PointInSet(Vector2d{kZTest, kThetaTest}));
 
   EXPECT_EQ(region.ambient_dimension(), 2);
   EXPECT_GE(region.MaximumVolumeInscribedEllipsoid().Volume(), 0.5);
@@ -355,7 +353,7 @@ void ConvexConfigurationSpace::PlotEnvironment() {
   Eigen::RowVectorXd theta1s = Eigen::RowVectorXd::LinSpaced(100, -1.5, 1.5);
   Eigen::Matrix3Xd points = Eigen::Matrix3Xd::Zero(3, 2 * theta1s.size());
   for (int i = 0; i < theta1s.size(); ++i) {
-    points(0, i) = physical_param_r_ - physical_param_l_ * cos(theta1s[i]);
+    points(0, i) = kPhysicalParamR - kPhysicalParamL * cos(theta1s[i]);
     points(1, i) = theta1s[i];
     points(0, points.cols() - i - 1) = 0;
     points(1, points.cols() - i - 1) = theta1s[i];
@@ -374,7 +372,7 @@ void ConvexConfigurationSpace::PlotRegion(const HPolyhedron& region) {
 
   meshcat_->SetObject("Test point", Sphere(0.03), Rgba(1, 0, 0));
   meshcat_->SetTransform("Test point", math::RigidTransform(Eigen::Vector3d(
-                                           z_test_, theta_test_, 0)));
+                                           kZTest, kThetaTest, 0)));
 
   MaybePauseForUser();
 }

--- a/planning/iris/test/iris_test_utilities.h
+++ b/planning/iris/test/iris_test_utilities.h
@@ -9,6 +9,7 @@
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
+#include "drake/multibody/rational/rational_forward_kinematics.h"
 #include "drake/planning/collision_checker.h"
 #include "drake/planning/scene_graph_collision_checker.h"
 
@@ -64,11 +65,6 @@ class DoublePendulum : public IrisTestFixture {
   void CheckRegion(const geometry::optimization::HPolyhedron& region);
   void PlotEnvironmentAndRegion(
       const geometry::optimization::HPolyhedron& region);
-  void PlotEnvironmentAndRegionRationalForwardKinematics(
-      const geometry::optimization::HPolyhedron& region,
-      const std::function<Eigen::VectorXd(const Eigen::VectorXd&)>&
-          parameterization,
-      const Eigen::Vector2d& region_query_point);
 
   std::shared_ptr<geometry::Meshcat> meshcat_;
 
@@ -84,6 +80,31 @@ class DoublePendulum : public IrisTestFixture {
   inline static const double physical_param_r_ = .5;
   inline static const double physical_param_w_ = 1.83;
   std::string urdf_;
+};
+
+class DoublePendulumRationalForwardKinematics : public DoublePendulum {
+ protected:
+  DoublePendulumRationalForwardKinematics();
+
+  void CheckParameterization(
+      const std::function<Eigen::VectorXd(const Eigen::VectorXd&)>&
+          parameterization);
+  void CheckRegionRationalForwardKinematics(
+      const geometry::optimization::HPolyhedron& region);
+  void PlotEnvironmentAndRegionRationalForwardKinematics(
+      const geometry::optimization::HPolyhedron& region,
+      const std::function<Eigen::VectorXd(const Eigen::VectorXd&)>&
+          parameterization,
+      const Eigen::Vector2d& region_query_point);
+
+  geometry::optimization::Hyperellipsoid
+      starting_ellipsoid_rational_forward_kinematics_;
+  geometry::optimization::HPolyhedron domain_rational_forward_kinematics_;
+
+  Eigen::Vector2d region_query_point_1_;
+  Eigen::Vector2d region_query_point_2_;
+
+  multibody::RationalForwardKinematics rational_kinematics_;
 };
 
 // A block on a vertical track, free to rotate (in the plane) with width `w` of

--- a/planning/iris/test/iris_test_utilities.h
+++ b/planning/iris/test/iris_test_utilities.h
@@ -71,10 +71,10 @@ class DoublePendulum : public IrisTestFixture {
   geometry::optimization::Hyperellipsoid starting_ellipsoid_;
   geometry::optimization::HPolyhedron domain_;
 
-  inline static const double physical_param_l1_ = 2.0;
-  inline static const double physical_param_l2_ = 1.0;
-  inline static const double physical_param_r_ = .5;
-  inline static const double physical_param_w_ = 1.83;
+  inline static const double kPhysicalParamL1 = 2.0;
+  inline static const double kPhysicalParamL2 = 1.0;
+  inline static const double kPhysicalParamR = .5;
+  inline static const double kPhysicalParamW = 1.83;
   std::string urdf_;
 };
 
@@ -182,11 +182,11 @@ class ConvexConfigurationSpace : public IrisTestFixture {
 
   // This point should be outside of the configuration space (in collision).
   // The particular value was found by visual inspection using meshcat.
-  inline static const double z_test_ = 0.0;
-  inline static const double theta_test_ = -1.55;
+  inline static const double kZTest = 0.0;
+  inline static const double kThetaTest = -1.55;
 
-  inline static const double physical_param_l_ = 1.5;
-  inline static const double physical_param_r_ = 0.1;
+  inline static const double kPhysicalParamL = 1.5;
+  inline static const double kPhysicalParamR = 0.1;
   std::string urdf_;
 };
 

--- a/planning/iris/test/iris_test_utilities.h
+++ b/planning/iris/test/iris_test_utilities.h
@@ -71,10 +71,6 @@ class DoublePendulum : public IrisTestFixture {
   geometry::optimization::Hyperellipsoid starting_ellipsoid_;
   geometry::optimization::HPolyhedron domain_;
 
-  geometry::optimization::Hyperellipsoid
-      starting_ellipsoid_rational_forward_kinematics_;
-  geometry::optimization::HPolyhedron domain_rational_forward_kinematics_;
-
   inline static const double physical_param_l1_ = 2.0;
   inline static const double physical_param_l2_ = 1.0;
   inline static const double physical_param_r_ = .5;

--- a/planning/iris/test/iris_test_utilities.h
+++ b/planning/iris/test/iris_test_utilities.h
@@ -37,7 +37,7 @@ class JointLimits1D : public IrisTestFixture {
   geometry::optimization::Hyperellipsoid starting_ellipsoid_;
   geometry::optimization::HPolyhedron domain_;
 
-  inline static const std::string urdf_ = R"(
+  const std::string urdf_ = R"(
 <robot name="limits">
   <link name="movable">
     <collision>
@@ -121,7 +121,7 @@ class BlockOnGround : public IrisTestFixture {
   geometry::optimization::Hyperellipsoid starting_ellipsoid_;
   geometry::optimization::HPolyhedron domain_;
 
-  inline static const std::string urdf_ = R"(
+  const std::string urdf_ = R"(
 <robot name="block">
   <link name="fixed">
     <collision name="ground">

--- a/planning/iris/test/iris_test_utilities.h
+++ b/planning/iris/test/iris_test_utilities.h
@@ -86,5 +86,57 @@ class DoublePendulum : public IrisTestFixture {
   std::string urdf_;
 };
 
+// A block on a vertical track, free to rotate (in the plane) with width `w` of
+// 2 and height `h` of 1, plus a ground plane at z=0.  The true configuration
+// space is min(q₀ ± .5w sin(q₁) ± .5h cos(q₁)) ≥ 0, where the min is over the
+// ±. This region is also visualized at
+// https://www.desmos.com/calculator/ok5ckpa1kp.
+class BlockOnGround : public IrisTestFixture {
+ protected:
+  BlockOnGround();
+
+  void CheckRegion(const geometry::optimization::HPolyhedron& region);
+  void PlotEnvironmentAndRegion(
+      const geometry::optimization::HPolyhedron& region);
+
+  std::shared_ptr<geometry::Meshcat> meshcat_;
+
+  geometry::optimization::Hyperellipsoid starting_ellipsoid_;
+  geometry::optimization::HPolyhedron domain_;
+
+  inline static const std::string urdf_ = R"(
+<robot name="block">
+  <link name="fixed">
+    <collision name="ground">
+      <origin rpy="0 0 0" xyz="0 0 -1"/>
+      <geometry><box size="10 10 2"/></geometry>
+    </collision>
+  </link>
+  <joint name="fixed_link_weld" type="fixed">
+    <parent link="world"/>
+    <child link="fixed"/>
+  </joint>
+  <link name="link1"/>
+  <joint name="joint1" type="prismatic">
+    <axis xyz="0 0 1"/>
+    <limit lower="0" upper="3.0"/>
+    <parent link="world"/>
+    <child link="link1"/>
+  </joint>
+  <link name="link2">
+    <collision name="block">
+      <geometry><box size="2 1 1"/></geometry>
+    </collision>
+  </link>
+  <joint name="joint2" type="revolute">
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.14159" upper="3.14159"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+  </joint>
+</robot>
+)";
+};
+
 }  // namespace planning
 }  // namespace drake

--- a/planning/iris/test/iris_test_utilities.h
+++ b/planning/iris/test/iris_test_utilities.h
@@ -71,10 +71,10 @@ class DoublePendulum : public IrisTestFixture {
   geometry::optimization::Hyperellipsoid starting_ellipsoid_;
   geometry::optimization::HPolyhedron domain_;
 
-  inline static const double kPhysicalParamL1 = 2.0;
-  inline static const double kPhysicalParamL2 = 1.0;
-  inline static const double kPhysicalParamR = .5;
-  inline static const double kPhysicalParamW = 1.83;
+  static constexpr double kPhysicalParamL1 = 2.0;
+  static constexpr double kPhysicalParamL2 = 1.0;
+  static constexpr double kPhysicalParamR = .5;
+  static constexpr double kPhysicalParamW = 1.83;
   std::string urdf_;
 };
 
@@ -182,11 +182,11 @@ class ConvexConfigurationSpace : public IrisTestFixture {
 
   // This point should be outside of the configuration space (in collision).
   // The particular value was found by visual inspection using meshcat.
-  inline static const double kZTest = 0.0;
-  inline static const double kThetaTest = -1.55;
+  static constexpr double kZTest = 0.0;
+  static constexpr double kThetaTest = -1.55;
 
-  inline static const double kPhysicalParamL = 1.5;
-  inline static const double kPhysicalParamR = 0.1;
+  static constexpr double kPhysicalParamL = 1.5;
+  static constexpr double kPhysicalParamR = 0.1;
   std::string urdf_;
 };
 

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -282,53 +282,15 @@ const char block_urdf[] = R"(
 // space is min(q₀ ± .5w sin(q₁) ± .5h cos(q₁)) ≥ 0, where the min is over the
 // ±. This region is also visualized at
 // https://www.desmos.com/calculator/ok5ckpa1kp.
-GTEST_TEST(IrisZoTest, BlockOnGround) {
-  const Vector2d sample{1.0, 0.0};
-  std::shared_ptr<Meshcat> meshcat = geometry::GetTestEnvironmentMeshcat();
-  meshcat->Delete("face_pt");
+TEST_F(BlockOnGround, IrisZoTest) {
   IrisZoOptions options;
   options.verbose = true;
-  options.meshcat = meshcat;
-  Hyperellipsoid starting_ellipsoid =
-      Hyperellipsoid::MakeHypersphere(1e-2, sample);
-  HPolyhedron region = IrisZoFromUrdf(block_urdf, starting_ellipsoid, options);
+  meshcat_->Delete();
+  options.meshcat = meshcat_;
 
-  EXPECT_EQ(region.ambient_dimension(), 2);
-  // Confirm that we've found a substantial region.
-  EXPECT_GE(region.MaximumVolumeInscribedEllipsoid().Volume(), 2.0);
-
-  {
-    meshcat->Set2dRenderMode(math::RigidTransformd(Eigen::Vector3d{0, 0, 1}), 0,
-                             3.25, -3.25, 3.25);
-    meshcat->SetProperty("/Grid", "visible", true);
-    Eigen::RowVectorXd thetas = Eigen::RowVectorXd::LinSpaced(100, -M_PI, M_PI);
-    const double w = 2, h = 1;
-    Eigen::Matrix3Xd points = Eigen::Matrix3Xd::Zero(3, 2 * thetas.size() + 1);
-    for (int i = 0; i < thetas.size(); ++i) {
-      const double a = 0.5 *
-                       (-w * std::sin(thetas[i]) - h * std::cos(thetas[i])),
-                   b = 0.5 *
-                       (-w * std::sin(thetas[i]) + h * std::cos(thetas[i])),
-                   c = 0.5 *
-                       (+w * std::sin(thetas[i]) - h * std::cos(thetas[i])),
-                   d = 0.5 *
-                       (+w * std::sin(thetas[i]) + h * std::cos(thetas[i]));
-      points(0, i) = std::max({a, b, c, d});
-      points(1, i) = thetas[i];
-      points(0, points.cols() - i - 2) = 3.0;
-      points(1, points.cols() - i - 2) = thetas[i];
-    }
-    points.col(points.cols() - 1) = points.col(0);
-    meshcat->SetLine("True C_free", points, 2.0, Rgba(0, 0, 1));
-    VPolytope vregion = VPolytope(region).GetMinimalRepresentation();
-    points.resize(3, vregion.vertices().cols() + 1);
-    points.topLeftCorner(2, vregion.vertices().cols()) = vregion.vertices();
-    points.topRightCorner(2, 1) = vregion.vertices().col(0);
-    points.bottomRows<1>().setZero();
-    meshcat->SetLine("IRIS Region", points, 2.0, Rgba(0, 1, 0));
-
-    MaybePauseForUser();
-  }
+  HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
+  CheckRegion(region);
+  PlotEnvironmentAndRegion(region);
 }
 
 struct IdentityConstraint {

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -246,45 +246,7 @@ TEST_F(DoublePendulumRationalForwardKinematics, BadParameterization) {
       ".*wrong dimension.*");
 }
 
-const char block_urdf[] = R"(
-<robot name="block">
-  <link name="fixed">
-    <collision name="ground">
-      <origin rpy="0 0 0" xyz="0 0 -1"/>
-      <geometry><box size="10 10 2"/></geometry>
-    </collision>
-  </link>
-  <joint name="fixed_link_weld" type="fixed">
-    <parent link="world"/>
-    <child link="fixed"/>
-  </joint>
-  <link name="link1"/>
-  <joint name="joint1" type="prismatic">
-    <axis xyz="0 0 1"/>
-    <limit lower="0" upper="3.0"/>
-    <parent link="world"/>
-    <child link="link1"/>
-  </joint>
-  <link name="link2">
-    <collision name="block">
-      <geometry><box size="2 1 1"/></geometry>
-    </collision>
-  </link>
-  <joint name="joint2" type="revolute">
-    <axis xyz="0 1 0"/>
-    <limit lower="-3.14159" upper="3.14159"/>
-    <parent link="link1"/>
-    <child link="link2"/>
-  </joint>
-</robot>
-)";
-
 // Reproduced from the IrisInConfigurationSpace unit tests.
-// A block on a vertical track, free to rotate (in the plane) with width `w` of
-// 2 and height `h` of 1, plus a ground plane at z=0.  The true configuration
-// space is min(q₀ ± .5w sin(q₁) ± .5h cos(q₁)) ≥ 0, where the min is over the
-// ±. This region is also visualized at
-// https://www.desmos.com/calculator/ok5ckpa1kp.
 TEST_F(BlockOnGround, IrisZoTest) {
   IrisZoOptions options;
   options.verbose = true;


### PR DESCRIPTION
This is the second PR in a series cleaning up the test cases for IrisZo. See #22945 for further details.

This PR does a bit of cleanup on how the double pendulum test works with the rational forward kinematics parameterization, and handles the test fixtures for the convex configuration space (and its many variants).

+@wernerpe for feature review

Marking "do not merge" so I can update the commit message later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22954)
<!-- Reviewable:end -->
