### PR TITLE
[pydrake] Stop relying on a deprecated internal pybind11 name

### DIFF
--- a/bindings/pydrake/common/eigen_pybind.h
+++ b/bindings/pydrake/common/eigen_pybind.h
@@ -94,7 +94,8 @@ struct type_caster<drake::EigenPtr<T>> {
   using InnerCaster = type_caster<RefType>;
 
  public:
-  PYBIND11_TYPE_CASTER(PtrType, _("Optional[") + InnerCaster::name + _("]"));
+  PYBIND11_TYPE_CASTER(
+      PtrType, const_name("Optional[") + InnerCaster::name + const_name("]"));
 
   bool load(handle src, bool convert) {
     value = PtrType(nullptr);

--- a/bindings/pydrake/common/sorted_pair_pybind.h
+++ b/bindings/pydrake/common/sorted_pair_pybind.h
@@ -13,7 +13,8 @@ struct type_caster<drake::SortedPair<T>> {
   using InnerCaster = make_caster<T>;
 
   // N.B. This macro assumes placement in `pybind11::detail`.
-  PYBIND11_TYPE_CASTER(Type, _("Tuple[") + type_caster<T>::name + _("]"));
+  PYBIND11_TYPE_CASTER(
+      Type, const_name("Tuple[") + type_caster<T>::name + const_name("]"));
 
   bool load(handle src, bool convert) {
     if (!convert && !tuple::check_(src)) {


### PR DESCRIPTION
Amends commit 30bda2d9237b034bd85e6035542c2657a2c75633; more call sites found.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23481)
<!-- Reviewable:end -->
