### PR TITLE
[setup] Add explicit requirement for `lsb_release` on Linux wheel builds

### DIFF
--- a/tools/wheel/image/packages-almalinux
+++ b/tools/wheel/image/packages-almalinux
@@ -15,6 +15,7 @@ pkgconf-pkg-config
 # Other general tools.
 diffutils
 file
+lsb-release
 patch
 patchelf
 wget


### PR DESCRIPTION
Likely related to the "trimming" that we experienced and resolved in #22903 with `diffutils`, and the change of packages for Noble in #22919 broke us as we're falling back on the wrong `libclang` version for `mkdoc`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22956)
<!-- Reviewable:end -->
