### PR TITLE
[tools] Prep for rules_python 1.7

### DIFF
--- a/bindings/pydrake/stubgen.py
+++ b/bindings/pydrake/stubgen.py
@@ -120,11 +120,14 @@ def _wrapper_main():
     hint = "--inner_process"
     if hint not in sys.argv:
         # Call ourself again with a new argument as a hint.
+        env = dict(os.environ)
+        env["PYTHONPATH"] = ":".join(sys.path)
         completed = subprocess.run(
             [sys.executable, "-B"] + sys.argv + [hint],
             encoding="utf-8",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            env=env,
         )
         if completed.returncode != 0:
             sys.stderr.write(completed.stdout)

--- a/bindings/pydrake/test/all_each_import_test.py
+++ b/bindings/pydrake/test/all_each_import_test.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import subprocess
 import sys
@@ -51,7 +52,13 @@ class TestAllEachImport(unittest.TestCase, metaclass=ValueParameterizedTest):
             with open("{temp_filename}", "wb") as f:
                 pickle.dump(has_common, f)
         """)
-        subprocess.run([sys.executable, "-c", script], check=True)
+        env = dict(os.environ)
+        env["PYTHONPATH"] = ":".join(sys.path)
+        subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            check=True,
+        )
 
         # Parse the output.
         with open(temp_filename, "rb") as f:

--- a/bindings/pydrake/visualization/BUILD.bazel
+++ b/bindings/pydrake/visualization/BUILD.bazel
@@ -240,6 +240,9 @@ drake_py_unittest(
         "@drake_models//:manipulation_station",
         "@drake_models//:wsg_50_description",
     ],
+    deps = [
+        "//bindings/pydrake",
+    ],
 )
 
 add_lint_tests_pydrake(

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -237,7 +237,9 @@ def reexecute_if_unbuffered():
             argv.insert(0, sys.executable)
         cmd = " ".join([shlex.quote(arg) for arg in argv])
         sys.stdout.flush()
+        os.environ["PYTHONPATH"] = ":".join(sys.path)
         os.execv(argv[0], argv)
+    os.environ.pop("PYTHONPATH", None)
 
 
 def traced(func, ignoredirs=None):

--- a/examples/hardware_sim/BUILD.bazel
+++ b/examples/hardware_sim/BUILD.bazel
@@ -154,6 +154,8 @@ drake_py_unittest(
     shard_count = 4,
     deps = [
         ":hardware_sim_test_common",
+        # This is only used by :demo_py, but it needs to be here.
+        "//bindings/pydrake",
     ],
 )
 

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -360,7 +360,7 @@ const std::string& PackageData::GetPathWithAutomaticFetching(
   const std::string downloader =
       FindResourceOrThrow("drake/multibody/parsing/package_downloader.py");
   const std::string command =
-      fmt::format("/usr/bin/python3 {} {} {} {}", downloader, json_filename,
+      fmt::format("/usr/bin/python3 -E {} {} {} {}", downloader, json_filename,
                   error_filename, "--disable-drake-valgrind-tracing");
   const int returncode = std::system(command.c_str());
   if (returncode != 0) {

--- a/tools/install/install_test.py
+++ b/tools/install/install_test.py
@@ -30,11 +30,13 @@ class InstallTest(unittest.TestCase):
         python = install_test_helper.get_python_executable()
 
         # Our launched processes should be independent, not inherit their
-        # runfiles from the install_test.py runner.
+        # runfiles from the install_test.py runner. However, the sys.path
+        # should be inherited.
         env = dict(os.environ)
         for key in ["RUNFILES_MANIFEST_FILE", "RUNFILES_DIR", "TEST_SRCDIR"]:
             if key in env:
                 del env[key]
+        env["PYTHONPATH"] = ":".join(sys.path)
 
         # Execute the test_command.
         print("+ {}".format(test_command), file=sys.stderr)

--- a/tools/jupyter/jupyter_bazel.py
+++ b/tools/jupyter/jupyter_bazel.py
@@ -45,6 +45,9 @@ def _jupyter_bazel_notebook_main(notebook_respath, argv):
     )
     args = parser.parse_args(argv)
 
+    # The notebook should be run with the same dependencies as we have now.
+    os.environ["PYTHONPATH"] = ":".join(sys.path)
+
     if not args.test:
         print("Running notebook interactively")
         notebook_path = os.path.realpath(notebook_path)


### PR DESCRIPTION
The new version of `rules_python` changes how the `sys.path` is prepared for a bazel- wrapped Python binary or test.  From their release notes:

> * For `--bootstrap_impl=system_python`, `PYTHONPATH` is no longer used to add import paths

Now, paths happen via `*.pth` files and `sys.executable` only knows about the standard library. Thus, anywhere we shell out to another interpreter via `sys.executable`, we need to pass along our current `sys.path`.

---

To test this locally, change `drake/MODULE.bazel` to say `bazel_dep(name = "rules_python", version = "1.7.0-rc6")`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23788)
<!-- Reviewable:end -->
