### PR TITLE
[workspace] Remove TODO to pin VTK

### DIFF
--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -181,9 +181,6 @@ def vtk_internal_repository(
         name,
         local_repository_override = None,
         repository = "Kitware/VTK",
-        # TODO(jwnimmer-tri) Once there's a tagged release with support for
-        # VTK_ABI_NAMESPACE, we should switch to an official version number
-        # here. That probably means waiting for the VTK 10 release.
         commit = "23daad7b687725f22b1b5e24e3ac5f1042658c92",
         sha256 = "bfd3f93e11bd3bb7f4780c33ecf632a9df9db7b05cd9be8e91dbf3ed9653c238",  # noqa
         build_file = ":package.BUILD.bazel",


### PR DESCRIPTION
VTK releases are infrequent enough that waiting to upgrade (and rebase our patches) until a tagged release would be too difficult.

(Using tagged releases would have been slightly nicer for our downstream customers who build their own VTK from source, but alas, the extra burden on us doesn't seem justified.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23682)
<!-- Reviewable:end -->
