### PR TITLE
[yaml] Port performance test away from second-order autodiff

### DIFF
--- a/common/yaml/test/yaml_performance_test.cc
+++ b/common/yaml/test/yaml_performance_test.cc
@@ -6,13 +6,23 @@
 #include <Eigen/Core>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <unsupported/Eigen/AutoDiff>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/name_value.h"
 #include "drake/common/test_utilities/limit_malloc.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/common/yaml/yaml_read_archive.h"
+
+// Add ADL Serialize method to drake::AutoDiffXd. For ADL to work, we need to
+// place the function in the correct namespace.
+namespace Eigen {
+template <typename Archive>
+void Serialize(Archive* a, Eigen::AutoDiffScalar<Eigen::VectorXd>* x) {
+  a->Visit(drake::MakeNameValue("value", &(x->value())));
+  a->Visit(drake::MakeNameValue("derivatives", &(x->derivatives())));
+}
+}  // namespace Eigen
 
 namespace drake {
 namespace yaml {
@@ -106,58 +116,31 @@ GTEST_TEST(YamlPerformanceTest, VectorNesting) {
   }
 }
 
-}  // namespace
-}  // namespace yaml
-}  // namespace drake
-
-using ADS1 = Eigen::AutoDiffScalar<drake::VectorX<double>>;
-using ADS2 = Eigen::AutoDiffScalar<drake::VectorX<ADS1>>;
-
-// Add ADL Serialize method to Eigen::AutoDiffScalar.
-namespace Eigen {
-template <typename Archive>
-void Serialize(Archive* a, ADS2* x) {
-  a->Visit(drake::MakeNameValue("value", &(x->value())));
-  a->Visit(drake::MakeNameValue("derivatives", &(x->derivatives())));
-}
-template <typename Archive>
-void Serialize(Archive* a, ADS1* x) {
-  a->Visit(drake::MakeNameValue("value", &(x->value())));
-  a->Visit(drake::MakeNameValue("derivatives", &(x->derivatives())));
-}
-}  // namespace Eigen
-
-namespace drake {
-namespace yaml {
-namespace {
-
 struct BigEigen {
   template <typename Archive>
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(value));
   }
 
-  MatrixX<ADS2> value;
+  MatrixX<AutoDiffXd> value;
 };
 
 GTEST_TEST(YamlPerformanceTest, EigenMatrix) {
   // Populate a resonably-sized but non-trival set of data, about ~10,000
   // numbers stored at various levels of nesting.
   BigEigen data;
-  const int kDim = 10;
+  const int kDim = 21;
   data.value.resize(kDim, kDim);
   double dummy = 1.0;
   for (int i = 0; i < data.value.rows(); ++i) {
     for (int j = 0; j < data.value.cols(); ++j) {
-      ADS2& x = data.value(i, j);
+      AutoDiffXd& x = data.value(i, j);
       x.value() = dummy;
       dummy += 1.0;
       x.derivatives().resize(kDim);
       for (int k = 0; k < x.derivatives().size(); ++k) {
-        ADS1& y = x.derivatives()(k);
-        y.value() = dummy;
+        x.derivatives()[k] = dummy;
         dummy += 1.0;
-        y.derivatives() = Eigen::VectorXd::Zero(kDim);
       }
     }
   }
@@ -177,16 +160,16 @@ GTEST_TEST(YamlPerformanceTest, EigenMatrix) {
   // usage is sane.
   BigEigen new_data;
   {
-    // When the performance of parsing was fixed and this test was added, this
-    // Accept operation used about 12,000 allocations and took less than 1
-    // second of wall clock time (for both release and debug builds).
+    // As of this writing, the Accept operation uses about 140,000 allocations
+    // and takes less than 1 second of wall clock time (for both release and
+    // debug builds).
     //
     // The prior implementation with gratuitous copies used over 1.6 million
-    // allocations.
+    // allocations (under a somewhat different test case).
     //
-    // We'll set the hard limit ~20x higher than currently observed to allow
+    // We'll set the hard limit ~3x higher than currently observed to allow
     // some flux as library implementations evolve, etc.
-    test::LimitMalloc guard({.max_num_allocations = 250000});
+    test::LimitMalloc guard({.max_num_allocations = 500'000});
     const LoadYamlOptions default_options;
     YamlReadArchive archive(std::move(yaml_root), default_options);
     archive.Accept(&new_data);
@@ -197,12 +180,8 @@ GTEST_TEST(YamlPerformanceTest, EigenMatrix) {
   ASSERT_EQ(new_data.value.cols(), kDim);
   for (int i = 0; i < kDim; ++i) {
     for (int j = 0; j < kDim; ++j) {
-      ADS2& x = new_data.value(i, j);
+      AutoDiffXd& x = new_data.value(i, j);
       ASSERT_EQ(x.derivatives().size(), kDim);
-      for (int k = 0; k < kDim; ++k) {
-        ADS1& y = x.derivatives()(k);
-        ASSERT_EQ(y.derivatives().size(), kDim);
-      }
     }
   }
 }


### PR DESCRIPTION
Towards #23820. We don't want to use second-order AutoDiff anywhere in Drake anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23829)
<!-- Reviewable:end -->
