### PR TITLE
Use NVI to consolidate code in MapVelocityToQDot().

### DIFF
--- a/multibody/tree/curvilinear_mobilizer.cc
+++ b/multibody/tree/curvilinear_mobilizer.cc
@@ -203,22 +203,16 @@ void CurvilinearMobilizer<T>::DoCalcNplusDotMatrix(
 }
 
 template <typename T>
-void CurvilinearMobilizer<T>::MapVelocityToQDot(
+void CurvilinearMobilizer<T>::DoMapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
   *qdot = v;
 }
 
 template <typename T>
-void CurvilinearMobilizer<T>::MapQDotToVelocity(
+void CurvilinearMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   *v = qdot;
 }
 

--- a/multibody/tree/curvilinear_mobilizer.h
+++ b/multibody/tree/curvilinear_mobilizer.h
@@ -208,14 +208,6 @@ class CurvilinearMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const override;
-
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const override;
-
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
@@ -230,6 +222,16 @@ class CurvilinearMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  // Maps qdot to v, which for this mobilizer is v = q̇.
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -178,22 +178,16 @@ void PlanarMobilizer<T>::DoCalcNplusDotMatrix(
 }
 
 template <typename T>
-void PlanarMobilizer<T>::MapVelocityToQDot(
+void PlanarMobilizer<T>::DoMapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
   *qdot = v;
 }
 
 template <typename T>
-void PlanarMobilizer<T>::MapQDotToVelocity(
+void PlanarMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   *v = qdot;
 }
 

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -216,22 +216,22 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
-
-  // Maps qdot to v, which for this mobilizer is v = q̇.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
-
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
 
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
+
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  // Maps qdot to v, which for this mobilizer is v = q̇.
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ = zero matrix.
   void DoCalcNDotMatrix(const systems::Context<T>& context,

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -143,22 +143,16 @@ void PrismaticMobilizer<T>::DoCalcNplusDotMatrix(
 }
 
 template <typename T>
-void PrismaticMobilizer<T>::MapVelocityToQDot(
+void PrismaticMobilizer<T>::DoMapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
   *qdot = v;
 }
 
 template <typename T>
-void PrismaticMobilizer<T>::MapQDotToVelocity(
+void PrismaticMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   *v = qdot;
 }
 

--- a/multibody/tree/prismatic_mobilizer.h
+++ b/multibody/tree/prismatic_mobilizer.h
@@ -124,16 +124,6 @@ class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const final { return true; }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
-
-  // Maps qdot to v, which for this mobilizer is v = q̇.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
-
  protected:
   // Constructor for a PrismaticMobilizer between the inboard frame F and the
   // outboard frame M, granting a single translational degree of freedom along
@@ -155,6 +145,16 @@ class PrismaticMobilizer : public MobilizerImpl<T, 1, 1> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  // Maps qdot to v, which for this mobilizer is v = q̇.
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
   void DoMapAccelerationToQDDot(const systems::Context<T>& context,

--- a/multibody/tree/quaternion_floating_mobilizer.cc
+++ b/multibody/tree/quaternion_floating_mobilizer.cc
@@ -386,12 +386,9 @@ void QuaternionFloatingMobilizer<T>::DoCalcNplusMatrix(
 }
 
 template <typename T>
-void QuaternionFloatingMobilizer<T>::MapVelocityToQDot(
+void QuaternionFloatingMobilizer<T>::DoMapVelocityToQDot(
     const systems::Context<T>& context, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
   const Quaternion<T> q_FM = get_quaternion(context);
   // Angular component, q̇_WB = N(q)⋅w_WB:
   qdot->template head<4>() =
@@ -401,12 +398,9 @@ void QuaternionFloatingMobilizer<T>::MapVelocityToQDot(
 }
 
 template <typename T>
-void QuaternionFloatingMobilizer<T>::MapQDotToVelocity(
+void QuaternionFloatingMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& qdot, EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   const Quaternion<T> q_FM = get_quaternion(context);
   // Angular component, w_WB = N⁺(q)⋅q̇_WB:
   v->template head<3>() =

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -264,14 +264,6 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
 
   bool is_velocity_equal_to_qdot() const final { return false; }
 
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
-
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
-
   // This mobilizer can't use the default implementaion because it is
   // required to preserve bit-identical state.
   std::pair<Eigen::Quaternion<T>, Vector3<T>> GetPosePair(
@@ -297,6 +289,14 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
 
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
+
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -142,22 +142,16 @@ void RevoluteMobilizer<T>::DoCalcNplusDotMatrix(
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::MapVelocityToQDot(
+void RevoluteMobilizer<T>::DoMapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
   *qdot = v;
 }
 
 template <typename T>
-void RevoluteMobilizer<T>::MapQDotToVelocity(
+void RevoluteMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   *v = qdot;
 }
 

--- a/multibody/tree/revolute_mobilizer.h
+++ b/multibody/tree/revolute_mobilizer.h
@@ -119,16 +119,6 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
                                              const T& theta_dot) const;
   bool is_velocity_equal_to_qdot() const final { return true; }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
-
-  // Maps qdot to v, which for this mobilizer is v = q̇.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
-
  protected:
   // Constructor for a RevoluteMobilizer between the inboard frame F and the
   // outboard frame M, granting a single rotational degree of freedom about a
@@ -150,6 +140,16 @@ class RevoluteMobilizer : public MobilizerImpl<T, 1, 1> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  // Maps qdot to v, which for this mobilizer is v = q̇.
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
   void DoMapAccelerationToQDDot(const systems::Context<T>& context,

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -212,13 +212,9 @@ void RpyBallMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>& context,
 }
 
 template <typename T>
-void RpyBallMobilizer<T>::MapVelocityToQDot(
+void RpyBallMobilizer<T>::DoMapVelocityToQDot(
     const systems::Context<T>& context, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
-
   using std::abs;
   using std::cos;
   using std::sin;
@@ -306,12 +302,9 @@ void RpyBallMobilizer<T>::MapVelocityToQDot(
 }
 
 template <typename T>
-void RpyBallMobilizer<T>::MapQDotToVelocity(
+void RpyBallMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& qdot, EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   using std::cos;
   using std::sin;
 

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -243,6 +243,13 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   bool is_velocity_equal_to_qdot() const override { return false; }
 
+ protected:
+  void DoCalcNMatrix(const systems::Context<T>& context,
+                     EigenPtr<MatrixX<T>> N) const final;
+
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const final;
+
   // Maps the generalized velocity v, which corresponds to the angular velocity
   // w_FM, to time derivatives of roll-pitch-yaw angles θ₀, θ₁, θ₂ in qdot.
   //
@@ -261,9 +268,9 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // in large errors for qdot), this method aborts when the absolute value of
   // the cosine of θ₁ is smaller than 10⁻³, a number arbitrarily chosen to this
   // end.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const override;
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
 
   // Maps time derivatives of the roll-pitch-yaw angles θ₀, θ₁, θ₂ in qdot to
   // the generalized velocity v, which corresponds to the angular velocity
@@ -277,16 +284,9 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // @param[out] v
   //   A vector of generalized velocities for this Mobilizer which should
   //   correspond to a vector in ℝ³ for an angular velocity w_FM of M in F.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const override;
-
- protected:
-  void DoCalcNMatrix(const systems::Context<T>& context,
-                     EigenPtr<MatrixX<T>> N) const final;
-
-  void DoCalcNplusMatrix(const systems::Context<T>& context,
-                         EigenPtr<MatrixX<T>> Nplus) const final;
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/tree/rpy_floating_mobilizer.cc
+++ b/multibody/tree/rpy_floating_mobilizer.cc
@@ -304,13 +304,9 @@ void RpyFloatingMobilizer<T>::DoCalcNplusMatrix(
 }
 
 template <typename T>
-void RpyFloatingMobilizer<T>::MapVelocityToQDot(
+void RpyFloatingMobilizer<T>::DoMapVelocityToQDot(
     const systems::Context<T>& context, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
-
   using std::abs;
   using std::cos;
   using std::sin;
@@ -398,12 +394,9 @@ void RpyFloatingMobilizer<T>::MapVelocityToQDot(
 }
 
 template <typename T>
-void RpyFloatingMobilizer<T>::MapQDotToVelocity(
+void RpyFloatingMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>& context,
     const Eigen::Ref<const VectorX<T>>& qdot, EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   using std::cos;
   using std::sin;
 

--- a/multibody/tree/rpy_floating_mobilizer.h
+++ b/multibody/tree/rpy_floating_mobilizer.h
@@ -291,42 +291,6 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
 
   bool is_velocity_equal_to_qdot() const final { return false; }
 
-  // Maps the generalized velocity v to time derivatives of configuration
-  // qdot.
-  //
-  // @param[in] context
-  //   The context of the model this mobilizer belongs to.
-  // @param[in] v
-  //   A vector of generalized velocities for this mobilizer, packed as
-  //   documented in get_generalized_velocities().
-  // @param[out] qdot
-  //   Rates of the generalized positions, packed as documented in
-  //   get_generalized_positions().
-  //
-  // @warning The mapping from angular velocity to Euler angle's rates is
-  // singular for angle θ₁ such that θ₁ = π/2 + kπ, ∀ k ∈ ℤ. To avoid
-  // working close to this singularity (which could potentially result in large
-  // errors for qdot), this method aborts when the absolute value of the
-  // cosine of θ₁ is smaller than 10⁻³, a number arbitrarily chosen to this end.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
-
-  // Maps time derivatives of the configuration in qdot to
-  // the generalized velocities v.
-  //
-  // @param[in] context
-  //   The context of the model this mobilizer belongs to.
-  // @param[in] qdot
-  //   Rates of the generalized positions, packed as documented in
-  //   get_generalized_positions().
-  // @param[out] v
-  //   A vector of generalized velocities for this mobilizer, packed as
-  //   documented in get_generalized_velocities().
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
-
  protected:
   std::optional<QVector<T>> DoPoseToPositions(
       const Eigen::Quaternion<T> orientation,
@@ -349,6 +313,42 @@ class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
   // Implements Mobilizer's NVI, see Mobilizer::DoCalcNplusMatrix() for details.
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
+
+  // Maps the generalized velocity v to time derivatives of configuration
+  // qdot.
+  //
+  // @param[in] context
+  //   The context of the model this mobilizer belongs to.
+  // @param[in] v
+  //   A vector of generalized velocities for this mobilizer, packed as
+  //   documented in get_generalized_velocities().
+  // @param[out] qdot
+  //   Rates of the generalized positions, packed as documented in
+  //   get_generalized_positions().
+  //
+  // @warning The mapping from angular velocity to Euler angle's rates is
+  // singular for angle θ₁ such that θ₁ = π/2 + kπ, ∀ k ∈ ℤ. To avoid
+  // working close to this singularity (which could potentially result in large
+  // errors for qdot), this method aborts when the absolute value of the
+  // cosine of θ₁ is smaller than 10⁻³, a number arbitrarily chosen to this end.
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  // Maps time derivatives of the configuration in qdot to
+  // the generalized velocities v.
+  //
+  // @param[in] context
+  //   The context of the model this mobilizer belongs to.
+  // @param[in] qdot
+  //   Rates of the generalized positions, packed as documented in
+  //   get_generalized_positions().
+  // @param[out] v
+  //   A vector of generalized velocities for this mobilizer, packed as
+  //   documented in get_generalized_velocities().
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const final;

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -175,22 +175,16 @@ void ScrewMobilizer<T>::DoCalcNplusDotMatrix(
 }
 
 template <typename T>
-void ScrewMobilizer<T>::MapVelocityToQDot(const systems::Context<T>&,
-                                          const Eigen::Ref<const VectorX<T>>& v,
-                                          EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
+void ScrewMobilizer<T>::DoMapVelocityToQDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
+    EigenPtr<VectorX<T>> qdot) const {
   *qdot = v;
 }
 
 template <typename T>
-void ScrewMobilizer<T>::MapQDotToVelocity(
+void ScrewMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   *v = qdot;
 }
 

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -271,16 +271,6 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // Maps v to qdot, which for this mobilizer is q̇ = v.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
-
-  // Maps qdot to v, which for this mobilizer is v = q̇.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
-
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
@@ -295,6 +285,16 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  // Maps qdot to v, which for this mobilizer is v = q̇.
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   // Maps vdot to qddot, which for this mobilizer is q̈ = v̇.
   void DoMapAccelerationToQDDot(const systems::Context<T>& context,

--- a/multibody/tree/universal_mobilizer.cc
+++ b/multibody/tree/universal_mobilizer.cc
@@ -170,22 +170,16 @@ void UniversalMobilizer<T>::DoCalcNplusDotMatrix(
 }
 
 template <typename T>
-void UniversalMobilizer<T>::MapVelocityToQDot(
+void UniversalMobilizer<T>::DoMapVelocityToQDot(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
   *qdot = v;
 }
 
 template <typename T>
-void UniversalMobilizer<T>::MapQDotToVelocity(
+void UniversalMobilizer<T>::DoMapQDotToVelocity(
     const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
     EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
   *v = qdot;
 }
 

--- a/multibody/tree/universal_mobilizer.h
+++ b/multibody/tree/universal_mobilizer.h
@@ -215,18 +215,6 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // Performs the identity mapping from v to qdot since, for this mobilizer,
-  // v = q̇.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const override;
-
-  // Performs the identity mapping from qdot to v since, for this mobilizer,
-  // v = q̇.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const override;
-
  protected:
   void DoCalcNMatrix(const systems::Context<T>& context,
                      EigenPtr<MatrixX<T>> N) const final;
@@ -241,6 +229,16 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = zero matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // Maps v to qdot, which for this mobilizer is q̇ = v.
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  // Maps qdot to v, which for this mobilizer is v = q̇.
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -62,14 +62,14 @@ void WeldMobilizer<T>::DoCalcNplusDotMatrix(const systems::Context<T>&,
                                             EigenPtr<MatrixX<T>>) const {}
 
 template <typename T>
-void WeldMobilizer<T>::DoMapVelocityToQDot(
-    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>&,
-    EigenPtr<VectorX<T>>) const {}
+void WeldMobilizer<T>::DoMapVelocityToQDot(const systems::Context<T>&,
+                                           const Eigen::Ref<const VectorX<T>>&,
+                                           EigenPtr<VectorX<T>>) const {}
 
 template <typename T>
-void WeldMobilizer<T>::DoMapQDotToVelocity(
-    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>&,
-    EigenPtr<VectorX<T>>) const {}
+void WeldMobilizer<T>::DoMapQDotToVelocity(const systems::Context<T>&,
+                                           const Eigen::Ref<const VectorX<T>>&,
+                                           EigenPtr<VectorX<T>>) const {}
 
 template <typename T>
 void WeldMobilizer<T>::DoMapAccelerationToQDDot(

--- a/multibody/tree/weld_mobilizer.cc
+++ b/multibody/tree/weld_mobilizer.cc
@@ -62,22 +62,14 @@ void WeldMobilizer<T>::DoCalcNplusDotMatrix(const systems::Context<T>&,
                                             EigenPtr<MatrixX<T>>) const {}
 
 template <typename T>
-void WeldMobilizer<T>::MapVelocityToQDot(const systems::Context<T>&,
-                                         const Eigen::Ref<const VectorX<T>>& v,
-                                         EigenPtr<VectorX<T>> qdot) const {
-  DRAKE_ASSERT(v.size() == kNv);
-  DRAKE_ASSERT(qdot != nullptr);
-  DRAKE_ASSERT(qdot->size() == kNq);
-}
+void WeldMobilizer<T>::DoMapVelocityToQDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>&,
+    EigenPtr<VectorX<T>>) const {}
 
 template <typename T>
-void WeldMobilizer<T>::MapQDotToVelocity(
-    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
-    EigenPtr<VectorX<T>> v) const {
-  DRAKE_ASSERT(qdot.size() == kNq);
-  DRAKE_ASSERT(v != nullptr);
-  DRAKE_ASSERT(v->size() == kNv);
-}
+void WeldMobilizer<T>::DoMapQDotToVelocity(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>&,
+    EigenPtr<VectorX<T>>) const {}
 
 template <typename T>
 void WeldMobilizer<T>::DoMapAccelerationToQDDot(

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -117,18 +117,6 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
 
   bool is_velocity_equal_to_qdot() const override { return true; }
 
-  // This override is a no-op since this mobilizer has no generalized
-  // velocities associated with it.
-  void MapVelocityToQDot(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& v,
-                         EigenPtr<VectorX<T>> qdot) const final;
-
-  // This override is a no-op since this mobilizer has no generalized
-  // velocities associated with it.
-  void MapQDotToVelocity(const systems::Context<T>& context,
-                         const Eigen::Ref<const VectorX<T>>& qdot,
-                         EigenPtr<VectorX<T>> v) const final;
-
   bool can_rotate() const final { return false; }
   bool can_translate() const final { return false; }
 
@@ -146,6 +134,18 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
   // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ = 0x0 matrix.
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
+
+  // This override is a no-op since this mobilizer has no generalized
+  // velocities associated with it.
+  void DoMapVelocityToQDot(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& v,
+                           EigenPtr<VectorX<T>> qdot) const final;
+
+  // This override is a no-op since this mobilizer has no generalized
+  // velocities associated with it.
+  void DoMapQDotToVelocity(const systems::Context<T>& context,
+                           const Eigen::Ref<const VectorX<T>>& qdot,
+                           EigenPtr<VectorX<T>> v) const final;
 
   // This override is a no-op since this mobilizer has no generalized
   // velocities associated with it.


### PR DESCRIPTION
This is one in a series of PRs to help address issue #22630. It improves MapQDotToVelocity() so it is no longer a virtual function. Instead, it does basic argument checking (which was formerly done in all Mobilizer sub-classes) and then calls the newly created virtual function DoMapQDotToVelocity(). This technique is used also for and MapVelocityToQDot().

The prior PR #22983 was a similar clean up MapQDDotToAcceleration() and MapAccelerationToQDDot().

FYI: Since mobilizers are Drake internal classes, after the internal mobilizer work is complete, there will be PRs (code and testing) for the public API in MultibodyPlant to address issue #22630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/22991)
<!-- Reviewable:end -->
