### PR TITLE
[workspace] Upgrade vtk_internal to latest commit

### DIFF
--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -184,8 +184,8 @@ def vtk_internal_repository(
         # TODO(jwnimmer-tri) Once there's a tagged release with support for
         # VTK_ABI_NAMESPACE, we should switch to an official version number
         # here. That probably means waiting for the VTK 10 release.
-        commit = "1d67dcfb29517a1533680a74736fa6786e5029d0",
-        sha256 = "82d86920dbba79d169183baacdf092e5b6f3acef12fea6bb90cd620632a1d567",  # noqa
+        commit = "8b4b72b71a1713d8e2f403c470ade615d0159440",
+        sha256 = "6cad67c914c34d0d5897602f4128a00d40c60690441eb2d6fb57d9b8bdd1daf3",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             # Drake's conventions for VTK patches are:


### PR DESCRIPTION
Towards #23138 

Reason for exclusion: fails locally (and vtk usually requires some manual intervention).

```
ERROR: /home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/bazel_tools/tools/build_defs/repo/utils.bzl:207:22: An error occurred during the fetch of repository '+internal_repositories+vtk_internal':
   Traceback (most recent call last):
	File "/home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/vtk_internal/repository.bzl", line 146, column 36, in _impl
		error = setup_github_repository(repo_ctx).error
	File "/home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/github.bzl", line 207, column 14, in setup_github_repository
		patch(repository_ctx)
	File "/home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/bazel_tools/tools/build_defs/repo/utils.bzl", line 207, column 22, in patch
		ctx.patch(patchfile, strip)
Error in patch: Error applying patch /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/vtk_internal/patches/upstream/common_core_rm_iostream.patch: in patch applied to /home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/+internal_repositories+vtk_internal/Common/DataModel/vtkAMRInformation.cxx: could not apply patch due to CONTENT_DOES_NOT_MATCH_TARGET, error applying change near line 293
ERROR: /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/geometry/BUILD.bazel:1208:15: in genquery rule //geometry:library_lint_extra_deps: errors were encountered while computing transitive closure of the scope: no such package '@@+internal_repositories+vtk_internal//': Error applying patch /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/vtk_internal/patches/upstream/common_core_rm_iostream.patch: in patch applied to /home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/+internal_repositories+vtk_internal/Common/DataModel/vtkAMRInformation.cxx: could not apply patch due to CONTENT_DOES_NOT_MATCH_TARGET, error applying change near line 293
ERROR: /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/geometry/BUILD.bazel:1208:15: Analysis of target '//geometry:library_lint_extra_deps' failed
ERROR: Analysis of target '//geometry:py/library_lint' failed; build aborted: Analysis failed
INFO: Elapsed time: 5.253s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
ERROR: Fetching some target dependencies failed with errors: Analysis of target '//geometry:py/library_lint' failed; build aborted: in genquery rule //geometry:library_lint_extra_deps: errors were encountered while computing transitive closure of the scope: no such package '@@+internal_repositories+vtk_internal//': Error applying patch /home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/vtk_internal/patches/upstream/common_core_rm_iostream.patch: in patch applied to /home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/+internal_repositories+vtk_internal/Common/DataModel/vtkAMRInformation.cxx: could not apply patch due to CONTENT_DOES_NOT_MATCH_TARGET, error applying change near line 293
```