### PR TITLE
Only ship relevant MOSEK licenses

### DIFF
--- a/tools/workspace/mosek/package.BUILD.bazel
+++ b/tools/workspace/mosek/package.BUILD.bazel
@@ -126,10 +126,14 @@ install_files(
 
 install(
     name = "install_licenses",
-    docs = [
-        "mosek-eula.pdf",
+    docs = select({
+        ":lazy_load": [],
+        "//conditions:default": [
+            "mosek-eula.pdf",
+            "@drake//tools/workspace/mosek:LICENSE.third_party",
+        ],
+    }) + [
         "@drake//tools/workspace/mosek:drake_mosek_redistribution.txt",
-        "@drake//tools/workspace/mosek:LICENSE.third_party",
     ],
     doc_strip_prefix = ["tools/workspace/mosek"],
     allowed_externals = ["@drake//:.bazelproject"],


### PR DESCRIPTION
When building against a MOSEK stub (i.e. wheels), which implies that we aren't shipping a copy of MOSEK but expecting the user to provide their own, also don't ship unnecessary MOSEK license files.