### PR TITLE
[CENIC] De-embrittle the EigenPool resizing API

### DIFF
--- a/multibody/contact_solvers/icf/eigen_pool.h
+++ b/multibody/contact_solvers/icf/eigen_pool.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <numeric>
 #include <span>
 #include <vector>
 
@@ -12,33 +13,6 @@ namespace multibody {
 namespace contact_solvers {
 namespace icf {
 namespace internal {
-
-/* Differentiate between fixed size (e.g. Matrix3d) and dynamic size (e.g.
-MatrixXd) Eigen types. */
-template <typename T>
-constexpr bool is_fixed_size_v =
-    is_eigen_type<T>::value && T::SizeAtCompileTime != Eigen::Dynamic;
-
-/* Detect fixed-size Eigen vectors, e.g. Vector3d. */
-template <typename T>
-constexpr bool is_fixed_size_vector_v =
-    is_eigen_vector<T>::value && is_fixed_size_v<T>;
-
-/* Detect dynamic-size Eigen vectors, e.g. VectorXd. */
-template <typename T>
-constexpr bool is_dynamic_size_vector_v =
-    is_eigen_vector<T>::value && !is_fixed_size_v<T>;
-
-/* Detect matrices with fixed number of rows, e.g. Matrix6Xd. */
-template <typename T>
-constexpr bool has_fixed_size_rows_v =
-    is_eigen_type<T>::value && T::RowsAtCompileTime != Eigen::Dynamic;
-
-/* Detect matrices with fixed number of columns, e.g. MatrixX4d. This includes
-vectors (e.g. VectorXd). */
-template <typename T>
-constexpr bool has_fixed_size_cols_v =
-    is_eigen_type<T>::value && T::ColsAtCompileTime != Eigen::Dynamic;
 
 /* Contiguous storage for a pool of fixed-size Eigen objects.
 
@@ -63,8 +37,11 @@ struct FixedSizeStorage {
   /* Set the size to zero, but keep the allocated memory. */
   void Clear() { data_.clear(); }
 
-  /* Resize to store `num_elements`, allocating additional memory if needed. */
-  void Resize(int num_elements) { data_.resize(num_elements); }
+  /* Resizes to store `num_elements`, allocating additional memory if needed.
+  @pre `rows` and `cols` must match the compile-time size of the EigenType. */
+  void Resize(int num_elements, int /* rows */, int /* cols */) {
+    data_.resize(num_elements);
+  }
 
   /* Sets all elements in the pool to zero. */
   void SetZero() {
@@ -113,43 +90,55 @@ struct DynamicSizeStorage {
 
   DynamicSizeStorage() = default;
 
-  /* Resize the pool to store MatrixX elements of the specified sizes.
-  N.B. rows (cols) are ignored if the rows (cols) of EigenType are fixed at
-  compile time. */
-  void Resize(std::span<const int> rows, std::span<const int> cols) {
-    static_assert(!is_fixed_size_v<EigenType>);
-    DRAKE_ASSERT(rows.size() == cols.size());
+  /* Resizes to store `num_elements` elements, each of size (rows x cols).
+  @pre If either RowsAtCompileTime or ColsAtCompileTime is not Eigen::Dynamic,
+  then the respective `rows` or `cols` argument must match the compile-time
+  size. */
+  void Resize(int num_elements, int rows, int cols) {
     Clear();
-    int total_size = 0;
-    for (int i = 0; i < ssize(rows); ++i) {
-      total_size += rows[i] * cols[i];
-    }
-    data_.reserve(total_size);
-    blocks_.reserve(ssize(rows));
-    for (int i = 0; i < ssize(rows); ++i) {
-      const int r = EigenType::RowsAtCompileTime >= 0
-                        ? EigenType::RowsAtCompileTime
-                        : rows[i];
-      const int c = EigenType::ColsAtCompileTime >= 0
-                        ? EigenType::ColsAtCompileTime
-                        : cols[i];
-      Add(r, c);
+    data_.reserve(num_elements * rows * cols);
+    blocks_.reserve(num_elements);
+    for (int i = 0; i < num_elements; ++i) {
+      Add(rows, cols);
     }
   }
 
-  /* Resize the pool to store `num_elements` elements, each of size (rows x
-  cols). */
-  void Resize(int num_elements, int rows, int cols) {
-    static_assert(!is_fixed_size_v<EigenType>);
-    const int r =
-        EigenType::RowsAtCompileTime >= 0 ? EigenType::RowsAtCompileTime : rows;
-    const int c =
-        EigenType::ColsAtCompileTime >= 0 ? EigenType::ColsAtCompileTime : cols;
+  /* Resizes to store `num_elements` elements with the given sizes.
+  @pre If either RowsAtCompileTime or ColsAtCompileTime is not Eigen::Dynamic,
+  then the respective `rows` or `cols` argument must be empty. */
+  void Resize(int num_elements, std::span<const int> rows,
+              std::span<const int> cols) {
     Clear();
-    data_.reserve(num_elements * r * c);
-    blocks_.reserve(num_elements);
-    for (int i = 0; i < num_elements; ++i) {
-      Add(r, c);
+    constexpr int fixed_rows = EigenType::RowsAtCompileTime;
+    constexpr int fixed_cols = EigenType::ColsAtCompileTime;
+    static_assert(fixed_rows == Eigen::Dynamic || fixed_cols == Eigen::Dynamic);
+    if constexpr (fixed_rows >= 0 || fixed_cols >= 0) {
+      // Only dynamic in one dimension.
+      const int fixed_dim = (fixed_rows >= 0) ? fixed_rows : fixed_cols;
+      const std::span<const int>& dyn_dims = (fixed_rows >= 0) ? cols : rows;
+      DRAKE_DEMAND(ssize(dyn_dims) == num_elements);
+      const int total_size =
+          fixed_dim * std::accumulate(dyn_dims.begin(), dyn_dims.end(), 0);
+      data_.reserve(total_size);
+      blocks_.reserve(num_elements);
+      for (int i = 0; i < num_elements; ++i) {
+        const int r = fixed_rows >= 0 ? fixed_rows : rows[i];
+        const int c = fixed_cols >= 0 ? fixed_cols : cols[i];
+        Add(r, c);
+      }
+    } else {
+      // Fully dynamic.
+      DRAKE_DEMAND(ssize(rows) == num_elements);
+      DRAKE_DEMAND(ssize(cols) == num_elements);
+      int total_size = 0;
+      for (int i = 0; i < num_elements; ++i) {
+        total_size += rows[i] * cols[i];
+      }
+      data_.reserve(total_size);
+      blocks_.reserve(num_elements);
+      for (int i = 0; i < num_elements; ++i) {
+        Add(rows[i], cols[i]);
+      }
     }
   }
 
@@ -201,8 +190,8 @@ struct StorageSelector<EigenType, Eigen::Dynamic> {
 
 /* A replacement for std::vector<MatrixX<T>> with a contiguous memory layout.
 
-@tparam EigenType The type of the Eigen elements. E.g. MatrixXd, Vector3d, etc.
-@pre EigenType must be an Eigen type derived from Eigen::MatrixBase. */
+@tparam EigenType The type of the Eigen elements, e.g. MatrixXd, Vector3d, etc.
+                  It must be an Eigen type derived from Eigen::MatrixBase. */
 template <typename EigenType>
 class EigenPool {
  public:
@@ -223,38 +212,41 @@ class EigenPool {
   // Resize methods allocate memory only if the current capacity is
   // insufficient, and do not reduce the capacity.
 
-  /* Resize a pool of fixed-size elements (e.g. Matrix3d). */
-  void Resize(int num_elements)
-    requires is_fixed_size_v<EigenType>
-  {
-    storage_.Resize(num_elements);
+  /* Resizes a pool using a homogenous size for all elements. If either or both
+  of RowsAtCompileTime or ColsAtCompileTime are not Eigen::Dynamic, then the
+  respective `rows` or `cols` argument must match the compile-time size. */
+  void Resize(int num_elements, int rows, int cols) {
+    DRAKE_DEMAND(EigenType::RowsAtCompileTime == Eigen::Dynamic ||
+                 rows == EigenType::RowsAtCompileTime);
+    DRAKE_DEMAND(EigenType::ColsAtCompileTime == Eigen::Dynamic ||
+                 cols == EigenType::ColsAtCompileTime);
+    storage_.Resize(num_elements, rows, cols);
   }
 
-  /* Resize a pool of dynamic-size matrices (e.g. MatrixXd).
-
-  N.B. rows (cols) are ignored if the rows (cols) of EigenType are fixed at
-  compile time. */
-  void Resize(std::span<const int> rows, std::span<const int> cols)
-    requires(!is_fixed_size_v<EigenType>)
-  {
-    storage_.Resize(rows, cols);
+  /* Resizes a pool using heterogenous row sizes for the elements but a fixed
+  size for `cols` that must match ColsAtCompileTime. */
+  void Resize(int num_elements, std::span<const int> rows, int cols = 1) {
+    static_assert(EigenType::RowsAtCompileTime == Eigen::Dynamic);
+    static_assert(EigenType::ColsAtCompileTime >= 0);
+    DRAKE_DEMAND(cols == EigenType::ColsAtCompileTime);
+    storage_.Resize(num_elements, rows, {});
   }
 
-  /* Resize a pool of matrices with a fixed number of rows or columns, e.g.
-  Matrix6Xd or VectorXd. */
-  void Resize(std::span<const int> sizes)
-    requires(has_fixed_size_rows_v<EigenType> ||
-             has_fixed_size_cols_v<EigenType>)
-  {
-    storage_.Resize(sizes, sizes);
+  /* Resizes a pool using heterogenous column sizes for the elements but a fixed
+  size for `rows` that must match RowsAtCompileTime. */
+  void Resize(int num_elements, int rows, std::span<const int> cols) {
+    static_assert(EigenType::RowsAtCompileTime >= 0);
+    static_assert(EigenType::ColsAtCompileTime == Eigen::Dynamic);
+    DRAKE_DEMAND(rows == EigenType::RowsAtCompileTime);
+    storage_.Resize(num_elements, {}, cols);
   }
 
-  /* Resize a pool of dynamic-size matrices (e.g. MatrixXd), where all elements
-  have the same size. Rows (cols) are ignored if the rows (cols) of EigenType
-  are fixed at compile time. */
-  void Resize(int num_elements, int rows, int cols)
-    requires(!is_fixed_size_v<EigenType>)
-  {
+  /* Resizes a pool using heterogenous sizes for the elements. Both
+  RowsAtCompileTime and ColsAtCompileTime must be Eigen::Dynamic. */
+  void Resize(int num_elements, std::span<const int> rows,
+              std::span<const int> cols) {
+    static_assert(EigenType::RowsAtCompileTime == Eigen::Dynamic);
+    static_assert(EigenType::ColsAtCompileTime == Eigen::Dynamic);
     storage_.Resize(num_elements, rows, cols);
   }
 

--- a/multibody/contact_solvers/icf/gain_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/gain_constraints_data_pool.cc
@@ -8,8 +8,9 @@ namespace internal {
 
 template <typename T>
 void GainConstraintsDataPool<T>::Resize(std::span<const int> constraint_size) {
-  gamma_pool_.Resize(constraint_size);
-  G_pool_.Resize(constraint_size, constraint_size);
+  const int num_elements = ssize(constraint_size);
+  gamma_pool_.Resize(num_elements, constraint_size);
+  G_pool_.Resize(num_elements, constraint_size, constraint_size);
 
   // We will only ever update the diagonal entries in Gk, so that off-diagonal
   // entires will forever remain zero.

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -270,7 +270,7 @@ void IcfBuilder<T>::UpdateModel(
   // Compute spatial velocity Jacobians J_WB for all bodies.
   const auto& world_frame = plant().world_frame();
   EigenPool<Matrix6X<T>>& J_WB = params->J_WB;
-  J_WB.Resize(body_jacobian_cols_);
+  J_WB.Resize(plant().num_bodies(), 6, body_jacobian_cols_);
 
   for (int b = 0; b < plant().num_bodies(); ++b) {
     const auto& body = plant().get_body(BodyIndex(b));

--- a/multibody/contact_solvers/icf/icf_data.cc
+++ b/multibody/contact_solvers/icf/icf_data.cc
@@ -14,7 +14,7 @@ void IcfData<T>::Cache::Resize(int num_bodies, int num_velocities,
                                std::span<const int> patch_sizes) {
   Av.resize(num_velocities);
   gradient.resize(num_velocities);
-  spatial_velocities.Resize(num_bodies);
+  spatial_velocities.Resize(num_bodies, 6, 1);
 
   coupler_constraints_data.Resize(num_couplers);
   gain_constraints_data.Resize(gain_sizes);
@@ -43,12 +43,12 @@ void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
   Clear();
   Av_minus_r.resize(num_velocities);
 
-  V_WB_alpha.Resize(num_bodies);
+  V_WB_alpha.Resize(num_bodies, 6, 1);
   v_alpha.resize(num_velocities);
 
   Gw_gain.resize(num_velocities);
   Gw_limit.resize(num_velocities);
-  U_AbB_W_pool.Resize(patch_sizes.size());
+  U_AbB_W_pool.Resize(ssize(patch_sizes), 6, 1);
 
   coupler_constraints_data.Resize(num_couplers);
   gain_constraints_data.Resize(gain_sizes);

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -32,8 +32,9 @@ void IcfModel<T>::ResetParameters(std::unique_ptr<IcfParameters<T>> params) {
   // Define the sparse dynamics matrix A = M + δt D and the diagonal Delassus
   // operator estimate W = diag(M)⁻¹.
   const std::vector<int>& clique_sizes = this->params().clique_sizes;
-  A_.Resize(clique_sizes, clique_sizes);
-  clique_delassus_.Resize(clique_sizes, clique_sizes);
+  const int num_cliques = ssize(clique_sizes);
+  A_.Resize(num_cliques, clique_sizes, clique_sizes);
+  clique_delassus_.Resize(num_cliques, clique_sizes);
   for (int c = 0; c < num_cliques_; ++c) {
     const int v_start = this->params().clique_start[c];
     const int nv = clique_sizes[c];
@@ -49,7 +50,7 @@ void IcfModel<T>::ResetParameters(std::unique_ptr<IcfParameters<T>> params) {
   r_ = Av0_ - time_step() * k0();
 
   // Compute the initial spatial velocity V_WB0 = J_WB⋅v0 for each body
-  V_WB0_.Resize(num_bodies_);
+  V_WB0_.Resize(num_bodies_, 6, 1);
   CalcBodySpatialVelocities(v0(), &V_WB0_);
 
   // Set the scaling factor diag(M)^{-1/2} for convergence checks
@@ -273,7 +274,7 @@ void IcfModel<T>::UpdateSearchDirection(
     const IcfData<T>& data, const VectorX<T>& w,
     SearchDirectionData<T>* search_data) const {
   search_data->w.resize(num_velocities());
-  search_data->U.Resize(num_bodies());
+  search_data->U.Resize(num_bodies(), 6, 1);
 
   // We'll use search_data->w as scratch, to avoid memory allocation.
   auto& tmp = search_data->w;

--- a/multibody/contact_solvers/icf/icf_model_gain_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/icf_model_gain_constraints_pool.cc
@@ -26,10 +26,11 @@ template <typename T>
 void IcfModel<T>::GainConstraintsPool::Resize(std::span<const int> sizes) {
   clique_.resize(sizes.size());
   constraint_sizes_.resize(sizes.size());
-  K_.Resize(sizes);
-  b_.Resize(sizes);
-  le_.Resize(sizes);
-  ue_.Resize(sizes);
+  const int num_elements = ssize(sizes);
+  K_.Resize(num_elements, sizes);
+  b_.Resize(num_elements, sizes);
+  le_.Resize(num_elements, sizes);
+  ue_.Resize(num_elements, sizes);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_model_limit_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/icf_model_limit_constraints_pool.cc
@@ -31,12 +31,13 @@ void IcfModel<T>::LimitConstraintsPool::Resize(
     std::span<const int> constrained_clique_sizes,
     std::span<const int> constraint_to_clique) {
   DRAKE_DEMAND(constrained_clique_sizes.size() == constraint_to_clique.size());
-  ql_.Resize(constrained_clique_sizes);
-  qu_.Resize(constrained_clique_sizes);
-  q0_.Resize(constrained_clique_sizes);
-  R_.Resize(constrained_clique_sizes);
-  vl_hat_.Resize(constrained_clique_sizes);
-  vu_hat_.Resize(constrained_clique_sizes);
+  const int num_elements = ssize(constrained_clique_sizes);
+  ql_.Resize(num_elements, constrained_clique_sizes);
+  qu_.Resize(num_elements, constrained_clique_sizes);
+  q0_.Resize(num_elements, constrained_clique_sizes);
+  vl_hat_.Resize(num_elements, constrained_clique_sizes);
+  vu_hat_.Resize(num_elements, constrained_clique_sizes);
+  R_.Resize(num_elements, constrained_clique_sizes);
   constraint_sizes_.assign(constrained_clique_sizes.begin(),
                            constrained_clique_sizes.end());
   constraint_to_clique_.assign(constraint_to_clique.begin(),

--- a/multibody/contact_solvers/icf/icf_model_patch_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/icf_model_patch_constraints_pool.cc
@@ -186,15 +186,15 @@ void IcfModel<T>::PatchConstraintsPool::Resize(
   // per-patch data.
   num_cliques_.resize(num_patches);
   bodies_.resize(num_patches);
-  p_AB_W_.Resize(num_patches);
+  p_AB_W_.Resize(num_patches, 3, 1);
   dissipation_.resize(num_patches);
   static_friction_.resize(num_patches);
   dynamic_friction_.resize(num_patches);
   Rt_.resize(num_patches);
 
   // per-pair data.
-  normal_W_.Resize(num_pairs);
-  p_BC_W_.Resize(num_pairs);
+  p_BC_W_.Resize(num_pairs, 3, 1);
+  normal_W_.Resize(num_pairs, 3, 1);
   stiffness_.resize(num_pairs);
   fn0_.resize(num_pairs);
   n0_.resize(num_pairs);

--- a/multibody/contact_solvers/icf/limit_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/limit_constraints_data_pool.cc
@@ -8,10 +8,11 @@ namespace internal {
 
 template <typename T>
 void LimitConstraintsDataPool<T>::Resize(std::span<const int> constraint_size) {
-  gamma_lower_pool_.Resize(constraint_size);
-  G_lower_pool_.Resize(constraint_size, constraint_size);
-  gamma_upper_pool_.Resize(constraint_size);
-  G_upper_pool_.Resize(constraint_size, constraint_size);
+  const int num_elements = ssize(constraint_size);
+  gamma_lower_pool_.Resize(num_elements, constraint_size);
+  G_lower_pool_.Resize(num_elements, constraint_size, constraint_size);
+  gamma_upper_pool_.Resize(num_elements, constraint_size);
+  G_upper_pool_.Resize(num_elements, constraint_size, constraint_size);
 
   // We will only ever update the diagonal entries in Gk, so that
   // off-diagonal entires will forever remain zero.

--- a/multibody/contact_solvers/icf/patch_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/patch_constraints_data_pool.cc
@@ -13,11 +13,11 @@ void PatchConstraintsDataPool<T>::Resize(std::span<const int> patch_size) {
 
   // Data per patch.
   cost_pool_.resize(num_patches_);
-  G_Bp_pool_.Resize(num_patches_);
-  Gamma_Bo_W_.Resize(num_patches_);
+  G_Bp_pool_.Resize(num_patches_, 6, 6);
+  Gamma_Bo_W_.Resize(num_patches_, 6, 1);
 
   // Data per pair.
-  v_AcBc_W_.Resize(num_pairs_);
+  v_AcBc_W_.Resize(num_pairs_, 3, 1);
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/test/eigen_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/eigen_pool_test.cc
@@ -28,21 +28,21 @@ GTEST_TEST(EigenPoolTest, ResizeForFixedSizedElements) {
   EXPECT_EQ(pool.size(), 0);
 
   // Reserve some memory by resizing, then clearing
-  pool.Resize(10);
+  pool.Resize(10, 3, 3);
   pool.Clear();
   EXPECT_EQ(pool.size(), 0);
 
   // We already reserved.
   {
     drake::test::LimitMalloc guard;
-    pool.Resize(3);
+    pool.Resize(4, 3, 3);
   }
-  EXPECT_EQ(pool.size(), 3);
+  EXPECT_EQ(pool.size(), 4);
 
   for (int i = 0; i < pool.size(); ++i) {
     pool[i] = i * S33;
   }
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 4; ++i) {
     EXPECT_EQ(pool[i], Matrix3d(i * S33));
   }
 
@@ -58,8 +58,7 @@ GTEST_TEST(EigenPoolTest, ResizeForPoolsOfVectorX) {
   {
     // We expect two allocations. One for scalars and one for meta-data (sizes).
     drake::test::LimitMalloc guard({.max_num_allocations = 2});
-    pool.Resize(sizes);
-    // N.B. pool.Resize(sizes, sizes) is valid also, though "cols" is ignored.
+    pool.Resize(3, sizes);
   }
   EXPECT_EQ(pool.size(), 3);
   EXPECT_EQ(pool[0].size(), 3);
@@ -83,7 +82,7 @@ GTEST_TEST(EigenPoolTest, ResizeForPoolsOfMatrixX) {
   {
     // We expect two allocations. One for scalars and one for meta-data (sizes).
     drake::test::LimitMalloc guard({.max_num_allocations = 2});
-    pool.Resize(rows, cols);
+    pool.Resize(3, rows, cols);
   }
   EXPECT_EQ(pool.size(), 3);
   EXPECT_EQ(pool[0].size(), 3);
@@ -106,7 +105,7 @@ GTEST_TEST(EigenPoolTest, ResizeForPoolsOfMatrixWithFixedRows) {
   {
     // We expect two allocations. One for scalars and one for meta-data (sizes).
     drake::test::LimitMalloc guard({.max_num_allocations = 2});
-    pool.Resize(cols);
+    pool.Resize(4, 3, cols);
   }
   EXPECT_EQ(pool.size(), 4);
   EXPECT_EQ(pool[0].size(), 3);


### PR DESCRIPTION
No more "this argument is ignored" (which also was sometimes true, and sometimes not).  The arguments to `EigenPool::Resize` are now always `(num_elements, rows, cols)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23781)
<!-- Reviewable:end -->
