### PR TITLE
[CENIC] Adjust test tolerances for coupler constraints

### DIFF
--- a/multibody/contact_solvers/pooled_sap/test/pooled_model_test.cc
+++ b/multibody/contact_solvers/pooled_sap/test/pooled_model_test.cc
@@ -692,8 +692,6 @@ GTEST_TEST(PooledSapModel, CouplerConstraint) {
                               MatrixCompareType::relative));
 
   const double gamma = couplers_data.gamma(0).value();
-  fmt::print("gamma = {}\n", gamma);
-  fmt::print("gamma0 = {}\n", gamma0.value());
   EXPECT_NEAR(gamma, gamma0.value(), std::abs(gamma) * kEps);
 
   // Verify contributions to Hessian.


### PR DESCRIPTION
Jenkins has been complaining on macOS:

```
[6:46:52 AM]  multibody/contact_solvers/pooled_sap/test/pooled_model_test.cc:695: Failure
[6:46:52 AM]  The difference between gamma and gamma0.value() is 7.2759576141834259e-12, where
[6:46:52 AM]  gamma evaluates to 57224.538716461444,
[6:46:52 AM]  gamma0.value() evaluates to 57224.538716461451.
[6:46:52 AM]  The abs_error parameter kEps evaluates to 2.2204460492503131e-16 which is smaller than the minimum distance between doubles for numbers of this magnitude which is 7.2759576141834259e-12, thus making this EXPECT_NEAR check equivalent to EXPECT_EQUAL. Consider using EXPECT_DOUBLE_EQ instead.
```
This changes that test from an absolute to a relative tolerance. Let's see if that fixes the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23727)
<!-- Reviewable:end -->
