### PR TITLE
Making revolute spring stiffness a parameter

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1085,8 +1085,12 @@ class TestPlant(unittest.TestCase):
 
         # Test RevoluteSpring accessors
         self.assertEqual(revolute_spring.joint(), revolute_joint)
-        self.assertEqual(revolute_spring.nominal_angle(), 0.1)
-        self.assertEqual(revolute_spring.stiffness(), 100.)
+        self.assertEqual(revolute_spring.default_nominal_angle(), 0.1)
+        self.assertEqual(revolute_spring.default_stiffness(), 100.)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(revolute_spring.nominal_angle(), 0.1)
+        with catch_drake_warnings(expected_count=1):
+            self.assertEqual(revolute_spring.stiffness(), 100.)
 
         # Test DoorHinge accessors
         self.assertEqual(door_hinge.joint(), revolute_joint)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1026,8 +1026,28 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.ctor.doc)
         .def("joint", &Class::joint, py_rvp::reference_internal,
             cls_doc.joint.doc)
-        .def("nominal_angle", &Class::nominal_angle, cls_doc.nominal_angle.doc)
-        .def("stiffness", &Class::stiffness, cls_doc.stiffness.doc);
+        .def("default_stiffness", &Class::default_stiffness,
+            cls_doc.default_stiffness.doc)
+        .def("GetStiffness", &Class::GetStiffness, py::arg("context"),
+            cls_doc.GetStiffness.doc)
+        .def("SetStiffness", &Class::SetStiffness, py::arg("context"),
+            py::arg("stiffness"), cls_doc.SetStiffness.doc)
+        .def("default_nominal_angle", &Class::default_nominal_angle,
+            cls_doc.default_nominal_angle.doc)
+        .def("GetNominalAngle", &Class::GetNominalAngle, py::arg("context"),
+            cls_doc.GetNominalAngle.doc)
+        .def("SetNominalAngle", &Class::SetNominalAngle, py::arg("context"),
+            py::arg("nominal_angle"), cls_doc.SetNominalAngle.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.def("stiffness",
+           WrapDeprecated(cls_doc.stiffness.doc_deprecated, &Class::stiffness),
+           cls_doc.stiffness.doc_deprecated)
+        .def("nominal_angle",
+            WrapDeprecated(
+                cls_doc.nominal_angle.doc_deprecated, &Class::nominal_angle),
+            cls_doc.nominal_angle.doc_deprecated);
+#pragma GCC diagnostic pop
   }
 
   {


### PR DESCRIPTION
Related to #13289, this PR adds two functions to the `RevoluteSpring` which store the stiffness value as a context dependent parameter. 

This also changes the existing stiffness value to be a default stiffness matching the treatment of the damping term in the `RevoluteJoint`. The existing `stiffness()` function is not removed but is listed as deprecated with an arbitrary date.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23146)
<!-- Reviewable:end -->
