### PR TITLE
[multibody] Fix model instance coordinate counts that broke GetPositionNames()

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1900,6 +1900,8 @@ std::vector<std::string> MultibodyPlant<T>::GetPositionNames(
 
   for (JointIndex joint_index : GetJointIndices()) {
     const Joint<T>& joint = get_joint(joint_index);
+    if (joint.num_positions() == 0) continue;  // Skip welds.
+
     const std::string prefix =
         add_model_instance_prefix
             ? fmt::format("{}_", GetModelInstanceName(joint.model_instance()))
@@ -1933,6 +1935,8 @@ std::vector<std::string> MultibodyPlant<T>::GetPositionNames(
 
   for (const auto& joint_index : joint_indices) {
     const Joint<T>& joint = get_joint(joint_index);
+    if (joint.num_positions() == 0) continue;  // Skip welds.
+
     // Sanity check: joint positions are in range.
     DRAKE_DEMAND(joint.position_start() >= position_offset);
     DRAKE_DEMAND(joint.position_start() + joint.num_positions() -
@@ -1963,6 +1967,8 @@ std::vector<std::string> MultibodyPlant<T>::GetVelocityNames(
 
   for (JointIndex joint_index : GetJointIndices()) {
     const Joint<T>& joint = get_joint(joint_index);
+    if (joint.num_positions() == 0) continue;  // Skip welds.
+
     const std::string prefix =
         add_model_instance_prefix
             ? fmt::format("{}_", GetModelInstanceName(joint.model_instance()))
@@ -1996,6 +2002,8 @@ std::vector<std::string> MultibodyPlant<T>::GetVelocityNames(
 
   for (const auto& joint_index : joint_indices) {
     const Joint<T>& joint = get_joint(joint_index);
+    if (joint.num_positions() == 0) continue;  // Skip welds.
+
     // Sanity check: joint velocities are in range.
     DRAKE_DEMAND(joint.velocity_start() >= velocity_offset);
     DRAKE_DEMAND(joint.velocity_start() + joint.num_velocities() -

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -6159,10 +6159,74 @@ GTEST_TEST(MultibodyPlantTest, GetNames) {
 GTEST_TEST(MultibodyPlantTest, FloatingJointNames) {
   {
     MultibodyPlant<double> plant(0.0);
-    plant.AddRigidBody("free_body", default_model_instance(),
-                       SpatialInertia<double>::MakeUnitary());
+    const ModelInstanceIndex my_model_instance =
+        plant.AddModelInstance("MyModelInstance");
+
+    // These bodies are in "my_model_instance" _not_ the default one. Their
+    // body frames are in the same model instance.
+    const RigidBody<double>& free_body = plant.AddRigidBody(
+        "free_body", my_model_instance, SpatialInertia<double>::MakeUnitary());
+    const RigidBody<double>& outer_body = plant.AddRigidBody(
+        "outer_body", my_model_instance, SpatialInertia<double>::MakeUnitary());
+
+    // But this frame is in the default model instance.
+    auto frame_on_outer_ptr = std::make_unique<FixedOffsetFrame<double>>(
+        "frame_on_outer", outer_body.body_frame(),
+        RigidTransform<double>(Vector3<double>(1, 0, 0)),
+        default_model_instance());
+    const Frame<double>& frame_on_outer =
+        plant.AddFrame(std::move(frame_on_outer_ptr));
+
+    // A joint inherits its model instance from the child _frame_, not the
+    // child _body_. Hence, this joint is in the default model instance while
+    // the ephemeral floating joint will be in my_model_instance. This caused
+    // a bug in the past (see issue #23379).
+    auto the_joint_ptr = std::make_unique<RevoluteJoint<double>>(
+        "the_joint", free_body.body_frame(), frame_on_outer,
+        Vector3<double>(0, 0, 1));
+    const Joint<double>& the_joint = plant.AddJoint(std::move(the_joint_ptr));
+
+    // This weld joint is in "my_model_instance", but follows an unrelated
+    // joint, so its "start coordinate" is outside the range of coordinates
+    // in use by my_model_instance. That shouldn't cause any problems, but
+    // did in the past (see issue #23379).
+    const RigidBody<double>& last_body = plant.AddRigidBody(
+        "last_body", my_model_instance, SpatialInertia<double>::MakeUnitary());
+    const Joint<double>& weld_joint =
+        plant.AddJoint<WeldJoint>("weld_joint", last_body, {}, outer_body, {},
+                                  RigidTransform<double>::Identity());
+
     plant.Finalize();
-    EXPECT_NO_THROW(plant.GetJointByName("free_body"));
+
+    // Check that an ephemeral floating joint was added and named "free_body" to
+    // match the body it mobilizes, and that it is in my_model_instance.
+    const Joint<double>& floating_joint = plant.GetJointByName("free_body");
+    EXPECT_EQ(floating_joint.num_positions(), 7);
+    EXPECT_EQ(floating_joint.num_velocities(), 6);
+    EXPECT_EQ(floating_joint.model_instance(), my_model_instance);
+
+    // Check that the revolute joint followed frame_on_outer's model instance,
+    // _not_ outer_body's. Its start coordinate follows the floating joint's 7.
+    EXPECT_EQ(the_joint.model_instance(), default_model_instance());
+    EXPECT_EQ(the_joint.position_start(), 7);
+    EXPECT_EQ(the_joint.num_positions(), 1);
+
+    // Check that the weld joint is in my_model_instance and that its start
+    // coordinate is out of range for that model instance, which has only
+    // 0-6 for the floating joint. The 7th is for the revolute joint (in the
+    // default model instance). Hence the next available is 8.
+    EXPECT_EQ(weld_joint.model_instance(), my_model_instance);
+    EXPECT_EQ(weld_joint.position_start(), 8);
+    EXPECT_EQ(weld_joint.num_positions(), 0);
+
+    // There was a bug where either
+    //   - the different model instances for child frame and child body, or
+    //   - the out-of-range start coordinate for the weld joint
+    // caused GetPositionNames(model_instance) to throw.
+    // Check that the various forms all work now.
+    EXPECT_NO_THROW(plant.GetPositionNames());
+    EXPECT_NO_THROW(plant.GetPositionNames(my_model_instance));
+    EXPECT_NO_THROW(plant.GetPositionNames(default_model_instance()));
   }
 
   // Verify that in case of a name conflict, we prepend with underscores

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1019,15 +1019,9 @@ void MultibodyTree<T>::CreateBodyNode(MobodIndex mobod_index) {
 template <typename T>
 void MultibodyTree<T>::FinalizeModelInstances() {
   // Add all of our mobilizers and joint actuators to the appropriate instance.
-  // The order of the mobilizers should match the order in which the bodies were
-  // added to the tree, which may not be the order in which the mobilizers were
-  // added, so we get the mobilizer through the BodyNode.
-  for (const auto& body_node : body_nodes_) {
-    if (body_node->get_num_mobilizer_positions() > 0 ||
-        body_node->get_num_mobilizer_velocities() > 0) {
-      model_instances_.get_mutable_element(body_node->model_instance())
-          .add_mobilizer(&body_node->get_mobilizer());
-    }
+  for (const auto& mobilizer : mobilizers_) {
+    model_instances_.get_mutable_element(mobilizer->model_instance())
+        .add_mobilizer(mobilizer.get());
   }
 
   // N.B. The result of the code below is that actuators are sorted by


### PR DESCRIPTION
Ensures that 
- Weld Joints are skipped when generating coordinate names, and
- ModelInstance coordinate counts are consistent with the Joints in that model instance.

Previously the counts were based on the joints' child _body_ (via `internal::BodyNode`), but the model instance membership for joints is based on the child _frame_. Now we use `internal::Mobilizer` which is guaranteed to have the same model instance as the joint it models.

These cases didn't appear in any unit tests so this PR adds tests that fail without this fix.

Fixes #23379

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23380)
<!-- Reviewable:end -->
