### PR TITLE
[pydrake] Fix CalcProbabililtyDensity type annotation

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -270,10 +270,8 @@ void InitLowLevelModules(py::module m) {
           doc.RandomDistribution.kExponential.doc);
 
   m.def("CalcProbabilityDensity", &CalcProbabilityDensity<double>,
-       py::arg("distribution"), py::arg("x"), doc.CalcProbabilityDensity.doc)
-      .def("CalcProbabilityDensity", &CalcProbabilityDensity<AutoDiffXd>,
-          py::arg("distribution"), py::arg("x"),
-          doc.CalcProbabilityDensity.doc);
+      py::arg("distribution"), py::arg("x"), doc.CalcProbabilityDensity.doc);
+  // N.B. The AutoDiffXd overload is bound later on in this function.
 
   // Adds a binding for drake::RandomGenerator.
   py::class_<RandomGenerator> random_generator_cls(m, "RandomGenerator",
@@ -380,6 +378,10 @@ discussion), use e.g.
   autodiffutils.doc() = "Bindings for Eigen AutoDiff Scalars";
   internal::DefineAutodiffutils(autodiffutils);
   ExecuteExtraPythonCode(autodiffutils, true);
+
+  // Define overloads in `pydrake.common` that require AutoDiffXd.
+  m.def("CalcProbabilityDensity", &CalcProbabilityDensity<AutoDiffXd>,
+      py::arg("distribution"), py::arg("x"), doc.CalcProbabilityDensity.doc);
 
   // Define `symbolic` top-level module.
   py::module symbolic = pydrake_top.def_submodule("symbolic");


### PR DESCRIPTION
Old signature:

https://drake.mit.edu/pydrake/pydrake.common.html#pydrake.common.CalcProbabilityDensity

(Look at the second overload -- it says `Eigen::AutoDiffScalar`.)

New signature:

<img width="1751" height="1635" alt="image" src="https://github.com/user-attachments/assets/c7050406-00a8-40f8-b2c1-9a892edda5fb" />

---

On the #23820 branch, the broken signature is flagged as a runtime error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23869)
<!-- Reviewable:end -->
