### PR TITLE
Remove unwanted autodiff_overloads.h includes

### DIFF
--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -5,7 +5,6 @@
 #include <unordered_map>
 
 #include "drake/common/autodiff.h"
-#include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"

--- a/multibody/meshcat/joint_sliders.cc
+++ b/multibody/meshcat/joint_sliders.cc
@@ -9,7 +9,6 @@
 
 #include <fmt/format.h>
 
-#include "drake/common/autodiff_overloads.h"
 #include "drake/common/overloaded.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/text_logging.h"


### PR DESCRIPTION
Its documentation says never to include it.

Towards #23820.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23824)
<!-- Reviewable:end -->
