### PR TITLE
[tools] Add reminder to upgrade Doxygen

### DIFF
--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -75,6 +75,7 @@ _IGNORED_REPOSITORIES = [
 # print a reminder to manually check for upgrades.
 _OTHER_REPOSITORIES = [
     "python",
+    "doxygen_internal",
 ]
 
 # For these repositories, ignore any tags that match the specified regex.


### PR DESCRIPTION
Even though Doxygen is hosted on GitHub (for which we have good infrastructure already), upgrading is a manual process, so the best we can reasonably do is print a reminder. They currently release ~3 times/year.

Alternatively, we could consider modifying `new_release.py` or writing a new script which extracts the version from `tools/workspace/doxygen_internal/repository.bzl` and polls GitHub to see if there is something newer, but this is not trivial; it's spelled like: https://github.com/RobotLocomotion/drake/blob/90aab5d33d8fd1a1f163f9e93c25b4808252f8ee/tools/workspace/doxygen_internal/repository.bzl#L9

Towards #23513.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23704)
<!-- Reviewable:end -->
