### PR TITLE
[lint] Enable ruff's isort

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -3,3 +3,22 @@ line-length = 80
 
 # Per our oldest supported platform (currently Ubuntu 22.04 "Jammy").
 target-version = "py310"
+
+[lint]
+
+# Enable import sorting.
+extend-select = ["I"]
+
+[lint.isort]
+
+# Interleave "straight" imports and "from" imports alphabetically.
+force-sort-within-sections = true
+
+# Group these separately from third-party imports.
+known-first-party = [
+    "doc",
+    "drake",
+    "examples",
+    "pydrake",
+    "tools",
+]

--- a/bindings/pydrake/_trajectories_extra.py
+++ b/bindings/pydrake/_trajectories_extra.py
@@ -2,6 +2,8 @@
 
 from pydrake.common import (
     _MangledName,
+)
+from pydrake.common import (
     pretty_class_name as _pretty_class_name,
 )
 

--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -33,6 +33,7 @@ from the Drake source tree.
 """
 
 # ruff: noqa: F401,F403 (unused-import, import-star)
+# ruff: isort: skip_file
 
 # Normal symbols.
 from . import getDrakePath

--- a/bindings/pydrake/autodiffutils/test/autodiffutils_test.py
+++ b/bindings/pydrake/autodiffutils/test/autodiffutils_test.py
@@ -1,4 +1,10 @@
-import pydrake.autodiffutils as mut
+import pydrake.autodiffutils as mut  # ruff: isort: skip
+
+import copy
+import itertools
+import unittest
+
+import numpy as np
 
 from pydrake.autodiffutils import (
     AutoDiffXd,
@@ -7,14 +13,6 @@ from pydrake.autodiffutils import (
     InitializeAutoDiff,
     InitializeAutoDiffTuple,
 )
-
-import copy
-import itertools
-import unittest
-
-import numpy as np
-import pydrake.math as drake_math
-
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.algebra_test_util import (
     ScalarAlgebra,
@@ -22,10 +20,11 @@ from pydrake.common.test_utilities.algebra_test_util import (
 )
 from pydrake.common.test_utilities.autodiffutils_test_util import (
     autodiff_scalar_pass_through,
-    autodiff_vector_pass_through,
     autodiff_vector3_pass_through,
+    autodiff_vector_pass_through,
 )
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
+import pydrake.math as drake_math
 
 # Use convenience abbreviation.
 AD = AutoDiffXd

--- a/bindings/pydrake/common/all.py
+++ b/bindings/pydrake/common/all.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401,F403 (unused-import, import-star)
+# ruff: isort: skip_file
 
 from . import *
 from .compatibility import *

--- a/bindings/pydrake/common/compatibility.py
+++ b/bindings/pydrake/common/compatibility.py
@@ -4,7 +4,6 @@ which may need changes for compatibility.
 
 import numpy as np
 
-
 _patches = {
     "numpy_formatters": {
         "applied": False,

--- a/bindings/pydrake/common/containers.py
+++ b/bindings/pydrake/common/containers.py
@@ -1,7 +1,8 @@
 """Provides extensions for containers of Drake-related objects."""
 
-import numpy as np
 import re
+
+import numpy as np
 
 
 class _EqualityProxyBase:

--- a/bindings/pydrake/common/cpp_template.py
+++ b/bindings/pydrake/common/cpp_template.py
@@ -5,7 +5,7 @@ import types
 
 from pydrake import _is_building_documentation
 from pydrake.common import _MangledName, pretty_class_name
-from pydrake.common.cpp_param import get_param_names, get_param_canonical
+from pydrake.common.cpp_param import get_param_canonical, get_param_names
 from pydrake.common.deprecation import _warn_deprecated
 
 

--- a/bindings/pydrake/common/jupyter.py
+++ b/bindings/pydrake/common/jupyter.py
@@ -12,7 +12,6 @@ from warnings import warn
 
 from IPython import get_ipython
 
-
 # Note: The implementation below was inspired by
 # https://github.com/Kirill888/jupyter-ui-poll , though I suspect it can be
 # optimized.

--- a/bindings/pydrake/common/test/compatibility_test.py
+++ b/bindings/pydrake/common/test/compatibility_test.py
@@ -1,4 +1,4 @@
-import pydrake.common.compatibility as mut
+import pydrake.common.compatibility as mut  # ruff: isort: skip
 
 from functools import partial
 from threading import Thread

--- a/bindings/pydrake/common/test/containers_test.py
+++ b/bindings/pydrake/common/test/containers_test.py
@@ -1,8 +1,8 @@
-from pydrake.common.containers import EqualToDict, namedview, NamedViewBase
-
 import unittest
 
 import numpy as np
+
+from pydrake.common.containers import EqualToDict, NamedViewBase, namedview
 
 
 class Comparison:

--- a/bindings/pydrake/common/test/cpp_param_test.py
+++ b/bindings/pydrake/common/test/cpp_param_test.py
@@ -7,13 +7,14 @@ N.B. The C++ types are not registered in this test. They are registered and
 tested in `cpp_param_test_util`, which is invoked from this test.
 """
 
+import pydrake.common.cpp_param as mut  # ruff: isort: skip
+
 import ctypes
 import unittest
 
 import numpy as np
 
 from pydrake.common import _MangledName
-import pydrake.common.cpp_param as mut
 import pydrake.common.cpp_param_test_util as cpp_test
 
 

--- a/bindings/pydrake/common/test/cpp_template_test.py
+++ b/bindings/pydrake/common/test/cpp_template_test.py
@@ -8,19 +8,18 @@ import unittest
 
 import pydrake
 import pydrake.common.cpp_template as m
-from pydrake.common.test_utilities.pickle_compare import assert_pickle
-from pydrake.common.test_utilities.deprecation import catch_drake_warnings
-
 from pydrake.common.cpp_template_test_util import (
     Callee,
     DefaultInst,
     SimpleFunction,
     SimpleTemplate,
     SimpleType,
-    simple_func,
     TemplateWithDefault,
     TemplateWithDefault_,
+    simple_func,
 )
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.test_utilities.pickle_compare import assert_pickle
 
 _TEST_MODULE = "cpp_template_test"
 

--- a/bindings/pydrake/common/test/deprecation_test.py
+++ b/bindings/pydrake/common/test/deprecation_test.py
@@ -69,8 +69,8 @@ class TestDeprecation(unittest.TestCase):
     def test_module_import_from_all(self):
         # N.B. This is done in another module because `from x import *` is not
         # well supported for `exec`.
-        import deprecation_example.import_all
-        import deprecation_example
+        import deprecation_example.import_all  # ruff: isort: skip
+        import deprecation_example  # ruff: isort: skip
 
         self.assertIsInstance(deprecation_example.sub_module, str)
 

--- a/bindings/pydrake/common/test/deprecation_utility_test.py
+++ b/bindings/pydrake/common/test/deprecation_utility_test.py
@@ -15,7 +15,7 @@ import unittest
 from pydrake.common import Parallelism
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 
-import deprecation_example.cc_module as mut_cc
+import deprecation_example.cc_module as mut_cc  # ruff: isort: skip
 
 
 class TestDeprecationExample(unittest.TestCase):

--- a/bindings/pydrake/common/test/eigen_geometry_test.py
+++ b/bindings/pydrake/common/test/eigen_geometry_test.py
@@ -1,4 +1,4 @@
-import pydrake.common.eigen_geometry as mut
+import pydrake.common.eigen_geometry as mut  # ruff: isort: skip
 
 import copy
 import pickle
@@ -7,11 +7,11 @@ import unittest
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
-from pydrake.symbolic import Expression
-from pydrake.common.value import Value
 import pydrake.common.test.eigen_geometry_test_util as test_util
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
+from pydrake.common.value import Value
+from pydrake.symbolic import Expression
 
 
 def normalize(x):

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -1,3 +1,6 @@
+import pydrake.common as mut  # ruff: isort: skip
+import pydrake.common._testing as mut_testing  # ruff: isort: skip
+
 import copy
 import os
 import pickle
@@ -6,10 +9,8 @@ import unittest
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
-import pydrake.common as mut
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.common.yaml import yaml_dump_typed, yaml_load_typed
-import pydrake.common._testing as mut_testing
 
 
 class TestCommon(unittest.TestCase):

--- a/bindings/pydrake/common/test/pybind11_version_test.py
+++ b/bindings/pydrake/common/test/pybind11_version_test.py
@@ -2,7 +2,7 @@
 Tests `pybind11` version information available from Drake.
 """
 
-import pydrake.common.pybind11_version as mut
+import pydrake.common.pybind11_version as mut  # ruff: isort: skip
 
 import unittest
 

--- a/bindings/pydrake/common/test/ref_cycle_test.py
+++ b/bindings/pydrake/common/test/ref_cycle_test.py
@@ -8,12 +8,12 @@ import unittest
 import weakref
 
 from pydrake.common.ref_cycle_test_util import (
+    IsDynamic,
+    NotDynamic,
     arbitrary_bad,
     arbitrary_ok,
     free_function,
     invalid_arg_index,
-    IsDynamic,
-    NotDynamic,
     ouroboros,
 )
 from pydrake.common.test_utilities.memory_test_util import actual_ref_count

--- a/bindings/pydrake/common/test/schema_serialization_test.py
+++ b/bindings/pydrake/common/test/schema_serialization_test.py
@@ -1,3 +1,5 @@
+import pydrake.common.schema as mut  # ruff: isort: skip
+
 import dataclasses as dc
 import math
 from textwrap import dedent
@@ -7,7 +9,6 @@ import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 
-import pydrake.common.schema as mut
 from pydrake.common.yaml import yaml_dump_typed, yaml_load, yaml_load_typed
 from pydrake.math import RollPitchYaw
 

--- a/bindings/pydrake/common/test/schema_test.py
+++ b/bindings/pydrake/common/test/schema_test.py
@@ -1,10 +1,11 @@
+import pydrake.common.schema as mut  # ruff: isort: skip
+
 import copy
 import unittest
 
 import numpy as np
 
 from pydrake.common import RandomGenerator
-import pydrake.common.schema as mut
 import pydrake.math
 
 

--- a/bindings/pydrake/common/test/type_safe_index_test.py
+++ b/bindings/pydrake/common/test/type_safe_index_test.py
@@ -8,8 +8,8 @@ import unittest
 from pydrake.common.type_safe_index_test_util import (
     Index,
     OtherIndex,
-    pass_thru_int,
     pass_thru_index,
+    pass_thru_int,
 )
 from pydrake.common.value import Value
 

--- a/bindings/pydrake/common/test/value_test.py
+++ b/bindings/pydrake/common/test/value_test.py
@@ -3,13 +3,12 @@ import unittest
 
 from pydrake.common import pretty_class_name
 from pydrake.common.cpp_param import List
-from pydrake.common.value import AbstractValue, Value
-
 from pydrake.common.test.value_test_util import (
-    make_abstract_value_cc_type_unregistered,
     CustomType,
     MoveOnlyType,
+    make_abstract_value_cc_type_unregistered,
 )
+from pydrake.common.value import AbstractValue, Value
 
 
 class TestValue(unittest.TestCase):

--- a/bindings/pydrake/common/test/wrap_pybind_test.py
+++ b/bindings/pydrake/common/test/wrap_pybind_test.py
@@ -3,8 +3,8 @@ import unittest
 
 from pydrake.common.test.wrap_test_util import (
     CheckTypeConversionExample,
-    FunctionNeedsWrapCallbacks_Bad,
     FunctionNeedsWrapCallbacks,
+    FunctionNeedsWrapCallbacks_Bad,
     MakeTypeConversionExample,
     MakeTypeConversionExampleBadRvp,
     MyContainerRawPtr,

--- a/bindings/pydrake/common/test/yaml_typed_test.py
+++ b/bindings/pydrake/common/test/yaml_typed_test.py
@@ -21,7 +21,6 @@ from pydrake.common.test_utilities.meta import (
 from pydrake.common.value import Value
 from pydrake.common.yaml import yaml_dump_typed, yaml_load_typed
 
-
 # To provide test coverage for all of the special cases of YAML loading, we'll
 # define some dataclasses. These classes mimic
 #  drake/common/yaml/test/example_structs.h

--- a/bindings/pydrake/common/test_utilities/numpy_compare.py
+++ b/bindings/pydrake/common/test_utilities/numpy_compare.py
@@ -11,8 +11,8 @@ Prefer comparisons in the following order:
 # TODO(eric.cousineau): Make custom assert-vectorize which will output
 # coordinates and stuff.
 
-from contextlib import contextmanager
 from collections import namedtuple
+from contextlib import contextmanager
 import functools
 import inspect
 from itertools import product
@@ -20,15 +20,15 @@ from itertools import product
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
+from pydrake.polynomial import Polynomial_ as RawPolynomial_
 from pydrake.symbolic import (
     Expression,
     Formula,
     Monomial,
     Polynomial,
-    Variable,
     RationalFunction,
+    Variable,
 )
-from pydrake.polynomial import Polynomial_ as RawPolynomial_
 
 
 class _UnwantedEquality(AssertionError):

--- a/bindings/pydrake/common/test_utilities/test/meta_test.py
+++ b/bindings/pydrake/common/test_utilities/test/meta_test.py
@@ -1,4 +1,4 @@
-import pydrake.common.test_utilities.meta as mut
+import pydrake.common.test_utilities.meta as mut  # ruff: isort: skip
 
 import unittest
 

--- a/bindings/pydrake/examples/gym/envs/cart_pole.py
+++ b/bindings/pydrake/examples/gym/envs/cart_pole.py
@@ -47,7 +47,6 @@ from pydrake.systems.primitives import (
 )
 from pydrake.systems.sensors import CameraInfo, RgbdSensor
 
-
 # Gym parameters.
 sim_time_step = 0.01
 gym_time_step = 0.05

--- a/bindings/pydrake/examples/gym/play_cart_pole.py
+++ b/bindings/pydrake/examples/gym/play_cart_pole.py
@@ -10,8 +10,8 @@ import stable_baselines3
 from stable_baselines3.common.env_checker import check_env
 
 from pydrake.common import configure_logging
-from pydrake.geometry import StartMeshcat
 from pydrake.examples.gym._bazel_cwd_helpers import bazel_chdir
+from pydrake.geometry import StartMeshcat
 
 
 def _run_playing(args):

--- a/bindings/pydrake/examples/gym/train_cart_pole.py
+++ b/bindings/pydrake/examples/gym/train_cart_pole.py
@@ -9,8 +9,8 @@ import stable_baselines3
 from stable_baselines3.common.env_checker import check_env
 
 from pydrake.common import configure_logging
-from pydrake.geometry import StartMeshcat
 from pydrake.examples.gym._bazel_cwd_helpers import bazel_chdir
+from pydrake.geometry import StartMeshcat
 
 _full_sb3_available = False
 if "drake_internal" not in stable_baselines3.__version__:

--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -3,10 +3,10 @@
 import argparse
 
 from pydrake.common import configure_logging
-from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.multibody.parsing import Parser
-from pydrake.systems.framework import DiagramBuilder
+from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.systems.analysis import Simulator
+from pydrake.systems.framework import DiagramBuilder
 from pydrake.visualization import AddDefaultVisualization
 
 

--- a/bindings/pydrake/examples/test/quadrotor_test.py
+++ b/bindings/pydrake/examples/test/quadrotor_test.py
@@ -2,12 +2,12 @@ import unittest
 
 import numpy as np
 
-from pydrake.geometry import SceneGraph
 from pydrake.examples import (
     QuadrotorGeometry,
     QuadrotorPlant,
     StabilizingLQRController,
 )
+from pydrake.geometry import SceneGraph
 from pydrake.systems.framework import DiagramBuilder
 
 

--- a/bindings/pydrake/geometry/_geometry_extra.py
+++ b/bindings/pydrake/geometry/_geometry_extra.py
@@ -47,7 +47,7 @@ def _start_meshcat_deepnote(*, params=None, restart_nginx=False):
     The optional arguments are not available to end users but might be helpful
     when debugging this function.
     """
-    from IPython.display import display, HTML
+    from IPython.display import HTML, display
 
     host = os.environ["DEEPNOTE_PROJECT_ID"]
     if params is None:

--- a/bindings/pydrake/geometry/test/bounding_box_test.py
+++ b/bindings/pydrake/geometry/test/bounding_box_test.py
@@ -1,4 +1,4 @@
-import pydrake.geometry as mut
+import pydrake.geometry as mut  # ruff: isort: skip
 
 import copy
 import unittest

--- a/bindings/pydrake/geometry/test/common_test.py
+++ b/bindings/pydrake/geometry/test/common_test.py
@@ -1,5 +1,5 @@
-import pydrake.geometry as mut
-import pydrake.geometry._testing as mut_testing
+import pydrake.geometry as mut  # ruff: isort: skip
+import pydrake.geometry._testing as mut_testing  # ruff: isort: skip
 
 import copy
 from pathlib import Path

--- a/bindings/pydrake/geometry/test/frame_id_test.py
+++ b/bindings/pydrake/geometry/test/frame_id_test.py
@@ -1,4 +1,4 @@
-import pydrake.geometry as mut
+import pydrake.geometry as mut  # ruff: isort: skip
 
 import unittest
 

--- a/bindings/pydrake/geometry/test/hydro_test.py
+++ b/bindings/pydrake/geometry/test/hydro_test.py
@@ -1,5 +1,5 @@
-import pydrake.geometry as mut
-import pydrake.geometry._testing as mut_testing
+import pydrake.geometry as mut  # ruff: isort: skip
+import pydrake.geometry._testing as mut_testing  # ruff: isort: skip
 
 import unittest
 

--- a/bindings/pydrake/geometry/test/meshes_test.py
+++ b/bindings/pydrake/geometry/test/meshes_test.py
@@ -1,12 +1,11 @@
-import pydrake.geometry as mut
-from pydrake.common.test_utilities import numpy_compare
-
+import pydrake.geometry as mut  # ruff: isort: skip
 import copy
 import unittest
 
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities import numpy_compare
 
 
 class TestGeometryMeshes(unittest.TestCase):

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -1,47 +1,47 @@
-import pydrake.geometry.optimization as mut
+import pydrake.geometry.optimization as mut  # ruff: isort: skip
 
+import copy
 import os.path
 import unittest
-import copy
 
 import numpy as np
 
-from pydrake.common import RandomGenerator, temp_directory, Parallelism
+from pydrake.common import Parallelism, RandomGenerator, temp_directory
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.geometry import (
     Box,
     Capsule,
-    Cylinder,
     Convex,
+    Cylinder,
     Ellipsoid,
     FramePoseVector,
     GeometryFrame,
+    GeometryId,
     GeometryInstance,
     ProximityProperties,
     SceneGraph,
     Sphere,
-    GeometryId,
 )
 from pydrake.math import RigidTransform
 from pydrake.multibody.inverse_kinematics import InverseKinematics
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.multibody.tree import BodyIndex
-from pydrake.systems.framework import DiagramBuilder
 from pydrake.solvers import (
     Binding,
     ClpSolver,
+    CommonSolverOption,
     Constraint,
     Cost,
     MathematicalProgram,
     MathematicalProgramResult,
-    SolverOptions,
-    CommonSolverOption,
-    ScsSolver,
     MosekSolver,
+    ScsSolver,
+    SolverOptions,
 )
-from pydrake.symbolic import Variable, Polynomial
+from pydrake.symbolic import Polynomial, Variable
+from pydrake.systems.framework import DiagramBuilder
 
 
 class TestGeometryOptimization(unittest.TestCase):

--- a/bindings/pydrake/geometry/test/render_engine_gl_test.py
+++ b/bindings/pydrake/geometry/test/render_engine_gl_test.py
@@ -1,4 +1,4 @@
-import pydrake.geometry as mut
+import pydrake.geometry as mut  # ruff: isort: skip
 
 import sys
 import unittest

--- a/bindings/pydrake/geometry/test/render_engine_subclass_test.py
+++ b/bindings/pydrake/geometry/test/render_engine_subclass_test.py
@@ -2,7 +2,7 @@
 confirm the semantics of deriving a RenderEngine implementation in python are
 flaky and are therefore being isolated (see issue #14720)."""
 
-import pydrake.geometry as mut
+import pydrake.geometry as mut  # ruff: isort: skip
 
 import gc
 from math import pi
@@ -13,9 +13,9 @@ from pydrake.math import RigidTransform
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.sensors import (
     CameraInfo,
-    ImageRgba8U,
     ImageDepth32F,
     ImageLabel16I,
+    ImageRgba8U,
 )
 
 

--- a/bindings/pydrake/geometry/test/render_test.py
+++ b/bindings/pydrake/geometry/test/render_test.py
@@ -1,4 +1,4 @@
-import pydrake.geometry as mut
+import pydrake.geometry as mut  # ruff: isort: skip
 
 import copy
 import logging
@@ -14,10 +14,10 @@ from pydrake.systems.framework import (
 )
 from pydrake.systems.sensors import (
     CameraInfo,
-    ImageRgba8U,
     ImageDepth16U,
     ImageDepth32F,
     ImageLabel16I,
+    ImageRgba8U,
     RgbdSensor,
 )
 

--- a/bindings/pydrake/geometry/test/scene_graph_test.py
+++ b/bindings/pydrake/geometry/test/scene_graph_test.py
@@ -1,21 +1,22 @@
-import pydrake.geometry as mut
+import pydrake.geometry as mut  # ruff: isort: skip
 
 from math import pi
-import numpy as np
 import unittest
+
+import numpy as np
 
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.value import Value
 from pydrake.math import RigidTransform_
+import pydrake.symbolic as sym
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import InputPort_, OutputPort_
 from pydrake.systems.sensors import (
     CameraInfo,
-    ImageRgba8U,
     ImageDepth32F,
     ImageLabel16I,
+    ImageRgba8U,
 )
-import pydrake.symbolic as sym
 
 
 class TestGeometrySceneGraph(unittest.TestCase):

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -1,4 +1,4 @@
-import pydrake.geometry as mut
+import pydrake.geometry as mut  # ruff: isort: skip
 
 import copy
 import gc
@@ -10,7 +10,7 @@ import weakref
 import numpy as np
 import umsgpack
 
-from drake import lcmt_viewer_load_robot, lcmt_viewer_draw
+from drake import lcmt_viewer_draw, lcmt_viewer_load_robot
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.lcm import DrakeLcm, Subscriber

--- a/bindings/pydrake/gym/test/mock_torch/torch/__init__.py
+++ b/bindings/pydrake/gym/test/mock_torch/torch/__init__.py
@@ -5,9 +5,7 @@
 
 # ruff: noqa: F401 (unused-import)
 
-from . import distributions
-from . import nn
-from . import optim
+from . import distributions, nn, optim
 
 Tensor = None
 device = None

--- a/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
+++ b/bindings/pydrake/manipulation/test/kuka_iiwa_test.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import pydrake.manipulation as mut
+import pydrake.manipulation as mut  # ruff: isort: skip
 
 import gc
 import unittest
-import numpy as np
 import weakref
+
+import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.lcm import DrakeLcm

--- a/bindings/pydrake/manipulation/test/schunk_wsg_test.py
+++ b/bindings/pydrake/manipulation/test/schunk_wsg_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import pydrake.manipulation as mut
+import pydrake.manipulation as mut  # ruff: isort: skip
 
 import unittest
+
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow

--- a/bindings/pydrake/manipulation/test/util_test.py
+++ b/bindings/pydrake/manipulation/test/util_test.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
-import pydrake.manipulation as mut
+import pydrake.manipulation as mut  # ruff: isort: skip
 
 import unittest
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.manipulation import (
+    ApplyDriverConfigs,
+    ApplyNamedPositionsAsDefaults,
+)
 from pydrake.multibody.parsing import (
     LoadModelDirectives,
     Parser,
     ProcessModelDirectives,
-)
-from pydrake.manipulation import (
-    ApplyDriverConfigs,
-    ApplyNamedPositionsAsDefaults,
 )
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.systems.framework import DiagramBuilder

--- a/bindings/pydrake/math/_math_extra.py
+++ b/bindings/pydrake/math/_math_extra.py
@@ -34,6 +34,8 @@ import numpy as np
 from pydrake.autodiffutils import AutoDiffXd as _AutoDiffXd
 from pydrake.common import (
     _MangledName,
+)
+from pydrake.common import (
     pretty_class_name as _pretty_class_name,
 )
 import pydrake.symbolic as _sym

--- a/bindings/pydrake/math/math_example.py
+++ b/bindings/pydrake/math/math_example.py
@@ -5,6 +5,7 @@ To see this interactively:
 """
 
 import os
+import webbrowser
 
 # To be a meaningful unit test, we must render the figure somehow.
 # The Agg backend (creating a PNG image) is suitably cross-platform.
@@ -14,7 +15,6 @@ os.environ["MPLBACKEND"] = "Agg"  # noqa
 # Now that the environment is set up, it's safe to import matplotlib, etc.
 import matplotlib.pyplot as plt
 import numpy as np
-import webbrowser
 
 from pydrake.math import BarycentricMesh
 

--- a/bindings/pydrake/math/test/math_overloads_matrix_test.py
+++ b/bindings/pydrake/math/test/math_overloads_matrix_test.py
@@ -1,4 +1,4 @@
-import pydrake.math as mut
+import pydrake.math as mut  # ruff: isort: skip
 
 import itertools
 import unittest

--- a/bindings/pydrake/math/test/math_test.py
+++ b/bindings/pydrake/math/test/math_test.py
@@ -1,13 +1,4 @@
-import pydrake.math as mut
-from pydrake.math import BarycentricMesh, wrap_to
-from pydrake.common import RandomGenerator
-from pydrake.common.cpp_param import List
-from pydrake.common.eigen_geometry import Isometry3_, Quaternion_, AngleAxis_
-from pydrake.common.value import Value
-from pydrake.autodiffutils import AutoDiffXd
-from pydrake.symbolic import Expression
-import pydrake.common.test_utilities.numpy_compare as numpy_compare
-from pydrake.common.test_utilities.pickle_compare import assert_pickle
+import pydrake.math as mut  # ruff: isort: skip
 
 import copy
 import math
@@ -16,6 +7,16 @@ import textwrap
 import unittest
 
 import numpy as np
+
+from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common import RandomGenerator
+from pydrake.common.cpp_param import List
+from pydrake.common.eigen_geometry import AngleAxis_, Isometry3_, Quaternion_
+import pydrake.common.test_utilities.numpy_compare as numpy_compare
+from pydrake.common.test_utilities.pickle_compare import assert_pickle
+from pydrake.common.value import Value
+from pydrake.math import BarycentricMesh, wrap_to
+from pydrake.symbolic import Expression
 
 
 class TestBarycentricMesh(unittest.TestCase):

--- a/bindings/pydrake/multibody/_inertia_fixer.py
+++ b/bindings/pydrake/multibody/_inertia_fixer.py
@@ -24,8 +24,8 @@ import xml.parsers.expat as expat
 import numpy as np
 
 from pydrake.geometry import Role, SceneGraph
-from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.tree import (
     BodyIndex,
     CalcSpatialInertia,

--- a/bindings/pydrake/multibody/_math_extra.py
+++ b/bindings/pydrake/multibody/_math_extra.py
@@ -3,6 +3,8 @@
 import pydrake.autodiffutils as _ad
 from pydrake.common import (
     _MangledName,
+)
+from pydrake.common import (
     pretty_class_name as _pretty_class_name,
 )
 import pydrake.symbolic as _sym

--- a/bindings/pydrake/multibody/_mesh_model_maker.py
+++ b/bindings/pydrake/multibody/_mesh_model_maker.py
@@ -1,8 +1,8 @@
 import logging
-import numpy as np
 from pathlib import Path
 import xml.etree.ElementTree
 
+import numpy as np
 
 from pydrake.geometry import (
     ReadObjToTriangleSurfaceMesh,

--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F401,F403 (unused-import, import-star)
+# ruff: isort: skip_file
 
 import warnings
 

--- a/bindings/pydrake/multibody/jupyter_widgets.py
+++ b/bindings/pydrake/multibody/jupyter_widgets.py
@@ -5,11 +5,11 @@ This is gui code; to test changes, please manually run
 //bindings/pydrake/multibody/examples/jupyter_widgets_examples.ipynb.
 """
 
-import numpy as np
 from functools import partial
 
-from ipywidgets import FloatSlider, Layout
 from IPython.display import display
+from ipywidgets import FloatSlider, Layout
+import numpy as np
 
 from pydrake.common.jupyter import process_ipywidget_events
 from pydrake.multibody.tree import JointIndex

--- a/bindings/pydrake/multibody/mesh_to_model.py
+++ b/bindings/pydrake/multibody/mesh_to_model.py
@@ -113,9 +113,10 @@ Properties of the resulting SDFormat file:
 """
 
 import argparse
-import numpy as np
 import os
 from pathlib import Path
+
+import numpy as np
 
 from pydrake.common import configure_logging as _configure_logging
 from pydrake.multibody._mesh_model_maker import (

--- a/bindings/pydrake/multibody/run_installed_fix_inertia.py
+++ b/bindings/pydrake/multibody/run_installed_fix_inertia.py
@@ -4,7 +4,7 @@
 Runs fix_inertia from an install tree.
 """
 
-from os.path import isdir, join, dirname, realpath
+from os.path import dirname, isdir, join, realpath
 import sys
 
 

--- a/bindings/pydrake/multibody/run_installed_mesh_to_model.py
+++ b/bindings/pydrake/multibody/run_installed_mesh_to_model.py
@@ -4,7 +4,7 @@
 Runs mesh_to_model from an install tree.
 """
 
-from os.path import isdir, join, dirname, realpath
+from os.path import dirname, isdir, join, realpath
 import sys
 
 

--- a/bindings/pydrake/multibody/test/fem_test.py
+++ b/bindings/pydrake/multibody/test/fem_test.py
@@ -1,9 +1,9 @@
 import unittest
-from pydrake.common.test_utilities import numpy_compare
 
+from pydrake.common.test_utilities import numpy_compare
 from pydrake.multibody.fem import (
-    MaterialModel,
     DeformableBodyConfig_,
+    MaterialModel,
 )
 
 

--- a/bindings/pydrake/multibody/test/fix_inertia_test.py
+++ b/bindings/pydrake/multibody/test/fix_inertia_test.py
@@ -13,12 +13,12 @@ from pydrake.common import (
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.geometry import Role, SceneGraph
 from pydrake.multibody._inertia_fixer import (
-    fix_inertia_from_string,
     GEOM_INERTIA_ROLE_ORDER_DEFAULT,
     InertiaFixer,
+    fix_inertia_from_string,
 )
-from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import MultibodyPlant
 
 
 class TestFixInertiaFromString(unittest.TestCase):

--- a/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pydrake.multibody.inverse_kinematics as mut
+import pydrake.multibody.inverse_kinematics as mut  # ruff: isort: skip
 
 import copy
 import unittest
@@ -12,14 +12,14 @@ from pydrake.common.value import Value
 from pydrake.common.yaml import yaml_dump_typed, yaml_load_typed
 from pydrake.math import RigidTransform
 from pydrake.multibody.math import SpatialVelocity
-from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.tree import PrismaticJoint, SpatialInertia
 from pydrake.planning import (
+    CollisionCheckerParams,
     DofMask,
     JointLimits,
     RobotDiagramBuilder,
-    CollisionCheckerParams,
     SceneGraphCollisionChecker,
 )
 from pydrake.solvers import SolverId

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -1,4 +1,4 @@
-from pydrake.multibody import inverse_kinematics as ik
+from pydrake.multibody import inverse_kinematics as ik  # ruff: isort: skip
 
 from collections import namedtuple
 from functools import partial, wraps
@@ -14,11 +14,11 @@ from pydrake.common import FindResourceOrThrow
 from pydrake.common.eigen_geometry import Quaternion
 from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.parsing import Parser
-from pydrake.multibody.plant import MultibodyPlant, AddMultibodyPlantSceneGraph
+from pydrake.multibody.plant import AddMultibodyPlantSceneGraph, MultibodyPlant
+from pydrake.planning import RobotDiagramBuilder, SceneGraphCollisionChecker
 import pydrake.solvers as mp
 from pydrake.symbolic import Variable
 from pydrake.systems.framework import DiagramBuilder
-from pydrake.planning import RobotDiagramBuilder, SceneGraphCollisionChecker
 
 # TODO(eric.cousineau): Replace manual coordinate indexing with more semantic
 # operations (`CalcRelativeTransform`, `SetFreeBodyPose`).

--- a/bindings/pydrake/multibody/test/math_test.py
+++ b/bindings/pydrake/multibody/test/math_test.py
@@ -4,12 +4,12 @@ import textwrap
 import unittest
 
 import numpy as np
+
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common.cpp_param import List
-from pydrake.common.value import Value
 import pydrake.common.test_utilities.numpy_compare as numpy_compare
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
-from pydrake.symbolic import Expression
+from pydrake.common.value import Value
 from pydrake.math import RotationMatrix_
 from pydrake.multibody.math import (
     SpatialAcceleration,
@@ -21,6 +21,7 @@ from pydrake.multibody.math import (
     SpatialVelocity,
     SpatialVelocity_,
 )
+from pydrake.symbolic import Expression
 
 
 class TestMultibodyTreeMath(unittest.TestCase):

--- a/bindings/pydrake/multibody/test/mesh_to_model_test.py
+++ b/bindings/pydrake/multibody/test/mesh_to_model_test.py
@@ -1,13 +1,14 @@
 """Unit tests for mesh_to_model."""
 
 import logging
-import numpy as np
 from pathlib import Path
 import re
 import shutil
 import subprocess
 import unittest
 import xml.etree.ElementTree
+
+import numpy as np
 
 from pydrake.common import (
     FindResourceOrThrow,

--- a/bindings/pydrake/multibody/test/meshcat_test.py
+++ b/bindings/pydrake/multibody/test/meshcat_test.py
@@ -1,11 +1,3 @@
-from pydrake.multibody.meshcat import (
-    ContactVisualizer_,
-    ContactVisualizerParams,
-    JointSliders,
-    _HydroelasticContactVisualizer,
-    _PointContactVisualizer,
-)
-
 import copy
 import unittest
 
@@ -20,6 +12,13 @@ from pydrake.common.test_utilities import (
 from pydrake.geometry import (
     Meshcat,
     Rgba,
+)
+from pydrake.multibody.meshcat import (
+    ContactVisualizer_,
+    ContactVisualizerParams,
+    JointSliders,
+    _HydroelasticContactVisualizer,
+    _PointContactVisualizer,
 )
 from pydrake.multibody.parsing import (
     Parser,

--- a/bindings/pydrake/multibody/test/optimization_test.py
+++ b/bindings/pydrake/multibody/test/optimization_test.py
@@ -1,10 +1,20 @@
-import copy
-import unittest
-import typing
 from collections import namedtuple
+import copy
+import typing
+import unittest
 
 import numpy as np
 
+from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities import numpy_compare
+from pydrake.geometry import (
+    Box,
+    Role,
+    Sphere,
+)
+from pydrake.math import RigidTransform
+import pydrake.multibody.inverse_kinematics as ik
 from pydrake.multibody.optimization import (
     CalcGridPointsOptions,
     CentroidalMomentumConstraint,
@@ -23,22 +33,12 @@ from pydrake.multibody.plant import (
 )
 from pydrake.multibody.tree import (
     PrismaticJoint,
-    UnitInertia,
     SpatialInertia,
+    UnitInertia,
 )
-import pydrake.multibody.inverse_kinematics as ik
 import pydrake.solvers as mp
 from pydrake.symbolic import Expression, MakeVectorVariable, Variable
 from pydrake.systems.framework import DiagramBuilder, DiagramBuilder_
-from pydrake.geometry import (
-    Box,
-    Role,
-    Sphere,
-)
-from pydrake.math import RigidTransform
-from pydrake.autodiffutils import AutoDiffXd
-from pydrake.common import FindResourceOrThrow
-from pydrake.common.test_utilities import numpy_compare
 from pydrake.trajectories import PiecewisePolynomial
 
 Environment = namedtuple(

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import copy
+import os
+from pathlib import Path
+import unittest
+
+from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities import numpy_compare
+from pydrake.geometry import SceneGraph
 from pydrake.multibody.parsing import (
     AddCollisionFilterGroup,
     AddDirectives,
@@ -20,22 +28,13 @@ from pydrake.multibody.parsing import (
     Parser,
     ProcessModelDirectives,
 )
-
-import copy
-import os
-from pathlib import Path
-import unittest
-
-from pydrake.common import FindResourceOrThrow
-from pydrake.common.test_utilities import numpy_compare
-from pydrake.geometry import SceneGraph
-from pydrake.multibody.tree import (
-    ModelInstanceIndex,
-)
 from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph,
     MultibodyPlant,
     MultibodyPlant_,
+)
+from pydrake.multibody.tree import (
+    ModelInstanceIndex,
 )
 from pydrake.systems.framework import DiagramBuilder
 

--- a/bindings/pydrake/multibody/test/rational_test.py
+++ b/bindings/pydrake/multibody/test/rational_test.py
@@ -1,14 +1,14 @@
-from pydrake.multibody import rational
-
-import numpy as np
 import unittest
 
+import numpy as np
+
 from pydrake.common import FindResourceOrThrow
-from pydrake.systems.framework import DiagramBuilder
-from pydrake.multibody.plant import MultibodyPlant, AddMultibodyPlantSceneGraph
-from pydrake.symbolic import Polynomial, RationalFunction, Variable, Expression
+from pydrake.multibody import rational
 from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import AddMultibodyPlantSceneGraph, MultibodyPlant
 import pydrake.symbolic as sym
+from pydrake.symbolic import Expression, Polynomial, RationalFunction, Variable
+from pydrake.systems.framework import DiagramBuilder
 
 
 class TestRationalForwardKinematics(unittest.TestCase):

--- a/bindings/pydrake/planning/test/collision_checker_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_test.py
@@ -1,4 +1,4 @@
-import pydrake.planning as mut
+import pydrake.planning as mut  # ruff: isort: skip
 
 import copy
 import textwrap

--- a/bindings/pydrake/planning/test/collision_checker_trace_test.py
+++ b/bindings/pydrake/planning/test/collision_checker_trace_test.py
@@ -1,4 +1,4 @@
-import pydrake.planning as mut
+import pydrake.planning as mut  # ruff: isort: skip
 
 import textwrap
 import unittest

--- a/bindings/pydrake/planning/test/dof_mask_test.py
+++ b/bindings/pydrake/planning/test/dof_mask_test.py
@@ -1,4 +1,4 @@
-import pydrake.planning as mut
+import pydrake.planning as mut  # ruff: isort: skip
 
 import unittest
 

--- a/bindings/pydrake/planning/test/graph_algorithms_test.py
+++ b/bindings/pydrake/planning/test/graph_algorithms_test.py
@@ -1,16 +1,17 @@
+import pydrake.planning as mut  # ruff: isort: skip
+
 import unittest
 
 import numpy as np
 import scipy.sparse as sp
 
-import pydrake.planning as mut
-from pydrake.solvers import (
-    SolverOptions,
-    CommonSolverOption,
-    MosekSolver,
-    GurobiSolver,
-)
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.solvers import (
+    CommonSolverOption,
+    GurobiSolver,
+    MosekSolver,
+    SolverOptions,
+)
 
 
 def GurobiOrMosekSolverAvailable():

--- a/bindings/pydrake/planning/test/iris_from_clique_cover_test.py
+++ b/bindings/pydrake/planning/test/iris_from_clique_cover_test.py
@@ -1,18 +1,19 @@
-import unittest
-
-import pydrake.planning as mut
-from pydrake.common import RandomGenerator, Parallelism
-from pydrake.planning import (
-    RobotDiagramBuilder,
-    SceneGraphCollisionChecker,
-    IrisNp2Options,
-    IrisZoOptions,
-)
-from pydrake.solvers import MosekSolver, GurobiSolver, SnoptSolver
-from pydrake.geometry.optimization import IrisOptions
+import pydrake.planning as mut  # ruff: isort: skip
 
 import textwrap
+import unittest
+
 import numpy as np
+
+from pydrake.common import Parallelism, RandomGenerator
+from pydrake.geometry.optimization import IrisOptions
+from pydrake.planning import (
+    IrisNp2Options,
+    IrisZoOptions,
+    RobotDiagramBuilder,
+    SceneGraphCollisionChecker,
+)
+from pydrake.solvers import GurobiSolver, MosekSolver, SnoptSolver
 
 
 def _snopt_and_mip_solver_available():

--- a/bindings/pydrake/planning/test/iris_test.py
+++ b/bindings/pydrake/planning/test/iris_test.py
@@ -1,20 +1,21 @@
+import pydrake.planning as mut  # ruff: isort: skip
+
 import unittest
 
-import pydrake.planning as mut
+import numpy as np
+
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import Parallelism
-from pydrake.geometry.optimization import Hyperellipsoid, HPolyhedron
+from pydrake.geometry.optimization import HPolyhedron, Hyperellipsoid
 from pydrake.multibody.inverse_kinematics import InverseKinematics
 from pydrake.multibody.rational import RationalForwardKinematics
 from pydrake.planning import (
+    IrisParameterizationFunction,
     RobotDiagramBuilder,
     SceneGraphCollisionChecker,
-    IrisParameterizationFunction,
 )
 from pydrake.solvers import IpoptSolver
 from pydrake.symbolic import Variable
-
-import numpy as np
 
 # Taken from iris_from_clique_cover_test.py
 cross_cspace_urdf = """

--- a/bindings/pydrake/planning/test/joint_limits_test.py
+++ b/bindings/pydrake/planning/test/joint_limits_test.py
@@ -1,9 +1,10 @@
+import pydrake.planning as mut  # ruff: isort: skip
+
 import unittest
 
 import numpy as np
 
 from pydrake.multibody.plant import MultibodyPlant
-import pydrake.planning as mut
 
 
 class TestJointLimits(unittest.TestCase):

--- a/bindings/pydrake/planning/test/robot_diagram_test.py
+++ b/bindings/pydrake/planning/test/robot_diagram_test.py
@@ -1,4 +1,4 @@
-import pydrake.planning as mut
+import pydrake.planning as mut  # ruff: isort: skip
 
 import gc
 import unittest

--- a/bindings/pydrake/planning/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/planning/test/trajectory_optimization_test.py
@@ -4,34 +4,34 @@ import weakref
 import numpy as np
 
 from pydrake.examples import PendulumPlant
-from pydrake.math import eq, BsplineBasis
+from pydrake.geometry.optimization import (
+    GcsGraphvizOptions,
+    GraphOfConvexSets,
+    GraphOfConvexSetsOptions,
+    HPolyhedron,
+    Point,
+    VPolytope,
+)
+from pydrake.math import BsplineBasis, eq
+from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import MultibodyPlant
 from pydrake.planning import (
     AddDirectCollocationConstraint,
     DirectCollocation,
     DirectCollocationConstraint,
     DirectTranscription,
     GcsTrajectoryOptimization,
-    KinematicTrajectoryOptimization,
     GetContinuousRevoluteJointIndices,
+    KinematicTrajectoryOptimization,
 )
-from pydrake.geometry.optimization import (
-    GraphOfConvexSetsOptions,
-    GraphOfConvexSets,
-    GcsGraphvizOptions,
-    HPolyhedron,
-    Point,
-    VPolytope,
-)
+import pydrake.solvers as mp
 from pydrake.solvers import (
     Binding,
-    Cost,
     Constraint,
-    ExpressionCost,
+    Cost,
     ExpressionConstraint,
+    ExpressionCost,
 )
-from pydrake.multibody.plant import MultibodyPlant
-from pydrake.multibody.parsing import Parser
-import pydrake.solvers as mp
 from pydrake.symbolic import Variable
 from pydrake.systems.framework import InputPortSelection
 from pydrake.systems.primitives import LinearSystem

--- a/bindings/pydrake/solvers/test/evaluators_test.py
+++ b/bindings/pydrake/solvers/test/evaluators_test.py
@@ -1,14 +1,14 @@
-import unittest
 import typing
+import unittest
 import weakref
 
 import numpy as np
 import scipy.sparse
 
+from pydrake.autodiffutils import InitializeAutoDiff
 import pydrake.solvers as mp
 import pydrake.solvers._testing as mp_testing
 import pydrake.symbolic as sym
-from pydrake.autodiffutils import InitializeAutoDiff
 
 
 class TestCost(unittest.TestCase):

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -7,10 +7,11 @@ import numpy as np
 import scipy.sparse
 
 from pydrake.autodiffutils import AutoDiffXd
-from pydrake.common import kDrakeAssertIsArmed, Parallelism
+from pydrake.common import Parallelism, kDrakeAssertIsArmed
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.yaml import yaml_dump_typed, yaml_load_typed
 from pydrake.math import ge
+import pydrake.solvers as mp
 from pydrake.solvers import (
     GurobiSolver,
     LinearConstraint,
@@ -25,10 +26,8 @@ from pydrake.solvers import (
     SolverOptions,
     SolverType,
 )
-import pydrake.solvers as mp
 import pydrake.solvers._testing as mp_testing
 import pydrake.symbolic as sym
-
 
 SNOPT_NO_GUROBI = SnoptSolver().available() and not GurobiSolver().available()
 # MathematicalProgram is only bound for float and AutoDiffXd.

--- a/bindings/pydrake/solvers/test/program_attribute_test.py
+++ b/bindings/pydrake/solvers/test/program_attribute_test.py
@@ -1,4 +1,5 @@
 import unittest
+
 from pydrake.solvers import ProgramAttribute, ProgramType
 
 

--- a/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
+++ b/bindings/pydrake/solvers/test/semidefinite_relaxation_test.py
@@ -1,10 +1,11 @@
-import numpy as np
 import unittest
+
+import numpy as np
 
 from pydrake.solvers import (
     MakeSemidefiniteRelaxation,
-    SemidefiniteRelaxationOptions,
     MathematicalProgram,
+    SemidefiniteRelaxationOptions,
 )
 from pydrake.symbolic import Variables
 

--- a/bindings/pydrake/solvers/test/unrevised_lemke_solver_test.py
+++ b/bindings/pydrake/solvers/test/unrevised_lemke_solver_test.py
@@ -3,9 +3,9 @@ import unittest
 import numpy as np
 
 from pydrake.solvers import (
-    UnrevisedLemkeSolver,
     MathematicalProgram,
     SolverType,
+    UnrevisedLemkeSolver,
 )
 
 

--- a/bindings/pydrake/stubgen.py
+++ b/bindings/pydrake/stubgen.py
@@ -2,11 +2,11 @@
 
 import importlib
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
 from mypy import stubgen
 

--- a/bindings/pydrake/symbolic/_symbolic_extra.py
+++ b/bindings/pydrake/symbolic/_symbolic_extra.py
@@ -5,8 +5,8 @@
 
 import functools
 import operator
-import typing
 import sys
+import typing
 
 
 def logical_and(*formulas):

--- a/bindings/pydrake/symbolic/test/symbolic_test.py
+++ b/bindings/pydrake/symbolic/test/symbolic_test.py
@@ -7,16 +7,16 @@ import warnings
 
 import numpy as np
 
-import pydrake.symbolic as sym
 import pydrake.common
+from pydrake.common.containers import EqualToDict
+from pydrake.common.deprecation import install_numpy_warning_filters
+from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.algebra_test_util import (
     ScalarAlgebra,
     VectorizedAlgebra,
 )
 import pydrake.math as drake_math
-from pydrake.common.containers import EqualToDict
-from pydrake.common.deprecation import install_numpy_warning_filters
-from pydrake.common.test_utilities import numpy_compare
+import pydrake.symbolic as sym
 
 # TODO(eric.cousineau): Replace usages of `sym` math functions with the
 # overloads from `pydrake.math`.

--- a/bindings/pydrake/symbolic/test/sympy_test.py
+++ b/bindings/pydrake/symbolic/test/sympy_test.py
@@ -1,8 +1,8 @@
-import pydrake.symbolic as mut
+import pydrake.symbolic as mut  # ruff: isort: skip
 
-import numpy as np
 import unittest
 
+import numpy as np
 import sympy
 
 from pydrake.symbolic import (

--- a/bindings/pydrake/systems/drawing.py
+++ b/bindings/pydrake/systems/drawing.py
@@ -6,7 +6,6 @@ from tempfile import NamedTemporaryFile
 
 from pydrake.common import temp_directory
 
-
 # TODO(eric.cousineau): Move `plot_graphviz` to something more accessible to
 # `call_python_client`.
 

--- a/bindings/pydrake/systems/drawing_graphviz_example.py
+++ b/bindings/pydrake/systems/drawing_graphviz_example.py
@@ -5,6 +5,7 @@ To see this interactively:
 """
 
 import os
+import webbrowser
 
 # We must render the figures somehow.
 # The Agg backend (creating a PNG image) is suitably cross-platform.
@@ -13,7 +14,6 @@ os.environ["MPLBACKEND"] = "Agg"  # noqa
 
 # Now that the environment is set up, it's safe to import matplotlib, etc.
 import matplotlib.pyplot as plt
-import webbrowser
 
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import AddMultibodyPlantSceneGraph

--- a/bindings/pydrake/systems/jupyter_widgets.py
+++ b/bindings/pydrake/systems/jupyter_widgets.py
@@ -7,17 +7,17 @@ This is gui code; to test changes, please manually execute:
     bazel run //bindings/pydrake/systems:jupyter_widgets_examples
 """
 
-import numpy as np
 from collections import namedtuple
 from functools import partial
 
 from IPython.display import display
 from ipywidgets import FloatSlider, Layout, Widget
+import numpy as np
 
 from pydrake.common.jupyter import process_ipywidget_events
 from pydrake.common.value import AbstractValue
-from pydrake.systems.framework import LeafSystem, PublishEvent
 from pydrake.math import RigidTransform, RollPitchYaw
+from pydrake.systems.framework import LeafSystem, PublishEvent
 
 
 class PoseSliders(LeafSystem):

--- a/bindings/pydrake/systems/pyplot_visualizer.py
+++ b/bindings/pydrake/systems/pyplot_visualizer.py
@@ -1,10 +1,10 @@
 import matplotlib
 import numpy as np
 
+from pydrake.systems._resample_interp1d import _resample_interp1d
 from pydrake.systems.framework import LeafSystem
 from pydrake.systems.primitives import VectorLog
 from pydrake.trajectories import Trajectory
-from pydrake.systems._resample_interp1d import _resample_interp1d
 
 
 class PyPlotVisualizer(LeafSystem):

--- a/bindings/pydrake/systems/scalar_conversion.py
+++ b/bindings/pydrake/systems/scalar_conversion.py
@@ -4,15 +4,15 @@ from functools import partial
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import pretty_class_name
+from pydrake.common.cpp_template import (
+    TemplateClass,
+    TemplateMethod,
+    _get_module_from_stack,
+)
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import (
     LeafSystem_,
     SystemScalarConverter,
-)
-from pydrake.common.cpp_template import (
-    _get_module_from_stack,
-    TemplateClass,
-    TemplateMethod,
 )
 
 

--- a/bindings/pydrake/systems/test/_resample_log_interp1d_test.py
+++ b/bindings/pydrake/systems/test/_resample_log_interp1d_test.py
@@ -3,8 +3,8 @@ import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from pydrake.systems.analysis import Simulator
 from pydrake.systems._resample_interp1d import _resample_interp1d
+from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder, VectorSystem
 from pydrake.systems.primitives import VectorLogSink
 

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -1,14 +1,37 @@
 import copy
 import gc
-import numpy as np
 import unittest
 import weakref
 
+import numpy as np
+
+from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import Parallelism
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.math import isnan
-from pydrake.symbolic import Variable, Expression
-from pydrake.autodiffutils import AutoDiffXd
+from pydrake.symbolic import Expression, Variable
+from pydrake.systems.analysis import (
+    ApplySimulatorConfig,
+    BatchEvalTimeDerivatives,
+    BatchEvalUniquePeriodicDiscreteUpdate,
+    DiscreteTimeApproximation,
+    ExtractSimulatorConfig,
+    InitializeParams,
+    IntegratorBase_,
+    PrintSimulatorStatistics,
+    RegionOfAttraction,
+    RegionOfAttractionOptions,
+    ResetIntegratorFromFlags,
+    RungeKutta2Integrator,
+    RungeKutta2Integrator_,
+    RungeKutta3Integrator,
+    RungeKutta3Integrator_,
+    Simulator,
+    Simulator_,
+    SimulatorConfig,
+    SimulatorStatus,
+)
+from pydrake.systems.framework import Context_, DiagramBuilder_, EventStatus
 from pydrake.systems.primitives import (
     AffineSystem_,
     ConstantVectorSource,
@@ -18,28 +41,6 @@ from pydrake.systems.primitives import (
     LinearSystem_,
     SymbolicVectorSystem,
     SymbolicVectorSystem_,
-)
-from pydrake.systems.framework import Context_, DiagramBuilder_, EventStatus
-from pydrake.systems.analysis import (
-    ApplySimulatorConfig,
-    BatchEvalUniquePeriodicDiscreteUpdate,
-    BatchEvalTimeDerivatives,
-    DiscreteTimeApproximation,
-    ExtractSimulatorConfig,
-    InitializeParams,
-    IntegratorBase_,
-    PrintSimulatorStatistics,
-    ResetIntegratorFromFlags,
-    RungeKutta2Integrator,
-    RungeKutta2Integrator_,
-    RungeKutta3Integrator,
-    RungeKutta3Integrator_,
-    RegionOfAttraction,
-    RegionOfAttractionOptions,
-    Simulator,
-    Simulator_,
-    SimulatorConfig,
-    SimulatorStatus,
 )
 from pydrake.trajectories import PiecewisePolynomial, PiecewisePolynomial_
 

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -6,9 +6,9 @@ import weakref
 import numpy as np
 
 from pydrake.examples import PendulumPlant
-from pydrake.multibody.tree import MultibodyForces
-from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import MultibodyPlant
+from pydrake.multibody.tree import MultibodyForces
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.controllers import (
     DiscreteTimeLinearQuadraticRegulator,
@@ -17,11 +17,11 @@ from pydrake.systems.controllers import (
     FiniteHorizonLinearQuadraticRegulatorOptions,
     FiniteHorizonLinearQuadraticRegulatorResult,
     FittedValueIteration,
-    InverseDynamicsController,
     InverseDynamics,
+    InverseDynamicsController,
     JointStiffnessController,
-    LinearQuadraticRegulator,
     LinearProgrammingApproximateDynamicProgramming,
+    LinearQuadraticRegulator,
     MakeFiniteHorizonLinearQuadraticRegulator,
     PeriodicBoundaryCondition,
     PidControlledSystem,
@@ -29,8 +29,8 @@ from pydrake.systems.controllers import (
 )
 from pydrake.systems.framework import (
     DiagramBuilder,
-    InputPortSelection,
     InputPort,
+    InputPortSelection,
     OutputPort,
 )
 from pydrake.systems.primitives import Integrator, LinearSystem

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -8,6 +8,7 @@ import weakref
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.value import Value
 from pydrake.symbolic import Expression
 from pydrake.systems.analysis import (
@@ -50,13 +51,10 @@ from pydrake.systems.primitives import (
     Adder,
     ZeroOrderHold,
 )
-
 from pydrake.systems.test.test_util import (
     call_leaf_system_overrides,
     call_vector_system_overrides,
 )
-
-from pydrake.common.test_utilities import numpy_compare
 
 
 def noop(*args, **kwargs):

--- a/bindings/pydrake/systems/test/estimators_test.py
+++ b/bindings/pydrake/systems/test/estimators_test.py
@@ -1,14 +1,15 @@
-import unittest
 import copy
+import unittest
+
 import numpy as np
 
 from pydrake.examples import PendulumPlant
-from pydrake.systems.primitives import LinearSystem
 from pydrake.systems.estimators import (
     DiscreteTimeSteadyStateKalmanFilter,
     LuenbergerObserver,
     SteadyStateKalmanFilter,
 )
+from pydrake.systems.primitives import LinearSystem
 
 
 class TestEstimators(unittest.TestCase):

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -3,8 +3,8 @@
 import copy
 import gc
 from textwrap import dedent
-
 import unittest
+
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
@@ -26,9 +26,9 @@ from pydrake.systems.analysis import (
 from pydrake.systems.framework import (
     BasicVector,
     BasicVector_,
-    ContextBase,
     Context,
     Context_,
+    ContextBase,
     ContinuousState,
     ContinuousState_,
     Diagram,
@@ -45,7 +45,6 @@ from pydrake.systems.framework import (
     InputPort,
     InputPort_,
     InputPortIndex,
-    kUseDefaultName,
     LeafContext,
     LeafContext_,
     LeafSystem,
@@ -66,17 +65,18 @@ from pydrake.systems.framework import (
     Supervector_,
     System,
     System_,
-    SystemVisitor,
     SystemBase,
     SystemOutput,
     SystemOutput_,
     SystemScalarConverter,
+    SystemVisitor,
+    TriggerType,
     VectorBase,
     VectorBase_,
-    TriggerType,
     VectorSystem,
     VectorSystem_,
     _ExternalSystemConstraint,
+    kUseDefaultName,
 )
 from pydrake.systems.primitives import (
     Adder,
@@ -91,8 +91,8 @@ from pydrake.systems.primitives import (
     ZeroOrderHold,
 )
 from pydrake.systems.test.test_util import (
-    MyVector2,
     MakeDummySystem,
+    MyVector2,
 )
 from pydrake.systems.test_utilities import framework_test_util
 

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -2,16 +2,13 @@
 Test bindings of LCM integration with the Systems framework.
 """
 
-import pydrake.systems.lcm as mut
-
 import collections
 import unittest
 
 import numpy as np
 
-from drake import lcmt_header, lcmt_quaternion
 import drake as drake_lcmtypes
-
+from drake import lcmt_header, lcmt_quaternion
 from pydrake.common.value import Value
 from pydrake.lcm import DrakeLcm, DrakeLcmParams, Subscriber
 from pydrake.systems.analysis import Simulator
@@ -20,6 +17,7 @@ from pydrake.systems.framework import (
     LeafSystem,
     TriggerType,
 )
+import pydrake.systems.lcm as mut
 from pydrake.systems.primitives import ConstantVectorSource
 
 

--- a/bindings/pydrake/systems/test/lifetime_test.py
+++ b/bindings/pydrake/systems/test/lifetime_test.py
@@ -8,6 +8,7 @@ lifetime of objects, eventually lock down capabilities as they are introduced.
 
 import gc
 import unittest
+
 import numpy as np
 
 from pydrake.systems.analysis import (

--- a/bindings/pydrake/systems/test/monte_carlo_test.py
+++ b/bindings/pydrake/systems/test/monte_carlo_test.py
@@ -5,8 +5,8 @@ import unittest
 from pydrake.common import RandomGenerator
 from pydrake.systems.analysis import (
     MonteCarloSimulation,
-    RandomSimulationResult,
     RandomSimulation,
+    RandomSimulationResult,
     Simulator,
 )
 from pydrake.systems.primitives import ConstantVectorSource

--- a/bindings/pydrake/systems/test/perception_test.py
+++ b/bindings/pydrake/systems/test/perception_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+
 import numpy as np
 
 from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix

--- a/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
+++ b/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
@@ -1,10 +1,10 @@
+import io
+import os
 import unittest
 
-from python.runfiles import Create as CreateRunfiles
-import io
 import numpy as np
-import os
 from PIL import Image
+from python.runfiles import Create as CreateRunfiles
 
 from pydrake.common import (
     FindResourceOrThrow,

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -1,7 +1,8 @@
 import copy
-import scipy.sparse
 import unittest
+
 import numpy as np
+import scipy.sparse
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import RandomDistribution, RandomGenerator
@@ -18,9 +19,6 @@ from pydrake.systems.framework import (
     TriggerType,
     VectorBase,
     kUseDefaultName,
-)
-from pydrake.systems.test.test_util import (
-    MyVector2,
 )
 from pydrake.systems.primitives import (
     Adder_,
@@ -57,10 +55,10 @@ from pydrake.systems.primitives import (
     LinearTransformDensity_,
     LogVectorOutput,
     MatrixGain,
-    Multiplexer,
-    Multiplexer_,
     MultilayerPerceptron,
     MultilayerPerceptron_,
+    Multiplexer,
+    Multiplexer_,
     ObservabilityMatrix,
     PassThrough,
     PassThrough_,
@@ -94,6 +92,9 @@ from pydrake.systems.primitives import (
     WrapToSystem_,
     ZeroOrderHold,
     ZeroOrderHold_,
+)
+from pydrake.systems.test.test_util import (
+    MyVector2,
 )
 from pydrake.trajectories import PiecewisePolynomial
 

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 
-from pydrake.systems.rendering import (
-    MultibodyPositionToGeometryPose,
-)
-
 import unittest
+
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import SceneGraph
-from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.parsing import Parser
+from pydrake.multibody.plant import MultibodyPlant
+from pydrake.systems.rendering import (
+    MultibodyPositionToGeometryPose,
+)
 
 
 def normalized(x):

--- a/bindings/pydrake/systems/test/scalar_conversion_test.py
+++ b/bindings/pydrake/systems/test/scalar_conversion_test.py
@@ -1,10 +1,11 @@
-import pydrake.systems.scalar_conversion as mut
+import pydrake.systems.scalar_conversion as mut  # ruff: isort: skip
 
 import copy
 import itertools
 import unittest
 
 from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common.cpp_template import TemplateClass
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import (
     DiagramBuilder_,
@@ -12,7 +13,6 @@ from pydrake.systems.framework import (
     SystemScalarConverter,
     _ExternalSystemConstraint,
 )
-from pydrake.common.cpp_template import TemplateClass
 
 
 @mut.TemplateSystem.define("Example_")

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -1,4 +1,4 @@
-import pydrake.systems.sensors as mut
+import pydrake.systems.sensors as mut  # ruff: isort: skip
 
 import copy
 import gc
@@ -7,6 +7,11 @@ import textwrap
 import unittest
 
 import numpy as np
+
+from drake import (
+    lcmt_image,
+    lcmt_image_array,
+)
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.common.value import Value
@@ -20,11 +25,11 @@ from pydrake.geometry import (
 )
 from pydrake.lcm import DrakeLcm
 from pydrake.math import RigidTransform
-from pydrake.multibody.plant import (
-    AddMultibodyPlantSceneGraph,
-)
 from pydrake.multibody.parsing import (
     Parser,
+)
+from pydrake.multibody.plant import (
+    AddMultibodyPlantSceneGraph,
 )
 from pydrake.systems.framework import (
     DiagramBuilder,
@@ -32,10 +37,6 @@ from pydrake.systems.framework import (
     OutputPort,
 )
 from pydrake.systems.lcm import LcmBuses, LcmInterfaceSystem, _Serializer_
-from drake import (
-    lcmt_image,
-    lcmt_image_array,
-)
 
 # Shorthand aliases, to reduce verbosity.
 pt = mut.PixelType

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -6,8 +6,8 @@ import unittest
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
-from pydrake.common.value import Value
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.value import Value
 from pydrake.symbolic import Expression
 from pydrake.systems.framework import (
     BasicVector,

--- a/bindings/pydrake/test/common_install_test.py
+++ b/bindings/pydrake/test/common_install_test.py
@@ -1,6 +1,7 @@
 import os
-import install_test_helper
 import unittest
+
+import install_test_helper
 
 
 class TestCommonInstall(unittest.TestCase):

--- a/bindings/pydrake/test/forward_diff_test.py
+++ b/bindings/pydrake/test/forward_diff_test.py
@@ -1,7 +1,9 @@
 import unittest
+
 import numpy as np
-from pydrake.forwarddiff import sin, cos, derivative, gradient, jacobian
+
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.forwarddiff import cos, derivative, gradient, jacobian, sin
 import pydrake.math as drake_math
 
 

--- a/bindings/pydrake/test/lcm_test.py
+++ b/bindings/pydrake/test/lcm_test.py
@@ -1,9 +1,8 @@
 import copy
 import unittest
 
-from pydrake.lcm import DrakeLcm, DrakeLcmInterface, DrakeLcmParams, Subscriber
-
 from drake import lcmt_quaternion
+from pydrake.lcm import DrakeLcm, DrakeLcmInterface, DrakeLcmParams, Subscriber
 
 
 class TestLcm(unittest.TestCase):

--- a/bindings/pydrake/test/memory_leak_test.py
+++ b/bindings/pydrake/test/memory_leak_test.py
@@ -18,11 +18,11 @@ from pydrake.common.test_utilities.memory_test_util import actual_ref_count
 from pydrake.geometry import Meshcat, SceneGraphConfig
 from pydrake.lcm import DrakeLcmParams
 from pydrake.manipulation import ApplyDriverConfigs, IiwaDriver
-from pydrake.multibody.plant import AddMultibodyPlant, MultibodyPlantConfig
 from pydrake.multibody.parsing import (
     LoadModelDirectivesFromString,
     ProcessModelDirectives,
 )
+from pydrake.multibody.plant import AddMultibodyPlant, MultibodyPlantConfig
 from pydrake.planning import RobotDiagramBuilder
 from pydrake.systems.analysis import (
     ApplySimulatorConfig,
@@ -34,7 +34,6 @@ from pydrake.systems.lcm import ApplyLcmBusConfig
 from pydrake.systems.primitives import ConstantVectorSource
 from pydrake.systems.sensors import ApplyCameraConfig, CameraConfig
 from pydrake.visualization import ApplyVisualizationConfig, VisualizationConfig
-
 
 # Developer-only configuration.
 VERBOSE = False

--- a/bindings/pydrake/test/mock_torch/torch.py
+++ b/bindings/pydrake/test/mock_torch/torch.py
@@ -5,7 +5,6 @@
 import os as _dl_flags
 import sys
 
-
 # Make the check in `pydrake/__init__.py` pass, but then undo the change.
 _old_flags = sys.getdlopenflags()
 sys.setdlopenflags(_dl_flags.RTLD_GLOBAL)

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -1,4 +1,4 @@
-import pydrake.perception as mut
+import pydrake.perception as mut  # ruff: isort: skip
 
 import copy
 import unittest
@@ -6,8 +6,8 @@ import unittest
 import numpy as np
 
 from pydrake.common.value import Value
-from pydrake.systems.sensors import CameraInfo, PixelType
 from pydrake.systems.framework import InputPort, OutputPort
+from pydrake.systems.sensors import CameraInfo, PixelType
 
 
 class TestPerception(unittest.TestCase):

--- a/bindings/pydrake/test/polynomial_test.py
+++ b/bindings/pydrake/test/polynomial_test.py
@@ -1,5 +1,6 @@
-import numpy as np
 import unittest
+
+import numpy as np
 
 from pydrake.common import ToleranceType
 from pydrake.common.test_utilities import numpy_compare

--- a/bindings/pydrake/test/stubgen_test.py
+++ b/bindings/pydrake/test/stubgen_test.py
@@ -3,9 +3,8 @@
 import os.path
 import unittest
 
-from python import runfiles
-
 import mypy.fastparse
+from python import runfiles
 
 
 class TestStubgen(unittest.TestCase):

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -1,8 +1,9 @@
 import copy
-import numpy as np
 import pickle
 from textwrap import dedent
 import unittest
+
+import numpy as np
 import scipy.sparse
 
 from pydrake.common import ToleranceType
@@ -12,6 +13,7 @@ from pydrake.common.test_utilities.pickle_compare import assert_pickle
 from pydrake.common.yaml import yaml_load_typed
 from pydrake.math import BsplineBasis_, RigidTransform_, RotationMatrix_
 from pydrake.polynomial import Polynomial_
+from pydrake.symbolic import Expression, Variable
 from pydrake.trajectories import (
     BezierCurve_,
     BsplineTrajectory_,
@@ -29,7 +31,6 @@ from pydrake.trajectories import (
     Trajectory_,
     _WrappedTrajectory_,
 )
-from pydrake.symbolic import Variable, Expression
 
 
 # Custom trajectory class used to test Trajectory subclassing in Python.

--- a/bindings/pydrake/tutorials.py
+++ b/bindings/pydrake/tutorials.py
@@ -20,6 +20,7 @@ notebook package on your system:
 
 def __main():
     import sys
+
     import pydrake
 
     sys.argv = ["notebook", f"{pydrake.getDrakePath()}/tutorials/index.ipynb"]

--- a/bindings/pydrake/visualization/_meldis.py
+++ b/bindings/pydrake/visualization/_meldis.py
@@ -6,11 +6,12 @@ import copy
 import hashlib
 import json
 import logging
-import numpy as np
 from pathlib import Path
 import re
 import sys
 import time
+
+import numpy as np
 
 from drake import (
     lcmt_contact_results_for_viz,
@@ -48,11 +49,11 @@ from pydrake.math import (
     RotationMatrix,
 )
 from pydrake.multibody.meshcat import (
+    ContactVisualizerParams,
     _HydroelasticContactVisualizer,
     _HydroelasticContactVisualizerItem,
     _PointContactVisualizer,
     _PointContactVisualizerItem,
-    ContactVisualizerParams,
 )
 from pydrake.perception import (
     BaseField,

--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -12,10 +12,10 @@ import numpy as np
 from pydrake.geometry import (
     Box,
     MeshcatCone,
+    RenderEngineVtkParams,
     Rgba,
     StartMeshcat,
 )
-from pydrake.geometry import RenderEngineVtkParams
 from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.meshcat import JointSliders
 from pydrake.multibody.tree import (
@@ -33,8 +33,8 @@ from pydrake.systems.sensors import (
     CameraConfig,
 )
 from pydrake.visualization import (
-    VisualizationConfig,
     ApplyVisualizationConfig,
+    VisualizationConfig,
 )
 from pydrake.visualization._triad import (
     AddFrameTriadIllustration,

--- a/bindings/pydrake/visualization/_plotting.py
+++ b/bindings/pydrake/visualization/_plotting.py
@@ -3,11 +3,11 @@ Provides some general visualization tools using matplotlib.  This is not
 related to `rendering`.
 """
 
-import numpy as np
 import matplotlib as mpl
+import numpy as np
 
-from pydrake.symbolic import Evaluate, Jacobian, Polynomial
 from pydrake.solvers import MathematicalProgram, Solve
+from pydrake.symbolic import Evaluate, Jacobian, Polynomial
 
 
 def plot_sublevelset_quadratic(ax, A, b=[0, 0], c=0, vertices=51, **kwargs):

--- a/bindings/pydrake/visualization/_video.py
+++ b/bindings/pydrake/visualization/_video.py
@@ -1,4 +1,5 @@
 import copy
+
 import numpy as np
 
 from pydrake.common.value import Value

--- a/bindings/pydrake/visualization/meldis.py
+++ b/bindings/pydrake/visualization/meldis.py
@@ -29,8 +29,8 @@ import webbrowser
 
 from pydrake.common import configure_logging as _configure_logging
 from pydrake.common.yaml import yaml_load_typed as _yaml_load_typed
-from pydrake.visualization._meldis import Meldis as _Meldis
 from pydrake.visualization._meldis import _DEFAULT_MESHCAT_PARAMS
+from pydrake.visualization._meldis import Meldis as _Meldis
 
 
 def _available_browsers():

--- a/bindings/pydrake/visualization/run_installed_meldis.py
+++ b/bindings/pydrake/visualization/run_installed_meldis.py
@@ -4,7 +4,7 @@
 Runs Meldis from an install tree.
 """
 
-from os.path import isdir, join, dirname, realpath
+from os.path import dirname, isdir, join, realpath
 import sys
 
 

--- a/bindings/pydrake/visualization/run_installed_model_visualizer.py
+++ b/bindings/pydrake/visualization/run_installed_model_visualizer.py
@@ -4,7 +4,7 @@
 Runs Model Visualizer from an install tree.
 """
 
-from os.path import isdir, join, dirname, realpath
+from os.path import dirname, isdir, join, realpath
 import sys
 
 

--- a/bindings/pydrake/visualization/test/config_test.py
+++ b/bindings/pydrake/visualization/test/config_test.py
@@ -1,4 +1,4 @@
-import pydrake.visualization as mut
+import pydrake.visualization as mut  # ruff: isort: skip
 
 import copy
 import unittest
@@ -7,18 +7,17 @@ from pydrake.geometry import (
     Meshcat,
     Rgba,
 )
-
 from pydrake.lcm import (
     DrakeLcm,
-)
-from pydrake.systems.lcm import (
-    LcmBuses,
 )
 from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph,
 )
 from pydrake.systems.framework import (
     DiagramBuilder,
+)
+from pydrake.systems.lcm import (
+    LcmBuses,
 )
 
 

--- a/bindings/pydrake/visualization/test/meldis_test.py
+++ b/bindings/pydrake/visualization/test/meldis_test.py
@@ -10,7 +10,7 @@ You can also visualize the LCM test data like so:
         TestMeldis.test_contact_applet_hydroelastic
 """
 
-import pydrake.visualization as mut
+import pydrake.visualization as mut  # ruff: isort: skip
 
 import functools
 import hashlib

--- a/bindings/pydrake/visualization/test/model_visualizer_camera_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_camera_test.py
@@ -1,4 +1,4 @@
-import pydrake.visualization as mut
+import pydrake.visualization as mut  # ruff: isort: skip
 
 import unittest
 

--- a/bindings/pydrake/visualization/test/model_visualizer_reload_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_reload_test.py
@@ -1,10 +1,11 @@
+import pydrake.visualization as mut  # ruff: isort: skip
+
 import subprocess
 import time
 import unittest
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import Meshcat
-import pydrake.visualization as mut
 
 
 class TestModelVisualizerReload(unittest.TestCase):

--- a/bindings/pydrake/visualization/test/model_visualizer_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_test.py
@@ -1,3 +1,6 @@
+import pydrake.visualization as mut  # ruff: isort: skip
+import pydrake.visualization._model_visualizer as mut_private  # ruff: isort: skip  # noqa
+
 import copy
 import inspect
 import subprocess
@@ -7,8 +10,6 @@ import unittest
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import Meshcat
 from pydrake.multibody.parsing import PackageMap
-import pydrake.visualization as mut
-import pydrake.visualization._model_visualizer as mut_private
 
 
 class TestModelVisualizerSubprocess(unittest.TestCase):

--- a/bindings/pydrake/visualization/test/plotting_test.py
+++ b/bindings/pydrake/visualization/test/plotting_test.py
@@ -1,8 +1,9 @@
-import pydrake.visualization as mut
+import pydrake.visualization as mut  # ruff: isort: skip
+
+import unittest
 
 import matplotlib.pyplot as plt
 import numpy as np
-import unittest
 
 from pydrake.symbolic import Variable
 

--- a/bindings/pydrake/visualization/test/sliders_test.py
+++ b/bindings/pydrake/visualization/test/sliders_test.py
@@ -1,7 +1,3 @@
-from pydrake.visualization import (
-    MeshcatPoseSliders,
-)
-
 import unittest
 
 from pydrake.geometry import (
@@ -9,6 +5,9 @@ from pydrake.geometry import (
 )
 from pydrake.math import (
     RigidTransform,
+)
+from pydrake.visualization import (
+    MeshcatPoseSliders,
 )
 
 

--- a/bindings/pydrake/visualization/test/triad_test.py
+++ b/bindings/pydrake/visualization/test/triad_test.py
@@ -1,3 +1,5 @@
+import pydrake.visualization as mut  # ruff: isort: skip
+
 import unittest
 
 import numpy as np
@@ -7,7 +9,6 @@ from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.tree import FixedOffsetFrame
 from pydrake.planning import RobotDiagramBuilder
-import pydrake.visualization as mut
 
 
 class TestTriad(unittest.TestCase):

--- a/bindings/pydrake/visualization/test/video_test.py
+++ b/bindings/pydrake/visualization/test/video_test.py
@@ -4,13 +4,12 @@ import sys
 import textwrap
 import unittest
 
-from pydrake.math import RollPitchYaw, RigidTransform
+from pydrake.math import RigidTransform, RollPitchYaw
 from pydrake.multibody.parsing import Parser
 from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.visualization import VideoWriter
-
 
 _PLATFORM_SUPPORTS_CV2 = "darwin" not in sys.platform
 

--- a/common/proto/call_python_client.py
+++ b/common/proto/call_python_client.py
@@ -183,9 +183,9 @@ def default_globals():
     # `CallPythonClient`) and the client user code (e.g. `plot(x, y)`).
     # TODO(eric.cousineau): Consider relegating this to a different module,
     # possibly when this falls under `pydrake`.
-    import numpy as np
-    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 (unused-import)
     import matplotlib
+    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 (unused-import)
+    import numpy as np
 
     # On Ubuntu the Debian package python3-tk is a recommended (but not
     # required) dependency of python3-matplotlib; help users understand that

--- a/common/test/drake_cc_googletest_main_test.py
+++ b/common/test/drake_cc_googletest_main_test.py
@@ -4,8 +4,8 @@ drake_cc_googletest bazel macro, by running
 with a variety of command-line flags.
 """
 
-import subprocess
 import os
+import subprocess
 import sys
 import unittest
 

--- a/common/test/resource_tool_installed_test.py
+++ b/common/test/resource_tool_installed_test.py
@@ -2,9 +2,9 @@
 
 import os
 from pathlib import Path
-import unittest
 import subprocess
 import sys
+import unittest
 
 import install_test_helper
 

--- a/common/test/resource_tool_test.py
+++ b/common/test/resource_tool_test.py
@@ -2,9 +2,9 @@
 command-line API through all corner cases.
 """
 
+import os
 import re
 import subprocess
-import os
 import sys
 import unittest
 

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -13,6 +13,7 @@ import sys
 import trace
 import unittest
 import warnings
+
 import xmlrunner
 
 try:
@@ -244,7 +245,6 @@ def traced(func, ignoredirs=None):
      Python code outside of the system prefix."""
     import functools
     import sys
-    import trace
     if ignoredirs is None:
         ignoredirs = ["/usr", sys.prefix]
     tracer = trace.Trace(trace=1, count=0, ignoredirs=ignoredirs)

--- a/doc/build.py
+++ b/doc/build.py
@@ -7,9 +7,9 @@ import os.path
 from pathlib import Path
 import sys
 import urllib.parse
+import xml.etree.ElementTree as ET
 
 from python import runfiles
-import xml.etree.ElementTree as ET
 
 from doc.defs import check_call, main
 

--- a/doc/defs.py
+++ b/doc/defs.py
@@ -7,9 +7,9 @@ import functools
 from http.server import SimpleHTTPRequestHandler
 import os.path
 from os.path import join
-from socketserver import ThreadingTCPServer
 import shlex
 import shutil
+from socketserver import ThreadingTCPServer
 import subprocess
 from subprocess import PIPE, STDOUT
 import sys

--- a/doc/doxygen_cxx/system_doxygen.py
+++ b/doc/doxygen_cxx/system_doxygen.py
@@ -18,8 +18,9 @@ python documentation.
 
 import re
 import sys
-import yaml
 from textwrap import indent
+
+import yaml
 
 
 def system_yaml_to_html(system_yaml):

--- a/doc/doxygen_cxx/test/system_doxygen_test.py
+++ b/doc/doxygen_cxx/test/system_doxygen_test.py
@@ -1,7 +1,7 @@
+import doc.doxygen_cxx.system_doxygen as mut  # ruff: isort: skip
+
 from textwrap import dedent, indent
 import unittest
-
-import doc.doxygen_cxx.system_doxygen as mut
 
 
 class TestSystemDoxygen(unittest.TestCase):

--- a/doc/pydrake/build.py
+++ b/doc/pydrake/build.py
@@ -7,9 +7,6 @@ import os
 from os.path import join
 import sys
 
-import pydrake._all_everything  # noqa: F401 (unused-import)
-from pydrake.common import _MangledName
-
 from doc.defs import (
     check_call,
     main,
@@ -17,6 +14,8 @@ from doc.defs import (
     symlink_input,
     verbose,
 )
+import pydrake._all_everything  # noqa: F401 (unused-import)
+from pydrake.common import _MangledName
 
 
 def _get_submodules(name):

--- a/doc/pydrake/pydrake_sphinx_extension.py
+++ b/doc/pydrake/pydrake_sphinx_extension.py
@@ -19,15 +19,14 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
 from sphinx import version_info as sphinx_version
-from sphinx.locale import _
 import sphinx.domains.python as pydoc
 from sphinx.ext import autodoc
+from sphinx.locale import _
 from sphinx.util.nodes import nested_parse_with_titles
 
+from doc.doxygen_cxx.system_doxygen import system_yaml_to_html
 from pydrake.common.cpp_template import TemplateBase
 from pydrake.common.deprecation import DrakeDeprecationWarning
-
-from doc.doxygen_cxx.system_doxygen import system_yaml_to_html
 
 
 def generate_sig_re(extended=False):

--- a/examples/acrobot/acrobot_io.py
+++ b/examples/acrobot/acrobot_io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pydrake.common.yaml import yaml_load, yaml_dump
+from pydrake.common.yaml import yaml_dump, yaml_load
 
 
 def load_scenario(*, filename=None, data=None):

--- a/examples/acrobot/optimizer_demo.py
+++ b/examples/acrobot/optimizer_demo.py
@@ -11,15 +11,13 @@ import tempfile
 
 import numpy as np
 
-from pydrake.common import FindResourceOrThrow
-
 from examples.acrobot.acrobot_io import (
     load_output,
     load_scenario,
     save_scenario,
 )
-
 from examples.acrobot.metrics import ensemble_cost, success_rate
+from pydrake.common import FindResourceOrThrow
 
 try:
     from scipy.optimize import fmin

--- a/examples/acrobot/spong_sim.py
+++ b/examples/acrobot/spong_sim.py
@@ -5,6 +5,7 @@ spong-controlled acrobot.
 import argparse
 import sys
 
+from examples.acrobot.acrobot_io import load_scenario, save_output
 from pydrake.examples import (
     AcrobotPlant,
     AcrobotSpongController,
@@ -12,8 +13,6 @@ from pydrake.examples import (
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.primitives import LogVectorOutput
-
-from examples.acrobot.acrobot_io import load_scenario, save_output
 
 
 def simulate(*, initial_state, controller_params, t_final, tape_period):

--- a/examples/acrobot/test/acrobot_io_test.py
+++ b/examples/acrobot/test/acrobot_io_test.py
@@ -1,14 +1,14 @@
-import numpy as np
 import unittest
 
-from pydrake.common import FindResourceOrThrow
+import numpy as np
 
 from examples.acrobot.acrobot_io import (
-    load_scenario,
-    save_scenario,
     load_output,
+    load_scenario,
     save_output,
+    save_scenario,
 )
+from pydrake.common import FindResourceOrThrow
 
 
 class TestIo(unittest.TestCase):

--- a/examples/acrobot/test/spong_sim_main_test.py
+++ b/examples/acrobot/test/spong_sim_main_test.py
@@ -3,10 +3,8 @@ import subprocess
 import sys
 import unittest
 
-from pydrake.common import FindResourceOrThrow
-
 from examples.acrobot.acrobot_io import load_output, load_scenario
-
+from pydrake.common import FindResourceOrThrow
 
 _backend = "py"
 

--- a/examples/hardware_sim/hardware_sim.py
+++ b/examples/hardware_sim/hardware_sim.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from pydrake.common import RandomGenerator
 from pydrake.common.yaml import yaml_load_typed
+from pydrake.geometry import SceneGraphConfig
 from pydrake.lcm import DrakeLcmParams
 from pydrake.manipulation import (
     ApplyDriverConfigs,
@@ -34,15 +35,14 @@ from pydrake.manipulation import (
     SchunkWsgDriver,
     ZeroForceDriver,
 )
-from pydrake.geometry import SceneGraphConfig
-from pydrake.multibody.plant import (
-    AddMultibodyPlant,
-    MultibodyPlantConfig,
-)
 from pydrake.multibody.parsing import (
     ModelDirective,
     ModelDirectives,
     ProcessModelDirectives,
+)
+from pydrake.multibody.plant import (
+    AddMultibodyPlant,
+    MultibodyPlantConfig,
 )
 from pydrake.systems.analysis import (
     ApplySimulatorConfig,

--- a/examples/hardware_sim/test/hardware_sim_test_common.py
+++ b/examples/hardware_sim/test/hardware_sim_test_common.py
@@ -14,9 +14,8 @@ import shlex
 import subprocess
 import sys
 
-import yaml
-
 from python.runfiles import Create as CreateRunfiles
+import yaml
 
 
 class HardwareSimTest:

--- a/examples/hardware_sim/test/robot_commander_test.py
+++ b/examples/hardware_sim/test/robot_commander_test.py
@@ -1,10 +1,10 @@
+import examples.hardware_sim.robot_commander as mut  # ruff: isort: skip
+
 import unittest
 
 from python.runfiles import Create as CreateRunfiles
 
 from pydrake.common.yaml import yaml_load
-
-import examples.hardware_sim.robot_commander as mut
 
 
 class RobotCommanderTest(unittest.TestCase):

--- a/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
+++ b/examples/hydroelastic/python_ball_paddle/contact_sim_demo.py
@@ -6,17 +6,18 @@ The ball is dropped on an edge of the paddle and bounces off.
 """
 
 import argparse
+
 import numpy as np
 
-from pydrake.math import RigidTransform
-from pydrake.math import RollPitchYaw
+from pydrake.math import RigidTransform, RollPitchYaw
 from pydrake.multibody.parsing import Parser
-from pydrake.multibody.plant import AddMultibodyPlant
-from pydrake.multibody.plant import MultibodyPlantConfig
-from pydrake.systems.analysis import ApplySimulatorConfig
-from pydrake.systems.analysis import Simulator
-from pydrake.systems.analysis import SimulatorConfig
-from pydrake.systems.analysis import PrintSimulatorStatistics
+from pydrake.multibody.plant import AddMultibodyPlant, MultibodyPlantConfig
+from pydrake.systems.analysis import (
+    ApplySimulatorConfig,
+    PrintSimulatorStatistics,
+    Simulator,
+    SimulatorConfig,
+)
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.primitives import VectorLogSink
 from pydrake.visualization import AddDefaultVisualization

--- a/examples/hydroelastic/python_nonconvex_mesh/drop_pepper.py
+++ b/examples/hydroelastic/python_nonconvex_mesh/drop_pepper.py
@@ -9,16 +9,18 @@ non-convex meshes. It reads SDFormat files of:
 """
 
 import argparse
+
 import numpy as np
 
 from pydrake.math import RigidTransform
 from pydrake.multibody.parsing import Parser
-from pydrake.multibody.plant import AddMultibodyPlant
-from pydrake.multibody.plant import MultibodyPlantConfig
-from pydrake.systems.analysis import ApplySimulatorConfig
-from pydrake.systems.analysis import Simulator
-from pydrake.systems.analysis import SimulatorConfig
-from pydrake.systems.analysis import PrintSimulatorStatistics
+from pydrake.multibody.plant import AddMultibodyPlant, MultibodyPlantConfig
+from pydrake.systems.analysis import (
+    ApplySimulatorConfig,
+    PrintSimulatorStatistics,
+    Simulator,
+    SimulatorConfig,
+)
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.visualization import AddDefaultVisualization
 

--- a/examples/van_der_pol/plot_limit_cycle.py
+++ b/examples/van_der_pol/plot_limit_cycle.py
@@ -2,12 +2,12 @@
 # The Agg backend (creating a PNG image) is suitably cross-platform.
 # Users should feel free to use a different back-end in their own code.
 import os
+import webbrowser
 
 os.environ["MPLBACKEND"] = "Agg"  # noqa
 
 # Now that the environment is set up, it's safe to import matplotlib, etc.
 import matplotlib.pyplot as plt
-import webbrowser
 
 from pydrake.examples import VanDerPolOscillator
 

--- a/geometry/render_gltf_client/test/integration_test.py
+++ b/geometry/render_gltf_client/test/integration_test.py
@@ -28,9 +28,9 @@ import subprocess
 import sys
 import unittest
 
-from python.runfiles import Create as CreateRunfiles
 import numpy as np
 from PIL import Image
+from python.runfiles import Create as CreateRunfiles
 
 COLOR_PIXEL_THRESHOLD = 20  # RGB pixel value tolerance.
 DEPTH_PIXEL_THRESHOLD = 0.001  # Depth measurement tolerance in meters.

--- a/geometry/render_gltf_client/test/server_demo.py
+++ b/geometry/render_gltf_client/test/server_demo.py
@@ -23,8 +23,8 @@ import tempfile
 from textwrap import dedent
 from typing import Dict, Union
 
-from python.runfiles import Create as CreateRunfiles
 from flask import Flask, request, send_file
+from python.runfiles import Create as CreateRunfiles
 
 """The main flask application."""
 app = Flask(__name__)

--- a/geometry/test/meshcat_websocket_client.py
+++ b/geometry/test/meshcat_websocket_client.py
@@ -5,9 +5,9 @@ import asyncio
 import json
 import logging
 import sys
+
 import umsgpack
 import websockets
-
 
 # BEGIN ugly hack
 #

--- a/multibody/parsing/package_downloader.py
+++ b/multibody/parsing/package_downloader.py
@@ -20,14 +20,14 @@ same time with the same arguments.
 import hashlib
 import json
 import logging
-from pathlib import Path
 import os
-import urllib.parse
-import urllib.request as request
+from pathlib import Path
 import shutil
 import sys
 import tempfile
 from typing import List
+import urllib.parse
+import urllib.request as request
 
 
 def _fail(message):

--- a/multibody/parsing/test/package_downloader_test.py
+++ b/multibody/parsing/test/package_downloader_test.py
@@ -1,13 +1,13 @@
+import multibody.parsing.package_downloader as mut  # ruff: isort: skip
+
 import hashlib
 import io
 import json
 from pathlib import Path
 import tempfile
-import zipfile
 import unittest
 from urllib.error import HTTPError
-
-import multibody.parsing.package_downloader as mut
+import zipfile
 
 # We'll mock out the internet-touching methods. We don't want our unit test
 # touching the internet. See setUp and tearDown below for details.

--- a/multibody/plant/images/stiction.py
+++ b/multibody/plant/images/stiction.py
@@ -2,9 +2,9 @@
 Produces stiction.png for contact documentation.
 """
 
+import matplotlib.patches as patches
 import numpy as np
 import pylab as plt
-import matplotlib.patches as patches
 
 
 def step5(x):

--- a/multibody/plant/images/test/scripts_test.py
+++ b/multibody/plant/images/test/scripts_test.py
@@ -1,7 +1,7 @@
 from os.path import isfile
-import unittest
 from subprocess import run
 import sys
+import unittest
 
 
 class TestCreatePlot(unittest.TestCase):

--- a/tools/clion/test/bazel_wrapper_test.py
+++ b/tools/clion/test/bazel_wrapper_test.py
@@ -6,7 +6,6 @@ import subprocess
 import tempfile
 import unittest
 
-
 bazel_wrapper = SourceFileLoader(
     "bazel_wrapper", "tools/clion/bazel_wrapper"
 ).load_module("bazel_wrapper")

--- a/tools/dynamic_analysis/kcov_tool
+++ b/tools/dynamic_analysis/kcov_tool
@@ -8,10 +8,10 @@ https://drake.mit.edu/bazel.html?highlight=kcov#kcov
 
 import argparse
 import glob
+import os
 import shutil
 import stat
 import subprocess
-import os
 import sys
 import zipfile
 

--- a/tools/install/installer.py
+++ b/tools/install/installer.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import re
 import shutil
 import stat
-from subprocess import check_output, check_call
+from subprocess import check_call, check_output
 import sys
 
 from python import runfiles

--- a/tools/install/otool.py
+++ b/tools/install/otool.py
@@ -2,11 +2,10 @@
 Pythonic wrappers for macOS `otool`.
 """
 
+from collections import namedtuple
 import os
 import re
 import subprocess
-
-from collections import namedtuple
 
 Library = namedtuple(
     "Library",

--- a/tools/install/test/install_meta_test.py
+++ b/tools/install/test/install_meta_test.py
@@ -1,12 +1,12 @@
 """Tests the behavior of targets that use `installer.py`."""
 
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 import io
 import os
 from os.path import isdir, join, relpath
-import unittest
 from subprocess import STDOUT, check_output
 import sys
+import unittest
 
 import tools.install.installer as installer
 

--- a/tools/install/test/install_test_helper_test.py
+++ b/tools/install/test/install_test_helper_test.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+
 import install_test_helper
 
 

--- a/tools/jupyter/jupyter_bazel.py
+++ b/tools/jupyter/jupyter_bazel.py
@@ -4,10 +4,8 @@ import sys
 import warnings
 
 from jupyter_core.command import main as _jupyter_main
-
-# http://nbconvert.readthedocs.io/en/latest/execute_api.html
-import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
+import nbformat
 from python import runfiles
 
 _ISSUE_12536_NOTES = """

--- a/tools/lcm_gen/__init__.py
+++ b/tools/lcm_gen/__init__.py
@@ -34,7 +34,7 @@ import re
 import struct
 import token
 import tokenize
-from typing import Optional, List, Union
+from typing import List, Optional, Union
 
 # A brief summary of LCM's grammar.
 #

--- a/tools/lint/buildifier.py
+++ b/tools/lint/buildifier.py
@@ -6,11 +6,11 @@ lint errors to a non-zero exitcode.
 """
 
 import os
+from pathlib import Path
 import re
 import subprocess
+from subprocess import PIPE, STDOUT, Popen
 import sys
-from pathlib import Path
-from subprocess import Popen, PIPE, STDOUT
 
 from python import runfiles
 

--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -6,6 +6,7 @@ This program is only supported on Ubuntu Noble 24.04.
 """
 
 import argparse
+from dataclasses import dataclass, field
 import hashlib
 import json
 import os
@@ -15,19 +16,15 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-import urllib.request
-from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+import urllib.request
 
 import boto3
-
 import docker
-
 import github3
 from github3.repos.release import Asset, Release
 from github3.repos.repo import Repository
 from github3.repos.tag import RepoTag
-
 
 _GITHUB_REPO_OWNER = "RobotLocomotion"
 _GITHUB_REPO_NAME = "drake"

--- a/tools/skylark/rewrite_osx_ar_hidden.py
+++ b/tools/skylark/rewrite_osx_ar_hidden.py
@@ -3,9 +3,9 @@ symbol visibility while doing so using `nmedit` to mark everything hidden.
 """
 
 import argparse
+from pathlib import Path
 import subprocess
 import tempfile
-from pathlib import Path
 
 
 def _rewrite(*, input: Path, output: Path, temp: Path):

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -4,7 +4,7 @@ import sys
 # Note: use setuptools.glob rather than the built-in glob; see
 # https://bugs.python.org/issue37578.
 import setuptools
-from setuptools import setup, find_packages, glob
+from setuptools import find_packages, glob, setup
 
 DRAKE_VERSION = os.environ.get('DRAKE_VERSION', '0.0.0')
 

--- a/tools/wheel/test/tests/libs-test.py
+++ b/tools/wheel/test/tests/libs-test.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 
 from pathlib import Path
-import re
 import sys
 from zipfile import ZipFile
-
 
 # Everything here must have its license installed as part of the wheel build.
 # This list must be kept in sync with the calls to copy_ubuntu_license in

--- a/tools/wheel/test/tests/pyi-install-test.py
+++ b/tools/wheel/test/tests/pyi-install-test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 import os
+
 import pydrake
+
 
 def assert_exists(path):
     assert os.path.exists(path), f'{path!r} does not exist!'

--- a/tools/wheel/test/tests/sanity-test.py
+++ b/tools/wheel/test/tests/sanity-test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-import numpy
 import platform
+
+import numpy
+
 import pydrake.all
 
 # Basic sanity checks.

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -2,25 +2,24 @@
 # //tools/wheel:builder for the user interface.
 
 import atexit
+from datetime import datetime, timezone
 import os
 import pathlib
 import subprocess
 import sys
 import tarfile
 
-from datetime import datetime, timezone
-
 from .common import (
     create_snopt_tgz,
     die,
+    find_tests,
     gripe,
+    resource_root,
     strip_tar_metadata,
     wheel_name,
+    wheelhouse,
 )
-from .common import resource_root, wheelhouse
-from .common import find_tests
-
-from .linux_types import Platform, Role, Target, BUILD, TEST
+from .linux_types import BUILD, TEST, Platform, Role, Target
 
 # Artifacts that need to be cleaned up. DO NOT MODIFY outside of this file.
 _files_to_remove = []

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -8,10 +8,16 @@ import shutil
 import subprocess
 import tempfile
 
-from .common import create_snopt_tgz, die, wheel_name
-from .common import build_root, resource_root, wheelhouse
-from .common import test_root, find_tests
-
+from .common import (
+    build_root,
+    create_snopt_tgz,
+    die,
+    find_tests,
+    resource_root,
+    test_root,
+    wheel_name,
+    wheelhouse,
+)
 from .macos_types import PythonTarget
 
 # This is the complete set of defined targets (i.e. potential wheels). By

--- a/tools/wheel/wheel_builder/main.py
+++ b/tools/wheel/wheel_builder/main.py
@@ -6,7 +6,6 @@ import sys
 
 from tools.wheel.wheel_builder.common import do_main as main
 
-
 if __name__ == "__main__":
     if sys.platform == "linux":
         from tools.wheel.wheel_builder import linux as platform

--- a/tools/workspace/bazelisk_internal/test/lint_test.py
+++ b/tools/workspace/bazelisk_internal/test/lint_test.py
@@ -1,8 +1,7 @@
-import unittest
 from pathlib import Path
+import unittest
 
 from python import runfiles
-
 
 _HOW_TO_FIX = """
 If you're seeing this, you probably didn't follow the upgrade instuctions in

--- a/tools/workspace/bzlmod_sync_test.py
+++ b/tools/workspace/bzlmod_sync_test.py
@@ -1,5 +1,5 @@
-import unittest
 from pathlib import Path
+import unittest
 
 from python import runfiles
 

--- a/tools/workspace/clarabel_cpp_internal/test/lint_test.py
+++ b/tools/workspace/clarabel_cpp_internal/test/lint_test.py
@@ -1,5 +1,5 @@
-import unittest
 from pathlib import Path
+import unittest
 
 
 class ClarabelCppInternalLintTest(unittest.TestCase):

--- a/tools/workspace/cmake_configure_file.py
+++ b/tools/workspace/cmake_configure_file.py
@@ -8,10 +8,9 @@ https://cmake.org/cmake/help/latest/command/configure_file.html
 """
 
 import argparse
+from collections import OrderedDict
 import os
 import re
-
-from collections import OrderedDict
 
 # Looks like "#cmakedefine VAR ..." or "#cmakedefine01 VAR".
 _cmakedefine = re.compile(

--- a/tools/workspace/ipopt_internal/test/lint_test.py
+++ b/tools/workspace/ipopt_internal/test/lint_test.py
@@ -1,5 +1,5 @@
-import unittest
 from pathlib import Path
+import unittest
 
 from python import runfiles
 

--- a/tools/workspace/lapack_internal/sources_gen.py
+++ b/tools/workspace/lapack_internal/sources_gen.py
@@ -8,7 +8,6 @@ import re
 
 from python import runfiles
 
-
 # These are the Makefile variables we need to extract (in order).
 _WANTED = (
     "ALLBLAS",

--- a/tools/workspace/lcm/test/no_lcm_warnings_test.py
+++ b/tools/workspace/lcm/test/no_lcm_warnings_test.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import warnings
 
-from lcm import EventLog, LCM
+from lcm import LCM, EventLog
 
 
 class Test(unittest.TestCase):

--- a/tools/workspace/libjpeg_turbo_internal/upgrade.py
+++ b/tools/workspace/libjpeg_turbo_internal/upgrade.py
@@ -7,9 +7,9 @@ This program is only tested / supported on Ubuntu.
 
 import logging
 import os
+from pathlib import Path
 import re
 import urllib.request
-from pathlib import Path
 
 
 def _main():

--- a/tools/workspace/mirror_to_s3.py
+++ b/tools/workspace/mirror_to_s3.py
@@ -26,7 +26,6 @@ import requests
 
 from tools.workspace.metadata import read_repository_metadata
 
-
 BUCKET_NAME = "drake-mirror"
 BUCKET_URL = "https://s3.amazonaws.com/drake-mirror/"
 CLOUDFRONT_URL = "https://drake-mirror.csail.mit.edu/"

--- a/tools/workspace/mkdoc_internal/libclang_setup.py
+++ b/tools/workspace/mkdoc_internal/libclang_setup.py
@@ -1,10 +1,9 @@
 import glob
-import platform
 import os
+import platform
 import subprocess
 
 from clang import cindex
-
 
 # Alternative: Make this a function in `mkdoc.py`, and import it from mkdoc as
 # a module? (if this was really authored in `mkdoc.py`...)

--- a/tools/workspace/mkdoc_internal/mkdoc.py
+++ b/tools/workspace/mkdoc_internal/mkdoc.py
@@ -50,7 +50,6 @@ from clang.cindex import AccessSpecifier, CursorKind, TypeKind
 from tools.workspace.mkdoc_internal.libclang_setup import add_library_paths
 from tools.workspace.mkdoc_internal.mkdoc_comment import process_comment
 
-
 CLASS_KINDS = [
     CursorKind.CLASS_DECL,
     CursorKind.STRUCT_DECL,

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -31,6 +31,7 @@ command line.
 """
 
 import argparse
+from dataclasses import dataclass
 import getpass
 import hashlib
 import json
@@ -39,11 +40,10 @@ import os
 import re
 import shlex
 import subprocess
-import time
-import urllib
-from dataclasses import dataclass
 from tempfile import TemporaryDirectory
+import time
 from typing import Optional, Set
+import urllib
 
 import git
 import github3

--- a/tools/workspace/sdformat_internal/embed_sdf.py
+++ b/tools/workspace/sdformat_internal/embed_sdf.py
@@ -1,7 +1,6 @@
 # A re-implementation of upstream's sdf/embedSdf.rb tool in Python.
 
 import sys
-
 import xml.etree.ElementTree as ET
 
 assert __name__ == "__main__"

--- a/tutorials/test/notebook_lint_test.py
+++ b/tutorials/test/notebook_lint_test.py
@@ -2,7 +2,6 @@ import sys
 
 from python import runfiles
 
-
 _PREAMBLE = """\
 {
  "cells": [


### PR DESCRIPTION
Towards #19827.

I didn't realize that import sorting was off by default.  This turns it on, along with some manual `ruff: isort: ...` comments in cases that break convention.

The import rules enforced are:
- put in three groups separated by a blank line: standard library, third party, first party
- within each group, sort alphabetically

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23672)
<!-- Reviewable:end -->
