### PR TITLE
[build] Adjust CMake warning for non-officially-supported Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,14 @@ if(ANDROID OR CYGWIN OR IOS OR NOT UNIX)
 endif()
 
 set(BAZELRC_IMPORTS "tools/bazel.rc")
-set(UNIX_DISTRIBUTION_ID)
 set(UNIX_DISTRIBUTION_CODENAME)
 
 # The minimum Darwin version and codename should correspond to the minimum
 # supported macOS version listed in doc/_pages/installation.md and
 # doc/_pages/from_source.md.
+# For Ubuntu, don't make as harsh a check for minimum supported version
+# since Drake *can* compile on non-Ubuntu UNIX, even though it's not
+# officially supported.
 set(MINIMUM_DARWIN_VERSION 23)
 set(MINIMUM_MACOS_CODENAME "Sonoma")
 
@@ -80,12 +82,13 @@ else()
     if(NOT LSB_RELEASE_CODENAME_SHORT_RESULT_VARIABLE EQUAL 0)
       message(WARNING "Could NOT run the lsb_release executable")
     else()
-      # TODO(tyler-yankee): Replicate the warning message with the minimum
-      # OS version logic from the macOS branch above, rather than giving an
-      # unclear warning message about an unfound .bazelrc file.
       set(MAYBE_RC "tools/ubuntu-${UNIX_DISTRIBUTION_CODENAME}.bazelrc")
       if(NOT EXISTS "${PROJECT_SOURCE_DIR}/${MAYBE_RC}")
-        message(WARNING "Could NOT find config file ${MAYBE_RC}")
+        message(WARNING "Could not find config file ${MAYBE_RC}. "
+          "This may indicate that you're using an OS or OS version that "
+          "is not officially supported, so the build configuration cannot be "
+          "fine-tuned. See https://drake.mit.edu/from_source.html for details "
+          "on officially supported platforms when building from source.")
       else()
         list(APPEND BAZELRC_IMPORTS "${MAYBE_RC}")
       endif()


### PR DESCRIPTION
The existing warning message for an older macOS version is much clearer than the Ubuntu, where it just says the .bazelrc file cannot be found. Clarify the warning to additionally point to the officially supported OS and OS versions when building from source.

See discussion on #23082 for context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23087)
<!-- Reviewable:end -->
