### PR TITLE
[tools] Enable Werror=uninitialized for GCC 13 (on Noble)

### DIFF
--- a/geometry/proximity/test/bvh_test.cc
+++ b/geometry/proximity/test/bvh_test.cc
@@ -181,8 +181,8 @@ TYPED_TEST(BvhTest, TestComputeBoundingVolume) {
 
   using FaceCentroidPair = std::pair<int, Vector3d>;
   // The positions of centroids are not relevant to this test.
-  std::vector<FaceCentroidPair> upper{{0, Vector3d()}};
-  std::vector<FaceCentroidPair> lower{{1, Vector3d()}};
+  std::vector<FaceCentroidPair> upper{{0, Vector3d::Zero()}};
+  std::vector<FaceCentroidPair> lower{{1, Vector3d::Zero()}};
 
   const BvType bv =
       BvhTester::ComputeBoundingVolume<BvType, TriangleSurfaceMesh<double>>(

--- a/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_friction_cone_constraint.cc
@@ -75,8 +75,10 @@ std::unique_ptr<AbstractValue> SapFrictionConeConstraint<T>::DoMakeData(
   // Bias term.
   const T vn_hat = -configuration_.phi / (time_step + taud);
 
-  SapFrictionConeConstraintData<T> data(parameters_.mu, Rt, Rn, vn_hat);
-  return SapConstraint<T>::MoveAndMakeAbstractValue(std::move(data));
+  // Create our return value in a way that avoids extra copies.
+  return std::unique_ptr<AbstractValue>(
+      new Value<SapFrictionConeConstraintData<T>>(parameters_.mu, Rt, Rn,
+                                                  vn_hat));
 }
 
 template <typename T>

--- a/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.cc
@@ -33,6 +33,12 @@ std::unique_ptr<AbstractValue> SapHuntCrossleyConstraint<T>::DoMakeData(
     const Eigen::Ref<const VectorX<T>>& delassus_estimation) const {
   using std::max;
 
+  // Prepare our return value storage in a way that avoids extra copies.
+  Value<SapHuntCrossleyConstraintData<T>>* downcast_result{};
+  std::unique_ptr<AbstractValue> result(
+      downcast_result = new Value<SapHuntCrossleyConstraintData<T>>());
+  SapHuntCrossleyConstraintData<T>& data = downcast_result->get_mutable_value();
+
   const T& mu = parameters_.friction;
   const T& d = parameters_.dissipation;
   const double stiction_tolerance = parameters_.stiction_tolerance;
@@ -49,7 +55,6 @@ std::unique_ptr<AbstractValue> SapHuntCrossleyConstraint<T>::DoMakeData(
       max(0.5 * (delassus_estimation(0) + delassus_estimation(1)), w_rms);
   const T Rt = sigma * wt;  // SAP's regularization.
 
-  SapHuntCrossleyConstraintData<T> data;
   typename SapHuntCrossleyConstraintData<T>::InvariantData& p =
       data.invariant_data;
   p.dt = time_step;
@@ -61,7 +66,7 @@ std::unique_ptr<AbstractValue> SapHuntCrossleyConstraint<T>::DoMakeData(
   const T sap_stiction_tolerance = mu * Rt * p.n0;
   p.epsilon_soft = max(stiction_tolerance, sap_stiction_tolerance);
 
-  return AbstractValue::Make(data);
+  return result;
 }
 
 template <typename T>

--- a/multibody/contact_solvers/sap/test/sap_model_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_model_test.cc
@@ -16,6 +16,7 @@ using Eigen::Vector3d;
 using Eigen::VectorXd;
 
 constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
 
 namespace drake {
 namespace multibody {
@@ -43,9 +44,9 @@ template <typename T>
 class SpringConstraint final : public SapConstraint<T> {
  public:
   struct Data {
-    Vector3<T> vc;
-    T R;
-    Vector3<T> v_hat;
+    Vector3<T> vc{Vector3d::Constant(kNaN)};
+    T R{kNaN};
+    Vector3<T> v_hat{Vector3d::Constant(kNaN)};
   };
 
   // Model a spring attached to `clique`, expected to be a 3D particle.

--- a/systems/analysis/test/discrete_time_approximation_test.cc
+++ b/systems/analysis/test/discrete_time_approximation_test.cc
@@ -278,7 +278,7 @@ class DirectFeedthroughSystem : public LeafSystem<T> {
 
     for (int i = 0; i < num_input_ports; ++i) {
       this->DeclareAbstractInputPort(kUseDefaultName,
-                                     Value(Eigen::Matrix3<T>()));
+                                     Value(Eigen::Matrix3<T>::Zero().eval()));
     }
 
     for (int j = 0; j < num_output_ports; ++j) {
@@ -302,7 +302,7 @@ class DirectFeedthroughSystem : public LeafSystem<T> {
           kUseDefaultName,
           []() {
             return std::make_unique<Value<Eigen::Matrix3<T>>>(
-                Eigen::Matrix3<T>());
+                Eigen::Matrix3<T>::Zero());
           },
           [this, connected_input_ports](const Context<T>& context,
                                         AbstractValue* out) {

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -73,9 +73,7 @@ GCC_CC_TEST_FLAGS = [
 GCC_VERSION_SPECIFIC_FLAGS = {
     13: [
         "-Werror=pessimizing-move",
-        # TODO(#21337) Investigate and resolve what to do about these warnings
-        # long-term. Some seem like true positives (i.e., bugs in Drake).
-        "-Wno-uninitialized",
+        "-Werror=uninitialized",
         # This falsely dings code that returns const references, e.g., our
         # MbP style for "add element" or "find by name" member functions.
         "-Wno-dangling-reference",


### PR DESCRIPTION
Closes #21337.

This warning dings a few places where we were copying around uninitialized memory.  Our runtime memory checkers like `valgrind` allow us to copy around uninitialized memory so long as we don't calculate with it later on.  But here with the compiler's static checker (which is more limited than a runtime checker), it dings us if we run the copy constructor on a halfway-initialized object.

For tests, the obvious answer is to just initialize our test inputs to not be garbage memory.

For the SAP constraints, the obvious answer is to respell the code to avoid calling the copy constructor in the first place.  The code _was_ trying to avoid copies by using `std::move`, but the objects being moved didn't have anything on the heap -- they were fixed-size structs of a dozen or so floats, so were being copied around anyway.  Here we fix the code to populate the object in-place, without an extra copy-over step at the end.  This both avoids the new warning, and fixes the code to match the original author's intent of no copying.

Of course another option would be to turn off this warning instead of changing our code, but my assessment is that the true and false positive rates of this warning are high (and low, resp), and so it's worth turning it on now and committing to fixing anything it dings in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23306)
<!-- Reviewable:end -->
