### PR TITLE
Add `Jenkinsfile`s

### DIFF
--- a/.jenkins/Jenkinsfile-cache-server-health-check
+++ b/.jenkins/Jenkinsfile-cache-server-health-check
@@ -1,0 +1,92 @@
+#!/usr/bin/env groovy
+
+properties([
+  parameters([
+    string(name: 'ciSha', defaultValue: 'main',
+      description: 'Commit SHA or branch name. ' +
+        'Enter branch name <code>pr/1234/head</code> ' +
+        'or <code>pr/1234/merge</code> for pull request #1234. ' +
+        'Defaults to <code>main</code>.'),
+  ]),
+  buildDiscarder(
+    logRotator(
+      daysToKeepStr: '90',
+      artifactDaysToKeepStr: '90'
+    )
+  )
+])
+
+// Define the main pipeline.
+node(getNodeLabel()) {
+  // Use a custom checkout step below, since there are
+  // multiple repositories with a particular directory layout.
+  skipDefaultCheckout()
+
+  fetchUtils()
+  def utils = load 'jenkins-utils/.jenkins/utils/utils.groovy'
+
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Use the CI branch parameter for checkout (defaults to main).
+            utils.checkout(params.ciSha)
+            echo "Checking the cache server:"
+            try {
+              sh "${env.WORKSPACE}/ci/cache_server/health_check.bash"
+            } catch(Exception e) {
+              currentBuild.result = 'FAILURE'
+            }
+          } finally {
+            try {
+              // Only send failure emails for production builds.
+              if (!"${env.JOB_NAME}".contains("experimental")) {
+                utils.emailFailureResults()
+              }
+            } finally {
+              utils.cleanWorkspace()
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Returns the node label from the job name.
+def getNodeLabel() {
+  def pattern = ~/^((linux|mac-arm)-[a-z]+(?:-unprovisioned)?)/
+  def match = "${env.JOB_NAME}" =~ pattern
+
+  if (match.find()) {
+    return match.group(1)
+  }
+  else {
+    return null
+  }
+}
+
+// Loads utils by performing a sparse checkout to WORKSPACE/jenkins-utils.
+def fetchUtils() {
+  def thisBranch = null
+  if (!env.CHANGE_ID?.trim()) {
+    thisBranch = scm.branches[0].name
+  }
+  else {
+    thisBranch = "pr/${env.CHANGE_ID}/head"
+  }
+  checkout([$class: 'GitSCM',
+    branches: [[name: thisBranch]],
+    extensions: [
+      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'jenkins-utils'],
+      [$class: 'CloneOption', honorRefspec: true, noTags: true],
+      [$class: 'SparseCheckoutPaths',
+        sparseCheckoutPaths: [[path: '.jenkins/utils/utils.groovy']]]],
+    userRemoteConfigs: [[
+      credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+      name: 'origin',
+      refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+        '+refs/pull/*:refs/remotes/origin/pr/*',
+      url: 'git@github.com:RobotLocomotion/drake.git']]])
+}

--- a/.jenkins/Jenkinsfile-experimental
+++ b/.jenkins/Jenkinsfile-experimental
@@ -1,0 +1,83 @@
+#!/usr/bin/env groovy
+
+properties([
+  parameters([
+    string(name: 'ciSha', defaultValue: 'main',
+      description: 'Commit SHA or branch name. ' +
+        'For pull requests, enter branch name <code>pr/1234/head</code> ' +
+        'or <code>pr/1234/merge</code> for pull request #1234. ' +
+        'Defaults to <code>main</code>.'),
+    ]),
+  buildDiscarder(
+    logRotator(
+      daysToKeepStr: '90',
+      artifactDaysToKeepStr: '90'
+    )
+  )
+])
+
+node(getNodeLabel()) {
+  // Use a custom checkout step below, since there are
+  // multiple repositories with a particular directory layout.
+  skipDefaultCheckout()
+
+  fetchUtils()
+  def utils = load 'jenkins-utils/.jenkins/utils/utils.groovy'
+
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Use the CI branch parameter for checkout (defaults to main).
+            def scmVars = utils.checkout(params.ciSha)
+            utils.doMainBuild(scmVars)
+          } finally {
+            try {
+              utils.addCDashBadge()
+            } finally {
+              utils.cleanWorkspace()
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Returns the node label from the job name.
+def getNodeLabel() {
+  def pattern = ~/^((linux|mac-arm)-[a-z]+(?:-unprovisioned)?)/
+  def match = "${env.JOB_NAME}" =~ pattern
+
+  if (match.find()) {
+    return match.group(1)
+  }
+  else {
+    return null
+  }
+}
+
+// Loads utils by performing a sparse checkout to WORKSPACE/jenkins-utils.
+def fetchUtils() {
+  def thisBranch = null
+  if (!env.CHANGE_ID?.trim()) {
+    thisBranch = scm.branches[0].name
+  }
+  else {
+    thisBranch = "pr/${env.CHANGE_ID}/head"
+  }
+  checkout([$class: 'GitSCM',
+    branches: [[name: thisBranch]],
+    extensions: [
+      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'jenkins-utils'],
+      [$class: 'CloneOption', honorRefspec: true, noTags: true],
+      [$class: 'SparseCheckoutPaths',
+        sparseCheckoutPaths: [[path: '.jenkins/utils/utils.groovy']]]],
+    userRemoteConfigs: [[
+      credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+      name: 'origin',
+      refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+        '+refs/pull/*:refs/remotes/origin/pr/*',
+      url: 'git@github.com:RobotLocomotion/drake.git']]])
+}

--- a/.jenkins/Jenkinsfile-external-examples
+++ b/.jenkins/Jenkinsfile-external-examples
@@ -1,0 +1,49 @@
+#!/usr/bin/env groovy
+
+properties([
+  parameters([
+    string(name: 'deePR', defaultValue: 'main',
+      description: 'Pull request name. ' +
+        'For pull requests, enter project name <code>PR-1234</code> ' +
+        'for pull request #1234. Defaults to <code>main</code>.'),
+  ]),
+  buildDiscarder(
+    logRotator(
+      daysToKeepStr: '90',
+      artifactDaysToKeepStr: '90'
+    )
+  )
+])
+
+def scmVars = null
+node(getNodeLabel()) {
+  stage('drake-checkout') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          scmVars = checkout scm
+        }
+      }
+    }
+  }
+}
+
+build(
+  job: "RobotLocomotion/drake-external-examples/${params.deePR}",
+  parameters: [
+    string(name: 'drakeSha', value: scmVars.GIT_COMMIT)
+  ]
+)
+
+// Returns the node label from the job name.
+def getNodeLabel() {
+  def pattern = ~/^((linux|mac-arm)-[a-z]+(?:-unprovisioned)?)/
+  def match = "${env.JOB_NAME}" =~ pattern
+
+  if (match.find()) {
+    return match.group(1)
+  }
+  else {
+    return null
+  }
+}

--- a/.jenkins/Jenkinsfile-production
+++ b/.jenkins/Jenkinsfile-production
@@ -1,0 +1,76 @@
+#!/usr/bin/env groovy
+
+properties([
+  buildDiscarder(
+    logRotator(
+      daysToKeepStr: '90',
+      artifactDaysToKeepStr: '90'
+    )
+  )
+])
+
+node(getNodeLabel()) {
+  // Use a custom checkout step below, since there are
+  // multiple repositories with a particular directory layout.
+  skipDefaultCheckout()
+
+  fetchUtils()
+  def utils = load 'jenkins-utils/.jenkins/utils/utils.groovy'
+
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Always use the main branch of CI for production builds.
+            def scmVars = utils.checkout()
+            utils.doMainBuild(scmVars)
+          } finally {
+            try {
+              utils.addCDashBadge()
+            } finally {
+              utils.cleanWorkspace()
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Returns the node label from the job name.
+def getNodeLabel() {
+  def pattern = ~/^((linux|mac-arm)-[a-z]+(?:-unprovisioned)?)/
+  def match = "${env.JOB_NAME}" =~ pattern
+
+  if (match.find()) {
+    return match.group(1)
+  }
+  else {
+    return null
+  }
+}
+
+// Loads utils by performing a sparse checkout to WORKSPACE/jenkins-utils.
+def fetchUtils() {
+  def thisBranch = null
+  if (!env.CHANGE_ID?.trim()) {
+    thisBranch = scm.branches[0].name
+  }
+  else {
+    thisBranch = "pr/${env.CHANGE_ID}/head"
+  }
+  checkout([$class: 'GitSCM',
+    branches: [[name: thisBranch]],
+    extensions: [
+      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'jenkins-utils'],
+      [$class: 'CloneOption', honorRefspec: true, noTags: true],
+      [$class: 'SparseCheckoutPaths',
+        sparseCheckoutPaths: [[path: '.jenkins/utils/utils.groovy']]]],
+    userRemoteConfigs: [[
+      credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+      name: 'origin',
+      refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+        '+refs/pull/*:refs/remotes/origin/pr/*',
+      url: 'git@github.com:RobotLocomotion/drake.git']]])
+}

--- a/.jenkins/Jenkinsfile-staging
+++ b/.jenkins/Jenkinsfile-staging
@@ -1,0 +1,101 @@
+#!/usr/bin/env groovy
+
+properties([
+  parameters([
+    string(name: 'drakeSha', defaultValue: 'master',
+      description: 'Commit SHA or branch name. ' +
+        'For pull requests, enter branch name <code>pr/1234/head</code> ' +
+        'or <code>pr/1234/merge</code> for pull request #1234. ' +
+        'Defaults to <code>master</code>.')
+    string(name: 'ciSha', defaultValue: 'main',
+      description: 'Commit SHA or branch name. ' +
+        'For pull requests, enter branch name <code>pr/1234/head</code> ' +
+        'or <code>pr/1234/merge</code> for pull request #1234. ' +
+        'Defaults to <code>main</code>.'),
+    string(name: 'release_version', defaultValue: 'unset',
+      description: 'Version to apply to the resulting release candidate ' +
+        'artifact(s). If the RC artifact(s) include wheel(s), the ' +
+        'version must follow <a href=' +
+        '"https://www.python.org/dev/peps/pep-0440/">PEP 440</a>.' +
+        'To test staging <tt>1.13.0</tt>, for example, a ' +
+        'version number such as <tt>1.13.0rc1</tt> could be used. ' +
+        'The version number must start with a number (<tt>v1.13.0</tt> ' +
+        'will be rejected). If in doubt, run <tt>bazel run ' +
+        '//tools/wheel:builder -- --pep440 [desired version number]' +
+        '</tt> to confirm whether your desired version number is ' +
+        'PEP 440 compliant.')
+    ])
+  buildDiscarder(
+    logRotator(
+      daysToKeepStr: '90',
+      artifactDaysToKeepStr: '90'
+    )
+  )
+])
+
+node(getNodeLabel()) {
+  // Use a custom checkout step below, since there are
+  // multiple repositories with a particular directory layout.
+  skipDefaultCheckout()
+
+  fetchUtils()
+  def utils = load 'jenkins-utils/.jenkins/utils/utils.groovy'
+
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Use the drake and ci branch parameters for checkout (defaults
+            // to master & main).
+            def scmVars = utils.checkout(params.ciSha, params.drakeSha)
+            utils.doMainBuild(scmVars, params.release_version)
+          } finally {
+            try {
+              utils.addCDashBadge()
+            } finally {
+              utils.cleanWorkspace()
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Returns the node label from the job name.
+def getNodeLabel() {
+  def pattern = ~/^((linux|mac-arm)-[a-z]+(?:-unprovisioned)?)/
+  def match = "${env.JOB_NAME}" =~ pattern
+
+  if (match.find()) {
+    return match.group(1)
+  }
+  else {
+    return null
+  }
+}
+
+// Loads utils by performing a sparse checkout to WORKSPACE/jenkins-utils.
+def fetchUtils() {
+  def thisBranch = null
+  if (!env.CHANGE_ID?.trim()) {
+    thisBranch = scm.branches[0].name
+  }
+  else {
+    thisBranch = "pr/${env.CHANGE_ID}/head"
+  }
+  checkout([$class: 'GitSCM',
+    branches: [[name: thisBranch]],
+    extensions: [
+      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'jenkins-utils'],
+      [$class: 'CloneOption', honorRefspec: true, noTags: true],
+      [$class: 'SparseCheckoutPaths',
+        sparseCheckoutPaths: [[path: '.jenkins/utils/utils.groovy']]]],
+    userRemoteConfigs: [[
+      credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+      name: 'origin',
+      refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+        '+refs/pull/*:refs/remotes/origin/pr/*',
+      url: 'git@github.com:RobotLocomotion/drake.git']]])
+}

--- a/.jenkins/utils/utils.groovy
+++ b/.jenkins/utils/utils.groovy
@@ -1,0 +1,108 @@
+// Performs the checkout step for drake and drake-ci.
+// * drake: Clones into WORKSPACE/'src' and checks out the branch
+//   specified from the build.
+// * drake-ci: Clones into WORKSPACE/'ci' and performs a custom
+//   checkout of either 'main' or the given parameter.
+def checkout(String ciSha = 'main', String drakeSha = null) {
+  def scmVars = null
+  retry(4) {
+    if (drakeSha) {
+      scmVars = checkout([$class: 'GitSCM',
+        branches: [[name: "${drakeSha}"]],
+        extensions: [[$class: 'AuthorInChangelog'],
+          [$class: 'CloneOption', honorRefspec: true, noTags: true],
+          [$class: 'RelativeTargetDirectory', relativeTargetDir: 'src'],
+          [$class: 'LocalBranch', localBranch: 'master']],
+        userRemoteConfigs: [[
+          credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+          name: 'origin',
+          refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+            '+refs/pull/*:refs/remotes/origin/pr/*',
+          url: 'git@github.com:RobotLocomotion/drake.git']]])
+    }
+    else {
+      dir("${env.WORKSPACE}/src") {
+        scmVars = checkout scm
+      }
+    }
+  }
+  retry(4) {
+    checkout([$class: 'GitSCM',
+      branches: [[name: "${ciSha}"]],
+      extensions: [[$class: 'AuthorInChangelog'],
+        [$class: 'CloneOption', honorRefspec: true, noTags: true],
+        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'ci'],
+        [$class: 'LocalBranch', localBranch: 'main']],
+      userRemoteConfigs: [[
+        credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        name: 'origin',
+        refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+          '+refs/pull/*:refs/remotes/origin/pr/*',
+        url: 'git@github.com:RobotLocomotion/drake-ci.git']]])
+  }
+  return scmVars
+}
+
+// Performs the main build step by calling into the drake-ci driver script
+// with the necessary credentials and environment variables.
+def doMainBuild(Map scmVars, String stagingReleaseVersion = null) {
+  withCredentials([
+    sshUserPrivateKey(credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+      keyFileVariable: 'SSH_PRIVATE_KEY_FILE'),
+    string(credentialsId: 'e21b9517-8aa7-419e-8f25-19cd42e10f68',
+      variable: 'DOCKER_USERNAME'),
+    file(credentialsId: '912dd413-d419-4760-b7ab-c132ab9e7c5e',
+      variable: 'DOCKER_PASSWORD_FILE')
+  ]) {
+    def environment = ["GIT_COMMIT=${scmVars.GIT_COMMIT}"]
+    if (stagingReleaseVersion) {
+      environment += "DRAKE_VERSION=${stagingReleaseVersion}"
+    }
+    withEnv(environment) {
+      sh "${env.WORKSPACE}/ci/ctest_driver_script_wrapper.bash"
+    }
+  }
+}
+
+// Sends an email to Drake developers when a build fails or is unstable.
+def emailFailureResults() {
+  if (fileExists('RESULT')) {
+    currentBuild.result = readFile 'RESULT'
+    if (currentBuild.result == 'FAILURE' ||
+        currentBuild.result == 'UNSTABLE') {
+      def subject = 'Build failed in Jenkins'
+      if (currentBuild.result == 'UNSTABLE') {
+        subject = 'Jenkins build is unstable'
+      }
+      emailext (
+        subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+        body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
+          "and <${env.BUILD_URL}changes>",
+        to: '$DEFAULT_RECIPIENTS',
+      )
+    }
+  }
+}
+
+// Deletes the workspace and tmp directories, for use at the end of a build.
+def cleanWorkspace() {
+  dir("${env.WORKSPACE}") {
+    deleteDir()
+  }
+  dir("${env.WORKSPACE}@tmp") {
+    deleteDir()
+  }
+}
+
+// Provides links to CDash to view the results of the build.
+def addCDashBadge() {
+  if (fileExists('CDASH')) {
+    def cDashUrl = readFile 'CDASH'
+    addBadge icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
+    addSummary icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
+  }
+}
+
+return this

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -65,17 +65,22 @@ builds.
 
 ## Scheduling Builds via the Jenkins User Interface
 
-Alternatively, to schedule a build of an open pull request or arbitrary commit
-in the ``RobotLocomotion/drake`` repository:
+Alternatively, to schedule a build of an open pull request in the
+``RobotLocomotion/drake`` repository:
 
-1. **Log in** to [Jenkins](https://drake-jenkins.csail.mit.edu/) using GitHub OAuth.
-   (Make sure that you see your name the upper-right corner, *not* the words "Log in".)
-2. Go to the list of [experimental builds](https://drake-jenkins.csail.mit.edu/view/Experimental/).
+1. **Log in** to [Jenkins](https://drake-jenkins.csail.mit.edu/) using GitHub
+   OAuth. (Make sure that you see your name the upper-right corner, *not* the
+   words "Log in".)
+2. Go to the list of
+   [experimental builds](https://drake-jenkins.csail.mit.edu/view/Experimental/).
 3. Click on the specific build you want to schedule.
-4. Click on "Build with Parameters" in the left menu.
-5. Enter ``pr/XYZ/head`` (HEAD of pull request), ``pr/XYZ/merge`` (pull request
-   merged with master), or the desired commit SHA in the ``sha1`` field.
-6. Click ``Build``.
+4. Click on "Pull Requests" towards the top, and select your pull request.
+5. Click on "Build with Parameters" in the left menu.
+6. (Optional) If you need to test your changes alongside a pull request or
+   branch of the ``RobotLocomotion/drake-ci`` repository, enter ``pr/XYZ/head``
+   (HEAD of pull request), ``pr/XYZ/merge`` (pull request merged with master)
+   for ``ciSha``. Otherwise, leave it set to "main."
+7. Click ``Build``.
 
 The list of experimental builds includes builds that automatically run on opened
 and updated pull requests, as well as numerous other builds for on-demand use.
@@ -236,8 +241,10 @@ comment on an open pull request using the following command:
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
 to schedule a build of the
 [external examples job](https://drake-jenkins.csail.mit.edu/view/Linux%20Jammy%20Unprovisioned/job/linux-jammy-unprovisioned-external-examples/).
-Note that this job provides parameters for branches of
-drake and drake-external-examples.
+Note that instead of providing a parameter for the branch of
+``RobotLocomotion/drake-ci``, this job instead provides one for
+drake-external-examples, which should be used if you need to test your Drake
+changes alongside changes downstream.
 
 ## GitHub Actions
 


### PR DESCRIPTION
Towards #22826. Adds `.jenkins/` for defining Jenkins job logic in Drake itself, rather than dynamically generating it in job definitions:

* Adds production, experimental, staging, cache server health check, and external examples pipelines in `Jenkinsfile`s
* Adds shared utils in `utils/utils.groovy`
* Fixes documentation in `jenkins.md` for how to use the new experimental jobs

The continuous, nightly, experimental, and pre-merge jobs will all use these files. Experimental and pre-merge jobs will look a little different, but function the same way in terms of providing parameters to run branches/PRs of drake and CI, running automatically on PRs, keeping the "@drake-jenkins-bot ..." comment triggers, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23009)
<!-- Reviewable:end -->
