### PR TITLE
Allow the User to Set the Solver for IrisNp2

### DIFF
--- a/bindings/pydrake/planning/planning_py_iris_np2.cc
+++ b/bindings/pydrake/planning/planning_py_iris_np2.cc
@@ -31,6 +31,9 @@ void DefinePlanningIrisNp2(py::module m) {
             .format(self.sampled_iris_options);
       });
 
+  DefReadWriteKeepAlive(
+      &iris_np2_options, "solver", &IrisNp2Options::solver, cls_doc.solver.doc);
+
   // The `options` contains a `Parallelism`; we must release the GIL.
   m.def("IrisNp2", &IrisNp2, py::arg("checker"), py::arg("starting_ellipsoid"),
       py::arg("domain"), py::arg("options") = IrisNp2Options(),

--- a/bindings/pydrake/planning/test/iris_test.py
+++ b/bindings/pydrake/planning/test/iris_test.py
@@ -11,6 +11,7 @@ from pydrake.planning import (
     CollisionCheckerParams,
     IrisParameterizationFunction,
 )
+from pydrake.solvers import IpoptSolver
 from pydrake.symbolic import Variable
 
 import numpy as np
@@ -180,6 +181,9 @@ class TestIrisNp2(unittest.TestCase):
 
         # Feature still TODO.
         options.sampled_iris_options.containment_points = None
+
+        # For speed reasons -- IPOPT seems to be faster than SNOPT here.
+        options.solver = IpoptSolver()
 
         domain = HPolyhedron.MakeBox(plant.GetPositionLowerLimits(),
                                      plant.GetPositionUpperLimits())

--- a/planning/iris/iris_np2.h
+++ b/planning/iris/iris_np2.h
@@ -5,6 +5,7 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/planning/iris/iris_common.h"
 #include "drake/planning/scene_graph_collision_checker.h"
+#include "drake/solvers/solve.h"
 
 namespace drake {
 namespace planning {
@@ -27,6 +28,11 @@ class IrisNp2Options {
   }
 
   IrisNp2Options() = default;
+
+  /** The user can specify a solver to use for the counterexample search
+   * program. If nullptr (the default value) is given, then
+   * solvers::MakeFirstAvailableSolver will be used to pick the solver. */
+  const solvers::SolverInterface* solver{nullptr};
 
   /** Options common to IRIS-type algorithms. */
   CommonSampledIrisOptions sampled_iris_options{};

--- a/planning/iris/test/iris_np2_test.cc
+++ b/planning/iris/test/iris_np2_test.cc
@@ -6,6 +6,9 @@
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/planning/iris/iris_common.h"
 #include "drake/planning/iris/test/iris_test_utilities.h"
+#include "drake/solvers/equality_constrained_qp_solver.h"
+#include "drake/solvers/ipopt_solver.h"
+#include "drake/solvers/nlopt_solver.h"
 
 namespace drake {
 namespace planning {
@@ -126,6 +129,22 @@ TEST_F(DoublePendulum, FilterCollisions) {
   PlotEnvironmentAndRegion(region);
 }
 
+// Verify we can specify the solver for the counterexample search by
+// deliberately specifying a solver that can't solve problems of that type, and
+// catch the error message.
+TEST_F(DoublePendulum, SpecifySolver) {
+  IrisNp2Options options;
+  auto sgcc_ptr = dynamic_cast<SceneGraphCollisionChecker*>(checker_.get());
+  ASSERT_TRUE(sgcc_ptr != nullptr);
+
+  solvers::EqualityConstrainedQPSolver invalid_solver;
+  options.solver = &invalid_solver;
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      IrisNp2(*sgcc_ptr, starting_ellipsoid_, domain_, options),
+      ".*EqualityConstrainedQPSolver is unable to solve.*");
+}
+
 TEST_F(BlockOnGround, IrisNp2Test) {
   IrisNp2Options options;
   auto sgcc_ptr = dynamic_cast<SceneGraphCollisionChecker*>(checker_.get());
@@ -156,6 +175,12 @@ TEST_F(ConvexConfigurationSpace, IrisNp2Test) {
   meshcat_->Delete();
   options.sampled_iris_options.meshcat = meshcat_;
   options.sampled_iris_options.verbose = true;
+
+  // We use IPOPT for this test since SNOPT has a large number of solve failures
+  // in this environment.
+  solvers::IpoptSolver solver;
+  options.solver = &solver;
+
   HPolyhedron region =
       IrisNp2(*sgcc_ptr, starting_ellipsoid_, domain_, options);
   CheckRegion(region);


### PR DESCRIPTION
Holding off on review until #23096 lands.

This PR also adds a warning to the user if the counterexample programs are failing frequently. This is a known pathology when using SNOPT or NLOPT (it happens particularly frequently in the "convex configuration space" test environment), so we suggest the user try IPOPT if this is happening. See the following images (each black dot indicates where a solve failed).

SNOPT:
![snopt](https://github.com/user-attachments/assets/a6bb2413-77f0-41cf-9d75-c9d59d28c8cd)

NLOPT:
![nlopt](https://github.com/user-attachments/assets/85e065a5-8ed3-4d88-8463-47ef8ca8df15)

IPOPT:
![ipopt](https://github.com/user-attachments/assets/7faf2660-1ce9-4128-99a4-9410ffb8d98f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23101)
<!-- Reviewable:end -->
