### PR TITLE
Remove spurious warning regarding illustration roles

### DIFF
--- a/bindings/generated_docstrings/geometry.h
+++ b/bindings/generated_docstrings/geometry.h
@@ -7008,15 +7008,7 @@ Warning:
     "initialize" itself after changes to properties that will affect
     how a geometry appears. If changing a geometry's illustration
     properties doesn't seem to be affecting the visualization,
-    retrigger its initialization action.
-
-Warning:
-    Due to a bug (see issue `#13597
-    <https://github.com/RobotLocomotion/drake/issues/13597>`_),
-    changing the illustration roles or properties in a
-    systems::Context will not have any apparent effect in certain
-    viewers. Please change the illustration role in the model prior to
-    allocating the context.)""";
+    retrigger its initialization action.)""";
         } AssignRole;
         // Symbol: drake::geometry::SceneGraph::ChangeShape
         struct /* ChangeShape */ {

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -544,13 +544,6 @@ void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
                                GeometryId geometry_id,
                                IllustrationProperties properties,
                                RoleAssign assign) const {
-  // TODO(#20962) We have deleted drake_visualizer. This warning is probably no
-  // longer accurate.
-  static const logging::Warn one_time(
-      "Due to a bug (see issue #13597), changing the illustration roles or "
-      "properties in the context will not have any apparent effect in "
-      "some viewer applications. Please change the illustration role in the "
-      "model prior to allocating the Context.");
   auto& g_state = mutable_geometry_state(context);
   g_state.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -968,12 +968,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
    "initialize" itself after changes to properties that will affect how a
    geometry appears. If changing a geometry's illustration properties doesn't
    seem to be affecting the visualization, retrigger its initialization action.
-
-   @warning Due to a bug (see issue
-   <a href="https://github.com/RobotLocomotion/drake/issues/13597">#13597</a>),
-   changing the illustration roles or properties in a systems::Context will not
-   have any apparent effect in certain viewers. Please change the illustration
-   role in the model prior to allocating the context.
    @pydrake_mkdoc_identifier{illustration_context}
    */
   void AssignRole(systems::Context<T>* context, SourceId source_id,


### PR DESCRIPTION
Removes a vestigial warning regarding assigning/updating illustration roles. Current Drake visualizers all key on geometry versions and will issue new descriptions of the world for such changes.

Resolves #20962.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23848)
<!-- Reviewable:end -->
