### PR TITLE
[tools] relnotes clusters deprecated tags as well

### DIFF
--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -68,6 +68,10 @@ the main body of the document:
   not the "Multibody" heading.
 * Expand all acronyms (eg, MBP -> MultibodyPlant, SG -> SceneGraph).
 * Commits can be omitted if they only affect tests or non-installed examples. {% comment %}TODO(jwnimmer-tri) Explain how to check if something is installed.{% endcomment %}
+* PRs that are tagged with release deprecation information _may_ appear twice.
+  They will be included once in the appropriate deprecation-related section
+  according to the deprecation tag. But they may also appear in their topical
+  section if they also include a tag such as "fix" or "feature".
 * In general you should mention deprecated/removed classes and methods using
   their exact name (for easier searching).
   * In the deprecation section you can provide the fully-qualified name as the

--- a/doc/_release-notes/template.txt
+++ b/doc/_release-notes/template.txt
@@ -11,6 +11,8 @@ released: YYYY-MM-DD
 
 # Breaking changes since v{prior_version}
 
+<!-- <relnotes for breaking-changes go here> -->
+
 * TBD
 
 Refer to our [Drake Stability Guidelines](/stable.html) for our policy
@@ -109,9 +111,13 @@ Fixes
 
 ## Newly-deprecated APIs
 
+<!-- <relnotes for newly-deprecated go here> -->
+
 * TBD
 
 ## Removal of deprecated items
+
+<!-- <relnotes for deprecated-removed go here> -->
 
 * TBD
 


### PR DESCRIPTION
For PRs that also have deprecated release notes tags, the bullets get copied into the newly- and removed-deprecated sections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23591)
<!-- Reviewable:end -->
