### PR TITLE
[systems] Fix IWYU for text_logging in integrator_base

### DIFF
--- a/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
+++ b/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
@@ -20,6 +20,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 #include "drake/examples/planar_gripper/planar_gripper_common.h"
 #include "drake/examples/planar_gripper/planar_gripper_lcm.h"
 #include "drake/lcm/drake_lcm.h"

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -6,6 +6,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"

--- a/planning/trajectory_optimization/test/direct_transcription_test.cc
+++ b/planning/trajectory_optimization/test/direct_transcription_test.cc
@@ -12,6 +12,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/autodiff.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"

--- a/systems/analysis/integrator_base.cc
+++ b/systems/analysis/integrator_base.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/analysis/integrator_base.h"
 
+#include "drake/common/text_logging.h"
+
 namespace drake {
 namespace systems {
 

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -11,7 +11,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/text_logging.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"

--- a/systems/analysis/monte_carlo.cc
+++ b/systems/analysis/monte_carlo.cc
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <thread>
 
+#include "drake/common/text_logging.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/system.h"
 

--- a/systems/analysis/radau_integrator.cc
+++ b/systems/analysis/radau_integrator.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/fmt_eigen.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace systems {

--- a/systems/analysis/test/simulator_gflags_main.cc
+++ b/systems/analysis/test/simulator_gflags_main.cc
@@ -1,5 +1,6 @@
 #include <gflags/gflags.h>
 
+#include "drake/common/text_logging.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/systems/analysis/simulator_config_functions.h"
 #include "drake/systems/analysis/simulator_gflags.h"

--- a/systems/sensors/test/rgbd_sensor_async_gl_test.cc
+++ b/systems/sensors/test/rgbd_sensor_async_gl_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/temp_directory.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/trajectories/piecewise_pose.h"
 #include "drake/geometry/render_gl/factory.h"
 #include "drake/multibody/parsing/parser.h"


### PR DESCRIPTION
This is work towards forbidding using `text_logging.h` in header files.

<!-- Reviewable:start -->
 ---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23633)
<!-- Reviewable:end -->
