### PR TITLE
Disable TSAN for `lcm_interface_system_test`

### DIFF
--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -175,6 +175,12 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "lcm_interface_system_test",
     flaky = True,
+    tags = [
+        # Since migrating CI Jenkins jobs from Jammy to Noble, this test
+        # causes the newly converted TSAN jobs to fail.
+        # TODO(#23110) Investigate, fix or suppress, then re-enable this test.
+        "no_tsan",
+    ],
     deps = [
         ":lcm_interface_system",
         ":lcm_subscriber_system",


### PR DESCRIPTION
Towards #23110

This test reported TSAN errors after the Jammy -> Noble platform switch. These changes temporarily disable TSAN for this test while we triage this error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23112)
<!-- Reviewable:end -->
