### PR TITLE
Allow getting/setting the parameters of SchunkWsgPositionController and SchunkWsgPdController.

### DIFF
--- a/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
@@ -43,7 +43,27 @@ void DefineManipulationSchunkWsg(py::module m) {
             py_rvp::reference_internal,
             cls_doc.get_generalized_force_output_port.doc)
         .def("get_grip_force_output_port", &Class::get_grip_force_output_port,
-            py_rvp::reference_internal, cls_doc.get_grip_force_output_port.doc);
+            py_rvp::reference_internal, cls_doc.get_grip_force_output_port.doc)
+        .def("set_kp_command", &Class::set_kp_command, py::arg("kp_command"),
+            cls_doc.set_kp_command.doc)
+        .def("set_kd_command", &Class::set_kd_command, py::arg("kd_command"),
+            cls_doc.set_kd_command.doc)
+        .def("set_kp_constraint", &Class::set_kp_constraint,
+            py::arg("kp_constraint"), cls_doc.set_kp_constraint.doc)
+        .def("set_kd_constraint", &Class::set_kd_constraint,
+            py::arg("kd_constraint"), cls_doc.set_kd_constraint.doc)
+        .def("set_default_force_limit", &Class::set_default_force_limit,
+            py::arg("default_force_limit"), cls_doc.set_default_force_limit.doc)
+        .def("get_kp_command", &Class::get_kp_command,
+            cls_doc.get_kp_command.doc)
+        .def("get_kd_command", &Class::get_kd_command,
+            cls_doc.get_kd_command.doc)
+        .def("get_kp_constraint", &Class::get_kp_constraint,
+            cls_doc.get_kp_constraint.doc)
+        .def("get_kd_constraint", &Class::get_kd_constraint,
+            cls_doc.get_kd_constraint.doc)
+        .def("get_default_force_limit", &Class::get_default_force_limit,
+            cls_doc.get_default_force_limit.doc);
   }
 
   {

--- a/bindings/pydrake/manipulation/test/schunk_wsg_test.py
+++ b/bindings/pydrake/manipulation/test/schunk_wsg_test.py
@@ -43,6 +43,18 @@ class TestSchunkWsg(unittest.TestCase):
         self.assertIsInstance(
             controller.get_grip_force_output_port(), OutputPort)
 
+        controller.set_kp_command(kp_command=100.0)
+        controller.set_kd_command(kd_command=10.0)
+        controller.set_kp_constraint(kp_constraint=4000.0)
+        controller.set_kd_constraint(kd_constraint=10.0)
+        controller.set_default_force_limit(default_force_limit=80.0)
+
+        self.assertIsInstance(controller.get_kp_command(), float)
+        self.assertIsInstance(controller.get_kd_command(), float)
+        self.assertIsInstance(controller.get_kp_constraint(), float)
+        self.assertIsInstance(controller.get_kd_constraint(), float)
+        self.assertIsInstance(controller.get_default_force_limit(), float)
+
         controller = mut.SchunkWsgController(kp=100., ki=2., kd=1.)
         self.assertIsInstance(
             controller.GetInputPort("command_message"), InputPort)

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
@@ -95,25 +95,27 @@ SchunkWsgPositionController::SchunkWsgPositionController(
     double time_step, double kp_command, double kd_command,
     double kp_constraint, double kd_constraint, double default_force_limit) {
   systems::DiagramBuilder<double> builder;
-  auto pd_controller = builder.AddSystem<SchunkWsgPdController>(
+  schunk_wsg_pd_controller_ = builder.AddSystem<SchunkWsgPdController>(
       kp_command, kd_command, kp_constraint, kd_constraint,
       default_force_limit);
+  DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
   state_interpolator_ =
       builder.AddSystem<systems::StateInterpolatorWithDiscreteDerivative>(
           1, time_step, true /* suppress_initial_transient */);
 
   builder.Connect(state_interpolator_->get_output_port(),
-                  pd_controller->get_desired_state_input_port());
+                  schunk_wsg_pd_controller_->get_desired_state_input_port());
   desired_position_input_port_ = builder.ExportInput(
       state_interpolator_->get_input_port(), "desired_position");
   force_limit_input_port_ = builder.ExportInput(
-      pd_controller->get_force_limit_input_port(), "force_limit");
-  state_input_port_ =
-      builder.ExportInput(pd_controller->get_state_input_port(), "state");
+      schunk_wsg_pd_controller_->get_force_limit_input_port(), "force_limit");
+  state_input_port_ = builder.ExportInput(
+      schunk_wsg_pd_controller_->get_state_input_port(), "state");
   generalized_force_output_port_ = builder.ExportOutput(
-      pd_controller->get_generalized_force_output_port(), "generalized_force");
+      schunk_wsg_pd_controller_->get_generalized_force_output_port(),
+      "generalized_force");
   grip_force_output_port_ = builder.ExportOutput(
-      pd_controller->get_grip_force_output_port(), "grip_force");
+      schunk_wsg_pd_controller_->get_grip_force_output_port(), "grip_force");
 
   builder.BuildInto(this);
 }

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.h
@@ -94,6 +94,24 @@ class SchunkWsgPdController : public systems::LeafSystem<double> {
     return get_output_port(grip_force_output_port_);
   }
 
+  void set_kp_command(double kp_command) { kp_command_ = kp_command; }
+  void set_kd_command(double kd_command) { kd_command_ = kd_command; }
+  void set_kp_constraint(double kp_constraint) {
+    kp_constraint_ = kp_constraint;
+  }
+  void set_kd_constraint(double kd_constraint) {
+    kd_constraint_ = kd_constraint;
+  }
+  void set_default_force_limit(double default_force_limit) {
+    default_force_limit_ = default_force_limit;
+  }
+
+  double get_kp_command() const { return kp_command_; }
+  double get_kd_command() const { return kd_command_; }
+  double get_kp_constraint() const { return kp_constraint_; }
+  double get_kd_constraint() const { return kd_constraint_; }
+  double get_default_force_limit() const { return default_force_limit_; }
+
  private:
   Eigen::Vector2d CalcGeneralizedForce(
       const systems::Context<double>& context) const;
@@ -105,11 +123,11 @@ class SchunkWsgPdController : public systems::LeafSystem<double> {
   void CalcGripForceOutput(const systems::Context<double>& context,
                            systems::BasicVector<double>* output_vector) const;
 
-  const double kp_command_;
-  const double kd_command_;
-  const double kp_constraint_;
-  const double kd_constraint_;
-  const double default_force_limit_;
+  double kp_command_;
+  double kd_command_;
+  double kp_constraint_;
+  double kd_constraint_;
+  double default_force_limit_;
 
   systems::InputPortIndex desired_state_input_port_{};
   systems::InputPortIndex force_limit_input_port_{};
@@ -174,8 +192,51 @@ class SchunkWsgPositionController : public systems::Diagram<double> {
     return get_output_port(grip_force_output_port_);
   }
 
+  void set_kp_command(double kp_command) {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    schunk_wsg_pd_controller_->set_kp_command(kp_command);
+  }
+  void set_kd_command(double kd_command) {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    schunk_wsg_pd_controller_->set_kd_command(kd_command);
+  }
+  void set_kp_constraint(double kp_constraint) {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    schunk_wsg_pd_controller_->set_kp_constraint(kp_constraint);
+  }
+  void set_kd_constraint(double kd_constraint) {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    schunk_wsg_pd_controller_->set_kd_constraint(kd_constraint);
+  }
+  void set_default_force_limit(double default_force_limit) {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    schunk_wsg_pd_controller_->set_default_force_limit(default_force_limit);
+  }
+
+  double get_kp_command() const {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    return schunk_wsg_pd_controller_->get_kp_command();
+  }
+  double get_kd_command() const {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    return schunk_wsg_pd_controller_->get_kd_command();
+  }
+  double get_kp_constraint() const {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    return schunk_wsg_pd_controller_->get_kp_constraint();
+  }
+  double get_kd_constraint() const {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    return schunk_wsg_pd_controller_->get_kd_constraint();
+  }
+  double get_default_force_limit() const {
+    DRAKE_ASSERT(schunk_wsg_pd_controller_ != nullptr);
+    return schunk_wsg_pd_controller_->get_default_force_limit();
+  }
+
  private:
   systems::StateInterpolatorWithDiscreteDerivative<double>* state_interpolator_;
+  SchunkWsgPdController* schunk_wsg_pd_controller_;
 
   systems::InputPortIndex desired_position_input_port_{};
   systems::InputPortIndex force_limit_input_port_{};

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -159,6 +159,48 @@ GTEST_TEST(SchunkWsgPositionControllerTest, SimTest) {
       0.0);
 }
 
+GTEST_TEST(SchunkWsgPdControllerTest, ChangeParametersTest) {
+  SchunkWsgPdController pd_controller;
+  SchunkWsgPositionController position_controller;
+
+  using ControllerVariant =
+      std::variant<SchunkWsgPdController*, SchunkWsgPositionController*>;
+  for (ControllerVariant controller_variant :
+       {ControllerVariant(&pd_controller),
+        ControllerVariant(&position_controller)}) {
+    std::visit(
+        [](auto* controller) {
+          // Values chosen to be twice the defaults.
+          double new_kp_command = 100.0;
+          double new_kd_command = 10.0;
+          double new_kp_constraint = 4000.0;
+          double new_kd_constraint = 10.0;
+          double new_default_force_limit = 80.0;
+
+          EXPECT_NE(new_kp_command, controller->get_kp_command());
+          EXPECT_NE(new_kd_command, controller->get_kd_command());
+          EXPECT_NE(new_kp_constraint, controller->get_kp_constraint());
+          EXPECT_NE(new_kd_constraint, controller->get_kd_constraint());
+          EXPECT_NE(new_default_force_limit,
+                    controller->get_default_force_limit());
+
+          controller->set_kp_command(new_kp_command);
+          controller->set_kd_command(new_kd_command);
+          controller->set_kp_constraint(new_kp_constraint);
+          controller->set_kd_constraint(new_kd_constraint);
+          controller->set_default_force_limit(new_default_force_limit);
+
+          EXPECT_EQ(new_kp_command, controller->get_kp_command());
+          EXPECT_EQ(new_kd_command, controller->get_kd_command());
+          EXPECT_EQ(new_kp_constraint, controller->get_kp_constraint());
+          EXPECT_EQ(new_kd_constraint, controller->get_kd_constraint());
+          EXPECT_EQ(new_default_force_limit,
+                    controller->get_default_force_limit());
+        },
+        controller_variant);
+  }
+}
+
 }  // namespace
 }  // namespace schunk_wsg
 }  // namespace manipulation


### PR DESCRIPTION
I have an application where I want to modify the controller parameters (e.g. kp, kd, ...) of a `SchunkWsgPositionController` after I've created it. As far as I can tell, these parameters are only ever used locally to calculate forces, so there should be no harm in changing them at any point in time.

cc @lexifol

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23276)
<!-- Reviewable:end -->
