### PR TITLE
[wheel] Depend on sqlite-devel for almalinux

### DIFF
--- a/tools/wheel/image/packages-almalinux
+++ b/tools/wheel/image/packages-almalinux
@@ -27,3 +27,4 @@ libXt-devel
 # Build dependencies (Python).
 openssl-devel
 xz
+sqlite-devel


### PR DESCRIPTION
Fixes #23636, which added (transitively) a dependency on `anysqlite`, which itself needs `sqlite-devel`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23637)
<!-- Reviewable:end -->
