### PR TITLE
[solvers] Remove MobyLCPSolver autodiff support

### DIFF
--- a/bindings/generated_docstrings/solvers.h
+++ b/bindings/generated_docstrings/solvers.h
@@ -8184,7 +8184,10 @@ latter) describe relevant matrix classes in more detail.
 * [Karmarkar 1984]  N. Karmarkar. A New Polynomial-Time Algorithm for
                     Linear Programming. Combinatorica, 4(4), pp. 373-395.
 * [Murty 1988]      K. Murty. Linear Complementarity, Linear and Nonlinear
-                    Programming. Heldermann Verlag, 1988.)""";
+                    Programming. Heldermann Verlag, 1988.
+
+Template parameter ``T``:
+    must be ``double``)""";
         // Symbol: drake::solvers::MobyLCPSolver::ComputeZeroTolerance
         struct /* ComputeZeroTolerance */ {
           // Source: drake/solvers/moby_lcp_solver.h

--- a/solvers/moby_lcp_solver.h
+++ b/solvers/moby_lcp_solver.h
@@ -66,6 +66,8 @@ class MobyLcpSolverId {
 ///                     Linear Programming. Combinatorica, 4(4), pp. 373-395.
 /// * [Murty 1988]      K. Murty. Linear Complementarity, Linear and Nonlinear
 ///                     Programming. Heldermann Verlag, 1988.
+///
+/// @tparam T must be `double`
 template <class T>
 class MobyLCPSolver final : public SolverBase {
  public:
@@ -286,9 +288,8 @@ class MobyLCPSolver final : public SolverBase {
 
   void ClearIndexVectors() const;
 
-  template <typename MatrixType, typename Scalar>
-  void FinishLemkeSolution(const MatrixType& M, const VectorX<Scalar>& q,
-                           const VectorX<Scalar>& x, VectorX<Scalar>* z) const;
+  void FinishLemkeSolution(const MatrixX<T>& M, const VectorX<T>& q,
+                           const VectorX<T>& x, VectorX<T>* z) const;
 
   // Records the number of pivoting operations used during the last solve.
   mutable unsigned pivots_{0};

--- a/solvers/test/moby_lcp_solver_test.cc
+++ b/solvers/test/moby_lcp_solver_test.cc
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
@@ -116,72 +115,6 @@ GTEST_TEST(testMobyLCP, testTrivial) {
   // Mangle the input matrix so that some regularization occurs.
   M(0, 8) = 10;
   RunRegularizedLcp(M, q, empty_z, true);
-}
-
-GTEST_TEST(testMobyLCP, testAutoDiffTrivial) {
-  typedef Eigen::AutoDiffScalar<Vector1d> Scalar;
-  Eigen::Matrix<Scalar, 9, 9> M;
-  // clang-format off
-  M <<
-      1, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 2, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 3, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 4, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 5, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 6, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 7, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 8, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 9;
-  // clang-format on
-
-  // Set the LCP vector and indicate that we are interested in how the solution
-  // changes as the first element changes.
-  VectorX<Scalar> q(9);
-  q << -1, -1, -1, -1, -1, -1, -1, -1, -1;
-  q(0).derivatives()(0) = 1;
-  VectorX<Scalar> fast_z, lemke_z;
-
-  // Attempt to compute the solution using both "fast" and Lemke algorithms.
-  MobyLCPSolver<Scalar> l;
-  bool result = l.SolveLcpFast(M, q, &fast_z);
-  EXPECT_TRUE(result);
-  result = l.SolveLcpLemke(M, q, &lemke_z);
-  EXPECT_TRUE(result);
-
-  // Since the LCP matrix is diagonal and the first number is 1.0, a unit
-  // increase in q(0) will result in a unit decrease in z(0).
-  const double tol = std::numeric_limits<double>::epsilon();
-  EXPECT_NEAR(fast_z(0).value(), 1.0, tol);
-  EXPECT_NEAR(fast_z(0).derivatives()(0), -1, tol);
-
-  // Check the solutions.
-  EXPECT_NEAR(fast_z[0].value(), lemke_z[0].value(), tol);
-  EXPECT_NEAR(fast_z[1].value(), lemke_z[1].value(), tol);
-  EXPECT_NEAR(fast_z[2].value(), lemke_z[2].value(), tol);
-  EXPECT_NEAR(fast_z[3].value(), lemke_z[3].value(), tol);
-  EXPECT_NEAR(fast_z[4].value(), lemke_z[4].value(), tol);
-  EXPECT_NEAR(fast_z[5].value(), lemke_z[5].value(), tol);
-  EXPECT_NEAR(fast_z[6].value(), lemke_z[6].value(), tol);
-  EXPECT_NEAR(fast_z[7].value(), lemke_z[7].value(), tol);
-  EXPECT_NEAR(fast_z[8].value(), lemke_z[8].value(), tol);
-
-  // Mangle the input matrix so that some regularization occurs.
-  fast_z.setZero();
-  lemke_z.setZero();
-  M(0, 8) = 10;
-  result = l.SolveLcpFastRegularized(M, q, &fast_z);
-  EXPECT_TRUE(result);
-  result = l.SolveLcpLemkeRegularized(M, q, &lemke_z);
-  EXPECT_TRUE(result);
-  EXPECT_NEAR(fast_z[0].value(), lemke_z[0].value(), tol);
-  EXPECT_NEAR(fast_z[1].value(), lemke_z[1].value(), tol);
-  EXPECT_NEAR(fast_z[2].value(), lemke_z[2].value(), tol);
-  EXPECT_NEAR(fast_z[3].value(), lemke_z[3].value(), tol);
-  EXPECT_NEAR(fast_z[4].value(), lemke_z[4].value(), tol);
-  EXPECT_NEAR(fast_z[5].value(), lemke_z[5].value(), tol);
-  EXPECT_NEAR(fast_z[6].value(), lemke_z[6].value(), tol);
-  EXPECT_NEAR(fast_z[7].value(), lemke_z[7].value(), tol);
-  EXPECT_NEAR(fast_z[8].value(), lemke_z[8].value(), tol);
 }
 
 GTEST_TEST(testMobyLCP, testProblem1) {


### PR DESCRIPTION
It was undocumented, nearly entirely untested, and [broken with newer Eigen versions](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-arm-sequoia-clang-wheel-continuous-release/153/console).

(Not a breaking change, because the API docs and header file signatures never mentioned that was available in the first place.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23775)
<!-- Reviewable:end -->
