### PR TITLE
[lint] Simplify find_all_sources

### DIFF
--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -23,6 +23,7 @@ drake_py_library(
     visibility = ["//visibility:private"],
     deps = [
         ":module_py",
+        "@rules_python//python/runfiles",
     ],
 )
 

--- a/tools/lint/buildifier.py
+++ b/tools/lint/buildifier.py
@@ -51,9 +51,9 @@ def _help(command):
     return process.returncode
 
 
-def _find_buildifier_sources(workspace_name):
+def _find_buildifier_sources():
     """Return a list of all filenames to be covered by buildifier."""
-    workspace, sources_relpath = find_all_sources(workspace_name)
+    workspace, sources_relpath = find_all_sources()
     exact_filenames = ["BUILD", "WORKSPACE"]
     extensions = ["bazel", "bzl", "BUILD"]
     return workspace, [
@@ -80,7 +80,7 @@ def _passes_check_mode(args):
         raise e
 
 
-def main(workspace_name="drake"):
+def main():
     # Slice out our overlay command-line argument "--all".
     argv = sys.argv[1:]
     find_all = False
@@ -104,7 +104,7 @@ def main(workspace_name="drake"):
         print("ERROR: no input files; did you want '--all'?")
         return 1
     if find_all:
-        workspace_dir, found = _find_buildifier_sources(workspace_name)
+        workspace_dir, found = _find_buildifier_sources()
         if len(found) == 0:
             print("ERROR: '--all' could not find anything")
             return 1

--- a/tools/lint/test/util_test.py
+++ b/tools/lint/test/util_test.py
@@ -6,7 +6,7 @@ from tools.lint.util import find_all_sources
 
 class UtilTest(unittest.TestCase):
     def test_find(self):
-        workspace_dir, relpaths = find_all_sources("drake")
+        workspace_dir, relpaths = find_all_sources()
 
         # Sanity-check workspace_dir.  Most of the correctness assertions are
         # already embedded within the subroutine itself.

--- a/tools/lint/util.py
+++ b/tools/lint/util.py
@@ -1,77 +1,45 @@
 """Common helpers for source-tree linter utilities."""
 
 import os
-import sys
+from pathlib import Path
+
+from python import runfiles
 
 
-def find_all_sources(workspace_name):
+def find_all_sources():
     """Return [workspace, paths] list, where `workspace` is a path to the root
-    of the given `workspace_name`, and `paths` are relative paths under it that
-    are all of `workspace_name`'s source files, excluding third_party files.
+    of Drake's source tree and `paths` are relative paths under it that are all
+    of `workspace_name`'s source files, excluding third_party files.
     Because this abuses (escapes from) the Bazel sandbox, this function should
     *only* be used by linter tools and their unit tests.  It is thus given
     private visibility in our BUILD.bazel file.
     """
-    # Our outermost `myprogram.runfiles` directory will contain a file named
-    # MANIFEST.  Because this py_library declares a `data=[]` dependency on
-    # the top-level .bazelproject file, the manifest will cite the original
-    # location of that file, which we can abuse to find the absolute path to
-    # the root of the source tree.  (For workspace_name values other than
-    # "drake", callers should declare a data dependency on their workspace's
-    # top-level .bazelproject file.)
-    workspace_root = None
-    for entry in sys.path:
-        if workspace_root is not None:
-            break
-        if not entry.endswith(".runfiles"):
-            continue
-        manifest = os.path.join(entry, "MANIFEST")
-        if not os.path.exists(manifest):
-            continue
-        with open(manifest, "r") as infile:
-            lines = infile.readlines()
-        for one_line in lines:
-            if not one_line.endswith("/.bazelproject\n"):
-                continue
-            _, source_sentinel = one_line.split(" ")
-            workspace_root = os.path.dirname(os.path.realpath(source_sentinel))
-            if not workspace_root.endswith("/" + workspace_name):
-                continue
-            assert workspace_root.startswith("/"), workspace_root
-            assert os.path.isdir(workspace_root), workspace_root
-            break
-    if not workspace_root:
-        raise RuntimeError("Cannot find .bazelproject in MANIFEST")
-    # Make sure we found the right place.
-    workspace_file = os.path.join(workspace_root, "WORKSPACE")
-    if not os.path.exists(workspace_file):
-        raise RuntimeError(f"Cannot find WORKSPACE at {workspace_root}")
-    required_line = f'workspace(name = "{workspace_name}")'
-    with open(workspace_file, "r") as f:
-        if (required_line + "\n") not in f.readlines():
-            raise RuntimeError(
-                f"Cannot find {required_line} in {workspace_file}"
-            )
+    manifest = runfiles.Create()
+    dotfile = Path(manifest.Rlocation("drake/.bazelproject"))
+    workspace_root = dotfile.absolute().resolve().parent
+
     # Walk the tree (ignoring symlinks), and collect a list of all workspace-
     # relative filenames, but excluding a few specific items.
     relpaths = []
-    for abs_dirpath, dirs, files in os.walk(workspace_root):
-        assert abs_dirpath.startswith(workspace_root)
-        rel_dirpath = abs_dirpath[len(workspace_root) + 1 :]
+    for abs_dirpath, dirs, files in os.walk(str(workspace_root)):
+        # TODO(jwnimmer-tri) Once we drop Jammy use Path.walk (vs os.walk),
+        # and remove this extra conversion.
+        abs_dirpath = Path(abs_dirpath)
         # Take all files within the currently-walked directory.
+        rel_dirpath = abs_dirpath.relative_to(workspace_root)
         for one_filename in files:
             if one_filename == ".DS_Store":
                 continue
-            relpaths.append(os.path.join(rel_dirpath, one_filename))
-        # Don't recurse into children of "third_party".
-        if abs_dirpath.endswith("/third_party"):
+            if rel_dirpath == "." and one_filename.startswith("bazel-"):
+                continue
+            relpaths.append(str(rel_dirpath / one_filename))
+        # Don't recurse into subdirectories of "third_party" (but do still
+        # return files directly in "third_party").
+        if abs_dirpath.name == "third_party":
             dirs[:] = ()
             continue
-        # Don't recurse into dotfile directories (such as ".git"), nor into
-        # build directories.
+        # Don't recurse into dotfile directories (such as ".git").
         for i, one_dir in reversed(list(enumerate(list(dirs)))):
             if one_dir.startswith("."):
-                dirs.pop(i)
-            elif rel_dirpath == "" and one_dir.startswith("bazel-"):
                 dirs.pop(i)
     return workspace_root, sorted(relpaths)


### PR DESCRIPTION
This function is (only) used by `bazel-bin/tools/lint/buildifier --all`.  (That's the command to manually test this out.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23677)
<!-- Reviewable:end -->
