### PR TITLE
[multibody] Topology changes related to optimized assemblies (composites)

### DIFF
--- a/multibody/topology/link_joint_graph.cc
+++ b/multibody/topology/link_joint_graph.cc
@@ -122,7 +122,7 @@ void LinkJointGraph::InvalidateForest() {
     DRAKE_DEMAND(ssize(data_.joint_name_to_index) == data_.num_user_joints);
     DRAKE_DEMAND(data_.ephemeral_link_name_to_index.empty());
     DRAKE_DEMAND(data_.ephemeral_joint_name_to_index.empty());
-    DRAKE_DEMAND(data_.link_composites.empty());
+    DRAKE_DEMAND(data_.welded_links_assemblies.empty());
     DRAKE_DEMAND(data_.num_user_links == ssize(data_.links));
     DRAKE_DEMAND(data_.num_user_joints == ssize(data_.joints));
     return;
@@ -143,7 +143,7 @@ void LinkJointGraph::InvalidateForest() {
     data_.ephemeral_link_name_to_index.clear();
     data_.links.erase(data_.links.begin() + data_.num_user_links,
                       data_.links.end());
-    DRAKE_DEMAND(ssize(links()) == data_.num_user_links);
+    DRAKE_DEMAND(num_links() == data_.num_user_links);
   }
 
   if (ssize(data_.joints) > num_user_joints()) {
@@ -161,7 +161,7 @@ void LinkJointGraph::InvalidateForest() {
   // Remove all as-modeled information from the user's graph.
   for (auto& link : data_.links) link.ClearModel(data_.max_user_joint_index);
   for (auto& joint : data_.joints) joint.ClearModel();
-  data_.link_composites.clear();
+  data_.welded_links_assemblies.clear();
 }
 
 const LinkJointGraph::Link& LinkJointGraph::world_link() const {
@@ -175,7 +175,7 @@ LinkIndex LinkJointGraph::AddLink(const std::string& link_name,
   DRAKE_DEMAND(model_instance.is_valid());
 
   // Reject use of world model instance for any Link other than World.
-  if (ssize(links()) > 0 && model_instance == world_model_instance()) {
+  if (num_links() > 0 && model_instance == world_model_instance()) {
     throw std::logic_error(fmt::format(
         "{}(): Model instance index {} is reserved for the World link. "
         " World is always predefined and is named '{}'.",
@@ -203,7 +203,7 @@ LinkIndex LinkJointGraph::AddLink(const std::string& link_name,
   InvalidateForest();
 
   const LinkIndex link_index(num_link_indexes());
-  const LinkOrdinal link_ordinal(ssize(links()));
+  const LinkOrdinal link_ordinal(num_links());
   data_.link_index_to_ordinal.push_back(link_ordinal);
 
   // provide fast name lookup
@@ -211,7 +211,7 @@ LinkIndex LinkJointGraph::AddLink(const std::string& link_name,
 
   data_.links.emplace_back(
       Link(link_index, link_ordinal, link_name, model_instance, flags));
-  data_.num_user_links = ssize(links());
+  data_.num_user_links = num_links();
   data_.max_user_link_index = link_index;
 
   Link& new_link = data_.links.back();
@@ -485,14 +485,15 @@ bool LinkJointGraph::IsJointTypeRegistered(
   return it != data_.joint_type_name_to_index.end();
 }
 
-void LinkJointGraph::CreateWorldLinkComposite() {
+void LinkJointGraph::CreateWorldWeldedLinksAssembly() {
   DRAKE_DEMAND(!links().empty());  // Better be at least World!
-  DRAKE_DEMAND(data_.link_composites.empty());
+  DRAKE_DEMAND(data_.welded_links_assemblies.empty());
   Link& world_link = data_.links[LinkOrdinal(0)];
-  DRAKE_DEMAND(!world_link.link_composite_index_.has_value());
-  data_.link_composites.emplace_back(LinkComposite{
-      .links = std::vector{world_link.index()}, .is_massless = false});
-  world_link.link_composite_index_ = LinkCompositeIndex(0);
+  DRAKE_DEMAND(!world_link.welded_links_assembly_index_.has_value());
+  WeldedLinksAssembly& assembly = data_.welded_links_assemblies.emplace_back();
+  assembly.links_.push_back(world_link.index());
+  assembly.is_massless_ = false;
+  world_link.welded_links_assembly_index_ = WeldedLinksAssemblyIndex(0);
 }
 
 LoopConstraintIndex LinkJointGraph::AddLoopClosingWeldConstraint(
@@ -602,42 +603,57 @@ JointIndex LinkJointGraph::AddEphemeralJointToWorld(
   return new_joint_index;
 }
 
-LinkCompositeIndex LinkJointGraph::AddToLinkComposite(
-    LinkOrdinal maybe_composite_link_ordinal, LinkOrdinal new_link_ordinal) {
-  DRAKE_ASSERT(maybe_composite_link_ordinal.is_valid() &&
+WeldedLinksAssemblyIndex LinkJointGraph::AddToWeldedLinksAssembly(
+    LinkOrdinal maybe_assembly_link_ordinal, LinkOrdinal new_link_ordinal,
+    JointOrdinal weld_joint_ordinal) {
+  DRAKE_ASSERT(maybe_assembly_link_ordinal.is_valid() &&
                new_link_ordinal.is_valid());
-  Link& maybe_composite_link = mutable_link(maybe_composite_link_ordinal);
+  Link& maybe_assembly_link = mutable_link(maybe_assembly_link_ordinal);
   Link& new_link = mutable_link(new_link_ordinal);
   DRAKE_DEMAND(!new_link.is_world());
 
-  std::optional<LinkCompositeIndex> existing_composite_index =
-      maybe_composite_link.link_composite_index_;
-  if (!existing_composite_index.has_value()) {
-    // We're starting a new LinkComposite. This must be the "active link"
-    // for this Composite because we saw it first while building the Forest.
-    existing_composite_index = maybe_composite_link.link_composite_index_ =
-        LinkCompositeIndex(ssize(data_.link_composites));
-    data_.link_composites.emplace_back(LinkComposite{
-        .links = std::vector<LinkIndex>{maybe_composite_link.index()},
-        .is_massless = maybe_composite_link.is_massless()});
+  std::optional<WeldedLinksAssemblyIndex> existing_assembly_index =
+      maybe_assembly_link.welded_links_assembly_index_;
+  if (!existing_assembly_index.has_value()) {
+    // We're starting a new WeldedLinksAssembly. This must be the "active link"
+    // for this Assembly because we saw it first while building the Forest.
+    existing_assembly_index = maybe_assembly_link.welded_links_assembly_index_ =
+        WeldedLinksAssemblyIndex(ssize(data_.welded_links_assemblies));
+    WeldedLinksAssembly& assembly =
+        data_.welded_links_assemblies.emplace_back();
+    assembly.links_.push_back(maybe_assembly_link.index());
+    assembly.is_massless_ = maybe_assembly_link.is_massless();
   }
 
-  LinkComposite& existing_composite =
-      data_.link_composites[*existing_composite_index];
-  existing_composite.links.push_back(new_link.index());
-  // For the composite to be massless, _all_ its links must be massless.
-  if (!new_link.is_massless()) existing_composite.is_massless = false;
-  new_link.link_composite_index_ = existing_composite_index;
+  WeldedLinksAssembly& existing_assembly =
+      data_.welded_links_assemblies[*existing_assembly_index];
+  existing_assembly.links_.push_back(new_link.index());
+  existing_assembly.joints_.push_back(joints(weld_joint_ordinal).index());
+  // For the assembly to be massless, _all_ its links must be massless.
+  if (!new_link.is_massless()) {
+    existing_assembly.is_massless_ = false;
+  }
+  new_link.welded_links_assembly_index_ = existing_assembly_index;
 
-  return *existing_composite_index;
+  return *existing_assembly_index;
 }
 
-void LinkJointGraph::AddUnmodeledJointToComposite(
+void LinkJointGraph::NoteUnmodeledJointInWeldedLinksAssembly(
     JointOrdinal unmodeled_joint_ordinal,
-    LinkCompositeIndex link_composite_index) {
+    WeldedLinksAssemblyIndex welded_links_assembly_index) {
   Joint& joint = mutable_joint(unmodeled_joint_ordinal);
-  DRAKE_DEMAND(joint.traits_index() == weld_joint_traits_index());
-  joint.how_modeled_ = link_composite_index;
+  DRAKE_DEMAND(joint.is_weld());
+  joint.how_modeled_ = welded_links_assembly_index;
+}
+
+void LinkJointGraph::AddUnmodeledJointToWeldedLinksAssembly(
+    JointOrdinal unmodeled_joint_ordinal,
+    WeldedLinksAssemblyIndex welded_links_assembly_index) {
+  WeldedLinksAssembly& assembly =
+      data_.welded_links_assemblies[welded_links_assembly_index];
+  assembly.joints_.push_back(joints(unmodeled_joint_ordinal).index());
+  NoteUnmodeledJointInWeldedLinksAssembly(unmodeled_joint_ordinal,
+                                          welded_links_assembly_index);
 }
 
 LinkOrdinal LinkJointGraph::AddShadowLink(LinkOrdinal primary_link_ordinal,
@@ -649,14 +665,14 @@ LinkOrdinal LinkJointGraph::AddShadowLink(LinkOrdinal primary_link_ordinal,
   const int shadow_num = primary_link.num_shadows() + 1;
   /* Name should be <primary_name>$<shadow_num> (unique within primary's model
   instance). In the unlikely event that a user has names like this, we'll keep
-  prepending "_" to the body name until this one is unique. Nothing much depends
+  prepending "_" to the link name until this one is unique. Nothing much depends
   on the details of this name. */
   std::string shadow_link_name =
       fmt::format("{}${}", primary_link.name(), shadow_num);
   while (HasLinkNamed(shadow_link_name, primary_link.model_instance()))
     shadow_link_name = "_" + shadow_link_name;
   const LinkIndex shadow_link_index(num_link_indexes());
-  const LinkOrdinal shadow_link_ordinal(ssize(links()));
+  const LinkOrdinal shadow_link_ordinal(num_links());
   DRAKE_DEMAND(shadow_link_ordinal >= num_user_links());  // A sanity check.
   data_.link_index_to_ordinal.push_back(shadow_link_ordinal);
   data_.ephemeral_link_name_to_index.insert(
@@ -667,13 +683,18 @@ LinkOrdinal LinkJointGraph::AddShadowLink(LinkOrdinal primary_link_ordinal,
   /* Caution: primary_link reference is invalid now -- don't use it! */
   Link& shadow_link = data_.links.back();
   shadow_link.primary_link_ = primary_link_index;
-  const Joint& shadow_joint = joints(shadow_joint_ordinal);
+  Joint& shadow_joint = mutable_joint(shadow_joint_ordinal);
   if (shadow_is_parent) {
     shadow_link.add_joint_as_parent(shadow_joint.index());
+    shadow_joint.set_effective_parent_link(shadow_link_index);
   } else {
     shadow_link.add_joint_as_child(shadow_joint.index());
+    shadow_joint.set_effective_child_link(shadow_link_index);
   }
-  mutable_link(primary_link_ordinal).shadow_links_.push_back(shadow_link_index);
+
+  Link& mutable_primary_link = mutable_link(primary_link_ordinal);
+  mutable_primary_link.shadow_links_.push_back(shadow_link_index);
+  mutable_primary_link.NoteRetargetedJoint(shadow_joint.index());
 
   return shadow_link_ordinal;
 }
@@ -720,7 +741,7 @@ std::vector<LinkIndex> LinkJointGraph::FindPathFromWorld(
   std::vector<LinkIndex> path(mobod->level() + 1);
   while (mobod->inboard().is_valid()) {
     const Link& link = links(mobod->link_ordinal());
-    path[mobod->level()] = link.index();  // Active Link if composite.
+    path[mobod->level()] = link.index();  // Active Link if optimized assembly.
     mobod = &forest().mobods(mobod->inboard());
   }
   DRAKE_DEMAND(mobod->is_world());
@@ -745,25 +766,25 @@ std::vector<LinkIndex> LinkJointGraph::FindSubtreeLinks(
   return forest().FindSubtreeLinks(root_mobod_index);
 }
 
-// Our link_composites collection doesn't include lone Links that aren't welded
-// to anything. The return from this function must include every Link, with
-// the World link in the first set (even if nothing is welded to it).
+// Our welded_links_assemblies collection doesn't include lone Links that aren't
+// welded to anything. The return from this function must include every Link,
+// with the World link in the first set (even if nothing is welded to it).
 std::vector<std::set<LinkIndex>> LinkJointGraph::GetSubgraphsOfWeldedLinks()
     const {
   ThrowIfForestNotBuiltYet(__func__);
 
   std::vector<std::set<LinkIndex>> subgraphs;
 
-  // First, collect all the precomputed Link Composites. World is always
+  // First, collect all the precomputed WeldedLinksAssemblies. World is always
   // the first one, even if nothing is welded to it.
-  for (const LinkComposite& composite : link_composites()) {
+  for (const WeldedLinksAssembly& assembly : welded_links_assemblies()) {
     subgraphs.emplace_back(
-        std::set<LinkIndex>(composite.links.cbegin(), composite.links.cend()));
+        std::set<LinkIndex>(assembly.links_.cbegin(), assembly.links_.cend()));
   }
 
-  // Finally, make one-Link subgraphs for Links that aren't in any composite.
+  // Finally, make one-Link subgraphs for Links that aren't in any assembly.
   for (const Link& link : links()) {
-    if (link.composite().has_value()) continue;
+    if (link.welded_links_assembly().has_value()) continue;
     subgraphs.emplace_back(std::set<LinkIndex>{link.index()});
   }
 
@@ -806,22 +827,23 @@ std::vector<std::set<LinkIndex>> LinkJointGraph::CalcSubgraphsOfWeldedLinks()
   return subgraphs;
 }
 
-// If the Link isn't part of a LinkComposite just return the Link. Otherwise,
-// return all the Links in its LinkComposite.
+// If the Link isn't part of a WeldedLinksAssembly just return the Link.
+// Otherwise, return all the Links in its WeldedLinksAssembly.
 std::set<LinkIndex> LinkJointGraph::GetLinksWeldedTo(
     LinkIndex link_index) const {
   ThrowIfForestNotBuiltYet(__func__);
   DRAKE_DEMAND(link_index.is_valid());
   DRAKE_THROW_UNLESS(has_link(link_index));
   const Link& link = link_by_index(link_index);
-  const std::optional<LinkCompositeIndex> composite_index = link.composite();
-  if (!composite_index.has_value()) return std::set<LinkIndex>{link_index};
+  const std::optional<WeldedLinksAssemblyIndex> assembly_index =
+      link.welded_links_assembly();
+  if (!assembly_index.has_value()) return std::set<LinkIndex>{link_index};
   const std::vector<LinkIndex>& welded_links =
-      link_composites(*composite_index).links;
+      welded_links_assemblies(*assembly_index).links();
   return std::set<LinkIndex>(welded_links.cbegin(), welded_links.cend());
 }
 
-// Without a Forest we don't have LinkComposites available so recursively
+// Without a Forest we don't have WeldedLinksAssemblies available so recursively
 // chase Weld joints instead.
 std::set<LinkIndex> LinkJointGraph::CalcLinksWeldedTo(
     LinkIndex link_index) const {
@@ -930,7 +952,8 @@ void LinkJointGraph::Link::ClearModel(JointIndex max_user_joint_index) {
   mobod_ = {};
   joint_ = {};
   shadow_links_.clear();
-  link_composite_index_ = {};
+  joints_moved_to_shadow_links_.clear();
+  welded_links_assembly_index_ = {};
 }
 
 LinkJointGraph::Joint::Joint(JointIndex index, JointOrdinal ordinal,
@@ -953,6 +976,8 @@ LinkJointGraph::Joint::Joint(JointIndex index, JointOrdinal ordinal,
                child_link_index_.is_valid());
   DRAKE_DEMAND(parent_link_index_ != child_link_index_);
   DRAKE_DEMAND(ordinal_ <= static_cast<int>(index_));
+  effective_parent_link_index_ = parent_link_index_;
+  effective_child_link_index_ = child_link_index_;
 }
 
 }  // namespace internal

--- a/multibody/topology/link_joint_graph_debug.cc
+++ b/multibody/topology/link_joint_graph_debug.cc
@@ -34,18 +34,19 @@ std::string LinkJointGraph::GenerateGraphvizString(
   if (show_as_modeled) graphviz += "\nred = ephemeral";
   graphviz += "\"]\n";
 
-  // Link composites are discovered during forest building. If there
-  // is no forest, there will be no composites. But if there are composites
-  // we'd like to draw boxes around them so we'll process composited links
+  // WeldedLinkAssemblies are discovered during forest building. If there
+  // is no forest, there will be no assemblies. But if there are assemblies
+  // we'd like to draw boxes around them so we'll process assembled links
   // first and then pick up the leftovers below.
-  for (LinkCompositeIndex index{0}; index < ssize(link_composites()); ++index) {
-    const LinkComposite& composite = link_composites(index);
+  for (WeldedLinksAssemblyIndex index{0};
+       index < ssize(welded_links_assemblies()); ++index) {
+    const WeldedLinksAssembly& assembly = welded_links_assemblies(index);
     // Oddly, in order to get the box and label for a subgraph, the _name_
     // of the subgraph must begin with "cluster"!
     graphviz += fmt::format("subgraph cluster{}", index) + " {\n";
-    graphviz += fmt::format("label=\"LinkComposite({}){}\";\n", index,
-                            composite.is_massless ? "*" : "");
-    for (const LinkIndex& link_index : composite.links) {
+    graphviz += fmt::format("label=\"WeldedLinksAssembly({}){}\";\n", index,
+                            assembly.is_massless() ? "*" : "");
+    for (const LinkIndex& link_index : assembly.links()) {
       const Link& link = link_by_index(link_index);
       const bool ephemeral = link_is_ephemeral(link.index());
       if (ephemeral && !include_ephemeral_elements) continue;
@@ -57,9 +58,9 @@ std::string LinkJointGraph::GenerateGraphvizString(
     graphviz += "}\n";
   }
 
-  // Now pick up the links that aren't in a composite.
+  // Now pick up the links that aren't in an assembly.
   for (const Link& link : links()) {
-    if (link.composite().has_value()) continue;
+    if (link.welded_links_assembly().has_value()) continue;
     const bool ephemeral = link_is_ephemeral(link.index());
     if (ephemeral && !include_ephemeral_elements) continue;
     graphviz +=

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -20,7 +20,7 @@ class SpanningForest;
 using LinkOrdinal = TypeSafeIndex<class LinkOrdinalTag>;
 
 using JointTraitsIndex = TypeSafeIndex<class JointTraitsTag>;
-using LinkCompositeIndex = TypeSafeIndex<class LinkCompositeTag>;
+using WeldedLinksAssemblyIndex = TypeSafeIndex<class WeldedLinksAssemblyTag>;
 using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;
 
 /* Link properties that can affect how the forest model gets built. Or-ing
@@ -48,7 +48,8 @@ enum class ForestBuildingOptions : uint32_t {
   kStatic = 1 << 0,                ///< Weld all links to World.
   kUseFixedBase = 1 << 1,          ///< Use welds rather than floating joints.
   kUseRpyFloatingJoints = 1 << 2,  ///< For floating, use RPY not quaternion.
-  kMergeLinkComposites = 1 << 3    ///< Make a single Mobod for welded Links.
+  kOptimizeWeldedLinksAssemblies =
+      1 << 3  ///< Make a single Mobod for welded Links.
 };
 
 // These overloads make the above enums behave like bitmasks for the operations

--- a/multibody/topology/link_joint_graph_inlines.h
+++ b/multibody/topology/link_joint_graph_inlines.h
@@ -6,6 +6,8 @@
 
 #include <optional>
 
+#include "drake/common/ssize.h"
+
 namespace drake {
 namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
@@ -51,13 +53,14 @@ inline void LinkJointGraph::set_primary_mobod_for_link(
   link.joint_ = primary_joint_index;
 }
 
-inline bool LinkJointGraph::link_and_its_composite_are_massless(
+inline bool LinkJointGraph::link_and_its_assembly_are_massless(
     LinkOrdinal link_ordinal) const {
   const Link& link = links(link_ordinal);
   if (!link.is_massless()) return false;
 
-  return link.composite().has_value()
-             ? link_composites(*link.composite()).is_massless
+  return link.welded_links_assembly().has_value()
+             ? welded_links_assemblies(*link.welded_links_assembly())
+                   .is_massless()
              : true;
 }
 

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -27,30 +27,30 @@ using WeldedMobodsIndex = TypeSafeIndex<class WeldedMobodsTag>;
 /* SpanningForest models a LinkJointGraph via a set of spanning trees and
 loop-closing constraints. This is a directed forest, with edges ordered from
 inboard (closer to World) to outboard. The nodes are mobilized bodies (Mobods)
-representing a body and its inboard mobilizer. While building the Forest we also
+representing a body and its inboard mobilizer. While building the forest we also
 study the original LinkJointGraph and update it to reflect:
   - how each of its elements was modeled,
   - any new elements that needed to be added for the model, and
-  - which Links are welded together into composites.
+  - which Links are welded together into WeldedLinksAssemblies.
 
 Welded-together Links have no relative motion so should be excluded from mutual
-collision computations and can (optionally) be modeled with a single mobilized
-body.
+collision computations and can (optionally) be optimized by modeling with one
+or more composite Mobods.
 
 Problem statement
 
 We're given a disjoint collection of directed, possibly cyclic, graphs whose
 nodes represent links and whose parent->child directed edges represent joints.
-Some graphs contain edges to World, others are free-floating. The task here is
+Some graphs contain edges from World, others are free-floating. The task here is
 to efficiently convert the input graph collection into a single directed
 _acyclic_ graph considered as a forest of directed trees. The nodes of the trees
 are _mobilized bodies_ (Mobods), each of which has a unique edge ("mobilizer")
 connecting it to its _inboard_ (closer to World) mobilized body, and directed
 inboard->outboard. Each tree spans one of the input graphs and is given an edge
-to World if there wasn't one already. Links are cut to break cycles, with each
-half getting its own Mobod. The forest is augmented with weld constraints
-that will act on the two Mobods to reconnect the Link halves. The resulting
-forest (with its associated welds) is to be optimized for computation speed and
+from World if there wasn't one already. Links are cut to break cycles, with each
+half getting its own Mobod. The forest is augmented with weld constraints that
+will act on the two Mobods to reconnect the Link halves. The resulting forest
+(with its associated welds) is to be optimized for computation speed and
 numerical accuracy, consistent with user preferences.
 
 Input links and joints can be annotated with properties that may affect how we
@@ -63,7 +63,7 @@ connect free-floating input graphs to World, and how they should be connected
 
 These are the properties the resulting forest _must_ have:
   - All nodes (Mobods) have a path from World.
-  - Massless bodies never appear as terminal nodes in the forest
+  - Massless bodies never appear as terminal nodes in the forest.
   - Mobod nodes are numbered depth-first.
   - Position and velocity coordinates q and v are assigned to the edges
     (mobilizers) with the same depth-first ordering.
@@ -75,33 +75,33 @@ And these additional properties are highly desirable:
   - The maximum branch length is minimized when breaking cycles.
   - Input parent->child edge directions are preserved as inboard->outboard
     directions when possible without increasing the maximum branch length.
-  - Welded-together links are combined into a single Mobod (optionally).
+  - Welded-together links are combined onto one composite Mobod (optionally).
 
 Discussion
 
 A LinkJointGraph consists of Links (user-defined rigid bodies) and Joints in a
 directed, possibly cyclic graph. Link 0 is designated as the World and is
-modeled by Mobod 0 in the Forest. Each Joint connects a "parent" Link to a
+modeled by Mobod 0 in the forest. Each Joint connects a "parent" Link to a
 "child" Link. The parent->child ordering is arbitrary but sets the user's
 expected sign conventions for the Joint coordinates. Those must be preserved,
-even though inboard->outboard ordering may differ from parent->child (even if
-there are no loops). We distinguish "moving" (or "articulated") Joints from
+even though inboard->outboard ordering may differ from parent->child, even if
+there are no loops. We distinguish "moving" (or "articulated") Joints from
 "weld" (0 dof) Joints; every moving Joint is modeled by a mobilizer, but welds
-may be eliminated by creating LinkComposites that require only a single
-mobilizer for a group of Links.
+may be eliminated by creating WeldedLinksAssemblies that can be modeled with
+composite Mobods.
 
-The SpanningForest contains a Mobod node corresponding to each Link or
-LinkComposite (group of welded-together Links). A mobilizer connects each Mobod
-to an inboard Mobod (except for World). An additional "shadow" Link and its
-Mobod is created whenever a loop is broken by cutting a Link, and a
-LoopConstraint is added to reconnect the primary Link to its shadow. Every
-moving Joint will map to a Mobod and there will be additional floating or weld
-mobilizers added as needed to connect tree root nodes (a.k.a. "base bodies") to
-World.
+Every Link is associated with a single Mobod in the SpanningForest. Multiple
+Links (contained in a WeldedLinksAssembly) may be represented by a single Mobod.
+A mobilizer connects each Mobod to an inboard Mobod (except for World). An
+additional "shadow" Link and its Mobod is created whenever a loop is broken by
+cutting a Link, and a LoopConstraint is added to reconnect the primary Link to
+its shadow. Every moving Joint will map to a Mobod and there will be additional
+floating or weld joints added as needed to connect tree root nodes (a.k.a. "base
+bodies") to World.
 
 When extra bodies, mobilizers, and constraints are needed to construct the
-Forest, corresponding _ephemeral_ Links, Joints, and LoopConstraints are added
-to the LinkJointGraph so a user can view the Forest as an extended
+forest, corresponding _ephemeral_ Links, Joints, and LoopConstraints are added
+to the LinkJointGraph so a user can view the forest as an extended
 LinkJointGraph (the original graph is retained). For example, added 6dof
 mobilizers can be viewed as though they had been floating Joints in the
 LinkJointGraph.
@@ -111,24 +111,25 @@ Mobod corresponding to World. The data structures are designed to support fast
 computation directly so that the information here does not need to be duplicated
 elsewhere.
 
-Things we get for free (O(1)) here as a side effect of building the Forest:
+Things we get for free (O(1)) here as a side effect of building the forest:
   - access the mobilized bodies (Mobods) in depth-first order
   - access Trees also in depth-first order and find out which Mobods belong
       to a given Tree and what range of coordinates belongs to each Tree or
       subtree
   - ask a Mobod which Tree it is in, and which coordinates it uses
   - find out which groups of Mobods are welded together (so have no relative
-    motion)
+      motion)
   - ask a Mobod which WeldedMobods grouping it belongs to, if any
   - ask a coordinate (q or v) which Mobod or Tree it belongs to
   - ask for the max height of a Tree or the level of a particular Mobod
   - determine which Mobods are anchored to World, directly or indirectly
   - find out which Mobod(s) represents a given Link
   - find out which Mobod (if any) represents a given Joint (welds internal
-    to LinkComposites are not modeled)
-  - find all the Links that follow a particular Mobod (for composites)
-  - find out what (ephemeral) Links, Joints, and LoopConstraints appear in the
-      Forest but not the source Graph.
+      to WeldedLinksAssemblies may be unmodeled)
+  - find all the Links that follow a particular Mobod (can be composite
+      Mobods for Links in WeldedLinksAssemblies)
+  - find out what (ephemeral) Links, Joints, and LoopConstraints appear in
+      the forest but not the source Graph.
 
 Supported operations at minimal cost:
   - find the path from World to a given Link or Mobod
@@ -187,7 +188,7 @@ class SpanningForest {
       MobodIndex mobod1_index, MobodIndex mobod2_index,
       std::vector<MobodIndex>* path1, std::vector<MobodIndex>* path2) const;
 
-  /* Finds all the Links following the Forest subtree whose root mobilized body
+  /* Finds all the Links following the forest subtree whose root mobilized body
   B is given. That is, we return all the Links that follow B or any other Mobod
   in the subtree rooted at B. The Links following B come first, and the rest
   follow the depth-first ordering of the Mobods. In particular, the result is
@@ -262,7 +263,7 @@ class SpanningForest {
   that weren't explicitly connected to World by a Joint come last. */
   const std::vector<Mobod>& mobods() const { return data_.mobods; }
 
-  /* Returns the number of Mobods in the Forest, including World.  This is the
+  /* Returns the number of Mobods in the forest, including World.  This is the
   same as `ssize(mobods())`. */
   [[nodiscard]] inline int num_mobods() const;
 
@@ -287,12 +288,12 @@ class SpanningForest {
       LoopConstraintIndex index) const;
 
   /* The partitioning of the forest of mobilized bodies into trees. Each Tree
-  has a base (root) mobilized body that is connected directly to the World
-  Mobod (which may represent a LinkComposite). World is not considered to
-  be part of any Tree; it is the root of the Forest. */
+  has a base (root) mobilized body that is connected directly to the World Mobod
+  (which may represent a WeldedLinksAssembly). World is not considered to be
+  part of any Tree; it is the root of the forest. */
   const std::vector<Tree>& trees() const { return data_.trees; }
 
-  /* Returns the number of Trees in the Forest.  This is the same as
+  /* Returns the number of Trees in the forest.  This is the same as
   `ssize(trees())`. */
   [[nodiscard]] inline int num_trees() const;
 
@@ -309,20 +310,24 @@ class SpanningForest {
   int height() const { return data_.forest_height; }
 
   /* Returns precalculated groups of mobilized bodies that are mutually
-  interconnected by Weld mobilizers so have no relative degrees of freedom.
-  Note that if you have chosen the modeling option to combine welded-together
-  Links into single bodies, then each LinkComposite gets only a single Mobod
-  and hence there won't be any WeldedMobods groups here (except for World which
-  is always considered to be in a WeldedMobods group even if nothing is welded
-  to it). Use mobod_to_links() to find all the Links following a single Mobod.
+  interconnected by Weld mobilizers so have no relative degrees of freedom. Note
+  that if you have chosen the modeling option to optimize welded-together Links
+  into single composite bodies, then each WeldedLinksAssembly gets only a single
+  Mobod and hence there won't be any WeldedMobods groups here (except for World,
+  see below). On the other hand, if some of the joints in a WeldedLinksAssembly
+  have been designated "must be modeled", the assembly will be split over
+  several Mobods connected by a weld mobilizer; in that case there will be a
+  corresponding WeldedMobods group. Use mobod_to_links() to find all the Links
+  following a single Mobod.
 
-  The World WeldedMobods group comes first and contains World, mobilized bodies
-  representing Links marked "Static", and bodies (if any) welded to Static
-  bodies or World (recursively). Those are the "anchored" mobilized bodies. The
-  other groups represent sets of welded-together mobilized bodies, with the
-  first one in the group the only Mobod with a non-weld inboard mobilizer.
-  That moving Mobod is necessarily the lowest numbered (most inboard) Mobod
-  of the WeldedMobods group. The remaining Mobods are in no particular order.
+  The always-present World WeldedMobods group comes first and contains World,
+  mobilized bodies representing Links marked "Static", and bodies (if any)
+  welded to Static bodies or World (recursively). Those are the "anchored"
+  mobilized bodies. The other groups represent sets of welded-together mobilized
+  bodies, with the first one in the group the only Mobod with a non-weld inboard
+  mobilizer. That moving Mobod (the "active Mobod") is necessarily the lowest
+  numbered (most inboard) Mobod of the WeldedMobods group. The remaining Mobods
+  are in no particular order.
 
   Except for World, Mobods not welded to any other Mobods do not appear here.
   @see mobod_to_links() */
@@ -352,14 +357,14 @@ class SpanningForest {
 
   /* Returns the Link that is represented by the given Mobod. This could be
   one of the Links from the original graph or an added shadow Link. If this
-  Mobod represents a LinkComposite, the Link returned here is the
+  Mobod represents a WeldedLinksAssembly, the Link returned here is the
   "active" Link, that is, the one whose mobilizer is used to move the whole
-  Composite. Cost is O(1) and very fast.
+  Assembly. Cost is O(1) and very fast.
   @pre mobod_index is in range */
   inline LinkOrdinal mobod_to_link_ordinal(MobodIndex mobod_index) const;
 
   /* Returns all the Links mobilized by this Mobod. The "active" Link returned
-  by mobod_to_link() comes first, then any other Links in the same Composite.
+  by mobod_to_link() comes first, then any other Links in the same Assembly.
   O(1), very fast.
   @pre mobod_index is in range  */
   inline const std::vector<LinkOrdinal>& mobod_to_link_ordinals(
@@ -429,8 +434,8 @@ class SpanningForest {
   std::string GenerateGraphvizString(std::string_view label) const;
 
   /* (Debugging, Testing) Runs a series of expensive tests to see that the
-  Graph and Forest are internally consistent and throws if not. Does nothing
-  if no Forest has been built. */
+  Graph and forest are internally consistent and throws if not. Does nothing
+  if no forest has been built. */
   void SanityCheckForest() const;
 
  private:
@@ -500,11 +505,11 @@ class SpanningForest {
                    int* num_unprocessed_links);
 
   // Grows the trees containing each of the given Joints by one level. The
-  // output parameter `J_out` (cleared on entry) on return
-  // contains the set of Joints that should be modeled at the next level.
-  // @pre the pointers are non-null and `J_in` is not empty. On return,
+  // output parameter `J_out` (cleared on entry) on return contains the set of
+  // Joints that should be modeled at the next level. On return,
   // num_unprocessed_links will have been decremented by the number of Links
   // that were modeled.
+  // @pre the pointers are non-null and `J_in` is not empty.
   void ExtendTreesOneLevel(const std::vector<JointIndex>& J_in,
                            std::vector<JointIndex>* J_out,
                            int* num_unprocessed_links);
@@ -519,13 +524,13 @@ class SpanningForest {
       const Joint& open_joint) const;
 
   // Helper for ExtendTreesOneLevel(). We're given a set of as-yet-unmodeled,
-  // "open" joints, each of which has one end already following the given Mobod.
-  // Returns a list of joints that represent the "next level" in the forest
-  // outboard of the given Mobod. For any joint that doesn't have to be a
-  // merged joint in a merged composite, that joint goes directly on the
-  // "next level" list. Otherwise, we have to extend the composite and find all
-  // the open joints where one end is part of the composite; those are the
-  // "next level".
+  // "open" joints, each of which has one end already following the given
+  // inboard Mobod. Returns a list of joints that represent the "next level" in
+  // the forest outboard of the given Mobod. For any joint that isn't going to
+  // be an unmodeled internal joint in an optimized WeldedLinksAssembly, that
+  // joint goes directly on the "next level" list. Otherwise, we have to extend
+  // the assembly and find all the open joints where one end is part of the
+  // assembly; those are the "next level".
   void FindNextLevelJoints(MobodIndex inboard_mobod_index,
                            const std::vector<JointIndex>& J_in,
                            std::vector<JointIndex>* J_level,
@@ -550,12 +555,12 @@ class SpanningForest {
 
   // Adds a new mobilized body outboard of the given inboard body:
   //  - sets the level to one higher than the inboard level
-  //  - if inboard is World, starts a new tree otherwise new Mobod is in
-  //    the same tree as inboard
+  //  - if inboard is World, starts a new tree otherwise new Mobod is in the
+  //    same tree as inboard
   //  - adds the new Mobod to the list of outboard Mobods in the inboard body
   //  - updates maps of link-to-mobod and joint-to-mobod
   //  - if joint type is Weld, we are creating or joining a WeldedMobods group
-  //    and LinkComposite; if welded to World the Mobod is "anchored". */
+  //    and WeldedLinksAssembly; if welded to World the Mobod is "anchored". */
   const Mobod& AddNewMobod(LinkOrdinal outboard_link_ordinal,
                            JointOrdinal joint_ordinal,
                            MobodIndex inboard_mobod_index, bool is_reversed);
@@ -567,21 +572,21 @@ class SpanningForest {
   // Sets the comparison function to be used in making the "best" choice.
   void SetBaseBodyChoicePolicy();
 
-  // The not-yet-modeled Joint given by `loop_joint_index` connects two Links
-  // both of which are already modeled in the Forest. We will model the Joint by
+  // The not-yet-modeled Joint given by `loop_joint_ordinal` connects two Links
+  // both of which are already modeled in the forest. We will model the Joint by
   // splitting off a shadow of one of the Links and mobilizing the shadow with a
   // forward or reversed Mobilizer of the Joint's type. Then we add a Weld
   // Constraint to attach the shadow to its primary. Some details:
   //  - if one link is massless, split the other one
   //  - if both are massless we have an invalid forest
-  //  - either or both Links may be composites; it is the mass properties
-  //    of the whole composite that determines masslessness.
+  //  - either or both Links may be part of a WeldedLinksAssembly; it is the
+  //    mass properties of the whole assembly that determines masslessness.
   void HandleLoopClosure(JointOrdinal loop_joint_ordinal);
 
   // Adds a shadow Link of the given primary and mobilizes the shadow with
   // the given joint which was originally connected to the primary. Adds a
   // weld constraint to reattach the shadow to the primary. The shadow and
-  // weld are added to the graph as ephemeral elements.
+  // weld constraint are added to the graph as ephemeral elements.
   const Mobod& AddShadowMobod(LinkOrdinal primary_link_ordinal,
                               JointOrdinal shadow_joint_ordinal);
 
@@ -621,34 +626,34 @@ class SpanningForest {
     return *data_.graph;
   }
 
-  // Returns true if this model instance requests optimization (link merging)
-  // of composites, either explicitly or via inheritance from the global
+  // Returns true if this model instance requests optimization (link merging) of
+  // WeldedLinksAssemblies, either explicitly or via inheritance from the global
   // settings.
-  bool should_merge_link_composites(ModelInstanceIndex index) const {
-    return static_cast<bool>(options(index) &
-                             ForestBuildingOptions::kMergeLinkComposites);
+  bool should_merge_welded_links_assemblies(ModelInstanceIndex index) const {
+    return static_cast<bool>(
+        options(index) & ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
   }
 
-  // This implements our policy for when to optimize LinkComposites by merging
-  // their constituent Links onto a single Mobod. We're given a Joint
-  // connecting parent and child Links and need to decide whether the parent
-  // and child will follow a single Mobod or two different Mobods. If we
-  // decide to merge them, the Joint won't be modeled at all since it will be
-  // interior to the composite.
+  // This implements our policy for when to optimize WeldedLinksAssemblies by
+  // merging their constituent Links onto a single Mobod. We're given a Joint
+  // connecting parent and child Links and need to decide whether the parent and
+  // child will follow a single Mobod or two different Mobods. If we decide to
+  // merge them, the Joint won't be modeled at all since it will be interior to
+  // the assembly.
   //
   // To return true (merge), the following must all be true:
   //   - The joint must be a weld, and
-  //   - the joint's model instance must request merging composites, and
-  //   - the joint has _not_ demanded that it be modeled.
+  //   - the joint's model instance must request optimizing assemblies, and
+  //   - the joint has _not_ demanded that it be separately modeled.
   bool should_merge_parent_and_child(const Joint& joint) const {
     return joint.is_weld() && !joint.must_be_modeled() &&
-           should_merge_link_composites(joint.model_instance());
+           should_merge_welded_links_assemblies(joint.model_instance());
   }
 
-  // Adds the follower Link to the LinkComposite that inboard_mobod is
-  // mobilizing and notes that the Joint is internal to that LinkComposite
-  // so is not modeled. Will create the LinkComposite if there was only one
-  // Link mobilized before.
+  // Adds the follower Link to the WeldedLinksAssembly that inboard_mobod is
+  // mobilizing and notes that the Joint is internal to that WeldedLinksAssembly
+  // so is not modeled. Will create the WeldedLinksAssembly if there was only
+  // one Link mobilized before.
   const Mobod& JoinExistingMobod(Mobod* inboard_mobod,
                                  LinkOrdinal follower_link_ordinal,
                                  JointOrdinal weld_joint_ordinal);
@@ -656,13 +661,13 @@ class SpanningForest {
   // We're given an existing Mobod and a to-be-merged weld joint where that
   // joint's inboard link is already following the Mobod. Greedily extend this
   // Mobod recursively to merge all links that are merge-welded to the inboard
-  // link. As we encounter non-merge joints attached to this composite we append
+  // link. As we encounter non-merge joints attached to this assembly we append
   // them to `open_joint_indexes` for processing next. Those constitute the
-  // "next level" outboard of this merged composite.
-  void GrowCompositeMobod(Mobod* inboard_mobod, LinkIndex outboard_link_index,
-                          JointOrdinal weld_joint_ordinal,
-                          std::vector<JointIndex>* open_joint_indexes,
-                          int* num_unprocessed_links);
+  // "next level" outboard of this optimized WeldedLinksAssembly.
+  void GrowAssemblyMobod(Mobod* inboard_mobod, LinkIndex outboard_link_index,
+                         JointOrdinal weld_joint_ordinal,
+                         std::vector<JointIndex>* open_joint_indexes,
+                         int* num_unprocessed_links);
 
   struct Data {
     // These are all default but definitions deferred to .cc file so
@@ -692,13 +697,13 @@ class SpanningForest {
     int forest_height{0};
 
     // Welded Mobod groups. These are disjoint sets of Mobods that have no
-    // relative motion due to _modeled_ weld Joints (and _not_ due to weld
-    // constraints). (If we are building LinkComposites, there won't be any
-    // Mobods welded together because we'll make all welded-together Links
-    // follow a single Mobod.) The World Mobod group is always present and comes
-    // first even if nothing is welded to it. Other Mobods appear here only if
-    // they are welded to at least one other Mobod. The indexes here must be
-    // renumbered by FixupForestToUseNewNumbering().
+    // relative motion due to _separately modeled_ weld Joints (and _not_ due to
+    // weld constraints). (If we are optimizing WeldedLinksAssemblies, there
+    // won't be any Mobods welded together because we'll make all
+    // welded-together Links follow a single Mobod.) The World Mobod group is
+    // always present and comes first even if nothing is welded to it. Other
+    // Mobods appear here only if they are welded to at least one other Mobod.
+    // The indexes here must be renumbered by FixupForestToUseNewNumbering().
     std::vector<std::vector<MobodIndex>> welded_mobods;
 
     // Map from mobilizer coordinates to their associated mobilized bodies.
@@ -707,7 +712,7 @@ class SpanningForest {
     std::vector<MobodIndex> q_to_mobod;  // size is nq (total number of q's)
     std::vector<MobodIndex> v_to_mobod;  // size is nv (total number of v's)
 
-    // Indexes of quaternion starts within the q vector, in increasing order.
+    // Indices of quaternion starts within the q vector, in increasing order.
     std::vector<int> quaternion_starts;
 
     // This policy is expressed as a "less than" comparator of the type used by
@@ -718,7 +723,7 @@ class SpanningForest {
 
     // Set to false if we had to end a branch with a massless body.
     bool dynamics_ok{true};
-    // Human-readable explanation for the above.
+    // Human-readable explanation for the above, if false.
     std::string why_no_dynamics;
   } data_;
 };

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -76,25 +76,27 @@ class SpanningForest::Mobod {
   %Mobod's level(). */
   const std::vector<MobodIndex>& outboards() const { return outboard_mobods_; }
 
-  /* Returns the ordinal of the Link mobilized by this %Mobod. If this %Mobod
-  models a LinkComposite (collection of welded-together Links), this is the
-  "active" Link of that composite, the one whose (non-Weld) Joint connects
-  the whole LinkComposite to its inboard %Mobod.
-  @see joint() */
+  /* Returns the ordinal of the Link mobilized by this %Mobod. If this is a
+  composite %Mobod (representing a collection of welded-together links), this is
+  the most-inboard link of that composite, the one with the Joint whose
+  mobilizer connects the composite %Mobod to its inboard %Mobod.
+  @see follower_link_ordinals(), joint() */
   LinkOrdinal link_ordinal() const { return follower_link_ordinals()[0]; }
 
   /* Returns true if _any_ of the follower links is massful, in which case
   this Mobod is also massful. */
   bool has_massful_follower_link() const { return has_massful_follower_link_; }
 
-  /* Returns all the Links that are mobilized by this %Mobod. If this %Mobod
-  represents a LinkComposite, the first Link returned is the "active" Link as
-  returned by link_ordinal(). There is always at least one Link. */
+  /* Returns all the Links that are mobilized by this %Mobod. If this is a
+  composite %Mobod, the first link returned is the most-inboard link as
+  returned by link_ordinal(). There is always at least one link.
+  @see link_ordinal() */
   const std::vector<LinkOrdinal>& follower_link_ordinals() const {
     DRAKE_ASSERT(!follower_link_ordinals_.empty());
     return follower_link_ordinals_;
   }
 
+  /* Returns true if the given Link is one of the followers of this %Mobod. */
   bool HasFollower(LinkOrdinal link_ordinal) const {
     DRAKE_DEMAND(link_ordinal.is_valid());
     return std::find(follower_link_ordinals_.cbegin(),
@@ -103,10 +105,10 @@ class SpanningForest::Mobod {
   }
 
   /* Returns the ordinal of the Joint represented by this %Mobod. If this
-  %Mobod represents a LinkComposite (which has internal weld Joints), the Joint
-  returned here is the "active" Joint that connects the Composite's active Link
-  to a Link that follows this %Mobod's inboard %Mobod in the forest. The
-  returned ordinal is invalid only if this is the World %Mobod. */
+  is a composite %Mobod (with internal, unmodeled weld joints), the joint
+  returned here is the modeled joint whose mobilizer connects the composite
+  %Mobod to its inboard %Mobod in the forest. The returned ordinal is invalid
+  only if this is the World %Mobod. */
   JointOrdinal joint_ordinal() const { return joint_ordinal_; }
 
   /* Returns the index of the Tree of which this %Mobod is a member. The
@@ -208,8 +210,8 @@ class SpanningForest::Mobod {
   // Set to true if _any_ follower link has mass.
   bool has_massful_follower_link_{false};
 
-  // Corresponding Joint (user or modeling joint). If this Mobod represents
-  // a LinkComposite, this is the Joint that mobilizes the whole Composite.
+  // Corresponding Joint (user or modeling joint). If this is a composite Mobod,
+  // this is the Joint whose mobilizer is this Mobod's inboard mobilizer.
   JointOrdinal joint_ordinal_;
 
   // For an already-existing Joint, must we use a reverse mobilizer? If true,

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -749,8 +749,9 @@ welds between Links that were merged onto a single Mobod. We visit the forest's
 mobilized bodies (Mobods) in depth-first order and create Mobilizers in the same
 order as Mobods. We make a stub 0th Mobilizer for World so that Mobilizers and
 Mobods are numbered identically. (Think of it as a weld of World to the
-universe.) Joints that are interior to merged LinkComposites won't get modeled
-at all since they don't appear in the forest. */
+universe.) Joints that are interior to optimized WeldedLinksAssemblies
+(composite bodies) won't get modeled at all since they don't appear in the
+forest. */
 template <typename T>
 void MultibodyTree<T>::CreateJointImplementations() {
   DRAKE_DEMAND(!is_finalized());
@@ -913,8 +914,8 @@ void MultibodyTree<T>::Finalize() {
       directed by inboard/outboard edges, and
     - added constraints where needed to close kinematic loops in the graph.
   The modeler sorts the mobilized bodies into depth-first order. Note that
-  welded-together Links (in a LinkComposite) may be merged into a single
-  mobilized body so there can be more Links than Mobods.
+  welded-together Links (in a WeldedLinksAssembly) may be optimized into a
+  single mobilized body so there can be more Links than Mobods.
 
   Every Link will be modeled with one "primary" body and possibly several
   "shadow" bodies. Every non-Weld Joint will be modeled with a mobilizer, with
@@ -1529,7 +1530,7 @@ void MultibodyTree<T>::CalcFrameBodyPoses(
   // M_BBo_B from the parameterization of that inertia.
   for (const SpanningForest::Mobod& mobod : forest().mobods()) {
     if (mobod.is_world()) continue;
-    // TODO(sherm1) Can't handle composites yet.
+    // TODO(sherm1) Can't handle optimized WeldedLinksAssemblies yet.
     DRAKE_DEMAND(ssize(mobod.follower_link_ordinals()) == 1);
     const Mobilizer<T>& mobilizer = get_mobilizer(mobod.index());
 
@@ -3585,15 +3586,16 @@ void MultibodyTree<T>::ThrowDefaultMassInertiaError() const {
     if (active_mobod.nq_outboard() > 0) continue;  // Not a terminal group.
 
     // At this point we're looking at a non-World, terminal WeldedMobods group.
-    // Find the matching LinkComposite that carries the mass properties.
-    const std::optional<LinkCompositeIndex> link_composite_index =
-        graph().links(active_mobod.link_ordinal()).composite();
-    DRAKE_DEMAND(link_composite_index.has_value());  // Should be composite!
-    const auto& link_composite = graph().link_composites(*link_composite_index);
-    DRAKE_DEMAND(link_composite.links[0] ==
+    // Find the matching WeldedLinksAssembly that carries the mass properties.
+    const std::optional<WeldedLinksAssemblyIndex> link_assembly_index =
+        graph().links(active_mobod.link_ordinal()).welded_links_assembly();
+    DRAKE_DEMAND(link_assembly_index.has_value());  // Should be an assembly!
+    const auto& link_assembly =
+        graph().welded_links_assemblies(*link_assembly_index);
+    DRAKE_DEMAND(link_assembly.links()[0] ==
                  graph().links(active_mobod.link_ordinal()).index());
 
-    ThrowIfTerminalBodyHasBadDefaultMassProperties(link_composite.links,
+    ThrowIfTerminalBodyHasBadDefaultMassProperties(link_assembly.links(),
                                                    active_mobod.index());
   }
 
@@ -3611,34 +3613,34 @@ void MultibodyTree<T>::ThrowDefaultMassInertiaError() const {
 // assumed to have the expected properties.
 template <typename T>
 void MultibodyTree<T>::ThrowIfTerminalBodyHasBadDefaultMassProperties(
-    const std::vector<BodyIndex>& link_composite,  // might be just a Link
+    const std::vector<BodyIndex>& link_assembly,  // might be just a Link
     MobodIndex active_mobilizer_index) const {
-  DRAKE_DEMAND(!link_composite.empty());
-  const bool is_composite = ssize(link_composite) > 1;
+  DRAKE_DEMAND(!link_assembly.empty());
+  const bool is_assembly = ssize(link_assembly) > 1;
   const Mobilizer<T>& active_mobilizer = get_mobilizer(active_mobilizer_index);
   const bool can_rotate = active_mobilizer.can_rotate();
   const bool can_translate = active_mobilizer.can_translate();
 
-  const std::string& active_link_name = get_body(link_composite[0]).name();
-  const char* description =
-      is_composite ? "the active body for a terminal composite body"
-                   : "a terminal body";
+  const std::string& active_link_name = get_body(link_assembly[0]).name();
+  const char* description = is_assembly
+                                ? "the active body for a terminal assembly"
+                                : "a terminal body";
 
-  if (can_translate && (CalcTotalDefaultMass(link_composite) == 0)) {
+  if (can_translate && (CalcTotalDefaultMass(link_assembly) == 0)) {
     throw std::logic_error(
         fmt::format("Body {} is {} that is massless, but its joint has a "
                     "translational degree of freedom.",
                     active_link_name, description));
   }
 
-  if (can_rotate && IsAnyDefaultRotationalInertiaNaN(link_composite)) {
+  if (can_rotate && IsAnyDefaultRotationalInertiaNaN(link_assembly)) {
     throw std::logic_error(fmt::format(
         "Body {} is {} that has a NaN rotational inertia, but its joint has a "
         "rotational degree of freedom.",
         active_link_name, description));
   }
 
-  if (can_rotate && AreAllDefaultRotationalInertiaZero(link_composite)) {
+  if (can_rotate && AreAllDefaultRotationalInertiaZero(link_assembly)) {
     throw std::logic_error(fmt::format(
         "Body {} is {} that has zero rotational inertia, but its joint has a "
         "rotational degree of freedom.",
@@ -4248,8 +4250,8 @@ std::optional<BodyIndex> MultibodyTree<T>::MaybeGetUniqueBaseBodyIndex(
 
   // We need only look at World's outboard mobods since those are the base
   // bodies of each tree in the forest. Each of those mobods has an
-  // associated Link (the active link in case of composites). We're only
-  // interested in links in the given model instance, and there should be
+  // associated Link (the active link in case of WeldedLinksAssemblies). We're
+  // only interested in links in the given model instance, and there should be
   // just one of those.
   const SpanningForest::Mobod& world = forest().world_mobod();
   std::optional<BodyIndex> base_body_index{};

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -949,7 +949,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithZeroMass) {
 
   // The next function is usually called from MultibodyPlant::Finalize().
   const std::string expected_message =
-      "Body bodyA is the active body for a terminal composite body that "
+      "Body bodyA is the active body for a terminal assembly that "
       "is massless, but its joint has a translational degree of freedom.";
   DRAKE_EXPECT_THROWS_MESSAGE(model.ThrowDefaultMassInertiaError(),
                               expected_message);
@@ -976,7 +976,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithZeroInertia) {
 
   // The next function is usually called from MultibodyPlant::Finalize().
   const std::string expected_message =
-      "Body bodyA is the active body for a terminal composite body that "
+      "Body bodyA is the active body for a terminal assembly that "
       "has zero rotational inertia, but its joint has a rotational degree "
       "of freedom.";
   DRAKE_EXPECT_THROWS_MESSAGE(model.ThrowDefaultMassInertiaError(),
@@ -1007,7 +1007,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithNaNInertia) {
 
   // The next function is usually called from MultibodyPlant::Finalize().
   const std::string expected_message =
-      "Body bodyA is the active body for a terminal composite body that "
+      "Body bodyA is the active body for a terminal assembly that "
       "has a NaN rotational inertia, but its joint has a rotational degree "
       "of freedom.";
   DRAKE_EXPECT_THROWS_MESSAGE(model.ThrowDefaultMassInertiaError(),


### PR DESCRIPTION
(Task 3 of the composite bodies Epic #23245)

This PR updates the `multibody/topology` code in two areas:
- untangles the terminology used for welded links assemblies and the two ways of modeling them
- guarantees inboard->outboard ordering of the links within an assembly to facilitate kinematics post-processing and enable reconstruction of reaction forces (when feasible)

In order to validate the promised inboard->outboard ordering I had to add a few additional functions to the multibody/topology code. The new functions required unit tests. Then the final validation is done in SanityCheckForest() which is invoked from each unit test.

### Terminology
There are several related objects we need to be able to talk about:
- a Mobod that models a single link, with mass properties identical to those of the link (a `single-link Mobod`)
- a Mobod that models several links as a single rigid body, with combined mass properties (a `composite Mobod` or `composite body`)
- the user's input subgraph of a bunch of links interconnected by weld joints (a `WeldedLinksAssembly`)
- the unoptimized modeling of an assembly as a set of single-link Mobods, each with a 0-dof weld mobilizer (an _unoptimized assembly_). (This is how we model assemblies currently.)
- the optimized modeling of an assembly as a single composite Mobod (an _optimized assembly_ or _composite body_)
- a _split assembly_ where an assembly is split into multiple Mobods where some or all are composite bodies.

Split assemblies are produced when a user designates some weld joints as important to model so that joint's reaction forces are calculated. A wrist force sensor is a typical example. Currently those are indicated internally with a `kMustBeModeled` Joint flag. (WorkingModel calls those "measured" joints.) When some of those "must be modeled" weld joints are present in a WeldedLinksAssembly, optimization will produce more than one Mobod, because the "must be modeled" welds map to mobilizers (so there can be more than one composite Mobod in the model for the assembly).

Ideas for better terminology are welcome -- the important thing is to be able to have short, clear names or phrases that make sense in comments and are clear in code.

### Release notes
All changes here are `internal::` so no release notes are required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23670)
<!-- Reviewable:end -->
