### PR TITLE
[CENIC] Add basic python regression tests

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -603,6 +603,7 @@ drake_py_unittest(
 
 drake_py_unittest(
     name = "cenic_regression_test",
+    timeout = "long",
     deps = [
         "//bindings/pydrake",
     ],

--- a/systems/analysis/test/cenic_regression_test.py
+++ b/systems/analysis/test/cenic_regression_test.py
@@ -227,5 +227,5 @@ class CenicRegressionTest(unittest.TestCase):
             xml=self.gripper_xml,
             x0=x0,
             sim_time=1.0,
-            use_hydro=False,
+            use_hydro=True,
         )


### PR DESCRIPTION
Adds some simple python tests that run a few of our toy test simulations from [error_control_demo.py](https://github.com/vincekurtz/drake/blob/cenic_main/examples/integrators/error_control_demo.py). Together with the tests we already have in `cenic_integrator_test.cc`, now `bazel test //...`:

- Covers the main code paths (all constraint types, error controlled and fixed-step modes, etc)
- Ensures that python bindings work
- Ensures that the prototype remains usable, e.g., for the project @joemasterjohn is working on

I'll probably still keep running
```
bazel run //examples/multibody/clutter:clutter
bazel run //examples/multibody/franka:franka
bazel run //examples/integrators:suction_gripper
```
every now and then, but this should reduce reliance on those manual tests as we clean up the prototype.

Toward #23754

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23787)
<!-- Reviewable:end -->
