### PR TITLE
MapQDDotToAcceleration() and MapAccelerationToQDDot() for rpy mobilizer.

### DIFF
--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -159,13 +159,11 @@ void RpyBallMobilizer<T>::DoCalcNMatrix(const systems::Context<T>& context,
   // Note: N(q) is singular for p = π/2 + kπ, for k = ±1, ±2, ...
   // See related code and comments in DoMapVelocityToQdot().
 
-  using std::abs;
   using std::cos;
   using std::sin;
   const Vector3<T> angles = get_angles(context);
   const T cp = cos(angles[1]);
-  const char* function_name_less_Do = __func__ + 2;
-  ThrowIfCosPitchNearZero(cp, angles[1], function_name_less_Do);
+  ThrowIfCosPitchNearZero(cp, angles[1], "CalcNMatrix");
 
   const T sp = sin(angles[1]);
   const T sy = sin(angles[2]);
@@ -238,8 +236,7 @@ void RpyBallMobilizer<T>::DoCalcNDotMatrix(const systems::Context<T>& context,
   const T sp = sin(angles[1]);
   const T sy = sin(angles[2]);
   const T cy = cos(angles[2]);
-  const char* function_name_less_Do = __func__ + 2;
-  ThrowIfCosPitchNearZero(cp, angles[1], function_name_less_Do);
+  ThrowIfCosPitchNearZero(cp, angles[1], "CalcNDotMatrix");
   const T cpi = 1.0 / cp;
   const T cpiSqr = cpi * cpi;
 
@@ -295,8 +292,7 @@ void RpyBallMobilizer<T>::DoCalcNplusDotMatrix(
 
   // Throw an exception with the proper function name if a singularity would be
   // encountered in DoMapVelocityToQDot().
-  const char* function_name_less_Do = __func__ + 2;
-  ThrowIfCosPitchNearZero(cp, angles[1], function_name_less_Do);
+  ThrowIfCosPitchNearZero(cp, angles[1], "CalcNplusDotMatrix");
 
   // Calculate time-derivative of roll, pitch, and yaw angles.
   const Vector3<T> v = get_angular_velocity(context);
@@ -348,7 +344,6 @@ void RpyBallMobilizer<T>::DoMapVelocityToQDot(
   // [Mitiguy August 2019] Mitiguy, P., 2019. Advanced Dynamics & Motion
   //                       Simulation.
 
-  using std::abs;
   using std::cos;
   using std::sin;
   const Vector3<T> angles = get_angles(context);
@@ -356,8 +351,7 @@ void RpyBallMobilizer<T>::DoMapVelocityToQDot(
   const T cp = cos(angles[1]);
   const T sy = sin(angles[2]);
   const T cy = cos(angles[2]);
-  const char* function_name_less_Do = __func__ + 2;
-  ThrowIfCosPitchNearZero(cp, angles[1], function_name_less_Do);
+  ThrowIfCosPitchNearZero(cp, angles[1], "MapVelocityToQDot");
   const T cpi = 1.0 / cp;
 
   // Although we can calculate q̇ = N(q) * v, it is more efficient to implicitly

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -512,7 +512,7 @@ void RpyBallMobilizer<T>::DoMapQDDotToAcceleration(
   // q = [r, p, y]ᵀ  denote roll, pitch, yaw angles (generalized positions).
   //
   // There are various ways to calculate v̇ = [ω̇x, ω̇y, ω̇z]ᵀ (the time-derivatives
-  // of the generalized velocities). The calculation below is straighforward in
+  // of the generalized velocities). The calculation below is straightforward in
   // that it simply differentiates v = N⁺(q)⋅q̇ to form v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
 
   // Form the Ṅ⁺(q,q̇)⋅q̇ term of the result now (start of this function) so any

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -132,17 +132,20 @@ void RpyBallMobilizer<T>::ProjectSpatialForce(
 }
 
 template <typename T>
-void RpyBallMobilizer<T>::ThrowSinceCosPitchIsNearZero(
-    const T& pitch, const char* function_name) const {
-  throw std::runtime_error(fmt::format(
-      "{}(): The RpyBallMobilizer (implementing a BallRpyJoint) between "
-      "body {} and body {} has reached a singularity. This occurs when the "
-      "pitch angle takes values near π/2 + kπ, ∀ k ∈ ℤ. At the current "
-      "configuration, we have pitch = {} radians. Drake does not yet support "
-      "a comparable joint using quaternions, but the feature request is "
-      "tracked in https://github.com/RobotLocomotion/drake/issues/12404.",
-      function_name, this->inboard_body().name(), this->outboard_body().name(),
-      pitch));
+void RpyBallMobilizer<T>::ThrowIfCosPitchNearZero(
+    const T& cos_pitch, const T& pitch_angle, const char* function_name) const {
+  using std::abs;
+  if (abs(cos_pitch) < 1.0e-3) {
+    throw std::runtime_error(fmt::format(
+        "{}(): The RpyBallMobilizer (implementing a BallRpyJoint) between "
+        "body {} and body {} has reached a singularity. This occurs when the "
+        "pitch angle takes values near π/2 + kπ, ∀ k ∈ ℤ. At the current "
+        "configuration, we have pitch = {} radians. Drake does not yet support "
+        "a comparable joint using quaternions, but the feature request is "
+        "tracked in https://github.com/RobotLocomotion/drake/issues/12404.",
+        function_name, this->inboard_body().name(),
+        this->outboard_body().name(), pitch_angle));
+  }
 }
 
 template <typename T>

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -527,7 +527,7 @@ void RpyBallMobilizer<T>::DoMapQDDotToAcceleration(
   // --------------------------------------------------------------------------
   // Form the Ṅ⁺(q,q̇)⋅q̇ term of the result now (start of this function) so any
   // singularity (if one exists) throws an exception referencing this function.
-  const Vector3<T> NplusDotTimesQdot =
+  const Vector3<T> NplusDot_times_Qdot =
       CalcAccelerationBiasForQDDot(context, __func__);
 
   // Although the function below was designed to calculate v = N⁺(q)⋅q̇, it can
@@ -535,7 +535,7 @@ void RpyBallMobilizer<T>::DoMapQDDotToAcceleration(
   DoMapQDotToVelocity(context, qddot, vdot);  // On return, vdot = N⁺(q)⋅q̈.
 
   // Sum the previous terms to form v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
-  *vdot += NplusDotTimesQdot;
+  *vdot += NplusDot_times_Qdot;
 }
 
 template <typename T>

--- a/multibody/tree/rpy_ball_mobilizer.cc
+++ b/multibody/tree/rpy_ball_mobilizer.cc
@@ -521,8 +521,8 @@ void RpyBallMobilizer<T>::DoMapQDDotToAcceleration(
   // q = [r, p, y]ᵀ  denote roll, pitch, yaw angles (generalized positions).
   //
   // There are various ways to calculate v̇ = [ω̇x, ω̇y, ω̇z]ᵀ (the time-derivatives
-  // of the generalized velocities). A straightforward one is to simply
-  // differentiate v = N⁺(q)⋅q̇ to form v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
+  // of the generalized velocities). The calculation below is straighforward in
+  // that it simply differentiates v = N⁺(q)⋅q̇ to form v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
   // --------------------------------------------------------------------------
   // Form the Ṅ⁺(q,q̇)⋅q̇ term of the result ath the start of this function so the
   // pitch singularity throws an exception that refers to this function.
@@ -532,7 +532,7 @@ void RpyBallMobilizer<T>::DoMapQDDotToAcceleration(
   // also be used to calculate N⁺(q)⋅q̈.
   DoMapQDotToVelocity(context, qddot, vdot);  // On return, vdot = N⁺(q)⋅q̈.
 
-  // Calculate v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
+  // Sum the previous terms to form v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
   *vdot += NplusDotTimesQdot;
 }
 

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -299,6 +299,20 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
                            const Eigen::Ref<const VectorX<T>>& qdot,
                            EigenPtr<VectorX<T>> v) const final;
 
+  // Maps vdot to qddot, which for this mobilizer is q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇.
+  // For simple mobilizers q̈ = v̇. This mobilizer's N and Ṅ are more elaborate.
+  void DoMapAccelerationToQDDot(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& vdot,
+                                EigenPtr<VectorX<T>> qddot) const final;
+
+#if 0
+  // Maps qddot to vdot, which for this mobilizer is v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
+  // For simple mobilizers v̇ = q̈. This mobilizer's N and Ṅ⁺ are more elaborate.
+  void DoMapQDDotToAcceleration(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& qddot,
+                                EigenPtr<VectorX<T>> vdot) const final;
+#endif
+
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;
 

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -333,6 +333,7 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
                                     const char* function_name) const;
   void ThrowIfCosPitchNearZero(const T& cos_pitch, const T& pitch_angle,
                                const char* function_name) const {
+    using std::abs;
     if (abs(cos_pitch) < 1.0e-3)
       ThrowSinceCosPitchIsNearZero(pitch_angle, function_name);
   }

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -261,10 +261,6 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
 
-  // Calculate the term Ṅ⁺(q,q̇)⋅q̇ which appears in v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
-  Vector3<T> CalcNplusDotTimesQdot(const systems::Context<T>& context,
-                                   const char* function_name) const;
-
   // Maps the generalized velocity v, which corresponds to the angular velocity
   // w_FM, to time derivatives of roll-pitch-yaw angles θ₀, θ₁, θ₂ in qdot.
   //
@@ -330,6 +326,10 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
                                     const char* function_name) const;
 
  private:
+  // Calculate the term Ṅ⁺(q,q̇)⋅q̇ which appears in v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
+  Vector3<T> CalcNplusDotTimesQdot(const systems::Context<T>& context,
+                                   const char* function_name) const;
+
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -261,6 +261,10 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   void DoCalcNplusDotMatrix(const systems::Context<T>& context,
                             EigenPtr<MatrixX<T>> NplusDot) const final;
 
+  // Calculate the term Ṅ⁺(q,q̇)⋅q̇ which appears in v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
+  Vector3<T> CalcNplusDotTimesQdot(const systems::Context<T>& context,
+                                   const char* function_name) const;
+
   // Maps the generalized velocity v, which corresponds to the angular velocity
   // w_FM, to time derivatives of roll-pitch-yaw angles θ₀, θ₁, θ₂ in qdot.
   //
@@ -304,6 +308,12 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   void DoMapAccelerationToQDDot(const systems::Context<T>& context,
                                 const Eigen::Ref<const VectorX<T>>& vdot,
                                 EigenPtr<VectorX<T>> qddot) const final;
+
+  // Maps qddot to vdot, which for this mobilizer is v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
+  // For simple mobilizers v̇ = q̈. This mobilizer's N and Ṅ⁺ are more elaborate.
+  void DoMapQDDotToAcceleration(const systems::Context<T>& context,
+                                const Eigen::Ref<const VectorX<T>>& qddot,
+                                EigenPtr<VectorX<T>> vdot) const final;
 
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -305,14 +305,6 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
                                 const Eigen::Ref<const VectorX<T>>& vdot,
                                 EigenPtr<VectorX<T>> qddot) const final;
 
-#if 0
-  // Maps qddot to vdot, which for this mobilizer is v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
-  // For simple mobilizers v̇ = q̈. This mobilizer's N and Ṅ⁺ are more elaborate.
-  void DoMapQDDotToAcceleration(const systems::Context<T>& context,
-                                const Eigen::Ref<const VectorX<T>>& qddot,
-                                EigenPtr<VectorX<T>> vdot) const final;
-#endif
-
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;
 

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -311,6 +311,10 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
                                 const Eigen::Ref<const VectorX<T>>& qddot,
                                 EigenPtr<VectorX<T>> vdot) const final;
 
+  // Calculate the term Ṅ⁺(q,q̇)⋅q̇ which appears in v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
+  Vector3<T> CalcAccelerationBiasForQDDot(const systems::Context<T>& context,
+                                          const char* function_name) const;
+
   std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;
 
@@ -326,10 +330,6 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
                                     const char* function_name) const;
 
  private:
-  // Calculate the term Ṅ⁺(q,q̇)⋅q̇ which appears in v̇ = Ṅ⁺(q,q̇)⋅q̇ + N⁺(q)⋅q̈.
-  Vector3<T> CalcNplusDotTimesQdot(const systems::Context<T>& context,
-                                   const char* function_name) const;
-
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>
   std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(

--- a/multibody/tree/rpy_ball_mobilizer.h
+++ b/multibody/tree/rpy_ball_mobilizer.h
@@ -329,14 +329,8 @@ class RpyBallMobilizer final : public MobilizerImpl<T, 3, 3> {
   // The tolerance 1.0e-3 is used to test whether the cosine of the pitch angle
   // is near zero, which occurs when the pitch angle ≈ π/2 ± n π (n=0, 1 2, …).
   // Throw an exception if a pitch angle is within ≈ 0.057° of a singularity.
-  void ThrowSinceCosPitchIsNearZero(const T& pitch,
-                                    const char* function_name) const;
   void ThrowIfCosPitchNearZero(const T& cos_pitch, const T& pitch_angle,
-                               const char* function_name) const {
-    using std::abs;
-    if (abs(cos_pitch) < 1.0e-3)
-      ThrowSinceCosPitchIsNearZero(pitch_angle, function_name);
-  }
+                               const char* function_name) const;
 
   // Helper method to make a clone templated on ToScalar.
   template <typename ToScalar>

--- a/multibody/tree/test/rpy_ball_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_ball_mobilizer_test.cc
@@ -258,7 +258,7 @@ TEST_F(RpyBallMobilizerTest, MapAccelerationToQDDotAndViceVersa) {
   Vector3<double> qdot;
   mobilizer_->MapVelocityToQDot(*context_, wxyz, &qdot);
   const Vector3<double> vdot_expected = Nplusdot * qdot + Nplus * qddot;
-  EXPECT_TRUE(CompareMatrices(vdot_expected, vdot, 16 * kTolerance,
+  EXPECT_TRUE(CompareMatrices(vdot_expected, wdot, 16 * kTolerance,
                               MatrixCompareType::relative));
 
   // Verify MapQDDotToAcceleration() is the inverse of MapAccelerationToQDDot().

--- a/multibody/tree/test/rpy_ball_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_ball_mobilizer_test.cc
@@ -223,6 +223,30 @@ TEST_F(RpyBallMobilizerTest, MapUsesNplus) {
                               MatrixCompareType::relative));
 }
 
+TEST_F(RpyBallMobilizerTest, MapAccelerationToQDDot) {
+  // Set an arbitrary non-zero state.
+  const Vector3<double> rpy(M_PI / 3, -M_PI / 4, M_PI / 5);
+  const Vector3<double> wxyz(5.4, -9.8, 3.2);
+  mobilizer_->SetAngles(context_.get(), rpy);
+  mobilizer_->SetAngularVelocity(context_.get(), wxyz);
+
+  // Set an arbitrary v̇ and use MapAccelerationToQDDot() to calculate q̈.
+  const Vector3<double> vdot(0.3, -0.2, 0.9);  // v̇ = [ẇx, ẇy, ẇz].
+  Vector3<double> qddot;
+  mobilizer_->MapAccelerationToQDDot(*context_, vdot, &qddot);
+
+  // Compute the 3x3 N(q) matrix and its time-derivative Ṅ(q,q̇).
+  MatrixX<double> N(3, 3), Ndot(3, 3);
+  mobilizer_->CalcNMatrix(*context_, &N);
+  mobilizer_->CalcNDotMatrix(*context_, &Ndot);
+
+  // Verify equivalence of q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇ and MapAccelerationToQDDot().
+  // PAUL FIX THIS TEST -- NOT WORKING.  SHOULD BE EXPECT_TRUE(...);
+  const Vector3<double> qddot_expected = Ndot * wxyz + N * vdot;
+  EXPECT_FALSE(CompareMatrices(qddot, qddot_expected, kTolerance,
+                               MatrixCompareType::relative));
+}
+
 TEST_F(RpyBallMobilizerTest, SingularityError) {
   // Set state in singularity
   const Vector3d rpy_value(M_PI / 3, M_PI / 2, M_PI / 5);

--- a/multibody/tree/test/rpy_ball_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_ball_mobilizer_test.cc
@@ -223,7 +223,7 @@ TEST_F(RpyBallMobilizerTest, MapUsesNplus) {
                               MatrixCompareType::relative));
 }
 
-TEST_F(RpyBallMobilizerTest, MapAccelerationToQDDot) {
+TEST_F(RpyBallMobilizerTest, MapAccelerationToQDDotAndViceVersa) {
   // Set an arbitrary non-zero state.
   const Vector3<double> rpy(M_PI / 3, -M_PI / 4, M_PI / 5);
   const Vector3<double> wxyz(5.4, -9.8, 3.2);
@@ -241,10 +241,9 @@ TEST_F(RpyBallMobilizerTest, MapAccelerationToQDDot) {
   mobilizer_->CalcNDotMatrix(*context_, &Ndot);
 
   // Verify equivalence of q̈ = Ṅ(q,q̇)⋅v + N(q)⋅v̇ and MapAccelerationToQDDot().
-  // PAUL FIX THIS TEST -- NOT WORKING.  SHOULD BE EXPECT_TRUE(...);
   const Vector3<double> qddot_expected = Ndot * wxyz + N * vdot;
-  EXPECT_FALSE(CompareMatrices(qddot, qddot_expected, kTolerance,
-                               MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(qddot, qddot_expected, kTolerance,
+                              MatrixCompareType::relative));
 }
 
 TEST_F(RpyBallMobilizerTest, SingularityError) {


### PR DESCRIPTION
This is one in a series of PRs to help address issue #22630. It creates DoMapAccelerationToQDDot() and DoMapQDDotToAcceleration() for an RPY ball mobilizer.

PR #22698 was already merged to handle simple mobilizers for the aforementioned methods. Subsequent PRs will create similar functions for other complex mobilizers (e.g., quaternion_floating_mobilizer).

FYI: Since mobilizers are Drake internal classes, after the internal mobilizer work is complete, there will be PRs (code and testing) for the public API in MultibodyPlant to address issue #22630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23092)
<!-- Reviewable:end -->
