### PR TITLE
[icf] Add coupler constraints

### DIFF
--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -12,6 +12,7 @@ drake_cc_package_library(
     name = "icf",
     visibility = ["//visibility:public"],
     deps = [
+        ":coupler_constraints_data_pool",
         ":eigen_pool",
         ":icf_data",
         ":icf_model",
@@ -30,11 +31,10 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "icf_data",
-    srcs = ["icf_data.cc"],
-    hdrs = ["icf_data.h"],
+    name = "coupler_constraints_data_pool",
+    srcs = ["coupler_constraints_data_pool.cc"],
+    hdrs = ["coupler_constraints_data_pool.h"],
     deps = [
-        ":eigen_pool",
         "//common:default_scalars",
         "//common:essential",
     ],
@@ -51,14 +51,29 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "icf_data",
+    srcs = ["icf_data.cc"],
+    hdrs = ["icf_data.h"],
+    deps = [
+        ":coupler_constraints_data_pool",
+        ":eigen_pool",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "icf_model",
     srcs = [
+        "coupler_constraints_pool.cc",
         "icf_model.cc",
     ],
     hdrs = [
+        "coupler_constraints_pool.h",
         "icf_model.h",
     ],
     deps = [
+        ":coupler_constraints_data_pool",
+        ":eigen_pool",
         ":icf_data",
         ":icf_search_direction_data",
         "//common:default_scalars",

--- a/multibody/contact_solvers/icf/coupler_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/coupler_constraints_data_pool.cc
@@ -1,0 +1,20 @@
+#include "drake/multibody/contact_solvers/icf/coupler_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+template <typename T>
+CouplerConstraintsDataPool<T>::~CouplerConstraintsDataPool() = default;
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        CouplerConstraintsDataPool);

--- a/multibody/contact_solvers/icf/coupler_constraints_data_pool.h
+++ b/multibody/contact_solvers/icf/coupler_constraints_data_pool.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+/* Stores data for coupler constraints. This data is updated at each solver
+iteration, as opposed to the CouplerConstraintsPool, which helps define the
+optimization problem. */
+template <typename T>
+class CouplerConstraintsDataPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CouplerConstraintsDataPool);
+
+  /* Constructs an empty pool. */
+  CouplerConstraintsDataPool() = default;
+
+  ~CouplerConstraintsDataPool();
+
+  /* Resizes the pool, allocating memory only as necessary. */
+  void Resize(int num_couplers) { gamma_pool_.resize(num_couplers); }
+
+  /* Returns the number of gain constraints this data is for. */
+  int num_constraints() const { return ssize(gamma_pool_); }
+
+  /* Returns the constraint impulse γ = -∇ℓ(v) for the k-th constraint in the
+  pool. See CouplerConstraintsPool for details. */
+  const T& gamma(int k) const { return gamma_pool_[k]; }
+  T& mutable_gamma(int k) { return gamma_pool_[k]; }
+
+  /* Returns the total constraint cost ℓ(v) for all coupler constraints in the
+  pool. */
+  const T& cost() const { return cost_; }
+  T& mutable_cost() { return cost_; }
+
+ private:
+  T cost_{0.0};                // Total cost over all coupler constraints.
+  std::vector<T> gamma_pool_;  // Constraint impulses
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        CouplerConstraintsDataPool);

--- a/multibody/contact_solvers/icf/coupler_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/coupler_constraints_pool.cc
@@ -1,0 +1,187 @@
+#include "drake/multibody/contact_solvers/icf/coupler_constraints_pool.h"
+
+#include <utility>
+
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+using contact_solvers::internal::BlockSparseSymmetricMatrix;
+
+template <typename T>
+CouplerConstraintsPool<T>::CouplerConstraintsPool(
+    const IcfModel<T>* parent_model)
+    : model_(parent_model) {
+  DRAKE_ASSERT(parent_model != nullptr);
+}
+
+template <typename T>
+CouplerConstraintsPool<T>::~CouplerConstraintsPool() = default;
+
+template <typename T>
+void CouplerConstraintsPool<T>::Clear() {
+  constraint_to_clique_.clear();
+  dofs_.clear();
+  gear_ratio_.clear();
+  g_hat_.clear();
+  R_.clear();
+}
+
+template <typename T>
+void CouplerConstraintsPool<T>::Resize(const int num_constraints) {
+  constraint_to_clique_.resize(num_constraints);
+  dofs_.resize(num_constraints);
+  gear_ratio_.resize(num_constraints);
+  g_hat_.resize(num_constraints);
+  R_.resize(num_constraints);
+}
+
+template <typename T>
+void CouplerConstraintsPool<T>::Set(int index, int clique, int i, int j,
+                                    const T& qi, const T& qj, T gear_ratio,
+                                    T offset) {
+  DRAKE_ASSERT(index >= 0 && index < num_constraints());
+  DRAKE_ASSERT(i >= 0 && i < model().clique_size(clique));
+  DRAKE_ASSERT(j >= 0 && j < model().clique_size(clique));
+
+  constraint_to_clique_[index] = clique;
+  dofs_[index] = std::make_pair(i, j);
+  gear_ratio_[index] = gear_ratio;
+
+  // Near-rigid regularization: this constraint acts as a very stiff
+  // critically-damped spring with time scale β⋅δt [Castro et al., 2022].
+  const double beta = 0.1;
+  const double eps = beta * beta / (4 * M_PI * M_PI) / (1 + beta / M_PI);
+
+  const T g0 = qi - gear_ratio * qj - offset;
+
+  // Eventually we will use
+  //  v̂ = −g₀ / (δt (1 + β/π)),
+  // However, since model.time_step() may change between now and when we
+  // actually solve the problem, we precompute ĝ = v̂⋅δt = −g₀/(1 + β/π), so that
+  // we can compute v̂ = ĝ/δt from the current time step in calls to CalcData().
+  g_hat_[index] = -g0 / (1.0 + beta / M_PI);
+
+  const auto w_clique = model().clique_diagonal_mass_inverse(clique);
+  // Approximation of W = Jᵀ⋅M⁻¹⋅J ≈ J⋅diag(M)⁻¹⋅Jᵀ, with
+  //  J = [0 ... 1 ... -ρ ... 0]
+  //             ↑      ↑
+  //             i      j
+  const T w = w_clique(i) + gear_ratio * gear_ratio * w_clique(j);
+
+  R_[index] = eps * w;  // Near-rigid regularization [Castro et al., 2022].
+}
+
+template <typename T>
+void CouplerConstraintsPool<T>::CalcData(
+    const VectorX<T>& v, CouplerConstraintsDataPool<T>* coupler_data) const {
+  DRAKE_ASSERT(coupler_data != nullptr);
+
+  T& cost = coupler_data->mutable_cost();
+  cost = 0;
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = constraint_to_clique_[k];
+    auto vk = model().clique_segment(c, v);
+    const int i = dofs_[k].first;
+    const int j = dofs_[k].second;
+    const T& rho = gear_ratio_[k];
+    const T v_hat = g_hat_[k] / model().time_step();
+    const T& R = R_[k];
+
+    const T vi = vk(i);
+    const T vj = vk(j);
+    const T vc = vi - rho * vj;  // Constraint velocity.
+
+    const T gamma = -(vc - v_hat) / R;
+    coupler_data->mutable_gamma(k) = gamma;
+    cost += 0.5 * (v_hat - vc) * gamma;
+  }
+}
+
+template <typename T>
+void CouplerConstraintsPool<T>::AccumulateGradient(const IcfData<T>& data,
+                                                   VectorX<T>* gradient) const {
+  const CouplerConstraintsDataPool<T>& coupler_data =
+      data.coupler_constraints_data();
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = constraint_to_clique_[k];
+    auto gradient_c = model().mutable_clique_segment(c, gradient);
+    const int i = dofs_[k].first;
+    const int j = dofs_[k].second;
+    const T& rho = gear_ratio_[k];
+
+    //  J = [0 ... 1 ... -ρ ... 0]
+    //             ↑      ↑
+    //             i      j
+    // Thus: ∇ℓ = −Jᵀ⋅γ = [0 ... -γₖ ... ρ⋅γₖ ... 0]ᵀ.
+    //                            ↑      ↑
+    //                            i      j
+    const T& gamma = coupler_data.gamma(k);
+    gradient_c(i) -= gamma;
+    gradient_c(j) += rho * gamma;
+  }
+}
+
+template <typename T>
+void CouplerConstraintsPool<T>::AccumulateHessian(
+    const IcfData<T>& data,
+    BlockSparseSymmetricMatrix<MatrixX<T>>* hessian) const {
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = constraint_to_clique_[k];
+    const int i = dofs_[k].first;
+    const int j = dofs_[k].second;
+    const T& rho = gear_ratio_[k];
+    const T& R = R_[k];
+
+    EigenPool<MatrixX<T>>& H_cc_pool = data.scratch().H_cc_pool;
+    H_cc_pool.Resize(1, model().clique_size(c), model().clique_size(c));
+    typename EigenPool<MatrixX<T>>::MatrixView Hc = H_cc_pool[0];
+    Hc.setZero();
+
+    // clang-format off
+    Hc(i, i) += 1.0 / R;  Hc(i, j) -= rho / R;
+    Hc(j, i) -= rho / R;  Hc(j, j) += rho * rho / R;
+    // clang-format on
+
+    hessian->AddToBlock(c, c, Hc);
+  }
+}
+
+template <typename T>
+void CouplerConstraintsPool<T>::CalcCostAlongLine(
+    const CouplerConstraintsDataPool<T>& coupler_data, const VectorX<T>& w,
+    T* dcost, T* d2cost) const {
+  *dcost = 0.0;
+  *d2cost = 0.0;
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = constraint_to_clique_[k];
+    const int i = dofs_[k].first;
+    const int j = dofs_[k].second;
+    const T& rho = gear_ratio_[k];
+    const T& R = R_[k];
+    const T& gamma = coupler_data.gamma(k);
+    auto w_c = model().clique_segment(c, w);
+
+    const T wi = w_c(i);
+    const T wj = w_c(j);
+    const T vw = wi - rho * wj;  // "Constraint velocity" evaluated on w.
+
+    (*dcost) -= gamma * vw;
+    (*d2cost) += vw * vw / R;
+  }
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        CouplerConstraintsPool);

--- a/multibody/contact_solvers/icf/coupler_constraints_pool.h
+++ b/multibody/contact_solvers/icf/coupler_constraints_pool.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/coupler_constraints_data_pool.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+// Forward declaration to break circular dependencies.
+template <typename T>
+class IcfModel;
+
+/* A pool of coupler constraints (qᵢ - ρqⱼ = Δq) linking generalized positions
+(qᵢ, qⱼ) with gear ratio ρ and offset Δq.
+
+Each coupler constraint is associated with a convex cost ℓ(v) that is added to
+the overall ICF cost. The gradient of this cost produces an impulse γ = -∇ℓ(v)
+that enforces the constraint when the convex ICF problem is solved.
+
+Coupler constraints only apply to joints within the same clique, so they do not
+change the sparsity structure of the problem.
+TODO(vincekurtz): consider relaxing this requirement.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class CouplerConstraintsPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CouplerConstraintsPool);
+
+  /* Constructs an empty pool. */
+  explicit CouplerConstraintsPool(const IcfModel<T>* parent_model);
+
+  ~CouplerConstraintsPool();
+
+  /* Returns a reference to the parent model. */
+  const IcfModel<T>& model() const { return *model_; }
+
+  /* Returns the total number of constraints stored in this pool. */
+  int num_constraints() const { return constraint_to_clique_.size(); }
+
+  /* Removes all constraints from this pool while keeping memory allocated. */
+  void Clear();
+
+  /* Resizes the constraints pool to store the given number of constraints.
+
+  @warning After resizing, constraints may hold invalid data until Set() is
+  called for each constraint index in [0, num_constraints()). */
+  void Resize(const int num_constraints);
+
+  /* Sets the given coupler constraint, qᵢ − ρqⱼ = Δq between two DoFs (i, j) in
+  the given clique.
+
+  @param index The index of the constraint within the pool,
+               must be in [0, num_constraints()).
+  @param clique The clique index where the constraint is applied. Both DoFs
+                must belong to the same clique.
+  @param i The clique-local index of the first DoF.
+  @param j The clique-local index of the second DoF.
+  @param qi The current position of the first DoF.
+  @param qj The current position of the second DoF.
+  @param gear_ratio The gear ratio ρ.
+  @param offset The offset Δq.
+
+  Calling this function several times with the same `index` overwrites the
+  previous constraint for that index. */
+  void Set(int index, int clique, int i, int j, const T& qi, const T& qj,
+           T gear_ratio, T offset);
+
+  /* Computes problem data as a function of the generalized velocities v for the
+  full IcfModel. */
+  void CalcData(const VectorX<T>& v,
+                CouplerConstraintsDataPool<T>* coupler_data) const;
+
+  /* Adds the gradient contribution of this constraint, ∇ℓ(v) = −γ, to the
+  model-wide gradient. */
+  void AccumulateGradient(const IcfData<T>& data, VectorX<T>* gradient) const;
+
+  /* Adds the contribution of this constraint to the model-wide Hessian. */
+  void AccumulateHessian(
+      const IcfData<T>& data,
+      contact_solvers::internal::BlockSparseSymmetricMatrix<MatrixX<T>>*
+          hessian) const;
+
+  /* Computes the first and second derivatives of the constraint cost
+  ℓ̃ (α) = ℓ(v + α⋅w).
+
+  @param coupler_data Constraint data computed at v + α⋅w.
+  @param w The search direction.
+  @param[out] dcost the first derivative dℓ̃ /dα on output.
+  @param[out] d2cost the second derivative d²ℓ̃ /dα² on output.
+
+  TODO(vincekurtz): factor out common documentation among constraints. */
+  void CalcCostAlongLine(const CouplerConstraintsDataPool<T>& coupler_data,
+                         const VectorX<T>& w, T* dcost, T* d2cost) const;
+
+ private:
+  const IcfModel<T>* const model_;  // The parent model.
+
+  // Clique for the k-th constraint, of size num_constraints().
+  std::vector<int> constraint_to_clique_;
+
+  // DOFs (i, j) for the k-th constraint, of size num_constraints().
+  std::vector<std::pair<int, int>> dofs_;
+
+  // Gear ratio ρ per constraint, of size num_constraints().
+  std::vector<T> gear_ratio_;
+
+  // Regularization and bias per constraint, of size num_constraints().
+  std::vector<T> g_hat_;  // The true bias is v̂ = ĝ / δt.
+  std::vector<T> R_;
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        CouplerConstraintsPool);

--- a/multibody/contact_solvers/icf/icf_data.cc
+++ b/multibody/contact_solvers/icf/icf_data.cc
@@ -9,26 +9,15 @@ namespace icf {
 namespace internal {
 
 template <typename T>
-void IcfData<T>::Scratch::Clear() {
-  Av_minus_r.Clear();
-  V_WB_alpha.Clear();
-  v_alpha.Clear();
-  H_BB_pool.Clear();
-  H_AA_pool.Clear();
-  H_AB_pool.Clear();
-  H_BA_pool.Clear();
-  GJa_pool.Clear();
-  GJb_pool.Clear();
-}
-
-template <typename T>
 void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
-                                 int max_clique_size) {
-  Clear();
+                                 int max_clique_size, int num_couplers) {
   Av_minus_r.Resize(1, num_velocities, 1);
 
   V_WB_alpha.Resize(num_bodies, 6, 1);
   v_alpha.Resize(1, num_velocities, 1);
+
+  coupler_constraints_data.Resize(num_couplers);
+  H_cc_pool.Resize(1, max_clique_size, max_clique_size);
 
   H_BB_pool.Resize(1, max_clique_size, max_clique_size);
   H_AA_pool.Resize(1, max_clique_size, max_clique_size);
@@ -42,13 +31,14 @@ template <typename T>
 IcfData<T>::~IcfData() = default;
 
 template <typename T>
-void IcfData<T>::Resize(int num_bodies, int num_velocities,
-                        int max_clique_size) {
+void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
+                        int num_couplers) {
   v_.resize(num_velocities);
   V_WB_.Resize(num_bodies, 6, 1);
   Av_.resize(num_velocities);
   gradient_.resize(num_velocities);
-  scratch_.Resize(num_bodies, num_velocities, max_clique_size);
+  coupler_constraints_data_.Resize(num_couplers);
+  scratch_.Resize(num_bodies, num_velocities, max_clique_size, num_couplers);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_data.h
+++ b/multibody/contact_solvers/icf/icf_data.h
@@ -3,6 +3,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/icf/coupler_constraints_data_pool.h"
 #include "drake/multibody/contact_solvers/icf/eigen_pool.h"
 
 namespace drake {
@@ -33,15 +34,17 @@ class IcfData {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IcfData);
 
-  /* Struct to store pre-allocated scratch space. Unlike the cache, this scratch
-  space is for intermediate computations, and is often cleared or overwritten as
-  needed. */
-  struct Scratch {
-    /* Clears all data without changing capacity. */
-    void Clear();
+  /* Struct to store pre-allocated scratch space. This scratch space is for
+  intermediate computations, and is often cleared or overwritten as needed. To
+  avoid nested function calls that accidentally overwrite the scratch space of
+  previous calls in the stack, we name these variables for their specific uses.
 
+  @warning Accidentally overwriting values in the scratch is not prevented by
+  this class. Calling code must ensure that scratch space is used safely. */
+  struct Scratch {
     /* Resizes the scratch space, allocating memory as needed. */
-    void Resize(int num_bodies, int num_velocities, int max_clique_size);
+    void Resize(int num_bodies, int num_velocities, int max_clique_size,
+                int num_couplers);
 
     // Scratch space for CalcMomentumTerms. Holds at most one vector of size
     // num_velocities().
@@ -54,6 +57,13 @@ class IcfData {
     // Generalized velocities at v + α⋅w. Holds at most one vector of size
     // num_velocities().
     EigenPool<VectorX<T>> v_alpha;
+
+    // Scratch data pools for CalcCostAlongLine
+    CouplerConstraintsDataPool<T> coupler_constraints_data;
+
+    // Scratch space for coupler constraints Hessian accumulation. Holds at most
+    // one matrix of size max_clique_size() x max_clique_size().
+    EigenPool<MatrixX<T>> H_cc_pool;
 
     // Scratch space for Hessian accumulation. These pools will only hold at
     // most one element, but using pools instead of a single MatrixX<T> allows
@@ -76,8 +86,10 @@ class IcfData {
 
   @param num_bodies Total number of bodies in the model.
   @param num_velocities Total number of generalized velocities.
-  @param max_clique_size Maximum number of velocities in any clique. */
-  void Resize(int num_bodies, int num_velocities, int max_clique_size);
+  @param max_clique_size Maximum number of velocities in any clique.
+  @param num_couplers Number of coupler constraints. */
+  void Resize(int num_bodies, int num_velocities, int max_clique_size,
+              int num_couplers);
 
   /* Returns the number of generalized velocities in the system. */
   int num_velocities() const { return v_.size(); }
@@ -116,6 +128,14 @@ class IcfData {
   const VectorX<T>& gradient() const { return gradient_; }
   VectorX<T>& mutable_gradient() { return gradient_; }
 
+  /* Returns the data pool for coupler constraints. */
+  const CouplerConstraintsDataPool<T>& coupler_constraints_data() const {
+    return coupler_constraints_data_;
+  }
+  CouplerConstraintsDataPool<T>& mutable_coupler_constraints_data() {
+    return coupler_constraints_data_;
+  }
+
   /* Returns a mutable scratch space for intermediate computations. We allow
   IcfModel to write on the scratch as needed. */
   Scratch& scratch() const { return scratch_; }
@@ -127,6 +147,9 @@ class IcfData {
   T momentum_cost_{0};          // 0.5 vᵀAv - rᵀv
   T cost_{0};                   // Total cost ℓ(v) = 0.5 vᵀA v - rᵀv + ℓᶜ(v)
   VectorX<T> gradient_;         // Total cost gradient ∇ℓ(v)
+
+  // Type-specific constraint pools.
+  CouplerConstraintsDataPool<T> coupler_constraints_data_;
 
   mutable Scratch scratch_;
 };

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/coupler_constraints_pool.h"
 #include "drake/multibody/contact_solvers/icf/eigen_pool.h"
 #include "drake/multibody/contact_solvers/icf/icf_data.h"
 #include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
@@ -136,10 +137,16 @@ class IcfModel {
   /* Returns the maximum number of velocities in any clique. */
   int max_clique_size() const { return max_clique_size_; }
 
-  /* Returns the total number of constraints of any type in the problem.. */
-  int num_constraints() const {
-    // TODO(#23769): add constraints to the model.
-    return 0;
+  /* Returns the total number of constraints of any type in the problem. */
+  int num_constraints() const { return num_coupler_constraints(); }
+
+  /* Provides mutable access to the pool of all coupler constraints. */
+  CouplerConstraintsPool<T>& coupler_constraints_pool() {
+    return coupler_constraints_pool_;
+  }
+
+  int num_coupler_constraints() const {
+    return coupler_constraints_pool_.num_constraints();
   }
 
   /* Returns the time step δt. */
@@ -220,13 +227,11 @@ class IcfModel {
   /* Returns the linear cost term r = A v₀ - δt k₀ */
   const VectorX<T>& r() const { return r_; }
 
-  /* Returns an approximation of the Delassus operator for the given clique.
-  The Delassus operator is W = J⋅M⁻¹⋅Jᵀ. For constraints for which vc = v,
-  i.e. the constraint Jacobian is the identity, we have W = M⁻¹. Further, we
-  simplify this estimation as W = diag(M)⁻¹. */
-  ConstVectorXView clique_delassus_approx(int clique) const {
+  /* Returns diag(M)⁻¹. This is often used to approximate the Delassus operator
+  W = J⋅M⁻¹⋅Jᵀ ≈ J⋅diag(M)⁻¹⋅Jᵀ. */
+  ConstVectorXView clique_diagonal_mass_inverse(int clique) const {
     DRAKE_ASSERT(0 <= clique && clique < num_cliques());
-    return clique_delassus_[clique];
+    return clique_diagonal_mass_inverse_[clique];
   }
 
   /* Returns the Hessian sparsity pattern. This is useful for detecting when the
@@ -343,7 +348,7 @@ class IcfModel {
   EigenPool<Vector6<T>> V_WB0_;  // Body spatial velocities at v₀, V = J_WB v₀.
   VectorX<T> scale_factor_;      // Scale diag(M)^{-1/2} for convergence check.
   EigenPool<MatrixX<T>> A_;  // Sparse linearized dynamics matrix A = M₀ + δtD₀.
-  EigenPool<VectorX<T>> clique_delassus_;  // Delassus estimate W = diag(M₀)⁻¹.
+  EigenPool<VectorX<T>> clique_diagonal_mass_inverse_;  // diag(M₀)⁻¹.
   VectorX<T> Av0_;  // Av₀ storage, used to recompute r with a new δt.
   VectorX<T> r_;    // Linear cost term r = Av₀ - δt k₀.
 
@@ -357,6 +362,9 @@ class IcfModel {
   // Sparsity pattern of the Hessian matrix. Defined on a per-clique basis.
   std::unique_ptr<contact_solvers::internal::BlockSparsityPattern>
       sparsity_pattern_;
+
+  // Fixed set of constraints.
+  CouplerConstraintsPool<T> coupler_constraints_pool_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/test/icf_data_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_data_test.cc
@@ -33,8 +33,9 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   const int num_bodies = 5;
   const int num_velocities = 12;
   const int max_clique_size = 6;
+  const int num_couplers = 2;
 
-  data.Resize(num_bodies, num_velocities, max_clique_size);
+  data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers);
 
   // Main data elements
   EXPECT_EQ(data.num_velocities(), num_velocities);
@@ -49,6 +50,10 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   EXPECT_EQ(data.scratch().Av_minus_r[0].size(), num_velocities);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
   EXPECT_EQ(data.scratch().v_alpha[0].size(), num_velocities);
+  EXPECT_EQ(data.scratch().coupler_constraints_data.num_constraints(),
+            num_couplers);
+  EXPECT_EQ(data.scratch().H_cc_pool[0].rows(), max_clique_size);
+  EXPECT_EQ(data.scratch().H_cc_pool[0].cols(), max_clique_size);
   EXPECT_EQ(data.scratch().H_BB_pool[0].rows(), max_clique_size);
   EXPECT_EQ(data.scratch().H_BB_pool[0].cols(), max_clique_size);
   EXPECT_EQ(data.scratch().H_AA_pool[0].rows(), max_clique_size);
@@ -61,18 +66,20 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   EXPECT_EQ(data.scratch().GJb_pool[0].cols(), max_clique_size);
 }
 
-/* Checks that calling Resize doesn't cost extra heap allocations. */
+/* Checks that calling Resize doesn't cost heap allocations when the new size is
+no larger than it has been previously. */
 GTEST_TEST(IcfData, LimitMallocOnResize) {
   IcfData<double> data;
   const int num_bodies = 3;
   const int num_velocities = 11;
   const int max_clique_size = 7;
+  const int num_couplers = 2;
 
-  data.Resize(num_bodies, num_velocities, max_clique_size);
+  data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers);
 
   // Clearing pools changes size but shouldn't change capacity.
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
-  data.scratch().Clear();
+  data.scratch().Resize(0, 0, 0, 0);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), 0);
 
   VectorX<double> v = VectorX<double>::LinSpaced(num_velocities, 1.0, 11.0);
@@ -80,7 +87,7 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
     // Restoring the data to the original size and setting velocities should not
     // cause any new allocations.
     drake::test::LimitMalloc guard;
-    data.Resize(num_bodies, num_velocities, max_clique_size);
+    data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers);
     data.set_v(v);
   }
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);

--- a/multibody/contact_solvers/icf/test/icf_model_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_model_test.cc
@@ -114,6 +114,36 @@ void MakeUnconstrainedModel(IcfModel<T>* model, bool single_clique = false,
   model->ResetParameters(std::move(params));
 }
 
+/* Adds a coupler constraint to the given model. */
+template <typename T>
+void AddCouplerConstraint(IcfModel<T>* model) {
+  const bool single_clique = model->num_cliques() == 1;
+
+  CouplerConstraintsPool<T>& couplers = model->coupler_constraints_pool();
+  couplers.Resize(1 /* one constraint */);
+
+  const int nv = model->num_velocities();
+  VectorX<T> q0 = VectorXd::LinSpaced(nv, -1.0, 1.0);
+
+  if (!single_clique) {
+    // This is a multi-clique model, so we'll put a coupler on clique 1.
+    const VectorX<T>& q0_clique = model->clique_segment(1, q0);
+    const double rho = 2.5;
+    const double offset = 0.1;
+    couplers.Set(0 /* constraint index */, 1 /* clique */, 1 /* i */, 3 /* j */,
+                 q0_clique(1), q0_clique(3), rho, offset);
+  } else {
+    // This is a single-clique model, so we'll put a coupler on clique 0.
+    // However, we'll choose indices that would have belonged to clique 1 in the
+    // multi-clique version.
+    const VectorX<T>& q0_clique = model->clique_segment(0, q0);
+    const double rho = 2.5;
+    const double offset = 0.1;
+    couplers.Set(0 /* constraint index */, 0 /* clique */, 7 /* i */, 9 /* j */,
+                 q0_clique(7), q0_clique(9), rho, offset);
+  }
+}
+
 /* Checks that a default constructed model is empty. */
 GTEST_TEST(IcfModel, EmptyModel) {
   IcfModel<double> model;
@@ -229,7 +259,7 @@ GTEST_TEST(IcfModel, PerBodyElements) {
 
     EXPECT_GT(model.body_mass(b), 0.0);
     if (!model.is_anchored(b)) {
-      EXPECT_GT(model.clique_delassus_approx(c).minCoeff(), 0.0);
+      EXPECT_GT(model.clique_diagonal_mass_inverse(c).minCoeff(), 0.0);
       model.mutable_clique_segment(c, &mutable_vector) +=
           VectorXd::Ones(clique_nv);
     }
@@ -247,17 +277,19 @@ GTEST_TEST(IcfModel, PerBodyElements) {
   EXPECT_EQ(num_anchored, 1);
 }
 
-/* Checks that gradients are computed correctly for an unconstrained problem. */
+/* Checks that gradients are computed correctly, even in the presence of
+constraints. */
 GTEST_TEST(IcfModel, CalcGradients) {
   IcfModel<AutoDiffXd> model;
-  // TODO(vincekurtz): run this test with constraints once they land.
   MakeUnconstrainedModel(&model);
+  AddCouplerConstraint(&model);
+  model.SetSparsityPattern();
   const int nv = model.num_velocities();
 
   IcfData<AutoDiffXd> data;
   model.ResizeData(&data);
-  EXPECT_EQ(data.num_velocities(), model.num_velocities());
-  EXPECT_EQ(model.num_constraints(), 0);
+  EXPECT_EQ(data.num_velocities(), nv);
+  EXPECT_EQ(model.num_constraints(), 1);
 
   VectorXd v_values = VectorXd::LinSpaced(nv, -10, 10.0);
   VectorX<AutoDiffXd> v(nv);
@@ -268,15 +300,15 @@ GTEST_TEST(IcfModel, CalcGradients) {
   const VectorXd cost_derivatives = data.cost().derivatives();
   const VectorXd gradient_value = math::ExtractValue(data.gradient());
 
-  EXPECT_TRUE(CompareMatrices(gradient_value, cost_derivatives, 8 * kEpsilon,
+  EXPECT_TRUE(CompareMatrices(gradient_value, cost_derivatives, 100 * kEpsilon,
                               MatrixCompareType::relative));
 }
 
 /* Checks the Hessian for a problem with a single clique. */
 GTEST_TEST(IcfModel, CalcDenseHessian) {
   IcfModel<AutoDiffXd> model;
-  // TODO(vincekurtz): run this test with constraints once they land.
   MakeUnconstrainedModel(&model, true /* single cliques */);
+  AddCouplerConstraint(&model);
   model.SetSparsityPattern();
   EXPECT_EQ(model.num_cliques(), 1);
   EXPECT_EQ(model.num_velocities(), 18);
@@ -316,14 +348,15 @@ GTEST_TEST(IcfModel, CalcDenseHessian) {
 break out the cliques. */
 GTEST_TEST(IcfModel, SingleVsMultipleCliques) {
   IcfModel<double> model_single;
-  // TODO(vincekurtz): run this test with constraints once they land.
   MakeUnconstrainedModel(&model_single, true);
+  AddCouplerConstraint(&model_single);
   model_single.SetSparsityPattern();
   EXPECT_EQ(model_single.num_cliques(), 1);
   EXPECT_EQ(model_single.num_velocities(), 18);
 
   IcfModel<double> model_multiple;
   MakeUnconstrainedModel(&model_multiple, false);
+  AddCouplerConstraint(&model_multiple);
   model_multiple.SetSparsityPattern();
   EXPECT_EQ(model_multiple.num_cliques(), 3);
   EXPECT_EQ(model_multiple.num_velocities(), 18);
@@ -368,10 +401,12 @@ GTEST_TEST(IcfModel, SingleVsMultipleCliques) {
 /* Checks that our exact linesearch computations are correct. */
 GTEST_TEST(IcfModel, CalcCostAlongLine) {
   IcfModel<AutoDiffXd> model;
-  // TODO(vincekurtz): run this test with constraints once they land.
   MakeUnconstrainedModel(&model);
+  AddCouplerConstraint(&model);
+  model.SetSparsityPattern();
   EXPECT_EQ(model.num_cliques(), 3);
   EXPECT_EQ(model.num_velocities(), 18);
+  EXPECT_EQ(model.num_constraints(), 1);
 
   // Allocate data, and additional scratch.
   IcfData<AutoDiffXd> data, scratch;
@@ -426,22 +461,25 @@ GTEST_TEST(IcfModel, CalcCostAlongLine) {
 model from scratch. */
 GTEST_TEST(IcfModel, UpdateTimeStep) {
   IcfModel<double> model_original;
-  // TODO(vincekurtz): run this test with constraints once they land.
   MakeUnconstrainedModel(&model_original, false, 0.02);
+  AddCouplerConstraint(&model_original);
   model_original.SetSparsityPattern();
   EXPECT_EQ(model_original.num_cliques(), 3);
   EXPECT_EQ(model_original.num_velocities(), 18);
   EXPECT_EQ(model_original.time_step(), 0.02);
+  EXPECT_EQ(model_original.num_constraints(), 1);
 
   const double new_time_step = 0.003;
 
   // Create a second model from scratch with the new time step.
   IcfModel<double> model_new;
   MakeUnconstrainedModel(&model_new, false, new_time_step);
+  AddCouplerConstraint(&model_new);
   model_new.SetSparsityPattern();
   EXPECT_EQ(model_new.num_cliques(), 3);
   EXPECT_EQ(model_new.num_velocities(), 18);
   EXPECT_EQ(model_new.time_step(), new_time_step);
+  EXPECT_EQ(model_new.num_constraints(), 1);
 
   // Now update the time step of the original model.
   EXPECT_NE(model_original.time_step(), new_time_step);
@@ -480,8 +518,107 @@ GTEST_TEST(IcfModel, ParamsAccessors) {
 
   const IcfParameters<double>* params1 = &model.params();
   std::unique_ptr<IcfParameters<double>> params2 = model.ReleaseParameters();
-
   EXPECT_EQ(params1, params2.get());
+}
+
+/* Verifies that the coupler constraint produces correct data. */
+GTEST_TEST(IcfModel, CouplerConstraint) {
+  IcfModel<AutoDiffXd> model;
+  MakeUnconstrainedModel(&model);
+  model.SetSparsityPattern();
+  EXPECT_EQ(model.num_cliques(), 3);
+  EXPECT_EQ(model.num_velocities(), 18);
+  EXPECT_EQ(model.num_constraints(), 0);
+
+  IcfData<AutoDiffXd> data;
+  model.ResizeData(&data);
+  EXPECT_EQ(data.num_velocities(), model.num_velocities());
+
+  // At this point there should be no coupler constraints.
+  EXPECT_EQ(model.num_coupler_constraints(), 0);
+
+  // Add coupler constraints.
+  AddCouplerConstraint(&model);
+  EXPECT_EQ(model.num_coupler_constraints(), 1);
+  EXPECT_EQ(model.num_constraints(), 1);
+
+  // Resize data to include coupler constraints.
+  model.ResizeData(&data);
+  EXPECT_EQ(data.coupler_constraints_data().num_constraints(), 1);
+
+  const int nv = model.num_velocities();
+  VectorXd v_value = VectorXd::LinSpaced(nv, -10, 10.0);
+  VectorX<AutoDiffXd> v(nv);
+  math::InitializeAutoDiff(v_value, &v);
+  model.CalcData(v, &data);
+
+  const double dt = model.time_step().value();
+  const VectorX<AutoDiffXd> q0 = VectorXd::LinSpaced(nv, -1.0, 1.0);
+  const double rho = 2.5;
+  const double offset = 0.1;
+  VectorX<AutoDiffXd> q = q0 + dt * v;
+  const auto q_clique = model.clique_segment(1, q);
+  const auto v_clique = model.clique_segment(1, v);
+
+  // Compute regularization manually.
+  const double beta =
+      0.1;  // Keep in sync with hard-coded value in the implementation.
+  const double m = 2.3;                           // "mass" for clique 1.
+  const double w_delassus = (1 + rho * rho) / m;  // Delassus for clique 1.
+  const double m_effective = 1.0 / w_delassus;    // Effective mass.
+  const double omega_near_rigid =
+      2 * M_PI / (beta * dt);  // period_nr = beta * dt, by definition.
+  const double k = m_effective * omega_near_rigid * omega_near_rigid;
+  const double tau = beta / M_PI * dt;
+
+  const CouplerConstraintsDataPool<AutoDiffXd>& couplers_data =
+      data.coupler_constraints_data();
+  EXPECT_EQ(couplers_data.num_constraints(), 1);
+
+  const VectorXd cost_gradient = couplers_data.cost().derivatives();
+
+  // Expected impulse.
+  const AutoDiffXd g0 = q_clique(1) - rho * q_clique(3) - offset;
+  const AutoDiffXd gdot0 = v_clique(1) - rho * v_clique(3);
+  const AutoDiffXd gamma0 = -dt * k * (g0 + tau * gdot0);
+  VectorXd tau_expected = VectorXd::Zero(nv);
+  tau_expected(6 + 1) = gamma0.value();
+  tau_expected(6 + 3) = -rho * gamma0.value();
+  EXPECT_TRUE(CompareMatrices(-cost_gradient, tau_expected, 10 * kEpsilon,
+                              MatrixCompareType::relative));
+
+  const double gamma = couplers_data.gamma(0).value();
+  EXPECT_NEAR(gamma, gamma0.value(), std::abs(gamma) * kEpsilon);
+
+  // Verify contributions to Hessian.
+  auto hessian = model.MakeHessian(data);
+  MatrixXd hessian_value = math::ExtractValue(hessian->MakeDenseMatrix());
+  MatrixXd gradient_derivatives = math::ExtractGradient(data.gradient());
+  EXPECT_TRUE(CompareMatrices(hessian_value, gradient_derivatives,
+                              10 * kEpsilon, MatrixCompareType::relative));
+
+  // Check that CalcCostAlongLine works for coupler constraints.
+  // Allocate search direction.
+  const VectorX<AutoDiffXd> w = VectorX<AutoDiffXd>::LinSpaced(
+      nv, 0.1, -0.2);  // Arbitrary search direction.
+  IcfSearchDirectionData<AutoDiffXd> search_data;
+
+  // Set data with constant value of v.
+  VectorX<AutoDiffXd> v_constant =
+      VectorX<AutoDiffXd>::LinSpaced(nv, -10, 10.0);
+  model.CalcData(v_constant, &data);
+  model.CalcSearchDirectionData(data, w, &search_data);
+
+  const AutoDiffXd alpha = {
+      0.35 /* arbitrary value */,
+      VectorXd::Ones(1) /* This is the independent variable */};
+  AutoDiffXd dcost, d2cost;
+  const AutoDiffXd cost =
+      model.CalcCostAlongLine(alpha, data, search_data, &dcost, &d2cost);
+
+  const double scale = std::abs(dcost.value());
+  EXPECT_NEAR(dcost.value(), cost.derivatives()[0], scale * kEpsilon);
+  EXPECT_NEAR(d2cost.value(), dcost.derivatives()[0], scale * kEpsilon);
 }
 
 }  // namespace


### PR DESCRIPTION
Adds coupler constraints (e.g., one joint angle tracks another) to the ICF formulation. This is the next step along the ICF PR train (#23769), and an example of a relatively simple constraint. 

For full context, see the [cenic_main](https://github.com/RobotLocomotion/drake/tree/cenic_main) dev branch, and especially the [ICF README](https://github.com/RobotLocomotion/drake/blob/cenic_main/multibody/contact_solvers/icf/README.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23860)
<!-- Reviewable:end -->
