### PR TITLE
IrisNp2 fix hyperplanes not being counted during inner iterations.

### DIFF
--- a/planning/iris/iris_np2.cc
+++ b/planning/iris/iris_np2.cc
@@ -737,7 +737,7 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
       for (int particle_index = 0;
            particle_index < num_particles_to_walk_toward; ++particle_index) {
         auto& particle = particles_to_work_on[particle_index];
-        if (num_hyperplanes_added >
+        if (num_hyperplanes_added >=
             options.sampled_iris_options.max_separating_planes_per_iteration) {
           break;
         }
@@ -866,6 +866,7 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
 
         bool add_hyperplane =
             solve_succeeded || options.add_hyperplane_if_solve_fails;
+        ++num_hyperplanes_added;
         VectorXd* point_to_add_hyperplane{nullptr};
 
         if (solve_succeeded) {


### PR DESCRIPTION
[We allow the user to set a limit on the maximum number of separating planes added per inner iteration](https://drake.mit.edu/doxygen_cxx/classdrake_1_1planning_1_1_common_sampled_iris_options.html#a453b11ce4f8e1460d19b014b83569257) -- setting this number smaller makes better regions but takes longer. But this option was not being respected by IrisNp2.

+@assignee:wernerpe for feature review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23593)
<!-- Reviewable:end -->
