### PR TITLE
Remove MOSEK from wheel

### DIFF
--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -129,6 +129,16 @@ python setup.py bdist_wheel
 
 if [[ "$(uname)" == "Darwin" ]]; then
     delocate-wheel -w wheelhouse -v dist/drake*.whl
+
+    # Remove libmosek from wheels
+    for w in dist/drake*.whl; do
+        zip --delete "$w" 'pydrake/lib/libmosek*'
+        change_lpath \
+            --wheel="$w" \
+            --old='@loader_path/libmosek' \
+            --new='@loader_path/../../mosek/libmosek' \
+            pydrake/lib/libdrake.so
+    done
 else
     GLIBC_VERSION=$(ldd --version | sed -n '1{s/.* //;s/[.]/_/p}')
 

--- a/tools/wheel/macos/change_lpath.py
+++ b/tools/wheel/macos/change_lpath.py
@@ -1,14 +1,50 @@
 """
 Given an input artifact (binary or library), apply a specified change to the
-path prefix of all libraries to which the artifact is linked.
+path prefix of all libraries to which the artifact is linked. The input can
+also be an artifact inside a wheel.
 """
 
 import argparse
+import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+import zipfile
 
 from tools.install import otool
+
+
+def _extract(wheel, path):
+    """
+    Extracts a file from a wheel (zipfile) and returns it as a TemporaryFile.
+    """
+    with zipfile.ZipFile(wheel, 'r') as zf:
+        tf = tempfile.NamedTemporaryFile()
+        shutil.copyfileobj(zf.open(path, 'r'), tf)
+        tf.flush()
+
+        return tf
+
+
+def _replace(wheel, path, content):
+    """
+    Replace a file in a wheel (zipfile) with the contents of a file-like
+    object.
+    """
+    tf = tempfile.NamedTemporaryFile()
+
+    with zipfile.ZipFile(wheel, 'r') as zold:
+        with zipfile.ZipFile(tf, 'w', zipfile.ZIP_DEFLATED) as znew:
+            for item in zold.infolist():
+                if item.filename == path:
+                    content.seek(0)
+                    znew.writestr(path, content.read())
+                else:
+                    znew.writestr(item, zold.read(item.filename))
+
+    os.replace(wheel, tf.name)
 
 
 def _chlpath(path, libs, old, new):
@@ -41,6 +77,9 @@ def main(args):
         '--new', required=True,
         help='Replacement prefix')
     parser.add_argument(
+        '--wheel',
+        help='Modify a file inside the specified wheel.')
+    parser.add_argument(
         'library', nargs='+',
         help='Dynamic library to modify')
 
@@ -49,8 +88,18 @@ def main(args):
 
     # Get list of dependent libraries and modify their prefixes.
     for path in options.library:
-        libs = otool.linked_libraries(path)
-        _chlpath(path, libs=libs, old=options.old, new=options.new)
+        libfile = None
+        libpath = path
+
+        if options.wheel:
+            libfile = _extract(options.wheel, path)
+            libpath = libfile.name
+
+        libs = otool.linked_libraries(libpath)
+        _chlpath(libpath, libs=libs, old=options.old, new=options.new)
+
+        if options.wheel:
+            _replace(options.wheel, path, libfile)
 
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Modify macOS wheel build to remove the bundled MOSEK library and patch libdrake to point to the PyPI-supplied version instead.

Fixes #20296.