### PR TITLE
Allow the user to draw samples in parallel in IrisZo and IrisNp2.

### DIFF
--- a/bindings/pydrake/planning/planning_py_iris_common.cc
+++ b/bindings/pydrake/planning/planning_py_iris_common.cc
@@ -53,13 +53,16 @@ void DefinePlanningCommonSampledIrisOptions(py::module m) {
       .def_readwrite("relative_termination_threshold",
           &CommonSampledIrisOptions::relative_termination_threshold,
           cls_doc.relative_termination_threshold.doc)
+      .def_readwrite("remove_all_collisions_possible",
+          &CommonSampledIrisOptions::remove_all_collisions_possible,
+          cls_doc.remove_all_collisions_possible.doc)
       .def_readwrite("random_seed", &CommonSampledIrisOptions::random_seed,
           cls_doc.random_seed.doc)
       .def_readwrite("mixing_steps", &CommonSampledIrisOptions::mixing_steps,
           cls_doc.mixing_steps.doc)
-      .def_readwrite("remove_all_collisions_possible",
-          &CommonSampledIrisOptions::remove_all_collisions_possible,
-          cls_doc.remove_all_collisions_possible.doc)
+      .def_readwrite("sample_particles_in_parallel",
+          &CommonSampledIrisOptions::sample_particles_in_parallel,
+          cls_doc.sample_particles_in_parallel.doc)
       .def("__repr__", [](const CommonSampledIrisOptions& self) {
         return py::str(
             "CommonSampledIrisOptions("
@@ -76,17 +79,19 @@ void DefinePlanningCommonSampledIrisOptions(py::module m) {
             "configuration_space_margin={}, "
             "termination_threshold={}, "
             "relative_termination_threshold={}, "
+            "remove_all_collisions_possible={}, "
             "random_seed={}, "
             "mixing_steps={}, "
-            "remove_all_collisions_possible={}, "
+            "sample_particles_in_parallel={}, "
             ")")
             .format(self.num_particles, self.tau, self.delta, self.epsilon,
                 self.max_iterations, self.max_iterations_separating_planes,
                 self.max_separating_planes_per_iteration, self.parallelism,
                 self.verbose, self.require_sample_point_is_contained,
                 self.configuration_space_margin, self.termination_threshold,
-                self.relative_termination_threshold, self.random_seed,
-                self.mixing_steps, self.remove_all_collisions_possible);
+                self.relative_termination_threshold,
+                self.remove_all_collisions_possible, self.random_seed,
+                self.mixing_steps, self.sample_particles_in_parallel);
       });
 
   DefReadWriteKeepAlive(&common_sampled_iris_options,

--- a/bindings/pydrake/planning/test/iris_test.py
+++ b/bindings/pydrake/planning/test/iris_test.py
@@ -80,6 +80,7 @@ def SetSampledIrisOptions(options):
     options.sampled_iris_options.relative_termination_threshold = 1e-3
     options.sampled_iris_options.random_seed = 1337
     options.sampled_iris_options.mixing_steps = 50
+    options.sampled_iris_options.sample_particles_in_parallel = False
     options.sampled_iris_options.remove_all_collisions_possible = True
 
 

--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -51,6 +51,9 @@ drake_cc_library(
         "//multibody/rational:rational_forward_kinematics",
         "//solvers:mathematical_program",
     ],
+    implementation_deps = [
+        "@common_robotics_utilities_internal//:common_robotics_utilities",
+    ],
 )
 
 drake_cc_library(

--- a/planning/iris/iris_common.cc
+++ b/planning/iris/iris_common.cc
@@ -1,5 +1,8 @@
 #include "drake/planning/iris/iris_common.h"
 
+#include <common_robotics_utilities/parallelism.hpp>
+
+#include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
 
 namespace drake {
@@ -62,6 +65,12 @@ IrisParameterizationFunction::IrisParameterizationFunction(
 }
 
 namespace internal {
+
+using common_robotics_utilities::parallelism::DegreeOfParallelism;
+using common_robotics_utilities::parallelism::ParallelForBackend;
+using common_robotics_utilities::parallelism::StaticParallelForRangeLoop;
+using common_robotics_utilities::parallelism::ThreadWorkRange;
+
 int unadaptive_test_samples(double epsilon, double delta, double tau) {
   return static_cast<int>(-2 * std::log(delta) / (tau * tau * epsilon) + 0.5);
 }
@@ -96,6 +105,32 @@ void AddTangentToPolytope(
         "surrounding the sample point must have an interior.");
   }
   *num_constraints += 1;
+}
+
+void PopulateParticlesByUniformSampling(
+    const geometry::optimization::HPolyhedron& P, int number_to_sample,
+    int mixing_steps, std::vector<RandomGenerator>* generators,
+    std::vector<Eigen::VectorXd>* particles) {
+  DRAKE_THROW_UNLESS(number_to_sample <= ssize(*particles));
+  const int num_threads = ssize(*generators);
+
+  const auto hit_and_run_sample_work =
+      [&P, &particles, &generators,
+       &mixing_steps](const ThreadWorkRange& work_range) {
+        const int64_t start_index = work_range.GetRangeStart();
+        const int64_t end_index = work_range.GetRangeEnd();
+        const int64_t thread_num = work_range.GetThreadNum();
+        RandomGenerator* generator = &(generators->at(thread_num));
+        (*particles)[start_index] = P.UniformSample(generator, mixing_steps);
+        for (int j = start_index + 1; j < end_index; ++j) {
+          (*particles)[j] =
+              P.UniformSample(generator, (*particles)[j - 1], mixing_steps);
+        }
+      };
+
+  StaticParallelForRangeLoop(DegreeOfParallelism(num_threads), 0,
+                             number_to_sample, hit_and_run_sample_work,
+                             ParallelForBackend::BEST_AVAILABLE);
 }
 
 }  // namespace internal

--- a/planning/iris/iris_common.h
+++ b/planning/iris/iris_common.h
@@ -3,12 +3,14 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <vector>
 
 #include <Eigen/Dense>
 
 #include "drake/common/name_value.h"
 #include "drake/common/parallelism.h"
 #include "drake/geometry/meshcat.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
 #include "drake/multibody/rational/rational_forward_kinematics.h"
 #include "drake/solvers/mathematical_program.h"
@@ -38,9 +40,10 @@ class CommonSampledIrisOptions {
     a->Visit(DRAKE_NVP(configuration_space_margin));
     a->Visit(DRAKE_NVP(termination_threshold));
     a->Visit(DRAKE_NVP(relative_termination_threshold));
+    a->Visit(DRAKE_NVP(remove_all_collisions_possible));
     a->Visit(DRAKE_NVP(random_seed));
     a->Visit(DRAKE_NVP(mixing_steps));
-    a->Visit(DRAKE_NVP(remove_all_collisions_possible));
+    a->Visit(DRAKE_NVP(sample_particles_in_parallel));
   }
 
   CommonSampledIrisOptions() = default;
@@ -124,6 +127,16 @@ class CommonSampledIrisOptions {
 
   /** Number of mixing steps used for hit-and-run sampling. */
   int mixing_steps{50};
+
+  /** If true, the hit-and-run procedure is run in parallel to quickly draw all
+   * the samples necessary. When the statistical test requires many samples
+   * (e.g. due to constructing regions with a very low fraction in collision
+   * with very high probability), the process of drawing the samples may become
+   * a major time cost. Drawing the samples in parallel can lead to a major
+   * speedup, at the cost of a sampling from a distribution that's slightly
+   * further from a uniform distribution (due to the lower cumulative mixing
+   * time). */
+  bool sample_particles_in_parallel{false};
 
   /** Passing a meshcat instance may enable debugging visualizations when the
    * configuration space is <= 3 dimensional.*/
@@ -252,6 +265,17 @@ void AddTangentToPolytope(
     double configuration_space_margin,
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>* A,
     Eigen::VectorXd* b, int* num_constraints);
+
+// Populates particles with random samples, drawn across potentially multiple
+// threads. number_to_sample must be smaller than ssize(particles), and
+// ssize(generators) threads will be used to draw samples.
+// @param[out] particles is an output-only argument, which must be preallocated
+// to size at least number_to_sample. The first number_to_sample elements will
+// be overwritten, and remaining elements are undefined.
+void PopulateParticlesByUniformSampling(
+    const geometry::optimization::HPolyhedron& P, int number_to_sample,
+    int mixing_steps, std::vector<RandomGenerator>* generators,
+    std::vector<Eigen::VectorXd>* particles);
 
 }  // namespace internal
 }  // namespace planning

--- a/planning/iris/iris_np2.cc
+++ b/planning/iris/iris_np2.cc
@@ -231,7 +231,20 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
   double last_iteration_volume = E.Volume();
   int iteration = 0;
   VectorXd closest(nq);
-  RandomGenerator generator(options.sampled_iris_options.random_seed);
+
+  const int num_threads_for_sampling =
+      options.sampled_iris_options.sample_particles_in_parallel
+          ? options.sampled_iris_options.parallelism.num_threads()
+          : 1;
+  std::vector<RandomGenerator> generators;
+  // This strategy for seeding multiple generators is acceptable, since Drake's
+  // RandomGenerator is a Mersenne Twister, where even nearby seeds are
+  // practically independent.
+  for (int generator_index = 0; generator_index < num_threads_for_sampling;
+       ++generator_index) {
+    generators.push_back(RandomGenerator(
+        options.sampled_iris_options.random_seed + generator_index));
+  }
 
   const SolverInterface* solver;
   std::unique_ptr<SolverInterface> default_solver =
@@ -275,6 +288,8 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
   }
 
   // TODO(cohnt): Do an argsort so we don't have to have two separate copies.
+  // TODO(cohnt): Switch to using a single large MatrixXd to avoid repeated
+  // VectorXd heap allocations.
   std::vector<Eigen::VectorXd> particles;
   std::vector<Eigen::VectorXd> particles_in_collision;
   particles.reserve(N_max);
@@ -310,17 +325,14 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
           options.sampled_iris_options.epsilon, delta_k,
           options.sampled_iris_options.tau);
 
+      particles.resize(N_k);  // Entries will be overwritten.
+
       // TODO(rhjiang): Implement the ray sampling strategy, and expose it as an
       // option to the user.
-      particles.resize(N_k);
-      particles.at(0) = P_candidate.UniformSample(
-          &generator, E.center(), options.sampled_iris_options.mixing_steps);
-      // Populate particles by uniform sampling.
-      for (int i = 1; i < N_k; ++i) {
-        particles.at(i) = P_candidate.UniformSample(
-            &generator, particles.at(i - 1),
-            options.sampled_iris_options.mixing_steps);
-      }
+      internal::PopulateParticlesByUniformSampling(
+          P_candidate, N_k, options.sampled_iris_options.mixing_steps,
+          &generators, &particles);
+
       // Find all particles in collision.
       std::vector<uint8_t> particle_col_free =
           checker.CheckConfigsCollisionFree(

--- a/planning/iris/test/iris_np2_test.cc
+++ b/planning/iris/test/iris_np2_test.cc
@@ -97,6 +97,14 @@ TEST_F(DoublePendulum, IrisNp2Test) {
   CheckRegion(region);
 
   PlotEnvironmentAndRegion(region);
+
+  // Changing the sampling options should lead to a still-correct, but
+  // slightly-different region.
+  options.sampled_iris_options.sample_particles_in_parallel = true;
+  HPolyhedron region2 =
+      IrisNp2(*sgcc_ptr, starting_ellipsoid_, domain_, options);
+  CheckRegion(region2);
+  EXPECT_FALSE(region.A().isApprox(region2.A(), 1e-10));
 }
 
 // Check that we can filter out certain collisions.
@@ -189,6 +197,8 @@ TEST_F(ConvexConfigurationSpace, IrisNp2Test) {
   IrisNp2Options options;
   auto sgcc_ptr = dynamic_cast<SceneGraphCollisionChecker*>(checker_.get());
   ASSERT_TRUE(sgcc_ptr != nullptr);
+
+  options.sampled_iris_options.sample_particles_in_parallel = true;
 
   // Turn on meshcat for addition debugging visualizations.
   // This example is truly adversarial for IRIS. After one iteration, the

--- a/planning/iris/test/iris_zo_test.cc
+++ b/planning/iris/test/iris_zo_test.cc
@@ -155,6 +155,14 @@ TEST_F(DoublePendulum, IrisZoTest) {
   CheckRegion(region);
 
   PlotEnvironmentAndRegion(region);
+
+  // Changing the sampling options should lead to a still-correct, but
+  // slightly-different region.
+  options.sampled_iris_options.sample_particles_in_parallel = true;
+  HPolyhedron region2 =
+      IrisZo(*checker_, starting_ellipsoid_, domain_, options);
+  CheckRegion(region2);
+  EXPECT_FALSE(region.A().isApprox(region2.A(), 1e-10));
 }
 
 TEST_F(DoublePendulum, PostprocessRemoveCollisions) {
@@ -272,6 +280,8 @@ TEST_F(BlockOnGround, IrisZoTest) {
 // Reproduced from the IrisInConfigurationSpace unit tests.
 TEST_F(ConvexConfigurationSpace, IrisZoTest) {
   IrisZoOptions options;
+
+  options.sampled_iris_options.sample_particles_in_parallel = true;
 
   // Turn on meshcat for addition debugging visualizations.
   // This example is truly adversarial for IRIS. After one iteration, the


### PR DESCRIPTION
When trying to compute a region with a very low fraction in-collision, the majority of the runtime of these algorithms may actually be spent drawing samples from the candidate region, rather than checking for collisions, locally optimizing the samples, etc. One way to speed this up is to draw the samples in parallel, although this comes at the cost of slightly less mixing time (and therefore a slightly less-uniform sampling distribution). To generate the regions from [this example](https://github.com/cohnt/PCC-GCS/), enabling parallel sampling led to a 2-3x speedup.

+@wernerpe for feature review

I'm also tagging this as a bug fix, since we were spuriously drawing samples twice per iteration for IrisZo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23111)
<!-- Reviewable:end -->
