### PR TITLE
[workspace] Retrieve Doxygen binaries from drake-mirror

### DIFF
--- a/tools/workspace/mirrors.bzl
+++ b/tools/workspace/mirrors.bzl
@@ -24,8 +24,8 @@ DEFAULT_MIRRORS = {
         "https://s3.amazonaws.com/drake-mirror/crates.io/{archive}",
     ],
     "doxygen": [
-        "https://drake-packages.csail.mit.edu/doxygen/{archive}",
-        "https://s3.amazonaws.com/drake-packages/doxygen/{archive}",
+        "https://drake-mirror.csail.mit.edu/other/doxygen/{archive}",
+        "https://s3.amazonaws.com/drake-mirror/other/doxygen/{archive}",
     ],
     "github": [
         # For github.com, we choose a pattern based on the kind of commit.


### PR DESCRIPTION
Copies stored in drake-packages recently hit the 5-year Glacier storage timeout, while drake-mirror does not define such a rule. Additionally, most other externals are stored in drake-mirror (including the Doxygen source tarballs), so this change moves towards consistency.

Towards #23016.