### PR TITLE
[workspace] Suppress usockets warnings from GCC 13

### DIFF
--- a/tools/workspace/usockets_internal/package.BUILD.bazel
+++ b/tools/workspace/usockets_internal/package.BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
     copts = [
         "-DLIBUS_NO_SSL",
         "-fvisibility=hidden",
+        "-w",
     ],
     linkstatic = 1,
 )


### PR DESCRIPTION
Here's the current warning being suppressed:

```
external/+internal_repositories+usockets_internal/src/eventing/epoll_kqueue.c:220:9: warning: pointer 'p' may be used after 'realloc' [-Wuse-after-free]
  220 |         us_internal_loop_update_pending_ready_polls(loop, p, new_p, events, events);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23077)
<!-- Reviewable:end -->
