### PR TITLE
[multibody] Reduce dependency on MultibodyTreeTopology in favor of SpanningForest

### DIFF
--- a/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
+++ b/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
@@ -143,8 +143,8 @@ class DrakeKukaIIwaRobot {
 
     // For each body, set the pose and spatial velocity in the position,
     // velocity, and acceleration caches with specified values for testing.
-    multibody::internal::PositionKinematicsCache<T> pc(tree().get_topology());
-    multibody::internal::VelocityKinematicsCache<T> vc(tree().get_topology());
+    multibody::internal::PositionKinematicsCache<T> pc(tree().forest());
+    multibody::internal::VelocityKinematicsCache<T> vc(tree().forest());
 
     // Retrieve end-effector pose from position kinematics cache.
     tree().CalcPositionKinematicsCache(*context_, &pc);
@@ -190,10 +190,10 @@ class DrakeKukaIIwaRobot {
     SetJointAnglesAnd1stDerivatives(q.data(), qDt.data());
 
     // Get the position, velocity, and acceleration cache from the context.
-    multibody::internal::PositionKinematicsCache<T> pc(tree().get_topology());
-    multibody::internal::VelocityKinematicsCache<T> vc(tree().get_topology());
+    multibody::internal::PositionKinematicsCache<T> pc(tree().forest());
+    multibody::internal::VelocityKinematicsCache<T> vc(tree().forest());
     multibody::internal::AccelerationKinematicsCache<T> ac(
-        tree().get_topology());
+        tree().forest());
     tree().CalcPositionKinematicsCache(*context_, &pc);
     tree().CalcVelocityKinematicsCache(*context_, pc, &vc);
     tree().CalcAccelerationKinematicsCache(*context_, pc, vc, qDDt, &ac);

--- a/multibody/contact_solvers/sap/sap_tendon_constraint.h
+++ b/multibody/contact_solvers/sap/sap_tendon_constraint.h
@@ -38,8 +38,8 @@ struct SapTendonConstraintData {
  https://mujoco.readthedocs.io/en/stable/XMLreference.html#tendon-fixed
 
  Though inspired to provide the same capability its MuJoCo counterpart does,
- here we implement it in terms of the theory develped in [Castro et al. 2024],
- with a true phyiscal parameterization of compliance parameters. See dicussion
+ here we implement it in terms of the theory developed in [Castro et al. 2024],
+ with a true physical parameterization of compliance parameters. See discussion
  in Drake's issue #22664 for further information on artifacts introduced by
  MuJoCo, which we solve here.
 
@@ -50,7 +50,7 @@ struct SapTendonConstraintData {
  Where it is assumed that the components of `a` have units such that l(q) has
  units of either meters (m) or radians (rad).
 
- This class imposes a set of two uni-lateral constraints such that this length
+ This class imposes a set of two unilateral constraints such that this length
  stays within lower and upper limits, lₗ and lᵤ respectively:
 
    lₗ ≤ l(q) ≤ lᵤ

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -36,13 +36,13 @@ namespace internal {
 
 template <typename T>
 AccelerationsDueNonConstraintForcesCache<
-    T>::AccelerationsDueNonConstraintForcesCache(const MultibodyTreeTopology&
-                                                     topology)
-    : forces(topology.num_rigid_bodies(), topology.num_velocities()),
-      abic(topology),
-      Zb_Bo_W(topology.num_mobods()),
-      aba_forces(topology),
-      ac(topology) {}
+    T>::AccelerationsDueNonConstraintForcesCache(const internal::SpanningForest&
+                                                     forest)
+    : forces(forest.num_links(), forest.num_velocities()),
+      abic(forest),
+      Zb_Bo_W(forest.num_mobods()),
+      aba_forces(forest),
+      ac(forest) {}
 
 template <typename T>
 CompliantContactManager<T>::CompliantContactManager() = default;
@@ -90,7 +90,7 @@ void CompliantContactManager<T>::DoDeclareCacheEntries() {
   // We cache non-contact forces, ABA forces and accelerations into an
   // AccelerationsDueNonConstraintForcesCache.
   AccelerationsDueNonConstraintForcesCache<T>
-      non_constraint_forces_accelerations(this->internal_tree().get_topology());
+      non_constraint_forces_accelerations(this->internal_tree().forest());
   const auto& non_constraint_forces_accelerations_cache_entry =
       this->DeclareCacheEntry(
           "Non-constraint forces and induced accelerations.",

--- a/multibody/plant/compliant_contact_manager.h
+++ b/multibody/plant/compliant_contact_manager.h
@@ -37,7 +37,7 @@ struct AccelerationsDueNonConstraintForcesCache {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(
       AccelerationsDueNonConstraintForcesCache);
   explicit AccelerationsDueNonConstraintForcesCache(
-      const MultibodyTreeTopology& topology);
+      const internal::SpanningForest& forest);
   MultibodyForces<T> forces;  // The external forces causing accelerations.
   ArticulatedBodyInertiaCache<T> abic;   // Articulated body inertia cache.
   std::vector<SpatialForce<T>> Zb_Bo_W;  // Articulated body biases cache.

--- a/multibody/plant/discrete_step_memory.cc
+++ b/multibody/plant/discrete_step_memory.cc
@@ -5,16 +5,16 @@ namespace multibody {
 namespace internal {
 
 template <typename T>
-DiscreteStepMemory::Data<T>::Data(const MultibodyTreeTopology& topology)
-    : acceleration_kinematics_cache(topology) {}
+DiscreteStepMemory::Data<T>::Data(const internal::SpanningForest& forest)
+    : acceleration_kinematics_cache(forest) {}
 
 template <typename T>
 DiscreteStepMemory::Data<T>::~Data() = default;
 
 template <typename T>
 DiscreteStepMemory::Data<T>& DiscreteStepMemory::Allocate(
-    const MultibodyTreeTopology& topology) {
-  auto new_data = std::make_shared<Data<T>>(topology);
+    const internal::SpanningForest& forest) {
+  auto new_data = std::make_shared<Data<T>>(forest);
   Data<T>* result = new_data.get();
   data = std::move(new_data);
   return *result;

--- a/multibody/plant/discrete_step_memory.h
+++ b/multibody/plant/discrete_step_memory.h
@@ -39,7 +39,7 @@ struct DiscreteStepMemory {
     DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Data);
 
     /* The constructor requires the topology to pre-size things. */
-    explicit Data(const MultibodyTreeTopology& topology);
+    explicit Data(const internal::SpanningForest& forest);
 
     ~Data();
 
@@ -62,7 +62,7 @@ struct DiscreteStepMemory {
   Returns a mutable reference to the new data.
   @tparam_default_scalar */
   template <typename T>
-  Data<T>& Allocate(const MultibodyTreeTopology& topology);
+  Data<T>& Allocate(const internal::SpanningForest& forest);
 
   /* If this memory holds data for scalar type T, then returns a const pointer
   to the data. Otherwise, returns nullptr. */

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -240,6 +240,9 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
     return internal::GetInternalTree(this->plant()).get_topology();
   }
 
+  const internal::SpanningForest& forest() const {
+    return internal::GetInternalTree(this->plant()).forest();
+  }
   /* Returns the pointer to the DeformableDriver owned by `this` manager if one
    exists. Otherwise, returns nullptr. */
   const DeformableDriver<double>* deformable_driver() const {

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1313,20 +1313,27 @@ void MultibodyPlant<T>::CalcSpatialAccelerationsFromVdot(
   this->ValidateContext(context);
   DRAKE_THROW_UNLESS(A_WB_array != nullptr);
   DRAKE_THROW_UNLESS(ssize(*A_WB_array) == num_bodies());
-  internal_tree().CalcSpatialAccelerationsFromVdot(
-      context, internal_tree().EvalPositionKinematics(context),
-      internal_tree().EvalVelocityKinematics(context), known_vdot, A_WB_array);
-  // Permute MobodIndex -> BodyIndex.
+  const internal::MultibodyTree<T>& multibody_tree = internal_tree();
+  const internal::SpanningForest& forest = multibody_tree.forest();
+
   // TODO(eric.cousineau): Remove dynamic allocations. Making this in-place
   //  still required dynamic allocation for recording permutation indices.
   //  Can change implementation once MultibodyTree becomes fully internal.
-  std::vector<SpatialAcceleration<T>> A_WB_array_mobod = *A_WB_array;
-  const internal::MultibodyTreeTopology& topology =
-      internal_tree().get_topology();
-  for (internal::MobodIndex mobod_index(1); mobod_index < topology.num_mobods();
-       ++mobod_index) {
-    const BodyIndex body_index = topology.get_body_node(mobod_index).rigid_body;
-    (*A_WB_array)[body_index] = A_WB_array_mobod[mobod_index];
+  std::vector<SpatialAcceleration<T>> A_WB_array_mobod(forest.num_mobods());
+  multibody_tree.CalcSpatialAccelerationsFromVdot(
+      context, multibody_tree.EvalPositionKinematics(context),
+      multibody_tree.EvalVelocityKinematics(context), known_vdot,
+      &A_WB_array_mobod);
+
+  // Permute MobodIndex -> BodyIndex.
+  for (const auto& mobod : forest.mobods()) {
+    // TODO(sherm1) Need to calculate accelerations (optionally?) for the
+    //  inactive links on a link composite following this mobod.
+    // Make sure there aren't any inactives for now.
+    DRAKE_DEMAND(ssize(mobod.follower_link_ordinals()) == 1);
+    const BodyIndex active_link_index =
+        forest.links(mobod.link_ordinal()).index();
+    (*A_WB_array)[active_link_index] = A_WB_array_mobod[mobod.index()];
   }
 }
 
@@ -1577,7 +1584,7 @@ void MultibodyPlant<T>::FinalizePlantOnly() {
   SetUpJointLimitsParameters();
   if (use_sampled_output_ports_) {
     auto cache = std::make_unique<AccelerationKinematicsCache<T>>(
-        internal_tree().get_topology());
+        internal_tree().forest());
     for (SpatialAcceleration<T>& A_WB : cache->get_mutable_A_WB_pool()) {
       A_WB.SetZero();
     }
@@ -3276,7 +3283,7 @@ systems::EventStatus MultibodyPlant<T>::CalcStepUnrestricted(
       next_state->get_mutable_discrete_state();
   DiscreteStepMemory::Data<T>& next_memory =
       next_state->template get_mutable_abstract_state<DiscreteStepMemory>(0)
-          .template Allocate<T>(internal_tree().get_topology());
+          .template Allocate<T>(internal_tree().forest());
   discrete_update_manager_->CalcDiscreteValues(context0, &next_discrete_state,
                                                &next_memory);
   next_memory.reaction_forces.resize(num_joints());

--- a/multibody/plant/test/compliant_contact_manager_tester.h
+++ b/multibody/plant/test/compliant_contact_manager_tester.h
@@ -22,6 +22,12 @@ class CompliantContactManagerTester {
   }
 
   template <typename T>
+  static const internal::SpanningForest& forest(
+      const CompliantContactManager<T>& manager) {
+    return manager.forest();
+  }
+
+  template <typename T>
   static BodyIndex FindBodyByGeometryId(
       const CompliantContactManager<T>& manager, geometry::GeometryId id) {
     return manager.FindBodyByGeometryId(id);

--- a/multibody/plant/test/discrete_step_memory_test.cc
+++ b/multibody/plant/test/discrete_step_memory_test.cc
@@ -28,7 +28,7 @@ GTEST_TEST(DiscreteStepMemoryTest, Lifecycle) {
   EXPECT_EQ(dut.template get<double>(), nullptr);
 
   // Allocation matches get().
-  const auto& data = dut.template Allocate<double>(tree.get_topology());
+  const auto& data = dut.template Allocate<double>(tree.forest());
   EXPECT_EQ(dut.template get<double>(), &data);
 
   // Access the wrong type yields empty.

--- a/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
+++ b/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
@@ -96,18 +96,17 @@ class MultibodyPlantReflectedInertiaTests : public ::testing::Test {
     const internal::MultibodyTree<double>& tree =
         MultibodyPlantTester::internal_tree(plant);
 
-    internal::ArticulatedBodyInertiaCache<double> abic(tree.get_topology());
+    internal::ArticulatedBodyInertiaCache<double> abic(tree.forest());
     tree.CalcArticulatedBodyInertiaCache(context, additional_diagonal_inertias,
                                          &abic);
-    internal::ArticulatedBodyForceCache<double> aba_force_cache(
-        tree.get_topology());
+    internal::ArticulatedBodyForceCache<double> aba_force_cache(tree.forest());
     MultibodyForces<double> forces(plant);
     plant.CalcForceElementsContribution(context, &forces);
     std::vector<SpatialForce<double>> Zb_Bo_W(plant.num_bodies());
     tree.CalcArticulatedBodyForceBias(context, abic, &Zb_Bo_W);
     tree.CalcArticulatedBodyForceCache(context, abic, Zb_Bo_W, forces,
                                        &aba_force_cache);
-    internal::AccelerationKinematicsCache<double> ac(tree.get_topology());
+    internal::AccelerationKinematicsCache<double> ac(tree.forest());
     tree.CalcArticulatedBodyAccelerations(context, abic, aba_force_cache, &ac);
     return ac.get_vdot();
   }

--- a/multibody/plant/test/sap_driver_joint_limits_test.cc
+++ b/multibody/plant/test/sap_driver_joint_limits_test.cc
@@ -399,7 +399,7 @@ TEST_F(KukaIiwaArmTests, CalcAccelerationKinematicsCache) {
   // Verify CompliantContactManager loads the acceleration kinematics with the
   // proper results.
   AccelerationKinematicsCache<double> ac(
-      CompliantContactManagerTester::topology(*manager_));
+      CompliantContactManagerTester::forest(*manager_));
   manager_->CalcAccelerationKinematicsCache(*context_, &ac);
   EXPECT_TRUE(CompareMatrices(ac.get_vdot(), a_expected));
   for (BodyIndex b(0); b < plant_.num_bodies(); ++b) {

--- a/multibody/rational/rational_forward_kinematics.cc
+++ b/multibody/rational/rational_forward_kinematics.cc
@@ -4,7 +4,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/multibody/rational/rational_forward_kinematics_internal.h"
-#include "drake/multibody/tree/multibody_tree_topology.h"
 #include "drake/multibody/tree/prismatic_mobilizer.h"
 #include "drake/multibody/tree/revolute_mobilizer.h"
 #include "drake/multibody/tree/weld_mobilizer.h"
@@ -61,15 +60,22 @@ RationalForwardKinematics::RationalForwardKinematics(
     : plant_(*plant) {
   DRAKE_DEMAND(plant != nullptr);
   const internal::MultibodyTree<double>& tree = GetInternalTree(plant_);
+  const internal::SpanningForest& forest = tree.forest();
   // Initialize map_mobilizer_to_s_index_ to -1, where -1 indicates "no s
   // variable".
   map_mobilizer_to_s_index_ = std::vector<int>(tree.num_mobilizers(), -1);
   for (BodyIndex body_index(1); body_index < plant_.num_bodies();
        ++body_index) {
-    const internal::RigidBodyTopology& rigid_body_topology =
-        tree.get_topology().get_rigid_body(body_index);
+    // Note: we're assuming a 1:1 correspondence between bodies and mobilizers.
+    // This won't work if there are merged link composites since multiple
+    // bodies will map to the same mobilizer.
+    const internal::MobodIndex mobod_index =
+      forest.link_by_index(body_index).mobod_index();
+    const internal::SpanningForest::Mobod& mobod = forest.mobods(mobod_index);
+    // Confirm that there is only one body following this Mobod.
+    DRAKE_DEMAND(ssize(mobod.follower_link_ordinals()) == 1);
     const internal::Mobilizer<double>* mobilizer =
-        &(tree.get_mobilizer(rigid_body_topology.inboard_mobilizer));
+         &(tree.get_mobilizer(mobod_index));
     if (IsRevolute(*mobilizer)) {
       const symbolic::Variable s_angle(fmt::format("s[{}]", s_.size()));
       s_.push_back(s_angle);
@@ -227,9 +233,9 @@ RationalForwardKinematics::CalcChildBodyPoseAsMultilinearPolynomial(
   // X_M'C' = X_PF.inverse()
   const internal::MultibodyTree<double>& tree = GetInternalTree(plant_);
   const internal::RigidBodyTopology& parent_topology =
-      tree.get_topology().get_rigid_body(parent);
+      tree.get_topology().get_rigid_body_topology(parent);
   const internal::RigidBodyTopology& child_topology =
-      tree.get_topology().get_rigid_body(child);
+      tree.get_topology().get_rigid_body_topology(child);
   internal::MobodIndex mobilizer_index;
   bool is_order_reversed{};
   if (parent_topology.parent_body.is_valid() &&

--- a/multibody/rational/rational_forward_kinematics_internal.cc
+++ b/multibody/rational/rational_forward_kinematics_internal.cc
@@ -40,19 +40,20 @@ std::vector<BodyIndex> FindPath(const MultibodyPlant<double>& plant,
     if (current == end) {
       break;
     }
-    const RigidBodyTopology& current_node = topology.get_rigid_body(current);
+    const RigidBodyTopology& current_node_topology =
+        topology.get_rigid_body_topology(current);
     if (current != world_index()) {
-      const BodyIndex parent = current_node.parent_body;
+      const BodyIndex parent = current_node_topology.parent_body;
       visit_edge(current, parent);
     }
-    for (BodyIndex child : current_node.child_bodies) {
+    for (BodyIndex child : current_node_topology.child_bodies) {
       visit_edge(current, child);
     }
   }
 
   // Retrieve the path in reverse order.
   std::vector<BodyIndex> path;
-  for (BodyIndex current = end; ; current = ancestors.at(current)) {
+  for (BodyIndex current = end;; current = ancestors.at(current)) {
     path.push_back(current);
     if (current == start) {
       break;
@@ -72,7 +73,7 @@ std::vector<MobodIndex> FindMobilizersOnPath(
   const MultibodyTree<double>& tree = GetInternalTree(plant);
   for (int i = 0; i < static_cast<int>(path.size()) - 1; ++i) {
     const RigidBodyTopology& rigid_body_topology =
-        tree.get_topology().get_rigid_body(path[i]);
+        tree.get_topology().get_rigid_body_topology(path[i]);
     if (path[i] != world_index() &&
         rigid_body_topology.parent_body == path[i + 1]) {
       // path[i] is the child of path[i+1] in MultibodyTreeTopology, they are
@@ -81,8 +82,9 @@ std::vector<MobodIndex> FindMobilizersOnPath(
     } else {
       // path[i] is the parent of path[i+1] in MultibodyTreeTopology, they are
       // connected by path[i+1]'s inboard mobilizer.
-      mobilizers_on_path.push_back(
-          tree.get_topology().get_rigid_body(path[i + 1]).inboard_mobilizer);
+      mobilizers_on_path.push_back(tree.get_topology()
+                                       .get_rigid_body_topology(path[i + 1])
+                                       .inboard_mobilizer);
     }
   }
   return mobilizers_on_path;

--- a/multibody/rational/test/rational_forward_kinematics_test_utilities.cc
+++ b/multibody/rational/test/rational_forward_kinematics_test_utilities.cc
@@ -81,7 +81,7 @@ IiwaTest::IiwaTest()
     iiwa_link_[i] =
         iiwa_->GetBodyByName("iiwa_link_" + std::to_string(i)).index();
     iiwa_joint_[i] = iiwa_tree_.get_topology()
-                         .get_rigid_body(iiwa_link_[i])
+                         .get_rigid_body_topology(iiwa_link_[i])
                          .inboard_mobilizer;
   }
 }
@@ -94,7 +94,7 @@ FinalizedIiwaTest::FinalizedIiwaTest()
     iiwa_link_[i] =
         iiwa_->GetBodyByName("iiwa_link_" + std::to_string(i)).index();
     iiwa_joint_[i] = iiwa_tree_.get_topology()
-                         .get_rigid_body(iiwa_link_[i])
+                         .get_rigid_body_topology(iiwa_link_[i])
                          .inboard_mobilizer;
   }
 }

--- a/multibody/test_utilities/floating_body_plant.cc
+++ b/multibody/test_utilities/floating_body_plant.cc
@@ -77,7 +77,7 @@ Vector3<T> AxiallySymmetricFreeBodyPlant<T>::get_translational_velocity(
 template<typename T>
 math::RigidTransform<T> AxiallySymmetricFreeBodyPlant<T>::CalcPoseInWorldFrame(
     const systems::Context<T>& context) const {
-  internal::PositionKinematicsCache<T> pc(this->tree().get_topology());
+  internal::PositionKinematicsCache<T> pc(this->tree().forest());
   this->tree().CalcPositionKinematicsCache(context, &pc);
   return math::RigidTransform<T>(pc.get_X_WB(body_->mobod_index()));
 }
@@ -86,9 +86,9 @@ template<typename T>
 SpatialVelocity<T>
 AxiallySymmetricFreeBodyPlant<T>::CalcSpatialVelocityInWorldFrame(
     const systems::Context<T>& context) const {
-  internal::PositionKinematicsCache<T> pc(this->tree().get_topology());
+  internal::PositionKinematicsCache<T> pc(this->tree().forest());
   this->tree().CalcPositionKinematicsCache(context, &pc);
-  internal::VelocityKinematicsCache<T> vc(this->tree().get_topology());
+  internal::VelocityKinematicsCache<T> vc(this->tree().forest());
   this->tree().CalcVelocityKinematicsCache(context, pc, &vc);
   return vc.get_V_WB(body_->mobod_index());
 }

--- a/multibody/topology/link_joint_graph_inlines.h
+++ b/multibody/topology/link_joint_graph_inlines.h
@@ -19,6 +19,10 @@ inline const LinkJointGraph::Link& LinkJointGraph::links(
   return data_.links[link_ordinal];
 }
 
+inline int LinkJointGraph::num_links() const {
+  return std::ssize(links());
+}
+
 inline const LinkJointGraph::Link& LinkJointGraph::link_by_index(
     LinkIndex link_index) const {
   const std::optional<LinkOrdinal>& ordinal =
@@ -63,6 +67,10 @@ inline const LinkJointGraph::Joint& LinkJointGraph::joints(
     JointOrdinal joint_ordinal) const {
   DRAKE_ASSERT(joint_ordinal < ssize(joints()));
   return data_.joints[joint_ordinal];
+}
+
+inline int LinkJointGraph::num_joints() const {
+  return std::ssize(joints());
 }
 
 inline const LinkJointGraph::Joint& LinkJointGraph::joint_by_index(

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -219,6 +219,11 @@ class SpanningForest {
   and accessed by LinkOrdinal. */
   const std::vector<Link>& links() const { return graph().links(); }
 
+  /* Returns the number of Links currently in the graph, including World and
+  ephemeral Links. This is the same as `ssize(links())`. Links that have been
+  removed are not counted. */
+  [[nodiscard]] int num_links() const { return graph().num_links(); }
+
   /* Provides convenient access to one of the owning graph's links. Requires
   a LinkOrdinal, not a plain integer.
   @pre link_ordinal is in range */
@@ -234,6 +239,11 @@ class SpanningForest {
   /* Provides convenient access to the owning graph's joints, contiguous
   and accessed by JointOrdinal. */
   const std::vector<Joint>& joints() const { return graph().joints(); }
+
+  /* Returns the number of Joints currently in the graph, including ephemeral
+  joints. This is the same as `ssize(joints())`. Joints that have been removed
+  are not counted. */
+  [[nodiscard]] int num_joints() const { return graph().num_joints(); }
 
   /* Provides convenient access to one of the owning graph's joints. Requires
   a JointOrdinal, not a plain integer.
@@ -251,6 +261,10 @@ class SpanningForest {
   then every Mobod in tree 0, then every Mobod in tree 1, etc. Free bodies
   that weren't explicitly connected to World by a Joint come last. */
   const std::vector<Mobod>& mobods() const { return data_.mobods; }
+
+  /* Returns the number of Mobods in the Forest, including World.  This is the
+  same as `ssize(mobods())`. */
+  [[nodiscard]] inline int num_mobods() const;
 
   /* Provides convenient access to a particular Mobod. Requires a MobodIndex,
   not a plain integer.
@@ -277,6 +291,10 @@ class SpanningForest {
   Mobod (which may represent a LinkComposite). World is not considered to
   be part of any Tree; it is the root of the Forest. */
   const std::vector<Tree>& trees() const { return data_.trees; }
+
+  /* Returns the number of Trees in the Forest.  This is the same as
+  `ssize(trees())`. */
+  [[nodiscard]] inline int num_trees() const;
 
   /* Provides convenient access to a particular Tree. Requires a TreeIndex,
   not a plain integer.
@@ -377,6 +395,17 @@ class SpanningForest {
     DRAKE_ASSERT(0 <= v_index && v_index < num_velocities());
     return data_.v_to_mobod[v_index];
   }
+
+  /* Returns the index of the Tree to which this Link's Mobod belongs. If this
+  is the ordinal of a Link that was split due to a loop, the returned index is
+  for the Tree to which the Primary (original) Link's Mobod belongs. An invalid
+  tree index is returned if the Link's Mobod is World. O(1), very fast.
+  @pre link_ordinal is in range [0, num_links) */
+  inline TreeIndex link_to_tree(LinkOrdinal link_ordinal) const;
+
+  /* Convenience signature that takes a LinkIndex rather than a LinkOrdinal.
+  @pre the index refers to a link that exists and hasn't been removed. */
+  inline TreeIndex link_to_tree(LinkIndex link_index) const;
 
   /* Returns the Tree to which a given position coordinate q belongs.
   O(1), very fast.

--- a/multibody/topology/spanning_forest_inlines.h
+++ b/multibody/topology/spanning_forest_inlines.h
@@ -19,6 +19,10 @@ inline auto SpanningForest::mobods(MobodIndex mobod_index) const
   return mobods()[mobod_index];
 }
 
+inline int SpanningForest::num_mobods() const {
+  return std::ssize(mobods());
+}
+
 inline LinkOrdinal SpanningForest::mobod_to_link_ordinal(
     MobodIndex mobod_index) const {
   return mobods(mobod_index).link_ordinal();
@@ -27,6 +31,14 @@ inline LinkOrdinal SpanningForest::mobod_to_link_ordinal(
 inline const std::vector<LinkOrdinal>& SpanningForest::mobod_to_link_ordinals(
     MobodIndex mobod_index) const {
   return mobods(mobod_index).follower_link_ordinals();
+}
+
+inline TreeIndex SpanningForest::link_to_tree(LinkOrdinal link_ordinal) const {
+  return mobods(links(link_ordinal).mobod_index()).tree();
+}
+
+inline TreeIndex SpanningForest::link_to_tree(LinkIndex link_index) const {
+  return mobods(link_by_index(link_index).mobod_index()).tree();
 }
 
 inline TreeIndex SpanningForest::q_to_tree(int q_index) const {
@@ -42,6 +54,10 @@ inline TreeIndex SpanningForest::v_to_tree(int v_index) const {
 inline auto SpanningForest::trees(TreeIndex tree_index) const -> const Tree& {
   DRAKE_ASSERT(tree_index.is_valid() && tree_index < ssize(trees()));
   return trees()[tree_index];
+}
+
+inline int SpanningForest::num_trees() const {
+  return std::ssize(trees());
 }
 
 // SpanningForest definitions deferred until LoopConstraint defined.

--- a/multibody/topology/test/link_joint_graph_test.cc
+++ b/multibody/topology/test/link_joint_graph_test.cc
@@ -677,14 +677,20 @@ GTEST_TEST(LinkJointGraph, SerialChainAndMore) {
       "to itself.");
 
   // Sanity check sizes.
-  EXPECT_EQ(ssize(graph.links()), 6);  // This includes the world Link.
-  EXPECT_EQ(ssize(graph.joints()), 5);
+  EXPECT_EQ(graph.num_links(), 6);  // This includes the world Link.
+  EXPECT_EQ(graph.num_joints(), 5);
 
   // Verify we can get bodies/joints.
   EXPECT_EQ(graph.link_by_index(LinkIndex(3)).name(), "link3");
   EXPECT_EQ(graph.joint_by_index(JointIndex(3)).name(), "pin4");
   EXPECT_THROW((void)graph.link_by_index(LinkIndex(9)), std::exception);
   EXPECT_THROW((void)graph.joint_by_index(JointIndex(9)), std::exception);
+
+  // Check that index to ordinal mappings work in the easy case where nothing
+  // has been removed. (We can't remove Links yet; Joint removal is tested
+  // below.)
+  EXPECT_EQ(graph.index_to_ordinal(LinkIndex(3)), LinkOrdinal(3));
+  EXPECT_EQ(graph.index_to_ordinal(JointIndex(3)), JointOrdinal(3));
 
   // Verify we can query if a Link/Joint is in the graph.
   const ModelInstanceIndex kInvalidModelInstance(666);
@@ -775,6 +781,11 @@ GTEST_TEST(LinkJointGraph, RemoveJoint) {
   //       0                 1           ordinals
   EXPECT_EQ(graph.joint_by_index(JointIndex(0)).ordinal(), 0);
   EXPECT_EQ(graph.joint_by_index(JointIndex(2)).ordinal(), 1);
+
+  // Check that index->ordinal mapping works across joint removal.
+  EXPECT_EQ(graph.index_to_ordinal(JointIndex(0)), 0);
+  EXPECT_EQ(graph.index_to_ordinal(JointIndex(2)), 1);
+
   EXPECT_EQ(ssize(graph.joints()), 2);
   EXPECT_EQ(graph.num_user_joints(), 2);
   EXPECT_FALSE(graph.has_joint(JointIndex(1)));
@@ -810,6 +821,10 @@ GTEST_TEST(LinkJointGraph, RemoveJoint) {
   EXPECT_EQ(graph.joint_by_index(JointIndex(0)).ordinal(), 0);
   EXPECT_EQ(graph.joint_by_index(JointIndex(2)).ordinal(), 1);
   EXPECT_EQ(graph.joint_by_index(JointIndex(3)).ordinal(), 2);
+
+  EXPECT_EQ(graph.index_to_ordinal(JointIndex(0)), 0);
+  EXPECT_EQ(graph.index_to_ordinal(JointIndex(2)), 1);
+  EXPECT_EQ(graph.index_to_ordinal(JointIndex(3)), 2);
 
   EXPECT_EQ(ssize(graph.joints()), 3);
   EXPECT_EQ(graph.num_user_joints(), 3);
@@ -864,6 +879,9 @@ GTEST_TEST(LinkJointGraph, RemoveJoint) {
   EXPECT_TRUE(graph.joint_is_ephemeral(JointIndex(5)));
   EXPECT_EQ(graph.joint_by_index(JointIndex(4)).ordinal(), 2);
   EXPECT_EQ(graph.joint_by_index(JointIndex(5)).ordinal(), 3);
+
+  EXPECT_EQ(graph.index_to_ordinal(JointIndex(4)), 2);
+  EXPECT_EQ(graph.index_to_ordinal(JointIndex(5)), 3);
 
   // Test the case of removing the highest-index user joint (3 in this case),
   // then build the forest, then make sure that no ephemeral joint gets that

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -69,6 +69,9 @@ GTEST_TEST(SpanningForest, WorldOnlyTest) {
             std::vector{world_link_index});
   EXPECT_FALSE(graph.link_composites(LinkCompositeIndex(0)).is_massless);
 
+  EXPECT_FALSE(forest.link_to_tree(LinkOrdinal(0)).is_valid());
+  EXPECT_FALSE(forest.link_to_tree(LinkIndex(0)).is_valid());
+
   // Check that the World-only forest makes sense.
   EXPECT_EQ(ssize(forest.mobods()), 1);
   EXPECT_TRUE(forest.mobods(world_mobod_index).has_massful_follower_link());
@@ -155,15 +158,25 @@ GTEST_TEST(SpanningForest, TreeAndLoopConstraintAPIs) {
   EXPECT_TRUE(graph.BuildForest());
 
   // Here's the forest we're expecting:
-  //            -> mobod1 -> mobod2
+  //            -> mobod1 -> mobod2                             tree0
   //     World                 ^
-  //            -> mobod3 =====+  loop weld constraint
+  //            -> mobod3 =====+  loop weld constraint          tree1
   //
   // We had to cut link2. Mobod2 is for the shadow link.
 
-  EXPECT_EQ(ssize(forest.trees()), 2);
-  EXPECT_EQ(ssize(forest.mobods()), 4);
+  EXPECT_EQ(forest.num_trees(), 2);
+  EXPECT_EQ(forest.num_mobods(), 4);
   EXPECT_EQ(ssize(forest.loop_constraints()), 1);
+
+  EXPECT_FALSE(forest.link_to_tree(LinkIndex(0)).is_valid());
+  EXPECT_EQ(forest.link_to_tree(LinkIndex(1)), TreeIndex(0));
+  // Link2's primary follows mobod3, which is in tree1.
+  EXPECT_EQ(forest.link_to_tree(LinkIndex(2)), TreeIndex(1));
+
+  // The index and ordinal values are the same here.
+  EXPECT_FALSE(forest.link_to_tree(LinkOrdinal(0)).is_valid());
+  EXPECT_EQ(forest.link_to_tree(LinkOrdinal(1)), TreeIndex(0));
+  EXPECT_EQ(forest.link_to_tree(LinkOrdinal(2)), TreeIndex(1));
 
   // Not much to check for the loop constraint.
   const auto& loop_constraint = forest.loop_constraints(LoopConstraintIndex(0));
@@ -304,9 +317,12 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
 
   // See that the graph got augmented properly to reflect the as-built forest.
   EXPECT_EQ(graph.num_user_links(), 16);
-  EXPECT_EQ(ssize(graph.links()), 16);  // no links added
+  EXPECT_EQ(graph.num_links(), 16);  // no links added
   EXPECT_EQ(graph.num_user_joints(), 12);
-  EXPECT_EQ(ssize(graph.joints()), 15);  // modeling adds 3 floating joints
+  EXPECT_EQ(graph.num_joints(), 15);  // modeling adds 3 floating joints
+
+  EXPECT_EQ(forest.num_links(), graph.num_links());
+  EXPECT_EQ(forest.num_joints(), graph.num_joints());
 
   // The only LinkComposite is the World composite and it is alone there.
   EXPECT_EQ(ssize(graph.link_composites()), 1);  // just World
@@ -314,8 +330,8 @@ GTEST_TEST(SpanningForest, MultipleBranchesDefaultOptions) {
   EXPECT_EQ(graph.link_composites(LinkCompositeIndex(0)).links[0],
             graph.world_link().index());
 
-  EXPECT_EQ(ssize(forest.trees()), 3);
-  EXPECT_EQ(ssize(forest.mobods()), 16);        // includes World
+  EXPECT_EQ(forest.num_trees(), 3);
+  EXPECT_EQ(forest.num_mobods(), 16);           // includes World
   EXPECT_EQ(ssize(forest.welded_mobods()), 1);  // just World
   EXPECT_EQ(forest.num_positions(), 33);   // 12 revolute, 3 x 7 quat floating
   EXPECT_EQ(forest.num_velocities(), 30);  // 12 revolute, 3 x 6 floating

--- a/multibody/tree/acceleration_kinematics_cache.h
+++ b/multibody/tree/acceleration_kinematics_cache.h
@@ -31,13 +31,13 @@ class AccelerationKinematicsCache {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(AccelerationKinematicsCache);
 
   // Constructs an acceleration kinematics cache entry for the given
-  // MultibodyTreeTopology.
+  // SpanningForest.
   // In Release builds specific entries are left uninitialized resulting in a
   // zero cost operation. However in Debug builds those entries are set to NaN
   // so that operations using this uninitialized cache entry fail fast, easing
   // bug detection.
-  explicit AccelerationKinematicsCache(const MultibodyTreeTopology& topology) {
-    Allocate(topology);
+  explicit AccelerationKinematicsCache(const internal::SpanningForest& forest) {
+    Allocate(forest);
     DRAKE_ASSERT_VOID(InitializeToNaN());
     // Sets defaults: drake::multibody::world_mobod_index() defines the unique
     // index to the world body and is defined in multibody_tree_indexes.h.
@@ -95,10 +95,10 @@ class AccelerationKinematicsCache {
   int get_num_mobods() const { return static_cast<int>(A_WB_pool_.size()); }
 
   // Allocates resources for this acceleration kinematics cache.
-  void Allocate(const MultibodyTreeTopology& topology) {
-    const int num_mobods = topology.num_mobods();
+  void Allocate(const internal::SpanningForest& forest) {
+    const int num_mobods = forest.num_mobods();
     A_WB_pool_.resize(num_mobods);
-    const int num_velocities = topology.num_velocities();
+    const int num_velocities = forest.num_velocities();
     vdot_.resize(num_velocities);
   }
 

--- a/multibody/tree/articulated_body_force_cache.h
+++ b/multibody/tree/articulated_body_force_cache.h
@@ -29,8 +29,8 @@ class ArticulatedBodyForceCache {
 
   // Constructs an %ArticulatedBodyForceCache object properly sized to
   // store the force bias terms for a model with the given `topology`.
-  explicit ArticulatedBodyForceCache(const MultibodyTreeTopology& topology)
-      : num_mobods_(topology.num_mobods()) {
+  explicit ArticulatedBodyForceCache(const internal::SpanningForest& forest)
+      : num_mobods_(forest.num_mobods()) {
     Allocate();
   }
 

--- a/multibody/tree/articulated_body_inertia_cache.h
+++ b/multibody/tree/articulated_body_inertia_cache.h
@@ -37,8 +37,8 @@ class ArticulatedBodyInertiaCache {
 
   // Constructs an articulated body cache entry for the given
   // MultibodyTreeTopology.
-  explicit ArticulatedBodyInertiaCache(const MultibodyTreeTopology& topology)
-      : num_mobods_(topology.num_mobods()) {
+  explicit ArticulatedBodyInertiaCache(const internal::SpanningForest& forest)
+      : num_mobods_(forest.num_mobods()) {
     Allocate();
   }
 

--- a/multibody/tree/block_system_jacobian_cache.cc
+++ b/multibody/tree/block_system_jacobian_cache.cc
@@ -7,7 +7,7 @@ namespace internal {
 template <typename T>
 BlockSystemJacobianCache<T>::BlockSystemJacobianCache(
     const SpanningForest& forest)
-    : total_rows_(6 * ssize(forest.mobods())),
+    : total_rows_(6 * forest.num_mobods()),
       total_cols_(forest.num_velocities()),
       block_system_jacobian_(forest.trees().size()) {
   // We're counting rows & columns just to verify consistency with the

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -105,6 +105,13 @@ class BodyNode : public MultibodyElement<T> {
 
   ~BodyNode() override;
 
+  // The Mobod associated with this BodyNode (and its Mobilizer).
+  const SpanningForest::Mobod& mobod() const { return get_mobilizer().mobod(); }
+
+  // The index of the associated Mobod (same as the index of this BodyNode
+  // and of its Mobilizer).
+  MobodIndex mobod_index() const { return mobod().index(); }
+
   // Method to update the list of child body nodes maintained by this node,
   // outboard to this node. Recall a %BodyNode is a tree node within the tree
   // structure of MultibodyTree. Therefore each %BodyNode has a unique parent
@@ -114,16 +121,7 @@ class BodyNode : public MultibodyElement<T> {
   // MultibodyTree::Finalize() method call.
   void add_child_node(const BodyNode<T>* child) { children_.push_back(child); }
 
-  MobodIndex mobod_index() const {
-    const MobodIndex mobod = get_mobilizer().mobod().index();
-    // TODO(sherm1) BodyNode shouldn't be a MultibodyElement, but is for now.
-    DRAKE_ASSERT(this->template index_impl<MobodIndex>() == mobod);
-    return mobod;
-  }
-
-  MobodIndex inboard_mobod_index() const {
-    return get_mobilizer().mobod().inboard();
-  }
+  MobodIndex inboard_mobod_index() const { return mobod().inboard(); }
 
   // Returns a constant reference to the body B associated with this node.
   const RigidBody<T>& body() const {
@@ -160,26 +158,17 @@ class BodyNode : public MultibodyElement<T> {
 
   // Returns the number of generalized positions for the Mobilizer in `this`
   // node.
-  int get_num_mobilizer_positions() const {
-    return topology_.num_mobilizer_positions;
-  }
+  int get_num_mobilizer_positions() const { return mobod().nq(); }
 
   // Returns the number of generalized velocities for the Mobilizer in `this`
   // node.
-  int get_num_mobilizer_velocities() const {
-    return topology_.num_mobilizer_velocities;
-  }
+  int get_num_mobilizer_velocities() const { return mobod().nv(); }
 
   // Returns the index to the first generalized velocity for this node
   // within the vector v of generalized velocities for the full multibody
   // system.
-  int velocity_start_in_v() const {
-    return topology_.mobilizer_velocities_start_in_v;
-  }
+  int velocity_start_in_v() const { return mobod().v_start(); }
   //@}
-
-  // Returns the topology information for this body node.
-  const BodyNodeTopology& get_topology() const { return topology_; }
 
   // Helper method to retrieve a Jacobian matrix with respect to generalized
   // velocities v for `this` node from an array storing the columns of a set of
@@ -198,33 +187,29 @@ class BodyNode : public MultibodyElement<T> {
   //   matrix for this node.
   Eigen::Map<const MatrixUpTo6<T>> GetJacobianFromArray(
       const std::vector<Vector6<T>>& H_array) const {
-    DRAKE_DEMAND(static_cast<int>(H_array.size()) ==
-                 this->get_parent_tree().num_velocities());
-    const int start_index_in_v = get_topology().mobilizer_velocities_start_in_v;
-    const int num_velocities = get_topology().num_mobilizer_velocities;
-    DRAKE_DEMAND(num_velocities == 0 ||
-                 start_index_in_v < this->get_parent_tree().num_velocities());
+    const SpanningForest& forest = this->get_parent_tree().forest();
+    DRAKE_DEMAND(static_cast<int>(H_array.size()) == forest.num_velocities());
+    const int start_index_in_v = mobod().v_start();
+    const int nv = mobod().nv();
+    DRAKE_DEMAND(nv == 0 || start_index_in_v < forest.num_velocities());
     // The first column of this node's hinge matrix H_PB_W:
-    const T* H_col0 =
-        num_velocities == 0 ? nullptr : H_array[start_index_in_v].data();
+    const T* H_col0 = nv == 0 ? nullptr : H_array[start_index_in_v].data();
     // Create an Eigen map to the full H_PB_W for this node:
-    return Eigen::Map<const MatrixUpTo6<T>>(H_col0, 6, num_velocities);
+    return Eigen::Map<const MatrixUpTo6<T>>(H_col0, 6, nv);
   }
 
   // Mutable version of GetJacobianFromArray().
   Eigen::Map<MatrixUpTo6<T>> GetMutableJacobianFromArray(
       std::vector<Vector6<T>>* H_array) const {
-    DRAKE_DEMAND(static_cast<int>(H_array->size()) ==
-                 this->get_parent_tree().num_velocities());
-    const int start_index_in_v = get_topology().mobilizer_velocities_start_in_v;
-    const int num_velocities = get_topology().num_mobilizer_velocities;
-    DRAKE_DEMAND(num_velocities == 0 ||
-                 start_index_in_v < this->get_parent_tree().num_velocities());
+    const SpanningForest& forest = this->get_parent_tree().forest();
+    DRAKE_DEMAND(static_cast<int>(H_array->size()) == forest.num_velocities());
+    const int start_index_in_v = mobod().v_start();
+    const int nv = mobod().nv();
+    DRAKE_DEMAND(nv == 0 || start_index_in_v < forest.num_velocities());
     // The first column of this node's hinge matrix H_PB_W:
-    T* H_col0 =
-        num_velocities == 0 ? nullptr : (*H_array)[start_index_in_v].data();
+    T* H_col0 = nv == 0 ? nullptr : (*H_array)[start_index_in_v].data();
     // Create an Eigen map to the full H_PB_W for this node:
-    return Eigen::Map<MatrixUpTo6<T>>(H_col0, 6, num_velocities);
+    return Eigen::Map<MatrixUpTo6<T>>(H_col0, 6, nv);
   }
 
   // This method is used by MultibodyTree within a base-to-tip loop to compute
@@ -645,7 +630,8 @@ class BodyNode : public MultibodyElement<T> {
   // method returns an invalid BodyIndex. Attempts to using invalid indexes
   // leads to an exception being thrown in Debug builds.
   BodyIndex get_parent_body_index() const {
-    return topology_.parent_rigid_body;
+    if (mobod().is_world()) return BodyIndex{};
+    return get_mobilizer().inboard_frame().body().index();
   }
 
   // =========================================================================
@@ -655,9 +641,7 @@ class BodyNode : public MultibodyElement<T> {
       const systems::Context<T>& context) const {
     const MultibodyTree<T>& tree = this->get_parent_tree();
     return tree.get_state_segment(
-        context,
-        tree.num_positions() + topology_.mobilizer_velocities_start_in_v,
-        topology_.num_mobilizer_velocities);
+        context, tree.num_positions() + mobod().v_start(), mobod().nv());
   }
 
   // Helper to get an Eigen expression of the vector of generalized velocities
@@ -667,29 +651,24 @@ class BodyNode : public MultibodyElement<T> {
   // to the operator.
   Eigen::VectorBlock<const VectorX<T>> get_mobilizer_velocities(
       const VectorX<T>& v) const {
-    return v.segment(topology_.mobilizer_velocities_start_in_v,
-                     topology_.num_mobilizer_velocities);
+    return v.segment(mobod().v_start(), mobod().nv());
   }
 
  private:
   friend class BodyNodeTester;
 
   // Implementation for MultibodyElement::DoSetTopology().
-  // At MultibodyTree::Finalize() time, each body retrieves its topology
-  // from the parent MultibodyTree.
   // TODO(sherm1) Get rid of this.
-  void DoSetTopology(const MultibodyTreeTopology& tree_topology) final {
-    DRAKE_DEMAND(mobilizer_ != nullptr);  // Should have been set already.
-    topology_ = tree_topology.get_body_node(mobod_index());
+  void DoSetTopology(const MultibodyTreeTopology&) final {
+    // BodyNode gets everything it needs at construction.
+    DRAKE_DEMAND(body_ != nullptr && mobilizer_ != nullptr);
   }
-
-  BodyNodeTopology topology_;
 
   const BodyNode<T>* parent_node_{nullptr};
   std::vector<const BodyNode<T>*> children_;
 
   // Pointers for fast access.
-  const RigidBody<T>* body_;
+  const RigidBody<T>* body_{nullptr};
   const Mobilizer<T>* mobilizer_{nullptr};
 };
 

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -636,7 +636,7 @@ class Frame : public MultibodyElement<T> {
   // Implementation for MultibodyElement::DoSetTopology().
   void DoSetTopology(
       const internal::MultibodyTreeTopology& tree_topology) final {
-    topology_ = tree_topology.get_frame(this->index());
+    topology_ = tree_topology.get_frame_topology(this->index());
     DRAKE_ASSERT(topology_.index == this->index());
   }
 

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -40,7 +40,7 @@ void JointActuator<T>::set_controller_gains(PdControllerGains gains) {
   // plant. On the other hand, if set_controller_gains is called post-Finalize
   // to add a controller on a continuous-time plant, we need to reject that
   // ourselves; the plant won't know to check for it.
-  const bool is_finalized = topology_.actuator_index_start >= 0;
+  const bool is_finalized = topology_.actuator_dof_start >= 0;
   if (is_finalized) {
     // N.B. Calling is_state_discrete() on a non-finalized plant will segfault;
     // we must be careful to only call it inside of the if-finalized guard.
@@ -78,22 +78,22 @@ void JointActuator<T>::set_actuation_vector(
   DRAKE_THROW_UNLESS(u != nullptr);
   DRAKE_THROW_UNLESS(u->size() == this->get_parent_tree().num_actuated_dofs());
   DRAKE_THROW_UNLESS(u_actuator.size() == num_inputs());
-  u->segment(topology_.actuator_index_start, num_inputs()) = u_actuator;
+  u->segment(topology_.actuator_dof_start, num_inputs()) = u_actuator;
 }
 
 template <typename T>
 int JointActuator<T>::input_start() const {
-  if (topology_.actuator_index_start < 0) {
+  if (topology_.actuator_dof_start < 0) {
     throw std::runtime_error(
         "JointActuator::input_start() must be called after the MultibodyPlant "
         "is finalized.");
   }
-  return topology_.actuator_index_start;
+  return topology_.actuator_dof_start;
 }
 
 template <typename T>
 int JointActuator<T>::num_inputs() const {
-  if (topology_.actuator_index_start < 0) {
+  if (topology_.actuator_dof_start < 0) {
     throw std::runtime_error(
         "JointActuator::num_inputs() must be called after the MultibodyPlant "
         "is finalized.");
@@ -105,7 +105,7 @@ int JointActuator<T>::num_inputs() const {
 template <typename T>
 void JointActuator<T>::DoSetTopology(
     const internal::MultibodyTreeTopology& mbt_topology) {
-  topology_ = mbt_topology.get_joint_actuator(this->index());
+  topology_ = mbt_topology.get_joint_actuator_topology(this->index());
 }
 
 template <typename T>

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -110,7 +110,7 @@ class JointActuator final : public MultibodyElement<T> {
   const Eigen::Ref<const VectorX<T>> get_actuation_vector(
       const VectorX<T>& u) const {
     DRAKE_DEMAND(u.size() == this->get_parent_tree().num_actuated_dofs());
-    return u.segment(topology_.actuator_index_start, joint().num_velocities());
+    return u.segment(topology_.actuator_dof_start, joint().num_velocities());
   }
 
   /// Given the actuation values `u_actuator` for `this` actuator, updates the

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -60,9 +60,8 @@ const FrameType<T>& MultibodyTree<T>::AddFrame(
         frame->name()));
   }
   DRAKE_DEMAND(frame->model_instance().is_valid());
-  const FrameIndex frame_index = topology_.add_frame(frame->body().index());
-  // This test MUST be performed BEFORE frames_.Add(). Do not move it around!
-  DRAKE_DEMAND(frame_index == num_frames());
+  const FrameIndex frame_index(num_frames());
+  topology_.add_frame_topology(frame_index, frame->body().index());
 
   // TODO(amcastro-tri): consider not depending on setting this pointer at
   //  all. Consider also removing MultibodyElement altogether.
@@ -109,13 +108,13 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
   // later to define mobilizers between those frames in a second tree2.
   mobilizer->inboard_frame().HasThisParentTreeOrThrow(this);   // F frame
   mobilizer->outboard_frame().HasThisParentTreeOrThrow(this);  // M frame
-  MobodIndex mobilizer_index = topology_.add_mobilizer(
-      mobilizer->mobod(), mobilizer->inboard_frame().index(),
-      mobilizer->outboard_frame().index());
 
-  // This DRAKE_DEMAND MUST be performed BEFORE mobilizers_.push_back()
-  // below. Do not move it around!
-  DRAKE_DEMAND(mobilizer_index == num_mobilizers());
+  // Sanity check that we are processing in the expected order.
+  DRAKE_DEMAND(mobilizer->mobod().index() == num_mobilizers());
+
+  topology_.add_mobilizer_topology(mobilizer->mobod(),
+                                   mobilizer->inboard_frame().index(),
+                                   mobilizer->outboard_frame().index());
 
   // TODO(sammy-tri) This effectively means that there's no way to
   //  programmatically add mobilizers from outside of MultibodyTree
@@ -127,7 +126,7 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
 
   // TODO(amcastro-tri): consider not depending on setting this pointer at
   //  all. Consider also removing MultibodyElement altogether.
-  mobilizer->set_parent_tree(this, mobilizer_index);
+  mobilizer->set_parent_tree(this, mobilizer->mobod().index());
 
   // Mark free bodies as needed.
   const BodyIndex outboard_body_index = mobilizer->outboard_body().index();
@@ -135,10 +134,10 @@ const MobilizerType<T>& MultibodyTree<T>::AddMobilizer(
       mobilizer->has_six_dofs() &&
       mobilizer->inboard_frame().body().index() == world_body().index();
 
-  topology_.get_mutable_rigid_body(outboard_body_index).is_floating_base =
-      is_floating_base_body;
-  topology_.get_mutable_rigid_body(outboard_body_index).has_quaternion_dofs =
-      mobilizer->has_quaternion_dofs();
+  topology_.get_mutable_rigid_body_topology(outboard_body_index)
+      .is_floating_base = is_floating_base_body;
+  topology_.get_mutable_rigid_body_topology(outboard_body_index)
+      .has_quaternion_dofs = mobilizer->has_quaternion_dofs();
 
   MobilizerType<T>* raw_mobilizer_ptr = mobilizer.get();
   mobilizers_.push_back(std::move(mobilizer));
@@ -312,8 +311,8 @@ const JointActuator<T>& MultibodyTree<T>::AddJointActuator(
   // Create the JointActuator before making any changes to our member fields, so
   // if the JointActuator constructor throws our state will still be valid.
   auto actuator = std::make_unique<JointActuator<T>>(name, joint, effort_limit);
-  const JointActuatorIndex actuator_index =
-      topology_.add_joint_actuator(joint.num_velocities());
+  const JointActuatorIndex actuator_index(actuators_.next_index());
+  topology_.add_joint_actuator_topology(actuator_index, joint.num_velocities());
   actuator->set_parent_tree(this, actuator_index);
   return actuators_.Add(std::move(actuator));
 }

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -551,7 +551,7 @@ class MultibodyTree {
   // Returns the number of generalized positions of the model.
   int num_positions() const {
     DRAKE_MBT_THROW_IF_NOT_FINALIZED();
-    return topology_.num_positions();
+    return forest().num_positions();
   }
 
   // Returns the number of generalized positions in a specific model instance.
@@ -563,7 +563,7 @@ class MultibodyTree {
   // Returns the number of generalized velocities of the model.
   int num_velocities() const {
     DRAKE_MBT_THROW_IF_NOT_FINALIZED();
-    return topology_.num_velocities();
+    return forest().num_velocities();
   }
 
   // Returns the number of generalized velocities in a specific model instance.
@@ -575,7 +575,7 @@ class MultibodyTree {
   // Returns the total size of the state vector in the model.
   int num_states() const {
     DRAKE_MBT_THROW_IF_NOT_FINALIZED();
-    return topology_.num_states();
+    return num_positions() + num_velocities();
   }
 
   // Returns the total size of the state vector in a specific model instance.

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -246,7 +246,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.position_kinematics =
       this->DeclareCacheEntry(
               std::string("position kinematics"),
-              PositionKinematicsCache<T>(internal_tree().get_topology()),
+              PositionKinematicsCache<T>(internal_tree().forest()),
               &MultibodyTreeSystem<T>::CalcPositionKinematicsCache,
               {position_ticket, this->all_parameters_ticket()})
           .cache_index();
@@ -286,7 +286,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.velocity_kinematics =
       this->DeclareCacheEntry(
               std::string("velocity kinematics"),
-              VelocityKinematicsCache<T>(internal_tree().get_topology()),
+              VelocityKinematicsCache<T>(internal_tree().forest()),
               &MultibodyTreeSystem<T>::CalcVelocityKinematicsCache,
               {position_ticket, velocity_ticket, this->all_parameters_ticket()})
           .cache_index();
@@ -322,7 +322,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.abi_cache_index =
       this->DeclareCacheEntry(
               std::string("Articulated Body Inertia"),
-              ArticulatedBodyInertiaCache<T>(internal_tree().get_topology()),
+              ArticulatedBodyInertiaCache<T>(internal_tree().forest()),
               &MultibodyTreeSystem<T>::CalcArticulatedBodyInertiaCache,
               {position_ticket, this->all_parameters_ticket()})
           .cache_index();
@@ -362,7 +362,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   // Articulated Body Algorithm (ABA) force cache.
   const auto& articulated_body_forces_cache_entry = this->DeclareCacheEntry(
       std::string("ABA force cache"),
-      ArticulatedBodyForceCache<T>(internal_tree().get_topology()),
+      ArticulatedBodyForceCache<T>(internal_tree().forest()),
       &MultibodyTreeSystem<T>::CalcArticulatedBodyForceCache,
       force_and_acceleration_prereqs);
   cache_indexes_.articulated_body_forces =
@@ -374,7 +374,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.acceleration_kinematics =
       this->DeclareCacheEntry(
               std::string("Accelerations"),
-              AccelerationKinematicsCache<T>(internal_tree().get_topology()),
+              AccelerationKinematicsCache<T>(internal_tree().forest()),
               &MultibodyTreeSystem<T>::CalcForwardDynamics,
               force_and_acceleration_prereqs)
           .cache_index();

--- a/multibody/tree/multibody_tree_topology.cc
+++ b/multibody/tree/multibody_tree_topology.cc
@@ -9,11 +9,10 @@ bool MultibodyTreeTopology::operator==(
   if (is_valid_ != other.is_valid_) return false;
   if (forest_height_ != other.forest_height_) return false;
 
-  if (frames_ != other.frames_) return false;
-  if (rigid_bodies_ != other.rigid_bodies_) return false;
-  if (mobilizers_ != other.mobilizers_) return false;
-  if (joint_actuators_ != other.joint_actuators_) return false;
-  if (body_nodes_ != other.body_nodes_) return false;
+  if (frame_topology_ != other.frame_topology_) return false;
+  if (rigid_body_topology_ != other.rigid_body_topology_) return false;
+  if (mobilizer_topology_ != other.mobilizer_topology_) return false;
+  if (joint_actuator_topology_ != other.joint_actuator_topology_) return false;
 
   if (num_positions_ != other.num_positions_) return false;
   if (num_velocities_ != other.num_velocities_) return false;
@@ -56,70 +55,42 @@ bool RigidBodyTopology::operator==(const RigidBodyTopology& other) const {
   return true;
 }
 
-bool BodyNodeTopology::operator==(const BodyNodeTopology& other) const {
-  if (index != other.index) return false;
-  if (level != other.level) return false;
-
-  if (parent_body_node.is_valid() != other.parent_body_node.is_valid())
-    return false;
-  if (parent_body_node.is_valid() && parent_body_node != other.parent_body_node)
-    return false;
-
-  if (rigid_body != other.rigid_body) return false;
-
-  if (parent_rigid_body.is_valid() != other.parent_rigid_body.is_valid())
-    return false;
-  if (parent_rigid_body.is_valid() &&
-      parent_rigid_body != other.parent_rigid_body)
-    return false;
-
-  if (child_nodes != other.child_nodes) return false;
-
-  if (num_mobilizer_positions != other.num_mobilizer_positions) return false;
-  if (mobilizer_positions_start != other.mobilizer_positions_start)
-    return false;
-  if (num_mobilizer_velocities != other.num_mobilizer_velocities) return false;
-  if (mobilizer_velocities_start_in_v != other.mobilizer_velocities_start_in_v)
-    return false;
-
-  return true;
-}
-
 MultibodyTreeTopology::~MultibodyTreeTopology() = default;
 
-const JointActuatorTopology& MultibodyTreeTopology::get_joint_actuator(
+const JointActuatorTopology& MultibodyTreeTopology::get_joint_actuator_topology(
     JointActuatorIndex index) const {
-  DRAKE_ASSERT(index < ssize(joint_actuators_));
-  DRAKE_DEMAND(joint_actuators_[index].has_value());
-  return *joint_actuators_[index];
+  DRAKE_ASSERT(index < ssize(joint_actuator_topology_));
+  DRAKE_DEMAND(joint_actuator_topology_[index].has_value());
+  return *joint_actuator_topology_[index];
 }
 
-std::pair<BodyIndex, FrameIndex> MultibodyTreeTopology::add_rigid_body() {
+void MultibodyTreeTopology::add_rigid_body_topology(
+    BodyIndex body_index, FrameIndex body_frame_index) {
   if (is_valid()) {
     throw std::logic_error(
         "This MultibodyTreeTopology is finalized already. "
         "Therefore adding more rigid bodies is not allowed. "
         "See documentation for Finalize() for details.");
   }
-  BodyIndex body_index = BodyIndex(num_rigid_bodies());
-  FrameIndex body_frame_index = add_frame(body_index);
-  rigid_bodies_.emplace_back(body_index, body_frame_index);
-  return std::make_pair(body_index, body_frame_index);
+  DRAKE_DEMAND(body_index == num_rigid_bodies());
+  DRAKE_DEMAND(body_frame_index == num_frames());
+  add_frame_topology(body_frame_index, body_index);
+  rigid_body_topology_.emplace_back(body_index, body_frame_index);
 }
 
-FrameIndex MultibodyTreeTopology::add_frame(BodyIndex body_index) {
+void MultibodyTreeTopology::add_frame_topology(FrameIndex frame_index,
+                                               BodyIndex body_index) {
   if (is_valid()) {
     throw std::logic_error(
         "This MultibodyTreeTopology is finalized already. "
         "Therefore adding more frames is not allowed. "
         "See documentation for Finalize() for details.");
   }
-  FrameIndex frame_index(num_frames());
-  frames_.emplace_back(frame_index, body_index);
-  return frame_index;
+  DRAKE_DEMAND(frame_index == num_frames());
+  frame_topology_.emplace_back(frame_index, body_index);
 }
 
-MobodIndex MultibodyTreeTopology::add_mobilizer(
+void MultibodyTreeTopology::add_mobilizer_topology(
     const SpanningForest::Mobod& mobod, FrameIndex in_frame,
     FrameIndex out_frame) {
   if (is_valid()) {
@@ -128,6 +99,10 @@ MobodIndex MultibodyTreeTopology::add_mobilizer(
         "Therefore adding more mobilizers is not allowed. "
         "See documentation for Finalize() for details.");
   }
+
+  const MobodIndex mobilizer_index(mobod.index());
+  DRAKE_DEMAND(mobilizer_index == num_mobilizers());
+
   // Note: MultibodyTree double checks the mobilizer's frames belong to that
   // tree. Therefore the validity of in_frame and out_frame is already
   // guaranteed. We add the checks here for additional security.
@@ -144,8 +119,8 @@ MobodIndex MultibodyTreeTopology::add_mobilizer(
         "More than one mobilizer between two frames is not allowed.",
         in_frame, out_frame));
   }
-  const BodyIndex inboard_body = frames_[in_frame].rigid_body;
-  const BodyIndex outboard_body = frames_[out_frame].rigid_body;
+  const BodyIndex inboard_body = frame_topology_[in_frame].rigid_body;
+  const BodyIndex outboard_body = frame_topology_[out_frame].rigid_body;
   if (IsThereAMobilizerBetweenRigidBodies(inboard_body, outboard_body)) {
     throw std::runtime_error(fmt::format(
         "This multibody tree already has a mobilizer connecting "
@@ -154,7 +129,7 @@ MobodIndex MultibodyTreeTopology::add_mobilizer(
         inboard_body, outboard_body));
   }
   // Checks for graph loops. Each body can have only one inboard mobilizer.
-  if (rigid_bodies_[outboard_body].inboard_mobilizer.is_valid()) {
+  if (rigid_body_topology_[outboard_body].inboard_mobilizer.is_valid()) {
     throw std::runtime_error(
         "When creating a model, an attempt was made to add two inboard "
         "joints to the same rigid body; this is not allowed. One possible "
@@ -171,76 +146,77 @@ MobodIndex MultibodyTreeTopology::add_mobilizer(
   // implementation. RigidBodyTopology::inboard_mobilizer and
   // RigidBodyTopology::parent_body are both set within this method right
   // after these checks.
-  DRAKE_DEMAND(!rigid_bodies_[outboard_body].inboard_mobilizer.is_valid());
-  DRAKE_DEMAND(!rigid_bodies_[outboard_body].parent_body.is_valid());
-  DRAKE_DEMAND(mobod.index() == num_mobilizers());
-  const MobodIndex mobilizer_index(num_mobilizers());
+  DRAKE_DEMAND(
+      !rigid_body_topology_[outboard_body].inboard_mobilizer.is_valid());
+  DRAKE_DEMAND(!rigid_body_topology_[outboard_body].parent_body.is_valid());
 
   // Make note of the inboard mobilizer for the outboard body.
-  rigid_bodies_[outboard_body].inboard_mobilizer = mobilizer_index;
+  rigid_body_topology_[outboard_body].inboard_mobilizer = mobilizer_index;
   // Similarly, record inboard_body as the parent of outboard_body.
-  rigid_bodies_[outboard_body].parent_body = inboard_body;
+  rigid_body_topology_[outboard_body].parent_body = inboard_body;
 
   // Records "child" rigid bodies for bookkeeping in the context of the tree
   // structure of the multibody forest.
-  rigid_bodies_[inboard_body].child_bodies.push_back(outboard_body);
+  rigid_body_topology_[inboard_body].child_bodies.push_back(outboard_body);
 
-  mobilizers_.emplace_back(mobilizer_index, in_frame, out_frame, inboard_body,
-                           outboard_body, mobod);
-  return mobilizer_index;
+  mobilizer_topology_.emplace_back(mobilizer_index, in_frame, out_frame,
+                                   inboard_body, outboard_body, mobod);
 }
 
-void MultibodyTreeTopology::add_world_mobilizer(
+void MultibodyTreeTopology::add_world_mobilizer_topology(
     const SpanningForest::Mobod& world_mobod, FrameIndex world_body_frame) {
   DRAKE_DEMAND(world_mobod.is_world());
-  const BodyIndex world_body_index = frames_[world_body_frame].rigid_body;
+  const BodyIndex world_body_index =
+      frame_topology_[world_body_frame].rigid_body;
   DRAKE_DEMAND(world_body_index == BodyIndex(0));
-  DRAKE_DEMAND(mobilizers_.empty());
+  DRAKE_DEMAND(mobilizer_topology_.empty());
   // There is no inboard frame for this mobilizer. We'll use the World body
   // frame and rigid body for both frames & bodies so we don't have to deal
   // with invalid indices. No computation depends on those.
-  mobilizers_.emplace_back(MobodIndex(0), world_body_frame, world_body_frame,
-                           world_body_index, world_body_index, world_mobod);
-  rigid_bodies_[world_body_index].inboard_mobilizer = MobodIndex(0);
+  mobilizer_topology_.emplace_back(MobodIndex(0), world_body_frame,
+                                   world_body_frame, world_body_index,
+                                   world_body_index, world_mobod);
+  rigid_body_topology_[world_body_index].inboard_mobilizer = MobodIndex(0);
 }
 
-JointActuatorIndex MultibodyTreeTopology::add_joint_actuator(int num_dofs) {
-  DRAKE_ASSERT(num_dofs > 0);
+void MultibodyTreeTopology::add_joint_actuator_topology(
+    JointActuatorIndex joint_actuator_index, int num_dofs) {
+  DRAKE_DEMAND(joint_actuator_index == num_joint_actuators());
+  DRAKE_DEMAND(num_dofs > 0);
   if (is_valid()) {
     throw std::logic_error(
         "This MultibodyTreeTopology is finalized already. "
         "Therefore adding more joint actuators is not allowed. "
         "See documentation for Finalize() for details.");
   }
-  const int actuator_index_start = num_actuated_dofs();
-  const JointActuatorIndex actuator_index(ssize(joint_actuators_));
-  joint_actuators_.push_back(
-      JointActuatorTopology{.index = actuator_index,
-                            .actuator_index_start = actuator_index_start,
+  const int actuator_dof_start = num_actuated_dofs();
+  joint_actuator_topology_.push_back(
+      JointActuatorTopology{.index = joint_actuator_index,
+                            .actuator_dof_start = actuator_dof_start,
                             .num_dofs = num_dofs});
   num_actuated_dofs_ += num_dofs;
-  return actuator_index;
 }
 
-void MultibodyTreeTopology::RemoveJointActuator(
+void MultibodyTreeTopology::RemoveJointActuatorTopology(
     JointActuatorIndex actuator_index) {
-  DRAKE_DEMAND(actuator_index < ssize(joint_actuators_));
+  DRAKE_DEMAND(actuator_index < ssize(joint_actuator_topology_));
   DRAKE_THROW_UNLESS(!is_valid());
-  DRAKE_THROW_UNLESS(joint_actuators_[actuator_index].has_value());
+  DRAKE_THROW_UNLESS(joint_actuator_topology_[actuator_index].has_value());
 
   // Reduce the total number of actuated dofs.
-  const int num_dofs = (*joint_actuators_[actuator_index]).num_dofs;
+  const int num_dofs = (*joint_actuator_topology_[actuator_index]).num_dofs;
   DRAKE_DEMAND(num_actuated_dofs_ >= num_dofs);
   num_actuated_dofs_ -= num_dofs;
 
   // Mark the actuator as "removed".
-  joint_actuators_[actuator_index] = std::nullopt;
+  joint_actuator_topology_[actuator_index] = std::nullopt;
 
-  // Update the actuator_index_start for all joint actuators that come after
+  // Update the actuator_dof_start for all joint actuators that come after
   // the one we just removed.
-  for (JointActuatorIndex i(actuator_index); i < ssize(joint_actuators_); ++i) {
-    if (joint_actuators_[i].has_value()) {
-      (*joint_actuators_[i]).actuator_index_start -= num_dofs;
+  for (JointActuatorIndex i(actuator_index);
+       i < ssize(joint_actuator_topology_); ++i) {
+    if (joint_actuator_topology_[i].has_value()) {
+      (*joint_actuator_topology_[i]).actuator_dof_start -= num_dofs;
     }
   }
 }
@@ -248,7 +224,7 @@ void MultibodyTreeTopology::RemoveJointActuator(
 // TODO(sherm1) For historical reasons we're extracting information from the
 //  Forest and distributing it but we should work directly from the Forest
 //  without duplication.
-void MultibodyTreeTopology::Finalize(const LinkJointGraph& graph) {
+void MultibodyTreeTopology::FinalizeTopology(const LinkJointGraph& graph) {
   // If the topology is valid it means that it was already finalized.
   // Re-compilation is not allowed.
   if (is_valid()) {
@@ -265,40 +241,17 @@ void MultibodyTreeTopology::Finalize(const LinkJointGraph& graph) {
   // we can use the same numbering for BodyNodes. Also update RigidBodyTopology,
   // though in the case where we combine welded-together rigid bodies only the
   // "active" body of each Composite gets updated here.
-  body_nodes_.reserve(ssize(forest.mobods()));
   for (const auto& mobod : forest.mobods()) {
     const MobodIndex node_index(mobod.index());
     const BodyIndex rigid_body_index =
         graph.links(mobod.link_ordinal()).index();
-    RigidBodyTopology& current_body = rigid_bodies_[rigid_body_index];
+    RigidBodyTopology& current_body = rigid_body_topology_[rigid_body_index];
     current_body.mobod_index = node_index;
     current_body.level = mobod.level();
     const MobodIndex mobilizer_index = current_body.inboard_mobilizer;
     DRAKE_DEMAND(mobilizer_index == node_index);
-    const MobilizerTopology& mobilizer = mobilizers_[mobilizer_index];
+    const MobilizerTopology& mobilizer = mobilizer_topology_[mobilizer_index];
     DRAKE_DEMAND(mobilizer.index == node_index);
-
-    MobodIndex parent_node;
-    const BodyIndex parent_body_index =
-        current_body.parent_body;  // invalid if World
-    if (node_index != 0) {         // Skip if World.
-      // N.B. This works because we're working depth-first so will already
-      // have processed this node's parent.
-      parent_node = rigid_bodies_[parent_body_index].mobod_index;
-      body_nodes_[parent_node].child_nodes.push_back(node_index);
-    }
-
-    // Creates a BodyNodeTopology.
-    DRAKE_DEMAND(node_index == ssize(body_nodes_));
-    body_nodes_.emplace_back(node_index, mobod.level(), parent_node,
-                             rigid_body_index, parent_body_index);
-
-    // Copy coordinate assignments from the MobilizerTopology.
-    BodyNodeTopology& node = body_nodes_.back();
-    node.mobilizer_positions_start = mobilizer.positions_start;
-    node.num_mobilizer_positions = mobilizer.num_positions;
-    node.num_mobilizer_velocities = mobilizer.num_velocities;
-    node.mobilizer_velocities_start_in_v = mobilizer.velocities_start_in_v;
   }
 
   num_positions_ = forest.num_positions();
@@ -307,13 +260,13 @@ void MultibodyTreeTopology::Finalize(const LinkJointGraph& graph) {
 
   // Update position/velocity indexes for free rigid bodies so that they are
   // easily accessible.
-  for (RigidBodyTopology& rigid_body : rigid_bodies_) {
-    if (rigid_body.is_floating_base) {
-      DRAKE_DEMAND(rigid_body.inboard_mobilizer.is_valid());
+  for (RigidBodyTopology& rigid_body_topology : rigid_body_topology_) {
+    if (rigid_body_topology.is_floating_base) {
+      DRAKE_DEMAND(rigid_body_topology.inboard_mobilizer.is_valid());
       const MobilizerTopology& mobilizer =
-          get_mobilizer(rigid_body.inboard_mobilizer);
-      rigid_body.floating_positions_start = mobilizer.positions_start;
-      rigid_body.floating_velocities_start_in_v =
+          get_mobilizer_topology(rigid_body_topology.inboard_mobilizer);
+      rigid_body_topology.floating_positions_start = mobilizer.positions_start;
+      rigid_body_topology.floating_velocities_start_in_v =
           mobilizer.velocities_start_in_v;
     }
   }
@@ -327,7 +280,7 @@ void MultibodyTreeTopology::Finalize(const LinkJointGraph& graph) {
 
 bool MultibodyTreeTopology::IsThereAMobilizerBetweenFrames(
     FrameIndex frame1, FrameIndex frame2) const {
-  for (const auto& mobilizer_topology : mobilizers_) {
+  for (const auto& mobilizer_topology : mobilizer_topology_) {
     if (mobilizer_topology.connects_frames(frame1, frame2)) return true;
   }
   return false;
@@ -337,7 +290,7 @@ bool MultibodyTreeTopology::IsThereAMobilizerBetweenFrames(
 // connecting the Links with indexes `body1` and `body2`.
 bool MultibodyTreeTopology::IsThereAMobilizerBetweenRigidBodies(
     BodyIndex body1, BodyIndex body2) const {
-  for (const auto& mobilizer_topology : mobilizers_) {
+  for (const auto& mobilizer_topology : mobilizer_topology_) {
     if (mobilizer_topology.connects_rigid_bodies(body1, body2)) return true;
   }
   return false;
@@ -351,8 +304,8 @@ void MultibodyTreeTopology::ExtractForestInfo(const LinkJointGraph& graph) {
   const SpanningForest& forest = graph.forest();
   forest_height_ = forest.height();
 
-  const BodyNodeTopology& root = get_body_node(MobodIndex(0));
-  DRAKE_DEMAND(ssize(root.child_nodes) == ssize(forest.trees()));
+  const SpanningForest::Mobod& root = forest.mobods(MobodIndex(0));
+  DRAKE_DEMAND(ssize(root.outboards()) == ssize(forest.trees()));
 
   tree_velocities_start_in_v_.resize(ssize(forest.trees()), -1);
   num_tree_velocities_.resize(ssize(forest.trees()), -1);
@@ -367,16 +320,14 @@ void MultibodyTreeTopology::ExtractForestInfo(const LinkJointGraph& graph) {
     velocity_to_tree_index_.emplace_back(forest.v_to_tree(v));
 
   // Map each Link in the graph (including shadows added to break loops) to
-  // the tree
-  // to which its modeling Mobod belongs.
-  rigid_body_to_tree_index_.resize(ssize(graph.links()));
+  // the tree to which its modeling Mobod belongs.
+  // TODO(sherm1) Really should be graph.num_link_indexes() which is private.
+  //  Doesn't matter though since we don't currently remove Links and this code
+  //  is going away soon.
+  rigid_body_to_tree_index_.resize(graph.num_links());
   for (const auto& link : graph.links()) {
-    const MobodIndex mobod_index = graph.link_to_mobod(link.index());
-    DRAKE_DEMAND(mobod_index.is_valid());
-    const SpanningForest::Mobod& mobod = forest.mobods(mobod_index);
-
     // The tree index will be invalid for World.
-    rigid_body_to_tree_index_[link.index()] = mobod.tree();
+    rigid_body_to_tree_index_[link.index()] = forest.link_to_tree(link.index());
   }
 }
 

--- a/multibody/tree/position_kinematics_cache.h
+++ b/multibody/tree/position_kinematics_cache.h
@@ -38,9 +38,9 @@ class PositionKinematicsCache {
   using RigidTransform = drake::math::RigidTransform<U>;
 
   // Constructs a position kinematics cache entry for the given
-  // MultibodyTreeTopology.
-  explicit PositionKinematicsCache(const MultibodyTreeTopology& topology)
-      : num_mobods_(topology.num_mobods()) {
+  // SpanningForest.
+  explicit PositionKinematicsCache(const SpanningForest& forest)
+      : num_mobods_(forest.num_mobods()) {
     Allocate();
   }
 

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -734,7 +734,7 @@ class RigidBody : public MultibodyElement<T> {
   // from the parent MultibodyTree.
   void DoSetTopology(
       const internal::MultibodyTreeTopology& tree_topology) final {
-    topology_ = tree_topology.get_rigid_body(this->index());
+    topology_ = tree_topology.get_rigid_body_topology(this->index());
     body_frame_.SetTopology(tree_topology);
   }
 

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -79,11 +79,11 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
   auto context = system.CreateDefaultContext();
 
   // Update cache.
-  PositionKinematicsCache<double> pc(tree.get_topology());
+  PositionKinematicsCache<double> pc(tree.forest());
   tree.CalcPositionKinematicsCache(*context, &pc);
 
   // Compute articulated body cache.
-  ArticulatedBodyInertiaCache<double> abc(tree.get_topology());
+  ArticulatedBodyInertiaCache<double> abc(tree.forest());
   tree.CalcArticulatedBodyInertiaCache(*context, &abc);
 
   // Get expected projected articulated body inertia of cylinder. Only the
@@ -196,11 +196,11 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   MC_joint.set_translation(context.get(), 0.2);
 
   // Update cache.
-  PositionKinematicsCache<double> pc(tree.get_topology());
+  PositionKinematicsCache<double> pc(tree.forest());
   tree.CalcPositionKinematicsCache(*context, &pc);
 
   // Compute articulated body cache.
-  ArticulatedBodyInertiaCache<double> abc(tree.get_topology());
+  ArticulatedBodyInertiaCache<double> abc(tree.forest());
   tree.CalcArticulatedBodyInertiaCache(*context, &abc);
 
   // Find the rotation R_WC from World to the Cylinder frame.

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -15,7 +15,6 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/tree/prismatic_joint.h"
-#include "drake/multibody/tree/prismatic_mobilizer.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/revolute_mobilizer.h"
 #include "drake/multibody/tree/rigid_body.h"
@@ -330,59 +329,30 @@ class TreeTopologyTests : public ::testing::Test {
   // Performs a number of tests on the BodyNodeTopology corresponding to the
   // body indexed by `body`.
   static void TestBodyNode(const MultibodyTreeTopology& topology,
-                           BodyIndex body) {
-    const MobodIndex node = topology.get_rigid_body(body).mobod_index;
+                           const SpanningForest& forest, BodyIndex body) {
+    // In case of merged composites, many links may follow the same mobod.
+    // Make sure the link's mobod agrees that the link follows it.
+    const LinkJointGraph::Link& link = forest.link_by_index(body);
+    const MobodIndex mobod_index = link.mobod_index();
+    const SpanningForest::Mobod& mobod = forest.mobods(mobod_index);
+    EXPECT_EQ(mobod.index(), mobod_index);
+    mobod.HasFollower(link.ordinal());
 
-    // Verify that the corresponding RigidBody and BodyNode reference each other
-    // correctly.
-    EXPECT_EQ(topology.get_rigid_body(body).mobod_index,
-              topology.get_body_node(node).index);
-    EXPECT_EQ(topology.get_body_node(node).rigid_body,
-              topology.get_rigid_body(body).index);
+    const MobodIndex parent_mobod_index = mobod.inboard();
+    EXPECT_TRUE(parent_mobod_index.is_valid() ^ link.is_world());
 
-    // They should belong to the same level.
-    EXPECT_EQ(topology.get_rigid_body(body).level,
-              topology.get_body_node(node).level);
+    if (link.is_world()) return;
 
-    const MobodIndex parent_node =
-        topology.get_body_node(node).parent_body_node;
-    // Either (and thus the exclusive or):
-    // 1. `body` is the world, and thus `parent_node` is invalid, XOR
-    // 2. `body` is not the world, and thus we have a valid `parent_node`.
-    EXPECT_TRUE(parent_node.is_valid() ^ (body == world_index()));
-
-    if (body != world_index()) {
-      // Verifies BodyNode has the parent node to the correct body.
-      const BodyIndex parent_body =
-          topology.get_body_node(parent_node).rigid_body;
-      EXPECT_TRUE(parent_body.is_valid());
-      EXPECT_EQ(parent_body, topology.get_rigid_body(body).parent_body);
-      EXPECT_EQ(topology.get_body_node(parent_node).index,
-                topology.get_rigid_body(parent_body).mobod_index);
-
-      // Verifies that BodyNode and Mobilizer indexes match.
-      const MobodIndex mobilizer = topology.get_body_node(node).index;
-      EXPECT_EQ(mobilizer, topology.get_rigid_body(body).inboard_mobilizer);
-      EXPECT_EQ(topology.get_mobilizer(mobilizer).index, node);
-
-      // Helper lambda to check if this "node" effectively is a child of
-      // "parent_node".
-      auto is_child_of_parent = [&]() {
-        const auto& children = topology.get_body_node(parent_node).child_nodes;
-        return std::find(children.begin(), children.end(), node) !=
-               children.end();
-      };
-      EXPECT_TRUE(is_child_of_parent());
-    }
+    // Verify that the link's mobod is actually a child of its parent mobod.
+    const SpanningForest::Mobod& parent_mobod =
+        forest.mobods(parent_mobod_index);
+    const std::vector<MobodIndex>& child_mobods = parent_mobod.outboards();
+    EXPECT_TRUE(std::find(child_mobods.begin(), child_mobods.end(),
+                          mobod_index) != child_mobods.end());
   }
 
-  static const BodyNodeTopology& node_topology_from_body_index(
-      const MultibodyTreeTopology& topology, int body_index) {
-    return topology.get_body_node(
-        topology.get_rigid_body(BodyIndex(body_index)).mobod_index);
-  }
-
-  static void VerifyTopology(const MultibodyTreeTopology& topology) {
+  static void VerifyTopology(const MultibodyTreeTopology& topology,
+                             const SpanningForest& forest) {
     const int kNumRigidBodies = 10;
 
     EXPECT_EQ(topology.num_rigid_bodies(), kNumRigidBodies);
@@ -390,63 +360,82 @@ class TreeTopologyTests : public ::testing::Test {
     EXPECT_EQ(topology.num_mobods(), kNumRigidBodies);
     EXPECT_EQ(topology.forest_height(), 4);
 
+    EXPECT_EQ(forest.num_links(), kNumRigidBodies);
+    EXPECT_EQ(forest.num_mobods(), kNumRigidBodies);
+    EXPECT_EQ(forest.height(), 4);
+
     // These sets contain the indexes of the RigidBodies in each tree level.
     // The order of these indexes in each set is not important, but only the
     // fact that they belong to the appropriate set.
-    set<BodyIndex> expected_level0 = {BodyIndex(0)};
-    set<BodyIndex> expected_level1 = {BodyIndex(4), BodyIndex(7), BodyIndex(5),
-                                      BodyIndex(9)};
-    set<BodyIndex> expected_level2 = {BodyIndex(2), BodyIndex(1), BodyIndex(3),
-                                      BodyIndex(8)};
-    set<BodyIndex> expected_level3 = {BodyIndex(6)};
+    const set<LinkIndex> expected_level0 = {LinkIndex(0)};
+    const set<LinkIndex> expected_level1 = {LinkIndex(4), LinkIndex(7),
+                                            LinkIndex(5), LinkIndex(9)};
+    const set<LinkIndex> expected_level2 = {LinkIndex(2), LinkIndex(1),
+                                            LinkIndex(3), LinkIndex(8)};
+    const set<LinkIndex> expected_level3 = {LinkIndex(6)};
 
-    std::vector<std::set<BodyIndex>> levels(topology.num_rigid_bodies());
+    std::vector<std::set<BodyIndex>> topo_levels(topology.num_rigid_bodies());
     for (BodyIndex index(0); index < topology.num_rigid_bodies(); ++index) {
       const RigidBodyTopology& rigid_body_topology =
-          topology.get_rigid_body(index);
-      levels[rigid_body_topology.level].insert(index);
+          topology.get_rigid_body_topology(index);
+      topo_levels[rigid_body_topology.level].insert(index);
     }
-
     // Comparison of sets. The order of the elements is not important.
+    EXPECT_EQ(topo_levels[0], expected_level0);
+    EXPECT_EQ(topo_levels[1], expected_level1);
+    EXPECT_EQ(topo_levels[2], expected_level2);
+    EXPECT_EQ(topo_levels[3], expected_level3);
+
+    // Repeat for the forest.
+    std::vector<std::set<LinkIndex>> levels(topology.num_rigid_bodies());
+    for (const LinkJointGraph::Link& link : forest.links()) {
+      const LinkIndex link_index = link.index();
+      const int level = forest.mobods(link.mobod_index()).level();
+      levels[level].insert(link_index);
+    }
     EXPECT_EQ(levels[0], expected_level0);
     EXPECT_EQ(levels[1], expected_level1);
     EXPECT_EQ(levels[2], expected_level2);
     EXPECT_EQ(levels[3], expected_level3);
 
+    const std::map<LinkIndex, int> expected_num_outboards{
+        {LinkIndex(0), 4}, {LinkIndex(1), 1}, {LinkIndex(2), 0},
+        {LinkIndex(3), 0}, {LinkIndex(4), 2}, {LinkIndex(5), 1},
+        {LinkIndex(6), 0}, {LinkIndex(7), 0}, {LinkIndex(8), 0},
+        {LinkIndex(9), 1}};
+
     // Verifies the expected number of child nodes.
-    EXPECT_EQ(node_topology_from_body_index(topology, 0).get_num_children(), 4);
-    EXPECT_EQ(node_topology_from_body_index(topology, 4).get_num_children(), 2);
-    EXPECT_EQ(node_topology_from_body_index(topology, 7).get_num_children(), 0);
-    EXPECT_EQ(node_topology_from_body_index(topology, 5).get_num_children(), 1);
-    EXPECT_EQ(node_topology_from_body_index(topology, 9).get_num_children(), 1);
-    EXPECT_EQ(node_topology_from_body_index(topology, 2).get_num_children(), 0);
-    EXPECT_EQ(node_topology_from_body_index(topology, 1).get_num_children(), 1);
-    EXPECT_EQ(node_topology_from_body_index(topology, 3).get_num_children(), 0);
-    EXPECT_EQ(node_topology_from_body_index(topology, 8).get_num_children(), 0);
-    EXPECT_EQ(node_topology_from_body_index(topology, 6).get_num_children(), 0);
+    for (const auto& [link_index, num_outboards] : expected_num_outboards) {
+      const LinkOrdinal ordinal = forest.graph().index_to_ordinal(link_index);
+      const LinkJointGraph::Link& link = forest.links(ordinal);
+      const SpanningForest::Mobod& mobod = forest.mobods(link.mobod_index());
+      EXPECT_EQ(ssize(mobod.outboards()), num_outboards);
+    }
 
     // Checks the correctness of each BodyNode associated with a Link.
     for (BodyIndex index(0); index < kNumRigidBodies; ++index) {
-      TestBodyNode(topology, index);
+      TestBodyNode(topology, forest, index);
     }
 
     // We now verify the precise expected topology. We use our internal
     // knowledge that branches are created according to the order in which
     // Joints are added. Refer to schematic in the documentation of this
     // test fixture.
-    EXPECT_EQ(world_mobod_index(), MobodIndex(0));
-    EXPECT_EQ(topology.get_body_node(MobodIndex(0)).rigid_body, 0);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(1)).rigid_body, 7);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(2)).rigid_body, 5);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(3)).rigid_body, 3);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(4)).rigid_body, 9);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(5)).rigid_body, 8);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(6)).rigid_body, 4);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(7)).rigid_body, 2);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(8)).rigid_body, 1);
-    EXPECT_EQ(topology.get_body_node(MobodIndex(9)).rigid_body, 6);
+    const std::map<MobodIndex, LinkIndex> expected_mobod_to_link = {
+        {MobodIndex(0), LinkIndex(0)}, {MobodIndex(1), LinkIndex(7)},
+        {MobodIndex(2), LinkIndex(5)}, {MobodIndex(3), LinkIndex(3)},
+        {MobodIndex(4), LinkIndex(9)}, {MobodIndex(5), LinkIndex(8)},
+        {MobodIndex(6), LinkIndex(4)}, {MobodIndex(7), LinkIndex(2)},
+        {MobodIndex(8), LinkIndex(1)}, {MobodIndex(9), LinkIndex(6)}};
 
-    // Verify the expected "forest" of trees.
+    for (const auto& [mobod_index, primary_link_index] :
+         expected_mobod_to_link) {
+      const SpanningForest::Mobod& mobod = forest.mobods(mobod_index);
+      const LinkJointGraph::Link& link = forest.links(mobod.link_ordinal());
+      EXPECT_EQ(link.index(), primary_link_index);
+    }
+
+    // Verify the expected forest of trees.
     EXPECT_EQ(topology.num_trees(), 4);
     EXPECT_EQ(topology.num_tree_velocities(TreeIndex(0)), 1);
     EXPECT_EQ(topology.num_tree_velocities(TreeIndex(1)), 2);
@@ -456,28 +445,57 @@ class TreeTopologyTests : public ::testing::Test {
     EXPECT_EQ(topology.tree_velocities_start_in_v(TreeIndex(1)), 1);
     EXPECT_EQ(topology.tree_velocities_start_in_v(TreeIndex(2)), 3);
     EXPECT_EQ(topology.tree_velocities_start_in_v(TreeIndex(3)), 3);
+
+    EXPECT_EQ(forest.num_trees(), 4);
+    EXPECT_EQ(forest.trees(TreeIndex(0)).nv(), 1);
+    EXPECT_EQ(forest.trees(TreeIndex(1)).nv(), 2);
+    EXPECT_EQ(forest.trees(TreeIndex(2)).nv(), 0);
+    EXPECT_EQ(forest.trees(TreeIndex(3)).nv(), 4);
+    EXPECT_EQ(forest.trees(TreeIndex(0)).v_start(), 0);
+    EXPECT_EQ(forest.trees(TreeIndex(1)).v_start(), 1);
+    EXPECT_EQ(forest.trees(TreeIndex(2)).v_start(), 3);
+    EXPECT_EQ(forest.trees(TreeIndex(3)).v_start(), 3);
+
+    const std::map<LinkIndex, TreeIndex> expected_link_to_tree = {
+        {LinkIndex(0), TreeIndex()},  {LinkIndex(1), TreeIndex(3)},
+        {LinkIndex(2), TreeIndex(3)}, {LinkIndex(3), TreeIndex(1)},
+        {LinkIndex(4), TreeIndex(3)}, {LinkIndex(5), TreeIndex(1)},
+        {LinkIndex(6), TreeIndex(3)}, {LinkIndex(7), TreeIndex(0)},
+        {LinkIndex(8), TreeIndex(2)}, {LinkIndex(9), TreeIndex(2)}};
+
     // The world body does not belong to a tree. Therefore the returned index is
     // invalid.
-    EXPECT_FALSE(topology.body_to_tree_index(world_index()).is_valid());
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(7)), TreeIndex(0));
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(5)), TreeIndex(1));
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(3)), TreeIndex(1));
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(9)), TreeIndex(2));
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(8)), TreeIndex(2));
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(4)), TreeIndex(3));
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(2)), TreeIndex(3));
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(1)), TreeIndex(3));
-    EXPECT_EQ(topology.body_to_tree_index(BodyIndex(6)), TreeIndex(3));
+    for (const auto& [link_index, tree_index] : expected_link_to_tree) {
+      if (link_index == world_index()) {
+        EXPECT_FALSE(topology.body_to_tree_index(link_index).is_valid());
+        continue;
+      }
+      EXPECT_EQ(topology.body_to_tree_index(link_index), tree_index);
+    }
+
+    for (const auto& [link_index, tree_index] : expected_link_to_tree) {
+      if (link_index == world_index()) {
+        EXPECT_FALSE(forest.link_to_tree(link_index).is_valid());
+        continue;
+      }
+      EXPECT_EQ(forest.link_to_tree(link_index), tree_index);
+    }
+
+    // No velocities map to Tree 2.
+    const std::map<int, TreeIndex> expected_velocity_to_tree = {
+        {0, TreeIndex(0)}, {1, TreeIndex(1)}, {2, TreeIndex(1)},
+        {3, TreeIndex(3)}, {4, TreeIndex(3)}, {5, TreeIndex(3)},
+        {6, TreeIndex(3)}};
 
     EXPECT_EQ(topology.num_velocities(), 7);
-    EXPECT_EQ(topology.velocity_to_tree_index(0), TreeIndex(0));
-    EXPECT_EQ(topology.velocity_to_tree_index(1), TreeIndex(1));
-    EXPECT_EQ(topology.velocity_to_tree_index(2), TreeIndex(1));
-    // No velocities map to Tree 2.
-    EXPECT_EQ(topology.velocity_to_tree_index(3), TreeIndex(3));
-    EXPECT_EQ(topology.velocity_to_tree_index(4), TreeIndex(3));
-    EXPECT_EQ(topology.velocity_to_tree_index(5), TreeIndex(3));
-    EXPECT_EQ(topology.velocity_to_tree_index(6), TreeIndex(3));
+    for (const auto& [velocity_index, tree_index] : expected_velocity_to_tree) {
+      EXPECT_EQ(topology.velocity_to_tree_index(velocity_index), tree_index);
+    }
+
+    EXPECT_EQ(forest.num_velocities(), 7);
+    for (const auto& [velocity_index, tree_index] : expected_velocity_to_tree) {
+      EXPECT_EQ(forest.v_to_tree(velocity_index), tree_index);
+    }
   }
 
  protected:
@@ -498,10 +516,15 @@ TEST_F(TreeTopologyTests, Finalize) {
   EXPECT_EQ(model_->num_mobilizers(), 10);
 
   const MultibodyTreeTopology& topology = model_->get_topology();
-  EXPECT_EQ(topology.num_mobods(), model_->num_bodies());
+  const SpanningForest& forest = model_->forest();
+
+  EXPECT_EQ(topology.num_mobods(), 10);
   EXPECT_EQ(topology.forest_height(), 4);
 
-  VerifyTopology(topology);
+  EXPECT_EQ(forest.num_mobods(), 10);
+  EXPECT_EQ(forest.height(), 4);
+
+  VerifyTopology(topology, forest);
 }
 
 // This unit tests verifies the correct number of generalized positions and
@@ -512,41 +535,37 @@ TEST_F(TreeTopologyTests, SizesAndIndexing) {
   EXPECT_EQ(model_->num_mobilizers(), 10);
   EXPECT_EQ(model_->num_joints(), 9);
 
+  // TODO(sherm1) First make sure topology and forest agree, then nuke the
+  //  old topology code.
   const MultibodyTreeTopology& topology = model_->get_topology();
+  const SpanningForest& forest = model_->forest();
+
   EXPECT_EQ(topology.num_mobods(), model_->num_bodies());
   EXPECT_EQ(topology.forest_height(), 4);
-
-  // Verifies the total number of generalized positions and velocities.
   EXPECT_EQ(topology.num_positions(), 7);
   EXPECT_EQ(topology.num_velocities(), 7);
   EXPECT_EQ(topology.num_states(), 14);
 
-  // Tip-to-Base recursion.
+  EXPECT_EQ(forest.num_mobods(), 10);
+  EXPECT_EQ(forest.height(), 4);
+  EXPECT_EQ(forest.num_positions(), 7);
+  EXPECT_EQ(forest.num_velocities(), 7);
+
   // In this case all mobilizers are RevoluteMobilizer objects with one
   // generalized position and one generalized velocity per mobilizer.
   int positions_index = 0;
   int velocities_index = 0;
-  for (MobodIndex mobod_index(1); /* Skips the world mobilized body. */
-       mobod_index < topology.num_mobods(); ++mobod_index) {
-    const BodyNodeTopology& node = topology.get_body_node(mobod_index);
-    const BodyIndex body_index = node.rigid_body;
-    const MobodIndex mobilizer_index = node.index;
+  for (const SpanningForest::Mobod& mobod : forest.mobods()) {
+    const LinkOrdinal active_link_ordinal = mobod.link_ordinal();
+    const LinkJointGraph::Link active_link = forest.links(active_link_ordinal);
 
-    const MobilizerTopology& mobilizer_topology =
-        topology.get_mobilizer(mobilizer_index);
+    EXPECT_EQ(active_link.mobod_index(), mobod.index());
+    EXPECT_EQ(active_link.ordinal(), active_link_ordinal);
 
-    EXPECT_EQ(body_index, bodies_[body_index]->index());
-
-    // Verify positions and velocity indexes.
-    EXPECT_EQ(positions_index, node.mobilizer_positions_start);
-    EXPECT_EQ(positions_index, mobilizer_topology.positions_start);
-    EXPECT_EQ(velocities_index, node.mobilizer_velocities_start_in_v);
-    EXPECT_EQ(velocities_index, mobilizer_topology.velocities_start_in_v);
-
-    // Mobilizers 5 and 8 are weld joints, with no velocities. All other
-    // mobilizers introduce one position and one velocity.
-    positions_index += mobilizer_topology.num_positions;
-    velocities_index += mobilizer_topology.num_velocities;
+    EXPECT_EQ(positions_index, mobod.q_start());
+    EXPECT_EQ(velocities_index, mobod.v_start());
+    positions_index += mobod.nq();
+    velocities_index += mobod.nv();
   }
   EXPECT_EQ(positions_index, topology.num_positions());
   EXPECT_EQ(velocities_index, topology.num_velocities());
@@ -567,6 +586,7 @@ TEST_F(TreeTopologyTests, Clone) {
   EXPECT_EQ(cloned_model->num_mobilizers(), 10);
   EXPECT_EQ(cloned_model->num_force_elements(), 1);
   const MultibodyTreeTopology& clone_topology = cloned_model->get_topology();
+  const SpanningForest& clone_forest = cloned_model->forest();
 
   // Verify the cloned topology actually is a different object.
   ASSERT_NE(&topology, &clone_topology);
@@ -577,7 +597,7 @@ TEST_F(TreeTopologyTests, Clone) {
 
   // Even though the test above confirms the two topologies are exactly equal,
   // we perform a number of additional tests.
-  VerifyTopology(clone_topology);
+  VerifyTopology(clone_topology, clone_forest);
 }
 
 // Verifies that the AutoDiffXd version of a given MultibodyTree model created
@@ -594,6 +614,7 @@ TEST_F(TreeTopologyTests, ToAutoDiffXd) {
   EXPECT_EQ(autodiff_model->num_mobilizers(), 10);
   const MultibodyTreeTopology& autodiff_topology =
       autodiff_model->get_topology();
+  const SpanningForest& autodiff_forest = autodiff_model->forest();
 
   // The topology of the clone must be exactly equal to the topology of the
   // original MultibodyTree.
@@ -601,7 +622,7 @@ TEST_F(TreeTopologyTests, ToAutoDiffXd) {
 
   // Even though the test above confirms the two topologies are exactly equal,
   // we perform a number of additional tests.
-  VerifyTopology(autodiff_topology);
+  VerifyTopology(autodiff_topology, autodiff_forest);
 }
 
 // Verifies that the symbolic version of a given MultibodyTree model created
@@ -618,6 +639,7 @@ TEST_F(TreeTopologyTests, ToSymbolic) {
   EXPECT_EQ(symbolic_model->num_mobilizers(), 10);
   const MultibodyTreeTopology& symbolic_topology =
       symbolic_model->get_topology();
+  const SpanningForest& symbolic_forest = symbolic_model->forest();
 
   // The topology of the clone must be exactly equal to the topology of the
   // original MultibodyTree.
@@ -625,7 +647,7 @@ TEST_F(TreeTopologyTests, ToSymbolic) {
 
   // Even though the test above confirms the two topologies are exactly equal,
   // we perform a number of additional tests.
-  VerifyTopology(symbolic_topology);
+  VerifyTopology(symbolic_topology, symbolic_forest);
 }
 
 // Confirm that the topology methods SpanningForest::FindPathFromWorld() and

--- a/multibody/tree/test/tree_from_joints_test.cc
+++ b/multibody/tree/test/tree_from_joints_test.cc
@@ -312,8 +312,8 @@ class PendulumTests : public ::testing::Test {
     pendulum_.shoulder().set_angular_rate(context_.get(), theta1dot);
     pendulum_.elbow().set_angular_rate(context_.get(), theta2dot);
 
-    internal::PositionKinematicsCache<double> pc(tree().get_topology());
-    internal::VelocityKinematicsCache<double> vc(tree().get_topology());
+    internal::PositionKinematicsCache<double> pc(tree().forest());
+    internal::VelocityKinematicsCache<double> vc(tree().forest());
     tree().CalcPositionKinematicsCache(*context_, &pc);
     tree().CalcVelocityKinematicsCache(*context_, pc, &vc);
 

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -49,9 +49,9 @@ VectorX<T> UniformGravityFieldElement<T>::CalcGravityGeneralizedForces(
   const internal::MultibodyTree<T>& model = this->get_parent_tree();
 
   // TODO(amcastro-tri): Get these from the cache.
-  internal::PositionKinematicsCache<T> pc(model.get_topology());
+  internal::PositionKinematicsCache<T> pc(model.forest());
   model.CalcPositionKinematicsCache(context, &pc);
-  internal::VelocityKinematicsCache<T> vc(model.get_topology());
+  internal::VelocityKinematicsCache<T> vc(model.forest());
   vc.InitializeToZero();
 
   // Create a multibody forces initialized by default to zero forces.

--- a/multibody/tree/velocity_kinematics_cache.h
+++ b/multibody/tree/velocity_kinematics_cache.h
@@ -37,13 +37,13 @@ class VelocityKinematicsCache {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VelocityKinematicsCache);
 
   // Constructs a velocity kinematics cache entry for the given
-  // MultibodyTreeTopology.
+  // SpanningForest.
   // In Release builds specific entries are left uninitialized resulting in a
   // zero cost operation. However in Debug builds those entries are set to NaN
   // so that operations using this uninitialized cache entry fail fast, easing
   // bug detection.
-  explicit VelocityKinematicsCache(const MultibodyTreeTopology& topology)
-      : num_mobods_(topology.num_mobods()) {
+  explicit VelocityKinematicsCache(const SpanningForest& forest)
+      : num_mobods_(forest.num_mobods()) {
     Allocate();
     DRAKE_ASSERT_VOID(InitializeToNaN());
     // Sets defaults.


### PR DESCRIPTION
This is a yak shave for merging welded-together bodies into a single mobilized body (see #23245). The goal here is to minimize (ideally eliminate) MbP internal code dependence on the old MultibodyTreeTopology data structures in favor of the identical ones in SpanningForest. The reason is that SpanningForest already understands composite bodies (not to mention everything else that is duplicated in MultibodyTreeTopology). Reworking the existing code to use the Forest will make it much easier to move away from the 1:1 body:mobod assumption that creeps in everywhere in MbT currently.

This PR gets only part of the way there (i.e., only part of the first task in the implementation plan in #23245!), but is big enough that I want to merge this first. All changes are internal and there should be no changes in functionality. What's here:
- Renamed some functions to make it clear that they return topology structs, e.g. `get_rigid_body() -> get_rigid_body_topology()`.  The code can be confusing to read without those changes.
- Many places that were being passed MultibodyTreeTopology now get SpanningForest instead, so dependence on the former is greatly reduced (but not yet eliminated).
- I added a few convenience functions to LinkJointGraph and SpanningForest to make the call sites look prettier.
- As a first installment, BodyNodeTopology is removed completely. One unit test had to be reworked to get its data from SpanningForest rather than BodyNodeTopology.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23272)
<!-- Reviewable:end -->
