### PR TITLE
Disable ASAN for `internal_opengl_context` test

### DIFF
--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -237,6 +237,11 @@ drake_cc_googletest_linux_only(
         # memcheck tests in order to make progress on related code.
         # TODO(#12962) Investigate, fix or suppress, then re-enable this test.
         "no_memcheck",
+
+        # Since migrating CI Jenkins jobs from Jammy to Noble, this test
+        # causes the newly converted ASAN jobs to fail.
+        # TODO(#23107) Investigate, fix or suppress, then re-enable this test.
+        "no_asan",
     ],
     deps = [
         ":internal_opengl_context",


### PR DESCRIPTION
Towards #23107

This test began failing after the Jammy -> Noble platform switch. These changes temporarily disable ASAN for this test to allow CI to run gracefully while we triage this error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23109)
<!-- Reviewable:end -->
