### PR TITLE
[tools] Add opt-in for ruff as a python linter

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,5 @@
+# Per our style guide.
+line-length = 80
+
+# Per our oldest supported platform (currently Ubuntu 22.04 "Jammy").
+target-version = "py310"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,7 @@ exports_files([
     ".bazelproject",
     ".clang-format",
     ".drake-find_resource-sentinel",
+    ".ruff.toml",
     "package.xml",
 ])
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -229,6 +229,18 @@ single_version_override(
     ],
 )
 
+bazel_dep(
+    name = "ruff_prebuilt",
+    dev_dependency = True,
+    repo_name = "ruff",
+)
+archive_override(
+    module_name = "ruff_prebuilt",
+    integrity = "sha256-if1EuMaZTepzAZ602iehkxgLNLhaErgtAeti1RVNoR0=",
+    strip_prefix = "ruff_prebuilt-0.13.0.1",
+    url = "https://github.com/RobotLocomotion/ruff_prebuilt/releases/download/0.13.0.1/ruff_prebuilt-0.13.0.1.tar.gz",  # noqa
+)
+
 # Load dependencies which are "private", i.e., not available for use by
 # downstream projects. These are all "internal use only".
 

--- a/doc/_pages/code_style_tools.md
+++ b/doc/_pages/code_style_tools.md
@@ -27,10 +27,17 @@ bazel test --config lint //common/...  # Check common/ and its child subdirector
 User manuals for the style-checking tools are as follows:
 
 * C/C++: See the cpplint ``USAGE`` string at
-  [https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py](https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py).
+  [https://github.com/cpplint/cpplint/blob/develop/cpplint.py](https://github.com/cpplint/cpplint/blob/develop/cpplint.py).
   * In particular, note the ``// NOLINT(foo/bar)`` syntax to disable a warning.
-* Python: See the pycodestyle manual at
-  [http://pycodestyle.readthedocs.io/en/latest/intro.html](http://pycodestyle.readthedocs.io/en/latest/intro.html).
+* Python:
+  * When the call to `add_lint_tests()` has `use_ruff = True`, we use `ruff` as
+    the linter. Drake uses both `check` mode along with `format --check` mode.
+    See the ruff manual at
+    [https://docs.astral.sh/ruff/linter/#error-suppression](https://docs.astral.sh/ruff/linter/#error-suppression)
+	and
+	[https://docs.astral.sh/ruff/formatter/#format-suppression](https://docs.astral.sh/ruff/formatter/#format-suppression).
+  * Otherwise, we use `pycodestyle`. See the pycodestyle manual at
+    [http://pycodestyle.readthedocs.io/en/latest/intro.html](http://pycodestyle.readthedocs.io/en/latest/intro.html).
   * The syntax ``# noqa`` can be used to quiet the warning about an overly-long
     line.
 * Bazel: Uses both pycodestyle like Python, and also the buildifier tool as
@@ -61,3 +68,12 @@ We have some tips for specific IDEs:
 * [CLion](/clion.html#formatting-files)
 * [Emacs](/emacs.html#c-code-formatting)
 * [VS Code](/vscode.html#c-code-formatting)
+
+## Python: Ruff Format
+
+To run ``ruff`` auto-formatter:
+
+```
+cd drake
+bazel run -- //tools/lint:ruff format path/to/my_file.py
+```

--- a/tools/lcm_gen/BUILD.bazel
+++ b/tools/lcm_gen/BUILD.bazel
@@ -157,4 +157,4 @@ drake_cc_googletest(
 # sub-struct. At the moment we have no test coverage of the legacy API's
 # nesting support (_encodeNoHash, _decodeNoHash, _computeHash).
 
-add_lint_tests()
+add_lint_tests(python_lint_use_ruff = True)

--- a/tools/lcm_gen/__init__.py
+++ b/tools/lcm_gen/__init__.py
@@ -57,24 +57,29 @@ from typing import Optional, List, Union
 #  [1] https://github.com/lcm-proj/lcm/commit/d9dcf8e3
 
 
-PrimitiveType = enum.Enum("PrimitiveType", " ".join([
-    "boolean",
-    "byte",
-    "double",
-    "float",
-    "int8_t",
-    "int16_t",
-    "int32_t",
-    "int64_t",
-    "string",
-]))
+PrimitiveType = enum.Enum(
+    "PrimitiveType",
+    " ".join(
+        [
+            "boolean",
+            "byte",
+            "double",
+            "float",
+            "int8_t",
+            "int16_t",
+            "int32_t",
+            "int64_t",
+            "string",
+        ]
+    ),
+)
 PrimitiveType.__str__ = lambda self: self.name
 
 
 @dataclasses.dataclass(frozen=True)
 class UserType:
-    """A struct name from an LCM message definition, e.g., "foo" or "foo.bar".
-    """
+    """A struct name from an LCM message definition, e.g., "foo" or "foo.bar"."""
+
     package: Optional[str]
     name: str
 
@@ -87,6 +92,7 @@ class UserType:
 @dataclasses.dataclass(frozen=True)
 class StructField:
     """A field within an LCM message definition."""
+
     name: str
     typ: Union[PrimitiveType, UserType]
     array_dims: List[Union[int, str]] = dataclasses.field(default_factory=list)
@@ -101,6 +107,7 @@ class StructField:
 @dataclasses.dataclass(frozen=True)
 class StructConstant:
     """A constant within an LCM message definition."""
+
     name: str
     typ: PrimitiveType
     value: Union[int, float]
@@ -113,6 +120,7 @@ class StructConstant:
 @dataclasses.dataclass(frozen=True)
 class Struct:
     """The parse tree for an LCM message definition."""
+
     typ: UserType
     fields: List[StructField] = dataclasses.field(default_factory=list)
     constants: List[StructConstant] = dataclasses.field(default_factory=list)
@@ -166,10 +174,13 @@ class Parser:
             m = re.search(r"/\*.*?\*/", data, flags=re.DOTALL)
             if not m:
                 break
-            replacement = "".join([
-                ch if ch == "\n" else " "
-                for ch in m.group()
-            ])
+            replacement = "".join(
+                [
+                    # All but newlines turn into whitespace.
+                    ch if ch == "\n" else " "
+                    for ch in m.group()
+                ]
+            )
             start, end = m.span()
             data = data[:start] + replacement + data[end:]
         return data
@@ -191,11 +202,7 @@ class Parser:
 
     def _syntax_error_details(self):
         """Provides the detail attribute of a SyntaxError."""
-        return (
-            self._filename,
-            self._tokens[self._i][2][0],
-            None,
-            None)
+        return (self._filename, self._tokens[self._i][2][0], None, None)
 
     def _expect(self, expected_type, expected_value=None):
         """Raises a syntax error unless the current token matches the expected
@@ -207,14 +214,15 @@ class Parser:
         expected_typename = token.tok_name[expected_type]
         if expected_value is not None and actual_value != expected_value:
             raise SyntaxError(
-                f"Expected '{expected_value}' "
-                f"but got '{actual_value}'",
-                self._syntax_error_details())
+                f"Expected '{expected_value}' but got '{actual_value}'",
+                self._syntax_error_details(),
+            )
         if actual_type != expected_type:
             raise SyntaxError(
                 f"Expected a token.{expected_typename}"
                 f" but got a token.{actual_typename} ('{actual_value}')",
-                self._syntax_error_details())
+                self._syntax_error_details(),
+            )
 
     def _advance(self):
         """Advances the parser to the next token, skipping whitespace."""
@@ -276,7 +284,8 @@ class Parser:
             self._i -= 1
             raise SyntaxError(
                 f"Expected a primitive type name but got '{typ_str}'",
-                self._syntax_error_details())
+                self._syntax_error_details(),
+            )
         self._const_definition(typ=typ)
         while self._current_value() == ",":
             self._consume(token.OP, ",")
@@ -302,9 +311,11 @@ class Parser:
             self._i -= 1
             raise SyntaxError(
                 f"Invalid constant value '{value_str}' for {typ.name}",
-                self._syntax_error_details())
-        self._result.constants.append(StructConstant(
-            name=name, typ=typ, value=value, value_str=value_str))
+                self._syntax_error_details(),
+            )
+        self._result.constants.append(
+            StructConstant(name=name, typ=typ, value=value, value_str=value_str)
+        )
 
     def _field_statement(self):
         """Parses a field_statement production."""
@@ -321,8 +332,9 @@ class Parser:
             self._consume(token.OP, "]")
             array_dims.append(dim)
         self._consume(token.OP, ";")
-        self._result.fields.append(StructField(
-            name=name, typ=typ, array_dims=array_dims))
+        self._result.fields.append(
+            StructField(name=name, typ=typ, array_dims=array_dims)
+        )
 
     def _qualified_identifier(self):
         """Parses a qualified_identifier production."""
@@ -709,10 +721,9 @@ class CppGen:
             for field in self._struct.fields
             if isinstance(field.typ, UserType)
         ]
-        includes = "\n".join([
-            f'#include "{filename}"\n'
-            for filename in sorted(set(filenames))
-        ])
+        includes = "\n".join(
+            [f'#include "{filename}"\n' for filename in sorted(set(filenames))]
+        )
         if includes:
             includes += "\n"
         self._replace("@@SUBSTRUCT_INCLUDES@@\n\n", includes)
@@ -729,19 +740,23 @@ class CppGen:
         package = self._struct.typ.package
         if package is None:
             return ("", "")
-        return (f"namespace {package} {{\n\n",
-                f"\n}}  // namespace {package}\n")
+        return (
+            f"namespace {package} {{\n\n",
+            f"\n}}  // namespace {package}\n",
+        )
 
     def _fill_member_constants(self):
         """Updates member constants for this message."""
-        content = "".join([
-            "  static constexpr {typ} {name} = {value};\n".format(
-                typ=self._full_typename(const.typ),
-                name=const.name,
-                value=const.value_str,
-            )
-            for const in self._struct.constants
-        ])
+        content = "".join(
+            [
+                "  static constexpr {typ} {name} = {value};\n".format(
+                    typ=self._full_typename(const.typ),
+                    name=const.name,
+                    value=const.value_str,
+                )
+                for const in self._struct.constants
+            ]
+        )
         if content:
             content += "\n"
         self._replace("@@MEMBER_CONSTANTS@@\n", content)
@@ -760,10 +775,12 @@ class CppGen:
 
     def _fill_member_fields(self):
         """Updates member fields for this message."""
-        content = "".join([
-            f"  {self._to_member_field_type(field)} {field.name};\n"
-            for field in self._struct.fields
-        ])
+        content = "".join(
+            [
+                f"  {self._to_member_field_type(field)} {field.name};\n"
+                for field in self._struct.fields
+            ]
+        )
         if content:
             content += "\n"
         self._replace("@@MEMBER_FIELDS@@\n", content)
@@ -836,25 +853,21 @@ class CppGen:
         operations = []
 
         # Check that all variable-length sizes are valid.
-        operations.extend([
-            f"({dim} >= 0)"
-            for dim in self._size_variables
-        ])
+        operations.extend([f"({dim} >= 0)" for dim in self._size_variables])
 
         # Encode the hash.
-        operations.extend([
-            "(with_hash ? _encode_field(_hash, _cursor, _end) : true)",
-        ])
+        operations.extend(
+            [
+                "(with_hash ? _encode_field(_hash, _cursor, _end) : true)",
+            ]
+        )
 
         # Encode the fields.
         for item in self._struct.fields:
             operations.extend(self._fill_one_encode(item))
 
         # Format the sequence of operations as a C++ short-circuit expression.
-        content = " &&\n".join([
-            " " * 8 + item
-            for item in operations
-        ]) + ";\n"
+        content = " &&\n".join([" " * 8 + item for item in operations]) + ";\n"
         self._replace("@@ENCODE@@\n", content)
 
     def _fill_one_encode(self, field):
@@ -874,20 +887,19 @@ class CppGen:
         operations = []
 
         # Decode the hash.
-        operations.extend([
-            "(with_hash ? _decode_field(&_hash, _cursor, _end) : true)",
-            "(_hash == _expected_hash)",
-        ])
+        operations.extend(
+            [
+                "(with_hash ? _decode_field(&_hash, _cursor, _end) : true)",
+                "(_hash == _expected_hash)",
+            ]
+        )
 
         # Decode the fields.
         for item in self._struct.fields:
             operations.extend(self._fill_one_decode(item))
 
         # Format the sequence of operations as a C++ short-circuit expression.
-        content = " &&\n".join([
-            " " * 8 + item
-            for item in operations
-        ]) + ";\n"
+        content = " &&\n".join([" " * 8 + item for item in operations]) + ";\n"
         self._replace("@@DECODE@@\n", content)
 
     def _fill_one_decode(self, field):
@@ -959,10 +971,12 @@ class CppGen:
         if has_any_user_types:
             self._replace(
                 "@@GET_HASH_DECLARE_NEW_PARENTS@@",
-                pad + "std::array<uint64_t, N + 1> new_parents{base_hash};")
+                pad + "std::array<uint64_t, N + 1> new_parents{base_hash};",
+            )
             self._replace(
                 "@@GET_HASH_UPDATE_NEW_PARENT@@",
-                pad + "  new_parents[n + 1] = parents[n];")
+                pad + "  new_parents[n + 1] = parents[n];",
+            )
         else:
             self._replace("@@GET_HASH_DECLARE_NEW_PARENTS@@\n", "")
             self._replace("@@GET_HASH_UPDATE_NEW_PARENT@@\n", "")
@@ -971,12 +985,13 @@ class CppGen:
 def main():
     description, _ = __doc__.split("# Details")
     parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("src", nargs="+", help="*.lcm source file(s)")
     parser.add_argument(
-        "src", nargs="+",
-        help="*.lcm source file(s)")
-    parser.add_argument(
-        "--outdir", required=True, type=pathlib.Path,
-        help="Directory where output files should be written")
+        "--outdir",
+        required=True,
+        type=pathlib.Path,
+        help="Directory where output files should be written",
+    )
     args = parser.parse_args()
 
     # If we were invoked via `bazel run`, we must be careful to interpret
@@ -985,7 +1000,6 @@ def main():
     if real_cwd is not None:
         os.chdir(real_cwd)
 
-    returncode = 0
     for src in args.src:
         struct = Parser.parse(filename=src)
         generator = CppGen(struct=struct)

--- a/tools/lcm_gen/test/lcm_gen_test.py
+++ b/tools/lcm_gen/test/lcm_gen_test.py
@@ -14,23 +14,19 @@ from tools.lcm_gen import (
 
 
 class BaseTest(unittest.TestCase):
+    @staticmethod
+    def _resource(relative_path: str) -> Path:
+        resource_path = f"drake/tools/lcm_gen/test/{relative_path}"
+        return Path(runfiles.Create().Rlocation(resource_path))
 
     def setUp(self):
         self.maxDiff = None
-        self._manifest = runfiles.Create()
-
-        self._lima_path = Path(self._manifest.Rlocation(
-            "drake/tools/lcm_gen/test/lima.lcm"))
-        self._lima_hpp_path = Path(self._manifest.Rlocation(
-            "drake/tools/lcm_gen/test/goal/lima.hpp"))
-        self._mike_path = Path(self._manifest.Rlocation(
-            "drake/tools/lcm_gen/test/mike.lcm"))
-        self._mike_hpp_path = Path(self._manifest.Rlocation(
-            "drake/tools/lcm_gen/test/goal/mike.hpp"))
-        self._november_path = Path(self._manifest.Rlocation(
-            "drake/tools/lcm_gen/test/november.lcm"))
-        self._november_hpp_path = Path(self._manifest.Rlocation(
-            "drake/tools/lcm_gen/test/goal/november.hpp"))
+        self._lima_path = self._resource("lima.lcm")
+        self._lima_hpp_path = self._resource("goal/lima.hpp")
+        self._mike_path = self._resource("mike.lcm")
+        self._mike_hpp_path = self._resource("goal/mike.hpp")
+        self._november_path = self._resource("november.lcm")
+        self._november_hpp_path = self._resource("goal/november.hpp")
 
         assert self._lima_path.exists()
         assert self._lima_hpp_path.exists()
@@ -52,42 +48,58 @@ class TestParser(BaseTest):
         error messages).
         """
         self.assertMultiLineEqual(
-            Parser._remove_c_comments(self._join_lines([
-                "foo",
-                "bar /* comment",
-                "still comment ",
-                "comment */ eol",
-                "bar/*quux*/baz",
-            ])),
-            self._join_lines([
-                "foo",
-                "bar           ",
-                "              ",
-                "           eol",
-                "bar        baz",
-            ]))
+            Parser._remove_c_comments(
+                self._join_lines(
+                    [
+                        "foo",
+                        "bar /* comment",
+                        "still comment ",
+                        "comment */ eol",
+                        "bar/*quux*/baz",
+                    ]
+                )
+            ),
+            self._join_lines(
+                [
+                    "foo",
+                    "bar           ",
+                    "              ",
+                    "           eol",
+                    "bar        baz",
+                ]
+            ),
+        )
 
     def test_remove_cpp_comments(self):
         """C++ comments are snipped to end-of-line."""
 
         self.assertMultiLineEqual(
-            Parser._remove_cpp_comments(self._join_lines([
-                "foo",
-                "bar // eol",
-                "// line",
-                "next",
-            ])),
-            self._join_lines([
-                "foo",
-                "bar ",
-                "",
-                "next"
-            ]))
+            Parser._remove_cpp_comments(
+                self._join_lines(
+                    [
+                        "foo",
+                        "bar // eol",
+                        "// line",
+                        "next",
+                    ]
+                )
+            ),
+            self._join_lines(
+                [
+                    "foo",
+                    "bar ",
+                    "",
+                    "next",
+                ]
+            ),
+        )
 
     def test_parse_lima(self):
         """Checks the parse tree for `lima.lcm`."""
         lima = Parser.parse(filename=self._lima_path)
-        self.assertEqual(str(lima), """\
+        self.assertEqual(
+            str(lima),
+            """\
 struct papa.lima {
   const double charlie_delta = 3.25e1;
   const float charlie_foxtrot = 4.5e2;
@@ -104,7 +116,8 @@ struct papa.lima {
   int32_t india32;
   int64_t india64;
 }
-""")
+""",
+        )
         # Check the value <=> value_str equivalence.
         for c in lima.constants:
             if c.typ in (PrimitiveType.float, PrimitiveType.double):
@@ -117,7 +130,9 @@ struct papa.lima {
     def test_parse_mike(self):
         """Checks the parse tree for `mike.lcm`."""
         mike = Parser.parse(filename=self._mike_path)
-        self.assertEqual(str(mike), """\
+        self.assertEqual(
+            str(mike),
+            """\
 struct papa.mike {
   double delta[3];
   float foxtrot[4][5];
@@ -133,7 +148,8 @@ struct papa.mike {
   papa.lima yankee[rows];
   papa.lima zulu[rows][2];
 }
-""")
+""",
+        )
         # Check one field carefully for its exact representation.
         (zulu,) = [f for f in mike.fields if f.name == "zulu"]
         self.assertEqual(zulu.typ.package, "papa")
@@ -144,13 +160,16 @@ struct papa.mike {
     def test_parse_november(self):
         """Checks the parse tree for `november.lcm`."""
         november = Parser.parse(filename=self._november_path)
-        self.assertEqual(str(november), """\
+        self.assertEqual(
+            str(november),
+            """\
 struct papa.november {
   papa.lima alpha;
   papa.lima bravo;
   int32_t charlie;
 }
-""")
+""",
+        )
 
     def test_type_str(self):
         """Tests UserType.__str__. The end-to-end tests of the parser wouldn't
@@ -164,19 +183,18 @@ struct papa.november {
 
     def _parse_str(self, content):
         with tempfile.NamedTemporaryFile(
-                mode="w",
-                prefix="lcm_gen_test_",
-                encoding="utf-8") as f:
+            mode="w", prefix="lcm_gen_test_", encoding="utf-8"
+        ) as f:
             f.write(content)
             f.flush()
             return Parser.parse(filename=f.name)
 
     def test_missing_package_semi(self):
         with self.assertRaisesRegex(SyntaxError, "Expected ';'.*got.*struct"):
-            self._parse_str('package foo /*;*/ struct empty { }')
+            self._parse_str("package foo /*;*/ struct empty { }")
 
     def test_multiline_const(self):
-        foo = self._parse_str('struct foo { const int8_t x = 1, y = 2; }')
+        foo = self._parse_str("struct foo { const int8_t x = 1, y = 2; }")
         self.assertEqual(foo.constants[0].name, "x")
         self.assertEqual(foo.constants[0].value, 1)
         self.assertEqual(foo.constants[1].name, "y")
@@ -186,15 +204,15 @@ struct papa.november {
         with self.assertRaisesRegex(SyntaxError, "Expected.*primitive type"):
             self._parse_str('struct bad { const string name = "foo"; }')
         with self.assertRaisesRegex(SyntaxError, "Expected.*primitive type"):
-            self._parse_str('struct bad { const bignum x = 2222; }')
+            self._parse_str("struct bad { const bignum x = 2222; }")
 
     def test_bad_const_value(self):
         with self.assertRaisesRegex(SyntaxError, "Invalid.*value.*0x7f"):
-            self._parse_str('struct bad { const int8_t x = 0x7f; }')
+            self._parse_str("struct bad { const int8_t x = 0x7f; }")
 
     def test_missing_const_name(self):
         with self.assertRaisesRegex(SyntaxError, "Expected.*NAME"):
-            self._parse_str('struct bad { const double /* name */ = 1; }')
+            self._parse_str("struct bad { const double /* name */ = 1; }")
 
 
 class TestCppGen(BaseTest):

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "drake_py_unittest",
 )
 load("//tools/skylark:drake_sh.bzl", "drake_sh_test")
+load("//tools/skylark:sh.bzl", "sh_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -108,6 +109,16 @@ drake_py_binary(
         ":module_py",
     ],
 )
+
+sh_binary(
+    name = "ruff",
+    srcs = ["ruff.sh"],
+    data = [
+        "@ruff",
+    ],
+)
+
+exports_files(["ruff_format_lint.sh"])
 
 # === test ===
 

--- a/tools/lint/lint.bzl
+++ b/tools/lint/lint.bzl
@@ -9,6 +9,7 @@ def add_lint_tests(
         cpplint_extra_srcs = None,
         python_lint_exclude = None,
         python_lint_extra_srcs = None,
+        python_lint_use_ruff = False,
         bazel_lint_ignore = None,
         bazel_lint_extra_srcs = None,
         bazel_lint_exclude = None,
@@ -35,6 +36,7 @@ def add_lint_tests(
         existing_rules = existing_rules,
         exclude = python_lint_exclude,
         extra_srcs = python_lint_extra_srcs,
+        use_ruff = python_lint_use_ruff,
     )
     bazel_lint(
         ignore = bazel_lint_ignore,

--- a/tools/lint/python_lint.bzl
+++ b/tools/lint/python_lint.bzl
@@ -1,19 +1,40 @@
 load("//tools/skylark:drake_py.bzl", "py_test_isolated")
+load("//tools/skylark:sh.bzl", "sh_test")
 
 # Internal helper.
-def _python_lint(name_prefix, files, disallow_executable):
-    # Pycodestyle.
+def _python_lint(*, name_prefix, files, use_ruff, disallow_executable):
     locations = ["$(location %s)" % f for f in files]
-    py_test_isolated(
-        name = name_prefix + "_pycodestyle",
-        size = "small",
-        srcs = ["@pycodestyle_internal//:pycodestyle"],
-        deps = ["@drake//tools/lint:module_py"],
-        data = files,
-        args = locations + ["--max-line-length=80"],
-        main = "@pycodestyle_internal//:pycodestyle.py",
-        tags = ["pycodestyle", "lint"],
-    )
+
+    if use_ruff:
+        # Ruff.
+        sh_test(
+            name = name_prefix + "_ruff_check_lint",
+            size = "small",
+            srcs = ["@ruff"],
+            data = ["//:.ruff.toml"] + files,
+            args = ["check"] + locations,
+            tags = ["ruff", "lint"],
+        )
+        sh_test(
+            name = name_prefix + "_ruff_format_lint",
+            size = "small",
+            srcs = ["//tools/lint:ruff_format_lint.sh"],
+            data = ["@ruff", "//:.ruff.toml"] + files,
+            args = locations,
+            tags = ["ruff", "lint"],
+        )
+    else:
+        # Pycodestyle.
+        py_test_isolated(
+            name = name_prefix + "_pycodestyle",
+            size = "small",
+            srcs = ["@pycodestyle_internal//:pycodestyle"],
+            deps = ["@drake//tools/lint:module_py"],
+            data = files,
+            args = locations + ["--max-line-length=80"],
+            main = "@pycodestyle_internal//:pycodestyle.py",
+            tags = ["pycodestyle", "lint"],
+        )
 
     # Additional Drake lint.
     drakelint_args = []
@@ -33,7 +54,8 @@ def _python_lint(name_prefix, files, disallow_executable):
 def python_lint(
         existing_rules = None,
         exclude = None,
-        extra_srcs = None):
+        extra_srcs = None,
+        use_ruff = False):
     """Runs the pycodestyle PEP 8 code style checker on all Python source files
     declared in rules in a BUILD file.  Also runs the drakelint.py linter.
 
@@ -43,9 +65,13 @@ def python_lint(
             internally (re-)computed.
         exclude: List of labels to exclude from linting, e.g., [:foo.py].
         extra_srcs: Source files that are not discoverable via rules.
+        use_ruff: When True, use ruff instead of pycodestyle.
     """
     if existing_rules == None:
         existing_rules = native.existing_rules().values()
+
+    # Collect all source files and de-duplicate.
+    files = []
     for rule in existing_rules:
         # Disable linting when requested (e.g., for generated code).
         if "nolint" in rule.get("tags"):
@@ -54,26 +80,38 @@ def python_lint(
         # Extract the list of python sources.
         srcs = rule.get("srcs", ())
         if type(srcs) == type(()):
-            files = [
+            files.extend([
                 s
                 for s in srcs
                 if s.endswith(".py") and s not in (exclude or [])
-            ]
+            ])
         else:
             # The select() syntax returns an object we (apparently) can't
             # inspect.  TODO(jwnimmer-tri) Figure out how to lint these files.
-            files = []
+            pass
+    files = depset(files).to_list()
 
-        # Add a lint test if necessary.
-        if files:
-            _python_lint(
-                name_prefix = rule["name"],
-                files = files,
-                disallow_executable = True,
-            )
+    # Our `drake_py_unittest` adds this to `srcs` for all tests. We don't want
+    # to lint it at those points of use, rather only in //common/test_utilities
+    # where it doesn't have the full bazel package name in front of it.
+    helper = "//common/test_utilities:drake_py_unittest_main.py"
+    if helper in files:
+        files.remove(helper)
+
+    # Add a lint test if necessary.
+    if len(files) > 0:
+        _python_lint(
+            name_prefix = "package",
+            files = files,
+            use_ruff = use_ruff,
+            disallow_executable = True,
+        )
+
+    # We must lint these separately due to `disallow_executable` varying.
     if extra_srcs:
         _python_lint(
             name_prefix = "extra_srcs",
             files = extra_srcs,
+            use_ruff = use_ruff,
             disallow_executable = False,
         )

--- a/tools/lint/ruff.sh
+++ b/tools/lint/ruff.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# A wrapper intended for Drake Developers via `bazel run` that restores the
+# current working directory before running `ruff`.
+
+set -eu
+
+# Find a stable path to ruff.
+RUFF=$(realpath ../ruff_prebuilt+/ruff)
+
+# Change back to the user's CWD.
+cd ${BUILD_WORKING_DIRECTORY}
+
+# Now relative paths on the command line will work correctly.
+exec $RUFF "$@"

--- a/tools/lint/ruff_format_lint.sh
+++ b/tools/lint/ruff_format_lint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# A helper script used by python_lint.bzl that wraps `ruff format --check` with
+# Drake-specific advice about how to fix the lint.
+
+set -eu
+
+# Loop over the files one by one so that we can give specific feedback.
+needs_format=""
+exitcode=0
+for file in "$@"; do
+  if ! ../ruff_prebuilt+/ruff format --check --quiet "${file}"; then
+    needs_format="${needs_format} ${file}"
+    exitcode=1
+  fi
+done
+
+if test -n "${needs_format}"; then
+  echo "ERROR: One or more files need ruff format" 1>&2
+  echo "note: fix via: bazel run -- //tools/lint:ruff format${needs_format}" 1>&2
+fi
+
+exit ${exitcode}


### PR DESCRIPTION
Towards #19827 and #13571.

The objective here is to get a foot in the door with this PR, and then soon afterward switch from opt-in to opt-out, port all of Drake to use it (fine-tuning the config file as we go), and then remove the opt-out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23427)
<!-- Reviewable:end -->
