### PR TITLE
Implement CalcNDotMatrix() for more mobilizers.

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -458,6 +458,7 @@ drake_cc_googletest(
         ":mobilizer_tester",
         ":tree",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -458,7 +458,6 @@ drake_cc_googletest(
         ":mobilizer_tester",
         ":tree",
         "//common/test_utilities:eigen_matrix_compare",
-        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/tree/curvilinear_mobilizer.cc
+++ b/multibody/tree/curvilinear_mobilizer.cc
@@ -191,6 +191,18 @@ void CurvilinearMobilizer<T>::DoCalcNplusMatrix(
 }
 
 template <typename T>
+void CurvilinearMobilizer<T>::DoCalcNDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> Ndot) const {
+  (*Ndot)(0, 0) = 0.0;
+}
+
+template <typename T>
+void CurvilinearMobilizer<T>::DoCalcNplusDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> NplusDot) const {
+  (*NplusDot)(0, 0) = 0.0;
+}
+
+template <typename T>
 void CurvilinearMobilizer<T>::MapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/curvilinear_mobilizer.h
+++ b/multibody/tree/curvilinear_mobilizer.h
@@ -223,6 +223,14 @@ class CurvilinearMobilizer final : public MobilizerImpl<T, 1, 1> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;
 

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -166,6 +166,18 @@ void PlanarMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
 }
 
 template <typename T>
+void PlanarMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                          EigenPtr<MatrixX<T>> Ndot) const {
+  *Ndot = Matrix3<T>::Zero();
+}
+
+template <typename T>
+void PlanarMobilizer<T>::DoCalcNplusDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> NplusDot) const {
+  *NplusDot = Matrix3<T>::Zero();
+}
+
+template <typename T>
 void PlanarMobilizer<T>::MapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -243,6 +243,14 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;
 

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -163,6 +163,18 @@ void ScrewMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
 }
 
 template <typename T>
+void ScrewMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                         EigenPtr<MatrixX<T>> Ndot) const {
+  (*Ndot)(0, 0) = 0.0;
+}
+
+template <typename T>
+void ScrewMobilizer<T>::DoCalcNplusDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> NplusDot) const {
+  (*NplusDot)(0, 0) = 0.0;
+}
+
+template <typename T>
 void ScrewMobilizer<T>::MapVelocityToQDot(const systems::Context<T>&,
                                           const Eigen::Ref<const VectorX<T>>& v,
                                           EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -298,6 +298,14 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;
 

--- a/multibody/tree/test/curvilinear_mobilizer_test.cc
+++ b/multibody/tree/test/curvilinear_mobilizer_test.cc
@@ -6,7 +6,6 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
-#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/trajectories/piecewise_constant_curvature_trajectory.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/curvilinear_joint.h"
@@ -255,22 +254,13 @@ TEST_F(CurvilinearMobilizerTest, KinematicMapping) {
 
   // Ensure Ṅ(q,q̇) = 1x1 zero matrix.
   MatrixX<double> NDot(1, 1);
-  DRAKE_EXPECT_THROWS_MESSAGE(mobilizer_->CalcNDotMatrix(*context_, &NDot),
-                              ".*The function DoCalcNDotMatrix\\(\\) has not "
-                              "been implemented for this mobilizer.*");
-  // TODO(Mitiguy) Uncomment next 2 lines when DoCalcNDotMatrix() is done.
-  // mobilizer_->CalcNDotMatrix(*context_, &NDot);
-  // EXPECT_EQ(NDot(0, 0), 0.0);
+  mobilizer_->CalcNDotMatrix(*context_, &NDot);
+  EXPECT_EQ(NDot(0, 0), 0.0);
 
   // Ensure Ṅ⁺(q,q̇) = 1x1 zero matrix.
   MatrixX<double> NplusDot(1, 1);
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot),
-      ".*The function DoCalcNplusDotMatrix\\(\\) has not "
-      "been implemented for this mobilizer.*");
-  // TODO(Mitiguy) Uncomment next 2 lines when DoCalcNplusDotMatrix() is done.
-  // mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot);
-  // EXPECT_EQ(NplusDot(0, 0), 0.0);
+  mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot);
+  EXPECT_EQ(NplusDot(0, 0), 0.0);
 }
 
 }  // namespace

--- a/multibody/tree/test/curvilinear_mobilizer_test.cc
+++ b/multibody/tree/test/curvilinear_mobilizer_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/trajectories/piecewise_constant_curvature_trajectory.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/tree/curvilinear_joint.h"
@@ -251,6 +252,25 @@ TEST_F(CurvilinearMobilizerTest, KinematicMapping) {
   MatrixX<double> Nplus(1, 1);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
   EXPECT_EQ(Nplus(0, 0), 1.0);
+
+  // Ensure Ṅ(q,q̇) = 1x1 zero matrix.
+  MatrixX<double> NDot(1, 1);
+  DRAKE_EXPECT_THROWS_MESSAGE(mobilizer_->CalcNDotMatrix(*context_, &NDot),
+                              ".*The function DoCalcNDotMatrix\\(\\) has not "
+                              "been implemented for this mobilizer.*");
+  // TODO(Mitiguy) Uncomment next 2 lines when DoCalcNDotMatrix() is done.
+  // mobilizer_->CalcNDotMatrix(*context_, &NDot);
+  // EXPECT_EQ(NDot(0, 0), 0.0);
+
+  // Ensure Ṅ⁺(q,q̇) = 1x1 zero matrix.
+  MatrixX<double> NplusDot(1, 1);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot),
+      ".*The function DoCalcNplusDotMatrix\\(\\) has not "
+      "been implemented for this mobilizer.*");
+  // TODO(Mitiguy) Uncomment next 2 lines when DoCalcNplusDotMatrix() is done.
+  // mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot);
+  // EXPECT_EQ(NplusDot(0, 0), 0.0);
 }
 
 }  // namespace

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -308,6 +308,16 @@ TEST_F(PlanarMobilizerTest, KinematicMapping) {
   MatrixX<double> Nplus(3, 3);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
   EXPECT_EQ(Nplus, Matrix3d::Identity());
+
+  // Ensure Ṅ(q,q̇) = 3x3 zero matrix.
+  MatrixX<double> NDot(3, 3);
+  mobilizer_->CalcNDotMatrix(*context_, &NDot);
+  EXPECT_EQ(NDot, Matrix3d::Zero());
+
+  // Ensure Ṅ⁺(q,q̇) = 3x3 zero matrix.
+  MatrixX<double> NplusDot(3, 3);
+  mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot);
+  EXPECT_EQ(NplusDot, Matrix3d::Zero());
 }
 
 TEST_F(PlanarMobilizerTest, MapUsesN) {

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -234,6 +234,19 @@ TEST_F(QuaternionFloatingMobilizerTest, KinematicMapping) {
 
   EXPECT_TRUE(CompareMatrices(Nplus_x_N, MatrixX<double>::Identity(6, 6),
                               kTolerance, MatrixCompareType::relative));
+
+  // Until it is implemented, ensure calculating Ṅ(q,q̇) throws an exception.
+  MatrixX<double> NDot(7, 6);
+  DRAKE_EXPECT_THROWS_MESSAGE(mobilizer_->CalcNDotMatrix(*context_, &NDot),
+                              ".*The function DoCalcNDotMatrix\\(\\) has not "
+                              "been implemented for this mobilizer.*");
+
+  // Until it is implemented, ensure calculating Ṅ⁺(q,q̇) throws an exception.
+  MatrixX<double> NplusDot(6, 7);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot),
+      ".*The function DoCalcNplusDotMatrix\\(\\) has not "
+      "been implemented for this mobilizer.*");
 }
 
 TEST_F(QuaternionFloatingMobilizerTest, CheckExceptionMessage) {

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -326,6 +326,16 @@ TEST_F(ScrewMobilizerTest, KinematicMapping) {
   MatrixX<double> Nplus(1, 1);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
   EXPECT_EQ(Nplus, Matrix1d::Identity().eval());
+
+  // Ensure Ṅ(q,q̇) = 1x1 zero matrix.
+  MatrixX<double> NDot(1, 1);
+  mobilizer_->CalcNDotMatrix(*context_, &NDot);
+  EXPECT_EQ(NDot(0, 0), 0.0);
+
+  // Ensure Ṅ⁺(q,q̇) = 1x1 zero matrix.
+  MatrixX<double> NplusDot(1, 1);
+  mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot);
+  EXPECT_EQ(NplusDot(0, 0), 0.0);
 }
 
 TEST_F(ScrewMobilizerTest, MapUsesN) {

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -263,6 +263,16 @@ TEST_F(UniversalMobilizerTest, KinematicMapping) {
   MatrixX<double> Nplus(2, 2);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
   EXPECT_EQ(Nplus, Matrix2d::Identity());
+
+  // Ensure Ṅ(q,q̇) = 2x2 zero matrix.
+  MatrixX<double> NDot(2, 2);
+  mobilizer_->CalcNDotMatrix(*context_, &NDot);
+  EXPECT_EQ(NDot, Matrix2d::Zero());
+
+  // Ensure Ṅ⁺(q,q̇) = 2x2 zero matrix.
+  MatrixX<double> NplusDot(2, 2);
+  mobilizer_->CalcNplusDotMatrix(*context_, &NplusDot);
+  EXPECT_EQ(NplusDot, Matrix2d::Zero());
 }
 
 TEST_F(UniversalMobilizerTest, MapUsesN) {

--- a/multibody/tree/test/weld_mobilizer_test.cc
+++ b/multibody/tree/test/weld_mobilizer_test.cc
@@ -110,6 +110,8 @@ TEST_F(WeldMobilizerTest, KinematicMapping) {
   MatrixX<double> N(0, 0);
   weld_body_to_world_->CalcNMatrix(*context_, &N);
   weld_body_to_world_->CalcNplusMatrix(*context_, &N);
+  weld_body_to_world_->CalcNDotMatrix(*context_, &N);
+  weld_body_to_world_->CalcNplusDotMatrix(*context_, &N);
 }
 
 // Since the functions involved are no-ops, MapUsesN and MapUsesNPlus

--- a/multibody/tree/universal_mobilizer.cc
+++ b/multibody/tree/universal_mobilizer.cc
@@ -158,6 +158,18 @@ void UniversalMobilizer<T>::DoCalcNplusMatrix(
 }
 
 template <typename T>
+void UniversalMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                             EigenPtr<MatrixX<T>> Ndot) const {
+  *Ndot = Matrix2<T>::Zero();
+}
+
+template <typename T>
+void UniversalMobilizer<T>::DoCalcNplusDotMatrix(
+    const systems::Context<T>&, EigenPtr<MatrixX<T>> NplusDot) const {
+  *NplusDot = Matrix2<T>::Zero();
+}
+
+template <typename T>
 void UniversalMobilizer<T>::MapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/universal_mobilizer.h
+++ b/multibody/tree/universal_mobilizer.h
@@ -234,6 +234,14 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;
 

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -54,6 +54,14 @@ void WeldMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
                                          EigenPtr<MatrixX<T>>) const {}
 
 template <typename T>
+void WeldMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>&,
+                                        EigenPtr<MatrixX<T>>) const {}
+
+template <typename T>
+void WeldMobilizer<T>::DoCalcNplusDotMatrix(const systems::Context<T>&,
+                                            EigenPtr<MatrixX<T>>) const {}
+
+template <typename T>
 void WeldMobilizer<T>::MapVelocityToQDot(const systems::Context<T>&,
                                          const Eigen::Ref<const VectorX<T>>& v,
                                          EigenPtr<VectorX<T>> qdot) const {

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -143,6 +143,14 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;
 

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -143,11 +143,11 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
-  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = 0x0 matrix.
   void DoCalcNDotMatrix(const systems::Context<T>& context,
                         EigenPtr<MatrixX<T>> Ndot) const final;
 
-  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = 0x0 matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
 


### PR DESCRIPTION
This is another PR in a series of PRs to help address issue #22630. It overrides DoCalcNDotMatrix() and DoCalcNplusDotMatrix() for five more mobilizers: WeldMobilizer, PlanarMobilizer, ScrewMobilizer, UniversalMobilizer, CurvilinearMobilizer.  
Note: Already done is RevoluteMobilizer and PrismaticMobilizer.

Subsequent PRs will create additional overrides for RpyBallMobilizer, RpyFloatingMobilizer, QuaternionFloatingMobilizer.  Collectively, all these PRs help facilitate implementation of MapQDDotToAcceleration() and MapAccelerationToQDDot().

FYI: Mobilizers are Drake internal classes.  After the internal mobilizer work is complete, there will be subsequent PRs for the public API in MultibodyPlant to address issue #22630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22961)
<!-- Reviewable:end -->
