### PR TITLE
[setup] Remove diff and file as source prereqs

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -626,6 +626,8 @@ drake_cc_library(
 drake_cc_binary(
     name = "resource_tool",
     srcs = ["resource_tool.cc"],
+    deprecation = "DRAKE DEPRECATED: The resource_tool binary is deprecated and will be removed from Drake on or after 2026-02-01",  # noqa
+    tags = ["manual"],
     deps = [
         ":add_text_logging_gflags",
         ":essential",

--- a/common/resource_tool.cc
+++ b/common/resource_tool.cc
@@ -1,3 +1,6 @@
+// DRAKE DEPRECATED: The resource_tool binary is deprecated and will be removed
+// from Drake on or after 2026-02-01.
+
 #include <iostream>
 
 #include <gflags/gflags.h>

--- a/setup/ubuntu/source_distribution/packages-jammy.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy.txt
@@ -1,5 +1,3 @@
-diffutils
-file
 gfortran
 libclang-15-dev
 libgl-dev

--- a/setup/ubuntu/source_distribution/packages-noble.txt
+++ b/setup/ubuntu/source_distribution/packages-noble.txt
@@ -1,5 +1,3 @@
-diffutils
-file
 gfortran
 libclang-19-dev
 libgl-dev

--- a/tools/lint/clang_format_lint.py
+++ b/tools/lint/clang_format_lint.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import subprocess
 import sys
 
@@ -41,16 +42,12 @@ def _is_cxx(filename):
 
 def _check_clang_format_idempotence(filename):
     clang_format = clang_format_lib.get_clang_format_path()
-    formatter = subprocess.Popen(
-        [clang_format, "-style=file", filename], stdout=subprocess.PIPE
+    current = Path(filename).read_text(encoding="utf-8")
+    formatted = subprocess.check_output(
+        [clang_format, "-style=file", filename],
+        encoding="utf-8",
     )
-    differ = subprocess.Popen(
-        ["/usr/bin/diff", "-u", "-", filename],
-        stdin=formatter.stdout,
-        stdout=subprocess.PIPE,
-    )
-    changes = differ.communicate()[0]
-    if not changes:
+    if current == formatted:
         return 0
     print(f"ERROR: {filename} needs clang-format")
     print(


### PR DESCRIPTION
The `resource_tool` program was one of the earliest parts of Drake, preceding even `pydrake`.  Now that we have `pydrake` which can handle this function and more, there is no longer a need to install a platform-specific binary (into `$prefix/share/drake`!).

I considered having `resource_tool` print a warning to stderr, but that might conceivably break people, so the deprecation will be announced in release notes but not with a runtime warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23523)
<!-- Reviewable:end -->
