### PR TITLE
Use NVI to consolidate code in MapAccelerationToQDDot().

### DIFF
--- a/multibody/tree/mobilizer.cc
+++ b/multibody/tree/mobilizer.cc
@@ -21,8 +21,9 @@ template <typename T>
 void Mobilizer<T>::DoMapAccelerationToQDDot(const systems::Context<T>&,
                                             const Eigen::Ref<const VectorX<T>>&,
                                             EigenPtr<VectorX<T>>) const {
-  // TODO(Mitiguy) remove this method when Mobilizer::DoMapAccelerationToQDDot()
-  //  is changed to a pure virtual function that requires override.
+  // TODO(Mitiguy) remove this base class implementation  when
+  //  Mobilizer::DoMapAccelerationToQDDot() is changed to a pure virtual
+  //  function that requires override.
   const std::string error_message = fmt::format(
       "The function {}() has not been implemented for this "
       "mobilizer.",
@@ -34,8 +35,9 @@ template <typename T>
 void Mobilizer<T>::DoMapQDDotToAcceleration(const systems::Context<T>&,
                                             const Eigen::Ref<const VectorX<T>>&,
                                             EigenPtr<VectorX<T>>) const {
-  // TODO(Mitiguy) remove this method when Mobilizer::DoMapQDDotToAcceleration()
-  //  is changed to a pure virtual function that requires override.
+  // TODO(Mitiguy) remove this base class implementation  when
+  //  Mobilizer::DoMapQDDotToAcceleration() is changed to a pure virtual
+  //  function that requires override.
   const std::string error_message = fmt::format(
       "The function {}() has not been implemented for this "
       "mobilizer.",

--- a/multibody/tree/mobilizer.cc
+++ b/multibody/tree/mobilizer.cc
@@ -21,7 +21,7 @@ template <typename T>
 void Mobilizer<T>::DoMapAccelerationToQDDot(const systems::Context<T>&,
                                             const Eigen::Ref<const VectorX<T>>&,
                                             EigenPtr<VectorX<T>>) const {
-  // TODO(Mitiguy) remove this base class implementation  when
+  // TODO(Mitiguy) remove this base class implementation when
   //  Mobilizer::DoMapAccelerationToQDDot() is changed to a pure virtual
   //  function that requires override.
   const std::string error_message = fmt::format(
@@ -35,7 +35,7 @@ template <typename T>
 void Mobilizer<T>::DoMapQDDotToAcceleration(const systems::Context<T>&,
                                             const Eigen::Ref<const VectorX<T>>&,
                                             EigenPtr<VectorX<T>>) const {
-  // TODO(Mitiguy) remove this base class implementation  when
+  // TODO(Mitiguy) remove this base class implementation when
   //  Mobilizer::DoMapQDDotToAcceleration() is changed to a pure virtual
   //  function that requires override.
   const std::string error_message = fmt::format(

--- a/multibody/tree/mobilizer.cc
+++ b/multibody/tree/mobilizer.cc
@@ -18,10 +18,10 @@ std::pair<Eigen::Quaternion<T>, Vector3<T>> Mobilizer<T>::GetPosePair(
 }
 
 template <typename T>
-void Mobilizer<T>::MapAccelerationToQDDot(const systems::Context<T>&,
-                                          const Eigen::Ref<const VectorX<T>>&,
-                                          EigenPtr<VectorX<T>>) const {
-  // TODO(Mitiguy) remove this function when Mobilizer::MapAccelerationToQDDot()
+void Mobilizer<T>::DoMapAccelerationToQDDot(const systems::Context<T>&,
+                                            const Eigen::Ref<const VectorX<T>>&,
+                                            EigenPtr<VectorX<T>>) const {
+  // TODO(Mitiguy) remove this method when Mobilizer::DoMapAccelerationToQDDot()
   //  is changed to a pure virtual function that requires override.
   const std::string error_message = fmt::format(
       "The function {}() has not been implemented for this "
@@ -31,10 +31,10 @@ void Mobilizer<T>::MapAccelerationToQDDot(const systems::Context<T>&,
 }
 
 template <typename T>
-void Mobilizer<T>::MapQDDotToAcceleration(const systems::Context<T>&,
-                                          const Eigen::Ref<const VectorX<T>>&,
-                                          EigenPtr<VectorX<T>>) const {
-  // TODO(Mitiguy) remove this function when Mobilizer::MapAccelerationToQDDot()
+void Mobilizer<T>::DoMapQDDotToAcceleration(const systems::Context<T>&,
+                                            const Eigen::Ref<const VectorX<T>>&,
+                                            EigenPtr<VectorX<T>>) const {
+  // TODO(Mitiguy) remove this method when Mobilizer::DoMapQDDotToAcceleration()
   //  is changed to a pure virtual function that requires override.
   const std::string error_message = fmt::format(
       "The function {}() has not been implemented for this "

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -650,21 +650,27 @@ class Mobilizer : public MultibodyElement<T> {
   // @param[in] context stores generalized positions q and velocities v.
   // @param[in] vdot (v̇) 1ˢᵗ time derivatives of generalized velocities.
   // @param[out] qddot (q̈) 2ⁿᵈ time derivatives of the generalized positions.
-  // TODO(Mitiguy) change this function to a pure virtual function when it has
-  //  been overridden in all subclasses.
-  virtual void MapAccelerationToQDDot(const systems::Context<T>& context,
-                                      const Eigen::Ref<const VectorX<T>>& vdot,
-                                      EigenPtr<VectorX<T>> qddot) const;
+  void MapAccelerationToQDDot(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& vdot,
+                              EigenPtr<VectorX<T>> qddot) const {
+    DRAKE_ASSERT(vdot.size() == num_velocities());
+    DRAKE_ASSERT(qddot != nullptr);
+    DRAKE_ASSERT(qddot->size() == num_positions());
+    DoMapAccelerationToQDDot(context, vdot, qddot);
+  }
 
   // Calculates v̇ from q̈, v, q using v̇ = N⁺(q)⋅q̈ + Ṅ⁺(q,v)⋅q̇ where q̇ = N(q)⋅v.
   // @param[in] context stores generalized positions q and velocities v.
   // @param[in] qddot (q̈) 2ⁿᵈ time derivatives of the generalized positions.
   // @param[out] vdot (v̇) 1ˢᵗ time derivatives of generalized velocities.
-  // TODO(Mitiguy) change this function to a pure virtual function when it has
-  //  been overridden in all subclasses.
-  virtual void MapQDDotToAcceleration(const systems::Context<T>& context,
-                                      const Eigen::Ref<const VectorX<T>>& qddot,
-                                      EigenPtr<VectorX<T>> vdot) const;
+  void MapQDDotToAcceleration(const systems::Context<T>& context,
+                              const Eigen::Ref<const VectorX<T>>& qddot,
+                              EigenPtr<VectorX<T>> vdot) const {
+    DRAKE_ASSERT(qddot.size() == num_positions());
+    DRAKE_ASSERT(vdot != nullptr);
+    DRAKE_ASSERT(vdot->size() == num_velocities());
+    DoMapQDDotToAcceleration(context, qddot, vdot);
+  }
   // @}
 
   // Returns a const Eigen expression of the vector of generalized positions
@@ -801,6 +807,24 @@ class Mobilizer : public MultibodyElement<T> {
   //  been overridden in all subclasses.
   virtual void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                                     EigenPtr<MatrixX<T>> NplusDot) const;
+
+  // NVI to MapAccelerationToQDDot(). Implementations can safely assume that
+  // qddot is not the nullptr, qddot has size kNq, and vdot has size kNv.
+  // TODO(Mitiguy) change this function to a pure virtual function when it has
+  //  been overridden in all subclasses.
+  virtual void DoMapAccelerationToQDDot(
+      const systems::Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& vdot,
+      EigenPtr<VectorX<T>> qddot) const;
+
+  // NVI to MapQDDotToAcceleration(). Implementations can safely assume that
+  // vdot is not the nullptr, vdot has size kNv, and qddot has size kNq.
+  // TODO(Mitiguy) change this function to a pure virtual function when it has
+  //  been overridden in all subclasses.
+  virtual void DoMapQDDotToAcceleration(
+      const systems::Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& qddot,
+      EigenPtr<VectorX<T>> vdot) const;
 
   // @name Methods to make a clone templated on different scalar types.
   //

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -653,9 +653,9 @@ class Mobilizer : public MultibodyElement<T> {
   void MapAccelerationToQDDot(const systems::Context<T>& context,
                               const Eigen::Ref<const VectorX<T>>& vdot,
                               EigenPtr<VectorX<T>> qddot) const {
-    DRAKE_ASSERT(vdot.size() == num_velocities());
-    DRAKE_ASSERT(qddot != nullptr);
-    DRAKE_ASSERT(qddot->size() == num_positions());
+    DRAKE_DEMAND(vdot.size() == num_velocities());
+    DRAKE_DEMAND(qddot != nullptr);
+    DRAKE_DEMAND(qddot->size() == num_positions());
     DoMapAccelerationToQDDot(context, vdot, qddot);
   }
 
@@ -666,9 +666,9 @@ class Mobilizer : public MultibodyElement<T> {
   void MapQDDotToAcceleration(const systems::Context<T>& context,
                               const Eigen::Ref<const VectorX<T>>& qddot,
                               EigenPtr<VectorX<T>> vdot) const {
-    DRAKE_ASSERT(qddot.size() == num_positions());
-    DRAKE_ASSERT(vdot != nullptr);
-    DRAKE_ASSERT(vdot->size() == num_velocities());
+    DRAKE_DEMAND(qddot.size() == num_positions());
+    DRAKE_DEMAND(vdot != nullptr);
+    DRAKE_DEMAND(vdot->size() == num_velocities());
     DoMapQDDotToAcceleration(context, qddot, vdot);
   }
   // @}

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -198,22 +198,16 @@ void PlanarMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
-void PlanarMobilizer<T>::MapAccelerationToQDDot(
+void PlanarMobilizer<T>::DoMapAccelerationToQDDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
     EigenPtr<VectorX<T>> qddot) const {
-  DRAKE_ASSERT(vdot.size() == kNv);
-  DRAKE_ASSERT(qddot != nullptr);
-  DRAKE_ASSERT(qddot->size() == kNq);
   *qddot = vdot;
 }
 
 template <typename T>
-void PlanarMobilizer<T>::MapQDDotToAcceleration(
+void PlanarMobilizer<T>::DoMapQDDotToAcceleration(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
     EigenPtr<VectorX<T>> vdot) const {
-  DRAKE_ASSERT(qddot.size() == kNq);
-  DRAKE_ASSERT(vdot != nullptr);
-  DRAKE_ASSERT(vdot->size() == kNv);
   *vdot = qddot;
 }
 

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -226,16 +226,6 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
 
-  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
-  void MapAccelerationToQDDot(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& vdot,
-                              EigenPtr<VectorX<T>> qddot) const final;
-
-  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
-  void MapQDDotToAcceleration(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& qddot,
-                              EigenPtr<VectorX<T>> vdot) const final;
-
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
@@ -250,6 +240,16 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void DoMapAccelerationToQDDot(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& vdot,
+                                EigenPtr<VectorX<T>> qddot) const final;
+
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void DoMapQDDotToAcceleration(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& qddot,
+                                EigenPtr<VectorX<T>> vdot) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -163,22 +163,16 @@ void PrismaticMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
-void PrismaticMobilizer<T>::MapAccelerationToQDDot(
+void PrismaticMobilizer<T>::DoMapAccelerationToQDDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
     EigenPtr<VectorX<T>> qddot) const {
-  DRAKE_ASSERT(vdot.size() == kNv);
-  DRAKE_ASSERT(qddot != nullptr);
-  DRAKE_ASSERT(qddot->size() == kNq);
   *qddot = vdot;
 }
 
 template <typename T>
-void PrismaticMobilizer<T>::MapQDDotToAcceleration(
+void PrismaticMobilizer<T>::DoMapQDDotToAcceleration(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
     EigenPtr<VectorX<T>> vdot) const {
-  DRAKE_ASSERT(qddot.size() == kNq);
-  DRAKE_ASSERT(vdot != nullptr);
-  DRAKE_ASSERT(vdot->size() == kNv);
   *vdot = qddot;
 }
 

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -134,16 +134,6 @@ class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
 
-  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
-  void MapAccelerationToQDDot(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& vdot,
-                              EigenPtr<VectorX<T>> qddot) const final;
-
-  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
-  void MapQDDotToAcceleration(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& qddot,
-                              EigenPtr<VectorX<T>> vdot) const final;
-
  protected:
   // Constructor for a PrismaticMobilizer between the inboard frame F and the
   // outboard frame M, granting a single translational degree of freedom along
@@ -165,6 +155,16 @@ class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void DoMapAccelerationToQDDot(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& vdot,
+                                EigenPtr<VectorX<T>> qddot) const final;
+
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void DoMapQDDotToAcceleration(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& qddot,
+                                EigenPtr<VectorX<T>> vdot) const final;
 
  private:
   // Joint axis expressed identically in frames F and M. This must be one of

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -162,22 +162,16 @@ void RevoluteMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::MapAccelerationToQDDot(
+void RevoluteMobilizer<T>::DoMapAccelerationToQDDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
     EigenPtr<VectorX<T>> qddot) const {
-  DRAKE_ASSERT(vdot.size() == kNv);
-  DRAKE_ASSERT(qddot != nullptr);
-  DRAKE_ASSERT(qddot->size() == kNq);
   *qddot = vdot;
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::MapQDDotToAcceleration(
+void RevoluteMobilizer<T>::DoMapQDDotToAcceleration(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
     EigenPtr<VectorX<T>> vdot) const {
-  DRAKE_ASSERT(qddot.size() == kNq);
-  DRAKE_ASSERT(vdot != nullptr);
-  DRAKE_ASSERT(vdot->size() == kNv);
   *vdot = qddot;
 }
 

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -129,16 +129,6 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
 
-  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
-  void MapAccelerationToQDDot(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& vdot,
-                              EigenPtr<VectorX<T>> qddot) const final;
-
-  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
-  void MapQDDotToAcceleration(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& qddot,
-                              EigenPtr<VectorX<T>> vdot) const final;
-
  protected:
   // Constructor for a RevoluteMobilizer between the inboard frame F and the
   // outboard frame M, granting a single rotational degree of freedom about a
@@ -160,6 +150,16 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void DoMapAccelerationToQDDot(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& vdot,
+                                EigenPtr<VectorX<T>> qddot) const final;
+
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void DoMapQDDotToAcceleration(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& qddot,
+                                EigenPtr<VectorX<T>> vdot) const final;
 
  private:
   // Joint axis expressed identically in frames F and M. This must be one of

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -195,22 +195,16 @@ void ScrewMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
-void ScrewMobilizer<T>::MapAccelerationToQDDot(
+void ScrewMobilizer<T>::DoMapAccelerationToQDDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
     EigenPtr<VectorX<T>> qddot) const {
-  DRAKE_ASSERT(vdot.size() == kNv);
-  DRAKE_ASSERT(qddot != nullptr);
-  DRAKE_ASSERT(qddot->size() == kNq);
   *qddot = vdot;
 }
 
 template <typename T>
-void ScrewMobilizer<T>::MapQDDotToAcceleration(
+void ScrewMobilizer<T>::DoMapQDDotToAcceleration(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
     EigenPtr<VectorX<T>> vdot) const {
-  DRAKE_ASSERT(qddot.size() == kNq);
-  DRAKE_ASSERT(vdot != nullptr);
-  DRAKE_ASSERT(vdot->size() == kNv);
   *vdot = qddot;
 }
 

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -281,16 +281,6 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
 
-  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
-  void MapAccelerationToQDDot(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& vdot,
-                              EigenPtr<VectorX<T>> qddot) const final;
-
-  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
-  void MapQDDotToAcceleration(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& qddot,
-                              EigenPtr<VectorX<T>> vdot) const final;
-
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
@@ -305,6 +295,16 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
+  void DoMapAccelerationToQDDot(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& vdot,
+                                EigenPtr<VectorX<T>> qddot) const final;
+
+  // Maps qddot to vdot, which for this mobilizer is v̇ = q̈.
+  void DoMapQDDotToAcceleration(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& qddot,
+                                EigenPtr<VectorX<T>> vdot) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -80,22 +80,14 @@ void WeldMobilizer<T>::MapQDotToVelocity(
 }
 
 template <typename T>
-void WeldMobilizer<T>::MapAccelerationToQDDot(
-    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& vdot,
-    EigenPtr<VectorX<T>> qddot) const {
-  DRAKE_ASSERT(vdot.size() == kNv);
-  DRAKE_ASSERT(qddot != nullptr);
-  DRAKE_ASSERT(qddot->size() == kNq);
-}
+void WeldMobilizer<T>::DoMapAccelerationToQDDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>&,
+    EigenPtr<VectorX<T>>) const {}
 
 template <typename T>
-void WeldMobilizer<T>::MapQDDotToAcceleration(
-    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qddot,
-    EigenPtr<VectorX<T>> vdot) const {
-  DRAKE_ASSERT(qddot.size() == kNq);
-  DRAKE_ASSERT(vdot != nullptr);
-  DRAKE_ASSERT(vdot->size() == kNv);
-}
+void WeldMobilizer<T>::DoMapQDDotToAcceleration(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>&,
+    EigenPtr<VectorX<T>>) const {}
 
 template <typename T>
 template <typename ToScalar>

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -121,18 +121,6 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
                          const Eigen::Ref<const VectorX<T>>& qdot,
                          EigenPtr<VectorX<T>> v) const final;
 
-  // This override is a no-op since this mobilizer has no generalized
-  // velocities associated with it.
-  void MapAccelerationToQDDot(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& vdot,
-                              EigenPtr<VectorX<T>> qddot) const final;
-
-  // This override is a no-op since this mobilizer has no generalized
-  // velocities associated with it.
-  void MapQDDotToAcceleration(const systems::Context<T>& context,
-                              const Eigen::Ref<const VectorX<T>>& qddot,
-                              EigenPtr<VectorX<T>> vdot) const final;
-
   bool can_rotate() const final { return false; }
   bool can_translate() const final { return false; }
 
@@ -150,6 +138,18 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = 0x0 matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // This override is a no-op since this mobilizer has no generalized
+  // velocities associated with it.
+  void DoMapAccelerationToQDDot(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& vdot,
+                                EigenPtr<VectorX<T>> qddot) const final;
+
+  // This override is a no-op since this mobilizer has no generalized
+  // velocities associated with it.
+  void DoMapQDDotToAcceleration(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& qddot,
+                                EigenPtr<VectorX<T>> vdot) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;


### PR DESCRIPTION
This is one in a series of PRs to help address issue #22630. It improves MapQDDotToAcceleration() so it is no longer a virtual function.  Instead, it does basic argument checking (which was formerly done in _all_ Mobilizer sub-classes) and then calls the newly created virtual function DoMapQDDotToAcceleration().  This technique is used also for and MapAccelerationToQDDot().

A subsequent PR will clean up MapQDotToVelocity() and MapVelocityToQDot().

FYI: Since mobilizers are Drake internal classes, after the internal mobilizer work is complete, there will be PRs (code and testing) for the public API in MultibodyPlant to address issue #22630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22983)
<!-- Reviewable:end -->
