### PR TITLE
Remove uses of deprecated std::aligned_storage

### DIFF
--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -400,8 +400,7 @@ class EigenPtr {
     RefType& raw_value() { return reinterpret_cast<RefType&>(storage_); }
 
     bool has_value_{};
-    typename std::aligned_storage<sizeof(RefType), alignof(RefType)>::type
-        storage_;
+    alignas(RefType) std::byte storage_[sizeof(RefType)];
   };
 
   // Use mutable, reassignable ref to permit pointer-like semantics (with

--- a/common/never_destroyed.h
+++ b/common/never_destroyed.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <new>
-#include <type_traits>
+#include <cstddef>
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
@@ -97,7 +96,7 @@ class never_destroyed {
   const T& access() const { return *reinterpret_cast<const T*>(&storage_); }
 
  private:
-  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage_;
+  alignas(T) std::byte storage_[sizeof(T)];
 };
 
 }  // namespace drake

--- a/common/test_utilities/limit_malloc.cc
+++ b/common/test_utilities/limit_malloc.cc
@@ -104,7 +104,7 @@ class never_destroyed {
   never_destroyed() { new (&storage_) T(); }
   T& access() { return *reinterpret_cast<T*>(&storage_); }
  private:
-  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage_;
+  alignas(T) std::byte storage_[sizeof(T)];
 };
 
 class ActiveMonitor {


### PR DESCRIPTION
As of C++23, this generates deprecation warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23145)
<!-- Reviewable:end -->
