### PR TITLE
[cpplint] Fix iwyu lint (1/5)

### DIFF
--- a/common/ad/internal/standard_operations.cc
+++ b/common/ad/internal/standard_operations.cc
@@ -6,7 +6,9 @@
 #include "drake/common/ad/auto_diff.h"
 /* clang-format on */
 
+#include <limits>
 #include <ostream>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/common/ad/test/standard_operations_max_test.cc
+++ b/common/ad/test/standard_operations_max_test.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "drake/common/ad/auto_diff.h"
 #include "drake/common/ad/test/standard_operations_test.h"
 

--- a/common/ad/test/standard_operations_min_test.cc
+++ b/common/ad/test/standard_operations_min_test.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "drake/common/ad/auto_diff.h"
 #include "drake/common/ad/test/standard_operations_test.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/common/ad/test/standard_operations_pow_special_test.cc
+++ b/common/ad/test/standard_operations_pow_special_test.cc
@@ -1,5 +1,8 @@
 #include <algorithm>
 #include <initializer_list>
+#include <limits>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 

--- a/common/benchmarking/benchmark_polynomial.cc
+++ b/common/benchmarking/benchmark_polynomial.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include <fmt/format.h>
 
 #include "drake/common/symbolic/monomial_util.h"

--- a/common/find_runfiles_stub.cc
+++ b/common/find_runfiles_stub.cc
@@ -14,6 +14,8 @@
 // test); it's not even used in the Bazel-installed binary release build (e.g.,
 // as called by Drake's CMakeLists.txt files).  It is nominally dead code.
 
+#include <string>
+
 namespace drake {
 
 bool HasRunfiles() {

--- a/common/schema/test/stochastic_test.cc
+++ b/common/schema/test/stochastic_test.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/common/symbolic/expression/expression.cc
+++ b/common/symbolic/expression/expression.cc
@@ -4,8 +4,14 @@
 /* clang-format on */
 
 #include <algorithm>
+#include <functional>
 #include <ios>
+#include <limits>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/inlined_vector.h"

--- a/common/symbolic/expression/formula.cc
+++ b/common/symbolic/expression/formula.cc
@@ -9,6 +9,8 @@
 #include <ostream>
 #include <set>
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include "drake/common/drake_assert.h"
 #define DRAKE_COMMON_SYMBOLIC_EXPRESSION_DETAIL_HEADER

--- a/common/symbolic/expression/test/boxed_cell_test.cc
+++ b/common/symbolic/expression/test/boxed_cell_test.cc
@@ -3,6 +3,7 @@
 /* clang-format on */
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/common/symbolic/expression/test/expression_cell_test.cc
+++ b/common/symbolic/expression/test/expression_cell_test.cc
@@ -2,6 +2,8 @@
 #include "drake/common/symbolic/expression/expression_cell.h"
 #undef DRAKE_COMMON_SYMBOLIC_EXPRESSION_DETAIL_HEADER
 
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/symbolic_test_util.h"

--- a/common/symbolic/expression/test/expression_differentiation_test.cc
+++ b/common/symbolic/expression/test/expression_differentiation_test.cc
@@ -2,6 +2,7 @@
 #include "drake/common/symbolic/expression/all.h"
 /* clang-format on */
 
+#include <algorithm>
 #include <cmath>
 #include <exception>
 #include <tuple>

--- a/common/symbolic/expression/test/expression_expansion_test.cc
+++ b/common/symbolic/expression/test/expression_expansion_test.cc
@@ -2,8 +2,10 @@
 #include "drake/common/symbolic/expression/all.h"
 /* clang-format on */
 
+#include <algorithm>
 #include <cmath>
 #include <functional>
+#include <iostream>
 #include <stdexcept>
 #include <utility>
 #include <vector>

--- a/common/symbolic/expression/test/expression_test.cc
+++ b/common/symbolic/expression/test/expression_test.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <random>

--- a/common/symbolic/expression/test/substitution_test.cc
+++ b/common/symbolic/expression/test/substitution_test.cc
@@ -2,6 +2,7 @@
 #include "drake/common/symbolic/expression/all.h"
 /* clang-format on */
 
+#include <algorithm>
 #include <functional>
 #include <stdexcept>
 #include <utility>

--- a/common/symbolic/expression/test/variable_test.cc
+++ b/common/symbolic/expression/test/variable_test.cc
@@ -2,7 +2,9 @@
 #include "drake/common/symbolic/expression/all.h"
 /* clang-format on */
 
+#include <algorithm>
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/common/symbolic/expression/variables.cc
+++ b/common/symbolic/expression/variables.cc
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <numeric>
 #include <ostream>
+#include <set>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/common/symbolic/test/chebyshev_basis_element_test.cc
+++ b/common/symbolic/test/chebyshev_basis_element_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/symbolic/chebyshev_basis_element.h"
 
+#include <unordered_map>
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/common/symbolic/test/chebyshev_polynomial_test.cc
+++ b/common/symbolic/test/chebyshev_polynomial_test.cc
@@ -2,6 +2,9 @@
 
 #include <limits>
 #include <ostream>
+#include <set>
+#include <unordered_map>
+#include <vector>
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>

--- a/common/symbolic/test/codegen_test.cc
+++ b/common/symbolic/test/codegen_test.cc
@@ -1,6 +1,8 @@
 #include "drake/common/symbolic/codegen.h"
 
+#include <algorithm>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include <fmt/format.h>

--- a/common/symbolic/test/decompose_test.cc
+++ b/common/symbolic/test/decompose_test.cc
@@ -1,7 +1,10 @@
 #include "drake/common/symbolic/decompose.h"
 
+#include <algorithm>
 #include <limits>
 #include <stdexcept>
+#include <unordered_map>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/common/symbolic/test/generic_polynomial_test.cc
+++ b/common/symbolic/test/generic_polynomial_test.cc
@@ -1,5 +1,9 @@
 #include "drake/common/symbolic/generic_polynomial.h"
 
+#include <algorithm>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic/polynomial_basis.h"

--- a/common/symbolic/test/latex_test.cc
+++ b/common/symbolic/test/latex_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/symbolic/latex.h"
 
+#include <algorithm>
+#include <limits>
 #include <vector>
 
 #include <fmt/format.h>

--- a/common/symbolic/test/monomial_basis_element_test.cc
+++ b/common/symbolic/test/monomial_basis_element_test.cc
@@ -1,5 +1,10 @@
 #include "drake/common/symbolic/monomial_basis_element.h"
 
+#include <map>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/common/symbolic/test/monomial_test.cc
+++ b/common/symbolic/test/monomial_test.cc
@@ -1,4 +1,5 @@
 #include <exception>
+#include <map>
 #include <stdexcept>
 #include <unordered_map>
 #include <utility>

--- a/common/symbolic/test/polynomial_basis_element_test.cc
+++ b/common/symbolic/test/polynomial_basis_element_test.cc
@@ -1,5 +1,9 @@
 #include "drake/common/symbolic/polynomial_basis_element.h"
 
+#include <map>
+#include <utility>
+#include <vector>
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/common/symbolic/test/polynomial_test.cc
+++ b/common/symbolic/test/polynomial_test.cc
@@ -1,6 +1,8 @@
 #include "drake/common/symbolic/polynomial.h"
 
+#include <algorithm>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/common/symbolic/test/rational_function_test.cc
+++ b/common/symbolic/test/rational_function_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/symbolic/rational_function.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic/expression.h"

--- a/common/symbolic/test/replace_bilinear_terms_test.cc
+++ b/common/symbolic/test/replace_bilinear_terms_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/symbolic/replace_bilinear_terms.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/symbolic_test_util.h"

--- a/common/symbolic/test/simplification_test.cc
+++ b/common/symbolic/test/simplification_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/symbolic/simplification.h"
 
+#include <algorithm>
 #include <functional>
 #include <stdexcept>
 

--- a/common/symbolic/test/trigonometric_polynomial_test.cc
+++ b/common/symbolic/test/trigonometric_polynomial_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/symbolic/trigonometric_polynomial.h"
 
+#include <unordered_map>
 #include <vector>
 
 #include <fmt/format.h>

--- a/common/test/autodiff_overloads_test.cc
+++ b/common/test/autodiff_overloads_test.cc
@@ -1,3 +1,4 @@
+#include <limits>
 #include <type_traits>
 
 #include <Eigen/Dense>

--- a/common/test/autodiffxd_heap_test.cc
+++ b/common/test/autodiffxd_heap_test.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/common/test/autodiffxd_max_test.cc
+++ b/common/test/autodiffxd_max_test.cc
@@ -3,6 +3,8 @@
 #include "drake/common/ad/test/standard_operations_test.h"
 /* clang-format on */
 
+#include <algorithm>
+
 namespace drake {
 namespace test {
 namespace {

--- a/common/test/autodiffxd_min_test.cc
+++ b/common/test/autodiffxd_min_test.cc
@@ -3,6 +3,8 @@
 #include "drake/common/ad/test/standard_operations_test.h"
 /* clang-format on */
 
+#include <algorithm>
+
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {

--- a/common/test/copyable_unique_ptr_test.cc
+++ b/common/test/copyable_unique_ptr_test.cc
@@ -1,8 +1,10 @@
 #include "drake/common/copyable_unique_ptr.h"
 
+#include <algorithm>
 #include <memory>
 #include <regex>
 #include <sstream>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/common/test/eigen_autodiff_types_test.cc
+++ b/common/test/eigen_autodiff_types_test.cc
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/common/test/eigen_types_test.cc
+++ b/common/test/eigen_types_test.cc
@@ -1,5 +1,8 @@
 #include "drake/common/eigen_types.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/nice_type_name.h"

--- a/common/test/file_source_test.cc
+++ b/common/test/file_source_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/file_source.h"
 
 #include <filesystem>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/common/test/find_cache_test.cc
+++ b/common/test/find_cache_test.cc
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/common/test/fmt_eigen_test.cc
+++ b/common/test/fmt_eigen_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/fmt_eigen.h"
 
+#include <string>
+
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 

--- a/common/test/hash_test.cc
+++ b/common/test/hash_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/hash.h"
 
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/common/test/hwy_dynamic_test.cc
+++ b/common/test/hwy_dynamic_test.cc
@@ -1,3 +1,6 @@
+#include <string>
+#include <utility>
+
 #include <Eigen/Dense>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/common/test/is_approx_equal_abstol_test.cc
+++ b/common/test/is_approx_equal_abstol_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/is_approx_equal_abstol.h"
 
+#include <limits>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/common/test/memory_file_test.cc
+++ b/common/test/memory_file_test.cc
@@ -1,6 +1,8 @@
 #include "drake/common/memory_file.h"
 
 #include <fstream>
+#include <string>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/common/test/name_value_test.cc
+++ b/common/test/name_value_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/name_value.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/common/test/never_destroyed_test.cc
+++ b/common/test/never_destroyed_test.cc
@@ -1,7 +1,9 @@
 #include "drake/common/never_destroyed.h"
 
 #include <random>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/common/test/nice_type_name_test.cc
+++ b/common/test/nice_type_name_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/nice_type_name.h"
 
 #include <complex>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/common/test/openmp_test.cc
+++ b/common/test/openmp_test.cc
@@ -1,5 +1,6 @@
 #include <numeric>
 #include <unordered_set>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/common/test/overloaded_test.cc
+++ b/common/test/overloaded_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/overloaded.h"
 
+#include <string>
 #include <variant>
 
 #include <gtest/gtest.h>

--- a/common/test/parallelism_test.cc
+++ b/common/test/parallelism_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/parallelism.h"
 
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/common/test/pointer_cast_test.cc
+++ b/common/test/pointer_cast_test.cc
@@ -1,5 +1,8 @@
 #include "drake/common/pointer_cast.h"
 
+#include <memory>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/common/test/polynomial_test.cc
+++ b/common/test/polynomial_test.cc
@@ -1,10 +1,12 @@
 #include "drake/common/polynomial.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <map>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include <Eigen/Dense>

--- a/common/test/random_test.cc
+++ b/common/test/random_test.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/common/test/reset_after_move_test.cc
+++ b/common/test/reset_after_move_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/reset_after_move.h"
 
 #include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/common/test/reset_on_copy_test.cc
+++ b/common/test/reset_on_copy_test.cc
@@ -1,6 +1,8 @@
 #include "drake/common/reset_on_copy.h"
 
+#include <algorithm>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/common/test/scoped_singleton_test.cc
+++ b/common/test/scoped_singleton_test.cc
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/common/test/sha256_test.cc
+++ b/common/test/sha256_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/sha256.h"
 
 #include <fstream>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/common/test/sorted_pair_test.cc
+++ b/common/test/sorted_pair_test.cc
@@ -1,7 +1,9 @@
 #include "drake/common/sorted_pair.h"
 
+#include <memory>
 #include <sstream>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <fmt/ranges.h>

--- a/common/test/string_container_test.cc
+++ b/common/test/string_container_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/string_map.h"

--- a/common/test/text_logging_ostream_test.cc
+++ b/common/test/text_logging_ostream_test.cc
@@ -2,6 +2,7 @@
 #include "drake/common/text_logging.h"
 /* clang-format on */
 
+#include <memory>
 #include <ostream>
 #include <sstream>
 

--- a/common/test/value_test.cc
+++ b/common/test/value_test.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/common/test_utilities/drake_cc_googletest_main.cc
+++ b/common/test_utilities/drake_cc_googletest_main.cc
@@ -1,6 +1,8 @@
 /// @file
 /// This is Drake's default main() function for gtest-based unit tests.
 
+#include <iostream>
+
 #include <gflags/gflags.h>
 #include <gmock/gmock.h>
 

--- a/common/test_utilities/test/eigen_matrix_compare_test.cc
+++ b/common/test_utilities/test/eigen_matrix_compare_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/common/test_utilities/test/limit_malloc_test.cc
+++ b/common/test_utilities/test/limit_malloc_test.cc
@@ -1,7 +1,9 @@
 #include "drake/common/test_utilities/limit_malloc.h"
 
 #include <cstdlib>
+#include <iostream>
 #include <stdexcept>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/common/trajectories/discrete_time_trajectory.cc
+++ b/common/trajectories/discrete_time_trajectory.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/common/trajectories/test/bezier_curve_test.cc
+++ b/common/trajectories/test/bezier_curve_test.cc
@@ -1,5 +1,8 @@
 #include "drake/common/trajectories/bezier_curve.h"
 
+#include <memory>
+#include <utility>
+
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 

--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
+#include <memory>
+#include <vector>
 
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>

--- a/common/trajectories/test/composite_trajectory_test.cc
+++ b/common/trajectories/test/composite_trajectory_test.cc
@@ -1,5 +1,8 @@
 #include "drake/common/trajectories/composite_trajectory.h"
 
+#include <memory>
+#include <vector>
+
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 

--- a/common/trajectories/test/derivative_trajectory_test.cc
+++ b/common/trajectories/test/derivative_trajectory_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/trajectories/derivative_trajectory.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/common/trajectories/test/discrete_time_trajectory_test.cc
+++ b/common/trajectories/test/discrete_time_trajectory_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/trajectories/discrete_time_trajectory.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_assert.h"

--- a/common/trajectories/test/exponential_plus_piecewise_polynomial_test.cc
+++ b/common/trajectories/test/exponential_plus_piecewise_polynomial_test.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <random>
+#include <vector>
 
 #include <Eigen/Core>
 #include <gtest/gtest.h>

--- a/common/trajectories/test/function_handle_trajectory_test.cc
+++ b/common/trajectories/test/function_handle_trajectory_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/trajectories/function_handle_trajectory.h"
 
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/common/trajectories/test/path_parameterized_trajectory_test.cc
+++ b/common/trajectories/test/path_parameterized_trajectory_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/trajectories/path_parameterized_trajectory.h"
 
 #include <algorithm>
+#include <memory>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/common/trajectories/test/piecewise_constant_curvature_trajectory_test.cc
+++ b/common/trajectories/test/piecewise_constant_curvature_trajectory_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/trajectories/piecewise_constant_curvature_trajectory.h"
 
 #include <random>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -3,6 +3,7 @@
 #include "drake/common/trajectories/piecewise_polynomial.h"
 /* clang-format on */
 
+#include <algorithm>
 #include <random>
 #include <vector>
 

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -1,7 +1,11 @@
 #include "drake/common/trajectories/piecewise_polynomial.h"
 
+#include <algorithm>
+#include <limits>
+#include <memory>
 #include <random>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include <Eigen/Core>

--- a/common/trajectories/test/piecewise_pose_test.cc
+++ b/common/trajectories/test/piecewise_pose_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/trajectories/piecewise_pose.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/common/trajectories/test/piecewise_quaternion_test.cc
+++ b/common/trajectories/test/piecewise_quaternion_test.cc
@@ -1,6 +1,8 @@
 #include "drake/common/trajectories/piecewise_quaternion.h"
 
+#include <algorithm>
 #include <random>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/common/trajectories/test/piecewise_trajectory_test.cc
+++ b/common/trajectories/test/piecewise_trajectory_test.cc
@@ -1,6 +1,8 @@
 #include "drake/common/trajectories/piecewise_trajectory.h"
 
+#include <memory>
 #include <random>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/common/trajectories/test/stacked_trajectory_test.cc
+++ b/common/trajectories/test/stacked_trajectory_test.cc
@@ -1,5 +1,8 @@
 #include "drake/common/trajectories/stacked_trajectory.h"
 
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/common/trajectories/test/trajectory_test.cc
+++ b/common/trajectories/test/trajectory_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/trajectories/trajectory.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/common/trajectories/test/wrapped_trajectory_test.cc
+++ b/common/trajectories/test/wrapped_trajectory_test.cc
@@ -1,5 +1,7 @@
 #include "drake/common/trajectories/wrapped_trajectory.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/common/trajectories/wrapped_trajectory.cc
+++ b/common/trajectories/wrapped_trajectory.cc
@@ -1,5 +1,6 @@
 #include "drake/common/trajectories/wrapped_trajectory.h"
 
+#include <utility>
 namespace drake {
 namespace trajectories {
 namespace internal {

--- a/common/yaml/test/json_test.cc
+++ b/common/yaml/test/json_test.cc
@@ -1,4 +1,5 @@
 #include <limits>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/common/yaml/test/yaml_doxygen_test.cc
+++ b/common/yaml/test/yaml_doxygen_test.cc
@@ -1,5 +1,8 @@
 #include <fstream>
+#include <map>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>

--- a/common/yaml/test/yaml_io_test.cc
+++ b/common/yaml/test/yaml_io_test.cc
@@ -1,6 +1,8 @@
 #include "drake/common/yaml/yaml_io.h"
 
 #include <fstream>
+#include <map>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/common/yaml/test/yaml_node_test.cc
+++ b/common/yaml/test/yaml_node_test.cc
@@ -1,5 +1,11 @@
 #include "drake/common/yaml/yaml_node.h"
 
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
 #include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/common/yaml/test/yaml_performance_test.cc
+++ b/common/yaml/test/yaml_performance_test.cc
@@ -1,3 +1,6 @@
+#include <map>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <Eigen/Core>

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -1,6 +1,7 @@
 #include "drake/common/yaml/yaml_read_archive.h"
 
 #include <filesystem>
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>

--- a/common/yaml/test/yaml_write_archive_defaults_test.cc
+++ b/common/yaml/test/yaml_write_archive_defaults_test.cc
@@ -2,6 +2,7 @@
 // is used to write out YAML details without repeating the default values.
 
 #include <cmath>
+#include <string>
 #include <vector>
 
 #include <Eigen/Core>

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -1,6 +1,9 @@
 #include "drake/common/yaml/yaml_write_archive.h"
 
 #include <filesystem>
+#include <map>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <fmt/args.h>

--- a/examples/acrobot/run_lqr_w_estimator.cc
+++ b/examples/acrobot/run_lqr_w_estimator.cc
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <iostream>
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/acrobot/run_plant_w_lcm.cc
+++ b/examples/acrobot/run_plant_w_lcm.cc
@@ -9,7 +9,9 @@
  * LcmPublisherSystem
  *
  */
+#include <limits>
 #include <memory>
+#include <string>
 #include <thread>
 
 #include <gflags/gflags.h>

--- a/examples/acrobot/spong_controller_w_lcm.cc
+++ b/examples/acrobot/spong_controller_w_lcm.cc
@@ -10,7 +10,9 @@
  *
  */
 #include <chrono>
+#include <limits>
 #include <memory>
+#include <string>
 
 #include <gflags/gflags.h>
 

--- a/examples/acrobot/test/acrobot_plant_test.cc
+++ b/examples/acrobot/test/acrobot_plant_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/acrobot/acrobot_plant.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -7,6 +7,12 @@
 /// current state of the hand, and a subscriber to read the posiiton commands
 /// of the finger joints.
 
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -5,6 +5,10 @@
 /// and defined by a command-line parameter. This demo also allows to specify
 /// whether the right or left hand is simulated.
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"

--- a/examples/allegro_hand/test/allegro_lcm_test.cc
+++ b/examples/allegro_hand/test/allegro_lcm_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/allegro_hand/allegro_lcm.h"
 
+#include <memory>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/bead_on_a_wire/test/bead_on_a_wire_test.cc
+++ b/examples/bead_on_a_wire/test/bead_on_a_wire_test.cc
@@ -1,5 +1,6 @@
 #include "drake/examples/bead_on_a_wire/bead_on_a_wire.h"
 
+#include <limits>
 #include <memory>
 
 #include <gtest/gtest.h>

--- a/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -1,6 +1,7 @@
 #include "drake/examples/bouncing_ball/bouncing_ball.h"
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/examples/compass_gait/test/compass_gait_test.cc
+++ b/examples/compass_gait/test/compass_gait_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/compass_gait/compass_gait.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/examples/cubic_polynomial/backward_reachability.cc
+++ b/examples/cubic_polynomial/backward_reachability.cc
@@ -9,6 +9,8 @@
 // TODO(jadecastro) Transcribe this example into Python.
 #include <cmath>
 #include <iostream>
+#include <map>
+#include <utility>
 
 #include "drake/common/proto/call_python.h"
 #include "drake/common/symbolic/polynomial.h"

--- a/examples/hardware_sim/hardware_sim.cc
+++ b/examples/hardware_sim/hardware_sim.cc
@@ -15,6 +15,10 @@ controller operates the robot, without extra hassle.
 Drake maintainers should keep this file in sync with hardware_sim.py. */
 
 #include <fstream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_copyable.h"

--- a/examples/kinova_jaco_arm/jaco_controller.cc
+++ b/examples/kinova_jaco_arm/jaco_controller.cc
@@ -3,6 +3,9 @@
 /// Implements a controller for a Kinova Jaco arm.
 
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -5,6 +5,7 @@
 
 #include <limits>
 #include <memory>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -2,9 +2,12 @@
 ///
 /// Implements a controller for a KUKA iiwa arm.
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <memory>
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/fmt_eigen.h"

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -5,7 +5,9 @@
 /// and lcmt_iiwa_command messages. It is intended to be a be a direct
 /// replacement for the KUKA iiwa driver and the actual robot hardware.
 
+#include <limits>
 #include <memory>
+#include <string>
 
 #include <gflags/gflags.h>
 

--- a/examples/kuka_iiwa_arm/test/kuka_torque_controller_test.cc
+++ b/examples/kuka_iiwa_arm/test/kuka_torque_controller_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/kuka_iiwa_arm/kuka_torque_controller.h"
 
+#include <memory>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/examples/mass_spring_cloth/run_cloth_spring_model.cc
+++ b/examples/mass_spring_cloth/run_cloth_spring_model.cc
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/mass_spring_cloth/test/cloth_spring_model_test.cc
+++ b/examples/mass_spring_cloth/test/cloth_spring_model_test.cc
@@ -1,5 +1,8 @@
 #include "drake/examples/mass_spring_cloth/cloth_spring_model.h"
 
+#include <memory>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/analysis/simulator.h"

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -1,4 +1,6 @@
 #include <memory>
+#include <string>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/cart_pole/test/cart_pole_test.cc
+++ b/examples/multibody/cart_pole/test/cart_pole_test.cc
@@ -1,5 +1,6 @@
 #include <limits>
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/deformable/bubble_gripper.cc
+++ b/examples/multibody/deformable/bubble_gripper.cc
@@ -1,4 +1,8 @@
 #include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/deformable/deformable_disabling.cc
+++ b/examples/multibody/deformable/deformable_disabling.cc
@@ -1,4 +1,7 @@
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/deformable/deformable_torus.cc
+++ b/examples/multibody/deformable/deformable_torus.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/four_bar/passive_simulation.cc
+++ b/examples/multibody/four_bar/passive_simulation.cc
@@ -9,6 +9,10 @@ a way to model a kinematic loop. It shows:
 
   Refer to README.md for more details.
 */
+#include <memory>
+#include <string>
+#include <utility>
+
 #include <gflags/gflags.h>
 
 #include "drake/multibody/parsing/parser.h"

--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/multibody/strandbeest/run_with_motor.cc
+++ b/examples/multibody/strandbeest/run_with_motor.cc
@@ -12,6 +12,10 @@ a way to model kinematic loops. It shows:
   Refer to README.md for more details on how to run and modify this example.
 */
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include <fmt/format.h>
 #include <gflags/gflags.h>
 

--- a/examples/pendulum/print_symbolic_dynamics.cc
+++ b/examples/pendulum/print_symbolic_dynamics.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 
 #include "drake/common/symbolic/expression.h"
 #include "drake/examples/pendulum/pendulum_plant.h"

--- a/examples/pendulum/test/pendulum_plant_test.cc
+++ b/examples/pendulum/test/pendulum_plant_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/pendulum/pendulum_plant.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/examples/pendulum/trajectory_optimization_simulation.cc
+++ b/examples/pendulum/trajectory_optimization_simulation.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/planar_gripper/planar_gripper_simulation.cc
+++ b/examples/planar_gripper/planar_gripper_simulation.cc
@@ -47,7 +47,11 @@
 // TODO(rcory) Include a README.md that explains the use cases for this
 //  example.
 
+#include <map>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
+++ b/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
@@ -12,7 +12,10 @@
 ///        the vertical case. Using these keyframes to simulate the horizontal
 ///        case may cause the simulation to fail.
 
+#include <map>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/planar_gripper/test/brick_static_equilibrium_constraint_test.cc
+++ b/examples/planar_gripper/test/brick_static_equilibrium_constraint_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/planar_gripper/brick_static_equilibrium_constraint.h"
 
+#include <vector>
+
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/compute_numerical_gradient.h"

--- a/examples/planar_gripper/test/planar_gripper_common_test.cc
+++ b/examples/planar_gripper/test/planar_gripper_common_test.cc
@@ -1,5 +1,8 @@
 #include "drake/examples/planar_gripper/planar_gripper_common.h"
 
+#include <map>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/examples/planar_gripper/test/planar_gripper_lcm_test.cc
+++ b/examples/planar_gripper/test/planar_gripper_lcm_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/planar_gripper/planar_gripper_lcm.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/lcmt_planar_gripper_command.hpp"

--- a/examples/planar_gripper/test/planar_manipuland_lcm_test.cc
+++ b/examples/planar_gripper/test/planar_manipuland_lcm_test.cc
@@ -1,5 +1,7 @@
 #include "drake/examples/planar_gripper/planar_manipuland_lcm.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/diagram.h"

--- a/examples/quadrotor/run_quadrotor_lqr.cc
+++ b/examples/quadrotor/run_quadrotor_lqr.cc
@@ -7,6 +7,7 @@
 ///   bazel run //tools:meldis -- -w
 
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/quadrotor/test/quadrotor_dynamics_test.cc
+++ b/examples/quadrotor/test/quadrotor_dynamics_test.cc
@@ -1,4 +1,7 @@
+#include <limits>
+#include <memory>
 #include <stdexcept>
+#include <utility>
 
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>

--- a/examples/rimless_wheel/test/rimless_wheel_test.cc
+++ b/examples/rimless_wheel/test/rimless_wheel_test.cc
@@ -1,5 +1,8 @@
 #include "drake/examples/rimless_wheel/rimless_wheel.h"
 
+#include <limits>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/analysis/simulator.h"

--- a/examples/rod2d/rod2d_sim.cc
+++ b/examples/rod2d/rod2d_sim.cc
@@ -1,8 +1,10 @@
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <utility>
 
 #include <gflags/gflags.h>
 

--- a/examples/rod2d/test/constraint_solver_test.cc
+++ b/examples/rod2d/test/constraint_solver_test.cc
@@ -1,7 +1,10 @@
 #include "drake/examples/rod2d/constraint_solver.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/examples/rod2d/test/rod2d_test.cc
+++ b/examples/rod2d/test/rod2d_test.cc
@@ -1,6 +1,9 @@
 #include "drake/examples/rod2d/rod2d.h"
 
+#include <limits>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 #include <utility>
 
 #include <gflags/gflags.h>

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -8,7 +8,9 @@
  and anchored) and their properties to see the effect on contact surface.  */
 
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -1,5 +1,6 @@
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <fmt/format.h>
 #include <gflags/gflags.h>

--- a/examples/zmp/zmp_example.cc
+++ b/examples/zmp/zmp_example.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <thread>
+#include <vector>
 
 #include "drake/common/proto/call_python.h"
 #include "drake/planning/locomotion/test_utilities/zmp_test_util.h"


### PR DESCRIPTION
This commit covers:
- common
- examples

Towards #22689.

The standard library IWYU linter on cc files has been accidentally disabled for a while.  This is the lint that accumulated in the meantime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23344)
<!-- Reviewable:end -->
