### PR TITLE
[setup] Add missing Clang library on Noble

### DIFF
--- a/setup/ubuntu/source_distribution/packages-noble-clang.txt
+++ b/setup/ubuntu/source_distribution/packages-noble-clang.txt
@@ -1,3 +1,4 @@
 clang-15
+libclang-rt-15-dev
 libomp-15-dev
 llvm-15


### PR DESCRIPTION
Towards #22996, fixing this error message:

```
/usr/bin/ld.gold: error: cannot open /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.lsan-x86_64.a: No such file or directory
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23054)
<!-- Reviewable:end -->
