### PR TITLE
Guard some Eigen realloc calls against zero

### DIFF
--- a/perception/test/point_cloud_test.cc
+++ b/perception/test/point_cloud_test.cc
@@ -335,7 +335,6 @@ GTEST_TEST(PointCloudTest, Basic) {
     EXPECT_FALSE(cloud.HasFields(pc_flags::kXYZs));
     // The rows size should be consistent with the new FPFH descriptor.
     EXPECT_EQ(cloud.descriptors().rows(), 33);
-    EXPECT_FALSE((cloud.descriptors().array().isNaN()).all());
   }
 
   // Test point cloud cropping.

--- a/solvers/sos_basis_generator.cc
+++ b/solvers/sos_basis_generator.cc
@@ -237,7 +237,14 @@ void RemoveWithRandomSeparatingHyperplanes(const ExponentList& exponents_of_p,
       }
     }
 
-    basis->conservativeResize(next_basis_size, basis->cols());
+    if (next_basis_size > 0) {
+      basis->conservativeResize(next_basis_size, Eigen::NoChange);
+    } else {
+      // Once Drake's minimum supported Eigen version is circa 2023 or newer, we
+      // can go back to calling conservativeResize even with a zero size, rather
+      // than this special 'else' case.
+      basis->resize(0, Eigen::NoChange);
+    }
 
     // Quit if the basis is now empty or if its size wasn't reduced
     // enough.


### PR DESCRIPTION
Calling 'realloc(size=0)' is typically a synonym for 'free', but this is not portable, and newer Valgrind has started flagging this.

Eigen 3.4.0 assumes the non-portable semantics during conservativeResize, so we need to clean up some our call sites that tickle that case.

This has been fixed upstream but not released yet: https://gitlab.com/libeigen/eigen/-/merge_requests/1148.

---

Towards #22996.

This is ready for review and merge anytime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23056)
<!-- Reviewable:end -->
