### PR TITLE
[cpplint] Fix iwyu lint (3/5)

### DIFF
--- a/multibody/benchmarking/acrobot.cc
+++ b/multibody/benchmarking/acrobot.cc
@@ -3,6 +3,9 @@
 //
 // This program is a successor to Hongkai Dai's original benchmark; see #8482.
 
+#include <memory>
+#include <utility>
+
 #include <benchmark/benchmark.h>
 
 #include "drake/common/eigen_types.h"

--- a/multibody/benchmarking/cassie.cc
+++ b/multibody/benchmarking/cassie.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <benchmark/benchmark.h>
 
 #include "drake/common/drake_assert.h"

--- a/multibody/benchmarking/iiwa_relaxed_pos_ik.cc
+++ b/multibody/benchmarking/iiwa_relaxed_pos_ik.cc
@@ -4,6 +4,10 @@
 // This benchmark is intended to analyze the performance of nonlinear
 // optimization with position constraints.
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
 #include "drake/multibody/inverse_kinematics/position_constraint.h"
 #include "drake/multibody/parsing/parser.h"

--- a/multibody/benchmarking/position_constraint.cc
+++ b/multibody/benchmarking/position_constraint.cc
@@ -6,6 +6,9 @@
 
 #include "drake/multibody/inverse_kinematics/position_constraint.h"
 
+#include <memory>
+#include <string>
+
 #include <benchmark/benchmark.h>
 
 #include "drake/multibody/parsing/parser.h"

--- a/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
+++ b/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
@@ -4,7 +4,10 @@
 //          Euler parameters for an axis-symmetric rigid body B, when the moment
 //          of forces on B about Bcm (B's center of mass) is zero (torque-free).
 //-----------------------------------------------------------------------------
+#include <algorithm>
 #include <cmath>
+#include <limits>
+#include <memory>
 #include <tuple>
 
 #include <gtest/gtest.h>

--- a/multibody/benchmarks/kuka_iiwa_robot/test/kuka_iiwa_robot_inverse_dynamics_test.cc
+++ b/multibody/benchmarks/kuka_iiwa_robot/test/kuka_iiwa_robot_inverse_dynamics_test.cc
@@ -1,3 +1,6 @@
+#include <limits>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/multibody/benchmarks/kuka_iiwa_robot/MG/MG_kuka_iiwa_robot.h"

--- a/multibody/benchmarks/kuka_iiwa_robot/test/kuka_iiwa_robot_kinematics_test.cc
+++ b/multibody/benchmarks/kuka_iiwa_robot/test/kuka_iiwa_robot_kinematics_test.cc
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/multibody/benchmarks/kuka_iiwa_robot/MG/MG_kuka_iiwa_robot.h"

--- a/multibody/benchmarks/mass_damper_spring/test/mass_damper_spring_analytical_solution_test.cc
+++ b/multibody/benchmarks/mass_damper_spring/test/mass_damper_spring_analytical_solution_test.cc
@@ -1,6 +1,8 @@
 #include "drake/multibody/benchmarks/mass_damper_spring/mass_damper_spring_analytical_solution.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/minimum_degree_ordering.cc
+++ b/multibody/contact_solvers/minimum_degree_ordering.cc
@@ -4,6 +4,7 @@
 #include <functional>
 #include <queue>
 #include <set>
+#include <tuple>
 #include <utility>
 
 #include "drake/multibody/contact_solvers/sap/partial_permutation.h"

--- a/multibody/contact_solvers/sap/test/contact_problem_graph_test.cc
+++ b/multibody/contact_solvers/sap/test/contact_problem_graph_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/contact_problem_graph.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/multibody/contact_solvers/sap/test/dense_supernodal_solver_test.cc
+++ b/multibody/contact_solvers/sap/test/dense_supernodal_solver_test.cc
@@ -1,6 +1,9 @@
 #include "drake/multibody/contact_solvers/sap/dense_supernodal_solver.h"
 
+#include <limits>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/partial_permutation_test.cc
+++ b/multibody/contact_solvers/sap/test/partial_permutation_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/contact_solvers/sap/partial_permutation.h"
 
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/multibody/contact_solvers/sap/test/sap_ball_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_ball_constraint_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_ball_constraint.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_bundle_test.cc
@@ -1,6 +1,9 @@
 #include "drake/multibody/contact_solvers/sap/sap_constraint_bundle.h"
 
+#include <limits>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_constraint_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_constraint.h"
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_contact_problem_test.cc
@@ -1,6 +1,10 @@
 #include "drake/multibody/contact_solvers/sap/sap_contact_problem.h"
 
+#include <limits>
+#include <memory>
 #include <set>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_coupler_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_coupler_constraint_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_coupler_constraint.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/multibody/contact_solvers/sap/test/sap_distance_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_distance_constraint_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_distance_constraint.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/multibody/contact_solvers/sap/test/sap_fixed_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_fixed_constraint_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/contact_solvers/sap/sap_fixed_constraint.h"
 
+#include <limits>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_friction_cone_constraint_test.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/contact_solvers/sap/sap_friction_cone_constraint.h"
 
+#include <limits>
+#include <memory>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/multibody/contact_solvers/sap/test/sap_holonomic_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_holonomic_constraint_test.cc
@@ -1,6 +1,8 @@
 #include "drake/multibody/contact_solvers/sap/sap_holonomic_constraint.h"
 
+#include <limits>
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_hunt_crossley_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_hunt_crossley_constraint_test.cc
@@ -1,6 +1,12 @@
 #include "drake/multibody/contact_solvers/sap/sap_hunt_crossley_constraint.h"
 
+#include <algorithm>
 #include <array>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_limit_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_limit_constraint_test.cc
@@ -1,5 +1,10 @@
 #include "drake/multibody/contact_solvers/sap/sap_limit_constraint.h"
 
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/multibody/contact_solvers/sap/test/sap_model_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_model_test.cc
@@ -1,6 +1,10 @@
 #include "drake/multibody/contact_solvers/sap/sap_model.h"
 
+#include <limits>
+#include <memory>
 #include <numeric>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_autodiff_test.cc
@@ -1,5 +1,9 @@
 #include <chrono>
+#include <limits>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_solver_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_solver_test.cc
@@ -1,6 +1,9 @@
 #include "drake/multibody/contact_solvers/sap/sap_solver.h"
 
+#include <limits>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_tendon_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_tendon_constraint_test.cc
@@ -1,6 +1,10 @@
 #include "drake/multibody/contact_solvers/sap/sap_tendon_constraint.h"
 
 #include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/sap/test/sap_weld_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_weld_constraint_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/sap/sap_weld_constraint.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/multibody/contact_solvers/test/block_3x3_sparse_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_3x3_sparse_matrix_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/block_3x3_sparse_matrix.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/contact_solvers/test/block_sparse_cholesky_solver_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_cholesky_solver_test.cc
@@ -2,7 +2,9 @@
 
 #include <memory>
 #include <numeric>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/test/block_sparse_lower_triangular_or_symmetric_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_lower_triangular_or_symmetric_matrix_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/contact_solvers/test/block_sparse_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_matrix_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/block_sparse_matrix.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/contact_solvers/test/eigen_block_3x3_sparse_symmetric_matrix_test.cc
+++ b/multibody/contact_solvers/test/eigen_block_3x3_sparse_symmetric_matrix_test.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/contact_solvers/eigen_block_3x3_sparse_symmetric_matrix.h"
 
+#include <limits>
+#include <utility>
+#include <vector>
+
 #include <Eigen/IterativeLinearSolvers>
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/test/linear_operator_test.cc
+++ b/multibody/contact_solvers/test/linear_operator_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/linear_operator.h"
 
+#include <string>
+
 #include <Eigen/SparseCore>
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/test/matrix_block_test.cc
+++ b/multibody/contact_solvers/test/matrix_block_test.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/contact_solvers/matrix_block.h"
 
+#include <limits>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/contact_solvers/test/minimum_degree_ordering_test.cc
+++ b/multibody/contact_solvers/test/minimum_degree_ordering_test.cc
@@ -1,7 +1,9 @@
 #include "drake/multibody/contact_solvers/minimum_degree_ordering.h"
 
 #include <memory>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/test/newton_with_bisection_test.cc
+++ b/multibody/contact_solvers/test/newton_with_bisection_test.cc
@@ -1,6 +1,11 @@
 #include "drake/multibody/contact_solvers/newton_with_bisection.h"
 
+#include <iostream>
+#include <limits>
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/contact_solvers/test/pgs_solver_test.cc
+++ b/multibody/contact_solvers/test/pgs_solver_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/contact_solvers/pgs_solver.h"
 
 #include <memory>
+#include <vector>
 
 #include <Eigen/SparseCore>
 #include <gtest/gtest.h>

--- a/multibody/contact_solvers/test/schur_complement_test.cc
+++ b/multibody/contact_solvers/test/schur_complement_test.cc
@@ -1,5 +1,10 @@
 #include "drake/multibody/contact_solvers/schur_complement.h"
 
+#include <limits>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/contact_solvers/test/sparse_linear_operator_test.cc
+++ b/multibody/contact_solvers/test/sparse_linear_operator_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/contact_solvers/sparse_linear_operator.h"
 
 #include <memory>
+#include <vector>
 
 #include <Eigen/SparseCore>
 #include <gtest/gtest.h>

--- a/multibody/contact_solvers/test/supernodal_solver_test.cc
+++ b/multibody/contact_solvers/test/supernodal_solver_test.cc
@@ -1,4 +1,7 @@
+#include <algorithm>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/fem/test/acceleration_newmark_scheme_test.cc
+++ b/multibody/fem/test/acceleration_newmark_scheme_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/fem/acceleration_newmark_scheme.h"
 
+#include <limits>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/dirichlet_boundary_condition_test.cc
+++ b/multibody/fem/test/dirichlet_boundary_condition_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/fem/dirichlet_boundary_condition.h"
 
+#include <memory>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/discrete_time_integrator_test.cc
+++ b/multibody/fem/test/discrete_time_integrator_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/fem/discrete_time_integrator.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/multibody/fem/test/fem_element_test.cc
+++ b/multibody/fem/test/fem_element_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/fem/fem_element.h"
 
+#include <memory>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/multibody/fem/test/dummy_element.h"

--- a/multibody/fem/test/fem_model_test.cc
+++ b/multibody/fem/test/fem_model_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/fem/fem_model.h"
 
+#include <limits>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/fem_solver_test.cc
+++ b/multibody/fem/test/fem_solver_test.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/fem/fem_solver.h"
 
+#include <limits>
+#include <memory>
+#include <unordered_set>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/fem_state_test.cc
+++ b/multibody/fem/test/fem_state_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/fem/fem_state.h"
 
+#include <memory>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/multibody/fem/test/force_density_field_base_test.cc
+++ b/multibody/fem/test/force_density_field_base_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/fem/force_density_field_base.h"
 
+#include <memory>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/multibody/plant/multibody_plant.h"

--- a/multibody/fem/test/linear_constitutive_model_data_test.cc
+++ b/multibody/fem/test/linear_constitutive_model_data_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/fem/linear_constitutive_model_data.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/linear_simplex_element_test.cc
+++ b/multibody/fem/test/linear_simplex_element_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/fem/linear_simplex_element.h"
 
+#include <limits>
 #include <memory>
 
 #include <gtest/gtest.h>

--- a/multibody/fem/test/matrix_utilities_test.cc
+++ b/multibody/fem/test/matrix_utilities_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/fem/matrix_utilities.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/multibody/fem/test/neohookean_model_data_test.cc
+++ b/multibody/fem/test/neohookean_model_data_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/fem/neohookean_model_data.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/schur_complement_test.cc
+++ b/multibody/fem/test/schur_complement_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/fem/schur_complement.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/velocity_newmark_scheme_test.cc
+++ b/multibody/fem/test/velocity_newmark_scheme_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/fem/velocity_newmark_scheme.h"
 
+#include <limits>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/volumetric_element_test.cc
+++ b/multibody/fem/test/volumetric_element_test.cc
@@ -1,5 +1,10 @@
 #include "drake/multibody/fem/volumetric_element.h"
 
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/fem/test/volumetric_model_test.cc
+++ b/multibody/fem/test/volumetric_model_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/fem/volumetric_model.h"
 
+#include <limits>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/hydroelastics/test/hydroelastic_engine_test.cc
+++ b/multibody/hydroelastics/test/hydroelastic_engine_test.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/inverse_kinematics/add_multibody_plant_constraints.h"
 
+#include <utility>
+
 #include "drake/multibody/inverse_kinematics/orientation_constraint.h"
 #include "drake/multibody/inverse_kinematics/point_to_point_distance_constraint.h"
 #include "drake/multibody/inverse_kinematics/position_constraint.h"

--- a/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
+++ b/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/inverse_kinematics/add_multibody_plant_constraints.h"
 
+#include <limits>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/inverse_kinematics/test/angle_between_vectors_cost_test.cc
+++ b/multibody/inverse_kinematics/test/angle_between_vectors_cost_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/inverse_kinematics/angle_between_vectors_cost.h"
 
 #include <limits>
+#include <memory>
 
 #include <gtest/gtest.h>
 

--- a/multibody/inverse_kinematics/test/com_in_polyhedron_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/com_in_polyhedron_constraint_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/inverse_kinematics/com_in_polyhedron_constraint.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/multibody/inverse_kinematics/test/com_position_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/com_position_constraint_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/inverse_kinematics/com_position_constraint.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h"

--- a/multibody/inverse_kinematics/test/constraint_relaxing_ik_test.cc
+++ b/multibody/inverse_kinematics/test/constraint_relaxing_ik_test.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/inverse_kinematics/constraint_relaxing_ik.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/random.h"

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_controller_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_controller_test.cc
@@ -1,6 +1,10 @@
 #include "drake/multibody/inverse_kinematics/differential_inverse_kinematics_controller.h"
 
+#include <map>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_integrator_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_integrator_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/inverse_kinematics/differential_inverse_kinematics_integrator.h"  // noqa
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_system_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_system_test.cc
@@ -3,6 +3,8 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/inverse_kinematics/differential_inverse_kinematics.h"
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <random>

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_collision_avoidance_test.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_collision_avoidance_test.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.h"
 #include "drake/solvers/gurobi_solver.h"

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_feasible_posture_test.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_feasible_posture_test.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "drake/multibody/inverse_kinematics/test/global_inverse_kinematics_test_util.h"
 #include "drake/solvers/gurobi_solver.h"
 

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
 
+#include <memory>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -1,4 +1,7 @@
 #include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/compute_numerical_gradient.h"

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/inverse_kinematics/orientation_constraint.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/math/rotation_matrix.h"

--- a/multibody/inverse_kinematics/test/orientation_cost_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_cost_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/inverse_kinematics/orientation_cost.h"
 
 #include <limits>
+#include <memory>
 
 #include <gtest/gtest.h>
 

--- a/multibody/inverse_kinematics/test/position_cost_test.cc
+++ b/multibody/inverse_kinematics/test/position_cost_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/inverse_kinematics/position_cost.h"
 
 #include <limits>
+#include <memory>
 
 #include <gtest/gtest.h>
 

--- a/multibody/math/test/spatial_algebra_test.cc
+++ b/multibody/math/test/spatial_algebra_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/math/spatial_algebra.h"
 
+#include <algorithm>
+#include <limits>
 #include <sstream>
 #include <string>
 

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/meshcat/joint_sliders.h"
 
+#include <algorithm>
 #include <chrono>
 #include <thread>
 #include <unordered_set>

--- a/multibody/meshcat/test/contact_visualizer_test.cc
+++ b/multibody/meshcat/test/contact_visualizer_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/meshcat/contact_visualizer.h"
 
+#include <memory>
+#include <string>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
+++ b/multibody/meshcat/test/hydroelastic_contact_visualizer_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/meshcat/hydroelastic_contact_visualizer.h"
 
+#include <memory>
+#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/multibody/meshcat/test/joint_sliders_test.cc
+++ b/multibody/meshcat/test/joint_sliders_test.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/meshcat/joint_sliders.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/mpm/mpm_model.cc
+++ b/multibody/mpm/mpm_model.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/mpm/mpm_model.h"
 
+#include <utility>
+
 #include "drake/multibody/mpm/mock_sparse_grid.h"
 #include "drake/multibody/mpm/solver_state.h"
 

--- a/multibody/mpm/test/bspline_weights_test.cc
+++ b/multibody/mpm/test/bspline_weights_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/mpm/bspline_weights.h"
 
+#include <limits>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/multibody/mpm/test/mpm_model_test.cc
+++ b/multibody/mpm/test/mpm_model_test.cc
@@ -1,5 +1,10 @@
 #include "drake/multibody/mpm/mpm_model.h"
 
+#include <limits>
+#include <set>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/mpm/test/particle_data_test.cc
+++ b/multibody/mpm/test/particle_data_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/mpm/particle_data.h"
 
+#include <limits>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/multibody/mpm/test/particle_sorter_test.cc
+++ b/multibody/mpm/test/particle_sorter_test.cc
@@ -1,6 +1,9 @@
 #include "drake/multibody/mpm/particle_sorter.h"
 
+#include <algorithm>
 #include <numeric>
+#include <set>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/mpm/test/sparse_grid_test.cc
+++ b/multibody/mpm/test/sparse_grid_test.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/mpm/sparse_grid.h"
 
+#include <limits>
+#include <set>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/multibody/mpm/test/spgrid_test.cc
+++ b/multibody/mpm/test/spgrid_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/mpm/spgrid.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/limit_malloc.h"

--- a/multibody/mpm/test/transfer_test.cc
+++ b/multibody/mpm/test/transfer_test.cc
@@ -1,5 +1,10 @@
 #include "drake/multibody/mpm/transfer.h"
 
+#include <algorithm>
+#include <limits>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/optimization/test/centroidal_momentum_constraint_test.cc
+++ b/multibody/optimization/test/centroidal_momentum_constraint_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/optimization/centroidal_momentum_constraint.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/optimization/test/contact_wrench_evaluator_test.cc
+++ b/multibody/optimization/test/contact_wrench_evaluator_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/optimization/contact_wrench_evaluator.h"
 
+#include <memory>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/optimization/test/manipulator_equation_constraint_test.cc
+++ b/multibody/optimization/test/manipulator_equation_constraint_test.cc
@@ -1,5 +1,11 @@
 #include "drake/multibody/optimization/manipulator_equation_constraint.h"
 
+#include <limits>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/optimization/test/quaternion_integration_constraint_test.cc
+++ b/multibody/optimization/test/quaternion_integration_constraint_test.cc
@@ -1,6 +1,8 @@
 #include "drake/multibody/optimization/quaternion_integration_constraint.h"
 
 #include <limits>
+#include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/optimization/test/static_equilibrium_constraint_test.cc
+++ b/multibody/optimization/test/static_equilibrium_constraint_test.cc
@@ -1,5 +1,11 @@
 #include "drake/multibody/optimization/static_equilibrium_constraint.h"
 
+#include <limits>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/optimization/test/static_equilibrium_problem_test.cc
+++ b/multibody/optimization/test/static_equilibrium_problem_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/optimization/static_equilibrium_problem.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -1,6 +1,9 @@
 #include "drake/multibody/optimization/toppra.h"
 
+#include <memory>
+#include <tuple>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/parsing/detail_common.h"
 
 #include <filesystem>
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 

--- a/multibody/parsing/scoped_names.cc
+++ b/multibody/parsing/scoped_names.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/parsing/scoped_names.h"
 
+#include <string>
+
 #include "drake/common/default_scalars.h"
 #include "drake/multibody/tree/scoped_name.h"
 

--- a/multibody/parsing/test/collision_filter_groups_test.cc
+++ b/multibody/parsing/test/collision_filter_groups_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/parsing/collision_filter_groups.h"
 
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/multibody/parsing/detail_collision_filter_groups_impl.h"

--- a/multibody/parsing/test/common_parser_test.cc
+++ b/multibody/parsing/test/common_parser_test.cc
@@ -6,6 +6,7 @@
 /// model in the appropriate format (URDF/SDF).
 
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
+++ b/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
@@ -1,5 +1,11 @@
 #include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
 
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/parsing/detail_common.h"
 
+#include <string>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/detail_make_model_name_test.cc
+++ b/multibody/parsing/test/detail_make_model_name_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/parsing/detail_make_model_name.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/multibody/parsing/test/detail_mesh_parser_test.cc
+++ b/multibody/parsing/test/detail_mesh_parser_test.cc
@@ -2,6 +2,8 @@
 
 #include <filesystem>
 #include <optional>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
@@ -1,3 +1,6 @@
+#include <string>
+#include <utility>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -1,6 +1,10 @@
 #include "drake/multibody/parsing/detail_mujoco_parser.h"
 
 #include <filesystem>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/multibody/parsing/test/detail_sdf_diagnostic_test.cc
+++ b/multibody/parsing/test/detail_sdf_diagnostic_test.cc
@@ -1,5 +1,8 @@
 #include "drake/multibody/parsing/detail_sdf_diagnostic.h"
 
+#include <string>
+#include <utility>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sdf/Root.hh>

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -5,6 +5,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1,10 +1,15 @@
 #include "drake/multibody/parsing/detail_sdf_parser.h"
 
 #include <filesystem>
+#include <limits>
+#include <map>
 #include <memory>
 #include <regex>
+#include <set>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/multibody/parsing/test/detail_select_parser_test.cc
+++ b/multibody/parsing/test/detail_select_parser_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/parsing/detail_select_parser.h"
 
+#include <string>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/detail_strongly_connected_components_test.cc
+++ b/multibody/parsing/test/detail_strongly_connected_components_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/parsing/detail_strongly_connected_components.h"
 
+#include <unordered_set>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/detail_tinyxml2_diagnostic_test.cc
+++ b/multibody/parsing/test/detail_tinyxml2_diagnostic_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/parsing/detail_tinyxml2_diagnostic.h"
 
+#include <string>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/detail_tinyxml_test.cc
+++ b/multibody/parsing/test/detail_tinyxml_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/parsing/detail_tinyxml.h"
 
 #include <locale>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -1,6 +1,9 @@
 #include "drake/multibody/parsing/detail_urdf_geometry.h"
 
 #include <memory>
+#include <string>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -1,9 +1,13 @@
 #include "drake/multibody/parsing/detail_urdf_parser.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <map>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gmock/gmock.h>

--- a/multibody/parsing/test/package_map_remote_test.cc
+++ b/multibody/parsing/test/package_map_remote_test.cc
@@ -1,4 +1,6 @@
 #include <fstream>
+#include <string>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <map>
+#include <string>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/parser_manual_test.cc
+++ b/multibody/parsing/test/parser_manual_test.cc
@@ -1,4 +1,5 @@
 #include <regex>
+#include <vector>
 
 #include <gflags/gflags.h>
 

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -1,6 +1,8 @@
 #include "drake/multibody/parsing/parser.h"
 
 #include <filesystem>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -2,7 +2,10 @@
 
 #include <filesystem>
 #include <memory>
+#include <set>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This commit covers:
- multibody (in part)

Towards #22689.

The standard library IWYU linter on cc files has been accidentally disabled for a while.  This is the lint that accumulated in the meantime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23346)
<!-- Reviewable:end -->
