### PR TITLE
Disable render_gl test under LSAN

### DIFF
--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -233,15 +233,17 @@ drake_cc_googletest_linux_only(
     display = True,
     tags = [
         # GLX functions show up with bad reads, bad writes, possibly lost, and
-        # definitely lost.  We will investiate soon but for now we'll omit the
+        # definitely lost.  We will investigate soon but for now we'll omit the
         # memcheck tests in order to make progress on related code.
         # TODO(#12962) Investigate, fix or suppress, then re-enable this test.
         "no_memcheck",
 
         # Since migrating CI Jenkins jobs from Jammy to Noble, this test
-        # causes the newly converted ASAN jobs to fail.
+        # causes the newly converted ASAN jobs to fail. It also fails for Noble
+        # LSAN jobs since upgrading the provisioned images on 2025-09-01.
         # TODO(#23107) Investigate, fix or suppress, then re-enable this test.
         "no_asan",
+        "no_lsan",
     ],
     deps = [
         ":internal_opengl_context",


### PR DESCRIPTION
This one has already been disabled under ASAN, and it's holding up image upgrades.

Closes #23366, FYI #23107.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23378)
<!-- Reviewable:end -->
