### PR TITLE
Add a getter for `parent_frame` in FixedOffsetFrame

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -5543,6 +5543,8 @@ GTEST_TEST(MultibodyPlantTests, FixedOffsetFrameFunctions) {
   RigidTransformd X_BP_check2 = frame_P.CalcPoseInBodyFrame(*context);
   EXPECT_TRUE(X_BP_check1.IsNearlyEqualTo(X_BP, kTolerance));
   EXPECT_TRUE(X_BP_check2.IsNearlyEqualTo(X_BP, kTolerance));
+  // Verify parent frame is body_B's frame
+  EXPECT_EQ(frame_P.parent_frame().index(), body_B.body_frame().index());
 
   // Verify frame P's pose in world W.
   RigidTransformd X_WP = X_WWp * X_WpP;

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -94,6 +94,11 @@ class FixedOffsetFrame final : public Frame<T> {
     return parent_frame_.GetFixedRotationMatrixInBody(R_PF.cast<T>());
   }
 
+  /// @returns The parent frame to which this frame is attached.
+  const Frame<T>& parent_frame() const {
+    return parent_frame_;
+  }
+
  protected:
   /// @pre The parent frame to this frame already has a clone in `tree_clone`.
   std::unique_ptr<Frame<double>> DoCloneToScalar(

--- a/multibody/tree/fixed_offset_frame.h
+++ b/multibody/tree/fixed_offset_frame.h
@@ -95,9 +95,7 @@ class FixedOffsetFrame final : public Frame<T> {
   }
 
   /// @returns The parent frame to which this frame is attached.
-  const Frame<T>& parent_frame() const {
-    return parent_frame_;
-  }
+  const Frame<T>& parent_frame() const { return parent_frame_; }
 
  protected:
   /// @pre The parent frame to this frame already has a clone in `tree_clone`.


### PR DESCRIPTION
For `FixedOffsetFrame`, parent frame variable `parent_frame_` is encapsulated and there is no easy way to get it- adding a constant getter so one can use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23221)
<!-- Reviewable:end -->
