### PR TITLE
[pydrake] Unify installed python main programs' logging config

### DIFF
--- a/bindings/pydrake/examples/gym/play_cart_pole.py
+++ b/bindings/pydrake/examples/gym/play_cart_pole.py
@@ -8,6 +8,7 @@ import gymnasium as gym
 import stable_baselines3
 from stable_baselines3.common.env_checker import check_env
 
+from pydrake.common import configure_logging
 from pydrake.geometry import StartMeshcat
 from pydrake.examples.gym._bazel_cwd_helpers import bazel_chdir
 
@@ -63,6 +64,7 @@ def _run_playing(args):
 
 def _main():
     bazel_chdir()
+    configure_logging()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--test', action='store_true')
     parser.add_argument('--debug', action='store_true')

--- a/bindings/pydrake/examples/gym/train_cart_pole.py
+++ b/bindings/pydrake/examples/gym/train_cart_pole.py
@@ -7,6 +7,7 @@ import gymnasium as gym
 import stable_baselines3
 from stable_baselines3.common.env_checker import check_env
 
+from pydrake.common import configure_logging
 from pydrake.geometry import StartMeshcat
 from pydrake.examples.gym._bazel_cwd_helpers import bazel_chdir
 
@@ -107,6 +108,7 @@ def _run_training(config, args):
 
 def _main():
     bazel_chdir()
+    configure_logging()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--test', action='store_true')
     parser.add_argument('--train_single_env', action='store_true')

--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -2,6 +2,7 @@
 
 import argparse
 
+from pydrake.common import configure_logging
 from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.framework import DiagramBuilder
@@ -10,6 +11,7 @@ from pydrake.visualization import AddDefaultVisualization
 
 
 def main():
+    configure_logging()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--target_realtime_rate", type=float, default=1.0,

--- a/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
+++ b/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
@@ -11,7 +11,7 @@ import argparse
 
 import numpy as np
 
-from pydrake.common import RandomGenerator
+from pydrake.common import RandomGenerator, configure_logging
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.symbolic import Variable
@@ -27,6 +27,7 @@ from pydrake.systems.primitives import Saturation
 
 
 def main():
+    configure_logging()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--num_samples", type=int, default=50,

--- a/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
@@ -7,7 +7,7 @@ import argparse
 
 import numpy as np
 
-from pydrake.common import temp_directory
+from pydrake.common import configure_logging, temp_directory
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.systems.analysis import Simulator
@@ -54,6 +54,7 @@ def run_pendulum_example(args):
 
 
 def main():
+    configure_logging()
     np.set_printoptions(precision=5, suppress=True)
     parser = argparse.ArgumentParser(
         description=__doc__,

--- a/bindings/pydrake/multibody/fix_inertia.py
+++ b/bindings/pydrake/multibody/fix_inertia.py
@@ -55,13 +55,10 @@ tags.
 """
 
 import argparse
-import logging
 import os
 
 from pydrake.common import configure_logging as _configure_logging
 from pydrake.multibody import _inertia_fixer
-
-_logger = logging.getLogger("drake")
 
 
 def _main():

--- a/bindings/pydrake/multibody/mesh_to_model.py
+++ b/bindings/pydrake/multibody/mesh_to_model.py
@@ -113,7 +113,6 @@ Properties of the resulting SDFormat file:
 """
 
 import argparse
-import logging
 import numpy as np
 import os
 from pathlib import Path
@@ -122,8 +121,6 @@ from pydrake.common import configure_logging as _configure_logging
 from pydrake.multibody._mesh_model_maker import (
     MeshModelMaker as _MeshModelMaker,
 )
-
-_logger = logging.getLogger("drake")
 
 
 def _CommaSeparatedXYZ(arg: str):

--- a/bindings/pydrake/visualization/_lcm_image_array_viewer.py
+++ b/bindings/pydrake/visualization/_lcm_image_array_viewer.py
@@ -7,6 +7,7 @@ import numpy as np
 from PIL import Image
 
 from drake import lcmt_image, lcmt_image_array
+from pydrake.common import configure_logging
 from pydrake.lcm import DrakeLcm
 from pydrake.systems.sensors import (
     ImageDepth16U,
@@ -188,6 +189,7 @@ class LcmImageArrayViewer:
 
 
 def main():
+    configure_logging()
     parser = argparse.ArgumentParser(
         description=__doc__,
     )

--- a/bindings/pydrake/visualization/model_visualizer.py
+++ b/bindings/pydrake/visualization/model_visualizer.py
@@ -40,6 +40,7 @@ import os
 from pathlib import Path
 import textwrap
 
+from pydrake.common import configure_logging as _configure_logging
 from pydrake.visualization._model_visualizer import (
     ModelVisualizer as _ModelVisualizer,
 )
@@ -47,11 +48,10 @@ from pydrake.visualization._model_visualizer import (
 
 def _main():
     # Use a few color highlights for the user's terminal output.
+    _configure_logging()
     logging.addLevelName(logging.INFO, "\033[36mINFO\033[0m")
     logging.addLevelName(logging.WARNING, "\033[33mWARNING\033[0m")
     logging.addLevelName(logging.ERROR, "\033[31mERROR\033[0m")
-    format = "%(levelname)s: %(message)s"
-    logging.basicConfig(level=logging.INFO, format=format)
 
     # Prepare to parse arguments.
     args_parser = argparse.ArgumentParser(


### PR DESCRIPTION
Every pydrake main program should use `configure_logging()`, for uniformity of default level, pattern, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23599)
<!-- Reviewable:end -->
