### PR TITLE
Rename block sparse matrix typedefs

### DIFF
--- a/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h
+++ b/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h
@@ -91,7 +91,7 @@ class BlockSparsityPattern {
   3. This class only allows square matrices and blocks on the diagonal must be
      square too.
  Most callers should use clearer and less verbose typedefs at the bottom of the
- file (e.g. `BlockSparseSymmetricMatrix`) rather than this class template
+ file (e.g. `BlockSparseSymmetricMatrixXd`) rather than this class template
  directly.
 
  @tparam MatrixType   The Eigen matrix type of each block in block sparse
@@ -303,14 +303,22 @@ class BlockSparseLowerTriangularOrSymmetricMatrix {
   std::vector<std::vector<int>> block_row_to_flat_;
 };
 
+template <typename Block>
 using BlockSparseLowerTriangularMatrix =
-    BlockSparseLowerTriangularOrSymmetricMatrix<MatrixX<double>, false>;
+    BlockSparseLowerTriangularOrSymmetricMatrix<Block, false>;
+
+template <typename Block>
 using BlockSparseSymmetricMatrix =
-    BlockSparseLowerTriangularOrSymmetricMatrix<MatrixX<double>, true>;
-using Block3x3SparseLowerTriangularMatrix =
-    BlockSparseLowerTriangularOrSymmetricMatrix<Matrix3<double>, false>;
-using Block3x3SparseSymmetricMatrix =
-    BlockSparseLowerTriangularOrSymmetricMatrix<Matrix3<double>, true>;
+    BlockSparseLowerTriangularOrSymmetricMatrix<Block, true>;
+
+using BlockSparseLowerTriangularMatrixXd =
+    BlockSparseLowerTriangularMatrix<MatrixX<double>>;
+using BlockSparseSymmetricMatrixXd =
+    BlockSparseSymmetricMatrix<MatrixX<double>>;
+using BlockSparseLowerTriangularMatrix3d =
+    BlockSparseLowerTriangularMatrix<Matrix3<double>>;
+using BlockSparseSymmetricMatrix3d =
+    BlockSparseSymmetricMatrix<Matrix3<double>>;
 
 }  // namespace internal
 }  // namespace contact_solvers

--- a/multibody/contact_solvers/block_sparse_supernodal_solver.cc
+++ b/multibody/contact_solvers/block_sparse_supernodal_solver.cc
@@ -75,7 +75,7 @@ BlockSparseSuperNodalSolver::BlockSparseSuperNodalSolver(
       sparsity[j].emplace_back(i);
     }
   }
-  H_ = std::make_unique<BlockSparseSymmetricMatrix>(
+  H_ = std::make_unique<BlockSparseSymmetricMatrixXd>(
       BlockSparsityPattern(std::move(block_sizes), std::move(sparsity)));
   /* The solver analyzes the sparsity pattern of the H_ (currently a zero
    matrix) so that subsequent updates to the matrix can use UpdateMatrix()

--- a/multibody/contact_solvers/block_sparse_supernodal_solver.h
+++ b/multibody/contact_solvers/block_sparse_supernodal_solver.h
@@ -71,7 +71,7 @@ class BlockSparseSuperNodalSolver final : public SuperNodalSolver {
   }
 
   /* Matrix H in the sparse system H⋅x = b where H = M + Jᵀ⋅G⋅J. */
-  std::unique_ptr<BlockSparseSymmetricMatrix> H_;
+  std::unique_ptr<BlockSparseSymmetricMatrixXd> H_;
   /* The i-th entry contains the indices into `jacobian_blocks_` for the
    jacobian blocks associated with the i-th block row of the full jacobian
    matrix. Each entry contains at least one and at most two entries. */

--- a/multibody/contact_solvers/eigen_block_3x3_sparse_symmetric_matrix.cc
+++ b/multibody/contact_solvers/eigen_block_3x3_sparse_symmetric_matrix.cc
@@ -14,7 +14,7 @@ using common_robotics_utilities::parallelism::ParallelForBackend;
 using common_robotics_utilities::parallelism::StaticParallelForIndexLoop;
 
 EigenBlock3x3SparseSymmetricMatrix::EigenBlock3x3SparseSymmetricMatrix(
-    const Block3x3SparseSymmetricMatrix* A, Parallelism parallelism)
+    const BlockSparseSymmetricMatrix3d* A, Parallelism parallelism)
     : A_(A), parallelism_(parallelism) {
   /* Precompute, for each block-row i, the list of block-cols j≤i
    such that A(i,j) is stored in blocks[j][…]. This is useful for the Multiply

--- a/multibody/contact_solvers/eigen_block_3x3_sparse_symmetric_matrix.h
+++ b/multibody/contact_solvers/eigen_block_3x3_sparse_symmetric_matrix.h
@@ -40,13 +40,13 @@ namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
-/* Wrapper class around Block3x3SparseSymmetricMatrix that's compatible
+/* Wrapper class around BlockSparseSymmetricMatrix3d that's compatible
  with Eigen::ConjugateGradient. This wrapper is supposed to be short-lived
  It should be constructed, used in an Eigen solver, and then discarded.
 
  Example usage:
  {
-  // A_blocks is a Block3x3SparseSymmetricMatrix.
+  // A_blocks is a BlockSparseSymmetricMatrix3d.
   EigenBlock3x3SparseSymmetricMatrix A(&A_blocks, Parallelism(true));
   Eigen::ConjugateGradient<EigenBlock3x3SparseSymmetricMatrix,
                             Eigen::Lower | Eigen::Upper>
@@ -74,9 +74,9 @@ class EigenBlock3x3SparseSymmetricMatrix
     IsRowMajor = false
   };
 
-  /* Constructs a matrix wrapper for Block3x3SparseSymmetricMatrix.
+  /* Constructs a matrix wrapper for BlockSparseSymmetricMatrix3d.
    @pre A is not null and outlives this object. */
-  EigenBlock3x3SparseSymmetricMatrix(const Block3x3SparseSymmetricMatrix* A,
+  EigenBlock3x3SparseSymmetricMatrix(const BlockSparseSymmetricMatrix3d* A,
                                      Parallelism parallelism = false);
 
   /* Required by EigenBase */
@@ -138,7 +138,7 @@ class EigenBlock3x3SparseSymmetricMatrix
   };
 
  private:
-  const Block3x3SparseSymmetricMatrix* const A_{};
+  const BlockSparseSymmetricMatrix3d* const A_{};
   VectorX<double> diagonal_;
   /* The connectivity pattern of the blocks in A. More specifically,
    `row_neighbors_[i][k]` gives the block column index of the k-th non-zero

--- a/multibody/contact_solvers/schur_complement.cc
+++ b/multibody/contact_solvers/schur_complement.cc
@@ -13,7 +13,7 @@ SchurComplement::SchurComplement() = default;
 
 SchurComplement::~SchurComplement() = default;
 
-SchurComplement::SchurComplement(const Block3x3SparseSymmetricMatrix& A,
+SchurComplement::SchurComplement(const BlockSparseSymmetricMatrix3d& A,
                                  const std::unordered_set<int>& D_indices)
     : D_indices_(D_indices.begin(), D_indices.end()) {
   /* Keep D_indices_ sorted. */

--- a/multibody/contact_solvers/schur_complement.h
+++ b/multibody/contact_solvers/schur_complement.h
@@ -93,7 +93,7 @@ class SchurComplement {
      v v v
 
    @pre D_indices is a subset of {0, ..., A.block_cols()-1}. */
-  SchurComplement(const Block3x3SparseSymmetricMatrix& A,
+  SchurComplement(const BlockSparseSymmetricMatrix3d& A,
                   const std::unordered_set<int>& D_indices);
 
   /* Returns the Schur complement for the block D of the matrix A,

--- a/multibody/contact_solvers/test/block_sparse_cholesky_solver_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_cholesky_solver_test.cc
@@ -62,7 +62,7 @@ Eigen::Matrix<double, 12, 12> MakeSpdMatrix(double scale) {
 }
 
 /* Makes an arbitrary SPD sparse matrix. */
-BlockSparseSymmetricMatrix MakeSparseSpdMatrix(double scale = 1.0) {
+BlockSparseSymmetricMatrixXd MakeSparseSpdMatrix(double scale = 1.0) {
   std::vector<std::vector<int>> sparsity;
   sparsity.emplace_back(std::vector<int>{0});
   sparsity.emplace_back(std::vector<int>{1, 2, 3});
@@ -71,7 +71,7 @@ BlockSparseSymmetricMatrix MakeSparseSpdMatrix(double scale = 1.0) {
   std::vector<int> block_sizes = {2, 3, 4, 3};
   BlockSparsityPattern block_pattern(block_sizes, sparsity);
 
-  BlockSparseSymmetricMatrix A(std::move(block_pattern));
+  BlockSparseSymmetricMatrixXd A(std::move(block_pattern));
   const std::vector<int>& starting_cols = A.starting_cols();
   const Eigen::Matrix<double, 12, 12> dense_A = MakeSpdMatrix(scale);
   std::vector<std::pair<int, int>> nonzero_lower_triangular_blocks{
@@ -86,7 +86,7 @@ BlockSparseSymmetricMatrix MakeSparseSpdMatrix(double scale = 1.0) {
 
 GTEST_TEST(BlockSparseCholeskySolverTest, Solve) {
   BlockSparseCholeskySolver<MatrixXd> solver;
-  BlockSparseSymmetricMatrix A = MakeSparseSpdMatrix();
+  BlockSparseSymmetricMatrixXd A = MakeSparseSpdMatrix();
   MatrixX<double> dense_A = A.MakeDenseMatrix();
   EXPECT_EQ(solver.solver_mode(),
             BlockSparseCholeskySolver<MatrixXd>::SolverMode::kEmpty);
@@ -118,7 +118,7 @@ GTEST_TEST(BlockSparseCholeskySolverTest, Solve) {
 
   /* Update the matrix with different numeric values but the same sparsity
    pattern. */
-  BlockSparseSymmetricMatrix A2 = MakeSparseSpdMatrix(10);
+  BlockSparseSymmetricMatrixXd A2 = MakeSparseSpdMatrix(10);
   MatrixX<double> dense_A2 = A2.MakeDenseMatrix();
   solver.UpdateMatrix(A2);
   success = solver.Factor();
@@ -135,7 +135,7 @@ GTEST_TEST(BlockSparseCholeskySolverTest, FailureDueToNonSpdness) {
   sparsity.emplace_back(std::vector<int>{1});
   std::vector<int> block_sizes = {4, 3};
   BlockSparsityPattern block_pattern(block_sizes, sparsity);
-  BlockSparseSymmetricMatrix A(std::move(block_pattern));
+  BlockSparseSymmetricMatrixXd A(std::move(block_pattern));
   A.AddToBlock(0, 0, -Matrix4d::Identity());
   A.AddToBlock(1, 1, -Matrix3d::Identity());
 
@@ -172,7 +172,7 @@ GTEST_TEST(BlockSparseCholeskySolverTest, FactorBeforeSetMatrixThrows) {
 
 GTEST_TEST(BlockSparseCholeskySolverTest, SolveBeforeFactorThrows) {
   BlockSparseCholeskySolver<MatrixXd> solver;
-  BlockSparseSymmetricMatrix A = MakeSparseSpdMatrix();
+  BlockSparseSymmetricMatrixXd A = MakeSparseSpdMatrix();
   solver.SetMatrix(A);
   VectorXd b = VectorXd::LinSpaced(A.cols(), 0.0, 10.0);
   EXPECT_THROW(solver.Solve(b), std::exception);
@@ -181,7 +181,7 @@ GTEST_TEST(BlockSparseCholeskySolverTest, SolveBeforeFactorThrows) {
 
 GTEST_TEST(BlockSparseCholeskySolverTest, PermutationMatrix) {
   BlockSparseCholeskySolver<MatrixXd> solver;
-  BlockSparseSymmetricMatrix A = MakeSparseSpdMatrix();
+  BlockSparseSymmetricMatrixXd A = MakeSparseSpdMatrix();
   const MatrixXd A_dense = A.MakeDenseMatrix();
   solver.SetMatrix(A);
   /* Trying to get L before factorization is an exception. */
@@ -198,7 +198,7 @@ GTEST_TEST(BlockSparseCholeskySolverTest, PermutationMatrix) {
 
 GTEST_TEST(BlockSparseCholeskySolverTest, PermutationMatrixPrecondition) {
   BlockSparseCholeskySolver<MatrixXd> solver;
-  BlockSparseSymmetricMatrix A = MakeSparseSpdMatrix();
+  BlockSparseSymmetricMatrixXd A = MakeSparseSpdMatrix();
   /* CalcPermutationMatrix() before setting the matrix throws. */
   EXPECT_THROW(solver.CalcPermutationMatrix(), std::exception);
   /* After setting the matrix, CalcPermutatoinMatrix() returns the same result
@@ -215,7 +215,7 @@ GTEST_TEST(BlockSparseCholeskySolverTest, PermutationMatrixPrecondition) {
 
 GTEST_TEST(BlockSparseCholeskySolverTest, SolverModeAfterMove) {
   BlockSparseCholeskySolver<MatrixXd> solver;
-  BlockSparseSymmetricMatrix A = MakeSparseSpdMatrix();
+  BlockSparseSymmetricMatrixXd A = MakeSparseSpdMatrix();
   solver.SetMatrix(A);
   EXPECT_EQ(solver.solver_mode(),
             BlockSparseCholeskySolver<MatrixXd>::SolverMode::kAnalyzed);
@@ -229,7 +229,7 @@ GTEST_TEST(BlockSparseCholeskySolverTest, SolverModeAfterMove) {
 
 GTEST_TEST(BlockSparseCholeskySolverTest, FactorAndCalcSchurComplement) {
   BlockSparseCholeskySolver<MatrixXd> solver;
-  BlockSparseSymmetricMatrix M = MakeSparseSpdMatrix();
+  BlockSparseSymmetricMatrixXd M = MakeSparseSpdMatrix();
   const int kNumBlocks = 4;
   /* All blocks are eliminated. */
   {

--- a/multibody/contact_solvers/test/block_sparse_lower_triangular_or_symmetric_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_lower_triangular_or_symmetric_matrix_test.cc
@@ -76,14 +76,14 @@ MatrixXd MakeDenseMatrix(bool is_symmetric) {
         -----------------
           0  | A21 | A22
  */
-BlockSparseLowerTriangularMatrix MakeLowerTriangularMatrix() {
+BlockSparseLowerTriangularMatrixXd MakeLowerTriangularMatrix() {
   std::vector<int> diag{2, 3, 4};
   std::vector<std::vector<int>> sparsity;
   sparsity.push_back(std::vector<int>{0});
   sparsity.push_back(std::vector<int>{1, 2});
   sparsity.push_back(std::vector<int>{2});
   BlockSparsityPattern pattern(diag, sparsity);
-  BlockSparseLowerTriangularMatrix A_blocks(pattern);
+  BlockSparseLowerTriangularMatrixXd A_blocks(pattern);
   A_blocks.SetBlock(0, 0, A00);
   A_blocks.SetBlock(1, 1, A11);
   A_blocks.SetBlock(2, 1, A21);
@@ -98,14 +98,14 @@ BlockSparseLowerTriangularMatrix MakeLowerTriangularMatrix() {
         -----------------
           0  | A21 | A22
  where A21 = A12.transpose(). */
-BlockSparseSymmetricMatrix MakeSymmetricMatrix() {
+BlockSparseSymmetricMatrixXd MakeSymmetricMatrix() {
   std::vector<int> diag{2, 3, 4};
   std::vector<std::vector<int>> sparsity;
   sparsity.push_back(std::vector<int>{0});
   sparsity.push_back(std::vector<int>{1, 2});
   sparsity.push_back(std::vector<int>{2});
   BlockSparsityPattern pattern(diag, sparsity);
-  BlockSparseSymmetricMatrix A_blocks(pattern);
+  BlockSparseSymmetricMatrixXd A_blocks(pattern);
   A_blocks.SetBlock(0, 0, A00);
   A_blocks.SetBlock(1, 1, A11);
   A_blocks.SetBlock(2, 1, A21);
@@ -130,26 +130,26 @@ GTEST_TEST(BlockSparsityPatternTest, CalcNumNonzeros) {
 }
 
 GTEST_TEST(TriangularBlockSparseMatrixTest, Construction) {
-  const BlockSparseLowerTriangularMatrix A_triangular =
+  const BlockSparseLowerTriangularMatrixXd A_triangular =
       MakeLowerTriangularMatrix();
-  const BlockSparseSymmetricMatrix A_symmetric = MakeSymmetricMatrix();
+  const BlockSparseSymmetricMatrixXd A_symmetric = MakeSymmetricMatrix();
   EXPECT_EQ(A_triangular.MakeDenseMatrix(), MakeDenseMatrix(false));
   EXPECT_EQ(A_symmetric.MakeDenseMatrix(), MakeDenseMatrix(true));
 }
 
 GTEST_TEST(TriangularBlockSparseMatrixTest, SetZero) {
-  BlockSparseLowerTriangularMatrix A_triangular = MakeLowerTriangularMatrix();
+  BlockSparseLowerTriangularMatrixXd A_triangular = MakeLowerTriangularMatrix();
   A_triangular.SetZero();
   EXPECT_EQ(A_triangular.MakeDenseMatrix(), MatrixXd::Zero(9, 9));
 
-  BlockSparseSymmetricMatrix A_symmetric = MakeSymmetricMatrix();
+  BlockSparseSymmetricMatrixXd A_symmetric = MakeSymmetricMatrix();
   A_symmetric.SetZero();
   EXPECT_EQ(A_symmetric.MakeDenseMatrix(), MatrixXd::Zero(9, 9));
 }
 
 GTEST_TEST(TriangularBlockSparseMatrixTest, Getter) {
-  BlockSparseLowerTriangularMatrix A_triangular = MakeLowerTriangularMatrix();
-  BlockSparseSymmetricMatrix A_symmetric = MakeSymmetricMatrix();
+  BlockSparseLowerTriangularMatrixXd A_triangular = MakeLowerTriangularMatrix();
+  BlockSparseSymmetricMatrixXd A_symmetric = MakeSymmetricMatrix();
   /* Existing diagonal blocks. */
   ASSERT_TRUE(A_triangular.HasBlock(0, 0));
   ASSERT_TRUE(A_symmetric.HasBlock(0, 0));
@@ -207,7 +207,7 @@ GTEST_TEST(TriangularBlockSparseMatrixTest, Getter) {
 }
 
 GTEST_TEST(TriangularBlockSparseMatrixTest, SetBlock) {
-  BlockSparseLowerTriangularMatrix A = MakeLowerTriangularMatrix();
+  BlockSparseLowerTriangularMatrixXd A = MakeLowerTriangularMatrix();
   MatrixXd m = MakeArbitraryMatrix(4, 3);
   A.SetBlock(2, 1, m);
   EXPECT_EQ(A.block(2, 1), m);
@@ -219,13 +219,13 @@ GTEST_TEST(TriangularBlockSparseMatrixTest, SetBlock) {
 
 GTEST_TEST(TriangularBlockSparseMatrixTest, ZeroRowsAndColumns) {
   /* Throws for lower triangular matrix. */
-  BlockSparseLowerTriangularMatrix A_triangular = MakeLowerTriangularMatrix();
+  BlockSparseLowerTriangularMatrixXd A_triangular = MakeLowerTriangularMatrix();
   DRAKE_EXPECT_THROWS_MESSAGE(A_triangular.ZeroRowsAndColumns({0, 1}),
                               ".*is_symmetric.*");
 
   /* Keeps the diagonal entries for the diagonal blocks 0 and 1. Keeps the
    diagonal block 2 untouched. All off-diagonal blocks are zeroed out. */
-  BlockSparseSymmetricMatrix A_symmetric = MakeSymmetricMatrix();
+  BlockSparseSymmetricMatrixXd A_symmetric = MakeSymmetricMatrix();
   A_symmetric.ZeroRowsAndColumns({0, 1});
 
   MatrixXd A_symmetric_dense = MatrixXd::Zero(9, 9);
@@ -241,12 +241,12 @@ GTEST_TEST(TriangularBlockSparseMatrixTest, ZeroRowsAndColumns) {
 }
 
 GTEST_TEST(TriangularBlockSparseMatrixTest, MakeDenseBottomRightCorner) {
-  BlockSparseLowerTriangularMatrix A_triangular = MakeLowerTriangularMatrix();
+  BlockSparseLowerTriangularMatrixXd A_triangular = MakeLowerTriangularMatrix();
   MatrixXd expected = MakeDenseMatrix(false).bottomRightCorner(7, 7);
   EXPECT_EQ(expected, A_triangular.MakeDenseBottomRightCorner(2));
   EXPECT_EQ(MatrixXd::Zero(0, 0), A_triangular.MakeDenseBottomRightCorner(0));
 
-  BlockSparseSymmetricMatrix A_symmetric = MakeSymmetricMatrix();
+  BlockSparseSymmetricMatrixXd A_symmetric = MakeSymmetricMatrix();
   expected = MakeDenseMatrix(true).bottomRightCorner(7, 7);
   EXPECT_EQ(expected, A_symmetric.MakeDenseBottomRightCorner(2));
   EXPECT_EQ(MatrixXd::Zero(0, 0), A_symmetric.MakeDenseBottomRightCorner(0));
@@ -254,8 +254,9 @@ GTEST_TEST(TriangularBlockSparseMatrixTest, MakeDenseBottomRightCorner) {
 
 GTEST_TEST(TriangularBlockSparseMatrixTest, InvalidOperations) {
   if (kDrakeAssertIsArmed) {
-    BlockSparseLowerTriangularMatrix A_triangular = MakeLowerTriangularMatrix();
-    BlockSparseSymmetricMatrix A_symmetric = MakeSymmetricMatrix();
+    BlockSparseLowerTriangularMatrixXd A_triangular =
+        MakeLowerTriangularMatrix();
+    BlockSparseSymmetricMatrixXd A_symmetric = MakeSymmetricMatrix();
     /* i <= block_rows() fails. */
     DRAKE_ASSERT_THROWS_MESSAGE_IF_ARMED(A_triangular.AddToBlock(200, 100, A00),
                                          ".*out of bound.*");

--- a/multibody/contact_solvers/test/eigen_block_3x3_sparse_symmetric_matrix_test.cc
+++ b/multibody/contact_solvers/test/eigen_block_3x3_sparse_symmetric_matrix_test.cc
@@ -58,7 +58,7 @@ Eigen::Matrix<double, 12, 12> MakeSpdMatrix() {
 }
 
 /* Makes a sparse version of the result from MakeSpdMatrix(). */
-Block3x3SparseSymmetricMatrix MakeSparseSpdMatrix() {
+BlockSparseSymmetricMatrix3d MakeSparseSpdMatrix() {
   std::vector<std::vector<int>> sparsity;
   sparsity.emplace_back(std::vector<int>{0});
   sparsity.emplace_back(std::vector<int>{1, 2, 3});
@@ -67,7 +67,7 @@ Block3x3SparseSymmetricMatrix MakeSparseSpdMatrix() {
   std::vector<int> block_sizes = {3, 3, 3, 3};
   BlockSparsityPattern block_pattern(block_sizes, sparsity);
 
-  Block3x3SparseSymmetricMatrix A(std::move(block_pattern));
+  BlockSparseSymmetricMatrix3d A(std::move(block_pattern));
   const std::vector<int>& starting_cols = A.starting_cols();
   const Eigen::Matrix<double, 12, 12> dense_A = MakeSpdMatrix();
   std::vector<std::pair<int, int>> nonzero_lower_triangular_blocks{
@@ -85,7 +85,7 @@ Block3x3SparseSymmetricMatrix MakeSparseSpdMatrix() {
 GTEST_TEST(EigenBlock3x3SparseSymmetricMatrixTest, Basic) {
   const double kTol = 4.0 * std::numeric_limits<double>::epsilon();
 
-  const Block3x3SparseSymmetricMatrix A = MakeSparseSpdMatrix();
+  const BlockSparseSymmetricMatrix3d A = MakeSparseSpdMatrix();
   const MatrixXd dense_A = A.MakeDenseMatrix();
   const EigenBlock3x3SparseSymmetricMatrix eigen_A(&A, Parallelism(true));
 
@@ -108,7 +108,7 @@ GTEST_TEST(EigenBlock3x3SparseSymmetricMatrixTest, Basic) {
 GTEST_TEST(EigenBlock3x3SparseSymmetricMatrixTest, ScaledIdentityTwoBlock) {
   const double kTol = 1e-14;
 
-  const Block3x3SparseSymmetricMatrix A = MakeSparseSpdMatrix();
+  const BlockSparseSymmetricMatrix3d A = MakeSparseSpdMatrix();
   const MatrixXd dense_A = A.MakeDenseMatrix();
   const EigenBlock3x3SparseSymmetricMatrix eigen_A(&A, Parallelism(true));
 

--- a/multibody/contact_solvers/test/schur_complement_test.cc
+++ b/multibody/contact_solvers/test/schur_complement_test.cc
@@ -58,13 +58,13 @@ Matrix3d A22() {
          A20 |  0  | A22
  where A02 = A20.transpose(). We choose values so that A is diagonally dominant
  and thus SPD. */
-Block3x3SparseSymmetricMatrix MakeBlockSparseMatrix() {
+BlockSparseSymmetricMatrix3d MakeBlockSparseMatrix() {
   std::vector<std::vector<int>> sparsity_pattern;
   sparsity_pattern.emplace_back(std::vector<int>{0, 1, 2});
   sparsity_pattern.emplace_back(std::vector<int>{1});
   sparsity_pattern.emplace_back(std::vector<int>{2});
   BlockSparsityPattern block_pattern({{3, 3, 3}}, std::move(sparsity_pattern));
-  Block3x3SparseSymmetricMatrix A(std::move(block_pattern));
+  BlockSparseSymmetricMatrix3d A(std::move(block_pattern));
   A.SetBlock(0, 0, A00());
   A.SetBlock(1, 0, A10());
   A.SetBlock(2, 0, A20());
@@ -83,7 +83,7 @@ Block3x3SparseSymmetricMatrix MakeBlockSparseMatrix() {
 
 and returns the Schur complement of the A11 block. */
 SchurComplement MakeSchurComplement() {
-  Block3x3SparseSymmetricMatrix block_sparse_matrix = MakeBlockSparseMatrix();
+  BlockSparseSymmetricMatrix3d block_sparse_matrix = MakeBlockSparseMatrix();
   const std::unordered_set<int> eliminated_blocks = {1};
   return SchurComplement(block_sparse_matrix, eliminated_blocks);
 }

--- a/multibody/fem/dirichlet_boundary_condition.cc
+++ b/multibody/fem/dirichlet_boundary_condition.cc
@@ -44,7 +44,7 @@ void DirichletBoundaryCondition<T>::ApplyBoundaryConditionToState(
 
 template <typename T>
 void DirichletBoundaryCondition<T>::ApplyBoundaryConditionToTangentMatrix(
-    contact_solvers::internal::Block3x3SparseSymmetricMatrix* tangent_matrix)
+    contact_solvers::internal::BlockSparseSymmetricMatrix3d* tangent_matrix)
     const {
   DRAKE_DEMAND(tangent_matrix != nullptr);
   if (node_to_boundary_state_.empty()) return;

--- a/multibody/fem/dirichlet_boundary_condition.h
+++ b/multibody/fem/dirichlet_boundary_condition.h
@@ -82,7 +82,7 @@ class DirichletBoundaryCondition {
    @pre Indices of all DoFs associated with nodes subject to `this` BC are
    smaller than `tangent_matrix->cols()`. */
   void ApplyBoundaryConditionToTangentMatrix(
-      contact_solvers::internal::Block3x3SparseSymmetricMatrix* tangent_matrix)
+      contact_solvers::internal::BlockSparseSymmetricMatrix3d* tangent_matrix)
       const;
 
   /* Modifies the given vector `v` (e.g, the residual of the system or the

--- a/multibody/fem/fem_model.cc
+++ b/multibody/fem/fem_model.cc
@@ -55,7 +55,7 @@ void FemModel<T>::CalcResidual(const FemState<T>& fem_state,
 template <typename T>
 void FemModel<T>::CalcTangentMatrix(
     const FemState<T>& fem_state,
-    contact_solvers::internal::Block3x3SparseSymmetricMatrix* tangent_matrix)
+    contact_solvers::internal::BlockSparseSymmetricMatrix3d* tangent_matrix)
     const {
   if constexpr (std::is_same_v<T, double>) {
     DRAKE_DEMAND(tangent_matrix != nullptr);
@@ -92,7 +92,7 @@ Vector3<T> FemModel<T>::CalcEffectiveAngularVelocity(
 }
 
 template <typename T>
-std::unique_ptr<contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+std::unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
 FemModel<T>::MakeTangentMatrix() const {
   if constexpr (std::is_same_v<T, double>) {
     return DoMakeTangentMatrix();

--- a/multibody/fem/fem_model.h
+++ b/multibody/fem/fem_model.h
@@ -168,7 +168,7 @@ class FemModel {
    @throws std::exception if T is not double. */
   void CalcTangentMatrix(
       const FemState<T>& fem_state,
-      contact_solvers::internal::Block3x3SparseSymmetricMatrix* tangent_matrix)
+      contact_solvers::internal::BlockSparseSymmetricMatrix3d* tangent_matrix)
       const;
 
   /** Calculates the position vector from the world origin Wo to the center
@@ -212,7 +212,7 @@ class FemModel {
    tangent matrix is `num_dofs()` by `num_dofs()`. All entries are initialized
    to zero.
    @throws std::exception if T is not double. */
-  std::unique_ptr<contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+  std::unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
   MakeTangentMatrix() const;
 
   /** Applies boundary condition set for this %FemModel to the input `state`.
@@ -300,7 +300,7 @@ class FemModel {
    guaranteed to be non-null and properly sized. */
   virtual void DoCalcTangentMatrix(
       const FemState<T>& fem_state,
-      contact_solvers::internal::Block3x3SparseSymmetricMatrix* tangent_matrix)
+      contact_solvers::internal::BlockSparseSymmetricMatrix3d* tangent_matrix)
       const = 0;
 
   /** FemModelImpl must override this method to provide an implementation for
@@ -324,7 +324,7 @@ class FemModel {
   /** FemModelImpl must override this method to provide an implementation for
    the NVI MakeTangentMatrix(). */
   virtual std::unique_ptr<
-      contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+      contact_solvers::internal::BlockSparseSymmetricMatrix3d>
   DoMakeTangentMatrix() const = 0;
 
   /** Updates the system that manages the states and the cache entries of this

--- a/multibody/fem/fem_model_impl.h
+++ b/multibody/fem/fem_model_impl.h
@@ -183,7 +183,7 @@ class FemModelImpl : public FemModel<typename Element::T> {
 
   void DoCalcTangentMatrix(
       const FemState<T>& fem_state,
-      contact_solvers::internal::Block3x3SparseSymmetricMatrix* tangent_matrix)
+      contact_solvers::internal::BlockSparseSymmetricMatrix3d* tangent_matrix)
       const final {
     /* We already check for the scalar type in `CalcTangentMatrix()` but the `if
      constexpr` here is still needed to make the compiler happy. */
@@ -220,7 +220,7 @@ class FemModelImpl : public FemModel<typename Element::T> {
     }
   }
 
-  std::unique_ptr<contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+  std::unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
   DoMakeTangentMatrix() const final {
     /* We already check for the scalar type in `MakeTangentMatrix()` but the `if
      constexpr` here is still needed to make the compiler happy. */
@@ -255,7 +255,7 @@ class FemModelImpl : public FemModel<typename Element::T> {
       contact_solvers::internal::BlockSparsityPattern block_pattern(
           std::vector<int>(this->num_nodes(), 3), std::move(sparsity_pattern));
       return std::make_unique<
-          contact_solvers::internal::Block3x3SparseSymmetricMatrix>(
+          contact_solvers::internal::BlockSparseSymmetricMatrix3d>(
           std::move(block_pattern));
     } else {
       DRAKE_UNREACHABLE();

--- a/multibody/fem/fem_solver.cc
+++ b/multibody/fem/fem_solver.cc
@@ -10,7 +10,7 @@ namespace multibody {
 namespace fem {
 namespace internal {
 
-using contact_solvers::internal::Block3x3SparseSymmetricMatrix;
+using contact_solvers::internal::BlockSparseSymmetricMatrix3d;
 using contact_solvers::internal::EigenBlock3x3SparseSymmetricMatrix;
 using contact_solvers::internal::SchurComplement;
 using LinearSolver =
@@ -123,7 +123,7 @@ int FemSolver<T>::SolveLinearModel(
   FemState<T>& state = *next_state_and_schur_complement_.state;
   VectorX<T>& b = scratch_.b;
   VectorX<T>& dz = scratch_.dz;
-  Block3x3SparseSymmetricMatrix& tangent_matrix = *scratch_.tangent_matrix;
+  BlockSparseSymmetricMatrix3d& tangent_matrix = *scratch_.tangent_matrix;
 
   model_->ApplyBoundaryCondition(&state);
   model_->CalcResidual(state, plant_data, &b);
@@ -147,7 +147,7 @@ int FemSolver<T>::SolveNonlinearModel(
   DRAKE_DEMAND(!model_->is_linear());
   VectorX<T>& b = scratch_.b;
   VectorX<T>& dz = scratch_.dz;
-  Block3x3SparseSymmetricMatrix& tangent_matrix = *scratch_.tangent_matrix;
+  BlockSparseSymmetricMatrix3d& tangent_matrix = *scratch_.tangent_matrix;
   FemState<T>& state = *next_state_and_schur_complement_.state;
   model_->ApplyBoundaryCondition(&state);
   model_->CalcResidual(state, plant_data, &b);

--- a/multibody/fem/fem_solver.h
+++ b/multibody/fem/fem_solver.h
@@ -184,8 +184,7 @@ class FemSolver {
      model. */
     void ReinitializeIfNeeded(const FemModel<T>& model);
 
-    copyable_unique_ptr<
-        contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+    copyable_unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
         tangent_matrix;
     VectorX<T> b;
     VectorX<T> dz;

--- a/multibody/fem/test/dirichlet_boundary_condition_test.cc
+++ b/multibody/fem/test/dirichlet_boundary_condition_test.cc
@@ -19,7 +19,7 @@ namespace {
 /* An arbitrary number of degree of freedom made up for testing purpose. */
 static constexpr int kNumDofs = 6;
 using DenseMatrix = Eigen::Matrix<double, kNumDofs, kNumDofs>;
-using contact_solvers::internal::Block3x3SparseSymmetricMatrix;
+using contact_solvers::internal::BlockSparseSymmetricMatrix3d;
 using Eigen::Matrix3d;
 using Eigen::VectorXd;
 using std::make_unique;
@@ -60,12 +60,12 @@ class DirichletBoundaryConditionTest : public ::testing::Test {
   /* Makes a block diagonal tangent matrix with
     [ A00   0;
       0    A11]. */
-  static unique_ptr<Block3x3SparseSymmetricMatrix> MakeTangentMatrix() {
+  static unique_ptr<BlockSparseSymmetricMatrix3d> MakeTangentMatrix() {
     const std::vector<std::vector<int>> sparsity = {std::vector<int>({0}),
                                                     std::vector<int>({1})};
     contact_solvers::internal::BlockSparsityPattern block_pattern(
         std::vector<int>(2, 3), sparsity);
-    auto A = make_unique<Block3x3SparseSymmetricMatrix>(block_pattern);
+    auto A = make_unique<BlockSparseSymmetricMatrix3d>(block_pattern);
     A->SetBlock(0, 0, A00);
     A->SetBlock(1, 1, A11);
     return A;

--- a/multibody/fem/test/fem_model_test.cc
+++ b/multibody/fem/test/fem_model_test.cc
@@ -188,7 +188,7 @@ GTEST_TEST(FemModelTest, CalcTangentMatrix) {
   builder.AddTwoElementsWithSharedNodes();
   builder.Build();
   unique_ptr<FemState<double>> fem_state = model.MakeFemState();
-  unique_ptr<contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+  unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
       tangent_matrix = model.MakeTangentMatrix();
   ASSERT_EQ(tangent_matrix->rows(), model.num_dofs());
   ASSERT_EQ(tangent_matrix->cols(), model.num_dofs());
@@ -245,7 +245,7 @@ GTEST_TEST(FemModelTest, CalcTangentMatrixNoAutoDiff) {
                               ".*only.*double.*");
   unique_ptr<FemState<T>> fem_state = fem_model->MakeFemState();
   contact_solvers::internal::BlockSparsityPattern empty_pattern({}, {});
-  contact_solvers::internal::Block3x3SparseSymmetricMatrix tangent_matrix(
+  contact_solvers::internal::BlockSparseSymmetricMatrix3d tangent_matrix(
       empty_pattern);
   DRAKE_EXPECT_THROWS_MESSAGE(
       fem_model->CalcTangentMatrix(*fem_state, &tangent_matrix),
@@ -278,7 +278,7 @@ GTEST_TEST(FemModelTest, IncompatibleModelState) {
 
   /* Trying to calculate tangent matrix with the old state causes an exception.
    */
-  unique_ptr<contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+  unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
       tangent_matrix = model.MakeTangentMatrix();
   ASSERT_EQ(tangent_matrix->rows(), model.num_dofs());
   ASSERT_EQ(tangent_matrix->cols(), model.num_dofs());
@@ -386,13 +386,13 @@ GTEST_TEST(FemModelTest, DirichletBoundaryCondition) {
     const Vector3d weights(0.1, 0.2, 0.3);
 
     unique_ptr<FemState<T>> state0 = model.MakeFemState();
-    unique_ptr<contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+    unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
         tangent_matrix0 = model.MakeTangentMatrix();
     model.CalcTangentMatrix(*state0, tangent_matrix0.get());
     const MatrixX<T> dense_tangent_matrix0 = tangent_matrix0->MakeDenseMatrix();
 
     unique_ptr<FemState<T>> state1 = model_without_bc.MakeFemState();
-    unique_ptr<contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+    unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
         tangent_matrix1 = model.MakeTangentMatrix();
     model_without_bc.CalcTangentMatrix(*state1, tangent_matrix1.get());
     MatrixX<T> dense_tangent_matrix1 = tangent_matrix1->MakeDenseMatrix();

--- a/multibody/plant/test/deformable_driver_contact_test.cc
+++ b/multibody/plant/test/deformable_driver_contact_test.cc
@@ -136,7 +136,7 @@ class DeformableDriverContactTest : public ::testing::Test {
                                        DeformableBodyIndex index) const {
     DeformableBodyId body_id = model_->GetBodyId(index);
     const FemModel<double>& fem_model = model_->GetFemModel(body_id);
-    std::unique_ptr<contact_solvers::internal::Block3x3SparseSymmetricMatrix>
+    std::unique_ptr<contact_solvers::internal::BlockSparseSymmetricMatrix3d>
         fem_tangent_matrix = fem_model.MakeTangentMatrix();
     const FemState<double>& free_motion_state =
         EvalFreeMotionFemState(context, index);


### PR DESCRIPTION
Fixes the naming conventions in `block_sparse_lower_triangular_or_symmetric_matrix.h` to allow for spellings like `BlockSparseSymmetricMatrix<MatrixX<T>>`.

Addresses a problem brought up in review of #23806.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23849)
<!-- Reviewable:end -->
