### PR TITLE
[parsing] Parse custom tendon constraint elements

### DIFF
--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -198,7 +198,8 @@ std::optional<MultibodyConstraintId> ParseBallConstraint(
     MultibodyPlant<double>* plant);
 
 // Adds a tendon constraint to `plant` from a reading interface in a URDF/SDF
-// agnostic manner. This function does no semantic parsing and leaves the
+// agnostic manner. This function validates that the specified joints exist in
+// the model, but otherwise does no semantic parsing and leaves the
 // responsibility of handling errors or missing values to the individual
 // parsers. All values are expected to exist and be well formed. Through this,
 // the API to specify the tendon_constraint tag in both SDF and URDF can be
@@ -228,9 +229,9 @@ std::optional<MultibodyConstraintId> ParseBallConstraint(
 //   <drake:tendon_constraint_damping value="0.01"/>
 // </drake:tendon_constraint>
 //
-// The various @p read_* functors may (at its option) throw std::exception, or
-// return nullptr when body parsing fails. Similarly, ParseTendonConstraint()
-// may return nullopt at its option.
+// The various @p read_* functors may (at its option) emit diagnostic errors or
+// warnings but should not throw. ParseTendonConstraint() may return nullopt at
+// its option.
 std::optional<MultibodyConstraintId> ParseTendonConstraint(
     const drake::internal::DiagnosticPolicy& diagnostic,
     ModelInstanceIndex model_instance, const ElementNode& constraint_node,

--- a/multibody/parsing/detail_common.h
+++ b/multibody/parsing/detail_common.h
@@ -197,6 +197,54 @@ std::optional<MultibodyConstraintId> ParseBallConstraint(
     const std::function<const RigidBody<double>*(const char*)>& read_body,
     MultibodyPlant<double>* plant);
 
+// Adds a tendon constraint to `plant` from a reading interface in a URDF/SDF
+// agnostic manner. This function does no semantic parsing and leaves the
+// responsibility of handling errors or missing values to the individual
+// parsers. All values are expected to exist and be well formed. Through this,
+// the API to specify the tendon_constraint tag in both SDF and URDF can be
+// controlled/modified in a single function.
+//
+// __SDF__:
+//
+// <drake:tendon_constraint>
+//   <drake:tendon_constraint_joint name='joint_A' a='10.0'/>
+//   <drake:tendon_constraint_joint name='joint_B' a='20.0'/>
+//   <drake:tendon_constraint_offset>0.5</drake:tendon_constraint_offset>
+//   <drake:tendon_constraint_lower_limit>-1.0</drake:tendon_constraint_lower_limit>
+//   <drake:tendon_constraint_upper_limit>1.0</drake:tendon_constraint_upper_limit>
+//   <drake:tendon_constraint_stiffness>0.1</drake:tendon_constraint_stiffness>
+//   <drake:tendon_constraint_damping>0.01</drake:tendon_constraint_damping>
+// </drake:tendon_constraint>
+//
+// __URDF__:
+//
+// <drake:tendon_constraint>
+//   <drake:tendon_constraint_joint name='joint_A' a='10.0'/>
+//   <drake:tendon_constraint_joint name='joint_B' a='20.0'/>
+//   <drake:tendon_constraint_offset value="0.5"/>
+//   <drake:tendon_constraint_lower_limit value="-1.0"/>
+//   <drake:tendon_constraint_upper_limit value="1.0"/>
+//   <drake:tendon_constraint_stiffness value="0.1"/>
+//   <drake:tendon_constraint_damping value="0.01"/>
+// </drake:tendon_constraint>
+//
+// The various @p read_* functors may (at its option) throw std::exception, or
+// return nullptr when body parsing fails. Similarly, ParseTendonConstraint()
+// may return nullopt at its option.
+std::optional<MultibodyConstraintId> ParseTendonConstraint(
+    const drake::internal::DiagnosticPolicy& diagnostic,
+    ModelInstanceIndex model_instance, const ElementNode& constraint_node,
+    const std::function<std::optional<double>(const char*)>& read_double,
+    const std::function<ElementNode(const ElementNode&, const char*)>&
+        next_child_element,
+    const std::function<ElementNode(const ElementNode&, const char*)>&
+        next_sibling_element,
+    const std::function<std::string(const ElementNode&, const char*)>&
+        read_string_attribute,
+    const std::function<double(const ElementNode&, const char*)>&
+        read_double_attribute,
+    MultibodyPlant<double>* plant);
+
 // TODO(@SeanCurtis-TRI): The real solution here is to create a wrapper
 // class that provides a consistent interface to either representation.
 // Then instantiate on the caller side and express the code here in terms of

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1811,7 +1811,7 @@ const LinearBushingRollPitchYaw<double>* AddBushingFromSpecification(
 
   // Functor to read a vector valued child tag with tag name: `element_name`
   // e.g. <element_name>0 0 0</element_name>
-  // Throws an error if the tag does not exist.
+  // Reports an error if the tag does not exist.
   auto read_vector = [&diagnostic,
                       node](const char* element_name) -> Eigen::Vector3d {
     return ParseVector3(diagnostic, node, element_name);
@@ -1819,8 +1819,8 @@ const LinearBushingRollPitchYaw<double>* AddBushingFromSpecification(
 
   // Functor to read a child tag with tag name: `element_name` that specifies a
   // frame name, e.g. <element_name>frame_name</element_name>
-  // Throws an error if the tag does not exist or if the frame does not exist in
-  // the plant.
+  // Reports an error if the tag does not exist or if the frame does not exist
+  // in the plant.
   auto read_frame = [&diagnostic, node, model_instance,
                      plant](const char* element_name) -> const Frame<double>* {
     return ParseFrame(diagnostic, node, model_instance, plant, element_name);
@@ -1842,7 +1842,7 @@ std::optional<MultibodyConstraintId> AddBallConstraintFromSpecification(
 
   // Functor to read a vector valued child tag with tag name: `element_name`
   // e.g. <element_name>0 0 0</element_name>
-  // Throws an error if the tag does not exist.
+  // Reports an error if the tag does not exist.
   auto read_vector = [&diagnostic,
                       node](const char* element_name) -> Eigen::Vector3d {
     return ParseVector3(diagnostic, node, element_name);
@@ -1850,7 +1850,7 @@ std::optional<MultibodyConstraintId> AddBallConstraintFromSpecification(
 
   // Functor to read a child tag with tag name: `element_name` that specifies a
   // body name, e.g. <element_name>body_name</element_name>
-  // Throws an error if the tag does not exist or if the body does not exist in
+  // Reports an error if the tag does not exist or if the body does not exist in
   // the plant.
   auto read_body = [&diagnostic, node, model_instance, plant](
                        const char* element_name) -> const RigidBody<double>* {
@@ -1876,7 +1876,7 @@ std::optional<MultibodyConstraintId> AddTendonConstraintFromSpecification(
 
   // Functor to read a scalar valued child tag with tag name: `element_name`
   // e.g. <element_name>0</element_name>
-  // Throws an error if the tag does not exist.
+  // Reports an error if the tag does not exist.
   auto read_double = [&diagnostic,
                       node](const char* element_name) -> std::optional<double> {
     return ParseDouble(diagnostic, node, element_name);
@@ -1893,8 +1893,8 @@ std::optional<MultibodyConstraintId> AddTendonConstraintFromSpecification(
         ->GetNextElement(std::string(element_name));
   };
   // Functor to read a string valued attribute with attribute name:
-  // `attribute_name` e.g. <element attribute_name="string"/> Throws an error if
-  // the attribute does not exist.
+  // `attribute_name` e.g. <element attribute_name="string"/>
+  // Reports an error if the attribute does not exist.
   auto get_string_attribute = [&diagnostic](
                                   const ElementNode& data_element,
                                   const char* attribute_name) -> std::string {
@@ -1910,8 +1910,8 @@ std::optional<MultibodyConstraintId> AddTendonConstraintFromSpecification(
         ->Get<std::string>(attribute_name);
   };
   // Functor to read a double valued attribute with attribute name:
-  // `attribute_name` e.g. <element attribute_name="0.0"/> Throws an error if
-  // the attribute does not exist or is not a valid number.
+  // `attribute_name` e.g. <element attribute_name="0.0"/>
+  // Reports an error if the attribute does not exist or is not a valid number.
   auto get_double_attribute = [&diagnostic](
                                   const ElementNode& data_element,
                                   const char* attribute_name) -> double {

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -84,6 +84,7 @@ class UrdfParser {
   std::pair<std::optional<ModelInstanceIndex>, std::string> Parse();
   void ParseBushing(XMLElement* node);
   void ParseBallConstraint(XMLElement* node);
+  void ParseTendonConstraint(XMLElement* node);
   void ParseFrame(XMLElement* node);
   void ParseTransmission(const JointEffortLimits& joint_effort_limits,
                          XMLElement* node);
@@ -1159,6 +1160,67 @@ void UrdfParser::ParseBallConstraint(XMLElement* node) {
   internal::ParseBallConstraint(read_vector, read_body, w_.plant);
 }
 
+void UrdfParser::ParseTendonConstraint(XMLElement* node) {
+  auto read_double = [node,
+                      this](const char* element_name) -> std::optional<double> {
+    const XMLElement* value_node = node->FirstChildElement(element_name);
+    if (value_node != nullptr) {
+      double value;
+      if (ParseScalarAttribute(value_node, "value", &value)) {
+        return value;
+      } else {
+        Error(
+            *node,
+            fmt::format("Unable to read the 'value' attribute for the <{}> tag",
+                        element_name));
+        return {};
+      }
+    } else {
+      Error(*node, fmt::format("Unable to find the <{}> tag", element_name));
+      return {};
+    }
+  };
+  auto next_child_element = [](const ElementNode& data_element,
+                               const char* element_name) {
+    return std::get<XMLElement*>(data_element)->FirstChildElement(element_name);
+  };
+  auto next_sibling_element = [](const ElementNode& data_element,
+                                 const char* element_name) {
+    return std::get<XMLElement*>(data_element)
+        ->NextSiblingElement(element_name);
+  };
+  auto get_string_attribute = [this](const ElementNode& data_element,
+                                     const char* attribute_name) {
+    std::string attribute_value;
+    XMLElement* anode = std::get<XMLElement*>(data_element);
+    if (!ParseStringAttribute(anode, attribute_name, &attribute_value)) {
+      Error(*anode,
+            fmt::format(
+                "The tag <{}> does not specify the required attribute \"{}\".",
+                anode->Value(), attribute_name));
+      // Fall through to return empty string.
+    }
+    return attribute_value;
+  };
+  auto get_double_attribute = [this](const ElementNode& data_element,
+                                     const char* attribute_name) {
+    std::string attribute_value;
+    XMLElement* anode = std::get<XMLElement*>(data_element);
+    if (!ParseStringAttribute(anode, attribute_name, &attribute_value)) {
+      Error(*anode, fmt::format("The tag <{}> does not specify the required"
+                                " attribute \"{}\".",
+                                anode->Value(), attribute_name));
+      return 0.0;
+    }
+    return std::stod(attribute_value);
+  };
+
+  internal::ParseTendonConstraint(
+      diagnostic_.MakePolicyForNode(node), model_instance_, node, read_double,
+      next_child_element, next_sibling_element, get_string_attribute,
+      get_double_attribute, w_.plant);
+}
+
 std::pair<std::optional<ModelInstanceIndex>, std::string> UrdfParser::Parse() {
   XMLElement* node = xml_doc_->FirstChildElement("robot");
   if (!node) {
@@ -1267,6 +1329,15 @@ std::pair<std::optional<ModelInstanceIndex>, std::string> UrdfParser::Parse() {
        ball_constraint_node =
            ball_constraint_node->NextSiblingElement("drake:ball_constraint")) {
     ParseBallConstraint(ball_constraint_node);
+  }
+
+  // Parses the model's custom Drake tendon constraint tags.
+  for (XMLElement* tendon_constraint_node =
+           node->FirstChildElement("drake:tendon_constraint");
+       tendon_constraint_node;
+       tendon_constraint_node = tendon_constraint_node->NextSiblingElement(
+           "drake:tendon_constraint")) {
+    ParseTendonConstraint(tendon_constraint_node);
   }
 
   return std::make_pair(model_instance_, model_name);

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -1204,15 +1204,15 @@ void UrdfParser::ParseTendonConstraint(XMLElement* node) {
   };
   auto get_double_attribute = [this](const ElementNode& data_element,
                                      const char* attribute_name) {
-    std::string attribute_value;
+    double attribute_value;
     XMLElement* anode = std::get<XMLElement*>(data_element);
-    if (!ParseStringAttribute(anode, attribute_name, &attribute_value)) {
-      Error(*anode, fmt::format("The tag <{}> does not specify the required"
-                                " attribute \"{}\".",
-                                anode->Value(), attribute_name));
+    if (!ParseScalarAttribute(anode, attribute_name, &attribute_value)) {
+      Error(*anode,
+            fmt::format("Unable to read the '{}' attribute for the <{}> tag",
+                        attribute_name, anode->Value()));
       return 0.0;
     }
-    return std::stod(attribute_value);
+    return attribute_value;
   };
 
   internal::ParseTendonConstraint(

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -307,6 +307,12 @@ Here is the full list of custom elements:
 - @ref tag_drake_rotor_inertia
 - @ref tag_drake_screw_thread_pitch
 - @ref tag_drake_stiffness_damping
+- @ref tag_drake_tendon_constraint_joint
+- @ref tag_drake_tendon_constraint_offset
+- @ref tag_drake_tendon_constraint_lower_limit
+- @ref tag_drake_tendon_constraint_upper_limit
+- @ref tag_drake_tendon_constraint_stiffness
+- @ref tag_drake_tendon_constraint_damping
 - @ref tag_drake_visual
 - @ref tag_drake_youngs_modulus
 
@@ -431,6 +437,118 @@ the `p_BQ` parameter.
 
 @see @ref tag_drake_ball_constraint,
 drake::multibody::MultibodyPlant::AddBallConstraint()
+
+@subsection tag_drake_tendon_constraint drake:tendon_constraint
+
+- SDFormat path: `//model/drake:tendon_constraint`
+- URDF path: `/robot/drake:tendon_constraint`
+- Syntax: Nested elements @ref tag_drake_tendon_constraint_joint, @ref
+tag_drake_tendon_constraint_offset, @ref
+tag_drake_tendon_constraint_lower_limit, @ref
+tag_drake_tendon_constraint_upper_limit, @ref
+tag_drake_tendon_constraint_stiffness, and @ref
+tag_drake_tendon_constraint_damping
+
+@subsection tag_drake_tendon_constraint_semantics Semantics
+
+The element adds a tendon constraint to the model via
+drake::multibody::MultibodyPlant::AddTendonConstraint().
+
+@subsection tag_drake_tendon_constraint_joint drake:tendon_constraint_joint
+
+- SDFormat path: `//model/drake:tendon_constraint/drake:tendon_constraint_joint`
+- URDF path: `/robot/drake:tendon_constraint/drake:tendon_constraint_joint`
+- Syntax: Two attributes `name` containing a string value and `a` containing a
+          floating point value.
+
+@subsection tag_drake_tendon_constraint_joint_semantics Semantics
+
+The string names a joint (expected to already be defined by this model) and the
+float specifies a joint configuration that will be passed to
+drake::multibody::MultibodyPlant::AddTendonConstraint() as the `joints` and `a`
+parameters, respectively. The tag can be repeated to specify multiple joints.
+
+@see @ref tag_drake_tendon_constraint,
+drake::multibody::MultibodyPlant::AddTendonConstraint()
+
+@subsection tag_drake_tendon_constraint_offset drake:tendon_constraint_offset
+
+- SDFormat path: `//model/drake:tendon_constraint/drake:tendon_constraint_offset`
+- URDF path: `/robot/drake:tendon_constraint/drake:tendon_constraint_offset/@value`
+- Syntax: Floating point value.
+
+@subsection tag_drake_tendon_constraint_offset_semantics Semantics
+
+A floating point value specifying the length offset in either [m] or [rad] that
+will be passed to drake::multibody::MultibodyPlant::AddTendonConstraint() as the
+`offset` parameter.
+
+@see @ref tag_drake_tendon_constraint,
+drake::multibody::MultibodyPlant::AddTendonConstraint()
+
+@subsection tag_drake_tendon_constraint_lower_limit drake:tendon_constraint_lower_limit
+
+- SDFormat path: `//model/drake:tendon_constraint/drake:tendon_constraint_lower_limit`
+- URDF path: `/robot/drake:tendon_constraint/drake:tendon_constraint_lower_limit/@value`
+- Syntax: Floating point value.
+
+@subsection tag_drake_tendon_constraint_lower_limit_semantics Semantics
+
+A floating point value specifying the lower bound on the constraint in either
+[m] or [rad] that will be passed to
+drake::multibody::MultibodyPlant::AddTendonConstraint() as the `lower_bound`
+parameter.
+
+@see @ref tag_drake_tendon_constraint,
+drake::multibody::MultibodyPlant::AddTendonConstraint()
+
+@subsection tag_drake_tendon_constraint_upper_limit drake:tendon_constraint_upper_limit
+
+- SDFormat path: `//model/drake:tendon_constraint/drake:tendon_constraint_upper_limit`
+- URDF path: `/robot/drake:tendon_constraint/drake:tendon_constraint_upper_limit/@value`
+- Syntax: Floating point value.
+
+@subsection tag_drake_tendon_constraint_upper_limit_semantics Semantics
+
+A floating point value specifying the upper bound on the constraint in either
+[m] or [rad] that will be passed to
+drake::multibody::MultibodyPlant::AddTendonConstraint() as the `upper_bound`
+parameter.
+
+@see @ref tag_drake_tendon_constraint,
+drake::multibody::MultibodyPlant::AddTendonConstraint()
+
+@subsection tag_drake_tendon_constraint_stiffness drake:tendon_constraint_stiffness
+
+- SDFormat path: `//model/drake:tendon_constraint/drake:tendon_constraint_stiffness`
+- URDF path: `/robot/drake:tendon_constraint/drake:tendon_constraint_stiffness/@value`
+- Syntax: Floating point value.
+
+@subsection tag_drake_tendon_constraint_stiffness_semantics Semantics
+
+A floating point value specifying the constraint stiffness in either [N/m] or
+[N⋅m/rad] that will be passed to
+drake::multibody::MultibodyPlant::AddTendonConstraint() as the `stiffness`
+parameter.
+
+@see @ref tag_drake_tendon_constraint,
+drake::multibody::MultibodyPlant::AddTendonConstraint()
+
+@subsection tag_drake_tendon_constraint_damping drake:tendon_constraint_damping
+
+- SDFormat path: `//model/drake:tendon_constraint/drake:tendon_constraint_damping`
+- URDF path: `/robot/drake:tendon_constraint/drake:tendon_constraint_damping/@value`
+- Syntax: Floating point value.
+
+@subsection tag_drake_tendon_constraint_damping_semantics Semantics
+
+A floating point value specifying the constraint damping in either [N⋅s/m] or
+[N⋅m⋅rad/s] that will be passed to
+drake::multibody::MultibodyPlant::AddTendonConstraint() as the `damping`
+parameter.
+
+@see @ref tag_drake_tendon_constraint,
+drake::multibody::MultibodyPlant::AddTendonConstraint()
 
 @subsection tag_drake_bushing_force_damping drake:bushing_force_damping
 

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -307,6 +307,7 @@ Here is the full list of custom elements:
 - @ref tag_drake_rotor_inertia
 - @ref tag_drake_screw_thread_pitch
 - @ref tag_drake_stiffness_damping
+- @ref tag_drake_tendon_constraint
 - @ref tag_drake_tendon_constraint_joint
 - @ref tag_drake_tendon_constraint_offset
 - @ref tag_drake_tendon_constraint_lower_limit
@@ -442,12 +443,12 @@ drake::multibody::MultibodyPlant::AddBallConstraint()
 
 - SDFormat path: `//model/drake:tendon_constraint`
 - URDF path: `/robot/drake:tendon_constraint`
-- Syntax: Nested elements @ref tag_drake_tendon_constraint_joint, @ref
-tag_drake_tendon_constraint_offset, @ref
-tag_drake_tendon_constraint_lower_limit, @ref
-tag_drake_tendon_constraint_upper_limit, @ref
-tag_drake_tendon_constraint_stiffness, and @ref
-tag_drake_tendon_constraint_damping
+- Syntax: Nested elements @ref tag_drake_tendon_constraint_joint,
+  @ref tag_drake_tendon_constraint_offset,
+  @ref tag_drake_tendon_constraint_lower_limit,
+  @ref tag_drake_tendon_constraint_upper_limit,
+  @ref tag_drake_tendon_constraint_stiffness,
+  and @ref tag_drake_tendon_constraint_damping
 
 @subsection tag_drake_tendon_constraint_semantics Semantics
 
@@ -463,8 +464,9 @@ drake::multibody::MultibodyPlant::AddTendonConstraint().
 
 @subsection tag_drake_tendon_constraint_joint_semantics Semantics
 
-The string names a joint (expected to already be defined by this model) and the
-float specifies a joint configuration that will be passed to
+The string names a joint (expected to already be defined by this model and be
+single-dof) and the float specifies a coefficient to be applied to the joint
+configuration to determine the tendon length. These will be passed to
 drake::multibody::MultibodyPlant::AddTendonConstraint() as the `joints` and `a`
 parameters, respectively. The tag can be repeated to specify multiple joints.
 

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -2559,6 +2559,108 @@ TEST_F(SdfParserTest, BallConstraintNonExistentBody) {
           "<drake:ball_constraint_body_B> does not exist in the model."));
 }
 
+TEST_F(SdfParserTest, TendonConstraint) {
+  AddSceneGraph();
+
+  // Test successful parsing.
+  ParseTestString(R"""(
+    <world name='World'>
+      <model name='Model'>
+        <link name='A'/>
+        <link name='B'/>
+        <link name='C'/>
+        <joint name='revolute_AB' type='revolute'>
+          <child>A</child>
+          <parent>B</parent>
+          <axis>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+        <joint name='prismatic_BC' type='prismatic'>
+          <child>B</child>
+          <parent>C</parent>
+          <axis>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+        <drake:tendon_constraint>
+          <drake:tendon_constraint_joint name='revolute_AB' a='10'/>
+          <drake:tendon_constraint_joint name='prismatic_BC' a='20'/>
+          <drake:tendon_constraint_offset>0.5</drake:tendon_constraint_offset>
+          <drake:tendon_constraint_lower_limit>-1.0</drake:tendon_constraint_lower_limit>
+          <drake:tendon_constraint_upper_limit>1.0</drake:tendon_constraint_upper_limit>
+          <drake:tendon_constraint_stiffness>0.1</drake:tendon_constraint_stiffness>
+          <drake:tendon_constraint_damping>0.01</drake:tendon_constraint_damping>
+        </drake:tendon_constraint>
+      </model>
+    </world>)""");
+
+  EXPECT_EQ(plant_.num_constraints(), 1);
+  EXPECT_EQ(plant_.num_tendon_constraints(), 1);
+
+  const std::map<MultibodyConstraintId, TendonConstraintSpec>&
+      tendon_constraints = plant_.get_tendon_constraint_specs();
+
+  ASSERT_EQ(ssize(tendon_constraints), 1);
+
+  const MultibodyConstraintId id = tendon_constraints.begin()->first;
+  const TendonConstraintSpec& tendon_constraint =
+      tendon_constraints.begin()->second;
+
+  ASSERT_EQ(ssize(tendon_constraint.joints), 2);
+  ASSERT_EQ(ssize(tendon_constraint.a), 2);
+
+  EXPECT_EQ(tendon_constraint.joints[0],
+            plant_.GetJointByName("revolute_AB").index());
+  EXPECT_EQ(tendon_constraint.a[0], 10.0);
+  EXPECT_EQ(tendon_constraint.joints[1],
+            plant_.GetJointByName("prismatic_BC").index());
+  EXPECT_EQ(tendon_constraint.a[1], 20.0);
+
+  EXPECT_EQ(tendon_constraint.offset, 0.5);
+  EXPECT_EQ(tendon_constraint.lower_limit, -1.0);
+  EXPECT_EQ(tendon_constraint.upper_limit, 1.0);
+  EXPECT_EQ(tendon_constraint.stiffness, 0.1);
+  EXPECT_EQ(tendon_constraint.damping, 0.01);
+  EXPECT_EQ(tendon_constraint.id, id);
+}
+
+TEST_F(SdfParserTest, TendonConstraintNonExistentJoint) {
+  AddSceneGraph();
+
+  // Test successful parsing.
+  ParseTestString(R"""(
+    <world name='World'>
+      <model name='Model'>
+        <link name='A'/>
+        <link name='B'/>
+        <link name='C'/>
+        <joint name='revolute_AB' type='revolute'>
+          <child>A</child>
+          <parent>B</parent>
+          <axis>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+        <drake:tendon_constraint>
+          <drake:tendon_constraint_joint name='revolute_AB' a='10'/>
+          <!-- Joint does not exist in the model -->
+          <drake:tendon_constraint_joint name='does_not_exist' a='20'/>
+          <drake:tendon_constraint_offset>0.5</drake:tendon_constraint_offset>
+          <drake:tendon_constraint_lower_limit>-1.0</drake:tendon_constraint_lower_limit>
+          <drake:tendon_constraint_upper_limit>1.0</drake:tendon_constraint_upper_limit>
+          <drake:tendon_constraint_stiffness>0.1</drake:tendon_constraint_stiffness>
+          <drake:tendon_constraint_damping>0.01</drake:tendon_constraint_damping>
+        </drake:tendon_constraint>
+      </model>
+    </world>)""");
+  EXPECT_THAT(
+      TakeError(),
+      MatchesRegex(
+          ".*<drake:tendon_constraint>: Joint 'does_not_exist' specified for "
+          "<drake:tendon_constraint_joint> does not exist in the model."));
+}
+
 TEST_F(SdfParserTest, BushingParsingGood) {
   AddSceneGraph();
   // Test successful parsing.  Add two copies of the model to make sure the


### PR DESCRIPTION
Implements SDF/URDF parsing support for tendon constraints on the MbP. The parsing code mostly mimics what already exists for other constraints, like `drake:ball_constraint`.

---

Let me know what you think is the correct SDF/URDF format for the joint name/coefficient pairs. Because they are associated pairwise (`joints[i]` references `a[i]`), it makes sense to specify them together. In both SDF and URDF, I have chosen this syntax:
```xml
<drake:tendon_constraint_joint name='revolute_AB' a='10'/>
```

But there may be other options, for example:
```xml
// SDF
<drake:tendon_constraint_joint a='10'>revolute_AB</drake:tendon_constraint_joint>
<drake:tendon_constraint_joint a='10'>revolute_BC</drake:tendon_constraint_joint>

// URDF
<drake:tendon_constraint_joint name='revolute_AB' a='10'/>
<drake:tendon_constraint_joint name='revolute_AB' a='10'/>
```
```xml
// SDF
<drake:tendon_constraint_joint>revolute_AB</drake:tendon_constraint_joint>
<drake:tendon_constraint_a>10</drake:tendon_constraint_a>
<drake:tendon_constraint_joint>revolute_BC</drake:tendon_constraint_joint>
<drake:tendon_constraint_a>10</drake:tendon_constraint_a>

// URDF
<drake:tendon_constraint_joint name='revolute_AB'/>
<drake:tendon_constraint_a value='10'/>
<drake:tendon_constraint_joint name='revolute_BC'/>
<drake:tendon_constraint_a value='10'/>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23273)
<!-- Reviewable:end -->
