### PR TITLE
[math] Copy and adapt MatrixExponential.h from unsupported/Eigen

### DIFF
--- a/bindings/generated_docstrings/math.h
+++ b/bindings/generated_docstrings/math.h
@@ -36,6 +36,7 @@
 // #include "drake/math/jacobian.h"
 // #include "drake/math/knot_vector_type.h"
 // #include "drake/math/linear_solve.h"
+// #include "drake/math/matrix_exponential.h"
 // #include "drake/math/matrix_util.h"
 // #include "drake/math/normalize_vector.h"
 // #include "drake/math/quadratic_form.h"

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -142,6 +142,7 @@ drake_cc_library(
         "//common:name_value",
         "//common:polynomial",
         "//math:binomial_coefficient",
+        "//math:matrix_exponential",
         "//math:matrix_util",
         "@fmt",
     ],

--- a/common/trajectories/exponential_plus_piecewise_polynomial.cc
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.cc
@@ -4,7 +4,7 @@
 
 #include <memory>
 
-#include <unsupported/Eigen/MatrixFunctions>
+#include "drake/math/matrix_exponential.h"
 
 namespace drake {
 namespace trajectories {
@@ -62,7 +62,7 @@ MatrixX<T> ExponentialPlusPiecewisePolynomial<T>::do_value(const T& t) const {
   int segment_index = this->get_segment_index(t);
   MatrixX<T> ret = piecewise_polynomial_part_.value(t);
   double tj = this->start_time(segment_index);
-  auto exponential = (A_ * (t - tj)).eval().exp().eval();
+  auto exponential = internal::CalcMatrixExponential(A_ * (t - tj));
   ret.noalias() += K_ * exponential * alpha_.col(segment_index);
   return ret;
 }

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -29,6 +29,7 @@ drake_cc_package_library(
         ":gray_code",
         ":jacobian",
         ":linear_solve",
+        ":matrix_exponential",
         ":matrix_util",
         ":quadratic_form",
         ":soft_min_max",
@@ -238,6 +239,15 @@ drake_cc_library(
     deps = [
         ":autodiff",
         ":vector3_util",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "matrix_exponential",
+    srcs = ["matrix_exponential.cc"],
+    hdrs = ["matrix_exponential.h"],
+    deps = [
         "//common:essential",
     ],
 )

--- a/math/matrix_exponential.cc
+++ b/math/matrix_exponential.cc
@@ -1,441 +1,157 @@
-// This file is part of Eigen, a lightweight C++ template library
-// for linear algebra.
+#include "drake/math/matrix_exponential.h"
+
+// This file was copied and modified from the Eigen library.
 //
 // Copyright (C) 2009, 2010, 2013 Jitse Niesen <jitse@maths.leeds.ac.uk>
 // Copyright (C) 2011, 2013 Chen-Pang He <jdh8@ms63.hinet.net>
+// Copyright (C) 2025 Drake Authors
 //
 // This Source Code Form is subject to the terms of the Mozilla
 // Public License v. 2.0. If a copy of the MPL was not distributed
 // with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#ifndef EIGEN_MATRIX_EXPONENTIAL
-#define EIGEN_MATRIX_EXPONENTIAL
+#include <Eigen/LU>
 
-#include "StemFunction.h"
+#include "drake/common/drake_assert.h"
 
-namespace Eigen {
+namespace drake {
 namespace internal {
+namespace {
 
-/** \brief Scaling operator.
- *
- * This struct is used by CwiseUnaryOp to scale a matrix by \f$ 2^{-s} \f$.
- */
-template <typename RealScalar>
-struct MatrixExponentialScalingOp
-{
-  /** \brief Constructor.
-   *
-   * \param[in] squarings  The integer \f$ s \f$ in this document.
-   */
-  MatrixExponentialScalingOp(int squarings) : m_squarings(squarings) { }
+using Eigen::MatrixXd;
 
-
-  /** \brief Scale a matrix coefficient.
-   *
-   * \param[in,out] x  The scalar to be scaled, becoming \f$ 2^{-s} x \f$.
-   */
-  inline const RealScalar operator() (const RealScalar& x) const
-  {
-    using std::ldexp;
-    return ldexp(x, -m_squarings);
-  }
-
-  typedef std::complex<RealScalar> ComplexScalar;
-
-  /** \brief Scale a matrix coefficient.
-   *
-   * \param[in,out] x  The scalar to be scaled, becoming \f$ 2^{-s} x \f$.
-   */
-  inline const ComplexScalar operator() (const ComplexScalar& x) const
-  {
-    using std::ldexp;
-    return ComplexScalar(ldexp(x.real(), -m_squarings), ldexp(x.imag(), -m_squarings));
-  }
-
-  private:
-    int m_squarings;
-};
-
-/** \brief Compute the (3,3)-Pad&eacute; approximant to the exponential.
- *
- *  After exit, \f$ (V+U)(V-U)^{-1} \f$ is the Pad&eacute;
- *  approximant of \f$ \exp(A) \f$ around \f$ A = 0 \f$.
- */
-template <typename MatA, typename MatU, typename MatV>
-void matrix_exp_pade3(const MatA& A, MatU& U, MatV& V)
-{
-  typedef typename MatA::PlainObject MatrixType;
-  typedef typename NumTraits<typename traits<MatA>::Scalar>::Real RealScalar;
-  const RealScalar b[] = {120.L, 60.L, 12.L, 1.L};
-  const MatrixType A2 = A * A;
-  const MatrixType tmp = b[3] * A2 + b[1] * MatrixType::Identity(A.rows(), A.cols());
-  U.noalias() = A * tmp;
-  V = b[2] * A2 + b[0] * MatrixType::Identity(A.rows(), A.cols());
+/* Computes the (3,3)-Padé approximant to the exponential.
+After exit, (V+U)(V-U)⁻¹ is the Padé approximant of eᴬ around A = 0. */
+void CalcMatrixExpPade3(const MatrixXd& A, MatrixXd* U, MatrixXd* V) {
+  const double b[] = {120.0, 60.0, 12.0, 1.0};
+  const MatrixXd A2 = A * A;
+  const MatrixXd tmp =
+      b[3] * A2 + b[1] * MatrixXd::Identity(A.rows(), A.cols());
+  U->noalias() = A * tmp;
+  *V = b[2] * A2 + b[0] * MatrixXd::Identity(A.rows(), A.cols());
 }
 
-/** \brief Compute the (5,5)-Pad&eacute; approximant to the exponential.
- *
- *  After exit, \f$ (V+U)(V-U)^{-1} \f$ is the Pad&eacute;
- *  approximant of \f$ \exp(A) \f$ around \f$ A = 0 \f$.
- */
-template <typename MatA, typename MatU, typename MatV>
-void matrix_exp_pade5(const MatA& A, MatU& U, MatV& V)
-{
-  typedef typename MatA::PlainObject MatrixType;
-  typedef typename NumTraits<typename traits<MatrixType>::Scalar>::Real RealScalar;
-  const RealScalar b[] = {30240.L, 15120.L, 3360.L, 420.L, 30.L, 1.L};
-  const MatrixType A2 = A * A;
-  const MatrixType A4 = A2 * A2;
-  const MatrixType tmp = b[5] * A4 + b[3] * A2 + b[1] * MatrixType::Identity(A.rows(), A.cols());
-  U.noalias() = A * tmp;
-  V = b[4] * A4 + b[2] * A2 + b[0] * MatrixType::Identity(A.rows(), A.cols());
+/* Computes the (5,5)-Padé approximant to the exponential.
+After exit, (V+U)(V-U)⁻¹ is the Padé approximant of eᴬ around A = 0. */
+void CalcMatrixExpPade5(const MatrixXd& A, MatrixXd* U, MatrixXd* V) {
+  const double b[] = {30240.0, 15120.0, 3360.0, 420.0, 30.0, 1.0};
+  const MatrixXd A2 = A * A;
+  const MatrixXd A4 = A2 * A2;
+  const MatrixXd tmp =
+      b[5] * A4 + b[3] * A2 + b[1] * MatrixXd::Identity(A.rows(), A.cols());
+  U->noalias() = A * tmp;
+  *V = b[4] * A4 + b[2] * A2 + b[0] * MatrixXd::Identity(A.rows(), A.cols());
 }
 
-/** \brief Compute the (7,7)-Pad&eacute; approximant to the exponential.
- *
- *  After exit, \f$ (V+U)(V-U)^{-1} \f$ is the Pad&eacute;
- *  approximant of \f$ \exp(A) \f$ around \f$ A = 0 \f$.
- */
-template <typename MatA, typename MatU, typename MatV>
-void matrix_exp_pade7(const MatA& A, MatU& U, MatV& V)
-{
-  typedef typename MatA::PlainObject MatrixType;
-  typedef typename NumTraits<typename traits<MatrixType>::Scalar>::Real RealScalar;
-  const RealScalar b[] = {17297280.L, 8648640.L, 1995840.L, 277200.L, 25200.L, 1512.L, 56.L, 1.L};
-  const MatrixType A2 = A * A;
-  const MatrixType A4 = A2 * A2;
-  const MatrixType A6 = A4 * A2;
-  const MatrixType tmp = b[7] * A6 + b[5] * A4 + b[3] * A2 
-    + b[1] * MatrixType::Identity(A.rows(), A.cols());
-  U.noalias() = A * tmp;
-  V = b[6] * A6 + b[4] * A4 + b[2] * A2 + b[0] * MatrixType::Identity(A.rows(), A.cols());
-
+/* Computes the (7,7)-Padé approximant to the exponential.
+After exit, (V+U)(V-U)⁻¹ is the Padé approximant of eᴬ around A = 0. */
+void CalcMatrixExpPade7(const MatrixXd& A, MatrixXd* U, MatrixXd* V) {
+  const double b[] = {17297280.0, 8648640.0, 1995840.0, 277200.0,
+                      25200.0,    1512.0,    56.0,      1.0};
+  const MatrixXd A2 = A * A;
+  const MatrixXd A4 = A2 * A2;
+  const MatrixXd A6 = A4 * A2;
+  const MatrixXd tmp = b[7] * A6 + b[5] * A4 + b[3] * A2 +
+                       b[1] * MatrixXd::Identity(A.rows(), A.cols());
+  U->noalias() = A * tmp;
+  *V = b[6] * A6 + b[4] * A4 + b[2] * A2 +
+       b[0] * MatrixXd::Identity(A.rows(), A.cols());
 }
 
-/** \brief Compute the (9,9)-Pad&eacute; approximant to the exponential.
- *
- *  After exit, \f$ (V+U)(V-U)^{-1} \f$ is the Pad&eacute;
- *  approximant of \f$ \exp(A) \f$ around \f$ A = 0 \f$.
- */
-template <typename MatA, typename MatU, typename MatV>
-void matrix_exp_pade9(const MatA& A, MatU& U, MatV& V)
-{
-  typedef typename MatA::PlainObject MatrixType;
-  typedef typename NumTraits<typename traits<MatrixType>::Scalar>::Real RealScalar;
-  const RealScalar b[] = {17643225600.L, 8821612800.L, 2075673600.L, 302702400.L, 30270240.L,
-                          2162160.L, 110880.L, 3960.L, 90.L, 1.L};
-  const MatrixType A2 = A * A;
-  const MatrixType A4 = A2 * A2;
-  const MatrixType A6 = A4 * A2;
-  const MatrixType A8 = A6 * A2;
-  const MatrixType tmp = b[9] * A8 + b[7] * A6 + b[5] * A4 + b[3] * A2 
-    + b[1] * MatrixType::Identity(A.rows(), A.cols());
-  U.noalias() = A * tmp;
-  V = b[8] * A8 + b[6] * A6 + b[4] * A4 + b[2] * A2 + b[0] * MatrixType::Identity(A.rows(), A.cols());
+/* Computes the (9,9)-Padé approximant to the exponential.
+After exit, (V+U)(V-U)⁻¹ is the Padé approximant of eᴬ around A = 0. */
+void CalcMatrixExpPade9(const MatrixXd& A, MatrixXd* U, MatrixXd* V) {
+  const double b[] = {17643225600.0, 8821612800.0, 2075673600.0, 302702400.0,
+                      30270240.0,    2162160.0,    110880.0,     3960.0,
+                      90.0,          1.0};
+  const MatrixXd A2 = A * A;
+  const MatrixXd A4 = A2 * A2;
+  const MatrixXd A6 = A4 * A2;
+  const MatrixXd A8 = A6 * A2;
+  const MatrixXd tmp = b[9] * A8 + b[7] * A6 + b[5] * A4 + b[3] * A2 +
+                       b[1] * MatrixXd::Identity(A.rows(), A.cols());
+  U->noalias() = A * tmp;
+  *V = b[8] * A8 + b[6] * A6 + b[4] * A4 + b[2] * A2 +
+       b[0] * MatrixXd::Identity(A.rows(), A.cols());
 }
 
-/** \brief Compute the (13,13)-Pad&eacute; approximant to the exponential.
- *
- *  After exit, \f$ (V+U)(V-U)^{-1} \f$ is the Pad&eacute;
- *  approximant of \f$ \exp(A) \f$ around \f$ A = 0 \f$.
- */
-template <typename MatA, typename MatU, typename MatV>
-void matrix_exp_pade13(const MatA& A, MatU& U, MatV& V)
-{
-  typedef typename MatA::PlainObject MatrixType;
-  typedef typename NumTraits<typename traits<MatrixType>::Scalar>::Real RealScalar;
-  const RealScalar b[] = {64764752532480000.L, 32382376266240000.L, 7771770303897600.L,
-                          1187353796428800.L, 129060195264000.L, 10559470521600.L, 670442572800.L,
-                          33522128640.L, 1323241920.L, 40840800.L, 960960.L, 16380.L, 182.L, 1.L};
-  const MatrixType A2 = A * A;
-  const MatrixType A4 = A2 * A2;
-  const MatrixType A6 = A4 * A2;
-  V = b[13] * A6 + b[11] * A4 + b[9] * A2; // used for temporary storage
-  MatrixType tmp = A6 * V;
-  tmp += b[7] * A6 + b[5] * A4 + b[3] * A2 + b[1] * MatrixType::Identity(A.rows(), A.cols());
-  U.noalias() = A * tmp;
+/* Computes the (13,13)-Padé approximant to the exponential.
+After exit, (V+U)(V-U)⁻¹ is the Padé approximant of eᴬ around A = 0. */
+void CalcMatrixExpPade13(const MatrixXd& A, MatrixXd* U, MatrixXd* V) {
+  const double b[] = {64764752532480000.0,
+                      32382376266240000.0,
+                      7771770303897600.0,
+                      1187353796428800.0,
+                      129060195264000.0,
+                      10559470521600.0,
+                      670442572800.0,
+                      33522128640.0,
+                      1323241920.0,
+                      40840800.0,
+                      960960.0,
+                      16380.0,
+                      182.0,
+                      1.0};
+  const MatrixXd A2 = A * A;
+  const MatrixXd A4 = A2 * A2;
+  const MatrixXd A6 = A4 * A2;
+  *V = b[13] * A6 + b[11] * A4 + b[9] * A2;  // used for temporary storage
+  MatrixXd tmp = A6 * *V;
+  tmp += b[7] * A6 + b[5] * A4 + b[3] * A2 +
+         b[1] * MatrixXd::Identity(A.rows(), A.cols());
+  U->noalias() = A * tmp;
   tmp = b[12] * A6 + b[10] * A4 + b[8] * A2;
-  V.noalias() = A6 * tmp;
-  V += b[6] * A6 + b[4] * A4 + b[2] * A2 + b[0] * MatrixType::Identity(A.rows(), A.cols());
+  V->noalias() = A6 * tmp;
+  *V += b[6] * A6 + b[4] * A4 + b[2] * A2 +
+        b[0] * MatrixXd::Identity(A.rows(), A.cols());
 }
 
-/** \brief Compute the (17,17)-Pad&eacute; approximant to the exponential.
- *
- *  After exit, \f$ (V+U)(V-U)^{-1} \f$ is the Pad&eacute;
- *  approximant of \f$ \exp(A) \f$ around \f$ A = 0 \f$.
- *
- *  This function activates only if your long double is double-double or quadruple.
- */
-#if LDBL_MANT_DIG > 64
-template <typename MatA, typename MatU, typename MatV>
-void matrix_exp_pade17(const MatA& A, MatU& U, MatV& V)
-{
-  typedef typename MatA::PlainObject MatrixType;
-  typedef typename NumTraits<typename traits<MatrixType>::Scalar>::Real RealScalar;
-  const RealScalar b[] = {830034394580628357120000.L, 415017197290314178560000.L,
-                          100610229646136770560000.L, 15720348382208870400000.L,
-                          1774878043152614400000.L, 153822763739893248000.L, 10608466464820224000.L,
-                          595373117923584000.L, 27563570274240000.L, 1060137318240000.L,
-                          33924394183680.L, 899510451840.L, 19554575040.L, 341863200.L, 4651200.L,
-                          46512.L, 306.L, 1.L};
-  const MatrixType A2 = A * A;
-  const MatrixType A4 = A2 * A2;
-  const MatrixType A6 = A4 * A2;
-  const MatrixType A8 = A4 * A4;
-  V = b[17] * A8 + b[15] * A6 + b[13] * A4 + b[11] * A2; // used for temporary storage
-  MatrixType tmp = A8 * V;
-  tmp += b[9] * A8 + b[7] * A6 + b[5] * A4 + b[3] * A2 
-    + b[1] * MatrixType::Identity(A.rows(), A.cols());
-  U.noalias() = A * tmp;
-  tmp = b[16] * A8 + b[14] * A6 + b[12] * A4 + b[10] * A2;
-  V.noalias() = tmp * A8;
-  V += b[8] * A8 + b[6] * A6 + b[4] * A4 + b[2] * A2 
-    + b[0] * MatrixType::Identity(A.rows(), A.cols());
-}
-#endif
-
-template <typename MatrixType, typename RealScalar = typename NumTraits<typename traits<MatrixType>::Scalar>::Real>
-struct matrix_exp_computeUV
-{
-  /** \brief Compute Pad&eacute; approximant to the exponential.
-    *
-    * Computes \c U, \c V and \c squarings such that \f$ (V+U)(V-U)^{-1} \f$ is a Pad&eacute;
-    * approximant of \f$ \exp(2^{-\mbox{squarings}}M) \f$ around \f$ M = 0 \f$, where \f$ M \f$
-    * denotes the matrix \c arg. The degree of the Pad&eacute; approximant and the value of squarings
-    * are chosen such that the approximation error is no more than the round-off error.
-    */
-  static void run(const MatrixType& arg, MatrixType& U, MatrixType& V, int& squarings);
-};
-
-template <typename MatrixType>
-struct matrix_exp_computeUV<MatrixType, float>
-{
-  template <typename ArgType>
-  static void run(const ArgType& arg, MatrixType& U, MatrixType& V, int& squarings)
-  {
-    using std::frexp;
-    using std::pow;
-    const float l1norm = arg.cwiseAbs().colwise().sum().maxCoeff();
-    squarings = 0;
-    if (l1norm < 4.258730016922831e-001f) {
-      matrix_exp_pade3(arg, U, V);
-    } else if (l1norm < 1.880152677804762e+000f) {
-      matrix_exp_pade5(arg, U, V);
-    } else {
-      const float maxnorm = 3.925724783138660f;
-      frexp(l1norm / maxnorm, &squarings);
-      if (squarings < 0) squarings = 0;
-      MatrixType A = arg.unaryExpr(MatrixExponentialScalingOp<float>(squarings));
-      matrix_exp_pade7(A, U, V);
+/* Computes Padé approximant to the exponential. Computes `U`, `V`, and
+`squarings` such that (V+U)(V-U)⁻¹ is a Padé approximant of `e^(2⁻ˢ𐞥ᵘᵃʳⁱⁿᵍˢM)`
+around M = 0. The degree of the Padé approximant and the value of squarings are
+chosen such that the approximation error is no more than the round-off error.
+@returns `squarings` */
+int ComputePadeApproximant(const MatrixXd& M, MatrixXd* U, MatrixXd* V) {
+  const double l1norm = M.cwiseAbs().colwise().sum().maxCoeff();
+  int squarings = 0;
+  if (l1norm < 1.495585217958292e-002) {
+    CalcMatrixExpPade3(M, U, V);
+  } else if (l1norm < 2.539398330063230e-001) {
+    CalcMatrixExpPade5(M, U, V);
+  } else if (l1norm < 9.504178996162932e-001) {
+    CalcMatrixExpPade7(M, U, V);
+  } else if (l1norm < 2.097847961257068e+000) {
+    CalcMatrixExpPade9(M, U, V);
+  } else {
+    const double maxnorm = 5.371920351148152;
+    std::frexp(l1norm / maxnorm, &squarings);
+    if (squarings < 0) {
+      squarings = 0;
     }
+    const MatrixXd A = M.unaryExpr([squarings](double x) {
+      return std::ldexp(x, -squarings);
+    });
+    CalcMatrixExpPade13(A, U, V);
   }
-};
+  return squarings;
+}
 
-template <typename MatrixType>
-struct matrix_exp_computeUV<MatrixType, double>
-{
-  typedef typename NumTraits<typename traits<MatrixType>::Scalar>::Real RealScalar;
-  template <typename ArgType>
-  static void run(const ArgType& arg, MatrixType& U, MatrixType& V, int& squarings)
-  {
-    using std::frexp;
-    using std::pow;
-    const RealScalar l1norm = arg.cwiseAbs().colwise().sum().maxCoeff();
-    squarings = 0;
-    if (l1norm < 1.495585217958292e-002) {
-      matrix_exp_pade3(arg, U, V);
-    } else if (l1norm < 2.539398330063230e-001) {
-      matrix_exp_pade5(arg, U, V);
-    } else if (l1norm < 9.504178996162932e-001) {
-      matrix_exp_pade7(arg, U, V);
-    } else if (l1norm < 2.097847961257068e+000) {
-      matrix_exp_pade9(arg, U, V);
-    } else {
-      const RealScalar maxnorm = 5.371920351148152;
-      frexp(l1norm / maxnorm, &squarings);
-      if (squarings < 0) squarings = 0;
-      MatrixType A = arg.unaryExpr(MatrixExponentialScalingOp<RealScalar>(squarings));
-      matrix_exp_pade13(A, U, V);
-    }
+}  // namespace
+
+MatrixXd CalcMatrixExponential(const MatrixXd& M) {
+  DRAKE_THROW_UNLESS(M.rows() == M.cols());
+  // Pade approximant is (U+V) / (-U+V).
+  MatrixXd U, V;
+  const int squarings = ComputePadeApproximant(M, &U, &V);
+  const MatrixXd numer = U + V;
+  const MatrixXd denom = -U + V;
+  MatrixXd result = denom.partialPivLu().solve(numer);
+  // Undo scaling by repeated squaring.
+  for (int i = 0; i < squarings; ++i) {
+    result *= result;
   }
-};
-  
-template <typename MatrixType>
-struct matrix_exp_computeUV<MatrixType, long double>
-{
-  template <typename ArgType>
-  static void run(const ArgType& arg, MatrixType& U, MatrixType& V, int& squarings)
-  {
-#if   LDBL_MANT_DIG == 53   // double precision
-    matrix_exp_computeUV<MatrixType, double>::run(arg, U, V, squarings);
-  
-#else
-  
-    using std::frexp;
-    using std::pow;
-    const long double l1norm = arg.cwiseAbs().colwise().sum().maxCoeff();
-    squarings = 0;
-  
-#if LDBL_MANT_DIG <= 64   // extended precision
-  
-    if (l1norm < 4.1968497232266989671e-003L) {
-      matrix_exp_pade3(arg, U, V);
-    } else if (l1norm < 1.1848116734693823091e-001L) {
-      matrix_exp_pade5(arg, U, V);
-    } else if (l1norm < 5.5170388480686700274e-001L) {
-      matrix_exp_pade7(arg, U, V);
-    } else if (l1norm < 1.3759868875587845383e+000L) {
-      matrix_exp_pade9(arg, U, V);
-    } else {
-      const long double maxnorm = 4.0246098906697353063L;
-      frexp(l1norm / maxnorm, &squarings);
-      if (squarings < 0) squarings = 0;
-      MatrixType A = arg.unaryExpr(MatrixExponentialScalingOp<long double>(squarings));
-      matrix_exp_pade13(A, U, V);
-    }
-  
-#elif LDBL_MANT_DIG <= 106  // double-double
-  
-    if (l1norm < 3.2787892205607026992947488108213e-005L) {
-      matrix_exp_pade3(arg, U, V);
-    } else if (l1norm < 6.4467025060072760084130906076332e-003L) {
-      matrix_exp_pade5(arg, U, V);
-    } else if (l1norm < 6.8988028496595374751374122881143e-002L) {
-      matrix_exp_pade7(arg, U, V);
-    } else if (l1norm < 2.7339737518502231741495857201670e-001L) {
-      matrix_exp_pade9(arg, U, V);
-    } else if (l1norm < 1.3203382096514474905666448850278e+000L) {
-      matrix_exp_pade13(arg, U, V);
-    } else {
-      const long double maxnorm = 3.2579440895405400856599663723517L;
-      frexp(l1norm / maxnorm, &squarings);
-      if (squarings < 0) squarings = 0;
-      MatrixType A = arg.unaryExpr(MatrixExponentialScalingOp<long double>(squarings));
-      matrix_exp_pade17(A, U, V);
-    }
-  
-#elif LDBL_MANT_DIG <= 113  // quadruple precision
-  
-    if (l1norm < 1.639394610288918690547467954466970e-005L) {
-      matrix_exp_pade3(arg, U, V);
-    } else if (l1norm < 4.253237712165275566025884344433009e-003L) {
-      matrix_exp_pade5(arg, U, V);
-    } else if (l1norm < 5.125804063165764409885122032933142e-002L) {
-      matrix_exp_pade7(arg, U, V);
-    } else if (l1norm < 2.170000765161155195453205651889853e-001L) {
-      matrix_exp_pade9(arg, U, V);
-    } else if (l1norm < 1.125358383453143065081397882891878e+000L) {
-      matrix_exp_pade13(arg, U, V);
-    } else {
-      const long double maxnorm = 2.884233277829519311757165057717815L;
-      frexp(l1norm / maxnorm, &squarings);
-      if (squarings < 0) squarings = 0;
-      MatrixType A = arg.unaryExpr(MatrixExponentialScalingOp<long double>(squarings));
-      matrix_exp_pade17(A, U, V);
-    }
-  
-#else
-  
-    // this case should be handled in compute()
-    eigen_assert(false && "Bug in MatrixExponential"); 
-  
-#endif
-#endif  // LDBL_MANT_DIG
-  }
-};
-
-template<typename T> struct is_exp_known_type : false_type {};
-template<> struct is_exp_known_type<float> : true_type {};
-template<> struct is_exp_known_type<double> : true_type {};
-#if LDBL_MANT_DIG <= 113
-template<> struct is_exp_known_type<long double> : true_type {};
-#endif
-
-template <typename ArgType, typename ResultType>
-void matrix_exp_compute(const ArgType& arg, ResultType &result, true_type) // natively supported scalar type
-{
-  typedef typename ArgType::PlainObject MatrixType;
-  MatrixType U, V;
-  int squarings;
-  matrix_exp_computeUV<MatrixType>::run(arg, U, V, squarings); // Pade approximant is (U+V) / (-U+V)
-  MatrixType numer = U + V;
-  MatrixType denom = -U + V;
-  result = denom.partialPivLu().solve(numer);
-  for (int i=0; i<squarings; i++)
-    result *= result;   // undo scaling by repeated squaring
+  return result;
 }
 
-
-/* Computes the matrix exponential
- *
- * \param arg    argument of matrix exponential (should be plain object)
- * \param result variable in which result will be stored
- */
-template <typename ArgType, typename ResultType>
-void matrix_exp_compute(const ArgType& arg, ResultType &result, false_type) // default
-{
-  typedef typename ArgType::PlainObject MatrixType;
-  typedef typename traits<MatrixType>::Scalar Scalar;
-  typedef typename NumTraits<Scalar>::Real RealScalar;
-  typedef typename std::complex<RealScalar> ComplexScalar;
-  result = arg.matrixFunction(internal::stem_function_exp<ComplexScalar>);
-}
-
-} // end namespace Eigen::internal
-
-/** \ingroup MatrixFunctions_Module
-  *
-  * \brief Proxy for the matrix exponential of some matrix (expression).
-  *
-  * \tparam Derived  Type of the argument to the matrix exponential.
-  *
-  * This class holds the argument to the matrix exponential until it is assigned or evaluated for
-  * some other reason (so the argument should not be changed in the meantime). It is the return type
-  * of MatrixBase::exp() and most of the time this is the only way it is used.
-  */
-template<typename Derived> struct MatrixExponentialReturnValue
-: public ReturnByValue<MatrixExponentialReturnValue<Derived> >
-{
-  public:
-    /** \brief Constructor.
-      *
-      * \param src %Matrix (expression) forming the argument of the matrix exponential.
-      */
-    MatrixExponentialReturnValue(const Derived& src) : m_src(src) { }
-
-    /** \brief Compute the matrix exponential.
-      *
-      * \param result the matrix exponential of \p src in the constructor.
-      */
-    template <typename ResultType>
-    inline void evalTo(ResultType& result) const
-    {
-      const typename internal::nested_eval<Derived, 10>::type tmp(m_src);
-      internal::matrix_exp_compute(tmp, result, internal::is_exp_known_type<typename Derived::RealScalar>());
-    }
-
-    Index rows() const { return m_src.rows(); }
-    Index cols() const { return m_src.cols(); }
-
-  protected:
-    const typename internal::ref_selector<Derived>::type m_src;
-};
-
-namespace internal {
-template<typename Derived>
-struct traits<MatrixExponentialReturnValue<Derived> >
-{
-  typedef typename Derived::PlainObject ReturnType;
-};
-}
-
-template <typename Derived>
-const MatrixExponentialReturnValue<Derived> MatrixBase<Derived>::exp() const
-{
-  eigen_assert(rows() == cols());
-  return MatrixExponentialReturnValue<Derived>(derived());
-}
-
-} // end namespace Eigen
-
-#endif // EIGEN_MATRIX_EXPONENTIAL
+}  // namespace internal
+}  // namespace drake

--- a/math/matrix_exponential.h
+++ b/math/matrix_exponential.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Eigen/Core>
+
+namespace drake {
+namespace internal {
+
+/* Computes the matrix exponential eᴹ. The matrix exponential of M is
+defined by `∑ₖ₌₀᪲ (Mᵏ / k!)` and can be used to solve linear ordinary
+differential equations: the solution of `y' = My` with the initial
+condition `y(0) = y_0` is given by `y(t) = eᴹ y_0`. */
+Eigen::MatrixXd CalcMatrixExponential(const Eigen::MatrixXd& M);
+
+}  // namespace internal
+}  // namespace drake

--- a/planning/locomotion/BUILD.bazel
+++ b/planning/locomotion/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common/trajectories:piecewise_polynomial",
+        "//math:matrix_exponential",
         "//systems/controllers:linear_quadratic_regulator",
     ],
 )

--- a/planning/locomotion/zmp_planner.cc
+++ b/planning/locomotion/zmp_planner.cc
@@ -2,9 +2,8 @@
 
 #include <vector>
 
-#include <unsupported/Eigen/MatrixFunctions>
-
 #include "drake/common/text_logging.h"
+#include "drake/math/matrix_exponential.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
 
 namespace drake {
@@ -149,8 +148,7 @@ void ZmpPlanner::Plan(const PiecewisePolynomial<double>& zmp_d,
     }
 
     double dt = zmp_d.duration(t);
-    Eigen::Matrix4d A2exp = A2 * dt;
-    A2exp = A2exp.exp();
+    const Eigen::Matrix4d A2exp = internal::CalcMatrixExponential(A2 * dt);
     for (int i = 0; i < zmp_d_degree + 1; i++)
       delta_time_vec[i] = std::pow(dt, i);
     tmp4 = tmp4 - beta[t] * delta_time_vec;
@@ -222,7 +220,7 @@ void ZmpPlanner::Plan(const PiecewisePolynomial<double>& zmp_d,
     a.block<4, 1>(0, t) = x - b[t].col(0);
 
     Az_exp = Az * dt;
-    Az_exp = Az_exp.exp();
+    Az_exp = internal::CalcMatrixExponential(Az_exp);
     for (int i = 0; i < zmp_d_degree + 1; i++)
       delta_time_vec[i] = std::pow(dt, i);
     x = I48 * Az_exp * a.col(t) + b[t] * delta_time_vec;

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -129,6 +129,7 @@ drake_cc_library(
     deps = [
         ":simulator_config_functions",
         "//common:nice_type_name",
+        "//math:matrix_exponential",
         "//systems/framework",
         "//systems/primitives:affine_system",
         "//systems/primitives:linear_system",

--- a/systems/analysis/discrete_time_approximation.cc
+++ b/systems/analysis/discrete_time_approximation.cc
@@ -10,9 +10,9 @@
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
-#include <unsupported/Eigen/MatrixFunctions>
 
 #include "drake/common/nice_type_name.h"
+#include "drake/math/matrix_exponential.h"
 #include "drake/systems/analysis/simulator_config_functions.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -340,7 +340,7 @@ std::unique_ptr<LinearSystem<T>> DiscreteTimeApproximation(
   Eigen::MatrixXd M(ns + ni, ns + ni);
   M << system.A(), system.B(), Eigen::MatrixXd::Zero(ni, ns + ni);
 
-  Eigen::MatrixXd Md = (M * time_period).exp();
+  Eigen::MatrixXd Md = drake::internal::CalcMatrixExponential(M * time_period);
 
   auto Ad = Md.block(0, 0, ns, ns);
   auto Bd = Md.block(0, ns, ns, ni);
@@ -365,7 +365,7 @@ std::unique_ptr<AffineSystem<T>> DiscreteTimeApproximation(
   M << system.A(), system.B(), system.f0(),
       Eigen::MatrixXd::Zero(ni + 1, ns + ni + 1);
 
-  Eigen::MatrixXd Md = (M * time_period).exp();
+  Eigen::MatrixXd Md = drake::internal::CalcMatrixExponential(M * time_period);
 
   auto Ad = Md.block(0, 0, ns, ns);
   auto Bd = Md.block(0, ns, ns, ni);


### PR DESCRIPTION
Towards #23820 -- we don't want to use any unsupported code from Eigen anymore.

The thesis here is to fork the code into our tree, simplify it, add tests, and then maintain it ourselves on an ongoing basis.  The math hasn't changed upstream for the past decade; the only upstream changes are fixing template naming problems once every year or two.

Most acutely, once we've done this, we could change our build system so that `#include <unsupported/Eigen/...>` is a compile error by default, so that additional uses of unsupported code don't sneak in.

Note that Reviewable r1 is the original file from Eigen, and r2+ are the Drake-specific edits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23831)
<!-- Reviewable:end -->
