### PR TITLE
[workspace] Upgrade abseil_cpp_internal to latest commit

### DIFF
--- a/tools/workspace/abseil_cpp_internal/patches/inline_namespace.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/inline_namespace.patch
@@ -22,13 +22,14 @@ designed for end-user customization, and that's basically all we're doing here.
 
 --- absl/debugging/symbolize_elf.inc
 +++ absl/debugging/symbolize_elf.inc
-@@ -1764,11 +1764,13 @@ bool Symbolize(const void *pc, char *out, int out_size) {
+@@ -1766,12 +1766,14 @@ bool Symbolize(const void *pc, char *out, int out_size) {
  ABSL_NAMESPACE_END
  }  // namespace absl
  
 +#if 0  // This (dead) code disobeys the drake_vendor inline namespace.
  extern "C" bool AbslInternalGetFileMappingHint(const void **start,
-                                                const void **end, uint64_t *offset,
+                                                const void **end,
+                                                uint64_t *offset,
                                                 const char **filename) {
    return absl::debugging_internal::GetFileMappingHint(start, end, offset,
                                                        filename);

--- a/tools/workspace/abseil_cpp_internal/repository.bzl
+++ b/tools/workspace/abseil_cpp_internal/repository.bzl
@@ -6,8 +6,8 @@ def abseil_cpp_internal_repository(
     github_archive(
         name = name,
         repository = "abseil/abseil-cpp",
-        commit = "e1ff6a3339138790a443b349647a83ddcb798ffa",
-        sha256 = "e5021a67aabc1a8296367bb11367b42809c7041765d7a4687f49fe2d43549907",  # noqa
+        commit = "bca1ec088c95808fa60c326eaa4c9c6a170ff673",
+        sha256 = "273f9a81ac5e3f8b500edb0267ec27f7500c2f256f5da44571330f7b24f34f13",  # noqa
         patches = [
             ":patches/upstream/specific_iostream_includes.patch",
             ":patches/disable_int128_on_clang.patch",


### PR DESCRIPTION
Towards #23138 

Reason for separation: fails locally
```
ERROR: /home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/bazel_tools/tools/build_defs/repo/utils.bzl:220:21: An error occurred during the fetch of repository '+internal_repositories+abseil_cpp_internal':
   Traceback (most recent call last):
	File "/home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/github.bzl", line 128, column 37, in _github_archive_real_impl
		result = setup_github_repository(repository_ctx)
	File "/home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/github.bzl", line 207, column 14, in setup_github_repository
		patch(repository_ctx)
	File "/home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/bazel_tools/tools/build_defs/repo/utils.bzl", line 220, column 21, in patch
		fail("Error applying patch %s:\n%s%s" %
Error in fail: Error applying patch @@//tools/workspace/abseil_cpp_internal:patches/inline_namespace.patch:
patching file absl/base/options.h
Hunk #1 succeeded at 148 (offset -57 lines).
patching file absl/debugging/symbolize_elf.inc
Hunk #1 FAILED at 1764.
1 out of 1 hunk FAILED -- saving rejects to file absl/debugging/symbolize_elf.inc.rej
ERROR: /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/visualization/BUILD.bazel:183:15: in genquery rule //visualization:library_lint_extra_deps: errors were encountered while computing transitive closure of the scope: no such package '@@+internal_repositories+abseil_cpp_internal//absl/container': Error applying patch @@//tools/workspace/abseil_cpp_internal:patches/inline_namespace.patch:
patching file absl/base/options.h
Hunk #1 succeeded at 148 (offset -57 lines).
patching file absl/debugging/symbolize_elf.inc
Hunk #1 FAILED at 1764.
1 out of 1 hunk FAILED -- saving rejects to file absl/debugging/symbolize_elf.inc.rej
ERROR: /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/visualization/BUILD.bazel:183:15: Analysis of target '//visualization:library_lint_extra_deps' failed
ERROR: Analysis of target '//visualization:library_lint_extra_deps' failed; build aborted
INFO: Elapsed time: 1.950s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
ERROR: Fetching some target dependencies failed with errors: Analysis of target '//visualization:library_lint_extra_deps' failed; build aborted: Analysis of target '//visualization:library_lint_extra_deps' failed
Traceback (most recent call last):
  File "/home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/execroot/_main/bazel-out/k8-opt/bin/tools/workspace/new_release.runfiles/_main/tools/workspace/new_release.py", line 709, in <module>
    main()
  File "/home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/execroot/_main/bazel-out/k8-opt/bin/tools/workspace/new_release.runfiles/_main/tools/workspace/new_release.py", line 675, in main
    metadata = read_repository_metadata(repositories=workspaces)
  File "/home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/execroot/_main/bazel-out/k8-opt/bin/tools/workspace/new_release.runfiles/_main/tools/workspace/metadata.py", line 94, in read_repository_metadata
    subprocess.check_call(["bazel", "fetch", "//..."])
  File "/usr/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['bazel', 'fetch', '//...']' returned non-zero exit status 2.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23140)
<!-- Reviewable:end -->
