### PR TITLE
Fix symbolic mass matrix computation

### DIFF
--- a/multibody/tree/parameter_conversion.h
+++ b/multibody/tree/parameter_conversion.h
@@ -73,8 +73,10 @@ SpatialInertia<T> ToSpatialInertia(
   const auto& spatial_inertia_vector = spatial_inertia_basic_vector.get_value();
   // Kinematics-only code sometimes specifies inertia as NaN since it isn't
   // needed. Convert back to NaN here rather than risk blowing up below.
-  if (spatial_inertia_vector.array().isNaN().any()) {
-    return SpatialInertia<T>::NaN();
+  if constexpr (scalar_predicate<T>::is_bool) {
+    if (spatial_inertia_vector.array().isNaN().any()) {
+      return SpatialInertia<T>::NaN();
+    }
   }
   return SpatialInertia<T>(
       spatial_inertia_vector[SpatialInertiaIndex::k_mass],

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -387,18 +387,23 @@ template <typename T>
 SpatialInertia<T>& SpatialInertia<T>::operator+=(
     const SpatialInertia<T>& M_BP_E) {
   const T total_mass = get_mass() + M_BP_E.get_mass();
-  if (total_mass != 0) {
-    p_PScm_E_ = (CalcComMoment() + M_BP_E.CalcComMoment()) / total_mass;
-    G_SP_E_.SetFromRotationalInertia(
-        CalcRotationalInertia() + M_BP_E.CalcRotationalInertia(), total_mass);
-  } else {
-    // Compose the spatial inertias of two massless bodies in the limit when
-    // the two bodies have the same mass. In this limit, p_PScm_E_ and G_SP_E_
-    // are the arithmetic mean of the constituent COMs and unit inertias.
-    p_PScm_E_ = 0.5 * (get_com() + M_BP_E.get_com());
-    G_SP_E_.SetFromRotationalInertia(
-        get_unit_inertia() + M_BP_E.get_unit_inertia(), 2.0);
+  if constexpr (scalar_predicate<T>::is_bool) {
+    if (total_mass == 0) {
+      // Compose the spatial inertias of two massless bodies in the limit when
+      // the two bodies have the same mass. In this limit, p_PScm_E_ and G_SP_E_
+      // are the arithmetic mean of the constituent COMs and unit inertias.
+      p_PScm_E_ = 0.5 * (get_com() + M_BP_E.get_com());
+      G_SP_E_.SetFromRotationalInertia(
+          get_unit_inertia() + M_BP_E.get_unit_inertia(), 2.0);
+      mass_ = total_mass;
+      return *this;
+    }
   }
+
+  // This is the normal case.
+  p_PScm_E_ = (CalcComMoment() + M_BP_E.CalcComMoment()) / total_mass;
+  G_SP_E_.SetFromRotationalInertia(
+      CalcRotationalInertia() + M_BP_E.CalcRotationalInertia(), total_mass);
   mass_ = total_mass;
   return *this;
 }


### PR DESCRIPTION
PR #22977 added a precalculation for body spatial inertias that broke some symbolic calculations (it did some numerical checks for NaNs and zeroes). This PR limits those checks to numerical scalars, and adds a missing unit test (thanks, Russ!) that will prevent recurrence.

Resolves #23025

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23027)
<!-- Reviewable:end -->
