### PR TITLE
[cpplint] Fix iwyu lint (6/5)

### DIFF
--- a/bindings/pydrake/common/text_logging_pybind.cc
+++ b/bindings/pydrake/common/text_logging_pybind.cc
@@ -3,6 +3,8 @@
 #include <atomic>
 #include <cstdlib>
 #include <memory>
+#include <string>
+#include <vector>
 
 // clang-format off to disable clang-format-includes
 // N.B. text-logging.h must be included before spdlog headers

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 
 #include "pybind11/eval.h"

--- a/bindings/pydrake/geometry/geometry_py_bounding_box.cc
+++ b/bindings/pydrake/geometry/geometry_py_bounding_box.cc
@@ -1,5 +1,8 @@
 /* @file This contains the bounding box functions for pydrake.geometry. */
 
+#include <set>
+#include <utility>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/geometry/geometry_py.h"
 #include "drake/geometry/proximity/aabb.h"

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -4,6 +4,10 @@
  represent the input values to all of those computations. They can be found in
  the pydrake.geometry module. */
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/identifier_pybind.h"

--- a/bindings/pydrake/geometry/geometry_py_meshes.cc
+++ b/bindings/pydrake/geometry/geometry_py_meshes.cc
@@ -2,6 +2,7 @@
  They can be found in the pydrake.geometry module. */
 
 #include <filesystem>
+#include <vector>
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -2,6 +2,13 @@
  drake::geometry::optimization namespace. They can be found in the
  pydrake.geometry.optimization module. */
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -2,6 +2,9 @@
  and drake/geometry/render* directories. They can be found in the
  pydrake.geometry module. */
 
+#include <memory>
+#include <string>
+
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"

--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -3,6 +3,12 @@
  queries, and the query result types as well. They can be found in the
  pydrake.geometry module. */
 
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -1,6 +1,10 @@
 /* @file This contains the bindings for the various visualizer System types
  found in drake::geometry. They can be found in the pydrake.geometry module. */
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/ref_cycle_pybind.h"

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -1,5 +1,9 @@
 #include "drake/bindings/pydrake/multibody/inverse_kinematics_py.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/ref_cycle_pybind.h"

--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/multibody/inverse_kinematics_py.h"

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1,5 +1,11 @@
 #include "drake/bindings/pydrake/multibody/tree_py.h"
 
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+
 #include "pybind11/eval.h"
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -1,3 +1,9 @@
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"

--- a/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
@@ -1,3 +1,7 @@
+#include <map>
+#include <memory>
+#include <string>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/planning/planning_py_dof_mask.cc
+++ b/bindings/pydrake/planning/planning_py_dof_mask.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/planning/planning_py_graph_algorithms.cc
+++ b/bindings/pydrake/planning/planning_py_graph_algorithms.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <vector>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/planning/planning_py_iris_common.cc
+++ b/bindings/pydrake/planning/planning_py_iris_common.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"

--- a/bindings/pydrake/planning/planning_py_iris_from_clique_cover.cc
+++ b/bindings/pydrake/planning/planning_py_iris_from_clique_cover.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -1,3 +1,9 @@
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/geometry/optimization_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"

--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -1,4 +1,7 @@
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_ids.cc
+++ b/bindings/pydrake/solvers/solvers_py_ids.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"
 #include "drake/solvers/solver_id.h"

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -1,6 +1,9 @@
 #include <cstddef>
 #include <memory>
 #include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_mixed_integer_optimization_util.cc
+++ b/bindings/pydrake/solvers/solvers_py_mixed_integer_optimization_util.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"

--- a/bindings/pydrake/solvers/solvers_py_options.cc
+++ b/bindings/pydrake/solvers/solvers_py_options.cc
@@ -1,3 +1,7 @@
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_py.h"

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -1,5 +1,10 @@
 #include "drake/bindings/pydrake/systems/framework_py_semantics.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -1,5 +1,11 @@
 #include "drake/bindings/pydrake/systems/framework_py_systems.h"
 
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "pybind11/eval.h"
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -1,6 +1,7 @@
 #include "drake/bindings/pydrake/systems/framework_py_values.h"
 
 #include <sstream>
+#include <string>
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"

--- a/bindings/pydrake/systems/sensors_py_image.cc
+++ b/bindings/pydrake/systems/sensors_py_image.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"

--- a/bindings/pydrake/systems/sensors_py_image_io.cc
+++ b/bindings/pydrake/systems/sensors_py_image_io.cc
@@ -1,3 +1,7 @@
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/systems/sensors_py_lcm.cc
+++ b/bindings/pydrake/systems/sensors_py_lcm.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/systems/sensors_py.h"

--- a/bindings/pydrake/systems/sensors_py_rgbd.cc
+++ b/bindings/pydrake/systems/sensors_py_rgbd.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"

--- a/bindings/pydrake/systems/sensors_py_rotary_encoders.cc
+++ b/bindings/pydrake/systems/sensors_py_rotary_encoders.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/systems/sensors_py.h"

--- a/bindings/pydrake/systems/value_producer_pybind.cc
+++ b/bindings/pydrake/systems/value_producer_pybind.cc
@@ -1,5 +1,8 @@
 #include "drake/bindings/pydrake/systems/value_producer_pybind.h"
 
+#include <string>
+#include <utility>
+
 namespace drake {
 namespace pydrake {
 

--- a/bindings/pydrake/visualization/visualization_py_sliders.cc
+++ b/bindings/pydrake/visualization/visualization_py_sliders.cc
@@ -1,3 +1,6 @@
+#include <string>
+#include <vector>
+
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/visualization/visualization_py.h"


### PR DESCRIPTION
This commit covers:
- bindings

Towards https://github.com/RobotLocomotion/drake/pull/22689.

The standard library IWYU linter on cc files has been accidentally disabled for a while. This is the lint that accumulated in the meantime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23386)
<!-- Reviewable:end -->
