### PR TITLE
[tools] Add rules_cc loads in prep for Bazel 9

### DIFF
--- a/third_party/com_github_bazelbuild_rules_cc/find_cc_toolchain.bzl
+++ b/third_party/com_github_bazelbuild_rules_cc/find_cc_toolchain.bzl
@@ -1,3 +1,5 @@
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+
 # This function is forked and modified from bazelbuild/rules_cc as of:
 # https://github.com/bazelbuild/rules_cc/blob/262ebec/cc/find_cc_toolchain.bzl
 def find_cc_toolchain(ctx):

--- a/third_party/com_github_bazelbuild_rules_cc/whole_archive.bzl
+++ b/third_party/com_github_bazelbuild_rules_cc/whole_archive.bzl
@@ -17,7 +17,7 @@ load(
     "//third_party:com_github_bazelbuild_rules_cc/find_cc_toolchain.bzl",
     "find_cc_toolchain",
 )
-load("//tools/skylark:cc.bzl", "CcInfo")
+load("//tools/skylark:cc.bzl", "CcInfo", "cc_common")
 
 # This function was inspired by bazelbuild/rules_cc as of:
 # https://github.com/bazelbuild/rules_cc/blob/262ebec3c2296296526740db4aefce68c80de7fa/examples/my_c_archive/my_c_archive.bzl

--- a/tools/install/libdrake/cc_defines.bzl
+++ b/tools/install/libdrake/cc_defines.bzl
@@ -1,4 +1,4 @@
-load("//tools/skylark:cc.bzl", "CcInfo")
+load("//tools/skylark:cc.bzl", "CcInfo", "cc_common")
 
 def _cc_defines_impl(ctx):
     deps_cc_infos = cc_common.merge_cc_infos(

--- a/tools/install/libdrake/header_lint.bzl
+++ b/tools/install/libdrake/header_lint.bzl
@@ -1,4 +1,4 @@
-load("//tools/skylark:cc.bzl", "CcInfo")
+load("//tools/skylark:cc.bzl", "CcInfo", "cc_common")
 load("//tools/skylark:sh.bzl", "sh_test")
 
 # This file contains a linter rule that ensures that only our allowed set of

--- a/tools/lcm_gen/BUILD.bazel
+++ b/tools/lcm_gen/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@drake//tools/skylark:cc.bzl", "cc_library")
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",

--- a/tools/skylark/cc.bzl
+++ b/tools/skylark/cc.bzl
@@ -10,6 +10,7 @@ load(
     "@rules_cc//cc:defs.bzl",
     _CcInfo = "CcInfo",
     _cc_binary = "cc_binary",
+    _cc_common = "cc_common",
     _cc_import = "cc_import",
     _cc_library = "cc_library",
     _cc_shared_library = "cc_shared_library",
@@ -36,3 +37,4 @@ def objc_library(**kwargs):
     _objc_library(**kwargs)
 
 CcInfo = _CcInfo
+cc_common = _cc_common

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -1,4 +1,11 @@
-load("//tools/skylark:cc.bzl", "CcInfo", "cc_binary", "cc_library", "cc_test")
+load(
+    "//tools/skylark:cc.bzl",
+    "CcInfo",
+    "cc_binary",
+    "cc_common",
+    "cc_library",
+    "cc_test",
+)
 load(
     "//tools/skylark:kwargs.bzl",
     "incorporate_allow_network",

--- a/tools/workspace/common_robotics_utilities_internal/package.BUILD.bazel
+++ b/tools/workspace/common_robotics_utilities_internal/package.BUILD.bazel
@@ -1,7 +1,7 @@
 # -*- bazel -*-
 
 load("@drake//tools/install:install.bzl", "install")
-load("@drake//tools/skylark:cc.bzl", "cc_library")
+load("@drake//tools/skylark:cc.bzl", "cc_library", "cc_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/workspace/curl_internal/package.BUILD.bazel
+++ b/tools/workspace/curl_internal/package.BUILD.bazel
@@ -1,6 +1,7 @@
 # -*- bazel -*-
 
 load("@drake//tools/install:install.bzl", "install")
+load("@drake//tools/skylark:cc.bzl", "cc_library")
 load(
     "@drake//tools/workspace:check_lists_consistency.bzl",
     "check_lists_consistency",

--- a/tools/workspace/highway_internal/patches/upstream/build.patch
+++ b/tools/workspace/highway_internal/patches/upstream/build.patch
@@ -1,0 +1,12 @@
+--- BUILD
++++ BUILD
+@@ -3,6 +3,9 @@
+ load("@bazel_skylib//lib:selects.bzl", "selects")
+ load("@rules_license//rules:license.bzl", "license")
+ # Placeholder#2 for Guitar, do not remove
++load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
++load("@rules_cc//cc:cc_test.bzl", "cc_test")
+ 
+ package(
+     default_applicable_licenses = ["//:license"],

--- a/tools/workspace/highway_internal/repository.bzl
+++ b/tools/workspace/highway_internal/repository.bzl
@@ -9,6 +9,7 @@ def highway_internal_repository(
         commit = "1.3.0",
         sha256 = "07b3c1ba2c1096878a85a31a5b9b3757427af963b1141ca904db2f9f4afe0bc2",  # noqa
         patches = [
+            ":patches/upstream/build.patch",
             ":patches/disabled_targets.patch",
             ":patches/linkstatic.patch",
             ":patches/target_get_index_inline_always.patch",

--- a/tools/workspace/lcm_internal/BUILD.bazel
+++ b/tools/workspace/lcm_internal/BUILD.bazel
@@ -1,5 +1,5 @@
+load("@drake//tools/skylark:cc.bzl", "cc_binary", "cc_library")
 load("@drake//tools/skylark:drake_cc.bzl", "cc_nolink_library")
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load(
     "//third_party:com_github_bazelbuild_rules_cc/whole_archive.bzl",
     "cc_whole_archive_library",

--- a/tools/workspace/onetbb_internal/package.BUILD.bazel
+++ b/tools/workspace/onetbb_internal/package.BUILD.bazel
@@ -1,6 +1,7 @@
 # -*- bazel -*-
 
 load("@drake//tools/install:install.bzl", "install", "install_files")
+load("@drake//tools/skylark:cc.bzl", "cc_library")
 
 # Here we use the header files from oneAPI but the runtime shared library from
 # @mosek//:tbb.  We use the MOSEK™ copy of TBB because that's what we've always

--- a/tools/workspace/python/package.BUILD.bazel
+++ b/tools/workspace/python/package.BUILD.bazel
@@ -1,5 +1,6 @@
 # -*- bazel -*-
 
+load("@drake//tools/skylark:cc.bzl", "cc_library")
 load("@rules_python//python:py_exec_tools_toolchain.bzl", "py_exec_tools_toolchain")  # noqa
 load("@rules_python//python:py_runtime.bzl", "py_runtime")
 load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")

--- a/tools/workspace/voxelized_geometry_tools_internal/package.BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools_internal/package.BUILD.bazel
@@ -1,6 +1,6 @@
 # -*- bazel -*-
 
-load("@drake//tools/skylark:cc.bzl", "cc_library")
+load("@drake//tools/skylark:cc.bzl", "cc_library", "cc_test")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
As of Bazel 9, C++ rules are no longer built-in. We must load C++ rules from the rules_cc module.

(Previously, we set `common --incompatible_autoload_externally=` in `tools/bazel.rc` to try to get out in front of this change, but apparently it didn't flag everything.  Testing with `9.0.0rc1` found some stragglers.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23706)
<!-- Reviewable:end -->
