### PR TITLE
[build] Switch `compiler_major` to a common option from CMake

### DIFF
--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -36,7 +36,7 @@ build:Release --compilation_mode=opt
 build:RelWithDebInfo --compilation_mode=opt --fission=no --copt=-g --host_copt=-g
 
 # Pass along the compiler version.
-build --@drake//tools/cc_toolchain:compiler_major=@DRAKE_CC_TOOLCHAIN_COMPILER_MAJOR@
+common --@drake//tools/cc_toolchain:compiler_major=@DRAKE_CC_TOOLCHAIN_COMPILER_MAJOR@
 
 # Match CMAKE_BUILD_TYPE as well as the WITH_FOO customizations.
 build @BAZEL_CONFIG@


### PR DESCRIPTION
Since CMake builds Drake by 'installing,' this flag is currently a no-op when using Drake as a CMake external.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23114)
<!-- Reviewable:end -->
