### PR TITLE
[common] Fold drake_throw.h into drake_assert.h

### DIFF
--- a/bindings/pydrake/autodiffutils/autodiffutils_py_everything.cc
+++ b/bindings/pydrake/autodiffutils/autodiffutils_py_everything.cc
@@ -6,7 +6,7 @@
 #include "drake/bindings/pydrake/autodiffutils/autodiffutils_py.h"
 #include "drake/bindings/pydrake/math_operators_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 

--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -8,8 +8,8 @@
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_assertion_error.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {

--- a/bindings/pydrake/common/ref_cycle_pybind.cc
+++ b/bindings/pydrake/common/ref_cycle_pybind.cc
@@ -3,7 +3,6 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace pydrake {

--- a/bindings/pydrake/common/serialize_pybind.h
+++ b/bindings/pydrake/common/serialize_pybind.h
@@ -15,8 +15,8 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {

--- a/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
+++ b/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
@@ -1,7 +1,7 @@
 #include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 
 using Eigen::Isometry3d;

--- a/bindings/pydrake/common/test/text_logging_test_helpers_py.cc
+++ b/bindings/pydrake/common/test/text_logging_test_helpers_py.cc
@@ -6,7 +6,7 @@
 
 #include "pybind11/pybind11.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 
 namespace py = pybind11;

--- a/bindings/pydrake/common/value_pybind.h
+++ b/bindings/pydrake/common/value_pybind.h
@@ -11,7 +11,7 @@
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/value.h"
 
 namespace drake {

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -89,7 +89,7 @@ drake_cc_library(
 drake_cc_library(
     name = "essential",
     srcs = [
-        "drake_assert_and_throw.cc",
+        "drake_assert.cc",
         "drake_deprecated.cc",
         "text_logging.cc",
     ],

--- a/common/drake_assert.cc
+++ b/common/drake_assert.cc
@@ -1,8 +1,4 @@
-// This file contains the implementation of both drake_assert and drake_throw.
-/* clang-format off to disable clang-format-includes */
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
-/* clang-format on */
 
 #include <atomic>
 #include <cstdlib>

--- a/common/drake_assert.h
+++ b/common/drake_assert.h
@@ -86,6 +86,9 @@
 
 namespace drake {
 namespace internal {
+// Throw an error message.
+[[noreturn]] void Throw(const char* condition, const char* func,
+                        const char* file, int line);
 // Abort the program with an error message.
 [[noreturn]] void Abort(const char* condition, const char* func,
                         const char* file, int line);
@@ -163,5 +166,39 @@ constexpr bool kDrakeAssertIsDisarmed = true;
   static_assert(std::is_convertible_v<decltype(expression), void>, \
                 "Expression should be void.")
 #endif
+
+/// Provides a convenient wrapper to throw an exception when a condition is
+/// unmet.  This is similar to an assertion, but uses exceptions instead of
+/// `::abort()`, and cannot be disabled.
+///
+/// Evaluates `condition` and iff the value is false will throw an exception
+/// with a message showing at least the condition text, function name, file,
+/// and line.
+///
+/// The condition must not be a pointer, where we'd implicitly rely on its
+/// nullness. Instead, always write out "!= nullptr" to be precise.
+///
+/// Correct: `DRAKE_THROW_UNLESS(foo != nullptr);`
+/// Incorrect: `DRAKE_THROW_UNLESS(foo);`
+///
+/// Because this macro is intended to provide a useful exception message to
+/// users, we should err on the side of extra detail about the failure. The
+/// meaning of "foo" isolated within error message text does not make it
+/// clear that a null pointer is the proximate cause of the problem.
+#define DRAKE_THROW_UNLESS(condition)                                         \
+  do {                                                                        \
+    typedef ::drake::assert::ConditionTraits<                                 \
+        typename std::remove_cv_t<decltype(condition)>>                       \
+        Trait;                                                                \
+    static_assert(Trait::is_valid, "Condition should be bool-convertible.");  \
+    static_assert(                                                            \
+        !std::is_pointer_v<decltype(condition)>,                              \
+        "When using DRAKE_THROW_UNLESS on a raw pointer, always write out "   \
+        "DRAKE_THROW_UNLESS(foo != nullptr), do not write DRAKE_THROW_UNLESS" \
+        "(foo) and rely on implicit pointer-to-bool conversion.");            \
+    if (!Trait::Evaluate(condition)) {                                        \
+      ::drake::internal::Throw(#condition, __func__, __FILE__, __LINE__);     \
+    }                                                                         \
+  } while (0)
 
 #endif  // DRAKE_DOXYGEN_CXX

--- a/common/drake_bool.h
+++ b/common/drake_bool.h
@@ -5,7 +5,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/double_overloads.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 

--- a/common/drake_deprecated.cc
+++ b/common/drake_deprecated.cc
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <stdexcept>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {

--- a/common/drake_throw.h
+++ b/common/drake_throw.h
@@ -1,48 +1,7 @@
 #pragma once
 
-#include <type_traits>
-
 #include "drake/common/drake_assert.h"
 
-/// @file
-/// Provides a convenient wrapper to throw an exception when a condition is
-/// unmet.  This is similar to an assertion, but uses exceptions instead of
-/// `::abort()`, and cannot be disabled.
-
-namespace drake {
-namespace internal {
-// Throw an error message.
-[[noreturn]] void Throw(const char* condition, const char* func,
-                        const char* file, int line);
-}  // namespace internal
-}  // namespace drake
-
-/// Evaluates @p condition and iff the value is false will throw an exception
-/// with a message showing at least the condition text, function name, file,
-/// and line.
-///
-/// The condition must not be a pointer, where we'd implicitly rely on its
-/// nullness. Instead, always write out "!= nullptr" to be precise.
-///
-/// Correct: `DRAKE_THROW_UNLESS(foo != nullptr);`
-/// Incorrect: `DRAKE_THROW_UNLESS(foo);`
-///
-/// Because this macro is intended to provide a useful exception message to
-/// users, we should err on the side of extra detail about the failure. The
-/// meaning of "foo" isolated within error message text does not make it
-/// clear that a null pointer is the proximate cause of the problem.
-#define DRAKE_THROW_UNLESS(condition)                                         \
-  do {                                                                        \
-    typedef ::drake::assert::ConditionTraits<                                 \
-        typename std::remove_cv_t<decltype(condition)>>                       \
-        Trait;                                                                \
-    static_assert(Trait::is_valid, "Condition should be bool-convertible.");  \
-    static_assert(                                                            \
-        !std::is_pointer_v<decltype(condition)>,                              \
-        "When using DRAKE_THROW_UNLESS on a raw pointer, always write out "   \
-        "DRAKE_THROW_UNLESS(foo != nullptr), do not write DRAKE_THROW_UNLESS" \
-        "(foo) and rely on implicit pointer-to-bool conversion.");            \
-    if (!Trait::Evaluate(condition)) {                                        \
-      ::drake::internal::Throw(#condition, __func__, __FILE__, __LINE__);     \
-    }                                                                         \
-  } while (0)
+// This file provides backwards compatiblity with an old include path. In new
+// code, please include drake_assert.h instead. TODO(jwnimmer-tri) On or after
+// 2027-01-01, schedule this file for removal (with deprecation).

--- a/common/find_loaded_library.cc
+++ b/common/find_loaded_library.cc
@@ -2,7 +2,7 @@
 
 #include <filesystem>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 // clang-format off
 #ifdef __APPLE__

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -9,8 +9,8 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_marker.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/find_loaded_library.h"
 #include "drake/common/find_runfiles.h"
 #include "drake/common/never_destroyed.h"

--- a/common/hash.h
+++ b/common/hash.h
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 /// @defgroup hash_append hash_append generic hashing
 /// @{

--- a/common/identifier.h
+++ b/common/identifier.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <utility>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 

--- a/common/memory_file.cc
+++ b/common/memory_file.cc
@@ -6,7 +6,7 @@
 
 #include <fmt/format.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"
 
 namespace drake {

--- a/common/network_policy.cc
+++ b/common/network_policy.cc
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <cstdlib>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {

--- a/common/parallelism.h
+++ b/common/parallelism.h
@@ -3,8 +3,8 @@
 #include <optional>
 #include <string_view>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 

--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 using Eigen::Dynamic;
 using Eigen::Matrix;

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -15,7 +15,6 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/common/symbolic/expression.h"
 

--- a/common/proto/rpc_pipe_temp_directory.cc
+++ b/common/proto/rpc_pipe_temp_directory.cc
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <filesystem>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace common {

--- a/common/schema/rotation.cc
+++ b/common/schema/rotation.cc
@@ -1,6 +1,6 @@
 #include "drake/common/schema/rotation.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/overloaded.h"
 #include "drake/math/random_rotation.h"
 #include "drake/math/rotation_matrix.h"

--- a/common/schema/transform.cc
+++ b/common/schema/transform.cc
@@ -5,7 +5,6 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {

--- a/common/scope_exit.h
+++ b/common/scope_exit.h
@@ -3,8 +3,8 @@
 #include <functional>
 #include <utility>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 

--- a/common/sha256.cc
+++ b/common/sha256.cc
@@ -7,7 +7,6 @@
 #include <picosha2.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 

--- a/common/symbolic/expression/expression.h
+++ b/common/symbolic/expression/expression.h
@@ -25,7 +25,6 @@
 #include "drake/common/cond.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/dummy_value.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"

--- a/common/symbolic/expression/test/formula_test.cc
+++ b/common/symbolic/expression/test/formula_test.cc
@@ -18,7 +18,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/is_memcpy_movable.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"

--- a/common/temp_directory.cc
+++ b/common/temp_directory.cc
@@ -5,7 +5,7 @@
 #include <cstdlib>
 #include <filesystem>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 

--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -12,7 +12,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 

--- a/common/test/sha256_test.cc
+++ b/common/test/sha256_test.cc
@@ -5,7 +5,7 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/temp_directory.h"
 
 namespace drake {

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -5,9 +5,9 @@
 
 #include <Eigen/Sparse>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/name_value.h"
 #include "drake/common/trajectories/trajectory.h"

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -9,7 +9,6 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/unused.h"
 #include "drake/math/binomial_coefficient.h"
 #include "drake/math/matrix_util.h"

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -18,8 +18,8 @@
 #include <Eigen/Core>
 #include <fmt/format.h>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/name_value.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/string_unordered_set.h"

--- a/examples/acrobot/acrobot_plant.cc
+++ b/examples/acrobot/acrobot_plant.cc
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"

--- a/examples/pendulum/test/pendulum_geometry_test.cc
+++ b/examples/pendulum/test/pendulum_geometry_test.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/geometry/scene_graph.h"

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -23,8 +23,8 @@
 #include <fmt/ranges.h>
 #include <msgpack.hpp>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_export.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/network_policy.h"
 #include "drake/common/overloaded.h"

--- a/geometry/proximity/calc_signed_distance_to_surface_mesh.h
+++ b/geometry/proximity/calc_signed_distance_to_surface_mesh.h
@@ -7,8 +7,8 @@
 #include <variant>
 #include <vector>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/sorted_pair.h"
 #include "drake/common/ssize.h"
 #include "drake/geometry/proximity/bvh.h"

--- a/geometry/proximity/plane.h
+++ b/geometry/proximity/plane.h
@@ -2,8 +2,8 @@
 
 #include <limits>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_eigen.h"
 #include "drake/geometry/proximity/mesh_traits.h"

--- a/geometry/proximity/posed_half_space.h
+++ b/geometry/proximity/posed_half_space.h
@@ -2,8 +2,8 @@
 
 #include <limits>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/mesh_traits.h"
 #include "drake/geometry/proximity/plane.h"

--- a/geometry/render_gl/internal_loaders.cc
+++ b/geometry/render_gl/internal_loaders.cc
@@ -12,7 +12,7 @@
 
 #include <fmt/format.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/unused.h"
 
 namespace drake {

--- a/geometry/render_gl/internal_opengl_context.cc
+++ b/geometry/render_gl/internal_opengl_context.cc
@@ -14,7 +14,6 @@
 #include <vtkglad/include/glad/glx.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"

--- a/geometry/rgba.h
+++ b/geometry/rgba.h
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <optional>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/name_value.h"
 

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -9,7 +9,7 @@
 
 #include <fmt/format.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/overloaded.h"
 #include "drake/geometry/proximity/make_convex_hull_mesh_impl.h"

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -11,7 +11,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/network_policy.h"
 #include "drake/common/text_logging.h"
 

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -12,8 +12,8 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/lcm/lcm_messages.h"
 
 namespace drake {

--- a/lcm/lcm_messages.h
+++ b/lcm/lcm_messages.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <vector>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/nice_type_name.h"
 
 namespace drake {

--- a/manipulation/kinova_jaco/jaco_command_receiver.cc
+++ b/manipulation/kinova_jaco/jaco_command_receiver.cc
@@ -1,7 +1,6 @@
 #include "drake/manipulation/kinova_jaco/jaco_command_receiver.h"
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/text_logging.h"
 #include "drake/lcm/lcm_messages.h"
 

--- a/manipulation/kuka_iiwa/iiwa_command_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.cc
@@ -2,7 +2,7 @@
 
 #include <limits>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/lcm/lcm_messages.h"
 
 namespace drake {

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.cc
@@ -1,6 +1,6 @@
 #include "drake/manipulation/kuka_iiwa/iiwa_status_receiver.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace manipulation {

--- a/manipulation/util/move_ik_demo_base.cc
+++ b/manipulation/util/move_ik_demo_base.cc
@@ -2,7 +2,7 @@
 
 #include <utility>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/text_logging.h"
 #include "drake/manipulation/util/robot_plan_utils.h"

--- a/manipulation/util/moving_average_filter.cc
+++ b/manipulation/util/moving_average_filter.cc
@@ -1,6 +1,6 @@
 #include "drake/manipulation/util/moving_average_filter.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {

--- a/manipulation/util/stl2obj.cc
+++ b/manipulation/util/stl2obj.cc
@@ -6,7 +6,7 @@
 #include <vtkSTLReader.h>       // vtkIOGeometry
 #include <vtkTriangleFilter.h>  // vtkFiltersCore
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 
 DEFINE_string(input, "", "STL filename to read");

--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -13,7 +13,7 @@ Utilities for arithmetic on AutoDiffScalar. */
 #include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/autodiff.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
 

--- a/math/bspline_basis.h
+++ b/math/bspline_basis.h
@@ -6,7 +6,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/name_value.h"
 #include "drake/math/knot_vector_type.h"

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -4,7 +4,6 @@
 #include <Eigen/LU>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/systems/primitives/linear_system_internal.h"
 

--- a/math/fourth_order_tensor.h
+++ b/math/fourth_order_tensor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {

--- a/math/matrix_util.h
+++ b/math/matrix_util.h
@@ -13,7 +13,6 @@
 #include <Eigen/SparseCore>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -11,7 +11,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/hash.h"
 #include "drake/common/never_destroyed.h"

--- a/math/soft_min_max.cc
+++ b/math/soft_min_max.cc
@@ -4,7 +4,7 @@
 #include <cmath>
 
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace math {

--- a/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.cc
+++ b/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.cc
@@ -4,7 +4,7 @@
 
 #include <fmt/format.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/fmt_eigen.h"
 
 namespace drake {

--- a/multibody/contact_solvers/contact_solver.h
+++ b/multibody/contact_solvers/contact_solver.h
@@ -6,7 +6,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
 #include "drake/multibody/contact_solvers/point_contact_data.h"

--- a/multibody/contact_solvers/newton_with_bisection.cc
+++ b/multibody/contact_solvers/newton_with_bisection.cc
@@ -3,7 +3,7 @@
 #include <functional>
 #include <utility>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {

--- a/multibody/contact_solvers/newton_with_bisection.h
+++ b/multibody/contact_solvers/newton_with_bisection.h
@@ -4,8 +4,8 @@
 #include <functional>
 #include <utility>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/contact_solvers/sap/partial_permutation.cc
+++ b/multibody/contact_solvers/sap/partial_permutation.cc
@@ -5,7 +5,7 @@
 
 #include <fmt/format.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/contact_solvers/sap/partial_permutation.h
+++ b/multibody/contact_solvers/sap/partial_permutation.h
@@ -2,8 +2,8 @@
 
 #include <vector>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/contact_solvers/sap/sap_contact_problem.cc
+++ b/multibody/contact_solvers/sap/sap_contact_problem.cc
@@ -3,7 +3,7 @@
 #include <utility>
 
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/ssize.h"
 #include "drake/math/autodiff_gradient.h"

--- a/multibody/fem/damping_model.cc
+++ b/multibody/fem/damping_model.cc
@@ -1,6 +1,6 @@
 #include "drake/multibody/fem/damping_model.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -17,7 +17,6 @@
 #include <tinyxml2.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/find_cache.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/find_runfiles.h"

--- a/multibody/plant/discrete_contact_data.h
+++ b/multibody/plant/discrete_contact_data.h
@@ -3,8 +3,8 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/plant/distance_constraint_params.cc
+++ b/multibody/plant/distance_constraint_params.cc
@@ -1,6 +1,6 @@
 #include "drake/multibody/plant/distance_constraint_params.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -10,7 +10,7 @@
 
 #include <fmt/ranges.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/ssize.h"
 #include "drake/common/text_logging.h"
 #include "drake/geometry/geometry_frame.h"

--- a/multibody/plant/tamsi_solver.h
+++ b/multibody/plant/tamsi_solver.h
@@ -7,7 +7,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {

--- a/multibody/topology/link_joint_graph.cc
+++ b/multibody/topology/link_joint_graph.cc
@@ -9,7 +9,6 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/string_unordered_map.h"
 #include "drake/multibody/topology/forest.h"
 #include "drake/multibody/topology/graph.h"

--- a/multibody/topology/spanning_forest_debug.cc
+++ b/multibody/topology/spanning_forest_debug.cc
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/multibody/topology/forest.h"
 
 namespace drake {

--- a/multibody/tree/element_collection.h
+++ b/multibody/tree/element_collection.h
@@ -6,7 +6,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/ssize.h"
 #include "drake/common/string_unordered_map.h"
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -12,7 +12,6 @@
 #include <fmt/ranges.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
 #include "drake/math/rigid_transform.h"

--- a/perception/depth_image_to_point_cloud.cc
+++ b/perception/depth_image_to_point_cloud.cc
@@ -3,7 +3,7 @@
 #include <limits>
 #include <optional>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/never_destroyed.h"
 
 using drake::AbstractValue;

--- a/perception/point_cloud.cc
+++ b/perception/point_cloud.cc
@@ -13,7 +13,6 @@
 #include <nanoflann.hpp>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/unused.h"
 
 using common_robotics_utilities::voxel_grid::DSHVGSetType;

--- a/perception/point_cloud_to_lcm.cc
+++ b/perception/point_cloud_to_lcm.cc
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <utility>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/lcmt_point_cloud.hpp"
 #include "drake/perception/point_cloud.h"
 

--- a/planning/body_shape_description.cc
+++ b/planning/body_shape_description.cc
@@ -1,6 +1,6 @@
 #include "drake/planning/body_shape_description.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/scene_graph.h"
 

--- a/planning/collision_checker.cc
+++ b/planning/collision_checker.cc
@@ -17,7 +17,7 @@
 #include <common_robotics_utilities/print.hpp>
 #include <common_robotics_utilities/utility.hpp>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/text_logging.h"
 #include "drake/planning/linear_distance_and_interpolation_provider.h"

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/parallelism.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/planning/body_shape_description.h"

--- a/planning/dev/voxel_self_filter_internal.h
+++ b/planning/dev/voxel_self_filter_internal.h
@@ -9,7 +9,7 @@
 #include <common_robotics_utilities/parallelism.hpp>
 #include <common_robotics_utilities/voxel_grid.hpp>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/parallelism.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/planning/dev/sphere_robot_model_collision_checker.h"

--- a/planning/distance_and_interpolation_provider.cc
+++ b/planning/distance_and_interpolation_provider.cc
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace planning {

--- a/planning/graph_algorithms/max_clique_solver_base.cc
+++ b/planning/graph_algorithms/max_clique_solver_base.cc
@@ -1,6 +1,6 @@
 #include "drake/planning/graph_algorithms/max_clique_solver_base.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace planning {

--- a/planning/graph_algorithms/min_clique_cover_solver_base.cc
+++ b/planning/graph_algorithms/min_clique_cover_solver_base.cc
@@ -1,6 +1,6 @@
 #include "drake/planning/graph_algorithms/min_clique_cover_solver_base.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace planning {

--- a/planning/graph_algorithms/min_clique_cover_solver_base.h
+++ b/planning/graph_algorithms/min_clique_cover_solver_base.h
@@ -4,7 +4,7 @@
 
 #include <Eigen/Sparse>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {

--- a/planning/joint_limits.cc
+++ b/planning/joint_limits.cc
@@ -4,7 +4,7 @@
 
 #include <fmt/format.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 #include "drake/multibody/plant/multibody_plant.h"
 

--- a/planning/linear_distance_and_interpolation_provider.cc
+++ b/planning/linear_distance_and_interpolation_provider.cc
@@ -5,7 +5,7 @@
 #include <common_robotics_utilities/math.hpp>
 #include <fmt/format.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/multibody/tree/quaternion_floating_joint.h"
 
 namespace drake {

--- a/planning/robot_clearance.cc
+++ b/planning/robot_clearance.cc
@@ -1,6 +1,6 @@
 #include "drake/planning/robot_clearance.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace planning {

--- a/planning/robot_diagram_builder.cc
+++ b/planning/robot_diagram_builder.cc
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <vector>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace planning {

--- a/solvers/evaluator_base.cc
+++ b/solvers/evaluator_base.cc
@@ -2,7 +2,7 @@
 
 #include <set>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/symbolic/latex.h"
 

--- a/systems/analysis/simulator_config_functions.cc
+++ b/systems/analysis/simulator_config_functions.cc
@@ -9,7 +9,7 @@
 
 #include <fmt/format.h>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/unused.h"

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -4,7 +4,7 @@
 #include <utility>
 
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_config_functions.h"

--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -5,7 +5,7 @@
 #include <utility>
 
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/dummy_value.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/vector_base.h"

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -6,7 +6,7 @@
 #include <utility>
 
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/fmt.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/context_base.h"

--- a/systems/framework/continuous_state.h
+++ b/systems/framework/continuous_state.h
@@ -5,7 +5,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/scalar_conversion_traits.h"
 #include "drake/systems/framework/vector_base.h"

--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -9,7 +9,6 @@
 #include <fmt/ranges.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace systems {

--- a/systems/framework/discrete_values.h
+++ b/systems/framework/discrete_values.h
@@ -9,7 +9,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/framework_common.h"

--- a/systems/framework/subvector.h
+++ b/systems/framework/subvector.h
@@ -5,8 +5,8 @@
 #include <fmt/format.h>
 
 #include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/systems/framework/vector_base.h"
 
 namespace drake {

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -17,7 +17,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/common/random.h"

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -11,7 +11,7 @@
 #include <variant>
 #include <vector>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/ssize.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/abstract_value_cloner.h"

--- a/systems/framework/system_constraint.h
+++ b/systems/framework/system_constraint.h
@@ -10,7 +10,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/type_safe_index.h"

--- a/systems/framework/test_utilities/my_vector.h
+++ b/systems/framework/test_utilities/my_vector.h
@@ -3,8 +3,8 @@
 #include <memory>
 #include <utility>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/systems/framework/basic_vector.h"

--- a/systems/framework/value_checker.h
+++ b/systems/framework/value_checker.h
@@ -4,7 +4,7 @@
 #include <stdexcept>
 #include <string>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/basic_vector.h"

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -10,7 +10,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/fmt_ostream.h"

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -9,7 +9,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/unused.h"

--- a/systems/lcm/lcm_buses.cc
+++ b/systems/lcm/lcm_buses.cc
@@ -6,7 +6,6 @@
 #include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 using drake::lcm::DrakeLcmInterface;
 

--- a/systems/lcm/lcm_config_functions.cc
+++ b/systems/lcm/lcm_config_functions.cc
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/lcm/lcm_interface_system.h"

--- a/systems/lcm/lcm_log_playback_system.cc
+++ b/systems/lcm/lcm_log_playback_system.cc
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <memory>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace systems {

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -5,8 +5,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/hash.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/framework/event.h"

--- a/systems/lcm/lcm_scope_system.cc
+++ b/systems/lcm/lcm_scope_system.cc
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/lcmt_scope.hpp"
 
 namespace drake {

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -6,8 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/leaf_system.h"

--- a/systems/lcm/serializer.h
+++ b/systems/lcm/serializer.h
@@ -6,7 +6,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/value.h"
 
 namespace drake {

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -8,7 +8,6 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic/decompose.h"
 #include "drake/systems/framework/basic_vector.h"

--- a/systems/primitives/constant_vector_source.h
+++ b/systems/primitives/constant_vector_source.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"

--- a/systems/primitives/shared_pointer_system.h
+++ b/systems/primitives/shared_pointer_system.h
@@ -5,7 +5,7 @@
 #include <utility>
 
 #include "drake/common/default_scalars.h"
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 

--- a/systems/primitives/sine.cc
+++ b/systems/primitives/sine.cc
@@ -1,6 +1,6 @@
 #include "drake/systems/primitives/sine.h"
 
-#include "drake/common/drake_throw.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/fmt_eigen.h"
 
 namespace drake {

--- a/systems/sensors/image.h
+++ b/systems/sensors/image.h
@@ -7,7 +7,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_throw.h"
 #include "drake/common/reset_after_move.h"
 #include "drake/systems/sensors/pixel_types.h"
 


### PR DESCRIPTION
This will simplify ongoing maintenance, as the two continue to share more code and co-evolve.

Towards #19229 and #7827.

It's also nicer UX to be able to call both `DRAKE_DEMAND` and `DRAKE_THROW_UNLESS` from a single include -- less typing in general, and less churn if we e.g. respell DEMAND to THROW.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23639)
<!-- Reviewable:end -->
