### PR TITLE
[planning] Replace DofMask vector-of-bool with a dynamic bitset

### DIFF
--- a/bindings/generated_docstrings/planning.h
+++ b/bindings/generated_docstrings/planning.h
@@ -17,6 +17,7 @@
 // #include "drake/planning/collision_checker.h"
 // #include "drake/planning/collision_checker_context.h"
 // #include "drake/planning/collision_checker_params.h"
+// #include "drake/planning/counted_dynamic_bitset.h"
 // #include "drake/planning/distance_and_interpolation_provider.h"
 // #include "drake/planning/dof_mask.h"
 // #include "drake/planning/edge_measure.h"

--- a/planning/BUILD.bazel
+++ b/planning/BUILD.bazel
@@ -109,8 +109,14 @@ drake_cc_library(
 
 drake_cc_library(
     name = "dof_mask",
-    srcs = ["dof_mask.cc"],
-    hdrs = ["dof_mask.h"],
+    srcs = [
+        "counted_dynamic_bitset.cc",
+        "dof_mask.cc",
+    ],
+    hdrs = [
+        "counted_dynamic_bitset.h",
+        "dof_mask.h",
+    ],
     deps = [
         "//multibody/plant",
     ],

--- a/planning/counted_dynamic_bitset.cc
+++ b/planning/counted_dynamic_bitset.cc
@@ -1,0 +1,180 @@
+#include "drake/planning/counted_dynamic_bitset.h"
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+
+namespace drake {
+namespace planning {
+namespace internal {
+
+namespace {
+
+// Copies a span of bools into a new unique_ptr<bool[]>.
+std::unique_ptr<bool[]> MakeBoolArray(std::span<const bool> values) {
+  // TODO(jwnimmer-tri) Use make_unique_for_overwrite once we have >= C++23.
+  std::unique_ptr<bool[]> result(new bool[values.size()]);
+  std::copy(values.begin(), values.end(), result.get());
+  return result;
+}
+
+// Broadcasts a single bool into a new unique_ptr<bool[]>.
+// @pre size >= 0
+std::unique_ptr<bool[]> MakeBoolArray(int size, bool value = false) {
+  DRAKE_ASSERT(size >= 0);
+  // TODO(jwnimmer-tri) Use make_unique_for_overwrite once we have >= C++23.
+  std::unique_ptr<bool[]> result(new bool[size]);
+  std::fill_n(result.get(), size, value);
+  return result;
+}
+
+// Copies the bool array at `other` into its complement (negation).
+// @pre size >= 0
+std::unique_ptr<bool[]> MakeComplement(std::span<const bool> other) {
+  // TODO(jwnimmer-tri) Use make_unique_for_overwrite once we have >= C++23.
+  std::unique_ptr<bool[]> result(new bool[other.size()]);
+  for (size_t i = 0; i < other.size(); ++i) {
+    result[i] = !other[i];
+  }
+  return result;
+}
+
+// The template argument for Merge(), immediately below.
+enum BinaryOperator {
+  kUnion,
+  kIntersect,
+  kSubtract,
+};
+
+// Returns a new bool array computed as a binary operator over the equally-
+// sized `a` and `b` input arrays.
+// @pre size >= 0
+template <BinaryOperator operation>
+__attribute__((noinline)) std::pair<std::unique_ptr<bool[]>, int /* count */>
+Merge(int size, const bool* a, const bool* b) {
+  DRAKE_ASSERT(size >= 0);
+  if (!(size >= 0)) __builtin_unreachable();
+  if (size == 0) {
+    return std::make_pair(/* buffer = */ std::unique_ptr<bool[]>{},
+                          /* count = */ 0);
+  }
+  // TODO(jwnimmer-tri) Use make_unique_for_overwrite once we have >= C++23.
+  std::unique_ptr<bool[]> buffer(new bool[size]);
+  int count = 0;
+  for (int i = 0; i < size; ++i) {
+    int bit;
+    if constexpr (operation == kUnion) {
+      bit = int{a[i]} | int{b[i]};
+    } else if constexpr (operation == kIntersect) {
+      bit = int{a[i]} & int{b[i]};
+    } else if constexpr (operation == kSubtract) {
+      bit = int{a[i]} & ~int{b[i]};
+    } else {
+      DRAKE_UNREACHABLE();
+    }
+    buffer[i] = (bit != 0);
+    count += bit;
+  }
+  return std::make_pair(std::move(buffer), count);
+}
+
+}  // namespace
+
+CountedDynamicBitset::CountedDynamicBitset(int size, bool value) {
+  DRAKE_THROW_UNLESS(size >= 0);
+  size_ = size;
+  count_ = value ? size : 0;
+  if (size_ > 0) {
+    buffer_ = MakeBoolArray(size, value);
+  }
+  CheckInvariants();
+}
+
+CountedDynamicBitset::CountedDynamicBitset(std::span<const bool> values) {
+  size_ = ssize(values);
+  if (size_ > 0) {
+    buffer_ = MakeBoolArray(values);
+    count_ = std::count(values.begin(), values.end(), true);
+  }
+  CheckInvariants();
+}
+
+// We can't use the defaulted implementation because of our unique_ptr member.
+// However, for simplicity we can just delegate to the copy-assignment operator.
+CountedDynamicBitset::CountedDynamicBitset(const CountedDynamicBitset& other) {
+  *this = other;
+  CheckInvariants();
+}
+
+// We can't use the defaulted implementation because of our unique_ptr member.
+CountedDynamicBitset& CountedDynamicBitset::operator=(
+    const CountedDynamicBitset& other) {
+  if (this == &other) [[unlikely]] {
+    return *this;
+  }
+  size_ = other.size();
+  count_ = other.count();
+  if (size_ > 0) {
+    buffer_ = MakeBoolArray(other.as_span());
+  } else {
+    buffer_.reset();
+  }
+  CheckInvariants();
+  return *this;
+}
+
+CountedDynamicBitset CountedDynamicBitset::Complement() const {
+  CountedDynamicBitset result(
+      /* size = */ size(),
+      /* count = */ size() - count());
+  if (size() > 0) {
+    result.buffer_ = MakeComplement(this->as_span());
+  }
+  result.CheckInvariants();
+  return result;
+}
+
+CountedDynamicBitset CountedDynamicBitset::Union(
+    const CountedDynamicBitset& other) const {
+  DRAKE_ASSERT(this->size() == other.size());
+  CountedDynamicBitset result(size(), /* count = */ 0);
+  if (size() > 0) {
+    std::tie(result.buffer_, result.count_) =
+        Merge<kUnion>(size(), buffer_.get(), other.buffer_.get());
+  }
+  result.CheckInvariants();
+  return result;
+}
+
+CountedDynamicBitset CountedDynamicBitset::Intersect(
+    const CountedDynamicBitset& other) const {
+  DRAKE_ASSERT(this->size() == other.size());
+  CountedDynamicBitset result(size(), /* count = */ 0);
+  std::tie(result.buffer_, result.count_) =
+      Merge<kIntersect>(size(), buffer_.get(), other.buffer_.get());
+  result.CheckInvariants();
+  return result;
+}
+
+CountedDynamicBitset CountedDynamicBitset::Subtract(
+    const CountedDynamicBitset& other) const {
+  DRAKE_ASSERT(this->size() == other.size());
+  CountedDynamicBitset result(size(), /* count = */ 0);
+  std::tie(result.buffer_, result.count_) =
+      Merge<kSubtract>(size(), buffer_.get(), other.buffer_.get());
+  result.CheckInvariants();
+  return result;
+}
+
+bool CountedDynamicBitset::operator==(const CountedDynamicBitset& other) const {
+  if (this->size() != other.size()) {
+    return false;
+  }
+  bool result = (std::memcmp(buffer_.get(), other.buffer_.get(), size()) == 0);
+  DRAKE_ASSERT((result == false) || (this->count() == other.count()));
+  return result;
+}
+
+}  // namespace internal
+}  // namespace planning
+}  // namespace drake

--- a/planning/counted_dynamic_bitset.h
+++ b/planning/counted_dynamic_bitset.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <memory>
+#include <span>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/reset_after_move.h"
+
+namespace drake {
+namespace planning {
+namespace internal {
+
+/* CountedDynamicBitset represents something like a `std::array<bool, N>` but
+with a few customizations:
+- the container size is determined at construction time instead of compile time;
+- the count of values set to `true` is pre-computed and stored;
+- convenient set-logic operations (complement, union, intersect, subtract). */
+class CountedDynamicBitset {
+ public:
+  DRAKE_DECLARE_COPY_AND_MOVE_AND_ASSIGN(CountedDynamicBitset);
+
+  /* Default constructor. Creates a bitset with size() = count() = 0. */
+  CountedDynamicBitset() = default;
+
+  /* Homogenous constructor. Creates a bitset with the given `size` where all
+  values are set to the given `value`.
+  @throws std::exception unless size >= 0 */
+  CountedDynamicBitset(int size, bool value);
+
+  /* Span constructor. Creates a bitset from a span of bools. */
+  explicit CountedDynamicBitset(std::span<const bool> values);
+
+  /* Returns this bitset's size. */
+  int size() const { return size_; }
+
+  /* Returns this bitset's count of values set to `true`. */
+  int count() const { return count_; }
+
+  /* Compares two bitsets for equality. Note that `other.size()` may differ from
+  `this->size()`; such comparisons will report as not equal. */
+  bool operator==(const CountedDynamicBitset& other) const;
+
+  /* Returns the value at the given `index`.
+  @pre `index` is in the range [0, size()). */
+  bool operator[](int index) const {
+    DRAKE_ASSERT(index >= 0 && index < size_);
+    return buffer_[index];
+  }
+
+  /* Returns a new bitset with `true` values replaced with `false` and vice
+  versa. The size is unchanged. */
+  [[nodiscard]] CountedDynamicBitset Complement() const;
+
+  /* Returns a new bitset with the union of `this` and `other`. The i'th bit is
+  `true` iff that bit in either `this` or `other` is `true`.
+  @pre `size() == other.size()`. */
+  [[nodiscard]] CountedDynamicBitset Union(
+      const CountedDynamicBitset& other) const;
+
+  /* Returns a new bitset with the intersection of `this` and `other`. The i'th
+  bit is `true` iff that bit in both `this` and `other` are `true`.
+  @pre `size() == other.size()`. */
+  [[nodiscard]] CountedDynamicBitset Intersect(
+      const CountedDynamicBitset& other) const;
+
+  /* Returns a new bitset with the set difference of `this` and `other`. The
+  i'th bit is `true` iff that bit is `true` in `this` and `false` in `other`.
+  @pre `size() == other.size()`. */
+  [[nodiscard]] CountedDynamicBitset Subtract(
+      const CountedDynamicBitset& other) const;
+
+ private:
+  CountedDynamicBitset(int size, int count) : size_(size), count_(count) {}
+
+  /* Returns a view of `buffer_`.
+  @pre buffer != nullptr */
+  std::span<const bool> as_span() const {
+    return std::span<const bool>(buffer_.get(), size_);
+  }
+
+  void CheckInvariants() {
+    DRAKE_ASSERT(size_ >= 0);
+    DRAKE_ASSERT(count_ <= size_);
+    DRAKE_ASSERT((buffer_.get() == nullptr) == (size_ == 0));
+  }
+
+  reset_after_move<int> size_{0};
+  reset_after_move<int> count_{0};
+  std::unique_ptr<bool[]> buffer_{nullptr};
+};
+
+// The move operations are cheap so are defined inline. The copy operations are
+// potentially expensive for larger bitsets, so are defined in the cc file.
+
+inline CountedDynamicBitset::CountedDynamicBitset(
+    CountedDynamicBitset&& other) = default;
+
+inline CountedDynamicBitset& CountedDynamicBitset::operator=(
+    CountedDynamicBitset&& other) = default;
+
+}  // namespace internal
+}  // namespace planning
+}  // namespace drake

--- a/planning/test/dof_mask_test.cc
+++ b/planning/test/dof_mask_test.cc
@@ -31,6 +31,15 @@ GTEST_TEST(DofMaskTest, ConstructorsAndSize) {
   EXPECT_EQ(dut1.count(), 0);
   EXPECT_EQ(dut1.size(), 0);
 
+  const DofMask dut1b(0, true);
+  EXPECT_EQ(dut1b.count(), 0);
+  EXPECT_EQ(dut1b.size(), 0);
+
+  std::vector<bool> bits1c;
+  const DofMask dut1c(bits1c);
+  EXPECT_EQ(dut1c.count(), 0);
+  EXPECT_EQ(dut1c.size(), 0);
+
   const DofMask dut2(13, true);
   EXPECT_EQ(dut2.count(), 13);
   EXPECT_EQ(dut2.size(), 13);
@@ -43,8 +52,8 @@ GTEST_TEST(DofMaskTest, ConstructorsAndSize) {
   EXPECT_EQ(dut4.count(), 3);
   EXPECT_EQ(dut4.size(), 5);
 
-  std::vector<bool> bits{true, true, false, true, true, false};
-  const DofMask dut5(bits);
+  std::vector<bool> bits5{true, true, false, true, true, false};
+  const DofMask dut5(bits5);
   EXPECT_EQ(dut5.count(), 4);
   EXPECT_EQ(dut5.size(), 6);
 }
@@ -52,6 +61,7 @@ GTEST_TEST(DofMaskTest, ConstructorsAndSize) {
 // In addition to testing move/copy semantics, this also provides testing for
 // operator==.
 GTEST_TEST(DofMaskTest, CopyMoveSemantics) {
+  const DofMask empty;
   const DofMask dofs({true, false, true, false});
 
   // Copy constructor.
@@ -79,9 +89,13 @@ GTEST_TEST(DofMaskTest, CopyMoveSemantics) {
   EXPECT_EQ(moved.count(), 0);
 
   // Copy assignment.
-  moved = copied;
+  DofMask target;
+  target = copied;
+  EXPECT_EQ(target, dofs);
   EXPECT_EQ(copied, dofs);
-  EXPECT_EQ(moved, dofs);
+  target = empty;
+  EXPECT_EQ(target, DofMask{});
+  EXPECT_EQ(empty, DofMask{});
 }
 
 // Confirms the factories work.
@@ -189,6 +203,9 @@ GTEST_TEST(DofMaskTest, Complement) {
   const DofMask expected({false, true, true});
 
   EXPECT_EQ(d1.Complement(), expected);
+
+  const DofMask empty;
+  EXPECT_EQ(empty.Complement(), DofMask{});
 }
 
 GTEST_TEST(DofMaskTest, Union) {
@@ -197,6 +214,9 @@ GTEST_TEST(DofMaskTest, Union) {
   const DofMask expected({true, false, true});
 
   EXPECT_EQ(d1.Union(d2), expected);
+
+  const DofMask empty;
+  EXPECT_EQ(empty.Union(empty), DofMask{});
 }
 
 GTEST_TEST(DofMaskTest, Intersect) {
@@ -205,6 +225,9 @@ GTEST_TEST(DofMaskTest, Intersect) {
   const DofMask expected({false, true, false});
 
   EXPECT_EQ(d1.Intersect(d2), expected);
+
+  const DofMask empty;
+  EXPECT_EQ(empty.Intersect(empty), DofMask{});
 }
 
 GTEST_TEST(DofMaskTest, Subtract) {
@@ -213,6 +236,9 @@ GTEST_TEST(DofMaskTest, Subtract) {
   const DofMask expected({true, false, false});
 
   EXPECT_EQ(d1.Subtract(d2), expected);
+
+  const DofMask empty;
+  EXPECT_EQ(empty.Subtract(empty), DofMask{});
 }
 
 GTEST_TEST(DofMaskTest, GetFromArrayWithReturn) {


### PR DESCRIPTION
Using `vector<bool>` is an abomination, so in my downtime I rewrote `DofMask` to use an array of bytes, instead.  Separating out the "dof" concept from the "container of bools" concept also improves readability.

If we like, in the future there are also further optimization opportunities available (compressing bitset of <= 64 bits or <= 128 -- which dof masks "always" are -- to be stored as a `uint64_t` or `unsigned __int128` and using the `popcount` built-in to tally them).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23644)
<!-- Reviewable:end -->
