### PR TITLE
Disable `//tools/lint:py/util_test` for kcov

### DIFF
--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -151,6 +151,9 @@ drake_py_unittest(
         "external",
         # This test looks outside the sandbox.
         "no-sandbox",
+        # Our custom install of kcov for Ubuntu 24.04 Noble in
+        # setup/ubuntu/install_kcov.sh trips up this test.
+        "no_kcov",
     ],
     deps = [":util"],
 )


### PR DESCRIPTION
Amends 13c422b, closes #23081.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23084)
<!-- Reviewable:end -->
