### PR TITLE
[multibody] Expose the JointOrdinal type and use it instead of a raw int.

### DIFF
--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -967,7 +967,8 @@ TEST_P(WeldedAndFloatingTest, ReactionForcesOrdinalIndexing) {
                                                    weld3_};
     const std::vector<JointIndex> expected_indices{
         JointIndex(4), JointIndex(5), JointIndex(2), JointIndex(3)};
-    const std::vector<int> expected_ordinals{2, 3, 0, 1};
+    const std::vector<JointOrdinal> expected_ordinals{
+        JointOrdinal(2), JointOrdinal(3), JointOrdinal(0), JointOrdinal(1)};
     for (int i = 0; i < 4; ++i) {
       EXPECT_EQ(joints[i]->index(), expected_indices[i]);
       EXPECT_EQ(joints[i]->ordinal(), expected_ordinals[i]);
@@ -991,7 +992,8 @@ TEST_P(WeldedAndFloatingTest, ReactionForcesOrdinalIndexing) {
                                                    weld2_, weld3_};
     const std::vector<JointIndex> expected_indices{
         JointIndex(0), JointIndex(1), JointIndex(2), JointIndex(3)};
-    const std::vector<int> expected_ordinals{0, 1, 2, 3};
+    const std::vector<JointOrdinal> expected_ordinals{
+        JointOrdinal(0), JointOrdinal(1), JointOrdinal(2), JointOrdinal(3)};
     for (int i = 0; i < 4; ++i) {
       EXPECT_EQ(joints[i]->index(), expected_indices[i]);
       EXPECT_EQ(joints[i]->ordinal(), expected_ordinals[i]);

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3644,8 +3644,8 @@ TEST_F(MultibodyPlantRemodeling, RemoveJoint) {
   // Validate that ordinals are assigned and updated contiguously.
   const Joint<double>& joint0 = plant_->get_joint(JointIndex(0));
   const Joint<double>& joint2 = plant_->get_joint(JointIndex(2));
-  EXPECT_EQ(joint0.ordinal(), 0);
-  EXPECT_EQ(joint2.ordinal(), 1);
+  EXPECT_EQ(joint0.ordinal(), JointOrdinal(0));
+  EXPECT_EQ(joint2.ordinal(), JointOrdinal(1));
 
   FinalizeAndBuild();
 
@@ -3668,9 +3668,9 @@ TEST_F(MultibodyPlantRemodeling, RemoveJoint) {
       plant_->GetJointByName<QuaternionFloatingJoint>("body1");
   EXPECT_EQ(body1_floating_joint.index(), JointIndex(3));
 
-  EXPECT_EQ(joint0.ordinal(), 0);
-  EXPECT_EQ(joint2.ordinal(), 1);
-  EXPECT_EQ(body1_floating_joint.ordinal(), 2);
+  EXPECT_EQ(joint0.ordinal(), JointOrdinal(0));
+  EXPECT_EQ(joint2.ordinal(), JointOrdinal(1));
+  EXPECT_EQ(body1_floating_joint.ordinal(), JointOrdinal(2));
 
   // Confirm that removed joint logic is preserved after cloning.
   std::unique_ptr<MultibodyPlant<double>> clone =
@@ -3687,9 +3687,9 @@ TEST_F(MultibodyPlantRemodeling, RemoveJoint) {
   EXPECT_THAT(
       clone->GetJointIndices(),
       testing::ElementsAre(JointIndex(0), JointIndex(2), JointIndex(3)));
-  EXPECT_EQ(clone->get_joint(JointIndex(0)).ordinal(), 0);
-  EXPECT_EQ(clone->get_joint(JointIndex(2)).ordinal(), 1);
-  EXPECT_EQ(clone->get_joint(JointIndex(3)).ordinal(), 2);
+  EXPECT_EQ(clone->get_joint(JointIndex(0)).ordinal(), JointOrdinal(0));
+  EXPECT_EQ(clone->get_joint(JointIndex(2)).ordinal(), JointOrdinal(1));
+  EXPECT_EQ(clone->get_joint(JointIndex(3)).ordinal(), JointOrdinal(2));
 }
 
 TEST_F(MultibodyPlantRemodeling, RemoveAndReplaceJoint) {
@@ -3703,7 +3703,7 @@ TEST_F(MultibodyPlantRemodeling, RemoveAndReplaceJoint) {
         "joint1", plant_->GetBodyByName("body0"), {},
         plant_->GetBodyByName("body1"), {}, Vector3d::UnitZ());
     EXPECT_EQ(joint1.index(), JointIndex(2 + i));
-    EXPECT_EQ(joint1.ordinal(), 2);
+    EXPECT_EQ(joint1.ordinal(), JointOrdinal(2));
     plant_->RemoveJoint(joint1);
   }
 
@@ -3727,9 +3727,9 @@ TEST_F(MultibodyPlantRemodeling, RemoveAndReplaceJoint) {
   // Validate that ordinals are assigned and updated contiguously.
   const Joint<double>& joint0 = plant_->get_joint(JointIndex(0));
   const Joint<double>& joint2 = plant_->get_joint(JointIndex(2));
-  EXPECT_EQ(joint0.ordinal(), 0);
-  EXPECT_EQ(joint2.ordinal(), 1);
-  EXPECT_EQ(joint1.ordinal(), 2);
+  EXPECT_EQ(joint0.ordinal(), JointOrdinal(0));
+  EXPECT_EQ(joint2.ordinal(), JointOrdinal(1));
+  EXPECT_EQ(joint1.ordinal(), JointOrdinal(2));
 
   FinalizeAndBuild();
 
@@ -3744,9 +3744,9 @@ TEST_F(MultibodyPlantRemodeling, RemoveAndReplaceJoint) {
   EXPECT_THAT(plant_->GetJointIndices(),
               testing::ElementsAre(JointIndex(0), JointIndex(2),
                                    JointIndex(2 + num_replacements)));
-  EXPECT_EQ(joint0.ordinal(), 0);
-  EXPECT_EQ(joint2.ordinal(), 1);
-  EXPECT_EQ(joint1.ordinal(), 2);
+  EXPECT_EQ(joint0.ordinal(), JointOrdinal(0));
+  EXPECT_EQ(joint2.ordinal(), JointOrdinal(1));
+  EXPECT_EQ(joint1.ordinal(), JointOrdinal(2));
 }
 
 TEST_F(MultibodyPlantRemodeling, RemoveJointWithActuator) {
@@ -3837,10 +3837,9 @@ class KukaArmTest : public ::testing::TestWithParam<double> {
     context_ = plant_->CreateDefaultContext();
   }
 
-  // Helper to set the multibody state x to x[i] = i for each i-th entry in the
-  // state vector.
-  // We use RevoluteJoint's methods to set the state in order to independently
-  // unit test the proper workings of
+  // Helper to set the multibody state x to x[i] = xc[i] for each i-th entry in
+  // the state vector. We use RevoluteJoint's methods to set the state in order
+  // to independently unit test the proper workings of
   // MultibodyTree::get_multibody_state_vector() and its mutable counterpart.
   void SetState(const VectorX<double>& xc) {
     const int nq = plant_->num_positions();

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -18,7 +18,6 @@ using LinkIndex = BodyIndex;
 class SpanningForest;
 
 using LinkOrdinal = TypeSafeIndex<class LinkOrdinalTag>;
-using JointOrdinal = TypeSafeIndex<class JointOrdinalTag>;
 
 using JointTraitsIndex = TypeSafeIndex<class JointTraitsTag>;
 using LinkCompositeIndex = TypeSafeIndex<class LinkCompositeTag>;

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -197,7 +197,9 @@ class Joint : public MultibodyElement<T> {
   /// thus a set of joints sorted by ordinal has the same ordering as if it were
   /// sorted by JointIndex. If joints have been removed from the plant, do *not*
   /// use index() to access contiguous containers with entries per Joint.
-  int ordinal() const { return this->ordinal_impl(); }
+  JointOrdinal ordinal() const {
+    return this->template ordinal_impl<JointOrdinal>();
+  }
 
   /// Returns the name of this joint.
   const std::string& name() const { return name_; }

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -120,9 +120,14 @@ class MultibodyElement {
   }
 
   /// Returns this element's unique ordinal.
-  int ordinal_impl() const {
+  /// @note The int64_t default is present for backwards compatibility but
+  /// you should not use it. Instead, define a ThingOrdinal specialization of
+  /// TypeSafeIndex for any element Thing that has a meaningful ordinal. Then
+  /// use that type explicitly in Thing's public `ordinal()` method.
+  template <typename ElementOrdinalType = int64_t>
+  ElementOrdinalType ordinal_impl() const {
     DRAKE_ASSERT(ordinal_ >= 0);
-    return ordinal_;
+    return ElementOrdinalType{ordinal_};
   }
 
   /// Returns a constant reference to the parent MultibodyTree that
@@ -216,7 +221,7 @@ class MultibodyElement {
     parent_tree_ = tree;
   }
 
-  void set_ordinal(int ordinal) { ordinal_ = ordinal; }
+  void set_ordinal(int64_t ordinal) { ordinal_ = ordinal; }
 
   void set_model_instance(ModelInstanceIndex model_instance) {
     model_instance_ = model_instance;
@@ -247,7 +252,7 @@ class MultibodyElement {
   // if MultibodyPlant does not expose any port that has an entry per concrete
   // MultibodyElement type.) This must be set to a valid ordinal value before
   // the element is released to the wild.
-  int ordinal_{-1};
+  int64_t ordinal_{-1};
 
   // The default model instance id is *invalid*. This must be set to a
   // valid index value before the element is released to the wild.

--- a/multibody/tree/multibody_tree_indexes.h
+++ b/multibody/tree/multibody_tree_indexes.h
@@ -41,6 +41,9 @@ using ForceElementIndex = TypeSafeIndex<class ForceElementTag>;
 /// Type used to identify joints by index within a multibody plant.
 using JointIndex = TypeSafeIndex<class JointElementTag>;
 
+/// Type used to identify joints by ordinal within a multibody plant.
+using JointOrdinal = TypeSafeIndex<class JointOrdinalTag>;
+
 /// Type used to identify actuators by index within a multibody plant.
 using JointActuatorIndex = TypeSafeIndex<class JointActuatorElementTag>;
 


### PR DESCRIPTION
(Tech debt cleanup)
### Background
Because Joints are removable, we have both the persistent JointIndex and possibly-changing JointOrdinal for each Joint (both of those are TypeSafeIndex specializations). Code in `multibody/topology` uses both types but code in `multibody/tree` is using just a raw int for JointOrdinal.

### Proposed change
This PR promotes JointOrdinal from `drake::multibody::internal` to `drake::multibody` and uses it where needed in MbT.

### Compatibility note
The return type of the MbP public method `Joint::ordinal()` is changed here from int to JointOrdinal. However, all TypeSafeIndex specializations have an implicit conversion to int64_t so any place where joint.ordinal() is used as an index (into reaction force results, e.g.) it still works unchanged. The reverse conversion of int to JointOrdinal must now be explicit; however, only internal code and unit tests of that code need to generate JointOrdinals from ints so I do not anticipate any user code needing to change. Nevertheless this is hypothetically a breaking change so should be noted that way in the release notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23214)
<!-- Reviewable:end -->
