### PR TITLE
Partially revert "Re-enable sanitization for render_gl tests"

### DIFF
--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -241,6 +241,13 @@ drake_cc_googletest_linux_only(
         # memcheck tests in order to make progress on related code.
         # TODO(#12962) Investigate, fix or suppress, then re-enable this test.
         "no_memcheck",
+
+        # Since migrating CI Jenkins jobs from Jammy to Noble, this test
+        # causes the newly converted ASAN jobs to fail. It also fails for Noble
+        # LSAN jobs since upgrading the provisioned images on 2025-09-01.
+        # TODO(#23107) Investigate, fix or suppress, then re-enable this test.
+        "no_asan",
+        "no_lsan",
     ],
     deps = [
         ":internal_opengl_context",


### PR DESCRIPTION
This reverts commit 75f746c1050407ac8fcd0c467da7ee073d00f456.

It seems that the suppression in #23421 was a step in the right direction, but there's still another leak to address.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23428)
<!-- Reviewable:end -->
