### PR TITLE
Add an L1 norm cost to MathematicalProgram using slack variables.

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -742,6 +742,10 @@ void BindMathematicalProgram(py::module m) {
           &MathematicalProgram::AddL2NormCostUsingConicConstraint, py::arg("A"),
           py::arg("b"), py::arg("vars"),
           doc.MathematicalProgram.AddL2NormCostUsingConicConstraint.doc)
+      .def("AddL1NormCostInEpigraphForm",
+          &MathematicalProgram::AddL1NormCostInEpigraphForm, py::arg("A"),
+          py::arg("b"), py::arg("vars"),
+          doc.MathematicalProgram.AddL1NormCostInEpigraphForm.doc)
       .def("AddMaximizeLogDeterminantCost",
           static_cast<std::tuple<Binding<LinearCost>,
               VectorX<symbolic::Variable>, MatrixX<symbolic::Expression>> (

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1118,6 +1118,17 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(len(prog.lorentz_cone_constraints()), 1)
         self.assertEqual(prog.num_vars(), 3)
 
+    def test_add_l1norm_cost_in_epigraph_form(self):
+        prog = mp.MathematicalProgram()
+        x = prog.NewContinuousVariables(2, "x")
+        s, linear_cost, linear_constraint = \
+            prog.AddL1NormCostInEpigraphForm(
+                A=np.array([[1, 2.], [3., 4]]),
+                b=np.array([1., 2.]), vars=x)
+        self.assertEqual(len(prog.linear_costs()), 1)
+        self.assertEqual(len(prog.linear_constraints()), 1)
+        self.assertEqual(prog.num_vars(), 4)
+
     def test_addcost_shared_ptr(self):
         # In particular, confirm that LinearCost ends up in linear_costs, etc.
         # as opposed to everything ending up as a generic_cost.

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -600,6 +600,40 @@ MathematicalProgram::AddL2NormCostUsingConicConstraint(
   return std::make_tuple(s, linear_cost, lorentz_cone_constraint);
 }
 
+std::tuple<VectorX<symbolic::Variable>, Binding<LinearCost>,
+           Binding<LinearConstraint>>
+MathematicalProgram::AddL1NormCostInEpigraphForm(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::VectorXd>& b,
+    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+  auto s = this->NewContinuousVariables(A.rows(), "l1_norm_cost_epigraph");
+  // We want to encode s >= Ax+b and s >= -(Ax+b), with a cost Σᵢsᵢ on s. This
+  // can be written as:
+  //   A_full = [-I  A]
+  //            [-I -A]
+  //   ub = [-b]
+  //        [ b]
+  // A_full * vars <= ub
+  // for variables [s; vars]
+  auto linear_cost = this->AddLinearCost(Eigen::VectorXd::Ones(A.rows()), 0, s);
+
+  Eigen::MatrixXd I = Eigen::MatrixXd::Identity(A.rows(), A.rows());
+  Eigen::MatrixXd A_full(2 * A.rows(), A.rows() + A.cols());
+  A_full.topRows(A.rows()) << -I, A;
+  A_full.bottomRows(A.rows()) << -I, -A;
+
+  Eigen::VectorXd lb = Eigen::VectorXd::Constant(
+      2 * A.rows(), -std::numeric_limits<double>::infinity());
+  Eigen::VectorXd ub(2 * A.rows());
+  ub.head(A.rows()) = -b;
+  ub.tail(A.rows()) = b;
+
+  solvers::VectorXDecisionVariable all_vars(s.size() + vars.size());
+  all_vars << s, vars;
+  auto linear_constraint = this->AddLinearConstraint(A_full, lb, ub, all_vars);
+  return std::make_tuple(s, linear_cost, linear_constraint);
+}
+
 Binding<PolynomialCost> MathematicalProgram::AddPolynomialCost(
     const Expression& e) {
   auto binding = AddCost(internal::ParsePolynomialCost(e));

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1233,6 +1233,21 @@ class MathematicalProgram {
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
 
   /**
+   * Adds an L1 norm cost min |Ax+b|₁ as a linear cost min Σᵢsᵢ on the slack
+   * variables sᵢ, together with the constraints (for each i) sᵢ ≥ (|Ax+b|)ᵢ,
+   * which itself is written sᵢ ≥ (Ax+b)ᵢ and sᵢ ≥ -(Ax+b)ᵢ.
+   * @return (s, linear_cost, linear_constraint). `s` is the vector of slack
+   * variables, `linear_cost` is the cost on `s`, and `linear_constraint` is the
+   * constraint encoding s ≥ Ax+b and s ≥ -(Ax+b).
+   */
+  std::tuple<VectorX<symbolic::Variable>, Binding<LinearCost>,
+             Binding<LinearConstraint>>
+  AddL1NormCostInEpigraphForm(
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const VectorXDecisionVariable>& vars);
+
+  /**
    * Adds a cost term in the polynomial form.
    * @param e A symbolic expression in the polynomial form.
    * @return The newly created cost and the bound variables.


### PR DESCRIPTION
Note that the existing L1NormCost object is treated as a generic cost, so you can't use it with solvers like Gurobi.

+@alexandreamice for feature review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23241)
<!-- Reviewable:end -->
