### PR TITLE
[workspace] Force external include paths to use isystem

### DIFF
--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -16,7 +16,6 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
-#include <tiny_gltf.h>
 
 // To ease build system upkeep, we annotate VTK includes with their deps.
 #include <vtkImageData.h>  // vtkCommonDataModel

--- a/tools/skylark/cc.bzl
+++ b/tools/skylark/cc.bzl
@@ -18,6 +18,70 @@ load(
     _objc_library = "objc_library",
 )
 
+def _cc_system_library_impl(ctx):
+    deps_cc_infos = cc_common.merge_cc_infos(
+        cc_infos = [dep[CcInfo] for dep in ctx.attr.deps],
+    )
+    old_context = deps_cc_infos.compilation_context
+    new_context = cc_common.create_compilation_context(
+        # We alter these fields.
+        quote_includes = depset(),
+        includes = depset(),
+        system_includes = depset(
+            transitive = [
+                old_context.quote_includes,
+                old_context.includes,
+                old_context.system_includes,
+            ],
+        ),
+        framework_includes = None,
+        # We pass along all other fields unchanged. Sadly, there is no iterator.
+        headers = old_context.headers,
+        defines = old_context.defines,
+        local_defines = old_context.local_defines,
+    )
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(
+                collect_data = True,
+                collect_default = True,
+            ),
+        ),
+        _CcInfo(
+            compilation_context = new_context,
+            linking_context = deps_cc_infos.linking_context,
+        ),
+    ]
+
+_cc_system_library = rule(
+    implementation = _cc_system_library_impl,
+    doc = """
+Changes the libary to use -isystem instead of -I for its include paths, which
+will suppress compiler warnings from its header files.
+""",
+    attrs = {
+        "deps": attr.label_list(providers = [_CcInfo]),
+    },
+    fragments = ["cpp"],
+)
+
+def _cc_library_isystem(**kwargs):
+    name = kwargs.pop("name")
+    testonly = kwargs.pop("testonly", None)
+    visibility = kwargs.pop("visibility", None)
+    hidden_name = "_{}_without_isystem".format(name)
+    _cc_library(
+        name = hidden_name,
+        visibility = ["//visibility:private"],
+        **kwargs
+    )
+    _cc_system_library(
+        name = name,
+        deps = [":" + hidden_name],
+        testonly = testonly,
+        visibility = visibility,
+    )
+
 def cc_binary(**kwargs):
     _cc_binary(**kwargs)
 
@@ -25,7 +89,13 @@ def cc_import(**kwargs):
     _cc_import(**kwargs)
 
 def cc_library(**kwargs):
-    _cc_library(**kwargs)
+    """Wraps cc_library from rules_cc, except if isystem=True then switches the
+    include spelling from -I to -isystem.
+    """
+    if kwargs.pop("isystem", False):
+        _cc_library_isystem(**kwargs)
+    else:
+        _cc_library(**kwargs)
 
 def cc_shared_library(**kwargs):
     _cc_shared_library(**kwargs)

--- a/tools/workspace/ccd_internal/package.BUILD.bazel
+++ b/tools/workspace/ccd_internal/package.BUILD.bazel
@@ -31,6 +31,7 @@ cc_library(
     hdrs = [":config"] + glob(["src/ccd/*.h"], allow_empty = False),
     defines = ["CCD_STATIC_DEFINE"],
     includes = ["src"],
+    isystem = True,
 )
 
 # Compile the code (using both its exported headers and its private headers).
@@ -42,6 +43,7 @@ cc_library(
         "-fvisibility=hidden",
     ],
     includes = ["src"],
+    isystem = True,
     linkstatic = True,
     deps = [":hdrs"],
 )

--- a/tools/workspace/clarabel_cpp_internal/package.BUILD.bazel
+++ b/tools/workspace/clarabel_cpp_internal/package.BUILD.bazel
@@ -30,6 +30,7 @@ cc_library_vendored(
         "FEATURE_SDP",
     ],
     includes = ["drake_hdr"],
+    isystem = True,
     linkstatic = True,
 )
 

--- a/tools/workspace/coinutils_internal/defs.bzl
+++ b/tools/workspace/coinutils_internal/defs.bzl
@@ -117,6 +117,7 @@ def coin_cc_library(
             x.replace("src/", "drake_src/")
             for x in includes_private
         ],
+        isystem = True,
         vendor_tool_args = vendor_tool_args,
         linkstatic = True,
         copts = [
@@ -150,6 +151,7 @@ def coin_cc_library(
             x.replace("src/", "drake_hdr/")
             for x in includes_public
         ],
+        isystem = True,
         vendor_tool_args = vendor_tool_args,
         linkstatic = True,
         deps = deps + [

--- a/tools/workspace/common_robotics_utilities_internal/package.BUILD.bazel
+++ b/tools/workspace/common_robotics_utilities_internal/package.BUILD.bazel
@@ -51,6 +51,7 @@ cc_library(
         "include/common_robotics_utilities/zlib_helpers.hpp",
     ],
     includes = ["include"],
+    isystem = True,
     copts = COPTS,
     linkstatic = True,
     deps = [

--- a/tools/workspace/csdp_internal/package.BUILD.bazel
+++ b/tools/workspace/csdp_internal/package.BUILD.bazel
@@ -65,6 +65,7 @@ cc_library(
         "-fno-openmp",
     ],
     includes = ["includes"],
+    isystem = True,
     linkstatic = 1,
     deps = [
         "@blas",

--- a/tools/workspace/curl_internal/package.BUILD.bazel
+++ b/tools/workspace/curl_internal/package.BUILD.bazel
@@ -255,6 +255,7 @@ cc_library(
     hdrs = _HDRS + [":lib/curl_config.h"],
     srcs = _SRCS,
     includes = _INCLUDES,
+    isystem = True,
     copts = _COPTS,
     linkopts = _LINKOPTS,
     linkstatic = 1,

--- a/tools/workspace/fcl_internal/package.BUILD.bazel
+++ b/tools/workspace/fcl_internal/package.BUILD.bazel
@@ -131,6 +131,7 @@ cc_library_vendored(
         "FCL_STATIC_DEFINE",
     ],
     includes = ["drake_hdr"],
+    isystem = True,
     linkstatic = True,
     deps = [
         "@ccd_internal//:ccd",

--- a/tools/workspace/gklib_internal/package.BUILD.bazel
+++ b/tools/workspace/gklib_internal/package.BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     srcs = glob(["src/*.c"], allow_empty = False),
     hdrs = glob(["include/*.h"], allow_empty = False),
     includes = ["include"],
+    isystem = True,
     copts = [
         # We don't allow Drake externals to use OpenMP until we wire up "max
         # parallelism" governance to a drake::Parallellism public API option.

--- a/tools/workspace/gz_math_internal/package.BUILD.bazel
+++ b/tools/workspace/gz_math_internal/package.BUILD.bazel
@@ -259,6 +259,7 @@ cc_library_vendored(
     copts = ["-w"],
     linkstatic = True,
     includes = ["drake_hdr"],
+    isystem = True,
     visibility = ["//visibility:public"],
     deps = [
         "@gz_utils_internal//:gz_utils",

--- a/tools/workspace/gz_utils_internal/package.BUILD.bazel
+++ b/tools/workspace/gz_utils_internal/package.BUILD.bazel
@@ -108,6 +108,7 @@ cc_library_vendored(
     copts = ["-w"],
     linkstatic = True,
     includes = ["drake_hdr"],
+    isystem = True,
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/libpng_internal/package.BUILD.bazel
+++ b/tools/workspace/libpng_internal/package.BUILD.bazel
@@ -75,6 +75,7 @@ cc_library(
         "//conditions:default": [],
     }),
     includes = ["."],
+    isystem = True,
     copts = [
         "-fvisibility=hidden",
         "-w",

--- a/tools/workspace/libtiff_internal/package.BUILD.bazel
+++ b/tools/workspace/libtiff_internal/package.BUILD.bazel
@@ -155,6 +155,7 @@ cc_library(
     hdrs = _PUBLIC_HDRS,
     srcs = _SRCS + _PRIVATE_HDRS,
     includes = ["libtiff"],
+    isystem = True,
     copts = [
         "-fvisibility=hidden",
         "-w",

--- a/tools/workspace/libtiff_internal/repository.bzl
+++ b/tools/workspace/libtiff_internal/repository.bzl
@@ -15,5 +15,10 @@ def libtiff_internal_repository(
         commit = "v4.7.1",
         sha256 = "a3faec056a490c62b8749847317521204f8c4d9933cce834e691a74524ec38fe",  # noqa
         build_file = ":package.BUILD.bazel",
+        patch_cmds = [
+            # On a macOS case-insensitive filesystem, this conflicts with
+            # `#include <version>` from the standard library.
+            "rm -f VERSION",
+        ],
         mirrors = mirrors,
     )

--- a/tools/workspace/metis_internal/package.BUILD.bazel
+++ b/tools/workspace/metis_internal/package.BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     srcs = glob(["libmetis/*.c"], allow_empty = False),
     hdrs = glob(["libmetis/*.h"], allow_empty = False) + ["include/metis.h"],
     includes = ["include"],
+    isystem = True,
     copts = [
         # We don't allow Drake externals to use OpenMP until we wire up "max
         # parallelism" governance to a drake::Parallellism public API option.

--- a/tools/workspace/msgpack_internal/package.BUILD.bazel
+++ b/tools/workspace/msgpack_internal/package.BUILD.bazel
@@ -36,6 +36,7 @@ cc_library_vendored(
         for x in _HDRS
     ],
     includes = ["drake_hdr"],
+    isystem = True,
     linkstatic = 1,
     deps = [":hdrs_no_vendor"],
     visibility = ["//visibility:public"],

--- a/tools/workspace/nanoflann_internal/package.BUILD.bazel
+++ b/tools/workspace/nanoflann_internal/package.BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
     name = "nanoflann",
     hdrs = ["include/nanoflann.hpp"],
     strip_include_prefix = "include",
+    isystem = True,
     linkstatic = 1,
 )
 

--- a/tools/workspace/nlohmann_internal/package.BUILD.bazel
+++ b/tools/workspace/nlohmann_internal/package.BUILD.bazel
@@ -14,6 +14,7 @@ cc_library(
         "single_include/nlohmann/json_fwd.hpp",
     ],
     strip_include_prefix = "single_include",
+    isystem = True,
     defines = [
         # The nlohmann/json code has logic that tries to infer whether or not
         # the compiler toolchain supports the spaceship operator (<=>).

--- a/tools/workspace/nlopt_internal/package.BUILD.bazel
+++ b/tools/workspace/nlopt_internal/package.BUILD.bazel
@@ -44,6 +44,7 @@ cc_library(
     name = "config",
     hdrs = [":src/nlopt_config.h"],
     includes = ["src"],
+    isystem = True,
     linkstatic = True,
 )
 
@@ -75,6 +76,7 @@ cc_library(
     hdrs = _HDRS_UTIL_CABI,
     copts = ["-w", "-fvisibility=hidden"],
     includes = ["src/api", "src/util"],
+    isystem = True,
     linkstatic = True,
     deps = [
         ":config",
@@ -146,6 +148,7 @@ cc_library(
         "src/algs/praxis",
         "src/algs/slsqp",
     ],
+    isystem = True,
     linkstatic = True,
     deps = [
         ":util",
@@ -188,6 +191,7 @@ cc_library_vendored(
     hdrs_vendored = ["drake_" + x for x in _HDRS_STOGO_CPPABI],
     copts = ["-w"],
     includes = ["drake_src/algs/stogo"],
+    isystem = True,
     linkstatic = True,
     deps = [
         ":util",
@@ -200,6 +204,7 @@ cc_library(
     hdrs = _HDRS_STOGO_CABI,
     copts = ["-w", "-fvisibility=hidden"],
     includes = ["src/algs/stogo"],
+    isystem = True,
     linkstatic = True,
     deps = [
         ":stogo_cppabi",
@@ -240,6 +245,7 @@ cc_library_vendored(
     hdrs_vendored = ["drake_" + x for x in _HDRS_AGS_CPPABI],
     copts = ["-w"],
     includes = ["drake_src/algs/ags"],
+    isystem = True,
     linkstatic = True,
 )
 
@@ -249,6 +255,7 @@ cc_library(
     hdrs = _HDRS_AGS_CABI,
     copts = ["-w", "-fvisibility=hidden"],
     includes = ["src/algs/ags"],
+    isystem = True,
     linkstatic = True,
     deps = [
         ":ags_cppabi",
@@ -371,6 +378,7 @@ cc_library_vendored(
     hdrs = ["genrule/nlopt.hpp"],
     hdrs_vendored = ["vendored/nlopt.hpp"],
     includes = ["vendored"],
+    isystem = True,
     linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/workspace/osqp_internal/package.BUILD.bazel
+++ b/tools/workspace/osqp_internal/package.BUILD.bazel
@@ -122,6 +122,7 @@ cc_library(
         "algebra/_common",
         "algebra/_common/lin_sys/qdldl",
     ],
+    isystem = True,
     copts = [
         "-fvisibility=hidden",
         "-w",

--- a/tools/workspace/picosha2_internal/package.BUILD.bazel
+++ b/tools/workspace/picosha2_internal/package.BUILD.bazel
@@ -13,6 +13,7 @@ cc_library(
     name = "picosha2",
     hdrs = ["picosha2.h"],
     includes = ["."],
+    isystem = True,
 )
 
 install(

--- a/tools/workspace/pkg_config.BUILD.tpl
+++ b/tools/workspace/pkg_config.BUILD.tpl
@@ -15,6 +15,7 @@ cc_library(
     copts = %{copts},
     defines = %{defines},
     includes = %{includes},
+    isystem = True,
     linkopts = %{linkopts},
     deps = %{deps},
     deprecation = %{extra_deprecation},

--- a/tools/workspace/poisson_disk_sampling_internal/package.BUILD.bazel
+++ b/tools/workspace/poisson_disk_sampling_internal/package.BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
     hdrs = ["include/thinks/tph_poisson.h"],
     srcs = [":implementation"],
     strip_include_prefix = "include/thinks",
+    isystem = True,
     linkstatic = 1,
     copts = [
         "-fvisibility=hidden",

--- a/tools/workspace/pybind11/package.BUILD.bazel
+++ b/tools/workspace/pybind11/package.BUILD.bazel
@@ -62,6 +62,7 @@ cc_library(
     name = "pybind11",
     hdrs = _HDRS,
     includes = ["include"],
+    isystem = True,
     deps = [
         "@eigen",
         "@drake//tools/workspace/python:cc_headers",

--- a/tools/workspace/qdldl_internal/package.BUILD.bazel
+++ b/tools/workspace/qdldl_internal/package.BUILD.bazel
@@ -65,6 +65,7 @@ cc_library(
     includes = [
         "include",
     ],
+    isystem = True,
     linkstatic = 1,
 )
 

--- a/tools/workspace/qhull_internal/package.BUILD.bazel
+++ b/tools/workspace/qhull_internal/package.BUILD.bazel
@@ -63,6 +63,7 @@ cc_library(
         "-w",
     ],
     includes = ["src"],
+    isystem = True,
     srcs = _SRCS_C,
     linkstatic = 1,
 )
@@ -82,6 +83,7 @@ cc_library_vendored(
     hdrs = _HDRS_CPP,
     hdrs_vendored = _HDRS_CPP_VENDORED,
     includes = ["drake_hdr"],
+    isystem = True,
     srcs = _SRCS_CPP,
     srcs_vendored = _SRCS_CPP_VENDORED,
     copts = ["-w"],

--- a/tools/workspace/scs_internal/package.BUILD.bazel
+++ b/tools/workspace/scs_internal/package.BUILD.bazel
@@ -38,6 +38,7 @@ cc_library(
         "include",
         "linsys",
     ],
+    isystem = True,
     copts = [
         "-fvisibility=hidden",
         "-w",

--- a/tools/workspace/sdformat_internal/package.BUILD.bazel
+++ b/tools/workspace/sdformat_internal/package.BUILD.bazel
@@ -263,6 +263,7 @@ cc_library_vendored(
         for x in _HDRS
     ],
     includes = ["drake_hdr"],
+    isystem = True,
     copts = ["-w"],
     defines = ["SDFORMAT_STATIC_DEFINE", "SDFORMAT_DISABLE_CONSOLE_LOGFILE"],
     linkstatic = 1,

--- a/tools/workspace/spgrid_internal/package.BUILD.bazel
+++ b/tools/workspace/spgrid_internal/package.BUILD.bazel
@@ -17,6 +17,7 @@ cc_library(
     include_prefix = "SPGrid/Core",
     # TODO(xuchenhan-tri): Enable Haswell on builds that support it.
     includes = ["."],
+    isystem = True,
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )

--- a/tools/workspace/spral_internal/package.BUILD.bazel
+++ b/tools/workspace/spral_internal/package.BUILD.bazel
@@ -21,6 +21,7 @@ cc_library(
     name = "compat",
     hdrs = ["src/compat.hxx"],
     includes = ["src"],
+    isystem = True,
     copts = _COPTS,
     linkstatic = True,
 )
@@ -29,6 +30,7 @@ cc_library(
     name = "contrib",
     hdrs = ["src/ssids/contrib.h"],
     includes = ["src"],
+    isystem = True,
     copts = _COPTS,
     linkstatic = True,
     deps = [
@@ -46,6 +48,7 @@ cc_library(
     ],
     hdrs = glob(["src/ssids/cpu/**/*.hxx"], allow_empty = False),
     includes = ["src"],
+    isystem = True,
     copts = _COPTS + ["-fvisibility=hidden"],
     linkstatic = True,
     deps = [
@@ -65,6 +68,7 @@ cc_library(
         "src/hw_topology/guess_topology.hxx",
     ],
     includes = ["src"],
+    isystem = True,
     copts = _COPTS,
     linkstatic = True,
     deps = [
@@ -77,6 +81,7 @@ cc_library(
     srcs = ["src/omp.cxx"],
     hdrs = ["src/omp.hxx"],
     includes = ["src"],
+    isystem = True,
     copts = _COPTS,
     linkstatic = True,
 )
@@ -88,6 +93,7 @@ cc_library(
     # The patches/no_fortran_profiling.patch removes the Fortran callers, so
     # we can omit it (so that it doesn't leak global symbols into our library).
     includes = ["src"],
+    isystem = True,
     copts = _COPTS,
     deps = [
         ":guess_topology",
@@ -346,6 +352,7 @@ cc_library(
     name = "spral",
     hdrs = ["include/spral_ssids.h"],
     includes = ["include"],
+    isystem = True,
     copts = _COPTS,
     linkstatic = True,
     deps = [

--- a/tools/workspace/stduuid_internal/package.BUILD.bazel
+++ b/tools/workspace/stduuid_internal/package.BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
     name = "stduuid",
     hdrs = ["include/uuid.h"],
     strip_include_prefix = "include",
+    isystem = True,
     linkstatic = 1,
 )
 

--- a/tools/workspace/suitesparse_internal/package.BUILD.bazel
+++ b/tools/workspace/suitesparse_internal/package.BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     srcs = ["SuiteSparse_config/SuiteSparse_config.c"],
     hdrs = ["SuiteSparse_config/SuiteSparse_config.h"],
     strip_include_prefix = "SuiteSparse_config",
+    isystem = True,
     copts = ["-fvisibility=hidden"],
     linkstatic = True,
     visibility = ["//visibility:public"],
@@ -25,6 +26,7 @@ cc_library(
         "AMD/Include/amd.h",
     ],
     strip_include_prefix = "AMD/Include",
+    isystem = True,
     linkstatic = True,
     deps = [
         ":config",

--- a/tools/workspace/tinygltf_internal/package.BUILD.bazel
+++ b/tools/workspace/tinygltf_internal/package.BUILD.bazel
@@ -25,6 +25,7 @@ cc_library_vendored(
         "TINYGLTF_NO_STB_IMAGE_WRITE",
     ],
     includes = ["drake_vendor"],
+    isystem = True,
     linkstatic = 1,
     deps = [
         "@nlohmann_internal//:nlohmann",

--- a/tools/workspace/tinyobjloader_internal/package.BUILD.bazel
+++ b/tools/workspace/tinyobjloader_internal/package.BUILD.bazel
@@ -17,6 +17,7 @@ cc_library_vendored(
     hdrs_vendored = ["drake_src/tiny_obj_loader.h"],
     defines = ["TINYOBJLOADER_USE_DOUBLE=1"],
     includes = ["drake_src"],
+    isystem = True,
     linkstatic = 1,
 )
 

--- a/tools/workspace/tinyxml2_internal/package.BUILD.bazel
+++ b/tools/workspace/tinyxml2_internal/package.BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     hdrs = ["tinyxml2.h"],
     srcs = ["tinyxml2.cpp"],
     includes = ["."],
+    isystem = True,
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )

--- a/tools/workspace/usockets_internal/package.BUILD.bazel
+++ b/tools/workspace/usockets_internal/package.BUILD.bazel
@@ -17,6 +17,7 @@ cc_library(
         "src/**/*.h",
     ]),
     includes = ["src"],
+    isystem = True,
     copts = [
         "-DLIBUS_NO_SSL",
         "-fvisibility=hidden",

--- a/tools/workspace/uwebsockets_internal/package.BUILD.bazel
+++ b/tools/workspace/uwebsockets_internal/package.BUILD.bazel
@@ -13,6 +13,7 @@ cc_library(
     name = "uwebsockets",
     hdrs = glob(["src/*.h"]),
     includes = ["src"],
+    isystem = True,
     deps = [
         "@usockets_internal//:usockets",
         "@zlib",

--- a/tools/workspace/voxelized_geometry_tools_internal/package.BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools_internal/package.BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     name = "cl_hpp",
     hdrs = ["include/voxelized_geometry_tools/cl.hpp"],
     includes = ["include"],
+    isystem = True,
     linkstatic = True,
     deps = ["@opencl"],
 )
@@ -37,6 +38,7 @@ cc_library(
         "include/voxelized_geometry_tools/vgt_namespace.hpp",
     ],
     includes = ["include"],
+    isystem = True,
     linkstatic = True,
     deps = [
         "@common_robotics_utilities_internal//:common_robotics_utilities",
@@ -59,6 +61,7 @@ cc_library(
         "include/voxelized_geometry_tools/vgt_namespace.hpp",
     ],
     includes = ["include"],
+    isystem = True,
     linkstatic = True,
     deps = [
         "@common_robotics_utilities_internal//:common_robotics_utilities",
@@ -77,6 +80,7 @@ cc_library(
         "include/voxelized_geometry_tools/vgt_namespace.hpp",
     ],
     includes = ["include"],
+    isystem = True,
     linkstatic = True,
     deps = [
         ":cl_hpp",
@@ -102,6 +106,7 @@ cc_library(
         "include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp",  # noqa
     ],
     includes = ["include"],
+    isystem = True,
     linkstatic = True,
     deps = [
         ":voxelized_geometry_tools",

--- a/tools/workspace/vtk_internal/rules.bzl
+++ b/tools/workspace/vtk_internal/rules.bzl
@@ -113,6 +113,7 @@ def _vtk_cc_module_impl(
             name = module_name + "_gen_hdrs",
             hdrs = gen_hdrs,
             strip_include_prefix = "gen/" + subdir,
+            isystem = True,
             linkstatic = True,
         )
         gen_hdrs_lib = [module_name + "_gen_hdrs"]
@@ -177,6 +178,7 @@ def _vtk_cc_module_impl(
         hdrs = hdrs,
         defines = defines_extra,
         includes = includes_extra,
+        isystem = True,
         strip_include_prefix = subdir + strip_include_prefix_extra,
         copts = copts,
         linkopts = linkopts,

--- a/tools/workspace/yaml_cpp_internal/package.BUILD.bazel
+++ b/tools/workspace/yaml_cpp_internal/package.BUILD.bazel
@@ -31,6 +31,7 @@ cc_library_vendored(
         for x in _HDRS
     ],
     includes = ["drake_hdr"],
+    isystem = True,
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This fixes compatibility issues with Bazel 9, where it switched `cc_library` include paths from using `-isystem` to just plain `-I`, which means we get new warnings we don't want when our code includes external headers that themselves have warnings.

---
The warning spam is because of this change to include paths from Bazel 8 to Bazel 9:

Bazel 8:
```
-iquote external/+internal_repositories+pkgconfig_eigen_internal
-iquote bazel-out/k8-opt/bin/external/+internal_repositories+pkgconfig_eigen_internal
-isystem external/+internal_repositories+pkgconfig_eigen_internal/include/_usr_include_eigen3
-isystem bazel-out/k8-opt/bin/external/+internal_repositories+pkgconfig_eigen_internal/include/_usr_include_eigen3
```

Bazel 9:
```
-iquote external/+internal_repositories+pkgconfig_eigen_internal
-iquote bazel-out/k8-opt/bin/external/+internal_repositories+pkgconfig_eigen_internal
-Iexternal/+internal_repositories+pkgconfig_eigen_internal/include/_usr_include_eigen3
-Ibazel-out/k8-opt/bin/external/+internal_repositories+pkgconfig_eigen_internal/include/_usr_include_eigen3
```

The first two lines are the same, but the latter two change from `-isystem` to `-I`.

GCC docs about `-I`: _Add the directory dir to the list of directories to be searched for header files. Directories named by `-I` are searched before the standard system include directories._

GCC docs about `-isystem`: _Search dir for header files, after all directories specified by `-I` but before the standard system directories. Mark it as a system directory, so that it gets the same special treatment as is applied to the standard system directories._

GCC docs about `-iquote:` _Directories specified with \-iquote apply only to the quote form of the directive, `#include "file"`. Directories specified with \-I, \-isystem, or \-idirafter apply to lookup for both the `#include "file"` and `#include <file>` directives._

So basically, unless we use `-isystem`, Drake ends up seeing all of our GCC/Clang warnings triggered by `#include <Eigen/Core>` and related externals.

Towards #23713.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23723)
<!-- Reviewable:end -->
