### PR TITLE
[doc] Document supported native CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -647,15 +647,26 @@ endif()
 
 set(BAZEL_INSTALL_ARGS "\${CMAKE_INSTALL_PREFIX}")
 
-if(CMAKE_INSTALL_NAME_TOOL)
-  list(INSERT BAZEL_INSTALL_ARGS 0
-    "--install_name_tool"
-    "${CMAKE_INSTALL_NAME_TOOL}"
+if(APPLE)
+  set(INSTALL_NAME_TOOL "" CACHE FILEPATH
+    "Path to the install name tool program"
   )
+  # Users should rarely need to modify this option.
+  mark_as_advanced(INSTALL_NAME_TOOL)
+  if(INSTALL_NAME_TOOL)
+    list(INSERT BAZEL_INSTALL_ARGS 0
+      "--install_name_tool" "${INSTALL_NAME_TOOL}"
+    )
+  endif()
 endif()
 
-if(CMAKE_STRIP)
-  list(INSERT BAZEL_INSTALL_ARGS 0 "--strip_tool" "${CMAKE_STRIP}")
+set(INSTALL_STRIP_TOOL "" CACHE FILEPATH
+  "Path to the strip program"
+)
+# Users should rarely need to modify this option.
+mark_as_advanced(INSTALL_STRIP_TOOL)
+if(INSTALL_STRIP_TOOL)
+  list(INSERT BAZEL_INSTALL_ARGS 0 "--strip_tool" "${INSTALL_STRIP_TOOL}")
 endif()
 
 # If CMAKE_BUILD_TYPE is Debug or RelWithDebInfo, do NOT strip symbols during

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -61,6 +61,11 @@ maybe require extra setup. See the
 
 # Building with CMake
 
+Drake's build rules are defined using Bazel `BUILD` files, but we provide a
+CMake wrapper for installing Drake. While this compiles and installs Drake by
+invoking Bazel under the hood, it does so according to CMake conventions
+and using the options provided via CMake.
+
 For sample projects that show how to import Drake as a CMake external project
 (either by building Drake from source, or by downloading a pre-compiled Drake
 release) please see our gallery of
@@ -85,10 +90,33 @@ make install
 To change the build options, you can run one of the standard CMake GUIs (e.g.,
 `ccmake` or `cmake-gui`) or specify command-line options with `-D` to `cmake`.
 
+Important note: when compiling Drake with Clang 17 or newer on Linux, you must
+add `-fno-assume-unique-vtables` to your project's `CMAKE_CXX_FLAGS`, or else
+Drake's use of run-time type information and dynamic casts will not work correctly.
+
+## Native CMake Options Supported by Drake
+
+A selection of
+[CMake variables](https://cmake.org/cmake/help/latest/manual/cmake-variables.7.html)
+can be specified by the user to be parsed by Drake's CMake and passed to the
+Bazel build.
+
+* [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
+* [`CMAKE_(C|CXX)_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html)
+* [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)
+
+Building and installing Drake also requires a working installation of Python.
+When `Python_EXECUTABLE` is specified, it uses the given path to the Python
+interpreter. Otherwise, it uses `find_package(Python)` to find the Python
+version supported by Drake on the host platform (falling back to finding any
+Python version at all if needed). See
+[`FindPython`](https://cmake.org/cmake/help/latest/module/FindPython.html)
+for further details.
+
 ## Drake-specific CMake Options
 
-These options can be set using `-DFOO=bar` on the CMake command line, or in one
-of the CMake GUIs.
+Drake also defines a number of CMake options to control different facets of
+the build.
 
 Adjusting open-source dependencies:
 
@@ -151,9 +179,12 @@ Adjusting closed-source (commercial) software dependencies:
   * This option is only valid for MIT- or TRI-affiliated Drake developers.
   * This option is mutally exclusive with `WITH_SNOPT`.
 
-Important note: when compiling Drake with Clang 17 or newer on Linux, you must
-add `-fno-assume-unique-vtables` to your project's `CXXFLAGS`, or else Drake's
-use of run-time type information and dynamic casts will not work correctly.
+Adjusting installation methods (advanced):
+
+* `INSTALL_NAME_TOOL`. When specified, uses the path to the
+  `install_name_tool` program.
+  * This option is only available on macOS.
+* `INSTALL_STRIP_TOOL`. When specified, uses the path to the `strip` program.
 
 ## CMake Caveats
 


### PR DESCRIPTION
Drake's build takes a number of `CMAKE_` options and converts them to Bazel flags. We should document such logic similar to the Drake-specific CMake options.

Also, remove the `CMAKE_` prefix from the install name tool and strip tool options. These are not (and have never been) native CMake variables, and aside from the issue that CMake reserves that naming convention, it's just confusing for developers.

Raised by discussion on https://github.com/RobotLocomotion/drake/pull/23298#pullrequestreview-3161594349.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23339)
<!-- Reviewable:end -->
