### PR TITLE
[parsing] GetScopedFrameByName accepts string_view

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -291,7 +291,7 @@ PYBIND11_MODULE(parsing, m) {
       [&m]<typename T>(T) {
         m.def("GetScopedFrameByName",
             overload_cast_explicit<const Frame<T>&, const MultibodyPlant<T>&,
-                const std::string&>(&parsing::GetScopedFrameByName),
+                std::string_view>(&parsing::GetScopedFrameByName),
             py::arg("plant"), py::arg("full_name"),
             py::return_value_policy::reference,
             py::keep_alive<0, 1>(),  // `return` keeps `plant` alive.
@@ -303,7 +303,7 @@ PYBIND11_MODULE(parsing, m) {
       [&m]<typename T>(T) {
         m.def("GetScopedFrameByNameMaybe",
             overload_cast_explicit<const Frame<T>*, const MultibodyPlant<T>&,
-                const std::string&>(&parsing::GetScopedFrameByNameMaybe),
+                std::string_view>(&parsing::GetScopedFrameByNameMaybe),
             py::arg("plant"), py::arg("full_name"),
             py::return_value_policy::reference,
             py::keep_alive<0, 1>(),  // `return` keeps `plant` alive.

--- a/multibody/parsing/scoped_names.cc
+++ b/multibody/parsing/scoped_names.cc
@@ -10,11 +10,11 @@ namespace parsing {
 template <typename T>
 const drake::multibody::Frame<T>* GetScopedFrameByNameMaybe(
     const drake::multibody::MultibodyPlant<T>& plant,
-    const std::string& full_name) {
+    std::string_view full_name) {
   if (full_name == "world") {
     return &plant.world_frame();
   }
-  auto scoped_name = multibody::ScopedName::Parse(full_name);
+  auto scoped_name = ScopedName::Parse(std::string{full_name});
   if (!scoped_name.get_namespace().empty()) {
     if (plant.HasModelInstanceNamed(scoped_name.get_namespace())) {
       auto instance = plant.GetModelInstanceByName(scoped_name.get_namespace());
@@ -31,11 +31,11 @@ const drake::multibody::Frame<T>* GetScopedFrameByNameMaybe(
 template <typename T>
 const drake::multibody::Frame<T>& GetScopedFrameByName(
     const drake::multibody::MultibodyPlant<T>& plant,
-    const std::string& full_name) {
+    std::string_view full_name) {
   if (full_name == "world") {
     return plant.world_frame();
   }
-  auto scoped_name = multibody::ScopedName::Parse(full_name);
+  auto scoped_name = ScopedName::Parse(std::string{full_name});
   if (!scoped_name.get_namespace().empty()) {
     auto instance = plant.GetModelInstanceByName(scoped_name.get_namespace());
     return plant.GetFrameByName(scoped_name.get_element(), instance);

--- a/multibody/parsing/scoped_names.h
+++ b/multibody/parsing/scoped_names.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include <string_view>
 
 #include "drake/multibody/plant/multibody_plant.h"
 
@@ -11,13 +11,13 @@ namespace parsing {
 /// Finds an optionally model-scoped frame.
 ///
 /// Returns `nullptr` if the frame is not found, as well as all the error
-/// cases of `MultibodyPlant::HasFrameByName(std::string)`.
+/// cases of `MultibodyPlant::HasFrameNamed(std::string_view)`.
 ///
 /// @tparam_default_scalar
 template <typename T>
 const drake::multibody::Frame<T>* GetScopedFrameByNameMaybe(
     const drake::multibody::MultibodyPlant<T>& plant,
-    const std::string& full_name);
+    std::string_view full_name);
 
 /// Equivalent to `GetScopedFrameByNameMaybe`, but throws if the frame
 /// is not found.
@@ -26,7 +26,7 @@ const drake::multibody::Frame<T>* GetScopedFrameByNameMaybe(
 template <typename T>
 const drake::multibody::Frame<T>& GetScopedFrameByName(
     const drake::multibody::MultibodyPlant<T>& plant,
-    const std::string& full_name);
+    std::string_view full_name);
 
 }  // namespace parsing
 }  // namespace multibody


### PR DESCRIPTION
If the caller only has a `string_view` in hand, this saves them a copy (and call site shrapnel).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23014)
<!-- Reviewable:end -->
