### PR TITLE
IrisNp2 allows the user to set solver options for the counterexample search program.

### DIFF
--- a/bindings/generated_docstrings/planning_iris.h
+++ b/bindings/generated_docstrings/planning_iris.h
@@ -569,6 +569,12 @@ R"""(The user can specify a solver to use for the counterexample search
 program. If nullptr (the default value) is given, then
 solvers::MakeFirstAvailableSolver will be used to pick the solver.)""";
         } solver;
+        // Symbol: drake::planning::IrisNp2Options::solver_options
+        struct /* solver_options */ {
+          // Source: drake/planning/iris/iris_np2.h
+          const char* doc =
+R"""(Options passed to the counterexample search program solver.)""";
+        } solver_options;
         auto Serialize__fields() const {
           return std::array{
             std::make_pair("add_hyperplane_if_solve_fails", add_hyperplane_if_solve_fails.doc),
@@ -577,6 +583,7 @@ solvers::MakeFirstAvailableSolver will be used to pick the solver.)""";
             std::make_pair("sampled_iris_options", sampled_iris_options.doc),
             std::make_pair("sampling_strategy", sampling_strategy.doc),
             std::make_pair("solver", solver.doc),
+            std::make_pair("solver_options", solver_options.doc),
           };
         }
       } IrisNp2Options;

--- a/bindings/pydrake/planning/planning_py_iris_np2.cc
+++ b/bindings/pydrake/planning/planning_py_iris_np2.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "drake/bindings/generated_docstrings/planning_iris.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
@@ -43,6 +45,15 @@ void DefinePlanningIrisNp2(py::module m) {
   const auto& cls_doc = doc.IrisNp2Options;
   py::class_<IrisNp2Options> iris_np2_options(m, "IrisNp2Options", cls_doc.doc);
   iris_np2_options.def(py::init<>())
+      .def_property("solver_options",
+          py::cpp_function(
+              [](IrisNp2Options& self) { return &(self.solver_options); },
+              py_rvp::reference_internal),
+          py::cpp_function(
+              [](IrisNp2Options& self, solvers::SolverOptions solver_options) {
+                self.solver_options = std::move(solver_options);
+              }),
+          cls_doc.solver_options.doc)
       .def_readwrite("sampled_iris_options",
           &IrisNp2Options::sampled_iris_options,
           cls_doc.sampled_iris_options.doc)

--- a/bindings/pydrake/planning/test/iris_test.py
+++ b/bindings/pydrake/planning/test/iris_test.py
@@ -11,7 +11,7 @@ from pydrake.planning import (
     SceneGraphCollisionChecker,
     IrisParameterizationFunction,
 )
-from pydrake.solvers import IpoptSolver
+from pydrake.solvers import IpoptSolver, SolverOptions
 from pydrake.symbolic import Variable
 
 import numpy as np
@@ -192,6 +192,7 @@ class TestIrisNp2(unittest.TestCase):
 
         # For speed reasons -- IPOPT seems to be faster than SNOPT here.
         options.solver = IpoptSolver()
+        self.assertTrue(isinstance(options.solver_options, SolverOptions))
 
         domain = HPolyhedron.MakeBox(plant.GetPositionLowerLimits(),
                                      plant.GetPositionUpperLimits())
@@ -246,6 +247,7 @@ class TestOptionsPrinting(unittest.TestCase):
     skip_fields = [
         "parameterization",  # a function
         "solver",  # a solver object
+        "solver_options",  # a solver_options object
     ]
 
     def get_options_fields(self, options, skip):

--- a/planning/iris/iris_np2.cc
+++ b/planning/iris/iris_np2.cc
@@ -807,7 +807,8 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
 
           // TODO(cohnt): Allow the user to specify the solver options used
           // here.
-          solve_succeeded = prog.Solve(*solver, particle, {}, &closest);
+          solve_succeeded =
+              prog.Solve(*solver, particle, options.solver_options, &closest);
         } else {
           // We did not find a collision pair corresponding to this particle, so
           // the particle must be violating one of the constraints from
@@ -860,8 +861,8 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
 
           // TODO(cohnt): Allow the user to specify the solver options used
           // here.
-          solve_succeeded =
-              counter_example_prog->Solve(*solver, particle, {}, &closest);
+          solve_succeeded = counter_example_prog->Solve(
+              *solver, particle, options.solver_options, &closest);
         }
 
         bool add_hyperplane =

--- a/planning/iris/iris_np2.h
+++ b/planning/iris/iris_np2.h
@@ -90,6 +90,9 @@ class IrisNp2Options {
    * solvers::MakeFirstAvailableSolver will be used to pick the solver. */
   const solvers::SolverInterface* solver{nullptr};
 
+  /** Options passed to the counterexample search program solver. */
+  solvers::SolverOptions solver_options{};
+
   /** Options common to IRIS-type algorithms. */
   CommonSampledIrisOptions sampled_iris_options{};
 


### PR DESCRIPTION
+assignee:@hongkai-dai for feature review, if you have time?

Unfortunately, I can't actually think of any way to test that it's functioning within drake's framework. Open to any suggestions. (I've verified that the options are being propagated by turning on printing to a file, and verifying that the logs are printed.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23735)
<!-- Reviewable:end -->
