### PR TITLE
[pydrake] fix FindCollisionCandidates return type binding

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -13,6 +13,7 @@
 #include "drake/bindings/generated_docstrings/geometry_query_results.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"
+#include "drake/bindings/pydrake/common/sorted_pair_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/geometry/geometry_py.h"

--- a/bindings/pydrake/geometry/test/scene_graph_test.py
+++ b/bindings/pydrake/geometry/test/scene_graph_test.py
@@ -964,6 +964,12 @@ class TestGeometrySceneGraph(unittest.TestCase):
             mut.HydroelasticContactRepresentation.kTriangle,
             mut.HydroelasticContactRepresentation.kPolygon,
         ):
+            # Check the non-empty return from FindCollisionCandidates() -- see
+            # issue #23839.
+            candidates = query_object.FindCollisionCandidates()
+            self.assertEqual(len(candidates), 1)
+            self.assertEqual(candidates[0], (g_id0, g_id1))
+
             expect_triangles = (
                 rep == mut.HydroelasticContactRepresentation.kTriangle
             )


### PR DESCRIPTION
Prior to this patch, this module was missing the necessary `type_caster` from sorted_pair_pybind.h, and the existing test only checked the trivial empty list return value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23852)
<!-- Reviewable:end -->
