### PR TITLE
[Jenkins] Point to the log page in failure emails

### DIFF
--- a/.jenkins/Jenkinsfile-experimental
+++ b/.jenkins/Jenkinsfile-experimental
@@ -120,8 +120,15 @@ def emailFailureResults() {
     }
     emailext (
       subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
-        "and <${env.BUILD_URL}changes>",
+      mimeType: 'text/html',
+      body: """\
+For details, see:
+<ul>
+  <li>Changes in this revision: ${env.BUILD_URL}changes</li>
+  <li>Changelog for this job: ${env.BUILD_URL}display/redirect?page=changes</li>
+  <li>Console log: ${env.BUILD_URL}console</li>
+</ul>
+""",
       to: '$DEFAULT_RECIPIENTS',
     )
   }

--- a/.jenkins/Jenkinsfile-external-examples
+++ b/.jenkins/Jenkinsfile-external-examples
@@ -120,8 +120,15 @@ def emailFailureResults() {
     }
     emailext (
       subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
-        "and <${env.BUILD_URL}changes>",
+      mimeType: 'text/html',
+      body: """\
+For details, see:
+<ul>
+  <li>Changes in this revision: ${env.BUILD_URL}changes</li>
+  <li>Changelog for this job: ${env.BUILD_URL}display/redirect?page=changes</li>
+  <li>Console log: ${env.BUILD_URL}console</li>
+</ul>
+""",
       to: '$DEFAULT_RECIPIENTS',
     )
   }

--- a/.jenkins/Jenkinsfile-production
+++ b/.jenkins/Jenkinsfile-production
@@ -120,8 +120,15 @@ def emailFailureResults() {
     }
     emailext (
       subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
-        "and <${env.BUILD_URL}changes>",
+      mimeType: 'text/html',
+      body: """\
+For details, see:
+<ul>
+  <li>Changes in this revision: ${env.BUILD_URL}changes</li>
+  <li>Changelog for this job: ${env.BUILD_URL}display/redirect?page=changes</li>
+  <li>Console log: ${env.BUILD_URL}console</li>
+</ul>
+""",
       to: '$DEFAULT_RECIPIENTS',
     )
   }

--- a/.jenkins/Jenkinsfile-staging
+++ b/.jenkins/Jenkinsfile-staging
@@ -120,8 +120,15 @@ def emailFailureResults() {
     }
     emailext (
       subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
-        "and <${env.BUILD_URL}changes>",
+      mimeType: 'text/html',
+      body: """\
+For details, see:
+<ul>
+  <li>Changes in this revision: ${env.BUILD_URL}changes</li>
+  <li>Changelog for this job: ${env.BUILD_URL}display/redirect?page=changes</li>
+  <li>Console log: ${env.BUILD_URL}console</li>
+</ul>
+""",
       to: '$DEFAULT_RECIPIENTS',
     )
   }

--- a/.jenkins/utils/utils.groovy
+++ b/.jenkins/utils/utils.groovy
@@ -117,8 +117,15 @@ def emailFailureResults() {
     }
     emailext (
       subject: "${subject}: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-      body: "See <${env.BUILD_URL}display/redirect?page=changes> " +
-        "and <${env.BUILD_URL}changes>",
+      mimeType: 'text/html',
+      body: """\
+For details, see:
+<ul>
+  <li>Changes in this revision: ${env.BUILD_URL}changes</li>
+  <li>Changelog for this job: ${env.BUILD_URL}display/redirect?page=changes</li>
+  <li>Console log: ${env.BUILD_URL}console</li>
+</ul>
+""",
       to: '$DEFAULT_RECIPIENTS',
     )
   }


### PR DESCRIPTION
The current emails list the same link twice. Sometimes the "changes" page is nice to see, but most often I'd like to see the console log page to see where a job failed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23471)
<!-- Reviewable:end -->
