### PR TITLE
[setup] Do not require lsb_release for wheel build

### DIFF
--- a/tools/wheel/image/packages-almalinux
+++ b/tools/wheel/image/packages-almalinux
@@ -15,7 +15,6 @@ pkgconf-pkg-config
 # Other general tools.
 diffutils
 file
-lsb-release
 patch
 patchelf
 wget

--- a/tools/workspace/pybind11/libclang_setup.py
+++ b/tools/workspace/pybind11/libclang_setup.py
@@ -40,12 +40,15 @@ def add_library_paths(parameters=None):
         # By default we expect Clang 15 to be installed, but on Ubuntu 24.04
         # we'll use Clang 17 for compatibility with GCC 14.
         version = 15
-        completed_process = subprocess.run(['lsb_release', '-sr'],
-                                           stdout=subprocess.PIPE,
-                                           encoding='utf-8')
-        if completed_process.returncode == 0:
-            if completed_process.stdout.strip() == '24.04':
-                version = 17
+        try:
+            completed_process = subprocess.run(['lsb_release', '-sr'],
+                                            stdout=subprocess.PIPE,
+                                            encoding='utf-8')
+            if completed_process.returncode == 0:
+                if completed_process.stdout.strip() == '24.04':
+                    version = 17
+        except Exception:
+            pass
         arch = platform.machine()
         llvm_root = f'/usr/lib64/llvm{version}'
         if os.path.exists(llvm_root):


### PR DESCRIPTION
Closes #22963 

This pr integrates the suggested revision, allowing `tools/workspace/pybind11/libclang_setup.py` to run without `lsb_release` installed via a `try-except` block that functionally treats non-zero exit codes and exceptions the same for the subprocess involving `lsb_release`.