### PR TITLE
[ad] Special case pow for non-negative exponents of a zero base

### DIFF
--- a/common/ad/internal/standard_operations.cc
+++ b/common/ad/internal/standard_operations.cc
@@ -163,75 +163,16 @@ AutoDiff log(AutoDiff x) {
 }
 
 namespace {
-
 constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
-
-// Iterates over the partials of `input`. For any non-zero elements, sets the
-// corresponding partial in `output` to NaN.
-// @pre output->MatchSizeOf(input) has already been performed.
-void UndefineOutputGradWhereInputGradNonzero(const AutoDiff& input,
-                                             AutoDiff* output) {
-  DRAKE_DEMAND(output != nullptr);
-
-  // If either input or output are empty, there's nothing to do.
-  if (output->partials().size() == 0) {
-    // MatchSizeOf guarantees this.
-    DRAKE_ASSERT(input.partials().size() == 0);
-    return;
-  }
-  if (input.partials().size() == 0) {
-    return;
-  }
-
-  // In case input and output are the same object, we need to call the
-  // non-const member function first.
-  auto& output_grad = output->partials().get_raw_storage_mutable();
-  const auto& input_grad = input.partials().make_const_xpr();
-
-  // Update the `output` per our API contract.
-  const int size = output_grad.size();
-  DRAKE_ASSERT(size == input_grad.size());
-  for (int i = 0; i < size; ++i) {
-    if (!(input_grad[i] == 0.0)) {
-      output_grad[i] = kNaN;
-    }
-  }
-}
-
 }  // namespace
 
-AutoDiff pow(AutoDiff base_ad, const AutoDiff& exp_ad) {
-  // It's convenient to immediately set up the result, so we'll need to take a
-  // picture of `base_ad.value()` first. Might as well do `exp` for convenience.
-  const double base = base_ad.value();
-  const double exp = exp_ad.value();
+AutoDiff pow(AutoDiff base, const AutoDiff& exp) {
+  // Compute p = bˣ.
+  const double b = base.value();
+  const double x = exp.value();
+  const double p = std::pow(b, x);
 
-  // Result starts out holding the proper return value, but its partials are
-  // just grad(base) to start.  We'll adjust them at the end; for now, just
-  // set them to the correct size.
-  AutoDiff result = std::move(base_ad);
-  result.value() = std::pow(base, exp);
-  result.partials().MatchSizeOf(exp_ad.partials());
-
-  // If any of {base, exp, result} are NaN, then grad(result) is always NaN.
-  if (std::isnan(result.value()) || std::isnan(base) || std::isnan(exp)) {
-    result.partials().Mul(kNaN);
-    result.partials().AddScaled(kNaN, exp_ad.partials());
-    return result;
-  }
-
-  // When dealing with infinities (or a zero base where a sign-change to the
-  // exponent introduces infinities), trying to compute well-defined gradients
-  // with appropriate symmetries is impractical. In that case, when grad(base)
-  // and grad(exp) are both zero we'll leave grad(result) as zero, but otherwise
-  // any non-zero input gradient becomes ill-defined in the result.
-  if (base == 0 || !std::isfinite(base) || !std::isfinite(exp)) {
-    UndefineOutputGradWhereInputGradNonzero(result, &result);
-    UndefineOutputGradWhereInputGradNonzero(exp_ad, &result);
-    return result;
-  }
-
-  // For the gradient, we have:
+  // For the derivative, we have:
   //    ∂/∂v bˣ
   //  = ∂/∂v eˡⁿ⁽ᵇ⁾ˣ                      # Power via logarithms
   //  = eˡⁿ⁽ᵇ⁾ˣ ∂/∂v ln(b)x               # Derivative of exponentiation
@@ -239,25 +180,39 @@ AutoDiff pow(AutoDiff base_ad, const AutoDiff& exp_ad) {
   //  = bˣ (x ∂/∂v ln(b) + ln(b) ∂x/∂v)   # Multiplication chain rule
   //  = bˣ (xb⁻¹ ∂b/∂v + ln(b) ∂x/∂v)     # Derivative of logarithm
   //  = xbˣ⁻¹ ∂b/∂v + bˣln(b) ∂x/∂v       # Distribute
+  //
+  // We can write that as `db_scale * ∂b/∂v + dx_scale * ∂x/∂v`.
+  double db_scale = x * std::pow(b, x - 1);
+  double dx_scale = p * std::log(b);
 
-  // Account for the contribution of grad(base) on grad(result).
-  // Don't try to compute (xbˣ⁻¹) with x == 0, in case it comes out as a NaN
-  // (e.g., 0 * ∞). Instead, just assume that the x == 0 wins, such that the
-  // grad(base) has no contribution to the result.
-  const double base_grad_scale = (exp == 0) ? 0 : exp * std::pow(base, exp - 1);
-  DRAKE_DEMAND(std::isfinite(base_grad_scale));
-  result.partials().Mul(base_grad_scale);
-
-  // Account for the contribution of grad(exp) on grad(result).
-  if (base < 0) {
-    UndefineOutputGradWhereInputGradNonzero(exp_ad, &result);
-  } else {
-    DRAKE_DEMAND(base > 0);
-    const double exp_grad_scale = result.value() * std::log(base);
-    DRAKE_DEMAND(std::isfinite(exp_grad_scale));
-    result.partials().AddScaled(exp_grad_scale, exp_ad.partials());
+  // However, there are several special cases that need customization:
+  if (!std::isfinite(b) || !std::isfinite(x) || !std::isfinite(p)) {
+    // It's impractical to choose well-defined derivatives of ±∞ and/or NaN.
+    db_scale = kNaN;
+    dx_scale = kNaN;
+  } else if (b < 0) {
+    // The result would be finite only if the exponent was an integer, which
+    // means that any non-zero entries in ∂x/∂vᵢ make our resulting derivative
+    // ill-defined (since an infinitesimal change would make change it from an
+    // integer to a non-integer).
+    dx_scale = kNaN;
+  } else if (b == 0) {
+    if (x == 0) {
+      // The xbˣ⁻¹ would come out as a NaN (0 × ∞), but we can reason about the
+      // limit for a better answer: the limit b→0 0/b is 0.
+      db_scale = 0;
+    } else if (x > 0) {
+      // The bˣln(b) would come out as NaN (0 × -∞), but we can reason about the
+      // limit for a better answer: for x > 0, the limit b→0⁺ bˣln(b) is 0.
+      dx_scale = 0;
+    }
   }
 
+  // Assemble the result.
+  AutoDiff result{p};
+  result.partials() = std::move(base.partials());
+  result.partials().Mul(db_scale);
+  result.partials().AddScaled(dx_scale, exp.partials());
   return result;
 }
 

--- a/common/ad/internal/standard_operations.h
+++ b/common/ad/internal/standard_operations.h
@@ -443,15 +443,12 @@ AutoDiff log(AutoDiff x);
 
 The resulting partial derivative ∂/∂vᵢ is undefined (i.e., NaN) for all of the
 following cases:
-- base is NaN
-- exp is NaN
-- pow(base, exp) is NaN
 - ∂base/∂vᵢ is non-zero and either:
-  - base is zero or not finite, or
-  - exp is not finite
+  - base, exp, or pow(base, exp) not finite, or
+  - base is 0 and exp < 0
 - ∂exp/∂vᵢ is non-zero and either:
-  - base is not positive-finite, or
-  - exp is not finite
+  - base, exp, or pow(base, exp) not finite, or
+  - base is < 0
 
 In all other cases, if the base and exp partial derivatives were well-defined
 then the resulting partial derivatives will also be well-defined. */

--- a/common/ad/test/standard_operations_pow_special_test.cc
+++ b/common/ad/test/standard_operations_pow_special_test.cc
@@ -27,23 +27,22 @@ struct PowCase {
   PowCase(double base_in, double exp_in) : base(base_in), exp(exp_in) {
     expected_value = std::pow(base, exp);
 
-    // Whether any of {base, exp, result} is a NaN.
-    is_nan = std::isnan(base) || std::isnan(exp) || std::isnan(expected_value);
+    // From the header doc:
+    //
+    // The resulting partial derivative ∂/∂vᵢ is undefined (i.e., NaN) for all
+    // of the following cases:
+    //
+    // - ∂base/∂vᵢ is non-zero and either:
+    //   - base, exp, or pow(base, exp) not finite, or
+    //   - base is 0 and exp < 0
+    const bool non_finite = !std::isfinite(base) || !std::isfinite(exp) ||
+                            !std::isfinite(expected_value);
+    ill_defined_base_grad = non_finite || ((base == 0) && (exp < 0));
 
-    // In some cases, any non-zero element in the grad(base) leads to an
-    // ill-defined (i.e., NaN) corresponding element in the grad(result).
-    ill_defined_base_grad =
-        (base == 0.0) || (!std::isfinite(base)) || (!std::isfinite(exp));
-
-    // In some cases, the grad(base) is unconditionally zeroed out because
-    // the result is a constant, and stays the same constant for infinitesimally
-    // small changes to the base.
-    ignore_base_grad = !ill_defined_base_grad && (exp == 0);
-
-    // In some cases, any non-zero element in the grad(exp) leads to an
-    // ill-defined (i.e., NaN) corresponding element in the grad(result).
-    ill_defined_exp_grad =
-        (base <= 0.0) || (!std::isfinite(base)) || (!std::isfinite(exp));
+    // - ∂exp/∂vᵢ is non-zero and either:
+    //   - base, exp, or pow(base, exp) not finite, or
+    //   - base < 0.
+    ill_defined_exp_grad = non_finite || (base < 0);
   }
 
   double base{};
@@ -51,9 +50,7 @@ struct PowCase {
 
   double expected_value{};
 
-  bool is_nan{};
   bool ill_defined_base_grad{};
-  bool ignore_base_grad{};
   bool ill_defined_exp_grad{};
 };
 
@@ -66,8 +63,8 @@ std::vector<PowCase> SweepAllCases() {
 
   // A representative sampling of both special and non-special values.
   std::initializer_list<double> sweep = {
-      -kInf, -2.5, -2.0, -1.5, -1.0, -0.5, -0.0, +0.0,
-      0.5,   1.0,  1.5,  2.0,  2.5,  kInf, kNaN,
+      -kInf, -3.0, -2.5, -2.0, -1.5, -1.0, -0.5, -0.0, +0.0,
+      0.5,   1.0,  1.5,  2.0,  2.5,  3.0,  kInf, kNaN,
   };
 
   // Let's do all-pairs testing!
@@ -109,8 +106,10 @@ std::string CalcTestName(const testing::TestParamInfo<PowCase>& info) {
 // as one-line wrappers the AD,AD function.
 TEST_P(PowSpecial, AdsAds) {
   const PowCase& pow_case = GetParam();
-  const AutoDiffDut base(pow_case.base, 3, 1);
-  const AutoDiffDut exp(pow_case.exp, 3, 2);
+  const double b = pow_case.base;
+  const double x = pow_case.exp;
+  const AutoDiffDut base(b, 3, 1);
+  const AutoDiffDut exp(x, 3, 2);
 
   const AutoDiffDut result = pow(base, exp);
   EXPECT_THAT(result.value(),
@@ -122,21 +121,11 @@ TEST_P(PowSpecial, AdsAds) {
   // That should remain true for the result as well.
   EXPECT_EQ(grad[0], 0.0);
 
-  // If the result was NaN, then the gradient should be NaN.
-  if (pow_case.is_nan) {
-    EXPECT_THAT(grad[1], testing::IsNan());
-    EXPECT_THAT(grad[2], testing::IsNan());
-    return;
-  }
-
   // The 1st grad index is the partial wrt base.
-  if (pow_case.ignore_base_grad) {
-    EXPECT_EQ(grad[1], 0.0);
-  } else if (pow_case.ill_defined_base_grad) {
+  if (pow_case.ill_defined_base_grad) {
     EXPECT_THAT(grad[1], testing::IsNan());
   } else {
-    const double expected =
-        pow_case.exp * std::pow(pow_case.base, pow_case.exp - 1);
+    const double expected = (x == 0) ? 0.0 : x * std::pow(b, x - 1);
     EXPECT_NEAR(grad[1], expected, kTol);
   }
 
@@ -144,7 +133,10 @@ TEST_P(PowSpecial, AdsAds) {
   if (pow_case.ill_defined_exp_grad) {
     EXPECT_THAT(grad[2], testing::IsNan());
   } else {
-    const double expected = pow_case.expected_value * std::log(pow_case.base);
+    const double expected = (b == 0 && x == 0) ? -kInf
+                            : (b == 0 && x > 0)
+                                ? 0.0
+                                : pow_case.expected_value * std::log(b);
     EXPECT_NEAR(grad[2], expected, kTol);
   }
 }


### PR DESCRIPTION
If base is zero and exponent is non-negative, then the result is now well-defined per the chain rule (instead of NaN).

This slightly reduces the symmetry of pow with positive vs negative exponents, but is necessary to support evaluating polynomials because our default guess for decision variables in mathematical programs is zero and most solvers cannot handle NaN gradients.

_In detail: exponentiating zero (with a non-zero gradient) to the 0th power (i.e., `(0+∂b)^(0)`) using a naive chain rule returns NaN for the new gradient. We have bˣ as zero and ln(b) as -inf, so their product is NaN. That is unacceptable to our mathematical solvers that use polynomials with a constant term as x^0._

_See also [the full spreadsheet of special cases](https://docs.google.com/spreadsheets/d/1HWKwWr2HySZU_vohyJ2o0qMLbGcZEEOPznOsK5x_iGw/edit?gid=0#gid=0) to understand the nature of the change.  There are tabs for this PR's behavior vs the prior behavior from #17655._

Towards  #23820.  Requires #23861.  Amends #17655.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23862)
<!-- Reviewable:end -->
