### PR TITLE
[workspace] Upgrade vtk_internal to latest commit

### DIFF
--- a/tools/workspace/vtk_internal/patches/common_core_nobacktrace.patch
+++ b/tools/workspace/vtk_internal/patches/common_core_nobacktrace.patch
@@ -8,8 +8,8 @@ Reasoning for not upstreaming this patch: Drake-specific build option.
 --- Common/Core/vtkDeserializer.cxx
 +++ Common/Core/vtkDeserializer.cxx
 @@ -186,8 +186,10 @@ vtkDeserializer::ConstructorType vtkDeserializer::GetConstructor(
-     name = superClassNames[--superClassId];
-   } while (superClassId > 0);
+     }
+   }
    vtkErrorMacro(<< "There is no constructor registered for type " << className
 -                << ". Check stack trace to see how we got here.");
 +                << ".");

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -184,8 +184,8 @@ def vtk_internal_repository(
         # TODO(jwnimmer-tri) Once there's a tagged release with support for
         # VTK_ABI_NAMESPACE, we should switch to an official version number
         # here. That probably means waiting for the VTK 10 release.
-        commit = "02b9b138d3a12cf594e8d393b92a390f762c799f",
-        sha256 = "aa2061f67119c8cca332a205db560bb59619578fe802d6d29527c2542975ec6a",  # noqa
+        commit = "1d67dcfb29517a1533680a74736fa6786e5029d0",
+        sha256 = "82d86920dbba79d169183baacdf092e5b6f3acef12fea6bb90cd620632a1d567",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             # Drake's conventions for VTK patches are:


### PR DESCRIPTION
Towards #23055 

~`vtk_internal` broke the `new_release` script. VTK typically requires manual intervention for the monthly upgrade process. See previous month's VTK upgrade here: #23038~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23064)
<!-- Reviewable:end -->
