### PR TITLE
Factor Out Common Options Between IRIS-ZO and IRIS-NP2

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -187,6 +187,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
+        "//bindings/pydrake/common:ref_cycle_pybind",
         "//bindings/pydrake/common:sorted_pair_pybind",
     ],
     cc_srcs = [

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -2,6 +2,7 @@
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
+#include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/common/sorted_pair_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -67,7 +68,8 @@ PYBIND11_MODULE(inverse_kinematics, m) {
   {
     using Class = InverseKinematics;
     constexpr auto& cls_doc = doc.InverseKinematics;
-    py::class_<Class> cls(m, "InverseKinematics", cls_doc.doc);
+    py::class_<Class> cls(
+        m, "InverseKinematics", py::dynamic_attr(), cls_doc.doc);
     cls.def(py::init<const MultibodyPlant<double>&, bool>(), py::arg("plant"),
            py::arg("with_joint_limits") = true,
            // Keep alive, reference: `self` keeps `plant` alive.
@@ -158,7 +160,8 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             py::arg("frameF"), py::arg("frameG"), py::arg("p_GP"), py::arg("A"),
             py::arg("b"), cls_doc.AddPolyhedronConstraint.doc)
         .def("q", &Class::q, cls_doc.q.doc)
-        .def("prog", &Class::prog, py_rvp::reference_internal, cls_doc.prog.doc)
+        .def("prog", &Class::prog, internal::ref_cycle<0, 1>(),
+            py_rvp::reference, cls_doc.prog.doc)
         .def("get_mutable_prog", &Class::get_mutable_prog,
             py_rvp::reference_internal, cls_doc.get_mutable_prog.doc)
         .def("context", &Class::context, py_rvp::reference_internal,

--- a/bindings/pydrake/planning/BUILD.bazel
+++ b/bindings/pydrake/planning/BUILD.bazel
@@ -43,6 +43,7 @@ drake_pybind_library(
         "planning_py_trajectory_optimization.cc",
         "planning_py_visibility_graph.cc",
         "planning_py_iris_from_clique_cover.cc",
+        "planning_py_iris_common.cc",
         "planning_py_iris_zo.cc",
         "planning_py_zmp_planner.cc",
     ],
@@ -140,7 +141,7 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
-    name = "iris_zo_test",
+    name = "iris_test",
     num_threads = 2,
     deps = [
         ":planning",

--- a/bindings/pydrake/planning/planning_py.cc
+++ b/bindings/pydrake/planning/planning_py.cc
@@ -29,6 +29,7 @@ and/or trajectories of dynamical systems.
   internal::DefinePlanningTrajectoryOptimization(m);
   internal::DefinePlanningVisibilityGraph(m);
   internal::DefinePlanningIrisFromCliqueCover(m);
+  internal::DefinePlanningIrisCommon(m);
   internal::DefinePlanningIrisZo(m);
   internal::DefinePlanningZmpPlanner(m);
 }

--- a/bindings/pydrake/planning/planning_py.h
+++ b/bindings/pydrake/planning/planning_py.h
@@ -26,6 +26,9 @@ void DefinePlanningGraphAlgorithms(py::module m);
 /* Defines bindings per planning_py_iris_from_clique_cover.cc. */
 void DefinePlanningIrisFromCliqueCover(py::module m);
 
+/* Defines bindings per planning_py_iris_common.cc. */
+void DefinePlanningIrisCommon(py::module m);
+
 /* Defines bindings per planning_py_iris_zo.cc. */
 void DefinePlanningIrisZo(py::module m);
 

--- a/bindings/pydrake/planning/planning_py_iris_common.cc
+++ b/bindings/pydrake/planning/planning_py_iris_common.cc
@@ -1,0 +1,152 @@
+#include "drake/bindings/pydrake/common/wrap_pybind.h"
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/planning/planning_py.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/symbolic_types_pybind.h"
+#include "drake/planning/iris/iris_common.h"
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+void DefinePlanningCommonSampledIrisOptions(py::module m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::planning;
+  constexpr auto& doc = pydrake_doc.drake.planning;
+
+  // CommonSampledIrisOptions
+  const auto& cls_doc = doc.CommonSampledIrisOptions;
+  py::class_<CommonSampledIrisOptions> common_sampled_iris_options(
+      m, "CommonSampledIrisOptions", cls_doc.doc);
+  common_sampled_iris_options.def(py::init<>())
+      .def_readwrite("num_particles", &CommonSampledIrisOptions::num_particles,
+          cls_doc.num_particles.doc)
+      .def_readwrite("tau", &CommonSampledIrisOptions::tau, cls_doc.tau.doc)
+      .def_readwrite(
+          "delta", &CommonSampledIrisOptions::delta, cls_doc.delta.doc)
+      .def_readwrite(
+          "epsilon", &CommonSampledIrisOptions::epsilon, cls_doc.epsilon.doc)
+      .def_readwrite("containment_points",
+          &CommonSampledIrisOptions::containment_points,
+          cls_doc.containment_points.doc)
+      .def_readwrite("max_iterations",
+          &CommonSampledIrisOptions::max_iterations, cls_doc.max_iterations.doc)
+      .def_readwrite("max_iterations_separating_planes",
+          &CommonSampledIrisOptions::max_iterations_separating_planes,
+          cls_doc.max_iterations_separating_planes.doc)
+      .def_readwrite("max_separating_planes_per_iteration",
+          &CommonSampledIrisOptions::max_separating_planes_per_iteration,
+          cls_doc.max_separating_planes_per_iteration.doc)
+      .def_readwrite("parallelism", &CommonSampledIrisOptions::parallelism,
+          cls_doc.parallelism.doc)
+      .def_readwrite(
+          "verbose", &CommonSampledIrisOptions::verbose, cls_doc.verbose.doc)
+      .def_readwrite("require_sample_point_is_contained",
+          &CommonSampledIrisOptions::require_sample_point_is_contained,
+          cls_doc.require_sample_point_is_contained.doc)
+      .def_readwrite("configuration_space_margin",
+          &CommonSampledIrisOptions::configuration_space_margin,
+          cls_doc.configuration_space_margin.doc)
+      .def_readwrite("termination_threshold",
+          &CommonSampledIrisOptions::termination_threshold,
+          cls_doc.termination_threshold.doc)
+      .def_readwrite("relative_termination_threshold",
+          &CommonSampledIrisOptions::relative_termination_threshold,
+          cls_doc.relative_termination_threshold.doc)
+      .def_readwrite("random_seed", &CommonSampledIrisOptions::random_seed,
+          cls_doc.random_seed.doc)
+      .def_readwrite("mixing_steps", &CommonSampledIrisOptions::mixing_steps,
+          cls_doc.mixing_steps.doc)
+      .def("__repr__", [](const CommonSampledIrisOptions& self) {
+        return py::str(
+            "CommonSampledIrisOptions("
+            "num_particles={}, "
+            "tau={}, "
+            "delta={}, "
+            "epsilon={}, "
+            "max_iterations={}, "
+            "max_iterations_separating_planes={}, "
+            "max_separating_planes_per_iteration={}, "
+            "parallelism={}, "
+            "verbose={}, "
+            "require_sample_point_is_contained={}, "
+            "configuration_space_margin={}, "
+            "termination_threshold={}, "
+            "relative_termination_threshold={}, "
+            "random_seed={}, "
+            "mixing_steps={}, "
+            ")")
+            .format(self.num_particles, self.tau, self.delta, self.epsilon,
+                self.max_iterations, self.max_iterations_separating_planes,
+                self.max_separating_planes_per_iteration, self.parallelism,
+                self.verbose, self.require_sample_point_is_contained,
+                self.configuration_space_margin, self.termination_threshold,
+                self.relative_termination_threshold, self.random_seed,
+                self.mixing_steps);
+      });
+
+  DefReadWriteKeepAlive(&common_sampled_iris_options,
+      "prog_with_additional_constraints",
+      &CommonSampledIrisOptions::prog_with_additional_constraints,
+      cls_doc.prog_with_additional_constraints.doc);
+}
+
+void DefinePlanningIrisParameterizationFunction(py::module m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::planning;
+  constexpr auto& doc = pydrake_doc.drake.planning;
+
+  // IrisParameterizationFunction
+  const auto& cls_doc = doc.IrisParameterizationFunction;
+  py::class_<IrisParameterizationFunction> iris_parameterization_function(
+      m, "IrisParameterizationFunction", cls_doc.doc);
+  iris_parameterization_function.def(py::init<>())
+      .def(
+          "set_parameterization",
+          [](IrisParameterizationFunction& self,
+              const IrisParameterizationFunction::ParameterizationFunction&
+                  parameterization,
+              int parameterization_dimension) {
+            self.set_parameterization(parameterization,
+                /* parameterization_is_threadsafe */ false,
+                parameterization_dimension);
+          },
+          py::arg("parameterization"), py::arg("parameterization_dimension"),
+          (std::string(cls_doc.set_parameterization.doc) +
+              "@note Due to GIL, it is inefficient to call a python function "
+              "concurrently across multiple C++ threads. So the "
+              "parameterization setter function automatically sets threadsafe "
+              "to false")
+              .c_str())
+      .def("SetParameterizationFromExpression",
+          &IrisParameterizationFunction::SetParameterizationFromExpression,
+          py::arg("expression_parameterization"), py::arg("variables"),
+          cls_doc.SetParameterizationFromExpression.doc)
+      .def("get_parameterization_is_threadsafe",
+          &IrisParameterizationFunction::get_parameterization_is_threadsafe,
+          cls_doc.get_parameterization_is_threadsafe.doc)
+      .def("get_parameterization_dimension",
+          &IrisParameterizationFunction::get_parameterization_dimension,
+          cls_doc.get_parameterization_dimension.doc)
+      .def("get_parameterization",
+          &IrisParameterizationFunction::get_parameterization,
+          cls_doc.get_parameterization.doc)
+      .def_static("CreateWithRationalKinematicParameterization",
+          IrisParameterizationFunction::
+              CreateWithRationalKinematicParameterization,
+          py::arg("kin"), py::arg("q_star_val"),
+          cls_doc.CreateWithRationalKinematicParameterization.doc);
+}
+
+}  // namespace
+
+namespace internal {
+
+void DefinePlanningIrisCommon(py::module m) {
+  DefinePlanningCommonSampledIrisOptions(m);
+  DefinePlanningIrisParameterizationFunction(m);
+}
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/planning/planning_py_iris_zo.cc
+++ b/bindings/pydrake/planning/planning_py_iris_zo.cc
@@ -18,108 +18,21 @@ void DefinePlanningIrisZo(py::module m) {
   const auto& cls_doc = doc.IrisZoOptions;
   py::class_<IrisZoOptions> iris_zo_options(m, "IrisZoOptions", cls_doc.doc);
   iris_zo_options.def(py::init<>())
-      .def_readwrite("num_particles", &IrisZoOptions::num_particles,
-          cls_doc.num_particles.doc)
-      .def_readwrite("tau", &IrisZoOptions::tau, cls_doc.tau.doc)
-      .def_readwrite("delta", &IrisZoOptions::delta, cls_doc.delta.doc)
-      .def_readwrite("epsilon", &IrisZoOptions::epsilon, cls_doc.epsilon.doc)
-      .def_readwrite("containment_points", &IrisZoOptions::containment_points,
-          cls_doc.containment_points.doc)
-      .def_readwrite("max_iterations", &IrisZoOptions::max_iterations,
-          cls_doc.max_iterations.doc)
-      .def_readwrite("max_iterations_separating_planes",
-          &IrisZoOptions::max_iterations_separating_planes,
-          cls_doc.max_iterations_separating_planes.doc)
-      .def_readwrite("max_separating_planes_per_iteration",
-          &IrisZoOptions::max_separating_planes_per_iteration,
-          cls_doc.max_separating_planes_per_iteration.doc)
+      .def_readwrite("sampled_iris_options",
+          &IrisZoOptions::sampled_iris_options,
+          cls_doc.sampled_iris_options.doc)
       .def_readwrite("bisection_steps", &IrisZoOptions::bisection_steps,
           cls_doc.bisection_steps.doc)
-      .def_readwrite(
-          "parallelism", &IrisZoOptions::parallelism, cls_doc.parallelism.doc)
-      .def_readwrite("verbose", &IrisZoOptions::verbose, cls_doc.verbose.doc)
-      .def_readwrite("require_sample_point_is_contained",
-          &IrisZoOptions::require_sample_point_is_contained,
-          cls_doc.require_sample_point_is_contained.doc)
-      .def_readwrite("configuration_space_margin",
-          &IrisZoOptions::configuration_space_margin,
-          cls_doc.configuration_space_margin.doc)
-      .def_readwrite("termination_threshold",
-          &IrisZoOptions::termination_threshold,
-          cls_doc.termination_threshold.doc)
-      .def_readwrite("relative_termination_threshold",
-          &IrisZoOptions::relative_termination_threshold,
-          cls_doc.relative_termination_threshold.doc)
-      .def_readwrite(
-          "random_seed", &IrisZoOptions::random_seed, cls_doc.random_seed.doc)
-      .def_readwrite("mixing_steps", &IrisZoOptions::mixing_steps,
-          cls_doc.mixing_steps.doc)
-      .def(
-          "set_parameterization",
-          [](IrisZoOptions& self,
-              const IrisZoOptions::ParameterizationFunction& parameterization,
-              int parameterization_dimension) {
-            self.set_parameterization(parameterization,
-                /* parameterization_is_threadsafe */ false,
-                parameterization_dimension);
-          },
-          py::arg("parameterization"), py::arg("parameterization_dimension"),
-          (std::string(cls_doc.set_parameterization.doc) +
-              "@note Due to GIL, it is inefficient to call a python function "
-              "concurrently across multiple C++ threads. So the "
-              "parameterization setter function automatically sets threadsafe "
-              "to false")
-              .c_str())
-      .def("SetParameterizationFromExpression",
-          &IrisZoOptions::SetParameterizationFromExpression,
-          py::arg("expression_parameterization"), py::arg("variables"),
-          cls_doc.SetParameterizationFromExpression.doc)
-      .def("get_parameterization_is_threadsafe",
-          &IrisZoOptions::get_parameterization_is_threadsafe,
-          cls_doc.get_parameterization_is_threadsafe.doc)
-      .def("get_parameterization_dimension",
-          &IrisZoOptions::get_parameterization_dimension,
-          cls_doc.get_parameterization_dimension.doc)
-      .def("get_parameterization", &IrisZoOptions::get_parameterization,
-          cls_doc.get_parameterization.doc)
-      .def("__repr__",
-          [](const IrisZoOptions& self) {
-            return py::str(
-                "IrisZoOptions("
-                "num_particles={}, "
-                "tau={}, "
-                "delta={}, "
-                "epsilon={}, "
-                "max_iterations={}, "
-                "max_iterations_separating_planes={}, "
-                "max_separating_planes_per_iteration={}, "
-                "bisection_steps={}, "
-                "parallelism={}, "
-                "verbose={}, "
-                "require_sample_point_is_contained={}, "
-                "configuration_space_margin={}, "
-                "termination_threshold={}, "
-                "relative_termination_threshold={}, "
-                "random_seed={}, "
-                "mixing_steps={}, "
-                ")")
-                .format(self.num_particles, self.tau, self.delta, self.epsilon,
-                    self.max_iterations, self.max_iterations_separating_planes,
-                    self.max_separating_planes_per_iteration,
-                    self.bisection_steps, self.parallelism, self.verbose,
-                    self.require_sample_point_is_contained,
-                    self.configuration_space_margin, self.termination_threshold,
-                    self.relative_termination_threshold, self.random_seed,
-                    self.mixing_steps);
-          })
-      .def_static("CreateWithRationalKinematicParameterization",
-          IrisZoOptions::CreateWithRationalKinematicParameterization,
-          py::arg("kin"), py::arg("q_star_val"),
-          cls_doc.CreateWithRationalKinematicParameterization.doc);
-
-  DefReadWriteKeepAlive(&iris_zo_options, "prog_with_additional_constraints",
-      &IrisZoOptions::prog_with_additional_constraints,
-      cls_doc.prog_with_additional_constraints.doc);
+      .def_readwrite("parameterization", &IrisZoOptions::parameterization,
+          cls_doc.parameterization.doc)
+      .def("__repr__", [](const IrisZoOptions& self) {
+        return py::str(
+            "IrisZoOptions("
+            "bisection_steps={}, "
+            "sampled_iris_options={}, "
+            ")")
+            .format(self.bisection_steps, self.sampled_iris_options);
+      });
 
   // The `options` contains a `Parallelism`; we must release the GIL.
   m.def("IrisZo", &IrisZo, py::arg("checker"), py::arg("starting_ellipsoid"),

--- a/bindings/pydrake/planning/test/iris_test.py
+++ b/bindings/pydrake/planning/test/iris_test.py
@@ -72,26 +72,35 @@ class TestIrisZo(unittest.TestCase):
         checker = SceneGraphCollisionChecker(**params)
         seed_point = np.zeros((2,))
         options = mut.IrisZoOptions()
-        options.num_particles = 1000
-        options.tau = 0.5
-        options.delta = 5e-2
-        options.epsilon = 1e-2
-        options.containment_points = np.array([[0, 0], [1, 0]])
-        options.max_iterations = 3
-        options.max_iterations_separating_planes = 20
-        options.max_separating_planes_per_iteration = -1
+        options.sampled_iris_options.num_particles = 1000
+        options.sampled_iris_options.tau = 0.5
+        options.sampled_iris_options.delta = 5e-2
+        options.sampled_iris_options.epsilon = 1e-2
+        options.sampled_iris_options.\
+            containment_points = np.array([[0, 0], [1, 0]])
+        options.sampled_iris_options.max_iterations = 3
+        options.sampled_iris_options.max_iterations_separating_planes = 20
+        options.sampled_iris_options.max_separating_planes_per_iteration = -1
         options.bisection_steps = 10
-        options.parallelism = Parallelism(True)
-        options.verbose = False
-        options.configuration_space_margin = 1e-2
-        options.termination_threshold = 1e-2
-        options.relative_termination_threshold = 1e-3
-        options.random_seed = 1337
-        options.mixing_steps = 50
+        options.sampled_iris_options.parallelism = Parallelism(True)
+        options.sampled_iris_options.verbose = False
+        options.sampled_iris_options.configuration_space_margin = 1e-2
+        options.sampled_iris_options.termination_threshold = 1e-2
+        options.sampled_iris_options.relative_termination_threshold = 1e-3
+        options.sampled_iris_options.random_seed = 1337
+        options.sampled_iris_options.mixing_steps = 50
         starting_ellipsoid = Hyperellipsoid.MakeHypersphere(0.01, seed_point)
-        options.prog_with_additional_constraints = InverseKinematics(
-            plant
-        ).prog()
+        ik = InverseKinematics(plant)
+        options.sampled_iris_options.\
+            prog_with_additional_constraints = ik.prog()
+        # TODO(cohnt): Debug why this segfaults or throws an Eigen error if we
+        # directly call
+        # options.sampled_iris_options.\
+        #     prog_with_additional_constraints = InverseKinematics(
+        #         plant
+        #     ).prog()
+        # Perhaps this is another instance like issue #20131 that wasn't caught
+        # in PR #22795?
         domain = HPolyhedron.MakeBox(plant.GetPositionLowerLimits(),
                                      plant.GetPositionUpperLimits())
         region = mut.IrisZo(checker=checker,
@@ -105,32 +114,53 @@ class TestIrisZo(unittest.TestCase):
 
         kin = RationalForwardKinematics(plant)
         q_star = np.zeros(2)
-        options = mut.IrisZoOptions.\
+        options.parameterization = mut.IrisParameterizationFunction.\
             CreateWithRationalKinematicParameterization(kin=kin,
                                                         q_star_val=q_star)
-        self.assertTrue(options.get_parameterization_is_threadsafe())
-        self.assertEqual(options.get_parameterization_dimension(), 2)
-        self.assertTrue(callable(options.get_parameterization()))
+        self.assertTrue(
+            options.parameterization.get_parameterization_is_threadsafe())
+        self.assertEqual(
+            options.parameterization.get_parameterization_dimension(), 2)
+        self.assertTrue(
+            callable(options.parameterization.get_parameterization()))
         s = np.array([0, 1])
-        q = options.get_parameterization()(s)
+        q = options.parameterization.get_parameterization()(s)
         self.assertTrue(np.allclose(q,
                                     kin.ComputeQValue(s, q_star), atol=0))
 
         options2 = mut.IrisZoOptions()
-        options2.set_parameterization(options.get_parameterization(),
-                                      options.get_parameterization_dimension())
-        self.assertFalse(options2.get_parameterization_is_threadsafe())
-        self.assertEqual(options2.get_parameterization_dimension(), 2)
-        self.assertTrue(callable(options2.get_parameterization()))
-        q2 = options2.get_parameterization()(np.array(s))
+        options2.parameterization.set_parameterization(
+            options.parameterization.get_parameterization(),
+            options.parameterization.get_parameterization_dimension())
+        self.assertFalse(
+            options2.parameterization.get_parameterization_is_threadsafe())
+        self.assertEqual(
+            options2.parameterization.get_parameterization_dimension(), 2)
+        self.assertTrue(
+            callable(options2.parameterization.get_parameterization()))
+        q2 = options2.parameterization.get_parameterization()(np.array(s))
         self.assertTrue(np.allclose(q2,
                                     kin.ComputeQValue(s, q_star), atol=0))
 
         options3 = mut.IrisZoOptions()
+        options3.parameterization = options2.parameterization
+        self.assertFalse(
+            options3.parameterization.get_parameterization_is_threadsafe())
+        self.assertEqual(
+            options3.parameterization.get_parameterization_dimension(), 2)
+        self.assertTrue(
+            callable(options3.parameterization.get_parameterization()))
+        q3 = options3.parameterization.get_parameterization()(np.array(s))
+        self.assertTrue(np.allclose(q3,
+                                    kin.ComputeQValue(s, q_star), atol=0))
+
+        options4 = mut.IrisZoOptions()
         v = Variable("v")
-        options3.SetParameterizationFromExpression(
+        options4.parameterization.SetParameterizationFromExpression(
               expression_parameterization=[2 * v + 1], variables=[v])
-        self.assertTrue(options3.get_parameterization_is_threadsafe())
-        self.assertEqual(options3.get_parameterization_dimension(), 1)
-        q3 = options3.get_parameterization()(np.zeros(1))[0]
+        self.assertTrue(
+            options4.parameterization.get_parameterization_is_threadsafe())
+        self.assertEqual(
+            options4.parameterization.get_parameterization_dimension(), 1)
+        q3 = options4.parameterization.get_parameterization()(np.zeros(1))[0]
         self.assertEqual(q3, 2 * 0 + 1)

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -470,8 +470,8 @@ void BindMathematicalProgramResult(py::module m) {
 
 void BindMathematicalProgram(py::module m) {
   constexpr auto& doc = pydrake_doc.drake.solvers;
-  py::class_<MathematicalProgram> prog_cls(
-      m, "MathematicalProgram", doc.MathematicalProgram.doc);
+  py::class_<MathematicalProgram> prog_cls(m, "MathematicalProgram",
+      py::dynamic_attr(), doc.MathematicalProgram.doc);
   prog_cls.def(py::init<>(), doc.MathematicalProgram.ctor.doc);
   DefClone(&prog_cls);
 

--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -13,6 +13,7 @@ drake_cc_package_library(
     name = "iris",
     visibility = ["//visibility:public"],
     deps = [
+        ":iris_common",
         ":iris_from_clique_cover",
         ":iris_zo",
     ],
@@ -39,10 +40,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "iris_common",
+    srcs = ["iris_common.cc"],
+    hdrs = ["iris_common.h"],
+    deps = [
+        "//common:name_value",
+        "//geometry:meshcat",
+        "//solvers:mathematical_program",
+    ],
+)
+
+drake_cc_library(
     name = "iris_zo",
     srcs = ["iris_zo.cc"],
     hdrs = ["iris_zo.h"],
     deps = [
+        ":iris_common",
         "//common:parallelism",
         "//common/symbolic:expression",
         "//geometry:meshcat",

--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -57,12 +57,10 @@ drake_cc_library(
     hdrs = ["iris_zo.h"],
     deps = [
         ":iris_common",
-        "//common:parallelism",
-        "//common/symbolic:expression",
-        "//geometry:meshcat",
         "//geometry/optimization:convex_set",
-        "//multibody/rational:rational_forward_kinematics",
         "//planning:collision_checker",
+    ],
+    implementation_deps = [
         "//solvers:choose_best_solver",
         "//solvers:clarabel_solver",
         "//solvers:gurobi_solver",
@@ -70,8 +68,6 @@ drake_cc_library(
         "//solvers:mosek_solver",
         "//solvers:osqp_solver",
         "//solvers:solve",
-    ],
-    implementation_deps = [
         "@common_robotics_utilities_internal//:common_robotics_utilities",
     ],
 )

--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -46,6 +46,7 @@ drake_cc_library(
     deps = [
         "//common:name_value",
         "//geometry:meshcat",
+        "//multibody/rational:rational_forward_kinematics",
         "//solvers:mathematical_program",
     ],
 )

--- a/planning/iris/iris_common.cc
+++ b/planning/iris/iris_common.cc
@@ -1,5 +1,68 @@
 #include "drake/planning/iris/iris_common.h"
 
 namespace drake {
-namespace planning {}  // namespace planning
+namespace planning {
+
+IrisParameterizationFunction
+IrisParameterizationFunction::CreateWithRationalKinematicParameterization(
+    const multibody::RationalForwardKinematics* kin,
+    const Eigen::Ref<const Eigen::VectorXd>& q_star_val) {
+  const int dimension = kin->plant().num_positions();
+  DRAKE_DEMAND(dimension > 0);
+  IrisParameterizationFunction instance;
+
+  auto evaluate_s_to_q = [kin, q_star_captured = Eigen::VectorXd(q_star_val)](
+                             const Eigen::VectorXd& s_val) {
+    return kin->ComputeQValue(s_val, q_star_captured);
+  };
+
+  instance.set_parameterization(evaluate_s_to_q,
+                                /* parameterization_is_threadsafe */ true,
+                                /* parameterization_dimension */ dimension);
+  return instance;
+}
+
+void IrisParameterizationFunction::SetParameterizationFromExpression(
+    const Eigen::VectorX<symbolic::Expression>& expression_parameterization,
+    const Eigen::VectorX<symbolic::Variable>& variables) {
+  // First, we check that the variables in expression_parameterization match the
+  // user-supplied variables.
+  symbolic::Variables expression_variables;
+  for (const auto& expression : expression_parameterization) {
+    expression_variables.insert(expression.GetVariables());
+  }
+  symbolic::Variables user_supplied_variables(variables);
+  DRAKE_THROW_UNLESS(expression_variables == user_supplied_variables);
+
+  // Check for duplicates in variables.
+  DRAKE_THROW_UNLESS(variables.size() == ssize(user_supplied_variables));
+
+  int dimension = ssize(expression_variables);
+
+  // Note that in this lambda, we copy the shared_ptr variables, ensuring that
+  // variables is kept alive without making a copy of the individual Variable
+  // objects (which would break the substitution machinery).
+  auto evaluate_expression =
+      [expression_parameterization_captured =
+           Eigen::VectorX<symbolic::Expression>(expression_parameterization),
+       variables_captured = Eigen::VectorX<symbolic::Variable>(variables)](
+          const Eigen::VectorXd& q) {
+        DRAKE_ASSERT(q.size() == variables_captured.size());
+        symbolic::Environment env;
+        for (int i = 0; i < q.size(); ++i) {
+          env.insert(variables_captured[i], q[i]);
+        }
+        Eigen::VectorXd out = expression_parameterization_captured.unaryExpr(
+            [&env](const symbolic::Expression& expression) {
+              return expression.Evaluate(env);
+            });
+        return out;
+      };
+
+  set_parameterization(evaluate_expression,
+                       /* parameterization_is_threadsafe */ true,
+                       /* parameterization_dimension */ dimension);
+}
+
+}  // namespace planning
 }  // namespace drake

--- a/planning/iris/iris_common.cc
+++ b/planning/iris/iris_common.cc
@@ -1,0 +1,5 @@
+#include "drake/planning/iris/iris_common.h"
+
+namespace drake {
+namespace planning {}  // namespace planning
+}  // namespace drake

--- a/planning/iris/iris_common.h
+++ b/planning/iris/iris_common.h
@@ -80,7 +80,7 @@ class CommonSampledIrisOptions {
 
   /** Maximum number of faces to add per inner iteration. Setting the value to
    * -1 means there is no limit to the number of faces that can be added. */
-  int max_separating_planes_per_iteration{-1};
+  int max_separating_planes_per_iteration{10};
 
   /** Number of threads to use when updating the particles. If the user requests
    * more threads than the CollisionChecker supports, that number of threads

--- a/planning/iris/iris_common.h
+++ b/planning/iris/iris_common.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+
+#include <Eigen/Dense>
+
+#include "drake/common/name_value.h"
+#include "drake/common/parallelism.h"
+#include "drake/geometry/meshcat.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace planning {
+
+class CommonSampledIrisOptions {
+ public:
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background.
+  Note: This only serializes options that are YAML built-in types. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(num_particles));
+    a->Visit(DRAKE_NVP(tau));
+    a->Visit(DRAKE_NVP(delta));
+    a->Visit(DRAKE_NVP(epsilon));
+    a->Visit(DRAKE_NVP(containment_points));
+    a->Visit(DRAKE_NVP(max_iterations));
+    a->Visit(DRAKE_NVP(max_iterations_separating_planes));
+    a->Visit(DRAKE_NVP(max_separating_planes_per_iteration));
+    a->Visit(DRAKE_NVP(verbose));
+    a->Visit(DRAKE_NVP(require_sample_point_is_contained));
+    a->Visit(DRAKE_NVP(configuration_space_margin));
+    a->Visit(DRAKE_NVP(termination_threshold));
+    a->Visit(DRAKE_NVP(relative_termination_threshold));
+    a->Visit(DRAKE_NVP(random_seed));
+    a->Visit(DRAKE_NVP(mixing_steps));
+  }
+
+  CommonSampledIrisOptions() = default;
+
+  /** Number of particles used to estimate the closest collision. */
+  int num_particles = 1e3;
+
+  /** Decision threshold for the unadaptive test. Choosing a small value
+   * increases both the cost and the power statistical test. Increasing the
+   * value of `tau` makes running an individual test cheaper but decreases its
+   * power to accept a polytope. We find choosing a value of 0.5 a good
+   * trade-off.
+   */
+  double tau = 0.5;
+
+  /** Upper bound on the probability the returned region has a
+   * fraction-in-collision greater than `epsilon`. */
+  double delta = 5e-2;
+
+  /** Admissible fraction of the region volume allowed to be in collision. */
+  double epsilon = 1e-2;
+
+  /** Points that are guaranteed to be contained in the final region
+   * provided their convex hull is collision free. Note that if the containment
+   * points are closer than configuration_margin to an obstacle we will relax
+   * the margin in favor of including the containment points. The matrix
+   * `containment_points` is expected to be of the shape dimension times number
+   * of points. IrisZo throws if the center of the starting ellipsoid is
+   * not contained in the convex hull of these containment points. */
+  std::optional<Eigen::MatrixXd> containment_points{std::nullopt};
+
+  /** Maximum number of alternations between the ellipsoid and the separating
+   * planes step (a.k.a. outer iterations). */
+  int max_iterations{3};
+
+  /** Maximum number of rounds of adding faces to the polytope per outer
+   * iteration. */
+  int max_iterations_separating_planes{20};
+
+  /** Maximum number of faces to add per inner iteration. Setting the value to
+   * -1 means there is no limit to the number of faces that can be added. */
+  int max_separating_planes_per_iteration{-1};
+
+  /** Number of threads to use when updating the particles. If the user requests
+   * more threads than the CollisionChecker supports, that number of threads
+   * will be used instead. However, see also `parameterization_is_threadsafe`.
+   */
+  Parallelism parallelism{Parallelism::Max()};
+
+  /** Enables print statements indicating the progress of IrisZo. */
+  bool verbose{false};
+
+  /** The initial polytope is guaranteed to contain the point if that point is
+   * collision-free. */
+  bool require_sample_point_is_contained{true};
+
+  /** We retreat by this margin from each C-space obstacle in order to avoid the
+   * possibility of requiring an infinite number of faces to approximate a
+   * curved boundary. */
+  double configuration_space_margin{1e-2};
+
+  /** IRIS will terminate if the change in the *volume* of the hyperellipsoid
+  between iterations is less that this threshold. This termination condition can
+  be disabled by setting to a negative value. */
+  double termination_threshold{2e-2};
+
+  /** IRIS will terminate if the change in the *volume* of the hyperellipsoid
+  between iterations is less that this percent of the previous best volume.
+  This termination condition can be disabled by setting to a negative value. */
+  double relative_termination_threshold{1e-3};
+
+  /** This option sets the random seed for random sampling throughout the
+   * algorithm. */
+  int random_seed{1234};
+
+  /** Number of mixing steps used for hit-and-run sampling. */
+  int mixing_steps{50};
+
+  /** Passing a meshcat instance may enable debugging visualizations; this
+  currently and when the
+  configuration space is <= 3 dimensional.*/
+  std::shared_ptr<geometry::Meshcat> meshcat{};
+
+  /** By default, IRIS-ZO only considers collision avoidance constraints. This
+  option can be used to pass additional constraints that should be satisfied by
+  the output region. We accept these in the form of a MathematicalProgram:
+
+    find q subject to g(q) ≤ 0.
+
+  The decision_variables() for the program are taken to define `q`. IRIS-ZO will
+  silently ignore any costs in `prog_with_additional_constraints`. If any
+  constraints are not threadsafe, then `parallelism` will be overridden, and
+  only one thread will be used.
+  @note If the user has specified a parameterization, then these constraints are
+  imposed on the points in the parameterized space Q, not the configuration
+  space C.
+  @note Internally, these constraints are checked after collisions checking is
+  performed. */
+  const solvers::MathematicalProgram* prog_with_additional_constraints{};
+};
+
+}  // namespace planning
+}  // namespace drake

--- a/planning/iris/iris_zo.cc
+++ b/planning/iris/iris_zo.cc
@@ -6,9 +6,7 @@
 #include <common_robotics_utilities/parallelism.hpp>
 
 #include "drake/common/fmt_eigen.h"
-#include "drake/common/symbolic/expression.h"
 #include "drake/common/text_logging.h"
-#include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/vpolytope.h"
 #include "drake/solvers/choose_best_solver.h"
@@ -25,7 +23,6 @@ using common_robotics_utilities::parallelism::DegreeOfParallelism;
 using common_robotics_utilities::parallelism::DynamicParallelForIndexLoop;
 using common_robotics_utilities::parallelism::ParallelForBackend;
 using common_robotics_utilities::parallelism::StaticParallelForIndexLoop;
-using geometry::Meshcat;
 using geometry::Sphere;
 using geometry::optimization::HPolyhedron;
 using geometry::optimization::Hyperellipsoid;
@@ -325,6 +322,7 @@ HPolyhedron IrisZo(const planning::CollisionChecker& checker,
   std::unique_ptr<SolverInterface> solver = solvers::MakeFirstAvailableSolver(
       {solvers::GurobiSolver::id(), solvers::ClarabelSolver::id(),
        solvers::MosekSolver::id(), solvers::OsqpSolver::id()});
+  // TODO(cohnt): Use solvers::ChooseBestSolver.
   while (true) {
     log()->info("IrisZo outer iteration {}", iteration);
 

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -16,6 +16,7 @@
 #include "drake/geometry/optimization/hyperellipsoid.h"
 #include "drake/multibody/rational/rational_forward_kinematics.h"
 #include "drake/planning/collision_checker.h"
+#include "drake/planning/iris/iris_common.h"
 
 namespace drake {
 namespace planning {
@@ -34,124 +35,17 @@ class IrisZoOptions {
   Note: This only serializes options that are YAML built-in types. */
   template <typename Archive>
   void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(num_particles));
-    a->Visit(DRAKE_NVP(tau));
-    a->Visit(DRAKE_NVP(delta));
-    a->Visit(DRAKE_NVP(epsilon));
-    a->Visit(DRAKE_NVP(containment_points));
-    a->Visit(DRAKE_NVP(max_iterations));
-    a->Visit(DRAKE_NVP(max_iterations_separating_planes));
-    a->Visit(DRAKE_NVP(max_separating_planes_per_iteration));
+    a->Visit(DRAKE_NVP(sampled_iris_options));
     a->Visit(DRAKE_NVP(bisection_steps));
-    a->Visit(DRAKE_NVP(verbose));
-    a->Visit(DRAKE_NVP(require_sample_point_is_contained));
-    a->Visit(DRAKE_NVP(configuration_space_margin));
-    a->Visit(DRAKE_NVP(termination_threshold));
-    a->Visit(DRAKE_NVP(relative_termination_threshold));
-    a->Visit(DRAKE_NVP(random_seed));
-    a->Visit(DRAKE_NVP(mixing_steps));
   }
 
   IrisZoOptions() = default;
 
-  /** Number of particles used to estimate the closest collision. */
-  int num_particles = 1e3;
-
-  /** Decision threshold for the unadaptive test. Choosing a small value
-   * increases both the cost and the power statistical test. Increasing the
-   * value of `tau` makes running an individual test cheaper but decreases its
-   * power to accept a polytope. We find choosing a value of 0.5 a good
-   * trade-off.
-   */
-  double tau = 0.5;
-
-  /** Upper bound on the probability the returned region has a
-   * fraction-in-collision greater than `epsilon`. */
-  double delta = 5e-2;
-
-  /** Admissible fraction of the region volume allowed to be in collision. */
-  double epsilon = 1e-2;
-
-  /** Points that are guaranteed to be contained in the final region
-   * provided their convex hull is collision free. Note that if the containment
-   * points are closer than configuration_margin to an obstacle we will relax
-   * the margin in favor of including the containment points. The matrix
-   * `containment_points` is expected to be of the shape dimension times number
-   * of points. IrisZo throws if the center of the starting ellipsoid is
-   * not contained in the convex hull of these containment points. */
-  std::optional<Eigen::MatrixXd> containment_points{std::nullopt};
-
-  /** Maximum number of alternations between the ellipsoid and the separating
-   * planes step (a.k.a. outer iterations). */
-  int max_iterations{3};
-
-  /** Maximum number of rounds of adding faces to the polytope per outer
-   * iteration. */
-  int max_iterations_separating_planes{20};
-
-  /** Maximum number of faces to add per inner iteration. Setting the value to
-   * -1 means there is no limit to the number of faces that can be added. */
-  int max_separating_planes_per_iteration{-1};
+  /** Options pertaining to the sampling and temrination conditions. */
+  CommonSampledIrisOptions sampled_iris_options{};
 
   /** Maximum number of bisection steps. */
   int bisection_steps{10};
-
-  /** Number of threads to use when updating the particles. If the user requests
-   * more threads than the CollisionChecker supports, that number of threads
-   * will be used instead. However, see also `parameterization_is_threadsafe`.
-   */
-  Parallelism parallelism{Parallelism::Max()};
-
-  /** Enables print statements indicating the progress of IrisZo. */
-  bool verbose{false};
-
-  /** The initial polytope is guaranteed to contain the point if that point is
-   * collision-free. */
-  bool require_sample_point_is_contained{true};
-
-  /** We retreat by this margin from each C-space obstacle in order to avoid the
-   * possibility of requiring an infinite number of faces to approximate a
-   * curved boundary. */
-  double configuration_space_margin{1e-2};
-
-  /** IRIS will terminate if the change in the *volume* of the hyperellipsoid
-  between iterations is less that this threshold. This termination condition can
-  be disabled by setting to a negative value. */
-  double termination_threshold{2e-2};
-
-  /** IRIS will terminate if the change in the *volume* of the hyperellipsoid
-  between iterations is less that this percent of the previous best volume.
-  This termination condition can be disabled by setting to a negative value. */
-  double relative_termination_threshold{1e-3};
-
-  /** This option sets the random seed for random sampling throughout the
-   * algorithm. */
-  int random_seed{1234};
-
-  /** Number of mixing steps used for hit-and-run sampling. */
-  int mixing_steps{50};
-
-  /** Passing a meshcat instance may enable debugging visualizations; this
-  currently and when the
-  configuration space is <= 3 dimensional.*/
-  std::shared_ptr<geometry::Meshcat> meshcat{};
-
-  /** By default, IRIS-ZO only considers collision avoidance constraints. This
-  option can be used to pass additional constraints that should be satisfied by
-  the output region. We accept these in the form of a MathematicalProgram:
-
-    find q subject to g(q) ≤ 0.
-
-  The decision_variables() for the program are taken to define `q`. IRIS-ZO will
-  silently ignore any costs in `prog_with_additional_constraints`. If any
-  constraints are not threadsafe, then `parallelism` will be overridden, and
-  only one thread will be used.
-  @note If the user has specified a parameterization, then these constraints are
-  imposed on the points in the parameterized space Q, not the configuration
-  space C.
-  @note Internally, these constraints are checked after collisions checking is
-  performed. */
-  const solvers::MathematicalProgram* prog_with_additional_constraints{};
 
   typedef std::function<Eigen::VectorXd(const Eigen::VectorXd&)>
       ParameterizationFunction;

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -1,20 +1,12 @@
 #pragma once
 
 #include <filesystem>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <utility>
-#include <vector>
 
-#include <Eigen/Dense>
-
-#include "drake/common/parallelism.h"
-#include "drake/common/symbolic/expression.h"
-#include "drake/geometry/meshcat.h"
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
-#include "drake/multibody/rational/rational_forward_kinematics.h"
 #include "drake/planning/collision_checker.h"
 #include "drake/planning/iris/iris_common.h"
 

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -47,88 +47,10 @@ class IrisZoOptions {
   /** Maximum number of bisection steps. */
   int bisection_steps{10};
 
-  typedef std::function<Eigen::VectorXd(const Eigen::VectorXd&)>
-      ParameterizationFunction;
-
-  /** Ordinarily, IRIS-ZO grows collision free regions in the robot's
-   * configuration space C. This allows the user to specify a function f:Q→C ,
-   * and grow the region in Q instead. The function should be a map R^m to
-   * R^n, where n is the dimension of the plant configuration space, determined
-   * via `checker.plant().num_positions()` and m is `parameterization_dimension`
-   * if specified. The user must provide `parameterization`, which is the
-   * function f, `parameterization_is_threadsafe`, which is whether or not
-   * `parametrization` can be called concurrently, and
-   * `parameterization_dimension`, the dimension of the input space Q. */
-  void set_parameterization(const ParameterizationFunction& parameterization,
-                            bool parameterization_is_threadsafe,
-                            int parameterization_dimension) {
-    parameterization_ = parameterization;
-    parameterization_is_threadsafe_ = parameterization_is_threadsafe;
-    parameterization_dimension_ = parameterization_dimension;
-  }
-
-  /** Alternative to `set_parameterization` that allows the user to define the
-   * parameterization using a `VectorX<Expression>`. The user must also provide
-   * a vector containing the variables used in `expression_parameterization`, in
-   * the order that they should be evaluated. Each `Variable` in `variables`
-   * must be used, each `Variable` used in `expression_parameterization` must
-   * appear in `variables`, and there must be no duplicates in `variables`.
-   * @note Expression parameterizations are always threadsafe.
-   * @throws if the number of variables used across
-   * `expression_parameterization` does not match `ssize(variables)`.
-   * @throws if any variables in `expression_parameterization` are not listed in
-   * `variables`.
-   * @throws if any variables in `variables` are not used anywhere in
-   * `expression_parameterization`. */
-  void SetParameterizationFromExpression(
-      const Eigen::VectorX<symbolic::Expression>& expression_parameterization,
-      const Eigen::VectorX<symbolic::Variable>& variables);
-
-  /** Get the parameterization function.
-   * @note If the user has not specified this with `set_parameterization()`,
-   * then the default value of `parameterization_` is the identity function,
-   * indicating that the regions should be grown in the full configuration space
-   * (in the standard coordinate system). */
-  const ParameterizationFunction& get_parameterization() const {
-    return parameterization_;
-  }
-
-  /** Returns whether or not the user has specified the parameterization to be
-   * threadsafe.
-   * @note The default `parameterization_` is the identity function, which is
-   * threadsafe. */
-  bool get_parameterization_is_threadsafe() const {
-    return parameterization_is_threadsafe_;
-  }
-
-  /** Returns what the user has specified as the input dimension for the
-   * parameterization function, or std::nullopt if it has not been set. A
-   * std::nullopt value indicates that
-   * IrisZo should use the ambient configuration space dimension as the input
-   * dimension to the parameterization. */
-  std::optional<int> get_parameterization_dimension() const {
-    return parameterization_dimension_;
-  }
-
-  /** Constructs an instance of IrisZoOptions that handles a rational kinematic
-   * parameterization. Regions are grown in the `s` variables, so as to minimize
-   * collisions in the `q` variables. See RationalForwardKinematics for details.
-   * @note The user is responsible for ensuring `kin` (and the underlying
-   * MultibodyPlant it is built on) is kept alive. If that object is deleted,
-   * then the parametrization can no longer be used. */
-  static IrisZoOptions CreateWithRationalKinematicParameterization(
-      const multibody::RationalForwardKinematics* kin,
-      const Eigen::Ref<const Eigen::VectorXd>& q_star_val);
-
- private:
-  bool parameterization_is_threadsafe_{true};
-
-  std::optional<int> parameterization_dimension_{std::nullopt};
-
-  std::function<Eigen::VectorXd(const Eigen::VectorXd&)> parameterization_{
-      [](const Eigen::VectorXd& q) -> Eigen::VectorXd {
-        return q;
-      }};
+  /** Parameterization of the subspace along which to grow the region. Default
+   * is the identity parameterization, corresponding to growing regions in the
+   * ordinary configuration space. */
+  IrisParameterizationFunction parameterization{};
 };
 
 /** The IRIS-ZO (Iterative Regional Inflation by Semidefinite programming - Zero

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -82,7 +82,7 @@ TEST_F(JointLimits1D, JointLimitsWithParameterization) {
             true);
 
   for (auto& options : vector_of_options) {
-    options.verbose = true;
+    options.sampled_iris_options.verbose = true;
 
     // Check that the parameterization was set correctly.
     ASSERT_TRUE(options.get_parameterization_dimension().has_value());
@@ -138,10 +138,10 @@ TEST_F(JointLimits1D, ParameterizationExpressionErrorChecks) {
 // Reproduced from the IrisInConfigurationSpace unit tests.
 TEST_F(DoublePendulum, IrisZoTest) {
   IrisZoOptions options;
-  options.verbose = true;
+  options.sampled_iris_options.verbose = true;
 
   meshcat_->Delete();
-  options.meshcat = meshcat_;
+  options.sampled_iris_options.meshcat = meshcat_;
 
   HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
   CheckRegion(region);
@@ -157,10 +157,10 @@ TEST_F(DoublePendulumRationalForwardKinematics,
       IrisZoOptions::CreateWithRationalKinematicParameterization(
           &rational_kinematics_,
           /* q_star_val */ Vector2d::Zero());
-  options.verbose = true;
+  options.sampled_iris_options.verbose = true;
 
   meshcat_->Delete();
-  options.meshcat = meshcat_;
+  options.sampled_iris_options.meshcat = meshcat_;
 
   // Check that the parameterization was set correctly.
   EXPECT_EQ(options.get_parameterization_is_threadsafe(), true);
@@ -225,9 +225,9 @@ TEST_F(DoublePendulumRationalForwardKinematics, BadParameterization) {
 // Reproduced from the IrisInConfigurationSpace unit tests.
 TEST_F(BlockOnGround, IrisZoTest) {
   IrisZoOptions options;
-  options.verbose = true;
+  options.sampled_iris_options.verbose = true;
   meshcat_->Delete();
-  options.meshcat = meshcat_;
+  options.sampled_iris_options.meshcat = meshcat_;
 
   HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
   CheckRegion(region);
@@ -247,8 +247,8 @@ TEST_F(ConvexConfigurationSpace, IrisZoTest) {
   // away from that corner. Open the meshcat visualization to step through the
   // details!
   meshcat_->Delete();
-  options.meshcat = meshcat_;
-  options.verbose = true;
+  options.sampled_iris_options.meshcat = meshcat_;
+  options.sampled_iris_options.verbose = true;
   HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
   CheckRegion(region);
   PlotEnvironmentAndRegion(region);
@@ -258,7 +258,7 @@ TEST_F(ConvexConfigurationSpace, IrisZoTest) {
 // collision, and when the initial point violates an additional constraint.
 TEST_F(ConvexConfigurationSpaceWithThreadsafeConstraint, BadInitialEllipsoid) {
   IrisZoOptions options;
-  options.prog_with_additional_constraints = &prog_;
+  options.sampled_iris_options.prog_with_additional_constraints = &prog_;
 
   Hyperellipsoid ellipsoid_in_collision =
       Hyperellipsoid::MakeHypersphere(1e-2, Eigen::Vector2d(-1.0, 1.0));
@@ -274,12 +274,12 @@ TEST_F(ConvexConfigurationSpaceWithThreadsafeConstraint, BadInitialEllipsoid) {
 
 TEST_F(ConvexConfigurationSpaceWithThreadsafeConstraint, IrisZoTest) {
   IrisZoOptions options;
-  options.prog_with_additional_constraints = &prog_;
-  options.max_iterations = 1;
-  options.max_iterations_separating_planes = 1;
+  options.sampled_iris_options.prog_with_additional_constraints = &prog_;
+  options.sampled_iris_options.max_iterations = 1;
+  options.sampled_iris_options.max_iterations_separating_planes = 1;
 
   meshcat_->Delete();
-  options.meshcat = meshcat_;
+  options.sampled_iris_options.meshcat = meshcat_;
 
   HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
   CheckRegion(region);
@@ -288,9 +288,9 @@ TEST_F(ConvexConfigurationSpaceWithThreadsafeConstraint, IrisZoTest) {
 
 TEST_F(ConvexConfigurationSpaceWithNotThreadsafeConstraint, IrisZoTest) {
   IrisZoOptions options;
-  options.prog_with_additional_constraints = &prog_;
-  options.max_iterations = 3;
-  options.max_iterations_separating_planes = 20;
+  options.sampled_iris_options.prog_with_additional_constraints = &prog_;
+  options.sampled_iris_options.max_iterations = 3;
+  options.sampled_iris_options.max_iterations_separating_planes = 20;
 
   HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
   CheckRegion(region);
@@ -298,7 +298,7 @@ TEST_F(ConvexConfigurationSpaceWithNotThreadsafeConstraint, IrisZoTest) {
 
 TEST_F(ConvexConfigurationSpaceWithThreadsafeConstraint, BadContainmentPoint) {
   IrisZoOptions options;
-  options.prog_with_additional_constraints = &prog_;
+  options.sampled_iris_options.prog_with_additional_constraints = &prog_;
 
   // If we have a containment point violating this constraint, IrisZo should
   // throw. Three points are needed to ensure the center of the starting
@@ -308,7 +308,7 @@ TEST_F(ConvexConfigurationSpaceWithThreadsafeConstraint, BadContainmentPoint) {
   containment_points << -0.2, -0.6, -0.6,
                          0.0,  0.1, -0.1;
   // clang-format on
-  options.containment_points = containment_points;
+  options.sampled_iris_options.containment_points = containment_points;
   DRAKE_EXPECT_THROWS_MESSAGE(
       IrisZo(*checker_, starting_ellipsoid_, domain_, options),
       ".*containment points violates a constraint.*");
@@ -328,7 +328,7 @@ TEST_F(ConvexConfigurationSubspace, AdditionalConstraintsDimensionMismatch) {
 
   solvers::MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
-  options.prog_with_additional_constraints = &prog;
+  options.sampled_iris_options.prog_with_additional_constraints = &prog;
 
   // Since we have a parameterization, the prog with additional constraints will
   // have the wrong dimension. We expect an error message.
@@ -382,9 +382,9 @@ TEST_F(FourCornersBoxes, SingleContainmentPoint) {
   single_containment_point << 0, 1;
 
   IrisZoOptions options;
-  options.verbose = true;
-  options.configuration_space_margin = 0.04;
-  options.containment_points = single_containment_point;
+  options.sampled_iris_options.verbose = true;
+  options.sampled_iris_options.configuration_space_margin = 0.04;
+  options.sampled_iris_options.containment_points = single_containment_point;
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       IrisZo(*checker_, starting_ellipsoid_, domain_, options),
@@ -401,11 +401,11 @@ TEST_F(FourCornersBoxes, TwoContainmentPoints) {
                         1, starting_ellipsoid_.center().y();
   // clang-format on
   IrisZoOptions options;
-  options.verbose = true;
+  options.sampled_iris_options.verbose = true;
   meshcat_->Delete();
-  options.meshcat = meshcat_;
-  options.configuration_space_margin = 0.04;
-  options.containment_points = containment_points;
+  options.sampled_iris_options.meshcat = meshcat_;
+  options.sampled_iris_options.configuration_space_margin = 0.04;
+  options.sampled_iris_options.containment_points = containment_points;
 
   HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
   CheckRegionContainsPoints(region, containment_points);
@@ -424,12 +424,12 @@ TEST_F(FourCornersBoxes, FourContainmentPoints) {
                          yw, yw, -yw, -yw;
   // clang-format on
   IrisZoOptions options;
-  options.verbose = true;
+  options.sampled_iris_options.verbose = true;
   meshcat_->Delete();
-  options.meshcat = meshcat_;
-  options.containment_points = containment_points;
-  options.max_iterations_separating_planes = 100;
-  options.max_iterations = -1;
+  options.sampled_iris_options.meshcat = meshcat_;
+  options.sampled_iris_options.containment_points = containment_points;
+  options.sampled_iris_options.max_iterations_separating_planes = 100;
+  options.sampled_iris_options.max_iterations = -1;
   HPolyhedron region = IrisZo(*checker_, starting_ellipsoid_, domain_, options);
 
   CheckRegionContainsPoints(region, containment_points);


### PR DESCRIPTION
Many of the options in IrisZoOptions are actually shared between IRIS-ZO and the soon-to-be-implemented IRIS-NP2 (#21822). This PR factors those options into two new classes, CommonSampledIrisOptions and IrisParameterizationFunction.

+@wernerpe for feature review

Because IrisZo is `@experimental`, I think we don't need to tag this as a breaking change? Not sure how to classify it, really, but given that it will break existing code, we should probably make some mention of it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22982)
<!-- Reviewable:end -->
