### PR TITLE
[doc] Allow pydrake docs to build on either Jammy or Noble

### DIFF
--- a/doc/pydrake/pydrake_sphinx_extension.py
+++ b/doc/pydrake/pydrake_sphinx_extension.py
@@ -121,7 +121,14 @@ class IrregularExpression:
         else:
             path = None
         if self.extended:
-            groups = (explicit_modname, path, base, arg, retann)
+            # Different versions of sphinx have different groups in their
+            # regular expressions, so our returned groups must match the
+            # signature of the specific version of sphinx being wrapped.
+            if sphinx_version[:3] >= (7, 1, 0):
+                type_par = ""
+                groups = (explicit_modname, path, base, type_par, arg, retann)
+            else:
+                groups = (explicit_modname, path, base, arg, retann)
         else:
             assert explicit_modname is None
             groups = (path, base, arg, retann)


### PR DESCRIPTION
Towards #23057.  For the Noble version of Sphinx, we need to adjust the number and meaning of regex match groups to track https://github.com/sphinx-doc/sphinx/pull/11444.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23078)
<!-- Reviewable:end -->
