### PR TITLE
[doc] Fix broken links to tutorials

### DIFF
--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -56,7 +56,7 @@ custom:
         - page: 'Getting Help'
           url: /getting_help.html
         - page: 'Tutorials'
-          url: 'https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/%2Findex.ipynb'
+          url: 'https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/index-753e3c9d261247ba9f0eb1d7868c18c8'
         - page: 'Troubleshooting'
           url: /troubleshooting.html
         - page: 'Python Bindings'

--- a/doc/_release-notes/v1.44.0.md
+++ b/doc/_release-notes/v1.44.0.md
@@ -12,6 +12,8 @@ released: 2025-08-15
   * Mosek packages declare an upper-bound on their supported Python version
     (<3.14); your package manager (e.g., Poetry) might require you to add
     that same bound in your `pyproject.toml` as a consequence.
+  * Known issue: macOS wheels have incorrect RECORD checksums in this release;
+    this will be fixed in v1.45.0.
 
 # Breaking changes since v1.43.0
 

--- a/doc/doxygen_cxx/header.html.patch
+++ b/doc/doxygen_cxx/header.html.patch
@@ -30,7 +30,7 @@
 +    <li class="site-menu-item site-menu-item-main">Resources
 +     <div class="sub">
 +      <a class="site-menu-item" href="/getting_help.html">Getting Help</a>
-+      <a class="site-menu-item" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/%2Findex.ipynb">Tutorials</a>
++      <a class="site-menu-item" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/index-753e3c9d261247ba9f0eb1d7868c18c8">Tutorials</a>
 +      <a class="site-menu-item" href="/python_bindings.html">Python Bindings</a>
 +      <a class="site-menu-item" href="/developers.html">For Developers</a>
 +      <a class="site-menu-item" href="/credits.html">Credits</a>

--- a/doc/index.md
+++ b/doc/index.md
@@ -39,19 +39,19 @@ purpose of the front page (HTML for layout, Markdown for content).
       <div class="core-el">
         <h4>Modeling Dynamical<br> Systems</h4>
         <div class="core-el-buttons">
-          <a class="button--text" href="/doxygen_cxx/group__systems.html" target="_blank">API</a><a class="button--text" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/%2Fdynamical_systems.ipynb" target="_blank">TUTORIAL</a>
+          <a class="button--text" href="/doxygen_cxx/group__systems.html" target="_blank">API</a><a class="button--text" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/dynamicalsystems-0da445e96cc24a358022b5075d7b0826" target="_blank">TUTORIAL</a>
         </div>
       </div>
       <div class="core-el">
         <h4>Solving Mathematical<br> Programs</h4>
         <div class="core-el-buttons">
-          <a class="button--text" href="/doxygen_cxx/group__solvers.html" target="_blank">API</a><a class="button--text" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/%2Fmathematical_program.ipynb" target="_blank">TUTORIAL</a>
+          <a class="button--text" href="/doxygen_cxx/group__solvers.html" target="_blank">API</a><a class="button--text" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/mathematicalprogram-a901caa611f54d3e9302233a4df1b0af" target="_blank">TUTORIAL</a>
         </div>
       </div>
       <div class="core-el">
         <h4>Multibody Kinematics<br> and Dynamics</h4>
         <div class="core-el-buttons">
-          <a class="button--text" href="/doxygen_cxx/group__multibody.html" target="_blank">API</a><a class="button--text" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/%2Fauthoring_multibody_simulation.ipynb" target="_blank">TUTORIAL</a>
+          <a class="button--text" href="/doxygen_cxx/group__multibody.html" target="_blank">API</a><a class="button--text" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/authoringmultibodysimulation-8159e3be6dc048a6a8ab6876017def4b" target="_blank">TUTORIAL</a>
         </div>
       </div>
     </div>
@@ -110,7 +110,7 @@ bug fixes, features, and examples!
 ## Tutorials
 
 Drake offers Python-based tutorials using Jupyter notebooks. We recommend that
-you [view the tutorials online](https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/%2Findex.ipynb).
+you [view the tutorials online](https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/index-753e3c9d261247ba9f0eb1d7868c18c8).
 
 Alternatively, to run the tutorials locally via `pip`, refer to
 [drake/tutorials/README.md](https://github.com/RobotLocomotion/drake/blob/master/tutorials/README.md).

--- a/doc/pydrake/layout.html
+++ b/doc/pydrake/layout.html
@@ -24,7 +24,7 @@
         </li>
         <li class="site-menu-item site-menu-item-main">Resources
           <div class="sub">
-            <a class="site-menu-item" href="/getting_help.html">Getting Help</a> <a class="site-menu-item" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/%2Findex.ipynb">Tutorials</a> <a class="site-menu-item" href="/python_bindings.html">Python Bindings</a> <a class="site-menu-item" href="/developers.html">For Developers</a> <a class="site-menu-item" href="/credits.html">Credits</a>
+            <a class="site-menu-item" href="/getting_help.html">Getting Help</a> <a class="site-menu-item" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/index-753e3c9d261247ba9f0eb1d7868c18c8">Tutorials</a> <a class="site-menu-item" href="/python_bindings.html">Python Bindings</a> <a class="site-menu-item" href="/developers.html">For Developers</a> <a class="site-menu-item" href="/credits.html">Credits</a>
           </div>
         </li>
         <li class="github-link">

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -36,7 +36,7 @@ class CompositeParse;
 /// MultibodyPlant provided to the parser at construction.
 ///
 /// For an introductory tutorial about parsing, see the <a
-/// href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/authoring_multibody_simulation-3c9697070d3541ee82c0bfe4054ada2d">Authoring
+/// href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/authoringmultibodysimulation-8159e3be6dc048a6a8ab6876017def4b">Authoring
 /// a Multibody Simulation</a> page.
 ///
 /// SDFormat files may contain multiple `<model>` elements.  New model

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -3,7 +3,7 @@
 Drake offers Python-based tutorials using Jupyter notebooks.
 
 We recommend that you
-[view the tutorials online](https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/%2Findex.ipynb).
+[view the tutorials online](https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/index-753e3c9d261247ba9f0eb1d7868c18c8).
 
 Alternatively, you may run the tutorials locally.
 


### PR DESCRIPTION
Towards #21588.

This fixes the links from our website to deepnote, but not the links from the deepnote Index notebook to the other notebooks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23293)
<!-- Reviewable:end -->
