### PR TITLE
[deformable] Enable deformable body collision filtering via MbP and parsing

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -500,7 +500,7 @@ drake_cc_googletest(
 filegroup(
     name = "process_model_directives_test_models",
     testonly = True,
-    data = glob(["test/process_model_directives_test/**"]),
+    data = glob(["test/process_model_directives_test/**"]) + [":test_models"],
     visibility = ["//bindings/pydrake/multibody:__pkg__"],
 )
 

--- a/multibody/parsing/detail_collision_filter_group_resolver.cc
+++ b/multibody/parsing/detail_collision_filter_group_resolver.cc
@@ -62,7 +62,11 @@ void CollisionFilterGroupResolver::AddGroup(
     const ScopedName scoped_body_name =
         ScopedName::Parse(FullyQualify(body_name, model_instance));
 
+    // The body name may refer to a rigid body or a deformable body. If the same
+    // scoped name exists as rigid and deformable in the model, then this code
+    // simply selects the rigid body.
     const RigidBody<double>* body{};
+    const DeformableBody<double>* deformable_body{};
     if (plant_->HasModelInstanceNamed(scoped_body_name.get_namespace())) {
       ModelInstanceIndex body_model =
           plant_->GetModelInstanceByName(scoped_body_name.get_namespace());
@@ -73,14 +77,28 @@ void CollisionFilterGroupResolver::AddGroup(
         continue;
       }
       body = FindBody(scoped_body_name.get_element(), body_model);
+      deformable_body = FindDeformableBody(
+          std::string(scoped_body_name.get_element()), body_model);
     }
-    if (!body) {
+
+    if (body && deformable_body) {
+      diagnostic.Error(
+          fmt::format("body name '{}' is ambiguous, refers to both a rigid and "
+                      "deformable body",
+                      scoped_body_name));
+      continue;
+    } else if (!body && !deformable_body) {
       diagnostic.Error(
           fmt::format("body with name '{}' not found", scoped_body_name));
       continue;
     }
+
     full_names.insert(std::string(scoped_body_name.get_full()));
-    geometry_set.Add(plant_->GetBodyFrameIdOrThrow(body->index()));
+    if (body) {
+      geometry_set.Add(plant_->GetBodyFrameIdOrThrow(body->index()));
+    } else if (deformable_body) {
+      geometry_set.Add(deformable_body->geometry_id());
+    }
   }
   groups_.insert({full_group_name, {full_names, geometry_set}});
 
@@ -273,6 +291,16 @@ const RigidBody<double>* CollisionFilterGroupResolver::FindBody(
     std::string_view name, ModelInstanceIndex model_instance) const {
   if (plant_->HasBodyNamed(name, model_instance)) {
     return &plant_->GetBodyByName(name, model_instance);
+  }
+  return {};
+}
+
+const DeformableBody<double>* CollisionFilterGroupResolver::FindDeformableBody(
+    std::string name, ModelInstanceIndex model_instance) const {
+  const auto& deformable_model = plant_->deformable_model();
+
+  if (deformable_model.HasBodyNamed(name, model_instance)) {
+    return &deformable_model.GetBodyByName(name, model_instance);
   }
   return {};
 }

--- a/multibody/parsing/detail_collision_filter_group_resolver.h
+++ b/multibody/parsing/detail_collision_filter_group_resolver.h
@@ -72,8 +72,8 @@ class CollisionFilterGroupResolver {
   }
 
   // Adds a collision filter group. Locates bodies by name immediately, and
-  // emits errors for illegal names, empty groups, missing bodies, or duplicate
-  // group definition attempts.
+  // emits errors for illegal or ambiguous names, empty groups, missing bodies,
+  // or duplicate group definition attempts.
   //
   // @param diagnostic          The error-reporting channel.
   // @param group_name          The name of the group being defined.
@@ -134,6 +134,8 @@ class CollisionFilterGroupResolver {
 
   const RigidBody<double>* FindBody(std::string_view name,
                                     ModelInstanceIndex model_instance) const;
+  const DeformableBody<double>* FindDeformableBody(
+      std::string name, ModelInstanceIndex model_instance) const;
 
   MultibodyPlant<double>* const plant_;
 

--- a/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
+++ b/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
@@ -15,7 +15,9 @@ namespace {
 using ::testing::MatchesRegex;
 
 using geometry::GeometryId;
+using geometry::GeometryInstance;
 using geometry::SceneGraph;
+using geometry::Sphere;
 using math::RigidTransformd;
 
 class CollisionFilterGroupResolverTest : public test::DiagnosticPolicyTestBase {
@@ -34,7 +36,7 @@ class CollisionFilterGroupResolverTest : public test::DiagnosticPolicyTestBase {
   }
 
  protected:
-  MultibodyPlant<double> plant_{0.0};
+  MultibodyPlant<double> plant_{0.01};
   SceneGraph<double> scene_graph_;
   const geometry::SceneGraphInspector<double>& inspector_{
       scene_graph_.model_inspector()};
@@ -163,6 +165,28 @@ TEST_F(CollisionFilterGroupResolverTest, MissingMemberGroupScoped) {
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::agroup'.*not found"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::sub::agroup'.*not found"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::zzz::agroup'.*not found"));
+}
+
+TEST_F(CollisionFilterGroupResolverTest, AmbiguousRigidAndDeformableName) {
+  ModelInstanceIndex model = plant_.AddModelInstance("amodel");
+
+  // Add a rigid body to the model.
+  AddBody("abody", model);
+
+  // Add a deformable body to the model with the same name.
+  auto& deformable_model = plant_.mutable_deformable_model();
+  auto sphere = std::make_unique<GeometryInstance>(
+      math::RigidTransformd::Identity(), std::make_unique<Sphere>(1.0),
+      "abody");
+  deformable_model.RegisterDeformableBody(std::move(sphere), model,
+                                          /*config=*/{},
+                                          /*resolution_hint=*/2.0);
+
+  // Ensure that the resolver catches the ambiguous name in the group body
+  // names.
+  resolver_.AddGroup(diagnostic_policy_, "a", {"abody"}, {}, model);
+  EXPECT_THAT(TakeError(),
+              MatchesRegex(".*body.*'amodel::abody'.*is ambiguous.*"));
 }
 
 TEST_F(CollisionFilterGroupResolverTest, GroupGlobalBodies) {

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -437,6 +437,57 @@ GTEST_TEST(ProcessModelDirectivesTest, DefaultPositions) {
       0.2);
 }
 
+// Test that collision filter groups can contain both rigid and deformable
+// bodies.
+GTEST_TEST(ProcessModelDirectivesTest,
+           CollisionFilterGroupMixRigidAndDeformable) {
+  std::string kDmdYaml = R"""(
+directives:
+
+- add_model:
+    name: rigid
+    file: package://process_model_directives_test/simple_model.sdf
+
+- add_model:
+    name: deformable_1
+    file: package://process_model_directives_test/deformable_model.sdf
+
+- add_model:
+    name: deformable_2
+    file: package://process_model_directives_test/deformable_model.sdf
+
+- add_collision_filter_group:
+    name: rigid_and_deformable
+    members: [rigid::base, deformable_1::body]
+    ignored_collision_filter_groups: [rigid_and_deformable]
+
+- add_collision_filter_group:
+    name: deformable_and_deformable
+    members: [deformable_1::body, deformable_2::body]
+    ignored_collision_filter_groups: [deformable_and_deformable]
+)""";
+
+  ModelDirectives directives = LoadModelDirectivesFromString(kDmdYaml);
+
+  DiagramBuilder<double> builder;
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.01);
+  auto parser = make_parser(&plant);
+  ProcessModelDirectives(directives, &plant, nullptr, parser.get());
+
+  // Make sure the plant is not finalized such that the Finalize() default
+  // filtering has not taken into effect yet. This guarantees that the
+  // collision filtering is applied due to the collision filter group parsing.
+  ASSERT_FALSE(plant.is_finalized());
+
+  std::set<CollisionPair> expected_filters = {
+      // From group 'rigid_and_deformable'.
+      {"rigid::collision", "deformable_1::body"},
+      // From group 'deformable_and_deformable'.
+      {"deformable_1::body", "deformable_2::body"},
+  };
+  VerifyCollisionFilters(scene_graph, expected_filters);
+}
+
 // Make sure we have good error messages.
 GTEST_TEST(ProcessModelDirectivesTest, ErrorMessages) {
   // When the user gives a bogus filename, at minimum we must echo it back to

--- a/multibody/parsing/test/process_model_directives_test/deformable_model.sdf
+++ b/multibody/parsing/test/process_model_directives_test/deformable_model.sdf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<sdf xmlns:drake="http://drake.mit.edu" version="1.7">
+  <model name='deformable'>
+    <link name='body'>
+      <collision name='collision'>
+        <geometry>
+          <mesh>
+            <uri>package://drake/multibody/parsing/test/single_tet.vtk</uri>
+          </mesh>
+        </geometry>
+      </collision>
+      <drake:deformable_properties></drake:deformable_properties>
+    </link>
+  </model>
+</sdf>

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1753,11 +1753,11 @@ void MultibodyPlant<T>::ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
 
   if (collision_filter_group_a.first == collision_filter_group_b.first) {
     scene_graph_->collision_filter_manager().Apply(
-        CollisionFilterDeclaration(CollisionFilterScope::kOmitDeformable)
+        CollisionFilterDeclaration(CollisionFilterScope::kAll)
             .ExcludeWithin(collision_filter_group_a.second));
   } else {
     scene_graph_->collision_filter_manager().Apply(
-        CollisionFilterDeclaration(CollisionFilterScope::kOmitDeformable)
+        CollisionFilterDeclaration(CollisionFilterScope::kAll)
             .ExcludeBetween(collision_filter_group_a.second,
                             collision_filter_group_b.second));
   }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -947,8 +947,11 @@ call to Finalize() must be performed. This call will:
 - declare collision filters to ignore collisions among rigid bodies:
   - between rigid bodies connected by a joint,
   - within subgraphs of welded rigid bodies.
-Note that MultibodyPlant will *not* introduce *any* collision filters
-on deformable bodies.
+
+Note that MultibodyPlant will *not* introduce any automatic collision filters on
+deformable bodies. Collision filters for deformable bodies can be explicitly
+applied via ExcludeCollisionGeometriesWithCollisionFilterGroupPair() or during
+parsing.
 
 <!-- TODO(amcastro-tri): Consider making the actual geometry registration
      with GS AFTER Finalize() so that we can tell if there are any bodies
@@ -2402,9 +2405,8 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const std::vector<geometry::GeometryId>& GetCollisionGeometriesForBody(
       const RigidBody<T>& body) const;
 
-  /// Excludes the rigid collision geometries between two given collision filter
-  /// groups. Note that collisions involving deformable geometries are not
-  /// filtered by this function.
+  /// Excludes the collision geometries between two given collision filter
+  /// groups.
   /// @pre RegisterAsSourceForSceneGraph() has been called.
   /// @pre Finalize() has *not* been called.
   void ExcludeCollisionGeometriesWithCollisionFilterGroupPair(

--- a/multibody/plant/test/deformable_collision_filter_test.cc
+++ b/multibody/plant/test/deformable_collision_filter_test.cc
@@ -1,5 +1,7 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/sorted_pair.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/plant/deformable_model.h"
@@ -29,9 +31,8 @@ class DeformableCollisionFilterTest : public ::testing::Test {
   /* Sets up a scene with a deformable sphere intersecting two rigid bodies, one
    welded to the world and the other free. */
   void SetUp() override {
-    systems::DiagramBuilder<double> builder;
     std::tie(plant_, scene_graph_) =
-        AddMultibodyPlantSceneGraph(&builder, 0.01);
+        AddMultibodyPlantSceneGraph(&builder_, 0.01);
     DeformableModel<double>& deformable_model =
         plant_->mutable_deformable_model();
     DeformableBodyId deformable_body_id =
@@ -71,33 +72,6 @@ class DeformableCollisionFilterTest : public ::testing::Test {
     free_geometry_id_ = plant_->RegisterCollisionGeometry(
         free_body, RigidTransformd(Vector3d(0.75, 0, 0)), box, "free",
         proximity_prop);
-
-    /* ExcludeCollisionGeometriesWithCollisionFilterGroupPair() is invoked
-     during parsing, but it still must adhere to MultibodyPlant's promise to
-     not introduce collision filters on deformable bodies. Rather than exercise
-     via parsing, we'll execute it here with some collision filters which
-     *explicitly* include the deformable body's geometry id. If the dut has
-     correct behavior (ignoring deformable geometries), there will be no
-     collision filters involving the deformable geometry. */
-    GeometrySet welded_and_deformable{deformable_geometry_id_,
-                                      welded_geometry_id_};
-    GeometrySet free_and_deformable{deformable_geometry_id_, free_geometry_id_};
-    std::pair<std::string, GeometrySet> collision_filter_group_a = {
-        "a", welded_and_deformable};
-    std::pair<std::string, GeometrySet> collision_filter_group_b = {
-        "b", free_and_deformable};
-    plant_->ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
-        collision_filter_group_a, collision_filter_group_a);
-    plant_->ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
-        collision_filter_group_a, collision_filter_group_b);
-    DRAKE_DEMAND(!scene_graph_->model_inspector().CollisionFiltered(
-        deformable_geometry_id_, welded_geometry_id_));
-    DRAKE_DEMAND(!scene_graph_->model_inspector().CollisionFiltered(
-        deformable_geometry_id_, free_geometry_id_));
-
-    plant_->Finalize();
-
-    diagram_ = builder.Build();
   }
 
   /* Registers a deformable octahedron with the given `name` in the world to the
@@ -137,19 +111,31 @@ class DeformableCollisionFilterTest : public ::testing::Test {
     return id;
   }
 
+  systems::DiagramBuilder<double> builder_;
   SceneGraph<double>* scene_graph_{nullptr};
   MultibodyPlant<double>* plant_{nullptr};
   GeometryId deformable_geometry_id_;
   GeometryId welded_geometry_id_;
   GeometryId free_geometry_id_;
-  std::unique_ptr<systems::Diagram<double>> diagram_{nullptr};
 };
 
-/* Tests that the default collision filters applied in MbP do not affect
- deformable bodies. That is, the deformable body is in contact with both rigid
- geometries. */
+/* Tests that multiple deformable bodies, which are adjacent to each other as
+ children of the world body, are not automatically filtered. */
 TEST_F(DeformableCollisionFilterTest, DefaultMbPFilterIgnoresDeformable) {
-  auto diagram_context = diagram_->CreateDefaultContext();
+  /* Add a second deformable body to the scene which is in contact with the
+   other rigid and deformable bodies. */
+  DeformableModel<double>& deformable_model =
+      plant_->mutable_deformable_model();
+  DeformableBodyId other_deformable_body_id =
+      RegisterDeformableOctahedron(&deformable_model, "other_deformable");
+  GeometryId other_deformable_geometry_id =
+      deformable_model.GetGeometryId(other_deformable_body_id);
+
+  /* Contact detection not allowed pre-Finalize. */
+  plant_->Finalize();
+  auto diagram = builder_.Build();
+
+  auto diagram_context = diagram->CreateDefaultContext();
   const auto& scene_graph_context =
       scene_graph_->GetMyContextFromRoot(*diagram_context);
   const QueryObject<double>& query_object =
@@ -157,19 +143,76 @@ TEST_F(DeformableCollisionFilterTest, DefaultMbPFilterIgnoresDeformable) {
           scene_graph_context);
   geometry::internal::DeformableContact<double> deformable_contact;
   query_object.ComputeDeformableContact(&deformable_contact);
-  /* Both rigid geometries should still be in collision with the deformable
-   geometry. */
-  EXPECT_EQ(deformable_contact.contact_surfaces().size(), 2);
+  /* No contacts are filtered, so each deformable contacts the other and both of
+   the rigid bodies. The rigid bodies do not contact each other due to their
+   placement. */
+  EXPECT_EQ(deformable_contact.contact_surfaces().size(), 5);
+
+  std::unordered_set<SortedPair<GeometryId>> expected_pairs = {
+      {deformable_geometry_id_, welded_geometry_id_},
+      {deformable_geometry_id_, free_geometry_id_},
+      {deformable_geometry_id_, other_deformable_geometry_id},
+      {other_deformable_geometry_id, welded_geometry_id_},
+      {other_deformable_geometry_id, free_geometry_id_},
+  };
+
+  std::unordered_set<SortedPair<GeometryId>> actual_pairs = {};
+  for (const auto& contact_surface : deformable_contact.contact_surfaces()) {
+    actual_pairs.insert({contact_surface.id_A(), contact_surface.id_B()});
+  }
+
+  EXPECT_THAT(expected_pairs, ::testing::ContainerEq(actual_pairs));
+}
+
+/* Tests that applying collision filters directly to the MbP via the
+ ExcludeCollisionGeometriesWithCollisionFilterGroupPair() method does affect
+ deformable geometries. */
+TEST_F(DeformableCollisionFilterTest, ExplicitlyFilterDeformableOnPlant) {
+  GeometrySet welded_and_deformable{deformable_geometry_id_,
+                                    welded_geometry_id_};
+  GeometrySet free_and_deformable{deformable_geometry_id_, free_geometry_id_};
+  std::pair<std::string, GeometrySet> collision_filter_group_a = {
+      "a", welded_and_deformable};
+  std::pair<std::string, GeometrySet> collision_filter_group_b = {
+      "b", free_and_deformable};
+  plant_->ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
+      collision_filter_group_a, collision_filter_group_a);
+  plant_->ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
+      collision_filter_group_a, collision_filter_group_b);
+  DRAKE_DEMAND(scene_graph_->model_inspector().CollisionFiltered(
+      deformable_geometry_id_, welded_geometry_id_));
+  DRAKE_DEMAND(scene_graph_->model_inspector().CollisionFiltered(
+      deformable_geometry_id_, free_geometry_id_));
+
+  /* Contact detection not allowed pre-Finalize. */
+  plant_->Finalize();
+  auto diagram = builder_.Build();
+
+  auto diagram_context = diagram->CreateDefaultContext();
+  const auto& scene_graph_context =
+      scene_graph_->GetMyContextFromRoot(*diagram_context);
+  const QueryObject<double>& query_object =
+      scene_graph_->get_query_output_port().Eval<QueryObject<double>>(
+          scene_graph_context);
+  geometry::internal::DeformableContact<double> deformable_contact;
+  query_object.ComputeDeformableContact(&deformable_contact);
+  /* All deformable contacts are filtered by the plant collision exclusion. */
+  EXPECT_EQ(deformable_contact.contact_surfaces().size(), 0);
 }
 
 /* Tests collision filter has an effect on deformable geometries if a collision
  filter is declared on the deformable geometry with the appropriate scope. */
 TEST_F(DeformableCollisionFilterTest, ExplicitlyFilterDeformable) {
+  /* Collision filter declaration and contact detection not allowed
+   pre-Finalize. */
+  plant_->Finalize();
+  auto diagram = builder_.Build();
+
   scene_graph_->collision_filter_manager().Apply(
       CollisionFilterDeclaration(CollisionFilterScope::kAll)
           .ExcludeBetween(GeometrySet(deformable_geometry_id_),
                           GeometrySet(welded_geometry_id_)));
-  auto diagram_context = diagram_->CreateDefaultContext();
+  auto diagram_context = diagram->CreateDefaultContext();
   const auto& scene_graph_context =
       scene_graph_->GetMyContextFromRoot(*diagram_context);
   const QueryObject<double>& query_object =
@@ -189,11 +232,16 @@ TEST_F(DeformableCollisionFilterTest, ExplicitlyFilterDeformable) {
  filter is declared on the deformable geometry with the omit deformable scope.
  */
 TEST_F(DeformableCollisionFilterTest, ExplicitlyFilterDeformableWrongScope) {
+  /* Collision filter declaration and contact detection not allowed
+   pre-Finalize. */
+  plant_->Finalize();
+  auto diagram = builder_.Build();
+
   scene_graph_->collision_filter_manager().Apply(
       CollisionFilterDeclaration(CollisionFilterScope::kOmitDeformable)
           .ExcludeBetween(GeometrySet(deformable_geometry_id_),
                           GeometrySet(welded_geometry_id_)));
-  auto diagram_context = diagram_->CreateDefaultContext();
+  auto diagram_context = diagram->CreateDefaultContext();
   const auto& scene_graph_context =
       scene_graph_->GetMyContextFromRoot(*diagram_context);
   const QueryObject<double>& query_object =


### PR DESCRIPTION
Allows collisions involving deformable bodies to be filtered via the MbP collision exclusion API and via collision filter groups in SDF or dmd files. Closes https://github.com/RobotLocomotion/drake/issues/22953.

**Primary design considerations:**
- When adding automatic collision filters for adjacent bodies during plant finalization, deformable bodies are ignored. All deformable bodies are children of the world body, so they are all adjacent and would otherwise have their collisions filtered. This is unchanged from the current behavior.
- Users can explicitly specify a collision filter involving deformable bodies either by `MultibodyPlant.ExcludeCollisionGeometriesWithCollisionFilterGroupPair()` or in the SDF file or dmd . This is changed from the current behavior.
    - The internal implementation to support this collision filtering already exists and is available to users by calling the `CollisionFilterManager`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23237)
<!-- Reviewable:end -->
