### PR TITLE
[inverse_kinematics] Avoid implicit context checker parallelism

### DIFF
--- a/bindings/generated_docstrings/multibody_inverse_kinematics.h
+++ b/bindings/generated_docstrings/multibody_inverse_kinematics.h
@@ -1081,6 +1081,12 @@ R"""(The collision checker for the robot being controlled. Note that its
 robot_model_instances() accessor also partitions which parts of the
 ``plant`` are the robot model vs its environment.)""";
           } collision_checker;
+          // Symbol: drake::multibody::DifferentialInverseKinematicsSystem::CallbackDetails::collision_checker_context
+          struct /* collision_checker_context */ {
+            // Source: drake/multibody/inverse_kinematics/differential_inverse_kinematics_system.h
+            const char* doc =
+R"""(A mutable context for the collision checker.)""";
+          } collision_checker_context;
           // Symbol: drake::multibody::DifferentialInverseKinematicsSystem::CallbackDetails::frame_list
           struct /* frame_list */ {
             // Source: drake/multibody/inverse_kinematics/differential_inverse_kinematics_system.h

--- a/multibody/inverse_kinematics/differential_inverse_kinematics_system.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics_system.h
@@ -271,6 +271,7 @@ class DifferentialInverseKinematicsSystem final
   systems::OutputPortIndex output_port_index_commanded_velocity_;
   systems::CacheIndex plant_context_cache_index_;
   systems::CacheIndex cartesian_desires_cache_index_;
+  systems::CacheIndex collision_checker_context_scratch_index_;
 };
 
 /** (Internal use only) A group of common arguments relevant to multiple
@@ -294,6 +295,9 @@ struct DifferentialInverseKinematicsSystem::CallbackDetails {
   Note that its robot_model_instances() accessor also partitions which parts of
   the `plant` are the robot model vs its environment. */
   const planning::CollisionChecker& collision_checker;
+
+  /** A mutable context for the collision checker. */
+  planning::CollisionCheckerContext& collision_checker_context;
 
   /** The active degrees of freedom in `collision_checker.plant()`. */
   const planning::DofMask& active_dof;

--- a/multibody/inverse_kinematics/test/differential_inverse_kinematics_system_test.cc
+++ b/multibody/inverse_kinematics/test/differential_inverse_kinematics_system_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/inverse_kinematics/differential_inverse_kinematics_system.h"
 
+#include <future>
 #include <memory>
 #include <optional>
 #include <string>
@@ -835,6 +836,45 @@ TEST_F(DifferentialInverseKinematicsTest, CollisionConstraint) {
                          .vd_WB = vd1,
                          .v_WB_expected = vd1,
                          .q_active = q_active_init}});
+}
+
+TEST_F(DifferentialInverseKinematicsTest, CollisionConstraintThreaded) {
+  // Make a simple recipe with a CollisionConstraint and an arbitrary cost.
+  auto recipe = std::make_shared<Recipe>();
+  AddLeastSquaresCost(recipe.get());
+  using Config = DiffIk::CollisionConstraint::Config;
+  auto ingredient = std::make_shared<DiffIk::CollisionConstraint>(Config{});
+  ingredient->SetConfig(
+      Config{.safety_distance = 0.25, .influence_distance = 10.0});
+  recipe->AddIngredient(ingredient);
+  const DiffIk dut = MakeDiffIk(std::move(recipe));
+
+  // A simple functor to exercise the DUT's computation.
+  auto do_work = [&dut](auto* context) {
+    // Set some arbitrary inputs.
+    const VectorXd q = VectorXd::Zero(dut.plant().num_positions());
+    dut.get_input_port_nominal_posture().FixValue(context, q);
+    dut.get_input_port_position().FixValue(context, q);
+    BusValue desired_velocities;
+    const auto Vd_TB = SpatialVelocity<double>::Zero();
+    desired_velocities.Set("robot::ball", Value{Vd_TB});
+    dut.get_input_port_desired_cartesian_velocities().FixValue(
+        context, desired_velocities);
+    // Evaluate the output.
+    dut.get_output_port_commanded_velocity().Eval(*context);
+  };
+
+  // Run two do_work functions concurrently. Our TSan (etc.) might trip if there
+  // are concurrency bugs.
+  auto context_1 = dut.CreateDefaultContext();
+  auto context_2 = context_1->Clone();
+  auto context_3 = dut.CreateDefaultContext();
+  auto future_1 = std::async(std::launch::async, do_work, context_1.get());
+  auto future_2 = std::async(std::launch::async, do_work, context_2.get());
+  auto future_3 = std::async(std::launch::async, do_work, context_3.get());
+  future_1.get();
+  future_2.get();
+  future_3.get();
 }
 
 /* The constraint on joint velocities is conceptually simple, but has some


### PR DESCRIPTION
It is generally unsafe when a single collision checker is shared by multiple DiffererentialInverseKinematicsSystem contexts. Parallel sims don't always use implicit parallelism; sometimes they are threaded.

---

I have confirmed locally that the new test fails on the unfixed implementation when run under TSan.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23726)
<!-- Reviewable:end -->
