### PR TITLE
Add an IRIS group to the C++ documentation.

### DIFF
--- a/geometry/optimization/c_iris_collision_geometry.h
+++ b/geometry/optimization/c_iris_collision_geometry.h
@@ -34,6 +34,8 @@ enum class PlaneSide {
  For the detailed algorithm please refer to the paper
  Certified Polyhedral Decompositions of Collision-Free Configuration Space
  by Hongkai Dai*, Alexandre Amice*, Peter Werner, Annan Zhang and Russ Tedrake.
+
+ @ingroup planning_iris
  */
 class CIrisCollisionGeometry {
  public:

--- a/geometry/optimization/cspace_free_box.h
+++ b/geometry/optimization/cspace_free_box.h
@@ -15,6 +15,7 @@ namespace optimization {
  This class tries to find large axis-aligned bounding boxes in the configuration
  space, such that all configurations in the boxes are collision free.
  Note that we don't guarantee to find the largest box.
+ @ingroup planning_iris
  */
 // CspaceFreeBox "is a" CspaceFreePolytopeBase because it can do anything inside
 // CspaceFreePolytopeBase. We factor out the common code in CspaceFreeBox and

--- a/geometry/optimization/cspace_free_polytope.h
+++ b/geometry/optimization/cspace_free_polytope.h
@@ -39,6 +39,8 @@ namespace optimization {
  Finding and Optimizing Certified, Collision-Free Regions in Configuration Space
  for Robot Manipulators
  by Alexandre Amice*, Hongkai Dai*, Peter Werner, Annan Zhang and Russ Tedrake.
+
+ @ingroup planning_iris
  */
 class CspaceFreePolytope : public CspaceFreePolytopeBase {
  public:

--- a/geometry/optimization/cspace_free_polytope_base.h
+++ b/geometry/optimization/cspace_free_polytope_base.h
@@ -27,6 +27,7 @@ namespace optimization {
  This virtual class is the base of CspaceFreePolytope and CspaceFreeBox. We take
  the common functionality between these concrete derived class to this shared
  parent class.
+ @ingroup planning_iris
  */
 class CspaceFreePolytopeBase {
  public:

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -19,6 +19,7 @@ namespace optimization {
 /** Configuration options for the IRIS algorithm.
 
 @ingroup geometry_optimization
+@ingroup planning_iris
 */
 struct IrisOptions {
   /** Passes this object to an Archive.
@@ -213,6 +214,7 @@ The @p obstacles, @p sample, and the @p domain must describe elements in the
 same ambient dimension (but that dimension can be any positive integer).
 
 @ingroup geometry_optimization
+@ingroup planning_iris
 */
 HPolyhedron Iris(const ConvexSets& obstacles,
                  const Eigen::Ref<const Eigen::VectorXd>& sample,
@@ -231,6 +233,7 @@ method will prioritize the representation that we expect is most performant
 for the current implementation of the IRIS algorithm.
 
 @ingroup geometry_optimization
+@ingroup planning_iris
 */
 ConvexSets MakeIrisObstacles(
     const QueryObject<double>& query_object,
@@ -262,7 +265,9 @@ run-time of the algorithm. The same goes for
 @throws std::exception if the sample configuration in @p context is infeasible.
 @throws std::exception if termination_func is invalid on the domain. See
 IrisOptions.termination_func for more details.
+
 @ingroup geometry_optimization
+@ingroup planning_iris
 */
 HPolyhedron IrisInConfigurationSpace(
     const multibody::MultibodyPlant<double>& plant,
@@ -279,7 +284,9 @@ is no longer contained in the IRIS region with tolerance tol.
 @throws std::exception if x_1.size() != x_2.size().
 @throws std::exception if epsilon <= 0. This is due to the fact that the
 hyperellipsoid for @p iris_options.starting_ellipse must have non-zero volume.
+
 @ingroup geometry_optimization
+@ingroup planning_iris
 */
 void SetEdgeContainmentTerminationCondition(
     IrisOptions* iris_options, const Eigen::Ref<const Eigen::VectorXd>& x_1,
@@ -287,7 +294,9 @@ void SetEdgeContainmentTerminationCondition(
     const double tol = 1e-6);
 
 /** Defines a standardized representation for (named) IrisRegions, which can be
-serialized in both C++ and Python. */
+serialized in both C++ and Python.
+
+@ingroup planning_iris */
 typedef std::map<std::string, HPolyhedron> IrisRegions;
 
 }  // namespace optimization

--- a/planning/iris/iris_common.h
+++ b/planning/iris/iris_common.h
@@ -21,6 +21,9 @@
 namespace drake {
 namespace planning {
 
+/** Various options which are common to the sampling-based algorithms IrisNp2
+ * and IrisZo for generating collision free polytopes in configuration space.
+ * @ingroup planning_iris */
 class CommonSampledIrisOptions {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CommonSampledIrisOptions);
@@ -172,7 +175,9 @@ class CommonSampledIrisOptions {
  * IrisNp2 requires that the user also provies a version of the function for
  * Eigen::VectorX<AutoDiffXd>. If not specified, the input dimension is assumed
  * to be equal to the output dimension. The user must also specify whether or
- * not the parameterization function can be called in parallel. */
+ * not the parameterization function can be called in parallel.
+ *
+ * @ingroup planning_iris */
 class IrisParameterizationFunction {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IrisParameterizationFunction);

--- a/planning/iris/iris_from_clique_cover.h
+++ b/planning/iris/iris_from_clique_cover.h
@@ -43,6 +43,8 @@ struct IrisFromCliqueCoverOptions {
    * IrisInConfigurationSpaceFromCliqueCover, the iris_options.parallelism is
    * ignored and the value of parallelism specified by `this.parallelism` will
    * be used instead.
+   *
+   * @ingroup planning_iris
    */
   std::variant<geometry::optimization::IrisOptions, IrisNp2Options,
                IrisZoOptions>
@@ -151,6 +153,8 @@ struct IrisFromCliqueCoverOptions {
  * @throw std::exception If the
  * options.iris_options.prog_with_additional_constraints is not nullptr i.e. if
  * a prog with additional constraints is provided.
+ *
+ * @ingroup planning_iris
  */
 void IrisInConfigurationSpaceFromCliqueCover(
     const CollisionChecker& checker, const IrisFromCliqueCoverOptions& options,

--- a/planning/iris/iris_np2.h
+++ b/planning/iris/iris_np2.h
@@ -30,7 +30,8 @@ IrisNp2SamplingStrategy iris_np2_sampling_strategy_from_string(
 }  // namespace internal
 
 /** RaySamplerOptions contains settings specific to the kRaySampler strategy for
- * drawing the initial samples. */
+ * drawing the initial samples.
+ * @ingroup planning_iris */
 struct RaySamplerOptions {
   /** Passes this object to an Archive.
   Refer to @ref yaml_serialization "YAML Serialization" for background.
@@ -65,7 +66,7 @@ struct RaySamplerOptions {
  *
  * @experimental
  * @see IrisNp2 for more details.
- **/
+ * @ingroup planning_iris */
 class IrisNp2Options {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IrisNp2Options);
@@ -158,7 +159,8 @@ supported.
 
 @throws if any collision pairs in `checker` have negative padding.
 @throws if any collision geometries have been been added in `checker`.
-*/
+
+@ingroup planning_iris */
 
 geometry::optimization::HPolyhedron IrisNp2(
     const SceneGraphCollisionChecker& checker,

--- a/planning/iris/iris_zo.h
+++ b/planning/iris/iris_zo.h
@@ -17,7 +17,7 @@ namespace planning {
  *
  * @experimental
  * @see IrisZo for more details.
- **/
+ * @ingroup planning_iris */
 class IrisZoOptions {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IrisZoOptions);
@@ -89,7 +89,8 @@ of the user-specified constraints in `options.prog_with_additional_constraints`.
 @note This can be a long running function that needs to solve many QPs. If you
 have a solver which requires a license, consider acquiring the license before
 solving this function. See AcquireLicense for more details.
-*/
+
+@ingroup planning_iris */
 
 geometry::optimization::HPolyhedron IrisZo(
     const CollisionChecker& checker,

--- a/planning/planning_doxygen.h
+++ b/planning/planning_doxygen.h
@@ -11,6 +11,7 @@
    @defgroup planning_trajectory
    @defgroup planning_collision_checker
    @defgroup planning_infrastructure
+   @defgroup planning_iris
  @}
 */
 
@@ -40,5 +41,11 @@
    Simplifications for managing @ref drake::systems::Diagram "Diagrams"
    containing @ref drake::multibody::MultibodyPlant "MultibodyPlant" and
    @ref drake::geometry::SceneGraph "SceneGraph" systems in planning tasks.
+ @}
+*/
+
+/** @addtogroup planning_iris Iris
+ @{
+  These algorithms help construct regions of configuration space that are collision free.
  @}
 */


### PR DESCRIPTION
Right now, it's very hard to find the new IrisNp2 and IrisZo functions. This PR collects these new methods, along with other algorithms in the Iris family, in a single doxygen page, to make them easier to discover. It adds a new entry under planning called "Iris"
<img width="216" height="246" alt="image" src="https://github.com/user-attachments/assets/5ad46b16-19ad-4190-8d09-fdf864a91952" />
This page contains all of the relevant functions, classes, etc.
<img width="1557" height="1444" alt="image" src="https://github.com/user-attachments/assets/b1d1b421-3eb7-4bfe-b11b-756186f9b6bb" />
If you want to preview the docs yourself, make sure to run
```
bazel run //doc:build -- --serve drake.geometry drake.planning
```
because it also contains some things from the geometry/optimization folder path.