### PR TITLE
[setup] Switch Noble's preferred Clang to clang-19

### DIFF
--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -32,7 +32,7 @@ officially supports when building from source:
 | Operating System ⁽¹⁾               | Architecture | Python ⁽²⁾ | Bazel | CMake | C/C++ Compiler ⁽³⁾           | Java       |
 |------------------------------------|--------------|------------|-------|-------|------------------------------|------------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 8.2   | 3.22  | GCC 11 (default) or Clang 15 | OpenJDK 11 |
-| Ubuntu 24.04 LTS (Noble Numbat)    | x86_64       | 3.12       | 8.2   | 3.28  | GCC 13 (default) or Clang 15 | OpenJDK 21 |
+| Ubuntu 24.04 LTS (Noble Numbat)    | x86_64       | 3.12       | 8.2   | 3.28  | GCC 13 (default) or Clang 19 | OpenJDK 21 |
 | macOS Sonoma (14)                  | arm64        | 3.13       | 8.2   | 4.0   | Apple LLVM 16 (Xcode 16.2)   | OpenJDK 23 |
 | macOS Sequoia (15)                 | arm64        | 3.13       | 8.2   | 4.0   | Apple LLVM 17 (Xcode 16.4)   | OpenJDK 23 |
 
@@ -81,7 +81,7 @@ make install
 To change the build options, you can run one of the standard CMake GUIs (e.g.,
 `ccmake` or `cmake-gui`) or specify command-line options with `-D` to `cmake`.
 
-##  Drake-specific CMake Options
+## Drake-specific CMake Options
 
 These options can be set using `-DFOO=bar` on the CMake command line, or in one
 of the CMake GUIs.
@@ -146,6 +146,10 @@ Adjusting closed-source (commercial) software dependencies:
   using a hard-coded and access-controlled download of SNOPT.
   * This option is only valid for MIT- or TRI-affiliated Drake developers.
   * This option is mutally exclusive with `WITH_SNOPT`.
+
+Important note: when compiling Drake with Clang 17 or newer on Linux, you must
+add `-fno-assume-unique-vtables` to your project's `CXXFLAGS`, or else Drake's
+use of run-time type information and dynamic casts will not work correctly.
 
 ## CMake Caveats
 

--- a/setup/ubuntu/source_distribution/packages-noble-clang.txt
+++ b/setup/ubuntu/source_distribution/packages-noble-clang.txt
@@ -1,4 +1,4 @@
-clang-15
-libclang-rt-15-dev
-libomp-15-dev
-llvm-15
+clang-19
+libclang-rt-19-dev
+libomp-19-dev
+llvm-19

--- a/setup/ubuntu/source_distribution/packages-noble.txt
+++ b/setup/ubuntu/source_distribution/packages-noble.txt
@@ -2,7 +2,7 @@ default-jdk
 diffutils
 file
 gfortran
-libclang-17-dev
+libclang-19-dev
 libgl-dev
 libglib2.0-dev
 libglx-dev

--- a/tools/dynamic_analysis/asan.sh
+++ b/tools/dynamic_analysis/asan.sh
@@ -6,6 +6,6 @@ export ASAN_OPTIONS="$ASAN_OPTIONS:check_initialization_order=1:detect_container
 # errors
 export LSAN_OPTIONS="$LSAN_OPTIONS:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/lsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
-export PATH="$PATH:/usr/lib/llvm-14/bin:/usr/lib/llvm-12/bin:/usr/local/opt/llvm/bin"
+export PATH="$PATH:/usr/lib/llvm-19/bin:/usr/lib/llvm-15/bin:/usr/local/opt/llvm/bin"
 # Run with ASLR disabled.
 setarch $(uname -m) -R "$@"

--- a/tools/dynamic_analysis/lsan.sh
+++ b/tools/dynamic_analysis/lsan.sh
@@ -3,6 +3,6 @@ me=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 export LSAN_OPTIONS="$LSAN_OPTIONS:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/lsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
-export PATH="$PATH:/usr/lib/llvm-14/bin:/usr/lib/llvm-12/bin:/usr/local/opt/llvm/bin"
+export PATH="$PATH:/usr/lib/llvm-19/bin:/usr/lib/llvm-15/bin:/usr/local/opt/llvm/bin"
 # Run with ASLR disabled.
 setarch $(uname -m) -R "$@"

--- a/tools/dynamic_analysis/tsan.sh
+++ b/tools/dynamic_analysis/tsan.sh
@@ -3,6 +3,6 @@ me=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
 export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=1:second_deadlock_stack=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/tsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
-export PATH="$PATH:/usr/lib/llvm-14/bin:/usr/lib/llvm-12/bin:/usr/local/opt/llvm/bin"
+export PATH="$PATH:/usr/lib/llvm-19/bin:/usr/lib/llvm-15/bin:/usr/local/opt/llvm/bin"
 # Run with ASLR disabled.
 setarch $(uname -m) -R "$@"

--- a/tools/dynamic_analysis/ubsan.sh
+++ b/tools/dynamic_analysis/ubsan.sh
@@ -6,5 +6,5 @@ mydir=$(dirname "$me")
 # clang without this option.
 export UBSAN_OPTIONS="$UBSAN_OPTIONS:halt_on_error=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/ubsan.supp"
 # Ensure executable named llvm-symbolizer is on the PATH.
-export PATH="$PATH:/usr/lib/llvm-14/bin:/usr/lib/llvm-12/bin:/usr/local/opt/llvm/bin"
+export PATH="$PATH:/usr/lib/llvm-19/bin:/usr/lib/llvm-15/bin:/usr/local/opt/llvm/bin"
 "$@"

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -1,11 +1,17 @@
 # Options for explicitly using Clang.
 # Keep this in sync with doc/_pages/from_source.md.
-common:clang --repo_env=CC=clang-15
-common:clang --repo_env=CXX=clang++-15
-build:clang --action_env=CC=clang-15
-build:clang --action_env=CXX=clang++-15
-build:clang --host_action_env=CC=clang-15
-build:clang --host_action_env=CXX=clang++-15
+common:clang --repo_env=CC=clang-19
+common:clang --repo_env=CXX=clang++-19
+build:clang --action_env=CC=clang-19
+build:clang --action_env=CXX=clang++-19
+build:clang --host_action_env=CC=clang-19
+build:clang --host_action_env=CXX=clang++-19
+# https://github.com/RobotLocomotion/drake/issues/22204
+# TODO(jwnimmer-tri) Ideally, our drake_cc.bzl logic for compiler-specific flags
+# should take over this option so we can ensure it's being used even in CMake
+# installs of Drake from source (if and only if Clang >= 17 is being used).
+build:clang --copt=-fno-assume-unique-vtables
+build:clang --host_copt=-fno-assume-unique-vtables
 
 build --define=UBUNTU_VERSION=24.04
 

--- a/tools/workspace/common_robotics_utilities_internal/package.BUILD.bazel
+++ b/tools/workspace/common_robotics_utilities_internal/package.BUILD.bazel
@@ -5,6 +5,8 @@ load("@drake//tools/skylark:cc.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+COPTS = ["-w"]
+
 cc_library(
     name = "common_robotics_utilities",
     srcs = [
@@ -49,7 +51,7 @@ cc_library(
         "include/common_robotics_utilities/zlib_helpers.hpp",
     ],
     includes = ["include"],
-    copts = ["-w"],
+    copts = COPTS,
     linkstatic = True,
     deps = [
         "@eigen",
@@ -64,6 +66,7 @@ cc_library(
 cc_test(
     name = "hausdorff_distance_test",
     srcs = ["test/hausdorff_distance_test.cpp"],
+    copts = COPTS,
     env = {"OMP_NUM_THREADS": "2"},
     tags = [
         "cpu:2",
@@ -79,6 +82,7 @@ cc_test(
 cc_test(
     name = "math_test",
     srcs = ["test/math_test.cpp"],
+    copts = COPTS,
     tags = ["no_kcov"],
     deps = [
         ":common_robotics_utilities",
@@ -90,6 +94,7 @@ cc_test(
 cc_test(
     name = "maybe_test",
     srcs = ["test/maybe_test.cpp"],
+    copts = COPTS,
     tags = ["no_kcov"],
     deps = [
         ":common_robotics_utilities",
@@ -102,6 +107,7 @@ cc_test(
 cc_test(
     name = "parallelism_test",
     srcs = ["test/parallelism_test.cpp"],
+    copts = COPTS,
     env = {"OMP_NUM_THREADS": "2"},
     tags = [
         "cpu:2",
@@ -121,6 +127,7 @@ cc_test(
 cc_test(
     name = "planning_test",
     srcs = ["test/planning_test.cpp"],
+    copts = COPTS,
     env = {"OMP_NUM_THREADS": "2"},
     tags = [
         "cpu:2",
@@ -138,6 +145,7 @@ cc_test(
 cc_test(
     name = "task_planning_test",
     srcs = ["test/task_planning_test.cpp"],
+    copts = COPTS,
     tags = ["no_kcov"],
     deps = [
         ":common_robotics_utilities",
@@ -148,6 +156,7 @@ cc_test(
 cc_test(
     name = "utility_test",
     srcs = ["test/utility_test.cpp"],
+    copts = COPTS,
     tags = ["no_kcov"],
     deps = [
         ":common_robotics_utilities",
@@ -159,6 +168,7 @@ cc_test(
 cc_test(
     name = "voxel_grid_test",
     srcs = ["test/voxel_grid_test.cpp"],
+    copts = COPTS,
     tags = ["no_kcov"],
     deps = [
         ":common_robotics_utilities",

--- a/tools/workspace/pybind11/libclang_setup.py
+++ b/tools/workspace/pybind11/libclang_setup.py
@@ -38,7 +38,7 @@ def add_library_paths(parameters=None):
                 parameters += ['-isysroot', sdkroot]
     elif platform.system() == 'Linux':
         # By default we expect Clang 15 to be installed, but on Ubuntu 24.04
-        # we'll use Clang 17 for compatibility with GCC 14.
+        # we'll use Clang 19 for compatibility with GCC 14.
         version = 15
         try:
             completed_process = subprocess.run(['lsb_release', '-sr'],
@@ -46,7 +46,7 @@ def add_library_paths(parameters=None):
                                                encoding='utf-8')
             if completed_process.returncode == 0:
                 if completed_process.stdout.strip() == '24.04':
-                    version = 17
+                    version = 19
         except Exception:
             pass
         arch = platform.machine()


### PR DESCRIPTION
The current Clang 15 is incompatible with GCC 14, which is installed on Noble by default when we apt-install Emacs.

This solves #22905 more thoroughly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23124)
<!-- Reviewable:end -->
