### PR TITLE
[multibody] Flesh out doxygen image generation smoke tests

### DIFF
--- a/multibody/plant/images/BUILD.bazel
+++ b/multibody/plant/images/BUILD.bazel
@@ -1,16 +1,22 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
+load("//tools/skylark:drake_py.bzl", "drake_py_binary", "drake_py_unittest")
 
-PYTHON_SCRIPTS = [
-    "ideal_stiction.py",
-    "stiction.py",
-]
+drake_py_binary(
+    name = "ideal_stiction",
+    srcs = ["ideal_stiction.py"],
+)
+
+drake_py_binary(
+    name = "stiction",
+    srcs = ["stiction.py"],
+)
 
 drake_py_unittest(
     name = "scripts_test",
-    data = PYTHON_SCRIPTS,
+    data = [
+        ":ideal_stiction",
+        ":stiction",
+    ],
 )
 
-add_lint_tests(
-    python_lint_extra_srcs = PYTHON_SCRIPTS,
-)
+add_lint_tests()

--- a/multibody/plant/images/test/scripts_test.py
+++ b/multibody/plant/images/test/scripts_test.py
@@ -1,19 +1,24 @@
-from os.path import isfile
-from subprocess import run
-import sys
+import os
+from pathlib import Path
+import subprocess
 import unittest
 
 
-class TestCreatePlot(unittest.TestCase):
-    def assert_isfile(self, file):
-        self.assertTrue(isfile(file), file)
-
-    def test_sripts(self):
-        # Must be run directly via Bazel.
-        python_bin = sys.executable
-        run(
-            [python_bin, "multibody/plant/images/ideal_stiction.py"], check=True
+class ScriptsTest(unittest.TestCase):
+    def test_ideal_stiction(self):
+        source = Path(".").absolute()
+        temp = Path(os.environ["TEST_TMPDIR"])
+        subprocess.check_call(
+            [source / "multibody/plant/images/ideal_stiction"],
+            cwd=temp,
         )
-        self.assert_isfile("./ideal_stiction.png")
-        run([python_bin, "multibody/plant/images/stiction.py"], check=True)
-        self.assert_isfile("./stribeck.png")
+        self.assertTrue((temp / "ideal_stiction.png").exists())
+
+    def test_stiction(self):
+        source = Path(".").absolute()
+        temp = Path(os.environ["TEST_TMPDIR"])
+        subprocess.check_call(
+            [source / "multibody/plant/images/stiction"],
+            cwd=temp,
+        )
+        self.assertTrue((temp / "stribeck.png").exists())


### PR DESCRIPTION
The prior smoke test took some shortcuts by calling `sys.executable`, to avoid writing BUILD rules for the programs. Even just for consistency and clarity, we should write BUILD rules and test by calling the program directly instead of `sys.executable`.  But also, in the future if (when) we start using `rules_python` to manage our Python dependencies, calling `sys.executable` will not work anymore in unit tests, because it will not have any third-party dependencies available (e.g., numpy).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23681)
<!-- Reviewable:end -->
