### PR TITLE
Fix macOS wheel RECORD

### DIFF
--- a/tools/wheel/macos/change_lpath.py
+++ b/tools/wheel/macos/change_lpath.py
@@ -1,54 +1,14 @@
 """
 Given one or more input artifacts (binaries or libraries), apply one or more
 specified changes to the path prefix of all libraries to which the artifacts
-are linked. The inputs can also be artifacts inside a wheel.
+are linked.
 """
 
 import argparse
-import os
-import re
-import pathlib
-import shutil
 import subprocess
 import sys
-import tempfile
-import zipfile
 
 from tools.install import otool
-
-
-def _extract(wheel, path, destination):
-    """
-    Extracts a file from a wheel (zipfile) and writes it to the specified
-    `destination`.
-    """
-    with zipfile.ZipFile(wheel, 'r') as zip_file:
-        with open(destination, 'wb') as out:
-            shutil.copyfileobj(zip_file.open(path, 'r'), out)
-
-
-def _replace(wheel, files):
-    """
-    Replaces file(s) in a wheel (zipfile).
-
-    Given an input dictionary mapping zip-file paths to on-disk paths, replaces
-    matching files in the specified wheel with the content of the respective
-    on-disk files.
-    """
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = os.path.join(temp_dir, 'wheel')
-
-        with zipfile.ZipFile(temp_path, 'w', zipfile.ZIP_DEFLATED) as zip_new:
-            with zipfile.ZipFile(wheel, 'r') as zip_old:
-                for item in zip_old.infolist():
-                    replacement = files.get(item.filename)
-                    if replacement is not None:
-                        content = pathlib.Path(replacement).read_bytes()
-                        zip_new.writestr(item, content)
-                    else:
-                        zip_new.writestr(item, zip_old.read(item.filename))
-
-        os.replace(temp_path, wheel)
 
 
 def _chlpath(path, replacements):
@@ -92,9 +52,6 @@ def main(args):
         '--new', required=True, action='append',
         help='Replacement prefix (must be specified once per --old)')
     parser.add_argument(
-        '--wheel',
-        help='Modify file(s) inside the specified wheel')
-    parser.add_argument(
         'library', nargs='+',
         help='Dynamic library to modify')
 
@@ -103,22 +60,9 @@ def main(args):
     assert len(options.old) == len(options.new)
     replacements = list(zip(options.old, options.new))
 
-    # Get list of dependent libraries and modify their prefixes.
-    if options.wheel:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            libs = {}
-            for i, path in enumerate(options.library):
-                lib_path = os.path.join(temp_dir, f'lib{i}')
-                _extract(options.wheel, path, lib_path)
-
-                _chlpath(lib_path, replacements)
-                libs[path] = lib_path
-
-            _replace(options.wheel, libs)
-
-    else:
-        for path in options.library:
-            _chlpath(path, replacements)
+    # Modify libraries.
+    for path in options.library:
+        _chlpath(path, replacements)
 
 
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Rewrite logic to remove the MOSEK libraries from the macOS wheel to use the `wheel` command to unpack and repack the wheel in order to perform modifications, rather than trying to perform the modifications in a more 'in place' manner. This is needed so that the wheel's RECORD is updated to reflect the changes.

Accordingly, remove logic in `change_lpath` to edit files inside wheels, since doing so results in a broken RECORD.

Fixes #23290.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23294)
<!-- Reviewable:end -->
