### PR TITLE
HasCollisions() bug fixed - anchored geometry is no longer confusing

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -806,6 +806,13 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     // Perform a query of the dynamic objects against themselves.
     dynamic_tree_.collide(&data, has_collisions::Callback);
 
+    // Testing to see if we've already discovered collisions here is not just
+    // a matter of efficiency; it is a matter of correctness. If the only
+    // observable collisions are between dynamic objects, blindly proceeding to
+    // examining collisions between dynamic-anchored pairs will end up
+    // overwriting the `collision_exist` value we'd already found.
+    if (data.collisions_exist) return true;
+
     // Perform a query of the dynamic objects against the anchored. We don't do
     // anchored against anchored because those pairs are implicitly filtered.
     FclCollide(dynamic_tree_, anchored_tree_, &data, has_collisions::Callback);


### PR DESCRIPTION
If anchored geometry had bounding boxes that overlapped dynamic geometries' bounding boxes, but the actual geometry *didn't* collide, HasCollisions() would get confused and say there were no collisions, even if there were collisions between dynamic geometry.

This removes that point of confusion.

Resolves #23406

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23409)
<!-- Reviewable:end -->
