### PR TITLE
model_visualizer environment map gets forwarded to render engine

### DIFF
--- a/bindings/pydrake/visualization/model_visualizer.py
+++ b/bindings/pydrake/visualization/model_visualizer.py
@@ -113,6 +113,13 @@ def _main():
         ".jpg, .png, etc.). HDR images are not supported yet.",
     )
     args_parser.add_argument(
+        "--no_lights",
+        action="store_true",
+        help="If set, meshcat's lights will be disabled, similarly if "
+        "--show_rgbd_sensor is enabled, the sensor will have no visible "
+        "lights. This should be used in conjunction with --environment_map.",
+    )
+    args_parser.add_argument(
         "--compliance_type",
         default=defaults["compliance_type"],
         help=textwrap.dedent("""Overrides the DefaultProximityProperties
@@ -179,6 +186,7 @@ def _main():
         browser_new=args.browser_new,
         pyplot=args.pyplot,
         environment_map=args.environment_map,
+        no_lights=args.no_lights,
         compliance_type=args.compliance_type,
     )
     package_map = visualizer.package_map()


### PR DESCRIPTION
If `--show_rgbd_sensor` is set and an environment map is provided, model_visualizer now forwards that environment map to the renderer.

In the spirit of better syncing what we see in meshcat with what we see in the render engine (consistent with syncing camera extrinsics) we also add the following:

  - Command-line parameter for simply turning all lights off (as we have no current means of synchronizing the lights between meshcat and VTK).
  - Set the render engine camera's field of view to match that of meshcat's.
  - Automatically enable tone mapping in the render engine (as meshcat likewise uses tone mapping).
    - Change the tone mapping algorithm that Drake's meshcat page uses from meshcat's default value to one that better matches RenderEngineVtk's algorithm. (See meshcat.html).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23771)
<!-- Reviewable:end -->
