### PR TITLE
[workspace] Adjust new_release for downloading from tag vs commit

### DIFF
--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -388,7 +388,10 @@ def _do_upgrade_github_archive(
 
     # Download the new source archive.
     info("Downloading new archive...")
-    new_url = f"https://github.com/{repository}/archive/{new_commit}.tar.gz"
+    if _smells_like_a_git_commit(new_commit):
+        new_url = f"https://github.com/{repository}/archive/{new_commit}.tar.gz"  # noqa
+    else:
+        new_url = f"https://github.com/{repository}/archive/refs/tags/{new_commit}.tar.gz"  # noqa
     new_filename = new_commit.replace("/", "_")
     new_checksum = _download(new_url, f"{temp_dir}/{new_filename}.tar.gz")
 


### PR DESCRIPTION
This overcomes the error seen in #23401.

+@Aiden2244 for feature review, please.  It's probably worth checking that this works both for SCS, as well as a repository that doesn't use tags (e.g., `drake_models`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23402)
<!-- Reviewable:end -->
