### PR TITLE
Warn when solving a QP with CLP.

### DIFF
--- a/solvers/clp_solver.cc
+++ b/solvers/clp_solver.cc
@@ -36,8 +36,9 @@ void ConstructClpModel(
                      nullptr /* rowObjective=nullptr */);
   if (quadratic_matrix.nonZeros() > 0) {
     static const logging::Warn log_once(
-        "Currently CLP solver has a memory issue when solving a QP. The user "
-        "should be aware of this risk.");
+        "Drake does not officially support using CLP to solve QPs, as it may "
+        "fail to solve certain problems which are known to be feasible. The "
+        "user should be aware of this risk.");
     model->loadQuadraticObjective(
         quadratic_matrix.cols(), quadratic_matrix.outerIndexPtr(),
         quadratic_matrix.innerIndexPtr(), quadratic_matrix.valuePtr());


### PR DESCRIPTION
Give a more appropriate warning when a user tries to solve a QP with CLP. This serves as a band-aid for #22985 until we actually decide what to do about CLP and QPs.

@jwnimmer-tri maybe you could take feature review for this one, since you've been active in that discussion?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23199)
<!-- Reviewable:end -->
