### PR TITLE
Change incorrect `@group` into `@name`

### DIFF
--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -552,7 +552,7 @@ class Meshcat {
   See @ref meshcat_path for the detailed semantics of deletion. */
   void Delete(std::string_view path = "");
 
-  /** @group Realtime Rate Reporting
+  /** @name Realtime Rate Reporting
 
    %Meshcat can be used to visualize the realtime rate of a simulation's
    computation in the meshcat visualizer webpage. Meshcat broadcasts a realtime

--- a/geometry/render_gl/internal_opengl_geometry.h
+++ b/geometry/render_gl/internal_opengl_geometry.h
@@ -52,7 +52,7 @@ struct VertexSpec {
   VertexAttrib uvs;
 };
 
-/* @group Frames, Geometries, and Instances
+/* @name Frames, Geometries, and Instances
 
  There are a number of frames relating to how geometries are handled in
  RenderEngineGl. What they are and how they relate can be confusing. This

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -50,7 +50,7 @@ class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
         depth_camera_{color_camera_.core(), {0.01, 0.011}},
         label_camera_{color_camera_} {}
 
-  /* @group No-op implementation of RenderEngine interface.  */
+  /* @name No-op implementation of RenderEngine interface.  */
   //@{
   void UpdateViewpoint(const math::RigidTransformd& X_WC) override {
     X_WC_ = X_WC;

--- a/multibody/contact_solvers/sap/sap_constraint.h
+++ b/multibody/contact_solvers/sap/sap_constraint.h
@@ -304,7 +304,7 @@ class SapConstraint {
     return std::make_unique<Value<U>>(std::move(owned_data));
   }
 
-  // @group NVI implementations. Specific constraints must implement these
+  // @name NVI implementations. Specific constraints must implement these
   // methods. Refer to the specific NVI documentation for details.
   // Proper argument sizes and valid non-null pointers are already guaranteed by
   // checks in the correspondng NVIs.

--- a/multibody/contact_solvers/supernodal_solver.h
+++ b/multibody/contact_solvers/supernodal_solver.h
@@ -81,7 +81,7 @@ class SuperNodalSolver {
  protected:
   SuperNodalSolver() = default;
 
-  // @group NVI implementations. Specific solvers must implement these
+  // @name NVI implementations. Specific solvers must implement these
   // methods. Refer to the specific NVI documentation for details.
   // @{
 


### PR DESCRIPTION
Some of the changes include documentation that does not get rendered. But to forestall cargoculting the wrong keyword, those have been included too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23697)
<!-- Reviewable:end -->
