### PR TITLE
[tools] Default to C++23 on Noble

### DIFF
--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -60,7 +60,7 @@ Drake's pre-compiled binaries:
 | Operating System                   | C/C++ Compiler             | Std   |
 |------------------------------------|----------------------------|-------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11                     | C++20 |
-| Ubuntu 24.04 LTS (Noble Numbat)    | GCC 13                     | C++20 |
+| Ubuntu 24.04 LTS (Noble Numbat)    | GCC 13                     | C++23 |
 | macOS Sonoma (14)                  | Apple LLVM 16 (Xcode 16.2) | C++20 |
 | macOS Sequoia (15)                 | Apple LLVM 17 (Xcode 16.4) | C++20 |
 

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -1,3 +1,7 @@
+# Use C++23 on Noble.
+build --cxxopt=-std=c++23
+build --host_cxxopt=-std=c++23
+
 # Options for explicitly using Clang.
 # Keep this in sync with doc/_pages/from_source.md.
 common:clang --repo_env=CC=clang-19

--- a/tools/workspace/vtk_internal/patches/upstream/common_executionmodel_vtkalgorithm_ternary.patch
+++ b/tools/workspace/vtk_internal/patches/upstream/common_executionmodel_vtkalgorithm_ternary.patch
@@ -1,0 +1,15 @@
+[vtk] Fix type error in ternary operator
+
+This didn't show up until Drake started using -std=c++23.
+
+--- Common/ExecutionModel/vtkAlgorithm.cxx
++++ Common/ExecutionModel/vtkAlgorithm.cxx
+@@ -1121,7 +1121,7 @@ void vtkAlgorithm::SetInputConnection(int port, vtkAlgorithmOutput* input)
+   // The connection is not present.
+   vtkDebugMacro("Setting connection to input port index "
+     << consumerPort << " from output port index " << producerPort << " on algorithm "
+-    << (producer ? producer->GetObjectDescription() : nullptr) << ".");
++    << (producer ? producer->GetObjectDescription() : std::string("nullptr")) << ".");
+ 
+   // Add this consumer to the new input's list of consumers.
+   if (newInfo)

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -196,6 +196,7 @@ def vtk_internal_repository(
             #   edited (e.g., patching IO/Image is named io_image_{foo}.patch).
             # - Use alphabetical order within a directory when listing patches.
             ":patches/upstream/common_core_rm_iostream.patch",
+            ":patches/upstream/common_executionmodel_vtkalgorithm_ternary.patch",  # noqa
             ":patches/upstream/io_geometry_gltf_default_scene.patch",
             ":patches/upstream/io_import_errors.patch",
             ":patches/upstream/rendering_opengl2_scaled_albedo_for_ibl.patch",


### PR DESCRIPTION
This updates our Noble release packages to use C++23, which allows downstream projects to use C++23 features in their own code if they like.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23147)
<!-- Reviewable:end -->
