### PR TITLE
[setup] Use patchelf from bzlmod instead of ubuntu

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -84,6 +84,7 @@ bazel_dep(name = "zlib", version = "1.3.1.bcr.7", repo_name = "module_zlib")
 # Add additional modules we use as tools (not runtime dependencies).
 
 bazel_dep(name = "nasm", version = "2.16.03.bcr.2")
+bazel_dep(name = "patchelf", version = "0.18.0")
 bazel_dep(name = "toolchains_llvm", version = "1.5.0")
 
 llvm = use_repo_rule("@toolchains_llvm//toolchain:rules.bzl", "llvm")

--- a/setup/ubuntu/source_distribution/packages-jammy.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy.txt
@@ -11,7 +11,6 @@ libx11-dev
 ocl-icd-opencl-dev
 opencl-headers
 patch
-patchelf
 pkg-config
 python3-all-dev
 zlib1g-dev

--- a/setup/ubuntu/source_distribution/packages-noble.txt
+++ b/setup/ubuntu/source_distribution/packages-noble.txt
@@ -11,7 +11,6 @@ libx11-dev
 ocl-icd-opencl-dev
 opencl-headers
 patch
-patchelf
 pkg-config
 python3-all-dev
 zlib1g-dev

--- a/tools/dynamic_analysis/drd.sh
+++ b/tools/dynamic_analysis/drd.sh
@@ -27,6 +27,6 @@ valgrind \
     --suppressions=/usr/lib/valgrind/python3.supp \
     --tool=drd \
     --trace-children=yes \
-    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-15,/usr/bin/clang-format-15,/usr/bin/curl,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
+    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-15,/usr/bin/clang-format-15,/usr/bin/curl,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
     --trace-children-skip-by-arg=--disable-drake-valgrind-tracing \
     "$@"

--- a/tools/dynamic_analysis/helgrind.sh
+++ b/tools/dynamic_analysis/helgrind.sh
@@ -27,6 +27,6 @@ valgrind \
     --suppressions=/usr/lib/valgrind/python3.supp \
     --tool=helgrind \
     --trace-children=yes \
-    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-15,/usr/bin/clang-format-15,/usr/bin/curl,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
+    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-15,/usr/bin/clang-format-15,/usr/bin/curl,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
     --trace-children-skip-by-arg=--disable-drake-valgrind-tracing \
     "$@"

--- a/tools/dynamic_analysis/valgrind.sh
+++ b/tools/dynamic_analysis/valgrind.sh
@@ -34,7 +34,7 @@ valgrind \
     --suppressions=/usr/lib/valgrind/python3.supp \
     --tool=memcheck \
     --trace-children=yes \
-    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-15,/usr/bin/clang-format-15,/usr/bin/curl,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
+    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-15,/usr/bin/clang-format-15,/usr/bin/curl,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
     --trace-children-skip-by-arg=--disable-drake-valgrind-tracing \
     --track-origins=yes \
     "$@"

--- a/tools/install/BUILD.bazel
+++ b/tools/install/BUILD.bazel
@@ -42,7 +42,11 @@ exports_files(
 drake_py_binary(
     name = "installer",
     srcs = ["installer.py"],
-    deps = [":otool"],
+    data = ["@patchelf"],
+    deps = [
+        ":otool",
+        "@rules_python//python/runfiles",
+    ],
 )
 
 drake_py_unittest(

--- a/tools/install/installer.py
+++ b/tools/install/installer.py
@@ -13,14 +13,17 @@ Installation script generated from a Bazel `install` target.
 import argparse
 import collections
 import filecmp
+import functools
 import itertools
 import os
+from pathlib import Path
 import re
 import shutil
 import stat
+from subprocess import check_output, check_call
 import sys
 
-from subprocess import check_output, check_call
+from python import runfiles
 
 from tools.install import otool
 
@@ -75,6 +78,12 @@ def _needs_install(src, dst, prefix):
 
     # File needs to be installed.
     return True
+
+
+@functools.cache
+def _patchelf_path() -> Path:
+    manifest = runfiles.Create()
+    return Path(manifest.Rlocation("patchelf/patchelf"))
 
 
 class Installer:
@@ -336,7 +345,7 @@ class Installer:
         # /opt.
         str_rpath = ":".join(x for x in rpath)
         check_output([
-            "patchelf",
+            _patchelf_path(),
             "--force-rpath",  # We need to override LD_LIBRARY_PATH.
             "--set-rpath", str_rpath,
             dst_full


### PR DESCRIPTION
This helps Drake be more portable when installing from source, and more hermetic when testing (one less undeclared dependency).

Note that the wheel build still uses the almalinux patchelf, but that's fine because it runs inside docker.