### PR TITLE
Disable memcheck for `iris_zo_test`

### DIFF
--- a/planning/iris/BUILD.bazel
+++ b/planning/iris/BUILD.bazel
@@ -131,6 +131,8 @@ drake_cc_googletest(
     tags = [
         "no_asan",
         "no_lsan",
+        # TODO(#22978) Re-enable this if possible.
+        "no_memcheck",
     ],
     deps = [
         ":iris_test_utilities",


### PR DESCRIPTION
See #22978. This test is failing too frequently at the moment, so it is best to disable it until #22978 is resolved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23184)
<!-- Reviewable:end -->
