### PR TITLE
[Jenkins] Generate Jenkinsfiles from a template

### DIFF
--- a/.jenkins/Jenkinsfile-experimental
+++ b/.jenkins/Jenkinsfile-experimental
@@ -1,5 +1,175 @@
 #!/usr/bin/env groovy
 
+// Load utils.
+/**
+ * Performs the checkout step for drake (cloning into WORKSPACE/'src') and
+ * drake-ci (cloning into WORKSPACE/'ci').
+ *
+ * @param ciSha the commit SHA or branch name to use for drake-ci
+ * @param drakeSha the commit SHA or branch name to use for drake; if none is
+ *                 given, uses the current branch or pull request
+ * @return the scmVars object from the drake checkout
+ */
+def checkout(String ciSha = 'main', String drakeSha = null) {
+  def scmVars = null
+  retry(4) {
+    // N.B. The userRemoteConfigs in the first case are crucially used for
+    // production builds in order to allow pushing to additional remote
+    // branches (e.g., nightly_release) beyond the one being cloned (master).
+    // The second case below (`checkout scm`) does not specify such an option,
+    // however, it is useful for checkout of the specific merge commit created
+    // by Jenkins for pull requests as they build after a merge with master
+    // (for this call, we have no access to that commit SHA).
+    if (drakeSha) {
+      scmVars = checkout([$class: 'GitSCM',
+        branches: [[name: drakeSha]],
+        extensions: [[$class: 'AuthorInChangelog'],
+          [$class: 'CloneOption', honorRefspec: true, noTags: true],
+          [$class: 'RelativeTargetDirectory', relativeTargetDir: 'src'],
+          [$class: 'LocalBranch', localBranch: 'master']],
+        userRemoteConfigs: [[
+          credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+          name: 'origin',
+          refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+            '+refs/pull/*:refs/remotes/origin/pr/*',
+          url: 'git@github.com:RobotLocomotion/drake.git']]])
+    }
+    else {
+      dir("${env.WORKSPACE}/src") {
+        scmVars = checkout scm
+      }
+    }
+  }
+  retry(4) {
+    checkout([$class: 'GitSCM',
+      branches: [[name: ciSha]],
+      extensions: [[$class: 'AuthorInChangelog'],
+        [$class: 'CloneOption', honorRefspec: true, noTags: true],
+        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'ci'],
+        [$class: 'LocalBranch', localBranch: 'main']],
+      userRemoteConfigs: [[
+        credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        name: 'origin',
+        refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+          '+refs/pull/*:refs/remotes/origin/pr/*',
+        url: 'git@github.com:RobotLocomotion/drake-ci.git']]])
+  }
+  return scmVars
+}
+
+/**
+ * Performs the main build step by calling into a drake-ci driver script
+ * with the necessary credentials and environment variables.
+ *
+ * @param scmVars the scmVars object from drake (obtained via checkout)
+ * @param stagingReleaseVersion for staging jobs, the value of the environment
+ *                              variable DRAKE_VERSION used by drake-ci
+ */
+def doMainBuild(Map scmVars, String stagingReleaseVersion = null) {
+  if (env.JOB_NAME.contains("cache-server-health-check")) {
+    echo "Checking the cache server:"
+    try {
+      sh "${env.WORKSPACE}/ci/cache_server/health_check.bash"
+    }
+    catch(exc) {
+      currentBuild.result = 'FAILURE'
+    }
+  }
+  else {
+    def credentials = [
+      sshUserPrivateKey(credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        keyFileVariable: 'SSH_PRIVATE_KEY_FILE')
+    ]
+    if (!env.JOB_NAME.contains("experimental")) {
+      // Use Docker credentials for production jobs only.
+      credentials += string(credentialsId: 'e21b9517-8aa7-419e-8f25-19cd42e10f68',
+        variable: 'DOCKER_USERNAME')
+      credentials += file(credentialsId: '912dd413-d419-4760-b7ab-c132ab9e7c5e',
+        variable: 'DOCKER_PASSWORD_FILE')
+    }
+    withCredentials(credentials) {
+      def environment = ["GIT_COMMIT=${scmVars.GIT_COMMIT}"]
+      if (stagingReleaseVersion) {
+        environment += "DRAKE_VERSION=${stagingReleaseVersion}"
+      }
+      withEnv(environment) {
+        sh "${env.WORKSPACE}/ci/ctest_driver_script_wrapper.bash"
+      }
+    }
+  }
+}
+
+/**
+ * Sets the build result from the file written out by drake-ci.
+ */
+def checkBuildResult() {
+  if (fileExists('RESULT')) {
+    currentBuild.result = readFile 'RESULT'
+  }
+}
+
+/**
+ * Sends an email to Drake developers when a build fails or is unstable.
+ */
+def emailFailureResults() {
+  if (currentBuild.result == 'FAILURE' ||
+      currentBuild.result == 'UNSTABLE') {
+    def subject = 'Build failed in Jenkins'
+    if (currentBuild.result == 'UNSTABLE') {
+      subject = 'Jenkins build is unstable'
+    }
+    emailext (
+      subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
+        "and <${env.BUILD_URL}changes>",
+      to: '$DEFAULT_RECIPIENTS',
+    )
+  }
+}
+
+/**
+ * Deletes the workspace and tmp directories, for use at the end of a build.
+ */
+def cleanWorkspace() {
+  dir(env.WORKSPACE) {
+    deleteDir()
+  }
+  dir("${env.WORKSPACE}@tmp") {
+    deleteDir()
+  }
+}
+
+/**
+ * Provides links to CDash to view the results of the build.
+ */
+def addCDashBadge() {
+  if (fileExists('CDASH')) {
+    def cDashUrl = readFile 'CDASH'
+    addBadge icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
+    addSummary icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
+  }
+}
+
+/**
+ * Extracts the node label from the job name.
+ *
+ * @return the node label
+ */
+def getNodeLabel() {
+  def pattern = ~/^((linux(-arm)?|mac-arm)-[A-Za-z]+(-unprovisioned)?).*/
+  def match = env.JOB_NAME =~ pattern
+
+  if (match.find()) {
+    return match.group(1)
+  }
+  else {
+    return null
+  }
+}
+
+
 node(getNodeLabel()) {
   // Define job properties. Other Jenkinsfiles which do not correspond to
   // multibranch pipelines (i.e., for non-experimental jobs) should inherit
@@ -26,84 +196,24 @@ node(getNodeLabel()) {
   }
   properties(props)
 
-  // Load utils.groovy for common utilities.
-  // If no such file exists on this branch, load it from master.
-  fetchUtils()
-  def jenkinsUtilsPath = 'jenkins-utils/.jenkins/utils/utils.groovy'
-  if (!fileExists(jenkinsUtilsPath)) {
-    fetchUtils('master')
-  }
-  def utils = load jenkinsUtilsPath
-  if (!utils) {
-    currentBuild.result = 'ABORTED'
-    error('Failed to load Drake Jenkins utilities.')
-  }
-
   stage('test') {
     timeout(600) {
       ansiColor('xterm') {
         timestamps {
           try {
             // Use the CI branch parameter for checkout (defaults to main).
-            def scmVars = utils.checkout(params.ciSha)
-            utils.doMainBuild(scmVars)
+            def scmVars = checkout(params.ciSha)
+            doMainBuild(scmVars)
           } finally {
             try {
-              utils.checkBuildResult()
-              utils.addCDashBadge()
+              checkBuildResult()
+              addCDashBadge()
             } finally {
-              utils.cleanWorkspace()
+              cleanWorkspace()
             }
           }
         }
       }
     }
   }
-}
-
-/**
- * Extracts the node label from the job name.
- *
- * @return the node label
- */
-def getNodeLabel() {
-  def pattern = ~/^((linux(-arm)?|mac-arm)-[A-Za-z]+(-unprovisioned)?).*/
-  def match = env.JOB_NAME =~ pattern
-
-  if (match.find()) {
-    return match.group(1)
-  }
-  else {
-    return null
-  }
-}
-
-/**
- * Loads utils by performing a sparse checkout to WORKSPACE/jenkins-utils.
- *
- * @param branch the branch from which to load utils; if none is given, tries
- *               to find the current branch or pull request
- */
-def fetchUtils(String branch = null) {
-  if (!branch) {
-    if (!env.CHANGE_ID?.trim()) {
-      branch = scm.branches[0].name
-    }
-    else {
-      branch = "pr/${env.CHANGE_ID}/head"
-    }
-  }
-  checkout([$class: 'GitSCM',
-    branches: [[name: branch]],
-    extensions: [
-      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'jenkins-utils'],
-      [$class: 'CloneOption', honorRefspec: true, noTags: true],
-      [$class: 'SparseCheckoutPaths',
-        sparseCheckoutPaths: [[path: '.jenkins/utils/utils.groovy']]]],
-    userRemoteConfigs: [[
-      credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
-      name: 'origin',
-      refspec: '+refs/heads/*:refs/remotes/origin/* ' +
-        '+refs/pull/*:refs/remotes/origin/pr/*',
-      url: 'git@github.com:RobotLocomotion/drake.git']]])
 }

--- a/.jenkins/Jenkinsfile-external-examples
+++ b/.jenkins/Jenkinsfile-external-examples
@@ -1,5 +1,175 @@
 #!/usr/bin/env groovy
 
+// Load utils.
+/**
+ * Performs the checkout step for drake (cloning into WORKSPACE/'src') and
+ * drake-ci (cloning into WORKSPACE/'ci').
+ *
+ * @param ciSha the commit SHA or branch name to use for drake-ci
+ * @param drakeSha the commit SHA or branch name to use for drake; if none is
+ *                 given, uses the current branch or pull request
+ * @return the scmVars object from the drake checkout
+ */
+def checkout(String ciSha = 'main', String drakeSha = null) {
+  def scmVars = null
+  retry(4) {
+    // N.B. The userRemoteConfigs in the first case are crucially used for
+    // production builds in order to allow pushing to additional remote
+    // branches (e.g., nightly_release) beyond the one being cloned (master).
+    // The second case below (`checkout scm`) does not specify such an option,
+    // however, it is useful for checkout of the specific merge commit created
+    // by Jenkins for pull requests as they build after a merge with master
+    // (for this call, we have no access to that commit SHA).
+    if (drakeSha) {
+      scmVars = checkout([$class: 'GitSCM',
+        branches: [[name: drakeSha]],
+        extensions: [[$class: 'AuthorInChangelog'],
+          [$class: 'CloneOption', honorRefspec: true, noTags: true],
+          [$class: 'RelativeTargetDirectory', relativeTargetDir: 'src'],
+          [$class: 'LocalBranch', localBranch: 'master']],
+        userRemoteConfigs: [[
+          credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+          name: 'origin',
+          refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+            '+refs/pull/*:refs/remotes/origin/pr/*',
+          url: 'git@github.com:RobotLocomotion/drake.git']]])
+    }
+    else {
+      dir("${env.WORKSPACE}/src") {
+        scmVars = checkout scm
+      }
+    }
+  }
+  retry(4) {
+    checkout([$class: 'GitSCM',
+      branches: [[name: ciSha]],
+      extensions: [[$class: 'AuthorInChangelog'],
+        [$class: 'CloneOption', honorRefspec: true, noTags: true],
+        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'ci'],
+        [$class: 'LocalBranch', localBranch: 'main']],
+      userRemoteConfigs: [[
+        credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        name: 'origin',
+        refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+          '+refs/pull/*:refs/remotes/origin/pr/*',
+        url: 'git@github.com:RobotLocomotion/drake-ci.git']]])
+  }
+  return scmVars
+}
+
+/**
+ * Performs the main build step by calling into a drake-ci driver script
+ * with the necessary credentials and environment variables.
+ *
+ * @param scmVars the scmVars object from drake (obtained via checkout)
+ * @param stagingReleaseVersion for staging jobs, the value of the environment
+ *                              variable DRAKE_VERSION used by drake-ci
+ */
+def doMainBuild(Map scmVars, String stagingReleaseVersion = null) {
+  if (env.JOB_NAME.contains("cache-server-health-check")) {
+    echo "Checking the cache server:"
+    try {
+      sh "${env.WORKSPACE}/ci/cache_server/health_check.bash"
+    }
+    catch(exc) {
+      currentBuild.result = 'FAILURE'
+    }
+  }
+  else {
+    def credentials = [
+      sshUserPrivateKey(credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        keyFileVariable: 'SSH_PRIVATE_KEY_FILE')
+    ]
+    if (!env.JOB_NAME.contains("experimental")) {
+      // Use Docker credentials for production jobs only.
+      credentials += string(credentialsId: 'e21b9517-8aa7-419e-8f25-19cd42e10f68',
+        variable: 'DOCKER_USERNAME')
+      credentials += file(credentialsId: '912dd413-d419-4760-b7ab-c132ab9e7c5e',
+        variable: 'DOCKER_PASSWORD_FILE')
+    }
+    withCredentials(credentials) {
+      def environment = ["GIT_COMMIT=${scmVars.GIT_COMMIT}"]
+      if (stagingReleaseVersion) {
+        environment += "DRAKE_VERSION=${stagingReleaseVersion}"
+      }
+      withEnv(environment) {
+        sh "${env.WORKSPACE}/ci/ctest_driver_script_wrapper.bash"
+      }
+    }
+  }
+}
+
+/**
+ * Sets the build result from the file written out by drake-ci.
+ */
+def checkBuildResult() {
+  if (fileExists('RESULT')) {
+    currentBuild.result = readFile 'RESULT'
+  }
+}
+
+/**
+ * Sends an email to Drake developers when a build fails or is unstable.
+ */
+def emailFailureResults() {
+  if (currentBuild.result == 'FAILURE' ||
+      currentBuild.result == 'UNSTABLE') {
+    def subject = 'Build failed in Jenkins'
+    if (currentBuild.result == 'UNSTABLE') {
+      subject = 'Jenkins build is unstable'
+    }
+    emailext (
+      subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
+        "and <${env.BUILD_URL}changes>",
+      to: '$DEFAULT_RECIPIENTS',
+    )
+  }
+}
+
+/**
+ * Deletes the workspace and tmp directories, for use at the end of a build.
+ */
+def cleanWorkspace() {
+  dir(env.WORKSPACE) {
+    deleteDir()
+  }
+  dir("${env.WORKSPACE}@tmp") {
+    deleteDir()
+  }
+}
+
+/**
+ * Provides links to CDash to view the results of the build.
+ */
+def addCDashBadge() {
+  if (fileExists('CDASH')) {
+    def cDashUrl = readFile 'CDASH'
+    addBadge icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
+    addSummary icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
+  }
+}
+
+/**
+ * Extracts the node label from the job name.
+ *
+ * @return the node label
+ */
+def getNodeLabel() {
+  def pattern = ~/^((linux(-arm)?|mac-arm)-[A-Za-z]+(-unprovisioned)?).*/
+  def match = env.JOB_NAME =~ pattern
+
+  if (match.find()) {
+    return match.group(1)
+  }
+  else {
+    return null
+  }
+}
+
+
 def scmVars = null
 
 node(getNodeLabel()) {
@@ -40,20 +210,3 @@ build(
     string(name: 'drakeSha', value: scmVars.GIT_COMMIT)
   ]
 )
-
-/**
- * Extracts the node label from the job name.
- *
- * @return the node label
- */
-def getNodeLabel() {
-  def pattern = ~/^((linux(-arm)?|mac-arm)-[A-Za-z]+(-unprovisioned)?).*/
-  def match = env.JOB_NAME =~ pattern
-
-  if (match.find()) {
-    return match.group(1)
-  }
-  else {
-    return null
-  }
-}

--- a/.jenkins/Jenkinsfile-production
+++ b/.jenkins/Jenkinsfile-production
@@ -1,35 +1,154 @@
 #!/usr/bin/env groovy
 
-node(getNodeLabel()) {
-  // Load utils.groovy for common utilities.
-  fetchUtils('master')
-  def jenkinsUtilsPath = 'jenkins-utils/.jenkins/utils/utils.groovy'
-  def utils = load jenkinsUtilsPath
-  if (!utils) {
-    currentBuild.result = 'ABORTED'
-    error('Failed to load Drake Jenkins utilities.')
-  }
-
-  stage('test') {
-    timeout(600) {
-      ansiColor('xterm') {
-        timestamps {
-          try {
-            // Always use drake-ci/main and drake/master for production builds.
-            def scmVars = utils.checkout('main', 'master')
-            utils.doMainBuild(scmVars)
-          } finally {
-            try {
-              utils.checkBuildResult()
-              utils.emailFailureResults()
-              utils.addCDashBadge()
-            } finally {
-              utils.cleanWorkspace()
-            }
-          }
-        }
+// Load utils.
+/**
+ * Performs the checkout step for drake (cloning into WORKSPACE/'src') and
+ * drake-ci (cloning into WORKSPACE/'ci').
+ *
+ * @param ciSha the commit SHA or branch name to use for drake-ci
+ * @param drakeSha the commit SHA or branch name to use for drake; if none is
+ *                 given, uses the current branch or pull request
+ * @return the scmVars object from the drake checkout
+ */
+def checkout(String ciSha = 'main', String drakeSha = null) {
+  def scmVars = null
+  retry(4) {
+    // N.B. The userRemoteConfigs in the first case are crucially used for
+    // production builds in order to allow pushing to additional remote
+    // branches (e.g., nightly_release) beyond the one being cloned (master).
+    // The second case below (`checkout scm`) does not specify such an option,
+    // however, it is useful for checkout of the specific merge commit created
+    // by Jenkins for pull requests as they build after a merge with master
+    // (for this call, we have no access to that commit SHA).
+    if (drakeSha) {
+      scmVars = checkout([$class: 'GitSCM',
+        branches: [[name: drakeSha]],
+        extensions: [[$class: 'AuthorInChangelog'],
+          [$class: 'CloneOption', honorRefspec: true, noTags: true],
+          [$class: 'RelativeTargetDirectory', relativeTargetDir: 'src'],
+          [$class: 'LocalBranch', localBranch: 'master']],
+        userRemoteConfigs: [[
+          credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+          name: 'origin',
+          refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+            '+refs/pull/*:refs/remotes/origin/pr/*',
+          url: 'git@github.com:RobotLocomotion/drake.git']]])
+    }
+    else {
+      dir("${env.WORKSPACE}/src") {
+        scmVars = checkout scm
       }
     }
+  }
+  retry(4) {
+    checkout([$class: 'GitSCM',
+      branches: [[name: ciSha]],
+      extensions: [[$class: 'AuthorInChangelog'],
+        [$class: 'CloneOption', honorRefspec: true, noTags: true],
+        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'ci'],
+        [$class: 'LocalBranch', localBranch: 'main']],
+      userRemoteConfigs: [[
+        credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        name: 'origin',
+        refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+          '+refs/pull/*:refs/remotes/origin/pr/*',
+        url: 'git@github.com:RobotLocomotion/drake-ci.git']]])
+  }
+  return scmVars
+}
+
+/**
+ * Performs the main build step by calling into a drake-ci driver script
+ * with the necessary credentials and environment variables.
+ *
+ * @param scmVars the scmVars object from drake (obtained via checkout)
+ * @param stagingReleaseVersion for staging jobs, the value of the environment
+ *                              variable DRAKE_VERSION used by drake-ci
+ */
+def doMainBuild(Map scmVars, String stagingReleaseVersion = null) {
+  if (env.JOB_NAME.contains("cache-server-health-check")) {
+    echo "Checking the cache server:"
+    try {
+      sh "${env.WORKSPACE}/ci/cache_server/health_check.bash"
+    }
+    catch(exc) {
+      currentBuild.result = 'FAILURE'
+    }
+  }
+  else {
+    def credentials = [
+      sshUserPrivateKey(credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        keyFileVariable: 'SSH_PRIVATE_KEY_FILE')
+    ]
+    if (!env.JOB_NAME.contains("experimental")) {
+      // Use Docker credentials for production jobs only.
+      credentials += string(credentialsId: 'e21b9517-8aa7-419e-8f25-19cd42e10f68',
+        variable: 'DOCKER_USERNAME')
+      credentials += file(credentialsId: '912dd413-d419-4760-b7ab-c132ab9e7c5e',
+        variable: 'DOCKER_PASSWORD_FILE')
+    }
+    withCredentials(credentials) {
+      def environment = ["GIT_COMMIT=${scmVars.GIT_COMMIT}"]
+      if (stagingReleaseVersion) {
+        environment += "DRAKE_VERSION=${stagingReleaseVersion}"
+      }
+      withEnv(environment) {
+        sh "${env.WORKSPACE}/ci/ctest_driver_script_wrapper.bash"
+      }
+    }
+  }
+}
+
+/**
+ * Sets the build result from the file written out by drake-ci.
+ */
+def checkBuildResult() {
+  if (fileExists('RESULT')) {
+    currentBuild.result = readFile 'RESULT'
+  }
+}
+
+/**
+ * Sends an email to Drake developers when a build fails or is unstable.
+ */
+def emailFailureResults() {
+  if (currentBuild.result == 'FAILURE' ||
+      currentBuild.result == 'UNSTABLE') {
+    def subject = 'Build failed in Jenkins'
+    if (currentBuild.result == 'UNSTABLE') {
+      subject = 'Jenkins build is unstable'
+    }
+    emailext (
+      subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
+        "and <${env.BUILD_URL}changes>",
+      to: '$DEFAULT_RECIPIENTS',
+    )
+  }
+}
+
+/**
+ * Deletes the workspace and tmp directories, for use at the end of a build.
+ */
+def cleanWorkspace() {
+  dir(env.WORKSPACE) {
+    deleteDir()
+  }
+  dir("${env.WORKSPACE}@tmp") {
+    deleteDir()
+  }
+}
+
+/**
+ * Provides links to CDash to view the results of the build.
+ */
+def addCDashBadge() {
+  if (fileExists('CDASH')) {
+    def cDashUrl = readFile 'CDASH'
+    addBadge icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
+    addSummary icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
   }
 }
 
@@ -50,32 +169,27 @@ def getNodeLabel() {
   }
 }
 
-/**
- * Loads utils by performing a sparse checkout to WORKSPACE/jenkins-utils.
- *
- * @param branch the branch from which to load utils; if none is given, tries
- *               to find the current branch or pull request
- */
-def fetchUtils(String branch = null) {
-  if (!branch) {
-    if (!env.CHANGE_ID?.trim()) {
-      branch = scm.branches[0].name
-    }
-    else {
-      branch = "pr/${env.CHANGE_ID}/head"
+
+node(getNodeLabel()) {
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Always use drake-ci/main and drake/master for production builds.
+            def scmVars = checkout('main', 'master')
+            doMainBuild(scmVars)
+          } finally {
+            try {
+              checkBuildResult()
+              emailFailureResults()
+              addCDashBadge()
+            } finally {
+              cleanWorkspace()
+            }
+          }
+        }
+      }
     }
   }
-  checkout([$class: 'GitSCM',
-    branches: [[name: branch]],
-    extensions: [
-      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'jenkins-utils'],
-      [$class: 'CloneOption', honorRefspec: true, noTags: true],
-      [$class: 'SparseCheckoutPaths',
-        sparseCheckoutPaths: [[path: '.jenkins/utils/utils.groovy']]]],
-    userRemoteConfigs: [[
-      credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
-      name: 'origin',
-      refspec: '+refs/heads/*:refs/remotes/origin/* ' +
-        '+refs/pull/*:refs/remotes/origin/pr/*',
-      url: 'git@github.com:RobotLocomotion/drake.git']]])
 }

--- a/.jenkins/Jenkinsfile-staging
+++ b/.jenkins/Jenkinsfile-staging
@@ -1,39 +1,154 @@
 #!/usr/bin/env groovy
 
-node(getNodeLabel()) {
-  // Load utils.groovy for common utilities.
-  // If no such file exists on this branch, load it from master.
-  fetchUtils(params.sha1)
-  def jenkinsUtilsPath = 'jenkins-utils/.jenkins/utils/utils.groovy'
-  if (!fileExists(jenkinsUtilsPath)) {
-    fetchUtils('master')
-  }
-  def utils = load jenkinsUtilsPath
-  if (!utils) {
-    currentBuild.result = 'ABORTED'
-    error('Failed to load Drake Jenkins utilities.')
-  }
-
-  stage('test') {
-    timeout(600) {
-      ansiColor('xterm') {
-        timestamps {
-          try {
-            // Always use drake-ci/main for staging builds, but use the
-            // drake SHA parameter for the drake checkout.
-            def scmVars = utils.checkout('main', params.sha1)
-            utils.doMainBuild(scmVars, params.release_version)
-          } finally {
-            try {
-              utils.checkBuildResult()
-              utils.addCDashBadge()
-            } finally {
-              utils.cleanWorkspace()
-            }
-          }
-        }
+// Load utils.
+/**
+ * Performs the checkout step for drake (cloning into WORKSPACE/'src') and
+ * drake-ci (cloning into WORKSPACE/'ci').
+ *
+ * @param ciSha the commit SHA or branch name to use for drake-ci
+ * @param drakeSha the commit SHA or branch name to use for drake; if none is
+ *                 given, uses the current branch or pull request
+ * @return the scmVars object from the drake checkout
+ */
+def checkout(String ciSha = 'main', String drakeSha = null) {
+  def scmVars = null
+  retry(4) {
+    // N.B. The userRemoteConfigs in the first case are crucially used for
+    // production builds in order to allow pushing to additional remote
+    // branches (e.g., nightly_release) beyond the one being cloned (master).
+    // The second case below (`checkout scm`) does not specify such an option,
+    // however, it is useful for checkout of the specific merge commit created
+    // by Jenkins for pull requests as they build after a merge with master
+    // (for this call, we have no access to that commit SHA).
+    if (drakeSha) {
+      scmVars = checkout([$class: 'GitSCM',
+        branches: [[name: drakeSha]],
+        extensions: [[$class: 'AuthorInChangelog'],
+          [$class: 'CloneOption', honorRefspec: true, noTags: true],
+          [$class: 'RelativeTargetDirectory', relativeTargetDir: 'src'],
+          [$class: 'LocalBranch', localBranch: 'master']],
+        userRemoteConfigs: [[
+          credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+          name: 'origin',
+          refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+            '+refs/pull/*:refs/remotes/origin/pr/*',
+          url: 'git@github.com:RobotLocomotion/drake.git']]])
+    }
+    else {
+      dir("${env.WORKSPACE}/src") {
+        scmVars = checkout scm
       }
     }
+  }
+  retry(4) {
+    checkout([$class: 'GitSCM',
+      branches: [[name: ciSha]],
+      extensions: [[$class: 'AuthorInChangelog'],
+        [$class: 'CloneOption', honorRefspec: true, noTags: true],
+        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'ci'],
+        [$class: 'LocalBranch', localBranch: 'main']],
+      userRemoteConfigs: [[
+        credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        name: 'origin',
+        refspec: '+refs/heads/*:refs/remotes/origin/* ' +
+          '+refs/pull/*:refs/remotes/origin/pr/*',
+        url: 'git@github.com:RobotLocomotion/drake-ci.git']]])
+  }
+  return scmVars
+}
+
+/**
+ * Performs the main build step by calling into a drake-ci driver script
+ * with the necessary credentials and environment variables.
+ *
+ * @param scmVars the scmVars object from drake (obtained via checkout)
+ * @param stagingReleaseVersion for staging jobs, the value of the environment
+ *                              variable DRAKE_VERSION used by drake-ci
+ */
+def doMainBuild(Map scmVars, String stagingReleaseVersion = null) {
+  if (env.JOB_NAME.contains("cache-server-health-check")) {
+    echo "Checking the cache server:"
+    try {
+      sh "${env.WORKSPACE}/ci/cache_server/health_check.bash"
+    }
+    catch(exc) {
+      currentBuild.result = 'FAILURE'
+    }
+  }
+  else {
+    def credentials = [
+      sshUserPrivateKey(credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
+        keyFileVariable: 'SSH_PRIVATE_KEY_FILE')
+    ]
+    if (!env.JOB_NAME.contains("experimental")) {
+      // Use Docker credentials for production jobs only.
+      credentials += string(credentialsId: 'e21b9517-8aa7-419e-8f25-19cd42e10f68',
+        variable: 'DOCKER_USERNAME')
+      credentials += file(credentialsId: '912dd413-d419-4760-b7ab-c132ab9e7c5e',
+        variable: 'DOCKER_PASSWORD_FILE')
+    }
+    withCredentials(credentials) {
+      def environment = ["GIT_COMMIT=${scmVars.GIT_COMMIT}"]
+      if (stagingReleaseVersion) {
+        environment += "DRAKE_VERSION=${stagingReleaseVersion}"
+      }
+      withEnv(environment) {
+        sh "${env.WORKSPACE}/ci/ctest_driver_script_wrapper.bash"
+      }
+    }
+  }
+}
+
+/**
+ * Sets the build result from the file written out by drake-ci.
+ */
+def checkBuildResult() {
+  if (fileExists('RESULT')) {
+    currentBuild.result = readFile 'RESULT'
+  }
+}
+
+/**
+ * Sends an email to Drake developers when a build fails or is unstable.
+ */
+def emailFailureResults() {
+  if (currentBuild.result == 'FAILURE' ||
+      currentBuild.result == 'UNSTABLE') {
+    def subject = 'Build failed in Jenkins'
+    if (currentBuild.result == 'UNSTABLE') {
+      subject = 'Jenkins build is unstable'
+    }
+    emailext (
+      subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
+        "and <${env.BUILD_URL}changes>",
+      to: '$DEFAULT_RECIPIENTS',
+    )
+  }
+}
+
+/**
+ * Deletes the workspace and tmp directories, for use at the end of a build.
+ */
+def cleanWorkspace() {
+  dir(env.WORKSPACE) {
+    deleteDir()
+  }
+  dir("${env.WORKSPACE}@tmp") {
+    deleteDir()
+  }
+}
+
+/**
+ * Provides links to CDash to view the results of the build.
+ */
+def addCDashBadge() {
+  if (fileExists('CDASH')) {
+    def cDashUrl = readFile 'CDASH'
+    addBadge icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
+    addSummary icon: '/userContent/cdash.png',
+      link: cDashUrl, text: 'View in CDash'
   }
 }
 
@@ -54,32 +169,27 @@ def getNodeLabel() {
   }
 }
 
-/**
- * Loads utils by performing a sparse checkout to WORKSPACE/jenkins-utils.
- *
- * @param branch the branch from which to load utils; if none is given, tries
- *               to find the current branch or pull request
- */
-def fetchUtils(String branch = null) {
-  if (!branch) {
-    if (!env.CHANGE_ID?.trim()) {
-      branch = scm.branches[0].name
-    }
-    else {
-      branch = "pr/${env.CHANGE_ID}/head"
+
+node(getNodeLabel()) {
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Always use drake-ci/main for staging builds, but use the
+            // drake SHA parameter for the drake checkout.
+            def scmVars = checkout('main', params.sha1)
+            doMainBuild(scmVars, params.release_version)
+          } finally {
+            try {
+              checkBuildResult()
+              addCDashBadge()
+            } finally {
+              cleanWorkspace()
+            }
+          }
+        }
+      }
     }
   }
-  checkout([$class: 'GitSCM',
-    branches: [[name: branch]],
-    extensions: [
-      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'jenkins-utils'],
-      [$class: 'CloneOption', honorRefspec: true, noTags: true],
-      [$class: 'SparseCheckoutPaths',
-        sparseCheckoutPaths: [[path: '.jenkins/utils/utils.groovy']]]],
-    userRemoteConfigs: [[
-      credentialsId: 'ad794d10-9bc8-4a7a-a2f3-998af802cab0',
-      name: 'origin',
-      refspec: '+refs/heads/*:refs/remotes/origin/* ' +
-        '+refs/pull/*:refs/remotes/origin/pr/*',
-      url: 'git@github.com:RobotLocomotion/drake.git']]])
 }

--- a/.jenkins/README.md
+++ b/.jenkins/README.md
@@ -1,0 +1,58 @@
+# Jenkins Pipelines
+
+This directory contains the Jenkinsfiles used for Drake's continuous
+integration, including flavors for experimental, continuous, nightly, and
+staging. See https://drake.mit.edu/jenkins.html for details on how to
+request builds on pull requests.
+
+## Layout
+
+The pipelines are:
+
+* [Jenkinsfile-experimental](./Jenkinsfile-experimental): used for on-demand
+and pre-merge (i.e., pull request) jobs
+* [Jenkinsfile-external-examples](./Jenkinsfile-external-examples): used for
+the experimental job(s) which build
+[drake-external-examples](https://github.com/RobotLocomotion/drake-external-examples)
+* [Jenkinsfile-production](./Jenkinsfile-production): used for continuous and
+nightly jobs
+* [Jenkinsfile-staging](./Jenkinsfile-staging): used for staging (release) jobs
+
+Corresponding templates for each of these files are contained in
+[templates](./templates/). Functions shared across the pipelines are stored
+in [utils.groovy](./utils/utils.groovy).
+
+Note that Drake's Jenkins jobs are configured to obtain the Jenkinsfiles from
+their current locations, so moving these files requires a simultaneous job
+reconfiguration. Contact `@BetsyMcPhail` for details on how to proceed with
+these changes.
+
+## Making Changes
+
+The Jenkinsfiles adjacent to this file should not be modified by hand. They
+are generated automatically from the [template files](templates/) using
+[utils/generate-Jenkinsfiles.cmake](utils/generate-Jenkinsfiles.cmake). In general,
+use the following procedure to update the Jenkinsfiles:
+
+1. Make the necessary changes. This could be to either the
+[template file(s)](templates/), or the [shared utilities](utils/utils.groovy).
+2. Run [utils/generate-Jenkinsfiles.cmake](utils/generate-Jenkinsfiles.cmake)
+as directed in the script to regenerate the Jenkinsfiles. This will insert
+the content of utilities into the Jenkinsfiles, so that changes to
+these file(s) does not require a rebase of every open pull request in order to
+obtain the updates.
+3. Push your changes to the remote in order to test them through Jenkins.
+
+## Testing Changes
+
+Drake's experimental Jenkins jobs are configured to build and test a merge of
+the master branch onto a given feature branch with an open pull request. This
+merge includes the Jenkinsfile itself, meaning that changes to the experimental
+pipeline can be tested directly using the existing CI on pull requests.
+
+The Jenkins jobs for production (i.e., continuous and nightly) and staging
+should never be run on pull request, so there are a few alternative options
+for testing changes to these pipelines depending on the nature of the change.
+Contact `@BetsyMcPhail` for how to proceed. (If the changes are concurrently
+being made to the experimental pipelines, then they can be tested there with a
+pull request and replicated in the production pipelines.)

--- a/.jenkins/templates/Jenkinsfile-experimental.in
+++ b/.jenkins/templates/Jenkinsfile-experimental.in
@@ -1,0 +1,52 @@
+#!/usr/bin/env groovy
+
+// Load utils.
+@UTILS_CONTENT@
+
+node(getNodeLabel()) {
+  // Define job properties. Other Jenkinsfiles which do not correspond to
+  // multibranch pipelines (i.e., for non-experimental jobs) should inherit
+  // properties from the original job definitions rather than calling
+  // properties() here.
+  def props = [
+    parameters([
+      string(name: 'ciSha', defaultValue: 'main',
+        description: 'Commit SHA or branch name. ' +
+          'For pull requests, enter branch name <code>pr/1234/head</code> ' +
+          'or <code>pr/1234/merge</code> for pull request #1234. ' +
+          'Defaults to <code>main</code>.'),
+      ]
+    ),
+    buildDiscarder(
+      logRotator(
+        daysToKeepStr: '90',
+        artifactDaysToKeepStr: '90'
+      )
+    )
+  ]
+  if (env.JOB_NAME.contains("cache-server-health-check")) {
+    props << disableConcurrentBuilds()
+  }
+  properties(props)
+
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Use the CI branch parameter for checkout (defaults to main).
+            def scmVars = checkout(params.ciSha)
+            doMainBuild(scmVars)
+          } finally {
+            try {
+              checkBuildResult()
+              addCDashBadge()
+            } finally {
+              cleanWorkspace()
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.jenkins/templates/Jenkinsfile-external-examples.in
+++ b/.jenkins/templates/Jenkinsfile-external-examples.in
@@ -1,0 +1,45 @@
+#!/usr/bin/env groovy
+
+// Load utils.
+@UTILS_CONTENT@
+
+def scmVars = null
+
+node(getNodeLabel()) {
+  // Define job properties. Other Jenkinsfiles which do not correspond to
+  // multibranch pipelines (i.e., for non-experimental jobs) should inherit
+  // properties from the original job definitions rather than calling
+  // properties() here.
+  properties([
+    parameters([
+      string(name: 'deePR', defaultValue: 'main',
+        description: 'Pull request name. ' +
+          'For pull requests, enter project name <code>PR-1234</code> ' +
+          'for pull request #1234. Defaults to <code>main</code>.'),
+    ]),
+    buildDiscarder(
+      logRotator(
+        daysToKeepStr: '90',
+        artifactDaysToKeepStr: '90'
+      )
+    ),
+    githubProjectProperty('https://github.com/RobotLocomotion/drake')
+  ])
+
+  stage('drake-checkout') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          scmVars = checkout scm
+        }
+      }
+    }
+  }
+}
+
+build(
+  job: "RobotLocomotion/drake-external-examples/${params.deePR}",
+  parameters: [
+    string(name: 'drakeSha', value: scmVars.GIT_COMMIT)
+  ]
+)

--- a/.jenkins/templates/Jenkinsfile-production.in
+++ b/.jenkins/templates/Jenkinsfile-production.in
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+// Load utils.
+@UTILS_CONTENT@
+
+node(getNodeLabel()) {
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Always use drake-ci/main and drake/master for production builds.
+            def scmVars = checkout('main', 'master')
+            doMainBuild(scmVars)
+          } finally {
+            try {
+              checkBuildResult()
+              emailFailureResults()
+              addCDashBadge()
+            } finally {
+              cleanWorkspace()
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.jenkins/templates/Jenkinsfile-staging.in
+++ b/.jenkins/templates/Jenkinsfile-staging.in
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+// Load utils.
+@UTILS_CONTENT@
+
+node(getNodeLabel()) {
+  stage('test') {
+    timeout(600) {
+      ansiColor('xterm') {
+        timestamps {
+          try {
+            // Always use drake-ci/main for staging builds, but use the
+            // drake SHA parameter for the drake checkout.
+            def scmVars = checkout('main', params.sha1)
+            doMainBuild(scmVars, params.release_version)
+          } finally {
+            try {
+              checkBuildResult()
+              addCDashBadge()
+            } finally {
+              cleanWorkspace()
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.jenkins/utils/generate-Jenkinsfiles.cmake
+++ b/.jenkins/utils/generate-Jenkinsfiles.cmake
@@ -1,0 +1,29 @@
+# This script exists to generate Jenkinsfiles in drake/.jenkins/ from the
+# templates in drake/.jenkins/templates/. It should be called from
+# drake/.jenkins/ as:
+#   cmake -P utils/generate-Jenkinsfiles.cmake
+# Maintainers should run this script to re-generate the Jenkinsfiles anytime
+# the Jenkinsfile templates or the utils change.
+
+# Load utils.groovy.
+set(UTILS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.groovy")
+file(READ ${UTILS_FILE} UTILS_CONTENT)
+
+# Define configurations. This list should match the Jenkinsfiles themselves,
+# as well as all of the files in templates/, and the README.
+set(JENKINS_CONFIGS
+  "experimental"
+  "external-examples"
+  "production"
+  "staging"
+)
+
+# Generate the output files.
+foreach(config IN LISTS JENKINS_CONFIGS)
+  set(JENKINSFILE_TEMPLATE "${CMAKE_CURRENT_SOURCE_DIR}/templates/Jenkinsfile-${config}.in")
+  set(JENKINSFILE_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/Jenkinsfile-${config}")
+  if (NOT EXISTS ${JENKINSFILE_TEMPLATE})
+    message(FATAL_ERROR "Failed to find template file ${JENKINSFILE_TEMPLATE}.")
+  endif()
+  configure_file(${JENKINSFILE_TEMPLATE} ${JENKINSFILE_OUTPUT} @ONLY)
+endforeach()

--- a/.jenkins/utils/utils.groovy
+++ b/.jenkins/utils/utils.groovy
@@ -149,6 +149,19 @@ def addCDashBadge() {
   }
 }
 
-// This must be present in order for this script to be consumed by
-// Jenkinsfiles when using 'load'.
-return this
+/**
+ * Extracts the node label from the job name.
+ *
+ * @return the node label
+ */
+def getNodeLabel() {
+  def pattern = ~/^((linux(-arm)?|mac-arm)-[A-Za-z]+(-unprovisioned)?).*/
+  def match = env.JOB_NAME =~ pattern
+
+  if (match.find()) {
+    return match.group(1)
+  }
+  else {
+    return null
+  }
+}


### PR DESCRIPTION
Simplify the process of loading `utils.groovy` by using a CMake script which generates Jenkinsfiles from templates. This way, changes to CI code are baked in when Jenkins merges master into older PR branches (rather than forcing a rebase).

Towards #23217.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23278)
<!-- Reviewable:end -->
