### PR TITLE
Avoid googletest header file warnings

### DIFF
--- a/geometry/test/meshcat_internal_test.cc
+++ b/geometry/test/meshcat_internal_test.cc
@@ -84,7 +84,7 @@ GTEST_TEST(UnbundleGltfAssetsTest, DataUri) {
   EXPECT_EQ(assets.front()->sha256(), expected_sha256);
 
   // Make sure the new URI seems correct.
-  EXPECT_THAT(json::parse(gltf_contents)["buffers"][0]["uri"],
+  EXPECT_THAT(std::string{json::parse(gltf_contents)["buffers"][0]["uri"]},
               testing::EndsWith(expected_sha256.to_string()));
 }
 
@@ -128,7 +128,7 @@ GTEST_TEST(UnbundleGltfAssetsTest, InMemoryData) {
           source.in_memory().supporting_files.at("fully_textured_pyramid.bin"))
           .sha256();
   // File storage provides a version-based prefix to the sha.
-  EXPECT_THAT(gltf_json["buffers"][0]["uri"],
+  EXPECT_THAT(std::string{gltf_json["buffers"][0]["uri"]},
               testing::EndsWith(bin_sha.to_string()));
   EXPECT_NE(storage.Find(bin_sha), nullptr);
 
@@ -138,7 +138,7 @@ GTEST_TEST(UnbundleGltfAssetsTest, InMemoryData) {
       MemoryFile::Make(gltf_dir / "fully_textured_pyramid_emissive.png")
           .sha256();
   // We happen to know that the emissive texture is texture 0.
-  EXPECT_THAT(gltf_json["images"][0]["uri"],
+  EXPECT_THAT(std::string{gltf_json["images"][0]["uri"]},
               testing::EndsWith(png_sha.to_string()));
   EXPECT_NE(storage.Find(png_sha), nullptr);
 }
@@ -187,7 +187,7 @@ GTEST_TEST(UnbundleGltfAssetsTest, RelativeUri) {
   EXPECT_EQ(assets.front()->sha256(), expected_sha256);
 
   // Make sure the new URI seems correct.
-  EXPECT_THAT(json::parse(gltf_contents)["buffers"][0]["uri"],
+  EXPECT_THAT(std::string{json::parse(gltf_contents)["buffers"][0]["uri"]},
               testing::EndsWith(expected_sha256.to_string()));
 }
 

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -198,30 +198,35 @@ TEST_F(AffineSystemTest, DefaultAndRandomState) {
 
 // Tests converting to different scalar types.
 TEST_F(AffineSystemTest, ConvertScalarType) {
-  EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
-    EXPECT_EQ(converted.A(), A_);
-    EXPECT_EQ(converted.B(), B_);
-    EXPECT_EQ(converted.f0(), f0_);
-    EXPECT_EQ(converted.C(), C_);
-    EXPECT_EQ(converted.D(), D_);
-    EXPECT_EQ(converted.y0(), y0_);
-    EXPECT_TRUE(CompareMatrices(
-        math::ExtractValue(converted.get_default_state()), x0_, 0.0));
-    EXPECT_TRUE(CompareMatrices(converted.get_random_state_covariance(),
-                                Sigma_x0_, 1e-16));
-  }));
-  EXPECT_TRUE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
-    EXPECT_EQ(converted.A(), A_);
-    EXPECT_EQ(converted.B(), B_);
-    EXPECT_EQ(converted.f0(), f0_);
-    EXPECT_EQ(converted.C(), C_);
-    EXPECT_EQ(converted.D(), D_);
-    EXPECT_EQ(converted.y0(), y0_);
-    EXPECT_TRUE(CompareMatrices(
-        symbolic::Evaluate(converted.get_default_state()), x0_, 0.0));
-    EXPECT_TRUE(CompareMatrices(converted.get_random_state_covariance(),
-                                Sigma_x0_, 1e-16));
-  }));
+  const testing::AssertionResult autodiff_ok =
+      is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
+        EXPECT_EQ(converted.A(), A_);
+        EXPECT_EQ(converted.B(), B_);
+        EXPECT_EQ(converted.f0(), f0_);
+        EXPECT_EQ(converted.C(), C_);
+        EXPECT_EQ(converted.D(), D_);
+        EXPECT_EQ(converted.y0(), y0_);
+        EXPECT_TRUE(CompareMatrices(
+            math::ExtractValue(converted.get_default_state()), x0_, 0.0));
+        EXPECT_TRUE(CompareMatrices(converted.get_random_state_covariance(),
+                                    Sigma_x0_, 1e-16));
+      });
+  EXPECT_TRUE(autodiff_ok);
+
+  const testing::AssertionResult symbolic_ok =
+      is_symbolic_convertible(*dut_, [&](const auto& converted) {
+        EXPECT_EQ(converted.A(), A_);
+        EXPECT_EQ(converted.B(), B_);
+        EXPECT_EQ(converted.f0(), f0_);
+        EXPECT_EQ(converted.C(), C_);
+        EXPECT_EQ(converted.D(), D_);
+        EXPECT_EQ(converted.y0(), y0_);
+        EXPECT_TRUE(CompareMatrices(
+            symbolic::Evaluate(converted.get_default_state()), x0_, 0.0));
+        EXPECT_TRUE(CompareMatrices(converted.get_random_state_covariance(),
+                                    Sigma_x0_, 1e-16));
+      });
+  EXPECT_TRUE(symbolic_ok);
 }
 
 class FeedthroughAffineSystemTest : public ::testing::Test {


### PR DESCRIPTION
As of Bazel 9, we receive warings from googltest header files, so we need to suppress and/or work around them.

Towards #23713.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23720)
<!-- Reviewable:end -->
