### PR TITLE
Constructors that dereference pointers do it safely

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -878,6 +878,15 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "drake_deref_test",
+    deps = [
+        ":essential",
+        "//common/test_utilities:expect_no_throw",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
     name = "is_cloneable_test",
     deps = [
         ":is_cloneable",

--- a/common/drake_assert.h
+++ b/common/drake_assert.h
@@ -258,6 +258,23 @@ template <typename... NamesAndValues>
   _GET_NTH_ARG(__VA_ARGS__ __VA_OPT__(, ) _e_4, _e_3, _e_2, _e_1, _e_0) \
   (__VA_ARGS__)
 
+/* Dereferences a pointer, throwing an exception for null.
+
+ The extraneous parameters are used to provide context in the thrown exception.
+
+ Note: if a pointer to a const type is passed in, a const reference comes out,
+ otherwise a non-const reference comes out. */
+template <typename PtrType>
+auto SafeDereference(PtrType& ptr, const char* condition, const char* func,
+                     const char* file, int line) -> decltype(*ptr)
+  requires std::is_reference_v<decltype(*ptr)>
+{
+  if (ptr == nullptr) {
+    Throw(condition, func, file, line);
+  }
+  return *ptr;
+}
+
 }  // namespace internal
 }  // namespace drake
 
@@ -310,5 +327,35 @@ template <typename... NamesAndValues>
           __LINE__ __VA_OPT__(, ACCUMULATE(__VA_ARGS__)));                    \
     }                                                                         \
   } while (0)
+
+/// Derferences a pointer, with null checking. If the provided pointer is null,
+/// throws an exception. Otherwise, returns a reference to the object being
+/// pointed to.
+///
+/// If the pointer points to a const type, a const reference is returned. If it
+/// points to a non-const type, a non-const reference is returned.
+///
+/// It will typically appear in a class's constructor when it aliases a an
+/// input parameter.
+///
+/// Example usage:
+///
+/// @code{cpp}
+///
+/// class Foo {
+///  public:
+///   Foo(const Bar* bar) : bar_(DRAKE_DEREF(bar)) {}
+///  private:
+///   const Bar& bar_;
+/// };
+///
+/// @warning The pointer passed must be an l-value; do not pass in temporaries.
+/// E.g., this includes function calls that return pointers and pointers to
+/// arrays (&x[0]).
+///
+/// @endcode
+#define DRAKE_DEREF(ptr)                                                \
+  ::drake::internal::SafeDereference(ptr, #ptr " != nullptr", __func__, \
+                                     __FILE__, __LINE__)
 
 #endif  // DRAKE_DOXYGEN_CXX

--- a/common/test/drake_deref_test.cc
+++ b/common/test/drake_deref_test.cc
@@ -1,0 +1,75 @@
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace {
+
+GTEST_TEST(DrakeDerefTest, Acceptance) {
+  // Raw pointers.
+  int x = 42;
+  int* p1 = &x;
+  int* const p2 = &x;
+  const int* p3 = &x;
+  const int* const p4 = &x;
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(p1));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(p2));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(p3));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(p4));
+
+  // To pass a boolean to gtest that comes from a type trait value that wraps a
+  // macro, we need to launder it through parentheses (hence the apparently
+  // superfluous parentheses).
+
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(p1)), int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(p2)), int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(p3)), const int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(p4)), const int&>));
+
+  // Unique pointers.
+  std::unique_ptr<int> up1 = std::make_unique<int>();
+  const std::unique_ptr<int> up2 = std::make_unique<int>();
+  const std::unique_ptr<const int> up3 = std::make_unique<int>();
+  std::unique_ptr<const int> up4 = std::make_unique<int>();
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(up1));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(up2));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(up3));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(up4));
+
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(up1)), int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(up2)), int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(up3)), const int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(up4)), const int&>));
+
+  // Shared pointers.
+  std::shared_ptr<int> sp1 = std::make_shared<int>();
+  const std::shared_ptr<int> sp2 = std::make_shared<int>();
+  const std::shared_ptr<const int> sp3 = std::make_shared<int>();
+  std::shared_ptr<const int> sp4 = std::make_shared<int>();
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(sp1));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(sp2));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(sp3));
+  DRAKE_EXPECT_NO_THROW(DRAKE_DEREF(sp4));
+
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(sp1)), int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(sp2)), int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(sp3)), const int&>));
+  EXPECT_TRUE((std::is_same_v<decltype(DRAKE_DEREF(sp4)), const int&>));
+}
+
+GTEST_TEST(DrakeDerefTest, RejectNull) {
+  int* p_null = nullptr;
+  DRAKE_EXPECT_THROWS_MESSAGE(DRAKE_DEREF(p_null),
+                              ".*condition 'p_null != nullptr' failed.*");
+  std::unique_ptr<int> up_null = nullptr;
+  DRAKE_EXPECT_THROWS_MESSAGE(DRAKE_DEREF(up_null),
+                              ".*condition 'up_null != nullptr' failed.*");
+  std::shared_ptr<int> sp_null = nullptr;
+  DRAKE_EXPECT_THROWS_MESSAGE(DRAKE_DEREF(sp_null),
+                              ".*condition 'sp_null != nullptr' failed.*");
+}
+
+}  // namespace

--- a/geometry/optimization/dev/cspace_free_path.cc
+++ b/geometry/optimization/dev/cspace_free_path.cc
@@ -82,7 +82,7 @@ CspaceFreePath::CspaceFreePath(const multibody::MultibodyPlant<double>* plant,
                                const Eigen::Ref<const Eigen::VectorXd>& q_star,
                                int maximum_path_degree, int plane_degree)
     : rational_forward_kin_(plant),
-      scene_graph_{*scene_graph},
+      scene_graph_{DRAKE_DEREF(scene_graph)},
       q_star_{q_star},
       link_geometries_{internal::GetCollisionGeometries(*plant, *scene_graph)},
       plane_degree_{plane_degree},

--- a/geometry/proximity/bvh_updater.h
+++ b/geometry/proximity/bvh_updater.h
@@ -3,6 +3,7 @@
 #include <limits>
 #include <vector>
 
+#include "drake/common/drake_assert.h"
 #include "drake/geometry/proximity/aabb.h"
 #include "drake/geometry/proximity/bvh.h"
 
@@ -40,10 +41,7 @@ class BvhUpdater {
    @pre bvh_M was constructed on mesh_M.
    @pre mesh_M != nullptr and bvh_M != nullptr. */
   BvhUpdater(const MeshType* mesh_M, Bvh<Aabb, MeshType>* bvh_M)
-      : mesh_(*mesh_M), bvh_(*bvh_M) {
-    DRAKE_DEMAND(mesh_M != nullptr);
-    DRAKE_DEMAND(bvh_M != nullptr);
-  }
+      : mesh_(DRAKE_DEREF(mesh_M)), bvh_(DRAKE_DEREF(bvh_M)) {}
 
   const MeshType& mesh() const { return mesh_; }
   const Bvh<Aabb, MeshType>& bvh() const { return bvh_; }

--- a/geometry/proximity/hydroelastic_calculator.cc
+++ b/geometry/proximity/hydroelastic_calculator.cc
@@ -4,6 +4,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/drake_assert.h"
 #include "drake/geometry/proximity/field_intersection.h"
 #include "drake/geometry/proximity/mesh_half_space_intersection.h"
 #include "drake/geometry/proximity/mesh_intersection.h"
@@ -63,6 +64,15 @@ std::unique_ptr<ContactSurface<T>> CalcCompliantCompliant(
       id_F, compliant_F.soft_mesh(), X_WF, id_G, compliant_G.soft_mesh(), X_WG,
       representation);
 }
+
+template <typename T>
+ContactCalculator<T>::ContactCalculator(
+    const std::unordered_map<GeometryId, math::RigidTransform<T>>* X_WGs,
+    const Geometries* geometries,
+    HydroelasticContactRepresentation representation)
+    : X_WGs_(DRAKE_DEREF(X_WGs)),
+      geometries_(DRAKE_DEREF(geometries)),
+      representation_(representation) {}
 
 template <typename T>
 typename ContactCalculator<T>::MaybeMakeContactSurfaceResult

--- a/geometry/proximity/hydroelastic_calculator.h
+++ b/geometry/proximity/hydroelastic_calculator.h
@@ -90,13 +90,7 @@ class ContactCalculator {
   ContactCalculator(
       const std::unordered_map<GeometryId, math::RigidTransform<T>>* X_WGs,
       const Geometries* geometries,
-      HydroelasticContactRepresentation representation)
-      : X_WGs_(*X_WGs),
-        geometries_(*geometries),
-        representation_(representation) {
-    DRAKE_DEMAND(X_WGs != nullptr);
-    DRAKE_DEMAND(geometries != nullptr);
-  }
+      HydroelasticContactRepresentation representation);
 
   struct MaybeMakeContactSurfaceResult {
     ContactSurfaceResult result;

--- a/geometry/proximity/polygon_surface_mesh.h
+++ b/geometry/proximity/polygon_surface_mesh.h
@@ -60,12 +60,9 @@ class SurfacePolygon {
    @param index      The index into the face data of where this polygon's data
                      starts; the value contained is the number of vertices for
                      this polygon. It is _not_ the publicly visible index of the
-                     polygon.
-   */
+                     polygon. */
   SurfacePolygon(const std::vector<int>* face_data, int index)
-      : index_(index), mesh_face_data_(*face_data) {
-    DRAKE_DEMAND(face_data != nullptr);
-  }
+      : index_(index), mesh_face_data_(DRAKE_DEREF(face_data)) {}
 
   /* The index of *this* polygon in the polygonal surface. The index points to
    the first entry, which contains the vertex count. */

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -8,6 +8,7 @@
 #include <fcl/fcl.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -67,7 +68,7 @@ class PointShapeAutoDiffSignedDistanceTester {
   PointShapeAutoDiffSignedDistanceTester(const Shape* shape,
                                          const RigidTransformd& X_WG,
                                          double tolerance)
-      : shape_(*shape), X_WG_(X_WG), tolerance_(tolerance) {}
+      : shape_(DRAKE_DEREF(shape)), X_WG_(X_WG), tolerance_(tolerance) {}
 
   // Perform the test with the particular N and Q.
   ::testing::AssertionResult Test(const Vector3d& p_GN_G,

--- a/geometry/render/render_mesh.cc
+++ b/geometry/render/render_mesh.cc
@@ -145,10 +145,7 @@ class MaterialLibraryServer final : public tinyobj::MaterialReader {
   // aliased and must remain valid for at least as long as `this`.
   MaterialLibraryServer(const MeshSource* mesh_source,
                         const DiagnosticPolicy* policy)
-      : source_(*mesh_source), policy_(*policy) {
-    DRAKE_DEMAND(mesh_source != nullptr);
-    DRAKE_DEMAND(policy != nullptr);
-  }
+      : source_(DRAKE_DEREF(mesh_source)), policy_(DRAKE_DEREF(policy)) {}
 
   // The virtual interface for loading .mtl data; note the parameter names
   // reflect those used in tinyobjloader itself.

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/test_utilities/dummy_render_engine.h"
@@ -18,7 +19,8 @@ namespace render {
 
 class RenderEngineTester {
  public:
-  explicit RenderEngineTester(const RenderEngine* engine) : engine_(*engine) {}
+  explicit RenderEngineTester(const RenderEngine* engine)
+      : engine_(DRAKE_DEREF(engine)) {}
 
   int num_geometries() const {
     return static_cast<int>(engine_.update_ids_.size() +

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -10,6 +10,7 @@
 #include <tiny_gltf.h>
 
 #include "drake/common/diagnostic_policy.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/overloaded.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/common/scope_exit.h"
@@ -1416,7 +1417,7 @@ class RenderEngineGl::GltfMeshExtractor {
   GltfMeshExtractor(const MeshSource* mesh_source,
                     std::vector<OpenGlGeometry>* geometries,
                     TextureLibrary* texture_library)
-      : mesh_source_(*mesh_source),
+      : mesh_source_(DRAKE_DEREF(mesh_source)),
         description_(mesh_source_.is_path()
                          ? fmt::format("the on-disk glTF file: '{}'",
                                        mesh_source_.description())

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -22,6 +22,7 @@
 #include <vtkNew.h>        // vtkCommonCore
 #include <vtkPNGReader.h>  // vtkIOImage
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/fmt_eigen.h"
 #include "drake/common/temp_directory.h"
@@ -63,9 +64,7 @@ class RenderEngineGlTester {
    the given `engine`; the engine must stay alive at least as long as the
    tester.  */
   explicit RenderEngineGlTester(const RenderEngineGl* engine)
-      : engine_(*engine) {
-    DRAKE_DEMAND(engine != nullptr);
-  }
+      : engine_(DRAKE_DEREF(engine)) {}
 
   const internal::OpenGlContext& opengl_context() const {
     return *engine_.opengl_context_;

--- a/geometry/test_utilities/geometry_set_tester.h
+++ b/geometry/test_utilities/geometry_set_tester.h
@@ -2,6 +2,7 @@
 
 #include <unordered_set>
 
+#include "drake/common/drake_assert.h"
 #include "drake/geometry/geometry_set.h"
 
 namespace drake {
@@ -10,7 +11,7 @@ namespace geometry {
 // Utility class for testing the implementation details of the GeometrySet.
 class GeometrySetTester {
  public:
-  explicit GeometrySetTester(const GeometrySet* set) : set_(*set) {}
+  explicit GeometrySetTester(const GeometrySet* set) : set_(DRAKE_DEREF(set)) {}
 
   const std::unordered_set<FrameId> frames() const { return set_.frames(); }
 

--- a/multibody/contact_solvers/sap/dense_supernodal_solver.cc
+++ b/multibody/contact_solvers/sap/dense_supernodal_solver.cc
@@ -2,24 +2,17 @@
 
 #include <vector>
 
+#include "drake/common/drake_assert.h"
+
 namespace drake {
 namespace multibody {
 namespace contact_solvers {
 namespace internal {
 
-template <typename T>
-const T& SafeDeference(std::string_view variable_name, const T* ptr) {
-  if (ptr == nullptr) {
-    throw std::runtime_error(
-        fmt::format("Condition '{} != nullptr' failed.", variable_name));
-  }
-  return *ptr;
-}
-
 DenseSuperNodalSolver::DenseSuperNodalSolver(
     const std::vector<MatrixX<double>>* A, const BlockSparseMatrix<double>* J)
-    : A_(SafeDeference("A", A)),
-      J_(SafeDeference("J", J)),
+    : A_(DRAKE_DEREF(A)),
+      J_(DRAKE_DEREF(J)),
       H_(Eigen::MatrixXd::Zero(J->cols(), J->cols())),
       Hldlt_(H_) {
   const int nv = [this]() {

--- a/multibody/contact_solvers/sap/test/dense_supernodal_solver_test.cc
+++ b/multibody/contact_solvers/sap/test/dense_supernodal_solver_test.cc
@@ -184,7 +184,7 @@ GTEST_TEST(DenseSuperNodalSolver, BasicChecks) {
       DenseSuperNodalSolver solver(nullptr, &J);
     };
     DRAKE_EXPECT_THROWS_MESSAGE(bad_constructor_call(),
-                                "Condition 'A != nullptr' failed.");
+                                ".*condition 'A != nullptr' failed.");
   }
 
   // J is nullptr.
@@ -194,7 +194,7 @@ GTEST_TEST(DenseSuperNodalSolver, BasicChecks) {
       DenseSuperNodalSolver solver(&A_not_a_binding, nullptr);
     };
     DRAKE_EXPECT_THROWS_MESSAGE(bad_constructor_call(),
-                                "Condition 'J != nullptr' failed.");
+                                ".*condition 'J != nullptr' failed.");
   }
 
   DenseSuperNodalSolver solver(&blocks_of_A, &J);

--- a/multibody/optimization/static_equilibrium_problem.cc
+++ b/multibody/optimization/static_equilibrium_problem.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/optimization/static_equilibrium_problem.h"
 
+#include "drake/common/drake_assert.h"
 #include "drake/multibody/optimization/static_equilibrium_constraint.h"
 #include "drake/multibody/optimization/static_friction_cone_complementarity_constraint.h"
 
@@ -10,7 +11,7 @@ StaticEquilibriumProblem::StaticEquilibriumProblem(
     systems::Context<AutoDiffXd>* context,
     const std::set<std::pair<geometry::GeometryId, geometry::GeometryId>>&
         ignored_collision_pairs)
-    : plant_{*plant},
+    : plant_{DRAKE_DEREF(plant)},
       context_{context},
       owned_prog_{new solvers::MathematicalProgram()},
       prog_{owned_prog_.get()},

--- a/multibody/plant/physical_model.cc
+++ b/multibody/plant/physical_model.cc
@@ -2,10 +2,16 @@
 
 #include <utility>
 
+#include "drake/common/drake_assert.h"
 #include "drake/multibody/plant/multibody_plant_model_attorney.h"
 
 namespace drake {
 namespace multibody {
+
+template <typename T>
+PhysicalModel<T>::PhysicalModel(MultibodyPlant<T>* owning_plant)
+    : owning_plant_(DRAKE_DEREF(owning_plant)),
+      mutable_owning_plant_(owning_plant) {}
 
 template <typename T>
 PhysicalModel<T>::~PhysicalModel() = default;

--- a/multibody/plant/physical_model.h
+++ b/multibody/plant/physical_model.h
@@ -67,10 +67,7 @@ class PhysicalModel : public internal::ScalarConvertibleComponent<T> {
    declares System resources from the `owning_plant` in the call to
    `DeclareSystemResources()` through the call to `MultibodyPlant::Finalize()`.
    @pre owning_plant != nullptr. */
-  explicit PhysicalModel(MultibodyPlant<T>* owning_plant)
-      : owning_plant_(*owning_plant), mutable_owning_plant_(owning_plant) {
-    DRAKE_DEMAND(owning_plant != nullptr);
-  }
+  explicit PhysicalModel(MultibodyPlant<T>* owning_plant);
 
   ~PhysicalModel() override;
 

--- a/multibody/rational/rational_forward_kinematics.cc
+++ b/multibody/rational/rational_forward_kinematics.cc
@@ -57,8 +57,7 @@ RationalForwardKinematics::Pose<Scalar2> CalcChildPose(
 
 RationalForwardKinematics::RationalForwardKinematics(
     const MultibodyPlant<double>* plant)
-    : plant_(*plant) {
-  DRAKE_DEMAND(plant != nullptr);
+    : plant_(DRAKE_DEREF(plant)) {
   const internal::MultibodyTree<double>& tree = GetInternalTree(plant_);
   const internal::SpanningForest& forest = tree.forest();
   // Initialize map_mobilizer_to_s_index_ to -1, where -1 indicates "no s

--- a/planning/collision_checker_context.cc
+++ b/planning/collision_checker_context.cc
@@ -3,6 +3,8 @@
 #include <memory>
 #include <utility>
 
+#include "drake/common/drake_assert.h"
+
 namespace drake {
 namespace planning {
 
@@ -10,17 +12,10 @@ using geometry::QueryObject;
 using std::unique_ptr;
 using systems::Context;
 
-namespace {
-template <typename T>
-T* NonNull(T* pointer) {
-  DRAKE_DEMAND(pointer != nullptr);
-  return pointer;
-}
-}  // namespace
-
 CollisionCheckerContext::CollisionCheckerContext(
     const RobotDiagram<double>* model)
-    : CollisionCheckerContext(NonNull(model), model->CreateDefaultContext()) {}
+    : CollisionCheckerContext(model,
+                              DRAKE_DEREF(model).CreateDefaultContext()) {}
 
 CollisionCheckerContext::~CollisionCheckerContext() = default;
 
@@ -42,11 +37,13 @@ unique_ptr<CollisionCheckerContext> CollisionCheckerContext::DoClone() const {
 CollisionCheckerContext::CollisionCheckerContext(
     const RobotDiagram<double>* model,
     unique_ptr<Context<double>> model_context)
-    : model_(*NonNull(model)),
+    : model_(DRAKE_DEREF(model)),
       model_context_(std::move(model_context)),
       plant_context_(&model_.mutable_plant_context(model_context_.get())),
       scene_graph_context_(
-          &model_.mutable_scene_graph_context(model_context_.get())) {}
+          &model_.mutable_scene_graph_context(model_context_.get())) {
+  DRAKE_DEMAND(model_context_ != nullptr);
+}
 
 }  // namespace planning
 }  // namespace drake

--- a/planning/collision_checker_context.h
+++ b/planning/collision_checker_context.h
@@ -85,7 +85,10 @@ class CollisionCheckerContext {
 
  private:
   /* The resulting object stores an alias to `model`; the passed model should
-   have a lifetime greater than the constructed object. */
+   have a lifetime greater than the constructed object.
+
+   @pre `model` is not null.
+   @pre `model_context` is not null and is allocated by `model`. */
   CollisionCheckerContext(
       const RobotDiagram<double>* model,
       std::unique_ptr<systems::Context<double>> model_context);

--- a/planning/trajectory_optimization/direct_collocation.cc
+++ b/planning/trajectory_optimization/direct_collocation.cc
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_assert.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 
@@ -106,7 +107,7 @@ DirectCollocationConstraint::DirectCollocationConstraint(
                  Eigen::VectorXd::Zero(num_states)),
       owned_system_(std::move(owned_pair.first)),
       owned_context_(std::move(owned_pair.second)),
-      system_(owned_system_ ? *owned_system_ : *system),
+      system_(owned_system_ ? *owned_system_ : DRAKE_DEREF(system)),
       context_sample_(owned_context_ ? owned_context_.get() : context_sample),
       context_next_sample_(owned_context_ ? owned_context_.get()
                                           : context_next_sample),

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -19,6 +19,7 @@
 // NOLINTNEXTLINE(build/include)
 #include "snopt.h"
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/scope_exit.h"
 #include "drake/common/text_logging.h"
 #include "drake/math/autodiff.h"
@@ -233,7 +234,8 @@ class SnoptUserFunInfo {
   // are retained internally, so the supplied objects must have lifetimes longer
   // than the SnoptUserFuncInfo object.
   explicit SnoptUserFunInfo(const MathematicalProgram* prog)
-      : this_pointer_as_int_array_(MakeThisAsInts()), prog_(*prog) {}
+      : this_pointer_as_int_array_(MakeThisAsInts()),
+        prog_(DRAKE_DEREF(prog)) {}
 
   const MathematicalProgram& mathematical_program() const { return prog_; }
 

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -2,6 +2,7 @@
 
 #include <thread>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/extract_double.h"
 #include "drake/common/text_logging.h"
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
@@ -13,27 +14,29 @@ namespace systems {
 template <typename T>
 Simulator<T>::Simulator(const System<T>& system,
                         std::unique_ptr<Context<T>> context)
-    : Simulator(&system, nullptr, std::move(context)) {}
+    : Simulator(&system, nullptr, std::move(context), false) {}
 
 template <typename T>
 Simulator<T>::Simulator(std::unique_ptr<const System<T>> owned_system,
                         std::unique_ptr<Context<T>> context)
-    : Simulator(nullptr, std::move(owned_system), std::move(context)) {}
+    : Simulator(nullptr, std::move(owned_system), std::move(context), true) {}
 
 template <typename T>
 std::unique_ptr<Simulator<T>> Simulator<T>::MakeWithSharedContext(
     const System<T>& system, std::shared_ptr<Context<T>> context) {
   // This slightly odd spelling allows access to the private constructor.
   return std::unique_ptr<Simulator<T>>(
-      new Simulator(&system, nullptr, std::move(context)));
+      new Simulator(&system, nullptr, std::move(context), false));
 }
 
 template <typename T>
 Simulator<T>::Simulator(const System<T>* system,
                         std::unique_ptr<const System<T>> owned_system,
-                        std::shared_ptr<Context<T>> context)
+                        std::shared_ptr<Context<T>> context,
+                        bool use_owned_system)
     : owned_system_(std::move(owned_system)),
-      system_(owned_system_ ? *owned_system_ : *system),
+      system_(use_owned_system ? DRAKE_DEREF(owned_system_)
+                               : DRAKE_DEREF(system)),
       context_{std::move(context)} {
   // TODO(dale.mcconachie) move this default to SimulatorConfig
   constexpr double kDefaultInitialStepSizeTarget = 1e-4;

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -766,9 +766,11 @@ class Simulator {
   };
 
   // All constructors delegate to here.
+  // @param use_owned_system  If true, `owned_system` must not be null. If
+  //                          false, `system` must not be null.
   Simulator(const System<T>* system,
             std::unique_ptr<const System<T>> owned_system,
-            std::shared_ptr<Context<T>> context);
+            std::shared_ptr<Context<T>> context, bool use_owned_system);
 
   [[nodiscard]] EventStatus HandleUnrestrictedUpdate(
       const EventCollection<UnrestrictedUpdateEvent<T>>& events);

--- a/systems/framework/input_port.cc
+++ b/systems/framework/input_port.cc
@@ -1,4 +1,26 @@
 #include "drake/systems/framework/input_port.h"
 
+namespace drake {
+namespace systems {
+template <typename T>
+InputPort<T>::InputPort(const System<T>* system,
+                        internal::SystemMessageInterface* system_interface,
+                        internal::SystemId system_id, std::string name,
+                        InputPortIndex index, DependencyTicket ticket,
+                        PortDataType data_type, int size,
+                        const std::optional<RandomDistribution>& random_type,
+                        EvalAbstractCallback eval,
+                        ValueProducer::AllocateCallback alloc)
+    : InputPortBase(system_interface, system_id, std::move(name), index, ticket,
+                    data_type, size, random_type, std::move(eval),
+                    std::move(alloc)),
+      system_(DRAKE_DEREF(system)) {
+  // Check the precondition on identical parameters; note that comparing as
+  // void* is only valid because we have single inheritance.
+  DRAKE_DEMAND(static_cast<const void*>(system) == system_interface);
+}
+}  // namespace systems
+}  // namespace drake
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::InputPort);

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -195,16 +195,7 @@ class InputPort final : public InputPortBase {
             InputPortIndex index, DependencyTicket ticket,
             PortDataType data_type, int size,
             const std::optional<RandomDistribution>& random_type,
-            EvalAbstractCallback eval, ValueProducer::AllocateCallback alloc)
-      : InputPortBase(system_interface, system_id, std::move(name), index,
-                      ticket, data_type, size, random_type, std::move(eval),
-                      std::move(alloc)),
-        system_(*system) {
-    DRAKE_DEMAND(system != nullptr);
-    // Check the precondition on identical parameters; note that comparing as
-    // void* is only valid because we have single inheritance.
-    DRAKE_DEMAND(static_cast<const void*>(system) == system_interface);
-  }
+            EvalAbstractCallback eval, ValueProducer::AllocateCallback alloc);
 
   const System<T>& system_;
 };

--- a/systems/framework/output_port.cc
+++ b/systems/framework/output_port.cc
@@ -3,6 +3,20 @@
 namespace drake::systems {
 
 template <typename T>
+OutputPort<T>::OutputPort(const System<T>* system,
+                          internal::SystemMessageInterface* system_interface,
+                          internal::SystemId system_id, std::string name,
+                          OutputPortIndex index, DependencyTicket ticket,
+                          PortDataType data_type, int size)
+    : OutputPortBase(system_interface, system_id, std::move(name), index,
+                     ticket, data_type, size),
+      system_{DRAKE_DEREF(system)} {
+  // Check the precondition on identical parameters; note that comparing as
+  // void* is only valid because we have single inheritance.
+  DRAKE_DEMAND(static_cast<const void*>(system) == system_interface);
+}
+
+template <typename T>
 OutputPort<T>::~OutputPort() = default;
 
 template <typename T>

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -189,14 +189,7 @@ class OutputPort : public OutputPortBase {
              internal::SystemMessageInterface* system_interface,
              internal::SystemId system_id, std::string name,
              OutputPortIndex index, DependencyTicket ticket,
-             PortDataType data_type, int size)
-      : OutputPortBase(system_interface, system_id, std::move(name), index,
-                       ticket, data_type, size),
-        system_{*system} {
-    // Check the precondition on identical parameters; note that comparing as
-    // void* is only valid because we have single inheritance.
-    DRAKE_DEMAND(static_cast<const void*>(system) == system_interface);
-  }
+             PortDataType data_type, int size);
 
   /** A concrete %OutputPort must provide a way to allocate a suitable object
   for holding the runtime value of this output port. The particulars may depend

--- a/systems/rendering/multibody_position_to_geometry_pose.cc
+++ b/systems/rendering/multibody_position_to_geometry_pose.cc
@@ -30,7 +30,7 @@ template <typename T>
 MultibodyPositionToGeometryPose<T>::MultibodyPositionToGeometryPose(
     std::unique_ptr<multibody::MultibodyPlant<T>> owned_plant,
     bool input_multibody_state)
-    : plant_(*owned_plant), owned_plant_(std::move(owned_plant)) {
+    : plant_(DRAKE_DEREF(owned_plant)), owned_plant_(std::move(owned_plant)) {
   DRAKE_DEMAND(owned_plant_ != nullptr);
   Configure(input_multibody_state);
 }


### PR DESCRIPTION
1. Introduce common utility.
2. Use the utility in various sites where classes would alias a constructor parameter (pointer stored as reference).
   - In two cases, the previous functionality was updated to use the common functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23873)
<!-- Reviewable:end -->
