### PR TITLE
[workspace] Upgrade openusd_internal to latest v25.05

### DIFF
--- a/tools/workspace/openusd_internal/repository.bzl
+++ b/tools/workspace/openusd_internal/repository.bzl
@@ -10,8 +10,8 @@ def openusd_internal_repository(
         After upgrading, you must re-generate the lockfile:
         bazel run //tools/workspace/openusd_internal:upgrade -- --relock
         """,
-        commit = "v25.02a",
-        sha256 = "475cd0990366a713f19d1f0701c37be17ecd9d3de7a3503a11bbdf80d3c003ce",  # noqa
+        commit = "v25.05",
+        sha256 = "231faca9ab71fa63d6c1e0da18bda0c365f82d9bef1cfd4b3d3d6784c8d5fb96",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/upstream/00_work_thread_limits_namespace.patch",


### PR DESCRIPTION
Towards #22928 

Sample Console Log:
```log
[5:30:08 PM]  ERROR: /media/ephemeral0/ubuntu/workspace/linux-jammy-clang-bazel-experimental-everything-release/_bazel_ubuntu/5e0ced017c744e846b192696bb0e77f4/external/+internal_repositories+openusd_internal/BUILD.bazel:28:21: Action external/+internal_repositories+openusd_internal/pxr/pxr.h failed: (Exit 1): cmake_configure_file failed: error executing Action command (from target @@+internal_repositories+openusd_internal//:config_genrule) bazel-out/k8-opt-exec-ST-d57f47055a04/bin/tools/workspace/cmake_configure_file --input external/+internal_repositories+openusd_internal/pxr/pxr.h.in --output ... (remaining 10 arguments skipped)
[5:30:08 PM]  
[5:30:08 PM]  Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
[5:30:08 PM]  Traceback (most recent call last):
[5:30:08 PM]    File "/media/ephemeral0/ubuntu/workspace/linux-jammy-clang-bazel-experimental-everything-release/_bazel_ubuntu/5e0ced017c744e846b192696bb0e77f4/sandbox/linux-sandbox/4783/execroot/_main/bazel-out/k8-opt-exec-ST-d57f47055a04/bin/tools/workspace/cmake_configure_file.runfiles/_main/tools/workspace/cmake_configure_file.py", line 247, in <module>
[5:30:08 PM]      main()
[5:30:08 PM]    File "/media/ephemeral0/ubuntu/workspace/linux-jammy-clang-bazel-experimental-everything-release/_bazel_ubuntu/5e0ced017c744e846b192696bb0e77f4/sandbox/linux-sandbox/4783/execroot/_main/bazel-out/k8-opt-exec-ST-d57f47055a04/bin/tools/workspace/cmake_configure_file.runfiles/_main/tools/workspace/cmake_configure_file.py", line 239, in main
[5:30:08 PM]      raise RuntimeError(f"The definitions of {sorted(unused_vars)} were"
[5:30:08 PM]  RuntimeError: The definitions of ['PXR_USE_INTERNAL_BOOST_PYTHON'] were ignored and therefore seem like dead code; remove them from defines= or undefines=.
```

Sample Jenkins Job: https://drake-jenkins.csail.mit.edu/job/linux-jammy-clang-bazel-experimental-everything-release/8279/consoleFull

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22969)
<!-- Reviewable:end -->
