### PR TITLE
[workspace] Downgrade abseil_cpp_internal to LTS release 20250814.1

### DIFF
--- a/tools/workspace/abseil_cpp_internal/patches/inline_namespace.patch
+++ b/tools/workspace/abseil_cpp_internal/patches/inline_namespace.patch
@@ -12,9 +12,8 @@ designed for end-user customization, and that's basically all we're doing here.
  // be changed to a new, unique identifier name.  In particular "head" is not
  // allowed.
  
--#define ABSL_OPTION_USE_INLINE_NAMESPACE 0
--#define ABSL_OPTION_INLINE_NAMESPACE_NAME head
-+#define ABSL_OPTION_USE_INLINE_NAMESPACE 1
+ #define ABSL_OPTION_USE_INLINE_NAMESPACE 1
+-#define ABSL_OPTION_INLINE_NAMESPACE_NAME lts_20250814
 +#define ABSL_OPTION_INLINE_NAMESPACE_NAME drake_vendor
  
  // ABSL_OPTION_HARDENED

--- a/tools/workspace/abseil_cpp_internal/repository.bzl
+++ b/tools/workspace/abseil_cpp_internal/repository.bzl
@@ -6,8 +6,8 @@ def abseil_cpp_internal_repository(
     github_archive(
         name = name,
         repository = "abseil/abseil-cpp",
-        commit = "79bdf3b41f01fe488dd2d82a2c6260cfbca544c4",
-        sha256 = "65917799606c65a0881df2512f7967278f54576ba354a6ec9b0c30d3416448fc",  # noqa
+        commit = "20250814.1",
+        sha256 = "1692f77d1739bacf3f94337188b78583cf09bab7e420d2dc6c5605a4f86785a1",  # noqa
         patches = [
             ":patches/upstream/specific_iostream_includes.patch",
             ":patches/disable_int128_on_clang.patch",


### PR DESCRIPTION
We will be tracking LTS from now on, not the main branch.

(In general, we prefer to tack release tags when possible, and in the case of ABSL it looks like the release history is fast enough pace for our needs.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23483)
<!-- Reviewable:end -->
