### PR TITLE
NLopt supports L2NormCost.

### DIFF
--- a/solvers/nlopt_solver_common.cc
+++ b/solvers/nlopt_solver_common.cc
@@ -33,7 +33,8 @@ bool NloptSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
           ProgramAttribute::kLorentzConeConstraint,
           ProgramAttribute::kRotatedLorentzConeConstraint,
           ProgramAttribute::kGenericCost, ProgramAttribute::kLinearCost,
-          ProgramAttribute::kQuadraticCost, ProgramAttribute::kCallback});
+          ProgramAttribute::kQuadraticCost, ProgramAttribute::kL2NormCost,
+          ProgramAttribute::kCallback});
   return AreRequiredAttributesSupported(prog.required_capabilities(),
                                         solver_capabilities.access());
 }

--- a/solvers/test/nlopt_solver_test.cc
+++ b/solvers/test/nlopt_solver_test.cc
@@ -81,6 +81,11 @@ TEST_F(QuadraticEqualityConstrainedProgram1, Test) {
                   false /* check dual */);
   }
 }
+
+GTEST_TEST(NloptSolverTest, TestL2NormCost) {
+  NloptSolver solver;
+  TestL2NormCost(solver, 1e-6);
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
NLopt supports generic costs, so certainly it should be okay with and `L2NormCost`. The new test case verifies this is fine.

+@alexandreamice for feature review