### PR TITLE
OSQP always reports primal and dual values regardless of the solver status.

### DIFF
--- a/solvers/osqp_solver.h
+++ b/solvers/osqp_solver.h
@@ -48,7 +48,14 @@ Drake uses OSQP's default values for all options except following:
   output deterministic (upstream default is `0`, which uses non-deterministic
   timing measurements to establish the interval). N.B. Generally the interval
   should be an integer multiple of `check_termination`, so if you choose to
-  override either option you should probably override both at once. */
+  override either option you should probably override both at once.
+
+At the end of OsqpSolver::Solve() function, we always return the value of the
+primal and dual variables inside the OSQP solver, regardless of the solver
+status (whether it is optimal, infeasible, unbounded, etc), except when the
+problem has an invalid input. Users should always check the solver status before
+interpreting the returned primal and dual variables.
+  */
 class OsqpSolver final : public SolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OsqpSolver);

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -228,11 +228,11 @@ GTEST_TEST(TestMathematicalProgramResult, InfeasibleProblem) {
   if (osqp_solver.available()) {
     const Eigen::VectorXd x_guess = Eigen::Vector2d::Zero();
     osqp_solver.Solve(prog, x_guess, {}, &result);
-    EXPECT_TRUE(CompareMatrices(
-        result.GetSolution(x),
-        Eigen::Vector2d::Constant(std::numeric_limits<double>::quiet_NaN())));
-    EXPECT_TRUE(std::isnan(result.GetSolution(x(0))));
-    EXPECT_TRUE(std::isnan(result.GetSolution(x(1))));
+    EXPECT_EQ(result.get_solution_result(),
+              SolutionResult::kInfeasibleConstraints);
+    EXPECT_EQ(result.GetSolution(x).size(), 2);
+    EXPECT_EQ(result.GetSolution().size(), 2);
+
     EXPECT_EQ(result.get_optimal_cost(),
               MathematicalProgram::kGlobalInfeasibleCost);
   }


### PR DESCRIPTION
Even when the problem is infeasible/unbounded/numerical_error.


This is requested by @AdityaBhat-TRI because he wants the OSQP solution of the diff IK even when the solver fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23028)
<!-- Reviewable:end -->
