### PR TITLE
[workspace] Use LCM runtime from lcm_internal (not lcm)

### DIFF
--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -68,7 +68,7 @@ drake_cc_library(
 drake_cc_library(
     name = "drake_lcm",
     srcs = select({
-        "//tools/workspace/lcm:flag_with_lcm_runtime_true": [
+        "//tools/workspace/lcm_internal:flag_with_lcm_runtime_true": [
             "drake_lcm.cc",
         ],
         "//conditions:default": [
@@ -87,10 +87,10 @@ drake_cc_library(
         "//common:essential",
     ],
     implementation_deps = select({
-        "//tools/workspace/lcm:flag_with_lcm_runtime_true": [
+        "//tools/workspace/lcm_internal:flag_with_lcm_runtime_true": [
             "//common:network_policy",
+            "//tools/workspace/lcm_internal:shared_library",
             "@glib",
-            "@lcm",
         ],
         "//conditions:default": [],
     }),
@@ -99,7 +99,7 @@ drake_cc_library(
 drake_cc_library(
     name = "lcm_log",
     srcs = select({
-        "//tools/workspace/lcm:flag_with_lcm_runtime_true": [
+        "//tools/workspace/lcm_internal:flag_with_lcm_runtime_true": [
             "drake_lcm_log.cc",
         ],
         "//conditions:default": [
@@ -117,9 +117,9 @@ drake_cc_library(
         "//common:essential",
     ],
     implementation_deps = select({
-        "//tools/workspace/lcm:flag_with_lcm_runtime_true": [
+        "//tools/workspace/lcm_internal:flag_with_lcm_runtime_true": [
             "//common:string_container",
-            "@lcm",
+            "//tools/workspace/lcm_internal:shared_library",
         ],
         "//conditions:default": [
             "//common:unused",
@@ -175,7 +175,7 @@ drake_cc_googletest(
         ":drake_lcm",
         ":lcmt_drake_signal_utils",
         "//common/test_utilities:expect_throws_message",
-        "@lcm",
+        "//tools/workspace/lcm_internal:shared_library",
     ],
 )
 
@@ -216,7 +216,7 @@ drake_cc_googletest(
     deps = [
         ":drake_lcm",
         ":lcmt_drake_signal_utils",
-        "@lcm",
+        "//tools/workspace/lcm_internal:shared_library",
     ],
 )
 

--- a/lcm/drake_lcm_log.cc
+++ b/lcm/drake_lcm_log.cc
@@ -7,7 +7,7 @@
 #include <utility>
 #include <vector>
 
-#include "lcm/lcm.h"
+#include <lcm/lcm.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/string_map.h"

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -7,8 +7,8 @@
 #include <thread>
 #include <utility>
 
-#include "lcm/lcm-cpp.hpp"
 #include <gtest/gtest.h>
+#include <lcm/lcm-cpp.hpp>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/lcm/lcmt_drake_signal_utils.h"

--- a/lcm/test/drake_lcm_thread_test.cc
+++ b/lcm/test/drake_lcm_thread_test.cc
@@ -5,8 +5,8 @@
 #include <string>
 #include <thread>
 
-#include "lcm/lcm-cpp.hpp"
 #include <gtest/gtest.h>
+#include <lcm/lcm-cpp.hpp>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/lcm/drake_lcm.h"

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -94,7 +94,7 @@ run_binary(
 generate_file(
     name = "with_lcm_runtime.cmake",
     content = select({
-        "//tools/workspace/lcm:flag_with_lcm_runtime_true": (
+        "//tools/workspace/lcm_internal:flag_with_lcm_runtime_true": (
             "set(WITH_LCM_RUNTIME ON)"
         ),
         "//conditions:default": (
@@ -374,7 +374,7 @@ cc_library(
         ":x11_deps",
         "//common:drake_marker_shared_library",
         "//tools/workspace/fmt:shared_library_maybe",
-        "//tools/workspace/lcm:shared_library_maybe",
+        "//tools/workspace/lcm_internal:shared_library_maybe",
         "//tools/workspace/spdlog:shared_library_maybe",
     ],
 )

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -154,7 +154,9 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "//tools/workspace/scs_internal:enabled": ["@scs_internal//:install"],
     "//conditions:default": [],
 }) + select({
-    "//tools/workspace/lcm:flag_with_lcm_runtime_true": ["@lcm//:install"],
+    "//tools/workspace/lcm_internal:flag_with_lcm_runtime_true": [
+        "//tools/workspace/lcm_internal:install",
+    ],
     "//conditions:default": [],
 })
 

--- a/tools/workspace/lcm/BUILD.bazel
+++ b/tools/workspace/lcm/BUILD.bazel
@@ -5,19 +5,9 @@ load(
     "drake_py_unittest",
 )
 
-config_setting(
-    name = "flag_with_lcm_runtime_true",
-    flag_values = {"//tools/flags:with_lcm_runtime": "True"},
-)
-
-cc_library(
-    name = "shared_library_maybe",
-    visibility = ["//tools/install/libdrake:__pkg__"],
-    deps = select({
-        ":flag_with_lcm_runtime_true": ["@lcm"],
-        "//conditions:default": [],
-    }),
-)
+# TODO(jwnimmer-tri) These tests are no longer relevant for Drake, but are kept
+# around as regression coverage of our `package.BUILD.bazel` file. This file
+# (and its tests) will be removed when the `@lcm` deprecation is removed.
 
 drake_py_test(
     name = "import_lcm_test",

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -1,6 +1,5 @@
 # -*- bazel -*-
 
-load("@drake//tools/install:install.bzl", "install")
 load("@drake//tools/skylark:cc.bzl", "cc_binary", "cc_library")
 load("@drake//tools/skylark:java.bzl", "java_binary", "java_library")
 load("@drake//tools/skylark:py.bzl", "py_library")
@@ -9,6 +8,10 @@ load(
     "generate_export_header",
 )
 load("@drake//tools/workspace:generate_file.bzl", "generate_file")
+
+# TODO(jwnimmer-tri) Nothing in this file is used by Drake anymore, but is kept
+# around for backwards compatibility. The @lcm repository will be deprecated for
+# removal soon.
 
 licenses([
     "notice",  # BSD-3-Clause
@@ -119,9 +122,6 @@ cc_library(
     linkstatic = True,
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 cc_binary(
     name = "lcm-logger",
     srcs = [
@@ -136,9 +136,6 @@ cc_binary(
     ],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 cc_binary(
     name = "lcm-logplayer",
     srcs = [
@@ -148,9 +145,6 @@ cc_binary(
     deps = [":lcm"],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 cc_binary(
     name = "lcm-gen",
     srcs = [
@@ -177,9 +171,6 @@ cc_binary(
     ],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 cc_binary(
     name = "_lcm.so",
     srcs = [
@@ -202,10 +193,6 @@ cc_binary(
     ],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
-#
 # Downstream users of lcm-python expect to say "import lcm". However, in the
 # sandbox the python package is located at lcm-python/lcm/__init__.py to match
 # the source tree structure of LCM; without declaring an `imports = [...]` path
@@ -242,9 +229,6 @@ exec(compile(_text, _filename, 'exec'))
     visibility = ["//visibility:private"],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 py_library(
     name = "lcm-python-upstream",
     srcs = ["lcm-python/lcm/__init__.py"],  # Actual code from upstream.
@@ -252,9 +236,6 @@ py_library(
     visibility = ["//visibility:private"],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 py_library(
     name = "lcm-python",
     srcs = ["gen/lcm/__init__.py"],  # Shim, from the genrule above.
@@ -262,9 +243,6 @@ py_library(
     deps = [":lcm-python-upstream"],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 java_library(
     name = "lcm-java",
     srcs = glob(["lcm-java/lcm/**/*.java"]),
@@ -277,18 +255,12 @@ java_library(
     ],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 java_binary(
     name = "lcm-logplayer-gui",
     main_class = "lcm.logging.LogPlayer",
     runtime_deps = [":lcm-java"],
 )
 
-# TODO(jwnimmer-tri) This is no longer used by Drake, but is kept around for
-# backwards compatibility. It will be deprecated for removal along with the
-# entire @lcm repository soon enough.
 java_binary(
     name = "lcm-spy",
     jvm_flags = [
@@ -299,15 +271,5 @@ java_binary(
     main_class = "lcm.spy.Spy",
     runtime_deps = [
         ":lcm-java",
-    ],
-)
-
-install(
-    name = "install",
-    targets = [
-        ":libdrake_lcm.so",
-    ],
-    docs = [
-        "COPYING",
     ],
 )

--- a/tools/workspace/lcm_internal/BUILD.bazel
+++ b/tools/workspace/lcm_internal/BUILD.bazel
@@ -1,3 +1,82 @@
+load("@drake//tools/skylark:drake_cc.bzl", "cc_nolink_library")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load(
+    "//third_party:com_github_bazelbuild_rules_cc/whole_archive.bzl",
+    "cc_whole_archive_library",
+)
+load("//tools/install:install.bzl", "install", "install_license")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+# LCM is LGPL-licensed and therefore we must build it as a shared library.
+# Because our `vendor_namespace.patch` uses different symbol names, we'll also
+# name it `libdrake_lcm.so` instead of `liblcm.so`, which means we can't use the
+# upstream shared_library rule. The following targets create our own link of the
+# library, with the Bazel label `":shared_library"` (the compile commands are
+# re-used from upstream; only the linking step is changed.)
+#
+# The "whole archive" annotates all of the object code as `alwayslink = True`,
+# so that we use the --whole-archive linker flag when creating libdrake_lcm.so.
+cc_whole_archive_library(
+    name = "whole_archive",
+    deps = ["@lcm_internal//lcm:lcm-shared"],
+)
+
+config_setting(
+    name = "linux",
+    constraint_values = ["@platforms//os:linux"],
+)
+
+cc_binary(
+    name = "libdrake_lcm.so",
+    linkopts = select({
+        ":linux": ["-Wl,-soname,libdrake_lcm.so"],
+        "//conditions:default": [],
+    }),
+    linkshared = True,
+    deps = [":whole_archive"],
+)
+
+cc_nolink_library(
+    name = "hdrs",
+    deps = ["@lcm_internal//lcm:lcm-shared"],
+)
+
+cc_library(
+    name = "shared_library",
+    srcs = [":libdrake_lcm.so"],
+    visibility = ["//visibility:public"],
+    deps = [":hdrs"],
+)
+
+# Rules for installing LCM.
+
+config_setting(
+    name = "flag_with_lcm_runtime_true",
+    flag_values = {"//tools/flags:with_lcm_runtime": "True"},
+)
+
+cc_library(
+    name = "shared_library_maybe",
+    visibility = ["//tools/install/libdrake:__pkg__"],
+    deps = select({
+        ":flag_with_lcm_runtime_true": [":shared_library"],
+        "//conditions:default": [],
+    }),
+)
+
+install_license(
+    name = "install_license",
+    doc_dest = "share/doc/lcm_internal",
+    licenses = ["@lcm_internal//:license"],
+)
+
+install(
+    name = "install",
+    targets = [":libdrake_lcm.so"],
+    visibility = ["//tools/workspace:__pkg__"],
+    deps = [":install_license"],
+)
 
 add_lint_tests()

--- a/tools/workspace/lcm_internal/patches/copts.patch
+++ b/tools/workspace/lcm_internal/patches/copts.patch
@@ -1,0 +1,30 @@
+[lcm] Add Drake-specific compiler flags
+
+Reasoning for not upstreaming this patch: upstream should fix the code
+to not have warnings in the first place, rather than suppressing them.
+
+--- lcm-bazel/private/copts.bzl
++++ lcm-bazel/private/copts.bzl
+@@ -6,5 +6,8 @@ WARNINGS_COPTS = select({
+         "-Wno-unused-parameter",
+         "-Wno-format-zero-length",
+         "-Wno-stringop-truncation",
++        # Additional Drake-specific options.
++        "-w",
++        "-std=gnu11",
+     ],
+ })
+
+--- lcm-logger/BUILD.bazel
++++ lcm-logger/BUILD.bazel
+@@ -12,6 +12,10 @@ cc_binary(
+         "glib_util.h",
+         "lcm_logger.c",
+     ],
++    copts = [
++        # Drake-specific options.
++        "-w"
++    ],
+     visibility = ["//visibility:public"],
+     deps = [
+         "//lcm:lcm-static",

--- a/tools/workspace/lcm_internal/patches/vendor_namespace.patch
+++ b/tools/workspace/lcm_internal/patches/vendor_namespace.patch
@@ -1,0 +1,19 @@
+[lcm] Add a Drake-specific symbol namespace
+
+Drake's LCM runtime library is a private dependency, so we need to use
+different symbol names in case the user has their own, distinct copy.
+
+Reasoning for not upstreaming this patch: Drake-specific
+vendoring.
+
+--- lcm/BUILD.bazel
++++ lcm/BUILD.bazel
+@@ -66,7 +66,7 @@ LCM_COMPILE_DEFINITIONS_PRIVATE = [
+ 
+ string_flag(
+     name = "LCM_C_NAMESPACE",
+-    build_setting_default = "lcm",
++    build_setting_default = "drake_vendor_lcm",
+ )
+ 
+ expand_flag_template(

--- a/tools/workspace/lcm_internal/repository.bzl
+++ b/tools/workspace/lcm_internal/repository.bzl
@@ -18,7 +18,9 @@ def lcm_internal_repository(
         commit = "e4bed2c86fbd6dd2280326801acf71cbd05074be",
         sha256 = "b2bf5bf7fed61805d72855c8ea9d247de95e5ca885ee6c5c8c9185aa87dda74c",  # noqa
         patches = [
+            ":patches/copts.patch",
             ":patches/respell_glib_deps.patch",
+            ":patches/vendor_namespace.patch",
         ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
We now use the upstream Bazel build rules for the shared library (with a few customizations for our vendoring).

This is the last part of `@lcm` we were using, so the next commit after this one will deprecate it for removal.

Towards #20731.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23474)
<!-- Reviewable:end -->
