### PR TITLE
Fix Eigen 3.4.1 compatibility issues

### DIFF
--- a/multibody/contact_solvers/sap/sap_limit_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_limit_constraint.cc
@@ -114,7 +114,7 @@ void SapLimitConstraint<T>::DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
   const VectorX<T>& v_hat = data.v_hat();
   data.mutable_vc() = vc;
   data.mutable_y() = R_inv.asDiagonal() * (v_hat - vc);
-  data.mutable_gamma() = data.y().array().max(0.0);
+  data.mutable_gamma() = data.y().array().max(T{0.0});
 }
 
 template <typename T>

--- a/systems/primitives/multilayer_perceptron.cc
+++ b/systems/primitives/multilayer_perceptron.cc
@@ -83,7 +83,7 @@ void Activation(
       dYdX->noalias() = (1.0 - X.array().tanh().square()).matrix();
     }
   } else if (type == kReLU) {
-    *Y = X.array().max(0.0).matrix();
+    *Y = X.array().max(T{0.0}).matrix();
     if (dYdX) {
       dYdX->noalias() = (X.array() <= 0).template cast<bool>().select(0 * X, 1);
     }

--- a/systems/primitives/test/multilayer_perceptron_test.cc
+++ b/systems/primitives/test/multilayer_perceptron_test.cc
@@ -138,7 +138,7 @@ void CalcOutputTest(
 
   Vector3<T> y0 = (W0 * x + b0);
   if (mlp.activation_type(0) == kReLU) {
-    y0 = y0.array().max(0.0).matrix();
+    y0 = y0.array().max(T{0.0}).matrix();
   } else if (mlp.activation_type(0) == kTanh) {
     y0 = y0.array().tanh().matrix();
   }
@@ -151,7 +151,7 @@ void CalcOutputTest(
 
   Vector3<T> y1 = (W1 * y0 + b1);
   if (mlp.activation_type(1) == kReLU) {
-    y1 = y1.array().max(0.0).matrix();
+    y1 = y1.array().max(T{0.0}).matrix();
   } else if (mlp.activation_type(1) == kTanh) {
     y1 = y1.array().tanh().matrix();
   }
@@ -164,7 +164,7 @@ void CalcOutputTest(
 
   Vector2<T> y = (W2 * y1 + b2);
   if (mlp.activation_type(2) == kReLU) {
-    y = y.array().max(0.0).matrix();
+    y = y.array().max(T{0.0}).matrix();
   } else if (mlp.activation_type(2) == kTanh) {
     y = y.array().tanh().matrix();
   }


### PR DESCRIPTION
Towards #23439 and #23660.

Apparently Eigen's elementwise `max` function no longer implicitly promotes its argument to `typename Scalar`.  We need to pass exactly the right scalar type when calling it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23669)
<!-- Reviewable:end -->
