### PR TITLE
 Test Fixtures and Cleanup for IrisZo (Part 3)

### DIFF
--- a/planning/iris/test/iris_test_utilities.h
+++ b/planning/iris/test/iris_test_utilities.h
@@ -232,5 +232,78 @@ class ConvexConfigurationSubspace : public ConvexConfigurationSpace {
   Vector1d region_query_point_2_;
 };
 
+/* A movable sphere with fixed boxes in all corners.
+┌───────────────┐
+│┌────┐   ┌────┐│
+││    │   │    ││
+│└────┘   └────┘│
+│       o       │
+│┌────┐   ┌────┐│
+││    │   │    ││
+│└────┘   └────┘│
+└───────────────┘ */
+class FourCornersBoxes : public IrisTestFixture {
+ protected:
+  FourCornersBoxes();
+
+  void CheckRegion(const geometry::optimization::HPolyhedron&);
+  void CheckRegionContainsPoints(
+      const geometry::optimization::HPolyhedron& region,
+      const Eigen::Matrix2Xd& containment_points);
+  void PlotEnvironmentAndRegion(
+      const geometry::optimization::HPolyhedron& region);
+  void PlotContainmentPoints(const Eigen::Matrix2Xd& containment_points);
+
+  std::shared_ptr<geometry::Meshcat> meshcat_;
+
+  geometry::optimization::Hyperellipsoid starting_ellipsoid_;
+  geometry::optimization::HPolyhedron domain_;
+
+  const std::string urdf_ = R"(
+<robot name="boxes">
+  <link name="fixed">
+    <collision name="top_left">
+      <origin rpy="0 0 0" xyz="-1 1 0"/>
+      <geometry><box size="1.4 1.4 1.4"/></geometry>
+    </collision>
+    <collision name="top_right">
+      <origin rpy="0 0 0" xyz="1 1 0"/>
+      <geometry><box size="1.4 1.4 1.4"/></geometry>
+    </collision>
+    <collision name="bottom_left">
+      <origin rpy="0 0 0" xyz="-1 -1 0"/>
+      <geometry><box size="1.4 1.4 1.4"/></geometry>
+    </collision>
+    <collision name="bottom_right">
+      <origin rpy="0 0 0" xyz="1 -1 0"/>
+      <geometry><box size="1.4 1.4 1.4"/></geometry>
+    </collision>
+  </link>
+  <joint name="fixed_link_weld" type="fixed">
+    <parent link="world"/>
+    <child link="fixed"/>
+  </joint>
+  <link name="movable">
+    <collision name="sphere">
+      <geometry><sphere radius="0.01"/></geometry>
+    </collision>
+  </link>
+  <link name="for_joint"/>
+  <joint name="x" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit lower="-2" upper="2"/>
+    <parent link="world"/>
+    <child link="for_joint"/>
+  </joint>
+  <joint name="y" type="prismatic">
+    <axis xyz="0 1 0"/>
+    <limit lower="-2" upper="2"/>
+    <parent link="for_joint"/>
+    <child link="movable"/>
+  </joint>
+</robot>
+)";
+};
+
 }  // namespace planning
 }  // namespace drake

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -36,30 +36,6 @@ using geometry::optimization::Hyperellipsoid;
 using geometry::optimization::VPolytope;
 using symbolic::Variable;
 
-// Helper method for testing FastIris from a urdf string.
-HPolyhedron IrisZoFromUrdf(const std::string urdf,
-                           const Hyperellipsoid& starting_ellipsoid,
-                           const IrisZoOptions& options,
-                           const HPolyhedron* maybe_domain = nullptr) {
-  CollisionCheckerParams params;
-  RobotDiagramBuilder<double> builder(0.0);
-
-  params.robot_model_instances =
-      builder.parser().AddModelsFromString(urdf, "urdf");
-
-  auto plant_ptr = &(builder.plant());
-  plant_ptr->Finalize();
-
-  params.model = builder.Build();
-  params.edge_step_size = 0.01;
-  HPolyhedron domain =
-      maybe_domain ? *maybe_domain
-                   : HPolyhedron::MakeBox(plant_ptr->GetPositionLowerLimits(),
-                                          plant_ptr->GetPositionUpperLimits());
-  planning::SceneGraphCollisionChecker checker(std::move(params));
-  return IrisZo(checker, starting_ellipsoid, domain, options);
-}
-
 // Reproduced from the IrisInConfigurationSpace unit tests.
 TEST_F(JointLimits1D, JointLimitsBasic) {
   IrisZoOptions options;
@@ -398,195 +374,68 @@ TEST_F(ConvexConfigurationSubspace, ExpressionParameterization) {
   CheckRegion(region);
 }
 
-/* A movable sphere with fixed boxes in all corners.
-┌───────────────┐
-│┌────┐   ┌────┐│
-││    │   │    ││
-│└────┘   └────┘│
-│       o       │
-│┌────┐   ┌────┐│
-││    │   │    ││
-│└────┘   └────┘│
-└───────────────┘ */
-const char boxes_in_corners_urdf[] = R"(
-<robot name="boxes">
-  <link name="fixed">
-    <collision name="top_left">
-      <origin rpy="0 0 0" xyz="-1 1 0"/>
-      <geometry><box size="1.4 1.4 1.4"/></geometry>
-    </collision>
-    <collision name="top_right">
-      <origin rpy="0 0 0" xyz="1 1 0"/>
-      <geometry><box size="1.4 1.4 1.4"/></geometry>
-    </collision>
-    <collision name="bottom_left">
-      <origin rpy="0 0 0" xyz="-1 -1 0"/>
-      <geometry><box size="1.4 1.4 1.4"/></geometry>
-    </collision>
-    <collision name="bottom_right">
-      <origin rpy="0 0 0" xyz="1 -1 0"/>
-      <geometry><box size="1.4 1.4 1.4"/></geometry>
-    </collision>
-  </link>
-  <joint name="fixed_link_weld" type="fixed">
-    <parent link="world"/>
-    <child link="fixed"/>
-  </joint>
-  <link name="movable">
-    <collision name="sphere">
-      <geometry><sphere radius="0.01"/></geometry>
-    </collision>
-  </link>
-  <link name="for_joint"/>
-  <joint name="x" type="prismatic">
-    <axis xyz="1 0 0"/>
-    <limit lower="-2" upper="2"/>
-    <parent link="world"/>
-    <child link="for_joint"/>
-  </joint>
-  <joint name="y" type="prismatic">
-    <axis xyz="0 1 0"/>
-    <limit lower="-2" upper="2"/>
-    <parent link="for_joint"/>
-    <child link="movable"/>
-  </joint>
-</robot>
-)";
-GTEST_TEST(IrisZoTest, ForceContainmentPointsTest) {
-  std::shared_ptr<Meshcat> meshcat;
-  meshcat = geometry::GetTestEnvironmentMeshcat();
-  meshcat->Delete("face_pt");
-  meshcat->Delete("True C_free");
-  meshcat->Delete("Test point");
-  meshcat->Set2dRenderMode(math::RigidTransformd(Eigen::Vector3d{0, 0, 1}),
-                           -3.25, 3.25, -3.25, 3.25);
-  meshcat->SetProperty("/Grid", "visible", true);
-  // Draw the true cspace.
-
-  Eigen::Matrix3Xd env_points(3, 5);
-  // clang-format off
-        env_points << -2, 2,  2, -2, -2,
-                        2, 2, -2, -2,  2,
-                        0, 0,  0,  0,  0;
-  // clang-format on
-  meshcat->SetLine("Domain", env_points, 8.0, Rgba(0, 0, 0));
-  Eigen::Matrix3Xd centers(3, 4);
-  double c = 1.0;
-  // clang-format off
-        centers << -c, c,  c, -c,
-                    c, c, -c, -c,
-                    0, 0,  0,  0;
-  // clang-format on
-  Eigen::Matrix3Xd obs_points(3, 5);
-  // Adding 0.01 offset to obstacles to acommodate for the radius of the
-  // spherical robot.
-  double s = 0.7 + 0.01;
-  // clang-format off
-        obs_points << -s, s,  s, -s, -s,
-                        s, s, -s, -s, s,
-                        s, 0,  0,  0,  0;
-  // clang-format on
-  for (int obstacle_idx = 0; obstacle_idx < 4; ++obstacle_idx) {
-    Eigen::Matrix3Xd obstacle = obs_points;
-    obstacle.colwise() += centers.col(obstacle_idx);
-    meshcat->SetLine(fmt::format("/obstacles/obs_{}", obstacle_idx), obstacle,
-                     8.0, Rgba(0, 0, 0));
-  }
-  const Vector2d sample{0.0, 0.0};
-  Hyperellipsoid starting_ellipsoid =
-      Hyperellipsoid::MakeHypersphere(1e-2, sample);
-
-  // Test if we can force the containment of a two points. This test is
-  // explicitly added to ensure that the procedure works when using fewer points
-  // than a simplex are given.
-  // First, we verify that IrisZo throws when a single containment point is
-  // passed. In this case, the convex hull of the containment points does not
-  // containt center of the starting ellipsoid.
+// First, we verify that IrisZo throws when a single containment point is
+// passed. In this case, the convex hull of the containment points does not
+// containt center of the starting ellipsoid.
+TEST_F(FourCornersBoxes, SingleContainmentPoint) {
   Eigen::Matrix2Xd single_containment_point(2, 1);
   single_containment_point << 0, 1;
 
   IrisZoOptions options;
   options.verbose = true;
-  options.meshcat = meshcat;
   options.configuration_space_margin = 0.04;
   options.containment_points = single_containment_point;
 
-  EXPECT_THROW(
-      IrisZoFromUrdf(boxes_in_corners_urdf, starting_ellipsoid, options),
-      std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      IrisZo(*checker_, starting_ellipsoid_, domain_, options),
+      ".*outside of the convex hull of the containment points.*");
+}
 
-  // Now we test that it works for a two point VPolytope.
-  Eigen::Matrix3Xd single_containment_point_and_ellipsoid_center(3, 2);
+// Test if we can force the containment of a two points (the ellipsoid center
+// and one other point). This test is explicitly added to ensure that the
+// procedure works when using fewer points than a simplex are given.
+TEST_F(FourCornersBoxes, TwoContainmentPoints) {
+  Eigen::Matrix2Xd containment_points(2, 2);
   // clang-format off
-        single_containment_point_and_ellipsoid_center << 0, sample.x(),
-                                                         1, sample.y(),
-                                                         0, 0;
+  containment_points << 0, starting_ellipsoid_.center().x(),
+                        1, starting_ellipsoid_.center().y();
   // clang-format on
-  options.containment_points =
-      single_containment_point_and_ellipsoid_center.topRows(2);
-  HPolyhedron region =
-      IrisZoFromUrdf(boxes_in_corners_urdf, starting_ellipsoid, options);
-  {
-    Eigen::Vector3d point_to_draw = Eigen::Vector3d::Zero();
-    std::string path = "cont_pt/0";
-    options.meshcat->SetObject(path, Sphere(0.04),
-                               geometry::Rgba(1, 0, 0.0, 1.0));
-    point_to_draw(0) = single_containment_point(0, 0);
-    point_to_draw(1) = single_containment_point(1, 0);
-    options.meshcat->SetTransform(path,
-                                  math::RigidTransform<double>(point_to_draw));
-    EXPECT_TRUE(region.PointInSet(single_containment_point.col(0).head(2)));
-    Eigen::Matrix3Xd points = Eigen::Matrix3Xd::Zero(3, 20);
+  IrisZoOptions options;
+  options.verbose = true;
+  meshcat_->Delete();
+  options.meshcat = meshcat_;
+  options.configuration_space_margin = 0.04;
+  options.containment_points = containment_points;
 
-    VPolytope vregion = VPolytope(region).GetMinimalRepresentation();
-    points.resize(3, vregion.vertices().cols() + 1);
-    points.topLeftCorner(2, vregion.vertices().cols()) = vregion.vertices();
-    points.topRightCorner(2, 1) = vregion.vertices().col(0);
-    points.bottomRows<1>().setZero();
-    meshcat->SetLine("IRIS Region", points, 2.0, Rgba(0, 1, 0));
+  HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
+  CheckRegionContainsPoints(region, containment_points);
+  PlotEnvironmentAndRegion(region);
+  PlotContainmentPoints(containment_points);
+  MaybePauseForUser();
+}
 
-    MaybePauseForUser();
-    meshcat->Delete("face_pt");
-    meshcat->Delete(path);
-  }
-
-  Eigen::Matrix3Xd cont_points(3, 4);
+TEST_F(FourCornersBoxes, FourContainmentPoints) {
+  Eigen::Matrix2Xd containment_points(2, 4);
   double xw, yw;
   xw = 0.4;
   yw = 0.28;
   // clang-format off
-        cont_points << -xw, xw,  xw, -xw,
-                        yw, yw, -yw, -yw,
-                        0,  0,  0,  0;
+  containment_points << -xw, xw,  xw, -xw,
+                         yw, yw, -yw, -yw;
   // clang-format on
-  options.containment_points = cont_points.topRows(2);
+  IrisZoOptions options;
+  options.verbose = true;
+  meshcat_->Delete();
+  options.meshcat = meshcat_;
+  options.containment_points = containment_points;
   options.max_iterations_separating_planes = 100;
   options.max_iterations = -1;
-  region = IrisZoFromUrdf(boxes_in_corners_urdf, starting_ellipsoid, options);
-  EXPECT_EQ(region.ambient_dimension(), 2);
-  {
-    for (int pt_to_draw = 0; pt_to_draw < cont_points.cols(); ++pt_to_draw) {
-      Eigen::Vector3d point_to_draw = Eigen::Vector3d::Zero();
-      std::string path = fmt::format("cont_pt/{}", pt_to_draw);
-      options.meshcat->SetObject(path, Sphere(0.04),
-                                 geometry::Rgba(1, 0, 0.0, 1.0));
-      point_to_draw(0) = cont_points(0, pt_to_draw);
-      point_to_draw(1) = cont_points(1, pt_to_draw);
-      options.meshcat->SetTransform(
-          path, math::RigidTransform<double>(point_to_draw));
-      EXPECT_TRUE(region.PointInSet(point_to_draw.head(2)));
-    }
-    Eigen::Matrix3Xd points = Eigen::Matrix3Xd::Zero(3, 20);
+  HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
 
-    VPolytope vregion = VPolytope(region).GetMinimalRepresentation();
-    points.resize(3, vregion.vertices().cols() + 1);
-    points.topLeftCorner(2, vregion.vertices().cols()) = vregion.vertices();
-    points.topRightCorner(2, 1) = vregion.vertices().col(0);
-    points.bottomRows<1>().setZero();
-    meshcat->SetLine("IRIS Region", points, 2.0, Rgba(0, 1, 0));
-
-    MaybePauseForUser();
-  }
+  CheckRegionContainsPoints(region, containment_points);
+  PlotEnvironmentAndRegion(region);
+  PlotContainmentPoints(containment_points);
+  MaybePauseForUser();
 }
 
 }  // namespace


### PR DESCRIPTION
This is the third and final PR in a series cleaning up the test cases for IrisZo. See #22945 for further details.

This test cleans up the final test case in IrisZo (and removes some code that was only still needed for that test, and is now only needed in `iris_test_fixtures.cc`).

+@wernerpe for feature review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22958)
<!-- Reviewable:end -->
