### PR TITLE
Fix meshcat capsule parsing

### DIFF
--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -589,7 +589,7 @@ class MeshcatShapeReifier : public ShapeReifier {
     auto geometry = std::make_unique<internal::CapsuleGeometryData>();
     geometry->uuid = uuid_generator_.GenerateRandom();
     geometry->radius = capsule.radius();
-    geometry->length = capsule.length();
+    geometry->height = capsule.length();
     lumped.geometry = std::move(geometry);
 
     // Meshcat cylinders have their long axis in y.

--- a/geometry/meshcat_types_internal.h
+++ b/geometry/meshcat_types_internal.h
@@ -211,7 +211,7 @@ struct CapsuleGeometryData : public GeometryData {
   // For a complete description of these parameters see:
   // https://threejs.org/docs/#api/en/geometries/CapsuleGeometry
   double radius{};
-  double length{};
+  double height{};
   double radialSegments{20};  // Number of segmented faces around the
                               // circumference of the capsule.
   double capSegments{10};     // Number of curve segments used to build
@@ -224,7 +224,7 @@ struct CapsuleGeometryData : public GeometryData {
     o.pack("CapsuleGeometry");
     PACK_MAP_VAR(o, uuid);
     PACK_MAP_VAR(o, radius);
-    PACK_MAP_VAR(o, length);
+    PACK_MAP_VAR(o, height);
     PACK_MAP_VAR(o, radialSegments);
     PACK_MAP_VAR(o, capSegments);
   }


### PR DESCRIPTION
The updated three.js version from #22932 changed the spelling of `capsule.length` to `capsule.height`, causing parsing problems (#22973). This fixes that spelling so capsules parse correctly.

Hotfix for #22932.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22975)
<!-- Reviewable:end -->
