### PR TITLE
GetBodiesKinematicallyAffectedBy no longer throws on welds

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1208,10 +1208,6 @@ std::vector<BodyIndex> MultibodyPlant<T>::GetBodiesKinematicallyAffectedBy(
                       "has been removed.",
                       __func__, joint));
     }
-    if (get_joint(joint).num_velocities() == 0) {
-      throw std::logic_error(
-          fmt::format("{}: joint with index {} is welded.", __func__, joint));
-    }
   }
   const std::set<BodyIndex> links =
       internal_tree().GetBodiesKinematicallyAffectedBy(joint_indexes);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -5097,11 +5097,22 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
       const RigidBody<T>& body) const;
 
   /// Returns all bodies whose kinematics are transitively affected by the given
-  /// vector of Joints. The affected bodies are returned in increasing order of
-  /// body indexes. Note that this is a kinematic relationship rather than a
-  /// dynamic one. For example, if one of the inboard joints is a free (6dof)
-  /// joint, the kinematic influence is still felt even though dynamically
-  /// there would be no influence on the outboard body.
+  /// vector of Joints. This is a _kinematic_ relationship rather than a
+  /// dynamic one. It is is inherently a query on the topology of the plant's
+  /// modeled tree. Constraints are likewise not considered.
+  ///
+  /// The affected bodies are returned in increasing order of body indices. A
+  /// body is included in the output if that body's spatial velocity is
+  /// affected by the generalized velocities v of one of the indicated joints.
+  ///
+  /// As such, there are some notable implications:
+  ///
+  ///   1. If a body has an inboard free (6 dof) joint, it will be
+  ///      _kinematically_ affected by joints further inboard, even though there
+  ///      might not be any dynamic influence on that body.
+  ///   2. If the set of joints have no velocities (i.e., they are all weld (0
+  ///      dof) joints), then, by definition, no bodies will be affected.
+  ///
   /// This function can be only be called post-finalize, see Finalize().
   /// @throws std::exception if any of the given joint has an invalid index,
   /// doesn't correspond to a mobilizer, or is welded.

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1819,10 +1819,13 @@ GTEST_TEST(MultibodyPlantTest, GetBodiesKinematicallyAffectedBy) {
   plant.Finalize();
   EXPECT_EQ(plant.GetBodiesKinematicallyAffectedBy(joints1), expected_bodies1);
 
-  // Test throw condition: weld joint.
+  // Adding a weld joint doesn't change the result; still the same bodies
+  // based on the non-weld joints.
   const std::vector<JointIndex> joints2{shoulder, elbow};
-  DRAKE_EXPECT_THROWS_MESSAGE(plant.GetBodiesKinematicallyAffectedBy(joints2),
-                              ".*joint with index.*welded.");
+  EXPECT_EQ(plant.GetBodiesKinematicallyAffectedBy(joints2), expected_bodies1);
+
+  // Passing only a weld joint produces no bodies.
+  EXPECT_TRUE(plant.GetBodiesKinematicallyAffectedBy({elbow}).empty());
 
   // Test throw condition: unregistered joint.
   std::vector<JointIndex> joint100{JointIndex(100)};


### PR DESCRIPTION
Previously, it would throw if the index of a weld joint is provided. The underlying implementation already did the "right" thing in the face of a weld joint -- nothing. So, rather than throwing, we simply clarify the documentation.

This isn't breaking, because all code that currently works will continue to work. The function just becomes more relaxed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23004)
<!-- Reviewable:end -->
