### PR TITLE
[ad] Change nearest-integer functions to return double

### DIFF
--- a/common/ad/internal/standard_operations.cc
+++ b/common/ad/internal/standard_operations.cc
@@ -276,30 +276,6 @@ AutoDiff sqrt(AutoDiff x) {
   return x;
 }
 
-AutoDiff ceil(AutoDiff x) {
-  x.value() = std::ceil(x.value());
-  x.partials().SetZero();
-  return x;
-}
-
-AutoDiff floor(AutoDiff x) {
-  x.value() = std::floor(x.value());
-  x.partials().SetZero();
-  return x;
-}
-
-AutoDiff round(AutoDiff x) {
-  x.value() = std::round(x.value());
-  x.partials().SetZero();
-  return x;
-}
-
-AutoDiff nexttoward(AutoDiff from, long double to) {
-  from.value() = std::nexttoward(from.value(), to);
-  from.partials().SetZero();
-  return from;
-}
-
 std::ostream& operator<<(std::ostream& s, const AutoDiff& x) {
   return s << fmt::format("{}", x.value());
 }

--- a/common/ad/internal/standard_operations.h
+++ b/common/ad/internal/standard_operations.h
@@ -529,19 +529,27 @@ AutoDiff tanh(AutoDiff x);
 
 /** ADL overload to mimic std::ceil from `<cmath>`.
 The result's derivatives are always zero. */
-AutoDiff ceil(AutoDiff x);
+inline double ceil(const AutoDiff& x) {
+  return std::ceil(x.value());
+}
 
 /** ADL overload to mimic std::floor from `<cmath>`.
 The result's derivatives are always zero. */
-AutoDiff floor(AutoDiff x);
+inline double floor(const AutoDiff& x) {
+  return std::floor(x.value());
+}
 
 /** ADL overload to mimic std::round from `<cmath>`.
 The result's derivatives are always zero. */
-AutoDiff round(AutoDiff x);
+inline double round(const AutoDiff& x) {
+  return std::round(x.value());
+}
 
 /** ADL overload to mimic std::nexttoward from `<cmath>`.
 The result's derivatives are always zero. */
-AutoDiff nexttoward(AutoDiff from, long double to);
+inline double nexttoward(const AutoDiff& from, long double to) {
+  return std::nexttoward(from.value(), to);
+}
 
 /** ADL overload to mimic std::isfinite from `<cmath>`.
 Because the return type is `bool`, the derivatives are not preserved. */

--- a/common/ad/test/standard_operations_integer_test.cc
+++ b/common/ad/test/standard_operations_integer_test.cc
@@ -9,30 +9,26 @@ namespace {
 
 TEST_F(StandardOperationsTest, Ceil) {
   const AutoDiffDut x{0.5, 3, 0};
-  const AutoDiffDut y = ceil(x);
-  EXPECT_EQ(y.value(), std::ceil(x.value()));
-  EXPECT_EQ(y.derivatives(), Eigen::Vector3d::Zero());
+  const double y = ceil(x);
+  EXPECT_EQ(y, std::ceil(x.value()));
 }
 
 TEST_F(StandardOperationsTest, Floor) {
   const AutoDiffDut x{0.5, 3, 0};
-  const AutoDiffDut y = floor(x);
-  EXPECT_EQ(y.value(), std::floor(x.value()));
-  EXPECT_EQ(y.derivatives(), Eigen::Vector3d::Zero());
+  const double y = floor(x);
+  EXPECT_EQ(y, std::floor(x.value()));
 }
 
 TEST_F(StandardOperationsTest, Round) {
   const AutoDiffDut x{0.5, 3, 0};
-  const AutoDiffDut y = round(x);
-  EXPECT_EQ(y.value(), std::round(x.value()));
-  EXPECT_EQ(y.derivatives(), Eigen::Vector3d::Zero());
+  const double y = round(x);
+  EXPECT_EQ(y, std::round(x.value()));
 }
 
 TEST_F(StandardOperationsTest, NextToward) {
   const AutoDiffDut x{0.5, 3, 0};
-  const AutoDiffDut y = nexttoward(x, 1.0);
-  EXPECT_EQ(y.value(), std::nexttoward(x.value(), 1.0));
-  EXPECT_EQ(y.derivatives(), Eigen::Vector3d::Zero());
+  const double y = nexttoward(x, 1.0);
+  EXPECT_EQ(y, std::nexttoward(x.value(), 1.0));
 }
 
 TEST_F(StandardOperationsTest, Classify) {


### PR DESCRIPTION
Towards #23820.  The legacy `AutoDiffScalar` API returns raw `double`, so we should probably do the same.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23825)
<!-- Reviewable:end -->
