### PR TITLE
[wheel] Fix MOSEK dynamic loading on manylinux

### DIFF
--- a/tools/wheel/README.rst
+++ b/tools/wheel/README.rst
@@ -34,6 +34,9 @@ This simplifies the process of testing changes locally. On macOS, the current
 checkout is used directly. In some cases, it may be necessary to run
 ``bazel clean`` before building a wheel.
 
+The wheels are sanity tested as part of the build. All files in the ``test``
+subdirectory are run against the installed wheel.
+
 On successful completion, the requested set of wheels will be written to the
 specified output directory (by default, the current working directory, unless
 overridden by ``--output-dir``), unless ``--no-extract`` was specified.

--- a/tools/wheel/test/tests/mosek-test.py
+++ b/tools/wheel/test/tests/mosek-test.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import os
+
+from pydrake.all import MosekSolver
+
+# Configure MOSEK to be enabled at runtime (but with broken license).
+os.environ["MOSEKLM_LICENSE_FILE"] = "/does/not/exist.lic"
+solver = MosekSolver()
+assert solver.enabled()
+
+# Check that MOSEK lazy loading works. Trying to get a license should trigger
+# the lazy loading. MOSEK will raise an error because the license is not valid.
+try:
+    solver.AcquireLicense()
+    message = None
+except Exception as e:
+    message = str(e)
+
+# Check `e` for text that indicates the _right_ error.
+expected = "Could not acquire MOSEK license"
+assert expected in message, message

--- a/tools/workspace/mosek/BUILD.bazel
+++ b/tools/workspace/mosek/BUILD.bazel
@@ -21,8 +21,11 @@ config_setting(
 )
 
 exports_files([
+    "drake_dlopen_mosek.cc",
     "drake_mosek_redistribution.txt",
     "LICENSE.third_party",
 ])
 
-add_lint_tests()
+add_lint_tests(
+    cpplint_extra_srcs = ["drake_dlopen_mosek.cc"],
+)

--- a/tools/workspace/mosek/drake_dlopen_mosek.cc
+++ b/tools/workspace/mosek/drake_dlopen_mosek.cc
@@ -1,0 +1,33 @@
+#include <dlfcn.h>
+
+#include <filesystem>
+#include <string>
+
+#include "drake/common/find_loaded_library.h"
+#include "drake/common/text_logging.h"
+
+using drake::LoadedLibraryPath;
+using drake::log;
+
+// This is a callack used by Implib.so as part of our ":implib_mosek" library to
+// load MOSEK™ lazily, which (currently) is only enabled during our wheel
+// builds, not normal packaging builds nor developer builds. It is called once
+// the first time Drake needs to call any function in the MOSEK shared library.
+extern "C" void* drake_dlopen_mosek(const char* lib_name) {
+  // Find libdrake in site-packages/pydrake/lib/libdrake.so.
+  std::optional<std::string> libdrake_dir = LoadedLibraryPath("libdrake.so");
+  if (!libdrake_dir.has_value()) {
+    log()->error("Cannot load MOSEK: cannot even find libdrake.so");
+    return nullptr;
+  }
+  // Respell from site-packages/pydrake/lib to site-packages/mosek.
+  const auto mosek_dir = std::filesystem::path{*libdrake_dir} / "../../mosek";
+  // Load libmosek from site-packages.
+  const std::string mosek_lib = (mosek_dir / lib_name).string();
+  void* handle = dlopen(mosek_lib.c_str(), RTLD_LAZY);
+  if (handle == nullptr) {
+    log()->error("Cannot load MOSEK: dlopen({}) failed: {}", mosek_lib,
+                 dlerror());
+  }
+  return handle;
+}

--- a/tools/workspace/mosek/package.BUILD.bazel
+++ b/tools/workspace/mosek/package.BUILD.bazel
@@ -83,13 +83,18 @@ genrule(
     name = "_gen_implib",
     srcs = [_MOSEK_MAJMIN_GLOB[0]],
     outs = _IMPLIB_SRCS,
-    cmd = "$(execpath @implib_so_internal//:gen) --outdir=$(RULEDIR) $<",
+    cmd = "$(execpath @implib_so_internal//:gen) --dlopen-callback=drake_dlopen_mosek --outdir=$(RULEDIR) $<",
     tools = ["@implib_so_internal//:gen"],
 )
 
 cc_library(
     name = "implib_mosek",
-    srcs = _IMPLIB_SRCS,
+    srcs = _IMPLIB_SRCS + [
+        "@drake//tools/workspace/mosek:drake_dlopen_mosek.cc",
+    ],
+    deps = [
+        "@drake//common:find_resource",
+    ],
     linkstatic = True,
 )
 


### PR DESCRIPTION
Closes #23608.

Amends #23128.

The error reporting here is not great, but improving that will be deferred as future work.

Tested locally via a local wheel build `bazel run -- //tools/wheel:builder 0.0.0 --python=312` + venv install.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23609)
<!-- Reviewable:end -->
