### PR TITLE
[tools] Disable -Wsign-compare in unit tests

### DIFF
--- a/planning/test_utilities/collision_checker_abstract_test_suite.cc
+++ b/planning/test_utilities/collision_checker_abstract_test_suite.cc
@@ -96,7 +96,7 @@ TEST_P(CollisionCheckerAbstractTestSuite, AddSpheres) {
   checker.AddCollisionShapeToFrame("test", dut_frame, geometry::Sphere(1.0),
                                    math::RigidTransform<double>());
   EXPECT_FALSE(checker.CheckConfigCollisionFree(qs_.q1));
-  EXPECT_NE(checker.GetAllAddedCollisionShapes().size(), 0);
+  EXPECT_NE(ssize(checker.GetAllAddedCollisionShapes()), 0);
 
   // While there are collisions, do some classifying.
   std::vector<RobotCollisionType> kinds =
@@ -113,21 +113,21 @@ TEST_P(CollisionCheckerAbstractTestSuite, AddSpheres) {
   // Also test the logic of removals and enumeration.
   checker.RemoveAllAddedCollisionShapes("other");
   EXPECT_FALSE(checker.CheckConfigCollisionFree(qs_.q1));
-  EXPECT_NE(checker.GetAllAddedCollisionShapes().size(), 0);
+  EXPECT_NE(ssize(checker.GetAllAddedCollisionShapes()), 0);
 
   checker.RemoveAllAddedCollisionShapes("test");
   EXPECT_TRUE(checker.CheckConfigCollisionFree(qs_.q1));
-  EXPECT_EQ(checker.GetAllAddedCollisionShapes().size(), 0);
+  EXPECT_EQ(ssize(checker.GetAllAddedCollisionShapes()), 0);
 
   // Re-add a shape to test removal of everything.
   checker.AddCollisionShapeToFrame("test", dut_frame, geometry::Sphere(1.0),
                                    math::RigidTransform<double>());
   EXPECT_FALSE(checker.CheckConfigCollisionFree(qs_.q1));
-  EXPECT_NE(checker.GetAllAddedCollisionShapes().size(), 0);
+  EXPECT_NE(ssize(checker.GetAllAddedCollisionShapes()), 0);
 
   checker.RemoveAllAddedCollisionShapes();
   EXPECT_TRUE(checker.CheckConfigCollisionFree(qs_.q1));
-  EXPECT_EQ(checker.GetAllAddedCollisionShapes().size(), 0);
+  EXPECT_EQ(ssize(checker.GetAllAddedCollisionShapes()), 0);
 }
 
 TEST_P(CollisionCheckerAbstractTestSuite, AddObstacles) {

--- a/solvers/test_utilities/check_gradient_sparsity_pattern.cc
+++ b/solvers/test_utilities/check_gradient_sparsity_pattern.cc
@@ -32,13 +32,13 @@ void CheckGradientSparsityPattern(const EvaluatorBase& evaluator,
     }
     for (int i = 0; i < y_grad.rows(); ++i) {
       for (int j = 0; j < y_grad.cols(); ++j) {
+        const bool gradient_nonzero_indices_has_ij =
+            gradient_nonzero_indices.contains(std::pair<int, int>(i, j));
         if (y_grad(i, j) != 0) {
-          EXPECT_GT(gradient_nonzero_indices.count(std::pair<int, int>(i, j)),
-                    0);
+          EXPECT_TRUE(gradient_nonzero_indices_has_ij);
         } else if (strict) {
           // y_grad(i, j) == 0
-          EXPECT_EQ(gradient_nonzero_indices.count(std::pair<int, int>(i, j)),
-                    0);
+          EXPECT_FALSE(gradient_nonzero_indices_has_ij);
         }
       }
     }

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -65,6 +65,11 @@ GCC_FLAGS = CXX_FLAGS + [
     "-Wno-missing-field-initializers",
 ]
 
+# The CC_TEST_FLAGS will be enabled for all cc_test rules in the project.
+CC_TEST_FLAGS = [
+    "-Wno-sign-compare",
+]
+
 # The GCC_CC_TEST_FLAGS will be enabled for all cc_test rules in the project
 # when building with gcc.
 GCC_CC_TEST_FLAGS = [
@@ -133,10 +138,11 @@ def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
         # In the case of no special arguments at all, we can save Bazel the
         # hassle of concatenating a bunch of empty stuff.
         return BASE_COPTS
-    test_gcc_copts = GCC_CC_TEST_FLAGS if cc_test else []
+    test_gcc_copts = (CC_TEST_FLAGS + GCC_CC_TEST_FLAGS) if cc_test else []
+    test_clang_copts = CC_TEST_FLAGS if cc_test else []
     return BASE_COPTS + rule_copts + select({
         "//tools/cc_toolchain:gcc": rule_gcc_copts + test_gcc_copts,
-        "//tools/cc_toolchain:clang": rule_clang_copts,
+        "//tools/cc_toolchain:clang": rule_clang_copts + test_clang_copts,
         "//conditions:default": [],
     })
 


### PR DESCRIPTION
Generally this warning is more noise than it's worth in tests, and with Bazel 9 it seems like googletest is pickier about sign-compare in the EXPECT_op macros. Best to just opt-out now.

The opt-out is only for tests (not test_utilities), so we also need to tweak a few utilities to avoid the forthcoming warnings in Bazel 9 (towards #23713).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23717)
<!-- Reviewable:end -->
