### PR TITLE
[build] Use prefer_pic_for_opt_binaries

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,6 +23,13 @@ bazel_dep(name = "rules_python", version = "0.40.0")
 bazel_dep(name = "rules_rust", version = "0.56.0")
 bazel_dep(name = "rules_shell", version = "0.3.0")
 
+single_version_override(
+    module_name = "rules_cc",
+    patches = [
+        "@drake//tools/workspace/rules_cc:patches/upstream/pr456.patch",
+    ],
+)
+
 # Customize our toolchains.
 
 cc_configure = use_extension(

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -14,6 +14,7 @@ common --incompatible_autoload_externally=
 
 # Default to an optimized build.
 build -c opt
+build --features=prefer_pic_for_opt_binaries
 
 # Default build options.
 build --strip=never

--- a/tools/ubuntu.bazelrc
+++ b/tools/ubuntu.bazelrc
@@ -1,6 +1,5 @@
 # Common options for Ubuntu, no matter the version.
 
-build --force_pic
 build --fission=dbg
 build --features=per_object_debug_info
 

--- a/tools/workspace/rules_cc/patches/upstream/pr456.patch
+++ b/tools/workspace/rules_cc/patches/upstream/pr456.patch
@@ -1,0 +1,24 @@
+From: Jeremy Nimmer <jeremy.nimmer@tri.global>
+Subject: Support prefer_pic_for_opt_binaries in linux auto-detecting toolchain
+
+--- cc/private/toolchain/unix_cc_toolchain_config.bzl
++++ cc/private/toolchain/unix_cc_toolchain_config.bzl
+@@ -347,6 +347,10 @@ def _impl(ctx):
+         name = "supports_pic",
+         enabled = True,
+     )
++    prefer_pic_for_opt_binaries_feature = feature(
++        name = "prefer_pic_for_opt_binaries",
++        enabled = False,
++    )
+     supports_start_end_lib_feature = feature(
+         name = "supports_start_end_lib",
+         enabled = True,
+@@ -1829,6 +1833,7 @@ def _impl(ctx):
+             strip_debug_symbols_feature,
+             coverage_feature,
+             supports_pic_feature,
++            prefer_pic_for_opt_binaries_feature,
+             asan_feature,
+             tsan_feature,
+             ubsan_feature,


### PR DESCRIPTION
Add a patch to `rules_cc` to allow the auto-detecting Linux toolchain to support `prefer_pic_for_opt_binaries`. Available with Bazel >= 7.0, this supplants the inconsistent use of `--force_pic`.

Towards #20336.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23180)
<!-- Reviewable:end -->
