### PR TITLE
Remove an Extra Sampling Step that Was Potentially Slowing IrisZo Down.

### DIFF
--- a/planning/iris/iris_zo.cc
+++ b/planning/iris/iris_zo.cc
@@ -637,18 +637,8 @@ HPolyhedron IrisZo(const planning::CollisionChecker& checker,
                         "ensure point containment",
                         max_relaxation));
       }
-
       if (probabilistic_test_passed) {
         break;
-      }
-
-      // Resampling particles in current polyhedron for next iteration.
-      particles[0] = P.UniformSample(&generator,
-                                     options.sampled_iris_options.mixing_steps);
-      for (int j = 1; j < options.sampled_iris_options.num_particles; ++j) {
-        particles[j] =
-            P.UniformSample(&generator, particles[j - 1],
-                            options.sampled_iris_options.mixing_steps);
       }
       ++num_iterations_separating_planes;
 


### PR DESCRIPTION
cc @jwnimmer-tri 

I'm not sure how to properly test this, since it's functionally a no-op. `particles` doesn't get touched by anything after this through the end of the loop's current iteration, and then at the start of the next loop, it's immediately overwritten again. Is the fact that the test cases still pass sufficient justification for the fix being valid?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23127)
<!-- Reviewable:end -->
