### PR TITLE
[fem] Parallel residual and tangent matrix computation

### DIFF
--- a/multibody/fem/acceleration_newmark_scheme.cc
+++ b/multibody/fem/acceleration_newmark_scheme.cc
@@ -6,6 +6,12 @@ namespace fem {
 namespace internal {
 
 template <typename T>
+std::unique_ptr<DiscreteTimeIntegrator<T>>
+AccelerationNewmarkScheme<T>::DoClone() const {
+  return std::make_unique<AccelerationNewmarkScheme<T>>(dt(), gamma_, beta_);
+}
+
+template <typename T>
 void AccelerationNewmarkScheme<T>::DoUpdateStateFromChangeInUnknowns(
     const VectorX<T>& dz, FemState<T>* state) const {
   const VectorX<T>& a = state->GetAccelerations();
@@ -39,5 +45,5 @@ void AccelerationNewmarkScheme<T>::DoAdvanceOneTimeStep(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::fem::internal::AccelerationNewmarkScheme);

--- a/multibody/fem/acceleration_newmark_scheme.h
+++ b/multibody/fem/acceleration_newmark_scheme.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "drake/common/default_scalars.h"
 #include "drake/multibody/fem/discrete_time_integrator.h"
 
@@ -24,7 +26,7 @@ namespace internal {
 
  [Newmark, 1959] Newmark, Nathan M. "A method of computation for structural
  dynamics." Journal of the engineering mechanics division 85.3 (1959): 67-94.
- @tparam_nonsymbolic_scalar */
+ @tparam_default_scalar */
 template <typename T>
 class AccelerationNewmarkScheme final : public DiscreteTimeIntegrator<T> {
  public:
@@ -45,6 +47,8 @@ class AccelerationNewmarkScheme final : public DiscreteTimeIntegrator<T> {
   using DiscreteTimeIntegrator<T>::dt;
 
  private:
+  std::unique_ptr<DiscreteTimeIntegrator<T>> DoClone() const final;
+
   /* The weights much match the partials in DoAdvanceOneTimeStep(). */
   Vector3<T> DoGetWeights() const final {
     return {beta_ * dt() * dt(), gamma_ * dt(), 1.0};
@@ -69,5 +73,5 @@ class AccelerationNewmarkScheme final : public DiscreteTimeIntegrator<T> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::fem::internal::AccelerationNewmarkScheme);

--- a/multibody/fem/discrete_time_integrator.cc
+++ b/multibody/fem/discrete_time_integrator.cc
@@ -42,5 +42,5 @@ void DiscreteTimeIntegrator<T>::AdvanceOneTimeStep(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::fem::internal::DiscreteTimeIntegrator);

--- a/multibody/fem/discrete_time_integrator.h
+++ b/multibody/fem/discrete_time_integrator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "drake/common/default_scalars.h"
 #include "drake/multibody/fem/fem_state.h"
 
@@ -40,13 +42,16 @@ namespace internal {
 
  DiscreteTimeIntegrator provides the interface to query the relationship between
  the states (`q`, `v`, and `a`) and the unknown variable `z`.
- @tparam_nonsymbolic_scalar */
+ @tparam_default_scalar */
 template <typename T>
 class DiscreteTimeIntegrator {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteTimeIntegrator);
 
   virtual ~DiscreteTimeIntegrator() = default;
+
+  /* Returns an identical copy of `this` DiscreteTimeIntegrator. */
+  std::unique_ptr<DiscreteTimeIntegrator<T>> Clone() const { return DoClone(); }
 
   /* Returns (αₚ, αᵥ, αₐ), the derivative of (q, v, a) with respect to the
    unknown variable z (See class documentation). These weights can be used to
@@ -88,6 +93,10 @@ class DiscreteTimeIntegrator {
   }
 
   /* Derived classes must override this method to implement the NVI
+   DoClone(). */
+  virtual std::unique_ptr<DiscreteTimeIntegrator<T>> DoClone() const = 0;
+
+  /* Derived classes must override this method to implement the NVI
    GetWeights(). */
   virtual Vector3<T> DoGetWeights() const = 0;
 
@@ -114,5 +123,5 @@ class DiscreteTimeIntegrator {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::fem::internal::DiscreteTimeIntegrator);

--- a/multibody/fem/fem_model.cc
+++ b/multibody/fem/fem_model.cc
@@ -51,16 +51,15 @@ void FemModel<T>::CalcResidual(const FemState<T>& fem_state,
 
 template <typename T>
 void FemModel<T>::CalcTangentMatrix(
-    const FemState<T>& fem_state, const Vector3<T>& weights,
+    const FemState<T>& fem_state,
     contact_solvers::internal::Block3x3SparseSymmetricMatrix* tangent_matrix)
     const {
   if constexpr (std::is_same_v<T, double>) {
     DRAKE_DEMAND(tangent_matrix != nullptr);
     DRAKE_DEMAND(tangent_matrix->rows() == num_dofs());
     DRAKE_DEMAND(tangent_matrix->cols() == num_dofs());
-    DRAKE_THROW_UNLESS(weights.minCoeff() >= 0.0);
     ThrowIfModelStateIncompatible(__func__, fem_state);
-    DoCalcTangentMatrix(fem_state, weights, tangent_matrix);
+    DoCalcTangentMatrix(fem_state, tangent_matrix);
     dirichlet_bc_.ApplyBoundaryConditionToTangentMatrix(tangent_matrix);
   } else {
     throw std::logic_error(
@@ -87,9 +86,12 @@ void FemModel<T>::ApplyBoundaryCondition(FemState<T>* fem_state) const {
 }
 
 template <typename T>
-FemModel<T>::FemModel()
+FemModel<T>::FemModel(const Vector3<T>& tangent_matrix_weights)
     : fem_state_system_(std::make_unique<internal::FemStateSystem<T>>(
-          VectorX<T>(0), VectorX<T>(0), VectorX<T>(0))) {}
+          VectorX<T>(0), VectorX<T>(0), VectorX<T>(0))),
+      tangent_matrix_weights_(tangent_matrix_weights) {
+  DRAKE_DEMAND(tangent_matrix_weights.minCoeff() >= 0.0);
+}
 
 template <typename T>
 void FemModel<T>::ThrowIfModelStateIncompatible(

--- a/multibody/fem/fem_solver.cc
+++ b/multibody/fem/fem_solver.cc
@@ -119,7 +119,7 @@ int FemSolver<T>::SolveLinearModel(
   model_->ApplyBoundaryCondition(&state);
   model_->CalcResidual(state, plant_data, &b);
   T residual_norm = b.norm();
-  model_->CalcTangentMatrix(state, integrator_->GetWeights(), &tangent_matrix);
+  model_->CalcTangentMatrix(state, &tangent_matrix);
   next_state_and_schur_complement_.schur_complement =
       contact_solvers::internal::SchurComplement(tangent_matrix,
                                                  nonparticipating_vertices);
@@ -141,7 +141,6 @@ int FemSolver<T>::SolveNonlinearModel(
   Block3x3SparseSymmetricMatrix& tangent_matrix = *scratch_.tangent_matrix;
   LinearSolver& linear_solver = scratch_.linear_solver;
   FemState<T>& state = *next_state_and_schur_complement_.state;
-
   model_->ApplyBoundaryCondition(&state);
   model_->CalcResidual(state, plant_data, &b);
   T residual_norm = b.norm();
@@ -156,8 +155,7 @@ int FemSolver<T>::SolveNonlinearModel(
   while (iter < max_iterations_ &&
          /* On first iteration, this is equivalent to residual_norm < abs_tol */
          !solver_converged(residual_norm, initial_residual_norm)) {
-    model_->CalcTangentMatrix(state, integrator_->GetWeights(),
-                              &tangent_matrix);
+    model_->CalcTangentMatrix(state, &tangent_matrix);
     linear_solver.UpdateMatrix(tangent_matrix);
     const bool factored = linear_solver.Factor();
     if (!factored) {
@@ -178,7 +176,7 @@ int FemSolver<T>::SolveNonlinearModel(
     return -1;
   }
   /* Build the Schur complement after the Newton iterations have converged. */
-  model_->CalcTangentMatrix(state, integrator_->GetWeights(), &tangent_matrix);
+  model_->CalcTangentMatrix(state, &tangent_matrix);
   next_state_and_schur_complement_.schur_complement =
       contact_solvers::internal::SchurComplement(tangent_matrix,
                                                  nonparticipating_vertices);

--- a/multibody/fem/test/discrete_time_integrator_test.cc
+++ b/multibody/fem/test/discrete_time_integrator_test.cc
@@ -22,6 +22,10 @@ class DummyScheme final : public DiscreteTimeIntegrator<double> {
   ~DummyScheme() = default;
 
  private:
+  std::unique_ptr<DiscreteTimeIntegrator<double>> DoClone() const final {
+    return std::make_unique<DummyScheme>(dt());
+  }
+
   Vector3d DoGetWeights() const final { return {1, 2, 3}; }
 
   const VectorXd& DoGetUnknowns(const FemState<double>& state) const final {

--- a/multibody/fem/test/dummy_element.h
+++ b/multibody/fem/test/dummy_element.h
@@ -25,6 +25,10 @@ struct DummyData {
   Vector<T, num_dofs> element_q;
   Vector<T, num_dofs> element_v;
   Vector<T, num_dofs> element_a;
+  Vector<T, num_dofs> inverse_dynamics;
+  Eigen::Matrix<T, num_dofs, num_dofs> stiffness_matrix;
+  Eigen::Matrix<T, num_dofs, num_dofs> damping_matrix;
+  Eigen::Matrix<T, num_dofs, num_dofs> tangent_matrix;
 };
 
 /* The traits for the DummyElement. In this case, all of the traits are unique
@@ -101,7 +105,8 @@ class DummyElement final : public FemElement<DummyElement<is_linear>> {
 
   /* Implements FemElement::ComputeData(). Returns the sum of the last entries
    in each state. */
-  typename Traits::Data DoComputeData(const FemState<T>& state) const {
+  typename Traits::Data DoComputeData(const FemState<T>& state,
+                                      const Vector3<T>& weights) const {
     const int state_dofs = state.num_dofs();
     const auto& q = state.GetPositions();
     const auto& v = state.GetVelocities();
@@ -113,33 +118,27 @@ class DummyElement final : public FemElement<DummyElement<is_linear>> {
     data.element_q = this->ExtractElementDofs(q);
     data.element_v = this->ExtractElementDofs(v);
     data.element_a = this->ExtractElementDofs(a);
+    CalcInverseDynamics(data, &data.inverse_dynamics);
+    data.stiffness_matrix = stiffness_matrix();
+    data.damping_matrix =
+        this->damping_model().stiffness_coeff_beta() * stiffness_matrix() +
+        this->damping_model().mass_coeff_alpha() * mass_matrix();
+    data.tangent_matrix = weights(0) * stiffness_matrix() +
+                          weights(1) * data.damping_matrix +
+                          weights(2) * mass_matrix();
     return data;
   }
 
-  /* Implements FemElement::CalcInverseDynamics().
-   The inverse dynamics force is equal to a dummy nonzero value if the element
-   has zero velocity and zero acceleration. Otherwise the force is zero.*/
-  void DoCalcInverseDynamics(
-      const Data& data, EigenPtr<Vector<T, kNumDofs>> external_force) const {
+  /*  A dummy inverse dynamics force computation such that the force is equal to
+   a dummy nonzero value if the element has zero velocity and zero acceleration.
+   Otherwise the force is zero.*/
+  void CalcInverseDynamics(const Data& data,
+                           EigenPtr<Vector<T, kNumDofs>> external_force) const {
     if (data.element_v.norm() == 0.0 && data.element_a.norm() == 0.0) {
       *external_force = this->inverse_dynamics_force();
     } else {
       external_force->setZero();
     }
-  }
-
-  /* Implements FemElement::AddScaledStiffnessMatrix(). */
-  void DoAddScaledStiffnessMatrix(
-      const Data&, const T& scale,
-      EigenPtr<Eigen::Matrix<T, kNumDofs, kNumDofs>> K) const {
-    *K += scale * stiffness_matrix();
-  }
-
-  /* Implements FemElement::AddScaledMassMatrix(). */
-  void DoAddScaledMassMatrix(
-      const Data&, const T& scale,
-      EigenPtr<Eigen::Matrix<T, kNumDofs, kNumDofs>> M) const {
-    *M += scale * mass_matrix();
   }
 
   /* Implements FemElement::DoAddScaledExternalForces(). Here we add the force

--- a/multibody/fem/test/dummy_model.h
+++ b/multibody/fem/test/dummy_model.h
@@ -53,12 +53,14 @@ class DummyModel final : public FemModelImpl<DummyElement<is_linear>> {
   };
 
   /* Constructs an empty DummyModel. */
-  DummyModel() = default;
+  explicit DummyModel(const Vector3<T>& weights)
+      : FemModelImpl<DummyElement<is_linear>>(weights) {}
 
   ~DummyModel() = default;
 
   std::unique_ptr<FemModel<T>> DoClone() const final {
-    auto clone = std::make_unique<DummyModel<is_linear>>();
+    auto clone =
+        std::make_unique<DummyModel<is_linear>>(this->tangent_matrix_weights());
     clone->reference_positions_ = reference_positions_;
     clone->SetFrom(*this);
     return clone;

--- a/multibody/fem/test/fem_element_test.cc
+++ b/multibody/fem/test/fem_element_test.cc
@@ -53,7 +53,9 @@ class FemElementTest : public ::testing::Test {
           /* There's only one element in the system. */
           element_data->resize(1);
           const FemState<T> fem_state(fem_state_system_.get(), &context);
-          (*element_data)[0] = this->element_.ComputeData(fem_state);
+          const Vector3d dummy_weights(1, 2, 3);
+          (*element_data)[0] =
+              this->element_.ComputeData(fem_state, dummy_weights);
         };
 
     cache_index_ =
@@ -102,60 +104,6 @@ TEST_F(FemElementTest, ExtractElementDofs) {
   }
   EXPECT_EQ(DummyElement<true>::ExtractElementDofs(kNodeIndices, q()),
             expected_element_q);
-}
-
-/* The following tests confirm that CalcInverseDynamics(),
- AddScaledStiffnessMatrix, AddScaledDampingMatrix(), AddScaledMassMatrix(),
- correctly invoke their DoCalc and DoAdd counterparts. We confirm this with a
- custom subclass of FemElement whose implementation returns/adds a specific
- value. */
-TEST_F(FemElementTest, InverseDynamics) {
-  Vector<T, DummyElementTraits::num_dofs> external_force;
-  element_.CalcInverseDynamics(EvalElementData(), &external_force);
-  const Vector<T, kNumDofs> zero_vector = Vector<T, kNumDofs>::Zero();
-  EXPECT_EQ(external_force, zero_vector);
-
-  fem_state_->SetPositions(zero_vector);
-  fem_state_->SetVelocities(zero_vector);
-  fem_state_->SetAccelerations(zero_vector);
-  element_.CalcInverseDynamics(EvalElementData(), &external_force);
-  EXPECT_EQ(external_force, element_.inverse_dynamics_force());
-}
-
-TEST_F(FemElementTest, StiffnessMatrix) {
-  Eigen::Matrix<T, DummyElementTraits::num_dofs, DummyElementTraits::num_dofs>
-      K;
-  K.setZero();
-  const T scale = 3.14;
-  element_.AddScaledStiffnessMatrix(EvalElementData(), scale, &K);
-  EXPECT_EQ(K, scale * element_.stiffness_matrix());
-}
-
-TEST_F(FemElementTest, DampingMatrix) {
-  Eigen::Matrix<T, DummyElementTraits::num_dofs, DummyElementTraits::num_dofs>
-      D;
-  D.setZero();
-  const T scale = 3.14;
-  element_.AddScaledDampingMatrix(EvalElementData(), scale, &D);
-
-  Eigen::Matrix<T, DummyElementTraits::num_dofs, DummyElementTraits::num_dofs>
-      expected_D;
-  expected_D.setZero();
-  element_.AddScaledMassMatrix(
-      EvalElementData(), scale * kDampingModel.mass_coeff_alpha(), &expected_D);
-  element_.AddScaledStiffnessMatrix(
-      EvalElementData(), scale * kDampingModel.stiffness_coeff_beta(),
-      &expected_D);
-  EXPECT_EQ(D, expected_D);
-}
-
-TEST_F(FemElementTest, MassMatrix) {
-  Eigen::Matrix<T, DummyElementTraits::num_dofs, DummyElementTraits::num_dofs>
-      M;
-  M.setZero();
-  const T scale = 3.14;
-  element_.AddScaledMassMatrix(EvalElementData(), scale, &M);
-  EXPECT_EQ(M, scale * element_.mass_matrix());
 }
 
 TEST_F(FemElementTest, ExternalForce) {

--- a/multibody/fem/velocity_newmark_scheme.cc
+++ b/multibody/fem/velocity_newmark_scheme.cc
@@ -6,6 +6,13 @@ namespace fem {
 namespace internal {
 
 template <typename T>
+std::unique_ptr<DiscreteTimeIntegrator<T>> VelocityNewmarkScheme<T>::DoClone()
+    const {
+  return std::make_unique<VelocityNewmarkScheme<T>>(dt(), gamma_,
+                                                    gamma_ * beta_over_gamma_);
+}
+
+template <typename T>
 void VelocityNewmarkScheme<T>::DoUpdateStateFromChangeInUnknowns(
     const VectorX<T>& dz, FemState<T>* state) const {
   const VectorX<T>& a = state->GetAccelerations();
@@ -41,5 +48,5 @@ void VelocityNewmarkScheme<T>::DoAdvanceOneTimeStep(
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::fem::internal::VelocityNewmarkScheme);

--- a/multibody/fem/velocity_newmark_scheme.h
+++ b/multibody/fem/velocity_newmark_scheme.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "drake/common/default_scalars.h"
 #include "drake/multibody/fem/discrete_time_integrator.h"
 
@@ -24,7 +26,7 @@ namespace internal {
 
  [Newmark, 1959] Newmark, Nathan M. "A method of computation for structural
  dynamics." Journal of the engineering mechanics division 85.3 (1959): 67-94.
- @tparam_nonsymbolic_scalar */
+ @tparam_default_scalar */
 template <typename T>
 class VelocityNewmarkScheme final : public DiscreteTimeIntegrator<T> {
  public:
@@ -48,6 +50,8 @@ class VelocityNewmarkScheme final : public DiscreteTimeIntegrator<T> {
   using DiscreteTimeIntegrator<T>::dt;
 
  private:
+  std::unique_ptr<DiscreteTimeIntegrator<T>> DoClone() const final;
+
   /* The weights much match the partials in DoAdvanceOneTimeStep(). */
   Vector3<T> DoGetWeights() const final {
     return {beta_over_gamma_ * dt(), 1.0, one_over_dt_gamma_};
@@ -73,5 +77,5 @@ class VelocityNewmarkScheme final : public DiscreteTimeIntegrator<T> {
 }  // namespace multibody
 }  // namespace drake
 
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::fem::internal::VelocityNewmarkScheme);

--- a/multibody/fem/volumetric_element.h
+++ b/multibody/fem/volumetric_element.h
@@ -40,6 +40,14 @@ struct VolumetricElementData {
   /* The derivative of first Piola stress with respect to the deformation
    gradient evaluated at quadrature points. */
   std::array<math::internal::FourthOrderTensor<T>, num_quadrature_points> dPdF;
+  /* Inverse dynamics: Ma-fₑ(x)-fᵥ(x, v). */
+  Vector<T, num_dofs> inverse_dynamics;
+  /* The stiffness matrix K. */
+  Eigen::Matrix<T, num_dofs, num_dofs> stiffness_matrix;
+  /* The damping matrix D = aM + bK where M is the mass matrix. */
+  Eigen::Matrix<T, num_dofs, num_dofs> damping_matrix;
+  /* The tangent matrix matrix = w0*K + w1*D + w2*D. */
+  Eigen::Matrix<T, num_dofs, num_dofs> tangent_matrix;
 };
 
 /* Forward declaration needed for defining the traits below. */
@@ -199,12 +207,12 @@ class VolumetricElement
     mass_matrix_ = PrecomputeMassMatrix();
   }
 
-  /* Calculates the elastic potential energy (in joules) stored in this element
-   using the given `data`. */
-  T CalcElasticEnergy(const Data& data) const {
+  /* Calculates the elastic potential energy (in joules) stored in this element.
+   */
+  T CalcElasticEnergy(const std::array<T, num_quadrature_points>& Psi) const {
     T elastic_energy = 0;
     for (int q = 0; q < num_quadrature_points; ++q) {
-      elastic_energy += reference_volume_[q] * data.Psi[q];
+      elastic_energy += reference_volume_[q] * Psi[q];
     }
     return elastic_energy;
   }
@@ -219,12 +227,13 @@ class VolumetricElement
    given force vector. The negative elastic force is the derivative of the
    elastic energy (see CalcElasticEnergy()) with respect to the generalized
    positions of the nodes.
-   @param[in] data            The FEM data on this element used to evaluate the
-                              negative elastic force.
+   @param[in] P               The first Piola-Kirchhoff stress evaluated at the
+                              quadrature points of this element.
    @param[in, out] neg_force  The negative force vector to be added to.
    @pre neg_force != nullptr. */
-  void AddNegativeElasticForce(const Data& data,
-                               EigenPtr<Vector<T, num_dofs>> neg_force) const {
+  void AddNegativeElasticForce(
+      const std::array<Matrix3<T>, num_quadrature_points>& P,
+      EigenPtr<Vector<T, num_dofs>> neg_force) const {
     DRAKE_ASSERT(neg_force != nullptr);
     auto neg_force_matrix = Eigen::Map<Eigen::Matrix<T, 3, num_nodes>>(
         neg_force->data(), 3, num_nodes);
@@ -234,29 +243,27 @@ class VolumetricElement
        Notice that Fᵢⱼ = xᵃᵢdSᵃ/dXⱼ, so dFᵢⱼ/dxᵇₖ = δᵃᵇδᵢₖdSᵃ/dXⱼ,
        and dΨ/dFᵢⱼ = Pᵢⱼ, so the integrand becomes
        PᵢⱼδᵃᵇδᵢₖdSᵃ/dXⱼ = PₖⱼdSᵇ/dXⱼ = P * dSdX.transpose() */
-      neg_force_matrix += reference_volume_[q] * data.P[q] * dSdX_transpose_[q];
+      neg_force_matrix += reference_volume_[q] * P[q] * dSdX_transpose_[q];
     }
   }
 
   /* Adds the negative damping force on the nodes of this element into the given
    `negative_damping_force`. The negative damping force is given by the product
    of the damping matrix with the velocity of the nodes.
-   @param[in] data            The FEM data on this element used to evaluate the
-                              negative damping force.
+   @param[in] damping_matrix  The damping matrix of this element.
+   @param[in] element_v       The velocities of the vertex nodes of this
+                              element.
    @param[in, out] neg_force  The negative force vector to be added to.
    @pre neg_force != nullptr. */
-  void AddNegativeDampingForce(const Data& data,
-                               EigenPtr<Vector<T, num_dofs>> neg_force) const {
+  void AddNegativeDampingForce(
+      const Eigen::Matrix<T, num_dofs, num_dofs>& damping_matrix,
+      const Vector<T, num_dofs>& element_v,
+      EigenPtr<Vector<T, num_dofs>> neg_force) const {
     DRAKE_ASSERT(neg_force != nullptr);
-    Eigen::Matrix<T, num_dofs, num_dofs> damping_matrix =
-        Eigen::Matrix<T, num_dofs, num_dofs>::Zero();
-    // TODO(xuchenhan-tri): We should cache the dampign matrix to avoid
-    // repeatedly calculate the mass and the stiffness matrix.
-    this->AddScaledDampingMatrix(data, 1, &damping_matrix);
     /* Note that the damping force fᵥ = -D * v, where D is the damping matrix.
      As we are accumulating the negative damping force here, the `+=` sign
      should be used. */
-    *neg_force += damping_matrix * data.element_v;
+    *neg_force += damping_matrix * element_v;
   }
 
   /* The matrix calculated here is the same as the stiffness matrix
@@ -287,14 +294,15 @@ class VolumetricElement
 
   /* Adds a scaled derivative of the elastic force on the nodes of this
    element into the given matrix.
-   @param[in] data    The FEM data on this element used to evaluate the elastic
-                      force derivatives.
+   @param[in] dPdF    The PK1 stress derivative w.r.t. the deformation gradient
+                      evaluated at the quadrature points of this element.
    @param[in] scale   The scaling factor applied to the derivative.
    @param[in, out] K  The scaled force derivative matrix to be added to.
    @pre K != nullptr. */
   void AddScaledElasticForceDerivative(
-      const Data& data, const T& scale,
-      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> K) const {
+      const std::array<math::internal::FourthOrderTensor<T>,
+                       num_quadrature_points>& dPdF,
+      const T& scale, EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> K) const {
     DRAKE_ASSERT(K != nullptr);
     // clang-format off
     /* Let e be the elastic energy, then the elastic force f is given by
@@ -319,7 +327,7 @@ class VolumetricElement
           /* Note that the scale is negated here because the tensor contraction
            gives the second derivative of energy, which is the opposite of the
            force derivative. */
-          data.dPdF[q].ContractWithVectors(
+          dPdF[q].ContractWithVectors(
               dSdX_transpose_[q].col(a),
               dSdX_transpose_[q].col(b) * reference_volume_[q] * -scale, &K_ab);
           AccumulateMatrixBlock(K_ab, a, b, K);
@@ -328,38 +336,61 @@ class VolumetricElement
     }
   }
 
-  /* Implements FemElement::CalcInverseDynamics(). */
-  void DoCalcInverseDynamics(const Data& data,
-                             EigenPtr<Vector<T, num_dofs>> residual) const {
+  /* Calculates the tangent matrix for the element by combining the stiffness
+   matrix, damping matrix, and the mass matrix according to the given `weights`.
+   In particular, given a weight of (w₀, w₁, w₂), the tangent matrix is equal to
+   w₀⋅K + w₁⋅D + w₂⋅M, where K, D, and M are stiffness, damping, and mass matrix
+   respectively.
+   @param[in]  weights           The weights to be used for the stiffness,
+                                 damping, and mass matrices.
+   @param[in]  stiffness_matrix  The stiffness matrix of this element.
+   @param[out] tangent_matrix    The tangent matrix of this element. All entries
+                                 are reset by this function. */
+  void CalcTangentMatrix(
+      const Vector3<T>& weights,
+      const Eigen::Matrix<T, num_dofs, num_dofs>& stiffness_matrix,
+      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> tangent_matrix) const {
+    DRAKE_ASSERT(tangent_matrix != nullptr);
+    const T stiffness_weight =
+        weights(0) + weights(1) * this->damping_model().stiffness_coeff_beta();
+    const T mass_weight =
+        weights(2) + weights(1) * this->damping_model().mass_coeff_alpha();
+    tangent_matrix->noalias() = stiffness_weight * stiffness_matrix;
+    tangent_matrix->noalias() += mass_weight * mass_matrix_;
+  }
+
+  /* Calculates the force required to induce the acceleration `a` given the
+   configuration `x` and velocities `v`, with `x`, `v`, and `a` stored in
+   `data`. The required force equals is ID(a, x, v) = Ma-fₑ(x)-fᵥ(x, v), where M
+   is the mass matrix, fₑ(x) is the elastic force, fᵥ(x, v) is the damping
+   force. The residual is then given by ID(a, x, v) - fₑₓₜ. Notice that the
+   result is "discrete" in space and "continuous" in time.
+   @param[in] damping_matrix  The damping matrix of this element.
+   @param[in] P               The first Piola-Kirchhoff stress evaluated at the
+                              quadrature points of this element.
+   @param[in] element_v       The velocities of the vertex nodes of this
+                              element.
+   @param[in] element_a       The accelerations of the vertex nodes of this
+                              element.
+   @param[out] result         The resulting inverse dynamics force. All values
+                              in `result` will be overwritten.
+   @pre result != nullptr */
+  void CalcInverseDynamics(
+      const Eigen::Matrix<T, num_dofs, num_dofs>& damping_matrix,
+      const std::array<Matrix3<T>, num_quadrature_points>& P,
+      const Vector<T, num_dofs>& element_v,
+      const Vector<T, num_dofs>& element_a,
+      EigenPtr<Vector<T, num_dofs>> result) const {
     /* residual = Ma-fₑ(x)-fᵥ(x, v), where M is the mass matrix, fₑ(x) is
      the elastic force, and fᵥ(x, v) is the damping force. */
-    *residual += mass_matrix_ * data.element_a;
-    this->AddNegativeElasticForce(data, residual);
-    AddNegativeDampingForce(data, residual);
-  }
-
-  /* Implements FemElement::DoAddScaledStiffnessMatrix().
-   @warning This method calculates a first-order approximation of the stiffness
-   matrix. In other words, the contribution of the term ∂fᵥ(x, v)/∂x is ignored
-   as it involves complex second derivatives of the elastic force. It also
-   filters out any negative eigenvalues by clamping them to zero. */
-  void DoAddScaledStiffnessMatrix(
-      const Data& data, const T& scale,
-      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> K) const {
-    /* Negate `scale` since stiffness matrix is the negative force derivative.
-     */
-    this->AddScaledElasticForceDerivative(data, -scale, K);
-  }
-
-  /* Implements FemElement::DoAddScaledMassMatrix(). */
-  void DoAddScaledMassMatrix(
-      const Data&, const T& scale,
-      EigenPtr<Eigen::Matrix<T, num_dofs, num_dofs>> M) const {
-    *M += scale * mass_matrix_;
+    *result = mass_matrix_ * element_a;
+    this->AddNegativeElasticForce(P, result);
+    AddNegativeDampingForce(damping_matrix, element_v, result);
   }
 
   /* Implements FemElement::ComputeData(). */
-  Data DoComputeData(const FemState<T>& state) const {
+  Data DoComputeData(const FemState<T>& state,
+                     const Vector3<T>& weights) const {
     Data data;
     data.element_q = this->ExtractElementDofs(state.GetPositions());
     data.element_q0 =
@@ -387,6 +418,14 @@ class VolumetricElement
       this->constitutive_model().CalcFilteredHessian(
           data.deformation_gradient_data[q], &(data.dPdF[q]));
     }
+    data.stiffness_matrix.setZero();
+    AddScaledElasticForceDerivative(data.dPdF, -1.0, &data.stiffness_matrix);
+    data.damping_matrix =
+        this->damping_model().stiffness_coeff_beta() * data.stiffness_matrix +
+        this->damping_model().mass_coeff_alpha() * mass_matrix_;
+    CalcInverseDynamics(data.damping_matrix, data.P, data.element_v,
+                        data.element_a, &data.inverse_dynamics);
+    CalcTangentMatrix(weights, data.stiffness_matrix, &data.tangent_matrix);
     return data;
   }
 

--- a/multibody/fem/volumetric_model.h
+++ b/multibody/fem/volumetric_model.h
@@ -165,7 +165,8 @@ class VolumetricModel : public FemModelImpl<Element> {
   };
 
   /* Creates a new empty VolumetricModel. */
-  VolumetricModel() = default;
+  explicit VolumetricModel(const Vector3<T>& tangent_matrix_weights)
+      : FemModelImpl<Element>(tangent_matrix_weights) {}
 
   ~VolumetricModel() = default;
 
@@ -180,14 +181,15 @@ class VolumetricModel : public FemModelImpl<Element> {
     DRAKE_DEMAND(static_cast<int>(element_data.size()) == this->num_elements());
     const auto& elements = this->elements();
     for (int e = 0; e < this->num_elements(); ++e) {
-      energy += elements[e].CalcElasticEnergy(element_data[e]);
+      energy += elements[e].CalcElasticEnergy(element_data[e].Psi);
     }
     return energy;
   }
 
  private:
   std::unique_ptr<FemModel<T>> DoClone() const final {
-    auto clone = std::make_unique<VolumetricModel<Element>>();
+    auto clone = std::make_unique<VolumetricModel<Element>>(
+        this->tangent_matrix_weights());
     clone->reference_positions_ = reference_positions_;
     clone->SetFrom(*this);
     return clone;

--- a/multibody/plant/deformable_driver.h
+++ b/multibody/plant/deformable_driver.h
@@ -12,7 +12,6 @@
 #include "drake/multibody/contact_solvers/sap/partial_permutation.h"
 #include "drake/multibody/contact_solvers/sap/sap_fixed_constraint.h"
 #include "drake/multibody/contact_solvers/schur_complement.h"
-#include "drake/multibody/fem/discrete_time_integrator.h"
 #include "drake/multibody/fem/fem_solver.h"
 #include "drake/multibody/plant/deformable_contact_info.h"
 #include "drake/multibody/plant/deformable_model.h"
@@ -367,9 +366,6 @@ class DeformableDriver : public ScalarConvertibleComponent<T> {
   /* Modeling information about all deformable bodies. */
   const DeformableModel<T>* const deformable_model_;
   const DiscreteUpdateManager<T>* const manager_;
-  /* The integrator used to advance deformable body free motion states in
-   time. */
-  std::unique_ptr<fem::internal::DiscreteTimeIntegrator<T>> integrator_;
 };
 
 }  // namespace internal

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -11,6 +11,7 @@
 #include "drake/common/parallelism.h"
 #include "drake/common/string_unordered_map.h"
 #include "drake/multibody/fem/deformable_body_config.h"
+#include "drake/multibody/fem/discrete_time_integrator.h"
 #include "drake/multibody/fem/fem_model.h"
 #include "drake/multibody/plant/constraint_specs.h"
 #include "drake/multibody/plant/deformable_ids.h"
@@ -350,6 +351,15 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
     return body_id_to_constraint_ids_.at(id);
   }
 
+  /** (Internal use only) Returns the time integrator used to for all FemModels
+   in this model.
+   @throws std::exception if the integrator hasn't been set. */
+  const multibody::fem::internal::DiscreteTimeIntegrator<T>& integrator()
+      const {
+    DRAKE_THROW_UNLESS(integrator_ != nullptr);
+    return *integrator_;
+  }
+
   /** Returns the output port index of the vertex positions port for all
    registered deformable bodies.
    @throws std::exception if called before `DeclareSceneGraphPorts()` is called.
@@ -479,6 +489,9 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
       fixed_constraint_specs_;
   systems::OutputPortIndex configuration_output_port_index_;
   Parallelism parallelism_{false};
+  /* The integrator used to advance deformable body free motion states in
+   time. */
+  std::unique_ptr<fem::internal::DiscreteTimeIntegrator<T>> integrator_;
 };
 
 }  // namespace multibody

--- a/multibody/plant/test/deformable_driver_contact_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_test.cc
@@ -134,8 +134,7 @@ class DeformableDriverContactTest : public ::testing::Test {
         fem_tangent_matrix = fem_model.MakeTangentMatrix();
     const FemState<double>& free_motion_state =
         EvalFreeMotionFemState(context, index);
-    fem_model.CalcTangentMatrix(free_motion_state, GetIntegratorWeights(),
-                                fem_tangent_matrix.get());
+    fem_model.CalcTangentMatrix(free_motion_state, fem_tangent_matrix.get());
     return fem_tangent_matrix->MakeDenseMatrix();
   }
 
@@ -164,7 +163,7 @@ class DeformableDriverContactTest : public ::testing::Test {
   }
 
   Vector3<double> GetIntegratorWeights() const {
-    return driver_->integrator_->GetWeights();
+    return model_->integrator().GetWeights();
   }
 
   MultibodyPlant<double>* plant_{nullptr};


### PR DESCRIPTION
Push more per-element computation into the parallel ComputeData function. This includes the inverser dynamics force, stiffness matrix, damping matrix, and the tangent matrix.

Remove the corresponding Calc methods from the FemElement class so that derived elements use their own signature to compute these quantities that better indicates the dependencies and allows more opportunistic optimizations.

The integrator weights are added to the FemState class as a parameter so that they could be passed to the element computation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22990)
<!-- Reviewable:end -->
