### PR TITLE
Clarify pydrake docstring for IrisParametrizationFunction constructor.

### DIFF
--- a/bindings/pydrake/planning/planning_py_iris_common.cc
+++ b/bindings/pydrake/planning/planning_py_iris_common.cc
@@ -166,10 +166,10 @@ void DefinePlanningIrisParameterizationFunction(py::module m) {
   // IrisParameterizationFunction
   const auto& cls_doc = doc.IrisParameterizationFunction;
 
-  const std::string parameterization_function_docstring =
-      std::string(cls_doc.ctor
-              .doc_3args_parameterization_double_parameterization_is_threadsafe_parameterization_dimension) +
-      R"(
+  const std::string parameterization_function_docstring = R"(
+Constructor for when the user provides a callable function to be used as the
+parameterization. ``parameterization`` is the function itself and ``dimension`` 
+is the input dimension.
 
 .. note:: In order to use IrisNp2, the user-provided parameterization function
    must support double and AutoDiffXd. If it does not support AutoDiffXd, then


### PR DESCRIPTION
In C++, we provide two separate functions -- one which takes in a `VectorX<double>`, and another which takes in a `VectorX<AutoDiffXd>`. In Python, we provide a single function, which should handle both types. (This is similar to how it's done in `MathematicalProgram::AddCost` and `MathematicalProgram::AddConstraint`.) This PR fixes the docstring to reflect that.

Old:
<img width="839" height="277" alt="docstring_old" src="https://github.com/user-attachments/assets/08596698-6fca-4125-bf90-efb0950d8e74" />
New:
<img width="839" height="277" alt="docstring_new" src="https://github.com/user-attachments/assets/b4c94e69-b73f-4029-9229-796245c4c21c" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23732)
<!-- Reviewable:end -->
