### PR TITLE
Configure renovate to upgrade .bazelversion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "automerge": false,
+  "timezone": "America/New_York",
+  "schedule": [
+    "at 6am on the first day of the month"
+  ],
+  "enabledManagers": [
+    "bazelisk"
+  ]
+}


### PR DESCRIPTION
Towards #23159 

This PR adds a `renovate.json` file to drake that automatically upgrades the version of bazel found in `.bazelversion` at 6am on the first of every month. For the time being, this is the only dependency that is automatically updated.

This PR replaces and includes all changes from #23160.