### PR TITLE
[build] Configure Renovate to upgrade BCR deps in MODULE.bazel

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
     "at 6am on the first day of the month"
   ],
   "enabledManagers": [
-    "bazelisk"
+    "bazelisk",
+    "bazel-module"
   ]
 }


### PR DESCRIPTION
Closes #23341.

Adds the "bazel-module" package manager to the "enabledManagers" array in `//.github/renovate.json`. Parses the MODULE.bazel file for "bazel_deps()" calls and recommends version bumps whenever they are detected.

Presently detected Renovate dependencies:
```
bazelisk
  .bazelversion
    bazel 8.3.1

bazel-module
  MODULE.bazel
    apple_support 1.17.1
    bazel_features 1.30.0
    bazel_skylib 1.8.0
    platforms 0.0.11
    rules_cc 0.1.1
    rules_java 8.12.0
    rules_license 1.0.0
    rules_python 0.40.0
    rules_rust 0.56.0
    rules_shell 0.3.0
    eigen 3.4.0.bcr.3
    fmt 11.0.2.bcr.1
    spdlog 1.15.0.bcr.4
    zlib 1.3.1.bcr.5
    toolchains_llvm 1.4.0
```
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23342)
<!-- Reviewable:end -->
