### PR TITLE
[ruff] Format pydrake/solvers

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -310,4 +310,4 @@ drake_py_unittest(
     ],
 )
 
-add_lint_tests_pydrake(python_lint_use_ruff_format = False)
+add_lint_tests_pydrake()

--- a/bindings/pydrake/solvers/_extra.py
+++ b/bindings/pydrake/solvers/_extra.py
@@ -14,7 +14,7 @@ def _resolve_array_type(x):
         # Search array for any non-builtin and non-numpy types.
         for xi in x.flat:
             t = type(xi)
-            if t.__module__ not in ('builtins', 'numpy'):
+            if t.__module__ not in ("builtins", "numpy"):
                 return t
         # Unable to infer type.
         return None
@@ -29,9 +29,11 @@ def _check_returned_array_type(cls_name, y, expected_type):
     if actual_type is None:
         raise TypeError(
             f"When {cls_name} is called with an array of type {expected_name} "
-            f"the return value must be the same type.")
+            f"the return value must be the same type."
+        )
     if actual_type is not expected_type:
         actual_name = actual_type.__name__
         raise TypeError(
             f"When {cls_name} is called with an array of type {expected_name} "
-            f"the return value must be the same type, not {actual_name}.")
+            f"the return value must be the same type, not {actual_name}."
+        )

--- a/bindings/pydrake/solvers/test/augmented_lagrangian_test.py
+++ b/bindings/pydrake/solvers/test/augmented_lagrangian_test.py
@@ -21,52 +21,50 @@ class TestAugmentedLagrangian(unittest.TestCase):
         self.prog.AddLinearConstraint(x[0] + x[1] <= 3)
 
     def test_eval_double_nonsmooth(self):
-        dut = AugmentedLagrangianNonsmooth(prog=self.prog,
-                                           include_x_bounds=True)
-        x_val = np.array([1., 3])
+        dut = AugmentedLagrangianNonsmooth(
+            prog=self.prog, include_x_bounds=True
+        )
+        x_val = np.array([1.0, 3])
         lambda_val = np.array([0.5])
-        al_val, constraint_residue, cost = dut.Eval(x=x_val,
-                                                    lambda_val=lambda_val,
-                                                    mu=0.1)
+        al_val, constraint_residue, cost = dut.Eval(
+            x=x_val, lambda_val=lambda_val, mu=0.1
+        )
         self.assertIsInstance(al_val, float)
         self.assertIsInstance(constraint_residue, np.ndarray)
         self.assertIsInstance(cost, float)
 
     def test_eval_double_smooth(self):
-        dut = AugmentedLagrangianSmooth(prog=self.prog,
-                                        include_x_bounds=True)
+        dut = AugmentedLagrangianSmooth(prog=self.prog, include_x_bounds=True)
         self.assertEqual(dut.s_size(), 1)
-        x_val = np.array([1., 3])
-        s_val = np.array([3.])
+        x_val = np.array([1.0, 3])
+        s_val = np.array([3.0])
         lambda_val = np.array([0.5])
-        al_val, constraint_residue, cost = dut.Eval(x=x_val,
-                                                    s=s_val,
-                                                    lambda_val=lambda_val,
-                                                    mu=0.1)
+        al_val, constraint_residue, cost = dut.Eval(
+            x=x_val, s=s_val, lambda_val=lambda_val, mu=0.1
+        )
         self.assertIsInstance(al_val, float)
         self.assertIsInstance(constraint_residue, np.ndarray)
         self.assertIsInstance(cost, float)
 
     def test_eval_ad_nonsmooth(self):
-        dut = AugmentedLagrangianNonsmooth(prog=self.prog,
-                                           include_x_bounds=True)
-        x_val = InitializeAutoDiff(np.array([1., 3]))
-        al_val, constraint_residue, cost = dut.Eval(x=x_val,
-                                                    lambda_val=np.array([0.5]),
-                                                    mu=0.1)
+        dut = AugmentedLagrangianNonsmooth(
+            prog=self.prog, include_x_bounds=True
+        )
+        x_val = InitializeAutoDiff(np.array([1.0, 3]))
+        al_val, constraint_residue, cost = dut.Eval(
+            x=x_val, lambda_val=np.array([0.5]), mu=0.1
+        )
         self.assertIsInstance(al_val, AutoDiffXd)
         self.assertIsInstance(constraint_residue, np.ndarray)
         self.assertIsInstance(cost, AutoDiffXd)
 
     def test_eval_ad_smooth(self):
-        dut = AugmentedLagrangianSmooth(prog=self.prog,
-                                        include_x_bounds=True)
-        x_val = InitializeAutoDiff(np.array([1., 3]))
-        s_val = np.array([AutoDiffXd(1.)])
-        al_val, constraint_residue, cost = dut.Eval(x=x_val,
-                                                    s=s_val,
-                                                    lambda_val=np.array([0.5]),
-                                                    mu=0.1)
+        dut = AugmentedLagrangianSmooth(prog=self.prog, include_x_bounds=True)
+        x_val = InitializeAutoDiff(np.array([1.0, 3]))
+        s_val = np.array([AutoDiffXd(1.0)])
+        al_val, constraint_residue, cost = dut.Eval(
+            x=x_val, s=s_val, lambda_val=np.array([0.5]), mu=0.1
+        )
         self.assertIsInstance(al_val, AutoDiffXd)
         self.assertIsInstance(constraint_residue, np.ndarray)
         self.assertIsInstance(cost, AutoDiffXd)
@@ -74,21 +72,39 @@ class TestAugmentedLagrangian(unittest.TestCase):
     def test_lagrangian_size(self):
         self.assertEqual(
             AugmentedLagrangianNonsmooth(
-                prog=self.prog, include_x_bounds=True).lagrangian_size(), 1)
+                prog=self.prog, include_x_bounds=True
+            ).lagrangian_size(),
+            1,
+        )
         self.assertEqual(
             AugmentedLagrangianNonsmooth(
-                prog=self.prog, include_x_bounds=False).lagrangian_size(), 1)
+                prog=self.prog, include_x_bounds=False
+            ).lagrangian_size(),
+            1,
+        )
         self.assertEqual(
             AugmentedLagrangianSmooth(
-                prog=self.prog, include_x_bounds=True).lagrangian_size(), 1)
+                prog=self.prog, include_x_bounds=True
+            ).lagrangian_size(),
+            1,
+        )
         self.assertEqual(
             AugmentedLagrangianSmooth(
-                prog=self.prog, include_x_bounds=False).lagrangian_size(), 1)
+                prog=self.prog, include_x_bounds=False
+            ).lagrangian_size(),
+            1,
+        )
 
     def test_is_equality(self):
         self.assertEqual(
             AugmentedLagrangianNonsmooth(
-                prog=self.prog, include_x_bounds=True).is_equality(), [False])
+                prog=self.prog, include_x_bounds=True
+            ).is_equality(),
+            [False],
+        )
         self.assertEqual(
             AugmentedLagrangianSmooth(
-                prog=self.prog, include_x_bounds=True).is_equality(), [False])
+                prog=self.prog, include_x_bounds=True
+            ).is_equality(),
+            [False],
+        )

--- a/bindings/pydrake/solvers/test/branch_and_bound_test.py
+++ b/bindings/pydrake/solvers/test/branch_and_bound_test.py
@@ -37,10 +37,12 @@ class TestMixedIntegerBranchAndBound(unittest.TestCase):
         self.assertAlmostEqual(dut1.GetSolution(x, 1)[0], 1.0)
         # For x₁ the optimal vs suboptimal ordering is not deterministic, so we
         # need to allow for either order.
-        x1_solutions = sorted([
-            dut1.GetSolution(x[1], 0),
-            dut1.GetSolution(x[1], 1),
-        ])
+        x1_solutions = sorted(
+            [
+                dut1.GetSolution(x[1], 0),
+                dut1.GetSolution(x[1], 1),
+            ]
+        )
         self.assertAlmostEqual(x1_solutions[0], 0.0)
         self.assertAlmostEqual(x1_solutions[1], 0.5)
 
@@ -52,5 +54,6 @@ class TestMixedIntegerBranchAndBound(unittest.TestCase):
         copy.copy(options)
 
         dut2 = MixedIntegerBranchAndBound(
-            prog=prog, solver_id=OsqpSolver().solver_id(), options=options)
+            prog=prog, solver_id=OsqpSolver().solver_id(), options=options
+        )
         solution_result = dut2.Solve()

--- a/bindings/pydrake/solvers/test/clarabel_solver_test.py
+++ b/bindings/pydrake/solvers/test/clarabel_solver_test.py
@@ -10,7 +10,6 @@ from pydrake.solvers import (
 
 
 class TestClarabelSolver(unittest.TestCase):
-
     def test_attributes(self):
         dut = ClarabelSolver()
         self.assertEqual(dut.solver_id(), ClarabelSolver.id())

--- a/bindings/pydrake/solvers/test/clp_solver_test.py
+++ b/bindings/pydrake/solvers/test/clp_solver_test.py
@@ -13,16 +13,15 @@ class TestClpSolver(unittest.TestCase):
     def _make_prog(self):
         prog = MathematicalProgram()
         x = prog.NewContinuousVariables(4, "x")
-        prog.AddLinearCost(-3*x[0] - 2*x[1])
+        prog.AddLinearCost(-3 * x[0] - 2 * x[1])
         prog.AddLinearCost(x[1] - 5 * x[2] - x[3] + 2)
-        prog.AddLinearConstraint(3*x[0] + x[1] + 2*x[2] == 30)
-        prog.AddLinearConstraint(2*x[0] + x[1] + 3 * x[2] + x[3] >= 15)
+        prog.AddLinearConstraint(3 * x[0] + x[1] + 2 * x[2] == 30)
+        prog.AddLinearConstraint(2 * x[0] + x[1] + 3 * x[2] + x[3] >= 15)
         prog.AddLinearConstraint(2 * x[1] + 3 * x[3] <= 25)
-        prog.AddLinearConstraint(
-            np.array([[1, 2]]), [-100], [40], [x[0], x[2]])
+        prog.AddLinearConstraint(np.array([[1, 2]]), [-100], [40], [x[0], x[2]])
         prog.AddBoundingBoxConstraint(0, np.inf, x)
         prog.AddLinearConstraint(x[1] <= 10)
-        x_expected = np.array([0, 0, 15., 25./3])
+        x_expected = np.array([0, 0, 15.0, 25.0 / 3])
         return prog, x, x_expected
 
     def test_clp_solver(self):
@@ -37,7 +36,7 @@ class TestClpSolver(unittest.TestCase):
         self.assertTrue(result.is_success())
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))
         self.assertEqual(result.get_solver_details().status, 0)
-        self.assertAlmostEqual(result.get_optimal_cost(), -244./3)
+        self.assertAlmostEqual(result.get_optimal_cost(), -244.0 / 3)
 
     def unavailable(self):
         """Per the BUILD file, this test is only run when Clp is disabled."""

--- a/bindings/pydrake/solvers/test/csdp_solver_test.py
+++ b/bindings/pydrake/solvers/test/csdp_solver_test.py
@@ -21,12 +21,24 @@ class TestCsdpSolver(unittest.TestCase):
         prog.AddPositiveSemidefiniteConstraint(x2)
         prog.AddLinearConstraint(y[0] >= 0)
         prog.AddLinearConstraint(y[1] >= 0)
-        prog.AddLinearEqualityConstraint(3*x1[0, 0] + 2*x1[0, 1] + 3*x1[1, 1]
-                                         + y[0] == 1)
-        prog.AddLinearEqualityConstraint(3*x2[0, 0] + 4*x2[1, 1] + 2*x2[0, 2]
-                                         + 5*x2[2, 2] + y[1] == 2)
-        prog.AddLinearCost(-(2*x1[0, 0] + 2*x1[0, 1] + 2*x1[1, 1] + 3*x2[0, 0]
-                             + 2*x2[1, 1] + 2*x2[0, 2] + 3*x2[2, 2]))
+        prog.AddLinearEqualityConstraint(
+            3 * x1[0, 0] + 2 * x1[0, 1] + 3 * x1[1, 1] + y[0] == 1
+        )
+        prog.AddLinearEqualityConstraint(
+            3 * x2[0, 0] + 4 * x2[1, 1] + 2 * x2[0, 2] + 5 * x2[2, 2] + y[1]
+            == 2
+        )
+        prog.AddLinearCost(
+            -(
+                2 * x1[0, 0]
+                + 2 * x1[0, 1]
+                + 2 * x1[1, 1]
+                + 3 * x2[0, 0]
+                + 2 * x2[1, 1]
+                + 2 * x2[0, 2]
+                + 3 * x2[2, 2]
+            )
+        )
         x1_expected = 0.125 * np.ones((2, 2))
         return prog, x1, x1_expected
 
@@ -42,30 +54,37 @@ class TestCsdpSolver(unittest.TestCase):
         solver_options.SetOption(
             solver.id(),
             "drake::RemoveFreeVariableMethod",
-            RemoveFreeVariableMethod.kNullspace)
+            RemoveFreeVariableMethod.kNullspace,
+        )
         result = solver.Solve(prog, None, solver_options)
         self.assertTrue(result.is_success())
         self.assertTrue(np.allclose(result.GetSolution(x1), x1_expected))
         self.assertEqual(result.get_solver_details().return_code, 0)
         np.testing.assert_allclose(
-            result.get_solver_details().primal_objective, 2.75)
+            result.get_solver_details().primal_objective, 2.75
+        )
         np.testing.assert_allclose(
-            result.get_solver_details().dual_objective, 2.75)
+            result.get_solver_details().dual_objective, 2.75
+        )
         np.testing.assert_allclose(
-            result.get_solver_details().y_val, np.array([0.75, 1.]))
+            result.get_solver_details().y_val, np.array([0.75, 1.0])
+        )
         z_expected = np.zeros((7, 7))
         z_expected[0, :2] = [0.25, -0.25]
         z_expected[1, :2] = [-0.25, 0.25]
-        z_expected[3:, 3:] = np.diag([2., 2., 0.75, 1.])
+        z_expected[3:, 3:] = np.diag([2.0, 2.0, 0.75, 1.0])
         np.testing.assert_allclose(
-            result.get_solver_details().Z_val.todense(), z_expected, atol=1e-8)
+            result.get_solver_details().Z_val.todense(), z_expected, atol=1e-8
+        )
 
         # Test removing free variables with a non-default method.
         solver = CsdpSolver()
         solver_options = SolverOptions()
         solver_options.SetOption(
-            solver.id(), "drake::RemoveFreeVariableMethod",
-            RemoveFreeVariableMethod.kLorentzConeSlack)
+            solver.id(),
+            "drake::RemoveFreeVariableMethod",
+            RemoveFreeVariableMethod.kLorentzConeSlack,
+        )
         result = solver.Solve(prog, None, solver_options)
         self.assertTrue(result.is_success())
 

--- a/bindings/pydrake/solvers/test/evaluators_test.py
+++ b/bindings/pydrake/solvers/test/evaluators_test.py
@@ -13,13 +13,13 @@ from pydrake.autodiffutils import InitializeAutoDiff
 
 class TestCost(unittest.TestCase):
     def test_linear_cost(self):
-        a = np.array([1., 2.])
+        a = np.array([1.0, 2.0])
         b = 0.5
         cost = mp.LinearCost(a, b)
         np.testing.assert_allclose(cost.a(), a)
         self.assertEqual(cost.b(), b)
-        cost.UpdateCoefficients(new_a=[2, 3.], new_b=1)
-        np.testing.assert_allclose(cost.a(), [2, 3.])
+        cost.UpdateCoefficients(new_a=[2, 3.0], new_b=1)
+        np.testing.assert_allclose(cost.a(), [2, 3.0])
         self.assertEqual(cost.b(), 1)
 
         cost.update_coefficient_entry(i=0, val=4)
@@ -30,8 +30,8 @@ class TestCost(unittest.TestCase):
         self.assertEqual(cost.b(), 2)
 
     def test_quadratic_cost(self):
-        Q = np.array([[1., 2.], [2., 3.]])
-        b = np.array([3., 4.])
+        Q = np.array([[1.0, 2.0], [2.0, 3.0]])
+        b = np.array([3.0, 4.0])
         c = 0.4
         cost = mp.QuadraticCost(Q, b, c)
         np.testing.assert_allclose(cost.Q(), Q)
@@ -42,24 +42,24 @@ class TestCost(unittest.TestCase):
         cost = mp.QuadraticCost(Q, b, c, is_convex=False)
         self.assertFalse(cost.is_convex())
 
-        cost = mp.QuadraticCost(np.array([[1., 2.], [2., 6.]]), b, c)
+        cost = mp.QuadraticCost(np.array([[1.0, 2.0], [2.0, 6.0]]), b, c)
         self.assertTrue(cost.is_convex())
 
         cost.UpdateCoefficients(
-            new_Q=np.array([[1, 3], [3, 6.]]),
-            new_b=np.array([2, 4.]),
+            new_Q=np.array([[1, 3], [3, 6.0]]),
+            new_b=np.array([2, 4.0]),
             new_c=1,
-            is_convex=False
+            is_convex=False,
         )
         np.testing.assert_allclose(cost.Q(), np.array([[1, 3], [3, 6]]))
-        np.testing.assert_allclose(cost.b(), np.array([2, 4.]))
+        np.testing.assert_allclose(cost.b(), np.array([2, 4.0]))
         self.assertEqual(cost.c(), 1)
 
         cost.UpdateHessianEntry(i=0, j=1, val=1, is_hessian_psd=None)
         np.testing.assert_allclose(cost.Q(), np.array([[1, 1], [1, 6]]))
         self.assertTrue(cost.is_convex())
         cost.update_linear_coefficient_entry(i=1, val=5)
-        np.testing.assert_allclose(cost.b(), np.array([2, 5.]))
+        np.testing.assert_allclose(cost.b(), np.array([2, 5.0]))
         cost.update_constant_term(new_c=2)
         self.assertEqual(cost.c(), 2)
 
@@ -68,52 +68,52 @@ class TestCost(unittest.TestCase):
         self.assertTrue(cost.is_convex())
 
     def test_l1norm_cost(self):
-        A = np.array([[1., 2.], [-.4, .7]])
-        b = np.array([0.5, -.4])
+        A = np.array([[1.0, 2.0], [-0.4, 0.7]])
+        b = np.array([0.5, -0.4])
         cost = mp.L1NormCost(A=A, b=b)
         np.testing.assert_allclose(cost.A(), A)
         np.testing.assert_allclose(cost.b(), b)
-        cost.UpdateCoefficients(new_A=2*A, new_b=2*b)
-        np.testing.assert_allclose(cost.A(), 2*A)
-        np.testing.assert_allclose(cost.b(), 2*b)
+        cost.UpdateCoefficients(new_A=2 * A, new_b=2 * b)
+        np.testing.assert_allclose(cost.A(), 2 * A)
+        np.testing.assert_allclose(cost.b(), 2 * b)
         cost.update_A_entry(i=0, j=1, val=0.5)
         np.testing.assert_allclose(cost.A(), np.array([[2, 0.5], [-0.8, 1.4]]))
         cost.update_b_entry(i=0, val=1)
         np.testing.assert_allclose(cost.b(), np.array([1, -0.8]))
 
     def test_l2norm_cost(self):
-        A = np.array([[1., 2.], [-.4, .7]])
-        b = np.array([0.5, -.4])
+        A = np.array([[1.0, 2.0], [-0.4, 0.7]])
+        b = np.array([0.5, -0.4])
         cost = mp.L2NormCost(A=A, b=b)
         np.testing.assert_allclose(cost.get_sparse_A().todense(), A)
         np.testing.assert_allclose(cost.GetDenseA(), A)
         np.testing.assert_allclose(cost.b(), b)
-        cost.UpdateCoefficients(new_A=2*A, new_b=2*b)
-        np.testing.assert_allclose(cost.b(), 2*b)
+        cost.UpdateCoefficients(new_A=2 * A, new_b=2 * b)
+        np.testing.assert_allclose(cost.b(), 2 * b)
 
     def test_linfnorm_cost(self):
-        A = np.array([[1., 2.], [-.4, .7]])
-        b = np.array([0.5, -.4])
+        A = np.array([[1.0, 2.0], [-0.4, 0.7]])
+        b = np.array([0.5, -0.4])
         cost = mp.LInfNormCost(A=A, b=b)
         np.testing.assert_allclose(cost.A(), A)
         np.testing.assert_allclose(cost.b(), b)
-        cost.UpdateCoefficients(new_A=2*A, new_b=2*b)
-        np.testing.assert_allclose(cost.A(), 2*A)
-        np.testing.assert_allclose(cost.b(), 2*b)
+        cost.UpdateCoefficients(new_A=2 * A, new_b=2 * b)
+        np.testing.assert_allclose(cost.A(), 2 * A)
+        np.testing.assert_allclose(cost.b(), 2 * b)
         cost.update_A_entry(i=0, j=1, val=0.5)
         np.testing.assert_allclose(cost.A(), np.array([[2, 0.5], [-0.8, 1.4]]))
         cost.update_b_entry(i=0, val=1)
         np.testing.assert_allclose(cost.b(), np.array([1, -0.8]))
 
     def test_perspective_quadratic_cost(self):
-        A = np.array([[1., 2.], [-.4, .7]])
-        b = np.array([0.5, -.4])
+        A = np.array([[1.0, 2.0], [-0.4, 0.7]])
+        b = np.array([0.5, -0.4])
         cost = mp.PerspectiveQuadraticCost(A=A, b=b)
         np.testing.assert_allclose(cost.A(), A)
         np.testing.assert_allclose(cost.b(), b)
-        cost.UpdateCoefficients(new_A=2*A, new_b=2*b)
-        np.testing.assert_allclose(cost.A(), 2*A)
-        np.testing.assert_allclose(cost.b(), 2*b)
+        cost.UpdateCoefficients(new_A=2 * A, new_b=2 * b)
+        np.testing.assert_allclose(cost.A(), 2 * A)
+        np.testing.assert_allclose(cost.b(), 2 * b)
         cost.update_A_entry(i=0, j=1, val=0.5)
         np.testing.assert_allclose(cost.A(), np.array([[2, 0.5], [-0.8, 1.4]]))
         cost.update_b_entry(i=0, val=1)
@@ -152,8 +152,9 @@ class TestCost(unittest.TestCase):
         y = sym.Variable("y")
         e = np.sin(x) + y
         cost = mp.ExpressionCost(e=e)
-        self.assertEqual(cost.ToLatex(vars=cost.vars(), precision=1),
-                         "(y + \\sin{x})")
+        self.assertEqual(
+            cost.ToLatex(vars=cost.vars(), precision=1), "(y + \\sin{x})"
+        )
         binding = mp.Binding[mp.ExpressionCost](cost, cost.vars())
         self.assertEqual(binding.ToLatex(precision=1), "(y + \\sin{x})")
 
@@ -187,7 +188,7 @@ class TestCost(unittest.TestCase):
     def test_binding_hash(self):
         x = sym.Variable("x")
         y = sym.Variable("y")
-        e = np.log(2*x) + y**2
+        e = np.log(2 * x) + y**2
         e2 = y
 
         cost1 = mp.ExpressionCost(e=e)
@@ -211,16 +212,20 @@ class TestCost(unittest.TestCase):
 class TestConstraints(unittest.TestCase):
     def test_bounding_box_constraint(self):
         constraint = mp.BoundingBoxConstraint(
-            lb=np.array([1., 2.]), ub=np.array([2., 3.]))
+            lb=np.array([1.0, 2.0]), ub=np.array([2.0, 3.0])
+        )
         np.testing.assert_array_equal(
-            constraint.lower_bound(), np.array([1., 2.]))
+            constraint.lower_bound(), np.array([1.0, 2.0])
+        )
         np.testing.assert_array_equal(
-            constraint.upper_bound(), np.array([2., 3.]))
+            constraint.upper_bound(), np.array([2.0, 3.0])
+        )
 
     def test_linear_constraint(self):
         A_sparse = scipy.sparse.csc_matrix(
-            (np.array([2, 1, 3]), np.array([0, 1, 0]),
-             np.array([0, 2, 2, 3])), shape=(2, 2))
+            (np.array([2, 1, 3]), np.array([0, 1, 0]), np.array([0, 2, 2, 3])),
+            shape=(2, 2),
+        )
         lb = -np.ones(2)
         ub = np.ones(2)
 
@@ -237,36 +242,43 @@ class TestConstraints(unittest.TestCase):
             new_A = np.ones_like(c.GetDenseA())
             new_A[1, 1] = 1e-20
 
-            c.UpdateCoefficients(new_A=new_A,
-                                 new_lb=np.ones(r),
-                                 new_ub=np.ones(r))
+            c.UpdateCoefficients(
+                new_A=new_A, new_lb=np.ones(r), new_ub=np.ones(r)
+            )
             c.RemoveTinyCoefficient(tol=1e-10)
             self.assertEqual(c.GetDenseA()[1, 1], 0)
-            c.UpdateCoefficients(new_A=c.get_sparse_A(),
-                                 new_lb=np.ones(r),
-                                 new_ub=np.ones(r))
+            c.UpdateCoefficients(
+                new_A=c.get_sparse_A(), new_lb=np.ones(r), new_ub=np.ones(r)
+            )
 
-            c.UpdateLowerBound(new_lb=-2*np.ones(r))
-            c.UpdateUpperBound(new_ub=2*np.ones(r))
-            c.set_bounds(new_lb=-3*np.ones(r), new_ub=3*np.ones(r))
+            c.UpdateLowerBound(new_lb=-2 * np.ones(r))
+            c.UpdateUpperBound(new_ub=2 * np.ones(r))
+            c.set_bounds(new_lb=-3 * np.ones(r), new_ub=3 * np.ones(r))
 
     def test_quadratic_constraint(self):
         hessian_type = mp.QuadraticConstraint.HessianType.kPositiveSemidefinite
         constraint = mp.QuadraticConstraint(
-            Q0=np.eye(2), b=np.array([1, 2.]), lb=-np.inf, ub=1.,
-            hessian_type=hessian_type)
+            Q0=np.eye(2),
+            b=np.array([1, 2.0]),
+            lb=-np.inf,
+            ub=1.0,
+            hessian_type=hessian_type,
+        )
         np.testing.assert_array_equal(constraint.Q(), np.eye(2))
-        np.testing.assert_array_equal(constraint.b(), np.array([1, 2.]))
+        np.testing.assert_array_equal(constraint.b(), np.array([1, 2.0]))
         self.assertEqual(constraint.hessian_type(), hessian_type)
         self.assertTrue(constraint.is_convex())
         hessian_type = mp.QuadraticConstraint.HessianType.kNegativeSemidefinite
         constraint.UpdateCoefficients(
-            new_Q=-np.eye(2), new_b=np.array([1., -1.]),
-            hessian_type=hessian_type)
+            new_Q=-np.eye(2),
+            new_b=np.array([1.0, -1.0]),
+            hessian_type=hessian_type,
+        )
         self.assertEqual(constraint.hessian_type(), hessian_type)
         self.assertFalse(constraint.is_convex())
         constraint.UpdateCoefficients(
-            new_Q=np.array([[1, 0], [0, -1.]]), new_b=np.array([1., -1]))
+            new_Q=np.array([[1, 0], [0, -1.0]]), new_b=np.array([1.0, -1])
+        )
         hessian_type = mp.QuadraticConstraint.HessianType.kIndefinite
         self.assertEqual(constraint.hessian_type(), hessian_type)
 
@@ -277,7 +289,8 @@ class TestConstraints(unittest.TestCase):
     def test_linear_matrix_inequality_constraint(self):
         constraint = mp.LinearMatrixInequalityConstraint(
             F=[np.eye(3), 2 * np.eye(3), np.ones((3, 3))],
-            symmetry_tolerance=1E-12)
+            symmetry_tolerance=1e-12,
+        )
         self.assertEqual(constraint.matrix_rows(), 3)
 
     def test_expression_constraint(self):
@@ -290,29 +303,37 @@ class TestConstraints(unittest.TestCase):
         self.assertTrue(v[0].EqualTo(constraint.expressions()[0]))
         self.assertTrue(v[1].EqualTo(constraint.expressions()[1]))
         self.assertEqual(
-            sym.Variables(constraint.vars()), sym.Variables([x, y]))
+            sym.Variables(constraint.vars()), sym.Variables([x, y])
+        )
         np.testing.assert_array_equal(lb, constraint.lower_bound())
         np.testing.assert_array_equal(ub, constraint.upper_bound())
 
     def test_lorentz_cone_constraint(self):
-        A = np.array([[1, 2], [-1, -3], [2, 3.]])
-        b = np.array([2., 3., 4.])
+        A = np.array([[1, 2], [-1, -3], [2, 3.0]])
+        b = np.array([2.0, 3.0, 4.0])
         constraint = mp.LorentzConeConstraint(
-            A=A, b=b,
-            eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth)
+            A=A, b=b, eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth
+        )
         np.testing.assert_array_equal(constraint.A().todense(), A)
         np.testing.assert_array_equal(constraint.b(), b)
         self.assertEqual(
             constraint.eval_type(),
-            mp.LorentzConeConstraint.EvalType.kConvexSmooth)
+            mp.LorentzConeConstraint.EvalType.kConvexSmooth,
+        )
         constraint.UpdateCoefficients(new_A=2 * A, new_b=3 * b)
         np.testing.assert_array_equal(constraint.A().todense(), 2 * A)
         np.testing.assert_array_equal(constraint.b(), 3 * b)
 
     def test_rotated_lorentz_cone_constraint(self):
         A = np.array(
-            [[1., 2., 3.], [4., 5., 6.], [7., 8., 9.], [10., 11., 12.]])
-        b = np.array([1., 2., 3, 4])
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0],
+                [7.0, 8.0, 9.0],
+                [10.0, 11.0, 12.0],
+            ]
+        )
+        b = np.array([1.0, 2.0, 3, 4])
         constraint = mp.RotatedLorentzConeConstraint(A=A, b=b)
         np.testing.assert_array_equal(constraint.A().todense(), A)
         np.testing.assert_array_equal(constraint.b(), b)
@@ -360,15 +381,16 @@ class TestConstraints(unittest.TestCase):
             x = sym.Variable("x")
             y = sym.Variable("y")
             e = np.sin(x) + y
-            constraint = mp.ExpressionConstraint(v=np.array([e]),
-                                                 lb=np.array([1.0]),
-                                                 ub=np.array([2.0]))
+            constraint = mp.ExpressionConstraint(
+                v=np.array([e]), lb=np.array([1.0]), ub=np.array([2.0])
+            )
             # Sett up the types to ensure the cast constructor is used.
             constraint_binding = mp.Binding[mp.ExpressionConstraint](
                 constraint, constraint.vars()
             )
             cast_binding = mp_testing.AcceptBindingEvaluatorBase(
-                constraint_binding)
+                constraint_binding
+            )
             spies.append(weakref.finalize(constraint, lambda: None))
             return cast_binding, spies
 
@@ -387,9 +409,9 @@ class TestConstraints(unittest.TestCase):
             x = sym.Variable("x")
             y = sym.Variable("y")
             e = np.sin(x) + y
-            constraint = mp.ExpressionConstraint(v=np.array([e]),
-                                                 lb=np.array([1.0]),
-                                                 ub=np.array([2.0]))
+            constraint = mp.ExpressionConstraint(
+                v=np.array([e]), lb=np.array([1.0]), ub=np.array([2.0])
+            )
             constraint_binding = mp.Binding[mp.ExpressionConstraint](
                 constraint, constraint.vars()
             )
@@ -406,9 +428,9 @@ class TestConstraints(unittest.TestCase):
         e1 = np.sin(x) + y
         e2 = np.cos(x) + y
         e3 = np.sin(z) + y
-        constraint1 = mp.ExpressionConstraint(v=np.array([e1]),
-                                              lb=np.array([1.0]),
-                                              ub=np.array([2.0]))
+        constraint1 = mp.ExpressionConstraint(
+            v=np.array([e1]), lb=np.array([1.0]), ub=np.array([2.0])
+        )
         constraint1_binding1 = mp.Binding[mp.ExpressionConstraint](
             constraint1, constraint1.vars()
         )
@@ -416,16 +438,16 @@ class TestConstraints(unittest.TestCase):
             constraint1, constraint1.vars()
         )
 
-        constraint2 = mp.ExpressionConstraint(v=np.array([e2]),
-                                              lb=np.array([1.0]),
-                                              ub=np.array([2.0]))
+        constraint2 = mp.ExpressionConstraint(
+            v=np.array([e2]), lb=np.array([1.0]), ub=np.array([2.0])
+        )
         constraint2_binding = mp.Binding[mp.ExpressionConstraint](
             constraint2, constraint2.vars()
         )
 
-        constraint3 = mp.ExpressionConstraint(v=np.array([e3]),
-                                              lb=np.array([1.0]),
-                                              ub=np.array([2.0]))
+        constraint3 = mp.ExpressionConstraint(
+            v=np.array([e3]), lb=np.array([1.0]), ub=np.array([2.0])
+        )
         constraint3_binding = mp.Binding[mp.ExpressionConstraint](
             constraint3, constraint3.vars()
         )
@@ -442,63 +464,72 @@ class TestConstraints(unittest.TestCase):
     def test_binding_hash(self):
         x = sym.Variable("x")
         y = sym.Variable("y")
-        e = np.log(2*x) + y**2
+        e = np.log(2 * x) + y**2
         e2 = y
-        constraint1 = mp.ExpressionConstraint(v=np.array([e]),
-                                              lb=np.array([1.0]),
-                                              ub=np.array([2.0]))
+        constraint1 = mp.ExpressionConstraint(
+            v=np.array([e]), lb=np.array([1.0]), ub=np.array([2.0])
+        )
         constraint1_binding1 = mp.Binding[mp.ExpressionConstraint](
             constraint1, constraint1.vars()
         )
         constraint1_binding2 = mp.Binding[mp.ExpressionConstraint](
             constraint1, constraint1.vars()
         )
-        constraint2 = mp.ExpressionConstraint(v=np.array([e2]),
-                                              lb=np.array([1.0]),
-                                              ub=np.array([2.0]))
-        self.assertEqual(hash(constraint1_binding1),
-                         hash(constraint1_binding2))
+        constraint2 = mp.ExpressionConstraint(
+            v=np.array([e2]), lb=np.array([1.0]), ub=np.array([2.0])
+        )
+        self.assertEqual(hash(constraint1_binding1), hash(constraint1_binding2))
         self.assertNotEqual(hash(constraint1_binding1), hash(constraint2))
 
 
 # A dummy value function for MinimumValue{Lower,Upper}BoundConstraint.
 def value_function(x: np.ndarray, v_influence: float) -> np.ndarray:
-    return np.array([x[0]**2, x[0]+1, 2*x[0]])
+    return np.array([x[0] ** 2, x[0] + 1, 2 * x[0]])
 
 
 class TestMinimumValueLowerBoundConstraint(unittest.TestCase):
     def test_constructor(self):
         # Test the constructor with value_function_double explicitly specified.
         dut = mp.MinimumValueLowerBoundConstraint(
-            num_vars=1, minimum_value_lower=0.,
-            influence_value_offset=1., max_num_values=3,
+            num_vars=1,
+            minimum_value_lower=0.0,
+            influence_value_offset=1.0,
+            max_num_values=3,
             value_function=value_function,
-            value_function_double=value_function)
+            value_function_double=value_function,
+        )
         self.assertEqual(dut.num_vars(), 1)
         self.assertEqual(dut.num_constraints(), 1)
-        self.assertTrue(dut.CheckSatisfied(np.array([1.])))
-        self.assertFalse(dut.CheckSatisfied(np.array([-5.])))
-        self.assertEqual(dut.minimum_value_lower(), 0.)
-        self.assertEqual(dut.influence_value(), 1.)
+        self.assertTrue(dut.CheckSatisfied(np.array([1.0])))
+        self.assertFalse(dut.CheckSatisfied(np.array([-5.0])))
+        self.assertEqual(dut.minimum_value_lower(), 0.0)
+        self.assertEqual(dut.influence_value(), 1.0)
 
         # Test the constructor with default value_function_double.
         dut = mp.MinimumValueLowerBoundConstraint(
-            num_vars=1, minimum_value_lower=0.,
-            influence_value_offset=1., max_num_values=3,
-            value_function=value_function)
-        self.assertTrue(dut.CheckSatisfied(np.array([1.])))
-        self.assertFalse(dut.CheckSatisfied(np.array([-5.])))
+            num_vars=1,
+            minimum_value_lower=0.0,
+            influence_value_offset=1.0,
+            max_num_values=3,
+            value_function=value_function,
+        )
+        self.assertTrue(dut.CheckSatisfied(np.array([1.0])))
+        self.assertFalse(dut.CheckSatisfied(np.array([-5.0])))
 
     def test_set_penalty_function(self):
         dut = mp.MinimumValueLowerBoundConstraint(
-            num_vars=1, minimum_value_lower=0.,
-            influence_value_offset=3., max_num_values=3,
+            num_vars=1,
+            minimum_value_lower=0.0,
+            influence_value_offset=3.0,
+            max_num_values=3,
             value_function=value_function,
-            value_function_double=value_function)
+            value_function_double=value_function,
+        )
 
         # Now set the new penalty function
-        def penalty(x: float, compute_grad: bool)\
-                -> typing.Tuple[float, typing.Optional[float]]:
+        def penalty(
+            x: float, compute_grad: bool
+        ) -> typing.Tuple[float, typing.Optional[float]]:
             if x < 0:
                 if compute_grad:
                     return x**2, 2 * x
@@ -506,52 +537,60 @@ class TestMinimumValueLowerBoundConstraint(unittest.TestCase):
                     return x**2, None
             else:
                 if compute_grad:
-                    return 0., 0.
+                    return 0.0, 0.0
                 else:
-                    return 0., None
+                    return 0.0, None
 
         dut.set_penalty_function(new_penalty_function=penalty)
-        self.assertTrue(dut.CheckSatisfied(np.array([1.])))
-        self.assertFalse(dut.CheckSatisfied(np.array([-5.])))
-        self.assertTrue(
-            dut.CheckSatisfied(InitializeAutoDiff(np.array([1.]))))
-        self.assertFalse(
-            dut.CheckSatisfied(InitializeAutoDiff(np.array([-2]))))
+        self.assertTrue(dut.CheckSatisfied(np.array([1.0])))
+        self.assertFalse(dut.CheckSatisfied(np.array([-5.0])))
+        self.assertTrue(dut.CheckSatisfied(InitializeAutoDiff(np.array([1.0]))))
+        self.assertFalse(dut.CheckSatisfied(InitializeAutoDiff(np.array([-2]))))
 
 
 class TestMinimumValueUpperBoundConstraint(unittest.TestCase):
     def test_constructor(self):
         # Test the constructor with value_function_double explicitly specified.
         dut = mp.MinimumValueUpperBoundConstraint(
-            num_vars=1, minimum_value_upper=2.,
-            influence_value_offset=1., max_num_values=3,
+            num_vars=1,
+            minimum_value_upper=2.0,
+            influence_value_offset=1.0,
+            max_num_values=3,
             value_function=value_function,
-            value_function_double=value_function)
+            value_function_double=value_function,
+        )
         self.assertEqual(dut.num_vars(), 1)
         self.assertEqual(dut.num_constraints(), 1)
-        self.assertTrue(dut.CheckSatisfied(np.array([1.])))
-        self.assertFalse(dut.CheckSatisfied(np.array([5.])))
+        self.assertTrue(dut.CheckSatisfied(np.array([1.0])))
+        self.assertFalse(dut.CheckSatisfied(np.array([5.0])))
         self.assertEqual(dut.minimum_value_upper(), 2)
         self.assertEqual(dut.influence_value(), 3)
 
         # Test the constructor with default value_function_double.
         dut = mp.MinimumValueUpperBoundConstraint(
-            num_vars=1, minimum_value_upper=2.,
-            influence_value_offset=1., max_num_values=3,
-            value_function=value_function)
-        self.assertTrue(dut.CheckSatisfied(np.array([1.])))
-        self.assertFalse(dut.CheckSatisfied(np.array([5.])))
+            num_vars=1,
+            minimum_value_upper=2.0,
+            influence_value_offset=1.0,
+            max_num_values=3,
+            value_function=value_function,
+        )
+        self.assertTrue(dut.CheckSatisfied(np.array([1.0])))
+        self.assertFalse(dut.CheckSatisfied(np.array([5.0])))
 
     def test_set_penalty_function(self):
         dut = mp.MinimumValueUpperBoundConstraint(
-            num_vars=1, minimum_value_upper=1.5,
-            influence_value_offset=3., max_num_values=3,
+            num_vars=1,
+            minimum_value_upper=1.5,
+            influence_value_offset=3.0,
+            max_num_values=3,
             value_function=value_function,
-            value_function_double=value_function)
+            value_function_double=value_function,
+        )
 
         # Now set the new penalty function
-        def penalty(x: float, compute_grad: bool)\
-                -> typing.Tuple[float, typing.Optional[float]]:
+        def penalty(
+            x: float, compute_grad: bool
+        ) -> typing.Tuple[float, typing.Optional[float]]:
             if x < 0:
                 if compute_grad:
                     return x**2, 2 * x
@@ -559,14 +598,14 @@ class TestMinimumValueUpperBoundConstraint(unittest.TestCase):
                     return x**2, None
             else:
                 if compute_grad:
-                    return 0., 0.
+                    return 0.0, 0.0
                 else:
-                    return 0., None
+                    return 0.0, None
 
         dut.set_penalty_function(new_penalty_function=penalty)
-        self.assertTrue(dut.CheckSatisfied(np.array([1.])))
-        self.assertTrue(dut.CheckSatisfied(np.array([-5.])))
-        self.assertTrue(
-            dut.CheckSatisfied(InitializeAutoDiff(np.array([1.]))))
+        self.assertTrue(dut.CheckSatisfied(np.array([1.0])))
+        self.assertTrue(dut.CheckSatisfied(np.array([-5.0])))
+        self.assertTrue(dut.CheckSatisfied(InitializeAutoDiff(np.array([1.0]))))
         self.assertFalse(
-            dut.CheckSatisfied(InitializeAutoDiff(np.array([5.]))))
+            dut.CheckSatisfied(InitializeAutoDiff(np.array([5.0])))
+        )

--- a/bindings/pydrake/solvers/test/gurobi_solver_test.py
+++ b/bindings/pydrake/solvers/test/gurobi_solver_test.py
@@ -27,7 +27,7 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertTrue(result.is_success())
         x_expected = np.array([1, 1])
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))
-        self.assertGreater(result.get_solver_details().optimizer_time, 0.)
+        self.assertGreater(result.get_solver_details().optimizer_time, 0.0)
         self.assertEqual(result.get_solver_details().error_code, 0)
         self.assertEqual(result.get_solver_details().optimization_status, 2)
         self.assertTrue(np.isnan(result.get_solver_details().objective_bound))
@@ -35,14 +35,17 @@ class TestMathematicalProgram(unittest.TestCase):
     def test_gurobi_socp_dual(self):
         prog = MathematicalProgram()
         x = prog.NewContinuousVariables(2, "x")
-        constraint = prog.AddLorentzConeConstraint([2., 2*x[0], 3 * x[1] + 1])
+        constraint = prog.AddLorentzConeConstraint(
+            [2.0, 2 * x[0], 3 * x[1] + 1]
+        )
         prog.AddLinearCost(x[1])
         solver = GurobiSolver()
         options = SolverOptions()
         options.SetOption(solver.solver_id(), "QCPDual", 1)
         result = solver.Solve(prog, None, options)
         np.testing.assert_allclose(
-            result.GetDualSolution(constraint), np.array([-1./12]), atol=1e-7)
+            result.GetDualSolution(constraint), np.array([-1.0 / 12]), atol=1e-7
+        )
 
     def test_gurobi_license(self):
         # Nominal use case.
@@ -86,11 +89,11 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddLinearCost(-b[0] - b[1])
 
         prog.SetSolverOption(GurobiSolver.id(), "Presolve", 0)
-        prog.SetSolverOption(GurobiSolver.id(), "Heuristics", 0.)
+        prog.SetSolverOption(GurobiSolver.id(), "Heuristics", 0.0)
         prog.SetSolverOption(GurobiSolver.id(), "Cuts", 0)
         prog.SetSolverOption(GurobiSolver.id(), "NodeMethod", 2)
 
-        b_init = np.array([0, 0., 0., 0.])
+        b_init = np.array([0, 0.0, 0.0, 0.0])
 
         prog.SetInitialGuess(b, b_init)
         solver = GurobiSolver()
@@ -103,7 +106,9 @@ class TestMathematicalProgram(unittest.TestCase):
 
         solver.AddMipNodeCallback(
             callback=lambda prog, solver_status_info, x, x_vals: node_callback(
-                prog, solver_status_info, x, x_vals))
+                prog, solver_status_info, x, x_vals
+            )
+        )
 
         best_objectives = []
 
@@ -113,7 +118,9 @@ class TestMathematicalProgram(unittest.TestCase):
 
         solver.AddMipSolCallback(
             callback=lambda prog, callback_info: sol_callback(
-                prog, callback_info, best_objectives))
+                prog, callback_info, best_objectives
+            )
+        )
 
         result = solver.Solve(prog)
         self.assertTrue(result.is_success())

--- a/bindings/pydrake/solvers/test/ipopt_solver_test.py
+++ b/bindings/pydrake/solvers/test/ipopt_solver_test.py
@@ -32,16 +32,19 @@ class TestIpoptSolver(unittest.TestCase):
         self.assertTrue(result.is_success())
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))
         self.assertEqual(result.get_solver_details().status, 0)
-        self.assertEqual(result.get_solver_details().ConvertStatusToString(),
-                         "Success")
+        self.assertEqual(
+            result.get_solver_details().ConvertStatusToString(), "Success"
+        )
         np.testing.assert_allclose(
-            result.get_solver_details().z_L, np.array([1., 1.]))
+            result.get_solver_details().z_L, np.array([1.0, 1.0])
+        )
         np.testing.assert_allclose(
-            result.get_solver_details().z_U, np.array([0., 0.]))
+            result.get_solver_details().z_U, np.array([0.0, 0.0])
+        )
+        np.testing.assert_allclose(result.get_solver_details().g, np.array([]))
         np.testing.assert_allclose(
-            result.get_solver_details().g, np.array([]))
-        np.testing.assert_allclose(
-            result.get_solver_details().lambda_val, np.array([]))
+            result.get_solver_details().lambda_val, np.array([])
+        )
 
     def unavailable(self):
         """Per the BUILD file, this test is only run when Ipopt is disabled."""

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -48,15 +48,18 @@ class TestQP:
             # Bounding box
             prog.AddLinearConstraint(x[0] >= 1),
             # Bounding box
-            prog.AddLinearConstraint(sym.logical_and(x[1] >= 1, x[1] <= 2.)),
+            prog.AddLinearConstraint(sym.logical_and(x[1] >= 1, x[1] <= 2.0)),
             # Linear inequality
             prog.AddLinearConstraint(3 * x[0] - x[1] <= 2),
             # Linear equality
-            prog.AddLinearConstraint(x[0] + 2 * x[1] == 3)]
+            prog.AddLinearConstraint(x[0] + 2 * x[1] == 3),
+        ]
 
         # TODO(eric.cousineau): Add constant terms
-        self.costs = [prog.AddLinearCost(e=x[0] + x[1]),
-                      prog.AddQuadraticCost(0.5 * (x[0]**2 + x[1]**2))]
+        self.costs = [
+            prog.AddLinearCost(e=x[0] + x[1]),
+            prog.AddQuadraticCost(0.5 * (x[0] ** 2 + x[1] ** 2)),
+        ]
 
 
 class TestMathematicalProgram(unittest.TestCase):
@@ -69,7 +72,6 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertTrue(prog.IsThreadSafe())
 
     def test_clone_and_copy_and_deepcopy(self):
-
         def via_clone(prog):
             return prog.Clone()
 
@@ -88,7 +90,8 @@ class TestMathematicalProgram(unittest.TestCase):
                 for i in range(2):
                     self.assertEqual(
                         prog_clone.decision_variables()[i].get_id(),
-                        x[i].get_id())
+                        x[i].get_id(),
+                    )
                 # Add variables to prog, prog_clone should be unchanged.
                 prog.NewContinuousVariables(3)
                 self.assertEqual(prog_clone.num_vars(), 2)
@@ -99,7 +102,7 @@ class TestMathematicalProgram(unittest.TestCase):
 
         # Add linear equality constraints; make sure the solver works.
         prog.AddLinearConstraint(x[0] + x[1] == 0)
-        prog.AddLinearConstraint(2*x[0] - x[1] == 1)
+        prog.AddLinearConstraint(2 * x[0] - x[1] == 1)
         solver_id = mp.ChooseBestSolver(prog)
         self.assertEqual(solver_id.name(), "Linear system")
         solver = mp.MakeSolver(solver_id)
@@ -128,8 +131,7 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertTrue(result.is_success())
         self.assertEqual(result.get_solver_id().name(), solver_id.name())
 
-        linear_solvers = mp.GetAvailableSolvers(
-            prog_type=mp.ProgramType.kLP)
+        linear_solvers = mp.GetAvailableSolvers(prog_type=mp.ProgramType.kLP)
         self.assertGreater(len(linear_solvers), 0)
 
     def test_module_level_solve_function_and_result_accessors(self):
@@ -138,18 +140,23 @@ class TestMathematicalProgram(unittest.TestCase):
         result = mp.Solve(qp.prog)
         self.assertTrue(result.is_success())
         self.assertTrue(np.allclose(result.get_x_val(), x_expected))
-        self.assertEqual(result.get_solution_result(),
-                         mp.SolutionResult.kSolutionFound)
+        self.assertEqual(
+            result.get_solution_result(), mp.SolutionResult.kSolutionFound
+        )
         self.assertAlmostEqual(result.get_optimal_cost(), 3.0, places=7)
         self.assertTrue(result.get_solver_id().name())
         self.assertTrue(np.allclose(result.GetSolution(), x_expected))
         self.assertAlmostEqual(result.GetSolution(qp.x[0]), 1.0)
         self.assertTrue(np.allclose(result.GetSolution(qp.x), x_expected))
-        self.assertTrue(result.GetSolution(sym.Expression(qp.x[0])).EqualTo(
-            result.GetSolution(qp.x[0])))
+        self.assertTrue(
+            result.GetSolution(sym.Expression(qp.x[0])).EqualTo(
+                result.GetSolution(qp.x[0])
+            )
+        )
         m = np.array([sym.Expression(qp.x[0]), sym.Expression(qp.x[1])])
-        self.assertTrue(result.GetSolution(m)[1, 0].EqualTo(
-            result.GetSolution(qp.x[1])))
+        self.assertTrue(
+            result.GetSolution(m)[1, 0].EqualTo(result.GetSolution(qp.x[1]))
+        )
         self.assertEqual(result.num_suboptimal_solution(), 0)
 
         x_val_new = np.array([1, 2])
@@ -172,8 +179,8 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertIn("\\min", s)
         self.assertIn("\\text{subject to}", s)
 
-# TODO(jwnimmer-tri) MOSEK is also able to solve mixed integer programs;
-# perhaps we should test both of them?
+    # TODO(jwnimmer-tri) MOSEK is also able to solve mixed integer programs;
+    # perhaps we should test both of them?
     @unittest.skipUnless(GurobiSolver().available(), "Requires Gurobi")
     def test_mixed_integer_optimization(self):
         prog = mp.MathematicalProgram()
@@ -184,8 +191,11 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddLinearConstraint(a.dot(x) <= 4)
         prog.AddLinearConstraint(x[0] + x[1], 1, np.inf)
         prog.AddConstraint(
-            LinearConstraint(np.array([[1., 1.]]), np.array([1]),
-                             np.array([np.inf])), [x[0], x[1]])
+            LinearConstraint(
+                np.array([[1.0, 1.0]]), np.array([1]), np.array([np.inf])
+            ),
+            [x[0], x[1]],
+        )
         solver = GurobiSolver()
         result = solver.Solve(prog, None, None)
         self.assertTrue(result.is_success())
@@ -211,8 +221,7 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddQuadraticCost(np.eye(2), np.zeros(2), 1, x, is_convex=True)
         prog.AddQuadraticCost(x.dot(x) + 2, is_convex=True)
         # Redundant costs just to check the spelling.
-        prog.AddQuadraticErrorCost(vars=x, Q=np.eye(2),
-                                   x_desired=np.zeros(2))
+        prog.AddQuadraticErrorCost(vars=x, Q=np.eye(2), x_desired=np.zeros(2))
         prog.AddQuadraticErrorCost(vars=x, w=1, x_desired=np.ones(2))
         prog.Add2NormSquaredCost(A=np.eye(2), b=np.zeros(2), vars=x)
 
@@ -225,9 +234,9 @@ class TestMathematicalProgram(unittest.TestCase):
     def test_symbolic_qp(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, "x")
-        prog.AddConstraint(x[0], 1., 100.)
+        prog.AddConstraint(x[0], 1.0, 100.0)
         prog.AddConstraint(x[1] >= 1)
-        prog.AddQuadraticCost(x[0]**2 + x[1]**2)
+        prog.AddQuadraticCost(x[0] ** 2 + x[1] ** 2)
         result = mp.Solve(prog)
         self.assertTrue(result.is_success())
 
@@ -237,13 +246,14 @@ class TestMathematicalProgram(unittest.TestCase):
     def test_bindings(self):
         qp = TestQP()
         self.assertEqual(
-            str(qp.constraints[0]),
-            "BoundingBoxConstraint\n1 <= x(0) <= inf\n")
+            str(qp.constraints[0]), "BoundingBoxConstraint\n1 <= x(0) <= inf\n"
+        )
         prog = qp.prog
         x = qp.x
 
-        self.assertEqual(prog.FindDecisionVariableIndices(vars=[x[0], x[1]]),
-                         [0, 1])
+        self.assertEqual(
+            prog.FindDecisionVariableIndices(vars=[x[0], x[1]]), [0, 1]
+        )
         self.assertEqual(prog.decision_variable_index()[x[0].get_id()], 0)
         self.assertEqual(prog.decision_variable_index()[x[1].get_id()], 1)
 
@@ -255,24 +265,25 @@ class TestMathematicalProgram(unittest.TestCase):
             self.assertIsInstance(binding.evaluator(), mp.Constraint)
 
         self.assertTrue(prog.linear_costs())
-        for (i, binding) in enumerate(prog.linear_costs()):
+        for i, binding in enumerate(prog.linear_costs()):
             cost = binding.evaluator()
             self.assertTrue(np.allclose(cost.a(), np.ones((1, 2))))
             self.assertIsNone(cost.gradient_sparsity_pattern())
 
         self.assertTrue(prog.quadratic_costs())
-        for (i, binding) in enumerate(prog.quadratic_costs()):
+        for i, binding in enumerate(prog.quadratic_costs()):
             cost = binding.evaluator()
             self.assertTrue(np.allclose(cost.Q(), np.eye(2)))
             self.assertTrue(np.allclose(cost.b(), np.zeros(2)))
             self.assertIsNone(cost.gradient_sparsity_pattern())
 
         self.assertTrue(prog.bounding_box_constraints())
-        for (i, binding) in enumerate(prog.bounding_box_constraints()):
+        for i, binding in enumerate(prog.bounding_box_constraints()):
             constraint = binding.evaluator()
             self.assertEqual(
                 prog.FindDecisionVariableIndex(var=binding.variables()[0]),
-                prog.FindDecisionVariableIndex(var=x[i]))
+                prog.FindDecisionVariableIndex(var=x[i]),
+            )
             self.assertIsNone(constraint.gradient_sparsity_pattern())
             num_constraints = constraint.num_constraints()
             if num_constraints == 1:
@@ -281,35 +292,41 @@ class TestMathematicalProgram(unittest.TestCase):
                 self.assertEqual(constraint.upper_bound(), np.inf)
             else:
                 self.assertTrue(np.allclose(constraint.GetDenseA(), np.eye(2)))
-                self.assertTrue(np.allclose(constraint.lower_bound(),
-                                            [1, -np.inf]))
-                self.assertTrue(np.allclose(constraint.upper_bound(),
-                                            [np.inf, 2]))
+                self.assertTrue(
+                    np.allclose(constraint.lower_bound(), [1, -np.inf])
+                )
+                self.assertTrue(
+                    np.allclose(constraint.upper_bound(), [np.inf, 2])
+                )
 
         self.assertTrue(prog.linear_constraints())
-        for (i, binding) in enumerate(prog.linear_constraints()):
+        for i, binding in enumerate(prog.linear_constraints()):
             constraint = binding.evaluator()
             self.assertIsNone(constraint.gradient_sparsity_pattern())
             self.assertEqual(
                 prog.FindDecisionVariableIndex(var=binding.variables()[0]),
-                prog.FindDecisionVariableIndex(var=x[0]))
+                prog.FindDecisionVariableIndex(var=x[0]),
+            )
             self.assertEqual(
                 prog.FindDecisionVariableIndex(var=binding.variables()[1]),
-                prog.FindDecisionVariableIndex(var=x[1]))
+                prog.FindDecisionVariableIndex(var=x[1]),
+            )
             self.assertTrue(np.allclose(constraint.GetDenseA(), [3, -1]))
             self.assertTrue(constraint.lower_bound(), -2)
             self.assertTrue(constraint.upper_bound(), np.inf)
 
         self.assertTrue(prog.linear_equality_constraints())
-        for (i, binding) in enumerate(prog.linear_equality_constraints()):
+        for i, binding in enumerate(prog.linear_equality_constraints()):
             self.assertIsNone(constraint.gradient_sparsity_pattern())
             constraint = binding.evaluator()
             self.assertEqual(
                 prog.FindDecisionVariableIndex(var=binding.variables()[0]),
-                prog.FindDecisionVariableIndex(var=x[0]))
+                prog.FindDecisionVariableIndex(var=x[0]),
+            )
             self.assertEqual(
                 prog.FindDecisionVariableIndex(var=binding.variables()[1]),
-                prog.FindDecisionVariableIndex(var=x[1]))
+                prog.FindDecisionVariableIndex(var=x[1]),
+            )
             self.assertTrue(np.allclose(constraint.GetDenseA(), [1, 2]))
             self.assertTrue(constraint.lower_bound(), 3)
             self.assertTrue(constraint.upper_bound(), 3)
@@ -322,15 +339,16 @@ class TestMathematicalProgram(unittest.TestCase):
 
     def test_constraint_api(self):
         prog = mp.MathematicalProgram()
-        x0, = prog.NewContinuousVariables(1, "x")
+        (x0,) = prog.NewContinuousVariables(1, "x")
         c = prog.AddLinearConstraint(x0 >= 2).evaluator()
-        ce = prog.AddLinearEqualityConstraint(2*x0, 1).evaluator()
+        ce = prog.AddLinearEqualityConstraint(2 * x0, 1).evaluator()
 
-        self.assertTrue(c.CheckSatisfied([2.], tol=1e-3))
+        self.assertTrue(c.CheckSatisfied([2.0], tol=1e-3))
         satisfied = c.CheckSatisfiedVectorized(
-            np.array([1., 2., 3.]).reshape((1, 3)), tol=1e-3)
+            np.array([1.0, 2.0, 3.0]).reshape((1, 3)), tol=1e-3
+        )
         self.assertEqual(satisfied, [False, True, True])
-        self.assertFalse(c.CheckSatisfied([AutoDiffXd(1.)]))
+        self.assertFalse(c.CheckSatisfied([AutoDiffXd(1.0)]))
         self.assertIsInstance(c.CheckSatisfied([x0]), sym.Formula)
 
         ce.set_description("my favorite constraint")
@@ -341,50 +359,50 @@ class TestMathematicalProgram(unittest.TestCase):
             self.assertTrue(np.allclose(c.lower_bound(), lb))
             self.assertTrue(np.allclose(c.upper_bound(), ub))
 
-        check_bounds(c, [1.], [2.], [np.inf])
-        c.UpdateLowerBound([3.])
-        check_bounds(c, [1.], [3.], [np.inf])
-        c.UpdateUpperBound([4.])
-        check_bounds(c, [1.], [3.], [4.])
-        c.set_bounds([-10.], [10.])
-        check_bounds(c, [1.], [-10.], [10.])
-        c.UpdateCoefficients([10.], [-20.], [-30.])
-        check_bounds(c, [10.], [-20.], [-30.])
+        check_bounds(c, [1.0], [2.0], [np.inf])
+        c.UpdateLowerBound([3.0])
+        check_bounds(c, [1.0], [3.0], [np.inf])
+        c.UpdateUpperBound([4.0])
+        check_bounds(c, [1.0], [3.0], [4.0])
+        c.set_bounds([-10.0], [10.0])
+        check_bounds(c, [1.0], [-10.0], [10.0])
+        c.UpdateCoefficients([10.0], [-20.0], [-30.0])
+        check_bounds(c, [10.0], [-20.0], [-30.0])
 
-        check_bounds(ce, [2.], [1.], [1.])
-        ce.UpdateCoefficients([10.], [20.])
-        check_bounds(ce, [10.], [20.], [20.])
+        check_bounds(ce, [2.0], [1.0], [1.0])
+        ce.UpdateCoefficients([10.0], [20.0])
+        check_bounds(ce, [10.0], [20.0], [20.0])
 
     def test_cost_api(self):
         prog = mp.MathematicalProgram()
-        x0, = prog.NewContinuousVariables(1, "x")
+        (x0,) = prog.NewContinuousVariables(1, "x")
         lc = prog.AddLinearCost([1], 2, [x0]).evaluator()
-        qc = prog.AddQuadraticCost(0.5*x0**2 + 2*x0 + 3).evaluator()
+        qc = prog.AddQuadraticCost(0.5 * x0**2 + 2 * x0 + 3).evaluator()
 
         def check_linear_cost(cost, a, b):
             self.assertTrue(np.allclose(cost.a(), a))
             self.assertTrue(np.allclose(cost.b(), b))
 
-        check_linear_cost(lc, [1.], 2.)
-        lc.UpdateCoefficients([10.])
-        check_linear_cost(lc, [10.], 0.)
+        check_linear_cost(lc, [1.0], 2.0)
+        lc.UpdateCoefficients([10.0])
+        check_linear_cost(lc, [10.0], 0.0)
 
         lc2 = prog.AddLinearCost([2], [x0]).evaluator()
-        check_linear_cost(lc2, [2], 0.)
+        check_linear_cost(lc2, [2], 0.0)
 
         def check_quadratic_cost(cost, Q, b, c):
             self.assertTrue(np.allclose(cost.Q(), Q))
             self.assertTrue(np.allclose(cost.b(), b))
             self.assertTrue(np.allclose(cost.c(), c))
 
-        check_quadratic_cost(qc, [1.], [2.], 3.)
-        qc.UpdateCoefficients([10.], [20.])
-        check_quadratic_cost(qc, [10.], [20.], 0)
+        check_quadratic_cost(qc, [1.0], [2.0], 3.0)
+        qc.UpdateCoefficients([10.0], [20.0])
+        check_quadratic_cost(qc, [10.0], [20.0], 0)
 
-        qc.UpdateCoefficients([-10.], [20.])
+        qc.UpdateCoefficients([-10.0], [20.0])
         self.assertFalse(qc.is_convex())
 
-        qc.UpdateCoefficients([10.], [20.], is_convex=True)
+        qc.UpdateCoefficients([10.0], [20.0], is_convex=True)
         self.assertTrue(qc.is_convex())
 
     def test_eval_binding(self):
@@ -392,45 +410,47 @@ class TestMathematicalProgram(unittest.TestCase):
         prog = qp.prog
 
         x = qp.x
-        x_expected = np.array([1., 1.])
+        x_expected = np.array([1.0, 1.0])
 
         costs = qp.costs
-        cost_values_expected = [2., 1.]
+        cost_values_expected = [2.0, 1.0]
         constraints = qp.constraints
-        constraint_values_expected = [1., 1., 2., 3.]
+        constraint_values_expected = [1.0, 1.0, 2.0, 3.0]
 
         result = mp.Solve(prog)
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))
 
         enum = zip(constraints, constraint_values_expected)
-        for (constraint, value_expected) in enum:
+        for constraint, value_expected in enum:
             value = result.EvalBinding(constraint)
             self.assertTrue(np.allclose(value, value_expected))
             value = prog.EvalBinding(constraint, x_expected)
             self.assertTrue(np.allclose(value, value_expected))
             value = prog.EvalBindingVectorized(
-                constraint,
-                np.vstack((x_expected, x_expected)).T)
+                constraint, np.vstack((x_expected, x_expected)).T
+            )
             a = np.vstack((value_expected, value_expected)).T
             self.assertTrue(np.allclose(value, a))
 
         enum = zip(costs, cost_values_expected)
-        for (cost, value_expected) in enum:
+        for cost, value_expected in enum:
             value = result.EvalBinding(cost)
             self.assertTrue(np.allclose(value, value_expected))
             value = prog.EvalBinding(cost, x_expected)
             self.assertTrue(np.allclose(value, value_expected))
             value = prog.EvalBindingVectorized(
-                cost,
-                np.vstack((x_expected, x_expected)).T)
-            self.assertTrue(np.allclose(
-                value, np.vstack((value_expected, value_expected)).T))
+                cost, np.vstack((x_expected, x_expected)).T
+            )
+            self.assertTrue(
+                np.allclose(
+                    value, np.vstack((value_expected, value_expected)).T
+                )
+            )
 
-        self.assertIsInstance(
-            result.EvalBinding(costs[0]), np.ndarray)
+        self.assertIsInstance(result.EvalBinding(costs[0]), np.ndarray)
 
         # Bindings for `Eval`.
-        x_list = (float(1.), AutoDiffXd(1.), sym.Variable("x"))
+        x_list = (float(1.0), AutoDiffXd(1.0), sym.Variable("x"))
         T_y_list = (float, AutoDiffXd, sym.Expression)
         evaluator = costs[0].evaluator()
         for x_i, T_y_i in zip(x_list, T_y_list):
@@ -441,32 +461,38 @@ class TestMathematicalProgram(unittest.TestCase):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(3)
         binding1 = prog.AddBoundingBoxConstraint(-1, 1, x[0])
-        binding2 = prog.AddLinearEqualityConstraint(x[1] + 2*x[2], 2)
-        x_val = np.array([-2., 1., 2.])
+        binding2 = prog.AddLinearEqualityConstraint(x[1] + 2 * x[2], 2)
+        x_val = np.array([-2.0, 1.0, 2.0])
         np.testing.assert_allclose(
-            prog.GetBindingVariableValues(binding1, x_val), np.array([-2]))
+            prog.GetBindingVariableValues(binding1, x_val), np.array([-2])
+        )
         np.testing.assert_allclose(
-            prog.GetBindingVariableValues(binding2, x_val), np.array([1, 2]))
+            prog.GetBindingVariableValues(binding2, x_val), np.array([1, 2])
+        )
 
     def test_prog_check_satisfied(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(3)
         binding1 = prog.AddBoundingBoxConstraint(-1, 1, x[0])
-        binding2 = prog.AddLinearConstraint(x[1]+x[2] <= 2.0)
-        x_val = np.array([-2, .1, .3])
+        binding2 = prog.AddLinearConstraint(x[1] + x[2] <= 2.0)
+        x_val = np.array([-2, 0.1, 0.3])
         self.assertTrue(
-            prog.CheckSatisfied(binding=binding2, prog_var_vals=x_val,
-                                tol=0.0))
+            prog.CheckSatisfied(binding=binding2, prog_var_vals=x_val, tol=0.0)
+        )
         self.assertFalse(
-            prog.CheckSatisfied(bindings=[binding1, binding2],
-                                prog_var_vals=x_val,
-                                tol=0.0))
+            prog.CheckSatisfied(
+                bindings=[binding1, binding2], prog_var_vals=x_val, tol=0.0
+            )
+        )
         prog.SetInitialGuessForAllVariables(x_val)
         self.assertTrue(
-            prog.CheckSatisfiedAtInitialGuess(binding=binding2, tol=0.0))
+            prog.CheckSatisfiedAtInitialGuess(binding=binding2, tol=0.0)
+        )
         self.assertFalse(
             prog.CheckSatisfiedAtInitialGuess(
-                bindings=[binding1, binding2], tol=0.0))
+                bindings=[binding1, binding2], tol=0.0
+            )
+        )
 
     def test_matrix_variables(self):
         prog = mp.MathematicalProgram()
@@ -484,9 +510,9 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.NewIndeterminates(2, 2, "y")
 
     def test_linear_constraint(self):
-        A = np.array([[1, 3, 4], [2., 4., 5]])
-        lb = np.array([1, 2.])
-        ub = np.array([3., 4.])
+        A = np.array([[1, 3, 4], [2.0, 4.0, 5]])
+        lb = np.array([1, 2.0])
+        ub = np.array([3.0, 4.0])
         # Constructor with dense A.
         dut = mp.LinearConstraint(A=A, lb=lb, ub=ub)
         self.assertEqual(dut.num_constraints(), 2)
@@ -494,49 +520,69 @@ class TestMathematicalProgram(unittest.TestCase):
         np.testing.assert_array_equal(dut.get_sparse_A().todense(), A)
 
         A_sparse = scipy.sparse.csc_matrix(
-            (np.array([2, 1., 3]), np.array([0, 1, 0]),
-             np.array([0, 2, 2, 3])), shape=(2, 3))
+            (
+                np.array([2, 1.0, 3]),
+                np.array([0, 1, 0]),
+                np.array([0, 2, 2, 3]),
+            ),
+            shape=(2, 3),
+        )
         dut = mp.LinearConstraint(
-            A=A_sparse, lb=np.array([1., 2.]), ub=np.array([2., 3.]))
+            A=A_sparse, lb=np.array([1.0, 2.0]), ub=np.array([2.0, 3.0])
+        )
         self.assertEqual(dut.num_constraints(), 2)
         self.assertEqual(dut.num_vars(), 3)
         self.assertEqual(dut.get_sparse_A().nnz, 3)
 
         dut.UpdateCoefficients(
-            new_A=A_sparse, new_lb=np.array([2, 3.]),
-            new_ub=np.array([3., 4.]))
+            new_A=A_sparse,
+            new_lb=np.array([2, 3.0]),
+            new_ub=np.array([3.0, 4.0]),
+        )
         np.testing.assert_array_equal(
-            dut.get_sparse_A().todense(), A_sparse.todense())
+            dut.get_sparse_A().todense(), A_sparse.todense()
+        )
 
         dut.UpdateCoefficients(
-            new_A=np.array([[1E-10, 0, 0], [0, 1, 1]]),
-            new_lb=np.array([2, 3]), new_ub=np.array([3, 4]))
-        dut.RemoveTinyCoefficient(tol=1E-5)
+            new_A=np.array([[1e-10, 0, 0], [0, 1, 1]]),
+            new_lb=np.array([2, 3]),
+            new_ub=np.array([3, 4]),
+        )
+        dut.RemoveTinyCoefficient(tol=1e-5)
         np.testing.assert_array_equal(
-            dut.GetDenseA(), np.array([[0, 0, 0], [0, 1, 1]]))
+            dut.GetDenseA(), np.array([[0, 0, 0], [0, 1, 1]])
+        )
 
     def test_linear_equality_constraint(self):
-        Aeq = np.array([[2, 3.], [1., 2.], [3, 4]])
-        beq = np.array([1., 2., 3.])
+        Aeq = np.array([[2, 3.0], [1.0, 2.0], [3, 4]])
+        beq = np.array([1.0, 2.0, 3.0])
         constraint = mp.LinearEqualityConstraint(Aeq=Aeq, beq=beq)
         np.testing.assert_array_equal(constraint.GetDenseA(), Aeq)
         np.testing.assert_array_equal(constraint.upper_bound(), beq)
         constraint.UpdateCoefficients(Aeq=Aeq, beq=beq)
 
         constraint = mp.LinearEqualityConstraint(
-            a=np.array([1., 2., 3.]), beq=1)
+            a=np.array([1.0, 2.0, 3.0]), beq=1
+        )
         np.testing.assert_array_equal(
-            constraint.GetDenseA(), np.array([[1., 2., 3.]]))
-        np.testing.assert_array_equal(constraint.upper_bound(), np.array([1.]))
+            constraint.GetDenseA(), np.array([[1.0, 2.0, 3.0]])
+        )
+        np.testing.assert_array_equal(constraint.upper_bound(), np.array([1.0]))
 
         A_sparse = scipy.sparse.csc_matrix(
-            (np.array([2, 1., 3]), np.array([0, 1, 0]),
-             np.array([0, 2, 2, 3])), shape=(2, 3))
-        dut = mp.LinearEqualityConstraint(Aeq=A_sparse, beq=np.array([1, 2.]))
+            (
+                np.array([2, 1.0, 3]),
+                np.array([0, 1, 0]),
+                np.array([0, 2, 2, 3]),
+            ),
+            shape=(2, 3),
+        )
+        dut = mp.LinearEqualityConstraint(Aeq=A_sparse, beq=np.array([1, 2.0]))
         np.testing.assert_array_equal(
-            dut.get_sparse_A().todense(), A_sparse.todense())
+            dut.get_sparse_A().todense(), A_sparse.todense()
+        )
 
-        dut.UpdateCoefficients(A_sparse, beq=np.array([1, 2.]))
+        dut.UpdateCoefficients(A_sparse, beq=np.array([1, 2.0]))
         self.assertFalse(dut.is_dense_A_constructed())
 
     def test_sdp(self):
@@ -547,22 +593,28 @@ class TestMathematicalProgram(unittest.TestCase):
         minor_indices = {0, 2}
         self.assertEqual(len(prog.positive_semidefinite_constraints()), 1)
         self.assertEqual(
-            prog.positive_semidefinite_constraints()[0].evaluator().
-            matrix_rows(), 3)
+            prog.positive_semidefinite_constraints()[0]
+            .evaluator()
+            .matrix_rows(),
+            3,
+        )
         prog.AddPrincipalSubmatrixIsPsdConstraint(S, minor_indices)
         self.assertEqual(len(prog.positive_semidefinite_constraints()), 2)
         self.assertEqual(
-            prog.positive_semidefinite_constraints()[1].evaluator().
-            matrix_rows(), 2)
-        prog.AddPositiveSemidefiniteConstraint(S+S)
-        prog.AddPrincipalSubmatrixIsPsdConstraint(S+S, minor_indices)
+            prog.positive_semidefinite_constraints()[1]
+            .evaluator()
+            .matrix_rows(),
+            2,
+        )
+        prog.AddPositiveSemidefiniteConstraint(S + S)
+        prog.AddPrincipalSubmatrixIsPsdConstraint(S + S, minor_indices)
         prog.AddPositiveDiagonallyDominantMatrixConstraint(X=S)
         prog.AddPositiveDiagonallyDominantDualConeMatrixConstraint(X=S)
-        prog.AddPositiveDiagonallyDominantDualConeMatrixConstraint(X=S+S)
+        prog.AddPositiveDiagonallyDominantDualConeMatrixConstraint(X=S + S)
         prog.AddScaledDiagonallyDominantMatrixConstraint(X=S)
-        prog.AddScaledDiagonallyDominantMatrixConstraint(X=S+S)
+        prog.AddScaledDiagonallyDominantMatrixConstraint(X=S + S)
         prog.AddScaledDiagonallyDominantDualConeMatrixConstraint(X=S)
-        prog.AddScaledDiagonallyDominantDualConeMatrixConstraint(X=S+S)
+        prog.AddScaledDiagonallyDominantDualConeMatrixConstraint(X=S + S)
         prog.AddLinearCost(np.trace(S))
         result = mp.Solve(prog)
         self.assertTrue(result.is_success())
@@ -592,9 +644,11 @@ class TestMathematicalProgram(unittest.TestCase):
         prog = mp.MathematicalProgram()
         x = prog.NewIndeterminates(3, "x")
         (poly1, gramian1) = prog.NewSosPolynomial(
-            indeterminates=sym.Variables(x), degree=4,
+            indeterminates=sym.Variables(x),
+            degree=4,
             type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
-            gram_name="M0")
+            gram_name="M0",
+        )
         self.assertIsInstance(poly1, sym.Polynomial)
         self.assertIsInstance(gramian1, np.ndarray)
 
@@ -602,26 +656,28 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.NewSosPolynomial(
             gramian=gramian2,
             monomial_basis=(sym.Monomial(x[0]), sym.Monomial(x[1])),
-            type=mp.MathematicalProgram.NonnegativePolynomial.kDsos)
+            type=mp.MathematicalProgram.NonnegativePolynomial.kDsos,
+        )
         self.assertIsInstance(gramian2, np.ndarray)
 
         poly3, gramian3 = prog.NewSosPolynomial(
             monomial_basis=(sym.Monomial(x[0]), sym.Monomial(x[1])),
             type=mp.MathematicalProgram.NonnegativePolynomial.kSos,
-            gram_name="M2")
+            gram_name="M2",
+        )
         self.assertIsInstance(poly3, sym.Polynomial)
         self.assertIsInstance(gramian3, np.ndarray)
 
     def test_new_even_degree_nonnegative_polynomial(self):
         prog = mp.MathematicalProgram()
         x = prog.NewIndeterminates(3, "x")
-        for poly_type in (mp.MathematicalProgram.NonnegativePolynomial.kSos,
-                          mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
-                          mp.MathematicalProgram.NonnegativePolynomial.kDsos):
-            poly, gram_odd, gram_even = (
-                prog.NewEvenDegreeNonnegativePolynomial(
-                    indeterminates=sym.Variables(x), degree=2, type=poly_type
-                )
+        for poly_type in (
+            mp.MathematicalProgram.NonnegativePolynomial.kSos,
+            mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
+            mp.MathematicalProgram.NonnegativePolynomial.kDsos,
+        ):
+            poly, gram_odd, gram_even = prog.NewEvenDegreeNonnegativePolynomial(
+                indeterminates=sym.Variables(x), degree=2, type=poly_type
             )
             self.assertIsInstance(poly, sym.Polynomial)
             self.assertIsInstance(gram_odd, np.ndarray)
@@ -631,14 +687,16 @@ class TestMathematicalProgram(unittest.TestCase):
         prog = mp.MathematicalProgram()
         x = prog.NewIndeterminates(1, "x")
         Q = prog.AddSosConstraint(
-           p=sym.Polynomial(x[0]**2 + 1),
-           monomial_basis=[sym.Monomial(x[0])],
-           type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
-           gram_name="Q")
-        Q, m = prog.AddSosConstraint(
-            p=sym.Polynomial(x[0]**2 + 2),
+            p=sym.Polynomial(x[0] ** 2 + 1),
+            monomial_basis=[sym.Monomial(x[0])],
             type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
-            gram_name="Q")
+            gram_name="Q",
+        )
+        Q, m = prog.AddSosConstraint(
+            p=sym.Polynomial(x[0] ** 2 + 2),
+            type=mp.MathematicalProgram.NonnegativePolynomial.kSdsos,
+            gram_name="Q",
+        )
 
     def test_sos(self):
         # Find a,b,c,d subject to
@@ -653,29 +711,35 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(prog.indeterminates_index()[x[0].get_id()], 0)
         poly = prog.NewFreePolynomial(sym.Variables(x), 1)
         (poly, binding) = prog.NewSosPolynomial(
-            indeterminates=sym.Variables(x), degree=2, gram_name="M0")
+            indeterminates=sym.Variables(x), degree=2, gram_name="M0"
+        )
         prog.NewEvenDegreeFreePolynomial(sym.Variables(x), 2)
         prog.NewOddDegreeFreePolynomial(sym.Variables(x), 3)
         y = prog.NewIndeterminates(1, "y")
         self.assertEqual(prog.indeterminates_index()[y[0].get_id()], 1)
         (poly, binding) = prog.NewSosPolynomial(
             monomial_basis=(sym.Monomial(x[0]), sym.Monomial(y[0])),
-            gram_name="M1")
+            gram_name="M1",
+        )
         d = prog.NewContinuousVariables(2, "d")
-        prog.AddSosConstraint(d[0]*x.dot(x), gram_name="Q1")
+        prog.AddSosConstraint(d[0] * x.dot(x), gram_name="Q1")
         prog.AddSosConstraint(
-            d[1]*x.dot(x), [sym.Monomial(x[0])], gram_name="Q2")
+            d[1] * x.dot(x), [sym.Monomial(x[0])], gram_name="Q2"
+        )
         prog.AddLinearEqualityConstraint(d[0] + d[1] == 1)
         result = mp.Solve(prog)
         self.assertTrue(result.is_success())
         result.GetSolution(poly)
 
         (poly, Q_oo, Q_ee) = prog.NewEvenDegreeSosPolynomial(
-            indeterminates=sym.Variables(x), degree=2)
+            indeterminates=sym.Variables(x), degree=2
+        )
         (poly, Q_oo, Q_ee) = prog.NewEvenDegreeSdsosPolynomial(
-            indeterminates=sym.Variables(x), degree=2)
+            indeterminates=sym.Variables(x), degree=2
+        )
         (poly, Q_oo, Q_ee) = prog.NewEvenDegreeDsosPolynomial(
-            indeterminates=sym.Variables(x), degree=2)
+            indeterminates=sym.Variables(x), degree=2
+        )
 
     def test_make_polynomial(self):
         prog = mp.MathematicalProgram()
@@ -715,7 +779,8 @@ class TestMathematicalProgram(unittest.TestCase):
         a = prog.NewContinuousVariables(2, "a")
         linear_eq_constraints = prog.AddEqualityConstraintBetweenPolynomials(
             sym.Polynomial(2 * a[0] * x[0] + a[1] + 2, x),
-            sym.Polynomial(2 * x[0] + 4, x))
+            sym.Polynomial(2 * x[0] + 4, x),
+        )
         self.assertEqual(len(linear_eq_constraints), 2)
         result = mp.Solve(prog)
         a_val = result.GetSolution(a)
@@ -730,8 +795,9 @@ class TestMathematicalProgram(unittest.TestCase):
         for i in range(3):
             pt = pts[i, :]
             prog.AddLinearConstraint(pt.dot(X.dot(pt)) <= 1)
-        linear_cost, log_det_t, log_det_Z = \
-            prog.AddMaximizeLogDeterminantCost(X=X)
+        linear_cost, log_det_t, log_det_Z = prog.AddMaximizeLogDeterminantCost(
+            X=X
+        )
         self.assertEqual(log_det_t.shape, (2,))
         self.assertEqual(log_det_Z.shape, (2, 2))
         result = mp.Solve(prog)
@@ -741,7 +807,8 @@ class TestMathematicalProgram(unittest.TestCase):
         prog = mp.MathematicalProgram()
         X = prog.NewSymmetricContinuousVariables(2)
         linear_constraint, t, Z = prog.AddLogDeterminantLowerBoundConstraint(
-            X=X, lower=1)
+            X=X, lower=1
+        )
         self.assertEqual(t.shape, (2,))
         self.assertEqual(Z.shape, (2, 2))
 
@@ -776,7 +843,7 @@ class TestMathematicalProgram(unittest.TestCase):
 
     def test_lcp(self):
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(2, 'x')
+        x = prog.NewContinuousVariables(2, "x")
         M = np.array([[1, 3], [4, 1]])
         q = np.array([-16, -15])
         binding = prog.AddLinearComplementarityConstraint(M, q, x)
@@ -785,22 +852,25 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(len(prog.linear_complementarity_constraints()), 1)
         result = mp.Solve(prog)
         self.assertTrue(result.is_success())
-        self.assertIsInstance(binding.evaluator(),
-                              mp.LinearComplementarityConstraint)
+        self.assertIsInstance(
+            binding.evaluator(), mp.LinearComplementarityConstraint
+        )
 
     def test_add_exponential_cone_constraint(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2)
-        A = np.array([[1., 2.], [2., 3.], [0., 1.]])
-        b = np.array([1., 2., 3.])
+        A = np.array([[1.0, 2.0], [2.0, 3.0], [0.0, 1.0]])
+        b = np.array([1.0, 2.0, 3.0])
         constraint1 = prog.AddExponentialConeConstraint(A=A, b=b, vars=x)
         np.testing.assert_array_equal(constraint1.evaluator().A(), A)
         np.testing.assert_array_equal(constraint1.evaluator().b(), b)
 
         constraint2 = prog.AddExponentialConeConstraint(
-            z=np.array([x[0] + 1, x[0] * 2, x[1] + 2]))
+            z=np.array([x[0] + 1, x[0] * 2, x[1] + 2])
+        )
         self.assertIsInstance(
-            constraint2.evaluator(), mp.ExponentialConeConstraint)
+            constraint2.evaluator(), mp.ExponentialConeConstraint
+        )
 
         self.assertEqual(len(prog.exponential_cone_constraints()), 2)
 
@@ -811,23 +881,25 @@ class TestMathematicalProgram(unittest.TestCase):
     def test_linear_constraints(self):
         # TODO(eric.cousineau): Add more general tests
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(2, 'x')
-        lb = [0., 0.]
-        ub = [1., 1.]
+        x = prog.NewContinuousVariables(2, "x")
+        lb = [0.0, 0.0]
+        ub = [1.0, 1.0]
 
         prog.AddBoundingBoxConstraint(lb, ub, x)
-        prog.AddBoundingBoxConstraint(0., 1., x[0])
-        prog.AddBoundingBoxConstraint(0., 1., x)
+        prog.AddBoundingBoxConstraint(0.0, 1.0, x[0])
+        prog.AddBoundingBoxConstraint(0.0, 1.0, x)
 
         A_dense = np.eye(2)
         dense1 = prog.AddLinearConstraint(
-            A=A_dense, lb=np.zeros(2), ub=np.ones(2), vars=x)
+            A=A_dense, lb=np.zeros(2), ub=np.ones(2), vars=x
+        )
         # Ensure that the dense version of the binding has been called.
         self.assertTrue(dense1.evaluator().is_dense_A_constructed())
 
         A_sparse = scipy.sparse.csc_matrix(A_dense)
         sparse1 = prog.AddLinearConstraint(
-            A=A_sparse, lb=np.zeros(2), ub=np.ones(2), vars=x)
+            A=A_sparse, lb=np.zeros(2), ub=np.ones(2), vars=x
+        )
         # Ensure that the sparse version of the binding has been called.
         self.assertFalse(sparse1.evaluator().is_dense_A_constructed())
         prog.AddLinearConstraint(a=[1, 1], lb=0, ub=0, vars=x)
@@ -836,12 +908,14 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddLinearConstraint(f=(x[0] == 0))
 
         dense2 = prog.AddLinearEqualityConstraint(
-            Aeq=A_dense, beq=np.zeros(2), vars=x)
+            Aeq=A_dense, beq=np.zeros(2), vars=x
+        )
         # Ensure that the dense version of the binding has been called.
         self.assertTrue(dense2.evaluator().is_dense_A_constructed())
 
         sparse2 = prog.AddLinearEqualityConstraint(
-            Aeq=A_sparse, beq=np.zeros(2), vars=x)
+            Aeq=A_sparse, beq=np.zeros(2), vars=x
+        )
         # Ensure that the sparse version of the binding has been called.
         self.assertFalse(sparse2.evaluator().is_dense_A_constructed())
         prog.AddLinearEqualityConstraint(a=[1, 1], beq=0, vars=x)
@@ -849,7 +923,8 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddLinearEqualityConstraint(formulas=[x[0] == 1, x[0] == 1])
         prog.AddLinearEqualityConstraint(e=x[0] + x[1], b=1)
         prog.AddLinearEqualityConstraint(
-            v=2 * x[:2] + np.array([0, 1]), b=np.array([3, 2]))
+            v=2 * x[:2] + np.array([0, 1]), b=np.array([3, 2])
+        )
 
     def test_constraint_set_bounds(self):
         prog = mp.MathematicalProgram()
@@ -858,43 +933,53 @@ class TestMathematicalProgram(unittest.TestCase):
 
         def constraint(x):
             return x[1] ** 2
+
         binding = prog.AddConstraint(
-            constraint, [0], [1], vars=x, description=description)
+            constraint, [0], [1], vars=x, description=description
+        )
         py_constraint = PyFunctionConstraint(
-            num_vars=2, func=constraint, lb=[0], ub=[1],
-            description=description)
+            num_vars=2, func=constraint, lb=[0], ub=[1], description=description
+        )
         for evaluator in [binding.evaluator(), py_constraint]:
             self.assertEqual(evaluator.get_description(), description)
             self.assertIsInstance(binding.evaluator(), PyFunctionConstraint)
             np.testing.assert_array_equal(
-                evaluator.lower_bound(), np.array([0.]))
+                evaluator.lower_bound(), np.array([0.0])
+            )
             np.testing.assert_array_equal(
-                evaluator.upper_bound(), np.array([1.]))
+                evaluator.upper_bound(), np.array([1.0])
+            )
             # Test UpdateLowerBound()
-            evaluator.UpdateLowerBound(new_lb=[-1.])
+            evaluator.UpdateLowerBound(new_lb=[-1.0])
             np.testing.assert_array_equal(
-                evaluator.lower_bound(), np.array([-1.]))
+                evaluator.lower_bound(), np.array([-1.0])
+            )
             np.testing.assert_array_equal(
-                evaluator.upper_bound(), np.array([1.]))
+                evaluator.upper_bound(), np.array([1.0])
+            )
             # Test UpdateLowerBound()
-            evaluator.UpdateUpperBound(new_ub=[2.])
+            evaluator.UpdateUpperBound(new_ub=[2.0])
             np.testing.assert_array_equal(
-                evaluator.lower_bound(), np.array([-1.]))
+                evaluator.lower_bound(), np.array([-1.0])
+            )
             np.testing.assert_array_equal(
-                evaluator.upper_bound(), np.array([2.]))
+                evaluator.upper_bound(), np.array([2.0])
+            )
             # Test set_bounds()
-            evaluator.set_bounds(lower_bound=[-3.], upper_bound=[4.])
+            evaluator.set_bounds(lower_bound=[-3.0], upper_bound=[4.0])
             np.testing.assert_array_equal(
-                evaluator.lower_bound(), np.array([-3.]))
+                evaluator.lower_bound(), np.array([-3.0])
+            )
             np.testing.assert_array_equal(
-                evaluator.upper_bound(), np.array([4.]))
+                evaluator.upper_bound(), np.array([4.0])
+            )
 
     def test_constraint_gradient_sparsity(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, "x")
 
         def cost(x):
-            return x[0]**2
+            return x[0] ** 2
 
         def constraint(x):
             return x[1] ** 2
@@ -910,36 +995,39 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(cost_evaluator.gradient_sparsity_pattern(), [(0, 0)])
         constraint_binding.evaluator().SetGradientSparsityPattern([(0, 1)])
         self.assertEqual(
-            constraint_evaluator.gradient_sparsity_pattern(),
-            [(0, 1)])
+            constraint_evaluator.gradient_sparsity_pattern(), [(0, 1)]
+        )
 
     def test_pycost_and_pyconstraint(self):
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(1, 'x')
+        x = prog.NewContinuousVariables(1, "x")
 
         def cost(x):
-            return (x[0]-1.)*(x[0]-1.)
+            return (x[0] - 1.0) * (x[0] - 1.0)
 
         def constraint(x):
             return x
 
         cost_binding = prog.AddCost(cost, vars=x)
         constraint_binding = prog.AddConstraint(
-            constraint, lb=[0.], ub=[2.], vars=x)
+            constraint, lb=[0.0], ub=[2.0], vars=x
+        )
         result = mp.Solve(prog)
         xstar = result.GetSolution(x)
-        self.assertAlmostEqual(xstar[0], 1.)
+        self.assertAlmostEqual(xstar[0], 1.0)
 
         # Verify that they can be evaluated.
-        self.assertAlmostEqual(cost_binding.evaluator().Eval(xstar), 0.)
-        self.assertAlmostEqual(constraint_binding.evaluator().Eval(xstar), 1.)
+        self.assertAlmostEqual(cost_binding.evaluator().Eval(xstar), 0.0)
+        self.assertAlmostEqual(constraint_binding.evaluator().Eval(xstar), 1.0)
         self.assertEqual(len(prog.generic_constraints()), 1)
         self.assertEqual(
             prog.generic_constraints()[0].evaluator(),
-            constraint_binding.evaluator())
+            constraint_binding.evaluator(),
+        )
         self.assertEqual(len(prog.generic_costs()), 1)
         self.assertEqual(
-            prog.generic_costs()[0].evaluator(), cost_binding.evaluator())
+            prog.generic_costs()[0].evaluator(), cost_binding.evaluator()
+        )
 
     def test_cost_and_constraint_python_wrapper_lost(self):
         # Ensure cost and constraints python wrappers are kept alive when added
@@ -952,13 +1040,14 @@ class TestMathematicalProgram(unittest.TestCase):
         def make_object_graph():
             spies = []
             prog = mp.MathematicalProgram()
-            x = prog.NewContinuousVariables(1, 'x')
+            x = prog.NewContinuousVariables(1, "x")
 
             cost = mp.LinearCost([1.0], 0.0)
             spies.append(weakref.finalize(cost, lambda: None))
 
-            constraint = mp.LinearConstraint(np.array([1.0]), np.array([1]),
-                                             np.array([np.inf]))
+            constraint = mp.LinearConstraint(
+                np.array([1.0]), np.array([1]), np.array([np.inf])
+            )
             spies.append(weakref.finalize(constraint, lambda: None))
 
             cost_binding = prog.AddCost(cost, vars=x)
@@ -984,7 +1073,8 @@ class TestMathematicalProgram(unittest.TestCase):
             return np.sum(x.dot(x))
 
         cost = PyFunctionCost(
-            num_vars=num_vars, func=cost, description=description)
+            num_vars=num_vars, func=cost, description=description
+        )
         self.assertEqual(cost.get_description(), description)
         self.assertEqual(cost.num_vars(), num_vars)
         self.assertEqual(cost.Eval([1.0, 1.0]), 2.0)
@@ -999,24 +1089,26 @@ class TestMathematicalProgram(unittest.TestCase):
             return x
 
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(1, 'x')
+        x = prog.NewContinuousVariables(1, "x")
         binding_bad_shape = prog.AddCost(user_cost_bad_shape, vars=x)
 
         for T in SCALAR_TYPES:
             array_T = np.vectorize(T)
-            x0 = array_T([0.])
-            x0_bad = array_T([0., 1.])
+            x0 = array_T([0.0])
+            x0_bad = array_T([0.0, 1.0])
             # Bad input (before function is called).
             if kDrakeAssertIsArmed:
                 # See note in `WrapUserFunc`.
                 input_error_cls = SystemExit
                 input_error_expected = (
-                    "x.rows() == num_vars_ || num_vars_ == Eigen::Dynamic")
+                    "x.rows() == num_vars_ || num_vars_ == Eigen::Dynamic"
+                )
             else:
                 input_error_cls = RuntimeError
                 input_error_expected = (
                     "PyFunctionCost: Input must be of .ndim = 1 or 2 (vector) "
-                    "and .size = 1. Got .ndim = 1 and .size = 2 instead.")
+                    "and .size = 1. Got .ndim = 1 and .size = 2 instead."
+                )
             with self.assertRaises(input_error_cls) as cm:
                 binding_bad_shape.evaluator().Eval(x0_bad)
             self.assertIn(input_error_expected, str(cm.exception))
@@ -1026,14 +1118,15 @@ class TestMathematicalProgram(unittest.TestCase):
             self.assertEqual(
                 str(cm.exception),
                 "PyFunctionCost: Return value must be of .ndim = 0 (scalar) "
-                "and .size = 1. Got .ndim = 1 and .size = 1 instead.")
+                "and .size = 1. Got .ndim = 1 and .size = 1 instead.",
+            )
 
             # Bad output dtype.
             U = self.get_different_scalar_type(T)
 
             def user_cost_bad_dtype(x):
                 # WARNING: This should return the same dtype as x!
-                return U(0.)
+                return U(0.0)
 
             binding_bad_dtype = prog.AddCost(user_cost_bad_dtype, vars=x)
             with self.assertRaises(TypeError) as cm:
@@ -1042,7 +1135,8 @@ class TestMathematicalProgram(unittest.TestCase):
                 str(cm.exception),
                 f"When PyFunctionCost is called with an array of type "
                 f"{T.__name__} the return value must be the same type, not "
-                f"{U.__name__}.")
+                f"{U.__name__}.",
+            )
 
     def test_pyconstraint_wrap_error(self):
         """Tests for checks using PyFunctionConstraint::Wrap."""
@@ -1054,26 +1148,29 @@ class TestMathematicalProgram(unittest.TestCase):
             return x[0]
 
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(1, 'x')
+        x = prog.NewContinuousVariables(1, "x")
         binding_bad_shape = prog.AddConstraint(
-            user_constraint_bad_shape, lb=[0.], ub=[2.], vars=x)
+            user_constraint_bad_shape, lb=[0.0], ub=[2.0], vars=x
+        )
 
         for T in SCALAR_TYPES:
             array_T = np.vectorize(T)
-            x0 = array_T([0.])
-            x0_bad = array_T([0., 1.])
+            x0 = array_T([0.0])
+            x0_bad = array_T([0.0, 1.0])
             # Bad input (before function is called).
             if kDrakeAssertIsArmed:
                 # See note in `WrapUserFunc`.
                 input_error_cls = SystemExit
                 input_error_expected = (
-                    "x.rows() == num_vars_ || num_vars_ == Eigen::Dynamic")
+                    "x.rows() == num_vars_ || num_vars_ == Eigen::Dynamic"
+                )
             else:
                 input_error_cls = RuntimeError
                 input_error_expected = (
                     "PyFunctionConstraint: Input must be of .ndim = 1 or 2 "
                     "(vector) and .size = 1. Got .ndim = 1 and .size = 2 "
-                    "instead.")
+                    "instead."
+                )
             with self.assertRaises(input_error_cls) as cm:
                 binding_bad_shape.evaluator().Eval(x0_bad)
             self.assertIn(input_error_expected, str(cm.exception))
@@ -1083,54 +1180,59 @@ class TestMathematicalProgram(unittest.TestCase):
             self.assertEqual(
                 str(cm.exception),
                 "PyFunctionConstraint: Return value must be of .ndim = 1 or 2 "
-                "(vector) and .size = 1. Got .ndim = 0 and .size = 1 instead.")
+                "(vector) and .size = 1. Got .ndim = 0 and .size = 1 instead.",
+            )
 
             # Bad output dtype.
             U = self.get_different_scalar_type(T)
 
             def user_constraint_bad_dtype(x):
                 # WARNING: This should return the same dtype as x!
-                return [U(0.)]
+                return [U(0.0)]
 
             binding_bad_dtype = prog.AddConstraint(
-                user_constraint_bad_dtype, lb=[0.], ub=[2.], vars=x)
+                user_constraint_bad_dtype, lb=[0.0], ub=[2.0], vars=x
+            )
             with self.assertRaises(TypeError) as cm:
                 binding_bad_dtype.evaluator().Eval(x0)
             self.assertEqual(
                 str(cm.exception),
                 f"When PyFunctionConstraint is called with an array of type "
                 f"{T.__name__} the return value must be the same type, not "
-                f"{U.__name__}.")
+                f"{U.__name__}.",
+            )
 
     def test_addcost_symbolic(self):
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(1, 'x')
-        prog.AddCost((x[0]-1.)**2)
+        x = prog.NewContinuousVariables(1, "x")
+        prog.AddCost((x[0] - 1.0) ** 2)
         prog.AddConstraint(0 <= x[0])
         prog.AddConstraint(x[0] <= 2)
         result = mp.Solve(prog)
-        self.assertAlmostEqual(result.GetSolution(x)[0], 1.)
+        self.assertAlmostEqual(result.GetSolution(x)[0], 1.0)
 
     def test_add_l2norm_cost(self):
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(2, 'x')
-        A = np.array([[1, 2.], [3., 4]])
-        b = np.array([1., 2.])
+        x = prog.NewContinuousVariables(2, "x")
+        A = np.array([[1, 2.0], [3.0, 4]])
+        b = np.array([1.0, 2.0])
         prog.AddL2NormCost(A=A, b=b, vars=x)
         self.assertEqual(len(prog.l2norm_costs()), 1)
         prog.AddL2NormCost(
-            e=np.linalg.norm(A@x+b), psd_tol=1e-8, coefficient_tol=1e-8)
+            e=np.linalg.norm(A @ x + b), psd_tol=1e-8, coefficient_tol=1e-8
+        )
         self.assertEqual(len(prog.l2norm_costs()), 2)
-        prog.AddCost(e=np.linalg.norm(A@x+b))
+        prog.AddCost(e=np.linalg.norm(A @ x + b))
         self.assertEqual(len(prog.l2norm_costs()), 3)
 
     def test_add_l2norm_cost_using_conic_constraint(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, "x")
-        s, linear_cost, lorentz_cone_constraint = \
+        s, linear_cost, lorentz_cone_constraint = (
             prog.AddL2NormCostUsingConicConstraint(
-                A=np.array([[1, 2.], [3., 4]]),
-                b=np.array([1., 2.]), vars=x)
+                A=np.array([[1, 2.0], [3.0, 4]]), b=np.array([1.0, 2.0]), vars=x
+            )
+        )
         self.assertEqual(len(prog.linear_costs()), 1)
         self.assertEqual(len(prog.lorentz_cone_constraints()), 1)
         self.assertEqual(prog.num_vars(), 3)
@@ -1138,10 +1240,9 @@ class TestMathematicalProgram(unittest.TestCase):
     def test_add_l1norm_cost_in_epigraph_form(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, "x")
-        s, linear_cost, linear_constraint = \
-            prog.AddL1NormCostInEpigraphForm(
-                A=np.array([[1, 2.], [3., 4]]),
-                b=np.array([1., 2.]), vars=x)
+        s, linear_cost, linear_constraint = prog.AddL1NormCostInEpigraphForm(
+            A=np.array([[1, 2.0], [3.0, 4]]), b=np.array([1.0, 2.0]), vars=x
+        )
         self.assertEqual(len(prog.linear_costs()), 1)
         self.assertEqual(len(prog.linear_constraints()), 1)
         self.assertEqual(prog.num_vars(), 4)
@@ -1174,7 +1275,7 @@ class TestMathematicalProgram(unittest.TestCase):
 
     def test_addconstraint_matrix(self):
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(1, 'x')
+        x = prog.NewContinuousVariables(1, "x")
         prog.AddConstraint(np.array([[x[0] <= 2], [x[0] >= -2]]))
         result = mp.Solve(prog)
         self.assertTrue(result.GetSolution(x)[0] <= 2)
@@ -1182,7 +1283,7 @@ class TestMathematicalProgram(unittest.TestCase):
 
     def test_addconstraint_binding(self):
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(1, 'x')
+        x = prog.NewContinuousVariables(1, "x")
         prog.AddConstraint(x[0] <= 2)
         # This ensures that constraint is of type Binding<Constraint> and not
         # a more specific type.
@@ -1194,7 +1295,7 @@ class TestMathematicalProgram(unittest.TestCase):
         prog = mp.MathematicalProgram()
         count = 6
         shape = (2, 3)
-        x = prog.NewContinuousVariables(count, 'x')
+        x = prog.NewContinuousVariables(count, "x")
         x_matrix = x.reshape(shape)
         x0 = np.arange(count)
         x0_matrix = x0.reshape(shape)
@@ -1203,8 +1304,7 @@ class TestMathematicalProgram(unittest.TestCase):
 
         def check_and_reset():
             self.assertTrue((prog.GetInitialGuess(x) == x0).all())
-            self.assertTrue(
-                (prog.GetInitialGuess(x_matrix) == x0_matrix).all())
+            self.assertTrue((prog.GetInitialGuess(x_matrix) == x0_matrix).all())
             prog.SetInitialGuess(x, all_nan)
             self.assertTrue(np.isnan(prog.GetInitialGuess(x)).all())
 
@@ -1243,18 +1343,24 @@ class TestMathematicalProgram(unittest.TestCase):
         x = prog.NewContinuousVariables(3)
         hessian_type = mp.QuadraticConstraint.HessianType.kPositiveSemidefinite
         prog.AddQuadraticConstraint(
-            Q=np.eye(2), b=np.array([1., 2.]), lb=0., ub=1., vars=x[:2],
-            hessian_type=hessian_type)
+            Q=np.eye(2),
+            b=np.array([1.0, 2.0]),
+            lb=0.0,
+            ub=1.0,
+            vars=x[:2],
+            hessian_type=hessian_type,
+        )
         self.assertEqual(len(prog.quadratic_constraints()), 1)
 
         hessian_type = mp.QuadraticConstraint.HessianType.kIndefinite
         prog.AddQuadraticConstraint(
-            x[0] * x[0] - x[2] * x[2], 1, 2, hessian_type=hessian_type)
+            x[0] * x[0] - x[2] * x[2], 1, 2, hessian_type=hessian_type
+        )
         self.assertEqual(len(prog.quadratic_constraints()), 2)
 
     @unittest.skipIf(
-        SNOPT_NO_GUROBI,
-        "SNOPT is unable to solve this problem (#10653).")
+        SNOPT_NO_GUROBI, "SNOPT is unable to solve this problem (#10653)."
+    )
     def test_lorentz_cone_constraint(self):
         # Set Up Mathematical Program
         prog = mp.MathematicalProgram()
@@ -1267,8 +1373,11 @@ class TestMathematicalProgram(unittest.TestCase):
             f=(z[0] >= np.linalg.norm(x)),
             eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth,
             psd_tol=1e-7,
-            coefficient_tol=1e-7)
-        prog.AddLorentzConeConstraint(np.array([0*x[0]+1, x[0]-1, x[1]-1]))
+            coefficient_tol=1e-7,
+        )
+        prog.AddLorentzConeConstraint(
+            np.array([0 * x[0] + 1, x[0] - 1, x[1] - 1])
+        )
         prog.AddLorentzConeConstraint(np.array([z[0], x[0], x[1]]))
         self.assertEqual(len(prog.lorentz_cone_constraints()), 3)
 
@@ -1281,7 +1390,7 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertTrue(result.is_success())
 
         # Check answer
-        x_expected = np.array([1-2**(-0.5), 1-2**(-0.5)])
+        x_expected = np.array([1 - 2 ** (-0.5), 1 - 2 ** (-0.5)])
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))
 
     def test_add_lorentz_cone_constraint(self):
@@ -1290,19 +1399,27 @@ class TestMathematicalProgram(unittest.TestCase):
         x = prog.NewContinuousVariables(3)
 
         prog.AddLorentzConeConstraint(
-            v=np.array([x[0]+1, x[1]+x[2], 2*x[1]]),
-            eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth)
+            v=np.array([x[0] + 1, x[1] + x[2], 2 * x[1]]),
+            eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth,
+        )
         prog.AddLorentzConeConstraint(
             linear_expression=x[0] + x[1] + 1,
-            quadratic_expression=x[0]*x[0] + x[1] * x[1] + 2 * x[0] * x[1] + 1,
-            tol=0., eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth)
+            quadratic_expression=x[0] * x[0]
+            + x[1] * x[1]
+            + 2 * x[0] * x[1]
+            + 1,
+            tol=0.0,
+            eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth,
+        )
         A = np.array([[1, 0], [0, 1], [1, 0], [0, 0]])
         b = np.array([1, 1, 0, 2])
         constraint = prog.AddLorentzConeConstraint(
-            A=A, b=b, vars=x[:2],
-            eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth)
-        np.testing.assert_allclose(
-            constraint.evaluator().A().todense(), A)
+            A=A,
+            b=b,
+            vars=x[:2],
+            eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth,
+        )
+        np.testing.assert_allclose(constraint.evaluator().A().todense(), A)
         np.testing.assert_allclose(constraint.evaluator().b(), b)
 
     def test_add_rotated_lorentz_cone_constraint(self):
@@ -1313,34 +1430,38 @@ class TestMathematicalProgram(unittest.TestCase):
         b = np.array([1, 0, 1, 0, 2])
         constraint = prog.AddRotatedLorentzConeConstraint(A=A, b=b, vars=x[:2])
         self.assertEqual(len(prog.rotated_lorentz_cone_constraints()), 1)
-        np.testing.assert_allclose(
-            constraint.evaluator().A().todense(), A)
+        np.testing.assert_allclose(constraint.evaluator().A().todense(), A)
         np.testing.assert_allclose(constraint.evaluator().b(), b)
 
         prog.AddRotatedLorentzConeConstraint(
-            v=[x[0]+1, x[0]+x[1], x[0], x[2]+1, 2])
+            v=[x[0] + 1, x[0] + x[1], x[0], x[2] + 1, 2]
+        )
         constraint = prog.AddRotatedLorentzConeConstraint(
-            linear_expression1=x[0]+1, linear_expression2=x[0]+x[1],
-            quadratic_expression=x[0]*x[0] + 2*x[0] + x[1]*x[1] + 5)
+            linear_expression1=x[0] + 1,
+            linear_expression2=x[0] + x[1],
+            quadratic_expression=x[0] * x[0] + 2 * x[0] + x[1] * x[1] + 5,
+        )
 
     def test_add_quadratic_as_rotated_lorentz_cone_constraint(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2)
         dut = prog.AddQuadraticAsRotatedLorentzConeConstraint(
-            Q=np.array([[1, 2.], [2., 10.]]),
-            b=np.array([1., 3.]),
+            Q=np.array([[1, 2.0], [2.0, 10.0]]),
+            b=np.array([1.0, 3.0]),
             c=0.5,
             vars=x,
-            psd_tol=0.)
+            psd_tol=0.0,
+        )
         self.assertIsInstance(dut.evaluator(), mp.RotatedLorentzConeConstraint)
 
     def test_add_linear_matrix_inequality_constraint(self):
         prog = mp.MathematicalProgram()
-        F = [np.eye(2), np.array([[0, 1], [1., 0.]])]
+        F = [np.eye(2), np.array([[0, 1], [1.0, 0.0]])]
         x = prog.NewContinuousVariables(1)
         constraint = prog.AddLinearMatrixInequalityConstraint(F=F, vars=x)
         self.assertIsInstance(
-            constraint.evaluator(), mp.LinearMatrixInequalityConstraint)
+            constraint.evaluator(), mp.LinearMatrixInequalityConstraint
+        )
         self.assertEqual(constraint.evaluator().matrix_rows(), 2)
         self.assertEqual(len(constraint.evaluator().F()), 2)
         np.testing.assert_array_equal(constraint.evaluator().F()[0], F[0])
@@ -1348,12 +1469,17 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(len(prog.linear_matrix_inequality_constraints()), 1)
 
         constraint2 = prog.AddLinearMatrixInequalityConstraint(
-            X=np.array([
-                [1, 2 + x[0], 3 - x[0]],
-                [2 + x[0], 1 - x[0], 1],
-                [3 - x[0], 1, 2]]))
+            X=np.array(
+                [
+                    [1, 2 + x[0], 3 - x[0]],
+                    [2 + x[0], 1 - x[0], 1],
+                    [3 - x[0], 1, 2],
+                ]
+            )
+        )
         self.assertIsInstance(
-            constraint2.evaluator(), mp.LinearMatrixInequalityConstraint)
+            constraint2.evaluator(), mp.LinearMatrixInequalityConstraint
+        )
         self.assertEqual(len(prog.linear_matrix_inequality_constraints()), 2)
 
     def test_solver_id(self):
@@ -1361,9 +1487,11 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertNotEqual(ScsSolver().solver_id(), OsqpSolver().solver_id())
         # Test the hash function, by checking the set size.
         self.assertEqual(
-            len({ScsSolver().solver_id(), ScsSolver().solver_id()}), 1)
+            len({ScsSolver().solver_id(), ScsSolver().solver_id()}), 1
+        )
         self.assertEqual(
-            len({ScsSolver().solver_id(), OsqpSolver().solver_id()}), 2)
+            len({ScsSolver().solver_id(), OsqpSolver().solver_id()}), 2
+        )
 
     def test_mathematical_program_solver_options(self):
         # To cover all of the bindings, we'll check the program's set and get
@@ -1376,17 +1504,23 @@ class TestMathematicalProgram(unittest.TestCase):
             prog.SetSolverOption(solver, "sierra", "3")
             expected = {"foxtrot": 1.0, "india": 2, "sierra": "3"}
             old_options = prog.solver_options()
-            self.assertEqual(old_options.options, {
-                gurobi_id.name(): expected,
-            })
+            self.assertEqual(
+                old_options.options,
+                {
+                    gurobi_id.name(): expected,
+                },
+            )
             new_options = copy.deepcopy(old_options)
             new_options.SetOption(gurobi_id, "india", 4)
             self.assertNotEqual(new_options, old_options)
             prog.SetSolverOptions(new_options)
             expected["india"] = 4
-            self.assertEqual(old_options.options, {
-                gurobi_id.name(): expected,
-            })
+            self.assertEqual(
+                old_options.options,
+                {
+                    gurobi_id.name(): expected,
+                },
+            )
 
     def test_solver_options(self):
         CSO = mp.CommonSolverOption
@@ -1400,7 +1534,9 @@ class TestMathematicalProgram(unittest.TestCase):
         dut.SetOption(CSO.kStandaloneReproductionFileName, "repro.txt")
         dut.SetOption(CSO.kMaxThreads, 4)
         expected_dummy = {
-            "float_key": 1.0, "int_key": 2, "str_key": "3",
+            "float_key": 1.0,
+            "int_key": 2,
+            "str_key": "3",
         }
         expected_common = {
             CSO.kPrintToConsole: True,
@@ -1408,13 +1544,15 @@ class TestMathematicalProgram(unittest.TestCase):
             CSO.kStandaloneReproductionFileName: "repro.txt",
             CSO.kMaxThreads: 4,
         }
-        self.assertEqual(dut.options, {
-            "dummy": expected_dummy,
-            "Drake": dict(
-                (key.name, value)
-                for key, value in expected_common.items()
-            )
-        })
+        self.assertEqual(
+            dut.options,
+            {
+                "dummy": expected_dummy,
+                "Drake": dict(
+                    (key.name, value) for key, value in expected_common.items()
+                ),
+            },
+        )
         self.assertTrue(dut == dut)
         self.assertFalse(dut != dut)
         copy.deepcopy(dut)
@@ -1487,7 +1625,8 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(len(infeasible), 0)
 
         infeasible_names = result.GetInfeasibleConstraintNames(
-                prog=prog, tol=1e-4)
+            prog=prog, tol=1e-4
+        )
         self.assertEqual(len(infeasible_names), 0)
 
     def test_add_indeterminates_and_decision_variables(self):
@@ -1512,7 +1651,6 @@ class TestMathematicalProgram(unittest.TestCase):
         numpy_compare.assert_equal(prog.indeterminate(1), x1)
 
     def test_required_capabilities(self):
-
         prog = mp.MathematicalProgram()
         X = prog.NewSymmetricContinuousVariables(3, "X")
         prog.AddPositiveSemidefiniteConstraint(X)
@@ -1524,7 +1662,8 @@ class TestMathematicalProgram(unittest.TestCase):
             mp.ProgramAttribute.kLinearCost,
             mp.ProgramAttribute.kLinearEqualityConstraint,
             mp.ProgramAttribute.kLinearConstraint,
-            mp.ProgramAttribute.kPositiveSemidefiniteConstraint]
+            mp.ProgramAttribute.kPositiveSemidefiniteConstraint,
+        ]
         for attribute in expected_attributes:
             self.assertIn(attribute, prog.required_capabilities())
         for attribute in prog.required_capabilities():
@@ -1535,11 +1674,12 @@ class TestMathematicalProgram(unittest.TestCase):
         scs_solver = ScsSolver()
         if scs_solver.available() and scs_solver.enabled():
             mp.MakeFirstAvailableSolver(
-                [gurobi_solver.solver_id(), scs_solver.solver_id()])
+                [gurobi_solver.solver_id(), scs_solver.solver_id()]
+            )
 
     def test_variable_scaling(self):
         prog = mp.MathematicalProgram()
-        x = prog.NewContinuousVariables(2, 'x')
+        x = prog.NewContinuousVariables(2, "x")
         scaling = prog.GetVariableScaling()
         self.assertIsInstance(scaling, dict)
         self.assertEqual(len(scaling), 0)
@@ -1633,18 +1773,22 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(len(prog.positive_semidefinite_constraints()), 0)
 
         lmi_con = prog.AddLinearMatrixInequalityConstraint(
-            [np.eye(3), np.eye(3), 2 * np.ones((3, 3))], x[:2])
+            [np.eye(3), np.eye(3), 2 * np.ones((3, 3))], x[:2]
+        )
         prog.RemoveConstraint(constraint=lmi_con)
         self.assertEqual(len(prog.linear_matrix_inequality_constraints()), 0)
 
         exponential_con = prog.AddExponentialConeConstraint(
-            A=np.array([[1, 3], [2, 4], [0, 1]]), b=np.array([0, 1, 3]),
-            vars=x[:2])
+            A=np.array([[1, 3], [2, 4], [0, 1]]),
+            b=np.array([0, 1, 3]),
+            vars=x[:2],
+        )
         prog.RemoveConstraint(constraint=exponential_con)
         self.assertEqual(len(prog.exponential_cone_constraints()), 0)
 
         lcp_con = prog.AddLinearComplementarityConstraint(
-            np.eye(3), np.ones((3,)), x)
+            np.eye(3), np.ones((3,)), x
+        )
         prog.RemoveConstraint(constraint=lcp_con)
         self.assertEqual(len(prog.linear_complementarity_constraints()), 0)
 
@@ -1652,7 +1796,8 @@ class TestMathematicalProgram(unittest.TestCase):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(3)
         callback = prog.AddVisualizationCallback(
-            lambda x_val: print(x_val[0]), x)
+            lambda x_val: print(x_val[0]), x
+        )
         count = prog.RemoveVisualizationCallback(callback=callback)
         self.assertEqual(count, 1)
         self.assertEqual(len(prog.visualization_callbacks()), 0)
@@ -1666,8 +1811,10 @@ class TestMathematicalProgram(unittest.TestCase):
 
     def test_mathematical_program_result(self):
         result = MathematicalProgramResult()
-        self.assertEqual(result.get_solution_result(),
-                         mp.SolutionResult.kSolutionResultNotSet)
+        self.assertEqual(
+            result.get_solution_result(),
+            mp.SolutionResult.kSolutionResultNotSet,
+        )
 
     def test_solve_in_parallel(self):
         prog = mp.MathematicalProgram()
@@ -1681,39 +1828,47 @@ class TestMathematicalProgram(unittest.TestCase):
         solver_ids = [ScsSolver().solver_id() for _ in range(num_progs)]
         solver_options = [SolverOptions() for _ in range(num_progs)]
 
-        results = mp.SolveInParallel(progs=progs,
-                                     initial_guesses=initial_guesses,
-                                     solver_options=solver_options,
-                                     solver_ids=solver_ids,
-                                     parallelism=Parallelism.Max(),
-                                     dynamic_schedule=False)
+        results = mp.SolveInParallel(
+            progs=progs,
+            initial_guesses=initial_guesses,
+            solver_options=solver_options,
+            solver_ids=solver_ids,
+            parallelism=Parallelism.Max(),
+            dynamic_schedule=False,
+        )
         self.assertEqual(len(results), len(progs))
         self.assertTrue(all([r.is_success() for r in results]))
 
-        results = mp.SolveInParallel(progs=progs,
-                                     initial_guesses=None,
-                                     solver_options=solver_options,
-                                     solver_ids=solver_ids,
-                                     parallelism=Parallelism.Max(),
-                                     dynamic_schedule=False)
+        results = mp.SolveInParallel(
+            progs=progs,
+            initial_guesses=None,
+            solver_options=solver_options,
+            solver_ids=solver_ids,
+            parallelism=Parallelism.Max(),
+            dynamic_schedule=False,
+        )
         self.assertEqual(len(results), len(progs))
         self.assertTrue(all([r.is_success() for r in results]))
 
-        results = mp.SolveInParallel(progs=progs,
-                                     initial_guesses=initial_guesses,
-                                     solver_options=None,
-                                     solver_ids=solver_ids,
-                                     parallelism=Parallelism.Max(),
-                                     dynamic_schedule=False)
+        results = mp.SolveInParallel(
+            progs=progs,
+            initial_guesses=initial_guesses,
+            solver_options=None,
+            solver_ids=solver_ids,
+            parallelism=Parallelism.Max(),
+            dynamic_schedule=False,
+        )
         self.assertEqual(len(results), len(progs))
         self.assertTrue(all([r.is_success() for r in results]))
 
-        results = mp.SolveInParallel(progs=progs,
-                                     initial_guesses=initial_guesses,
-                                     solver_options=solver_options,
-                                     solver_ids=solver_ids,
-                                     parallelism=Parallelism.Max(),
-                                     dynamic_schedule=False)
+        results = mp.SolveInParallel(
+            progs=progs,
+            initial_guesses=initial_guesses,
+            solver_options=solver_options,
+            solver_ids=solver_ids,
+            parallelism=Parallelism.Max(),
+            dynamic_schedule=False,
+        )
         self.assertEqual(len(results), len(progs))
         self.assertTrue(all([r.is_success() for r in results]))
 
@@ -1722,41 +1877,49 @@ class TestMathematicalProgram(unittest.TestCase):
         initial_guesses[0] = None
         solver_options[0] = None
         solver_ids[0] = None
-        results = mp.SolveInParallel(progs=progs,
-                                     initial_guesses=initial_guesses,
-                                     solver_options=solver_options,
-                                     solver_ids=solver_ids,
-                                     parallelism=Parallelism.Max(),
-                                     dynamic_schedule=False)
+        results = mp.SolveInParallel(
+            progs=progs,
+            initial_guesses=initial_guesses,
+            solver_options=solver_options,
+            solver_ids=solver_ids,
+            parallelism=Parallelism.Max(),
+            dynamic_schedule=False,
+        )
         self.assertEqual(len(results), len(progs))
         self.assertTrue(all([r.is_success() for r in results]))
 
         # Now we test the overload
-        results = mp.SolveInParallel(progs=progs,
-                                     initial_guesses=None,
-                                     solver_options=SolverOptions(),
-                                     solver_id=ScsSolver().solver_id(),
-                                     parallelism=Parallelism.Max(),
-                                     dynamic_schedule=False)
+        results = mp.SolveInParallel(
+            progs=progs,
+            initial_guesses=None,
+            solver_options=SolverOptions(),
+            solver_id=ScsSolver().solver_id(),
+            parallelism=Parallelism.Max(),
+            dynamic_schedule=False,
+        )
         self.assertEqual(len(results), len(progs))
         self.assertTrue(all([r.is_success() for r in results]))
 
-        results = mp.SolveInParallel(progs=progs,
-                                     initial_guesses=initial_guesses,
-                                     solver_options=SolverOptions(),
-                                     solver_id=ScsSolver().solver_id(),
-                                     parallelism=Parallelism.Max(),
-                                     dynamic_schedule=False)
+        results = mp.SolveInParallel(
+            progs=progs,
+            initial_guesses=initial_guesses,
+            solver_options=SolverOptions(),
+            solver_id=ScsSolver().solver_id(),
+            parallelism=Parallelism.Max(),
+            dynamic_schedule=False,
+        )
         self.assertEqual(len(results), len(progs))
         self.assertTrue(all([r.is_success() for r in results]))
 
         # Ensure that all options being None does not cause ambiguity.
-        results = mp.SolveInParallel(progs=progs,
-                                     initial_guesses=None,
-                                     solver_options=None,
-                                     solver_id=None,
-                                     parallelism=Parallelism.Max(),
-                                     dynamic_schedule=False)
+        results = mp.SolveInParallel(
+            progs=progs,
+            initial_guesses=None,
+            solver_options=None,
+            solver_id=None,
+            parallelism=Parallelism.Max(),
+            dynamic_schedule=False,
+        )
         self.assertEqual(len(results), len(progs))
         self.assertTrue(all([r.is_success() for r in results]))
 
@@ -1776,7 +1939,6 @@ class TestMathematicalProgram(unittest.TestCase):
 
 
 class DummySolverInterface(SolverInterface):
-
     ID = SolverId("dummy")
 
     def __init__(self):
@@ -1792,8 +1954,7 @@ class DummySolverInterface(SolverInterface):
     def solver_id(self):
         return DummySolverInterface.ID
 
-    def Solve(self, prog, initial_guess=None, solver_options=None,
-              result=None):
+    def Solve(self, prog, initial_guess=None, solver_options=None, result=None):
         # TODO(jwnimmer-tri) This trampoline for Solve is quite awkward.
         if result is not None:
             self._DoSolve(prog, initial_guess, solver_options, result)

--- a/bindings/pydrake/solvers/test/mixed_integer_optimization_util_test.py
+++ b/bindings/pydrake/solvers/test/mixed_integer_optimization_util_test.py
@@ -31,13 +31,14 @@ class TestMixedIntegerOptimizationUtil(unittest.TestCase):
             satisfied = True
             for binding in prog.GetAllConstraints():
                 satisfied = satisfied and binding.evaluator().CheckSatisfied(
-                    prog.GetBindingVariableValues(binding, x_val))
+                    prog.GetBindingVariableValues(binding, x_val)
+                )
             self.assertEqual(satisfied, satisfied_expected)
 
-        check_val([0], [0.2, 0.8, 0.], True)
-        check_val([0], [0.2, 0.7, 0.], False)
-        check_val([1], [0.2, 0.7, 0.], False)
-        check_val([1], [0., 0.3, 0.7], True)
+        check_val([0], [0.2, 0.8, 0.0], True)
+        check_val([0], [0.2, 0.7, 0.0], False)
+        check_val([1], [0.2, 0.7, 0.0], False)
+        check_val([1], [0.0, 0.3, 0.7], True)
 
     def test_AddSos2Constraint(self):
         prog = MathematicalProgram()
@@ -54,15 +55,16 @@ class TestMixedIntegerOptimizationUtil(unittest.TestCase):
             satisfied = True
             for binding in prog.GetAllConstraints():
                 satisfied = satisfied and binding.evaluator().CheckSatisfied(
-                    prog.GetBindingVariableValues(binding, x_val))
+                    prog.GetBindingVariableValues(binding, x_val)
+                )
             self.assertEqual(satisfied, satisfied_expected)
 
-        check_val([1, 0], [0.2, 0.8, 0.], True)
-        check_val([1, 0], [0.2, 0.7, 0.], False)
-        check_val([0, 1], [0.2, 0.7, 0.], False)
-        check_val([0, 1], [0., 0.3, 0.7], True)
-        check_val([1, 1], [0., 0.3, 0.7], False)
-        check_val([0, 0], [0., 0.3, 0.7], False)
+        check_val([1, 0], [0.2, 0.8, 0.0], True)
+        check_val([1, 0], [0.2, 0.7, 0.0], False)
+        check_val([0, 1], [0.2, 0.7, 0.0], False)
+        check_val([0, 1], [0.0, 0.3, 0.7], True)
+        check_val([1, 1], [0.0, 0.3, 0.7], False)
+        check_val([0, 0], [0.0, 0.3, 0.7], False)
 
     def test_AddLogarithmicSos1Constraint(self):
         prog = MathematicalProgram()
@@ -75,7 +77,8 @@ class TestMixedIntegerOptimizationUtil(unittest.TestCase):
             satisfied = True
             for binding in prog.GetAllConstraints():
                 satisfied = satisfied and binding.evaluator().CheckSatisfied(
-                    prog.GetBindingVariableValues(binding, x_val))
+                    prog.GetBindingVariableValues(binding, x_val)
+                )
             self.assertEqual(satisfied, satisfied_expected)
 
         check_val([1, 0], [0, 0, 0, 1], True)
@@ -83,15 +86,16 @@ class TestMixedIntegerOptimizationUtil(unittest.TestCase):
         check_val([1, 0], [0, 0, 0.5, 0.5], False)
 
     def test_AddBilinearProductMcCormickEnvelopeSos2(self):
-        '''
-            Test that this constraint works when using a linear binning option.
-            The logarithmic binning case requires slightly more involved setup,
-            but uses the same codepath, so it's not tested here.
-        '''
+        """
+        Test that this constraint works when using a linear binning option.
+        The logarithmic binning case requires slightly more involved setup,
+        but uses the same codepath, so it's not tested here.
+        """
 
         def setup_and_test_prog(
-                setup_aux, expected_xyw, expected_Bx, expected_By):
-            '''
+            setup_aux, expected_xyw, expected_Bx, expected_By
+        ):
+            """
             1) Setup an optimization with 1D continuous variables x, y, and
                w.
             2) Constraint x*y=w using this piecewise McCormick envelope
@@ -100,7 +104,7 @@ class TestMixedIntegerOptimizationUtil(unittest.TestCase):
                to add additional costs and constraints for testing.
             4) Solve the program and assert that the solver finds the
                expected xyw values and the expected binary setting.
-            '''
+            """
             prog = MathematicalProgram()
 
             w, x, y = prog.NewContinuousVariables(3)
@@ -109,12 +113,19 @@ class TestMixedIntegerOptimizationUtil(unittest.TestCase):
             Bx = prog.NewBinaryVariables(N_x_divisions)
             By = prog.NewBinaryVariables(N_y_divisions)
             # Divide range [0, 1] into appropriate number of bins.
-            phi_x = np.linspace(0., 1., N_x_divisions+1)
-            phi_y = np.linspace(0., 1., N_y_divisions+1)
+            phi_x = np.linspace(0.0, 1.0, N_x_divisions + 1)
+            phi_y = np.linspace(0.0, 1.0, N_y_divisions + 1)
             binning = IntervalBinning.kLinear
             AddBilinearProductMcCormickEnvelopeSos2(
-                prog=prog, x=x, y=y, w=w, phi_x=phi_x, phi_y=phi_y,
-                Bx=Bx, By=By, binning=binning
+                prog=prog,
+                x=x,
+                y=y,
+                w=w,
+                phi_x=phi_x,
+                phi_y=phi_y,
+                Bx=Bx,
+                By=By,
+                binning=binning,
             )
             setup_aux(prog, x, y, w)
             solver = MixedIntegerBranchAndBound(prog, ClpSolver().solver_id())
@@ -130,31 +141,32 @@ class TestMixedIntegerOptimizationUtil(unittest.TestCase):
         # extreme values.
         setup_and_test_prog(
             lambda prog, x, y, w: prog.AddLinearCost(x + y + w),
-            expected_xyw=[0., 0., 0.],
-            expected_Bx=[1.],
-            expected_By=[1., 0., 0.]
+            expected_xyw=[0.0, 0.0, 0.0],
+            expected_Bx=[1.0],
+            expected_By=[1.0, 0.0, 0.0],
         )
         setup_and_test_prog(
             lambda prog, x, y, w: prog.AddLinearCost(x - y - w),
-            expected_xyw=[0., 1., 0.],
-            expected_Bx=[1.],
-            expected_By=[0., 0., 1.]
+            expected_xyw=[0.0, 1.0, 0.0],
+            expected_Bx=[1.0],
+            expected_By=[0.0, 0.0, 1.0],
         )
         setup_and_test_prog(
             lambda prog, x, y, w: prog.AddLinearCost(-x - y - w),
-            expected_xyw=[1., 1., 1.],
-            expected_Bx=[1.],
-            expected_By=[0., 0., 1.]
+            expected_xyw=[1.0, 1.0, 1.0],
+            expected_Bx=[1.0],
+            expected_By=[0.0, 0.0, 1.0],
         )
 
         # Force x=1, w=0.5, (y=0.5), which should activate the
         # middle bin for y.
         def setup_aux(prog, x, y, w):
             prog.AddLinearEqualityConstraint(w == 0.5)
-            prog.AddLinearEqualityConstraint(x == 1.)
+            prog.AddLinearEqualityConstraint(x == 1.0)
+
         setup_and_test_prog(
             setup_aux,
-            expected_xyw=[1., 0.5, 0.5],
-            expected_Bx=[1.],
-            expected_By=[0., 1., 0.]
+            expected_xyw=[1.0, 0.5, 0.5],
+            expected_Bx=[1.0],
+            expected_By=[0.0, 1.0, 0.0],
         )

--- a/bindings/pydrake/solvers/test/mixed_integer_rotation_constraint_test.py
+++ b/bindings/pydrake/solvers/test/mixed_integer_rotation_constraint_test.py
@@ -19,9 +19,9 @@ class TestMixedIntegerRotationConstraint(unittest.TestCase):
         so3_generator = Generator(
             approach=approach,
             num_intervals_per_half_axis=n_intervals,
-            interval_binning=binning
+            interval_binning=binning,
         )
-        assert so3_generator.phi().shape == (n_intervals*2 + 1,)
+        assert so3_generator.phi().shape == (n_intervals * 2 + 1,)
         assert so3_generator.phi_nonnegative().shape == (n_intervals + 1,)
         assert so3_generator.num_intervals_per_half_axis() == n_intervals
         assert so3_generator.interval_binning() == binning

--- a/bindings/pydrake/solvers/test/mobylcp_solver_test.py
+++ b/bindings/pydrake/solvers/test/mobylcp_solver_test.py
@@ -10,12 +10,12 @@ from pydrake.solvers import (
 
 
 class TestMobyLCPSolver(unittest.TestCase):
-
     def _make_prog(self):
         prog = MathematicalProgram()
         x = prog.NewContinuousVariables(3)
         prog.AddLinearComplementarityConstraint(
-            M=np.eye(3), q=np.ones(3), vars=x)
+            M=np.eye(3), q=np.ones(3), vars=x
+        )
         x_expected = np.zeros(3)
         return prog, x, x_expected
 

--- a/bindings/pydrake/solvers/test/mosek_solver_test.py
+++ b/bindings/pydrake/solvers/test/mosek_solver_test.py
@@ -31,7 +31,7 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))
         self.assertEqual(result.get_solver_details().solution_status, 1)
         self.assertEqual(result.get_solver_details().rescode, 0)
-        self.assertGreater(result.get_solver_details().optimizer_time, 0.)
+        self.assertGreater(result.get_solver_details().optimizer_time, 0.0)
 
     def test_mosek_license(self):
         # Nominal use case.

--- a/bindings/pydrake/solvers/test/nlopt_solver_test.py
+++ b/bindings/pydrake/solvers/test/nlopt_solver_test.py
@@ -17,7 +17,7 @@ class TestNloptSolver(unittest.TestCase):
         prog.AddLinearConstraint(x[0] >= 1)
         prog.AddLinearConstraint(x[1] >= 1)
         prog.AddQuadraticCost(np.eye(2), np.zeros(2), x)
-        x_expected = np.array([1., 1.])
+        x_expected = np.array([1.0, 1.0])
 
         solver = NloptSolver()
         self.assertEqual(solver.solver_id(), NloptSolver.id())
@@ -28,7 +28,8 @@ class TestNloptSolver(unittest.TestCase):
         result = solver.Solve(prog, None, None)
         self.assertTrue(result.is_success())
         numpy_compare.assert_float_allclose(
-            result.GetSolution(x), x_expected, atol=1E-7)
+            result.GetSolution(x), x_expected, atol=1e-7
+        )
         self.assertEqual(result.get_solver_details().status, 4)
 
         self.assertIsInstance(NloptSolver.ConstraintToleranceName(), str)

--- a/bindings/pydrake/solvers/test/noscipy_test.py
+++ b/bindings/pydrake/solvers/test/noscipy_test.py
@@ -23,9 +23,9 @@ class TestMathematicalProgram(unittest.TestCase):
         # they should still be able to call the dense overload, even when the
         # matrix requires conversion (from numpy's row-major default to the
         # col-major requirement for passing a `const Eigen::MatrixXd`).
-        A = np.array([[1, 3, 4], [2., 4., 5]])
-        lb = np.array([1, 2.])
-        ub = np.array([3., 4.])
+        A = np.array([[1, 3, 4], [2.0, 4.0, 5]])
+        lb = np.array([1, 2.0])
+        ub = np.array([3.0, 4.0])
         dut = LinearConstraint(A=A, lb=lb, ub=ub)
         self.assertEqual(dut.num_constraints(), 2)
         self.assertEqual(dut.num_vars(), 3)
@@ -33,11 +33,14 @@ class TestMathematicalProgram(unittest.TestCase):
         # UpdateCoefficients is similarly overloaded for sparse or dense, and
         # the user should be able to invoke the dense overload without scipy.
         dut.UpdateCoefficients(
-            new_A=np.array([[1E-10, 0, 0], [0, 1, 1]]),
-            new_lb=np.array([2, 3]), new_ub=np.array([3, 4]))
-        dut.RemoveTinyCoefficient(tol=1E-5)
+            new_A=np.array([[1e-10, 0, 0], [0, 1, 1]]),
+            new_lb=np.array([2, 3]),
+            new_ub=np.array([3, 4]),
+        )
+        dut.RemoveTinyCoefficient(tol=1e-5)
         np.testing.assert_array_equal(
-            dut.GetDenseA(), np.array([[0, 0, 0], [0, 1, 1]]))
+            dut.GetDenseA(), np.array([[0, 0, 0], [0, 1, 1]])
+        )
 
         # When testing in Drake CI, scipy will not be installed. When drake
         # developers run this test locally, they might have scipy installed
@@ -45,10 +48,13 @@ class TestMathematicalProgram(unittest.TestCase):
         # that our Bazel logic for disabling scipy is working properly.
         try:
             import scipy
+
             self.assertNotIn(
-                "/scipy_stub/", scipy.__file__,
+                "/scipy_stub/",
+                scipy.__file__,
                 "The BUILD dependencies for this test MUST NOT depend on"
-                " :scipy_stub_py, either directly or transitively.")
+                " :scipy_stub_py, either directly or transitively.",
+            )
             self.fail("Somehow, the scipy_none dependency isn't working?!")
         except ModuleNotFoundError:
             pass

--- a/bindings/pydrake/solvers/test/osqp_solver_test.py
+++ b/bindings/pydrake/solvers/test/osqp_solver_test.py
@@ -25,11 +25,12 @@ class TestOsqpSolver(unittest.TestCase):
         x_expected = np.array([1, 1])
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))
         self.assertEqual(result.get_solver_details().status_val, 1)
-        self.assertEqual(result.get_solver_details().primal_res, 0.)
+        self.assertEqual(result.get_solver_details().primal_res, 0.0)
         np.testing.assert_allclose(
-            result.get_solver_details().y, np.array([-1., -1.]))
-        np.testing.assert_allclose(result.GetDualSolution(constraint1), [1.])
-        np.testing.assert_allclose(result.GetDualSolution(constraint2), [1.])
+            result.get_solver_details().y, np.array([-1.0, -1.0])
+        )
+        np.testing.assert_allclose(result.GetDualSolution(constraint1), [1.0])
+        np.testing.assert_allclose(result.GetDualSolution(constraint2), [1.0])
 
     def unavailable(self):
         """Per the BUILD file, this test is only run when OSQP is disabled."""

--- a/bindings/pydrake/solvers/test/program_attribute_test.py
+++ b/bindings/pydrake/solvers/test/program_attribute_test.py
@@ -1,8 +1,5 @@
 import unittest
-from pydrake.solvers import (
-    ProgramAttribute,
-    ProgramType
-)
+from pydrake.solvers import ProgramAttribute, ProgramType
 
 
 class TestProgramAttribute(unittest.TestCase):

--- a/bindings/pydrake/solvers/test/projected_gradient_descent_solver_test.py
+++ b/bindings/pydrake/solvers/test/projected_gradient_descent_solver_test.py
@@ -19,8 +19,9 @@ class TestProjectedGradientDescentSolver(unittest.TestCase):
         prog.AddLinearCost(x[0])
 
         solver = ProjectedGradientDescentSolver()
-        self.assertEqual(solver.solver_id(),
-                         ProjectedGradientDescentSolver.id())
+        self.assertEqual(
+            solver.solver_id(), ProjectedGradientDescentSolver.id()
+        )
         self.assertTrue(solver.available())
         self.assertTrue(solver.enabled())
 
@@ -28,27 +29,33 @@ class TestProjectedGradientDescentSolver(unittest.TestCase):
         result = solver.Solve(prog, None, None)
         self.assertTrue(result.is_success())
         numpy_compare.assert_float_allclose(
-            result.GetSolution(x), [0., 1.], atol=1E-7)
+            result.GetSolution(x), [0.0, 1.0], atol=1e-7
+        )
 
         # Test that we can specify a projection solver interface.
         projection_solver = ClarabelSolver()
         solver.SetProjectionSolverInterface(
-            projection_solver_interface=projection_solver)
+            projection_solver_interface=projection_solver
+        )
 
         result = solver.Solve(prog, None, None)
         self.assertTrue(result.is_success())
         numpy_compare.assert_float_allclose(
-            result.GetSolution(x), [0., 1.], atol=1E-7)
+            result.GetSolution(x), [0.0, 1.0], atol=1e-7
+        )
 
         # Test that we can specify a custom gradient function.
         def custom_gradient_function(y):
             return np.array([1.0, 0.0])
+
         solver.SetCustomGradientFunction(
-            custom_gradient_function=custom_gradient_function)
+            custom_gradient_function=custom_gradient_function
+        )
         result = solver.Solve(prog, None, None)
         self.assertTrue(result.is_success())
         numpy_compare.assert_float_allclose(
-            result.GetSolution(x), [0., 1.], atol=1E-7)
+            result.GetSolution(x), [0.0, 1.0], atol=1e-7
+        )
 
         # Test that we can specify a custom projection function.
         def custom_projection_function(y):
@@ -59,55 +66,70 @@ class TestProjectedGradientDescentSolver(unittest.TestCase):
             prog.AddQuadraticErrorCost(1, y, z)
             result = projection_solver.Solve(prog)
             return result.is_success(), result.GetSolution(z)
+
         solver.SetCustomProjectionFunction(
-            custom_projection_function=custom_projection_function)
+            custom_projection_function=custom_projection_function
+        )
         result = solver.Solve(prog, None, None)
         self.assertTrue(result.is_success())
         numpy_compare.assert_float_allclose(
-            result.GetSolution(x), [0., 1.], atol=1E-7)
+            result.GetSolution(x), [0.0, 1.0], atol=1e-7
+        )
 
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.ConvergenceTolOptionName(),
-                str))
+                ProjectedGradientDescentSolver.ConvergenceTolOptionName(), str
+            )
+        )
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.MaxIterationsOptionName(),
-                str))
+                ProjectedGradientDescentSolver.MaxIterationsOptionName(), str
+            )
+        )
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.BacktrackingCOptionName(),
-                str))
+                ProjectedGradientDescentSolver.BacktrackingCOptionName(), str
+            )
+        )
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.BacktrackingTauOptionName(),
-                str))
+                ProjectedGradientDescentSolver.BacktrackingTauOptionName(), str
+            )
+        )
         self.assertTrue(
             isinstance(
                 ProjectedGradientDescentSolver.BacktrackingAlpha0OptionName(),
-                str))
+                str,
+            )
+        )
 
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.kDefaultConvergenceTol,
-                float))
+                ProjectedGradientDescentSolver.kDefaultConvergenceTol, float
+            )
+        )
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.kDefaultMaxIterations,
-                int))
+                ProjectedGradientDescentSolver.kDefaultMaxIterations, int
+            )
+        )
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.kDefaultBacktrackingC,
-                float))
+                ProjectedGradientDescentSolver.kDefaultBacktrackingC, float
+            )
+        )
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.kDefaultBacktrackingTau,
-                float))
+                ProjectedGradientDescentSolver.kDefaultBacktrackingTau, float
+            )
+        )
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.kDefaultBacktrackingAlpha0,
-                float))
+                ProjectedGradientDescentSolver.kDefaultBacktrackingAlpha0, float
+            )
+        )
         self.assertTrue(
             isinstance(
-                ProjectedGradientDescentSolver.kDefaultMaxLineSearchSteps,
-                int))
+                ProjectedGradientDescentSolver.kDefaultMaxLineSearchSteps, int
+            )
+        )

--- a/bindings/pydrake/solvers/test/scs_solver_test.py
+++ b/bindings/pydrake/solvers/test/scs_solver_test.py
@@ -30,16 +30,21 @@ class TestScsSolver(unittest.TestCase):
         # Use a loose tolerance for the check since the correctness of the
         # solver has been validated in the C++ code, while the Python test
         # just verifies if the binding works or not.
-        atol = 1E-3
+        atol = 1e-3
         numpy_compare.assert_float_allclose(
-            result.GetSolution(x), [1.0, 1.0], atol=atol)
+            result.GetSolution(x), [1.0, 1.0], atol=atol
+        )
         numpy_compare.assert_float_allclose(
-            result.get_solver_details().primal_objective, 1.0, atol=atol)
+            result.get_solver_details().primal_objective, 1.0, atol=atol
+        )
         numpy_compare.assert_float_allclose(
-            result.get_solver_details().primal_residue, np.array([0.]),
-            atol=atol)
+            result.get_solver_details().primal_residue,
+            np.array([0.0]),
+            atol=atol,
+        )
         numpy_compare.assert_float_allclose(
-            result.get_solver_details().y, np.array([1., 1.]), atol=atol)
+            result.get_solver_details().y, np.array([1.0, 1.0]), atol=atol
+        )
 
     def unavailable(self):
         """Per the BUILD file, this test is only run when SCS is disabled."""

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -21,9 +21,7 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         relaxation = MakeSemidefiniteRelaxation(prog=prog, options=options)
 
         self.assertEqual(relaxation.num_vars(), 6)
-        self.assertEqual(
-            len(relaxation.positive_semidefinite_constraints()), 1
-        )
+        self.assertEqual(len(relaxation.positive_semidefinite_constraints()), 1)
         self.assertEqual(len(relaxation.linear_equality_constraints()), 1)
         self.assertEqual(len(relaxation.linear_constraints()), 2)
 
@@ -49,9 +47,7 @@ class TestSemidefiniteRelaxation(unittest.TestCase):
         # with the "1" variable double counted. Therefore, there are
         # 5 choose 2 + 4 choose 2 - 1 variables.
         self.assertEqual(relaxation.num_vars(), 10 + 6 - 1)
-        self.assertEqual(
-            len(relaxation.positive_semidefinite_constraints()), 2
-        )
+        self.assertEqual(len(relaxation.positive_semidefinite_constraints()), 2)
         self.assertEqual(len(relaxation.linear_equality_constraints()), 1)
         self.assertEqual(len(relaxation.linear_constraints()), 2 + 1)
 

--- a/bindings/pydrake/solvers/test/snopt_solver_test.py
+++ b/bindings/pydrake/solvers/test/snopt_solver_test.py
@@ -29,26 +29,32 @@ class TestSnoptSolver(unittest.TestCase):
             result = solver.Solve(prog, None, None)
             self.assertTrue(result.is_success())
             numpy_compare.assert_float_allclose(
-                result.GetSolution(x), [0., 1.], atol=1E-7)
+                result.GetSolution(x), [0.0, 1.0], atol=1e-7
+            )
             self.assertEqual(result.get_solver_details().info, 1)
             np.testing.assert_allclose(
-                result.get_solver_details().xmul, np.array([0., -1]))
+                result.get_solver_details().xmul, np.array([0.0, -1])
+            )
             np.testing.assert_allclose(
-                result.get_solver_details().F, np.array([0, 1.]))
+                result.get_solver_details().F, np.array([0, 1.0])
+            )
             np.testing.assert_allclose(
-                result.get_solver_details().Fmul, np.array([0, 1.]))
+                result.get_solver_details().Fmul, np.array([0, 1.0])
+            )
             self.assertGreater(result.get_solver_details().solve_time, 0)
 
     def test_solver_specific_error(self):
         # Intentionally write a constraint with incorrect gradients.
         def my_constraint(x):
             return [AutoDiffXd(np.sin(x[0].value()), np.ones(1))]
+
         prog = MathematicalProgram()
         x = prog.NewContinuousVariables(1, "x")
         prog.AddConstraint(my_constraint, [1], [1], x)
         solver = SnoptSolver()
         result = solver.Solve(prog)
         self.assertEqual(result.is_success(), False)
-        self.assertEqual(result.get_solution_result(),
-                         SolutionResult.kSolverSpecificError)
+        self.assertEqual(
+            result.get_solution_result(), SolutionResult.kSolverSpecificError
+        )
         self.assertEqual(result.get_solver_details().info, 41)

--- a/bindings/pydrake/solvers/test/unrevised_lemke_solver_test.py
+++ b/bindings/pydrake/solvers/test/unrevised_lemke_solver_test.py
@@ -10,12 +10,12 @@ from pydrake.solvers import (
 
 
 class TestUnrevisedLemkeSolver(unittest.TestCase):
-
     def _make_prog(self):
         prog = MathematicalProgram()
         x = prog.NewContinuousVariables(3)
         prog.AddLinearComplementarityConstraint(
-            M=np.eye(3), q=np.ones(3), vars=x)
+            M=np.eye(3), q=np.ones(3), vars=x
+        )
         x_expected = np.zeros(3)
         return prog, x, x_expected
 


### PR DESCRIPTION
Towards #19827.

The first commit is ruff's formatter.  The second commit (if any) are my own fixups.
