### PR TITLE
[fem] Add NeoHookean model

### DIFF
--- a/bindings/pydrake/multibody/fem_py.cc
+++ b/bindings/pydrake/multibody/fem_py.cc
@@ -22,6 +22,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         .value("kLinearCorotated", Class::kLinearCorotated,
             cls_doc.kLinearCorotated.doc)
         .value("kCorotated", Class::kCorotated, cls_doc.kCorotated.doc)
+        .value("kNeoHookean", Class::kNeoHookean, cls_doc.kNeoHookean.doc)
         .value("kLinear", Class::kLinear, cls_doc.kLinear.doc);
   }
 }

--- a/bindings/pydrake/multibody/test/fem_test.py
+++ b/bindings/pydrake/multibody/test/fem_test.py
@@ -30,6 +30,7 @@ class TestMultibodyFem(unittest.TestCase):
         models = [
             MaterialModel.kLinearCorotated,
             MaterialModel.kCorotated,
+            MaterialModel.kNeoHookean,
             MaterialModel.kLinear,
         ]
         for model in models:

--- a/multibody/fem/BUILD.bazel
+++ b/multibody/fem/BUILD.bazel
@@ -39,6 +39,8 @@ drake_cc_package_library(
         ":linear_corotated_model_data",
         ":linear_simplex_element",
         ":matrix_utilities",
+        ":neohookean_model",
+        ":neohookean_model_data",
         ":quadrature",
         ":schur_complement",
         ":simplex_gaussian_quadrature",
@@ -413,6 +415,40 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "neohookean_model",
+    srcs = [
+        "neohookean_model.cc",
+    ],
+    hdrs = [
+        "neohookean_model.h",
+    ],
+    deps = [
+        ":calc_lame_parameters",
+        ":constitutive_model",
+        ":matrix_utilities",
+        ":neohookean_model_data",
+        "//common:autodiff",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "neohookean_model_data",
+    srcs = [
+        "neohookean_model_data.cc",
+    ],
+    hdrs = [
+        "neohookean_model_data.h",
+    ],
+    deps = [
+        ":deformation_gradient_data",
+        ":matrix_utilities",
+        "//common:autodiff",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "quadrature",
     srcs = [
         "quadrature.cc",
@@ -533,6 +569,7 @@ drake_cc_library(
         ":linear_constitutive_model",
         ":linear_corotated_model",
         ":matrix_utilities",
+        ":neohookean_model",
         "//common:autodiff",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
@@ -733,6 +770,23 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",
         "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "neohookean_model_test",
+    deps = [
+        ":constitutive_model_test_utilities",
+        ":neohookean_model",
+    ],
+)
+
+drake_cc_googletest(
+    name = "neohookean_model_data_test",
+    deps = [
+        ":neohookean_model",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 

--- a/multibody/fem/constitutive_model.h
+++ b/multibody/fem/constitutive_model.h
@@ -102,7 +102,8 @@ class ConstitutiveModel {
   /* Calculates the filtered Hessian of the first Piola stress with respect to
    the deformation gradient, given the deformation gradient related quantities
    contained in `data`. The filtered Hessian is the result of
-   `CalcFirstPiolaStressDerivative` with eigenvalues clamped at 0 from below. */
+   `CalcFirstPiolaStressDerivative` with negative eigenvalues replaced with tiny
+   positive ones.*/
   void CalcFilteredHessian(
       const Data& data, math::internal::FourthOrderTensor<T>* hessian) const {
     DRAKE_ASSERT(hessian != nullptr);
@@ -144,10 +145,10 @@ class ConstitutiveModel {
 
   /* Derived classes *may* shadow this method to provide a more efficient
    implementation of the filtered Hessian. The default implementation is
-   `CalcFirstPiolaStressDerivative` followed by an eigenvalue decomposition of
-   the 9-by-9 matrix. The eigenvalues are clamped at 0 from below and the
-   filtered Hessian is reconstructed from the eigenvalues and eigenvectors. The
-   output argument is guaranteed to be non-null. */
+   CalcFirstPiolaStressDerivative() followed by an eigenvalue decomposition of
+   the 9-by-9 matrix. The negative eigenvalues are replaced with tiny positive
+   ones and the filtered Hessian is reconstructed from the eigenvalues and
+   eigenvectors. The output argument is guaranteed to be non-null. */
   void CalcFilteredHessianImpl(
       const Data& data, math::internal::FourthOrderTensor<T>* hessian) const {
     CalcFirstPiolaStressDerivative(data, hessian);

--- a/multibody/fem/constitutive_model.h
+++ b/multibody/fem/constitutive_model.h
@@ -99,6 +99,16 @@ class ConstitutiveModel {
     derived().CalcFirstPiolaStressDerivativeImpl(data, dPdF);
   }
 
+  /* Calculates the filtered Hessian of the first Piola stress with respect to
+   the deformation gradient, given the deformation gradient related quantities
+   contained in `data`. The filtered Hessian is the result of
+   `CalcFirstPiolaStressDerivative` with eigenvalues clamped at 0 from below. */
+  void CalcFilteredHessian(
+      const Data& data, math::internal::FourthOrderTensor<T>* hessian) const {
+    DRAKE_ASSERT(hessian != nullptr);
+    derived().CalcFilteredHessianImpl(data, hessian);
+  }
+
  protected:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ConstitutiveModel);
 
@@ -130,6 +140,31 @@ class ConstitutiveModel {
         fmt::format("The derived class {} must provide a shadow definition of "
                     "CalcFirstPiolaStressDerivativeImpl() to be correct.",
                     NiceTypeName::Get(derived())));
+  }
+
+  /* Derived classes *may* shadow this method to provide a more efficient
+   implementation of the filtered Hessian. The default implementation is
+   `CalcFirstPiolaStressDerivative` followed by an eigenvalue decomposition of
+   the 9-by-9 matrix. The eigenvalues are clamped at 0 from below and the
+   filtered Hessian is reconstructed from the eigenvalues and eigenvectors. The
+   output argument is guaranteed to be non-null. */
+  void CalcFilteredHessianImpl(
+      const Data& data, math::internal::FourthOrderTensor<T>* hessian) const {
+    CalcFirstPiolaStressDerivative(data, hessian);
+    const T kTol = 1e-14;
+    using Matrix9 = Eigen::Matrix<T, 9, 9>;
+    using Vector9 = Eigen::Matrix<T, 9, 1>;
+    const Matrix9& matrix = hessian->data();
+    Eigen::SelfAdjointEigenSolver<Matrix9> eigensolver(matrix);
+    DRAKE_THROW_UNLESS(eigensolver.info() == Eigen::Success);
+    Vector9 eigenvalues = eigensolver.eigenvalues();
+    for (int i = 0; i < 9; ++i) {
+      if (eigenvalues(i) < kTol) eigenvalues(i) = kTol;
+    }
+    const Matrix9& eigenvectors = eigensolver.eigenvectors();
+    Matrix9& filtered_hessian = hessian->mutable_data();
+    filtered_hessian =
+        eigenvectors * eigenvalues.asDiagonal() * eigenvectors.transpose();
   }
 
  private:

--- a/multibody/fem/deformable_body_config.h
+++ b/multibody/fem/deformable_body_config.h
@@ -20,10 +20,12 @@ enum class MaterialModel {
    Convex Formulation of Frictional Contact between Rigid and Deformable
    Bodies." arXiv preprint arXiv:2303.08912 (2023). */
   kLinearCorotated,
-  /** Corotational model. More computationally expensive and less robust than
-   the linear corotational model. May require smaller time steps. Recommended
-   when capturing large rotation velocity is important. */
+  /** Corotational model. More computationally expensive. Recommended when
+   capturing large rotation velocity is important. */
   kCorotated,
+  /** Neohookean model. More computationally expensive. Recommended when
+   capturing large rotation velocity is important. */
+  kNeoHookean,
   /** Linear elasticity model (rarely used).
    Less computationally expensive than other models but leads to artifacts
    when large rotational deformations occur. */

--- a/multibody/fem/deformable_body_config.h
+++ b/multibody/fem/deformable_body_config.h
@@ -21,10 +21,22 @@ enum class MaterialModel {
    Bodies." arXiv preprint arXiv:2303.08912 (2023). */
   kLinearCorotated,
   /** Corotational model. More computationally expensive. Recommended when
-   capturing large rotation velocity is important. */
+   capturing large rotation velocity is important.
+
+   [Stomakhin et al., 2012] Stomakhin, Alexey, et al. "Energetically consistent
+   invertible elasticity." Proceedings of the 11th ACM SIGGRAPH/Eurographics
+   conference on Computer Animation. 2012. */
   kCorotated,
   /** Neohookean model. More computationally expensive. Recommended when
-   capturing large rotation velocity is important. */
+   capturing large rotation velocity is important. There are subtle differences
+   in physical behavior between the Corotated model and the Neo-Hookean model.
+   See [Smith et al., 2019; Stomakhin et al., 2012] for details. In practice, we
+   often choose the Neo-Hookean model over the Corotated model simply because
+   it's computationally more efficient.
+
+   [Smith et al., 2019] Smith, Breannan, Fernando De Goes, and Theodore Kim.
+   "Stable Neo-Hookean flesh simulation." ACM Transactions on Graphics
+   (TOG) 37.2 (2018): 1-15. */
   kNeoHookean,
   /** Linear elasticity model (rarely used).
    Less computationally expensive than other models but leads to artifacts

--- a/multibody/fem/linear_constitutive_model.cc
+++ b/multibody/fem/linear_constitutive_model.cc
@@ -58,6 +58,12 @@ void LinearConstitutiveModel<T>::CalcFirstPiolaStressDerivativeImpl(
   *dPdF = dPdF_;
 }
 
+template <typename T>
+void LinearConstitutiveModel<T>::CalcFilteredHessianImpl(
+    const Data&, math::internal::FourthOrderTensor<T>* hessian) const {
+  *hessian = dPdF_;
+}
+
 template class LinearConstitutiveModel<float>;
 template class LinearConstitutiveModel<double>;
 template class LinearConstitutiveModel<AutoDiffXd>;

--- a/multibody/fem/linear_constitutive_model.h
+++ b/multibody/fem/linear_constitutive_model.h
@@ -74,7 +74,8 @@ class LinearConstitutiveModel final
   void CalcFirstPiolaStressDerivativeImpl(
       const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const;
 
-  /* Shadows ConstitutiveModel::CalcFilteredHessian() in the CRTP base class. */
+  /* Shadows ConstitutiveModel::CalcFilteredHessianImpl() in the CRTP base
+   class. */
   void CalcFilteredHessianImpl(
       const Data& data, math::internal::FourthOrderTensor<T>* hessian) const;
 

--- a/multibody/fem/linear_constitutive_model.h
+++ b/multibody/fem/linear_constitutive_model.h
@@ -74,6 +74,10 @@ class LinearConstitutiveModel final
   void CalcFirstPiolaStressDerivativeImpl(
       const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const;
 
+  /* Shadows ConstitutiveModel::CalcFilteredHessian() in the CRTP base class. */
+  void CalcFilteredHessianImpl(
+      const Data& data, math::internal::FourthOrderTensor<T>* hessian) const;
+
   T E_;       // Young's modulus, N/m².
   T nu_;      // Poisson's ratio.
   T mu_;      // Lamé's second parameter/Shear modulus, N/m².

--- a/multibody/fem/linear_corotated_model.cc
+++ b/multibody/fem/linear_corotated_model.cc
@@ -101,6 +101,12 @@ void LinearCorotatedModel<T>::CalcFirstPiolaStressDerivativeImpl(
   }
 }
 
+template <typename T>
+void LinearCorotatedModel<T>::CalcFilteredHessianImpl(
+    const Data& data, math::internal::FourthOrderTensor<T>* hessian) const {
+  CalcFirstPiolaStressDerivativeImpl(data, hessian);
+}
+
 template class LinearCorotatedModel<float>;
 template class LinearCorotatedModel<double>;
 template class LinearCorotatedModel<AutoDiffXd>;

--- a/multibody/fem/linear_corotated_model.h
+++ b/multibody/fem/linear_corotated_model.h
@@ -74,7 +74,8 @@ class LinearCorotatedModel final
   void CalcFirstPiolaStressDerivativeImpl(
       const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const;
 
-  /* Shadows ConstitutiveModel::CalcFilteredHessian() in the CRTP base class. */
+  /* Shadows ConstitutiveModel::CalcFilteredHessianImpl() in the CRTP base
+   class. */
   void CalcFilteredHessianImpl(
       const Data& data, math::internal::FourthOrderTensor<T>* hessian) const;
 

--- a/multibody/fem/matrix_utilities.cc
+++ b/multibody/fem/matrix_utilities.cc
@@ -50,6 +50,26 @@ void PolarDecompose(const Matrix3<T>& F, EigenPtr<Matrix3<T>> R,
 }
 
 template <typename T>
+void RotationSvd(const Matrix3<T>& F, EigenPtr<Matrix3<T>> U,
+                 EigenPtr<Matrix3<T>> V, EigenPtr<Vector3<T>> sigma) {
+  /* According to https://eigen.tuxfamily.org/dox/classEigen_1_1BDCSVD.html,
+   for matrix of size < 16, it's preferred to used JacobiSVD. */
+  const Eigen::JacobiSVD<Matrix3<T>, Eigen::HouseholderQRPreconditioner> svd(
+      F, Eigen::ComputeFullU | Eigen::ComputeFullV);
+  *U = svd.matrixU();
+  *V = svd.matrixV();
+  *sigma = svd.singularValues();
+  if (U->determinant() < 0.0) {
+    U->col(0) *= -1.0;
+    (*sigma)(0) *= -1.0;
+  }
+  if (V->determinant() < 0.0) {
+    V->col(0) *= -1.0;
+    (*sigma)(0) *= -1.0;
+  }
+}
+
+template <typename T>
 void AddScaledRotationalDerivative(
     const Matrix3<T>& R, const Matrix3<T>& S, const T& scale,
     math::internal::FourthOrderTensor<T>* scaled_dRdF) {
@@ -175,6 +195,7 @@ VectorX<T> PermuteBlockVector(const Eigen::Ref<const VectorX<T>>& v,
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     (&CalcConditionNumberOfInvertibleMatrix<T>,  // BR
      &PolarDecompose<T>,                         // BR
+     &RotationSvd<T>,                            // BR
      &AddScaledRotationalDerivative<T>,          // BR
      &CalcCofactorMatrix<T>,                     // BR
      &AddScaledCofactorMatrixDerivative<T>,      // BR
@@ -183,6 +204,10 @@ DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
 template void PolarDecompose<float>(const Matrix3<float>& F,
                                     EigenPtr<Matrix3<float>> R,
                                     EigenPtr<Matrix3<float>> S);
+template void RotationSvd<float>(const Matrix3<float>& F,
+                                 EigenPtr<Matrix3<float>> U,
+                                 EigenPtr<Matrix3<float>> V,
+                                 EigenPtr<Vector3<float>> sigma);
 template void AddScaledRotationalDerivative<float>(
     const Matrix3<float>& R, const Matrix3<float>& S, const float& scale,
     math::internal::FourthOrderTensor<float>* scaled_dRdF);

--- a/multibody/fem/matrix_utilities.cc
+++ b/multibody/fem/matrix_utilities.cc
@@ -59,6 +59,8 @@ void RotationSvd(const Matrix3<T>& F, EigenPtr<Matrix3<T>> U,
   *U = svd.matrixU();
   *V = svd.matrixV();
   *sigma = svd.singularValues();
+  /* We flip an arbitrary singular vector if needed to ensure U and V are
+   rotation matrices. */
   if (U->determinant() < 0.0) {
     U->col(0) *= -1.0;
     (*sigma)(0) *= -1.0;

--- a/multibody/fem/matrix_utilities.h
+++ b/multibody/fem/matrix_utilities.h
@@ -34,9 +34,13 @@ template <typename T>
 void PolarDecompose(const Matrix3<T>& F, EigenPtr<Matrix3<T>> R,
                     EigenPtr<Matrix3<T>> S);
 
-/* Calculates the Singular Value Decomposition (SVD) of a 3-by-3 matrix
- F = USV^T where U and V are rotation matrices and S = diag(σ₁, σ₂, σ₃) is a
- diagonal matrix.
+/* Calculates a Singular Value Decomposition (SVD) of a 3-by-3 matrix
+ F=U⋅S⋅Vᵀ where U and V are rotation matrices and S = diag(σ₁, σ₂, σ₃) is a
+ diagonal matrix. Such SVD is not unique and we pick an arbitrary valid one.
+ See Appendix F of [Kim and Eberle, 2020] for details.
+ [Kim and Eberle, 2020] Kim, Theodore, and David Eberle. "Dynamic deformables:
+ implementation and production practicalities." Acm siggraph 2020 courses. 2020.
+ 1-182.
  @tparam T The scalar type, can be a double, float, or AutoDiffXd. */
 template <typename T>
 void RotationSvd(const Matrix3<T>& F, EigenPtr<Matrix3<T>> U,

--- a/multibody/fem/matrix_utilities.h
+++ b/multibody/fem/matrix_utilities.h
@@ -34,6 +34,14 @@ template <typename T>
 void PolarDecompose(const Matrix3<T>& F, EigenPtr<Matrix3<T>> R,
                     EigenPtr<Matrix3<T>> S);
 
+/* Calculates the Singular Value Decomposition (SVD) of a 3-by-3 matrix
+ F = USV^T where U and V are rotation matrices and S = diag(σ₁, σ₂, σ₃) is a
+ diagonal matrix.
+ @tparam T The scalar type, can be a double, float, or AutoDiffXd. */
+template <typename T>
+void RotationSvd(const Matrix3<T>& F, EigenPtr<Matrix3<T>> U,
+                 EigenPtr<Matrix3<T>> V, EigenPtr<Vector3<T>> sigma);
+
 /* Computes the derivative of the rotation matrix from the polar decomposition
  (see PolarDecompose()) with respect to the original matrix.
  @param[in] R               The rotation matrix in the polar decomposition

--- a/multibody/fem/neohookean_model.cc
+++ b/multibody/fem/neohookean_model.cc
@@ -1,0 +1,186 @@
+#include "drake/multibody/fem/neohookean_model.h"
+
+#include <array>
+#include <numbers>
+#include <utility>
+
+#include "drake/common/autodiff.h"
+#include "drake/multibody/fem/calc_lame_parameters.h"
+#include "drake/multibody/fem/matrix_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+NeoHookeanModel<T>::NeoHookeanModel(const T& youngs_modulus,
+                                    const T& poissons_ratio)
+    : E_(youngs_modulus), nu_(poissons_ratio) {
+  const LameParameters<T> lame_params = CalcLameParameters(E_, nu_);
+  mu_ = lame_params.mu;
+  lambda_ = lame_params.lambda;
+  mu_over_lambda_ = mu_ / lambda_;
+}
+
+template <typename T>
+void NeoHookeanModel<T>::CalcElasticEnergyDensityImpl(const Data& data,
+                                                      T* Psi) const {
+  const T& Ic = data.Ic();
+  const T& volume_correction = data.Jm1() - mu_over_lambda_;
+  *Psi = 0.5 *
+         (mu_ * (Ic - 3.0) + lambda_ * volume_correction * volume_correction);
+}
+
+template <typename T>
+void NeoHookeanModel<T>::CalcFirstPiolaStressImpl(const Data& data,
+                                                  Matrix3<T>* P) const {
+  const Matrix3<T>& dJdF = data.dJdF();
+  const T& volume_correction = data.Jm1() - mu_over_lambda_;
+  const Matrix3<T>& F = data.deformation_gradient();
+  (*P) = mu_ * F + lambda_ * volume_correction * dJdF;
+}
+
+template <typename T>
+void NeoHookeanModel<T>::CalcFirstPiolaStressDerivativeImpl(
+    const Data& data, math::internal::FourthOrderTensor<T>* dPdF) const {
+  const T& Jm1 = data.Jm1();
+  const T& volume_correction = Jm1 - mu_over_lambda_;
+  const Matrix3<T>& F = data.deformation_gradient();
+  const Matrix3<T>& JFinvT = data.dJdF();
+  auto& local_dPdF = (*dPdF);
+  local_dPdF.SetAsOuterProduct(lambda_ * JFinvT, JFinvT);
+  /* The contribution from derivatives of F. */
+  local_dPdF.mutable_data().diagonal().array() += mu_;
+  /* The contribution from derivatives of JFinvT. */
+  internal::AddScaledCofactorMatrixDerivative<T>(F, lambda_ * volume_correction,
+                                                 &local_dPdF);
+}
+
+template <typename T>
+void NeoHookeanModel<T>::CalcFilteredHessianImpl(
+    const Data& data, math::internal::FourthOrderTensor<T>* hessian) const {
+  using Matrix9T = Eigen::Matrix<T, 9, 9>;
+  using Vector9T = Eigen::Matrix<T, 9, 1>;
+
+  Vector9T eigenvalues;
+  Matrix9T eigenvectors;
+
+  const T& Jm1 = data.Jm1();
+  const T J = Jm1 + 1.0;
+  const Vector3<T>& sigma = data.sigma();
+  const Matrix3<T>& U = data.U();
+  const Matrix3<T>& V = data.V();
+
+  /* Compute the twist and flip eigenvalues. */
+  {
+    /* Twist eigenvalues */
+    eigenvalues.template segment<3>(0) = sigma;
+    /* Flip eigenvalues */
+    eigenvalues.template segment<3>(3) = -sigma;
+    const T scale = lambda_ * data.Jm1() - mu_;
+    eigenvalues.template segment<6>(0) *= scale;
+    eigenvalues.template segment<6>(0).array() += mu_;
+  }
+
+  /* Compute the twist and flip eigenvectors. */
+  BuildTwistAndFlipEigenvectors(U, V, &eigenvectors);
+
+  /* Compute the remaining three eigenvalues and eigenvectors. */
+  {
+    Matrix3<T> A;
+    const T s0s0 = sigma(0) * sigma(0);
+    const T s1s1 = sigma(1) * sigma(1);
+    const T s2s2 = sigma(2) * sigma(2);
+    A(0, 0) = mu_ + lambda_ * s1s1 * s2s2;
+    A(1, 1) = mu_ + lambda_ * s0s0 * s2s2;
+    A(2, 2) = mu_ + lambda_ * s0s0 * s1s1;
+    const T scale = lambda_ * (2.0 * J - 1.0) - mu_;
+    A(0, 1) = scale * sigma(2);
+    A(1, 0) = A(0, 1);
+    A(0, 2) = scale * sigma(1);
+    A(2, 0) = A(0, 2);
+    A(1, 2) = scale * sigma(0);
+    A(2, 1) = A(1, 2);
+
+    const Eigen::SelfAdjointEigenSolver<Matrix3<T>> solver(A);
+    eigenvalues.template segment<3>(6) = solver.eigenvalues();
+
+    Eigen::Map<Matrix3<T>>(eigenvectors.data() + 54).noalias() =
+        U * solver.eigenvectors().col(0).asDiagonal() * V.transpose();
+    Eigen::Map<Matrix3<T>>(eigenvectors.data() + 63).noalias() =
+        U * solver.eigenvectors().col(1).asDiagonal() * V.transpose();
+    Eigen::Map<Matrix3<T>>(eigenvectors.data() + 72).noalias() =
+        U * solver.eigenvectors().col(2).asDiagonal() * V.transpose();
+  }
+
+  /* An arbitrary small positive to guarantee that the resulting Hessian is
+   positive semidefinite (even with numerical rounding). In practice, the
+   assembled Hessian is always positive-definite (SPD) (due to the SPD mass
+   matrix). */
+  const T kTol = 1e-14;
+  /* Clamp the eigenvalues. */
+  for (int i = 0; i < 9; ++i) {
+    if (eigenvalues(i) < kTol) {
+      eigenvalues(i) = kTol;
+    }
+  }
+  hessian->mutable_data().noalias() =
+      eigenvectors * eigenvalues.asDiagonal() * eigenvectors.transpose();
+}
+
+template <typename T>
+void NeoHookeanModel<T>::BuildTwistAndFlipEigenvectors(
+    const Matrix3<T>& U, const Matrix3<T>& V, Eigen::Matrix<T, 9, 9>* Q) const {
+  const T scale = 1.0 / std::numbers::sqrt2;
+  const Matrix3<T> sV = scale * V;
+
+  Matrix3<T> A;
+  A << sV(0, 2) * U(0, 1), sV(1, 2) * U(0, 1), sV(2, 2) * U(0, 1),
+      sV(0, 2) * U(1, 1), sV(1, 2) * U(1, 1), sV(2, 2) * U(1, 1),
+      sV(0, 2) * U(2, 1), sV(1, 2) * U(2, 1), sV(2, 2) * U(2, 1);
+
+  Matrix3<T> B;
+  B << sV(0, 1) * U(0, 2), sV(1, 1) * U(0, 2), sV(2, 1) * U(0, 2),
+      sV(0, 1) * U(1, 2), sV(1, 1) * U(1, 2), sV(2, 1) * U(1, 2),
+      sV(0, 1) * U(2, 2), sV(1, 1) * U(2, 2), sV(2, 1) * U(2, 2);
+
+  Matrix3<T> C;
+  C << sV(0, 2) * U(0, 0), sV(1, 2) * U(0, 0), sV(2, 2) * U(0, 0),
+      sV(0, 2) * U(1, 0), sV(1, 2) * U(1, 0), sV(2, 2) * U(1, 0),
+      sV(0, 2) * U(2, 0), sV(1, 2) * U(2, 0), sV(2, 2) * U(2, 0);
+
+  Matrix3<T> D;
+  D << sV(0, 0) * U(0, 2), sV(1, 0) * U(0, 2), sV(2, 0) * U(0, 2),
+      sV(0, 0) * U(1, 2), sV(1, 0) * U(1, 2), sV(2, 0) * U(1, 2),
+      sV(0, 0) * U(2, 2), sV(1, 0) * U(2, 2), sV(2, 0) * U(2, 2);
+
+  Matrix3<T> E;
+  E << sV(0, 1) * U(0, 0), sV(1, 1) * U(0, 0), sV(2, 1) * U(0, 0),
+      sV(0, 1) * U(1, 0), sV(1, 1) * U(1, 0), sV(2, 1) * U(1, 0),
+      sV(0, 1) * U(2, 0), sV(1, 1) * U(2, 0), sV(2, 1) * U(2, 0);
+
+  Matrix3<T> F;
+  F << sV(0, 0) * U(0, 1), sV(1, 0) * U(0, 1), sV(2, 0) * U(0, 1),
+      sV(0, 0) * U(1, 1), sV(1, 0) * U(1, 1), sV(2, 0) * U(1, 1),
+      sV(0, 0) * U(2, 1), sV(1, 0) * U(2, 1), sV(2, 0) * U(2, 1);
+
+  /* Twist eigenvectors */
+  Eigen::Map<Matrix3<T>>(Q->data()) = B - A;
+  Eigen::Map<Matrix3<T>>(Q->data() + 9) = D - C;
+  Eigen::Map<Matrix3<T>>(Q->data() + 18) = F - E;
+
+  /* Flip eigenvectors */
+  Eigen::Map<Matrix3<T>>(Q->data() + 27) = A + B;
+  Eigen::Map<Matrix3<T>>(Q->data() + 36) = C + D;
+  Eigen::Map<Matrix3<T>>(Q->data() + 45) = E + F;
+}
+
+template class NeoHookeanModel<float>;
+template class NeoHookeanModel<double>;
+template class NeoHookeanModel<AutoDiffXd>;
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/neohookean_model_data.cc
+++ b/multibody/fem/neohookean_model_data.cc
@@ -1,0 +1,37 @@
+#include "drake/multibody/fem/neohookean_model_data.h"
+
+#include "drake/common/autodiff.h"
+#include "drake/multibody/fem/matrix_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+NeoHookeanModelData<T>::NeoHookeanModelData() {
+  Ic_ = 3.0;
+  Jm1_ = 0;
+  dJdF_ = Matrix3<T>::Identity();
+  U_ = Matrix3<T>::Identity();
+  V_ = Matrix3<T>::Identity();
+  sigma_ = Vector3<T>::Ones();
+}
+
+template <typename T>
+void NeoHookeanModelData<T>::UpdateFromDeformationGradient() {
+  const Matrix3<T>& F = this->deformation_gradient();
+  Ic_ = F.squaredNorm();
+  Jm1_ = F.determinant() - 1.0;
+  internal::CalcCofactorMatrix<T>(F, &dJdF_);
+  internal::RotationSvd<T>(F, &U_, &V_, &sigma_);
+}
+
+template class NeoHookeanModelData<float>;
+template class NeoHookeanModelData<double>;
+template class NeoHookeanModelData<AutoDiffXd>;
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/neohookean_model_data.h
+++ b/multibody/fem/neohookean_model_data.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <array>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/deformation_gradient_data.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Data supporting calculations in NeoHookeanModel. The constitutive model is
+ described in section 3.4 in [Smith, 2019]. In particular, this class stores
+ the SVD of the deformation gradient F, along with J-1, the first Cauchy-Green
+ invariant (Ic = tr(FᵀF)). and JF⁻ᵀ (J = det(F)) used in evaluating the energy
+ density and its derivatives. See DeformationGradientData for more about
+ constitutive model data.
+ @tparam T The scalar type, can be a double, float, or AutoDiffXd. */
+template <typename T>
+class NeoHookeanModelData
+    : public DeformationGradientData<NeoHookeanModelData<T>> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(NeoHookeanModelData);
+
+  /* Constructs a NeoHookeanModelData with no deformation. */
+  NeoHookeanModelData();
+
+  /* Returns the first Cauchy-Green invariant Ic = tr(FᵀF) where F is the
+   deformation gradient. */
+  const T& Ic() const { return Ic_; }
+
+  /* Returns the J-1 where J is the determinant of the deformation gradient. */
+  const T& Jm1() const { return Jm1_; }
+
+  /* Returns the dJdF = JF⁻ᵀ. */
+  const Matrix3<T>& dJdF() const { return dJdF_; }
+
+  /* Returns the U matrix from the SVD of F = USVᵀ. */
+  const Matrix3<T>& U() const { return U_; }
+
+  /* Returns the V matrix from the SVD of F = USVᵀ. */
+  const Matrix3<T>& V() const { return V_; }
+
+  /* Returns the singular values of F from the SVD of F = USVᵀ. */
+  const Vector3<T>& sigma() const { return sigma_; }
+
+ private:
+  friend DeformationGradientData<NeoHookeanModelData<T>>;
+
+  /* Shadows DeformationGradientData::UpdateFromDeformationGradient() as
+   required by the CRTP base class. */
+  void UpdateFromDeformationGradient();
+  /* tr(FᵀF) */
+  T Ic_;
+  /* The determinant of F minus 1, or J-1. */
+  T Jm1_;
+  /* The derivative of J wrt F, which is the the cofactor matrix of F, or JF⁻ᵀ.
+   */
+  Matrix3<T> dJdF_;
+  /* The SVD of F = USVᵀ where U and V are both rotation matrices and
+   S = diag(σ₁, σ₂, σ₃) is a diagonal matrix with the singular values of F. */
+  Matrix3<T> U_;
+  Matrix3<T> V_;
+  Vector3<T> sigma_;
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/neohookean_model_data.h
+++ b/multibody/fem/neohookean_model_data.h
@@ -11,11 +11,14 @@ namespace fem {
 namespace internal {
 
 /* Data supporting calculations in NeoHookeanModel. The constitutive model is
- described in section 3.4 in [Smith, 2019]. In particular, this class stores
- the SVD of the deformation gradient F, along with J-1, the first Cauchy-Green
- invariant (Ic = tr(FᵀF)). and JF⁻ᵀ (J = det(F)) used in evaluating the energy
- density and its derivatives. See DeformationGradientData for more about
- constitutive model data.
+ described in section 3.4 in [Smith et al., 2019]. In particular, this class
+ stores the SVD of the deformation gradient F, along with J-1, the first
+ Cauchy-Green invariant (Ic = tr(FᵀF)). and JF⁻ᵀ (J = det(F)) used in evaluating
+ the energy density and its derivatives. See DeformationGradientData for more
+ about constitutive model data.
+ [Smith et al., 2019] Smith, Breannan, Fernando De Goes, and Theodore Kim.
+ "Stable Neo-Hookean flesh simulation." ACM Transactions on Graphics (TOG) 37.2
+ (2018): 1-15.
  @tparam T The scalar type, can be a double, float, or AutoDiffXd. */
 template <typename T>
 class NeoHookeanModelData
@@ -59,7 +62,8 @@ class NeoHookeanModelData
    */
   Matrix3<T> dJdF_;
   /* The SVD of F = USVᵀ where U and V are both rotation matrices and
-   S = diag(σ₁, σ₂, σ₃) is a diagonal matrix with the singular values of F. */
+   S = diag(σ₁, σ₂, σ₃) is a diagonal matrix with the singular values of F (that
+   may be negative) to force U and V to be rotation matrices. */
   Matrix3<T> U_;
   Matrix3<T> V_;
   Vector3<T> sigma_;

--- a/multibody/fem/test/constitutive_model_test_utilities.cc
+++ b/multibody/fem/test/constitutive_model_test_utilities.cc
@@ -10,6 +10,7 @@
 #include "drake/multibody/fem/linear_constitutive_model.h"
 #include "drake/multibody/fem/linear_corotated_model.h"
 #include "drake/multibody/fem/matrix_utilities.h"
+#include "drake/multibody/fem/neohookean_model.h"
 
 namespace drake {
 namespace multibody {
@@ -59,7 +60,7 @@ Matrix3<AutoDiffXd> MakeDeformationGradientsWithoutDerivatives() {
 /* Tests the constructors correctly initializes St.Venant-Kichhoff like
 constitutive models and rejects invalid Young's modulus and Poisson's ratio.
 @tparam Model    Must be instantiations of LinearConstitutiveModel,
-LinearCorotatedModel, or CorotatedModel. */
+LinearCorotatedModel, NeoHookeanModel, or CorotatedModel. */
 template <class Model>
 void TestParameters() {
   using T = typename Model::T;
@@ -93,7 +94,7 @@ state.
 @tparam Model    Must be instantiations of LinearConstitutiveModel,
 LinearCorotatedModel, or CorotatedModel. */
 template <class Model>
-void TestUndeformedState() {
+void TestUndeformedState(bool nonzero_rest_state) {
   using T = typename Model::T;
 
   const T kYoungsModulus = 100.0;
@@ -107,9 +108,11 @@ void TestUndeformedState() {
   const T analytic_energy_density{0};
   /* At the undeformed state, the stress should be zero. */
   const Matrix3<T> analytic_stress{Matrix3d::Zero()};
-  T energy_density;
-  model.CalcElasticEnergyDensity(data, &energy_density);
-  EXPECT_EQ(energy_density, analytic_energy_density);
+  if (!nonzero_rest_state) {
+    T energy_density;
+    model.CalcElasticEnergyDensity(data, &energy_density);
+    EXPECT_EQ(energy_density, analytic_energy_density);
+  }
   Matrix3<T> stress;
   model.CalcFirstPiolaStress(data, &stress);
   EXPECT_EQ(stress, analytic_stress);
@@ -178,26 +181,88 @@ void TestdPdFIsDerivativeOfP() {
   }
 }
 
+template <class Model>
+void TestSpdness() {
+  using T = typename Model::T;
+  const T kYoungsModulus = 100.0;
+  const T kPoissonRatio = 0.25;
+  const Model model(kYoungsModulus, kPoissonRatio);
+  typename Model::Traits::Data data;
+  Matrix3<T> F;
+  // clang-format off
+  F << 0.18, 0.63, 0.54,
+       0.13, 0.92, 0.17,
+       0.03, 0.86, 0.85;
+  // clang-format on
+  const Matrix3<T> F0 = F;
+  data.UpdateData(F, F0);
+  math::internal::FourthOrderTensor<T> unfiltered;
+  math::internal::FourthOrderTensor<T> filtered;
+
+  model.CalcFirstPiolaStressDerivative(data, &unfiltered);
+  model.CalcFilteredHessian(data, &filtered);
+
+  using Matrix9T = Eigen::Matrix<T, 9, 9>;
+  using Vector9d = Eigen::Matrix<double, 9, 1>;
+  // Check that the filtered Hessian is SPD.
+  const Matrix9T filtered_matrix = filtered.data();
+  const Eigen::SelfAdjointEigenSolver<Matrix9T> eigensolver(filtered_matrix);
+  ASSERT_TRUE(eigensolver.info() == Eigen::Success);
+  const Vector9d eigenvalues = math::DiscardGradient(eigensolver.eigenvalues());
+  const Eigen::SelfAdjointEigenSolver<Matrix9T> eigensolver2(unfiltered.data());
+  ASSERT_TRUE(eigensolver2.info() == Eigen::Success);
+  const Vector9d unfiltered_eigenvalues =
+      math::DiscardGradient(eigensolver2.eigenvalues());
+  // For the filtered Hessian, the eigenvalues should either be the same of the
+  // unfiltered hessian and positive or clamped at zero.
+  const double kTol = 1e-12;
+  for (int i = 0; i < 9; ++i) {
+    const double eigenvalue = eigenvalues(i);
+    const double unfiltered_eigenvalue = unfiltered_eigenvalues(i);
+    EXPECT_GE(eigenvalue, -kTol);
+    if (eigenvalue > kTol) {
+      EXPECT_NEAR(eigenvalue, unfiltered_eigenvalue, kTol);
+    } else {
+      EXPECT_NEAR(eigenvalue, 0, kTol);
+    }
+  }
+}
+
 template void TestParameters<LinearConstitutiveModel<double>>();
 template void TestParameters<LinearConstitutiveModel<AutoDiffXd>>();
-template void TestUndeformedState<LinearConstitutiveModel<double>>();
-template void TestUndeformedState<LinearConstitutiveModel<AutoDiffXd>>();
+template void TestUndeformedState<LinearConstitutiveModel<double>>(bool);
+template void TestUndeformedState<LinearConstitutiveModel<AutoDiffXd>>(bool);
+template void TestSpdness<LinearConstitutiveModel<double>>();
+template void TestSpdness<LinearConstitutiveModel<AutoDiffXd>>();
 template void TestPIsDerivativeOfPsi<LinearConstitutiveModel<AutoDiffXd>>();
 template void TestdPdFIsDerivativeOfP<LinearConstitutiveModel<AutoDiffXd>>();
 
 template void TestParameters<CorotatedModel<double>>();
 template void TestParameters<CorotatedModel<AutoDiffXd>>();
-template void TestUndeformedState<CorotatedModel<double>>();
-template void TestUndeformedState<CorotatedModel<AutoDiffXd>>();
+template void TestUndeformedState<CorotatedModel<double>>(bool);
+template void TestUndeformedState<CorotatedModel<AutoDiffXd>>(bool);
+template void TestSpdness<CorotatedModel<double>>();
+template void TestSpdness<CorotatedModel<AutoDiffXd>>();
 template void TestPIsDerivativeOfPsi<CorotatedModel<AutoDiffXd>>();
 template void TestdPdFIsDerivativeOfP<CorotatedModel<AutoDiffXd>>();
 
 template void TestParameters<LinearCorotatedModel<double>>();
 template void TestParameters<LinearCorotatedModel<AutoDiffXd>>();
-template void TestUndeformedState<LinearCorotatedModel<double>>();
-template void TestUndeformedState<LinearCorotatedModel<AutoDiffXd>>();
+template void TestUndeformedState<LinearCorotatedModel<double>>(bool);
+template void TestUndeformedState<LinearCorotatedModel<AutoDiffXd>>(bool);
+template void TestSpdness<LinearCorotatedModel<double>>();
+template void TestSpdness<LinearCorotatedModel<AutoDiffXd>>();
 template void TestPIsDerivativeOfPsi<LinearCorotatedModel<AutoDiffXd>>();
 template void TestdPdFIsDerivativeOfP<LinearCorotatedModel<AutoDiffXd>>();
+
+template void TestParameters<NeoHookeanModel<double>>();
+template void TestParameters<NeoHookeanModel<AutoDiffXd>>();
+template void TestUndeformedState<NeoHookeanModel<double>>(bool);
+template void TestUndeformedState<NeoHookeanModel<AutoDiffXd>>(bool);
+template void TestSpdness<NeoHookeanModel<double>>();
+template void TestSpdness<NeoHookeanModel<AutoDiffXd>>();
+template void TestPIsDerivativeOfPsi<NeoHookeanModel<AutoDiffXd>>();
+template void TestdPdFIsDerivativeOfP<NeoHookeanModel<AutoDiffXd>>();
 
 }  // namespace test
 }  // namespace internal

--- a/multibody/fem/test/constitutive_model_test_utilities.cc
+++ b/multibody/fem/test/constitutive_model_test_utilities.cc
@@ -92,7 +92,7 @@ void TestParameters() {
 /* Tests that the energy density and the stress are zero at the undeformed
 state.
 @tparam Model    Must be instantiations of LinearConstitutiveModel,
-LinearCorotatedModel, or CorotatedModel. */
+                 LinearCorotatedModel, NeoHookeanModel or CorotatedModel. */
 template <class Model>
 void TestUndeformedState(bool nonzero_rest_state) {
   using T = typename Model::T;
@@ -204,7 +204,7 @@ void TestSpdness() {
 
   using Matrix9T = Eigen::Matrix<T, 9, 9>;
   using Vector9d = Eigen::Matrix<double, 9, 1>;
-  // Check that the filtered Hessian is SPD.
+  /* Check that the filtered Hessian is SPD. */
   const Matrix9T filtered_matrix = filtered.data();
   const Eigen::SelfAdjointEigenSolver<Matrix9T> eigensolver(filtered_matrix);
   ASSERT_TRUE(eigensolver.info() == Eigen::Success);
@@ -213,8 +213,8 @@ void TestSpdness() {
   ASSERT_TRUE(eigensolver2.info() == Eigen::Success);
   const Vector9d unfiltered_eigenvalues =
       math::DiscardGradient(eigensolver2.eigenvalues());
-  // For the filtered Hessian, the eigenvalues should either be the same of the
-  // unfiltered hessian and positive or clamped at zero.
+  /* For the filtered Hessian, the eigenvalues should either be the same of the
+   unfiltered hessian and positive or clamped at zero. */
   const double kTol = 1e-12;
   for (int i = 0; i < 9; ++i) {
     const double eigenvalue = eigenvalues(i);
@@ -225,6 +225,11 @@ void TestSpdness() {
     } else {
       EXPECT_NEAR(eigenvalue, 0, kTol);
     }
+  }
+  /* Check that the filtering is actively doing something by checking that the
+   filtered Hessian is not equal to the unfiltered Hessian. */
+  if (!model.is_linear) {
+    EXPECT_FALSE(CompareMatrices(filtered_matrix, unfiltered.data(), 0.1));
   }
 }
 

--- a/multibody/fem/test/constitutive_model_test_utilities.h
+++ b/multibody/fem/test/constitutive_model_test_utilities.h
@@ -19,15 +19,15 @@ Matrix3<AutoDiffXd> MakeDeformationGradients();
 
 /* Tests the constructor and the accessors for St.Venant-Kirchhoff like
 constitutive models.
-@tparam Model    Must be instantiations of LinearConstitutiveModel or
-CorotatedModel. */
+@tparam Model    Must be instantiations of LinearConstitutiveModel,
+                 LinearCorotatedModel, CorotatedModel, or NeoHookeanModel. */
 template <class Model>
 void TestParameters();
 
 /* Tests that the energy density and the stress are zero at the undeformed
 state.
-@param  nonzero_rest_state The model is allowed to have none zero energy at the
-                           undeformed state, i.e. the energy minimun value is
+@param  nonzero_rest_state The model is allowed to have non-zero energy at the
+                           undeformed state, i.e. the energy minimum value is
                            not zero.
 @tparam Model    Must be instantiations of a concrete ConstitutiveModel. */
 template <class Model>
@@ -48,8 +48,8 @@ ConstitutiveModel. */
 template <class Model>
 void TestdPdFIsDerivativeOfP();
 
-/* Tests that the filtered Hessian is dPdF with eigenvalues clamped at 0 from
-below.
+/* Tests that the filtered Hessian is dPdF with its negative eigenvalues set to
+tiny positive numbers.
 @tparam Model    Must be AutoDiffXd instantiations of a concrete
 ConstitutiveModel. */
 template <class Model>

--- a/multibody/fem/test/constitutive_model_test_utilities.h
+++ b/multibody/fem/test/constitutive_model_test_utilities.h
@@ -26,9 +26,12 @@ void TestParameters();
 
 /* Tests that the energy density and the stress are zero at the undeformed
 state.
+@param  nonzero_rest_state The model is allowed to have none zero energy at the
+                           undeformed state, i.e. the energy minimun value is
+                           not zero.
 @tparam Model    Must be instantiations of a concrete ConstitutiveModel. */
 template <class Model>
-void TestUndeformedState();
+void TestUndeformedState(bool nonzero_rest_state = false);
 
 /* Tests that the energy density and the stress are consistent by verifying
 the stress matches the derivative of energy density produced by automatic
@@ -44,6 +47,13 @@ the handcrafted derivative matches that produced by automatic differentiation.
 ConstitutiveModel. */
 template <class Model>
 void TestdPdFIsDerivativeOfP();
+
+/* Tests that the filtered Hessian is dPdF with eigenvalues clamped at 0 from
+below.
+@tparam Model    Must be AutoDiffXd instantiations of a concrete
+ConstitutiveModel. */
+template <class Model>
+void TestSpdness();
 
 }  // namespace test
 }  // namespace internal

--- a/multibody/fem/test/corotated_model_test.cc
+++ b/multibody/fem/test/corotated_model_test.cc
@@ -30,6 +30,11 @@ GTEST_TEST(CorotatedModelTest, dPdFIsDerivativeOfP) {
   TestdPdFIsDerivativeOfP<CorotatedModel<AutoDiffXd>>();
 }
 
+GTEST_TEST(CorotatedModelTest, FilteredHessian) {
+  TestSpdness<CorotatedModel<double>>();
+  TestSpdness<CorotatedModel<AutoDiffXd>>();
+}
+
 }  // namespace test
 }  // namespace internal
 }  // namespace fem

--- a/multibody/fem/test/linear_constitutive_model_test.cc
+++ b/multibody/fem/test/linear_constitutive_model_test.cc
@@ -30,6 +30,11 @@ GTEST_TEST(LinearConstitutiveModelTest, dPdFIsDerivativeOfP) {
   TestdPdFIsDerivativeOfP<LinearConstitutiveModel<AutoDiffXd>>();
 }
 
+GTEST_TEST(LinearConstitutiveModelTest, FilteredHessian) {
+  TestSpdness<LinearConstitutiveModel<double>>();
+  TestSpdness<LinearConstitutiveModel<AutoDiffXd>>();
+}
+
 }  // namespace test
 }  // namespace internal
 }  // namespace fem

--- a/multibody/fem/test/linear_corotated_model_test.cc
+++ b/multibody/fem/test/linear_corotated_model_test.cc
@@ -30,6 +30,11 @@ GTEST_TEST(LinearLinearCorotatedModelTest, dPdFIsDerivativeOfP) {
   TestdPdFIsDerivativeOfP<LinearCorotatedModel<AutoDiffXd>>();
 }
 
+GTEST_TEST(LinearCorotatedModelTest, FilteredHessian) {
+  TestSpdness<LinearCorotatedModel<double>>();
+  TestSpdness<LinearCorotatedModel<AutoDiffXd>>();
+}
+
 }  // namespace test
 }  // namespace internal
 }  // namespace fem

--- a/multibody/fem/test/matrix_utilities_test.cc
+++ b/multibody/fem/test/matrix_utilities_test.cc
@@ -85,11 +85,6 @@ GTEST_TEST(MatrixUtilitiesTest, RotationSvd) {
     /* 3) Proper rotations: det > 0 */
     EXPECT_GT(U.determinant(), 0.0);
     EXPECT_GT(V.determinant(), 0.0);
-
-    /* 4) Singular values sorted and non-negative */
-    EXPECT_GE(sigma(0), sigma(1));
-    EXPECT_GE(sigma(1), sigma(2));
-    EXPECT_GE(sigma(2), 0.0);
   };
 
   {
@@ -99,7 +94,7 @@ GTEST_TEST(MatrixUtilitiesTest, RotationSvd) {
   /* Pure scaling */
   {
     Matrix3<double> F = Matrix3<double>::Zero();
-    F.diagonal() << 3.0, 2.0, 1.0;  // knows S = diag(3,2,1)
+    F.diagonal() << 3.0, 2.0, -1.0;
     check_svd(F);
   }
 
@@ -108,10 +103,18 @@ GTEST_TEST(MatrixUtilitiesTest, RotationSvd) {
     math::RotationMatrix<double> R1(math::RollPitchYaw<double>(1, 2, 3));
     math::RotationMatrix<double> R2(math::RollPitchYaw<double>(4, 5, 6));
     Matrix3<double> S = Matrix3<double>::Zero();
-    S.diagonal() << 5.0, 4.0, 2.0;
+    /* We choose F so that a standard SVD (with all non-negative singular
+     values) produce a non-rotation U and V. */
+    S.diagonal() << 5.0, -4.0, -2.0;
 
     Matrix3<double> F = R1.matrix() * S * R2.matrix().transpose();
     check_svd(F);
+
+    Eigen::JacobiSVD<Matrix3<double>> svd(
+        F, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    const Matrix3<double> U = svd.matrixU();
+    const Matrix3<double> V = svd.matrixV();
+    EXPECT_TRUE(U.determinant() < 0 || V.determinant() < 0);
   }
 }
 

--- a/multibody/fem/test/neohookean_model_data_test.cc
+++ b/multibody/fem/test/neohookean_model_data_test.cc
@@ -1,0 +1,56 @@
+#include "drake/multibody/fem/neohookean_model_data.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+constexpr double kTol = 4.0 * std::numeric_limits<double>::epsilon();
+
+/* Tests that the deformation gradient is initialized to the identity matrix and
+ the deformation gradient dependent data are initialized to be consistent with
+ the initial deformation gradient. */
+GTEST_TEST(NeoHookeanModelDataTest, Initialization) {
+  const NeoHookeanModelData<double> neohookean_model_data;
+  EXPECT_TRUE(CompareMatrices(neohookean_model_data.deformation_gradient(),
+                              Matrix3<double>::Identity()));
+  EXPECT_EQ(neohookean_model_data.Ic(), 3.0);
+  EXPECT_EQ(neohookean_model_data.Jm1(), 0.0);
+  EXPECT_TRUE(CompareMatrices(neohookean_model_data.dJdF(),
+                              Matrix3<double>::Identity()));
+}
+
+GTEST_TEST(NeoHookeanModelDataTest, UpdateData) {
+  NeoHookeanModelData<double> neohookean_model_data;
+  // clang-format off
+  const Matrix3<double> F = (Matrix3<double>() <<
+         6, 1, 2,
+         1, 4, 1,
+         2, 1, 5)
+  .finished();
+  const Matrix3<double> F0 = (Matrix3<double>() <<
+         1, 0, 0,
+         0, 1, 0,
+         0, 0, 1)
+  .finished();
+  // clang-format on
+  neohookean_model_data.UpdateData(F, F0);
+  EXPECT_EQ(neohookean_model_data.Ic(), F.squaredNorm());
+  EXPECT_TRUE(CompareMatrices(neohookean_model_data.deformation_gradient(), F));
+  EXPECT_NEAR(neohookean_model_data.Jm1(), F.determinant() - 1.0, kTol);
+  EXPECT_TRUE(CompareMatrices(neohookean_model_data.dJdF(),
+                              F.determinant() * F.inverse().transpose(), kTol));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/test/neohookean_model_test.cc
+++ b/multibody/fem/test/neohookean_model_test.cc
@@ -18,9 +18,9 @@ GTEST_TEST(NeoHookeanModelTest, Parameters) {
 }
 
 GTEST_TEST(NeoHookeanModelTest, UndeformedState) {
-  TestUndeformedState<NeoHookeanModel<double>>(/*nonzero rest state =*/true);
+  TestUndeformedState<NeoHookeanModel<double>>(/* nonzero rest state */ true);
   TestUndeformedState<NeoHookeanModel<AutoDiffXd>>(
-      /*nonzero_rest_state =*/true);
+      /* nonzero_rest_state */ true);
 }
 
 GTEST_TEST(NeoHookeanModelTest, PIsDerivativeOfPsi) {

--- a/multibody/fem/test/neohookean_model_test.cc
+++ b/multibody/fem/test/neohookean_model_test.cc
@@ -1,0 +1,43 @@
+#include "drake/multibody/fem/neohookean_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/fem/test/constitutive_model_test_utilities.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace test {
+
+GTEST_TEST(NeoHookeanModelTest, Parameters) {
+  TestParameters<NeoHookeanModel<double>>();
+  TestParameters<NeoHookeanModel<AutoDiffXd>>();
+  NeoHookeanModel<double> model(100, 0.4);
+  EXPECT_FALSE(model.is_linear);
+}
+
+GTEST_TEST(NeoHookeanModelTest, UndeformedState) {
+  TestUndeformedState<NeoHookeanModel<double>>(/*nonzero rest state =*/true);
+  TestUndeformedState<NeoHookeanModel<AutoDiffXd>>(
+      /*nonzero_rest_state =*/true);
+}
+
+GTEST_TEST(NeoHookeanModelTest, PIsDerivativeOfPsi) {
+  TestPIsDerivativeOfPsi<NeoHookeanModel<AutoDiffXd>>();
+}
+
+GTEST_TEST(NeoHookeanModelTest, dPdFIsDerivativeOfP) {
+  TestdPdFIsDerivativeOfP<NeoHookeanModel<AutoDiffXd>>();
+}
+
+GTEST_TEST(NeoHookeanModelTest, FilteredHessian) {
+  TestSpdness<NeoHookeanModel<double>>();
+  TestSpdness<NeoHookeanModel<AutoDiffXd>>();
+}
+
+}  // namespace test
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/volumetric_element.h
+++ b/multibody/fem/volumetric_element.h
@@ -341,7 +341,8 @@ class VolumetricElement
   /* Implements FemElement::DoAddScaledStiffnessMatrix().
    @warning This method calculates a first-order approximation of the stiffness
    matrix. In other words, the contribution of the term ∂fᵥ(x, v)/∂x is ignored
-   as it involves complex second derivatives of the elastic force. */
+   as it involves complex second derivatives of the elastic force. It also
+   filters out any negative eigenvalues by clamping them to zero. */
   void DoAddScaledStiffnessMatrix(
       const Data& data, const T& scale,
       EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> K) const {
@@ -383,7 +384,7 @@ class VolumetricElement
           data.deformation_gradient_data[q], &(data.Psi[q]));
       this->constitutive_model().CalcFirstPiolaStress(
           data.deformation_gradient_data[q], &(data.P[q]));
-      this->constitutive_model().CalcFirstPiolaStressDerivative(
+      this->constitutive_model().CalcFilteredHessian(
           data.deformation_gradient_data[q], &(data.dPdF[q]));
     }
     return data;

--- a/multibody/mpm/particle_data.cc
+++ b/multibody/mpm/particle_data.cc
@@ -15,6 +15,9 @@ ConstitutiveModelVariant<T> MakeConstitutiveModel(
     case fem::MaterialModel::kCorotated:
       return fem::internal::CorotatedModel<T>(config.youngs_modulus(),
                                               config.poissons_ratio());
+    case fem::MaterialModel::kNeoHookean:
+      return fem::internal::NeoHookeanModel<T>(config.youngs_modulus(),
+                                               config.poissons_ratio());
     case fem::MaterialModel::kLinearCorotated:
       return fem::internal::LinearCorotatedModel<T>(config.youngs_modulus(),
                                                     config.poissons_ratio());
@@ -31,6 +34,8 @@ DeformationGradientDataVariant<T> MakeDeformationGradientData(
   switch (config.material_model()) {
     case fem::MaterialModel::kCorotated:
       return fem::internal::CorotatedModelData<T>();
+    case fem::MaterialModel::kNeoHookean:
+      return fem::internal::NeoHookeanModelData<T>();
     case fem::MaterialModel::kLinearCorotated:
       return fem::internal::LinearCorotatedModelData<T>();
     case fem::MaterialModel::kLinear:

--- a/multibody/mpm/particle_data.h
+++ b/multibody/mpm/particle_data.h
@@ -9,6 +9,7 @@
 #include "drake/multibody/fem/deformable_body_config.h"
 #include "drake/multibody/fem/linear_constitutive_model.h"
 #include "drake/multibody/fem/linear_corotated_model.h"
+#include "drake/multibody/fem/neohookean_model.h"
 #include "drake/multibody/mpm/mass_and_momentum.h"
 
 namespace drake {
@@ -21,12 +22,14 @@ namespace internal {
 template <typename T>
 using ConstitutiveModelVariant =
     std::variant<fem::internal::CorotatedModel<T>,
+                 fem::internal::NeoHookeanModel<T>,
                  fem::internal::LinearCorotatedModel<T>,
                  fem::internal::LinearConstitutiveModel<T>>;
 
 template <typename T>
 using DeformationGradientDataVariant =
     std::variant<fem::internal::CorotatedModelData<T>,
+                 fem::internal::NeoHookeanModelData<T>,
                  fem::internal::LinearCorotatedModelData<T>,
                  fem::internal::LinearConstitutiveModelData<T>>;
 

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -9,6 +9,7 @@
 #include "drake/multibody/fem/linear_constitutive_model.h"
 #include "drake/multibody/fem/linear_corotated_model.h"
 #include "drake/multibody/fem/linear_simplex_element.h"
+#include "drake/multibody/fem/neohookean_model.h"
 #include "drake/multibody/fem/simplex_gaussian_quadrature.h"
 #include "drake/multibody/fem/volumetric_model.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -392,6 +393,10 @@ DeformableModel<T>::BuildLinearVolumetricModel(
     case MaterialModel::kCorotated:
       BuildLinearVolumetricModelHelper<fem::internal::CorotatedModel>(id, mesh,
                                                                       config);
+      break;
+    case MaterialModel::kNeoHookean:
+      BuildLinearVolumetricModelHelper<fem::internal::NeoHookeanModel>(id, mesh,
+                                                                       config);
       break;
     case MaterialModel::kLinearCorotated:
       BuildLinearVolumetricModelHelper<fem::internal::LinearCorotatedModel>(


### PR DESCRIPTION
In addtion, add FemModel::CalcFilteredHessian that computes an SPD approximation of the tangent matrix of the model. The approximation is computed by assembling filtered element Hessians. In particular, the new NeoHookean model supports an efficient Hessian filtering through analytic eigen-decomposition.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22968)
<!-- Reviewable:end -->
