### PR TITLE
[icf] Add gain constraints

### DIFF
--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     deps = [
         ":coupler_constraints_data_pool",
         ":eigen_pool",
+        ":gain_constraints_data_pool",
         ":icf_data",
         ":icf_model",
         ":icf_search_direction_data",
@@ -41,6 +42,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "gain_constraints_data_pool",
+    srcs = ["gain_constraints_data_pool.cc"],
+    hdrs = ["gain_constraints_data_pool.h"],
+    deps = [
+        ":eigen_pool",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "icf_search_direction_data",
     hdrs = ["icf_search_direction_data.h"],
     deps = [
@@ -57,6 +69,7 @@ drake_cc_library(
     deps = [
         ":coupler_constraints_data_pool",
         ":eigen_pool",
+        ":gain_constraints_data_pool",
         "//common:essential",
     ],
 )
@@ -65,10 +78,12 @@ drake_cc_library(
     name = "icf_model",
     srcs = [
         "coupler_constraints_pool.cc",
+        "gain_constraints_pool.cc",
         "icf_model.cc",
     ],
     hdrs = [
         "coupler_constraints_pool.h",
+        "gain_constraints_pool.h",
         "icf_model.h",
     ],
     deps = [

--- a/multibody/contact_solvers/icf/coupler_constraints_data_pool.h
+++ b/multibody/contact_solvers/icf/coupler_constraints_data_pool.h
@@ -13,7 +13,9 @@ namespace internal {
 
 /* Stores data for coupler constraints. This data is updated at each solver
 iteration, as opposed to the CouplerConstraintsPool, which helps define the
-optimization problem. */
+optimization problem.
+
+@tparam_nonsymbolic_scalar */
 template <typename T>
 class CouplerConstraintsDataPool {
  public:
@@ -41,7 +43,7 @@ class CouplerConstraintsDataPool {
   T& mutable_cost() { return cost_; }
 
  private:
-  T cost_{0.0};                // Total cost over all coupler constraints.
+  T cost_{NAN};                // Total cost over all coupler constraints.
   std::vector<T> gamma_pool_;  // Constraint impulses
 };
 

--- a/multibody/contact_solvers/icf/coupler_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/coupler_constraints_pool.cc
@@ -16,7 +16,7 @@ template <typename T>
 CouplerConstraintsPool<T>::CouplerConstraintsPool(
     const IcfModel<T>* parent_model)
     : model_(parent_model) {
-  DRAKE_ASSERT(parent_model != nullptr);
+  DRAKE_DEMAND(parent_model != nullptr);
 }
 
 template <typename T>
@@ -44,9 +44,9 @@ template <typename T>
 void CouplerConstraintsPool<T>::Set(int index, int clique, int i, int j,
                                     const T& qi, const T& qj, T gear_ratio,
                                     T offset) {
-  DRAKE_ASSERT(index >= 0 && index < num_constraints());
-  DRAKE_ASSERT(i >= 0 && i < model().clique_size(clique));
-  DRAKE_ASSERT(j >= 0 && j < model().clique_size(clique));
+  DRAKE_ASSERT(0 <= index && index < num_constraints());
+  DRAKE_ASSERT(0 <= i && i < model().clique_size(clique));
+  DRAKE_ASSERT(0 <= j && j < model().clique_size(clique));
 
   constraint_to_clique_[index] = clique;
   dofs_[index] = std::make_pair(i, j);
@@ -105,6 +105,8 @@ void CouplerConstraintsPool<T>::CalcData(
 template <typename T>
 void CouplerConstraintsPool<T>::AccumulateGradient(const IcfData<T>& data,
                                                    VectorX<T>* gradient) const {
+  DRAKE_ASSERT(gradient != nullptr);
+
   const CouplerConstraintsDataPool<T>& coupler_data =
       data.coupler_constraints_data();
 
@@ -131,6 +133,8 @@ template <typename T>
 void CouplerConstraintsPool<T>::AccumulateHessian(
     const IcfData<T>& data,
     BlockSparseSymmetricMatrix<MatrixX<T>>* hessian) const {
+  DRAKE_ASSERT(hessian != nullptr);
+
   for (int k = 0; k < num_constraints(); ++k) {
     const int c = constraint_to_clique_[k];
     const int i = dofs_[k].first;
@@ -156,6 +160,8 @@ template <typename T>
 void CouplerConstraintsPool<T>::CalcCostAlongLine(
     const CouplerConstraintsDataPool<T>& coupler_data, const VectorX<T>& w,
     T* dcost, T* d2cost) const {
+  DRAKE_ASSERT(dcost != nullptr);
+  DRAKE_ASSERT(d2cost != nullptr);
   *dcost = 0.0;
   *d2cost = 0.0;
   for (int k = 0; k < num_constraints(); ++k) {

--- a/multibody/contact_solvers/icf/gain_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/gain_constraints_data_pool.cc
@@ -1,0 +1,27 @@
+#include "drake/multibody/contact_solvers/icf/gain_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+template <typename T>
+GainConstraintsDataPool<T>::~GainConstraintsDataPool() = default;
+
+template <typename T>
+void GainConstraintsDataPool<T>::Resize(std::span<const int> constraint_size) {
+  const int num_elements = ssize(constraint_size);
+  gamma_pool_.Resize(num_elements, constraint_size);
+  G_pool_.Resize(num_elements, constraint_size);
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        GainConstraintsDataPool);

--- a/multibody/contact_solvers/icf/gain_constraints_data_pool.h
+++ b/multibody/contact_solvers/icf/gain_constraints_data_pool.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <span>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+/* Data pool for torque-limited actuation constraints τ = clamp(−K⋅v + b, e).
+This data is updated at each solver iteration, as opposed to the
+GainConstraintsPool, which defines the constraints themselves and is fixed for
+the lifetime of the optimization problem.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class GainConstraintsDataPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GainConstraintsDataPool);
+
+  using VectorXView = typename EigenPool<VectorX<T>>::MatrixView;
+  using ConstVectorXView = typename EigenPool<VectorX<T>>::ConstMatrixView;
+
+  /* Constructs an empty pool. */
+  GainConstraintsDataPool() = default;
+
+  ~GainConstraintsDataPool();
+
+  /* Resizes the data pool to hold constraints of the given sizes.
+  @param constraint_size The number of velocities for each gain constraint. */
+  void Resize(std::span<const int> constraint_size);
+
+  /* Returns the number of gain constraints this data pool is for. */
+  int num_constraints() const { return gamma_pool_.size(); }
+
+  /* Returns the total constraint cost ℓ(v) for all gain constraints in the
+  pool. See GainConstraintsPool for details. */
+  const T& cost() const { return cost_; }
+  T& mutable_cost() { return cost_; }
+
+  /* Returns the constraint impulse γ = -∇ℓ(v) for the k-th constraint in the
+  pool.*/
+  ConstVectorXView gamma(int k) const { return gamma_pool_[k]; }
+  VectorXView mutable_gamma(int k) { return gamma_pool_[k]; }
+
+  /* Returns the (diagonal) Hessian block G = -∂γ/∂v for the k-th constraint in
+  the pool. */
+  ConstVectorXView G(int k) const { return G_pool_[k]; }
+  VectorXView mutable_G(int k) { return G_pool_[k]; }
+
+ private:
+  T cost_{NAN};                       // Total cost over all gain constraints.
+  EigenPool<VectorX<T>> gamma_pool_;  // Generalized impulses per constraint.
+  EigenPool<VectorX<T>> G_pool_;      // Diagonal Hessians G = -∂γ/∂v ≥ 0.
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        GainConstraintsDataPool);

--- a/multibody/contact_solvers/icf/gain_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/gain_constraints_pool.cc
@@ -1,0 +1,189 @@
+#include "drake/multibody/contact_solvers/icf/gain_constraints_pool.h"
+
+#include <algorithm>
+
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+using contact_solvers::internal::BlockSparseSymmetricMatrix;
+using Eigen::VectorBlock;
+
+template <typename T>
+GainConstraintsPool<T>::GainConstraintsPool(const IcfModel<T>* parent_model)
+    : model_(parent_model) {
+  DRAKE_DEMAND(parent_model != nullptr);
+}
+
+template <typename T>
+GainConstraintsPool<T>::~GainConstraintsPool() = default;
+
+template <typename T>
+void GainConstraintsPool<T>::Resize(std::span<const int> sizes) {
+  clique_.resize(sizes.size());
+  constraint_size_.resize(sizes.size());
+  const int num_elements = ssize(sizes);
+  K_.Resize(num_elements, sizes);
+  b_.Resize(num_elements, sizes);
+  le_.Resize(num_elements, sizes);
+  ue_.Resize(num_elements, sizes);
+}
+
+template <typename T>
+void GainConstraintsPool<T>::Set(int index, int clique, const VectorX<T>& K,
+                                 const VectorX<T>& b, const VectorX<T>& e) {
+  DRAKE_ASSERT(0 <= index && index < num_constraints());
+  const int nv = model().clique_size(clique);
+  DRAKE_ASSERT(K.size() == nv);
+  DRAKE_ASSERT(b.size() == nv);
+  DRAKE_ASSERT(e.size() == nv);
+  clique_[index] = clique;
+  constraint_size_[index] = nv;
+  K_[index] = K;
+  b_[index] = b;
+  le_[index] = -e;
+  ue_[index] = e;
+}
+
+template <typename T>
+void GainConstraintsPool<T>::CalcData(
+    const VectorX<T>& v, GainConstraintsDataPool<T>* gain_data) const {
+  DRAKE_ASSERT(gain_data != nullptr);
+
+  T& cost = gain_data->mutable_cost();
+  cost = 0;
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+    VectorBlock<const VectorX<T>> vk = model().clique_segment(c, v);
+    VectorXView gamma_k = gain_data->mutable_gamma(k);
+    VectorXView Gk = gain_data->mutable_G(k);
+    cost += Clamp(k, vk, &gamma_k, &Gk);
+  }
+}
+
+template <typename T>
+void GainConstraintsPool<T>::AccumulateGradient(const IcfData<T>& data,
+                                                VectorX<T>* gradient) const {
+  DRAKE_ASSERT(gradient != nullptr);
+
+  const GainConstraintsDataPool<T>& gain_data = data.gain_constraints_data();
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+    VectorBlock<VectorX<T>> gradient_c =
+        model().mutable_clique_segment(c, gradient);
+    ConstVectorXView gamma_k = gain_data.gamma(k);
+    gradient_c -= gamma_k;
+  }
+}
+
+template <typename T>
+void GainConstraintsPool<T>::AccumulateHessian(
+    const IcfData<T>& data,
+    BlockSparseSymmetricMatrix<MatrixX<T>>* hessian) const {
+  DRAKE_ASSERT(hessian != nullptr);
+
+  const GainConstraintsDataPool<T>& gain_data = data.gain_constraints_data();
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+
+    // TODO(vincekurtz): use data.scratch() to avoid allocating Gk here.
+    const MatrixX<T> Gk = gain_data.G(k).asDiagonal();
+    hessian->AddToBlock(c, c, Gk);
+  }
+}
+
+template <typename T>
+void GainConstraintsPool<T>::CalcCostAlongLine(
+    const GainConstraintsDataPool<T>& gain_data, const VectorX<T>& w,
+    EigenPool<VectorX<T>>* Gw_scratch, T* dcost, T* d2cost) const {
+  DRAKE_ASSERT(Gw_scratch != nullptr);
+  DRAKE_ASSERT(dcost != nullptr);
+  DRAKE_ASSERT(d2cost != nullptr);
+  EigenPool<VectorX<T>>& Gw_pool = *Gw_scratch;
+
+  *dcost = 0.0;
+  *d2cost = 0.0;
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+    VectorBlock<const VectorX<T>> w_c = model().clique_segment(c, w);
+    Gw_pool.Resize(1, model().clique_size(c), 1);
+    VectorXView G_times_w = Gw_pool[0];
+
+    ConstVectorXView gamma_k = gain_data.gamma(k);
+    ConstVectorXView Gk = gain_data.G(k);
+    G_times_w = Gk.asDiagonal() * w_c;
+    (*dcost) -= w_c.dot(gamma_k);
+    (*d2cost) += w_c.dot(G_times_w);
+  }
+}
+
+template <typename T>
+T GainConstraintsPool<T>::Clamp(int k, const Eigen::Ref<const VectorX<T>>& v,
+                                EigenPtr<VectorX<T>> gamma,
+                                EigenPtr<VectorX<T>> G) const {
+  const int nv = v.size();
+  DRAKE_DEMAND(gamma->size() == nv);
+  DRAKE_DEMAND(G->size() == nv);
+  using std::max;
+  using std::min;
+
+  const T& dt = model().time_step();
+
+  T cost = 0;
+  for (int i = 0; i < nv; ++i) {
+    const T& ki = K_[k][i];
+    const T& bi = b_[k][i];
+    const T& lei = le_[k][i];
+    const T& uei = ue_[k][i];
+    const T& vi = v[i];
+    T& gamma_i = (*gamma)[i];
+    T& Gi = (*G)[i];
+
+    const T yi = -ki * vi + bi;
+
+    if (yi < lei) {
+      // Below lower limit.
+      gamma_i = dt * lei;
+      Gi = 0.0;
+      if (ki > 0) {
+        cost += gamma_i * (yi - 0.5 * lei) / ki;
+      } else {
+        cost -= gamma_i * vi;  // Zero gain case.
+      }
+    } else if (yi > uei) {
+      // Above upper limit.
+      gamma_i = dt * uei;
+      Gi = 0.0;
+      if (ki > 0) {
+        cost += gamma_i * (yi - 0.5 * uei) / ki;
+      } else {
+        cost -= gamma_i * vi;  // Zero gain case.
+      }
+    } else {
+      // Within limit.
+      gamma_i = dt * yi;
+      Gi = dt * ki;
+      if (ki > 0) {
+        cost += 0.5 * yi * yi * dt / ki;
+      } else {
+        cost -= gamma_i * vi;  // Zero gain case.
+      }
+    }
+  }
+
+  return cost;
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        GainConstraintsPool);

--- a/multibody/contact_solvers/icf/gain_constraints_pool.h
+++ b/multibody/contact_solvers/icf/gain_constraints_pool.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <span>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+#include "drake/multibody/contact_solvers/icf/gain_constraints_data_pool.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+// Forward declaration to break circular dependencies.
+template <typename T>
+class IcfModel;
+
+/* A pool of gain constraints organized by cliques.
+
+A gain constraint models generalized forces acting on a given clique as
+
+ τ = clamp(-K⋅v + b, -e, e)
+
+where K is a non-negative diagonal gain matrix, b is a bias term, and e is a
+double-sided effort limit.
+
+Each gain constraint is associated with a convex cost ℓ(v) that is added to the
+overall ICF cost. The gradient of this cost produces an impulse
+
+  γ = -∇ℓ(v) = -δt⋅τ
+
+that enforces the constraint when the convex ICF problem is solved.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class GainConstraintsPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GainConstraintsPool);
+
+  using VectorXView = typename EigenPool<VectorX<T>>::MatrixView;
+  using ConstVectorXView = typename EigenPool<VectorX<T>>::ConstMatrixView;
+
+  /* Constructs an empty pool. */
+  explicit GainConstraintsPool(const IcfModel<T>* parent_model);
+
+  ~GainConstraintsPool();
+
+  /* Returns a reference to the parent model. */
+  const IcfModel<T>& model() const { return *model_; }
+
+  /* Returns the total number of gain constraints stored in this pool. */
+  int num_constraints() const { return clique_.size(); }
+
+  /* Returns the number of velocities for each gain constraint. */
+  std::span<const int> constraint_sizes() const {
+    return std::span<const int>(constraint_size_);
+  }
+
+  /* Resizes this pool to store gain constraints of the given sizes.
+
+  @param sizes The number of velocities associated with each gain constraint.
+
+  @warning After resizing, constraints may hold invalid data until Set() is
+  called for each constraint index in [0, num_constraints()). */
+  void Resize(std::span<const int> sizes);
+
+  /* Defines the gain constraint τ = clamp(-K⋅v + b, -e, e) for a given clique.
+
+  @param index The index of this gain constraint in the pool.
+  @param clique The clique to which this gain constraint applies.
+  @param K The diagonal entries of gain matrix K. They must be >= 0.
+  @param b The bias term.
+  @param e The vector of double-sided effort limits for each DoF of the clique.
+
+  Calling this function several times with the same `index` overwrites the
+  previous constraint for that index.
+
+  @pre K, b, e are of size model().clique_size(clique). */
+  void Set(int index, int clique, const VectorX<T>& K, const VectorX<T>& b,
+           const VectorX<T>& e);
+
+  /* Computes problem data as a function of the generalized velocities `v` for
+  the full plant. */
+  void CalcData(const VectorX<T>& v,
+                GainConstraintsDataPool<T>* gain_data) const;
+
+  /* Adds the gradient contribution of this constraint, ∇ℓ = −γ, to the
+  model-wide gradient. */
+  void AccumulateGradient(const IcfData<T>& data, VectorX<T>* gradient) const;
+
+  /* Adds the contribution of this constraint to the model-wide Hessian. */
+  void AccumulateHessian(
+      const IcfData<T>& data,
+      contact_solvers::internal::BlockSparseSymmetricMatrix<MatrixX<T>>*
+          hessian) const;
+
+  /* Computes the first and second derivatives of the constraint cost
+  ℓ̃(α) = ℓ(v + α⋅w).
+
+  @param gain_data Constraint data computed at v + α⋅w.
+  @param w The search direction.
+  @param Gw_scratch Scratch space for intermediate values for each clique.
+  @param[out] dcost The first derivative dℓ̃ /dα on output.
+  @param[out] d2cost The second derivative d²ℓ̃ /dα² on output. */
+  void CalcCostAlongLine(const GainConstraintsDataPool<T>& gain_data,
+                         const VectorX<T>& w, EigenPool<VectorX<T>>* Gw_scratch,
+                         T* dcost, T* d2cost) const;
+
+ private:
+  /* Computes the cost, gradient, and Hessian contribution for a single gain
+  constraint.
+
+  @param k The index of the gain constraint.
+  @param v The velocity associated with the corresponding clique.
+  @param[out] gamma The computed impulse γ = -∇ℓ(v) on output.
+  @param[out] G The computed (diagonal) Hessian G = -∂γ/∂v on output.
+  @returns The cost ℓ(v) associated with this gain constraint. */
+  T Clamp(int k, const Eigen::Ref<const VectorX<T>>& v,
+          EigenPtr<VectorX<T>> gamma, EigenPtr<VectorX<T>> G) const;
+
+  const IcfModel<T>* const model_;  // The parent model.
+
+  // We always add gain constraints per-clique. Each of the following has size
+  // num_constraints().
+  std::vector<int> clique_;           // Clique the k-th gain belongs to.
+  std::vector<int> constraint_size_;  // Clique size for the k-th constraint.
+  EigenPool<VectorX<T>> K_;
+  EigenPool<VectorX<T>> b_;
+  EigenPool<VectorX<T>> le_;  // Lower effort limit.
+  EigenPool<VectorX<T>> ue_;  // Upper effort limit.
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        GainConstraintsPool);

--- a/multibody/contact_solvers/icf/icf_data.cc
+++ b/multibody/contact_solvers/icf/icf_data.cc
@@ -10,13 +10,18 @@ namespace internal {
 
 template <typename T>
 void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
-                                 int max_clique_size, int num_couplers) {
+                                 int max_clique_size, int num_couplers,
+                                 std::span<const int> gain_sizes) {
   Av_minus_r.Resize(1, num_velocities, 1);
 
   V_WB_alpha.Resize(num_bodies, 6, 1);
   v_alpha.Resize(1, num_velocities, 1);
 
+  Gw_gain.Resize(1, max_clique_size, 1);
+
   coupler_constraints_data.Resize(num_couplers);
+  gain_constraints_data.Resize(gain_sizes);
+
   H_cc_pool.Resize(1, max_clique_size, max_clique_size);
 
   H_BB_pool.Resize(1, max_clique_size, max_clique_size);
@@ -32,13 +37,15 @@ IcfData<T>::~IcfData() = default;
 
 template <typename T>
 void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
-                        int num_couplers) {
+                        int num_couplers, std::span<const int> gain_sizes) {
   v_.resize(num_velocities);
   V_WB_.Resize(num_bodies, 6, 1);
   Av_.resize(num_velocities);
   gradient_.resize(num_velocities);
   coupler_constraints_data_.Resize(num_couplers);
-  scratch_.Resize(num_bodies, num_velocities, max_clique_size, num_couplers);
+  gain_constraints_data_.Resize(gain_sizes);
+  scratch_.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
+                  gain_sizes);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -11,6 +11,7 @@
 #include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
 #include "drake/multibody/contact_solvers/icf/coupler_constraints_pool.h"
 #include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+#include "drake/multibody/contact_solvers/icf/gain_constraints_pool.h"
 #include "drake/multibody/contact_solvers/icf/icf_data.h"
 #include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
 
@@ -138,15 +139,27 @@ class IcfModel {
   int max_clique_size() const { return max_clique_size_; }
 
   /* Returns the total number of constraints of any type in the problem. */
-  int num_constraints() const { return num_coupler_constraints(); }
+  int num_constraints() const {
+    return num_coupler_constraints() + num_gain_constraints();
+  }
 
   /* Provides mutable access to the pool of all coupler constraints. */
   CouplerConstraintsPool<T>& coupler_constraints_pool() {
     return coupler_constraints_pool_;
   }
 
+  /* Provides mutable access to the pool of all gain (e.g., actuation)
+  constraints. */
+  GainConstraintsPool<T>& gain_constraints_pool() {
+    return gain_constraints_pool_;
+  }
+
   int num_coupler_constraints() const {
     return coupler_constraints_pool_.num_constraints();
+  }
+
+  int num_gain_constraints() const {
+    return gain_constraints_pool_.num_constraints();
   }
 
   /* Returns the time step δt. */
@@ -365,6 +378,7 @@ class IcfModel {
 
   // Fixed set of constraints.
   CouplerConstraintsPool<T> coupler_constraints_pool_;
+  GainConstraintsPool<T> gain_constraints_pool_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/test/icf_data_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_data_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/contact_solvers/icf/icf_data.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/limit_malloc.h"
@@ -19,6 +21,7 @@ GTEST_TEST(IcfData, DefaultConstructedIsEmpty) {
   EXPECT_EQ(data.scratch().Av_minus_r.size(), 0);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), 0);
   EXPECT_EQ(data.scratch().v_alpha.size(), 0);
+  EXPECT_EQ(data.scratch().Gw_gain.size(), 0);
   EXPECT_EQ(data.scratch().H_BB_pool.size(), 0);
   EXPECT_EQ(data.scratch().H_AA_pool.size(), 0);
   EXPECT_EQ(data.scratch().H_AB_pool.size(), 0);
@@ -34,8 +37,10 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   const int num_velocities = 12;
   const int max_clique_size = 6;
   const int num_couplers = 2;
+  const std::vector<int> gain_sizes = {3, 2};
 
-  data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers);
+  data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
+              gain_sizes);
 
   // Main data elements
   EXPECT_EQ(data.num_velocities(), num_velocities);
@@ -50,8 +55,11 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   EXPECT_EQ(data.scratch().Av_minus_r[0].size(), num_velocities);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
   EXPECT_EQ(data.scratch().v_alpha[0].size(), num_velocities);
+  EXPECT_EQ(data.scratch().Gw_gain[0].size(), max_clique_size);
   EXPECT_EQ(data.scratch().coupler_constraints_data.num_constraints(),
             num_couplers);
+  EXPECT_EQ(data.scratch().gain_constraints_data.num_constraints(),
+            ssize(gain_sizes));
   EXPECT_EQ(data.scratch().H_cc_pool[0].rows(), max_clique_size);
   EXPECT_EQ(data.scratch().H_cc_pool[0].cols(), max_clique_size);
   EXPECT_EQ(data.scratch().H_BB_pool[0].rows(), max_clique_size);
@@ -74,12 +82,14 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
   const int num_velocities = 11;
   const int max_clique_size = 7;
   const int num_couplers = 2;
+  const std::vector<int> gain_sizes = {3};
 
-  data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers);
+  data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
+              gain_sizes);
 
   // Clearing pools changes size but shouldn't change capacity.
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
-  data.scratch().Resize(0, 0, 0, 0);
+  data.scratch().Resize(0, 0, 0, 0, gain_sizes);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), 0);
 
   VectorX<double> v = VectorX<double>::LinSpaced(num_velocities, 1.0, 11.0);
@@ -87,7 +97,8 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
     // Restoring the data to the original size and setting velocities should not
     // cause any new allocations.
     drake::test::LimitMalloc guard;
-    data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers);
+    data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
+                gain_sizes);
     data.set_v(v);
   }
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);


### PR DESCRIPTION
Adds gain constraints (e.g., linearized external actuation) to the ICF formulation. This is the next step along the ICF PR train (https://github.com/RobotLocomotion/drake/issues/23769).

For full context, see the [cenic_main](https://github.com/RobotLocomotion/drake/tree/cenic_main) dev branch, and especially the [ICF README](https://github.com/RobotLocomotion/drake/blob/cenic_main/multibody/contact_solvers/icf/README.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23874)
<!-- Reviewable:end -->
