### PR TITLE
[build] Pass a more specific compiler from CMake to Bazel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,19 @@ if(NOT APPLE)
     " --repo_env=CC=${CMAKE_C_COMPILER}"
     " --repo_env=CXX=${CMAKE_CXX_COMPILER}"
   )
+  # Pass a Bazel flag which enforces the underlying compiler so that
+  # compiler- and version-specific logic (e.g., warnings) is enforced in the
+  # build, since rules_cc's support for compiler identification is not as
+  # robust as using CMake's CMAKE_<LANG>_COMPILER_ID.
+  if(CMAKE_C_COMPILER_ID STREQUAL Clang)
+    string(APPEND BAZEL_REPO_ENV
+      " --@drake//tools/cc_toolchain:compiler=clang"
+    )
+  elseif(CMAKE_C_COMPILER_ID STREQUAL GNU)
+    string(APPEND BAZEL_REPO_ENV
+      " --@drake//tools/cc_toolchain:compiler=gcc"
+    )
+  endif()
 endif()
 
 get_filename_component(PROJECT_BINARY_DIR_REALPATH

--- a/tools/cc_toolchain/BUILD.bazel
+++ b/tools/cc_toolchain/BUILD.bazel
@@ -21,6 +21,33 @@ string_flag(
     ],
 )
 
+# In our developer builds and CMake installs, we use the following two flags
+# as optional hints for configuring compiler warnings. It's not strictly
+# necessary to set these, but doing so will tweak the compiler flags and
+# reduce warning spam during the build.
+#
+# These are intended for internal use only, not for users to configure.
+#
+# TODO(jwnimmer-tri) Ideally, rules_cc would provide,
+# * for 'compiler', a check for the real underlying compiler by invoking it
+#   (akin to CMake) instead of just parsing the filename; and
+# * for 'compiler_major', some toolchain attribute that we could query.
+# Neither of these seem to exist yet.
+string_flag(
+    name = "compiler",
+    build_setting_default = "",
+    values = [
+        "",
+        "gcc",
+        "clang",
+    ],
+)
+
+int_flag(
+    name = "compiler_major",
+    build_setting_default = 0,
+)
+
 config_setting(
     name = "apple",
     constraint_values = ["@platforms//os:osx"],
@@ -41,11 +68,37 @@ config_setting(
     flag_values = {":error_severity": "error"},
 )
 
+config_setting(
+    name = "compiler_clang",
+    flag_values = {":compiler": "clang"},
+)
+
+config_setting(
+    name = "compiler_gcc",
+    flag_values = {":compiler": "gcc"},
+)
+
+selects.config_setting_group(
+    name = "clang",
+    match_any = [
+        "@rules_cc//cc/compiler:clang",
+        ":compiler_clang",
+    ],
+)
+
+selects.config_setting_group(
+    name = "gcc",
+    match_any = [
+        "@rules_cc//cc/compiler:gcc",
+        ":compiler_gcc",
+    ],
+)
+
 selects.config_setting_group(
     name = "apple_clang_with_warnings",
     match_all = [
         ":apple",
-        "@rules_cc//cc/compiler:clang",
+        ":clang",
         ":error_severity_warning",
     ],
 )
@@ -54,7 +107,7 @@ selects.config_setting_group(
     name = "apple_clang_with_errors",
     match_all = [
         ":apple",
-        "@rules_cc//cc/compiler:clang",
+        ":clang",
         ":error_severity_error",
     ],
 )
@@ -62,7 +115,7 @@ selects.config_setting_group(
 selects.config_setting_group(
     name = "gcc_with_warnings",
     match_all = [
-        "@rules_cc//cc/compiler:gcc",
+        ":gcc",
         ":error_severity_warning",
     ],
 )
@@ -70,7 +123,7 @@ selects.config_setting_group(
 selects.config_setting_group(
     name = "gcc_with_errors",
     match_all = [
-        "@rules_cc//cc/compiler:gcc",
+        ":gcc",
         ":error_severity_error",
     ],
 )
@@ -79,7 +132,7 @@ selects.config_setting_group(
     name = "linux_clang_with_warnings",
     match_all = [
         ":linux",
-        "@rules_cc//cc/compiler:clang",
+        ":clang",
         ":error_severity_warning",
     ],
 )
@@ -88,7 +141,7 @@ selects.config_setting_group(
     name = "linux_clang_with_errors",
     match_all = [
         ":linux",
-        "@rules_cc//cc/compiler:clang",
+        ":clang",
         ":error_severity_error",
     ],
 )
@@ -96,19 +149,6 @@ selects.config_setting_group(
 config_setting(
     name = "debug",
     values = {"compilation_mode": "dbg"},
-)
-
-# In our developer builds and CMake installs, we use this as an optional hint
-# for configuring compiler warnings. It's not strictly necessary to set this,
-# but doing so might reduce warning spam during the build.
-#
-# This is intended for internal use only, not for users to configure.
-#
-# TODO(jwnimmer-tri) Ideally, rules_cc would provide this as a toolchain
-# attribute that we could query, but it doesn't seem to exist there yet.
-int_flag(
-    name = "compiler_major",
-    build_setting_default = 0,
 )
 
 config_setting(
@@ -119,7 +159,7 @@ config_setting(
 selects.config_setting_group(
     name = "gcc_13_with_warnings",
     match_all = [
-        "@rules_cc//cc/compiler:gcc",
+        ":gcc",
         ":compiler_major_13",
         ":error_severity_warning",
     ],
@@ -128,7 +168,7 @@ selects.config_setting_group(
 selects.config_setting_group(
     name = "gcc_13_with_errors",
     match_all = [
-        "@rules_cc//cc/compiler:gcc",
+        ":gcc",
         ":compiler_major_13",
         ":error_severity_error",
     ],

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -124,8 +124,8 @@ def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
         return BASE_COPTS
     test_gcc_copts = GCC_CC_TEST_FLAGS if cc_test else []
     return BASE_COPTS + rule_copts + select({
-        "@rules_cc//cc/compiler:gcc": rule_gcc_copts + test_gcc_copts,
-        "@rules_cc//cc/compiler:clang": rule_clang_copts,
+        "//tools/cc_toolchain:gcc": rule_gcc_copts + test_gcc_copts,
+        "//tools/cc_toolchain:clang": rule_clang_copts,
         "//conditions:default": [],
     })
 

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -5,7 +5,7 @@ load("//tools/skylark:drake_py.bzl", "drake_py_library", "drake_py_test")
 load("//tools/skylark:py.bzl", "py_library")
 
 EXTRA_PYBIND_COPTS = select({
-    "@rules_cc//cc/compiler:clang": [
+    "@drake//tools/cc_toolchain:clang": [
         # GCC and Clang don't always agree / succeed when inferring storage
         # duration (#9600). Workaround it for now.
         "-Wno-unused-lambda-capture",


### PR DESCRIPTION
Closes #23119.

Add a Bazel flag to opt in to tweaking compiler-specific flags, so that CMake can use it when checking against `CMAKE_<LANG>_COMPILER_ID`. This allows Linux CMake users to inherit Bazel's `cc_toolchain` logic without having to specify `CMAKE_<LANG>_COMPILER` (notably, when the compiler is 'cc'/'c++').

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23117)
<!-- Reviewable:end -->
