### PR TITLE
Revert "[tools] Use mold linker on Linux debug builds"

### DIFF
--- a/setup/ubuntu/source_distribution/packages-noble-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-noble-test-only.txt
@@ -1,6 +1,5 @@
 curl
 libstdc++6-10-dbg
-mold
 python3-dateutil
 python3-dbg
 python3-flask

--- a/tools/cc_toolchain/BUILD.bazel
+++ b/tools/cc_toolchain/BUILD.bazel
@@ -1,10 +1,5 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load(
-    "@bazel_skylib//rules:common_settings.bzl",
-    "bool_flag",
-    "int_flag",
-    "string_flag",
-)
+load("@bazel_skylib//rules:common_settings.bzl", "int_flag", "string_flag")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:sh.bzl", "sh_binary")
 
@@ -154,33 +149,6 @@ selects.config_setting_group(
 config_setting(
     name = "debug",
     values = {"compilation_mode": "dbg"},
-)
-
-# (Internal use only.)  When this is set to True, some Drake builds may use the
-# mold linker, primarily for its improved handling of DWARF debug
-# information. It should be False (the default) for all builds initiated via
-# Drake's CMake wrappers. See the other "mold_linker" settings below and issue
-# #21836.
-bool_flag(
-    name = "allow_mold_linker",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "mold_linker_allowed",
-    flag_values = {":allow_mold_linker": "True"},
-)
-
-selects.config_setting_group(
-    name = "use_mold_linker",
-    match_all = [
-        # TODO(rpoyner-tri): consider removing the "noble" requirement when
-        # Drake's support of "jammy" ends. Jammy is excluded because its
-        # version of the mold linker is too old.
-        "//tools:ubuntu_noble",
-        ":debug",
-        ":mold_linker_allowed",
-    ],
 )
 
 config_setting(

--- a/tools/cc_toolchain/bazel.rc
+++ b/tools/cc_toolchain/bazel.rc
@@ -9,11 +9,6 @@ build --action_env=CCACHE_DISABLE=1
 # command line, or promote *any* warnings even from externals to errors via
 # --copt=-Werror.
 #
-# When compiling Drake as an external package, this rcfile is not loaded and we
+# When compiilng Drake as an external package, this rcfile is not loaded and we
 # won't promote warnings to errors by default.
 build --@drake//tools/cc_toolchain:error_severity=error
-
-# Similarly, only allow using the mold linker when Drake is the main
-# module. Other conditions will be checked as well; see
-# //tools/cc_toolchain:use_mold_linker for more details.
-build --@drake//tools/cc_toolchain:allow_mold_linker=true

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -129,16 +129,6 @@ def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
         "//conditions:default": [],
     })
 
-# The BASE_LINKOPTS are used for all drake_cc_{binary,library,test} rules.
-BASE_LINKOPTS = select({
-    "@drake//tools/cc_toolchain:use_mold_linker": [
-        "-fuse-ld=mold",
-        "-Wl,--compress-debug-sections=zlib",
-        "-Wl,--thread-count=2",
-    ],
-    "//conditions:default": [],
-})
-
 def _check_library_deps_blacklist(name, deps):
     """Report an error if a library should not use something from deps."""
     if not deps:
@@ -606,7 +596,6 @@ def drake_cc_library(
         copts = [],
         clang_copts = [],
         gcc_copts = [],
-        linkopts = [],
         linkstatic = 1,
         internal = False,
         compile_once_per_scalar = False,
@@ -660,7 +649,6 @@ def drake_cc_library(
     should be surrounded with `#if DRAKE_ONCE_PER_SCALAR_PHASE == 0`.
     """
     new_copts = _platform_copts(copts, gcc_copts, clang_copts)
-    new_linkopts = BASE_LINKOPTS + linkopts
     new_tags = kwargs.pop("tags", None) or []
     if internal:
         if install_hdrs_exclude != []:
@@ -702,7 +690,6 @@ def drake_cc_library(
         deps = deps + add_deps,
         implementation_deps = implementation_deps,
         copts = new_copts,
-        linkopts = new_linkopts,
         linkstatic = linkstatic,
         declare_installed_headers = declare_installed_headers,
         install_hdrs_exclude = install_hdrs_exclude,
@@ -796,13 +783,11 @@ def drake_cc_binary(
     defaults using test_rule_args=["-f", "--bar=42"] or test_rule_size="baz".
     """
     new_copts = _platform_copts(copts, gcc_copts, clang_copts)
-    new_linkopts = BASE_LINKOPTS + linkopts
     new_srcs, add_deps = _maybe_add_pruned_private_hdrs_dep(
         base_name = name,
         srcs = srcs,
         deps = deps,
         copts = new_copts,
-        linkopts = new_linkopts,
         testonly = testonly,
         **kwargs
     )
@@ -816,7 +801,7 @@ def drake_cc_binary(
         testonly = testonly,
         linkshared = linkshared,
         linkstatic = linkstatic,
-        linkopts = new_linkopts,
+        linkopts = linkopts,
         features = [
             # We should deduplicate symbols while linking (for a ~6% reduction
             # in disk use), to conserve space in CI; see #18545 for details.
@@ -835,7 +820,6 @@ def drake_cc_binary(
             data = data + test_rule_data,
             deps = deps + add_deps,
             copts = copts,
-            linkopts = new_linkopts,
             gcc_copts = gcc_copts,
             size = test_rule_size,
             timeout = test_rule_timeout,
@@ -855,7 +839,6 @@ def drake_cc_test(
         copts = [],
         gcc_copts = [],
         clang_copts = [],
-        linkopts = [],
         allow_network = None,
         display = False,
         num_threads = None,
@@ -885,13 +868,11 @@ def drake_cc_test(
     kwargs = incorporate_display(kwargs, display = display)
     kwargs = incorporate_num_threads(kwargs, num_threads = num_threads)
     new_copts = _platform_copts(copts, gcc_copts, clang_copts, cc_test = 1)
-    new_linkopts = BASE_LINKOPTS + linkopts
     new_srcs, add_deps = _maybe_add_pruned_private_hdrs_dep(
         base_name = name,
         srcs = srcs,
         deps = deps,
         copts = new_copts,
-        linkopts = new_linkopts,
         **kwargs
     )
     cc_test(
@@ -901,7 +882,6 @@ def drake_cc_test(
         args = args,
         deps = deps + add_deps,
         copts = new_copts,
-        linkopts = new_linkopts,
         features = [
             # We should deduplicate symbols while linking (for a ~6% reduction
             # in disk use), to conserve space in CI; see #18545 for details.


### PR DESCRIPTION
Dear @rpoyner-tri ,

 The on-call build cop, @BetsyMcPhail,  believes that your PR #22951 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are: 
https://drake-jenkins.csail.mit.edu/job/linux-noble-gcc-bazel-experimental-debug/413
https://drake-jenkins.csail.mit.edu/job/linux-noble-gcc-bazel-experimental-debug/416
https://drake-jenkins.csail.mit.edu/job/linux-noble-gcc-bazel-experimental-debug/418

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23239)
<!-- Reviewable:end -->
