### PR TITLE
[workspace] Add two flags for opting-out of LCM features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,6 +636,22 @@ if(WITH_MOSEK)
   string(APPEND BAZEL_CONFIG " --config=mosek")
 endif()
 
+option(WITH_LCM_RUNTIME "Build with LCM runtime library support" ON)
+
+if(WITH_LCM_RUNTIME)
+  string(APPEND BAZEL_CONFIG " --@drake//tools/flags:with_lcm_runtime=True")
+else()
+  string(APPEND BAZEL_CONFIG " --@drake//tools/flags:with_lcm_runtime=False")
+endif()
+
+option(WITH_DRAKE_LCMTYPES_JAVA "Build lcmtypes_drake.jar" ON)
+
+if(WITH_DRAKE_LCMTYPES_JAVA)
+  string(APPEND BAZEL_CONFIG " --@drake//tools/flags:with_drake_lcmtypes_java=True")
+else()
+  string(APPEND BAZEL_CONFIG " --@drake//tools/flags:with_drake_lcmtypes_java=False")
+endif()
+
 option(WITH_OPENMP "Build with support for OpenMP" OFF)
 if(WITH_OPENMP)
   string(APPEND BAZEL_CONFIG " --config=omp")

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -49,9 +49,10 @@ PYBIND11_MODULE(lcm, m) {
                   channel, [handler](const void* data, int size) {
                     handler(py::bytes(static_cast<const char*>(data), size));
                   });
-              DRAKE_DEMAND(subscription != nullptr);
-              // This is already the default, but for clarity we'll repeat it.
-              subscription->set_unsubscribe_on_delete(false);
+              if (subscription != nullptr) {
+                // This is already the default, but for clarity we'll repeat it.
+                subscription->set_unsubscribe_on_delete(false);
+              }
             },
             py::arg("channel"), py::arg("handler"), cls_doc.Subscribe.doc)
         .def(
@@ -64,9 +65,10 @@ PYBIND11_MODULE(lcm, m) {
                     handler(channel,
                         py::bytes(static_cast<const char*>(data), size));
                   });
-              DRAKE_DEMAND(subscription != nullptr);
-              // This is already the default, but for clarity we'll repeat it.
-              subscription->set_unsubscribe_on_delete(false);
+              if (subscription != nullptr) {
+                // This is already the default, but for clarity we'll repeat it.
+                subscription->set_unsubscribe_on_delete(false);
+              }
             },
             py::arg("regex"), py::arg("handler"),
             cls_doc.SubscribeMultichannel.doc)
@@ -79,9 +81,10 @@ PYBIND11_MODULE(lcm, m) {
                     handler(channel,
                         py::bytes(static_cast<const char*>(data), size));
                   });
-              DRAKE_DEMAND(subscription != nullptr);
-              // This is already the default, but for clarity we'll repeat it.
-              subscription->set_unsubscribe_on_delete(false);
+              if (subscription != nullptr) {
+                // This is already the default, but for clarity we'll repeat it.
+                subscription->set_unsubscribe_on_delete(false);
+              }
             },
             py::arg("handler"), cls_doc.SubscribeAllChannels.doc)
         .def("HandleSubscriptions", &DrakeLcmInterface::HandleSubscriptions,
@@ -108,7 +111,8 @@ PYBIND11_MODULE(lcm, m) {
         .def(py::init<std::string>(), py::arg("lcm_url"),
             cls_doc.ctor.doc_1args_lcm_url)
         .def(py::init<DrakeLcmParams>(), py::arg("params"),
-            cls_doc.ctor.doc_1args_params);
+            cls_doc.ctor.doc_1args_params)
+        .def_static("available", &Class::available, cls_doc.available.doc);
   }
 
   ExecuteExtraPythonCode(m);

--- a/bindings/pydrake/test/lcm_test.py
+++ b/bindings/pydrake/test/lcm_test.py
@@ -16,6 +16,7 @@ class TestLcm(unittest.TestCase):
         self.count = 0
 
     def test_lcm(self):
+        self.assertTrue(DrakeLcm.available())
         dut = DrakeLcm()
         self.assertIsInstance(dut, DrakeLcmInterface)
         dut.get_lcm_url()

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -153,6 +153,13 @@ Adjusting open-source dependencies:
 * `WITH_NLOPT` (default `ON`). When `ON`, enables the `NloptSolver` in the build.
 * `WITH_OSQP` (default `ON`). When `ON`, enables the `OsqpSolver` in the build.
 * `WITH_SCS` (default `ON`). When `ON`, enables the `ScsSolver` in the build.
+* `WITH_LCM_RUNTIME` (default `ON`). When `ON`, the LGPL-licensed LCM runtime
+  library will be installed alongside Drake. When OFF, the library will not be
+  installed and the static methods `DrakeLcm::available()` and
+  `DrakeLcmLog::available()` will return `false`.
+* `WITH_DRAKE_LCMTYPES_JAVA` (default `ON`). When `ON`, the message library
+  `lcmtypes_drake.jar` will be compiled and installed. Setting to `OFF` might be
+  helpful to avoid depending on a JDK during the build.
 
 Adjusting closed-source (commercial) software dependencies:
 

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -68,32 +68,62 @@ drake_cc_library(
 
 drake_cc_library(
     name = "drake_lcm",
-    srcs = ["drake_lcm.cc"],
+    srcs = select({
+        "//tools/workspace/lcm:flag_with_lcm_runtime_true": [
+            "drake_lcm.cc",
+        ],
+        "//conditions:default": [
+            "drake_lcm_disabled.cc",
+        ],
+    }),
     hdrs = ["drake_lcm.h"],
+    tags = [
+        # The select() confuses add_lint_tests(). Instead of linting this
+        # library, we'll add its sources to cpplint_extra_srcs, below.
+        "nolint",
+    ],
     deps = [
         ":drake_lcm_params",
         ":interface",
         "//common:essential",
     ],
-    implementation_deps = [
-        "//common:network_policy",
-        "@glib",
-        "@lcm",
-    ],
+    implementation_deps = select({
+        "//tools/workspace/lcm:flag_with_lcm_runtime_true": [
+            "//common:network_policy",
+            "@glib",
+            "@lcm",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 drake_cc_library(
     name = "lcm_log",
-    srcs = ["drake_lcm_log.cc"],
+    srcs = select({
+        "//tools/workspace/lcm:flag_with_lcm_runtime_true": [
+            "drake_lcm_log.cc",
+        ],
+        "//conditions:default": [
+            "drake_lcm_log_disabled.cc",
+        ],
+    }),
     hdrs = ["drake_lcm_log.h"],
+    tags = [
+        # The select() confuses add_lint_tests(). Instead of linting this
+        # library, we'll add its sources to cpplint_extra_srcs, below.
+        "nolint",
+    ],
     deps = [
         ":interface",
         "//common:essential",
     ],
-    implementation_deps = [
-        "//common:string_container",
-        "@lcm",
-    ],
+    implementation_deps = select({
+        "//tools/workspace/lcm:flag_with_lcm_runtime_true": [
+            "//common:string_container",
+            "@lcm",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 drake_cc_library(
@@ -158,6 +188,28 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "drake_lcm_disabled_test",
+    srcs = [
+        "drake_lcm.h",
+        "drake_lcm_disabled.cc",
+        "drake_lcm_log.h",
+        "drake_lcm_log_disabled.cc",
+        "test/drake_lcm_disabled_test.cc",
+    ],
+    tags = [
+        # To avoid linting these files twice, we'll turn off lint here and then
+        # add the test file to cpplint_extra_srcs, below.
+        "nolint",
+    ],
+    deps = [
+        ":drake_lcm_params",
+        ":interface",
+        "//common/test_utilities:expect_throws_message",
+        "//lcmtypes:drake_signal",
+    ],
+)
+
+drake_cc_googletest(
     name = "drake_lcm_thread_test",
     flaky = True,
     deps = [
@@ -212,4 +264,14 @@ drake_py_test(
     deps = ["@lcm//:lcm-python"],
 )
 
-add_lint_tests()
+add_lint_tests(
+    cpplint_extra_srcs = [
+        "drake_lcm.h",
+        "drake_lcm.cc",
+        "drake_lcm_disabled.cc",
+        "drake_lcm_log.h",
+        "drake_lcm_log.cc",
+        "drake_lcm_log_disabled.cc",
+        "test/drake_lcm_disabled_test.cc",
+    ],
+)

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -371,5 +371,9 @@ DrakeLcm::~DrakeLcm() {
   ::lcm_destroy(impl_->lcm_);
 }
 
+bool DrakeLcm::available() {
+  return true;
+}
+
 }  // namespace lcm
 }  // namespace drake

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -58,6 +58,12 @@ class DrakeLcm : public DrakeLcmInterface {
       MultichannelHandlerFunction) override;
   int HandleSubscriptions(int) override;
 
+  /** Returns true if the LCM runtime library is enabled in this build of Drake.
+   * When false, functions that require the runtime (e.g., HandleSubscriptions
+   * and Publish) will throw an error.
+   */
+  static bool available();
+
  private:
   friend class DrakeLcmTester;
 

--- a/lcm/drake_lcm_disabled.cc
+++ b/lcm/drake_lcm_disabled.cc
@@ -1,0 +1,78 @@
+/* clang-format off */
+#include "drake/lcm/drake_lcm.h"
+/* clang-format on */
+
+#include <memory>
+#include <source_location>
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace lcm {
+namespace {
+[[noreturn]] void ThrowError(
+    std::source_location caller = std::source_location::current()) {
+  throw std::logic_error(fmt::format(
+      "{} cannot be used because the LCM runtime library has been disabled "
+      "in this build of Drake",
+      caller.function_name()));
+}
+}  // namespace
+
+class DrakeLcm::Impl {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Impl);
+};
+
+DrakeLcm::DrakeLcm() = default;
+
+DrakeLcm::DrakeLcm(std::string) {}
+
+DrakeLcm::DrakeLcm(const DrakeLcmParams&) {}
+
+DrakeLcm::~DrakeLcm() = default;
+
+std::string DrakeLcm::get_lcm_url() const {
+  return "unavailable://";
+}
+
+void DrakeLcm::Publish(const std::string&, const void*, int,
+                       std::optional<double>) {
+  ThrowError();
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcm::Subscribe(
+    const std::string&, HandlerFunction) {
+  return nullptr;
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcm::SubscribeMultichannel(
+    std::string_view, MultichannelHandlerFunction) {
+  return nullptr;
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcm::SubscribeAllChannels(
+    MultichannelHandlerFunction) {
+  return nullptr;
+}
+
+int DrakeLcm::HandleSubscriptions(int) {
+  ThrowError();
+}
+
+void* DrakeLcm::get_native_lcm_handle_for_unit_testing() {
+  ThrowError();
+}
+
+void DrakeLcm::OnHandleSubscriptionsError(const std::string&) {
+  ThrowError();
+}
+
+bool DrakeLcm::available() {
+  return false;
+}
+
+}  // namespace lcm
+}  // namespace drake

--- a/lcm/drake_lcm_log.cc
+++ b/lcm/drake_lcm_log.cc
@@ -162,5 +162,9 @@ void DrakeLcmLog::OnHandleSubscriptionsError(const std::string& error_message) {
   throw std::runtime_error(error_message);
 }
 
+bool DrakeLcmLog::available() {
+  return true;
+}
+
 }  // namespace lcm
 }  // namespace drake

--- a/lcm/drake_lcm_log.h
+++ b/lcm/drake_lcm_log.h
@@ -140,6 +140,12 @@ class DrakeLcmLog : public DrakeLcmInterface {
 
   std::string get_lcm_url() const override;
 
+  /** Returns true if the LCM runtime library is enabled in this build of Drake.
+   * When false, functions that require the runtime (which at the moment is all
+   * functions, including the constructor) will throw an error.
+   */
+  static bool available();
+
  private:
   void OnHandleSubscriptionsError(const std::string&) override;
 

--- a/lcm/drake_lcm_log_disabled.cc
+++ b/lcm/drake_lcm_log_disabled.cc
@@ -1,0 +1,81 @@
+/* clang-format off */
+#include "drake/lcm/drake_lcm_log.h"
+/* clang-format on */
+
+#include <memory>
+#include <source_location>
+#include <stdexcept>
+#include <string>
+
+namespace drake {
+namespace lcm {
+namespace {
+[[noreturn]] void ThrowError(
+    std::source_location caller = std::source_location::current()) {
+  throw std::logic_error(fmt::format(
+      "{} cannot be used because the LCM runtime library has been disabled "
+      "in this build of Drake",
+      caller.function_name()));
+}
+}  // namespace
+
+class DrakeLcmLog::Impl {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Impl);
+};
+
+DrakeLcmLog::DrakeLcmLog(const std::string&, bool is_write,
+                         bool overwrite_publish_time_with_system_clock)
+    : is_write_{/* ignored */},
+      overwrite_publish_time_with_system_clock_{/* ignored */} {
+  ThrowError();
+}
+
+DrakeLcmLog::~DrakeLcmLog() = default;
+
+std::string DrakeLcmLog::get_lcm_url() const {
+  ThrowError();
+}
+
+void DrakeLcmLog::Publish(const std::string&, const void*, int,
+                          std::optional<double>) {
+  ThrowError();
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcmLog::Subscribe(
+    const std::string&, HandlerFunction) {
+  ThrowError();
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcmLog::SubscribeMultichannel(
+    std::string_view, MultichannelHandlerFunction) {
+  ThrowError();
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcmLog::SubscribeAllChannels(
+    MultichannelHandlerFunction) {
+  ThrowError();
+}
+
+int DrakeLcmLog::HandleSubscriptions(int) {
+  ThrowError();
+}
+
+double DrakeLcmLog::GetNextMessageTime() const {
+  ThrowError();
+}
+
+void DrakeLcmLog::DispatchMessageAndAdvanceLog(double) {
+  ThrowError();
+}
+
+void DrakeLcmLog::OnHandleSubscriptionsError(const std::string&) {
+  ThrowError();
+}
+
+bool DrakeLcmLog::available() {
+  return false;
+}
+
+}  // namespace lcm
+}  // namespace drake

--- a/lcm/test/drake_lcm_disabled_test.cc
+++ b/lcm/test/drake_lcm_disabled_test.cc
@@ -1,0 +1,48 @@
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcm/drake_lcm_log.h"
+#include "drake/lcmt_drake_signal.hpp"
+
+namespace drake {
+namespace lcm {
+namespace {
+
+GTEST_TEST(DrakeLcmDisabledTest, DrakeLcm) {
+  EXPECT_FALSE(DrakeLcm::available());
+
+  DrakeLcm dut;
+  EXPECT_NO_THROW(std::make_unique<DrakeLcm>("memq://"));
+  EXPECT_NO_THROW(std::make_unique<DrakeLcm>(DrakeLcmParams{"memq://"}));
+
+  const std::string channel = "DRAKE_LCM_DISABLED_TEST";
+  const lcmt_drake_signal signal{};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      Publish(&dut, channel, signal),
+      ".*DrakeLcm::Publish.*cannot be used.*disabled.*");
+
+  EXPECT_NO_THROW(dut.get_lcm_url());
+
+  auto ignore = [](auto&&...) {};
+  EXPECT_NO_THROW(dut.Subscribe(channel, ignore));
+  EXPECT_NO_THROW(dut.SubscribeMultichannel(channel, ignore));
+  EXPECT_NO_THROW(dut.SubscribeAllChannels(ignore));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.HandleSubscriptions(0),
+      ".*DrakeLcm::HandleSubscriptions.*cannot be used.*disabled.*");
+}
+
+GTEST_TEST(DrakeLcmDisabledTest, DrakeLcmLog) {
+  EXPECT_FALSE(DrakeLcmLog::available());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DrakeLcmLog("write.lcmlog", true),
+      ".*DrakeLcmLog::DrakeLcmLog.*cannot be used.*disabled.*");
+}
+
+}  // namespace
+}  // namespace lcm
+}  // namespace drake

--- a/lcm/test/drake_lcm_log_test.cc
+++ b/lcm/test/drake_lcm_log_test.cc
@@ -16,6 +16,8 @@ namespace {
 // Generates a log file using the write-only interface, then plays it back
 // and check message content with a subscriber.
 GTEST_TEST(LcmLogTest, LcmLogTestSaveAndRead) {
+  EXPECT_TRUE(DrakeLcmLog::available());
+
   auto w_log = std::make_unique<DrakeLcmLog>("test.log", true);
   const std::string channel_name("test_channel");
 

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -74,6 +74,7 @@ class DrakeLcmTest : public ::testing::Test {
 };
 
 TEST_F(DrakeLcmTest, DefaultUrlTest) {
+  EXPECT_TRUE(DrakeLcm::available());
   EXPECT_GT(dut_->get_lcm_url().size(), 0);
 }
 

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -318,36 +318,41 @@ drake_transitive_installed_hdrs_filegroup(
 )
 
 install(
-    name = "install_drake_cc_headers",
+    name = "install_lcmtypes_cc",
     hdrs = [":lcmtypes_drake_cc_headers"],
     hdr_dest = "include",
     visibility = ["//visibility:private"],
 )
 
-# Provide an opt-out that avoids installing Java LCM libraries (e.g., we don't
-# need to install Java typtes when we're building a Python wheel).
+install(
+    name = "install_lcmtypes_python",
+    targets = [":lcmtypes_drake_py"],
+    visibility = ["//visibility:private"],
+)
+
+install(
+    name = "install_lcmtypes_java",
+    targets = [":lcmtypes_drake_java"],
+    rename = {"share/java/liblcmtypes_drake_java.jar": "lcmtypes_drake.jar"},
+    visibility = ["//visibility:private"],
+)
+
 config_setting(
-    name = "lcm_install_java_is_off",
-    values = {"define": "LCM_INSTALL_JAVA=OFF"},
+    name = "flag_with_drake_lcmtypes_java_true",
+    flag_values = {"//tools/flags:with_drake_lcmtypes_java": "True"},
 )
 
 install(
     name = "install",
-    targets = [
-        ":lcmtypes_drake_py",
-    ] + select({
-        ":lcm_install_java_is_off": [],
-        "//conditions:default": [
-            ":lcmtypes_drake_java",
-        ],
-    }),
-    rename = {
-        "share/java/liblcmtypes_drake_java.jar": "lcmtypes_drake.jar",
-    },
     deps = [
-        ":install_drake_cc_headers",
-        "@lcm//:install",
-    ],
+        ":install_lcmtypes_cc",
+        ":install_lcmtypes_python",
+    ] + select({
+        ":flag_with_drake_lcmtypes_java_true": [
+            ":install_lcmtypes_java",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 # === test/ ===

--- a/tools/flags/BUILD.bazel
+++ b/tools/flags/BUILD.bazel
@@ -305,5 +305,23 @@ bool_flag(
 )
 
 # -----------------------------------------------------------------------------
+# Configuration for LCM (http://lcm-proj.github.io/lcm/).
+
+# When False, LCM is not available at runtime (i.e., DrakeLcm::available() and
+# DrakeLcmLog::available() will both be `false`). This does not affect lcm-gen
+# code generation for messages.
+bool_flag(
+    name = "with_lcm_runtime",
+    build_setting_default = True,
+)
+
+# When False, lcmtypes_drake.jar will not be installed. (This might be helpful
+# to avoid depending on a JDK during the build.)
+bool_flag(
+    name = "with_drake_lcmtypes_java",
+    build_setting_default = True,
+)
+
+# -----------------------------------------------------------------------------
 
 add_lint_tests()

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -279,8 +279,8 @@ cc_library(
         ":x11_deps",
         "//common:drake_marker_shared_library",
         "//tools/workspace/fmt:shared_library_maybe",
+        "//tools/workspace/lcm:shared_library_maybe",
         "//tools/workspace/spdlog:shared_library_maybe",
-        "@lcm",
     ],
 )
 

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -21,7 +21,6 @@ build --repository_cache=/var/cache/bazel/repository_cache
 build --repo_env=DRAKE_WHEEL=1
 build --repo_env=SNOPT_PATH=${SNOPT_PATH}
 build --config=packaging
-build --define=LCM_INSTALL_JAVA=OFF
 # Enable MOSEK lazy loading. Right now this is only done for Linux builds.
 build --@drake//solvers:mosek_lazy_load=True
 EOF
@@ -35,6 +34,7 @@ cmake ../drake-src \
     -DWITH_USER_BLAS=OFF \
     -DWITH_USER_LAPACK=OFF \
     -DWITH_USER_ZLIB=OFF \
+    -DWITH_DRAKE_LCMTYPES_JAVA=OFF \
     -DDRAKE_VERSION_OVERRIDE="${DRAKE_VERSION}" \
     -DDRAKE_GIT_SHA_OVERRIDE="${DRAKE_GIT_SHA}" \
     -DCMAKE_INSTALL_PREFIX=/tmp/drake-wheel-build/drake-dist \

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -48,7 +48,6 @@ build --repository_cache=$HOME/.cache/drake-wheel-build/bazel/repository_cache
 build --repo_env=DRAKE_WHEEL=1
 build --repo_env=SNOPT_PATH=${SNOPT_PATH}
 build --config=packaging
-build --define=LCM_INSTALL_JAVA=OFF
 # See tools/wheel/wheel_builder/macos.py for more on this env variable.
 build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
 EOF
@@ -62,6 +61,7 @@ cmake "$git_root" \
     -DWITH_USER_BLAS=OFF \
     -DWITH_USER_LAPACK=OFF \
     -DWITH_USER_ZLIB=OFF \
+    -DWITH_DRAKE_LCMTYPES_JAVA=OFF \
     -DDRAKE_VERSION_OVERRIDE="${DRAKE_VERSION}" \
     -DCMAKE_INSTALL_PREFIX="/tmp/drake-wheel-build/drake-dist" \
     -DPython_EXECUTABLE="$python_executable"

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -88,7 +88,6 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "gz_math_internal",
     "gz_utils_internal",
     "ipopt_internal",
-    "lcm",
     "libpng_internal",
     "libtiff_internal",
     "meshcat",
@@ -151,6 +150,9 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "//conditions:default": [],
 }) + select({
     "//tools/workspace/scs_internal:enabled": ["@scs_internal//:install"],
+    "//conditions:default": [],
+}) + select({
+    "//tools/workspace/lcm:flag_with_lcm_runtime_true": ["@lcm//:install"],
     "//conditions:default": [],
 })
 

--- a/tools/workspace/lcm/BUILD.bazel
+++ b/tools/workspace/lcm/BUILD.bazel
@@ -1,6 +1,20 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
 
+config_setting(
+    name = "flag_with_lcm_runtime_true",
+    flag_values = {"//tools/flags:with_lcm_runtime": "True"},
+)
+
+cc_library(
+    name = "shared_library_maybe",
+    visibility = ["//tools/install/libdrake:__pkg__"],
+    deps = select({
+        ":flag_with_lcm_runtime_true": ["@lcm"],
+        "//conditions:default": [],
+    }),
+)
+
 drake_py_unittest(
     name = "no_lcm_warnings_test",
     deps = ["@lcm//:lcm-python"],


### PR DESCRIPTION
(1) Formalize the "don't install drake java lcmtypes" option used by the wheel build, making it available to the public.

(2) Add a new option to disable the LCM runtime entirely.  This is helpful for users who wish to avoid LGPL code.