### PR TITLE
Work around test error in coverage builds (kcov 339)

### DIFF
--- a/multibody/tree/test/multibody_forces_test.cc
+++ b/multibody/tree/test/multibody_forces_test.cc
@@ -15,6 +15,7 @@
 
 namespace drake {
 namespace multibody {
+namespace kcov339_avoidance_magic {
 namespace {
 
 using Eigen::Vector2d;
@@ -122,5 +123,6 @@ TEST_F(MultibodyForcesTests, NonZeroForces) {
 }
 
 }  // namespace
+}  // namespace kcov339_avoidance_magic
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Add a dummy namespcae to perturb the elf header.

Try same trick as https://github.com/RobotLocomotion/drake/pull/17071.

Fixes CI job: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-noble-gcc-bazel-nightly-coverage/50/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23256)
<!-- Reviewable:end -->
