### PR TITLE
Bind constructors for PyFunctionCost and PyFunctionConstraint

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1602,10 +1602,25 @@ void BindSolutionResult(py::module m) {
           doc.SolutionResult.kSolutionResultNotSet.doc);
 }
 
+void BindPyFunctionCost(py::module m) {
+  py::class_<PyFunctionCost, Cost, std::shared_ptr<PyFunctionCost>>(
+      m, "PyFunctionCost", "Cost with its evaluator as a Python function")
+      .def(py::init<int, const py::function&, const std::string&>(),
+          py::arg("num_vars"), py::arg("func"), py::arg("description") = "",
+          "Constructs a cost for a python function `func`, applied to "
+          "`num_vars` variables.");
+}
+
 void BindPyFunctionConstraint(py::module m) {
   py::class_<PyFunctionConstraint, Constraint,
       std::shared_ptr<PyFunctionConstraint>>(m, "PyFunctionConstraint",
       "Constraint with its evaluator as a Python function")
+      .def(py::init<int, const py::function&, const Eigen::VectorXd&,
+               const Eigen::VectorXd&, const std::string&>(),
+          py::arg("num_vars"), py::arg("func"), py::arg("lb"), py::arg("ub"),
+          py::arg("description") = "",
+          "Constructs a constraint for a python function `func`, encoding `lb` "
+          "<= `func` (x) <= `ub`, where x is of size `num_vars`.")
       .def("UpdateLowerBound", &PyFunctionConstraint::UpdateLowerBound,
           py::arg("new_lb"), "Update the lower bound of the constraint.")
       .def("UpdateUpperBound", &PyFunctionConstraint::UpdateUpperBound,
@@ -1713,6 +1728,7 @@ void BindFreeFunctions(py::module m) {
 namespace internal {
 void DefineSolversMathematicalProgram(py::module m) {
   // This list must remain in topological dependency order.
+  BindPyFunctionCost(m);
   BindPyFunctionConstraint(m);
   BindMathematicalProgram(m);
   BindSolutionResult(m);


### PR DESCRIPTION
Closes #23170.

+@jwnimmer-tri for feature review if you have the time, since you were involved in the discussion of the issue that led to this PR? But feel free to reassign. I ended up doing something slightly different then the solution you mentioned (turns out PyFunctionConstraint was already bound, but its constructor was not).

cc @sageshoyu -- this should make the costs/constraints we're working with a lot easier to do

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23291)
<!-- Reviewable:end -->
