### PR TITLE
[common] Move logging::get_disk_sink to new header

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -71,6 +71,7 @@
 // #include "drake/common/string_unordered_set.h"
 // #include "drake/common/temp_directory.h"
 // #include "drake/common/text_logging.h"
+// #include "drake/common/text_logging_spdlog.h"
 // #include "drake/common/timer.h"
 // #include "drake/common/type_safe_index.h"
 // #include "drake/common/unused.h"
@@ -3166,7 +3167,7 @@ For example:
       } Warn;
       // Symbol: drake::logging::get_dist_sink
       struct /* get_dist_sink */ {
-        // Source: drake/common/text_logging.h
+        // Source: drake/common/text_logging_spdlog.h
         const char* doc =
 R"""((Advanced) Retrieves the default sink for all Drake logs. When spdlog
 is enabled, the return value can be cast to

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -66,6 +66,7 @@ drake_cc_package_library(
         ":sorted_pair",
         ":string_container",
         ":temp_directory",
+        ":text_logging_spdlog",
         ":timer",
         ":type_safe_index",
         ":unused",
@@ -111,12 +112,26 @@ drake_cc_library(
         "never_destroyed.h",
         "ssize.h",
         "text_logging.h",
+        # Remove with deprecation on 2026-03-01.
+        "text_logging_spdlog.h",
     ],
     deps = [
         ":fmt",
         "@eigen",
         "@fmt",
         "@spdlog",
+    ],
+)
+
+drake_cc_library(
+    name = "text_logging_spdlog",
+    hdrs = ["text_logging_spdlog.h"],
+    tags = [
+        # Don't lint us twice. (Remove with deprecation on 2026-03-01.)
+        "nolint",
+    ],
+    deps = [
+        ":essential",
     ],
 )
 
@@ -1221,6 +1236,7 @@ drake_cc_googletest(
     use_default_main = False,
     deps = [
         ":essential",
+        ":text_logging_spdlog",
     ],
 )
 
@@ -1235,6 +1251,9 @@ drake_cc_googletest(
         "test/text_logging_test.cc",
         "text_logging.cc",
         "text_logging.h",
+        # Remove both of these with deprecation on 2026-03-01.
+        "drake_deprecated.h",
+        "text_logging_spdlog.h",
     ],
     defines = [
         "TEXT_LOGGING_TEST_SPDLOG=0",
@@ -1255,6 +1274,9 @@ drake_cc_googletest(
         "test/text_logging_ostream_test.cc",
         "text_logging.cc",
         "text_logging.h",
+        # Remove both of these with deprecation on 2026-03-01.
+        "drake_deprecated.h",
+        "text_logging_spdlog.h",
     ],
     defines = [
         "TEXT_LOGGING_TEST_SPDLOG=0",

--- a/common/test/text_logging_ostream_test.cc
+++ b/common/test/text_logging_ostream_test.cc
@@ -31,6 +31,8 @@
 #ifdef HAVE_SPDLOG
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
+
+#include "drake/common/text_logging_spdlog.h"
 #endif  // HAVE_SPDLOG
 
 #include "drake/common/fmt_ostream.h"
@@ -70,7 +72,14 @@ GTEST_TEST(TextLoggingTest, SmokeTestStreamable) {
 // We must run this test last because it changes the default configuration.
 GTEST_TEST(TextLoggingTest, ZZZ_ChangeDefaultSink) {
   // The getter should never return nullptr, even with spdlog disabled.
+#if TEXT_LOGGING_TEST_SPDLOG
   drake::logging::sink* const sink_base = drake::logging::get_dist_sink();
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  drake::logging::sink* const sink_base = drake::logging::get_dist_sink();
+#pragma GCC diagnostic pop
+#endif
   ASSERT_NE(sink_base, nullptr);
 
 // The remainder of the test case only makes sense when spdlog is enabled.

--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -43,6 +43,7 @@ logging::logger* log() {
   return g_logger.access().get();
 }
 
+// Move into text_logging_spdlog.cc upon 2026-03-01 deprecation removal.
 logging::sink* logging::get_dist_sink() {
   // Extract the dist_sink_mt from Drake's logger instance.
   auto* sink = log()->sinks().empty() ? nullptr : log()->sinks().front().get();
@@ -133,6 +134,7 @@ logging::logger* log() {
   return &g_logger;
 }
 
+// Delete upon 2026-03-01 deprecation removal.
 logging::sink* logging::get_dist_sink() {
   // An empty sink instance.
   static logging::sink g_sink;

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -103,10 +103,6 @@ namespace logging {
 See the text_logging.h documentation for a short tutorial. */
 using logger = spdlog::logger;
 
-/** When spdlog is enabled in this build, drake::logging::sink is an alias for
-spdlog::sinks::sink.  When spdlog is disabled, it is an empty class. */
-using spdlog::sinks::sink;
-
 /** True only if spdlog is enabled in this build. */
 constexpr bool kHaveSpdlog = true;
 
@@ -140,14 +136,6 @@ class logger {
   void critical(const Args&...) {}
 };
 
-// A stubbed-out version of `spdlog::sinks::sink`.
-class sink {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(sink);
-
-  sink();
-};
-
 }  // namespace logging
 
 #define DRAKE_LOGGER_TRACE(...)
@@ -164,13 +152,6 @@ See the text_logging.h documentation for a short tutorial. */
 logging::logger* log();
 
 namespace logging {
-
-/** (Advanced) Retrieves the default sink for all Drake logs.  When spdlog is
-enabled, the return value can be cast to spdlog::sinks::dist_sink_mt and thus
-allows consumers of Drake to redirect Drake's text logs to locations other than
-the default of stderr.  When spdlog is disabled, the return value is an empty
-class. */
-sink* get_dist_sink();
 
 /** When constructed, logs a message (at "warn" severity); the destructor is
 guaranteed to be trivial.  This is useful for declaring an instance of this
@@ -225,3 +206,8 @@ extern const char* const kSetLogPatternHelpMessage;
 
 }  // namespace logging
 }  // namespace drake
+
+// Providing the `get_dist_sink()` API via "drake/common/text_logging.h" is
+// deprecated and will be removed from Drake on or after 2026-03-01. To access
+// the sink, instead `#include "drake/common/text_logging_spdlog.h"` directly.
+#include "drake/common/text_logging_spdlog.h"

--- a/common/text_logging_spdlog.h
+++ b/common/text_logging_spdlog.h
@@ -1,0 +1,46 @@
+#pragma once
+
+/** @file
+This file contains functions that are only available when spdlog is enabled in
+Drake's build flags. */
+
+#ifdef HAVE_SPDLOG
+#include <spdlog/spdlog.h>
+#endif  // HAVE_SPDLOG
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
+
+namespace drake {
+namespace logging {
+
+#ifdef HAVE_SPDLOG
+
+/** When spdlog is enabled in this build, drake::logging::sink is an alias for
+spdlog::sinks::sink. When spdlog is disabled, it is an empty class. */
+using spdlog::sinks::sink;
+
+/** (Advanced) Retrieves the default sink for all Drake logs. When spdlog is
+enabled, the return value can be cast to spdlog::sinks::dist_sink_mt and thus
+allows consumers of Drake to redirect Drake's text logs to locations other than
+the default of stderr. When spdlog is disabled, the return value is an empty
+class. */
+sink* get_dist_sink();
+
+#else  // HAVE_SPDLOG
+
+/* A stubbed-out version of `spdlog::sinks::sink`. */
+class sink {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(sink);
+  sink();
+};
+
+DRAKE_DEPRECATED("2026-03-01",
+                 "When spdlog is disabled, this header file may not be used.")
+sink* get_dist_sink();
+
+#endif  // HAVE_SPDLOG
+
+}  // namespace logging
+}  // namespace drake


### PR DESCRIPTION
Deprecate the use of its prior location and its use when spdlog is disabled.

Towards #23797; early getting out in front of one of the deprecations (maybe the only one?).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23815)
<!-- Reviewable:end -->
