### PR TITLE
[tools] Remove polyfill of implementation_deps

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -484,22 +484,9 @@ def _raw_drake_cc_library(
         textual_hdrs = srcs
         srcs = new_srcs
 
-    # If we're using implementation_deps, then the result of compiling our srcs
-    # needs to use an intermediate label name. The actual `name` label will be
-    # used for the "implementation sandwich", below.
-    # TODO(jwnimmer-tri) Once https://github.com/bazelbuild/bazel/issues/12350
-    # is fixed and Bazel offers implementation_deps natively, then we can
-    # switch to that implementation instead of making our own sandwich.
-    compiled_name = name
-    compiled_visibility = visibility
-    compiled_deprecation = deprecation
-    if implementation_deps:
-        if not linkstatic:
-            fail("implementation_deps are only supported for static libraries")
-        compiled_name = "_{}_compiled_cc_impl".format(name)
-        compiled_visibility = ["//visibility:private"]
+    # Finally, do the actual compilation.
     cc_library(
-        name = compiled_name,
+        name = name,
         srcs = srcs,
         hdrs = hdrs,
         textual_hdrs = textual_hdrs,
@@ -508,54 +495,16 @@ def _raw_drake_cc_library(
         copts = copts,
         defines = defines,
         data = data,
-        deps = (deps or []) + (implementation_deps or []),
+        deps = deps,
+        implementation_deps = implementation_deps,
         linkstatic = linkstatic,
         linkopts = linkopts,
         alwayslink = alwayslink,
         tags = tags,
         testonly = testonly,
-        visibility = compiled_visibility,
-        deprecation = compiled_deprecation,
+        visibility = visibility,
+        deprecation = deprecation,
     )
-
-    # If we're using implementation_deps, then make me an "implementation
-    # sandwich".  Create one library with our headers, one library with only
-    # our static archive, and then squash them together to the final result.
-    if implementation_deps:
-        headers_name = "_{}_headers_cc_impl".format(name)
-        cc_library(
-            name = headers_name,
-            hdrs = hdrs,
-            textual_hdrs = None,
-            strip_include_prefix = strip_include_prefix,
-            include_prefix = include_prefix,
-            defines = defines,
-            deps = deps,  # N.B. No implementation_deps!
-            linkstatic = 1,
-            tags = tags,
-            testonly = testonly,
-            visibility = ["//visibility:private"],
-        )
-        archive_name = "_{}_archive_cc_impl".format(name)
-        cc_linkonly_library(
-            name = archive_name,
-            deps = [":" + compiled_name],
-            visibility = ["//visibility:private"],
-            tags = tags,
-            testonly = testonly,
-        )
-        cc_library(
-            name = name,
-            deps = [
-                ":" + headers_name,
-                ":" + archive_name,
-            ],
-            linkstatic = 1,
-            tags = tags,
-            testonly = testonly,
-            visibility = visibility,
-            deprecation = deprecation,
-        )
 
 def _maybe_add_pruned_private_hdrs_dep(
         base_name,


### PR DESCRIPTION
Our rules_cc (and bazel) versions are new enough to offer this natively.

The polyfilll interacts poorly with our newer cpplint (#22689).
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23384)
<!-- Reviewable:end -->
