### PR TITLE
[py visualization] Fix meldis crash on gltf embedded png

### DIFF
--- a/bindings/pydrake/visualization/_meldis.py
+++ b/bindings/pydrake/visualization/_meldis.py
@@ -256,15 +256,12 @@ class _GeometryFileHasher:
             _logger.warning(f"glTF file is not valid JSON: {path}")
             return
 
-        # Handle the images
-        for image in document.get("images", []):
-            if not image.get("uri", "").startswith("data:"):
-                self.on_texture_from_disk(path.parent / image["uri"])
-
-        # Handle the .bin files.
-        for buffer in document.get("buffers", []):
-            if not buffer.get("uri", "").startswith("data:"):
-                self._read_file(path.parent / buffer["uri"])
+        # Handle images and .bin files cited via URIs.
+        for array_property in ("images", "buffers"):
+            for item in document.get(array_property, []):
+                uri = item.get("uri", None)
+                if uri and not uri.startswith("data:"):
+                    self.on_texture_from_disk(path.parent / uri)
 
 
 class _ViewerApplet:

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -413,12 +413,31 @@ class TestMeldis(unittest.TestCase):
         self.assertNotEqual(gltf_hash_2, empty_hash)
         self.assertNotEqual(gltf_hash_2, gltf_hash_1)
 
-        # Valid glTF file reference an external image.
+        # Valid glTF file references an external image.
         with open(gltf_filename, "w") as f:
             f.write(json.dumps({"images": [{"uri": str(png_filename)}]}))
         gltf_hash_3 = dut(message)
         self.assertNotEqual(gltf_hash_3, empty_hash)
         self.assertNotEqual(gltf_hash_3, gltf_hash_2)
+
+        # Valid glTF file references an inline image.
+        with open(gltf_filename, "w") as f:
+            data_uri = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD"
+            f.write(json.dumps({"images": [{"uri": data_uri}]}))
+        gltf_hash_4 = dut(message)
+        self.assertNotEqual(gltf_hash_4, empty_hash)
+        self.assertNotEqual(gltf_hash_4, gltf_hash_3)
+
+        # Valid glTF file references a buffer image.
+        with open(gltf_filename, "w") as f:
+            f.write(json.dumps({
+                "buffers": [{"byteLength": 0}],
+                "bufferViews": [{"buffer": 0, "byteLength": 0}],
+                "images": [{"bufferView": 1}],
+            }))
+        gltf_hash_5 = dut(message)
+        self.assertNotEqual(gltf_hash_5, empty_hash)
+        self.assertNotEqual(gltf_hash_5, gltf_hash_4)
 
         # Now finally, the glTF file has a .bin. This time, as a cross-check,
         # inspect the filenames that were hashed instead of the hash itself.


### PR DESCRIPTION
When an image lacked a uri (e.g., when using a bufferView), the checksum logic would crash.