### PR TITLE
[pydrake] Fix typing.Union compatibility for Python 3.14

### DIFF
--- a/bindings/pydrake/common/cpp_param.py
+++ b/bindings/pydrake/common/cpp_param.py
@@ -146,18 +146,23 @@ class _Generic:
         return f"<Generic {self._name}>"
 
 
-def _dict_instantiator(params):
-    return dict[params]
+def _dict_instantiator(params: tuple):
+    (param_key, param_value) = params
+    return dict[param_key, param_value]
 
 
-def _list_instantiator(params):
-    return list[params]
+def _list_instantiator(params: tuple):
+    (param,) = params
+    return list[param]
 
 
-def _optional_instantiator(params):
-    # Unpack the tuple into the (single) argument required by typing.Optional.
+def _optional_instantiator(params: tuple):
     (param,) = params
     return typing.Optional[param]
+
+
+def _union_instantiator(params: tuple):
+    return typing.Union[params]
 
 
 # A generic type `dict[KT, VT]` for the C++ class std::map<KT, VT>.
@@ -171,4 +176,4 @@ List = _Generic("List", _list_instantiator, 1)
 Optional = _Generic("Optional", _optional_instantiator, 1)
 
 # A generic type `typing.Union[X, ...]` for the C++ class std::variant<X, ...>.
-Union = _Generic("Union", typing.Union.__getitem__, None)
+Union = _Generic("Union", _union_instantiator, None)


### PR DESCRIPTION
Towards #23592.

Unfortunately this is not testable in CI yet.  It can be manually tested by using #23612.  On that branch  `bazel run -- //tools/wheel:builder --python=314 0.0.0` makes it pretty far along, reaching the point of a "Mosek doesn't support Python 3.14" error during final testing. However if we revert this commit from that branch, then the same command crashes much earlier in the process with an error about `typing.Union`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23611)
<!-- Reviewable:end -->
