### PR TITLE
[build] Fix minimum supported macOS versions in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,17 @@ set(BAZELRC_IMPORTS "tools/bazel.rc")
 set(UNIX_DISTRIBUTION_ID)
 set(UNIX_DISTRIBUTION_CODENAME)
 
+# The minimum Darwin version and codename should correspond to the minimum
+# supported macOS version listed in doc/_pages/installation.md and
+# doc/_pages/from_source.md.
+set(MINIMUM_DARWIN_VERSION 23)
+set(MINIMUM_MACOS_CODENAME "Sonoma")
+
 if(APPLE)
-  if(CMAKE_SYSTEM_VERSION VERSION_LESS 21)
-    message(WARNING
-      "Darwin ${CMAKE_SYSTEM_VERSION} is NOT supported. Please use "
-      "Darwin 21.x (macOS Monterey) or newer."
+  if(CMAKE_SYSTEM_VERSION VERSION_LESS ${MINIMUM_DARWIN_VERSION})
+    message(WARNING "Darwin ${CMAKE_SYSTEM_VERSION} is NOT supported. "
+      "Please use Darwin ${MINIMUM_DARWIN_VERSION}.x (macOS "
+      "${MINIMUM_MACOS_CODENAME}) or newer."
     )
   endif()
 
@@ -74,6 +80,9 @@ else()
     if(NOT LSB_RELEASE_CODENAME_SHORT_RESULT_VARIABLE EQUAL 0)
       message(WARNING "Could NOT run the lsb_release executable")
     else()
+      # TODO(tyler-yankee): Replicate the warning message with the minimum
+      # OS version logic from the macOS branch above, rather than giving an
+      # unclear warning message about an unfound .bazelrc file.
       set(MAYBE_RC "tools/ubuntu-${UNIX_DISTRIBUTION_CODENAME}.bazelrc")
       if(NOT EXISTS "${PROJECT_SOURCE_DIR}/${MAYBE_RC}")
         message(WARNING "Could NOT find config file ${MAYBE_RC}")
@@ -114,7 +123,7 @@ endif()
 
 # The minimum compiler versions should match those listed in both
 # doc/_pages/from_source.md and tools/workspace/cc/repository.bzl.
-set(MINIMUM_APPLE_CLANG_VERSION 14)
+set(MINIMUM_APPLE_CLANG_VERSION 16)
 set(MINIMUM_CLANG_VERSION 15)
 set(MINIMUM_GNU_VERSION 11)
 


### PR DESCRIPTION
Amend d8b670b0 and make additional cleanup to ensure consistent minimum versioning policies in Drake's CMake code for macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23082)
<!-- Reviewable:end -->
