### PR TITLE
[doc] Remove parsing of template instantiation macros

### DIFF
--- a/common/default_scalars.h
+++ b/common/default_scalars.h
@@ -6,6 +6,9 @@
 // N.B. `CommonScalarPack` and `NonSymbolicScalarPack` in `systems_pybind.h`
 // should be kept in sync with this file.
 
+// N.B. The spelling of the macro names between doc/Doxyfile_CXX.in and this
+// file should be kept in sync.
+
 /// @defgroup default_scalars Default Scalars
 /// @ingroup technical_notes
 /// @{

--- a/common/drake_copyable.h
+++ b/common/drake_copyable.h
@@ -1,9 +1,7 @@
 #pragma once
 
-// ============================================================================
 // N.B. The spelling of the macro names between doc/Doxyfile_CXX.in and this
-// file must be kept in sync!
-// ============================================================================
+// file must be kept in sync.
 
 /** @file
 Provides careful macros to selectively enable or disable the special member

--- a/common/drake_deprecated.h
+++ b/common/drake_deprecated.h
@@ -3,6 +3,9 @@
 #include <string>
 #include <string_view>
 
+// N.B. The spelling of the macro name between doc/Doxyfile_CXX.in and this
+// file must be kept in sync.
+
 /** @file
 Provides a portable macro for use in generating compile-time warnings for
 use of code that is permitted but discouraged. */

--- a/doc/doxygen_cxx/Doxyfile_CXX.in
+++ b/doc/doxygen_cxx/Doxyfile_CXX.in
@@ -303,8 +303,9 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = DRAKE_DOXYGEN_CXX=1 \
                          HAVE_SPDLOG=1
 # =============================================================================
-# N.B. The spelling of the macro names between common/drake_copyable.h and this
-# file must be kept in sync!
+# N.B. The spelling of the macro names between common/drake_copyable.h,
+# common/drake_deprecated.h, common/default_scalars.h and this file must be
+# kept in sync!
 # =============================================================================
 # The following macros are carefully crafted to retain good markup when they
 # pass through Doxygen's preprocessor.
@@ -336,6 +337,15 @@ PREDEFINED            += "DRAKE_DEPRECATED(removal_date,message):= \
 /** (Deprecated.) \deprecated message <br> \
 This will be removed from Drake on or after removal_date. */ \
 "
+# N.B. The two macros below can't be parsed like the ones above, because the
+# fully-qualified class name is always passed to the macro instead of just the
+# unqualified name (so "\relates X" doesn't work). The template instantiation
+# is already indicated by Drake's @tparam_default_scalar and
+# @tparam_nonsymbolic_scalar documentation, so the additional documentation is
+# not needed. To avoid listing the macro as a function in the header files
+# where they're used, we'll define them as empty here.
+PREDEFINED            += DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(X):=
+PREDEFINED            += DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(X):=
 # =============================================================================
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES


### PR DESCRIPTION
See `Doxyfile_CXX.in` for details.

For an example of the current issue, see: https://drake.mit.edu/doxygen_cxx/rigid__transform_8h.html#aa7b1534bec3a3bcf63686133f87fb80e.

Towards #23513.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23654)
<!-- Reviewable:end -->
