### PR TITLE
Make the rational forward kinematics parameterization support autodiff.

### DIFF
--- a/planning/iris/iris_common.cc
+++ b/planning/iris/iris_common.cc
@@ -19,9 +19,11 @@ IrisParameterizationFunction::IrisParameterizationFunction(
                 Eigen::VectorXd(q_star_val)](const Eigen::VectorXd& s_val) {
         return kin->ComputeQValue(s_val, q_star_captured);
       };
-  // TODO(cohnt): Construct a VectorX<AutoDiffXd> parameterization when using
-  // this constructor as well.
-  parameterization_autodiff_ = nullptr;
+  parameterization_autodiff_ = [kin,
+                                q_star_captured = Eigen::VectorXd(q_star_val)](
+                                   const Eigen::VectorX<AutoDiffXd>& s_val) {
+    return kin->ComputeQValue(s_val, q_star_captured);
+  };
 
   parameterization_is_threadsafe_ = true;
   parameterization_dimension_ = dimension;

--- a/planning/iris/test/iris_np2_test.cc
+++ b/planning/iris/test/iris_np2_test.cc
@@ -149,9 +149,10 @@ TEST_F(DoublePendulum, PaddingUnsupported) {
       ".*negative padding.*");
 }
 
-// Check the error message for a parameterization from rational kinematics.
+// Test growing a region for the double pendulum along a parameterization of the
+// configuration space built from RationalForwardKinematics.
 TEST_F(DoublePendulumRationalForwardKinematics,
-       ParameterizationMissingAutodiff) {
+       ParameterizationFromStaticConstructor) {
   IrisNp2Options options;
   auto scene_graph_checker =
       dynamic_cast<SceneGraphCollisionChecker*>(checker_.get());
@@ -160,9 +161,29 @@ TEST_F(DoublePendulumRationalForwardKinematics,
   options.parameterization =
       IrisParameterizationFunction(&rational_kinematics_,
                                    /* q_star_val */ Vector2d::Zero());
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      IrisNp2(*scene_graph_checker, starting_ellipsoid_, domain_, options),
-      ".*autodiff-compatible parameterization.*");
+  options.sampled_iris_options.verbose = true;
+
+  meshcat_->Delete();
+  options.sampled_iris_options.meshcat = meshcat_;
+
+  // Check that the parameterization was set correctly.
+  EXPECT_EQ(options.parameterization.get_parameterization_is_threadsafe(),
+            true);
+  ASSERT_TRUE(
+      options.parameterization.get_parameterization_dimension().has_value());
+  EXPECT_EQ(options.parameterization.get_parameterization_dimension().value(),
+            2);
+
+  CheckParameterization(options.parameterization.get_parameterization_double());
+
+  HPolyhedron region = IrisNp2(*scene_graph_checker,
+                               starting_ellipsoid_rational_forward_kinematics_,
+                               domain_rational_forward_kinematics_, options);
+
+  CheckRegionRationalForwardKinematics(region);
+  PlotEnvironmentAndRegionRationalForwardKinematics(
+      region, options.parameterization.get_parameterization_double(),
+      region_query_point_1_);
 }
 
 TEST_F(DoublePendulum, IrisNp2Test) {


### PR DESCRIPTION
This allows it to be used with IrisNp2 as well as IrisZo. It's a pretty simple change, since I didn't realize that `RationalForwardKinematics::ComputeQValue` was templated on scalar types.

+@wernerpe for feature review