### PR TITLE
[multibody/contact_solvers] Remove inline destructors

### DIFF
--- a/multibody/contact_solvers/contact_solver.cc
+++ b/multibody/contact_solvers/contact_solver.cc
@@ -2,5 +2,64 @@
 
 #include "drake/common/default_scalars.h"
 
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <typename T>
+ContactSolver<T>::~ContactSolver() = default;
+
+template <typename T>
+void ContactSolver<T>::FormDelassusOperatorMatrix(
+    const LinearOperator<T>& G, const LinearOperator<T>& Ainv,
+    const LinearOperator<T>& J, Eigen::SparseMatrix<T>* W) const {
+  const int num_velocities = Ainv.rows();
+  const int num_impulses = J.rows();
+  DRAKE_DEMAND(G.rows() == num_impulses);
+  DRAKE_DEMAND(G.cols() == num_velocities);
+  DRAKE_DEMAND(Ainv.rows() == num_velocities);
+  DRAKE_DEMAND(Ainv.cols() == num_velocities);
+  DRAKE_DEMAND(J.rows() == num_impulses);
+  DRAKE_DEMAND(J.cols() == num_velocities);
+  DRAKE_DEMAND(W->rows() == num_impulses);
+  DRAKE_DEMAND(W->cols() == num_impulses);
+
+  Eigen::SparseVector<T> ej(num_impulses);
+  // N.B. ej.makeCompressed() is not available for SparseVector.
+  ej.coeffRef(0) = 1.0;  // Effectively allocate one non-zero entry.
+
+  Eigen::SparseVector<T> JTcolj(num_velocities);
+  Eigen::SparseVector<T> AinvJTcolj(num_velocities);
+  Eigen::SparseVector<T> Wcolj(num_impulses);
+  // Reserve maximum number of non-zeros.
+  JTcolj.reserve(num_velocities);
+  AinvJTcolj.reserve(num_velocities);
+  Wcolj.reserve(num_impulses);
+
+  // Loop over the j-th column.
+  for (int j = 0; j < W->cols(); ++j) {
+    // By changing the inner index, we change what entry is the non-zero with
+    // value 1.0.
+    *ej.innerIndexPtr() = j;
+
+    // Reset to nnz = 0. Memory is not freed.
+    JTcolj.setZero();
+    AinvJTcolj.setZero();
+    Wcolj.setZero();
+
+    // Apply each operator in sequence.
+    J.MultiplyByTranspose(ej, &JTcolj);  // JTcolj = Jᵀ * ej
+    Ainv.Multiply(JTcolj, &AinvJTcolj);
+    G.Multiply(AinvJTcolj, &Wcolj);
+    W->col(j) = Wcolj;
+  }
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::multibody::contact_solvers::internal::ContactSolver);

--- a/multibody/contact_solvers/contact_solver.h
+++ b/multibody/contact_solvers/contact_solver.h
@@ -250,7 +250,7 @@ class ContactSolver {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactSolver);
   ContactSolver() = default;
-  virtual ~ContactSolver() = default;
+  virtual ~ContactSolver();
 
   // Generic interface to invoke the contact solver given an initial guess
   // `v_guess`.
@@ -288,48 +288,7 @@ class ContactSolver {
   void FormDelassusOperatorMatrix(const LinearOperator<T>& G,
                                   const LinearOperator<T>& Ainv,
                                   const LinearOperator<T>& J,
-                                  Eigen::SparseMatrix<T>* W) const {
-    const int num_velocities = Ainv.rows();
-    const int num_impulses = J.rows();
-    DRAKE_DEMAND(G.rows() == num_impulses);
-    DRAKE_DEMAND(G.cols() == num_velocities);
-    DRAKE_DEMAND(Ainv.rows() == num_velocities);
-    DRAKE_DEMAND(Ainv.cols() == num_velocities);
-    DRAKE_DEMAND(J.rows() == num_impulses);
-    DRAKE_DEMAND(J.cols() == num_velocities);
-    DRAKE_DEMAND(W->rows() == num_impulses);
-    DRAKE_DEMAND(W->cols() == num_impulses);
-
-    Eigen::SparseVector<T> ej(num_impulses);
-    // N.B. ej.makeCompressed() is not available for SparseVector.
-    ej.coeffRef(0) = 1.0;  // Effectively allocate one non-zero entry.
-
-    Eigen::SparseVector<T> JTcolj(num_velocities);
-    Eigen::SparseVector<T> AinvJTcolj(num_velocities);
-    Eigen::SparseVector<T> Wcolj(num_impulses);
-    // Reserve maximum number of non-zeros.
-    JTcolj.reserve(num_velocities);
-    AinvJTcolj.reserve(num_velocities);
-    Wcolj.reserve(num_impulses);
-
-    // Loop over the j-th column.
-    for (int j = 0; j < W->cols(); ++j) {
-      // By changing the inner index, we change what entry is the non-zero with
-      // value 1.0.
-      *ej.innerIndexPtr() = j;
-
-      // Reset to nnz = 0. Memory is not freed.
-      JTcolj.setZero();
-      AinvJTcolj.setZero();
-      Wcolj.setZero();
-
-      // Apply each operator in sequence.
-      J.MultiplyByTranspose(ej, &JTcolj);  // JTcolj = Jᵀ * ej
-      Ainv.Multiply(JTcolj, &AinvJTcolj);
-      G.Multiply(AinvJTcolj, &Wcolj);
-      W->col(j) = Wcolj;
-    }
-  }
+                                  Eigen::SparseMatrix<T>* W) const;
 };
 }  // namespace internal
 }  // namespace contact_solvers

--- a/multibody/contact_solvers/linear_operator.cc
+++ b/multibody/contact_solvers/linear_operator.cc
@@ -8,6 +8,9 @@ namespace contact_solvers {
 namespace internal {
 
 template <typename T>
+LinearOperator<T>::~LinearOperator() = default;
+
+template <typename T>
 void LinearOperator<T>::DoMultiplyByTranspose(
     const Eigen::Ref<const Eigen::SparseVector<T>>&,
     Eigen::SparseVector<T>*) const {

--- a/multibody/contact_solvers/linear_operator.h
+++ b/multibody/contact_solvers/linear_operator.h
@@ -43,7 +43,7 @@ class LinearOperator {
   // Creates an operator with a given `name`.
   explicit LinearOperator(const std::string& name) : name_(name) {}
 
-  virtual ~LinearOperator() = default;
+  virtual ~LinearOperator();
 
   const std::string& name() const { return name_; }
   virtual int rows() const = 0;

--- a/multibody/contact_solvers/supernodal_solver.cc
+++ b/multibody/contact_solvers/supernodal_solver.cc
@@ -7,6 +7,8 @@ namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
+SuperNodalSolver::~SuperNodalSolver() = default;
+
 void SuperNodalSolver::SetWeightMatrix(
     const std::vector<Eigen::MatrixXd>& weight_matrix) {
   bool weight_matrix_compatible = DoSetWeightMatrix(weight_matrix);

--- a/multibody/contact_solvers/supernodal_solver.h
+++ b/multibody/contact_solvers/supernodal_solver.h
@@ -45,7 +45,7 @@ class SuperNodalSolver {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SuperNodalSolver);
 
-  virtual ~SuperNodalSolver() = default;
+  virtual ~SuperNodalSolver();
 
   // Sets the block-diagonal weight matrix G.  The block rows of J and G both
   // partition the set {1, 2, ..., num_rows(J)}. Similar to the mass_matrix,


### PR DESCRIPTION
Towards [#22015](https://github.com/RobotLocomotion/drake/issues/22015).  +@jwnimmer-tri for review please, thanks! 

I also moved ContactSolver<T>::FormDelassusOperatorMatrix definition from .h to .cc since it consists of more than 10 lines as mentioned in [the style guide](https://drake.mit.edu/styleguide/cppguide.html#Defining_Functions_in_Header_Files).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23709)
<!-- Reviewable:end -->
