### PR TITLE
[common] Move fmt_floating_point definition to cc file

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -2994,7 +2994,10 @@ Note:
 R"""(Returns ``fmt::to_string(x)`` but always with at least one digit after
 the decimal point. Different versions of fmt disagree on whether to
 omit the trailing ".0" when formatting integer-valued floating-point
-numbers.)""";
+numbers.
+
+Template parameter ``T``:
+    must be either ``float`` or ``double``.)""";
     } fmt_floating_point;
     // Symbol: drake::fmt_runtime
     struct /* fmt_runtime */ {

--- a/common/fmt.cc
+++ b/common/fmt.cc
@@ -2,6 +2,17 @@
 
 namespace drake {
 
+template <typename T>
+std::string fmt_floating_point(T x)
+  requires(std::is_same_v<T, float> || std::is_same_v<T, double>)
+{
+  std::string result = fmt::format("{:#}", x);
+  if (result.back() == '.') {
+    result.push_back('0');
+  }
+  return result;
+}
+
 // We can simplify this after we drop support for Ubuntu 22.04 Jammy.
 std::string fmt_debug_string(std::string_view x) {
 #if FMT_VERSION >= 90000
@@ -45,5 +56,8 @@ std::string fmt_debug_string(std::string_view x) {
   return result;
 #endif
 }
+
+template std::string fmt_floating_point<float>(float);
+template std::string fmt_floating_point<double>(double);
 
 }  // namespace drake

--- a/common/fmt.h
+++ b/common/fmt.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #include <fmt/format.h>
 
@@ -32,9 +33,20 @@ inline auto fmt_runtime(std::string_view s) {
 
 /** Returns `fmt::to_string(x)` but always with at least one digit after the
 decimal point. Different versions of fmt disagree on whether to omit the
-trailing ".0" when formatting integer-valued floating-point numbers. */
+trailing ".0" when formatting integer-valued floating-point numbers.
+@tparam T must be either `float` or `double`. */
 template <typename T>
-std::string fmt_floating_point(T x) {
+std::string fmt_floating_point(T x)
+  requires(std::is_same_v<T, float> || std::is_same_v<T, double>);
+
+template <typename T>
+[[deprecated(
+    "\nDRAKE DEPRECATED: The fmt_floating_point function now only allows "
+    "'float' and 'double' as template arguments; other types are deprecated.\n"
+    "The deprecated code will be removed from Drake on or after 2026-02-01.")]]
+std::string fmt_floating_point(T x)
+  requires(!(std::is_same_v<T, float> || std::is_same_v<T, double>))
+{
   std::string result = fmt::format("{:#}", x);
   if (result.back() == '.') {
     result.push_back('0');

--- a/common/test/fmt_test.cc
+++ b/common/test/fmt_test.cc
@@ -79,6 +79,14 @@ GTEST_TEST(FmtTest, FloatingPoint) {
   EXPECT_EQ(fmt_floating_point(1.0f), "1.0");
 }
 
+GTEST_TEST(FmtTest, FloatingPointDeprecated) {
+  const long double high_resolution_one = 1;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(fmt_floating_point(high_resolution_one), "1.0");
+#pragma GCC diagnostic pop
+}
+
 GTEST_TEST(FmtTest, DebugString) {
   // We'll use these named fmt args to help make our expected values clear.
   fmt::dynamic_format_arg_store<fmt::format_context> args;


### PR DESCRIPTION
It does not meet our style guide requirements for inline.

Towards #19229.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23638)
<!-- Reviewable:end -->
