### PR TITLE
[common] Port autodiff_overloads_test away from fixed-size autodiff

### DIFF
--- a/common/ad/internal/standard_operations.cc
+++ b/common/ad/internal/standard_operations.cc
@@ -277,5 +277,9 @@ AutoDiff sqrt(AutoDiff x) {
   return x;
 }
 
+AutoDiff copysign(const AutoDiff& mag, const AutoDiff& sgn) {
+  return std::signbit(mag.value()) == std::signbit(sgn.value()) ? mag : -mag;
+}
+
 }  // namespace ad
 }  // namespace drake

--- a/common/ad/internal/standard_operations.h
+++ b/common/ad/internal/standard_operations.h
@@ -551,6 +551,9 @@ inline double nexttoward(const AutoDiff& from, long double to) {
   return std::nexttoward(from.value(), to);
 }
 
+/** ADL overload to mimic std::copysign from `<cmath>`. */
+AutoDiff copysign(const AutoDiff& mag, const AutoDiff& sgn);
+
 /** ADL overload to mimic std::isfinite from `<cmath>`.
 Because the return type is `bool`, the derivatives are not preserved. */
 inline bool isfinite(const AutoDiff& x) {

--- a/common/ad/test/standard_operations_integer_test.cc
+++ b/common/ad/test/standard_operations_integer_test.cc
@@ -31,6 +31,14 @@ TEST_F(StandardOperationsTest, NextToward) {
   EXPECT_EQ(y, std::nexttoward(x.value(), 1.0));
 }
 
+TEST_F(StandardOperationsTest, CopySign) {
+  const AutoDiffDut x{0.5, 3, 0};
+  const AutoDiffDut x_pos = copysign(x, 22.2);
+  const AutoDiffDut x_neg = copysign(x, -22.2);
+  EXPECT_EQ(x_pos, x);
+  EXPECT_EQ(x_neg, -x);
+}
+
 TEST_F(StandardOperationsTest, Classify) {
   const AutoDiffDut a{0.5, 3, 0};
   const AutoDiffDut b{std::numeric_limits<double>::infinity(), 3, 0};


### PR DESCRIPTION
Add missing `copysign` support in our custom autodiff.

Towards #23820.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23863)
<!-- Reviewable:end -->
