### PR TITLE
[deformable] Report reaction force for rigid bodies

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -874,6 +874,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "multibody_plant_reaction_forces_test",
     timeout = "moderate",
+    data = ["test/box.vtk"],
     deps = [
         ":plant",
         "//common/test_utilities:eigen_matrix_compare",

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -874,7 +874,10 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "multibody_plant_reaction_forces_test",
     timeout = "moderate",
-    data = ["test/box.vtk"],
+    data = [
+        "test/box.vtk",
+        "test/deformable_box.sdf",
+    ],
     deps = [
         ":plant",
         "//common/test_utilities:eigen_matrix_compare",
@@ -882,6 +885,7 @@ drake_cc_googletest(
         "//geometry:drake_visualizer",
         "//lcm",
         "//math:geometric_transform",
+        "//multibody/parsing",
         "//multibody/plant:contact_results_to_lcm",
         "//systems/analysis:implicit_euler_integrator",
         "//systems/analysis:simulator",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3279,15 +3279,8 @@ systems::EventStatus MultibodyPlant<T>::CalcStepUnrestricted(
           .template Allocate<T>(internal_tree().get_topology());
   discrete_update_manager_->CalcDiscreteValues(context0, &next_discrete_state,
                                                &next_memory);
-  if (discrete_update_manager_->deformable_driver() == nullptr) {
-    next_memory.reaction_forces.resize(num_joints());
-    CalcReactionForces(context0, &next_memory.reaction_forces);
-  } else {
-    // For deformables, SapDriver does not yet support the computation of
-    // reaction forces. Therefore, we skip it here and delay throwing an
-    // exception until someone asks for this output during
-    // CalcReactionForcesOutput<true>().
-  }
+  next_memory.reaction_forces.resize(num_joints());
+  CalcReactionForces(context0, &next_memory.reaction_forces);
   return systems::EventStatus::Succeeded();
 }
 
@@ -3991,16 +3984,6 @@ void MultibodyPlant<T>::CalcReactionForcesOutput(
   this->ValidateContext(context);
   DRAKE_DEMAND(output != nullptr);
   DRAKE_DEMAND(ssize(*output) == num_joints());
-
-  if (discrete_update_manager_ != nullptr &&
-      discrete_update_manager_->deformable_driver() != nullptr) {
-    // SapDriver<T>::CalcDiscreteUpdateMultibodyForces doesn't support
-    // reaction forces yet, so our CalcStepUnrestricted can't sample
-    // this output port.
-    throw std::logic_error(
-        "The computation of MultibodyForces must be updated to include "
-        "deformable objects.");
-  }
 
   // Sampled mode is a simple copy.
   if constexpr (sampled) {

--- a/multibody/plant/test/deformable_box.sdf
+++ b/multibody/plant/test/deformable_box.sdf
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<sdf xmlns:drake="http://drake.mit.edu" version="1.8">
+  <model name='deformable'>
+    <link name='base'>
+      <collision name='collision'>
+        <geometry>
+          <mesh>
+            <uri>box.vtk</uri>
+          </mesh>
+        </geometry>
+        <drake:proximity_properties>
+          <drake:mu_dynamic>0.4</drake:mu_dynamic>
+        </drake:proximity_properties>
+      </collision>
+      <visual name='visual'>
+        <geometry>
+          <empty/>
+        </geometry>
+        <material>
+          <diffuse>0.82 0.71 0.55 1</diffuse>
+        </material>
+      </visual>
+      <drake:deformable_properties>
+        <drake:youngs_modulus>1e5</drake:youngs_modulus>
+        <drake:poissons_ratio>0.4</drake:poissons_ratio>
+        <drake:stiffness_damping>0.01</drake:stiffness_damping>
+        <drake:mass_density>1.0</drake:mass_density>
+      </drake:deformable_properties>
+    </link>
+  </model>
+</sdf>

--- a/multibody/plant/test/deformable_box.sdf
+++ b/multibody/plant/test/deformable_box.sdf
@@ -6,6 +6,7 @@
         <geometry>
           <mesh>
             <uri>box.vtk</uri>
+            <scale>0.1 0.1 0.1</scale>
           </mesh>
         </geometry>
         <drake:proximity_properties>
@@ -21,10 +22,10 @@
         </material>
       </visual>
       <drake:deformable_properties>
-        <drake:youngs_modulus>1e5</drake:youngs_modulus>
+        <drake:youngs_modulus>1e7</drake:youngs_modulus>
         <drake:poissons_ratio>0.4</drake:poissons_ratio>
         <drake:stiffness_damping>0.01</drake:stiffness_damping>
-        <drake:mass_density>1.0</drake:mass_density>
+        <drake:mass_density>1e3</drake:mass_density>
       </drake:deformable_properties>
     </link>
   </model>

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -1155,9 +1155,9 @@ class DeformableReactionForcesTest : public ::testing::Test {
                                 kTolerance, MatrixCompareType::relative));
   }
 
-  // Deformable object parameters
-  const double kMassDensity{1.0};  // Mass density in kg/m³
-  const double kBoxSize{1.0};      // Size of the box edge in m
+  // Deformable object parameters (from the SDFormat file).
+  const double kMassDensity{1000.0};  // Mass density in kg/m³
+  const double kBoxSize{0.1};         // Size of the box edge in m
 
   // Floor parameters
   const double kFloorWidth{10.0};  // Width of the floor in m
@@ -1165,12 +1165,12 @@ class DeformableReactionForcesTest : public ::testing::Test {
   const double kFloorMass{10.0};   // Mass of the floor in kg
 
   // Simulation parameters
-  const double kTimeStep{0.001};        // Time step in s
-  const double kSimulationTime{2.0};    // Maximum simulation time in s
+  const double kTimeStep{0.01};         // Time step in s
+  const double kSimulationTime{1.0};    // Maximum simulation time in s
   const double kTargetRealtimeRate{0};  // Target realtime rate
   const double kGravity{9.81};          // Gravity in m/s²
   const CoulombFriction<double> kFriction{0.4, 0.4};  // Friction
-  const double kTolerance{1e-6};  // Tolerance for comparisons
+  const double kTolerance{1e-8};  // Tolerance for comparisons
 
   // System components
   MultibodyPlant<double>* plant_{nullptr};


### PR DESCRIPTION
Adds support for reporting reaction forces on rigid bodies when a deformable is present (fixes https://github.com/RobotLocomotion/drake/issues/22942).

Specific changes include:
- Unit test to validate the reported reaction force for a scene including one rigid body and one deformable
- `CalcReactionForces` not skipped when a deformable is present (see `MultibodyPlant<T>::CalcStepUnrestricted`)
- Update `CalcDiscreteUpdateMultibodyForces` to properly account for deformable bodies (e.g. set the correct size of `constraint_spatial_forces`)
- Remove instances where Drake would throw in this scenario (i.e. `throw std::logic_error(
        "The computation of MultibodyForces must be updated to include deformable objects.");` )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23026)
<!-- Reviewable:end -->
