### PR TITLE
[workspace] Upgrade highway_internal to latest release 1.3.0

### DIFF
--- a/tools/workspace/highway_internal/repository.bzl
+++ b/tools/workspace/highway_internal/repository.bzl
@@ -6,8 +6,8 @@ def highway_internal_repository(
     github_archive(
         name = name,
         repository = "google/highway",
-        commit = "1.2.0",
-        sha256 = "7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343",  # noqa
+        commit = "1.3.0",
+        sha256 = "07b3c1ba2c1096878a85a31a5b9b3757427af963b1141ca904db2f9f4afe0bc2",  # noqa
         patches = [
             ":patches/disabled_targets.patch",
             ":patches/linkstatic.patch",


### PR DESCRIPTION
Towards #23365 

Fails in CI with an undefined symbol error. Relevant error output is as follows:

```shell
[12:53:35 PM]  FAIL: //common:hwy_dynamic_test (Exit 127) (see /media/ephemeral0/ubuntu/workspace/el-experimental-release_PR-23373/_bazel_ubuntu/0ec80af814994c9ee2147aa241705b51/execroot/_main/bazel-out/k8-opt/testlogs/common/hwy_dynamic_test/test.log)
[12:53:35 PM]  ==================== Test output for //common:hwy_dynamic_test:
[12:53:35 PM]  /media/ephemeral0/ubuntu/workspace/el-experimental-release_PR-23373/_bazel_ubuntu/0ec80af814994c9ee2147aa241705b51/sandbox/linux-sandbox/17389/execroot/_main/bazel-out/k8-opt/bin/common/hwy_dynamic_test.runfiles/_main/common/hwy_dynamic_test: symbol lookup error: /media/ephemeral0/ubuntu/workspace/el-experimental-release_PR-23373/_bazel_ubuntu/0ec80af814994c9ee2147aa241705b51/execroot/_main/bazel-out/k8-opt/bin/common/../_solib_k8/libexternal_S+internal_Urepositories+highway_Uinternal_Slibtimer.so: undefined symbol: _ZN3hwy4WarnEPKciS1_z
```