### PR TITLE
[Jenkins] Fix reporting for cache server health

### DIFF
--- a/.jenkins/utils/utils.groovy
+++ b/.jenkins/utils/utils.groovy
@@ -58,7 +58,12 @@ def checkout(String ciSha = 'main', String drakeSha = null) {
 def doMainBuild(Map scmVars, String stagingReleaseVersion = null) {
   if (env.JOB_NAME.contains("cache-server-health-check")) {
     echo "Checking the cache server:"
-    sh "${env.WORKSPACE}/ci/cache_server/health_check.bash"
+    try {
+      sh "${env.WORKSPACE}/ci/cache_server/health_check.bash"
+    }
+    catch(exc) {
+      currentBuild.result = 'FAILURE'
+    }
   }
   else {
     withCredentials([


### PR DESCRIPTION
This one requires special logic because drake-ci doesn't output the same `RESULT` file.

Towards #22826.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23266)
<!-- Reviewable:end -->
