### PR TITLE
Create CalcNDotMatrix() and CalcNplusDotMatrix() for rpy_ball_mobilizer.

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -531,6 +531,7 @@ drake_cc_googletest(
         ":mobilizer_tester",
         ":tree",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -138,8 +138,8 @@ void RpyBallMobilizer<T>::ThrowSinceCosPitchIsNearZero(
       "{}(): The RpyBallMobilizer (implementing a BallRpyJoint) between "
       "body {} and body {} has reached a singularity. This occurs when the "
       "pitch angle takes values near π/2 + kπ, ∀ k ∈ ℤ. At the current "
-      "configuration, we have pitch = {}. Drake does not yet support a "
-      "comparable joint using quaternions, but the feature request is "
+      "configuration, we have pitch = {} radians. Drake does not yet support "
+      "a comparable joint using quaternions, but the feature request is "
       "tracked in https://github.com/RobotLocomotion/drake/issues/12404.",
       function_name, this->inboard_body().name(), this->outboard_body().name(),
       pitch));
@@ -292,6 +292,13 @@ void RpyBallMobilizer<T>::DoCalcNplusDotMatrix(
   const T sp = sin(angles[1]);
   const T sy = sin(angles[2]);
   const T cy = cos(angles[2]);
+
+  // Throw an exception with the proper function name if a singularity would be
+  // encountered in DoMapVelocityToQDot().
+  if (abs(cp) < 1.0e-3) {
+    const char* function_name_less_Do = __func__ + 2;
+    ThrowSinceCosPitchIsNearZero(angles[1], function_name_less_Do);
+  }
 
   // Calculate time-derivative of roll, pitch, and yaw angles.
   const Vector3<T> v = get_angular_velocity(context);

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -226,8 +226,12 @@ void RpyBallMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>& context,
   //
   // where cp = cos(p), sp = sin(p), cy = cos(y), sy = sin(y).
   // Note: Although the elements of Ṅ(q,q̇) are simply the time-derivatives of
-  // the corresponding elements of N(q), the result for Ṅ[2, 0] was shortened
-  // as cp cy/cp ṗ + sp² cy/cp² ṗ simplifies to cy/cp² ṗ. Similarly for Ṅ[2, 1].
+  // corresponding elements of N(q), result were simplified as follows.
+  // Ṅ[2, 0] = cy ṗ + sp² cy/cp² ṗ - sp sy/cp ẏ
+  //         =            cy/cp² ṗ - sp sy/cp ẏ.
+  // Ṅ[2, 1] = sy ṗ̇ + sp² sy/cp² ṗ + sp cy/cp ẏ
+  //         =            sy/cp² ṗ + sp cy/cp ẏ.
+
   using std::cos;
   using std::sin;
   const Vector3<T> angles = get_angles(context);
@@ -421,7 +425,7 @@ void RpyBallMobilizer<T>::DoMapQDotToVelocity(
   const T cy = cos(angles[2]);
   const T cp_x_rdot = cp * rdot;
 
-  // Compute the product v = N⁺(q) * q̇ element-by-element to leverate the zeros
+  // Compute the product v = N⁺(q) * q̇ element-by-element to leverage the zeros
   // in N⁺(q) -- which is more efficient than matrix multiplication N⁺(q) * q̇.
   *v = Vector3<T>(cy * cp_x_rdot - sy * pdot, /*+ 0 * ydot*/
                   sy * cp_x_rdot + cy * pdot, /*+ 0 * ydot*/

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -132,15 +132,17 @@ void RpyBallMobilizer<T>::ProjectSpatialForce(
 }
 
 template <typename T>
-void RpyBallMobilizer<T>::ThrowSinceCosPitchIsNearZero(const T& pitch) const {
+void RpyBallMobilizer<T>::ThrowSinceCosPitchIsNearZero(
+    const T& pitch, const char* function_name) const {
   throw std::runtime_error(fmt::format(
-      "The RpyBallMobilizer (implementing a BallRpyJoint) between "
+      "{}(): The RpyBallMobilizer (implementing a BallRpyJoint) between "
       "body {} and body {} has reached a singularity. This occurs when the "
       "pitch angle takes values near π/2 + kπ, ∀ k ∈ ℤ. At the current "
       "configuration, we have pitch = {}. Drake does not yet support a "
       "comparable joint using quaternions, but the feature request is "
       "tracked in https://github.com/RobotLocomotion/drake/issues/12404.",
-      this->inboard_body().name(), this->outboard_body().name(), pitch));
+      function_name, this->inboard_body().name(), this->outboard_body().name(),
+      pitch));
 }
 
 template <typename T>
@@ -162,7 +164,10 @@ void RpyBallMobilizer<T>::DoCalcNMatrix(const systems::Context<T>& context,
   using std::sin;
   const Vector3<T> angles = get_angles(context);
   const T cp = cos(angles[1]);
-  if (abs(cp) < 1.0e-3) ThrowSinceCosPitchIsNearZero(angles[1]);
+  if (abs(cp) < 1.0e-3) {
+    const char* function_name_less_Do = __func__ + 2;
+    ThrowSinceCosPitchIsNearZero(angles[1], function_name_less_Do);
+  }
   const T sp = sin(angles[1]);
   const T sy = sin(angles[2]);
   const T cy = cos(angles[2]);
@@ -229,7 +234,10 @@ void RpyBallMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>& context,
   const T sp = sin(angles[1]);
   const T sy = sin(angles[2]);
   const T cy = cos(angles[2]);
-  if (abs(cp) < 1.0e-3) ThrowSinceCosPitchIsNearZero(angles[1]);
+  if (abs(cp) < 1.0e-3) {
+    const char* function_name_less_Do = __func__ + 2;
+    ThrowSinceCosPitchIsNearZero(angles[1], function_name_less_Do);
+  }
   const T cpi = 1.0 / cp;
   const T cpiSqr = cpi * cpi;
 
@@ -343,7 +351,10 @@ void RpyBallMobilizer<T>::DoMapVelocityToQDot(
   const T cp = cos(angles[1]);
   const T sy = sin(angles[2]);
   const T cy = cos(angles[2]);
-  if (abs(cp) < 1.0e-3) ThrowSinceCosPitchIsNearZero(angles[1]);
+  if (abs(cp) < 1.0e-3) {
+    const char* function_name_less_Do = __func__ + 2;
+    ThrowSinceCosPitchIsNearZero(angles[1], function_name_less_Do);
+  }
   const T cpi = 1.0 / cp;
 
   // Although we can calculate q̇ = N(q) * v, it is more efficient to implicitly

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -229,7 +229,7 @@ void RpyBallMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>& context,
   // corresponding elements of N(q), result were simplified as follows.
   // Ṅ[2, 0] = cy ṗ + sp² cy/cp² ṗ - sp sy/cp ẏ
   //         =            cy/cp² ṗ - sp sy/cp ẏ.
-  // Ṅ[2, 1] = sy ṗ̇ + sp² sy/cp² ṗ + sp cy/cp ẏ
+  // Ṅ[2, 1] = sy ṗ + sp² sy/cp² ṗ + sp cy/cp ẏ
   //         =            sy/cp² ṗ + sp cy/cp ẏ.
 
   using std::cos;

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -222,11 +222,12 @@ void RpyBallMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>& context,
   //
   //          ⌈ -sy/cp ẏ + cy sp/cp² ṗ    cy/cp ẏ + sy sp/cp² ṗ,   0 ⌉
   // Ṅ(q,q̇) = |                  -cy ẏ,                   -sy ẏ,   0 |
-  //          ⌊  cy/cp² ṗ̇ - sp sy/cp ẏ,   sy/cp² ṗ + sp cy/cp ẏ,   0 ⌋
+  //          ⌊  cy/cp² ṗ - sp sy/cp ẏ,   sy/cp² ṗ + sp cy/cp ẏ,   0 ⌋
   //
   // where cp = cos(p), sp = sin(p), cy = cos(y), sy = sin(y).
-  // Note: Ṅ[2, 0] simplifies using: cp cy/cp ṗ + sp² cy/cp² ṗ = cy/cp² ṗ.
-  // Note: Ṅ[2, 1] simplifies using: cp sy/cp ṗ̇ + sp² sy/cp² ṗ = sy/cp² ṗ.
+  // Note: Although the elements of Ṅ(q,q̇) are simply the time-derivatives of
+  // the corresponding elements of N(q), the result for Ṅ[2, 0] was shortened
+  // as cp cy/cp ṗ + sp² cy/cp² ṗ simplifies to cy/cp² ṗ. Similarly for Ṅ[2, 1].
   using std::cos;
   using std::sin;
   const Vector3<T> angles = get_angles(context);
@@ -283,8 +284,6 @@ void RpyBallMobilizer<T>::DoCalcNplusDotMatrix(
   //           ⌊              -cp ṗ,       0,   0 ⌋
   //
   // where cp = cos(p), sp = sin(p), cy = cos(y), sy = sin(y).
-  // Note: Ṅ[2, 0] simplifies using: cp cy/cp ṗ + sp² cy/cp² ṗ = cy/cp² ṗ.
-  // Note: Ṅ[2, 1] simplifies using: cp sy/cp ṗ̇ + sp² sy/cp² ṗ = sy/cp² ṗ.
   using std::cos;
   using std::sin;
   const Vector3<T> angles = get_angles(context);

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -308,6 +308,8 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // Certain roll pitch yaw calculations (e.g., calculating the N(q) matrix)
   // have a singularity (divide-by-zero error) when cos(pitch) ≈ 0.
   void ThrowSinceCosPitchIsNearZero(const T& pitch) const;
+  void ThrowSinceCosPitchIsNearZero(const T& pitch,
+                                    const char* function_name) const;
 
  private:
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -307,7 +307,6 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   // Certain roll pitch yaw calculations (e.g., calculating the N(q) matrix)
   // have a singularity (divide-by-zero error) when cos(pitch) ≈ 0.
-  void ThrowSinceCosPitchIsNearZero(const T& pitch) const;
   void ThrowSinceCosPitchIsNearZero(const T& pitch,
                                     const char* function_name) const;
 

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -306,7 +306,7 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
       const MultibodyTree<symbolic::Expression>& tree_clone) const override;
 
   // Certain roll pitch yaw calculations (e.g., calculating the N(q) matrix)
-  // have  a singularity (divide-by-zero error) when cos(pitch) ≈ 0.
+  // have a singularity (divide-by-zero error) when cos(pitch) ≈ 0.
   void ThrowSinceCosPitchIsNearZero(const T& pitch) const;
 
  private:

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -250,6 +250,14 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   void DoCalcNplusMatrix(const systems::Context<T>& context,
                          EigenPtr<MatrixX<T>> Nplus) const final;
 
+  // Generally, q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇. For this mobilizer, Ṅ is not simple.
+  void DoCalcNDotMatrix(const systems::Context<T>& context,
+                        EigenPtr<MatrixX<T>> Ndot) const final;
+
+  // Generally, v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈. For this mobilizer, Ṅ⁺ is not simple.
+  void DoCalcNplusDotMatrix(const systems::Context<T>& context,
+                            EigenPtr<MatrixX<T>> NplusDot) const final;
+
   // Maps the generalized velocity v, which corresponds to the angular velocity
   // w_FM, to time derivatives of roll-pitch-yaw angles θ₀, θ₁, θ₂ in qdot.
   //
@@ -296,6 +304,10 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
 
   std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
       const MultibodyTree<symbolic::Expression>& tree_clone) const override;
+
+  // Certain roll pitch yaw calculations (e.g., calculating the N(q) matrix)
+  // have  a singularity (divide-by-zero error) when cos(pitch) ≈ 0.
+  void ThrowSinceCosPitchIsNearZero(const T& pitch) const;
 
  private:
   // Helper method to make a clone templated on ToScalar.

--- a/multibody/tree/test/rpy_ball_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_ball_mobilizer_test.cc
@@ -103,8 +103,8 @@ TEST_F(RpyBallMobilizerTest, ZeroState) {
 }
 
 // For an arbitrary state, verify that calculating the Nplus matrix N⁺(q) is the
-// inverse of N(q).  Similarly, verify that the NplusDot matrix Ṅ⁺(q,q̇) is the
-// inverse of the NDot matrix Ṅ(q,q̇).
+// inverse of N(q), e.g., verify N⁺(q) * N(q) = [I] (the identity matrix). Also
+// verify the time derivatives of N⁺(q) * N(q) and N(q) * N⁺(q) are both zero.
 TEST_F(RpyBallMobilizerTest, KinematicMapping) {
   const Vector3d rpy(M_PI / 3, -M_PI / 3, M_PI / 5);
   mobilizer_->SetAngles(context_.get(), rpy);


### PR DESCRIPTION
This is one in a series of PRs to help address issue #22630. It creates DoCalcNDotMatrix() and DoCalcNplusDotMatrix() for an RPY ball mobilizer.

PR #22950 was already merged to handle simple mobilizers for the aforementioned methods.  Subsequent PRs will create similar functions for other complex mobilizers (e.g., quaternion_floating_mobilizer). A follow-on PR will create MapQDDotToAcceleration() and MapAccelerationToQDDot() for the rpy_ball_mobilizer.

FYI: Since mobilizers are Drake internal classes, after the internal mobilizer work is complete, there will be PRs (code and testing) for the public API in MultibodyPlant to address issue #22630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23030)
<!-- Reviewable:end -->
