### PR TITLE
Disable some render tests under TSan

### DIFF
--- a/geometry/benchmarking/BUILD.bazel
+++ b/geometry/benchmarking/BUILD.bazel
@@ -83,7 +83,11 @@ drake_cc_googlebench_binary(
         "--benchmark_filter=.*/1/1/320/240",
     ],
     test_display = True,
-    test_tags = vtk_test_tags(),
+    test_tags = vtk_test_tags() + [
+        # TODO(#23113) Re-enable this test once we can suppress MESA false
+        # positives in CI.
+        "no_tsan",
+    ],
     deps = [
         "//common:add_text_logging_gflags",
         "//geometry/render",

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -265,7 +265,11 @@ drake_cc_googletest_linux_only(
         "//geometry/render:test_models",
     ] + glob(["test/*.png"]),
     display = True,
-    tags = vtk_test_tags(),
+    tags = vtk_test_tags() + [
+        # TODO(#23113) Re-enable this test once we can suppress MESA false
+        # positives in CI.
+        "no_tsan",
+    ],
     deps = [
         ":internal_render_engine_gl",
         "//common:find_resource",

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -161,7 +161,11 @@ drake_cc_googletest(
         "//geometry:test_obj_files",
         "//geometry/render:test_models",
     ],
-    tags = vtk_test_tags(),
+    tags = vtk_test_tags() + [
+        # TODO(#23113) Re-enable this test once we can suppress MESA false
+        # positives in CI.
+        "no_tsan",
+    ],
     deps = [
         ":internal_render_engine_vtk",
         "//common:find_resource",
@@ -206,7 +210,11 @@ drake_cc_googletest(
         ":osx": ["--gtest_filter=-*"],
         "//conditions:default": [],
     }),
-    tags = vtk_test_tags(),
+    tags = vtk_test_tags() + [
+        # TODO(#23113) Re-enable this test once we can suppress MESA false
+        # positives in CI.
+        "no_tsan",
+    ],
     deps = [
         ":factory",
         "//common/test_utilities",


### PR DESCRIPTION
Our version of MESA in Noble CI has false positives.  See #23113.