### PR TITLE
[workspace] Upgrade curl_internal to latest release curl-8_15_0

### DIFF
--- a/tools/workspace/curl_internal/repository.bzl
+++ b/tools/workspace/curl_internal/repository.bzl
@@ -10,8 +10,8 @@ def curl_internal_repository(
         In case of a cmake_configure_file build error when upgrading curl,
         update cmakedefines.bzl to match the new upstream definitions.
         """,
-        commit = "curl-8_14_1",
-        sha256 = "6cf947ec831e8522b30d7fa8784ce5fcdf1f21581111861d82085a2729c59ba9",  # noqa
+        commit = "curl-8_15_0",
+        sha256 = "2937cadde007aa3a52a17c21ac9153ea054700f37926d1d96602bf07e888c847",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/base64_definition.patch",


### PR DESCRIPTION
Towards #23226 

Relevant error log:

```
ERROR: Traceback (most recent call last):
	File "/home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/d8f67396fa92625d9dd7f1218b66f6d2/external/+internal_repositories+curl_internal/BUILD.bazel", line 167, column 24, in <toplevel>
		check_lists_consistency(
	File "/home/local/KHQ/aiden.mccormack/drake-aiden2244/drake/tools/workspace/check_lists_consistency.bzl", line 24, column 13, in check_lists_consistency
		fail("The following files matched a glob of upstream sources, but " +
Error in fail: The following files matched a glob of upstream sources, but were not covered by the package.BUILD.bazel file: ["lib/curlx/inet_ntop.c", "lib/curlx/wait.c"]
```