### PR TITLE
[tools] Add 80-column rule to drakelint

### DIFF
--- a/bindings/pydrake/multibody/test/fix_inertia_test.py
+++ b/bindings/pydrake/multibody/test/fix_inertia_test.py
@@ -384,7 +384,8 @@ class TestFixInertiaFromString(unittest.TestCase):
   <link name="world"/>
   <link name="b">
     <inertial>
-      <inertia ixx="0.16667" ixy="0" ixz="0" iyy="0.16667" iyz="0" izz="0.16667"/>
+      <inertia ixx="0.16667" ixy="0" ixz="0" iyy="0.16667" iyz="0" \
+izz="0.16667"/>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <mass value="1"/>
     </inertial>
@@ -401,7 +402,7 @@ class TestFixInertiaFromString(unittest.TestCase):
       </geometry>
     </collision>
   </link>
-</robot>"""  # noqa
+</robot>"""
         output_illustration = fix_inertia_from_string(
             input_text, "urdf", geom_inertia_role_order=[Role.kIllustration],
         )
@@ -412,7 +413,8 @@ class TestFixInertiaFromString(unittest.TestCase):
   <link name="world"/>
   <link name="b">
     <inertial>
-      <inertia ixx="0.0016667" ixy="0" ixz="0" iyy="0.0016667" iyz="0" izz="0.0016667"/>
+      <inertia ixx="0.0016667" ixy="0" ixz="0" iyy="0.0016667" iyz="0" \
+izz="0.0016667"/>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <mass value="1"/>
     </inertial>
@@ -429,7 +431,7 @@ class TestFixInertiaFromString(unittest.TestCase):
       </geometry>
     </collision>
   </link>
-</robot>"""  # noqa
+</robot>"""
         output_proximity = fix_inertia_from_string(
             input_text, "urdf", geom_inertia_role_order=[Role.kProximity],
         )

--- a/bindings/pydrake/test/memory_leak_test.py
+++ b/bindings/pydrake/test/memory_leak_test.py
@@ -165,13 +165,15 @@ def _dut_full_example():
     directives:
     - add_model:
         name: amazon_table
-        file: package://drake_models/manipulation_station/amazon_table_simplified.sdf
+        file: |-
+          package://drake_models/manipulation_station/amazon_table_simplified.sdf
     - add_weld:
         parent: world
         child: amazon_table::amazon_table
     - add_model:
         name: iiwa
-        file: package://drake_models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
+        file: |-
+          package://drake_models/iiwa_description/urdf/iiwa14_primitive_collision.urdf
         default_joint_positions:
           iiwa_joint_1: [-0.2]
           iiwa_joint_2: [0.79]
@@ -191,7 +193,8 @@ def _dut_full_example():
         child: iiwa::base
     - add_model:
         name: wsg
-        file: package://drake_models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+        file: |-
+          package://drake_models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
         default_joint_positions:
           left_finger_sliding_joint: [-0.02]
           right_finger_sliding_joint: [0.02]
@@ -206,7 +209,8 @@ def _dut_full_example():
         child: wsg::body
     - add_model:
         name: bell_pepper
-        file: package://drake_models/veggies/yellow_bell_pepper_no_stem_low.sdf
+        file: |-
+          package://drake_models/veggies/yellow_bell_pepper_no_stem_low.sdf
         default_free_body_pose:
           flush_bottom_center__z_up:
             base_frame: amazon_table::amazon_table

--- a/doc/pydrake/pydrake_sphinx_extension.py
+++ b/doc/pydrake/pydrake_sphinx_extension.py
@@ -342,7 +342,7 @@ class PydrakeSystemDirective(Directive):
     See also:
     - https://www.sphinx-doc.org/en/1.6.7/extdev/tutorial.html#the-directive-classes
     - https://docutils.sourceforge.io/docs/howto/rst-directives.html#error-handling
-    - Example: https://github.com/sphinx-contrib/autoprogram/blob/0.1.5/sphinxcontrib/autoprogram.py
+    - https://github.com/sphinx-contrib/autoprogram/blob/0.1.5/sphinxcontrib/autoprogram.py
     """  # noqa
 
     has_content = True

--- a/tools/lcm_gen/__init__.py
+++ b/tools/lcm_gen/__init__.py
@@ -78,7 +78,8 @@ PrimitiveType.__str__ = lambda self: self.name
 
 @dataclasses.dataclass(frozen=True)
 class UserType:
-    """A struct name from an LCM message definition, e.g., "foo" or "foo.bar"."""
+    """A struct name from an LCM message definition, e.g., "foo" (when
+    `package` is None) or "foo.bar" (`package` is "foo"; `name` is "bar")."""
 
     package: Optional[str]
     name: str


### PR DESCRIPTION
When replacing pycodestyle with ruff, the only important lint check we will lose is the max line length of 80, so we need to add that check to drakelint.

Towards #19827. 