### PR TITLE
[doc] Python style now allows 80 characters instead of 79

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,4 +19,3 @@ trim_trailing_whitespace = false
 
 [*.{bazel,bzl,py}]
 indent_size = 4
-max_line_length = 79

--- a/doc/_pages/code_style_guide.md
+++ b/doc/_pages/code_style_guide.md
@@ -54,7 +54,9 @@ TODO(eric.cousineau): Move these clarifications and exceptions to styleguide
 
 ## Exceptions
 
-* Lines containing a long URL may be longer than 80 columns if necessary to
+* Drake uses an 80-character limit, instead of PEP 8's limit of 79. Docstrings
+  may also use all 80 characters (ignoring the limit of 72 from PEP 8).
+* Lines containing a long URL may be longer than 80 characters if necessary to
   avoid splitting the URL.
 
 ## Additional Rules

--- a/tools/workspace/styleguide/repository.bzl
+++ b/tools/workspace/styleguide/repository.bzl
@@ -6,8 +6,8 @@ def styleguide_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/styleguide",
-        commit = "63d2e8ef2a1931f014f35d1939e4e902dc57ef13",
-        sha256 = "23e25b88ef9ccb916b7f5097300956147f8cb51157fbc1967f24ebe2b445c82e",  # noqa
+        commit = "6cc89c4a3f4bf4189bbea727d04b5762517bc3f2",
+        sha256 = "72618239fee8e4619c85e897ae8a3c94d93f33ae1c09ed12f79b84d0d7b7bd58",  # noqa
         # TODO(jwnimmer-tri) Simplify on 2025-06-01 during deprecation removal.
         build_file = "@drake//tools/workspace/styleguide:package.BUILD.bazel" if "internal" in name else ":package-deprecated.BUILD.bazel",  # noqa
         mirrors = mirrors,


### PR DESCRIPTION
In general we try to stray as little as possible from PEP 8, just to remain uniform with the rest of the ecosystem.

However, since our C++ limit is 80, our project's editor configuration can be simplified if _all_ of our files in the tree have the same limit.  (We also have been using 80 for our `*.md` documentation files.)

The PEP 8 rationale for 79 ("some editors have an EOL glyph that eats the 80'th column") is moot for us, since our C++ code would already be causing trouble in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23424)
<!-- Reviewable:end -->
