### PR TITLE
[workspace] Deprecate the `@x11` external for removal

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -82,15 +82,13 @@ single_version_override(
 # default but can be changed using the Bazel flags at @drake//tools/flags.
 # For first-party Bazel builds (by Drake Developers), the non-module flavor
 # is used by default.
-#
-# TODO(jwnimmer-tri) There is a "libx11" module in BCR, but I haven't been able
-# to get it to work yet, so for the moment we don't offer it as a module option.
 
 bazel_dep(name = "glib", version = "2.82.2.bcr.5", repo_name = "module_glib")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.7", repo_name = "module_zlib")
 
-# Add additional modules we use as tools (not runtime dependencies).
+# Add additional modules we use at build-time (not runtime dependencies).
 
+bazel_dep(name = "libx11", version = "1.8.12.bcr.3")
 bazel_dep(name = "nasm", version = "2.16.03.bcr.2")
 bazel_dep(name = "patchelf", version = "0.18.0")
 bazel_dep(name = "toolchains_llvm", version = "1.5.0")
@@ -133,7 +131,6 @@ use_repo(
     "glib",
     "lapack",
     "opencl",
-    "x11",
     "zlib",
     #
     # First-party dependencies (i.e., drake-maintained).
@@ -165,6 +162,10 @@ use_repo(
     # dedicated commit.
     #
     "lcm",
+    #
+    # Deprecated for removal on 2026-02-01.
+    #
+    "x11",
 )
 
 # Load Java dependencies.
@@ -292,7 +293,6 @@ use_repo(
     "pkgconfig_lapack_internal",
     "pkgconfig_opencl_internal",
     "pkgconfig_spdlog_internal",
-    "pkgconfig_x11_internal",
     "poisson_disk_sampling_internal",
     "qdldl_internal",
     "qhull_internal",
@@ -352,6 +352,10 @@ use_repo(
     #
     "doxygen_internal",
     "styleguide_internal",
+    #
+    # Deprecated for removal on 2026-02-01.
+    #
+    "pkgconfig_x11_internal",
 )
 
 crate_universe = use_extension(

--- a/setup/ubuntu/source_distribution/packages-jammy.txt
+++ b/setup/ubuntu/source_distribution/packages-jammy.txt
@@ -5,7 +5,6 @@ libglib2.0-dev
 libglx-dev
 liblapack-dev
 libopengl-dev
-libx11-dev
 ocl-icd-opencl-dev
 opencl-headers
 patch

--- a/setup/ubuntu/source_distribution/packages-noble.txt
+++ b/setup/ubuntu/source_distribution/packages-noble.txt
@@ -5,7 +5,6 @@ libglib2.0-dev
 libglx-dev
 liblapack-dev
 libopengl-dev
-libx11-dev
 ocl-icd-opencl-dev
 opencl-headers
 patch

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -226,7 +226,6 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "libjpeg_turbo_internal",
     "opencl",
     "spdlog",
-    "x11",
     "zlib",
     # Remove with resource_tool deprecation 2026-02-01.
     "gflags",

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -186,8 +186,9 @@ def _drake_dep_repositories_impl(module_ctx):
         "lapack",
         "opencl",
         "spdlog",
-        "x11",
         "zlib",
+        # Deprecated for removal on 2026-02-01.
+        "x11",
     ]
     for name in ALIAS_REPOSITORIES:
         actual = "@drake//tools/workspace/" + name

--- a/tools/workspace/pkgconfig_x11_internal/repository.bzl
+++ b/tools/workspace/pkgconfig_x11_internal/repository.bzl
@@ -1,5 +1,7 @@
 load("//tools/workspace:pkg_config.bzl", "setup_pkg_config_repository")
 
+# Deprecated for removal on 2026-02-01.
+
 def _impl(repo_ctx):
     # N.B. We do not check the return value here for errors. Sometimes this
     # rule is evaluated on systems where pkg-config will fail but where the

--- a/tools/workspace/vtk_internal/BUILD.bazel
+++ b/tools/workspace/vtk_internal/BUILD.bazel
@@ -1,6 +1,7 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
     "//tools/skylark:drake_cc.bzl",
+    "cc_nolink_library",
     "drake_cc_googletest",
     "drake_cc_library",
 )
@@ -11,6 +12,12 @@ exports_files(
     ] + glob([
         "gen/**",
     ]),
+)
+
+cc_nolink_library(
+    name = "x11_hdrs",
+    visibility = ["@vtk_internal//:__pkg__"],
+    deps = ["@libx11"],
 )
 
 drake_cc_library(

--- a/tools/workspace/vtk_internal/settings.bzl
+++ b/tools/workspace/vtk_internal/settings.bzl
@@ -99,7 +99,7 @@ MODULE_SETTINGS = {
         "deps_extra": select({
             ":osx": [],
             "//conditions:default": [
-                "@drake//tools/workspace/x11:hdrs",
+                "@drake//tools/workspace/vtk_internal:x11_hdrs",
             ],
         }),
     },

--- a/tools/workspace/x11/BUILD.bazel
+++ b/tools/workspace/x11/BUILD.bazel
@@ -1,31 +1,11 @@
 load("//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_cc.bzl", "cc_nolink_library")
 
-# ---- Logic for choosing which x11 to use. ---
-
-# TODO(jwnimmer-tri) There is a "libx11" module in BCR, but I haven't been able
-# to get it to work yet, so for the moment we don't offer it as an option.
-
+# Deprecated for removal on 2026-02-01.
 alias(
     name = "x11",
     actual = "@pkgconfig_x11_internal",
     visibility = ["//visibility:public"],
-)
-
-cc_nolink_library(
-    name = "hdrs",
-    visibility = ["@vtk_internal//:__pkg__"],
-    deps = ["@x11"],
-)
-
-# ---- Logic for installing x11-related files. ---
-
-install(
-    name = "install",
-    visibility = ["//tools/workspace:__pkg__"],
-    # There's nothing to do here. We aren't redistributing X11, so we don't
-    # need to install its license.
 )
 
 add_lint_tests()


### PR DESCRIPTION
With #23604 behind us, we don't need to depend on host X11 at built-time anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23641)
<!-- Reviewable:end -->
