### PR TITLE
[common] Avoid make_coherent in autodiff

### DIFF
--- a/common/autodiff_overloads.h
+++ b/common/autodiff_overloads.h
@@ -121,13 +121,19 @@ pow(const Eigen::AutoDiffScalar<DerTypeA>& base,
                     typename internal::remove_all<DerTypeA>::type::PlainObject,
                     typename internal::remove_all<DerTypeB>::type::PlainObject>,
                 "The derivative types must match.");
-
-  internal::make_coherent(base.derivatives(), exponent.derivatives());
+  using DerType = typename internal::remove_all<DerTypeB>::type::PlainObject;
 
   const auto& x = base.value();
-  const auto& xgrad = base.derivatives();
+  const DerType& xgrad = base.derivatives();
   const auto& y = exponent.value();
-  const auto& ygrad = exponent.derivatives();
+  const DerType& ygrad = exponent.derivatives();
+
+  // Make the derivative sizes coherenent.
+  if (xgrad.size() == 0 && ygrad.size() > 0) {
+    return pow(MakeAutoDiffScalar(x, DerType::Zero(ygrad.size())), exponent);
+  } else if (xgrad.size() > 0 && ygrad.size() == 0) {
+    return pow(base, MakeAutoDiffScalar(y, DerType::Zero(xgrad.size())));
+  }
 
   using std::log;
   using std::pow;


### PR DESCRIPTION
Towards #23477.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23528)
<!-- Reviewable:end -->
