### PR TITLE
[workspace] fix variable rename in metadata script

### DIFF
--- a/tools/workspace/metadata.py
+++ b/tools/workspace/metadata.py
@@ -111,7 +111,7 @@ def read_repository_metadata(repositories=None):
         if expect_to_find and not found:
             logging.warn(f"Missing metadata for {apparent_name}")
         elif not expect_to_find and found:
-            logging.warn(f"Unexpectedly found metadata for {name}")
+            logging.warn(f"Unexpectedly found metadata for {apparent_name}")
 
     # Add 'magic' metadata for repositories that don't/can't generate it the
     # usual way.


### PR DESCRIPTION
Follow-up to #23455 

Tweak variable name in `metadata.py` which caused `new_release` script to break.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23497)
<!-- Reviewable:end -->
