### PR TITLE
[tools] Remove unused python_lint_ignore customization

### DIFF
--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -1,10 +1,5 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
-    "//tools/lint:python_lint.bzl",
-    "PYTHON_LINT_IGNORE_DEFAULT",
-    "python_lint",
-)
-load(
     "//tools/skylark:drake_py.bzl",
     "drake_py_binary",
     "drake_py_library",
@@ -136,13 +131,6 @@ drake_py_unittest(
         "no_kcov",
     ],
     deps = [":util"],
-)
-
-# Exercise `ignore` for `python_lint`.
-python_lint(
-    existing_rules = [],
-    extra_srcs = ["test/python_lint_ignore_example.py"],
-    ignore = ["E402"],
 )
 
 add_lint_tests()

--- a/tools/lint/lint.bzl
+++ b/tools/lint/lint.bzl
@@ -7,7 +7,6 @@ load("//tools/lint:python_lint.bzl", "python_lint")
 def add_lint_tests(
         cpplint_data = None,
         cpplint_extra_srcs = None,
-        python_lint_ignore = None,
         python_lint_exclude = None,
         python_lint_extra_srcs = None,
         bazel_lint_ignore = None,
@@ -34,7 +33,6 @@ def add_lint_tests(
     )
     python_lint(
         existing_rules = existing_rules,
-        ignore = python_lint_ignore,
         exclude = python_lint_exclude,
         extra_srcs = python_lint_extra_srcs,
     )

--- a/tools/lint/python_lint.bzl
+++ b/tools/lint/python_lint.bzl
@@ -1,13 +1,7 @@
 load("//tools/skylark:drake_py.bzl", "py_test_isolated")
 
-# N.B. Copied from `DEFAULT_IGNORE` in `pycodestyle.py`.
-PYTHON_LINT_IGNORE_DEFAULT = "E121,E123,E126,E226,E24,E704,W503".split(",")
-
 # Internal helper.
-def _python_lint(name_prefix, files, ignore, disallow_executable):
-    ignore_types = PYTHON_LINT_IGNORE_DEFAULT + (ignore or [])
-    ignore_args = ["--ignore={}".format(",".join(ignore_types))]
-
+def _python_lint(name_prefix, files, disallow_executable):
     # Pycodestyle.
     locations = ["$(location %s)" % f for f in files]
     py_test_isolated(
@@ -16,7 +10,7 @@ def _python_lint(name_prefix, files, ignore, disallow_executable):
         srcs = ["@pycodestyle_internal//:pycodestyle"],
         deps = ["@drake//tools/lint:module_py"],
         data = files,
-        args = ignore_args + locations + ["--max-line-length=80"],
+        args = locations + ["--max-line-length=80"],
         main = "@pycodestyle_internal//:pycodestyle.py",
         tags = ["pycodestyle", "lint"],
     )
@@ -38,7 +32,6 @@ def _python_lint(name_prefix, files, ignore, disallow_executable):
 
 def python_lint(
         existing_rules = None,
-        ignore = None,
         exclude = None,
         extra_srcs = None):
     """Runs the pycodestyle PEP 8 code style checker on all Python source files
@@ -48,8 +41,6 @@ def python_lint(
         existing_rules: The value of native.existing_result().values(), in case
             it has already been computed.  When not supplied, the value will be
             internally (re-)computed.
-        ignore: List of errors to ignore, in addition to
-            PYTHON_LINT_IGNORE_DEFAULT (as strings, with the 'E' or 'W').
         exclude: List of labels to exclude from linting, e.g., [:foo.py].
         extra_srcs: Source files that are not discoverable via rules.
     """
@@ -78,13 +69,11 @@ def python_lint(
             _python_lint(
                 name_prefix = rule["name"],
                 files = files,
-                ignore = ignore,
                 disallow_executable = True,
             )
     if extra_srcs:
         _python_lint(
             name_prefix = "extra_srcs",
             files = extra_srcs,
-            ignore = ignore,
             disallow_executable = False,
         )


### PR DESCRIPTION
This prep work helps simplify #23427.

If we don't pass any ignore flags to pycodestyle, it uses its built-in default automatically.  We don't need to repeat it in our code unless we're going to customize it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23452)
<!-- Reviewable:end -->
