### PR TITLE
[CENIC] Rework non-plant continuous-time state integrator

### DIFF
--- a/bindings/generated_docstrings/systems_framework.h
+++ b/bindings/generated_docstrings/systems_framework.h
@@ -8397,11 +8397,6 @@ EvalKineticEnergy() to avoid unnecessary recalculation.
 See also:
     EvalKineticEnergy() for more information.)""";
         } CalcKineticEnergy;
-        // Symbol: drake::systems::System::CalcMiscStateTimeDerivatives
-        struct /* CalcMiscStateTimeDerivatives */ {
-          // Source: drake/systems/framework/system.h
-          const char* doc = R"""()""";
-        } CalcMiscStateTimeDerivatives;
         // Symbol: drake::systems::System::CalcNextUpdateTime
         struct /* CalcNextUpdateTime */ {
           // Source: drake/systems/framework/system.h
@@ -8714,11 +8709,6 @@ See EvalKineticEnergy() for details on what you must compute here. In
 particular, your kinetic energy method must *not* depend explicitly on
 time or any input port values.)""";
         } DoCalcKineticEnergy;
-        // Symbol: drake::systems::System::DoCalcMiscStateTimeDerivatives
-        struct /* DoCalcMiscStateTimeDerivatives */ {
-          // Source: drake/systems/framework/system.h
-          const char* doc = R"""()""";
-        } DoCalcMiscStateTimeDerivatives;
         // Symbol: drake::systems::System::DoCalcNextUpdateTime
         struct /* DoCalcNextUpdateTime */ {
           // Source: drake/systems/framework/system.h

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -318,34 +318,6 @@ void Diagram<T>::DoCalcTimeDerivatives(const Context<T>& context,
 }
 
 template <typename T>
-void Diagram<T>::DoCalcMiscStateTimeDerivatives(
-    const Context<T>& context, ContinuousState<T>* derivatives) const {
-  auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
-  DRAKE_DEMAND(diagram_context != nullptr);
-  auto diagram_derivatives =
-      dynamic_cast<DiagramContinuousState<T>*>(derivatives);
-  DRAKE_DEMAND(diagram_derivatives != nullptr);
-  const int n = diagram_derivatives->num_substates();
-  DRAKE_DEMAND(num_subsystems() == n);
-
-  // TODO(amcastro-tri): Avoid the computation of xdot for systems that have
-  // both continuous tate and misc state.
-  // While correct, the implementation below also computes xdot if it exists.
-
-  // Evaluate the derivatives of each constituent system, with misc state only.
-  for (SubsystemIndex i(0); i < n; ++i) {
-    const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
-    const int num_z = subcontext.get_continuous_state().num_z();
-
-    if (num_z > 0) {
-      ContinuousState<T>& subderivatives =
-          diagram_derivatives->get_mutable_substate(i);
-      registered_systems_[i]->CalcTimeDerivatives(subcontext, &subderivatives);
-    }
-  }
-}
-
-template <typename T>
 void Diagram<T>::DoCalcImplicitTimeDerivativesResidual(
     const Context<T>& context, const ContinuousState<T>& proposed_derivatives,
     EigenPtr<VectorX<T>> residual) const {

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -514,9 +514,6 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const final;
 
-  void DoCalcMiscStateTimeDerivatives(
-      const Context<T>& context, ContinuousState<T>* derivatives) const final;
-
   void DoCalcImplicitTimeDerivativesResidual(
       const Context<T>& context, const ContinuousState<T>& proposed_derivatives,
       EigenPtr<VectorX<T>> residual) const final;

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -278,14 +278,6 @@ void System<T>::CalcTimeDerivatives(const Context<T>& context,
 }
 
 template <typename T>
-void System<T>::CalcMiscStateTimeDerivatives(
-    const Context<T>& context, ContinuousState<T>* derivatives) const {
-  DRAKE_DEMAND(derivatives != nullptr);
-  ValidateContext(context);
-  DoCalcMiscStateTimeDerivatives(context, derivatives);
-}
-
-template <typename T>
 void System<T>::CalcImplicitTimeDerivativesResidual(
     const Context<T>& context, const ContinuousState<T>& proposed_derivatives,
     EigenPtr<VectorX<T>> residual) const {
@@ -1219,15 +1211,6 @@ void System<T>::DoCalcTimeDerivatives(const Context<T>& context,
   // state. Other Systems must override this method!
   unused(context);
   DRAKE_DEMAND(derivatives->size() == 0);
-}
-
-template <typename T>
-void System<T>::DoCalcMiscStateTimeDerivatives(
-    const Context<T>& context, ContinuousState<T>* derivatives) const {
-  // This default implementation is only valid for Systems with no misc
-  // state. Other Systems must override this method!
-  unused(context);
-  DRAKE_DEMAND(derivatives->num_z() == 0);
 }
 
 template <typename T>

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -534,9 +534,6 @@ class System : public SystemBase {
   void CalcTimeDerivatives(const Context<T>& context,
                            ContinuousState<T>* derivatives) const;
 
-  void CalcMiscStateTimeDerivatives(const Context<T>& context,
-                                    ContinuousState<T>* derivatives) const;
-
   /** Evaluates the implicit form of the %System equations and returns the
   residual.
 
@@ -1691,9 +1688,6 @@ class System : public SystemBase {
   size zero and aborts otherwise. */
   virtual void DoCalcTimeDerivatives(const Context<T>& context,
                                      ContinuousState<T>* derivatives) const;
-
-  virtual void DoCalcMiscStateTimeDerivatives(
-      const Context<T>& context, ContinuousState<T>* derivatives) const;
 
   /** Override this if you have an efficient way to evaluate the implicit
   time derivatives residual for this System. Otherwise the default


### PR DESCRIPTION
Instead of integrating the diagram's z state, we integrate all continuous state except the plant. We still use explicit euler, even if the (non-plant) subsystem defined its state with q,v.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23865)
<!-- Reviewable:end -->
