### PR TITLE
[wheel] Drop 3.12 and add 3.14 on macOS

### DIFF
--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -37,7 +37,7 @@ officially supports when building from source:
 |------------------------------------|--------------|------------|-------|-------|------------------------------|------------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 8.4   | 3.22  | GCC 11 (default) or Clang 15 | OpenJDK 11 |
 | Ubuntu 24.04 LTS (Noble Numbat)    | x86_64       | 3.12       | 8.4   | 3.28  | GCC 13 (default) or Clang 19 | OpenJDK 21 |
-| macOS Sequoia (15)                 | arm64        | 3.13       | 8.4   | 4.1   | Apple LLVM 17 (Xcode 26.0)   | OpenJDK 23 |
+| macOS Sequoia (15)                 | arm64        | 3.13 ⁽⁵⁾    | 8.4   | 4.1   | Apple LLVM 17 (Xcode 26.0)   | OpenJDK 23 |
 | macOS Tahoe (26) ⁽⁴⁾               | arm64        | TBD        | TBD   | TBD   | TBD                          | TBD        |
 
 "Official support" means that we have Continuous Integration test coverage to
@@ -61,6 +61,9 @@ maybe require extra setup. See the
 
 ⁽⁴⁾ Tahoe support is in development; refer to
 [#23439](https://github.com/RobotLocomotion/drake/issues/23439) for details.
+
+⁽⁵⁾ Python 3.14 support is in development; refer to
+[#23592](https://github.com/RobotLocomotion/drake/issues/23592) for details.
 
 # Building with CMake
 

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -45,8 +45,8 @@ that Conda is involved.
 
 ⁽³⁾ The Python version shown in the table is supported for all installation
 channels. Additionally, when installing via ``pip``
-on Ubuntu Python versions 3.10 through 3.14 (inclusive) are supported⁽⁶⁾ and
-on macOS Python versions 3.12 through 3.13 (inclusive) are supported.
+on Ubuntu Python versions 3.10 through 3.14 (inclusive) are supported ⁽⁶⁾ and
+on macOS Python versions 3.13 through 3.14 (inclusive) are supported ⁽⁶⁾.
 Refer to [OS Support](/stable.html#os-support) for details on our "end of life"
 timeline for changing which Python versions are supported.
 

--- a/doc/_release-notes/end_of_support.md
+++ b/doc/_release-notes/end_of_support.md
@@ -48,13 +48,17 @@ If you need to use these, you can use an old release of Drake.
 
 # Wheel packages
 
+* Python 3.14 (Wheel)
+  * On Linux, Drake still supports Python 3.14 wheels.
+  * On macOS arm64, Drake still supports Python 3.14 wheels.
 * Python 3.13 (Wheel)
   * On Linux, Drake still supports Python 3.13 wheels.
   * On macOS arm64, Drake still supports Python 3.13 wheels.
   * On macOS x86_64, there was never support for Python 3.13 wheels.
 * Python 3.12 (Wheel)
   * On Linux, Drake still supports Python 3.12 wheels.
-  * On macOS arm64, Drake still supports Python 3.12 wheels.
+  * On macOS arm64, the last version with support for Python 3.12 wheels was
+    [v1.46.0](https://github.com/RobotLocomotion/drake/releases/tag/v1.46.0).
   * On macOS x86_64, the last version with support for Python 3.12 wheels was
     [v1.34.0](https://github.com/RobotLocomotion/drake/releases/tag/v1.34.0).
 * Python 3.11 (Wheel)

--- a/setup/mac/source_distribution/Brewfile-developer
+++ b/setup/mac/source_distribution/Brewfile-developer
@@ -7,5 +7,5 @@ brew 'coreutils'
 
 # Python(s) for building wheels.  These should be kept in sync with
 # `python_targets` in `tools/wheel/wheel_builder/macos.py`.
-brew 'python@3.12'
 brew 'python@3.13'
+brew 'python@3.14'

--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -142,8 +142,8 @@ def _download_binaries(*, timestamp, staging, version):
                 f"drake-{version[1:]}-cp311-cp311-manylinux_2_34_x86_64.whl",
                 f"drake-{version[1:]}-cp312-cp312-manylinux_2_34_x86_64.whl",
                 f"drake-{version[1:]}-cp313-cp313-manylinux_2_34_x86_64.whl",
-                f"drake-{version[1:]}-cp312-cp312-macosx_15_0_arm64.whl",
                 f"drake-{version[1:]}-cp313-cp313-macosx_15_0_arm64.whl",
+                f"drake-{version[1:]}-cp314-cp314-macosx_15_0_arm64.whl",
                 # Deb filenames.
                 f"drake-dev_{version[1:]}-1_amd64-jammy.deb",
                 f"drake-dev_{version[1:]}-1_amd64-noble.deb",

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -71,7 +71,13 @@ cp -r -t ${WHEEL_DIR}/pydrake \
 cp -r -t ${WHEEL_DIR}/pydrake/lib \
     /tmp/drake-wheel-build/drake-dist/lib/libdrake*.so
 
-if [[ "$(uname)" == "Darwin" ]]; then
+# See tools/wheel/image/build-drake.sh for details on the lack of MOSEK support
+# for Python 3.14.
+PYTHON_MINOR=$(python -c "import sys; print(sys.version_info.minor)")
+MOSEK_ENABLED=1
+[ ${PYTHON_MINOR} -ge 14 ] && MOSEK_ENABLED=
+
+if [[ "$(uname)" == "Darwin" && -n "${MOSEK_ENABLED}" ]]; then
     # MOSEK is "sort of" third party, but is procured as part of Drake's build
     # and ends up in /tmp/drake-wheel-build/drake-dist/. It should end up in
     # the same place as libdrake.so.
@@ -131,38 +137,40 @@ if [[ "$(uname)" == "Darwin" ]]; then
     delocate-wheel -w wheelhouse -v dist/drake*.whl
 
     # Remove libmosek from wheels.
-    for w in wheelhouse/drake*.whl; do
-        mkdir fixup-wheel
-        wheel unpack --dest fixup-wheel "$w"
+    if [[ -n "${MOSEK_ENABLED}" ]]; then
+        for w in wheelhouse/drake*.whl; do
+            mkdir fixup-wheel
+            wheel unpack --dest fixup-wheel "$w"
 
-        rm fixup-wheel/drake-*/pydrake/lib/libmosek*
-        rm fixup-wheel/drake-*/pydrake/lib/libtbb*
-        rm fixup-wheel/drake-*/pydrake/doc/mosek/mosek-eula.pdf
-        rm fixup-wheel/drake-*/pydrake/doc/mosek/LICENSE.third_party
+            rm fixup-wheel/drake-*/pydrake/lib/libmosek*
+            rm fixup-wheel/drake-*/pydrake/lib/libtbb*
+            rm fixup-wheel/drake-*/pydrake/doc/mosek/mosek-eula.pdf
+            rm fixup-wheel/drake-*/pydrake/doc/mosek/LICENSE.third_party
 
-        change_lpath \
-            --old='@loader_path/libtbb' \
-            --old='@loader_path/libmosek' \
-            --new='@loader_path/../../mosek/libtbb' \
-            --new='@loader_path/../../mosek/libmosek' \
-            fixup-wheel/drake-*/pydrake/lib/*.so
-        change_lpath \
-            --old='@loader_path/lib/libtbb' \
-            --old='@loader_path/lib/libmosek' \
-            --new='@loader_path/../mosek/libtbb' \
-            --new='@loader_path/../mosek/libmosek' \
-            fixup-wheel/drake-*/pydrake/*.so
-        change_lpath \
-            --old='@loader_path/../lib/libtbb' \
-            --old='@loader_path/../lib/libmosek' \
-            --new='@loader_path/../../mosek/libtbb' \
-            --new='@loader_path/../../mosek/libmosek' \
-            fixup-wheel/drake-*/pydrake/*/*.so
+            change_lpath \
+                --old='@loader_path/libtbb' \
+                --old='@loader_path/libmosek' \
+                --new='@loader_path/../../mosek/libtbb' \
+                --new='@loader_path/../../mosek/libmosek' \
+                fixup-wheel/drake-*/pydrake/lib/*.so
+            change_lpath \
+                --old='@loader_path/lib/libtbb' \
+                --old='@loader_path/lib/libmosek' \
+                --new='@loader_path/../mosek/libtbb' \
+                --new='@loader_path/../mosek/libmosek' \
+                fixup-wheel/drake-*/pydrake/*.so
+            change_lpath \
+                --old='@loader_path/../lib/libtbb' \
+                --old='@loader_path/../lib/libmosek' \
+                --new='@loader_path/../../mosek/libtbb' \
+                --new='@loader_path/../../mosek/libmosek' \
+                fixup-wheel/drake-*/pydrake/*/*.so
 
-        rm "$w"
-        wheel pack --dest wheelhouse fixup-wheel/drake-*/
-        rm -rf fixup-wheel
-    done
+            rm "$w"
+            wheel pack --dest wheelhouse fixup-wheel/drake-*/
+            rm -rf fixup-wheel
+        done
+    fi
 else
     GLIBC_VERSION=$(ldd --version | sed -n '1{s/.* //;s/[.]/_/p}')
 

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -52,6 +52,15 @@ build --config=packaging
 build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
 EOF
 
+# See tools/wheel/image/build-drake.sh for details on the lack of MOSEK support
+# for Python 3.14.
+PYTHON_MINOR=$($python_executable -c "import sys; print(sys.version_info.minor)")
+if [[ ${PYTHON_MINOR} -ge 14 ]]; then
+    cat >> "$build_root/drake.bazelrc" << EOF
+build --@drake//tools/flags:with_mosek=False
+EOF
+fi
+
 # Install Drake.
 # N.B. When you change anything here, also fix wheel/image/build-drake.sh.
 cmake "$git_root" \

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -31,8 +31,8 @@ python_targets = (
     # tallies in doc/_pages/release_playbook.md (search `Attach binaries`)
     # and, if necessary, the set of Python versions for which lockfiles are
     # generated in tools/workspace/python/venv_upgrade.
-    PythonTarget(3, 12),
     PythonTarget(3, 13),
+    PythonTarget(3, 14),
 )
 
 


### PR DESCRIPTION
Drake's sources and binaries still run under Python 3.13; this commit only rotates the wheels.

Towards #23592, see also https://github.com/RobotLocomotion/drake/pull/23655#pullrequestreview-3438448654.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23729)
<!-- Reviewable:end -->
