### PR TITLE
Revisit the near-rigid regime for implicit PD constraints

### DIFF
--- a/multibody/contact_solvers/sap/sap_pd_controller_constraint.h
+++ b/multibody/contact_solvers/sap/sap_pd_controller_constraint.h
@@ -104,9 +104,12 @@ class SapPdControllerConstraint final : public SapConstraint<T> {
 
     // TODO(amcastro-tri): Consider extending support for both gains being zero.
     /* Constructs a valid set of parameters.
-     @param Kp Proportional gain. It must be strictly positive.
+     @param Kp Proportional gain. It must be non-negative.
      @param Kd Derivative gain. It must be non-negative.
      @param effort_limit Effort limit. It must be strictly positive.
+
+     @pre At least one of Kp and Kd must be strictly positive. That is, they
+     cannot both be zero.
      @note Units will depend on the joint type on which this constraint is
      added. E.g. For a prismatic joint, Kp will be in N/m, Kd in N⋅s/m, and
      effort_limit in N. */


### PR DESCRIPTION
We revisit how we cmpute near-rigid parameters to control numerical conditioning for implicit PD constraints.

For context, a user trid to do velocity control with a very large derivative gain and a zero position gain. This put the implicit PD gain into near-rigid regime, but our logic in master sets both non-zero Kp and Kd gains to be in a critically damped regime for position control, which is not what the user wanted in the first place.

Therefore in this PR we do allow users to set either Kp or Kd to zero (but not both). The new near-rigid treatment ensures that we use effective gains that preserve the user provided ratio Kp/Kd.