### PR TITLE
[setup] Remove JRE and JDK from install_prereqs

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-jammy.txt
+++ b/setup/ubuntu/binary_distribution/packages-jammy.txt
@@ -1,4 +1,3 @@
-default-jre
 jupyter-notebook
 libblas-dev
 libegl1

--- a/setup/ubuntu/binary_distribution/packages-noble.txt
+++ b/setup/ubuntu/binary_distribution/packages-noble.txt
@@ -1,4 +1,3 @@
-default-jre
 jupyter-notebook
 libblas-dev
 libegl1

--- a/setup/ubuntu/source_distribution/packages-jammy.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy.txt
@@ -1,4 +1,3 @@
-default-jdk
 diffutils
 file
 gfortran

--- a/setup/ubuntu/source_distribution/packages-noble.txt
+++ b/setup/ubuntu/source_distribution/packages-noble.txt
@@ -1,4 +1,3 @@
-default-jdk
 diffutils
 file
 gfortran

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -23,6 +23,14 @@ build --strict_system_includes
 # Use the host Python interpreter by default.
 build --extra_toolchains=@python//:all
 
+# For background, see https://bazel.build/docs/bazel-and-java.
+# The java_runtime_version defaults to local_jdk, which is some uncontrolled
+# version from Ubuntu or Homebrew that can lead to build failures. Instead,
+# we'll set it (and correspondingly the java_language_version) to an arbitrary
+# value that's compatible with what `lcm.jar` needs.
+build --java_language_version=11
+build --java_runtime_version=remotejdk_11
+
 # Use C++23 by default.
 build --cxxopt=-std=c++23
 build --host_cxxopt=-std=c++23

--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -1,11 +1,5 @@
 # Common options for macOS, no matter the arch (x86 or arm).
 
-# The runtime_version defaults to local_jdk, which is some uncontrolled
-# version from homebrew that can lead to build failures. Instead, we'll
-# set it to match the default java_language_version.
-# For background, see https://bazel.build/docs/bazel-and-java.
-build --java_runtime_version=remotejdk_11
-
 # Suppress numerous "'_FORTIFY_SOURCE' macro redefined" warnings when using
 # sanitizers.
 build:asan --copt=-Wno-macro-redefined

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -24,12 +24,6 @@ build --config=packaging
 build --define=LCM_INSTALL_JAVA=OFF
 # Enable MOSEK lazy loading. Right now this is only done for Linux builds.
 build --@drake//solvers:mosek_lazy_load=True
-# The JDK mentioned here is not actually used, but must not be local_jdk
-# because we don't have any local JDK installed and rules_java fails fast
-# when that option is selected but no JDK can be found.
-# TODO(jwnimmer-tri) Offer an official //tools/flags and CMake option to
-# disable Drake's Java support, and use it here.
-build --java_runtime_version=remotejdk_11
 EOF
 
 # Install Drake using our wheel-build-specific Python interpreter.


### PR DESCRIPTION
Since we no longer install the LCM java tools, our binary packages don't depend on a JRE.

When building Drake from source, instead of installing a JDK machine- wide we can ask Bazel to fetch one for us. This avoids cluttering up the whole machine, is more hermetic, and de-risks JDK version shear leading to build failures.