### PR TITLE
Improve benchmark test performance

### DIFF
--- a/tools/performance/defs.bzl
+++ b/tools/performance/defs.bzl
@@ -52,10 +52,10 @@ def drake_cc_googlebench_binary(
             timeout = test_timeout,
             display = test_display,
             args = [
-                # When running as a unit test, run each function only once to
-                # save time. (Once should be sufficient to prove the lack of
-                # runtime errors.)
-                "--benchmark_min_time=0s",
+                # Google benchmark has a flag designed to do the minimal work
+                # to confirm that the tests run: dry run. For tests, that's
+                # sufficient.
+                "--benchmark_dry_run",
             ] + (test_args or []),
             tags = (test_tags or []) + ["nolint", "no_kcov"],
         )


### PR DESCRIPTION
This is in response to timeouts on tests on benchmarks.

The drake_cc_googlebench_binary build target *intended* to minimize work in the test. This updates the parameter to more effectively exercise the googlebench API to achieve that end.

Reseolves #23509

-------------------------------------------

## The explanation

The old flag `--benchmark_min_time=0s` is a misspelling. At best, it should've been `--benchmark_min_time=1x`. The suffix 's' implies a minimum *run* time (easy to satisfy running at least 0 seconds). The suffix `x` implies run it this number of times (a very counter-intuitive interpretation given the parameter *name*). However, googlebench provides a very specific 
parameter [`--benchmark_dry_run`](https://google.github.io/benchmark/user_guide.html#dry-runs) to achieve the desired effect. In fact, on my machine, the dry run parameter was better than the 1x parameter (which itself was an improvement over the 0s).

## Testing locally:

On master, run:

```bash
bazel test -c dbg //geometry/benchmarking:compliant_mesh_intersection_benchmark_test \
     --cache_test_results=false --test_output=all
```

Two things of note (on my puget):
1. It takes about 180s.
2. The iterations taken can be in the hundreds of thousands. (The same is apparent in the logs for the timeouts -- lots and lots of iterations).

Run the same on this branch and you'll see:

1. Shorter run time (30s on my machine).
2. Iterations are all simply 1.

## Further possible optimization

We could extend `drake_cc_googlebench_binary` to include a `test_rule_args` and then pass a [benchmark filter](https://google.github.io/benchmark/user_guide.html#running-a-subset-of-benchmarks) to sample only some portion of the parameter combinations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23805)
<!-- Reviewable:end -->
