### PR TITLE
[ad] Fix logical sparsity in derivatives

### DIFF
--- a/common/ad/internal/partials.h
+++ b/common/ad/internal/partials.h
@@ -23,7 +23,12 @@ never returns back to being zero-sized (unless the Partials is moved-from).
 In particular, note that the result of a binary operation takes on the size from
 either operand, e.g., foo.Add(bar) with foo.size() == 0 and bar.size() == 4 will
 will result in foo.size() == 4 after the addition, and that's true even if bar's
-vector was all zeros. */
+vector was all zeros.
+
+When a scale factor is applied to a Partials object (e.g., with Mul, Div, or
+AddScaled), any zero values will remain zero, even if the factor is ±∞ or NaN.
+We treat them as "missing" (i.e., sparse), not IEEE zero, so multiplication by
+non-finite numbers is still well-defined. */
 class Partials {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Partials);
@@ -56,10 +61,10 @@ class Partials {
   void SetZero() { derivatives_.setZero(); }
 
   /* Scales this vector by the given amount. */
-  void Mul(double factor) { derivatives_ *= factor; }
+  void Mul(double factor);
 
   /* Scales this vector by the reciprocal of the given amount. */
-  void Div(double factor) { derivatives_ /= factor; }
+  void Div(double factor);
 
   /* Adds `other` into `this`. */
   void Add(const Partials& other);

--- a/common/ad/internal/standard_operations.cc
+++ b/common/ad/internal/standard_operations.cc
@@ -216,6 +216,7 @@ AutoDiff pow(AutoDiff base_ad, const AutoDiff& exp_ad) {
   // If any of {base, exp, result} are NaN, then grad(result) is always NaN.
   if (std::isnan(result.value()) || std::isnan(base) || std::isnan(exp)) {
     result.partials().Mul(kNaN);
+    result.partials().AddScaled(kNaN, exp_ad.partials());
     return result;
   }
 

--- a/common/ad/test/standard_operations_atan2_test.cc
+++ b/common/ad/test/standard_operations_atan2_test.cc
@@ -5,6 +5,29 @@ namespace drake {
 namespace test {
 namespace {
 
+// The Eigen::AutoDiffScalar reference implementation of atan2 doesn't handle
+// atan2(0, 0) correctly, so we'll define a shim that does and test it instead.
+AutoDiff3 atan2_for_testing(const AutoDiff3& y, const AutoDiff3& x) {
+  if (x.value() == 0 && x.derivatives().isZero(0.0) && y.value() == 0 &&
+      y.derivatives().isZero(0.0)) {
+    return AutoDiff3(0.0, Eigen::Vector3d::Zero());
+  }
+  return atan2(y, x);
+}
+
+// We need to provide a like-named stub for the device under test, but without
+// any adjustments to the computation.
+AutoDiffDut atan2_for_testing(const AutoDiffDut& y, const AutoDiffDut& x) {
+  return atan2(y, x);
+}
+
+TEST_F(StandardOperationsTest, Atan2AdsAds) {
+  CHECK_BINARY_FUNCTION_ADS_ADS(atan2_for_testing, x, y, 0.1);
+  CHECK_BINARY_FUNCTION_ADS_ADS(atan2_for_testing, x, y, -0.1);
+  CHECK_BINARY_FUNCTION_ADS_ADS(atan2_for_testing, y, x, 0.4);
+  CHECK_BINARY_FUNCTION_ADS_ADS(atan2_for_testing, y, x, -0.4);
+}
+
 // Eigen doesn't provide mixed-scalar atan2() overloads, so we need to do it.
 // This assumes the standard_operations_test.h is implemented using AutoDiff3.
 AutoDiff3 atan2(const AutoDiff3& y, double x) {
@@ -12,13 +35,6 @@ AutoDiff3 atan2(const AutoDiff3& y, double x) {
 }
 AutoDiff3 atan2(double y, const AutoDiff3& x) {
   return atan2(AutoDiff3{y}, x);
-}
-
-TEST_F(StandardOperationsTest, Atan2AdsAds) {
-  CHECK_BINARY_FUNCTION_ADS_ADS(atan2, x, y, 0.1);
-  CHECK_BINARY_FUNCTION_ADS_ADS(atan2, x, y, -0.1);
-  CHECK_BINARY_FUNCTION_ADS_ADS(atan2, y, x, 0.4);
-  CHECK_BINARY_FUNCTION_ADS_ADS(atan2, y, x, -0.4);
 }
 
 TEST_F(StandardOperationsTest, Atan2AdsDouble) {

--- a/common/ad/test/standard_operations_pow_special_test.cc
+++ b/common/ad/test/standard_operations_pow_special_test.cc
@@ -118,17 +118,16 @@ TEST_P(PowSpecial, AdsAds) {
   ASSERT_EQ(result.derivatives().size(), 3);
   const Eigen::Vector3d grad = result.derivatives();
 
+  // Neither base nor exp has an input gradient in the 0th index.
+  // That should remain true for the result as well.
+  EXPECT_EQ(grad[0], 0.0);
+
   // If the result was NaN, then the gradient should be NaN.
   if (pow_case.is_nan) {
-    EXPECT_THAT(grad[0], testing::IsNan());
     EXPECT_THAT(grad[1], testing::IsNan());
     EXPECT_THAT(grad[2], testing::IsNan());
     return;
   }
-
-  // Neither base nor exp has an input gradient in the 0th index.
-  // That should remain true for the result as well.
-  EXPECT_EQ(grad[0], 0.0);
 
   // The 1st grad index is the partial wrt base.
   if (pow_case.ignore_base_grad) {


### PR DESCRIPTION
If a particular derivative index is zero by definition (i.e., sparse), then it should remain zero even when combined using the chain rule. Previously, if the scale factor was infinite or NaN, the zero would become NaN due to IEEE multiplication rules.

Towards #23862 and therefore towards #23820.

~See also [the full spreadsheet of special cases](https://docs.google.com/spreadsheets/d/1HWKwWr2HySZU_vohyJ2o0qMLbGcZEEOPznOsK5x_iGw/edit?gid=0#gid=0) to understand the nature of the change.  There are tabs for this PR's behavior vs the original behavior.~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23861)
<!-- Reviewable:end -->
