### PR TITLE
Update dependency apple_support to v1.24.4

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ module(
 
 # Add starlark rules.
 
-bazel_dep(name = "apple_support", version = "1.24.3")  # Keep this in sync with cmake/MODULE.bazel.in.  # noqa
+bazel_dep(name = "apple_support", version = "1.24.4")  # Keep this in sync with cmake/MODULE.bazel.in.  # noqa
 bazel_dep(name = "bazel_features", version = "1.38.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/cmake/MODULE.bazel.in
+++ b/cmake/MODULE.bazel.in
@@ -1,6 +1,6 @@
 module(name = "drake_cmake")
 
-bazel_dep(name = "apple_support", version = "1.24.3")
+bazel_dep(name = "apple_support", version = "1.24.4")
 bazel_dep(name = "rules_python", version = "1.6.3")
 
 bazel_dep(name = "drake")


### PR DESCRIPTION
This provides support for Bazel 9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23736)
<!-- Reviewable:end -->
