### PR TITLE
[doc] Add reference to unprovisioned job requests file

### DIFF
--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -56,10 +56,9 @@ For example:
 * ``@drake-jenkins-bot mac-arm-sonoma-clang-bazel-experimental-release please``
 * ``@drake-jenkins-bot linux-noble-clang-bazel-experimental-valgrind-memcheck please``
 
-A list of Jenkins bot commands for experimental builds that cover the full
-set of continuous and nightly production jobs is available
-[here](https://github.com/RobotLocomotion/drake/blob/jenkins-jobs-experimental/request-jobs-experimental.txt).
-Both provisioned and unprovisioned jobs are listed.
+Lists of Jenkins bot commands for experimental builds that cover the full
+set of continuous and nightly production jobs are available
+[here](https://github.com/RobotLocomotion/drake/blob/jenkins-jobs-experimental).
 
 ## Scheduling Builds via the Jenkins User Interface
 
@@ -110,10 +109,11 @@ and ``new_release.py``). Again, it is expected that a given prerequisite will
 only appear in one of these lists.
 
 When updating prerequisites with these scripts, the normal experimental CI will
-most likely fail. To test new prerequisites on Linux, you should first request an
-unprovisioned experimental build, e.g.:
-
-* ``@drake-jenkins-bot linux-noble-unprovisioned-gcc-bazel-experimental-release please``
+most likely fail. To test new prerequisites on Linux, you should request
+unprovisioned experimental builds. A list of Jenkins bot commands for experimental
+unprovisioned builds covering the full set of corresponding continuous and nightly
+production builds (including provisioned) is available
+[here](https://github.com/RobotLocomotion/drake/blob/jenkins-jobs-experimental/request-jobs-unprovisioned.txt).
 
 Testing changes to the source distribution prerequisites for macOS is a work
 in progress as there are no longer unprovisioned builds.


### PR DESCRIPTION
04fcec4af7 added `request-jobs-unprovisioned.txt`; this commit documents it accordingly.

Towards #23125.