### PR TITLE
Accommodate mac tolerance on deformable integration test

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -1049,11 +1049,6 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "deformable_integration_test",
     timeout = "moderate",
-    args = select({
-        # TODO(#23854): This test is currently broken on macOS.
-        "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],
-        "//conditions:default": [],
-    }),
     deps = [
         ":multibody_plant_config_functions",
         ":multibody_plant_core",

--- a/multibody/plant/test/deformable_integration_test.cc
+++ b/multibody/plant/test/deformable_integration_test.cc
@@ -251,7 +251,7 @@ TEST_F(DeformableIntegrationTest, SteadyState) {
         SpatialForce<double>(Vector3d::Zero(), f_C_W.segment<3>(3 * i))
             .Shift(p_VC_W);
   }
-  const double kTol = 16.0 * std::numeric_limits<double>::epsilon();
+  const double kTol = 32.0 * std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(CompareMatrices(contact_info.F_Ac_W().translational(),
                               F_Ac_W_expected.translational(), kTol));
   EXPECT_TRUE(CompareMatrices(contact_info.F_Ac_W().rotational(),


### PR DESCRIPTION
A recent update on mac meant that the tolerance we had in a particular test was half a bit tighter than the mac wanted to give. So, we've added another bit to the tolerance to buy some breathing room (still a very reasonable tolerance for 64-bit floats).

Resolves #23854

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23858)
<!-- Reviewable:end -->
