### PR TITLE
[wheel] Refactor HOMEBREW_PREFIX computation in image/build-wheel.sh

### DIFF
--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -5,7 +5,7 @@
 set -eu -o pipefail
 
 if [[ "$(uname)" == "Darwin" ]]; then
-    HOMEBREW="$(brew config | \grep -E '^HOMEBREW_PREFIX' | cut -c18-)"
+    HOMEBREW="$(brew --prefix)"
 
     # Use GNU 'cp' on macOS so we have a consistent CLI.
     cp()


### PR DESCRIPTION
```
$  [[ "$(brew config | \grep -E '^HOMEBREW_PREFIX' | cut -c18-)" = "$(brew --prefix)" ]] && echo "true"
true
```

Also used here: 

https://github.com/RobotLocomotion/drake/blob/3bb881e305e999527c6c11283b50f1c6544391c9/tools/wheel/macos/build-wheel.sh#L26

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23443)
<!-- Reviewable:end -->
