### PR TITLE
[doc] Update macOS CMake to 4.1

### DIFF
--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -28,13 +28,17 @@ officially supports when building from source:
      CMakeLists.txt and tools/workspace/cc/repository.bzl. -->
 <!-- The minimum Python version(s) should match those listed in both the root
      CMakeLists.txt and setup/python/pyproject.toml. -->
+<!-- The minimum CMake version across all platforms should match that listed
+     in CMakeLists.txt, and the version range should match that listed in
+     tools/install/libdrake/drake-config.cmake.in (and all corresponding tests).
+     -->
 
 | Operating System ⁽¹⁾               | Architecture | Python ⁽²⁾ | Bazel | CMake | C/C++ Compiler ⁽³⁾           | Java       |
 |------------------------------------|--------------|------------|-------|-------|------------------------------|------------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 8.2   | 3.22  | GCC 11 (default) or Clang 15 | OpenJDK 11 |
 | Ubuntu 24.04 LTS (Noble Numbat)    | x86_64       | 3.12       | 8.2   | 3.28  | GCC 13 (default) or Clang 19 | OpenJDK 21 |
-| macOS Sonoma (14)                  | arm64        | 3.13       | 8.2   | 4.0   | Apple LLVM 16 (Xcode 16.2)   | OpenJDK 23 |
-| macOS Sequoia (15)                 | arm64        | 3.13       | 8.2   | 4.0   | Apple LLVM 17 (Xcode 16.4)   | OpenJDK 23 |
+| macOS Sonoma (14)                  | arm64        | 3.13       | 8.2   | 4.1   | Apple LLVM 16 (Xcode 16.2)   | OpenJDK 23 |
+| macOS Sequoia (15)                 | arm64        | 3.13       | 8.2   | 4.1   | Apple LLVM 17 (Xcode 16.4)   | OpenJDK 23 |
 
 "Official support" means that we have Continuous Integration test coverage to
 notice regressions, so if it doesn't work for you then please file a bug report.

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -10,7 +10,7 @@ if(CMAKE_VERSION VERSION_LESS 3.9.0)
   message(FATAL_ERROR "CMake >= 3.9 required")
 endif()
 cmake_policy(PUSH)
-cmake_policy(VERSION 3.9...4.0)
+cmake_policy(VERSION 3.9...4.1)
 set(CMAKE_IMPORT_FILE_VERSION 1)
 
 include(CMakeFindDependencyMacro)

--- a/tools/install/libdrake/test/drake_python_dir_install_test.py
+++ b/tools/install/libdrake/test/drake_python_dir_install_test.py
@@ -15,7 +15,7 @@ class DrakePythonDirInstallTest(unittest.TestCase):
         cmake_prefix_path = install_test_helper.get_install_dir()
 
         cmake_content = """
-            cmake_minimum_required(VERSION 3.9...4.0)
+            cmake_minimum_required(VERSION 3.9...4.1)
             project(drake_python_dir_install_test)
             set(CMAKE_PREFIX_PATH {cmake_prefix_path})
             find_package(drake CONFIG REQUIRED)

--- a/tools/install/libdrake/test/find_package_drake_install_test.py
+++ b/tools/install/libdrake/test/find_package_drake_install_test.py
@@ -26,7 +26,7 @@ class FindPackageDrakeInstallTest(unittest.TestCase):
         cmake_prefix_path = install_test_helper.get_install_dir()
 
         cmake_content = """
-            cmake_minimum_required(VERSION 3.9...4.0)
+            cmake_minimum_required(VERSION 3.9...4.1)
             project(find_package_drake_install_test)
             set(CMAKE_PREFIX_PATH {cmake_prefix_path})
             find_package(drake CONFIG REQUIRED)


### PR DESCRIPTION
Homebrew has jumped to [CMake 4.1](https://cmake.org/cmake/help/latest/release/4.1.html). The next time I re-provision images (which is at the latest next month, but likely sooner with changes in RobotLocomotion/drake-ci#346), CI will run the new version, so that is what we officially support.