### PR TITLE
[deformable] Add bindings for deformable body

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -111,6 +111,7 @@ drake_pybind_library(
         ":math_py",
         ":module_py",
         "//bindings/pydrake/systems:framework_py",
+        "//bindings/pydrake/geometry",
     ],
     py_srcs = [
         "_tree_extra.py",

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1696,19 +1696,12 @@ PYBIND11_MODULE(plant, m) {
     auto cls = py::class_<Class>(m, "PhysicalModel", cls_doc.doc);
   }
 
-  // Deformable identifier.
-  {
-    BindIdentifier<DeformableBodyId>(
-        m, "DeformableBodyId", doc.DeformableBodyId.doc);
-  }
-
   // DeformableModel
   {
     using Class = DeformableModel<double>;
     constexpr auto& cls_doc = doc.DeformableModel;
     py::class_<Class, PhysicalModel<T>> cls(m, "DeformableModel", cls_doc.doc);
     cls  // BR
-        .def(py::init<MultibodyPlant<T>*>(), cls_doc.ctor.doc)
         .def("num_bodies", &Class::num_bodies, cls_doc.num_bodies.doc)
         .def(
             "RegisterDeformableBody",
@@ -1742,26 +1735,81 @@ PYBIND11_MODULE(plant, m) {
             cls_doc.SetWallBoundaryCondition.doc)
         .def("AddFixedConstraint", &Class::AddFixedConstraint,
             py::arg("body_A_id"), py::arg("body_B"), py::arg("X_BA"),
-            py::arg("shape"), py::arg("X_BG"), cls_doc.AddFixedConstraint.doc)
+            py::arg("shape_G"), py::arg("X_BG"), cls_doc.AddFixedConstraint.doc)
         .def("GetDiscreteStateIndex", &Class::GetDiscreteStateIndex,
             py::arg("id"), cls_doc.GetDiscreteStateIndex.doc)
         .def("SetPositions", &Class::SetPositions, py::arg("context"),
             py::arg("id"), py::arg("q"), cls_doc.SetPositions.doc)
         .def("GetPositions", &Class::GetPositions, py::arg("context"),
             py::arg("id"), cls_doc.GetPositions.doc)
+        // TODO(xuchenhan-tri): Bind AddExternalForce and GetExternalForces.
+        .def("Disable", &Class::Disable, py::arg("id"), py::arg("context"),
+            cls_doc.Disable.doc)
+        .def("Enable", &Class::Enable, py::arg("id"), py::arg("context"),
+            cls_doc.Enable.doc)
+        .def("is_enabled", &Class::is_enabled, py::arg("id"),
+            py::arg("context"), cls_doc.is_enabled.doc)
+        // TODO(xuchenhan-tri): Bind GetFemModel or make it internal.
         .def("GetReferencePositions", &Class::GetReferencePositions,
             py::arg("id"), py_rvp::reference_internal,
             cls_doc.GetReferencePositions.doc)
-        .def("GetGeometryId", &Class::GetGeometryId, py::arg("id"),
-            cls_doc.GetGeometryId.doc)
+        .def(
+            "GetBodyId",
+            [](const Class* self, DeformableBodyIndex index) {
+              return self->GetBodyId(index);
+            },
+            py::arg("index"), cls_doc.GetBodyId.doc_1args_index)
         .def(
             "GetBodyId",
             [](const Class* self, geometry::GeometryId geometry_id) {
               return self->GetBodyId(geometry_id);
             },
             py::arg("geometry_id"), cls_doc.GetBodyId.doc_1args_geometry_id)
+        .def("GetBody",
+            overload_cast_explicit<const DeformableBody<T>&, DeformableBodyId>(
+                &Class::GetBody),
+            py::arg("id"), py_rvp::reference_internal,
+            cls_doc.GetBody.doc_1args_id)
+        .def("GetBody",
+            overload_cast_explicit<const DeformableBody<T>&,
+                DeformableBodyIndex>(&Class::GetBody),
+            py::arg("index"), py_rvp::reference_internal,
+            cls_doc.GetBody.doc_1args_index)
+        .def("GetMutableBody", &Class::GetMutableBody, py::arg("id"),
+            py_rvp::reference_internal, cls_doc.GetMutableBody.doc)
+        .def(
+            "HasBodyNamed",
+            [](const Class* self, const std::string& name) {
+              return self->HasBodyNamed(name);
+            },
+            py::arg("name"), cls_doc.HasBodyNamed.doc_1args)
+        .def(
+            "HasBodyNamed",
+            [](const Class* self, const std::string& name,
+                ModelInstanceIndex model_instance) {
+              return self->HasBodyNamed(name, model_instance);
+            },
+            py::arg("name"), py::arg("model_instance"),
+            cls_doc.HasBodyNamed.doc_2args)
+        .def("GetBodyByName",
+            overload_cast_explicit<const DeformableBody<T>&,
+                const std::string&>(&Class::GetBodyByName),
+            py::arg("name"), py_rvp::reference_internal,
+            cls_doc.GetBodyByName.doc_1args)
+        .def("GetBodyByName",
+            overload_cast_explicit<const DeformableBody<T>&, const std::string&,
+                ModelInstanceIndex>(&Class::GetBodyByName),
+            py::arg("name"), py::arg("model_instance"),
+            py_rvp::reference_internal, cls_doc.GetBodyByName.doc_2args)
         .def("GetBodyIds", &Class::GetBodyIds, py::arg("model_instance"),
             cls_doc.GetBodyIds.doc)
+        .def("GetBodyIndex", &Class::GetBodyIndex, py::arg("id"),
+            cls_doc.GetBodyIndex.doc)
+        .def("GetGeometryId", &Class::GetGeometryId, py::arg("id"),
+            cls_doc.GetGeometryId.doc)
+        .def("HasConstraint", &Class::HasConstraint, py::arg("id"),
+            cls_doc.HasConstraint.doc)
+        .def("is_empty", &Class::is_empty, cls_doc.is_empty.doc)
         /* The parallelism configuration is for internal-use only and thus the
          naming choice. This will go away when we figure out a more principled
          way of using threads in a single deformable sim. */

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -80,7 +80,6 @@ from pydrake.multibody.plant import (
     ContactResultsToLcmSystem,
     CoulombFriction_,
     DeformableContactInfo_,
-    DeformableModel,
     DiscreteContactApproximation,
     DiscreteContactSolver,
     DistanceConstraintParams,
@@ -133,6 +132,7 @@ from pydrake.math import (
 )
 from pydrake.systems.analysis import Simulator_
 from pydrake.systems.framework import (
+    AbstractParameterIndex,
     DiagramBuilder,
     DiagramBuilder_,
     DiscreteStateIndex,
@@ -3366,89 +3366,316 @@ class TestPlant(unittest.TestCase):
         numpy_compare.assert_equal(dut.F_Ac_W().rotational(),
                                    F_Ac_W.rotational())
 
-    def test_deformable_model(self):
+    def test_deformable_model_empty_model(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.01)
+        dut = plant.deformable_model()
+        self.assertEqual(dut.num_bodies(), 0)
+        self.assertTrue(dut.is_empty())
+
+    def test_deformable_model_registration_and_query(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.01)
+        dut = plant.mutable_deformable_model()
+
+        config = DeformableBodyConfig_[float]()
+        sphere = GeometryInstance(RigidTransform(), Sphere(1.0), "sphere")
+        props = ProximityProperties()
+        props.AddProperty("material", "coulomb_friction",
+                          CoulombFriction_[float](1.0, 1.0))
+        sphere.set_proximity_properties(props)
+        id1 = dut.RegisterDeformableBody(
+            geometry_instance=sphere,
+            config=config,
+            resolution_hint=1.0)
+
+        model_instance = plant.AddModelInstance("deformable_instance")
+        sphere2 = GeometryInstance(RigidTransform(), Sphere(2.0), "sphere2")
+        sphere2.set_proximity_properties(props)
+        id2 = dut.RegisterDeformableBody(
+            geometry_instance=sphere2,
+            model_instance=model_instance,
+            config=config,
+            resolution_hint=1.0)
+
+        # Two bodies registered
+        self.assertEqual(dut.num_bodies(), 2)
+
+        # Round-trip geometry <-> body id
+        geom_id = dut.GetGeometryId(id1)
+        self.assertEqual(dut.GetBodyId(geometry_id=geom_id), id1)
+
+        # GetBody by id
+        body1 = dut.GetBody(id=id1)
+        index1 = body1.index()
+
+        # GetBody by index
+        body1_again = dut.GetBody(index=index1)
+        self.assertEqual(body1.body_id(), body1_again.body_id())
+
+        # index <-> id
+        self.assertEqual(dut.GetBodyId(index=index1), id1)
+        self.assertEqual(dut.GetBodyIndex(id=id1), index1)
+
+        # Mutable body
+        self.assertEqual(dut.GetMutableBody(id=id1).body_id(), id1)
+
+        # Per-instance listing
+        ids = dut.GetBodyIds(model_instance=model_instance)
+        self.assertEqual(ids, [id2])
+
+        # Name-based lookup
+        self.assertTrue(dut.HasBodyNamed(name="sphere"))
+        self.assertTrue(
+            dut.HasBodyNamed(name="sphere2", model_instance=model_instance))
+        body1 = plant.deformable_model().GetBodyByName(name="sphere")
+        self.assertEqual(body1.body_id(), id1)
+        body2 = plant.deformable_model().GetBodyByName(
+            name="sphere2", model_instance=model_instance)
+        self.assertEqual(body2.body_id(), id2)
+
+    def test_deformable_model_constraints_and_lookup(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.01)
+        dut = plant.mutable_deformable_model()
+
+        # Register one body
+        config = DeformableBodyConfig_[float]()
+        geometry = GeometryInstance(RigidTransform(), Sphere(1.0), "sphere")
+        body_id = dut.RegisterDeformableBody(
+            geometry_instance=geometry, config=config, resolution_hint=1.0)
+
+        # Wall boundary condition
+        dut.SetWallBoundaryCondition(id=body_id, p_WQ=[0, 0, 0], n_W=[0, 0, 1])
+
+        # Add a rigid body and fixed constraint
+        model_instance = plant.AddModelInstance("deformable_instance")
+        inertia = SpatialInertia_[float].SolidCubeWithDensity(1, 1)
+        rigid_body = plant.AddRigidBody("rigid_body", model_instance, inertia)
+        dut.AddFixedConstraint(
+            body_A_id=body_id,
+            body_B=rigid_body,
+            X_BA=RigidTransform(),
+            shape_G=Box(1, 1, 1),
+            X_BG=RigidTransform())
+        self.assertTrue(dut.HasConstraint(id=body_id))
+
+    def test_deformable_model_parallelism(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.01)
+        dut = plant.mutable_deformable_model()
+
+        # Switch to 2 threads
+        dut._set_parallelism(parallelism=Parallelism(2))
+        self.assertEqual(dut._parallelism().num_threads(), 2)
+        # Back to single thread
+        dut._set_parallelism(parallelism=Parallelism(False))
+        self.assertEqual(dut._parallelism().num_threads(), 1)
+
+    def test_deformable_model_simulation_and_positions(self):
         builder = DiagramBuilder_[float]()
         plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 1.0e-3)
         dut = plant.mutable_deformable_model()
-        self.assertEqual(dut.num_bodies(), 0)
-        # Add two deformable bodies to the model with the two overloads of
-        # RegisterDeformableBody.
-        deformable_body_config = DeformableBodyConfig_[float]()
-        geometry = GeometryInstance(X_PG=RigidTransform(),
-                                    shape=Sphere(1.0), name="sphere")
+
+        # Register one body
+        config = DeformableBodyConfig_[float]()
+        geometry = GeometryInstance(RigidTransform(), Sphere(1.0), "sphere")
         props = ProximityProperties()
         props.AddProperty("material", "coulomb_friction",
                           CoulombFriction_[float](1.0, 1.0))
         geometry.set_proximity_properties(props)
         body_id = dut.RegisterDeformableBody(
-            geometry_instance=geometry,
-            config=deformable_body_config,
-            resolution_hint=1.0)
-        model_instance = plant.AddModelInstance("deformable_instance")
-        geometry2 = GeometryInstance(X_PG=RigidTransform(),
-                                     shape=Sphere(2.0), name="sphere2")
-        geometry2.set_proximity_properties(props)
-        body_id2 = dut.RegisterDeformableBody(
-            geometry_instance=geometry2,
-            config=deformable_body_config,
-            model_instance=model_instance,
-            resolution_hint=1.0)
-        self.assertEqual(dut.num_bodies(), 2)
-
-        geometry_id = dut.GetGeometryId(body_id)
-        self.assertEqual(dut.GetBodyId(geometry_id), body_id)
-        deformable_body_ids = dut.GetBodyIds(model_instance=model_instance)
-        self.assertEqual(len(deformable_body_ids), 1)
-        self.assertEqual(deformable_body_ids[0], body_id2)
-        dut.SetWallBoundaryCondition(body_id, [1, 1, -1], [0, 0, 1])
-
-        spatial_inertia = SpatialInertia_[float].SolidCubeWithDensity(1, 1)
-        rigid_body = plant.AddRigidBody("rigid_body", model_instance,
-                                        spatial_inertia)
-        dut.AddFixedConstraint(body_A_id=body_id,
-                               body_B=rigid_body,
-                               X_BA=RigidTransform(), shape=Box(1, 1, 1),
-                               X_BG=RigidTransform())
-
-        # Verify that both bodies have been added to the model.
-        self.assertIsInstance(dut.GetReferencePositions(body_id), np.ndarray)
-
-        deformable_model = plant.deformable_model()
-        self.assertEqual(deformable_model.num_bodies(), 2)
-
-        mutable_deformable_model = plant.mutable_deformable_model()
-        mutable_deformable_model._set_parallelism(parallelism=Parallelism(2))
-        self.assertEqual(deformable_model._parallelism().num_threads(), 2)
-        mutable_deformable_model._set_parallelism(
-            parallelism=Parallelism(False))
-        self.assertEqual(deformable_model._parallelism().num_threads(), 1)
+            geometry_instance=geometry, config=config, resolution_hint=1.0)
 
         plant.Finalize()
-
-        self.assertIsInstance(
-            plant.get_deformable_body_configuration_output_port(),
-            OutputPort_[float])
-        self.assertIsInstance(deformable_model.GetDiscreteStateIndex(body_id),
-                              DiscreteStateIndex)
-
         diagram = builder.Build()
-        # Ensure we can simulate this system.
-        simulator = Simulator_[float](diagram)
-        simulator.AdvanceTo(0.01)
-        plant_context = plant.GetMyContextFromRoot(simulator.get_context())
+        sim = Simulator_[float](diagram)
+        sim.AdvanceTo(0.01)
+        plant_context = plant.GetMyContextFromRoot(sim.get_context())
+
+        # Reference vs. simulated positions
+        q_ref = dut.GetReferencePositions(id=body_id).reshape((3, -1))
+        q_sim = dut.GetPositions(context=plant_context, id=body_id)
+        numpy_compare.assert_float_not_equal(q_ref, q_sim)
+
+        # Positions from state
+        num_dofs = q_sim.size
+        state_index = dut.GetDiscreteStateIndex(id=body_id)
+        discrete_state = plant_context.get_discrete_state(state_index)
+        state_value = discrete_state.get_value()
+        q_state = state_value[:num_dofs]
+        numpy_compare.assert_float_equal(q_state.reshape((3, -1), order='F'),
+                                         q_sim)
+
+        # Round-trip set/get under context
+        dut.SetPositions(context=plant_context, id=body_id, q=q_ref)
+        q2 = dut.GetPositions(context=plant_context, id=body_id)
+        numpy_compare.assert_float_equal(q_ref, q2)
+
         contact_results = (
             plant.get_contact_results_output_port().Eval(plant_context))
-
-        q0 = dut.GetReferencePositions(body_id).reshape((3, -1))
-        q1 = dut.GetPositions(context=plant_context, id=body_id)
-        numpy_compare.assert_float_not_equal(q0, q1)
-        dut.SetPositions(context=plant_context, id=body_id, q=q0)
-        q2 = dut.GetPositions(context=plant_context, id=body_id)
-        numpy_compare.assert_float_equal(q0, q2)
-
         # There is no deformable contact, but we can still try the API.
         self.assertEqual(contact_results.num_deformable_contacts(), 0)
         # Complains about index out of range.
         with self.assertRaisesRegex(SystemExit,
                                     '.*i < num_deformable_contacts().*'):
             contact_results.deformable_contact_info(0)
+
+    def test_deformable_model_disable_enable(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 1.0e-3)
+        dut = plant.deformable_model()
+
+        # Register one body
+        config = DeformableBodyConfig_[float]()
+        geometry = GeometryInstance(RigidTransform(), Sphere(1.0), "sphere")
+        props = ProximityProperties()
+        props.AddProperty("material", "coulomb_friction",
+                          CoulombFriction_[float](1.0, 1.0))
+        geometry.set_proximity_properties(props)
+        body_id = dut.RegisterDeformableBody(
+            geometry_instance=geometry, config=config, resolution_hint=1.0)
+
+        plant.Finalize()
+        diagram = builder.Build()
+        context = diagram.CreateDefaultContext()
+        plant_context = plant.GetMyContextFromRoot(context)
+
+        # Disable and re-enable the deformable body
+        self.assertTrue(
+            dut.is_enabled(id=body_id, context=plant_context))
+        dut.Disable(id=body_id, context=plant_context)
+        self.assertFalse(dut.is_enabled(id=body_id, context=plant_context))
+        dut.Enable(id=body_id, context=plant_context)
+        self.assertTrue(dut.is_enabled(id=body_id, context=plant_context))
+
+    def test_deformable_body_creation_and_metadata(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(
+            builder=builder, time_step=0.01)
+        deformable_model = plant.mutable_deformable_model()
+
+        config = DeformableBodyConfig_[float]()
+        props = ProximityProperties()
+        props.AddProperty("material", "coulomb_friction",
+                          CoulombFriction_[float](static_friction=1.0,
+                                                  dynamic_friction=1.0))
+        geometry = GeometryInstance(
+            X_PG=RigidTransform(), shape=Sphere(radius=1.0), name="sphere")
+        geometry.set_proximity_properties(properties=props)
+
+        body_id = deformable_model.RegisterDeformableBody(
+            geometry_instance=geometry,
+            config=config,
+            resolution_hint=1.0)
+        plant.Finalize()
+
+        body = deformable_model.GetBody(id=body_id)
+
+        # body_id, name, geometry_id, config
+        self.assertEqual(body.body_id(), body_id)
+        self.assertEqual(body.name(), "sphere")
+        self.assertEqual(body.geometry_id(),
+                         deformable_model.GetGeometryId(id=body_id))
+        self.assertIsInstance(body.config(),
+                              DeformableBodyConfig_[float])
+
+        # num_dofs() and reference_positions()
+        num_dofs = body.num_dofs()
+        reference_positions = body.reference_positions()
+        self.assertIsInstance(reference_positions, np.ndarray)
+        self.assertEqual(num_dofs, reference_positions.size)
+
+        # discrete_state_index()
+        state_index = body.discrete_state_index()
+        self.assertIsInstance(state_index, DiscreteStateIndex)
+
+        # is_enabled_parameter_index()
+        parameter_index = body.is_enabled_parameter_index()
+        self.assertIsInstance(parameter_index, AbstractParameterIndex)
+
+    def test_deformable_body_boundary_and_constraints(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(
+            builder=builder, time_step=0.01)
+        deformable_model = plant.mutable_deformable_model()
+
+        config = DeformableBodyConfig_[float]()
+        props = ProximityProperties()
+        props.AddProperty("material", "coulomb_friction",
+                          CoulombFriction_[float](static_friction=1.0,
+                                                  dynamic_friction=1.0))
+        geometry = GeometryInstance(
+            X_PG=RigidTransform(), shape=Sphere(radius=1.0), name="sphere")
+        geometry.set_proximity_properties(properties=props)
+        id = deformable_model.RegisterDeformableBody(
+            geometry_instance=geometry,
+            config=config,
+            resolution_hint=1.0)
+        body = deformable_model.GetBody(id=id)
+
+        # No fixed constraint yet
+        self.assertFalse(body.has_fixed_constraint())
+
+        # Wall boundary condition
+        body.SetWallBoundaryCondition(p_WQ=[0, 0, 1], n_W=[0, 0, 1])
+
+        # Add a fixed constraint.
+        inertia = SpatialInertia_[float].SolidCubeWithDensity(1, 1)
+        rigid_body = plant.AddRigidBody("rigid_body", inertia)
+        constraint_id = body.AddFixedConstraint(
+            body_B=rigid_body,
+            X_BA=RigidTransform(),
+            shape_G=Box(width=0.5, depth=0.5, height=0.5),
+            X_BG=RigidTransform())
+        self.assertTrue(body.has_fixed_constraint())
+
+    def test_deformable_body_state_methods(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(
+            builder=builder, time_step=0.01)
+        deformable_model = plant.mutable_deformable_model()
+
+        config = DeformableBodyConfig_[float]()
+        props = ProximityProperties()
+        props.AddProperty(
+            "material", "coulomb_friction",
+            CoulombFriction_[float](static_friction=1.0,
+                                    dynamic_friction=1.0))
+        geometry = GeometryInstance(
+            X_PG=RigidTransform(), shape=Sphere(radius=1.0), name="sphere")
+        geometry.set_proximity_properties(properties=props)
+        body_id = deformable_model.RegisterDeformableBody(
+            geometry_instance=geometry,
+            config=config,
+            resolution_hint=1.0)
+
+        # Build and finalize the diagram
+        plant.Finalize()
+        diagram = builder.Build()
+        diagram_context = diagram.CreateDefaultContext()
+        plant_context = plant.GetMyContextFromRoot(
+            root_context=diagram_context)
+
+        body = deformable_model.GetBody(id=body_id)
+
+        # Enabled by default
+        self.assertTrue(body.is_enabled(context=plant_context))
+
+        # Disable then re-enable
+        body.Disable(context=plant_context)
+        self.assertFalse(body.is_enabled(context=plant_context))
+        body.Enable(context=plant_context)
+        self.assertTrue(body.is_enabled(context=plant_context))
+
+        # Round-trip SetPositions / GetPositions
+        reference_positions = body.reference_positions()
+        reference_positions_reshaped = reference_positions.reshape(
+            (3, -1), order='F')
+        body.SetPositions(
+            context=plant_context,
+            q=reference_positions_reshaped)
+        positions_after = body.GetPositions(
+            context=plant_context)
+        numpy_compare.assert_float_equal(
+            reference_positions_reshaped, positions_after)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -106,10 +106,14 @@ void DoScalarIndependentDefinitions(py::module m) {
   BindTypeSafeIndex<JointIndex>(m, "JointIndex", doc.JointIndex.doc);
   BindTypeSafeIndex<JointActuatorIndex>(
       m, "JointActuatorIndex", doc.JointActuatorIndex.doc);
-  BindTypeSafeIndex<ModelInstanceIndex>(
-      m, "ModelInstanceIndex", doc.ModelInstanceIndex.doc);
   BindIdentifier<MultibodyConstraintId>(
       m, "MultibodyConstraintId", doc.MultibodyConstraintId.doc);
+  BindTypeSafeIndex<ModelInstanceIndex>(
+      m, "ModelInstanceIndex", doc.ModelInstanceIndex.doc);
+  BindIdentifier<DeformableBodyId>(
+      m, "DeformableBodyId", doc.DeformableBodyId.doc);
+  BindTypeSafeIndex<DeformableBodyIndex>(
+      m, "DeformableBodyIndex", doc.DeformableBodyIndex.doc);
   m.def("world_index", &world_index, doc.world_index.doc);
   m.def("world_frame_index", &world_frame_index, doc.world_frame_index.doc);
   m.def("world_model_instance", &world_model_instance,
@@ -1163,6 +1167,44 @@ void DefineMultibodyForces(py::module m, T) {
     DefCopyAndDeepCopy(&cls);
   }
 }
+
+void DefineDeformableBody(py::module m) {
+  using Class = DeformableBody<double>;
+  constexpr auto& cls_doc = doc.DeformableBody;
+  py::class_<Class> cls(m, "DeformableBody", cls_doc.doc);
+  BindMultibodyElementMixin<double>(&cls);
+  cls  // BR
+      .def("body_id", &Class::body_id)
+      .def("name", &Class::name)
+      .def("geometry_id", &Class::geometry_id)
+      .def("config", &Class::config, py_rvp::reference_internal,
+          cls_doc.config.doc)
+      .def("num_dofs", &Class::num_dofs, cls_doc.num_dofs.doc)
+      .def("reference_positions", &Class::reference_positions,
+          py_rvp::reference_internal, cls_doc.reference_positions.doc)
+      // TODO(xuchenhan-tri): Bind fem_model() or make it internal.
+      // TODO(xuchenhan-tri): Bind external_forces().
+      .def("discrete_state_index", &Class::discrete_state_index,
+          cls_doc.discrete_state_index.doc)
+      .def("is_enabled_parameter_index", &Class::is_enabled_parameter_index,
+          cls_doc.is_enabled_parameter_index.doc)
+      .def("SetWallBoundaryCondition", &Class::SetWallBoundaryCondition,
+          py::arg("p_WQ"), py::arg("n_W"), cls_doc.SetWallBoundaryCondition.doc)
+      .def("AddFixedConstraint", &Class::AddFixedConstraint, py::arg("body_B"),
+          py::arg("X_BA"), py::arg("shape_G"), py::arg("X_BG"),
+          cls_doc.AddFixedConstraint.doc)
+      .def("has_fixed_constraint", &Class::has_fixed_constraint,
+          cls_doc.has_fixed_constraint.doc)
+      .def("SetPositions", &Class::SetPositions, py::arg("context"),
+          py::arg("q"), cls_doc.SetPositions.doc)
+      .def("GetPositions", &Class::GetPositions, py::arg("context"),
+          cls_doc.GetPositions.doc)
+      .def("is_enabled", &Class::is_enabled, py::arg("context"),
+          cls_doc.is_enabled.doc)
+      .def("Disable", &Class::Disable, py::arg("context"), cls_doc.Disable.doc)
+      .def("Enable", &Class::Enable, py::arg("context"), cls_doc.Enable.doc);
+}
+
 }  // namespace
 
 PYBIND11_MODULE(tree, m) {
@@ -1173,7 +1215,9 @@ PYBIND11_MODULE(tree, m) {
 
   py::module::import("pydrake.common.eigen_geometry");
   py::module::import("pydrake.multibody.math");
+  py::module::import("pydrake.multibody.fem");
   py::module::import("pydrake.systems.framework");
+  py::module::import("pydrake.geometry");
 
   internal::DefineTreeInertia(m);
   DoScalarIndependentDefinitions(m);
@@ -1183,6 +1227,7 @@ PYBIND11_MODULE(tree, m) {
         DoScalarDependentDefinitions(m, dummy);
       },
       CommonScalarPack{});
+  DefineDeformableBody(m);
 
   ExecuteExtraPythonCode(m);
 }

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -4230,8 +4230,8 @@ TEST_F(SdfParserTest, ParseMinimalDeformableModel) {
   plant_.Finalize();
   EXPECT_EQ(plant_.deformable_model().num_bodies(), 1);
   // Without specifying any proximity properties, the default values are used.
-  GeometryId g_id = plant_.deformable_model().GetGeometryId(
-      plant_.deformable_model().GetBodyIdByName("body"));
+  GeometryId g_id =
+      plant_.deformable_model().GetBodyByName("body").geometry_id();
   const auto* proximity_props_ptr =
       scene_graph_.model_inspector().GetProximityProperties(g_id);
   ASSERT_NE(proximity_props_ptr, nullptr);
@@ -4282,7 +4282,7 @@ TEST_F(SdfParserTest, ParseFullFeatureDeformableModel) {
   plant_.Finalize();
   EXPECT_EQ(plant_.deformable_model().num_bodies(), 1);
   const DeformableBodyId body_id =
-      plant_.deformable_model().GetBodyIdByName("body");
+      plant_.deformable_model().GetBodyByName("body").body_id();
   auto geometry_id = plant_.deformable_model().GetGeometryId(body_id);
   const geometry::ProximityProperties* props =
       scene_graph_.model_inspector().GetProximityProperties(geometry_id);
@@ -4578,7 +4578,7 @@ TEST_F(SdfParserTest, ComposedPoseForDeformable) {
   plant_.Finalize();
   EXPECT_EQ(plant_.deformable_model().num_bodies(), 1);
   const DeformableBodyId body_id =
-      plant_.deformable_model().GetBodyIdByName("body");
+      plant_.deformable_model().GetBodyByName("body").body_id();
   const VectorXd q_WB =
       plant_.deformable_model().GetReferencePositions(body_id);
   VectorXd q_WB_expected(12);

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -262,12 +262,6 @@ const DeformableBody<T>& DeformableModel<T>::GetBodyByName(
 }
 
 template <typename T>
-DeformableBodyId DeformableModel<T>::GetBodyIdByName(
-    const std::string& name) const {
-  return GetBodyByName(name).body_id();
-}
-
-template <typename T>
 std::vector<DeformableBodyId> DeformableModel<T>::GetBodyIds(
     ModelInstanceIndex model_instance) const {
   std::vector<DeformableBodyId> result;

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -236,6 +236,8 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
 
   // TODO(xuchenhan-tri): filter collisions for the disabled deformable body's
   // geometry.
+  // TODO(xuchenhan-tri): The `context` parameter should come before the `id`
+  // parameter for Disable/Enable/is_enabled() methods.
   /** Disables the deformable body with the given `id` in the given context.
    Disabling a deformable body sets its vertex velocities and accelerations to
    zero and freezes its vertex positions. A disabled deformable body is not
@@ -298,6 +300,11 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
    registered in this model. */
   DeformableBodyId GetBodyId(DeformableBodyIndex index) const;
 
+  /** Returns the DeformableBodyId associated with the given `geometry_id`.
+   @throws std::exception if the given `geometry_id` does not correspond to a
+   deformable body registered with this model. */
+  DeformableBodyId GetBodyId(geometry::GeometryId geometry_id) const;
+
   /** Returns the deformable body with the given `id`.
    @throws std::exception if no deformable body with the given `id` has been
    registered in this model. */
@@ -359,21 +366,13 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
   const DeformableBody<T>& GetBodyByName(
       const std::string& name, ModelInstanceIndex model_instance) const;
 
-  // TODO(xuchenhan-tri): This function can be removed.
-  /** Returns the DeformableBodyId of the body with the given name.
-   @throws std::exception if there's no body with the given name or if more than
-   one model instance contains deformable body with the given name. */
-  DeformableBodyId GetBodyIdByName(const std::string& name) const;
-
   /** Returns the DeformableIds of the bodies that belong to the given model
    instance. Returns the empty vector if no deformable bodies are registered
    with the given model instance. */
   std::vector<DeformableBodyId> GetBodyIds(
       ModelInstanceIndex model_instance) const;
 
-  /** (Internal) Returns the DeformableBodyIndex of the body with the given id.
-   This function is for internal bookkeeping use only. Most users should use
-   DeformableBodyId instead.
+  /** Returns the DeformableBodyIndex of the body with the given id.
    @throws std::exception if no body with the given `id` has been registered. */
   DeformableBodyIndex GetBodyIndex(DeformableBodyId id) const;
 
@@ -382,13 +381,8 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
    @throws std::exception if no body with the given `id` has been registered. */
   geometry::GeometryId GetGeometryId(DeformableBodyId id) const;
 
-  /** Returns the DeformableBodyId associated with the given `geometry_id`.
-   @throws std::exception if the given `geometry_id` does not correspond to a
-   deformable body registered with this model. */
-  DeformableBodyId GetBodyId(geometry::GeometryId geometry_id) const;
-
-  /** (Internal use only) Returns the true iff the deformable body with the
-   given `id` has constraints associated with it. */
+  /** Returns the true if the deformable body with the given `id` has
+   constraints associated with it. */
   bool HasConstraint(DeformableBodyId id) const {
     return GetBody(id).has_fixed_constraint();
   }
@@ -402,8 +396,8 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
     return *integrator_;
   }
 
-  /** Returns the output port index of the vertex positions port for all
-   registered deformable bodies.
+  /** (Internal use only) Returns the output port index of the vertex positions
+   port for all registered deformable bodies.
    @throws std::exception if called before `DeclareSceneGraphPorts()` is called.
   */
   systems::OutputPortIndex configuration_output_port_index() const {

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -726,12 +726,8 @@ TEST_F(DeformableModelTest, Parallelism) {
 TEST_F(DeformableModelTest, BodyName) {
   const DeformableBodyId body_id = RegisterSphere(0.5);
   EXPECT_TRUE(deformable_model_ptr_->HasBodyNamed("sphere"));
-  EXPECT_EQ(deformable_model_ptr_->GetBodyIdByName("sphere"), body_id);
   EXPECT_EQ(deformable_model_ptr_->GetBodyByName("sphere").body_id(), body_id);
   EXPECT_FALSE(deformable_model_ptr_->HasBodyNamed("nonexistent_body_name"));
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      deformable_model_ptr_->GetBodyIdByName("nonexistent_body_name"),
-      ".*No deformable body.*nonexistent_body_name.*registered.*");
 }
 
 /* Tests registering deformable bodies into a prescribed model instance as well


### PR DESCRIPTION
Add bindings for the new class `multibody::DeformableBody`.
Add missing bindings for `multibody::DeformableModel`.
Reorganize tests for bindings for DeformableModel to be more readable.
Remove `DeformableModel::GetBodyIdByName`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23062)
<!-- Reviewable:end -->
