### PR TITLE
[doc] Fix pydrake styling to have red background again

### DIFF
--- a/doc/pydrake/_static/css/custom.css
+++ b/doc/pydrake/_static/css/custom.css
@@ -764,7 +764,7 @@ pre code {
   margin-bottom: 10px;
 }
 
-.rst-content dl:not(.docutils) dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
+.rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt {
   display: inline-block;
   margin: 6px 0;
   font-size: 90%;


### PR DESCRIPTION
Closes #23204.

For an example, look at https://drake.mit.edu/pydrake/pydrake.forwarddiff.html today.  The background is blue behind the function names -- a regression when we upgraded to Noble.  As of this PR, it's back to being red.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23350)
<!-- Reviewable:end -->
