### PR TITLE
Fix "required braces on conditionals" per style guide

### DIFF
--- a/common/autodiff_overloads.h
+++ b/common/autodiff_overloads.h
@@ -88,10 +88,11 @@ Eigen::AutoDiffScalar<DerType> copysign(const Eigen::AutoDiffScalar<DerType>& x,
                                         const T& y) {
   using std::isnan;
   if (isnan(x)) return (y >= 0) ? NAN : -NAN;
-  if ((x < 0 && y >= 0) || (x >= 0 && y < 0))
+  if ((x < 0 && y >= 0) || (x >= 0 && y < 0)) {
     return -x;
-  else
+  } else {
     return x;
+  }
 }
 
 /// Overloads copysign from <cmath>.
@@ -99,10 +100,11 @@ template <typename DerType>
 double copysign(double x, const Eigen::AutoDiffScalar<DerType>& y) {
   using std::isnan;
   if (isnan(x)) return (y >= 0) ? NAN : -NAN;
-  if ((x < 0 && y >= 0) || (x >= 0 && y < 0))
+  if ((x < 0 && y >= 0) || (x >= 0 && y < 0)) {
     return -x;
-  else
+  } else {
     return x;
+  }
 }
 
 /// Overloads pow for an AutoDiffScalar base and exponent, implementing the

--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -297,9 +297,10 @@ Polynomial<T> Polynomial<T>::Substitute(
 template <typename T>
 Polynomial<T> Polynomial<T>::Derivative(int derivative_order) const {
   DRAKE_DEMAND(derivative_order >= 0);
-  if (!is_univariate_)
+  if (!is_univariate_) {
     throw runtime_error(
         "Derivative is only defined for univariate polynomials");
+  }
   if (derivative_order == 0) {
     return *this;
   }

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -209,9 +209,10 @@ class Polynomial {
     typedef typename std::remove_const_t<typename Product<T, U>::type>
         ProductType;
 
-    if (!is_univariate_)
+    if (!is_univariate_) {
       throw std::runtime_error(
           "this method can only be used for univariate polynomials");
+    }
 
     DRAKE_DEMAND(derivative_order >= 0);
     ProductType value = 0;
@@ -421,10 +422,11 @@ class Polynomial {
 
     for (typename std::vector<Term>::const_iterator iter = m.terms.begin();
          iter != m.terms.end(); iter++) {
-      if (print_star)
+      if (print_star) {
         os << '*';
-      else
+      } else {
         print_star = true;
+      }
       os << IdToVariableName(iter->var);
       if (iter->power != 1) {
         os << "^" << iter->power;

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -33,14 +33,16 @@ PiecewisePolynomial<T>::PiecewisePolynomial(
     : PiecewiseTrajectory<T>(breaks), polynomials_(polynomials) {
   DRAKE_ASSERT(breaks.size() == (polynomials.size() + 1));
   for (int i = 1; i < this->get_number_of_segments(); i++) {
-    if (polynomials[i].rows() != polynomials[0].rows())
+    if (polynomials[i].rows() != polynomials[0].rows()) {
       throw std::runtime_error(
           "The polynomial matrix for each segment must have the same number of "
           "rows.");
-    if (polynomials[i].cols() != polynomials[0].cols())
+    }
+    if (polynomials[i].cols() != polynomials[0].cols()) {
       throw std::runtime_error(
           "The polynomial matrix for each segment must have the same number of "
           "columns.");
+    }
   }
 }
 
@@ -246,9 +248,10 @@ int PiecewisePolynomial<T>::getSegmentPolynomialDegree(int segment_index,
 template <typename T>
 PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator+=(
     const PiecewisePolynomial<T>& other) {
-  if (!this->SegmentTimesEqual(other))
+  if (!this->SegmentTimesEqual(other)) {
     throw runtime_error(
         "Addition not yet implemented when segment times are not equal");
+  }
   for (size_t i = 0; i < polynomials_.size(); i++)
     polynomials_[i] += other.polynomials_[i];
   return *this;
@@ -257,9 +260,10 @@ PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator+=(
 template <typename T>
 PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator-=(
     const PiecewisePolynomial<T>& other) {
-  if (!this->SegmentTimesEqual(other))
+  if (!this->SegmentTimesEqual(other)) {
     throw runtime_error(
         "Subtraction not yet implemented when segment times are not equal");
+  }
   for (size_t i = 0; i < polynomials_.size(); i++)
     polynomials_[i] -= other.polynomials_[i];
   return *this;
@@ -268,9 +272,10 @@ PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator-=(
 template <typename T>
 PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator*=(
     const PiecewisePolynomial<T>& other) {
-  if (!this->SegmentTimesEqual(other))
+  if (!this->SegmentTimesEqual(other)) {
     throw runtime_error(
         "Multiplication not yet implemented when segment times are not equal");
+  }
   for (size_t i = 0; i < polynomials_.size(); i++) {
     polynomials_[i] *= other.polynomials_[i];
   }
@@ -808,10 +813,11 @@ PiecewisePolynomial<T> PiecewisePolynomial<T>::FirstOrderHold(
 
 template <typename T>
 static int sign(T val, T tol) {
-  if (val < -tol)
+  if (val < -tol) {
     return -1;
-  else if (val > tol)
+  } else if (val > tol) {
     return 1;
+  }
   return 0;
 }
 

--- a/common/trajectories/piecewise_trajectory.cc
+++ b/common/trajectories/piecewise_trajectory.cc
@@ -63,12 +63,13 @@ int PiecewiseTrajectory<T>::GetSegmentIndexRecursive(const T& time, int start,
   // one or two numbers
   if (end - start <= 1) return start;
 
-  if (time < breaks_[mid])
+  if (time < breaks_[mid]) {
     return GetSegmentIndexRecursive(time, start, mid);
-  else if (time > breaks_[mid])
+  } else if (time > breaks_[mid]) {
     return GetSegmentIndexRecursive(time, mid, end);
-  else
+  } else {
     return mid;
+  }
 }
 
 template <typename T>

--- a/common/trajectories/test/piecewise_quaternion_test.cc
+++ b/common/trajectories/test/piecewise_quaternion_test.cc
@@ -64,10 +64,11 @@ bool CheckSlerpInterpolation(const PiecewiseQuaternionSlerp<Scalar>& spline,
   Vector3<Scalar> w0 = spline.angular_velocity(t0);
   Quaternion<Scalar> q1 = EulerIntegrateQuaternion(q0, w0, dt);
 
-  if (q_spline.isApprox(q1, 1e-10))
+  if (q_spline.isApprox(q1, 1e-10)) {
     return true;
-  else
+  } else {
     return false;
+  }
 }
 
 // Generates a vector of random orientation using randomized axis angles.

--- a/examples/allegro_hand/allegro_common.cc
+++ b/examples/allegro_hand/allegro_common.cc
@@ -125,14 +125,15 @@ Eigen::Vector4d AllegroHandMotionState::FingerGraspJointPosition(
   // medium size object, such as the mug. The final positions of the joints
   // are usually larger than the preset values, so that the fingers continuously
   // apply force on the object.
-  if (finger_index == 0)
+  if (finger_index == 0) {
     position << 1.396, 0.85, 0, 1.3;
-  else if (finger_index == 1)
+  } else if (finger_index == 1) {
     position << 0.08, 0.9, 0.75, 1.5;
-  else if (finger_index == 2)
+  } else if (finger_index == 2) {
     position << 0.1, 0.9, 0.75, 1.5;
-  else
+  } else {
     position << 0.12, 0.9, 0.75, 1.5;
+  }
   return position;
 }
 

--- a/examples/bead_on_a_wire/bead_on_a_wire.cc
+++ b/examples/bead_on_a_wire/bead_on_a_wire.cc
@@ -137,10 +137,11 @@ Eigen::VectorXd BeadOnAWire<T>::CalcVelocityChangeFromConstraintImpulses(
 
   // The bead on the wire is unit mass, so the velocity change is equal to
   // simply Jᵀλ
-  if (coordinate_type_ == kAbsoluteCoordinates)
+  if (coordinate_type_ == kAbsoluteCoordinates) {
     return J.transpose() * lambda;
-  else
+  } else {
     return Eigen::Matrix<T, 1, 1>(0);
+  }
 }
 
 template <class T>

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -23,10 +23,11 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
   // Verify that the simulation approach is either piecewise DAE or
   // compliant ODE.
   if (system_type == SystemType::kDiscretized) {
-    if (dt <= 0.0)
+    if (dt <= 0.0) {
       throw std::logic_error(
           "Discretization approach must be constructed using"
           " strictly positive step size.");
+    }
 
     // Discretization approach requires three position variables and
     // three velocity variables, all discrete, and periodic update.
@@ -36,10 +37,11 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
     state_output_port_ =
         &this->DeclareStateOutputPort("state_output", state_index);
   } else {
-    if (dt != 0)
+    if (dt != 0) {
       throw std::logic_error(
           "Piecewise DAE and compliant approaches must be "
           "constructed using zero step size.");
+    }
 
     // Both piecewise DAE and compliant approach require six continuous
     // variables.
@@ -851,12 +853,13 @@ template <class T>
 T Rod2D<T>::CalcMuStribeck(const T& mu_s, const T& mu_d, const T& s) {
   DRAKE_ASSERT(mu_s >= 0 && mu_d >= 0 && s >= 0);
   T mu_stribeck;
-  if (s >= 3)
+  if (s >= 3) {
     mu_stribeck = mu_d;  // sliding
-  else if (s >= 1)
+  } else if (s >= 1) {
     mu_stribeck = mu_s - (mu_s - mu_d) * step5((s - 1) / 2);  // Stribeck
-  else
+  } else {
     mu_stribeck = mu_s * step5(s);  // 0 <= s < 1 (stiction)
+  }
   return mu_stribeck;
 }
 

--- a/geometry/proximity/make_cylinder_mesh.cc
+++ b/geometry/proximity/make_cylinder_mesh.cc
@@ -350,10 +350,11 @@ VolumeMesh<T> MakeCylinderVolumeMeshWithMa(const Cylinder& cylinder,
   const double smaller_measure = std::min(top_z, cylinder.radius());
   const double tolerance = DistanceToPointRelativeTolerance(smaller_measure);
   CylinderClass cylinder_class = CylinderClass::kMedium;
-  if (top_z - cylinder.radius() > tolerance)
+  if (top_z - cylinder.radius() > tolerance) {
     cylinder_class = CylinderClass::kLong;
-  else if (cylinder.radius() - top_z > tolerance)
+  } else if (cylinder.radius() - top_z > tolerance) {
     cylinder_class = CylinderClass::kShort;
+  }
 
   // At the minimum 3 vertices per circular rims of the cylinder, the mesh
   // will cover a triangular prism inside the cylinder. The larger value

--- a/geometry/proximity/test/hydroelastic_calculator_test.cc
+++ b/geometry/proximity/test/hydroelastic_calculator_test.cc
@@ -181,8 +181,9 @@ class TestScene {
     // transformation of both points and vectors will accumulate derivatives.
 
     if (this->shape_A_type_ == ShapeType::kHalfSpace &&
-        this->shape_B_type_ == ShapeType::kHalfSpace)
+        this->shape_B_type_ == ShapeType::kHalfSpace) {
       return;
+    }
 
     // The distance from the world origin to the surface of a shape. In other
     // words, a point at Wo needs to be moved `distance` units to lie on the

--- a/geometry/render_gltf_client/internal_http_service_curl.cc
+++ b/geometry/render_gltf_client/internal_http_service_curl.cc
@@ -68,22 +68,23 @@ int DebugCallback(CURL* /* handle */, curl_infotype type, char* data,
 
 // Used in logging curl data, returns a human friendly string.
 std::string CurlInfoTypeAsString(curl_infotype type) {
-  if (type == CURLINFO_TEXT)
+  if (type == CURLINFO_TEXT) {
     return "CURLINFO_TEXT";
-  else if (type == CURLINFO_HEADER_IN)
+  } else if (type == CURLINFO_HEADER_IN) {
     return "CURLINFO_HEADER_IN";
-  else if (type == CURLINFO_HEADER_OUT)
+  } else if (type == CURLINFO_HEADER_OUT) {
     return "CURLINFO_HEADER_OUT";
-  else if (type == CURLINFO_DATA_IN)
+  } else if (type == CURLINFO_DATA_IN) {
     return "CURLINFO_DATA_IN";
-  else if (type == CURLINFO_DATA_OUT)
+  } else if (type == CURLINFO_DATA_OUT) {
     return "CURLINFO_DATA_OUT";
-  else if (type == CURLINFO_SSL_DATA_IN)
+  } else if (type == CURLINFO_SSL_DATA_IN) {
     return "CURLINFO_SSL_DATA_IN";
-  else if (type == CURLINFO_SSL_DATA_OUT)
+  } else if (type == CURLINFO_SSL_DATA_OUT) {
     return "CURLINFO_SSL_DATA_OUT";
-  else if (type == CURLINFO_END)
+  } else if (type == CURLINFO_END) {
     return "CURLINFO_END";
+  }
   return fmt::format("UNKNOWN_CURLINFO_TYPE={}", fmt_streamed(type));
 }
 

--- a/geometry/render_gltf_client/test/client_demo.cc
+++ b/geometry/render_gltf_client/test/client_demo.cc
@@ -108,10 +108,11 @@ DEFINE_bool(
     "server.");
 
 static bool valid_render_engine(const char* flagname, const std::string& val) {
-  if (val == "vtk")
+  if (val == "vtk") {
     return true;
-  else if (val == "client")
+  } else if (val == "client") {
     return true;
+  }
   drake::log()->error("Invalid value for {}: '{}'; options: 'client' or 'vtk'.",
                       flagname, val);
   return false;

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -3125,10 +3125,11 @@ TEST_F(GeometryStateTest, AssignRolesToGeometry) {
                                    : "not expected, but found. ");
       passes = false;
     }
-    if (passes)
+    if (passes) {
       return ::testing::AssertionSuccess();
-    else
+    } else {
       return failure;
+    }
   };
 
   // Given three role types, assign all eight types of assignments.
@@ -3600,10 +3601,11 @@ TEST_F(GeometryStateTest, ChildGeometryRoleCount) {
                 << role << " role. Found " << actual_count;
       }
     }
-    if (success)
+    if (success) {
       return ::testing::AssertionSuccess();
-    else
+    } else {
       return failure;
+    }
   };
 
   // Assert initial conditions.

--- a/multibody/contact_solvers/sap/sap_contact_problem.cc
+++ b/multibody/contact_solvers/sap/sap_contact_problem.cc
@@ -244,9 +244,10 @@ int SapContactProblem<T>::AddConstraint(std::unique_ptr<SapConstraint<T>> c) {
   }
 
   for (int object_index : c->objects()) {
-    if (object_index < 0 || object_index >= num_objects())
+    if (object_index < 0 || object_index >= num_objects()) {
       throw std::runtime_error(
           "Constraint object indices must be in the range [0, num_objects()).");
+    }
   }
 
   // Update graph.

--- a/multibody/contact_solvers/sap/sap_solver.cc
+++ b/multibody/contact_solvers/sap/sap_solver.cc
@@ -623,8 +623,9 @@ std::pair<T, int> SapSolver<T>::PerformExactLineSearch(
   // small, we allow the Newton solver to take a full step and therefore we
   // return with a step size of one.
   if (-dell_dalpha0 <
-      parameters_.cost_abs_tolerance + parameters_.cost_rel_tolerance * ell0)
+      parameters_.cost_abs_tolerance + parameters_.cost_rel_tolerance * ell0) {
     return std::make_pair(1.0, 0);
+  }
 
   // N.B. We place the data needed to evaluate cost and gradients into a single
   // struct so that cost_and_gradient only needs to capture a single pointer.

--- a/multibody/inverse_kinematics/com_in_polyhedron_constraint.cc
+++ b/multibody/inverse_kinematics/com_in_polyhedron_constraint.cc
@@ -27,9 +27,10 @@ ComInPolyhedronConstraint::ComInPolyhedronConstraint(
       context_double_{plant_context},
       plant_autodiff_(nullptr),
       context_autodiff_(nullptr) {
-  if (plant_context == nullptr)
+  if (plant_context == nullptr) {
     throw std::invalid_argument(
         "ComInPolyhedronConstraint: plant_context is nullptr.");
+  }
   this->set_description("com in polyhedron constraint");
   if (model_instances_.has_value() && model_instances_.value().empty()) {
     throw std::invalid_argument(
@@ -54,9 +55,10 @@ ComInPolyhedronConstraint::ComInPolyhedronConstraint(
       context_double_{nullptr},
       plant_autodiff_{plant},
       context_autodiff_{plant_context} {
-  if (plant_context == nullptr)
+  if (plant_context == nullptr) {
     throw std::invalid_argument(
         "ComInPolyhedronConstraint: plant_context is nullptr.");
+  }
   this->set_description("com in polyhedron constraint");
   if (model_instances_.has_value() && model_instances_.value().empty()) {
     throw std::invalid_argument(

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -38,9 +38,10 @@ PositionConstraint::PositionConstraint(
   if (plant == nullptr) {
     throw std::invalid_argument("PositionConstraint(): plant is nullptr.");
   }
-  if (plant_context == nullptr)
+  if (plant_context == nullptr) {
     throw std::invalid_argument(
         "PositionConstraint(): plant_context is nullptr.");
+  }
 }
 
 PositionConstraint::PositionConstraint(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -6594,10 +6594,11 @@ struct AddMultibodyPlantSceneGraphResult final {
   // Provided to support C++'s structured binding.
   template <std::size_t N>
   decltype(auto) get() const {
-    if constexpr (N == 0)
+    if constexpr (N == 0) {
       return plant;
-    else if constexpr (N == 1)
+    } else if constexpr (N == 1) {
       return scene_graph;
+    }
   }
 #endif
 

--- a/multibody/topology/link_joint_graph_debug.cc
+++ b/multibody/topology/link_joint_graph_debug.cc
@@ -94,10 +94,11 @@ std::string LinkJointGraph::GenerateGraphvizString(
     LinkOrdinal revised_child_ordinal = child_ordinal;
     if (show_as_modeled && joint.mobod_index().is_valid()) {
       const SpanningForest::Mobod& mobod = forest().mobods(joint.mobod_index());
-      if (mobod.is_reversed())
+      if (mobod.is_reversed()) {
         revised_parent_ordinal = mobod.link_ordinal();
-      else
+      } else {
         revised_child_ordinal = mobod.link_ordinal();
+      }
     }
 
     // Draw the effective joint connection.

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -511,10 +511,11 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   // we are in continuous or discrete mode.
   void CalcForwardDynamics(const systems::Context<T>& context,
                            AccelerationKinematicsCache<T>* ac) const {
-    if (is_discrete())
+    if (is_discrete()) {
       CalcForwardDynamicsDiscrete(context, ac);
-    else
+    } else {
       CalcForwardDynamicsContinuous(context, ac);
+    }
   }
 
   // When in continuous mode, this method is used to compute forward dynamics.

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -30,10 +30,11 @@ void UniformGravityFieldElement<T>::set_enabled(
   if (model_instance >= this->get_parent_tree().num_model_instances()) {
     throw std::logic_error("Model instance index is invalid.");
   }
-  if (is_enabled)
+  if (is_enabled) {
     disabled_model_instances_.erase(model_instance);
-  else
+  } else {
     disabled_model_instances_.insert(model_instance);
+  }
 }
 
 template <typename T>

--- a/perception/point_cloud_flags.h
+++ b/perception/point_cloud_flags.h
@@ -118,10 +118,11 @@ class Fields {
   /// specified.
   Fields& operator|=(const Fields& rhs) {
     base_fields_ = base_fields_ | rhs.base_fields_;
-    if (has_descriptor())
+    if (has_descriptor()) {
       throw std::runtime_error(
           "Cannot have multiple Descriptor flags. "
           "Can only add flags iff (!rhs.has_descriptor()).");
+    }
     descriptor_type_ = rhs.descriptor_type_;
     return *this;
   }

--- a/planning/iris/iris_zo.cc
+++ b/planning/iris/iris_zo.cc
@@ -472,8 +472,9 @@ HPolyhedron IrisZo(const planning::CollisionChecker& checker,
           if (hyperplanes_added == options.sampled_iris_options
                                        .max_separating_planes_per_iteration &&
               options.sampled_iris_options.max_separating_planes_per_iteration >
-                  0)
+                  0) {
             break;
+          }
 
           particle_is_redundant.at(i) = true;
 

--- a/solvers/test/mixed_integer_rotation_constraint_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_test.cc
@@ -122,10 +122,11 @@ class TestMixedIntegerRotationConstraint {
     // Requires 2 intervals per half axis to catch.
     if (num_intervals_per_half_axis_ == 1 &&
         approach_ == MixedIntegerRotationConstraintGenerator::Approach::
-                         kBoxSphereIntersection)
+                         kBoxSphereIntersection) {
       EXPECT_TRUE(IsFeasible(R_test));
-    else
+    } else {
       EXPECT_FALSE(IsFeasible(R_test));
+    }
 
     // Checks the det(R)=-1 case.
     // (only ruled out by the cross-product constraint).
@@ -150,10 +151,11 @@ class TestMixedIntegerRotationConstraint {
     EXPECT_GT(R_test.row(2).lpNorm<1>(), 1.0);
     if (num_intervals_per_half_axis_ == 1 &&
         approach_ == MixedIntegerRotationConstraintGenerator::Approach::
-                         kBoxSphereIntersection)
+                         kBoxSphereIntersection) {
       EXPECT_TRUE(IsFeasible(R_test));
-    else
+    } else {
       EXPECT_FALSE(IsFeasible(R_test));
+    }
   }
   virtual ~TestMixedIntegerRotationConstraint() = default;
 

--- a/systems/analysis/bogacki_shampine3_integrator.cc
+++ b/systems/analysis/bogacki_shampine3_integrator.cc
@@ -28,10 +28,11 @@ void BogackiShampine3Integrator<T>::DoInitialize() {
   // Set an artificial step size target, if not set already.
   if (isnan(this->get_initial_step_size_target())) {
     // Verify that maximum step size has been set.
-    if (isnan(this->get_maximum_step_size()))
+    if (isnan(this->get_maximum_step_size())) {
       throw std::logic_error(
           "Neither initial step size target nor maximum step size has been "
           "set!");
+    }
 
     this->request_initial_step_size_target(this->get_maximum_step_size() *
                                            kMaxStepFraction);
@@ -43,10 +44,11 @@ void BogackiShampine3Integrator<T>::DoInitialize() {
   // If the user asks for accuracy that is looser than the loosest this
   // integrator can provide, use the integrator's loosest accuracy setting
   // instead.
-  if (working_accuracy > kLoosestAccuracy)
+  if (working_accuracy > kLoosestAccuracy) {
     working_accuracy = kLoosestAccuracy;
-  else if (isnan(working_accuracy))
+  } else if (isnan(working_accuracy)) {
     working_accuracy = kDefaultAccuracy;
+  }
   this->set_accuracy_in_use(working_accuracy);
 }
 

--- a/systems/analysis/implicit_euler_integrator.cc
+++ b/systems/analysis/implicit_euler_integrator.cc
@@ -43,10 +43,11 @@ void ImplicitEulerIntegrator<T>::DoInitialize() {
   // Set an artificial step size target, if not set already.
   if (isnan(this->get_initial_step_size_target())) {
     // Verify that maximum step size has been set.
-    if (isnan(this->get_maximum_step_size()))
+    if (isnan(this->get_maximum_step_size())) {
       throw std::logic_error(
           "Neither initial step size target nor maximum step size has been "
           "set!");
+    }
 
     this->request_initial_step_size_target(this->get_maximum_step_size());
   }
@@ -57,10 +58,11 @@ void ImplicitEulerIntegrator<T>::DoInitialize() {
   // If the user asks for accuracy that is looser than the loosest this
   // integrator can provide, use the integrator's loosest accuracy setting
   // instead.
-  if (isnan(working_accuracy))
+  if (isnan(working_accuracy)) {
     working_accuracy = kDefaultAccuracy;
-  else if (working_accuracy > kLoosestAccuracy)
+  } else if (working_accuracy > kLoosestAccuracy) {
     working_accuracy = kLoosestAccuracy;
+  }
   this->set_accuracy_in_use(working_accuracy);
 
   // Reset the Jacobian matrix (so that recomputation is forced).

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -220,10 +220,11 @@ class IntegratorBase {
   // TODO(edrumwri): complain if integrator with error estimation wants to drop
   //                 below the minimum step size
   void set_target_accuracy(double accuracy) {
-    if (!supports_error_estimation())
+    if (!supports_error_estimation()) {
       throw std::logic_error(
           "Integrator does not support accuracy estimation "
           "and user has requested error control");
+    }
     target_accuracy_ = accuracy;
     accuracy_in_use_ = accuracy;
   }
@@ -657,10 +658,11 @@ class IntegratorBase {
    */
   void request_initial_step_size_target(const T& step_size) {
     using std::isnan;
-    if (!supports_error_estimation())
+    if (!supports_error_estimation()) {
       throw std::logic_error(
           "Integrator does not support error estimation and "
           "user has initial step size target");
+    }
     req_initial_step_size_ = step_size;
   }
 
@@ -1067,10 +1069,11 @@ class IntegratorBase {
           "IntegrateWithSingleFixedStepToTime() called with "
           "a negative step size.");
     }
-    if (!this->get_fixed_step_mode())
+    if (!this->get_fixed_step_mode()) {
       throw std::logic_error(
           "IntegrateWithSingleFixedStepToTime() requires "
           "fixed stepping.");
+    }
 
     if (!Step(h)) {
       return false;

--- a/systems/analysis/radau_integrator.cc
+++ b/systems/analysis/radau_integrator.cc
@@ -97,10 +97,11 @@ void RadauIntegrator<T, num_stages>::DoInitialize() {
   // integrator can provide, use the integrator's loosest accuracy setting
   // instead.
   double working_accuracy = this->get_target_accuracy();
-  if (isnan(working_accuracy))
+  if (isnan(working_accuracy)) {
     working_accuracy = kDefaultAccuracy;
-  else if (working_accuracy > kLoosestAccuracy)
+  } else if (working_accuracy > kLoosestAccuracy) {
     working_accuracy = kLoosestAccuracy;
+  }
   this->set_accuracy_in_use(working_accuracy);
 
   // Reset the Jacobian matrix (so that recomputation is forced).

--- a/systems/analysis/runge_kutta3_integrator.cc
+++ b/systems/analysis/runge_kutta3_integrator.cc
@@ -22,10 +22,11 @@ void RungeKutta3Integrator<T>::DoInitialize() {
   // Set an artificial step size target, if not set already.
   if (isnan(this->get_initial_step_size_target())) {
     // Verify that maximum step size has been set.
-    if (isnan(this->get_maximum_step_size()))
+    if (isnan(this->get_maximum_step_size())) {
       throw std::logic_error(
           "Neither initial step size target nor maximum step size has been "
           "set!");
+    }
 
     this->request_initial_step_size_target(this->get_maximum_step_size() *
                                            kMaxStepFraction);
@@ -37,10 +38,11 @@ void RungeKutta3Integrator<T>::DoInitialize() {
   // If the user asks for accuracy that is looser than the loosest this
   // integrator can provide, use the integrator's loosest accuracy setting
   // instead.
-  if (working_accuracy > kLoosestAccuracy)
+  if (working_accuracy > kLoosestAccuracy) {
     working_accuracy = kLoosestAccuracy;
-  else if (isnan(working_accuracy))
+  } else if (isnan(working_accuracy)) {
     working_accuracy = kDefaultAccuracy;
+  }
   this->set_accuracy_in_use(working_accuracy);
 }
 

--- a/systems/analysis/runge_kutta5_integrator.cc
+++ b/systems/analysis/runge_kutta5_integrator.cc
@@ -23,10 +23,11 @@ void RungeKutta5Integrator<T>::DoInitialize() {
   // Set an artificial step size target, if not set already.
   if (isnan(this->get_initial_step_size_target())) {
     // Verify that maximum step size has been set.
-    if (isnan(this->get_maximum_step_size()))
+    if (isnan(this->get_maximum_step_size())) {
       throw std::logic_error(
           "Neither initial step size target nor maximum "
           "step size has been set!");
+    }
 
     this->request_initial_step_size_target(this->get_maximum_step_size() *
                                            kMaxStepFraction);
@@ -38,10 +39,11 @@ void RungeKutta5Integrator<T>::DoInitialize() {
   // If the user asks for accuracy that is looser than the loosest this
   // integrator can provide, use the integrator's loosest accuracy setting
   // instead.
-  if (working_accuracy > kLoosestAccuracy)
+  if (working_accuracy > kLoosestAccuracy) {
     working_accuracy = kLoosestAccuracy;
-  else if (isnan(working_accuracy))
+  } else if (isnan(working_accuracy)) {
     working_accuracy = kDefaultAccuracy;
+  }
   this->set_accuracy_in_use(working_accuracy);
 }
 

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -82,11 +82,13 @@ IntegratorBase<T>& ResetIntegratorFromGflags(Simulator<T>* simulator) {
   } else {
     // Integrator is running in fixed step mode, therefore we warn the user if
     // the accuracy flag was changed from the command line.
-    if (FLAGS_simulator_accuracy != drake::systems::SimulatorConfig{}.accuracy)
+    if (FLAGS_simulator_accuracy !=
+        drake::systems::SimulatorConfig{}.accuracy) {
       log()->warn(
           "Integrator accuracy provided, however the integrator is running in "
           "fixed step mode. The 'simulator_accuracy' flag will be ignored. "
           "Switch to an error controlled scheme if you want accuracy control.");
+    }
   }
   return integrator;
 }

--- a/systems/analysis/velocity_implicit_euler_integrator.cc
+++ b/systems/analysis/velocity_implicit_euler_integrator.cc
@@ -45,10 +45,11 @@ void VelocityImplicitEulerIntegrator<T>::DoInitialize() {
   // Set an artificial step size target, if not set already.
   if (isnan(this->get_initial_step_size_target())) {
     // Verify that the maximum step size has been set.
-    if (isnan(this->get_maximum_step_size()))
+    if (isnan(this->get_maximum_step_size())) {
       throw std::logic_error(
           "Neither initial step size target nor maximum "
           "step size has been set for VelocityImplicitEulerIntegrator.");
+    }
 
     this->request_initial_step_size_target(this->get_maximum_step_size());
   }
@@ -59,10 +60,11 @@ void VelocityImplicitEulerIntegrator<T>::DoInitialize() {
   // If the user asks for accuracy that is looser than the loosest this
   // integrator can provide, use the integrator's loosest accuracy setting
   // instead.
-  if (isnan(working_accuracy))
+  if (isnan(working_accuracy)) {
     working_accuracy = kDefaultAccuracy;
-  else if (working_accuracy > kLoosestAccuracy)
+  } else if (working_accuracy > kLoosestAccuracy) {
     working_accuracy = kLoosestAccuracy;
+  }
   this->set_accuracy_in_use(working_accuracy);
 
   // Reset the Jacobian matrix (so that recomputation is forced).

--- a/systems/controllers/test/setpoint_test.cc
+++ b/systems/controllers/test/setpoint_test.cc
@@ -35,10 +35,11 @@ GTEST_TEST(testQPInverseDynamicsController, testPoseSetpoint) {
                                              Vector6<double>::Zero());
 
     double err = ang_d - ang;
-    if (err > M_PI)
+    if (err > M_PI) {
       err -= 2 * M_PI;
-    else if (err < -M_PI)
+    } else if (err < -M_PI) {
       err += 2 * M_PI;
+    }
 
     expected.head<3>() = err * vec_d;
     EXPECT_TRUE(

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -247,10 +247,11 @@ std::vector<std::string> SystemBase::GetGraphvizPortLabels(bool input) const {
   result.reserve(num_ports);
   for (int i = 0; i < num_ports; ++i) {
     const PortBase& port = [&]() -> const PortBase& {
-      if (input)
+      if (input) {
         return GetInputPortBaseOrThrow("", i, /* warn_deprecated = */ false);
-      else
+      } else {
         return GetOutputPortBaseOrThrow("", i, /* warn_deprecated = */ false);
+      }
     }();
     std::string label = HtmlEscape(port.get_name());
     // For deprecated ports, use strikethrough and a unicode headstone (🪦).

--- a/systems/primitives/trajectory_source.cc
+++ b/systems/primitives/trajectory_source.cc
@@ -26,10 +26,11 @@ TrajectorySource<T>::TrajectorySource(const Trajectory<T>& trajectory,
   DRAKE_THROW_UNLESS(output_derivative_order >= 0);
 
   for (int i = 0; i < output_derivative_order; ++i) {
-    if (i == 0)
+    if (i == 0) {
       derivatives_.push_back(trajectory_->MakeDerivative());
-    else
+    } else {
       derivatives_.push_back(derivatives_[i - 1]->MakeDerivative());
+    }
   }
 
   CheckInvariants();
@@ -100,10 +101,11 @@ void TrajectorySource<T>::UpdateTrajectory(
 
   trajectory_ = trajectory.Clone();
   for (int i = 0; i < ssize(derivatives_); ++i) {
-    if (i == 0)
+    if (i == 0) {
       derivatives_[i] = trajectory_->MakeDerivative();
-    else
+    } else {
       derivatives_[i] = derivatives_[i - 1]->MakeDerivative();
+    }
   }
 
   failsafe_trajectory_ = nullptr;

--- a/visualization/meshcat_pose_sliders.cc
+++ b/visualization/meshcat_pose_sliders.cc
@@ -46,10 +46,11 @@ double AdjustAngle(double x, double lower_bound, double upper_bound) {
   }
 
   // If after adjusting, x is outside of bounds, return the closest bound.
-  if (x < lower_bound)
+  if (x < lower_bound) {
     return lower_bound;
-  else if (x > upper_bound)
+  } else if (x > upper_bound) {
     return upper_bound;
+  }
 
   // Otherwise, return the adjusted angle.
   return x;


### PR DESCRIPTION
While working on the revised style guide text for https://github.com/RobotLocomotion/styleguide/pull/57, I looked into our formatting for `if` blocks that don't use braces, and found many style violations.

This is the output of clang-format's  `InsertBraces: True`, manually filtered to only contain the style violations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23333)
<!-- Reviewable:end -->
