### PR TITLE
IrisNp2 Support Additional Containment Points

### DIFF
--- a/bindings/pydrake/planning/test/iris_test.py
+++ b/bindings/pydrake/planning/test/iris_test.py
@@ -185,9 +185,6 @@ class TestIrisNp2(unittest.TestCase):
         options = mut.IrisNp2Options()
         SetSampledIrisOptions(options)
 
-        # Feature still TODO.
-        options.sampled_iris_options.containment_points = None
-
         # For speed reasons -- IPOPT seems to be faster than SNOPT here.
         options.solver = IpoptSolver()
 
@@ -223,6 +220,15 @@ class TestIrisNp2(unittest.TestCase):
         domain_shifted = HPolyhedron.MakeBox([-1.5, -1.5], [0.5, 0.5])
         starting_ellipsoid_shifted = Hyperellipsoid.MakeHypersphere(
             0.01, inverse_parameterization(starting_ellipsoid.center()))
+
+        # We also need to shift the containment points.
+        new_containment_points = options.sampled_iris_options.\
+            containment_points.copy()
+        for i in range(new_containment_points.shape[1]):
+            new_containment_points[:, i] = inverse_parameterization(
+                new_containment_points[:, i])
+        options.sampled_iris_options.\
+            containment_points = new_containment_points
         region = mut.IrisNp2(checker=checker,
                              starting_ellipsoid=starting_ellipsoid_shifted,
                              domain=domain_shifted,

--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -49,7 +49,9 @@ drake_cc_library(
         "//geometry:meshcat",
         "//geometry/optimization:convex_set",
         "//multibody/rational:rational_forward_kinematics",
+        "//planning:collision_checker",
         "//solvers:mathematical_program",
+        "//solvers:solve",
     ],
     implementation_deps = [
         "@common_robotics_utilities_internal//:common_robotics_utilities",

--- a/planning/iris/iris_common.cc
+++ b/planning/iris/iris_common.cc
@@ -78,6 +78,8 @@ using common_robotics_utilities::parallelism::DynamicParallelForIndexLoop;
 using common_robotics_utilities::parallelism::ParallelForBackend;
 using common_robotics_utilities::parallelism::StaticParallelForRangeLoop;
 using common_robotics_utilities::parallelism::ThreadWorkRange;
+using geometry::optimization::Hyperellipsoid;
+using geometry::optimization::VPolytope;
 
 int unadaptive_test_samples(double epsilon, double delta, double tau) {
   return static_cast<int>(-2 * std::log(delta) / (tau * tau * epsilon) + 0.5);
@@ -107,12 +109,43 @@ void AddTangentToPolytope(
   if (A->row(*num_constraints) * E.center() > (*b)[*num_constraints]) {
     throw std::logic_error(
         "The current center of the IRIS region is within "
-        "options.sampled_iris_options.configuration_space_margin of being "
+        "sampled_iris_options.configuration_space_margin of being "
         "infeasible.  Check your sample point and/or any additional "
         "constraints you've passed in via the options. The configuration "
         "space surrounding the sample point must have an interior.");
   }
   *num_constraints += 1;
+}
+
+void AddTangentToPolytope(
+    const geometry::optimization::Hyperellipsoid& E,
+    const Eigen::Ref<const Eigen::VectorXd>& point, const VPolytope& cvxh_vpoly,
+    const solvers::SolverInterface& solver, double configuration_space_margin,
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>* A,
+    Eigen::VectorXd* b, int* num_constraints, double* max_relaxation) {
+  Eigen::VectorXd a_face =
+      internal::ComputeFaceTangentToDistCvxh(E, point, cvxh_vpoly, solver);
+  a_face.normalize();
+  double b_face = a_face.transpose() * point - configuration_space_margin;
+
+  // Relax cspace margin to contain points.
+  const Eigen::VectorXd result = a_face.transpose() * cvxh_vpoly.vertices();
+  const double relaxation = result.maxCoeff() - b_face;
+  if (relaxation > 0) {
+    b_face += relaxation;
+    if (*max_relaxation < relaxation) {
+      *max_relaxation = relaxation;
+    }
+  }
+  A->row(*num_constraints) = a_face.transpose();
+  (*b)(*num_constraints) = b_face;
+  *num_constraints += 1;
+
+  // Resize A matrix if we need more faces.
+  if (A->rows() <= *num_constraints) {
+    A->conservativeResize(A->rows() * 2, A->cols());
+    b->conservativeResize(b->rows() * 2);
+  }
 }
 
 bool CheckProgConstraints(const solvers::MathematicalProgram* prog_ptr,
@@ -152,6 +185,92 @@ std::vector<uint8_t> CheckProgConstraintsParallel(
                               actual_end_index, check_particle_work,
                               ParallelForBackend::BEST_AVAILABLE);
   return is_valid;
+}
+
+VPolytope ParseAndCheckContainmentPoints(
+    const CollisionChecker& checker,
+    const CommonSampledIrisOptions& sampled_iris_options,
+    const IrisParameterizationFunction& parameterization,
+    const geometry::optimization::Hyperellipsoid& starting_ellipsoid,
+    const double constraints_tol) {
+  if (!sampled_iris_options.containment_points.has_value()) {
+    return {};
+  }
+
+  VPolytope cvxh_vpoly(sampled_iris_options.containment_points.value());
+  if (parameterization.get_parameterization_dimension().has_value()) {
+    DRAKE_THROW_UNLESS(
+        parameterization.get_parameterization_dimension().value() ==
+        sampled_iris_options.containment_points->rows());
+  }
+
+  constexpr float kPointInSetTol = 1e-5;
+  if (!cvxh_vpoly.PointInSet(starting_ellipsoid.center(), kPointInSetTol)) {
+    throw std::runtime_error(
+        "Iris precondition failure: The center of the starting ellipsoid lies "
+        "outside of the convex hull of the containment points.");
+  }
+
+  cvxh_vpoly = cvxh_vpoly.GetMinimalRepresentation();
+
+  std::vector<Eigen::VectorXd> cont_vec;
+  cont_vec.reserve((sampled_iris_options.containment_points->cols()));
+
+  for (int col = 0; col < sampled_iris_options.containment_points->cols();
+       ++col) {
+    Eigen::VectorXd conf = sampled_iris_options.containment_points->col(col);
+    cont_vec.emplace_back(parameterization.get_parameterization_double()(conf));
+    DRAKE_ASSERT(cont_vec.back().size() == checker.plant().num_positions());
+  }
+
+  std::vector<uint8_t> containment_point_col_free =
+      checker.CheckConfigsCollisionFree(cont_vec,
+                                        sampled_iris_options.parallelism);
+  for (const auto col_free : containment_point_col_free) {
+    if (!col_free) {
+      throw std::runtime_error(
+          "Iris precondition failure: One or more containment points are in "
+          "collision!");
+    }
+  }
+  for (int i = 0; i < sampled_iris_options.containment_points->cols(); ++i) {
+    if (!CheckProgConstraints(
+            sampled_iris_options.prog_with_additional_constraints,
+            sampled_iris_options.containment_points->col(i), constraints_tol)) {
+      throw std::runtime_error(
+          "Iris precondition failure: One or more containment points violates "
+          "a constraint in "
+          "sampled_iris_options.prog_with_additional_constraints!");
+    }
+  }
+  return cvxh_vpoly;
+}
+
+Eigen::VectorXd ComputeFaceTangentToDistCvxh(
+    const Hyperellipsoid& E, const Eigen::Ref<const Eigen::VectorXd>& point,
+    const VPolytope& cvxh_vpoly, const solvers::SolverInterface& solver) {
+  Eigen::VectorXd a_face = E.A().transpose() * E.A() * (point - E.center());
+  double b_face = a_face.transpose() * point;
+
+  // Return standard iris face if either the face does not chop off any
+  // containment points or collision lies inside of the convex hull of the
+  // containment points.
+  if (cvxh_vpoly.PointInSet(point) ||
+      (a_face.transpose() * cvxh_vpoly.vertices()).maxCoeff() - b_face <= 0) {
+    return a_face;
+  } else {
+    solvers::MathematicalProgram prog;
+    const int dim = cvxh_vpoly.ambient_dimension();
+    const auto x = prog.NewContinuousVariables(dim);
+    cvxh_vpoly.AddPointInSetConstraints(&prog, x);
+    const Eigen::MatrixXd identity = Eigen::MatrixXd::Identity(dim, dim);
+    prog.AddQuadraticErrorCost(identity, point, x);
+    solvers::MathematicalProgramResult result;
+    solver.Solve(prog, std::nullopt, std::nullopt, &result);
+    DRAKE_THROW_UNLESS(result.is_success());
+    a_face = point - result.GetSolution(x);
+    return a_face;
+  }
 }
 
 void PopulateParticlesByUniformSampling(

--- a/planning/iris/iris_np2.h
+++ b/planning/iris/iris_np2.h
@@ -92,8 +92,7 @@ IrisNp2 is still in development, so certain features of
 SceneGraphCollisionChecker and parts of [Werner et al., 2024] are not yet
 supported.
 
-@throws if you set `options.sampled_iris_options.containment_points` or
-`options.parameterization`.
+@throws if you set `options.parameterization`.
 @throws if any collision pairs in `checker` have negative padding.
 @throws if any collision geometries have been been added in `checker`.
 */


### PR DESCRIPTION
When creating a collision-free polytope with IrisNp2, the user can specify additional points that must be contained in the resulting region.

Builds upon #23116, so I'll wait until that merges to start feature review.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23121)
<!-- Reviewable:end -->
