### PR TITLE
[workspace] Upgrade gz_math_internal to latest release gz-math8_8.2.0

### DIFF
--- a/tools/workspace/gz_math_internal/repository.bzl
+++ b/tools/workspace/gz_math_internal/repository.bzl
@@ -9,8 +9,8 @@ def gz_math_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "gazebosim/gz-math",
-        commit = "gz-math8_8.1.1",
-        sha256 = "0455b24069c61172b625c55348f3a722652058262422019176d0ff43551f7093",  # noqa
+        commit = "gz-math8_8.2.0",
+        sha256 = "6a6e9af99378b4ab81392bd8ad58be1c611f917c669c981b39cf20fc03d412f4",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Towards #23138 

Reason for exclusion: fails locally.

```
ERROR: Traceback (most recent call last):
	File "/home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/+internal_repositories+gz_math_internal/BUILD.bazel", line 133, column 24, in <toplevel>
		check_lists_consistency(
	File "/home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/check_lists_consistency.bzl", line 24, column 13, in check_lists_consistency
		fail("The following files matched a glob of upstream sources, but " +
Error in fail: The following files matched a glob of upstream sources, but were not covered by the package.BUILD.bazel file: ["include/gz/math/AxisAlignedBoxHelpers.hh", "include/gz/math/detail/AxisAlignedBoxHelpers.hh"]
ERROR: /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/bindings/pydrake/multibody/BUILD.bazel:557:23: in genquery rule //bindings/pydrake/multibody:install_lint_genquery_install: errors were encountered while computing transitive closure of the scope: no such target '@@+internal_repositories+gz_math_internal//:install': target 'install' not declared in package '' defined by /home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/+internal_repositories+gz_math_internal/BUILD.bazel
ERROR: /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/bindings/pydrake/multibody/BUILD.bazel:557:23: Analysis of target '//bindings/pydrake/multibody:install_lint_genquery_install' failed
ERROR: Analysis of target '//bindings/pydrake/multibody:py/install_lint' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.989s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
ERROR: Fetching some target dependencies failed with errors: Analysis of target '//bindings/pydrake/multibody:py/install_lint' failed; build aborted: in genquery rule //bindings/pydrake/multibody:install_lint_genquery_install: errors were encountered while computing transitive closure of the scope: no such target '@@+internal_repositories+gz_math_internal//:install': target 'install' not declared in package '' defined by /home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/+internal_repositories+gz_math_internal/BUILD.bazel
```