### PR TITLE
[solvers] SnoptSolver honors user requests to allocate extra memory

### DIFF
--- a/solvers/csdp_solver.cc
+++ b/solvers/csdp_solver.cc
@@ -421,7 +421,7 @@ std::string MaybeWriteCsdpParams(internal::SpecificOptions* options,
     constexpr int kLorentzConeSlack =
         static_cast<int>(RemoveFreeVariableMethod::kLorentzConeSlack);
     const int method =
-        options->template Pop<int>("drake::RemoveFreeVariableMethod")
+        options->Pop<int>("drake::RemoveFreeVariableMethod")
             .value_or(kNullspace);
     if (!(method >= kTwoSlackVariables && method <= kLorentzConeSlack)) {
       throw std::logic_error(fmt::format(

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -940,7 +940,7 @@ void GurobiSolver::DoSolve2(const MathematicalProgram& prog,
 
   // A couple options don't use the standard GRBset{...}param API.
   const bool compute_iis = [&options]() {
-    const int value = options->template Pop<int>("GRBcomputeIIS").value_or(0);
+    const int value = options->Pop<int>("GRBcomputeIIS").value_or(0);
     if (!(value == 0 || value == 1)) {
       throw std::runtime_error(fmt::format(
           "GurobiSolver(): option GRBcomputeIIS should be either 0 or 1, but "


### PR DESCRIPTION
Also unify our spelling of Pop vs 'template' keyword across all solvers.

Closes #23032.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23039)
<!-- Reviewable:end -->
