### PR TITLE
[math] Deprecate unused jacobian and hessian free functions

### DIFF
--- a/bindings/generated_docstrings/math.h
+++ b/bindings/generated_docstrings/math.h
@@ -4994,7 +4994,7 @@ Returns:
       // Symbol: drake::math::hessian
       struct /* hessian */ {
         // Source: drake/math/jacobian.h
-        const char* doc =
+        const char* doc_deprecated =
 R"""(Computes a matrix of AutoDiffScalars from which the value, Jacobian,
 and Hessian of a function
 
@@ -5020,7 +5020,12 @@ Parameter ``x``:
 
 Returns:
     AutoDiffScalar matrix corresponding to the Hessian of f evaluated
-    at x)""";
+    at x / (Deprecated.)
+
+Deprecated:
+    Removed with no replacement; copy the code into your project if
+    you still need it This will be removed from Drake on or after
+    2026-04-01.)""";
       } hessian;
       // Symbol: drake::math::intRange
       struct /* intRange */ {
@@ -5049,7 +5054,7 @@ Returns:
       // Symbol: drake::math::jacobian
       struct /* jacobian */ {
         // Source: drake/math/jacobian.h
-        const char* doc =
+        const char* doc_deprecated =
 R"""(Computes a matrix of AutoDiffScalars from which both the value and the
 Jacobian of a function
 
@@ -5098,7 +5103,12 @@ Parameter ``x``:
 
 Returns:
     AutoDiffScalar matrix corresponding to the Jacobian of f evaluated
-    at x.)""";
+    at x. / (Deprecated.)
+
+Deprecated:
+    Removed with no replacement; copy the code into your project if
+    you still need it This will be removed from Drake on or after
+    2026-04-01.)""";
       } jacobian;
       // Symbol: drake::math::matGradMult
       struct /* matGradMult */ {

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -453,6 +453,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "jacobian_test",
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":gradient",
         ":jacobian",

--- a/math/jacobian.h
+++ b/math/jacobian.h
@@ -6,6 +6,8 @@
 #include <Eigen/Dense>
 #include <unsupported/Eigen/AutoDiff>
 
+#include "drake/common/drake_deprecated.h"
+
 namespace drake {
 namespace math {
 
@@ -53,6 +55,9 @@ namespace math {
    at x.
  */
 template <int MaxChunkSize = 10, class F, class Arg>
+DRAKE_DEPRECATED("2026-04-01",
+                 "Removed with no replacement; copy the code into your project "
+                 "if you still need it")
 decltype(auto) jacobian(F&& f, Arg&& x) {
   using Eigen::AutoDiffScalar;
   using Eigen::Index;
@@ -159,6 +164,9 @@ decltype(auto) jacobian(F&& f, Arg&& x) {
  */
 template <int MaxChunkSizeOuter = 10, int MaxChunkSizeInner = 10, class F,
           class Arg>
+DRAKE_DEPRECATED("2026-04-01",
+                 "Removed with no replacement; copy the code into your project "
+                 "if you still need it")
 decltype(auto) hessian(F&& f, Arg&& x) {
   auto jac_fun = [&](const auto& x_inner) {
     return jacobian<MaxChunkSizeInner>(f, x_inner);


### PR DESCRIPTION
Towards #23820.  These functions rely on fixed-size autodiff, which Drake no longer aims to support. They are also entirely unused within Drake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23823)
<!-- Reviewable:end -->
