### PR TITLE
[py solvers] Partially revert "Remove deprecated API 2025-05"

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_options.cc
+++ b/bindings/pydrake/solvers/solvers_py_options.cc
@@ -55,6 +55,46 @@ void DefineSolversOptions(py::module m) {
     DefAttributesUsingSerialize(&cls);
     DefReprUsingSerialize(&cls);
     DefCopyAndDeepCopy(&cls);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("GetOptions",
+            WrapDeprecated(doc.SolverOptions.GetOptionsDouble.doc_deprecated,
+                [](const SolverOptions& solver_options, SolverId solver_id) {
+                  py::dict out;
+                  py::object update = out.attr("update");
+                  update(solver_options.GetOptionsDouble(solver_id));
+                  update(solver_options.GetOptionsInt(solver_id));
+                  update(solver_options.GetOptionsStr(solver_id));
+                  return out;
+                }),
+            py::arg("solver_id"),
+            doc.SolverOptions.GetOptionsDouble.doc_deprecated)
+        .def("common_solver_options",
+            WrapDeprecated(
+                doc.SolverOptions.common_solver_options.doc_deprecated,
+                &SolverOptions::common_solver_options),
+            doc.SolverOptions.common_solver_options.doc_deprecated)
+        .def("get_print_file_name",
+            WrapDeprecated(doc.SolverOptions.get_print_file_name.doc_deprecated,
+                &SolverOptions::get_print_file_name),
+            doc.SolverOptions.get_print_file_name.doc_deprecated)
+        .def("get_print_to_console",
+            WrapDeprecated(
+                doc.SolverOptions.get_print_to_console.doc_deprecated,
+                &SolverOptions::get_print_to_console),
+            doc.SolverOptions.get_print_to_console.doc_deprecated)
+        .def("get_standalone_reproduction_file_name",
+            WrapDeprecated(
+                doc.SolverOptions.get_standalone_reproduction_file_name
+                    .doc_deprecated,
+                &SolverOptions::get_standalone_reproduction_file_name))
+        .def("get_max_threads",
+            WrapDeprecated(doc.SolverOptions.get_max_threads.doc_deprecated,
+                &SolverOptions::get_max_threads),
+            doc.SolverOptions.get_max_threads.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 }
 

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1390,6 +1390,19 @@ class TestMathematicalProgram(unittest.TestCase):
                 for key, value in expected_common.items()
             )
         })
+        with catch_drake_warnings(expected_count=1):
+            self.assertDictEqual(dut.GetOptions(solver_id), expected_dummy)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.common_solver_options(), expected_common)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.get_print_to_console(), True)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.get_print_file_name(), "print.log")
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.get_standalone_reproduction_file_name(),
+                             "repro.txt")
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(dut.get_max_threads(), 4)
         self.assertTrue(dut == dut)
         self.assertFalse(dut != dut)
         copy.deepcopy(dut)


### PR DESCRIPTION
Partially reverts #22938 for a handful of bindings that were dated 2025-09 not 2025-05.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23015)
<!-- Reviewable:end -->
