### PR TITLE
Suppress more ASan/LSan warnings from render_gl

### DIFF
--- a/tools/dynamic_analysis/lsan.supp
+++ b/tools/dynamic_analysis/lsan.supp
@@ -2,3 +2,6 @@
 # LSan can't discern that the g_display (and memory associated with it) is
 # still reachable at the end of the program.
 leak:drake::geometry::render_gl::internal::GladLoaderLoadGlx
+# LSan also can't discern that the pointer passed to this function is the
+# same singleton as the one created with the function above.
+leak:drake::geometry::render_gl::internal::(anonymous namespace)::vtk_glad_glXCreateContextAttribsARB


### PR DESCRIPTION
75f746c10 wasn't wide enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23426)
<!-- Reviewable:end -->
