### PR TITLE
Correct bvh collision test (restore test on mac)

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -1100,11 +1100,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "bvh_test",
-    args = select({
-        # TODO(#23855): This test is currently broken on macOS.
-        "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],
-        "//conditions:default": [],
-    }),
     deps = [
         ":bvh",
         ":make_ellipsoid_mesh",


### PR DESCRIPTION
The test had two errors in assessing the commutativity of GetCollisionCandidates().

1. It naively assumed that the total number of candidates constituted equivalent sets. While this is a necessary condition for commutativity, it has been shown to be insufficient for making the test robust (see the next point).
2. The articulation of the transitivity pose used the *same* pose when colliding A vs B as when colliding B vs A. When inverting the problem, the transform must also be inverted to create an equivalent result. It was sheer luck (probably attributable to symmetries in the problem) that we produced the same *number* of candidates.

We've made the test robust and corrected the invocation (leaving some documentation on how the test could be made more robust, but at a much higher computational cost, if even this change eventually proves insufficient).

Resolves #23855

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23857)
<!-- Reviewable:end -->
