### PR TITLE
Disable some tests on macOS

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -1100,6 +1100,11 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "bvh_test",
+    args = select({
+        # TODO(#23855): This test is currently broken on macOS.
+        "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":bvh",
         ":make_ellipsoid_mesh",

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -1049,6 +1049,11 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "deformable_integration_test",
     timeout = "moderate",
+    args = select({
+        # TODO(#23854): This test is currently broken on macOS.
+        "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":multibody_plant_config_functions",
         ":multibody_plant_core",


### PR DESCRIPTION
These fail under Xcode 26.1.

Towards #23439, see also #23855 #23854.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23856)
<!-- Reviewable:end -->
