### PR TITLE
[pydrake] Stop relying on a deprecated internal pybind11 name

### DIFF
--- a/bindings/pydrake/common/cpp_param_pybind.h
+++ b/bindings/pydrake/common/cpp_param_pybind.h
@@ -77,9 +77,9 @@ namespace internal {
 // Wrapper for Object.
 struct wrapper_pydrake_object {
   using Type = Object;
-  static constexpr auto original_name = py::detail::_("pydrake::Object");
+  static constexpr auto original_name = py::detail::const_name("pydrake::Object");
   using WrappedType = py::object;
-  static constexpr auto wrapped_name = py::detail::_("object");
+  static constexpr auto wrapped_name = py::detail::const_name("object");
 
   static Object unwrap(const py::object& obj) {
     return Object::from_pyobject(obj);

--- a/bindings/pydrake/common/test/wrap_test_util_py.cc
+++ b/bindings/pydrake/common/test/wrap_test_util_py.cc
@@ -36,9 +36,9 @@ struct TypeConversionExample {
 // Wrapper for TypeConversionExample.
 struct wrapper_type_conversion_exaple {
   using Type = TypeConversionExample;
-  static constexpr auto original_name = py::detail::_("TypeConversionExample");
+  static constexpr auto original_name = py::detail::const_name("TypeConversionExample");
   using WrappedType = std::string;
-  static constexpr auto wrapped_name = py::detail::_("str");
+  static constexpr auto wrapped_name = py::detail::const_name("str");
 
   static TypeConversionExample unwrap(const std::string& value) {
     return TypeConversionExample{value};


### PR DESCRIPTION
Yes, there was a template function called pybind11::detail::_(). It got a better name in pybind11 2.9 or so.