### PR TITLE
[Jenkins] Cancel experimental builds on updates

### DIFF
--- a/.jenkins/Jenkinsfile-experimental
+++ b/.jenkins/Jenkinsfile-experimental
@@ -203,11 +203,11 @@ node(getNodeLabel()) {
         daysToKeepStr: '90',
         artifactDaysToKeepStr: '90'
       )
+    ),
+    disableConcurrentBuilds(
+      abortPrevious: true
     )
   ]
-  if (env.JOB_NAME.contains("cache-server-health-check")) {
-    props << disableConcurrentBuilds()
-  }
   properties(props)
 
   stage('test') {

--- a/.jenkins/Jenkinsfile-external-examples
+++ b/.jenkins/Jenkinsfile-external-examples
@@ -190,7 +190,9 @@ node(getNodeLabel()) {
         artifactDaysToKeepStr: '90'
       )
     ),
-    githubProjectProperty('https://github.com/RobotLocomotion/drake')
+    disableConcurrentBuilds(
+      abortPrevious: true
+    ),
   ])
 
   stage('drake-checkout') {

--- a/.jenkins/templates/Jenkinsfile-experimental.in
+++ b/.jenkins/templates/Jenkinsfile-experimental.in
@@ -36,11 +36,11 @@ node(getNodeLabel()) {
         daysToKeepStr: '90',
         artifactDaysToKeepStr: '90'
       )
+    ),
+    disableConcurrentBuilds(
+      abortPrevious: true
     )
   ]
-  if (env.JOB_NAME.contains("cache-server-health-check")) {
-    props << disableConcurrentBuilds()
-  }
   properties(props)
 
   stage('test') {

--- a/.jenkins/templates/Jenkinsfile-external-examples.in
+++ b/.jenkins/templates/Jenkinsfile-external-examples.in
@@ -23,7 +23,9 @@ node(getNodeLabel()) {
         artifactDaysToKeepStr: '90'
       )
     ),
-    githubProjectProperty('https://github.com/RobotLocomotion/drake')
+    disableConcurrentBuilds(
+      abortPrevious: true
+    ),
   ])
 
   stage('drake-checkout') {


### PR DESCRIPTION
The deprecated GHPRB had a setting to cancel currently-running builds when a PR is updated, favoring the current one to save resources. Replicate that functionality with concurrency, since a unique "job" is defined for each pull request.

Also, remove the no-op `githubProjectProperty` from the DEE pipeline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23322)
<!-- Reviewable:end -->
