### PR TITLE
[doc] Fix unmatched backticks in Doxygen

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -1084,7 +1084,7 @@ characters.)""";
       struct /* filename_hint */ {
         // Source: drake/common/memory_file.h
         const char* doc =
-R"""(Returns the notional "filename" for this file`.)""";
+R"""(Returns the notional "filename" for this ``file``.)""";
       } filename_hint;
       // Symbol: drake::MemoryFile::sha256
       struct /* sha256 */ {

--- a/bindings/generated_docstrings/common_symbolic.h
+++ b/bindings/generated_docstrings/common_symbolic.h
@@ -2324,10 +2324,10 @@ Raises:
 
 Parameter ``y``:
     The bilinear product between ``x`` and ``y`` will be replaced by
-    the corresponding term in ``W.
+    the corresponding term in ``W``.
 
 Raises:
-    RuntimeError if `y`` contains duplicate entries.
+    RuntimeError if ``y`` contains duplicate entries.
 
 Parameter ``W``:
     Bilinear product term x(i) * y(j) will be replaced by W(i, j). If

--- a/bindings/generated_docstrings/common_symbolic_expression.h
+++ b/bindings/generated_docstrings/common_symbolic_expression.h
@@ -4061,7 +4061,7 @@ following methods which take ``f`` and ``args:`` ``VisitConstant``,
 ``VisitSqrt``, `VisitPow`, ``VisitSin``, `VisitCos`, ``VisitTan``,
 `VisitAsin`, ``VisitAtan``, `VisitAtan2`, ``VisitSinh``, `VisitCosh`,
 ``VisitTanh``, `VisitMin`, ``VisitMax``, `VisitCeil`, ``VisitFloor``,
-`VisitIfThenElse`, `VisitUninterpretedFunction.
+`VisitIfThenElse`, ``VisitUninterpretedFunction``.
 
 Raises:
     RuntimeError if NaN is detected during a visit.)""";

--- a/bindings/generated_docstrings/common_trajectories.h
+++ b/bindings/generated_docstrings/common_trajectories.h
@@ -414,7 +414,7 @@ Precondition:
 
 Precondition:
     ∀i, ``segments[i].rows() == segments[0].rows()`` and
-    segments[i].cols() == segments[0].cols()`.)""";
+    ``segments[i].cols() == segments[0].cols()``.)""";
         } AlignAndConcatenate;
         // Symbol: drake::trajectories::CompositeTrajectory::CompositeTrajectory<T>
         struct /* ctor */ {
@@ -430,7 +430,7 @@ Precondition:
 
 Precondition:
     ∀i, ``segments[i].rows() == segments[0].rows()`` and
-    segments[i].cols() == segments[0].cols()`.)""";
+    ``segments[i].cols() == segments[0].cols()``.)""";
         } ctor;
         // Symbol: drake::trajectories::CompositeTrajectory::segment
         struct /* segment */ {
@@ -1716,7 +1716,7 @@ coefficient-wise multiplication). If ``this`` corresponds to t² and
 Raises:
     RuntimeError if every element of ``other.get_segment_times()`` is
     not within PiecewiseTrajectory::kEpsilonTime from
-    `this->get_segment_times()1.)""";
+    ``this->get_segment_times()``.)""";
         } operator_mul;
         // Symbol: drake::trajectories::PiecewisePolynomial::operator*=
         struct /* operator_imul */ {
@@ -1731,7 +1731,7 @@ other`` will correspond to t⁵.
 Raises:
     RuntimeError if every element of ``other.get_segment_times()`` is
     not within PiecewiseTrajectory::kEpsilonTime from
-    `this->get_segment_times().)""";
+    ``this->get_segment_times()``.)""";
         } operator_imul;
         // Symbol: drake::trajectories::PiecewisePolynomial::operator+
         struct /* operator_add */ {
@@ -1745,7 +1745,7 @@ other`` will correspond to t³ + t².
 Raises:
     RuntimeError if every element of ``other.get_segment_times()`` is
     not within PiecewiseTrajectory::kEpsilonTime from
-    `this->get_segment_times().)""";
+    ``this->get_segment_times()``.)""";
         } operator_add;
         // Symbol: drake::trajectories::PiecewisePolynomial::operator+=
         struct /* operator_iadd */ {
@@ -1759,7 +1759,7 @@ corresponds to t³, ``this += other`` will correspond to t³ + t².
 Raises:
     RuntimeError if every element of ``other.get_segment_times()`` is
     not within PiecewiseTrajectory::kEpsilonTime from
-    `this->get_segment_times().)""";
+    ``this->get_segment_times()``.)""";
         } operator_iadd;
         // Symbol: drake::trajectories::PiecewisePolynomial::operator-
         struct /* operator_sub */ {
@@ -1773,7 +1773,7 @@ other`` will correspond to t² - t³.
 Raises:
     RuntimeError if every element of ``other.get_segment_times()`` is
     not within PiecewiseTrajectory::kEpsilonTime from
-    `this->get_segment_times().)""";
+    ``this->get_segment_times()``.)""";
           // Source: drake/common/trajectories/piecewise_polynomial.h
           const char* doc_0args =
 R"""(Implements unary minus operator. Multiplies each Polynomial in
@@ -1792,7 +1792,7 @@ t³.
 Raises:
     RuntimeError if every element of ``other.get_segment_times()`` is
     not within PiecewiseTrajectory::kEpsilonTime from
-    `this->get_segment_times().)""";
+    ``this->get_segment_times()``.)""";
         } operator_isub;
         // Symbol: drake::trajectories::PiecewisePolynomial::rows
         struct /* rows */ {

--- a/bindings/generated_docstrings/geometry.h
+++ b/bindings/generated_docstrings/geometry.h
@@ -133,7 +133,7 @@ materials can optionally provide defaults for missing properties.
 Raises:
     RuntimeError if ``dissipation`` is negative, ``point_stiffness``
     is not positive, of any of the contact material properties have
-    already been defined in ``properties`.
+    already been defined in ``properties``.
 
 Precondition:
     ``properties`` is not nullptr.)""";
@@ -7870,9 +7870,9 @@ returned, otherwise all geometries will be returned.
 
 Note:
     Specifying ``role`` *can* have the effect of filtering geometries
-    *from* the given geometry_set` -- if a GeometryId is an explicit
-    member of the geometry set but does not have the requested role,
-    it will not be contained in the output.
+    *from* the given ``geometry_set`` -- if a GeometryId is an
+    explicit member of the geometry set but does not have the
+    requested role, it will not be contained in the output.
 
 Parameter ``geometry_set``:
     The encoding of the set of geometries.

--- a/bindings/generated_docstrings/math.h
+++ b/bindings/generated_docstrings/math.h
@@ -2503,11 +2503,12 @@ Parameter ``theta_lambda``:
 
 Parameter ``p``:
     position vector from frame A's origin to frame B's origin,
-    expressed in frame A. In monogram notation p is denoted ``p_AoBo_A
+    expressed in frame A. In monogram notation p is denoted
+    ``p_AoBo_A``.
 
 Raises:
     RuntimeError in debug builds if the rotation matrix that is built
-    from `theta_lambda`` is invalid.
+    from ``theta_lambda`` is invalid.
 
 See also:
     RotationMatrix::RotationMatrix(const Eigen::AngleAxis<T>&))""";
@@ -5060,7 +5061,7 @@ The derivative vector for each AutoDiffScalar in the output contains
 the derivatives with respect to all components of the argument
 :math:`x`.
 
-The return type of this function is a matrix with the `best' possible
+The return type of this function is a matrix with the 'best' possible
 AutoDiffScalar scalar type, in the following sense: - If the number of
 derivatives can be determined at compile time, the AutoDiffScalar
 derivative vector will have that fixed size. - If the maximum number

--- a/bindings/generated_docstrings/multibody_benchmarks_free_body.h
+++ b/bindings/generated_docstrings/multibody_benchmarks_free_body.h
@@ -111,8 +111,8 @@ std::tuple | Description
 -----------|------------------------------------------------- quat_NB
 | Quaternion relating frame N to frame B: [e0, e1, e2, e3] | Note:
 quat_NB is analogous to the rotation matrix R_NB. quatDt |
-Time-derivative of `quat_NB', i.e., [ė0, ė1, ė2, ė3]. w_NB_B | B's
-angular velocity in N, expressed in B. alpha_NB_B | B's angular
+Time-derivative of ``quat_NB``, i.e., [ė0, ė1, ė2, ė3]. w_NB_B |
+B's angular velocity in N, expressed in B. alpha_NB_B | B's angular
 acceleration in N, expressed in B.
 
 - [Kane, 1983] "Spacecraft Dynamics," McGraw-Hill Book Co., New York,

--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -3160,8 +3160,8 @@ Raises:
 
 Raises:
     RuntimeError if ``this`` MultibodyPlant's underlying contact
-    solver is not SAP. (i.e. ``get_discrete_contact_solver() !=
-    DiscreteContactSolver::kSap``).)""";
+    solver is not SAP. (i.e. get_discrete_contact_solver() !=
+    DiscreteContactSolver::kSap).)""";
         } AddTendonConstraint;
         // Symbol: drake::multibody::MultibodyPlant::AddWeldConstraint
         struct /* AddWeldConstraint */ {
@@ -5518,8 +5518,8 @@ positions q of a specified model instance in a given Context.
 
 Note:
     q_out is a dense vector of dimension
-    ``num_positions(model_instance)' associated with `model_instance``
-    and is populated by copying from ``context``.
+    ``num_positions(model_instance)`` associated with
+    ``model_instance`` and is populated by copying from ``context``.
 
 Note:
     This function is guaranteed to allocate no heap.

--- a/bindings/generated_docstrings/multibody_tree.h
+++ b/bindings/generated_docstrings/multibody_tree.h
@@ -2173,7 +2173,7 @@ method computes the pose ``X_BQ`` of frame Q in the body frame B to
 which this frame is attached. In other words, if the pose of ``this``
 frame F in the body frame B is ``X_BF``, this method computes the pose
 ``X_BQ`` of frame Q in the body frame B as ``X_BQ = X_BF * X_FQ``. In
-particular, if ``this`` **is**` the body frame B, i.e. ``X_BF`` is the
+particular, if ``this`` **is** the body frame B, i.e. ``X_BF`` is the
 identity transformation, this method directly returns ``X_FQ``.
 Specific frame subclasses can override this method to provide faster
 implementations if needed.)""";

--- a/bindings/generated_docstrings/planning.h
+++ b/bindings/generated_docstrings/planning.h
@@ -1287,15 +1287,15 @@ R"""(Gets the DistanceAndInterpolationProvider in use.)""";
           // Source: drake/planning/collision_checker.h
           const char* doc =
 R"""(Returns:
-    a ``const`` body reference to a body in the full model's plant for
-    the given ``body_index``.)""";
+    a const body reference to a body in the full model's plant for the
+    given ``body_index``.)""";
         } get_body;
         // Symbol: drake::planning::CollisionChecker::model
         struct /* model */ {
           // Source: drake/planning/collision_checker.h
           const char* doc =
 R"""(Returns:
-    a ``const`` reference to the full model.)""";
+    a const reference to the full model.)""";
         } model;
         // Symbol: drake::planning::CollisionChecker::model_context
         struct /* model_context */ {
@@ -1308,9 +1308,9 @@ Parameter ``context_number``:
     Optional implicit context number.
 
 Returns:
-    a ``const`` reference to either the collision checking context
-    given by the ``context_number``, or when nullopt the context to be
-    used with the current OpenMP thread.
+    a const reference to either the collision checking context given
+    by the ``context_number``, or when nullopt the context to be used
+    with the current OpenMP thread.
 
 See also:
     ccb_implicit_contexts "Implicit Context Parallelism".)""";
@@ -1327,7 +1327,7 @@ R"""(Returns:
           // Source: drake/planning/collision_checker.h
           const char* doc =
 R"""(Returns:
-    a `const reference to the full model's plant.)""";
+    a const reference to the full model's plant.)""";
         } plant;
         // Symbol: drake::planning::CollisionChecker::plant_context
         struct /* plant_context */ {
@@ -1340,8 +1340,8 @@ Parameter ``context_number``:
     Optional implicit context number.
 
 Returns:
-    a ``const`` reference to the multibody plant sub-context within
-    the context given by the ``context_number``, or when nullopt the
+    a const reference to the multibody plant sub-context within the
+    context given by the ``context_number``, or when nullopt the
     context to be used with the current OpenMP thread.
 
 See also:

--- a/bindings/generated_docstrings/solvers.h
+++ b/bindings/generated_docstrings/solvers.h
@@ -3709,7 +3709,7 @@ available, throws a RuntimeError.)""";
 R"""(Converts an input of type ``F`` to a nonlinear cost.
 
 Template parameter ``FF``:
-    The forwarded function type (e.g., ``const F&, `F&&``, ...). The
+    The forwarded function type (e.g., ``const F&``, `F&&`, ...). The
     class ``F`` should have functions numInputs(), numOutputs(), and
     eval(x, y).)""";
       } MakeFunctionCost;

--- a/bindings/generated_docstrings/systems_controllers.h
+++ b/bindings/generated_docstrings/systems_controllers.h
@@ -1425,7 +1425,7 @@ Parameter ``kd``:
 
 Raises:
     RuntimeError if ``kp``, ``ki`` and ``kd`` have different
-    dimensions or `P_x.row() != 2 * |kp|'.)""";
+    dimensions or ``P_x.row() != 2 * |kp|``.)""";
             // Source: drake/systems/controllers/pid_controller.h
             const char* doc_5args =
 R"""(Constructs a PID controller. This assumes that

--- a/common/memory_file.h
+++ b/common/memory_file.h
@@ -62,7 +62,7 @@ class MemoryFile final {
   /** Returns the checksum of `this` instance's `contents()`. */
   const Sha256& sha256() const { return sha256_.value().checksum; }
 
-  /** Returns the notional "filename" for this file`. */
+  /** Returns the notional "filename" for this `file`. */
   const std::string& filename_hint() const { return filename_hint_; }
 
   /** Returns a string representation. Note: the file contents will be limited

--- a/common/symbolic/expression/expression_visitor.h
+++ b/common/symbolic/expression/expression_visitor.h
@@ -83,7 +83,7 @@ Result VisitPolynomial(Visitor* v, const Expression& e, Args&&... args) {
 /// `VisitSqrt`, `VisitPow`, `VisitSin`, `VisitCos`, `VisitTan`, `VisitAsin`,
 /// `VisitAtan`, `VisitAtan2`, `VisitSinh`, `VisitCosh`, `VisitTanh`,
 /// `VisitMin`, `VisitMax`, `VisitCeil`, `VisitFloor`, `VisitIfThenElse`,
-/// `VisitUninterpretedFunction.
+/// `VisitUninterpretedFunction`.
 ///
 /// @throws std::exception if NaN is detected during a visit.
 template <typename Result, typename Visitor, typename... Args>

--- a/common/symbolic/replace_bilinear_terms.h
+++ b/common/symbolic/replace_bilinear_terms.h
@@ -19,7 +19,7 @@ namespace symbolic {
  * corresponding term in `W`.
  * @throws std::exception if `x` contains duplicate entries.
  * @param y The bilinear product between `x` and `y` will be replaced by the
- * corresponding term in `W.
+ * corresponding term in `W`.
  * @throws std::exception if `y` contains duplicate entries.
  * @param W Bilinear product term x(i) * y(j) will be replaced by W(i, j). If
  * W(i,j) is not a single variable, but an expression, then this expression

--- a/common/trajectories/composite_trajectory.h
+++ b/common/trajectories/composite_trajectory.h
@@ -26,7 +26,7 @@ class CompositeTrajectory final : public trajectories::PiecewiseTrajectory<T> {
   /** Constructs a composite trajectory from a list of Trajectories.
   @pre ∀i, `segments[i].get() != nullptr`.
   @pre ∀i, `segments[i+1].start_time() == segments[i].end_time()`.
-  @pre ∀i, `segments[i].rows() == segments[0].rows()` and segments[i].cols() ==
+  @pre ∀i, `segments[i].rows() == segments[0].rows()` and `segments[i].cols() ==
   segments[0].cols()`. */
   explicit CompositeTrajectory(
       std::vector<copyable_unique_ptr<Trajectory<T>>> segments);
@@ -53,7 +53,7 @@ class CompositeTrajectory final : public trajectories::PiecewiseTrajectory<T> {
   /** Constructs a composite trajectory from a list of trajectories whose start
   and end times may not coincide, by translating their start and end times.
   @pre ∀i, `segments[i].get() != nullptr`.
-  @pre ∀i, `segments[i].rows() == segments[0].rows()` and segments[i].cols() ==
+  @pre ∀i, `segments[i].rows() == segments[0].rows()` and `segments[i].cols() ==
   segments[0].cols()`. */
   static CompositeTrajectory<T> AlignAndConcatenate(
       const std::vector<copyable_unique_ptr<Trajectory<T>>>& segments);

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -586,7 +586,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * t³, `this += other` will correspond to t³ + t².
    * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
-   * `this->get_segment_times().
+   * `this->get_segment_times()`.
    */
   PiecewisePolynomial& operator+=(const PiecewisePolynomial& other);
 
@@ -597,7 +597,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * t³, `this -= other` will correspond to t² - t³.
    * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
-   * `this->get_segment_times().
+   * `this->get_segment_times()`.
    */
   PiecewisePolynomial& operator-=(const PiecewisePolynomial& other);
 
@@ -609,7 +609,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * correspond to t⁵.
    * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
-   * `this->get_segment_times().
+   * `this->get_segment_times()`.
    */
   PiecewisePolynomial& operator*=(const PiecewisePolynomial& other);
 
@@ -624,7 +624,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * t³, `this + other` will correspond to t³ + t².
    * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
-   * `this->get_segment_times().
+   * `this->get_segment_times()`.
    */
   const PiecewisePolynomial operator+(const PiecewisePolynomial& other) const;
 
@@ -635,7 +635,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * t³, `this - other` will correspond to t² - t³.
    * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
-   * `this->get_segment_times().
+   * `this->get_segment_times()`.
    */
   const PiecewisePolynomial operator-(const PiecewisePolynomial& other) const;
 
@@ -652,7 +652,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * corresponds to t³, `this *= other` will correspond to t⁵.
    * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
-   * `this->get_segment_times()1.
+   * `this->get_segment_times()`.
    */
   const PiecewisePolynomial operator*(const PiecewisePolynomial& other) const;
 

--- a/examples/rod2d/constraint_solver.h
+++ b/examples/rod2d/constraint_solver.h
@@ -249,7 +249,7 @@ class ConstraintSolver {
   /// is:
   /// -# Call ConstructBaseDiscretizedTimeLcp()
   /// -# Select an integration step size, dt
-  /// -# Compute `kᴺ' and `kᴸ` in the problem data, accounting for dt as
+  /// -# Compute `kᴺ` and `kᴸ` in the problem data, accounting for dt as
   ///    necessary
   /// -# Call UpdateDiscretizedTimeLcp(), obtaining MM and qq that encode the
   ///    linear complementarity problem

--- a/geometry/geometry_instance.h
+++ b/geometry/geometry_instance.h
@@ -75,7 +75,7 @@ namespace geometry {
  will return this *canonicalized* name.
 
  <!-- Note to developers: The sdf requirements for naming are captured in a
- unit test in `scene_graph_parser_detail_test.cc. See test
+ unit test in `scene_graph_parser_detail_test.cc`. See test
  VisualGeometryNameRequirements and keep those tests and this list in sync. -->
  */
 class GeometryInstance {

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -414,7 +414,7 @@ class GeometryProperties {
 
 #ifndef DRAKE_DOXYGEN_CXX
   // Note: these overloads of the property access methods exist to enable
-  // calls like `properties.AddProperty("group", "property", "string literal");
+  // calls like `properties.AddProperty("group", "property", "string literal");`
   // Template matching would deduce that the `ValueType` in this case is a const
   // char* (which is not copyable). By explicitly declaring this API, we can
   // implicitly convert the string literals to copyable std::strings. We assume

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -946,7 +946,7 @@ class GraphOfConvexSets {
   // Specifically given a constraint h(x) ≤ b, this method implements its
   // perspective:
   // h(x) ≤ b ⇒ h(ϕx) ≤ ϕb
-  // vars` is a vector of variables to be used in the constraint consisting of
+  // `vars` is a vector of variables to be used in the constraint consisting of
   // ϕ, and ϕ times the variables in the original constraint.
   void AddPerspectiveConstraint(
       solvers::MathematicalProgram* prog,

--- a/geometry/proximity/test/pressure_field_invariants.h
+++ b/geometry/proximity/test/pressure_field_invariants.h
@@ -28,7 +28,7 @@ relation ship.
 
 For such pressure fields, this function verifies the invariants:
  1. The two fields are defined on the same mesh.
- 2. Pressure on the surface is uniform and equal to p̃₀`.
+ 2. Pressure on the surface is uniform and equal to `p̃₀`.
  3. The linear relationship slope is uniform and equal to s.
 
 @param[in] field_no_margin The pressure field for δ = 0.

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -112,7 +112,7 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
  *
  * @throws std::exception if `dissipation` is negative, `point_stiffness` is
  * not positive, of any of the contact material properties have already been
- * defined in ``properties`.
+ * defined in `properties`.
  * @pre `properties` is not nullptr.
  */
 void AddContactMaterial(

--- a/geometry/render_gl/internal_opengl_geometry.h
+++ b/geometry/render_gl/internal_opengl_geometry.h
@@ -36,7 +36,7 @@ struct VertexAttrib {
   int byte_offset{};
   /* The byte distance between subsequent elements. Zero is a valid value;
    OpenGL will assume compact representation and use a stride equal to
-   `components_per_element * sizeof("value_type"). */
+   `components_per_element * sizeof("value_type")`. */
   int stride{};
   /* The numeric type of the single values (e.g., GL_INT, GL_FLOAT, etc.). */
   int numeric_type{};

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -120,7 +120,7 @@ class SceneGraphInspector {
    will be returned.
 
    @note Specifying `role` *can* have the effect of filtering geometries *from*
-   the given geometry_set` -- if a GeometryId is an explicit member of the
+   the given `geometry_set` -- if a GeometryId is an explicit member of the
    geometry set but does not have the requested role, it will not be contained
    in the output.
 

--- a/math/jacobian.h
+++ b/math/jacobian.h
@@ -19,7 +19,7 @@ namespace math {
    The derivative vector for each AutoDiffScalar in the output contains the
    derivatives with respect to all components of the argument @f$ x @f$.
 
-   The return type of this function is a matrix with the `best' possible
+   The return type of this function is a matrix with the 'best' possible
    AutoDiffScalar scalar type, in the following sense:
    - If the number of derivatives can be determined at compile time, the
      AutoDiffScalar derivative vector will have that fixed size.

--- a/math/quaternion.h
+++ b/math/quaternion.h
@@ -171,7 +171,7 @@ boolean<T> AreQuaternionsEqualForOrientation(const Eigen::Quaternion<T>& quat1,
 }
 
 // Note: To avoid dependence on Eigen's internal ordering of elements in its
-// Quaternion class, herein we use `e0 = quat.w()', `e1 = quat.x()`, etc.
+// Quaternion class, herein we use `e0 = quat.w()`, `e1 = quat.x()`, etc.
 // Return value `quatDt` *does* have a specific order as defined above.
 /** This function calculates a quaternion's time-derivative from its quaternion
  * and angular velocity. Algorithm from [Kane, 1983] Section 1.13, Pages 58-59.
@@ -202,7 +202,7 @@ Vector4<T> CalculateQuaternionDtFromAngularVelocityExpressedInB(
 }
 
 // Note: To avoid dependence on Eigen's internal ordering of elements in its
-// Quaternion class, herein we use `e0 = quat.w()', `e1 = quat.x()`, etc.
+// Quaternion class, herein we use `e0 = quat.w()`, `e1 = quat.x()`, etc.
 // Parameter `quatDt` *does* have a specific order as defined above.
 /** This function calculates angular velocity from a quaternion and its time-
  * derivative. Algorithm from [Kane, 1983] Section 1.13, Pages 58-59.

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -115,7 +115,7 @@ class RigidTransform {
   /// direction herein called `lambda`) is non-zero and finite, but which may or
   /// may not have unit length [i.e., `lambda.norm()` does not have to be 1].
   /// @param[in] p position vector from frame A's origin to frame B's origin,
-  /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A
+  /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
   /// @throws std::exception in debug builds if the rotation matrix
   /// that is built from `theta_lambda` is invalid.
   /// @see RotationMatrix::RotationMatrix(const Eigen::AngleAxis<T>&)
@@ -1021,7 +1021,7 @@ static_assert(sizeof(RigidTransform<double>) == 12 * sizeof(double),
 
 /// Stream insertion operator to write an instance of RigidTransform into a
 /// `std::ostream`. Especially useful for debugging.
-/// @relates RigidTransform.
+/// @relates RigidTransform
 template <typename T>
 std::ostream& operator<<(std::ostream& out, const RigidTransform<T>& X);
 

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -567,7 +567,7 @@ class RotationMatrix {
     // 4. The current RotationMatrix::cast() method incurs overhead due to its
     //    underlying call to a RotationMatrix constructor. Perhaps create
     //    specialized code to return a reference if casting to the same type,
-    //    e.g., casting from `<double>` to `<double>' should be inexpensive.
+    //    e.g., casting from `<double>` to `<double>` should be inexpensive.
     return RotationMatrix<U>::MakeUnchecked(R_AB_.template cast<U>());
   }
 

--- a/multibody/benchmarks/free_body/free_body.h
+++ b/multibody/benchmarks/free_body/free_body.h
@@ -137,7 +137,7 @@ class FreeBody {
   /// -----------|-------------------------------------------------
   /// quat_NB    | Quaternion relating frame N to frame B: [e0, e1, e2, e3]
   ///            | Note: quat_NB is analogous to the rotation matrix R_NB.
-  /// quatDt     | Time-derivative of `quat_NB', i.e., [ė0, ė1, ė2, ė3].
+  /// quatDt     | Time-derivative of `quat_NB`, i.e., [ė0, ė1, ė2, ė3].
   /// w_NB_B     | B's angular velocity in N, expressed in B.
   /// alpha_NB_B | B's angular acceleration in N, expressed in B.
   ///

--- a/multibody/fem/isoparametric_element.h
+++ b/multibody/fem/isoparametric_element.h
@@ -141,7 +141,7 @@ class IsoparametricElement {
   /* Computes the Jacobian matrix, dx/dξ, at each sample location in the parent
    domain provided at construction.
    @param xa  Spatial coordinates for each element node stored column-wise.
-   @returns an std::array of size 'num_sample_locations`. The q-th entry
+   @returns an std::array of size `num_sample_locations`. The q-th entry
    contains the Jacobian matrix dx/dξ, of size
    `spatial_dimension`-by-`natural_dimension`, evaluated at the q-th sample
    location in the parent domain provided at construction. */

--- a/multibody/mpm/particle_sorter.h
+++ b/multibody/mpm/particle_sorter.h
@@ -359,7 +359,7 @@ class ParticleSorter {
    indices. */
   void UnpackResults();
 
-  /* Helper for `Sort`()` that builds `colored_ranges_`. */
+  /* Helper for `Sort()` that builds `colored_ranges_`. */
   template <typename SpGrid>
   void BuildColoredRanges(const SpGrid& spgrid, int num_particles) {
     /* Keep track of where each new "page" begins. */

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2161,8 +2161,8 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `this` %MultibodyPlant is not a discrete model
   /// (`is_discrete() == false`).
   /// @throws std::exception if `this` %MultibodyPlant's underlying contact
-  /// solver is not SAP. (i.e. `get_discrete_contact_solver() !=
-  /// DiscreteContactSolver::kSap`).
+  /// solver is not SAP. (i.e. get_discrete_contact_solver() !=
+  /// DiscreteContactSolver::kSap).
   MultibodyConstraintId AddTendonConstraint(std::vector<JointIndex> joints,
                                             std::vector<double> a,
                                             std::optional<double> offset,
@@ -2870,7 +2870,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// (Advanced) Populates output vector q_out with the generalized positions q
   /// of a specified model instance in a given Context.
   /// @note q_out is a dense vector of dimension
-  ///       `num_positions(model_instance)' associated with `model_instance`
+  ///       `num_positions(model_instance)` associated with `model_instance`
   ///       and is populated by copying from `context`.
   /// @note This function is guaranteed to allocate no heap.
   /// @throws std::exception if `context` does not correspond to the Context
@@ -5606,7 +5606,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns a Graphviz string describing the topology of this plant.
-  /// To render the string, use the Graphviz tool, ``dot``.
+  /// To render the string, use the Graphviz tool, `dot`.
   /// http://www.graphviz.org/
   ///
   /// Note: this method can be called either before or after `Finalize()`.
@@ -6041,7 +6041,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
       MaybeModelInstanceIndex model_instance = {});
 
   // Estimates a global set of point contact parameters given a
-  // `penetration_allowance`. See set_penetration_allowance()` for details.
+  // `penetration_allowance`. See `set_penetration_allowance()` for details.
   // TODO(amcastro-tri): Once #13064 is resolved, make this a method outside MBP
   // with signature:
   // EstimatePointContactParameters(double penetration_allowance,

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -216,7 +216,7 @@ class BodyNode : public MultibodyElement<T> {
       PositionKinematicsCache<T>* pc) const = 0;
 
   // Calculates the hinge matrix H_PB_W, the `6 x nm` hinge matrix that relates
-  // V_PB_W`(body B's spatial velocity in its parent body P, expressed in world
+  // `V_PB_W`(body B's spatial velocity in its parent body P, expressed in world
   // W) to this node's nm generalized velocities (or mobilities) v_B as
   // V_PB_W = H_PB_W * v_B.
   //
@@ -482,7 +482,7 @@ class BodyNode : public MultibodyElement<T> {
   // @param[out] aba_force_cache
   //   A pointer to a valid, non nullptr, force bias cache.
   //
-  // @pre pc, vc, and abic previously computed to be in sync with `context.
+  // @pre pc, vc, and abic previously computed to be in sync with `context`.
   // @pre CalcArticulatedBodyForceCache_TipToBase() must have already been
   // called for all the child nodes of `this` node (and, by recursive
   // precondition, all successor nodes in the tree.)
@@ -529,7 +529,7 @@ class BodyNode : public MultibodyElement<T> {
   // @param[out] ac
   //   A pointer to a valid, non nullptr, acceleration kinematics cache.
   //
-  // @pre pc, vc, and abic previously computed to be in sync with `context.
+  // @pre pc, vc, and abic previously computed to be in sync with `context`.
   // @pre CalcArticulatedBodyAccelerations_BaseToTip() must have already been
   // called for the parent node (and, by recursive precondition, all
   // predecessor nodes in the tree.)

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -154,7 +154,7 @@ class Frame : public MultibodyElement<T> {
   /// In other words, if the pose of `this` frame F in the body frame B is
   /// `X_BF`, this method computes the pose `X_BQ` of frame Q in the body frame
   /// B as `X_BQ = X_BF * X_FQ`.
-  /// In particular, if `this` **is**` the body frame B, i.e. `X_BF` is the
+  /// In particular, if `this` **is** the body frame B, i.e. `X_BF` is the
   /// identity transformation, this method directly returns `X_FQ`.
   /// Specific frame subclasses can override this method to provide faster
   /// implementations if needed.

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2730,7 +2730,7 @@ class MultibodyTree {
   // `Js_v_WFpi_W` is either nullptr or a `3*p x n` matrix, where p is the
   // number of points in Fpi and n is the number of elements in 𝑠.
   // @throws std::exception if any of the following occurs:
-  // - The size of `p_WoFpi_W' differs from `3 x n`.
+  // - The size of `p_WoFpi_W` differs from `3 x n`.
   // - `Js_w_WF_W` and `Js_v_WFpi_W` are both nullptr.
   // - `Js_w_WF_W` is not nullptr and its size differs from `3 x n`.
   // - `Js_v_WFpi_W` is not nullptr and its size differs from `3*p x n`.

--- a/planning/collision_checker.h
+++ b/planning/collision_checker.h
@@ -206,7 +206,7 @@ class CollisionChecker {
    These methods all provide access to the underlying robot model's contents. */
   //@{
 
-  /** @returns a `const` reference to the full model. */
+  /** @returns a const reference to the full model. */
   const RobotDiagram<double>& model() const {
     if (IsInitialSetup()) {
       return *setup_model_;
@@ -216,12 +216,12 @@ class CollisionChecker {
     }
   }
 
-  /** @returns a `const reference to the full model's plant. */
+  /** @returns a const reference to the full model's plant. */
   const multibody::MultibodyPlant<double>& plant() const {
     return model().plant();
   }
 
-  /** @returns a `const` body reference to a body in the full model's plant for
+  /** @returns a const body reference to a body in the full model's plant for
    the given `body_index`. */
   const multibody::RigidBody<double>& get_body(
       multibody::BodyIndex body_index) const {
@@ -260,7 +260,7 @@ class CollisionChecker {
   /** Accesses a collision checking context from within the implicit context
    pool owned by this collision checker.
    @param context_number Optional implicit context number.
-   @returns a `const` reference to either the collision checking context given
+   @returns a const reference to either the collision checking context given
    by the `context_number`, or when nullopt the context to be used with the
    current OpenMP thread.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */
@@ -271,7 +271,7 @@ class CollisionChecker {
   /** Accesses a multibody plant sub-context context from within the implicit
    context pool owned by this collision checker.
    @param context_number Optional implicit context number.
-   @returns a `const` reference to the multibody plant sub-context within
+   @returns a const reference to the multibody plant sub-context within
    the context given by the `context_number`, or when nullopt the context to be
    used with the current OpenMP thread.
    @see @ref ccb_implicit_contexts "Implicit Context Parallelism". */

--- a/planning/trajectory_optimization/direct_transcription.h
+++ b/planning/trajectory_optimization/direct_transcription.h
@@ -89,7 +89,7 @@ class DirectTranscription : public MultipleShooting {
   /// @throws std::exception if `context.has_only_discrete_state() == false`.
   ///
   /// @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.  When
-  /// we do bind it, we should probably rename `system` to tv_linear_system` or
+  /// we do bind it, we should probably rename `system` to `tv_linear_system` or
   /// similar, so that kwargs determine which overload is suggested, instead of
   /// hoping that type checking does the right thing.}
   DirectTranscription(

--- a/solvers/cost.h
+++ b/solvers/cost.h
@@ -695,7 +695,7 @@ class ExpressionCost : public Cost {
 
 /**
  * Converts an input of type @p F to a nonlinear cost.
- * @tparam FF The forwarded function type (e.g., `const F&, `F&&`, ...).
+ * @tparam FF The forwarded function type (e.g., `const F&`, `F&&`, ...).
  * The class `F` should have functions numInputs(), numOutputs(), and
  * eval(x, y).
  *

--- a/systems/controllers/pid_controller.h
+++ b/systems/controllers/pid_controller.h
@@ -73,7 +73,7 @@ class PidController : public LeafSystem<T>,
    * @param kd D gain.
    *
    * @throws std::exception if @p kp, @p ki and @p kd have different
-   * dimensions or `P_x.row() != 2 * |kp|'.
+   * dimensions or `P_x.row() != 2 * |kp|`.
    */
   PidController(const MatrixX<double>& state_projection,
                 const Eigen::VectorXd& kp, const Eigen::VectorXd& ki,


### PR DESCRIPTION
Aside from being overly pedantic, these are landmines for the documentation generation.

Here's the `find` command, for lines with odd numbers of backticks but excluding triple backticks (for code blocks) or lines which also have an odd number on the next or previous line. This wasn't perfect, but it pared it down enough to spot check the results.

```
find . -type f -name "*.h" -exec awk '{
    line = $0
    gsub(/```/, "", line)
    n = gsub(/`/, "", line)

    lines[FILENAME, NR] = $0
    count[FILENAME, NR] = n
    max[FILENAME] = NR
}
END {
    for (f in max)
        for (i = 1; i <= max[f]; i++) {
            odd_prev = (count[f, i-1] % 2 == 1)
            odd_curr = (count[f, i]   % 2 == 1)
            odd_next = (count[f, i+1] % 2 == 1)

            if (odd_curr && !odd_prev && !odd_next)
                print f ":" i ":" lines[f, i]
        }
}' {} +
```

Towards #23513.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23652)
<!-- Reviewable:end -->
