### PR TITLE
[geometry] Remove obscure constant

### DIFF
--- a/geometry/proximity/bvh.cc
+++ b/geometry/proximity/bvh.cc
@@ -113,7 +113,7 @@ BvType Bvh<BvType, SourceMeshType>::ComputeBoundingVolume(
   for (auto pair = start; pair < end; ++pair) {
     const auto& element = mesh.element(pair->first);
     // Check each vertex in the element.
-    for (int v = 0; v < kElementVertexCount; ++v) {
+    for (int v = 0; v < MeshType::kVertexPerElement; ++v) {
       vertices.insert(element.vertex(v));
     }
   }
@@ -127,11 +127,11 @@ Vector3d Bvh<BvType, SourceMeshType>::ComputeCentroid(
   Vector3d centroid{0, 0, 0};
   const auto& element = mesh.element(i);
   // Calculate average from all vertices.
-  for (int v = 0; v < kElementVertexCount; ++v) {
+  for (int v = 0; v < MeshType::kVertexPerElement; ++v) {
     const Vector3d& vertex = convert_to_double(mesh.vertex(element.vertex(v)));
     centroid += vertex;
   }
-  centroid /= kElementVertexCount;
+  centroid /= MeshType::kVertexPerElement;
   return centroid;
 }
 

--- a/geometry/proximity/bvh.h
+++ b/geometry/proximity/bvh.h
@@ -387,8 +387,6 @@ class Bvh {
     }
   }
 
-  static constexpr int kElementVertexCount = MeshType::kVertexPerElement;
-
   copyable_unique_ptr<NodeType> root_node_;
 };
 

--- a/geometry/proximity/bvh_updater.h
+++ b/geometry/proximity/bvh_updater.h
@@ -83,7 +83,6 @@ class BvhUpdater {
                        const std::vector<Vector3<double>>& vertices) {
     /* Intentionally uninitialized. */
     Eigen::Vector3d lower, upper;
-    constexpr int kElementVertexCount = MeshType::kVertexPerElement;
     constexpr double kInf = std::numeric_limits<double>::infinity();
     if (node->is_leaf()) {
       // TODO(SeanCurtis-TRI): This is the limiting factor on supporting Obb.
@@ -94,7 +93,7 @@ class BvhUpdater {
       const int num_elements = node->num_element_indices();
       for (int e = 0; e < num_elements; ++e) {
         const auto& element = mesh_.element(node->element_index(e));
-        for (int i = 0; i < kElementVertexCount; ++i) {
+        for (int i = 0; i < MeshType::kVertexPerElement; ++i) {
           const Eigen::Vector3d& p_MV =
               convert_to_double(vertices[element.vertex(i)]);
           lower = lower.cwiseMin(p_MV);


### PR DESCRIPTION
Using a made-up alias that indirects through a header file serves only to obscure the reality of what's going on.  Any given idea should have exactly one name, which we should use everywhere.

(Noticed while reviewing our GSG's new test about the naming for static constants.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23351)
<!-- Reviewable:end -->
