### PR TITLE
[doc] Update macOS to CMake 4.2 and Xcode 26.1

### DIFF
--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -37,7 +37,7 @@ officially supports when building from source:
 |------------------------------------|--------------|------------|-------|-------|------------------------------|------------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 8.4   | 3.22  | GCC 11 (default) or Clang 15 | OpenJDK 11 |
 | Ubuntu 24.04 LTS (Noble Numbat)    | x86_64       | 3.12       | 8.4   | 3.28  | GCC 13 (default) or Clang 19 | OpenJDK 21 |
-| macOS Sequoia (15)                 | arm64        | 3.14       | 8.4   | 4.1   | Apple LLVM 17 (Xcode 26.0)   | OpenJDK 23 |
+| macOS Sequoia (15)                 | arm64        | 3.14       | 8.4   | 4.2   | Apple LLVM 17 (Xcode 26.1)   | OpenJDK 23 |
 | macOS Tahoe (26) ⁽⁴⁾               | arm64        | TBD        | TBD   | TBD   | TBD                          | TBD        |
 
 "Official support" means that we have Continuous Integration test coverage to

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -67,7 +67,7 @@ Drake's pre-compiled binaries:
 |------------------------------------|----------------------------|-------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | GCC 11                     | C++20 |
 | Ubuntu 24.04 LTS (Noble Numbat)    | GCC 13                     | C++23 |
-| macOS Sequoia (15)                 | Apple LLVM 17 (Xcode 26.0) | C++23 |
+| macOS Sequoia (15)                 | Apple LLVM 17 (Xcode 26.1) | C++23 |
 | macOS Tahoe (26)                   | TBD                        | TBD   |
 
 Any other configuration not listed here will lead to undefined behavior

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -10,7 +10,7 @@ if(CMAKE_VERSION VERSION_LESS 3.9.0)
   message(FATAL_ERROR "CMake >= 3.9 required")
 endif()
 cmake_policy(PUSH)
-cmake_policy(VERSION 3.9...4.1)
+cmake_policy(VERSION 3.9...4.2)
 set(CMAKE_IMPORT_FILE_VERSION 1)
 
 include(CMakeFindDependencyMacro)

--- a/tools/install/libdrake/test/drake_python_dir_install_test.py
+++ b/tools/install/libdrake/test/drake_python_dir_install_test.py
@@ -14,7 +14,7 @@ class DrakePythonDirInstallTest(unittest.TestCase):
         cmake_prefix_path = install_test_helper.get_install_dir()
 
         cmake_content = """
-            cmake_minimum_required(VERSION 3.9...4.1)
+            cmake_minimum_required(VERSION 3.9...4.2)
             project(drake_python_dir_install_test)
             set(CMAKE_PREFIX_PATH {cmake_prefix_path})
             find_package(drake CONFIG REQUIRED)

--- a/tools/install/libdrake/test/find_package_drake_install_test.py
+++ b/tools/install/libdrake/test/find_package_drake_install_test.py
@@ -26,7 +26,7 @@ class FindPackageDrakeInstallTest(unittest.TestCase):
         cmake_prefix_path = install_test_helper.get_install_dir()
 
         cmake_content = """
-            cmake_minimum_required(VERSION 3.9...4.1)
+            cmake_minimum_required(VERSION 3.9...4.2)
             project(find_package_drake_install_test)
             set(CMAKE_PREFIX_PATH {cmake_prefix_path})
             find_package(drake CONFIG REQUIRED)


### PR DESCRIPTION
CMake 4.2 was recently released and shipped by Homebrew. Xcode 26.1 was recently released.

Both will be used by Drake CI once the AWS images are updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23816)
<!-- Reviewable:end -->
