### PR TITLE
[workspace] Upgrade scs_internal to latest release 3.2.8

### DIFF
--- a/tools/workspace/scs_internal/repository.bzl
+++ b/tools/workspace/scs_internal/repository.bzl
@@ -10,8 +10,8 @@ def scs_internal_repository(
         When updating this commit, see
         drake/tools/workspace/qdldl_internal/README.md.
         """,
-        commit = "3.2.7",
-        sha256 = "bc8211cfd213f3117676ceb7842f4ed8a3bc7ed9625c4238cc7d83f666e22cc9",  # noqa
+        commit = "3.2.8",
+        sha256 = "22d2d785b7c7a9ee8a260d2684cf17ae4733271b8421fdbc78f281d19910ca1b",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/upstream/fix_arg.patch",


### PR DESCRIPTION
Towards #23365, Closes #23401

Currently fails with the following error when running new_release script locally:

```shell
ERROR: /home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/f55484cc56c1e9e8b497d666eb5ef850/external/bazel_tools/tools/build_defs/repo/utils.bzl:217:21: An error occurred during the fetch of repository '+internal_repositories+scs_internal':
   Traceback (most recent call last):
	File "/home/local/KHQ/aiden.mccormack/aiden2244/drake/tools/workspace/github.bzl", line 128, column 37, in _github_archive_real_impl
		result = setup_github_repository(repository_ctx)
	File "/home/local/KHQ/aiden.mccormack/aiden2244/drake/tools/workspace/github.bzl", line 207, column 14, in setup_github_repository
		patch(repository_ctx)
	File "/home/local/KHQ/aiden.mccormack/.cache/bazel/_bazel_aiden.mccormack/f55484cc56c1e9e8b497d666eb5ef850/external/bazel_tools/tools/build_defs/repo/utils.bzl", line 217, column 21, in patch
		fail("Error applying patch %s:\n%s%s" %
Error in fail: Error applying patch @@//tools/workspace/scs_internal:patches/upstream/fix_arg.patch:
patching file linsys/cpu/direct/private.c
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file linsys/cpu/direct/private.c.rej
patching file linsys/cpu/direct/private.h
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file linsys/cpu/direct/private.h.rej
ERROR: /home/local/KHQ/aiden.mccormack/aiden2244/drake/bindings/pydrake/common/BUILD.bazel:752:23: in genquery rule //bindings/pydrake/common:install_lint_genquery__init_py_install: errors were encountered while computing transitive closure of the scope: no such package '@@+internal_repositories+scs_internal//': Error applying patch @@//tools/workspace/scs_internal:patches/upstream/fix_arg.patch:
patching file linsys/cpu/direct/private.c
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file linsys/cpu/direct/private.c.rej
patching file linsys/cpu/direct/private.h
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file linsys/cpu/direct/private.h.rej
ERROR: /home/local/KHQ/aiden.mccormack/aiden2244/drake/bindings/pydrake/common/BUILD.bazel:752:23: Analysis of target '//bindings/pydrake/common:install_lint_genquery__init_py_install' (config: 2890b93) failed
ERROR: Analysis of target '//bindings/pydrake/common:install_lint_genquery__init_py_install' failed; build aborted
```