### PR TITLE
Fix error estimate order for the RK5 integrator

### DIFF
--- a/systems/analysis/runge_kutta5_integrator.h
+++ b/systems/analysis/runge_kutta5_integrator.h
@@ -13,7 +13,7 @@ namespace systems {
 // clang-format off
 /**
  A fifth-order, seven-stage, first-same-as-last (FSAL) Runge Kutta integrator
- with a fourth order error estimate.
+ with a fifth order error estimate.
 
  For a discussion of this Runge-Kutta method, see [Dormand, 1980] and
  [Hairer, 1993]. The embedded error estimate was derived as described
@@ -71,7 +71,7 @@ class RungeKutta5Integrator final : public IntegratorBase<T> {
   bool supports_error_estimation() const override { return true; }
 
   /// The order of the asymptotic term in the error estimate.
-  int get_error_estimate_order() const override { return 4; }
+  int get_error_estimate_order() const override { return 5; }
 
  private:
   void DoInitialize() override;


### PR DESCRIPTION
@amcastro-tri and I found a small bug in the `RungeKutta5Integrator`. This integrator propagates a 5th order solution and uses a 4th order embedded scheme to obtain a 5th order error estimate. The order of the error estimate was incorrectly set to 4.

This bug fix results in a small but measurable performance improvement. For a double pendulum simulated for 30 seconds at accuracy 1e-4, we get the following:

Old version:
```
time steps taken:                  1453
steps shrunk due to error control: 1061
wall time (s):                     0.075
```

Correct version:
```
time steps taken:                  1406
steps shrunk due to error control: 876
wall time (s):                     0.072
```