### PR TITLE
[cpplint] Fix iwyu lint (5/5)

### DIFF
--- a/solvers/benchmarking/benchmark_mathematical_program.cc
+++ b/solvers/benchmarking/benchmark_mathematical_program.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "drake/common/symbolic/monomial_util.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/tools/performance/fixture_common.h"

--- a/solvers/clarabel_solver_common.cc
+++ b/solvers/clarabel_solver_common.cc
@@ -2,6 +2,8 @@
 #include "drake/solvers/clarabel_solver.h"
 /* clang-format on */
 
+#include <string>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"

--- a/solvers/clp_solver_common.cc
+++ b/solvers/clp_solver_common.cc
@@ -2,6 +2,8 @@
 #include "drake/solvers/clp_solver.h"
 /* clang-format on */
 
+#include <string>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"

--- a/solvers/gurobi_solver_common.cc
+++ b/solvers/gurobi_solver_common.cc
@@ -4,6 +4,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/aggregate_costs_constraints.h"

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -5,6 +5,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/solvers/mosek_solver_common.cc
+++ b/solvers/mosek_solver_common.cc
@@ -4,6 +4,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/aggregate_costs_constraints.h"

--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cstdio>
 #include <limits>
 
 #include "drake/common/fmt_ostream.h"

--- a/solvers/nlopt_solver_common.cc
+++ b/solvers/nlopt_solver_common.cc
@@ -2,6 +2,8 @@
 #include "drake/solvers/nlopt_solver.h"
 /* clang-format on */
 
+#include <string>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/mathematical_program.h"
 

--- a/solvers/no_gurobi.cc
+++ b/solvers/no_gurobi.cc
@@ -2,6 +2,7 @@
 #include "drake/solvers/gurobi_solver.h"
 /* clang-format on */
 
+#include <memory>
 #include <stdexcept>
 
 namespace drake {

--- a/solvers/no_mosek.cc
+++ b/solvers/no_mosek.cc
@@ -2,6 +2,7 @@
 #include "drake/solvers/mosek_solver.h"
 /* clang-format on */
 
+#include <memory>
 #include <stdexcept>
 
 using std::runtime_error;

--- a/solvers/osqp_solver_common.cc
+++ b/solvers/osqp_solver_common.cc
@@ -2,6 +2,8 @@
 #include "drake/solvers/osqp_solver.h"
 /* clang-format on */
 
+#include <string>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"

--- a/solvers/projected_gradient_descent_solver.cc
+++ b/solvers/projected_gradient_descent_solver.cc
@@ -1,5 +1,8 @@
 #include "drake/solvers/projected_gradient_descent_solver.h"
 
+#include <memory>
+#include <vector>
+
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/solvers/choose_best_solver.h"

--- a/solvers/scs_solver_common.cc
+++ b/solvers/scs_solver_common.cc
@@ -2,6 +2,8 @@
 #include "drake/solvers/scs_solver.h"
 /* clang-format on */
 
+#include <string>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"

--- a/solvers/snopt_solver_common.cc
+++ b/solvers/snopt_solver_common.cc
@@ -2,6 +2,8 @@
 #include "drake/solvers/snopt_solver.h"
 /* clang-format on */
 
+#include <string>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/mathematical_program.h"
 

--- a/solvers/specific_options.cc
+++ b/solvers/specific_options.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include <fmt/ranges.h>

--- a/solvers/test/aggregate_costs_constraints_test.cc
+++ b/solvers/test/aggregate_costs_constraints_test.cc
@@ -1,6 +1,10 @@
 #include "drake/solvers/aggregate_costs_constraints.h"
 
 #include <limits>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 #include <fmt/format.h>
 #include <gmock/gmock.h>

--- a/solvers/test/augmented_lagrangian_test.cc
+++ b/solvers/test/augmented_lagrangian_test.cc
@@ -1,6 +1,8 @@
 #include "drake/solvers/augmented_lagrangian.h"
 
 #include <limits>
+#include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/binding_test.cc
+++ b/solvers/test/binding_test.cc
@@ -1,5 +1,9 @@
 #include "drake/solvers/binding.h"
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/branch_and_bound_test.cc
+++ b/solvers/test/branch_and_bound_test.cc
@@ -1,6 +1,11 @@
 #include "drake/solvers/branch_and_bound.h"
 
 #include <algorithm>
+#include <limits>
+#include <list>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/choose_best_solver_test.cc
+++ b/solvers/test/choose_best_solver_test.cc
@@ -1,5 +1,10 @@
 #include "drake/solvers/choose_best_solver.h"
 
+#include <memory>
+#include <set>
+#include <unordered_set>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/solvers/test/clarabel_solver_test.cc
+++ b/solvers/test/clarabel_solver_test.cc
@@ -1,6 +1,7 @@
 #include "drake/solvers/clarabel_solver.h"
 
 #include <fstream>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -1,6 +1,7 @@
 #include "drake/solvers/constraint.h"
 
 #include <limits>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/solvers/test/cost_test.cc
+++ b/solvers/test/cost_test.cc
@@ -4,6 +4,8 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/create_constraint_test.cc
+++ b/solvers/test/create_constraint_test.cc
@@ -1,6 +1,8 @@
 #include "drake/solvers/create_constraint.h"
 
 #include <limits>
+#include <memory>
+#include <set>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/csdp_solver_internal_test.cc
+++ b/solvers/test/csdp_solver_internal_test.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/csdp_solver_test.cc
+++ b/solvers/test/csdp_solver_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/csdp_solver.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/disabled_solvers_test.cc
+++ b/solvers/test/disabled_solvers_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/solvers/test/evaluator_base_test.cc
+++ b/solvers/test/evaluator_base_test.cc
@@ -4,6 +4,7 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/get_program_type_test.cc
+++ b/solvers/test/get_program_type_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/get_program_type.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/solvers/test/gurobi_solver_internal_test.cc
+++ b/solvers/test/gurobi_solver_internal_test.cc
@@ -1,6 +1,7 @@
 #include "drake/solvers/gurobi_solver_internal.h"
 
 #include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/gurobi_solver_license_retention_test_helper.cc
+++ b/solvers/test/gurobi_solver_license_retention_test_helper.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "drake/solvers/gurobi_solver.h"
 
 using drake::solvers::GurobiSolver;

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -3,7 +3,9 @@
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include <gflags/gflags.h>
 #include <gmock/gmock.h>

--- a/solvers/test/integer_inequality_solver_test.cc
+++ b/solvers/test/integer_inequality_solver_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/integer_inequality_solver.h"
 
+#include <set>
+
 #include <gtest/gtest.h>
 namespace drake {
 namespace solvers {

--- a/solvers/test/ipopt_solver_internal_test.cc
+++ b/solvers/test/ipopt_solver_internal_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/ipopt_solver_internal.h"
 
+#include <vector>
+
 #include <IpIpoptApplication.hpp>
 #include <IpTNLP.hpp>
 #include <gtest/gtest.h>

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -1,6 +1,7 @@
 #include "drake/solvers/ipopt_solver.h"
 
 #include <filesystem>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/mathematical_program_result_test.cc
+++ b/solvers/test/mathematical_program_result_test.cc
@@ -1,6 +1,10 @@
 #include "drake/solvers/mathematical_program_result.h"
 
 #include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/solvers/test/mixed_integer_optimization_test.cc
+++ b/solvers/test/mixed_integer_optimization_test.cc
@@ -1,3 +1,6 @@
+#include <limits>
+#include <list>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/mixed_integer_optimization_util_test.cc
+++ b/solvers/test/mixed_integer_optimization_util_test.cc
@@ -1,5 +1,8 @@
 #include "drake/solvers/mixed_integer_optimization_util.h"
 
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/mixed_integer_rotation_constraint_corner_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_corner_test.cc
@@ -2,6 +2,9 @@
 #include "drake/solvers/mixed_integer_rotation_constraint.h"
 /* clang-format on */
 
+#include <tuple>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_assert.h"

--- a/solvers/test/mixed_integer_rotation_constraint_internal_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_internal_test.cc
@@ -2,6 +2,10 @@
 #include "drake/solvers/mixed_integer_rotation_constraint_internal.h"
 /* clang-format on */
 
+#include <algorithm>
+#include <limits>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/mixed_integer_rotation_constraint_limit_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_limit_test.cc
@@ -2,6 +2,9 @@
 #include "drake/solvers/mixed_integer_rotation_constraint.h"
 /* clang-format on */
 
+#include <tuple>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/mixed_integer_rotation_constraint_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_test.cc
@@ -1,6 +1,10 @@
 #include "drake/solvers/mixed_integer_rotation_constraint.h"
 
+#include <memory>
 #include <random>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/moby_lcp_solver_test.cc
+++ b/solvers/test/moby_lcp_solver_test.cc
@@ -1,5 +1,6 @@
 #include "drake/solvers/moby_lcp_solver.h"
 
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/solvers/test/mosek_solver_internal_test.cc
+++ b/solvers/test/mosek_solver_internal_test.cc
@@ -1,6 +1,9 @@
 #include "drake/solvers/mosek_solver_internal.h"
 
 #include <limits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -1,6 +1,8 @@
 #include "drake/solvers/mosek_solver.h"
 
 #include <filesystem>
+#include <limits>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/non_convex_optimization_util_test.cc
+++ b/solvers/test/non_convex_optimization_util_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/non_convex_optimization_util.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/osqp_solver_test.cc
+++ b/solvers/test/osqp_solver_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/osqp_solver.h"
 
+#include <limits>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/solvers/test/plot_feasible_rotation_matrices.cc
+++ b/solvers/test/plot_feasible_rotation_matrices.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <limits>
+#include <memory>
 
 #include "drake/common/proto/call_python.h"
 #include "drake/solvers/mathematical_program.h"

--- a/solvers/test/projected_gradient_descent_solver_test.cc
+++ b/solvers/test/projected_gradient_descent_solver_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/projected_gradient_descent_solver.h"
 
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/scaled_diagonally_dominant_dual_cone_matrix_test.cc
+++ b/solvers/test/scaled_diagonally_dominant_dual_cone_matrix_test.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/ssize.h"

--- a/solvers/test/scaled_diagonally_dominant_matrix_test.cc
+++ b/solvers/test/scaled_diagonally_dominant_matrix_test.cc
@@ -1,4 +1,5 @@
 #include <limits>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -1,6 +1,8 @@
 #include "drake/solvers/scs_solver.h"
 
 #include <fstream>
+#include <iostream>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/solvers/test/sdpa_free_format_test.cc
+++ b/solvers/test/sdpa_free_format_test.cc
@@ -3,7 +3,9 @@
 #include <filesystem>
 #include <fstream>
 #include <limits>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/semidefinite_relaxation_internal_test.cc
+++ b/solvers/test/semidefinite_relaxation_internal_test.cc
@@ -1,5 +1,12 @@
 #include "drake/solvers/semidefinite_relaxation_internal.h"
 
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/ssize.h"

--- a/solvers/test/semidefinite_relaxation_test.cc
+++ b/solvers/test/semidefinite_relaxation_test.cc
@@ -1,5 +1,9 @@
 #include "drake/solvers/semidefinite_relaxation.h"
 
+#include <limits>
+#include <map>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -3,8 +3,11 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <regex>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/solvers/test/solve_in_parallel_test.cc
+++ b/solvers/test/solve_in_parallel_test.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/solvers/choose_best_solver.h"

--- a/solvers/test/solver_base_test.cc
+++ b/solvers/test/solver_base_test.cc
@@ -1,5 +1,9 @@
 #include "drake/solvers/solver_base.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/solvers/test/solver_id_test.cc
+++ b/solvers/test/solver_id_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/solver_id.h"
 
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/limit_malloc.h"

--- a/solvers/test/solver_options_test.cc
+++ b/solvers/test/solver_options_test.cc
@@ -1,6 +1,8 @@
 #include "drake/solvers/solver_options.h"
 
 #include <limits>
+#include <string>
+#include <unordered_set>
 
 // Remove this include on 2025-09-01 upon completion of deprecation.
 #include <sstream>

--- a/solvers/test/sos_basis_generator_test.cc
+++ b/solvers/test/sos_basis_generator_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/sos_basis_generator.h"
 
+#include <set>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/symbolic/monomial_util.h"

--- a/solvers/test/sparse_and_dense_matrix_test.cc
+++ b/solvers/test/sparse_and_dense_matrix_test.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/solvers/test/unrevised_lemke_solver_test.cc
+++ b/solvers/test/unrevised_lemke_solver_test.cc
@@ -1,6 +1,8 @@
 #include "drake/solvers/unrevised_lemke_solver.h"
 
+#include <limits>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/systems/analysis/discrete_time_approximation.cc
+++ b/systems/analysis/discrete_time_approximation.cc
@@ -2,8 +2,11 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/analysis/antiderivative_function.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/systems/analysis/test/bogacki_shampine3_integrator_test.cc
+++ b/systems/analysis/test/bogacki_shampine3_integrator_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/analysis/bogacki_shampine3_integrator.h"
 
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 

--- a/systems/analysis/test/discrete_time_approximation_test.cc
+++ b/systems/analysis/test/discrete_time_approximation_test.cc
@@ -1,5 +1,11 @@
 #include "drake/systems/analysis/discrete_time_approximation.h"
 
+#include <map>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
 #include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/analysis/explicit_euler_integrator.h"
 
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/analysis/hermitian_dense_output.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/analysis/implicit_euler_integrator.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/systems/analysis/test/implicit_integrator_test.cc
+++ b/systems/analysis/test/implicit_integrator_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/analysis/implicit_integrator.h"
 
+#include <limits>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/pointer_cast.h"

--- a/systems/analysis/test/initial_value_problem_test.cc
+++ b/systems/analysis/test/initial_value_problem_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/analysis/initial_value_problem.h"
 
 #include <algorithm>
+#include <memory>
 
 #include <gtest/gtest.h>
 

--- a/systems/analysis/test/integrator_base_test.cc
+++ b/systems/analysis/test/integrator_base_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/analysis/integrator_base.h"
 
+#include <limits>
+#include <memory>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/analysis/test/monte_carlo_test.cc
+++ b/systems/analysis/test/monte_carlo_test.cc
@@ -1,7 +1,10 @@
 #include "drake/systems/analysis/monte_carlo.h"
 
 #include <cmath>
+#include <memory>
 #include <thread>
+#include <unordered_set>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/analysis/test/radau_integrator_test.cc
+++ b/systems/analysis/test/radau_integrator_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/analysis/radau_integrator.h"
 
+#include <limits>
+#include <memory>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/systems/analysis/test/realtime_rate_calculator_test.cc
+++ b/systems/analysis/test/realtime_rate_calculator_test.cc
@@ -2,7 +2,9 @@
 
 #include <ios>
 #include <limits>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>

--- a/systems/analysis/test/runge_kutta2_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta2_integrator_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
 
 #include <cmath>
+#include <limits>
+#include <memory>
 
 #include <gtest/gtest.h>
 

--- a/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
 
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 

--- a/systems/analysis/test/runge_kutta5_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta5_integrator_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/analysis/runge_kutta5_integrator.h"
 
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 

--- a/systems/analysis/test/scalar_initial_value_problem_test.cc
+++ b/systems/analysis/test/scalar_initial_value_problem_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/analysis/scalar_initial_value_problem.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/analysis/scalar_view_dense_output.h"
 
+#include <memory>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"

--- a/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/analysis/semi_explicit_euler_integrator.h"
 
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 

--- a/systems/analysis/test/simulator_config_functions_test.cc
+++ b/systems/analysis/test/simulator_config_functions_test.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/analysis/simulator_config_functions.h"
 
+#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/systems/analysis/test/simulator_status_test.cc
+++ b/systems/analysis/test/simulator_status_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/analysis/simulator_status.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -3,7 +3,14 @@
 #include <cmath>
 #include <complex>
 #include <functional>
+#include <iostream>
+#include <limits>
 #include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/systems/analysis/test/velocity_implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/velocity_implicit_euler_integrator_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/analysis/velocity_implicit_euler_integrator.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/analysis/test_utilities/implicit_integrator_test.h"

--- a/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
+++ b/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/analysis/test_utilities/controlled_spring_mass_system.h"
 
+#include <memory>
+
 #include "gtest/gtest.h"
 #include <Eigen/Dense>
 

--- a/systems/analysis/test_utilities/test/spring_mass_system_test.cc
+++ b/systems/analysis/test_utilities/test/spring_mass_system_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/analysis/test_utilities/spring_mass_system.h"
 
 #include <memory>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/systems/benchmarking/framework_benchmarks.cc
+++ b/systems/benchmarking/framework_benchmarks.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <vector>
+
 #include <benchmark/benchmark.h>
 
 #include "drake/systems/framework/diagram_builder.h"

--- a/systems/benchmarking/multilayer_perceptron_benchmark.cc
+++ b/systems/benchmarking/multilayer_perceptron_benchmark.cc
@@ -2,6 +2,9 @@
 Measures the performance of the MultilayerPerceptron implementation.
 Refer to the README.md for more information. */
 
+#include <memory>
+#include <vector>
+
 #include <gflags/gflags.h>
 
 #include "drake/systems/primitives/multilayer_perceptron.h"

--- a/systems/controllers/test/dynamic_programming_test.cc
+++ b/systems/controllers/test/dynamic_programming_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/controllers/dynamic_programming.h"
 
 #include <cmath>
+#include <memory>
 
 #include <gtest/gtest.h>
 

--- a/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/controllers/finite_horizon_linear_quadratic_regulator.h"
 
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/controllers/inverse_dynamics_controller.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/controllers/test/inverse_dynamics_test.cc
+++ b/systems/controllers/test/inverse_dynamics_test.cc
@@ -1,8 +1,10 @@
 #include "drake/systems/controllers/inverse_dynamics.h"
 
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/controllers/test/joint_stiffness_controller_test.cc
+++ b/systems/controllers/test/joint_stiffness_controller_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/controllers/joint_stiffness_controller.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/controllers/test/linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/linear_quadratic_regulator_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"

--- a/systems/controllers/test/pid_controlled_system_test.cc
+++ b/systems/controllers/test/pid_controlled_system_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/controllers/pid_controlled_system.h"
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/estimators/test/kalman_filter_test.cc
+++ b/systems/estimators/test/kalman_filter_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/estimators/kalman_filter.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/estimators/test/luenberger_observer_test.cc
+++ b/systems/estimators/test/luenberger_observer_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/estimators/luenberger_observer.h"
 
 #include <cmath>
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/systems/framework/bus_value.cc
+++ b/systems/framework/bus_value.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/framework/bus_value.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "absl/container/flat_hash_map.h"
 
 #include "drake/common/drake_export.h"

--- a/systems/framework/test/abstract_value_cloner_test.cc
+++ b/systems/framework/test/abstract_value_cloner_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/framework/abstract_value_cloner.h"
 
+#include <memory>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/basic_vector.h"

--- a/systems/framework/test/abstract_values_test.cc
+++ b/systems/framework/test/abstract_values_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/framework/abstract_values.h"
 
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -1,7 +1,9 @@
 #include "drake/systems/framework/basic_vector.h"
 
 #include <cmath>
+#include <memory>
 #include <sstream>
+#include <string>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/systems/framework/test/bus_value_test.cc
+++ b/systems/framework/test/bus_value_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/framework/bus_value.h"
 
+#include <algorithm>
+#include <string>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/framework/cache_entry.h"
 
+#include <map>
+#include <set>
+#include <string>
+
 #include "drake/common/test_utilities/expect_no_throw.h"
 
 // Tests the System (const) side of caching, which consists of a CacheEntry

--- a/systems/framework/test/cache_test.cc
+++ b/systems/framework/test/cache_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/framework/cache.h"
 
+#include <string>
+
 #include "drake/common/test_utilities/expect_no_throw.h"
 
 // Tests the Context (runtime) side of caching, which consists of a

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -4,6 +4,9 @@
 #include "drake/systems/framework/continuous_state.h"
 
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/framework/diagram_builder.h"
 
+#include <memory>
 #include <regex>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -1,6 +1,10 @@
 #include "drake/systems/framework/diagram_context.h"
 
+#include <memory>
+#include <set>
 #include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <Eigen/Dense>

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1,5 +1,10 @@
 #include "drake/systems/framework/diagram.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <fmt/ranges.h>
 #include <gmock/gmock.h>

--- a/systems/framework/test/discrete_values_test.cc
+++ b/systems/framework/test/discrete_values_test.cc
@@ -5,6 +5,8 @@
 
 #include <memory>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/framework/input_port.h"
 
+#include <memory>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/framework/leaf_context.h"
 
+#include <map>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/systems/framework/test/leaf_system_deprecation_test.cc
+++ b/systems/framework/test/leaf_system_deprecation_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/leaf_system.h"

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1,10 +1,14 @@
 #include "drake/systems/framework/leaf_system.h"
 
 #include <limits>
+#include <map>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <typeinfo>
+#include <utility>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gmock/gmock.h>

--- a/systems/framework/test/model_values_test.cc
+++ b/systems/framework/test/model_values_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/framework/model_values.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/default_scalars.h"

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/systems/framework/test/parameters_test.cc
+++ b/systems/framework/test/parameters_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/framework/parameters.h"
 
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/test_utilities/pack_value.h"

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/framework/system_base.h"
 
+#include <map>
 #include <memory>
 #include <string>
 

--- a/systems/framework/test/system_constraint_test.cc
+++ b/systems/framework/test/system_constraint_test.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/framework/system_constraint.h"
 
+#include <limits>
 #include <memory>
 #include <stdexcept>
 

--- a/systems/framework/test/system_output_test.cc
+++ b/systems/framework/test/system_output_test.cc
@@ -1,7 +1,9 @@
 #include "drake/systems/framework/system_output.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/framework/test/system_scalar_conversion_doxygen_test.cc
+++ b/systems/framework/test/system_scalar_conversion_doxygen_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/examples/pendulum/pendulum_plant.h"

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/framework/system_scalar_converter.h"
 
+#include <memory>
+#include <string>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/systems/framework/test/system_symbolic_inspector_test.cc
+++ b/systems/framework/test/system_symbolic_inspector_test.cc
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -1,7 +1,12 @@
 #include "drake/systems/framework/system.h"
 
+#include <limits>
+#include <map>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gmock/gmock.h>

--- a/systems/framework/test/system_visitor_test.cc
+++ b/systems/framework/test/system_visitor_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/framework/system_visitor.h"
 
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/framework/test/value_producer_test.cc
+++ b/systems/framework/test/value_producer_test.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/framework/value_producer.h"
 
+#include <memory>
 #include <stdexcept>
 #include <string>
 

--- a/systems/framework/test/value_to_abstract_value_test.cc
+++ b/systems/framework/test/value_to_abstract_value_test.cc
@@ -1,7 +1,9 @@
 #include "drake/systems/framework/value_to_abstract_value.h"
 
 #include <memory>
+#include <string>
 #include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/framework/vector_system.h"
 
+#include <memory>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include <Eigen/Dense>

--- a/systems/framework/test/wrapped_system_test.cc
+++ b/systems/framework/test/wrapped_system_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/framework/wrapped_system.h"
 
+#include <memory>
+#include <utility>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/systems/framework/wrapped_system_builder.cc
+++ b/systems/framework/wrapped_system_builder.cc
@@ -2,6 +2,9 @@
 #include "drake/systems/framework/wrapped_system.h"
 /* clang-format on */
 
+#include <memory>
+#include <utility>
+
 #include "drake/common/default_scalars.h"
 #include "drake/systems/framework/diagram_builder.h"
 

--- a/systems/lcm/test/lcm_buses_test.cc
+++ b/systems/lcm/test/lcm_buses_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/lcm/lcm_buses.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/lcm/drake_lcm.h"

--- a/systems/lcm/test/lcm_config_functions_test.cc
+++ b/systems/lcm/test/lcm_config_functions_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/lcm/lcm_config_functions.h"
 
+#include <map>
+#include <string>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/systems/lcm/test/lcm_interface_system_test.cc
+++ b/systems/lcm/test/lcm_interface_system_test.cc
@@ -1,7 +1,10 @@
 #include "drake/systems/lcm/lcm_interface_system.h"
 
 #include <chrono>
+#include <memory>
+#include <string>
 #include <thread>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -1,3 +1,6 @@
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/lcm/drake_lcm_log.h"

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -2,6 +2,8 @@
 
 #include <cmath>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/systems/lcm/test/lcm_scope_system_test.cc
+++ b/systems/lcm/test/lcm_scope_system_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/lcm/lcm_scope_system.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/lcmt_scope.hpp"

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -2,6 +2,8 @@
 
 #include <array>
 #include <future>
+#include <memory>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/systems/lcm/test/lcm_system_graphviz_test.cc
+++ b/systems/lcm/test/lcm_system_graphviz_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/lcm/lcm_system_graphviz.h"
 
+#include <string>
+#include <vector>
+
 #include "absl/strings/str_split.h"
 #include <fmt/ranges.h>
 #include <gmock/gmock.h>

--- a/systems/lcm/test/serializer_test.cc
+++ b/systems/lcm/test/serializer_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/lcm/serializer.h"
 
 #include <cstdint>
+#include <memory>
+#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/systems/optimization/test/system_constraint_adapter_test.cc
+++ b/systems/optimization/test/system_constraint_adapter_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/optimization/system_constraint_adapter.h"
 
+#include <limits>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/optimization/test/system_constraint_wrapper_test.cc
+++ b/systems/optimization/test/system_constraint_wrapper_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/optimization/system_constraint_wrapper.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/primitives/bus_creator.cc
+++ b/systems/primitives/bus_creator.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/primitives/bus_creator.h"
 
+#include <utility>
+
 #include "drake/common/default_scalars.h"
 
 namespace drake {

--- a/systems/primitives/bus_selector.cc
+++ b/systems/primitives/bus_selector.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/primitives/bus_selector.h"
 
+#include <utility>
+
 #include "drake/common/default_scalars.h"
 
 namespace drake {

--- a/systems/primitives/selector.cc
+++ b/systems/primitives/selector.cc
@@ -1,6 +1,10 @@
 #include "drake/systems/primitives/selector.h"
 
+#include <algorithm>
 #include <deque>
+#include <map>
+#include <set>
+#include <utility>
 
 #include "drake/systems/primitives/selector_internal.h"
 

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/primitives/affine_system.h"
 
+#include <memory>
+#include <string>
+
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/autodiff.h"

--- a/systems/primitives/test/barycentric_system_test.cc
+++ b/systems/primitives/test/barycentric_system_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/barycentric_system.h"
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/bus_creator_test.cc
+++ b/systems/primitives/test/bus_creator_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/primitives/bus_creator.h"
 
+#include <map>
+#include <string>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"

--- a/systems/primitives/test/demultiplexer_test.cc
+++ b/systems/primitives/test/demultiplexer_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/demultiplexer.h"
 
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/primitives/linear_system.h"
 
+#include <memory>
 #include <stdexcept>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/linear_transform_density_test.cc
+++ b/systems/primitives/test/linear_transform_density_test.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/matrix_gain_test.cc
+++ b/systems/primitives/test/matrix_gain_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/primitives/matrix_gain.h"
 
+#include <memory>
+
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/primitives/test/affine_linear_test.h"
 

--- a/systems/primitives/test/multilayer_perceptron_test.cc
+++ b/systems/primitives/test/multilayer_perceptron_test.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/port_switch_test.cc
+++ b/systems/primitives/test/port_switch_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/port_switch.h"
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include <gtest/gtest.h>

--- a/systems/primitives/test/random_source_test.cc
+++ b/systems/primitives/test/random_source_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/primitives/random_source.h"
 
+#include <memory>
 #include <stdexcept>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/saturation_test.cc
+++ b/systems/primitives/test/saturation_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/saturation.h"
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/selector_test.cc
+++ b/systems/primitives/test/selector_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/selector.h"
 
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/shared_pointer_system_test.cc
+++ b/systems/primitives/test/shared_pointer_system_test.cc
@@ -1,7 +1,9 @@
 #include "drake/systems/primitives/shared_pointer_system.h"
 
+#include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/trajectory_affine_system_test.cc
+++ b/systems/primitives/test/trajectory_affine_system_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/primitives/trajectory_affine_system.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/primitives/test/trajectory_linear_system_test.cc
+++ b/systems/primitives/test/trajectory_linear_system_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/primitives/trajectory_linear_system.h"
 
+#include <memory>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/primitives/test/trajectory_source_test.cc
+++ b/systems/primitives/test/trajectory_source_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/primitives/trajectory_source.h"
 
+#include <algorithm>
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 

--- a/systems/primitives/test/vector_log_test.cc
+++ b/systems/primitives/test/vector_log_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/primitives/vector_log.h"
 
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/default_scalars.h"

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -4,6 +4,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>

--- a/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
+++ b/systems/rendering/test/multibody_position_to_geometry_pose_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/rendering/multibody_position_to_geometry_pose.h"
 
+#include <memory>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/systems/sensors/camera_config_functions.cc
+++ b/systems/sensors/camera_config_functions.cc
@@ -5,6 +5,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/systems/sensors/image_io_load.cc
+++ b/systems/sensors/image_io_load.cc
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 // To ease build system upkeep, we annotate VTK includes with their deps.

--- a/systems/sensors/image_io_save.cc
+++ b/systems/sensors/image_io_save.cc
@@ -3,6 +3,7 @@
 /* clang-format on */
 
 #include <stdexcept>
+#include <string>
 
 // To ease build system upkeep, we annotate VTK includes with their deps.
 #include <vtkImageData.h>     // vtkCommonDataModel

--- a/systems/sensors/lcm_image_array_receive_example.cc
+++ b/systems/sensors/lcm_image_array_receive_example.cc
@@ -4,6 +4,9 @@
 /// depth frames, and retransmits the images.  The output can be viewed in
 /// Meldis once #18862 is finished.
 
+#include <memory>
+#include <utility>
+
 #include <gflags/gflags.h>
 
 #include "drake/lcmt_image_array.hpp"

--- a/systems/sensors/test/accelerometer_test.cc
+++ b/systems/sensors/test/accelerometer_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/sensors/accelerometer.h"
 
+#include <limits>
+#include <memory>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/systems/sensors/test/camera_config_test.cc
+++ b/systems/sensors/test/camera_config_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/sensors/camera_config.h"
 
+#include <limits>
+#include <string>
 #include <vector>
 
 #include <fmt/format.h>

--- a/systems/sensors/test/gyroscope_test.cc
+++ b/systems/sensors/test/gyroscope_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/sensors/gyroscope.h"
 
+#include <limits>
+#include <memory>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"

--- a/systems/sensors/test/image_io_test.cc
+++ b/systems/sensors/test/image_io_test.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/sensors/image_io.h"
 
 #include <fstream>
+#include <string>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/systems/sensors/test/image_test.cc
+++ b/systems/sensors/test/image_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/sensors/image.h"
 
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 namespace drake {

--- a/systems/sensors/test/image_to_lcm_image_array_t_test.cc
+++ b/systems/sensors/test/image_to_lcm_image_array_t_test.cc
@@ -1,5 +1,8 @@
 #include "drake/systems/sensors/image_to_lcm_image_array_t.h"
 
+#include <memory>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include "drake/lcmt_image_array.hpp"

--- a/systems/sensors/test/lcm_image_array_to_images_test.cc
+++ b/systems/sensors/test/lcm_image_array_to_images_test.cc
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 

--- a/systems/sensors/test/rgbd_sensor_async_gl_test.cc
+++ b/systems/sensors/test/rgbd_sensor_async_gl_test.cc
@@ -1,3 +1,7 @@
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/systems/sensors/test/rgbd_sensor_async_test.cc
+++ b/systems/sensors/test/rgbd_sensor_async_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/sensors/rgbd_sensor_async.h"
 
+#include <memory>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/systems/sensors/test/rgbd_sensor_discrete_test.cc
+++ b/systems/sensors/test/rgbd_sensor_discrete_test.cc
@@ -1,5 +1,9 @@
 #include "drake/systems/sensors/rgbd_sensor_discrete.h"
 
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/geometry/scene_graph.h"

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <utility>
 

--- a/systems/sensors/test/vtk_image_reader_writer_test.cc
+++ b/systems/sensors/test/vtk_image_reader_writer_test.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/tools/lcm_gen/test/functional_test.cc
+++ b/tools/lcm_gen/test/functional_test.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/tools/workspace/ccd_internal/test/is_zero_uses_relative_epsilon_test.cc
+++ b/tools/workspace/ccd_internal/test/is_zero_uses_relative_epsilon_test.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <vector>
 
 #include <fcl/fcl.h>
 #include <gtest/gtest.h>

--- a/visualization/test/concatenate_images_test.cc
+++ b/visualization/test/concatenate_images_test.cc
@@ -1,5 +1,8 @@
 #include "drake/visualization/concatenate_images.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/systems/sensors/test_utilities/image_compare.h"

--- a/visualization/test/inertia_visualizer_test.cc
+++ b/visualization/test/inertia_visualizer_test.cc
@@ -1,5 +1,10 @@
 #include "drake/visualization/inertia_visualizer.h"
 
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/visualization/test/meshcat_pose_sliders_test.cc
+++ b/visualization/test/meshcat_pose_sliders_test.cc
@@ -1,5 +1,10 @@
 #include "drake/visualization/meshcat_pose_sliders.h"
 
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/visualization/test/visualization_config_functions_test.cc
+++ b/visualization/test/visualization_config_functions_test.cc
@@ -1,5 +1,10 @@
 #include "drake/visualization/visualization_config_functions.h"
 
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This commit covers:
- solvers
- systems
- tools
- visualization

Towards #22689.

The standard library IWYU linter on cc files has been accidentally disabled for a while.  This is the lint that accumulated in the meantime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23348)
<!-- Reviewable:end -->
