### PR TITLE
Re-enable sanitization for render_gl tests

### DIFF
--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -241,13 +241,6 @@ drake_cc_googletest_linux_only(
         # memcheck tests in order to make progress on related code.
         # TODO(#12962) Investigate, fix or suppress, then re-enable this test.
         "no_memcheck",
-
-        # Since migrating CI Jenkins jobs from Jammy to Noble, this test
-        # causes the newly converted ASAN jobs to fail. It also fails for Noble
-        # LSAN jobs since upgrading the provisioned images on 2025-09-01.
-        # TODO(#23107) Investigate, fix or suppress, then re-enable this test.
-        "no_asan",
-        "no_lsan",
     ],
     deps = [
         ":internal_opengl_context",

--- a/tools/dynamic_analysis/lsan.supp
+++ b/tools/dynamic_analysis/lsan.supp
@@ -1,0 +1,4 @@
+# This function purposefully creates a never-deleted singleton display, but
+# LSan can't discern that the g_display (and memory associated with it) is
+# still reachable at the end of the program.
+leak:drake::geometry::render_gl::internal::GladLoaderLoadGlx


### PR DESCRIPTION
Drake's use of a global singleton Display pointer is a known, constant leak.

Closes #23107.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23421)
<!-- Reviewable:end -->
