### PR TITLE
[build] Add a flag to opt-in to the new AutoDiff implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,6 +746,15 @@ if(WITH_ROBOTLOCOMOTION_SNOPT OR WITH_SNOPT)
   endif()
 endif()
 
+option(DRAKE_USE_EIGEN_LEGACY_AUTODIFF "Use <unsupported/Eigen/AutoDiff> for autodiff support." ON)
+
+if(DRAKE_USE_EIGEN_LEGACY_AUTODIFF)
+  # TODO(jwnimmer-tri) On 2026-02-01, add a deprecation warning to this mode.
+  string(APPEND BAZEL_CONFIG " --@drake//tools/flags:use_eigen_legacy_autodiff=True")
+else()
+  string(APPEND BAZEL_CONFIG " --@drake//tools/flags:use_eigen_legacy_autodiff=False")
+endif()
+
 if(DRAKE_CI_ENABLE_PACKAGING)
   string(APPEND BAZEL_CONFIG " --config=packaging")
 endif()

--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -13,8 +13,7 @@
 #endif
 
 // #include "drake/common/autodiff.h"
-// #include "drake/common/autodiff_overloads.h"
-// #include "drake/common/autodiffxd.h"
+// #include "drake/common/autodiff_config.h"
 // #include "drake/common/bit_cast.h"
 // #include "drake/common/cond.h"
 // #include "drake/common/constants.h"
@@ -33,7 +32,6 @@
 // #include "drake/common/drake_path.h"
 // #include "drake/common/drake_throw.h"
 // #include "drake/common/dummy_value.h"
-// #include "drake/common/eigen_autodiff_types.h"
 // #include "drake/common/eigen_types.h"
 // #include "drake/common/extract_double.h"
 // #include "drake/common/file_source.h"
@@ -222,16 +220,16 @@ object.)""";
     } AbstractValue;
     // Symbol: drake::AutoDiffVecXd
     struct /* AutoDiffVecXd */ {
-      // Source: drake/common/eigen_autodiff_types.h
+      // Source: drake/common/autodiff.h
       const char* doc =
-R"""(A dynamic-sized vector of autodiff variables, each with a
-dynamic-sized vector of partials.)""";
+R"""(A dynamic-sized vector of autodiff variables.)""";
     } AutoDiffVecXd;
     // Symbol: drake::AutoDiffXd
     struct /* AutoDiffXd */ {
-      // Source: drake/common/eigen_autodiff_types.h
+      // Source: drake/common/autodiff.h
       const char* doc =
-R"""(An autodiff variable with a dynamic number of partials.)""";
+R"""(A scalar type that performs automatic differentiation. Always use this
+``AutoDiffXd`` alias when referring to the scalar type.)""";
     } AutoDiffXd;
     // Symbol: drake::CalcProbabilityDensity
     struct /* CalcProbabilityDensity */ {
@@ -435,13 +433,15 @@ R"""(Precondition:
     } EigenPtr;
     // Symbol: drake::ExtractDoubleOrThrow
     struct /* ExtractDoubleOrThrow */ {
-      // Source: drake/common/autodiff_overloads.h
-      const char* doc_was_unable_to_choose_unambiguous_names =
-R"""(Returns the autodiff scalar's value() as a double. Never throws.
-Overloads ExtractDoubleOrThrow from common/extract_double.h.
-
-See also:
-    math::ExtractValue(), math::DiscardGradient())""";
+      // Source: drake/common/extract_double.h
+      const char* doc_1args_scalar =
+R"""(Returns ``scalar`` as a double. Never throws.)""";
+      // Source: drake/common/extract_double.h
+      const char* doc_1args_constEigenMatrixBase =
+R"""(Returns ``matrix`` as an Eigen::Matrix<double, ...> with the same size
+allocation as ``matrix``. Calls ExtractDoubleOrThrow on each element
+of the matrix, and therefore throws if any one of the extractions
+fail.)""";
     } ExtractDoubleOrThrow;
     // Symbol: drake::FileSource
     struct /* FileSource */ {
@@ -2610,12 +2610,8 @@ the matrix ``m``. An empty matrix returns false.)""";
     } assert;
     // Symbol: drake::cond
     struct /* cond */ {
-      // Source: drake/common/autodiff_overloads.h
-      const char* doc_3args =
-R"""(Provides special case of cond expression for Eigen::AutoDiffScalar
-type.)""";
       // Source: drake/common/cond.h
-      const char* doc_1args =
+      const char* doc =
 R"""(@name cond Constructs conditional expression (similar to Lisp's cond).
 
 
@@ -3036,13 +3032,6 @@ R"""(Provides hash_append for a range, as given by two iterators.)""";
     } hash_append_range;
     // Symbol: drake::if_then_else
     struct /* if_then_else */ {
-      // Source: drake/common/autodiff_overloads.h
-      const char* doc_3args_bool_constEigenAutoDiffScalar_constEigenAutoDiffScalar =
-R"""(Provides if-then-else expression for Eigen::AutoDiffScalar type. To
-support Eigen's generic expressions, we use casting to the plain
-object after applying Eigen::internal::remove_all. It is based on the
-Eigen's implementation of min/max function for AutoDiffScalar type
-(https://bitbucket.org/eigen/eigen/src/10a1de58614569c9250df88bdfc6402024687bc6/unsupported/Eigen/src/AutoDiff/AutoDiffScalar.h?at=default&fileviewer=file-view-default#AutoDiffScalar.h-546).)""";
       // Source: drake/common/double_overloads.h
       const char* doc_3args_f_cond_v_then_v_else =
 R"""(The semantics is similar but not exactly the same as C++'s conditional

--- a/bindings/generated_docstrings/tools/defs.bzl
+++ b/bindings/generated_docstrings/tools/defs.bzl
@@ -31,6 +31,13 @@ def generate_docstrings(*, subdir):
         exclude_hdr_patterns = [
             # Anonymous namespace and deduction guides both confuse pybind.
             "drake/common/overloaded.h",
+            # These headers are deprecated for removal on 2026-07-01, and are
+            # conditionally omitted when the use_eigen_legacy_autodiff is off.
+            # To avoid confusing the docstrings diff_test, we'll omit them from
+            # generation entirely, since we don't need any of their docs anyway.
+            "drake/common/autodiff_overloads.h",
+            "drake/common/autodiffxd.h",
+            "drake/common/eigen_autodiff_types.h",
         ],
         root_name = "pydrake_doc_{}".format(identifier),
         targets = ["//tools/install/libdrake:drake_headers"],

--- a/bindings/pydrake/autodiffutils/autodiffutils_py_everything.cc
+++ b/bindings/pydrake/autodiffutils/autodiffutils_py_everything.cc
@@ -1,5 +1,4 @@
 #include <Eigen/Core>
-#include <unsupported/Eigen/AutoDiff>
 
 #include "drake/bindings/generated_docstrings/math.h"
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
@@ -10,7 +9,6 @@
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 
-using Eigen::AutoDiffScalar;
 using Eigen::VectorXd;
 using std::cos;
 using std::sin;

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:cc.bzl", "cc_library")
 load(
     "//tools/skylark:drake_cc.bzl",
     "drake_cc_binary",
@@ -12,6 +13,7 @@ load(
     "drake_py_binary",
     "drake_py_unittest",
 )
+load("//tools/workspace:generate_file.bzl", "generate_file")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -185,19 +187,49 @@ drake_cc_library(
     hdrs = ["double_overloads.h"],
 )
 
+# TODO(jwnimmer-tri) On 2026-07-01 remove all of the deprecated legacy stuff.
+config_setting(
+    name = "flag_use_eigen_legacy_autodiff_true",
+    flag_values = {
+        "//tools/flags:use_eigen_legacy_autodiff": "True",
+    },
+)
+
+generate_file(
+    name = "autodiff_config.h",
+    content = select({
+        ":flag_use_eigen_legacy_autodiff_true": (
+            "#define DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF 1\n"
+        ),
+        "//conditions:default": (
+            "#define DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF 0\n"
+        ),
+    }),
+)
+
 drake_cc_library(
     name = "autodiff",
     hdrs = [
         "autodiff.h",
-        "autodiff_overloads.h",
-        "autodiffxd.h",
-        "eigen_autodiff_types.h",
-    ],
-    deps = [
-        ":cond",
-        ":dummy_value",
-        ":essential",
-    ],
+        ":autodiff_config.h",
+    ] + select({
+        ":flag_use_eigen_legacy_autodiff_true": [
+            "autodiff_overloads.h",
+            "autodiffxd.h",
+            "eigen_autodiff_types.h",
+        ],
+        "//conditions:default": [],
+    }),
+    deps = select({
+        ":flag_use_eigen_legacy_autodiff_true": [
+            ":cond",
+            ":dummy_value",
+            ":essential",
+        ],
+        "//conditions:default": [
+            "//common/ad",
+        ],
+    }),
 )
 
 drake_cc_library(
@@ -677,6 +709,22 @@ install(
 
 # === test/ ===
 
+# A config file that forces legacy mode (for legacy-specific tests).
+# TODO(jwnimmer-tri) On 2026-07-01 remove all of the deprecated legacy stuff.
+generate_file(
+    name = "test/drake/common/autodiff_config.h",
+    content = "#define DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF 1\n",
+)
+
+cc_library(
+    name = "autodiff_config_legacy",
+    testonly = True,
+    hdrs = [":test/drake/common/autodiff_config.h"],
+    strip_include_prefix = "test",
+    visibility = ["//visibility:private"],
+)
+
+# TODO(jwnimmer-tri) On 2026-07-01 remove this test of deprecated code.
 drake_cc_googletest(
     name = "autodiffxd_test",
     # The following `autodiffxd_*_test.cc` files were in a single
@@ -684,6 +732,10 @@ drake_cc_googletest(
     # this test. So we split it into multiple .cc files. We observed about
     # 8x speed-up.
     srcs = [
+        "autodiff.h",
+        "autodiff_overloads.h",
+        "autodiffxd.h",
+        "eigen_autodiff_types.h",
         "test/autodiffxd_abs2_test.cc",
         "test/autodiffxd_abs_test.cc",
         "test/autodiffxd_acos_test.cc",
@@ -714,7 +766,13 @@ drake_cc_googletest(
         "-DStandardOperationsTest=AutoDiffXdTest",
     ],
     deps = [
-        ":autodiff",
+        # We must not use ":autodiff" but instead use ":autodiff_config_legacy"
+        # and put all of the autodiff headers in `srcs` because this test should
+        # always check the legacy AutoDiffXd, even if the build has enabled the
+        # new AutoDiffXd.
+        ":autodiff_config_legacy",
+        ":cond",
+        ":dummy_value",
         "//common/ad:standard_operations_test_h",
         "//common/test_utilities:eigen_matrix_compare",
     ],
@@ -732,6 +790,8 @@ drake_cc_googletest(
     name = "autodiff_overloads_test",
     deps = [
         ":autodiff",
+        ":cond",
+        ":dummy_value",
         ":essential",
         ":extract_double",
         "//common/test_utilities:eigen_matrix_compare",

--- a/common/ad/BUILD.bazel
+++ b/common/ad/BUILD.bazel
@@ -10,7 +10,7 @@ package(default_visibility = ["//visibility:private"])
 
 drake_cc_package_library(
     name = "ad",
-    visibility = ["//common/benchmarking:__pkg__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":auto_diff",
     ],

--- a/common/autodiff.h
+++ b/common/autodiff.h
@@ -1,20 +1,50 @@
 #pragma once
-/// @file
-/// This header provides a single inclusion point for autodiff-related header
-/// files in the `drake/common` directory. Users should include this file.
-/// Including other individual headers such as `drake/common/autodiffxd.h`
-/// will generate a compile-time warning.
 
-// In each header included below, it asserts that this macro
-// `DRAKE_COMMON_AUTODIFF_HEADER` is defined. If the macro is not defined, it
-// generates diagnostic warning messages.
-#define DRAKE_COMMON_AUTODIFF_HEADER
+/** @file
+This header provides a single inclusion point for autodiff-related header files
+in the `drake/common` directory. Users should include this file. Including other
+individual headers such as `drake/common/autodiffxd.h` is not supported. */
+
+#include "drake/common/autodiff_config.h"
+
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 0
+
+#include <Eigen/Core>
+
+#include "drake/common/ad/auto_diff.h"
+
+namespace drake {
+
+/** A scalar type that performs automatic differentiation. Always use this
+`AutoDiffXd` alias when referring to the scalar type. */
+using AutoDiffXd = drake::ad::AutoDiff;
+
+/** A dynamic-sized vector of autodiff variables. */
+using AutoDiffVecXd = Eigen::Matrix<AutoDiffXd, Eigen::Dynamic, 1>;
+
+}  // namespace drake
+
+#else  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 
 #include <Eigen/Core>
 #include <unsupported/Eigen/AutoDiff>
 
+namespace drake {
+
+/** A scalar type that performs automatic differentiation. Always use this
+`AutoDiffXd` alias when referring to the scalar type. */
+using AutoDiffXd = Eigen::AutoDiffScalar<Eigen::VectorXd>;
+
+/** A dynamic-sized vector of autodiff variables. */
+using AutoDiffVecXd = Eigen::Matrix<AutoDiffXd, Eigen::Dynamic, 1>;
+
+}  // namespace drake
+
+// Each Drake header below checks that this macro is defined and warns if not.
+#define DRAKE_COMMON_AUTODIFF_HEADER
+
 // Do not alpha-sort the following block of hard-coded #includes, which is
-// protected by `clang-format on/off`.
+// protected by `clang-format` markers.
 //
 // Rationale: We want to maximize the use of this header, `autodiff.h`, even
 // inside of the autodiff-related files to avoid any mistakes which might not be
@@ -29,3 +59,5 @@
 #include "drake/common/autodiff_overloads.h"
 // clang-format on
 #undef DRAKE_COMMON_AUTODIFF_HEADER
+
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF

--- a/common/eigen_autodiff_types.h
+++ b/common/eigen_autodiff_types.h
@@ -18,9 +18,6 @@
 
 namespace drake {
 
-/// An autodiff variable with a dynamic number of partials.
-using AutoDiffXd = Eigen::AutoDiffScalar<Eigen::VectorXd>;
-
 // TODO(hongkai-dai): Recursive template to get arbitrary gradient order.
 
 /// An autodiff variable with `num_vars` partials.
@@ -30,9 +27,5 @@ using AutoDiffd = Eigen::AutoDiffScalar<Eigen::Matrix<double, num_vars, 1> >;
 /// A vector of `rows` autodiff variables, each with `num_vars` partials.
 template <int num_vars, int rows>
 using AutoDiffVecd = Eigen::Matrix<AutoDiffd<num_vars>, rows, 1>;
-
-/// A dynamic-sized vector of autodiff variables, each with a dynamic-sized
-/// vector of partials.
-typedef AutoDiffVecd<Eigen::Dynamic, Eigen::Dynamic> AutoDiffVecXd;
 
 }  // namespace drake

--- a/common/nice_type_name.cc
+++ b/common/nice_type_name.cc
@@ -90,6 +90,7 @@ string NiceTypeName::Canonicalize(const string& demangled) {
       // ... AutoDiff.
       SPair(std::regex("Eigen::AutoDiffScalar<Eigen::VectorXd>"),
             "drake::AutoDiffXd"),
+      SPair(std::regex("drake::ad::AutoDiff"), "drake::AutoDiffXd"),
 
       // Recognize Identifier ...
       // Change e.g., "drake::Identifier<drake::package::FooTag>" to

--- a/common/symbolic/expression/BUILD.bazel
+++ b/common/symbolic/expression/BUILD.bazel
@@ -47,6 +47,7 @@ drake_cc_library(
     ],
     deps = [
         "//common:drake_bool",
+        "//common:dummy_value",
         "//common:essential",
         "//common:hash",
         "//common:random",

--- a/common/test/autodiff_overloads_test.cc
+++ b/common/test/autodiff_overloads_test.cc
@@ -396,6 +396,7 @@ GTEST_TEST(AutodiffOverloadsTest, DummyValue) {
   EXPECT_EQ(derivatives.rows(), 0);
 }
 
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
 GTEST_TEST(AutodiffOverloadsTest, DummyValue2) {
   using T = Eigen::AutoDiffScalar<Vector2d>;
   const T dummy_2d = dummy_value<T>::get();
@@ -406,6 +407,7 @@ GTEST_TEST(AutodiffOverloadsTest, DummyValue2) {
   EXPECT_TRUE(std::isnan(derivatives(0)));
   EXPECT_TRUE(std::isnan(derivatives(1)));
 }
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 
 }  // namespace
 }  // namespace common

--- a/common/test/eigen_autodiff_types_test.cc
+++ b/common/test/eigen_autodiff_types_test.cc
@@ -6,16 +6,13 @@
 
 namespace drake {
 namespace {
+
 GTEST_TEST(EigenAutodiffTypesTest, CheckingInheritance) {
-  typedef double Scalar;
-  typedef Eigen::Matrix<Scalar, 2, 2> Deriv;
-  typedef Eigen::AutoDiffScalar<Deriv> AD;
-
-  typedef std::numeric_limits<AD> ADLimits;
-  typedef std::numeric_limits<Scalar> ScalarLimits;
-
-  bool res = std::is_base_of_v<ScalarLimits, ADLimits>;
-  EXPECT_TRUE(res);
+  using ScalarLimits = std::numeric_limits<double>;
+  using AutoDiffLimits = std::numeric_limits<AutoDiffXd>;
+  const bool result = std::is_base_of_v<ScalarLimits, AutoDiffLimits>;
+  EXPECT_TRUE(result);
 }
+
 }  // namespace
 }  // namespace drake

--- a/common/yaml/test/yaml_performance_test.cc
+++ b/common/yaml/test/yaml_performance_test.cc
@@ -16,6 +16,7 @@
 
 // Add ADL Serialize method to drake::AutoDiffXd. For ADL to work, we need to
 // place the function in the correct namespace.
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
 namespace Eigen {
 template <typename Archive>
 void Serialize(Archive* a, Eigen::AutoDiffScalar<Eigen::VectorXd>* x) {
@@ -23,6 +24,17 @@ void Serialize(Archive* a, Eigen::AutoDiffScalar<Eigen::VectorXd>* x) {
   a->Visit(drake::MakeNameValue("derivatives", &(x->derivatives())));
 }
 }  // namespace Eigen
+#else
+namespace drake {
+namespace ad {
+template <typename Archive>
+void Serialize(Archive* a, drake::ad::AutoDiff* x) {
+  a->Visit(drake::MakeNameValue("value", &(x->value())));
+  a->Visit(drake::MakeNameValue("derivatives", &(x->derivatives())));
+}
+}  // namespace ad
+}  // namespace drake
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 
 namespace drake {
 namespace yaml {

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -226,6 +226,14 @@ Adjusting closed-source (commercial) software dependencies:
   * This option is only valid for MIT- or TRI-affiliated Drake developers.
   * This option is mutally exclusive with `WITH_SNOPT`.
 
+Adjusting features:
+
+* `DRAKE_USE_EIGEN_LEGACY_AUTODIFF` (default `ON`).
+  When `ON`, Drake uses `<unsupported/Eigen/AutoDiff>` for its autodiff support.
+  When `OFF`, Drake uses a custom re-implementation. Using `ON` is deprecated
+  and will be removed from Drake on or after 2026-07-01. The default will change
+  to `OFF` on or after 2026-04-01.
+
 Adjusting installation methods (advanced):
 
 * `INSTALL_NAME_TOOL`. When specified, uses the path to the

--- a/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
@@ -411,7 +411,7 @@ TEST_F(PenetrationAsPointPairCallbackTest, TestGradient) {
   // nhat_BA_W = -p_WBo / |p_WBo|, hence ∂nhat_BA_W /∂p_WBo = -∂(p_WBo/|p_WBo|)
   // / ∂p_WBo
   EXPECT_TRUE(CompareMatrices(math::ExtractGradient(result.nhat_BA_W),
-                              -dp_WBo_normalized_dp_WBo, kEps));
+                              -dp_WBo_normalized_dp_WBo, 2 * kEps));
   // p_WCa = radius * p_WBo / |p_WBo|.
   const Eigen::Matrix3d dp_WCa_dp_WBo = dp_WBo_normalized_dp_WBo * kRadius;
   EXPECT_TRUE(CompareMatrices(math::ExtractGradient(result.p_WCa),

--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -10,7 +10,10 @@ Utilities for arithmetic on AutoDiffScalar. */
 #include <utility>
 
 #include <Eigen/Dense>
+
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
 #include <unsupported/Eigen/AutoDiff>
+#endif
 
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"
@@ -165,10 +168,15 @@ void InitializeAutoDiff(const Eigen::MatrixBase<Derived>& value,
 
 /** The appropriate AutoDiffScalar matrix type given the value type and the
 number of derivatives at compile time. */
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
 template <typename Derived, int nq>
 using AutoDiffMatrixType =
-    MatrixLikewise<Eigen::AutoDiffScalar<Vector<typename Derived::Scalar, nq>>,
+    MatrixLikewise<Eigen::AutoDiffScalar<Vector<typename Derived::Scalar, nq> >,
                    Derived>;
+#else
+template <typename Derived, int nq>
+using AutoDiffMatrixType = MatrixLikewise<AutoDiffXd, Derived>;
+#endif
 
 /** Initializes a single AutoDiff matrix given the corresponding value matrix.
 

--- a/math/linear_solve.h
+++ b/math/linear_solve.h
@@ -23,8 +23,13 @@ inline constexpr bool is_double_or_symbolic_v =
 template <typename T>
 struct is_autodiff : std::false_type {};
 
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
 template <int N>
 struct is_autodiff<drake::AutoDiffd<N>> : std::true_type {};
+#else
+template <>
+struct is_autodiff<drake::AutoDiffXd> : std::true_type {};
+#endif
 
 template <typename T>
 inline constexpr bool is_autodiff_v = is_autodiff<T>::value;

--- a/math/test/autodiff_test.cc
+++ b/math/test/autodiff_test.cc
@@ -221,7 +221,9 @@ GTEST_TEST(AdditionalAutodiffTest, InitializeNoGradientMatrix) {
   // Since value was fixed size, ad_return should be also.
   EXPECT_EQ(decltype(ad4_return)::ColsAtCompileTime, 2);
   EXPECT_EQ(decltype(ad4_return)::RowsAtCompileTime, 2);
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
   EXPECT_EQ(decltype(ad4_return)::Scalar::DerType::RowsAtCompileTime, 4);
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
   EXPECT_TRUE(CompareMatrices(ExtractValue(ad4_return), value));
   EXPECT_TRUE(CompareMatrices(ExtractGradient(ad4_return),
                               Eigen::Matrix4d::Identity()));
@@ -294,6 +296,7 @@ GTEST_TEST(AdditionalAutodiffTest, InitializeWithGradientMatrix) {
       (Eigen::Matrix2d() << 1.0, 2.0, 3.0, 4.0).finished();
   const Eigen::Matrix4d gradient = 2 * Eigen::Matrix4d::Identity();
 
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
   // Fixed-size value, fixed-size gradient.
   Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Vector4d>, 2, 2> autodiff2;
   // This is the general method. The other (value, gradient) signature just
@@ -310,6 +313,7 @@ GTEST_TEST(AdditionalAutodiffTest, InitializeWithGradientMatrix) {
   EXPECT_EQ(decltype(ad2_return)::Scalar::DerType::RowsAtCompileTime, 4);
   EXPECT_TRUE(CompareMatrices(ExtractValue(ad2_return), value));
   EXPECT_TRUE(CompareMatrices(ExtractGradient(ad2_return), gradient));
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 
   // Repeat the last two tests using dynamically-sized matrices. This should
   // produce dynamically-sized results.
@@ -359,8 +363,10 @@ GTEST_TEST(AdditionalAutodiffTest, InitializeAutoDiffTuple) {
   // This is the expected type of the derivatives vector (in every element).
   const Eigen::Matrix<double, 12, 1>& deriv_12 =
       std::get<1>(tuple).coeffRef(2).derivatives();
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
   // Check that we didn't create a new copy (i.e. we got the right type).
   EXPECT_EQ(&deriv_12, &std::get<1>(tuple).coeffRef(2).derivatives());
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 
   // Since vec3[2] is the 7th variable, we expect only element 7 of its
   // derivatives vector to be 1.
@@ -393,6 +399,7 @@ GTEST_TEST(AdditionalAutodiffTest, InitializeAutoDiffTuple) {
   EXPECT_EQ(deriv_12d, expected);
 }
 
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
 // See note in class documentation for our AutoDiffXd specialization in
 // common/autodiffxd.h for why we initialize the value field even though
 // that is not part of the Eigen::AutoDiffScalar contract.
@@ -400,6 +407,7 @@ GTEST_TEST(AdditionalAutodiffTest, ValueIsInitializedToNaN) {
   AutoDiffXd autodiff;
   EXPECT_TRUE(std::isnan(autodiff.value()));
 }
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 
 GTEST_TEST(AdditionalAutodiffTest, DiscardGradient) {
   // Test the double case:

--- a/math/test/linear_solve_test.cc
+++ b/math/test/linear_solve_test.cc
@@ -3,12 +3,13 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <unsupported/Eigen/AutoDiff>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
 #if EIGEN_VERSION_AT_LEAST(5, 0, 1)
 // Eigen 5.0.1's implementation of fixed-size AutoDiff doesn't compile vs
 // HouseholderQR's linear solver. We need to shim in overloads for sqrt
@@ -36,6 +37,7 @@ auto operator+(const Eigen::AutoDiffScalar<Eigen::Vector3d>& a,
 }
 }  // namespace Eigen
 #endif  // EIGEN_VERSION_AT_LEAST
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 
 namespace drake {
 namespace math {
@@ -212,6 +214,7 @@ class LinearSolveTest : public ::testing::Test {
     const symbolic::Variable sym_v("v");
     b_sym_ << sym_u, 1, sym_v, -sym_u + sym_v, 3, 2;
 
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
     for (int i = 0; i < 2; ++i) {
       for (int j = 0; j < 2; ++j) {
         A_ad_fixed_der_size_(i, j).value() = A_ad_(i, j).value();
@@ -225,6 +228,7 @@ class LinearSolveTest : public ::testing::Test {
             b_mat_ad_(i, j).derivatives();
       }
     }
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
   }
 
  protected:
@@ -236,11 +240,13 @@ class LinearSolveTest : public ::testing::Test {
   Eigen::Matrix<AutoDiffXd, 2, 3> b_mat_ad_;
   Eigen::Matrix<symbolic::Expression, 2, 2> A_sym_;
   Eigen::Matrix<symbolic::Expression, 2, 3> b_sym_;
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
   // Use fixed-sized AutoDiffScalar.
   Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Vector3d>, 2, 2>
       A_ad_fixed_der_size_;
   Eigen::Matrix<Eigen::AutoDiffScalar<Eigen::Vector3d>, 2, 3>
       b_ad_fixed_der_size_;
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 };
 
 TEST_F(LinearSolveTest, TestDoubleAandb) {
@@ -344,6 +350,7 @@ TEST_F(LinearSolveTest, TestAwithGrad) {
   TestSolveLinearSystem<PartialPivLU>(A_ad_, b_mat_val_.cast<AutoDiffXd>());
 }
 
+#if DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF == 1
 TEST_F(LinearSolveTest, TestFixedDerivativeSize) {
   // Test SolveLinearSystem with either or both A and b containing
   // AutoDiffScalar, The AutoDiffScalar has a fixed derivative size.
@@ -369,6 +376,7 @@ TEST_F(LinearSolveTest, TestFixedDerivativeSize) {
   TestSolveLinearSystem<ColPivHouseholderQR>(A_ad_fixed_der_size_, b_mat_val_);
   TestSolveLinearSystem<PartialPivLU>(A_ad_fixed_der_size_, b_mat_val_);
 }
+#endif  // DRAKE_INTERNAL_USE_EIGEN_LEGACY_AUTODIFF
 
 TEST_F(LinearSolveTest, TestAbWithGrad) {
   // Test SolveLinearSystem with both A and b containing gradient.

--- a/solvers/test/cost_test.cc
+++ b/solvers/test/cost_test.cc
@@ -518,7 +518,7 @@ GTEST_TEST(TestL2NormCost, Eval) {
     const Matrix<double, 1, 4> grad_expected =
         (x0.transpose() * A.transpose() * A + b.transpose() * A) / (z.norm());
     EXPECT_TRUE(
-        CompareMatrices(math::ExtractGradient(y), grad_expected, 1e-15));
+        CompareMatrices(math::ExtractGradient(y), grad_expected, 1e-14));
   }
 
   // Test Symbolic.

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -76,6 +76,9 @@ build --test_env=MPLBACKEND=Template
 
 ### A configuration that enables all optional dependencies. ###
 build:everything --test_tag_filters=-no_everything
+# We'll also use it to test our custom AutoDiff until 2026-04-01 when this flag
+# gets flipped.
+build:everything --@drake//tools/flags:use_eigen_legacy_autodiff=False
 
 ### A configuration that enables Gurobi. ###
 # -- To use this config, the GRB_LICENSE_FILE environment variable must be set

--- a/tools/flags/BUILD.bazel
+++ b/tools/flags/BUILD.bazel
@@ -375,6 +375,18 @@ bool_flag(
 )
 
 # -----------------------------------------------------------------------------
+# Configuration for Drake features.
+
+# When True, Drake uses <unsupported/Eigen/AutoDiff> for its autodiff support.
+# When False, Drake uses a custom re-implementation. Using "True" is deprecated
+# and will be removed from Drake on or after 2026-07-01. The default will change
+# to "False" on or after 2026-04-01.
+bool_flag(
+    name = "use_eigen_legacy_autodiff",
+    build_setting_default = True,
+)
+
+# -----------------------------------------------------------------------------
 # Configuration for Drake's CMake install.
 #
 # The Bazel spelling of these flags should be consisered "internal use only".

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -9,6 +9,7 @@
 # should commit the changes made by the refresh script.
 LIBDRAKE_COMPONENTS = [
     "//common",
+    "//common/ad",
     "//common/proto",
     "//common/schema",
     "//common/symbolic",


### PR DESCRIPTION
Towards #23820 and #17492.

- CMake builds have a new flag that defaults to `DRAKE_USE_EIGEN_LEGACY_AUTODIFF=ON`.
- Bazel builds have a new flag that defaults to `--@drake//tools/flags:use_eigen_legacy_autodiff=True`.
- When `ON` / `True`, Drake uses `<unsupported/Eigen/AutoDiff>` for its autodiff support.
- When `OFF` / `False`, Drake uses a custom re-implementation at `drake/common/ad/...`.
- On 2026-04-01, both defaults will flip to `OFF` / `False`.
- On 2026-07-01, support for `ON` / `True` will be removed.
- Users should experiment with flipping the flag to `OFF` / `False` as soon as practical, to discover any problems early and file Drake issues when relevant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23870)
<!-- Reviewable:end -->
