### PR TITLE
[cpplint] Fix iwyu lint (2/5)

### DIFF
--- a/geometry/benchmarking/compliant_mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/compliant_mesh_intersection_benchmark.cc
@@ -1,3 +1,7 @@
+#include <memory>
+#include <tuple>
+#include <utility>
+
 #include <benchmark/benchmark.h>
 #include <fmt/format.h>
 

--- a/geometry/benchmarking/iris_np_benchmarks.cc
+++ b/geometry/benchmarking/iris_np_benchmarks.cc
@@ -1,3 +1,7 @@
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <benchmark/benchmark.h>
 #include <gflags/gflags.h>
 

--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -1,4 +1,9 @@
 #include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include <benchmark/benchmark.h>
 #include <fmt/format.h>

--- a/geometry/benchmarking/proximity_defaults_benchmark.cc
+++ b/geometry/benchmarking/proximity_defaults_benchmark.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <benchmark/benchmark.h>
 #include <fmt/format.h>
 

--- a/geometry/benchmarking/render_benchmark.cc
+++ b/geometry/benchmarking/render_benchmark.cc
@@ -2,7 +2,13 @@
 
 #include <unistd.h>
 
+#include <algorithm>
 #include <filesystem>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
 
 #include <benchmark/benchmark.h>
 #include <fmt/format.h>

--- a/geometry/optimization/dev/test/cspace_free_path_test.cc
+++ b/geometry/optimization/dev/test/cspace_free_path_test.cc
@@ -1,5 +1,9 @@
 #include "drake/geometry/optimization/dev/cspace_free_path.h"
 
+#include <algorithm>
+#include <memory>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/symbolic_test_util.h"

--- a/geometry/optimization/dev/test/cspace_free_path_with_mosek_test.cc
+++ b/geometry/optimization/dev/test/cspace_free_path_with_mosek_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <unordered_map>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/polynomial.h"

--- a/geometry/optimization/test/affine_ball_test.cc
+++ b/geometry/optimization/test/affine_ball_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/optimization/affine_ball.h"
 
 #include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/affine_subspace_test.cc
+++ b/geometry/optimization/test/affine_subspace_test.cc
@@ -1,5 +1,11 @@
 #include "drake/geometry/optimization/affine_subspace.h"
 
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/optimization/test/c_iris_collision_geometry_test.cc
+++ b/geometry/optimization/test/c_iris_collision_geometry_test.cc
@@ -1,6 +1,8 @@
 #include "drake/geometry/optimization/c_iris_collision_geometry.h"
 
+#include <algorithm>
 #include <memory>
+#include <vector>
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>

--- a/geometry/optimization/test/cartesian_product_test.cc
+++ b/geometry/optimization/test/cartesian_product_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/optimization/cartesian_product.h"
 
 #include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/convex_set_limit_malloc_test.cc
+++ b/geometry/optimization/test/convex_set_limit_malloc_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/limit_malloc.h"

--- a/geometry/optimization/test/convex_set_test.cc
+++ b/geometry/optimization/test/convex_set_test.cc
@@ -1,5 +1,9 @@
 #include "drake/geometry/optimization/convex_set.h"
 
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/is_approx_equal_abstol.h"

--- a/geometry/optimization/test/cspace_free_box_with_mosek_test.cc
+++ b/geometry/optimization/test/cspace_free_box_with_mosek_test.cc
@@ -1,5 +1,7 @@
 #include <limits>
 #include <queue>
+#include <unordered_map>
+#include <vector>
 
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/optimization/test/cspace_free_internal_test.cc
+++ b/geometry/optimization/test/cspace_free_internal_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/optimization/cspace_free_internal.h"
 
+#include <unordered_set>
+
 #include <gtest/gtest.h>
 
 #include "drake/geometry/optimization/test/c_iris_test_utilities.h"

--- a/geometry/optimization/test/cspace_free_polytope_base_test.cc
+++ b/geometry/optimization/test/cspace_free_polytope_base_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/optimization/cspace_free_polytope_base.h"
 
+#include <unordered_map>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/cspace_free_polytope_test.cc
+++ b/geometry/optimization/test/cspace_free_polytope_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/optimization/cspace_free_polytope.h"
 
 #include <limits>
+#include <unordered_set>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/cspace_free_polytope_with_mosek_test.cc
+++ b/geometry/optimization/test/cspace_free_polytope_with_mosek_test.cc
@@ -1,4 +1,7 @@
 #include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/geodesic_convexity_test.cc
+++ b/geometry/optimization/test/geodesic_convexity_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/optimization/geodesic_convexity.h"
 
+#include <utility>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1,6 +1,13 @@
 #include "drake/geometry/optimization/graph_of_convex_sets.h"
 
 #include <forward_list>
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -1,6 +1,11 @@
 #include "drake/geometry/optimization/hpolyhedron.h"
 
 #include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/hyperellipsoid_test.cc
+++ b/geometry/optimization/test/hyperellipsoid_test.cc
@@ -1,6 +1,10 @@
 #include "drake/geometry/optimization/hyperellipsoid.h"
 
 #include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/hyperrectangle_test.cc
+++ b/geometry/optimization/test/hyperrectangle_test.cc
@@ -1,6 +1,8 @@
 #include "drake/geometry/optimization/hyperrectangle.h"
 
 #include <limits>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/implicit_graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/implicit_graph_of_convex_sets_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/optimization/implicit_graph_of_convex_sets.h"
 
+#include <map>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/geometry/optimization/test/intersection_test.cc
+++ b/geometry/optimization/test/intersection_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/optimization/intersection.h"
 
 #include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/iris_internal_test.cc
+++ b/geometry/optimization/test/iris_internal_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/optimization/iris_internal.h"
 
+#include <memory>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/optimization/test/iris_np_test.cc
+++ b/geometry/optimization/test/iris_np_test.cc
@@ -1,3 +1,9 @@
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -1,5 +1,10 @@
 #include "drake/geometry/optimization/iris.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/optimization/test/minkowski_sum_test.cc
+++ b/geometry/optimization/test/minkowski_sum_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/optimization/minkowski_sum.h"
 
 #include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/point_test.cc
+++ b/geometry/optimization/test/point_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/optimization/point.h"
 
 #include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/spectrahedron_test.cc
+++ b/geometry/optimization/test/spectrahedron_test.cc
@@ -1,6 +1,8 @@
 #include "drake/geometry/optimization/spectrahedron.h"
 
 #include <limits>
+#include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -1,7 +1,10 @@
 #include "drake/geometry/optimization/vpolytope.h"
 
 #include <limits>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/inflate_mesh.cc
+++ b/geometry/proximity/inflate_mesh.cc
@@ -3,6 +3,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/geometry/proximity/mesh_to_vtk.cc
+++ b/geometry/proximity/mesh_to_vtk.cc
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/geometry/proximity/refine_mesh.cc
+++ b/geometry/proximity/refine_mesh.cc
@@ -2,6 +2,8 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <string>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/geometry/proximity/test/boxes_overlap_test.cc
+++ b/geometry/proximity/test/boxes_overlap_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/proximity/boxes_overlap.h"
 
+#include <memory>
 #include <string>
 
 #pragma GCC diagnostic push

--- a/geometry/proximity/test/bvh_test.cc
+++ b/geometry/proximity/test/bvh_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/proximity/bvh.h"
 
+#include <algorithm>
+#include <set>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/bvh_updater_test.cc
+++ b/geometry/proximity/test/bvh_updater_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/proximity/bvh_updater.h"
 
+#include <limits>
 #include <utility>
 #include <vector>
 

--- a/geometry/proximity/test/calc_distance_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/calc_distance_to_surface_mesh_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/proximity/calc_distance_to_surface_mesh.h"
 
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/geometry/proximity/make_box_mesh.h"

--- a/geometry/proximity/test/calc_obb_test.cc
+++ b/geometry/proximity/test/calc_obb_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/calc_obb.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/geometry/proximity/test/calc_signed_distance_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/calc_signed_distance_to_surface_mesh_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/proximity/calc_signed_distance_to_surface_mesh.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/proximity/test/collision_filter_test.cc
+++ b/geometry/proximity/test/collision_filter_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/proximity/collision_filter.h"
 
+#include <set>
 #include <tuple>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/geometry/proximity/test/collisions_exist_callback_test.cc
+++ b/geometry/proximity/test/collisions_exist_callback_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/collisions_exist_callback.h"
 
+#include <memory>
+#include <unordered_set>
 #include <utility>
 
 #include <fcl/fcl.h>

--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/deformable_contact_geometries_test.cc
+++ b/geometry/proximity/test/deformable_contact_geometries_test.cc
@@ -1,5 +1,11 @@
 #include "drake/geometry/proximity/deformable_contact_geometries.h"
 
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"

--- a/geometry/proximity/test/deformable_contact_internal_test.cc
+++ b/geometry/proximity/test/deformable_contact_internal_test.cc
@@ -1,5 +1,12 @@
 #include "drake/geometry/proximity/deformable_contact_internal.h"
 
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/geometry/proximity/test/deformable_field_intersection_test.cc
+++ b/geometry/proximity/test/deformable_field_intersection_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/deformable_field_intersection.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/geometry/proximity/test/deformable_mesh_intersection_test.cc
+++ b/geometry/proximity/test/deformable_mesh_intersection_test.cc
@@ -1,6 +1,8 @@
 #include "drake/geometry/proximity/deformable_mesh_intersection.h"
 
+#include <limits>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/detect_zero_simplex_test.cc
+++ b/geometry/proximity/test/detect_zero_simplex_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/detect_zero_simplex.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -1,6 +1,10 @@
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <regex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -1,5 +1,10 @@
 #include "drake/geometry/proximity/distance_to_point_callback.h"
 
+#include <limits>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
 #include <fcl/fcl.h>
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/distance_to_point_characterize_test.cc
+++ b/geometry/proximity/test/distance_to_point_characterize_test.cc
@@ -1,4 +1,7 @@
+#include <limits>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/geometry/proximity/test/distance_to_shape_characterize_test.cc
+++ b/geometry/proximity/test/distance_to_shape_characterize_test.cc
@@ -1,4 +1,6 @@
+#include <limits>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/geometry/proximity/test/distance_to_shape_touching_test.cc
+++ b/geometry/proximity/test/distance_to_shape_touching_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/distance_to_shape_touching.h"
 
+#include <memory>
+
 #include <fcl/fcl.h>
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/field_intersection_test.cc
+++ b/geometry/proximity/test/field_intersection_test.cc
@@ -1,7 +1,9 @@
 #include "drake/geometry/proximity/field_intersection.h"
 
 #include <memory>
+#include <set>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>

--- a/geometry/proximity/test/find_collision_candidates_callback_test.cc
+++ b/geometry/proximity/test/find_collision_candidates_callback_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/find_collision_candidates_callback.h"
 
+#include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -1,9 +1,14 @@
 #include "drake/geometry/proximity/hydroelastic_internal.h"
 
+#include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <functional>
 #include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>

--- a/geometry/proximity/test/inflate_mesh_test.cc
+++ b/geometry/proximity/test/inflate_mesh_test.cc
@@ -1,8 +1,11 @@
 #include "drake/geometry/proximity/inflate_mesh.h"
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <numeric>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/make_box_field_test.cc
+++ b/geometry/proximity/test/make_box_field_test.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/make_box_mesh_test.cc
+++ b/geometry/proximity/test/make_box_mesh_test.cc
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/make_capsule_field_test.cc
+++ b/geometry/proximity/test/make_capsule_field_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/make_capsule_field.h"
 
 #include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/make_capsule_mesh_test.cc
+++ b/geometry/proximity/test/make_capsule_mesh_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/proximity/make_capsule_mesh.h"
 
+#include <algorithm>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/geometry/proximity/test/make_convex_field_test.cc
+++ b/geometry/proximity/test/make_convex_field_test.cc
@@ -1,6 +1,8 @@
 #include "drake/geometry/proximity/make_convex_field.h"
 
 #include <limits>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/make_convex_hull_mesh_impl_test.cc
+++ b/geometry/proximity/test/make_convex_hull_mesh_impl_test.cc
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/geometry/proximity/test/make_convex_hull_mesh_test.cc
+++ b/geometry/proximity/test/make_convex_hull_mesh_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/make_convex_hull_mesh.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/geometry/proximity/test/make_convex_mesh_test.cc
+++ b/geometry/proximity/test/make_convex_mesh_test.cc
@@ -1,5 +1,10 @@
 #include "drake/geometry/proximity/make_convex_mesh.h"
 
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/geometry/proximity/test/make_cylinder_field_test.cc
+++ b/geometry/proximity/test/make_cylinder_field_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/make_cylinder_field.h"
 
 #include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -1,5 +1,9 @@
 #include "drake/geometry/proximity/make_cylinder_mesh.h"
 
+#include <algorithm>
+#include <limits>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/geometry/proximity/test/make_sphere_field_test.cc
+++ b/geometry/proximity/test/make_sphere_field_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/make_sphere_field.h"
 
 #include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/make_sphere_mesh_test.cc
+++ b/geometry/proximity/test/make_sphere_mesh_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/make_sphere_mesh.h"
 
 #include <algorithm>
+#include <limits>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/geometry/proximity/test/mesh_deformer_test.cc
+++ b/geometry/proximity/test/mesh_deformer_test.cc
@@ -2,6 +2,9 @@
  Test SetAllPositions() functions for VolumeMesh, TriangleSurfaceMesh, and
  PolygonSurfaceMesh. */
 
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/geometry/proximity/test/mesh_distance_boundary_test.cc
+++ b/geometry/proximity/test/mesh_distance_boundary_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/mesh_distance_boundary.h"
 
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/geometry/proximity/volume_mesh.h"

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -1,8 +1,11 @@
 #include "drake/geometry/proximity/mesh_field_linear.h"
 
 #include <cmath>
+#include <limits>
 #include <memory>
+#include <set>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -1,8 +1,11 @@
 #include "drake/geometry/proximity/mesh_half_space_intersection.h"
 
+#include <algorithm>
 #include <functional>
 #include <limits>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -1,10 +1,13 @@
 #include "drake/geometry/proximity/mesh_plane_intersection.h"
 
+#include <algorithm>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <set>
+#include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <fmt/ranges.h>

--- a/geometry/proximity/test/mesh_to_vtk_test.cc
+++ b/geometry/proximity/test/mesh_to_vtk_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/mesh_to_vtk.h"
 
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/meshing_utilities_test.cc
+++ b/geometry/proximity/test/meshing_utilities_test.cc
@@ -1,6 +1,8 @@
 #include "drake/geometry/proximity/meshing_utilities.h"
 
 #include <algorithm>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/obb_test.cc
+++ b/geometry/proximity/test/obb_test.cc
@@ -1,5 +1,11 @@
 #include "drake/geometry/proximity/obb.h"
 
+#include <limits>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
@@ -1,5 +1,9 @@
 #include "drake/geometry/proximity/penetration_as_point_pair_callback.h"
 
+#include <limits>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/geometry/proximity/test/polygon_surface_mesh_test.cc
+++ b/geometry/proximity/test/polygon_surface_mesh_test.cc
@@ -1,6 +1,10 @@
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 
+#include <limits>
 #include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -2,6 +2,8 @@
 
 #include <memory>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 #include <fcl/fcl.h>
 #include <gtest/gtest.h>

--- a/geometry/proximity/test/sorted_triplet_test.cc
+++ b/geometry/proximity/test/sorted_triplet_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/sorted_triplet.h"
 
+#include <map>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/geometry/proximity/test/triangle_surface_mesh_test.cc
+++ b/geometry/proximity/test/triangle_surface_mesh_test.cc
@@ -1,7 +1,9 @@
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 
+#include <limits>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/volume_mesh_refiner_test.cc
+++ b/geometry/proximity/test/volume_mesh_refiner_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/proximity/volume_mesh_refiner.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/memory_file.h"

--- a/geometry/proximity/test/volume_mesh_test.cc
+++ b/geometry/proximity/test/volume_mesh_test.cc
@@ -1,7 +1,9 @@
 #include "drake/geometry/proximity/volume_mesh.h"
 
+#include <limits>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/volume_mesh_topology_test.cc
+++ b/geometry/proximity/test/volume_mesh_topology_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/volume_mesh_topology.h"
 
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/proximity/test/volume_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/volume_to_surface_mesh_test.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <set>
 #include <tuple>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/query_results/test/deformable_contact_test.cc
+++ b/geometry/query_results/test/deformable_contact_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/query_results/deformable_contact.h"
 
+#include <unordered_set>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/ssize.h"

--- a/geometry/render/test/render_camera_test.cc
+++ b/geometry/render/test/render_camera_test.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <stdexcept>
+#include <string>
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/render/render_engine.h"
 
+#include <memory>
 #include <optional>
 #include <set>
 #include <unordered_map>

--- a/geometry/render/test/render_material_test.cc
+++ b/geometry/render/test/render_material_test.cc
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/geometry/render/test/render_mesh_test.cc
+++ b/geometry/render/test/render_mesh_test.cc
@@ -2,6 +2,8 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/geometry/render_gl/internal_loaders.cc
+++ b/geometry/render_gl/internal_loaders.cc
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <stdexcept>
+#include <string>
 
 #if !defined(__APPLE__)
 #include <vtkglad/include/glad/egl.h>

--- a/geometry/render_gl/no_factory.cc
+++ b/geometry/render_gl/no_factory.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "drake/geometry/render_gl/factory.h"
 #include "drake/geometry/render_gl/render_engine_gl_params.h"
 

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -1,11 +1,17 @@
 #include "drake/geometry/render_gl/internal_render_engine_gl.h"
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <filesystem>
+#include <limits>
+#include <memory>
 #include <optional>
 #include <source_location>
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>

--- a/geometry/render_gl/test/multithread_safety_test.cc
+++ b/geometry/render_gl/test/multithread_safety_test.cc
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <future>
+#include <memory>
 #include <optional>
 #include <string>
 #include <variant>

--- a/geometry/render_gl/test/render_engine_gl_params_test.cc
+++ b/geometry/render_gl/test/render_engine_gl_params_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/render_gl/render_engine_gl_params.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/yaml/yaml_io.h"

--- a/geometry/render_gl/test/thread_test.cc
+++ b/geometry/render_gl/test/thread_test.cc
@@ -1,5 +1,7 @@
 #include <filesystem>
 #include <future>
+#include <memory>
+#include <string>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/geometry/render_gltf_client/test/client_demo.cc
+++ b/geometry/render_gltf_client/test/client_demo.cc
@@ -45,7 +45,9 @@
 
 #include <filesystem>
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <gflags/gflags.h>

--- a/geometry/render_gltf_client/test/factory_test.cc
+++ b/geometry/render_gltf_client/test/factory_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/render_gltf_client/factory.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/geometry/render/render_engine.h"

--- a/geometry/render_gltf_client/test/internal_http_service_curl_test.cc
+++ b/geometry/render_gltf_client/test/internal_http_service_curl_test.cc
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
 
 #include <fmt/format.h>
 #include <gmock/gmock.h>

--- a/geometry/render_gltf_client/test/internal_http_service_test.cc
+++ b/geometry/render_gltf_client/test/internal_http_service_test.cc
@@ -2,6 +2,8 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/geometry/render_gltf_client/test/internal_merge_gltf_test.cc
+++ b/geometry/render_gltf_client/test/internal_merge_gltf_test.cc
@@ -6,6 +6,7 @@
 #include <ostream>
 #include <regex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/geometry/render_gltf_client/test/internal_render_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_client_test.cc
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -2,7 +2,11 @@
 
 #include <filesystem>
 #include <fstream>
+#include <map>
+#include <memory>
 #include <set>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <common_robotics_utilities/base64_helpers.hpp>

--- a/geometry/render_gltf_client/test/render_engine_gltf_client_params_test.cc
+++ b/geometry/render_gltf_client/test/render_engine_gltf_client_params_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/render_gltf_client/render_engine_gltf_client_params.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/yaml/yaml_io.h"

--- a/geometry/render_vtk/test/internal_render_engine_vtk_no_display_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_no_display_test.cc
@@ -1,5 +1,8 @@
 #include <stdlib.h>
 
+#include <memory>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -3,11 +3,13 @@
 #include <cstring>
 #include <filesystem>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <source_location>
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 

--- a/geometry/render_vtk/test/internal_vtk_gltf_parser_patch_test.cc
+++ b/geometry/render_vtk/test/internal_vtk_gltf_parser_patch_test.cc
@@ -24,6 +24,8 @@
       - This, again, can only be tested once the TODO in
         RenderEngineVtk::ImplementGltf is resolved. */
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 // To ease build system upkeep, we annotate VTK includes with their deps.

--- a/geometry/render_vtk/test/render_engine_vtk_params_test.cc
+++ b/geometry/render_vtk/test/render_engine_vtk_params_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/render_vtk/render_engine_vtk_params.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/geometry/test/collision_filter_declaration_test.cc
+++ b/geometry/test/collision_filter_declaration_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/collision_filter_declaration.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/geometry/geometry_ids.h"

--- a/geometry/test/deformable_mesh_with_bvh_test.cc
+++ b/geometry/test/deformable_mesh_with_bvh_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/deformable_mesh_with_bvh.h"
 
+#include <algorithm>
 #include <limits>
 #include <utility>
 

--- a/geometry/test/geometry_instance_test.cc
+++ b/geometry/test/geometry_instance_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/geometry_instance.h"
 
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/geometry/test/geometry_properties_test.cc
+++ b/geometry/test/geometry_properties_test.cc
@@ -1,5 +1,10 @@
 #include "drake/geometry/geometry_properties.h"
 
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -7,6 +7,9 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>

--- a/geometry/test/in_memory_mesh_test.cc
+++ b/geometry/test/in_memory_mesh_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/in_memory_mesh.h"
 
+#include <string>
+
 #include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/internal_geometry.h"
 
+#include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/geometry/test/kinematics_vector_test.cc
+++ b/geometry/test/kinematics_vector_test.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <set>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/geometry/test/make_mesh_for_deformable_test.cc
+++ b/geometry/test/make_mesh_for_deformable_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/make_mesh_for_deformable.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/geometry/test/mesh_deformation_interpolator_test.cc
+++ b/geometry/test/mesh_deformation_interpolator_test.cc
@@ -1,5 +1,8 @@
 #include "drake/geometry/mesh_deformation_interpolator.h"
 
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/geometry/test/mesh_source_test.cc
+++ b/geometry/test/mesh_source_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/mesh_source.h"
 
+#include <utility>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/geometry/test/meshcat_file_storage_internal_test.cc
+++ b/geometry/test/meshcat_file_storage_internal_test.cc
@@ -2,6 +2,10 @@
 
 #include <deque>
 #include <future>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -3,7 +3,11 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <memory>
+#include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/geometry/test/meshcat_params_test.cc
+++ b/geometry/test/meshcat_params_test.cc
@@ -1,6 +1,8 @@
 #include "drake/geometry/meshcat_params.h"
 
+#include <string>
 #include <tuple>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/test/meshcat_point_cloud_visualizer_test.cc
+++ b/geometry/test/meshcat_point_cloud_visualizer_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/meshcat_point_cloud_visualizer.h"
 
+#include <memory>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/geometry/test/meshcat_recording_internal_test.cc
+++ b/geometry/test/meshcat_recording_internal_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/meshcat_recording_internal.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -1,9 +1,13 @@
 #include "drake/geometry/meshcat.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <memory>
+#include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/meshcat_visualizer.h"
 
+#include <memory>
+#include <string>
 #include <thread>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/geometry/test/poisson_disk_test.cc
+++ b/geometry/test/poisson_disk_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/poisson_disk.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -1,9 +1,14 @@
 #include "drake/geometry/proximity_engine.h"
 
+#include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <limits>
+#include <memory>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity_properties.h"
 
 #include <sstream>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -1,6 +1,8 @@
 #include "drake/geometry/query_object.h"
 
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/test/read_gltf_to_memory_test.cc
+++ b/geometry/test/read_gltf_to_memory_test.cc
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/geometry/test/read_obj_test.cc
+++ b/geometry/test/read_obj_test.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/read_obj.h"
 
 #include <filesystem>
+#include <memory>
+#include <set>
+#include <string>
 #include <unordered_set>
 
 #include <gmock/gmock.h>

--- a/geometry/test/rgba_test.cc
+++ b/geometry/test/rgba_test.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/rgba.h"
 
 #include <limits>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/geometry/test/scene_graph_config_test.cc
+++ b/geometry/test/scene_graph_config_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/scene_graph_config.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -1,7 +1,10 @@
 #include "drake/geometry/scene_graph.h"
 
+#include <limits>
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -1,7 +1,11 @@
 #include "drake/geometry/shape_specification.h"
 
 #include <filesystem>
+#include <limits>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/geometry/test/shape_specification_thread_test.cc
+++ b/geometry/test/shape_specification_thread_test.cc
@@ -1,4 +1,5 @@
 #include <future>
+#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/lcm/test/drake_lcm_interface_test.cc
+++ b/lcm/test/drake_lcm_interface_test.cc
@@ -2,6 +2,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/lcm/test/drake_lcm_log_test.cc
+++ b/lcm/test/drake_lcm_log_test.cc
@@ -1,7 +1,9 @@
 #include "drake/lcm/drake_lcm_log.h"
 
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -1,8 +1,11 @@
 #include "drake/lcm/drake_lcm.h"
 
 #include <chrono>
+#include <memory>
 #include <stdexcept>
+#include <string>
 #include <thread>
+#include <utility>
 
 #include "lcm/lcm-cpp.hpp"
 #include <gtest/gtest.h>

--- a/lcm/test/drake_lcm_thread_test.cc
+++ b/lcm/test/drake_lcm_thread_test.cc
@@ -2,6 +2,7 @@
 #include <chrono>
 #include <mutex>
 #include <stdexcept>
+#include <string>
 #include <thread>
 
 #include "lcm/lcm-cpp.hpp"

--- a/lcm/test/initialization_sequence_test_stub.cc
+++ b/lcm/test/initialization_sequence_test_stub.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 #include <thread>
 
 #include <gflags/gflags.h>

--- a/lcm/test/lcm_messages_test.cc
+++ b/lcm/test/lcm_messages_test.cc
@@ -1,5 +1,7 @@
 #include "drake/lcm/lcm_messages.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/lcmtypes/benchmarking/benchmark.cc
+++ b/lcmtypes/benchmarking/benchmark.cc
@@ -1,3 +1,6 @@
+#include <string>
+#include <vector>
+
 #include <benchmark/benchmark.h>
 
 #include "drake/lcmt_image.hpp"

--- a/manipulation/kinova_jaco/test/jaco_command_receiver_test.cc
+++ b/manipulation/kinova_jaco/test/jaco_command_receiver_test.cc
@@ -1,5 +1,7 @@
 #include "drake/manipulation/kinova_jaco/jaco_command_receiver.h"
 
+#include <memory>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/manipulation/kinova_jaco/test/jaco_command_sender_test.cc
+++ b/manipulation/kinova_jaco/test/jaco_command_sender_test.cc
@@ -1,5 +1,8 @@
 #include "drake/manipulation/kinova_jaco/jaco_command_sender.h"
 
+#include <memory>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/manipulation/kinova_jaco/test/jaco_status_receiver_test.cc
+++ b/manipulation/kinova_jaco/test/jaco_status_receiver_test.cc
@@ -1,5 +1,8 @@
 #include "drake/manipulation/kinova_jaco/jaco_status_receiver.h"
 
+#include <memory>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/manipulation/kinova_jaco/test/jaco_status_sender_test.cc
+++ b/manipulation/kinova_jaco/test/jaco_status_sender_test.cc
@@ -1,5 +1,8 @@
 #include "drake/manipulation/kinova_jaco/jaco_status_sender.h"
 
+#include <memory>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/manipulation/kuka_iiwa/sim_iiwa_driver.cc
+++ b/manipulation/kuka_iiwa/sim_iiwa_driver.cc
@@ -1,6 +1,8 @@
 #include "drake/manipulation/kuka_iiwa/sim_iiwa_driver.h"
 
+#include <limits>
 #include <string>
+#include <vector>
 
 #include "drake/common/default_scalars.h"
 #include "drake/systems/controllers/inverse_dynamics_controller.h"

--- a/manipulation/kuka_iiwa/test/build_iiwa_control_test.cc
+++ b/manipulation/kuka_iiwa/test/build_iiwa_control_test.cc
@@ -2,6 +2,8 @@
 
 #include <cmath>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/manipulation/kuka_iiwa/test/iiwa_command_receiver_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_command_receiver_test.cc
@@ -1,5 +1,8 @@
 #include "drake/manipulation/kuka_iiwa/iiwa_command_receiver.h"
 
+#include <memory>
+#include <utility>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/manipulation/kuka_iiwa/test/iiwa_command_sender_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_command_sender_test.cc
@@ -1,5 +1,9 @@
 #include "drake/manipulation/kuka_iiwa/iiwa_command_sender.h"
 
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/manipulation/kuka_iiwa/test/iiwa_driver_functions_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_driver_functions_test.cc
@@ -1,5 +1,9 @@
 #include "drake/manipulation/kuka_iiwa/iiwa_driver_functions.h"
 
+#include <map>
+#include <string>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/manipulation/kuka_iiwa/test/iiwa_status_receiver_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_status_receiver_test.cc
@@ -1,5 +1,8 @@
 #include "drake/manipulation/kuka_iiwa/iiwa_status_receiver.h"
 
+#include <memory>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/manipulation/kuka_iiwa/test/iiwa_status_sender_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_status_sender_test.cc
@@ -1,5 +1,8 @@
 #include "drake/manipulation/kuka_iiwa/iiwa_status_sender.h"
 
+#include <memory>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/manipulation/kuka_iiwa/test/sim_iiwa_driver_test.cc
+++ b/manipulation/kuka_iiwa/test/sim_iiwa_driver_test.cc
@@ -1,6 +1,8 @@
 #include "drake/manipulation/kuka_iiwa/sim_iiwa_driver.h"
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/manipulation/schunk_wsg/schunk_wsg_plain_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_plain_controller.cc
@@ -1,5 +1,6 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_plain_controller.h"
 
+#include <utility>
 #include <vector>
 
 #include "drake/systems/controllers/pid_controller.h"

--- a/manipulation/schunk_wsg/test/build_schunk_wsg_control_test.cc
+++ b/manipulation/schunk_wsg/test/build_schunk_wsg_control_test.cc
@@ -1,6 +1,7 @@
 #include "drake/manipulation/schunk_wsg/build_schunk_wsg_control.h"
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include <gtest/gtest.h>

--- a/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
@@ -1,6 +1,7 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_controller.h"
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/manipulation/schunk_wsg/test/schunk_wsg_driver_functions_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_driver_functions_test.cc
@@ -1,5 +1,8 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_driver_functions.h"
 
+#include <map>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/lcm/drake_lcm_params.h"

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -1,6 +1,7 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_position_controller.h"
 
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/manipulation/schunk_wsg/test/schunk_wsg_trajectory_generator_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_trajectory_generator_test.cc
@@ -1,6 +1,7 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h"
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/manipulation/util/test/make_arm_controller_model_test.cc
+++ b/manipulation/util/test/make_arm_controller_model_test.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <numeric>
+#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/manipulation/util/test/moving_average_filter_test.cc
+++ b/manipulation/util/test/moving_average_filter_test.cc
@@ -1,6 +1,7 @@
 #include "drake/manipulation/util/moving_average_filter.h"
 
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/manipulation/util/test/named_positions_functions_test.cc
+++ b/manipulation/util/test/named_positions_functions_test.cc
@@ -1,5 +1,7 @@
 #include "drake/manipulation/util/named_positions_functions.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/manipulation/util/test/robot_plan_interpolator_test.cc
+++ b/manipulation/util/test/robot_plan_interpolator_test.cc
@@ -1,5 +1,9 @@
 #include "drake/manipulation/util/robot_plan_interpolator.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/lcmt_robot_plan.hpp"

--- a/manipulation/util/test/robot_plan_utils_test.cc
+++ b/manipulation/util/test/robot_plan_utils_test.cc
@@ -1,5 +1,6 @@
 #include "drake/manipulation/util/robot_plan_utils.h"
 
+#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/math/test/bspline_basis_test.cc
+++ b/math/test/bspline_basis_test.cc
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/math/test/convert_time_derivative_test.cc
+++ b/math/test/convert_time_derivative_test.cc
@@ -1,5 +1,7 @@
 #include "drake/math/convert_time_derivative.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/math/test/differentiable_norm_test.cc
+++ b/math/test/differentiable_norm_test.cc
@@ -1,5 +1,7 @@
 #include "drake/math/differentiable_norm.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/math/test/eigen_sparse_triplet_test.cc
+++ b/math/test/eigen_sparse_triplet_test.cc
@@ -1,5 +1,7 @@
 #include "drake/math/eigen_sparse_triplet.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/math/test/evenly_distributed_pts_on_sphere_test.cc
+++ b/math/test/evenly_distributed_pts_on_sphere_test.cc
@@ -1,5 +1,7 @@
 #include "drake/math/evenly_distributed_pts_on_sphere.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/math/test/fast_pose_composition_functions_test.cc
+++ b/math/test/fast_pose_composition_functions_test.cc
@@ -1,5 +1,6 @@
 #include "drake/math/fast_pose_composition_functions.h"
 
+#include <string>
 #include <tuple>
 
 #pragma GCC diagnostic push

--- a/math/test/matrix_util_test.cc
+++ b/math/test/matrix_util_test.cc
@@ -1,5 +1,9 @@
 #include "drake/math/matrix_util.h"
 
+#include <limits>
+#include <set>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic/expression.h"

--- a/math/test/quaternion_test.cc
+++ b/math/test/quaternion_test.cc
@@ -3,6 +3,7 @@
 #include "drake/math/quaternion.h"
 
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 

--- a/math/test/random_rotation_test.cc
+++ b/math/test/random_rotation_test.cc
@@ -1,5 +1,7 @@
 #include "drake/math/random_rotation.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic/expression.h"

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -1,5 +1,9 @@
 #include "drake/math/rigid_transform.h"
 
+#include <cstdio>
+#include <limits>
+#include <string>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -1,6 +1,8 @@
 #include "drake/math/roll_pitch_yaw.h"
 
 #include <cmath>
+#include <limits>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/math/test/rotation_conversion_test.cc
+++ b/math/test/rotation_conversion_test.cc
@@ -2,6 +2,8 @@
 /// Tests that rotation conversion functions are inverses.
 
 #include <cmath>
+#include <limits>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -1,5 +1,8 @@
 #include "drake/math/rotation_matrix.h"
 
+#include <limits>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/extract_double.h"

--- a/math/test/soft_min_max_test.cc
+++ b/math/test/soft_min_max_test.cc
@@ -1,5 +1,7 @@
 #include "drake/math/soft_min_max.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/math/test/unit_vector_test.cc
+++ b/math/test/unit_vector_test.cc
@@ -1,5 +1,8 @@
 #include "drake/math/unit_vector.h"
 
+#include <limits>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic/expression.h"


### PR DESCRIPTION
This commit covers:
- geometry
- lcm
- lcmtypes
- manipulation
- math

Towards #22689.

The standard library IWYU linter on cc files has been accidentally disabled for a while.  This is the lint that accumulated in the meantime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23345)
<!-- Reviewable:end -->
