### PR TITLE
Update Mosek to 11.0.24

### DIFF
--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2027,7 +2027,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/10.1/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
@@ -2039,7 +2039,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/10.1/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @param vars x in the documentation above.
    @param hessian_type Whether the Hessian is positive semidefinite, negative
@@ -2061,7 +2061,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/10.1/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @param vars x in the documentation above.
    @param hessian_type Whether the Hessian is positive semidefinite, negative
@@ -2083,7 +2083,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/10.1/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    */
   Binding<QuadraticConstraint> AddQuadraticConstraint(
@@ -2510,7 +2510,7 @@ class MathematicalProgram {
    * cone. When solving the optimization problem using conic solvers (like
    * Mosek, Gurobi, SCS, etc), it is numerically preferable to impose the
    * convex quadratic constraint as rotated Lorentz cone constraint. See
-   * https://docs.mosek.com/latest/capi/prob-def-quadratic.html#a-recommendation
+   * https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation
    * @throw exception if this quadratic constraint is not convex (Q is not
    * positive semidefinite)
    * @param Q The Hessian of the quadratic constraint. Should be positive

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -314,7 +314,7 @@ class MathematicalProgramResult final {
    *    solution to the (rotated) Lorentz cone constraint doesn't have the
    *    "shadow price" interpretation, but should lie in the dual cone, and
    *    satisfy the KKT condition. For more information, refer to
-   *    https://docs.mosek.com/10.1/capi/prob-def-conic.html#duality-for-conic-optimization
+   *    https://docs.mosek.com/11.0/capi/prob-def-conic.html#duality-for-conic-optimization
    *    as an explanation.
    *
    * The interpretation for the dual variable to conic constraint x ∈ K can be

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -52,7 +52,7 @@ class MosekSolver::License {
     if (rescode != MSK_RES_OK) {
       throw std::runtime_error(
           fmt::format("Could not acquire MOSEK license: {}. See "
-                      "https://docs.mosek.com/10.1/capi/"
+                      "https://docs.mosek.com/11.0/capi/"
                       "response-codes.html#mosek.rescode for details.",
                       fmt_streamed(rescode)));
     }
@@ -258,7 +258,7 @@ void MosekSolver::DoSolve2(const MathematicalProgram& prog,
 
   // Since Mosek 10, it allows setting the initial guess for both continuous and
   // integer/binary variables. See
-  // https://docs.mosek.com/latest/rmosek/tutorial-mio-shared.html#specifying-an-initial-solution
+  // https://docs.mosek.com/11.0/rmosek/tutorial-mio-shared.html#specifying-an-initial-solution
   // for more details.
   if (initial_guess.array().isFinite().any()) {
     DRAKE_ASSERT(initial_guess.size() == prog.num_vars());
@@ -284,7 +284,7 @@ void MosekSolver::DoSolve2(const MathematicalProgram& prog,
     MSKrescodee trmcode;  // termination code
     rescode = MSK_optimizetrm(impl.task(), &trmcode);
     // Refer to
-    // https://docs.mosek.com/latest/capi/debugging-tutorials.html#debugging-tutorials
+    // https://docs.mosek.com/11.0/capi/debugging-tutorials.html#debugging-tutorials
     // on printing the solution summary.
     if (is_printing) {
       if (rescode == MSK_RES_OK) {

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -18,15 +18,15 @@ namespace solvers {
  */
 struct MosekSolverDetails {
   /// The MOSEK™ optimization time. Please refer to MSK_DINF_OPTIMIZER_TIME in
-  /// https://docs.mosek.com/10.1/capi/constants.html?highlight=msk_dinf_optimizer_time
+  /// https://docs.mosek.com/11.0/capi/constants.html?highlight=msk_dinf_optimizer_time
   double optimizer_time{};
   /// The response code returned from MOSEK™ solver. Check
-  /// https://docs.mosek.com/10.1/capi/response-codes.html for the meaning on
+  /// https://docs.mosek.com/11.0/capi/response-codes.html for the meaning on
   /// the response code.
   int rescode{};
   /// The solution status after solving the problem. Check
-  /// https://docs.mosek.com/10.1/capi/accessing-solution.html and
-  /// https://docs.mosek.com/10.1/capi/constants.html#mosek.solsta for the
+  /// https://docs.mosek.com/11.0/capi/accessing-solution.html and
+  /// https://docs.mosek.com/11.0/capi/constants.html#mosek.solsta for the
   /// meaning on the solution status.
   int solution_status{};
 };
@@ -54,19 +54,19 @@ struct MosekSolverDetails {
  * (MOSEK™ might change the values of the integer/binary variables in the
  * subsequent iterations.) If the specified integer solution is infeasible or
  * incomplete, MOSEK™ will simply ignore it. For more details, check
- * https://docs.mosek.com/10.1/capi/tutorial-mio-shared.html?highlight=initial
+ * https://docs.mosek.com/11.0/capi/tutorial-mio-shared.html?highlight=initial
  *
  * MOSEK™ supports many solver parameters. You can refer to the full list of
  * parameters in
- * https://docs.mosek.com/10.1/capi/param-groups.html#doc-param-groups. On top
+ * https://docs.mosek.com/11.0/capi/param-groups.html#doc-param-groups. On top
  * of these parameters, we also provide the following additional parameters
  *
  * - "writedata"
  *    set to a file name so that MOSEK™ solver will write the
  *    optimization model to this file. check
- *    https://docs.mosek.com/10.1/capi/solver-io.html#saving-a-problem-to-a-file
+ *    https://docs.mosek.com/11.0/capi/solver-io.html#saving-a-problem-to-a-file
  *    for more details. The supported file extensions are listed in
- *    https://docs.mosek.com/10.1/capi/supported-file-formats.html#doc-shared-file-formats.
+ *    https://docs.mosek.com/11.0/capi/supported-file-formats.html#doc-shared-file-formats.
  *    Set this parameter to "" if you don't want to write to a file. Default is
  *    not to write to a file.
  */

--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -52,7 +52,7 @@ MosekSolverProgram::MosekSolverProgram(const MathematicalProgram& prog,
     : map_decision_var_to_mosek_var_{prog} {
   // Create the optimization task.
   // task is initialized as a null pointer, same as in Mosek's documentation
-  // https://docs.mosek.com/10.1/capi/design.html#hello-world-in-mosek
+  // https://docs.mosek.com/11.0/capi/design.html#hello-world-in-mosek
   task_ = nullptr;
   MSK_maketask(env, 0,
                map_decision_var_to_mosek_var_
@@ -734,7 +734,7 @@ MSKrescodee MosekSolverProgram::AddQuadraticConstraints(
     }
 
     // Pre-allocate the size for the Q matrix according to
-    // https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.putqcon
+    // https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.putqcon
     rescode = MSK_putmaxnumqnz(task_, qcsubi.size());
     if (rescode != MSK_RES_OK) {
       return rescode;
@@ -952,7 +952,7 @@ MSKrescodee MosekSolverProgram::AddLinearMatrixInequalityConstraint(
     std::unordered_map<Binding<LinearMatrixInequalityConstraint>, MSKint64t>*
         acc_indices) {
   // Use Mosek's "affine cone constraint". See
-  // https://docs.mosek.com/latest/capi/tutorial-sdo-shared.html#example-sdo-lmi-linear-matrix-inequalities-and-the-vectorized-semidefinite-domain
+  // https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html#example-sdo-lmi-linear-matrix-inequalities-and-the-vectorized-semidefinite-domain
   // for more details.
   DRAKE_ASSERT(acc_indices != nullptr);
   MSKrescodee rescode = MSK_RES_OK;
@@ -1631,8 +1631,8 @@ void ThrowForInvalidOption(MSKrescodee rescode, const std::string& option,
 
 // This function is used to print information for each iteration to the console,
 // it will show PRSTATUS, PFEAS, DFEAS, etc. For more information, check out
-// https://docs.mosek.com/10.1/capi/solver-io.html. This printstr is copied
-// directly from https://docs.mosek.com/10.1/capi/solver-io.html#stream-logging.
+// https://docs.mosek.com/11.0/capi/solver-io.html. This printstr is copied
+// directly from https://docs.mosek.com/11.0/capi/solver-io.html#stream-logging.
 void MSKAPI printstr(void*, const char str[]) {
   printf("%s", str);
 }
@@ -1648,7 +1648,7 @@ void MosekSolverProgram::UpdateOptions(
   // Copy all remaining options into our `task_`.
   options->Respell([&](const auto& common, auto* respelled) {
     // This is a convenient place to configure printing (i.e., logging); see
-    // https://docs.mosek.com/10.1/capi/solver-io.html#stream-logging.
+    // https://docs.mosek.com/11.0/capi/solver-io.html#stream-logging.
     // Printing to console vs file are mutually exclusive; if the user has
     // requested both, then we must throw an error BEFORE we create the log
     // file; otherwise we might create it but never close it.
@@ -1733,7 +1733,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   if (which_sol == MSK_SOL_ITG) {
     // Mosek cannot return dual solution if the solution type is MSK_SOL_ITG
     // (which stands for mixed integer optimizer), see
-    // https://docs.mosek.com/10.1/capi/accessing-solution.html#available-solutions
+    // https://docs.mosek.com/11.0/capi/accessing-solution.html#available-solutions
     return rescode;
   }
   int num_mosek_vars{0};
@@ -1743,7 +1743,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   }
   // Mosek dual variables for variable lower bounds (slx) and upper bounds
   // (sux). Refer to
-  // https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
+  // https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
   // for more explanation.
   std::vector<MSKrealt> slx(num_mosek_vars);
   std::vector<MSKrealt> sux(num_mosek_vars);
@@ -1762,7 +1762,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   }
   // Mosek dual variables for linear constraints lower bounds (slc) and upper
   // bounds (suc). Refer to
-  // https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
+  // https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
   // for more explanation.
   std::vector<MSKrealt> slc(num_linear_constraints);
   std::vector<MSKrealt> suc(num_linear_constraints);

--- a/solvers/mosek_solver_internal.h
+++ b/solvers/mosek_solver_internal.h
@@ -20,10 +20,10 @@ namespace drake {
 namespace solvers {
 namespace internal {
 // Mosek treats psd matrix variables in a special manner.
-// Check https://docs.mosek.com/10.1/capi/tutorial-sdo-shared.html for more
+// Check https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html for more
 // details. To summarize, Mosek stores a positive semidefinite (psd) matrix
 // variable as a "bar var" (as called in Mosek's API, for example
-// https://docs.mosek.com/10.1/capi/tutorial-sdo-shared.html). Inside Mosek, it
+// https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html). Inside Mosek, it
 // accesses each of the psd matrix variable with a unique ID. Moreover, the
 // Mosek user cannot access the entries of the psd matrix variable individually;
 // instead, the user can only access the matrix X̅ as a whole. To impose
@@ -79,7 +79,7 @@ class MatrixVariableEntry {
 
 // Mosek stores dual variable in different categories, called slc, suc, slx, sux
 // and snx. Refer to
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
+// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
 // for more information.
 enum class DualVarType {
   kLinearConstraint,  ///< Corresponds to Mosek's slc and suc.
@@ -177,9 +177,9 @@ class MosekSolverProgram {
   // expression format
   // ∑ⱼ fᵢⱼ xⱼ + ∑ⱼ<F̅ᵢⱼ, X̅ⱼ>
   // Please refer to
-  // https://docs.mosek.com/latest/capi/tutorial-acc-optimizer.html for an
+  // https://docs.mosek.com/11.0/capi/tutorial-acc-optimizer.html for an
   // introduction on Mosek affine expression, and
-  // https://docs.mosek.com/latest/capi/tutorial-sdo-shared.html for the affine
+  // https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html for the affine
   // expression with matrix variables.
   // F̅ᵢⱼ is a weighted sum of the symmetric matrix E stored inside Mosek.
   // bar_F[i][j] stores the indices of E and the weights of E.
@@ -538,13 +538,13 @@ MSKrescodee MosekSolverProgram::AddConeConstraints(
 }
 
 // @param slx Mosek dual variables for variable lower bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getslx
+// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getslx
 // @param sux Mosek dual variables for variable upper bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsux
+// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsux
 // @param slc Mosek dual variables for linear constraint lower bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getslc
+// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getslc
 // @param suc Mosek dual variables for linear constraint upper bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsuc
+// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsuc
 void SetVariableBoundsDualSolution(
     const std::vector<Binding<BoundingBoxConstraint>>& bb_constraints,
     const std::vector<Binding<PositiveSemidefiniteConstraint>>& psd_constraints,
@@ -589,10 +589,10 @@ void SetLinearConstraintDualSolution(
 
 // @param slc Mosek dual variables for linear and quadratic constraint lower
 // bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getslc
+// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getslc
 // @param suc Mosek dual variables for linear and quadratic constraint upper
 // bound. See
-// https://docs.mosek.com/10.1/capi/alphabetic-functionalities.html#mosek.task.getsuc
+// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsuc
 void SetQuadraticConstraintDualSolution(
     const std::vector<Binding<QuadraticConstraint>>& constraints,
     const std::vector<MSKrealt>& slc, const std::vector<MSKrealt>& suc,
@@ -605,7 +605,7 @@ void SetQuadraticConstraintDualSolution(
  * @param bindings The constraint for which the dual solution will be set.
  * @param task The Mosek task.
  * @param whichsol The solution type. See
- * https://docs.mosek.com/latest/capi/constants.html#mosek.soltype
+ * https://docs.mosek.com/11.0/capi/constants.html#mosek.soltype
  * @param acc_indices Maps each constraint to the affine cone constraint
  * indices.
  * @param[out] result The dual solution in `result` will be set.

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -53,7 +53,7 @@ that the SCS code on github master might be more up-to-date than the version
 used in Drake.
 
 "MOSEK™" -- Parameter name and values as specified in Mosek Reference
-https://docs.mosek.com/9.3/capi/parameters.html
+https://docs.mosek.com/11.0/capi/parameters.html
 
 "OSQP" -- Parameter name and values as specified in OSQP Reference
 https://osqp.org/docs/interfaces/solver_settings.html#solver-settings

--- a/solvers/test/linear_program_examples.h
+++ b/solvers/test/linear_program_examples.h
@@ -79,7 +79,7 @@ class LinearProgram1 : public OptimizationProgram {
 };
 
 // Test a simple linear programming problem
-// Adapted from https://docs.mosek.com/10.1/capi/tutorial-lo-shared.html
+// Adapted from https://docs.mosek.com/11.0/capi/tutorial-lo-shared.html
 // min -3x0 - x1 - 5x2 - x3
 // s.t     3x0 +  x1 + 2x2        = 30
 //   15 <= 2x0 +  x1 + 3x2 +  x3 <= inf

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -45,7 +45,7 @@ TEST_F(UnboundedLinearProgramTest0, Test) {
         result.get_solver_details<MosekSolver>();
     EXPECT_EQ(mosek_solver_details.rescode, 0);
     // This problem status is defined in
-    // https://docs.mosek.com/10.1/capi/constants.html#mosek.prosta
+    // https://docs.mosek.com/11.0/capi/constants.html#mosek.prosta
     const int MSK_SOL_STA_DUAL_INFEAS_CER = 6;
     EXPECT_EQ(mosek_solver_details.solution_status,
               MSK_SOL_STA_DUAL_INFEAS_CER);
@@ -326,7 +326,7 @@ GTEST_TEST(MosekTest, SolverOptionsTest) {
   mosek_solver.Solve(prog, {}, solver_options, &result);
   EXPECT_FALSE(result.is_success());
   // This response code is defined in
-  // https://docs.mosek.com/10.1/capi/response-codes.html#mosek.rescode
+  // https://docs.mosek.com/11.0/capi/response-codes.html#mosek.rescode
   const int MSK_RES_ERR_HUGE_C{1375};
   EXPECT_EQ(result.get_solver_details<MosekSolver>().rescode,
             MSK_RES_ERR_HUGE_C);

--- a/solvers/test/semidefinite_program_examples.h
+++ b/solvers/test/semidefinite_program_examples.h
@@ -70,7 +70,7 @@ void SolveEigenvalueProblem(const SolverInterface& solver,
                             double tol, bool check_dual);
 
 /// Solve an SDP with a second order cone constraint. This example is taken from
-/// https://docs.mosek.com/10.1/capi/tutorial-sdo-shared.html
+/// https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html
 void SolveSDPwithSecondOrderConeExample1(const SolverInterface& solver,
                                          double tol);
 

--- a/tools/workspace/mosek/LICENSE.third_party
+++ b/tools/workspace/mosek/LICENSE.third_party
@@ -9,9 +9,11 @@ https://docs.mosek.com/latest/licensing/license-agreement-info.html
 3.1 MOSEK end-user license agreement
 
 Before using the MOSEK software, please read the license agreement available in
-the distribution at <MSKHOME>/mosek/10.0/mosek-eula.pdf or on the MOSEK website
+the distribution at <MSKHOME>/mosek/11.0/mosek-eula.pdf or on the MOSEK website
 https://mosek.com/products/license-agreement. By using MOSEK you agree to the
-terms of that license agreement.  3.2 Third party licenses
+terms of that license agreement.
+
+3.2 Third party licenses
 
 MOSEK uses some third-party open-source libraries. Their license details follow.
 

--- a/tools/workspace/mosek/repository.bzl
+++ b/tools/workspace/mosek/repository.bzl
@@ -6,15 +6,17 @@ def mosek_repository(
     repository_impl(
         name = name,
         # When the version is updated:
+        # - Documentation in solvers needs updating, e.g.:
+        #     git grep -l 'https://docs.mosek.com/' | xargs -n1 sed -i \
+        #     '/https:\/\/docs\.mosek\.com/s,/11\.0/capi,/11.1/capi,
         # - tools/dynamic_analysis/tsan.supp may also need updating
         # - LICENSE.third_party may also need updating to match
         #   https://docs.mosek.com/latest/licensing/license-agreement-info.html
-        version = "10.1.21",
+        version = "11.0.24",
         sha256 = {
-            "mosektoolslinuxaarch64.tar.bz2": "c2d15979dc1190ff83949b2e79244137ed4013fdb47de90fb62836088749e0ca",  # noqa
-            "mosektoolslinux64x86.tar.bz2": "f37b7b3806e467c64a02e95b2ab009f6fe8430f25ffc72ed56885f7684dec486",  # noqa
-            "mosektoolsosxaarch64.tar.bz2": "f6e862cab171b7897a6f1ad21c3c0fbdf33dc1310f50c792295ab008321950c7",  # noqa
-            "mosektoolsosx64x86.tar.bz2": "3ad45f7e535b6d3bb8be955f403ded30a7f186424057f11024afc57427cbb012",  # noqa
+            "mosektoolslinuxaarch64.tar.bz2": "68e94abb10087bf38dd4b378cc51a412dc1f94171ef50dff9075a4c1bf909bb6",  # noqa
+            "mosektoolslinux64x86.tar.bz2": "f058e4bec5cde899cf5193f7ac966a923a256c335466a0678604068a51404362",  # noqa
+            "mosektoolsosxaarch64.tar.bz2": "b0bd9232e45597d098b9464eb6302b17cf0f3bd5679e06bce1e74c046604da34",  # noqa
         },
         mirrors = mirrors,
     )


### PR DESCRIPTION
In order to allow wheels to use Mosek provided from PyPI without version support regressions, we need to use a newer version of Mosek (in particular, 11.x). Therefore, update Mosek to the latest version currently available.

Also remove support for x86 macOS, which is not supported by Mosek 11.

Toward #20296.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23151)
<!-- Reviewable:end -->
