### PR TITLE
[solvers] Document when Solve is called with an initial guess and MathematicalProgram Initial guess is set.

### DIFF
--- a/bindings/generated_docstrings/solvers.h
+++ b/bindings/generated_docstrings/solvers.h
@@ -10295,7 +10295,10 @@ Parameter ``prog``:
     options.
 
 Parameter ``initial_guess``:
-    The initial guess for the decision variables.
+    The initial guess for the decision variables. If an
+    ``initial_guess`` is provided, then the solver uses
+    ``initial_guess`` and ignores the initial guess stored in
+    ``prog``.
 
 Parameter ``solver_options``:
     The options in addition to those stored in ``prog``. For each
@@ -10502,11 +10505,13 @@ string.)""";
           const char* doc =
 R"""(Solves an optimization program with optional initial guess and solver
 options. Note that these initial guess and solver options are not
-written to ``prog``. If the ``prog`` has set an option for a solver,
-and ``solver_options`` contains a different value for the same option
-on the same solver, then ``solver_options`` takes priority. Derived
-implementations of this interface may elect to throw RuntimeError for
-badly formed programs.)""";
+written to ``prog``. If the ``prog`` has set an initial guess, and
+``initial_guess`` is set, then ``initial_guess`` takes priority. If
+the ``prog`` has set an option for a solver, and ``solver_options``
+contains a different value for the same option on the same solver,
+then ``solver_options`` takes priority. Derived implementations of
+this interface may elect to throw RuntimeError for badly formed
+programs.)""";
         } Solve;
         // Symbol: drake::solvers::SolverInterface::SolverInterface
         struct /* ctor */ {

--- a/solvers/solve.h
+++ b/solvers/solve.h
@@ -19,7 +19,9 @@ namespace solvers {
  * result is stored in the return argument.
  * @param prog Contains the formulation of the program, and possibly solver
  * options.
- * @param initial_guess The initial guess for the decision variables.
+ * @param initial_guess The initial guess for the decision variables. If an
+ * @p initial_guess is provided, then the solver uses @p initial_guess and
+ * ignores the initial guess stored in @p prog.
  * @param solver_options The options in addition to those stored in @p prog.
  * For each option entry (like print out), there are 4 ways to set that option,
  * and the priority given to the solver options is as follows (from lowest /

--- a/solvers/solver_interface.h
+++ b/solvers/solver_interface.h
@@ -59,6 +59,8 @@ class SolverInterface {
   /// Solves an optimization program with optional initial guess and solver
   /// options. Note that these initial guess and solver options are not written
   /// to @p prog.
+  /// If the @p prog has set an initial guess, and @p initial_guess is
+  /// set, then @p initial_guess takes priority.
   /// If the @p prog has set an option for a solver, and @p solver_options
   /// contains a different value for the same option on the same solver, then @p
   /// solver_options takes priority.


### PR DESCRIPTION
Towards [#22252](https://github.com/RobotLocomotion/drake/issues/22252). @AlexandreAmice, @hongkai-dai for review, thanks! 
Hi, supposing that [prioritizing the provided `initial_guess` is the expected behavior](https://github.com/RobotLocomotion/drake/blob/5675aaee7322e5d68eb9a6a247e8be1d712963d2/solvers/solver_base.cc#L69), I have found the behavior already [tested in `GTEST_TEST(SolverBaseTest, SolveAsOutputArgument)`](https://github.com/RobotLocomotion/drake/blob/5675aaee7322e5d68eb9a6a247e8be1d712963d2/solvers/test/solver_base_test.cc#L187). So I updated the documentation accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23795)
<!-- Reviewable:end -->
