### PR TITLE
ProjectedGradientDescentSolver Bugfix where the Wrong Projection Solver is Selected

### DIFF
--- a/solvers/projected_gradient_descent_solver.cc
+++ b/solvers/projected_gradient_descent_solver.cc
@@ -153,7 +153,7 @@ void ProjectedGradientDescentSolver::DoSolve2(
   // previous feasible iterate, or some other strategy.)
   std::unique_ptr<solvers::SolverInterface> projection_solver_interface;
   if (!projection_solver_interface_) {
-    const SolverId solver_id = ChooseBestSolver(prog);
+    const SolverId solver_id = ChooseBestSolver(*projection_prog_ptr);
     projection_solver_interface = MakeSolver(solver_id);
   }
   std::function<bool(const VectorXd&, VectorXd*)> projection_function =

--- a/solvers/test/projected_gradient_descent_solver_test.cc
+++ b/solvers/test/projected_gradient_descent_solver_test.cc
@@ -290,8 +290,15 @@ TEST_F(UnboundedLinearProgramTest0, TestProjectedGradientDescentSolver) {
 
 GTEST_TEST(ProjectedGradientDescentSolverTest, TestNonconvexQP) {
   ProjectedGradientDescentSolver solver;
-  const double kTol = 2e-4;
-  TestNonconvexQP(solver, false, kTol);
+
+  const double kConvergenceTol = 1e-7;
+  SolverOptions options;
+  options.SetOption(ProjectedGradientDescentSolver::id(),
+                    ProjectedGradientDescentSolver::ConvergenceTolOptionName(),
+                    kConvergenceTol);
+
+  const double kTol = 3e-4;
+  TestNonconvexQP(solver, false, kTol, &options);
 }
 
 GTEST_TEST(ProjectedGradientDescentSolverTest, TestL2NormCost) {

--- a/solvers/test/quadratic_program_examples.cc
+++ b/solvers/test/quadratic_program_examples.cc
@@ -682,7 +682,7 @@ void TestEqualityConstrainedQPDualSolution2(const SolverInterface& solver) {
 }
 
 void TestNonconvexQP(const SolverInterface& solver, bool convex_solver,
-                     double tol) {
+                     double tol, SolverOptions* options) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>();
   auto nonconvex_cost = prog.AddQuadraticCost(-x(0) * x(0) + x(1) * x(1) + 2);
@@ -700,7 +700,11 @@ void TestNonconvexQP(const SolverInterface& solver, bool convex_solver,
   } else {
     MathematicalProgramResult result;
     // Use a non-zero initial guess, since at x = [0, 0], the gradient is 0.
-    solver.Solve(prog, Eigen::Vector2d(0.1, 0.1), std::nullopt, &result);
+    if (options) {
+      solver.Solve(prog, Eigen::Vector2d(0.1, 0.1), *options, &result);
+    } else {
+      solver.Solve(prog, Eigen::Vector2d(0.1, 0.1), std::nullopt, &result);
+    }
     EXPECT_TRUE(result.is_success());
     EXPECT_TRUE(
         CompareMatrices(result.GetSolution(x), Eigen::Vector2d(1, 0), tol));

--- a/solvers/test/quadratic_program_examples.h
+++ b/solvers/test/quadratic_program_examples.h
@@ -192,7 +192,7 @@ void TestEqualityConstrainedQPDualSolution2(const SolverInterface& solver);
  * Test nonconvex QP.
  */
 void TestNonconvexQP(const SolverInterface& solver, bool convex_solver,
-                     double tol = 1E-5);
+                     double tol = 1E-5, SolverOptions* options = nullptr);
 
 /**
  Test formulating a QP where adding costs or constraints where the `vars` vector


### PR DESCRIPTION
+@hongkai-dai for feature review.

cc @rpoyner-tri since you were platform review for that PR -- I assume we'll want to get this fix in pretty quickly?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22987)
<!-- Reviewable:end -->
