### PR TITLE
[multibody] Some minor performance tweaks & prep for M-frame algorithms

### DIFF
--- a/math/cross_product.h
+++ b/math/cross_product.h
@@ -13,7 +13,11 @@ drake::Matrix3<typename Derived::Scalar> VectorToSkewSymmetric(
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<Derived>, 3);
 
   drake::Matrix3<typename Derived::Scalar> ret;
-  ret << 0.0, -p(2), p(1), p(2), 0.0, -p(0), -p(1), p(0), 0.0;
+  // clang-format off
+  ret <<  0.0, -p(2), p(1),
+          p(2), 0.0, -p(0),
+         -p(1), p(0), 0.0;
+  // clang-format on
   return ret;
 }
 

--- a/multibody/benchmarking/cassie.cc
+++ b/multibody/benchmarking/cassie.cc
@@ -25,21 +25,19 @@ using systems::System;
 // In the benchmark case instantiations at the bottom of this file, we'll use
 // a bitmask for the case's "Arg" to denote which quantities are in scope as
 // either gradients (for T=AutoDiffXd) or variables (for T=Expression).
-constexpr int kWantNoGrad   = 0x0;
-constexpr int kWantGradQ    = 0x1;
-constexpr int kWantGradV    = 0x2;
-constexpr int kWantGradX    = kWantGradQ | kWantGradV;
+constexpr int kWantNoGrad = 0x0;
+constexpr int kWantGradQ = 0x1;
+constexpr int kWantGradV = 0x2;
+constexpr int kWantGradX = kWantGradQ | kWantGradV;
 constexpr int kWantGradVdot = 0x4;
-constexpr int kWantGradU    = 0x8;
+constexpr int kWantGradU = 0x8;
 
 // Fixture that holds a Cassie robot model and offers helper functions to
 // configure the benchmark case.
 template <typename T>
 class Cassie : public benchmark::Fixture {
  public:
-  Cassie() {
-    tools::performance::AddMinMaxStatistics(this);
-  }
+  Cassie() { tools::performance::AddMinMaxStatistics(this); }
 
   void SetUp(benchmark::State& state) override {
     SetUpNonZeroState();
@@ -89,24 +87,28 @@ class Cassie : public benchmark::Fixture {
   // those would get computed once and re-used (like in real applications) but
   // with caching off they would get recalculated repeatedly, affecting the
   // timing results.
-  void InvalidateInput() {
-    input_.GetMutableData();
-  }
-  void InvalidateState() {
-    context_->NoteContinuousStateChange();
-  }
+  void InvalidateInput() { input_.GetMutableData(); }
+  void InvalidateState() { context_->NoteContinuousStateChange(); }
 
   // Runs the PositionKinematics benchmark.
   // NOLINTNEXTLINE(runtime/references)
   void DoPositionKinematics(benchmark::State& state) {
     DRAKE_DEMAND(want_grad_vdot(state) == false);
     DRAKE_DEMAND(want_grad_u(state) == false);
-    // A distal body. Asking for pose of one body calculates poses of all
-    // of them in the PositionKinematicsCache.
-    const RigidBody<T>& toe_right = plant_->GetBodyByName("toe_right");
     for (auto _ : state) {
       InvalidateState();
-      plant_->EvalBodyPoseInWorld(*context_, toe_right);
+      plant_->EvalPositionKinematics(*context_);
+    }
+  }
+
+  // Runs the CompositeBodyInertiaInWorld benchmark.
+  // NOLINTNEXTLINE(runtime/references)
+  void DoCompositeBodyInertiaInWorld(benchmark::State& state) {
+    DRAKE_DEMAND(want_grad_vdot(state) == false);
+    DRAKE_DEMAND(want_grad_u(state) == false);
+    for (auto _ : state) {
+      InvalidateState();
+      plant_->EvalCompositeBodyInertiaInWorldCache(*context_);
     }
   }
 
@@ -115,13 +117,21 @@ class Cassie : public benchmark::Fixture {
   void DoPosAndVelKinematics(benchmark::State& state) {
     DRAKE_DEMAND(want_grad_vdot(state) == false);
     DRAKE_DEMAND(want_grad_u(state) == false);
-    // A distal body. Asking for kinematics of one body calculates it for all
-    // of them in the PositionKinematicsCache and VelocityKinematicsCache.
-    const RigidBody<T>& toe_right = plant_->GetBodyByName("toe_right");
     for (auto _ : state) {
       InvalidateState();
       // This requires both position and velocity kinematics.
-      plant_->EvalBodySpatialVelocityInWorld(*context_, toe_right);
+      plant_->EvalVelocityKinematics(*context_);
+    }
+  }
+
+  // Runs the MassMatrixViaID benchmark.
+  // NOLINTNEXTLINE(runtime/references)
+  void DoMassMatrixViaID(benchmark::State& state) {
+    DRAKE_DEMAND(want_grad_vdot(state) == false);
+    DRAKE_DEMAND(want_grad_u(state) == false);
+    for (auto _ : state) {
+      InvalidateState();
+      plant_->CalcMassMatrixViaInverseDynamics(*context_, &mass_matrix_out_);
     }
   }
 
@@ -201,8 +211,8 @@ void Cassie<T>::SetUpNonZeroState() {
       VectorX<T>::LinSpaced(nq_ + nv_, 0.1, 0.9));
   for (const BodyIndex& index : plant_->GetFloatingBaseBodies()) {
     const RigidBody<T>& body = plant_->get_body(index);
-    const RigidTransform<T> pose(
-        RollPitchYaw<T>(0.1, 0.2, 0.3), Vector3<T>(0.4, 0.5, 0.6));
+    const RigidTransform<T> pose(RollPitchYaw<T>(0.1, 0.2, 0.3),
+                                 Vector3<T>(0.4, 0.5, 0.6));
     plant_->SetFreeBodyPose(context_.get(), body, pose);
   }
 
@@ -303,6 +313,15 @@ BENCHMARK_REGISTER_F(CassieDouble, PositionKinematics)
     ->Unit(benchmark::kMicrosecond)
     ->Arg(kWantNoGrad);
 
+BENCHMARK_DEFINE_F(CassieDouble, CompositeBodyInertiaInWorld)
+// NOLINTNEXTLINE(runtime/references)
+(benchmark::State& state) {
+  DoCompositeBodyInertiaInWorld(state);
+}
+BENCHMARK_REGISTER_F(CassieDouble, CompositeBodyInertiaInWorld)
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad);
+
 // NOLINTNEXTLINE(runtime/references)
 BENCHMARK_DEFINE_F(CassieDouble, PosAndVelKinematics)(benchmark::State& state) {
   DoPosAndVelKinematics(state);
@@ -312,28 +331,36 @@ BENCHMARK_REGISTER_F(CassieDouble, PosAndVelKinematics)
     ->Arg(kWantNoGrad);
 
 // NOLINTNEXTLINE(runtime/references)
+BENCHMARK_DEFINE_F(CassieDouble, MassMatrixViaID)(benchmark::State& state) {
+  DoMassMatrixViaID(state);
+}
+BENCHMARK_REGISTER_F(CassieDouble, MassMatrixViaID)
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad);
+
+// NOLINTNEXTLINE(runtime/references)
 BENCHMARK_DEFINE_F(CassieDouble, MassMatrix)(benchmark::State& state) {
   DoMassMatrix(state);
 }
 BENCHMARK_REGISTER_F(CassieDouble, MassMatrix)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad);
 
 // NOLINTNEXTLINE(runtime/references)
 BENCHMARK_DEFINE_F(CassieDouble, InverseDynamics)(benchmark::State& state) {
   DoInverseDynamics(state);
 }
 BENCHMARK_REGISTER_F(CassieDouble, InverseDynamics)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad);
 
 // NOLINTNEXTLINE(runtime/references)
 BENCHMARK_DEFINE_F(CassieDouble, ForwardDynamics)(benchmark::State& state) {
   DoForwardDynamics(state);
 }
 BENCHMARK_REGISTER_F(CassieDouble, ForwardDynamics)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad);
 
 BENCHMARK_DEFINE_F(CassieAutoDiff, PositionKinematics)
 // NOLINTNEXTLINE(runtime/references)
@@ -362,41 +389,41 @@ BENCHMARK_DEFINE_F(CassieAutoDiff, MassMatrix)(benchmark::State& state) {
   DoMassMatrix(state);
 }
 BENCHMARK_REGISTER_F(CassieAutoDiff, MassMatrix)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad)
-  ->Arg(kWantGradQ)
-  ->Arg(kWantGradV)
-  ->Arg(kWantGradX);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad)
+    ->Arg(kWantGradQ)
+    ->Arg(kWantGradV)
+    ->Arg(kWantGradX);
 
 // NOLINTNEXTLINE(runtime/references)
 BENCHMARK_DEFINE_F(CassieAutoDiff, InverseDynamics)(benchmark::State& state) {
   DoInverseDynamics(state);
 }
 BENCHMARK_REGISTER_F(CassieAutoDiff, InverseDynamics)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad)
-  ->Arg(kWantGradQ)
-  ->Arg(kWantGradV)
-  ->Arg(kWantGradX)
-  ->Arg(kWantGradVdot)
-  ->Arg(kWantGradQ|kWantGradVdot)
-  ->Arg(kWantGradV|kWantGradVdot)
-  ->Arg(kWantGradX|kWantGradVdot);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad)
+    ->Arg(kWantGradQ)
+    ->Arg(kWantGradV)
+    ->Arg(kWantGradX)
+    ->Arg(kWantGradVdot)
+    ->Arg(kWantGradQ | kWantGradVdot)
+    ->Arg(kWantGradV | kWantGradVdot)
+    ->Arg(kWantGradX | kWantGradVdot);
 
 // NOLINTNEXTLINE(runtime/references)
 BENCHMARK_DEFINE_F(CassieAutoDiff, ForwardDynamics)(benchmark::State& state) {
   DoForwardDynamics(state);
 }
 BENCHMARK_REGISTER_F(CassieAutoDiff, ForwardDynamics)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad)
-  ->Arg(kWantGradQ)
-  ->Arg(kWantGradV)
-  ->Arg(kWantGradX)
-  ->Arg(kWantGradU)
-  ->Arg(kWantGradQ|kWantGradU)
-  ->Arg(kWantGradV|kWantGradU)
-  ->Arg(kWantGradX|kWantGradU);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad)
+    ->Arg(kWantGradQ)
+    ->Arg(kWantGradV)
+    ->Arg(kWantGradX)
+    ->Arg(kWantGradU)
+    ->Arg(kWantGradQ | kWantGradU)
+    ->Arg(kWantGradV | kWantGradU)
+    ->Arg(kWantGradX | kWantGradU);
 
 BENCHMARK_DEFINE_F(CassieExpression, PositionKinematics)
 // NOLINTNEXTLINE(runtime/references)
@@ -425,38 +452,38 @@ BENCHMARK_DEFINE_F(CassieExpression, MassMatrix)(benchmark::State& state) {
   DoMassMatrix(state);
 }
 BENCHMARK_REGISTER_F(CassieExpression, MassMatrix)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad)
-  ->Arg(kWantGradQ)
-  ->Arg(kWantGradV)
-  ->Arg(kWantGradX);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad)
+    ->Arg(kWantGradQ)
+    ->Arg(kWantGradV)
+    ->Arg(kWantGradX);
 
 // NOLINTNEXTLINE(runtime/references)
 BENCHMARK_DEFINE_F(CassieExpression, InverseDynamics)(benchmark::State& state) {
   DoInverseDynamics(state);
 }
 BENCHMARK_REGISTER_F(CassieExpression, InverseDynamics)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad)
-  ->Arg(kWantGradQ)
-  ->Arg(kWantGradV)
-  ->Arg(kWantGradX)
-  ->Arg(kWantGradVdot)
-  ->Arg(kWantGradQ|kWantGradVdot)
-  ->Arg(kWantGradV|kWantGradVdot)
-  ->Arg(kWantGradX|kWantGradVdot);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad)
+    ->Arg(kWantGradQ)
+    ->Arg(kWantGradV)
+    ->Arg(kWantGradX)
+    ->Arg(kWantGradVdot)
+    ->Arg(kWantGradQ | kWantGradVdot)
+    ->Arg(kWantGradV | kWantGradVdot)
+    ->Arg(kWantGradX | kWantGradVdot);
 
 // NOLINTNEXTLINE(runtime/references)
 BENCHMARK_DEFINE_F(CassieExpression, ForwardDynamics)(benchmark::State& state) {
   DoForwardDynamics(state);
 }
 BENCHMARK_REGISTER_F(CassieExpression, ForwardDynamics)
-  ->Unit(benchmark::kMicrosecond)
-  ->Arg(kWantNoGrad)
-  // N.B. MbP does not support forward dynamics with Variables in 'q'.
-  ->Arg(kWantGradV)
-  ->Arg(kWantGradU)
-  ->Arg(kWantGradV|kWantGradU);
+    ->Unit(benchmark::kMicrosecond)
+    ->Arg(kWantNoGrad)
+    // N.B. MbP does not support forward dynamics with Variables in 'q'.
+    ->Arg(kWantGradV)
+    ->Arg(kWantGradU)
+    ->Arg(kWantGradV | kWantGradU);
 
 }  // namespace
 }  // namespace multibody

--- a/multibody/math/spatial_velocity.h
+++ b/multibody/math/spatial_velocity.h
@@ -107,7 +107,7 @@ class SpatialVelocity : public SpatialVector<SpatialVelocity, T> {
   /// @see ShiftInPlace() for more information and how V_MC_E is calculated.
   SpatialVelocity<T> Shift(const Vector3<T>& offset) const {
     SpatialVelocity<T> result(*this);
-    result.ShiftInPlace(offset);
+    result.ShiftInPlace(offset);  // 12 flops
     return result;
   }
 

--- a/multibody/plant/test/external_forces_test.cc
+++ b/multibody/plant/test/external_forces_test.cc
@@ -1,14 +1,11 @@
 #include <limits>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "drake/common/autodiff.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/limit_malloc.h"
 #include "drake/multibody/plant/test/kuka_iiwa_model_tests.h"
 #include "drake/multibody/tree/frame.h"
-#include "drake/multibody/tree/rigid_body.h"
 
 namespace drake {
 

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -2990,13 +2990,15 @@ TEST_F(SplitPendulum, MassMatrix) {
   // We choose an arbitrary angle since the mass matrix is independent of the
   // state.
   const double theta = M_PI / 3;
-
-  MatrixX<double> M(1, 1);
   pin_->set_angle(context_.get(), theta);
-  plant_.CalcMassMatrixViaInverseDynamics(*context_, &M);
+
+  MatrixX<double> M_via_id(1, 1), M_via_W(1, 1);
+  plant_.CalcMassMatrixViaInverseDynamics(*context_, &M_via_id);
+  plant_.CalcMassMatrix(*context_, &M_via_W);
 
   // We can only expect values within the precision specified in the sdf file.
-  EXPECT_NEAR(M(0, 0), Io, 1.0e-6);
+  EXPECT_NEAR(M_via_id(0, 0), Io, 1.0e-6);
+  EXPECT_NEAR(M_via_W(0, 0), Io, 1.0e-6);
 }
 
 // This test ensures that we can create a symbolic mass matrix successfully.
@@ -3033,16 +3035,18 @@ TEST_F(SplitPendulum, SymbolicMassMatrix) {
   sym_plant->SetPositions(sym_context.get(), q);
   sym_plant->SetVelocities(sym_context.get(), v);
 
-  // Calculate the mass matrix two different ways and verify that evaluating
-  // the resulting expressions yields the same result numerically.
-  Eigen::MatrixX<symbolic::Expression> M(1, 1), M_id(1, 1);
-  sym_plant->CalcMassMatrix(*sym_context, &M);
-  sym_plant->CalcMassMatrixViaInverseDynamics(*sym_context, &M_id);
+  // Calculate the mass matrix two different ways, via Inverse Dynamics
+  // ("_via_id") and using the Composite Body Algorithm via recursion of
+  // World-frame quantities ("_via_W"). Verify that evaluating the resulting
+  // expressions yields the same result numerically.
+  Eigen::MatrixX<symbolic::Expression> M_via_id(1, 1), M_via_W(1, 1);
+  sym_plant->CalcMassMatrixViaInverseDynamics(*sym_context, &M_via_id);
+  sym_plant->CalcMassMatrix(*sym_context, &M_via_W);
 
   const symbolic::Environment env{{q_var(0), 2.0}, {v_var(0), 10.},
                                   {m_var(0), 3.0}, {m_var(1), 4.0},
                                   {l_var(0), 5.0}, {l_var(1), 6.0}};
-  EXPECT_NEAR(M(0, 0).Evaluate(env), M_id(0, 0).Evaluate(env), 1e-14);
+  EXPECT_NEAR(M_via_W(0, 0).Evaluate(env), M_via_id(0, 0).Evaluate(env), 1e-14);
 
   // Generate symbolic expressions for a few more quantities here just as a
   // sanity check that we can do so. We won't look at the results.

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -500,7 +500,7 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcInverseDynamics_TipToBase(
   //   Ftot_BBo = M_B * A_WB + Fb_Bo
   const SpatialInertia<T>& M_B_W = M_B_W_cache[mobod_index()];
   const SpatialAcceleration<T>& A_WB = A_WB_array[mobod_index()];
-  SpatialForce<T> Ftot_BBo_W = M_B_W * A_WB;  // 66 flops
+  SpatialForce<T> Ftot_BBo_W = M_B_W * A_WB;  // 45 flops
   if (Fb_Bo_W_cache != nullptr) {
     // Dynamic bias for body B.
     const SpatialForce<T>& Fb_Bo_W = (*Fb_Bo_W_cache)[mobod_index()];

--- a/multibody/tree/body_node_impl.h
+++ b/multibody/tree/body_node_impl.h
@@ -84,28 +84,28 @@ class BodyNodeImpl final : public BodyNode<T> {
       const std::vector<Vector6<T>>& H_PB_W_cache, const T* velocities,
       VelocityKinematicsCache<T>* vc) const final;
 
-  void CalcMassMatrixContribution_TipToBase(
+  void CalcMassMatrixContributionViaWorld_TipToBase(
       const PositionKinematicsCache<T>& pc,
-      const std::vector<SpatialInertia<T>>& Mc_B_W_cache,
+      const std::vector<SpatialInertia<T>>& K_BBo_W_cache,  // composites
       const std::vector<Vector6<T>>& H_PB_W_cache,
       EigenPtr<MatrixX<T>> M) const final;
 
   // Declare functions for the six sizes of mass matrix off-diagonal
   // blocks.
-#define DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(Rnv)                     \
-  void CalcMassMatrixOffDiagonalBlock##Rnv(                             \
-      int R_start_in_v, const std::vector<Vector6<T>>& H_PB_W_cache,    \
-      const Eigen::Matrix<T, 6, Rnv>& Fm_CCo_W, EigenPtr<MatrixX<T>> M) \
+#define DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK_VIA_WORLD(Bnv)           \
+  void CalcMassMatrixOffDiagonalBlockViaWorld##Bnv(                     \
+      int B_start_in_v, const std::vector<Vector6<T>>& H_PB_W_cache,    \
+      const Eigen::Matrix<T, 6, Bnv>& Fm_CCo_W, EigenPtr<MatrixX<T>> M) \
       const final
 
-  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(1);
-  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(2);
-  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(3);
-  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(4);
-  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(5);
-  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK(6);
+  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK_VIA_WORLD(1);
+  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK_VIA_WORLD(2);
+  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK_VIA_WORLD(3);
+  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK_VIA_WORLD(4);
+  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK_VIA_WORLD(5);
+  DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK_VIA_WORLD(6);
 
-#undef DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK
+#undef DECLARE_MASS_MATRIX_OFF_DIAGONAL_BLOCK_VIA_WORLD
 
   void CalcSpatialAcceleration_BaseToTip(
       const FrameBodyPoseCache<T>& frame_body_pose_cache, const T* positions,

--- a/multibody/tree/body_node_world.h
+++ b/multibody/tree/body_node_world.h
@@ -44,27 +44,27 @@ class BodyNodeWorld final : public BodyNode<T> {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcMassMatrixContribution_TipToBase(
+  void CalcMassMatrixContributionViaWorld_TipToBase(
       const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
       const std::vector<Vector6<T>>&, EigenPtr<MatrixX<T>>) const final {
     DRAKE_UNREACHABLE();
   }
 
-#define DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(Rnv)                                \
-  void CalcMassMatrixOffDiagonalBlock##Rnv(                                 \
-      int, const std::vector<Vector6<T>>&, const Eigen::Matrix<T, 6, Rnv>&, \
+#define DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(Bnv)                      \
+  void CalcMassMatrixOffDiagonalBlockViaWorld##Bnv(                         \
+      int, const std::vector<Vector6<T>>&, const Eigen::Matrix<T, 6, Bnv>&, \
       EigenPtr<MatrixX<T>>) const final {                                   \
     DRAKE_UNREACHABLE();                                                    \
   }
 
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(1)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(2)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(3)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(4)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(5)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(6)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(1)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(2)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(3)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(4)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(5)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(6)
 
-#undef DEFINE_DUMMY_OFF_DIAGONAL_BLOCK
+#undef DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD
 
   void CalcSpatialAcceleration_BaseToTip(
       const FrameBodyPoseCache<T>&, const T*, const PositionKinematicsCache<T>&,
@@ -111,7 +111,7 @@ class BodyNodeWorld final : public BodyNode<T> {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcCompositeBodyInertia_TipToBase(
+  void CalcCompositeBodyInertiaInWorld_TipToBase(
       const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
       std::vector<SpatialInertia<T>>*) const final {
     DRAKE_UNREACHABLE();

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1325,16 +1325,14 @@ void MultibodyTree<T>::CalcPositionKinematicsCache(
   // information for each body, we are now in position to perform a base-to-tip
   // recursion to update world positions and parent to child body transforms.
   // This skips the world, level = 0.
-  for (int level = 1; level < forest_height(); ++level) {
-    for (MobodIndex mobod_index : body_node_levels_[level]) {
-      const BodyNode<T>& node = *body_nodes_[mobod_index];
+  // Performs a base-to-tip recursion computing body poses.
+  // Skip the World which is mobod_index(0).
+  for (MobodIndex mobod_index(1); mobod_index < num_mobods(); ++mobod_index) {
+    const BodyNode<T>& node = *body_nodes_[mobod_index];
+    DRAKE_ASSERT(node.mobod_index() == mobod_index);
 
-      DRAKE_ASSERT(node.get_topology().level == level);
-      DRAKE_ASSERT(node.mobod_index() == mobod_index);
-
-      // Update per-node kinematics.
-      node.CalcPositionKinematicsCache_BaseToTip(frame_body_pose_cache, q, pc);
-    }
+    // Update per-node kinematics.
+    node.CalcPositionKinematicsCache_BaseToTip(frame_body_pose_cache, q, pc);
   }
 }
 
@@ -1359,8 +1357,7 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
 
   // Performs a base-to-tip recursion computing body velocities.
   // Skip the World which is mobod_index(0).
-  for (MobodIndex mobod_index(1); mobod_index < ssize(body_nodes_);
-       ++mobod_index) {
+  for (MobodIndex mobod_index(1); mobod_index < num_mobods(); ++mobod_index) {
     const BodyNode<T>& node = *body_nodes_[mobod_index];
     DRAKE_ASSERT(node.mobod_index() == mobod_index);
 
@@ -1397,7 +1394,8 @@ void MultibodyTree<T>::CalcSpatialInertiasInWorld(
         frame_body_pose_cache.get_M_BBo_B(body.mobod_index());
     // Re-express body B's spatial inertia in the world frame W.
     SpatialInertia<T>& M_BBo_W = (*M_B_W_all)[body.mobod_index()];
-    M_BBo_W = M_BBo_B.ReExpress(R_WB);
+    M_BBo_W = M_BBo_B;               // Wrong frame.
+    M_BBo_W.ReExpressInPlace(R_WB);  // Fixed.
   }
 }
 
@@ -1476,21 +1474,20 @@ void MultibodyTree<T>::CalcFrameBodyPoses(
 template <typename T>
 void MultibodyTree<T>::CalcCompositeBodyInertiasInWorld(
     const systems::Context<T>& context,
-    std::vector<SpatialInertia<T>>* Mc_B_W_all) const {
+    std::vector<SpatialInertia<T>>* K_BBo_W_all) const {
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  const std::vector<SpatialInertia<T>>& M_B_W_all =
+  const std::vector<SpatialInertia<T>>& M_BBo_W_all =
       EvalSpatialInertiaInWorldCache(context);
 
   // Perform tip-to-base recursion for each composite body, skipping the world.
-  for (int level = forest_height() - 1; level > 0; --level) {
-    for (MobodIndex mobod_index : body_node_levels_[level]) {
-      // Node corresponding to the base of composite body C. We'll add in
-      // everything outboard of this node.
-      const BodyNode<T>& composite_node = *body_nodes_[mobod_index];
+  for (MobodIndex mobod_index(num_mobods() - 1); mobod_index > 0;
+       --mobod_index) {
+    // Node corresponding to the base of composite body C. We'll add in
+    // everything outboard of this node.
+    const BodyNode<T>& composite_node = *body_nodes_[mobod_index];
 
-      composite_node.CalcCompositeBodyInertia_TipToBase(pc, M_B_W_all,
-                                                        &*Mc_B_W_all);
-    }
+    composite_node.CalcCompositeBodyInertiaInWorld_TipToBase(pc, M_BBo_W_all,
+                                                             &*K_BBo_W_all);
   }
 }
 
@@ -1948,15 +1945,15 @@ void MultibodyTree<T>::CalcMassMatrix(const systems::Context<T>& context,
   //   is the across-mobilizer Jacobian such that we can write
   //   V_PB_W = H_PB_W * v_B, with v_B the generalized velocities of body B's
   //   mobilizer.
-  // - In code we use the monogram notation Mc_C_W to denote the spatial inertia
-  //   of composite body C, about it's frame origin Co, and expressed in the
-  //   world frame W.
+  // - In code we use the monogram notation K_BBo_W to denote the spatial
+  //   inertia of composite body B, about it's frame origin Bo, and expressed in
+  //   the world frame W.
   //
   // - [Jain 2010] Jain, A., 2010. Robot and multibody dynamics: analysis and
   //               algorithms. Springer Science & Business Media, pp. 123-130.
 
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  const std::vector<SpatialInertia<T>>& Mc_B_W_cache =
+  const std::vector<SpatialInertia<T>>& K_BBo_W_cache =
       EvalCompositeBodyInertiaInWorldCache(context);
   const std::vector<Vector6<T>>& H_PB_W_cache =
       EvalAcrossNodeJacobianWrtVExpressedInWorld(context);
@@ -1964,20 +1961,20 @@ void MultibodyTree<T>::CalcMassMatrix(const systems::Context<T>& context,
 
   // The algorithm below does not recurse zero entries and therefore these must
   // be set a priori.
-  // In addition, we initialize diagonal entries to include the effect of rotor
-  // reflected inertia. See JointActuator::reflected_inertia().
-  (*M) = reflected_inertia.asDiagonal();
+  M->setZero();
 
   // Perform tip-to-base recursion for each composite body, skipping the world.
-  for (int level = forest_height() - 1; level > 0; --level) {
-    for (MobodIndex mobod_index : body_node_levels_[level]) {
-      // Node corresponding to the composite body C.
-      const BodyNode<T>& composite_node = *body_nodes_[mobod_index];
+  for (MobodIndex mobod_index(num_mobods() - 1); mobod_index > 0;
+       --mobod_index) {
+    // Node corresponding to the composite body C.
+    const BodyNode<T>& composite_node = *body_nodes_[mobod_index];
 
-      composite_node.CalcMassMatrixContribution_TipToBase(pc, Mc_B_W_cache,
-                                                          H_PB_W_cache, M);
-    }
+    composite_node.CalcMassMatrixContributionViaWorld_TipToBase(
+        pc, K_BBo_W_cache, H_PB_W_cache, M);
   }
+
+  // Account for reflected inertia.
+  M->diagonal() += reflected_inertia;
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1416,21 +1416,22 @@ class MultibodyTree {
   void CalcFrameBodyPoses(const systems::Context<T>& context,
                           FrameBodyPoseCache<T>* frame_body_poses) const;
 
-  // Computes the composite body inertia Mc_B_W(q) for each body B in the
+  // Computes the composite body inertia K_BBo_W(q) for each body B in the
   // model about its frame origin Bo and expressed in the world frame W.
   // The composite body inertia is the effective mass properties B would have
   // if every joint outboard of B was welded in its current configuration.
   // @param[in] context
   //   The context storing the state of the model.
-  // @param[out] Mc_B_W_all
-  //   For each body in the model, entry RigidBody::mobod_index() in M_B_W_all
-  //   contains the updated composite body inertia `Mc_B_W(q)` for that body.
-  //   On input it must be a valid pointer to a vector of size num_bodies().
-  // @throws std::exception if Mc_B_W_all is nullptr or if its size is not
-  // num_bodies().
+  // @param[out] K_BBo_W_all
+  //   For each body B in the model, entry RigidBody::mobod_index() in
+  //   M_BBo_W_all contains the updated composite body inertia K_BBo_W(q) for
+  //   that body. On input it must be a valid pointer to a vector of size
+  //   num_mobods().
+  // @throws std::exception if K_BBo_W_all is nullptr or if its size is not
+  //   num_mobods().
   void CalcCompositeBodyInertiasInWorld(
       const systems::Context<T>& context,
-      std::vector<SpatialInertia<T>>* Mc_B_W_all) const;
+      std::vector<SpatialInertia<T>>* K_BBo_W_all) const;
 
   // Computes the bias force `Fb_Bo_W(q, v)` for each body in the model.
   // For a body B, this is the bias term `Fb_Bo_W` in the equation

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -261,10 +261,10 @@ void MultibodyTreeSystem<T>::Finalize() {
               {position_kinematics_cache_entry().ticket()})
           .cache_index();
 
-  // Allocate cache entry for composite-body inertias Mc_B_W(q) for each body.
+  // Allocate cache entry for composite-body inertias K_BBo_W(q) for each body.
   cache_indexes_.composite_body_inertia_in_world =
       this->DeclareCacheEntry(
-              std::string("composite body inertia in world (Mc_B_W)"),
+              std::string("composite body inertia in world (K_BBo_W)"),
               std::vector<SpatialInertia<T>>(internal_tree().num_bodies(),
                                              SpatialInertia<T>::NaN()),
               &MultibodyTreeSystem<T>::CalcCompositeBodyInertiasInWorld,

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -171,7 +171,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   }
 
   /* Returns a reference to the up-to-date cache of composite-body inertias
-  in the given Context, recalculating it first if necessary. */
+  K_BBo_W in the given Context, recalculating it first if necessary. */
   const std::vector<SpatialInertia<T>>& EvalCompositeBodyInertiaInWorldCache(
       const systems::Context<T>& context) const {
     this->ValidateContext(context);
@@ -427,9 +427,8 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
 
   void CalcCompositeBodyInertiasInWorld(
       const systems::Context<T>& context,
-      std::vector<SpatialInertia<T>>* composite_body_inertias) const {
-    internal_tree().CalcCompositeBodyInertiasInWorld(context,
-                                                     composite_body_inertias);
+      std::vector<SpatialInertia<T>>* K_BBo_W_all) const {
+    internal_tree().CalcCompositeBodyInertiasInWorld(context, K_BBo_W_all);
   }
 
   void CalcAcrossNodeJacobianWrtVExpressedInWorld(

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -31,12 +31,20 @@ namespace internal {
  The generalized velocities for this mobilizer are the rate of change of the
  coordinates, v = q̇.
 
- H_FM₆ₓ₃=[0 0 0]    Hdot_FM = 0₆ₓ₃
-         [0 0 0]
-         [0 0 1]
-         [1 0 0]
-         [0 1 0]
-         [0 0 0]
+ H_FM_F₆ₓ₃ = [0 0 0]    Hdot_FM_F = 0₆ₓ₃
+             [0 0 0]
+             [0 0 1]    R_FM(q₂) = [c -s  0]
+             [1 0 0]               [s  c  0]
+             [0 1 0]               [0  0  1]
+             [0 0 0]
+
+ H_FM_M = R_MF ⋅ H_FM_F       Hdot_FM_M
+        = [ 0 0 0]            = [ 0  0  0]
+          [ 0 0 0]              [ 0  0  0]
+          [ 0 0 1]              [ 0  0  1]
+          [ c s 0]              [-s  c  0]⋅v₂
+          [-s c 0]              [-c -s  0]⋅v₂
+          [ 0 0 0]              [ 0  0  0]
 
  @tparam_default_scalar */
 template <typename T>
@@ -160,18 +168,19 @@ class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
   }
 
   /* Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame
-   M measured and expressed in frame F as a function of the input velocity v. */
+  M measured and expressed in frame F as a function of the input velocity v. */
   SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
     return SpatialVelocity<T>(Vector3<T>(0.0, 0.0, v[2]),
                               Vector3<T>(v[0], v[1], 0.0));
   }
-  /* Returns H_FM⋅vdot + Hdot_FM⋅v. See class description for definitions. */
+
+  /* Returns H_FM_F⋅vdot + Hdot_FM_F⋅v. See class description. */
   SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
     return SpatialAcceleration<T>(Vector3<T>(0.0, 0.0, vdot[2]),
                                   Vector3<T>(vdot[0], vdot[1], 0.0));
   }
 
-  /* Returns tau = H_FMᵀ⋅F */
+  /* Returns tau = H_FM_Fᵀ⋅F_F */
   void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
     DRAKE_ASSERT(tau != nullptr);
     const Vector3<T>& t_B_F = F_BMo_F.rotational();       // torque

--- a/multibody/tree/quaternion_floating_mobilizer.h
+++ b/multibody/tree/quaternion_floating_mobilizer.h
@@ -31,7 +31,10 @@ namespace internal {
 // introduces the angular velocity w_FM of frame M in F and the linear
 // velocity v_FM of frame M's origin in frame F, ordered (w_FM, v_FM).
 //
-//   H_FM₆ₓ₆ = I₆ₓ₆     Hdot_FM₆ₓ₆ = 0₆ₓ₆
+//   H_FM_F₆ₓ₆ = I₆ₓ₆     Hdot_FM_F₆ₓ₆ = 0₆ₓ₆
+//
+//   H_FM_M = R_MF ⋅ H_FM_F = [ R_MF   0  ]
+//                            [   0  R_MF ]
 //
 // @tparam_default_scalar
 template <typename T>
@@ -232,15 +235,16 @@ class QuaternionFloatingMobilizer final : public MobilizerImpl<T, 7, 6> {
     return SpatialVelocity<T>(V_FM);  // w_FM, v_FM
   }
 
-  // We chose the generalized velocities for this mobilizer so that H=I, Hdot=0.
-  // Therefore A_FM = H⋅vdot + Hdot⋅v = vdot.
+  // We chose the generalized velocities for this mobilizer so that
+  // H_F = Identity, Hdot_F = 0. Therefore A_FM_F = H_F⋅vdot + Hdot_F⋅v = vdot.
+  // 0 flops
   SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
     DRAKE_ASSERT(vdot != nullptr);
     const Eigen::Map<const VVector<T>> A_FM(vdot);
     return SpatialAcceleration<T>(A_FM);
   }
 
-  // Returns tau = H_FMᵀ⋅F. H is identity for this mobilizer.
+  // Returns tau = H_FM_Fᵀ⋅F_F. H is identity for this mobilizer.
   void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
     DRAKE_ASSERT(tau != nullptr);
     Eigen::Map<VVector<T>> tau_as_vector(tau);

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -17,9 +17,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/extract_double.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -328,7 +326,7 @@ class RotationalInertia {
   /// @see operator+().
   // TODO(Mitiguy) Issue #6145, add direct unit test for this method.
   RotationalInertia<T>& operator+=(const RotationalInertia<T>& I_BP_E) {
-    this->get_mutable_triangular_view() += I_BP_E.get_matrix();
+    this->get_mutable_triangular_view() += I_BP_E.get_matrix();  // 6 flops
     return *this;
   }
 
@@ -341,7 +339,7 @@ class RotationalInertia {
   /// @return The sum of `this` rotational inertia and `I_BP_E`.
   /// @see operator+=().
   RotationalInertia<T> operator+(const RotationalInertia<T>& I_BP_E) const {
-    return RotationalInertia(*this) += I_BP_E;
+    return RotationalInertia(*this) += I_BP_E;  // 6 flops
   }
 
   /// Subtracts a rotational inertia `I_BP_E` from `this` rotational inertia.
@@ -453,7 +451,8 @@ class RotationalInertia {
   /// @see operator/().
   RotationalInertia<T>& operator/=(const T& positive_scalar) {
     DRAKE_ASSERT_VOID(ThrowIfDivideByZeroOrNegativeScalar(positive_scalar));
-    this->get_mutable_triangular_view() /= positive_scalar;
+    const T one_over_positive_scalar = 1 / positive_scalar;
+    this->get_mutable_triangular_view() *= one_over_positive_scalar;
     return *this;
   }
 
@@ -638,7 +637,7 @@ class RotationalInertia {
   /// @throws std::exception for Debug builds if the rotational inertia that
   /// is re-expressed-in frame A violates CouldBePhysicallyValid().
   /// @see ReExpress().
-  void ReExpressInPlace(const math::RotationMatrix<T>& R_AE);
+  void ReExpressInPlace(const math::RotationMatrix<T>& R_AE);  // 57 flops
 
   /// Re-expresses `this` rotational inertia `I_BP_E` to `I_BP_A`
   /// i.e., re-expresses body B's rotational inertia from frame E to frame A.
@@ -650,7 +649,7 @@ class RotationalInertia {
   [[nodiscard]] RotationalInertia<T> ReExpress(
       const math::RotationMatrix<T>& R_AE) const {
     RotationalInertia result(*this);
-    result.ReExpressInPlace(R_AE);
+    result.ReExpressInPlace(R_AE);  // 57 flops
     return result;
   }
 
@@ -795,7 +794,7 @@ class RotationalInertia {
   /// @see operator-=().
   RotationalInertia<T>& MinusEqualsUnchecked(
       const RotationalInertia<T>& I_BP_E) {
-    this->get_mutable_triangular_view() -= I_BP_E.get_matrix();
+    this->get_mutable_triangular_view() -= I_BP_E.get_matrix();  // 6 flops
     return *this;
   }
 

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -57,8 +57,11 @@ namespace internal {
 // @note The roll-pitch-yaw (space x-y-z) Euler sequence is also known as the
 // Tait-Bryan angles or Cardan angles.
 //
-//    H_FM₆ₓ₃=[ I₃ₓ₃ ]    Hdot_FM = 0₆ₓ₃
-//            [ 0₃ₓ₃ ]
+//    H_FM_F₆ₓ₃ = [ I₃ₓ₃ ]    Hdot_FM_F = 0₆ₓ₃
+//                [ 0₃ₓ₃ ]
+//
+//    H_FM_M = R_MF ⋅ H_FM_F = [ R_MF ]
+//                             [  0   ]
 //
 // @tparam_default_scalar
 template <typename T>
@@ -201,8 +204,8 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
     return SpatialVelocity<T>(w_FM, Vector3<T>::Zero());
   }
 
-  // Here H₆ₓ₃=[I₃ₓ₃ 0₃ₓ₃]ᵀ so Hdot=0 and
-  // A_FM = H⋅vdot + Hdot⋅v = [vdot, 0₃]ᵀ
+  // Here H_F₆ₓ₃=[I₃ₓ₃ 0₃ₓ₃]ᵀ so Hdot_F=0 and
+  // A_FM_F = H_F⋅vdot + Hdot_F⋅v = [vdot, 0₃]ᵀ
   SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
     const Eigen::Map<const Vector3<T>> alpha_FM(vdot);
     return SpatialAcceleration<T>(alpha_FM, Vector3<T>::Zero());

--- a/multibody/tree/rpy_floating_mobilizer.h
+++ b/multibody/tree/rpy_floating_mobilizer.h
@@ -60,6 +60,9 @@ namespace internal {
 //
 //   H_FM₆ₓ₆ = I₆ₓ₆     Hdot_FM₆ₓ₆ = 0₆ₓ₆
 //
+//   H_FM_M = R_MF ⋅ H_FM_F = [ R_MF   0₃ₓ₃ ]
+//                            [ 0₃ₓ₃   R_MF ]
+//
 // @tparam_default_scalar
 template <typename T>
 class RpyFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {

--- a/multibody/tree/screw_mobilizer.h
+++ b/multibody/tree/screw_mobilizer.h
@@ -34,7 +34,7 @@ T GetScrewRotationFromTranslation(const T& z, double screw_pitch) {
   return revolution_amount * 2 * M_PI;
 }
 
-/* This mobilizer models a screw joint between an inboard frame F and an
+/* This Mobilizer models a screw joint between an inboard frame F and an
  outboard frame M that enables translation along an axis while
  rotating about it, such that the axis is constant when measured
  in either this mobilizer's inboard or outboard frames.
@@ -50,10 +50,11 @@ T GetScrewRotationFromTranslation(const T& z, double screw_pitch) {
  to the right-hand-rule with the thumb aligned in the direction of
  frame F's axis â. The axis â in frame F and in frame M are aligned
  at all times for this mobilizer. The generalized velocity for this mobilizer
- is the rate of change of the coordinate, ω =˙θ (θ_dot).
+ is the rate of change of the coordinate, ω =θ̇ (θ_dot).
 
- H_FM₆ₓ₁ = [axisᵀ f⋅axisᵀ]ᵀ where f=pitch/2π
- Hdot_FM = 0₆ₓ₁
+ H_FM_F₆ₓ₁ = [axis_Fᵀ  f⋅axis_Fᵀ]ᵀ with f=pitch/2π    Hdot_FM_F = 0₆ₓ₁
+ H_FM_M₆ₓ₁ = [axis_Mᵀ  f⋅axis_Mᵀ]ᵀ                    Hdot_FM_M = 0₆ₓ₁
+    where axis_M == axis_F
 
  @tparam_default_scalar */
 template <typename T>
@@ -212,7 +213,7 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
   /* Computes the across-mobilizer velocity V_FM(q, v) of the outboard frame
    M measured and expressed in frame F as a function of the input velocity v,
    which is the angular velocity. We scale that by the pitch to find the
-   related translational velocity. */
+   related translational velocity. 8 flops */
   SpatialVelocity<T> calc_V_FM(const T*, const T* v) const {
     DRAKE_ASSERT(v != nullptr);
     const T f_v = GetScrewTranslationFromRotation(v[0], screw_pitch_);
@@ -221,14 +222,14 @@ class ScrewMobilizer final : public MobilizerImpl<T, 1, 1> {
 
   /* Our lone generalized acceleration is the angular acceleration θdotdot about
   the screw axis. Therefore we have H₆ₓ₁=[axis f⋅axis] where f=pitch/2π, and
-  Hdot=0, so A_FM = H⋅vdot + Hdot⋅v = [axis⋅vdot, f⋅axis⋅vdot]ᵀ */
+  Hdot=0, so A_FM = H⋅vdot + Hdot⋅v = [axis⋅vdot, f⋅axis⋅vdot]ᵀ. 8 flops */
   SpatialAcceleration<T> calc_A_FM(const T*, const T*, const T* vdot) const {
     DRAKE_ASSERT(vdot != nullptr);
     const T f_vdot = GetScrewTranslationFromRotation(vdot[0], screw_pitch_);
     return SpatialAcceleration<T>(vdot[0] * axis_, f_vdot * axis_);
   }
 
-  /* Returns tau = H_FMᵀ⋅F. See above for H. */
+  /* Returns tau = H_FMᵀ⋅F. See above for H. 12 flops */
   void calc_tau(const T*, const SpatialForce<T>& F_BMo_F, T* tau) const {
     DRAKE_ASSERT(tau != nullptr);
     const T f = screw_pitch_ / (2 * M_PI);

--- a/multibody/tree/spatial_inertia.cc
+++ b/multibody/tree/spatial_inertia.cc
@@ -383,66 +383,36 @@ void SpatialInertia<T>::ThrowIfNotPhysicallyValidImpl() const {
     throw std::runtime_error(*invalidity_report);
   }
 }
+
 template <typename T>
 SpatialInertia<T>& SpatialInertia<T>::operator+=(
     const SpatialInertia<T>& M_BP_E) {
-  const T total_mass = get_mass() + M_BP_E.get_mass();
+  T this_mass = get_mass();
+  T other_mass = M_BP_E.get_mass();
+  T total_mass = this_mass + other_mass;  // 1 flop
+  mass_ = total_mass;
+
+  // For two massless bodies we just want the arithmetic mean of the COMs
+  // and unit inertias. Lie about the mass properties to make this happen below.
+  // (Skip for symbolic T.)
   if constexpr (scalar_predicate<T>::is_bool) {
     if (total_mass == 0) {
-      // Compose the spatial inertias of two massless bodies in the limit when
-      // the two bodies have the same mass. In this limit, p_PScm_E_ and G_SP_E_
-      // are the arithmetic mean of the constituent COMs and unit inertias.
-      p_PScm_E_ = 0.5 * (get_com() + M_BP_E.get_com());
-      G_SP_E_.SetFromRotationalInertia(
-          get_unit_inertia() + M_BP_E.get_unit_inertia(), 2.0);
-      mass_ = total_mass;
-      return *this;
+      DRAKE_ASSERT(this_mass == 0 && other_mass == 0);  // No negative mass!
+      this_mass = other_mass = 1;
+      total_mass = 2;
     }
   }
 
-  // This is the normal case.
-  p_PScm_E_ = (CalcComMoment() + M_BP_E.CalcComMoment()) / total_mass;
-  G_SP_E_.SetFromRotationalInertia(
-      CalcRotationalInertia() + M_BP_E.CalcRotationalInertia(), total_mass);
-  mass_ = total_mass;
-  return *this;
-}
+  const T one_over_total_mass = 1 / total_mass;             // ~6 flops
+  const T this_factor = this_mass * one_over_total_mass;    // 1 flop
+  const T other_factor = other_mass * one_over_total_mass;  // 1 flop
+  p_PScm_E_ =                                               // 9 flops
+      this_factor * get_com() + other_factor * M_BP_E.get_com();
 
-template <typename T>
-void SpatialInertia<T>::ShiftFromCenterOfMassInPlace(
-    const Vector3<T>& p_ScmP_E) {
-  DRAKE_ASSERT(p_PScm_E_ == Vector3<T>::Zero());
-  G_SP_E_.ShiftFromCenterOfMassInPlace(p_ScmP_E);
-  p_PScm_E_ = -p_ScmP_E;
-  // On entry, `this` is M_SScm_E. On return, `this` is M_SP_E.
-}
-
-template <typename T>
-SpatialInertia<T> SpatialInertia<T>::ShiftFromCenterOfMass(
-    const Vector3<T>& p_ScmP_E) const {
-  SpatialInertia result(*this);
-  result.ShiftFromCenterOfMassInPlace(p_ScmP_E);
-  return result;
-}
-
-template <typename T>
-void SpatialInertia<T>::ShiftToCenterOfMassInPlace() {
-  G_SP_E_.ShiftToCenterOfMassInPlace(p_PScm_E_);
-  p_PScm_E_ = Vector3<T>::Zero();
-  // On entry, `this` is M_SP_E. On return, `this` is M_SScm_E.
-}
-
-template <typename T>
-void SpatialInertia<T>::ShiftInPlace(const Vector3<T>& p_PQ_E) {
-  const Vector3<T> p_QScm_E = p_PScm_E_ - p_PQ_E;
-  // The following two lines apply the parallel axis theorem (in place) so that:
-  //  G_SQ = G_SP + px_QScm² - px_PScm²
-  G_SP_E_.ShiftFromCenterOfMassInPlace(p_QScm_E);
-  G_SP_E_.ShiftToCenterOfMassInPlace(p_PScm_E_);
-  p_PScm_E_ = p_QScm_E;
-  // Note: It would be an implementation bug if a shift starts with a valid
-  // spatial inertia and the shift produces an invalid spatial inertia.
-  // Hence, no need to use DRAKE_ASSERT_VOID(CheckInvariants()).
+  // 18 flops (lower triangle only)
+  G_SP_E_ = UnitInertia<T>(this_factor * get_unit_inertia() +
+                           other_factor * M_BP_E.get_unit_inertia());
+  return *this;  // total ~36 flops
 }
 
 template <typename T>
@@ -457,10 +427,10 @@ SpatialForce<T> SpatialInertia<T>::operator*(
   return SpatialForce<T>(
       // Note: p_PScm_E here is p_BoBcm in the above notation.
       // Rotational
-      mass_ * (G_SP_E_ * alpha_WB_E + p_PScm_E_.cross(a_WBo_E)),
+      mass_ * (G_SP_E_ * alpha_WB_E + p_PScm_E_.cross(a_WBo_E)),  // 30 flops
       // Translational: notice the order of the cross product is the reversed
       // of the documentation above and thus no minus sign is needed.
-      mass_ * (alpha_WB_E.cross(p_PScm_E_) + a_WBo_E));
+      mass_ * (alpha_WB_E.cross(p_PScm_E_) + a_WBo_E));  // 15 flops
 }
 
 template <typename T>
@@ -475,10 +445,10 @@ SpatialMomentum<T> SpatialInertia<T>::operator*(
   return SpatialMomentum<T>(
       // Note: p_PScm_E here is p_BoBcm in the above notation.
       // Rotational
-      mass_ * (G_SP_E_ * w_WB_E + p_PScm_E_.cross(v_WP_E)),
+      mass_ * (G_SP_E_ * w_WB_E + p_PScm_E_.cross(v_WP_E)),  // 30 flops
       // Translational: notice the order of the cross product is the reversed
       // of the documentation above and thus no minus sign is needed.
-      mass_ * (w_WB_E.cross(p_PScm_E_) + v_WP_E));
+      mass_ * (w_WB_E.cross(p_PScm_E_) + v_WP_E));  // 15 flops
 }
 
 template <typename T>

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -709,7 +709,7 @@ class SpatialInertia {
     M.template block<3, 3>(0, 3) = mass_ * VectorToSkewSymmetric(p_PScm_E_);
     M.template block<3, 3>(3, 0) = -M.template block<3, 3>(0, 3);
     M.template block<3, 3>(3, 3) = mass_ * Matrix3<T>::Identity();
-    return M;
+    return M;  // 33 flops and 36 copies
   }
 
   /// Sets `this` spatial inertia to have NaN entries. Typically used for quick
@@ -752,9 +752,9 @@ class SpatialInertia {
   /// On return, `this` is now re-expressed in frame A, that is, `M_SP_A`.
   /// @param[in] R_AE Rotation matrix from frame E to frame A.
   void ReExpressInPlace(const math::RotationMatrix<T>& R_AE) {
-    p_PScm_E_ = R_AE * p_PScm_E_;    // Now p_PScm_A
-    G_SP_E_.ReExpressInPlace(R_AE);  // Now I_SP_A
-    // Now M_SP_A
+    p_PScm_E_ = R_AE * p_PScm_E_;    // Now p_PScm_A, 15 flops
+    G_SP_E_.ReExpressInPlace(R_AE);  // Now I_SP_A, 57 flops
+    // Now M_SP_A, total 72 flops
   }
 
   /// Given `this` spatial inertia `M_SP_E` for some body or composite body S,
@@ -784,7 +784,17 @@ class SpatialInertia {
   /// @param[in] p_PQ_E position vector from the original about-point P to the
   ///                   new about-point Q, expressed in the same frame E that
   ///                   `this` spatial inertia is expressed in.
-  void ShiftInPlace(const Vector3<T>& p_PQ_E);
+  void ShiftInPlace(const Vector3<T>& p_PQ_E) {
+    const Vector3<T> p_QScm_E = p_PScm_E_ - p_PQ_E;  // 3 flops
+    // Use the shift theorem (parallel axis theorem) to first shift
+    // G_SP to G_SScm and then shift G_SScm to G_SQ.
+    G_SP_E_.ShiftToCenterOfMassInPlace(p_PScm_E_);   // 17 flops
+    G_SP_E_.ShiftFromCenterOfMassInPlace(p_QScm_E);  // 17 flops
+    p_PScm_E_ = p_QScm_E;
+    // Note: It would be an implementation bug if a shift starts with a valid
+    // spatial inertia and the shift produces an invalid spatial inertia.
+    // Hence, no need to use DRAKE_ASSERT_VOID(CheckInvariants()).
+  }
 
   /// Given `this` spatial inertia `M_SP_E` for some body or composite body S,
   /// computed about point P, and expressed in frame E, this method uses
@@ -800,7 +810,7 @@ class SpatialInertia {
   ///                   but computed about a new point Q.
   SpatialInertia<T> Shift(const Vector3<T>& p_PQ_E) const {
     SpatialInertia result(*this);
-    result.ShiftInPlace(p_PQ_E);
+    result.ShiftInPlace(p_PQ_E);  // 37 flops
     return result;
   }
 
@@ -929,7 +939,11 @@ class SpatialInertia {
   // @param[in] p_ScmP_E Position vector from Scm to P, expressed-in frame E.
   // @pre On entry, the about-point for `this` SpatialInertia is Scm. Hence, on
   // entry the position vector p_PScm underlying `this` is the zero vector.
-  void ShiftFromCenterOfMassInPlace(const Vector3<T>& p_ScmP_E);
+  void ShiftFromCenterOfMassInPlace(const Vector3<T>& p_ScmP_E) {
+    DRAKE_ASSERT(p_PScm_E_ == Vector3<T>::Zero());
+    G_SP_E_.ShiftFromCenterOfMassInPlace(p_ScmP_E);
+    p_PScm_E_ = -p_ScmP_E;
+  }
 
   // Calculates the spatial inertia that results from shifting `this` spatial
   // inertia for a body (or composite body) S from about-point Scm (S's center
@@ -940,7 +954,11 @@ class SpatialInertia {
   // @pre On entry, the about-point for `this` SpatialInertia is Scm. Hence, on
   // entry the position vector p_PScm underlying `this` is the zero vector.
   [[nodiscard]] SpatialInertia<T> ShiftFromCenterOfMass(
-      const Vector3<T>& p_ScmP_E) const;
+      const Vector3<T>& p_ScmP_E) const {
+    SpatialInertia result(*this);
+    result.ShiftFromCenterOfMassInPlace(p_ScmP_E);
+    return result;
+  }
 
   // Shifts `this` spatial inertia for a body (or composite body) S from
   // about-point P to about-point Scm (S's center of mass). In other words,
@@ -948,7 +966,10 @@ class SpatialInertia {
   // @note On return, the about-point for `this` SpatialInertia is Scm. Hence,
   // on return the position vector p_PScm underlying `this` is the zero vector.
   // @see SpatialInertia::ShiftToCenterOfMass(), ShiftFromCenterOfMassInPlace().
-  void ShiftToCenterOfMassInPlace();
+  void ShiftToCenterOfMassInPlace() {
+    G_SP_E_.ShiftToCenterOfMassInPlace(p_PScm_E_);
+    p_PScm_E_ = Vector3<T>::Zero();
+  }
 
   // Calculates the spatial inertia that results from shifting `this` spatial
   // inertia for a body (or composite body) S from about-point P to

--- a/multibody/tree/test/body_node_test.cc
+++ b/multibody/tree/test/body_node_test.cc
@@ -86,27 +86,27 @@ class DummyBodyNode : public BodyNode<double> {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcMassMatrixContribution_TipToBase(
+  void CalcMassMatrixContributionViaWorld_TipToBase(
       const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
       const std::vector<Vector6<T>>&, EigenPtr<MatrixX<T>>) const final {
     DRAKE_UNREACHABLE();
   }
 
-#define DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(Rnv)                                \
-  void CalcMassMatrixOffDiagonalBlock##Rnv(                                 \
-      int, const std::vector<Vector6<T>>&, const Eigen::Matrix<T, 6, Rnv>&, \
+#define DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(Bnv)                      \
+  void CalcMassMatrixOffDiagonalBlockViaWorld##Bnv(                         \
+      int, const std::vector<Vector6<T>>&, const Eigen::Matrix<T, 6, Bnv>&, \
       EigenPtr<MatrixX<T>>) const final {                                   \
     DRAKE_UNREACHABLE();                                                    \
   }
 
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(1)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(2)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(3)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(4)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(5)
-  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK(6)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(1)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(2)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(3)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(4)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(5)
+  DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD(6)
 
-#undef DEFINE_DUMMY_OFF_DIAGONAL_BLOCK
+#undef DEFINE_DUMMY_OFF_DIAGONAL_BLOCK_VIA_WORLD
 
   void CalcSpatialAcceleration_BaseToTip(
       const FrameBodyPoseCache<T>&, const T*, const PositionKinematicsCache<T>&,
@@ -153,7 +153,7 @@ class DummyBodyNode : public BodyNode<double> {
     DRAKE_UNREACHABLE();
   }
 
-  void CalcCompositeBodyInertia_TipToBase(
+  void CalcCompositeBodyInertiaInWorld_TipToBase(
       const PositionKinematicsCache<T>&, const std::vector<SpatialInertia<T>>&,
       std::vector<SpatialInertia<T>>*) const final {
     DRAKE_UNREACHABLE();

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -1510,7 +1510,8 @@ GTEST_TEST(SpatialInertia, VerifyMinimumBoundingBoxLengths) {
       M_BBcm_B.CalcPrincipalHalfLengthsAndPoseForMinimumBoundingBox();
   EXPECT_TRUE(CompareMatrices(Vector3<double>(a, b, c), abc, kTolerance));
   EXPECT_TRUE(X_BA.rotation().IsExactlyEqualTo(R_identity));
-  EXPECT_TRUE(X_BA.translation() == Vector3<double>::Zero());
+  EXPECT_TRUE(
+      CompareMatrices(X_BA.translation(), Vector3<double>::Zero(), kTolerance));
 
   // Verify CalcMinimumPhysicalLength() returns the length of the face-diagonal
   // of the minimum bounding rectangle (i.e., √[(2*a)² + (2*b)²] = 500).
@@ -1533,7 +1534,8 @@ GTEST_TEST(SpatialInertia, VerifyMinimumBoundingBoxLengths) {
       M_BBcm_B.CalcPrincipalHalfLengthsAndPoseForMinimumBoundingBox();
   EXPECT_TRUE(CompareMatrices(Vector3<double>(a, b, c), abc, kTolerance));
   EXPECT_TRUE(X_BA.rotation().IsExactlyEqualTo(R_identity));
-  EXPECT_TRUE(X_BA.translation() == Vector3<double>::Zero());
+  EXPECT_TRUE(
+      CompareMatrices(X_BA.translation(), Vector3<double>::Zero(), kTolerance));
 
   // Verify CalcMinimumPhysicalLength() returns the length of the space-diagonal
   // of the minimum bounding box (i.e., √[(2*a)² + (2*b)² + (2*c)²] = 390 m).

--- a/multibody/tree/test/tree_from_joints_test.cc
+++ b/multibody/tree/test/tree_from_joints_test.cc
@@ -242,13 +242,16 @@ class PendulumTests : public ::testing::Test {
     pendulum_.elbow().set_angle(context_.get(), theta2);
 
     // MultibodyTree mass matrix:
-    Matrix2d H;
-    tree().CalcMassMatrixViaInverseDynamics(*context_, &H);
+    Matrix2d H_id, H_in_world;
+    tree().CalcMassMatrixViaInverseDynamics(*context_, &H_id);
+    tree().CalcMassMatrix(*context_, &H_in_world);
 
-    // Benchmark mass matrix:
+    // Benchmark mass matrix (doesn't actually depend on theta1):
     Matrix2d H_expected = acrobot_benchmark_.CalcMassMatrix(theta2);
 
-    EXPECT_TRUE(CompareMatrices(H, H_expected, kTolerance,
+    EXPECT_TRUE(CompareMatrices(H_id, H_expected, kTolerance,
+                                MatrixCompareType::relative));
+    EXPECT_TRUE(CompareMatrices(H_in_world, H_expected, kTolerance,
                                 MatrixCompareType::relative));
   }
 

--- a/multibody/tree/unit_inertia.cc
+++ b/multibody/tree/unit_inertia.cc
@@ -8,27 +8,6 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
-UnitInertia<T>& UnitInertia<T>::SetFromRotationalInertia(
-    const RotationalInertia<T>& I, const T& mass) {
-  DRAKE_THROW_UNLESS(mass > 0);
-  RotationalInertia<T>::operator=(I / mass);
-  return *this;
-}
-
-template <typename T>
-UnitInertia<T> UnitInertia<T>::PointMass(const Vector3<T>& p_FQ) {
-  // Square each coefficient in p_FQ, perhaps better with p_FQ.array().square()?
-  const Vector3<T> p2m = p_FQ.cwiseAbs2();  // [x²  y²  z²].
-  const T mp0 = -p_FQ(0);                   // -x
-  const T mp1 = -p_FQ(1);                   // -y
-  return UnitInertia<T>(
-      // Gxx = y² + z²,  Gyy = x² + z²,  Gzz = x² + y²
-      p2m[1] + p2m[2], p2m[0] + p2m[2], p2m[0] + p2m[1],
-      // Gxy = -x y,  Gxz = -x z,   Gyz = -y z
-      mp0 * p_FQ[1], mp0 * p_FQ[2], mp1 * p_FQ[2]);
-}
-
-template <typename T>
 UnitInertia<T> UnitInertia<T>::SolidEllipsoid(const T& a, const T& b,
                                               const T& c) {
   const T a2 = a * a;

--- a/multibody/tree/universal_mobilizer.h
+++ b/multibody/tree/universal_mobilizer.h
@@ -43,13 +43,13 @@ namespace internal {
 // aligned in the direction of their respective axes. The generalized
 // velocities for this mobilizer are the rate of change of the angles, v = q̇.
 //
-//    H_FM₆ₓ₂ = [Hw_FM₃ₓ₂]        Hw_FM = [ 1   0   ]        Hv_FM = 0₃ₓ₂
-//              [Hv_FM₃ₓ₂]                [ 0 c(q₀) ]
-//                                        [ 0 s(q₀) ]
+//    H_FM_F₆ₓ₂ = [Hw_FM₃ₓ₂]        Hw_FM_F = [ 1   0   ]       Hv_FM_F = 0₃ₓ₂
+//                [Hv_FM₃ₓ₂]                  [ 0 c(q₀) ]
+//                                            [ 0 s(q₀) ]
 //
-// Hdot_FM₆ₓ₂ = [Hwdot_FM₃ₓ₂]  Hwdot_FM = [ 0    0     ]  Hvdot_FM = 0₃ₓ₂
-//              [Hvdot_FM₃ₓ₂]             [ 0 -v₀s(q₀) ]
-//                                        [ 0  v₀c(q₀) ]
+// Hdot_FM_F₆ₓ₂ = [Hwdot_FM₃ₓ₂]  Hwdot_FM_F = [ 0    0     ]  Hvdot_FM_F = 0₃ₓ₂
+//                [Hvdot_FM₃ₓ₂]               [ 0 -v₀s(q₀) ]
+//                                            [ 0  v₀c(q₀) ]
 //
 // @tparam_default_scalar
 template <typename T>
@@ -128,13 +128,13 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
   // frame F and the outboard frame M as a function of the angles (θ₀, θ₁)
   // stored in `context`.
   math::RigidTransform<T> calc_X_FM(const T* q) const {
-    const T s1 = sin(q[0]), c1 = cos(q[0]);
-    const T s2 = sin(q[1]), c2 = cos(q[1]);
+    const T s0 = sin(q[0]), c0 = cos(q[0]);
+    const T s1 = sin(q[1]), c1 = cos(q[1]);
     Matrix3<T> R_FM_matrix;
     // clang-format off
-    R_FM_matrix <<   c2,    0.0,  s2,
-                   s1 * s2, c1,  -s1 * c2,
-                  -c1 * s2, s1,   c1 * c2;
+    R_FM_matrix <<   c1,    0.0,  s1,
+                   s0 * s1, c0,  -s0 * c1,
+                  -c0 * s1, s0,   c0 * c1;
     // clang-format on
     return math::RigidTransform<T>(
         math::RotationMatrix<T>::MakeUnchecked(R_FM_matrix),
@@ -173,9 +173,9 @@ class UniversalMobilizer final : public MobilizerImpl<T, 2, 2> {
                                   Vector3<T>::Zero());
   }
 
-  // Returns tau = H_FMᵀ⋅F. See above for the structure of H.
+  // Returns tau = H_FM_Fᵀ ⋅ F_F. See above for the structure of H.
   void calc_tau(const T* q, const SpatialForce<T>& F_BMo_F, T* tau) const {
-    DRAKE_ASSERT(tau != nullptr);
+    DRAKE_ASSERT(q != nullptr && tau != nullptr);
     Eigen::Map<VVector<T>> tau_as_vector(tau);
     const Vector3<T>& t_B_F = F_BMo_F.rotational();  // torque
     const Eigen::Matrix<T, 3, 2> Hw_FM = this->CalcHwMatrix(q);

--- a/multibody/tree/weld_mobilizer.h
+++ b/multibody/tree/weld_mobilizer.h
@@ -81,8 +81,8 @@ class WeldMobilizer final : public MobilizerImpl<T, 0, 0> {
     return v_M;
   }
 
-  /* Computes the across-mobilizer velocity V_FM which for this mobilizer is
-  always zero. */
+  // Computes the across-mobilizer velocity V_FM which for this mobilizer is
+  // always zero since the outboard frame M is fixed to the inboard frame F.
   SpatialVelocity<T> calc_V_FM(const T*, const T*) const {
     return SpatialVelocity<T>::Zero();
   }


### PR DESCRIPTION
During development of M-frame algorithms in #22253 I made many small changes in performance, testing, formatting, and documentation that applied to both the new M-frame algorithms and the existing W-frame ones. This PR extracts all the changes from that branch that affect existing code (i.e. none of the M-frame stuff), with some small performance improvements, mostly via inlining of some small inertia methods.

The main purpose of this PR is to allow the upcoming M-frame PRs (which will be a lot of code) to be focused on the new algorithms without the distraction of generic changes. The notation changes in the Composite Body Inertia are similar to those in #23036 -- avoid the confusion caused by multiple uses of "C" to mean "Composite" and "Child". Per Paul's suggestion, we are now using "K" for "Komposite" for Composite Body Inertias, e.g. K_BBo_W is body B's Composite Body Inertia about Bo and expressed in World. Also, a number of names now add "in_world" or "in_W", to distinguish them from the "in_M"s of the near future. A few other implied frames are made explicit in names and documentation.

The Cassie benchmark now separates out Composite Body Inertia timing from Mass Matrix times, and adds timing for the (very slow) Mass Matrix via Inverse Dynamics method.

All the visible code changes are `internal::` so no release notes are needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23061)
<!-- Reviewable:end -->
