### PR TITLE
[doc] Switch to Ubuntu Noble as the primary development platform

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -312,7 +312,7 @@ To view the documentation rendered in Sphinx:
 
     bazel run //doc/pydrake:serve_sphinx [-- --browser=false]
 
-@note Drake's online Python documentation is generated on Ubuntu Jammy, and it
+@note Drake's online Python documentation is generated on Ubuntu Noble, and it
 is suggested to preview documentation using this platform. Other platforms may
 have slightly different generated documentation.
 

--- a/doc/_pages/apt.md
+++ b/doc/_pages/apt.md
@@ -91,6 +91,6 @@ Nightly packages are retained for 56 days from their date of creation.
 To install a nightly apt package, download the archive and install it directly:
 
 ```bash
-wget https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-jammy.deb
-sudo apt-get install --no-install-recommends ./drake-dev_latest-1_amd64-jammy.deb
+wget https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-noble.deb
+sudo apt-get install --no-install-recommends ./drake-dev_latest-1_amd64-noble.deb
 ```

--- a/doc/_pages/docker.md
+++ b/doc/_pages/docker.md
@@ -43,7 +43,7 @@ The docker tags for Drake's stable releases are spelled like:
 
 * ``jammy-X.Y.Z`` for the Ubuntu 22.04 image of Drake vX.Y.Z.
 * ``noble-X.Y.Z`` for the Ubuntu 24.04 image of Drake vX.Y.Z.
-* ``X.Y.Z`` is a synonym for ``jammy-X.Y.Z``.
+* ``X.Y.Z`` is a synonym for ``noble-X.Y.Z``.
 
 Refer to [Quickstart](/installation.html#quickstart) for next steps.
 
@@ -63,7 +63,7 @@ The docker tags for Drake's nightly releases are spelled like:
 * ``jammy`` is a synonym for the most recent ``jammy-YYYYMMDD``.
 * ``noble-YYYYMMDD`` for the Ubuntu 24.04 image of Drake as of date YYYY-MM-DD.
 * ``noble`` is a synonym for the most recent ``noble-YYYYMMDD``.
-* ``YYYYMMDD`` is a synonym for the most recent ``jammy-YYYYMMDD``.
+* ``YYYYMMDD`` is a synonym for the most recent ``noble-YYYYMMDD``.
 * ``latest`` is a synonym for the most recent ``YYYYMMDD``.
 
 Refer to [Quickstart](/installation.html#quickstart) for next steps.

--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -16,7 +16,7 @@ The website infrastructure uses a combination of
 # Prerequisites
 
 Documentation generation and preview as described in this document are
-supported on Ubuntu **22.04** only.
+supported on Ubuntu 22.04 (Jammy) and 24.04 (Noble).
 
 Before getting started, install Drake's prerequisites with the additional
 ``--with-doc-only`` command line option, i.e.:
@@ -81,7 +81,7 @@ If you would like to check Jenkins results on a pull request, you need to
 by posting a comment
 
 ```
-@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-documentation please
+@drake-jenkins-bot linux-noble-unprovisioned-gcc-bazel-experimental-documentation please
 ```
 
 # Advanced Building

--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -112,7 +112,7 @@ Refer to [Quickstart](/installation.html#quickstart) for next steps.
 
 ## Nightly Releases
 
-Binary packages of Drake for Ubuntu 22.04 (Jammy) and
+Binary packages of Drake for Ubuntu 22.04 (Jammy), Ubuntu 24.04 (Noble), and
 Mac are generated nightly and are available to download at:
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz)

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -48,7 +48,7 @@ with other versions of Python or Java. However, these are not supported
 so if it doesn't work for you then please file a pull request with the fix,
 not a bug report.
 
-All else being equal, we would recommend developers use Ubuntu 22.04 (Jammy).
+All else being equal, we would recommend developers use Ubuntu 24.04 (Noble).
 
 ⁽¹⁾ Drake features that perform image rendering (e.g., camera simulation)
 maybe require extra setup. See the

--- a/doc/_pages/getting_help.md
+++ b/doc/_pages/getting_help.md
@@ -39,7 +39,7 @@ If you wish to contribute a patch, please see how to [submit a pull request](/de
 When reporting an issue, please consider providing the following information
 (``helper command in monospace``):
 
-* Operating system (e.g., Ubuntu Jammy 22.04 or macOS Sonoma)
+* Operating system (e.g., Ubuntu Noble 24.04 or macOS Sonoma)
 * Installation method (e.g., pip, apt, binary tar.gz, docker image, or
   rebuilding from source)
 * Language you are using (C++ or [Python](/python_bindings.html))

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -54,7 +54,7 @@ where ``<job-name>`` is the name of an
 For example:
 
 * ``@drake-jenkins-bot mac-arm-sonoma-clang-bazel-experimental-release please``
-* ``@drake-jenkins-bot linux-jammy-clang-bazel-experimental-valgrind-memcheck please``
+* ``@drake-jenkins-bot linux-noble-clang-bazel-experimental-valgrind-memcheck please``
 
 A list of Jenkins bot commands that cover the full set of continuous and nightly
 production jobs are available for
@@ -110,7 +110,7 @@ When updating prerequisites with these scripts, the normal experimental CI will
 most likely fail. To test new prerequisites on Linux, you should first request an
 unprovisioned experimental build, e.g.:
 
-* ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-release please``
+* ``@drake-jenkins-bot linux-noble-unprovisioned-gcc-bazel-experimental-release please``
 
 Testing changes to the source distribution prerequisites for macOS is a work
 in progress as there are no longer unprovisioned builds.
@@ -128,31 +128,40 @@ To schedule an "experimental" build of a [binary package](/from_binary.html)
 or [debian package](/apt.html), comment on an open pull request using one or
 more of these commands:
 
-* ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-bazel-experimental-packaging please``
-* ``@drake-jenkins-bot mac-arm-sonoma-clang-bazel-experimental-packaging please``
+* ``@drake-jenkins-bot linux-noble-unprovisioned-gcc-cmake-experimental-packaging please``
+* ``@drake-jenkins-bot mac-arm-sonoma-clang-cmake-experimental-packaging please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
 to schedule a build of one of the [Packaging](https://drake-jenkins.csail.mit.edu/view/Packaging/)
 jobs with **experimental** in its name.
 
 To download the built package, open the Jenkins console log for the completed
-build (click on "Console Output" then "Full Log") and search for the text
-"Upload complete" to find the download URL.  For example:
+build (click on "Details" for a packaging build in the pull request's
+list of checks, then "Console Output") and search for the text "Artifacts
+uploaded to AWS" to find the download URL (usually about a screen's-worth of
+text above the end of the log).  For example:
 
 ```
 ...
-[9:49:51 AM]  -- Upload complete: https://drake-packages.csail.mit.edu/drake/experimental/drake-20230427164706-0b666a17ba2ce3ca7505655dc724960d88a34645-jammy.tar.gz
-...
-[9:49:53 AM]  -- Upload complete: https://drake-packages.csail.mit.edu/drake/experimental/drake-dev_0.0.20230427164706-0b666a17ba2ce3ca7505655dc724960d88a34645-1_amd64-jammy.deb
+[2:30:23 PM]  -- Artifacts uploaded to AWS:
+[2:30:23 PM]  https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.20250530.180720%2Bgit3468349f-noble.tar.gz
+[2:30:23 PM]  https://drake-packages.csail.mit.edu/drake/experimental/drake-dev_0.0.20250530.180720%2Bgit3468349f-1_amd64-noble.deb
 ...
 ```
+
+(In some cases, it may be necessary to click the "Full Log" and search for the
+text "Upload complete", particularly if you wish to also find the checksum
+URLs.)
+
+To download the package, simply click the link or use your favorite HTTP
+retrieval tool (e.g. ``wget`` or ``curl``).
 
 ### Wheel
 
 To schedule an "experimental" build of a [wheel package](/pip.html),
 comment on an open pull request using one or more of these commands:
 
-* ``@drake-jenkins-bot linux-jammy-unprovisioned-gcc-wheel-experimental-release please``
+* ``@drake-jenkins-bot linux-noble-unprovisioned-gcc-wheel-experimental-release please``
 * ``@drake-jenkins-bot mac-arm-sonoma-clang-wheel-experimental-release please``
 
 or follow the [instructions above](#scheduling-builds-via-the-jenkins-user-interface)
@@ -167,8 +176,11 @@ text above the end of the log).  For example:
 
 ```
 ...
-[12:00:00 AM]  -- Artifacts uploaded to AWS:
-[12:00:00 AM]  https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.1999.1.1.0.0.0%2Bgitffffffff-cp310-cp310-manylinux_2_31_x86_64.whl
+[2:17:49 PM]  -- Artifacts uploaded to AWS:
+[2:17:49 PM]  https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.20250521.172625%2Bgitbbcde5ab-cp310-cp310-manylinux_2_34_x86_64.whl
+[2:17:49 PM]  https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.20250521.172625%2Bgitbbcde5ab-cp311-cp311-manylinux_2_34_x86_64.whl
+[2:17:49 PM]  https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.20250521.172625%2Bgitbbcde5ab-cp312-cp312-manylinux_2_34_x86_64.whl
+[2:17:49 PM]  https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.20250521.172625%2Bgitbbcde5ab-cp313-cp313-manylinux_2_34_x86_64.whl
 ...
 ```
 

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -125,7 +125,7 @@ the main body of the document:
 2. Launch the staging builds for that git commit sha:
    1. Open the following Jenkins jobs (e.g., each in its own
       new window, so you can copy-and-paste sha1 and version easily):
-      - [Linux Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-wheel-staging-release/)
+      - [Linux Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-noble-unprovisioned-gcc-wheel-staging-release/)
       - [macOS arm Wheel Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/mac-arm-sonoma-clang-wheel-staging-release/)
       - [Jammy Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-jammy-unprovisioned-gcc-cmake-staging-packaging/)
       - [Noble Packaging Staging](https://drake-jenkins.csail.mit.edu/view/Staging/job/linux-noble-unprovisioned-gcc-cmake-staging-packaging/)
@@ -154,7 +154,7 @@ the main body of the document:
       [download_release_candidate.py](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/download_release_candidate.py).)
 6. Merge the release notes PR.
    1. Take care when squashing not to accept github's auto-generated commit message if it is not appropriate.
-   2. After merge, go to <https://drake-jenkins.csail.mit.edu/view/Documentation/job/linux-jammy-unprovisioned-gcc-bazel-nightly-documentation/> and push "Build now".
+   2. After merge, go to <https://drake-jenkins.csail.mit.edu/view/Documentation/job/linux-noble-unprovisioned-gcc-bazel-nightly-documentation/> and push "Build now".
       * If you don't have "Build now" click "Log in" first in upper right.
 7. Open <https://github.com/RobotLocomotion/drake/releases> and choose "Draft
    a new release".  Note that this page has neither history nor undo.  Be

--- a/tools/install/dockerhub/jammy/README.md
+++ b/tools/install/dockerhub/jammy/README.md
@@ -3,18 +3,18 @@
 To create a Docker image similar to those hosted on
 [Docker Hub](https://hub.docker.com/r/robotlocomotion/drake), download the
 latest [binary package](https://drake.mit.edu/from_binary.html)
-`drake-latest-jammy.tar.gz` to this directory, and then run the following
+`drake-latest-noble.tar.gz` to this directory, and then run the following
 command:
 
 ```bash
-docker build -t robotlocomotion/drake:jammy .
+docker build -t robotlocomotion/drake:noble .
 ```
 
 To start a Docker container with an interactive pseudo-terminal, run the
 following command:
 
 ```bash
-docker run -it robotlocomotion/drake:jammy
+docker run -it robotlocomotion/drake:noble
 ```
 
 The environment variables `PATH` and `PYTHONPATH` are preset to suitable values


### PR DESCRIPTION
Towards #22996, closes #23052.

This coincides with CI changes to jobs that were previously Jammy-only now being Noble-only.

Include changing the 'default' Dockerhub image (i.e. only specifying `X.Y.Z` or `YYYYMMDD`, without an OS version) to Noble. Exclude documentation changes which are not ready to switch yet:
* tools/release_engineering and tools/workspace/new_release.py
* Deepnote tutorials
* CLion docs

Also fix the language of the Packaging section of jenkins.md to mirror the Wheel section.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23066)
<!-- Reviewable:end -->
