### PR TITLE
[icf] Add limit constraints

### DIFF
--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
         ":icf_data",
         ":icf_model",
         ":icf_search_direction_data",
+        ":limit_constraints_data_pool",
     ],
 )
 
@@ -53,6 +54,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "limit_constraints_data_pool",
+    srcs = ["limit_constraints_data_pool.cc"],
+    hdrs = ["limit_constraints_data_pool.h"],
+    deps = [
+        ":eigen_pool",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "icf_search_direction_data",
     hdrs = ["icf_search_direction_data.h"],
     deps = [
@@ -70,6 +82,7 @@ drake_cc_library(
         ":coupler_constraints_data_pool",
         ":eigen_pool",
         ":gain_constraints_data_pool",
+        ":limit_constraints_data_pool",
         "//common:essential",
     ],
 )
@@ -80,17 +93,20 @@ drake_cc_library(
         "coupler_constraints_pool.cc",
         "gain_constraints_pool.cc",
         "icf_model.cc",
+        "limit_constraints_pool.cc",
     ],
     hdrs = [
         "coupler_constraints_pool.h",
         "gain_constraints_pool.h",
         "icf_model.h",
+        "limit_constraints_pool.h",
     ],
     deps = [
         ":coupler_constraints_data_pool",
         ":eigen_pool",
         ":icf_data",
         ":icf_search_direction_data",
+        ":limit_constraints_data_pool",
         "//common:default_scalars",
         "//common:essential",
         "//multibody/contact_solvers:block_sparse_lower_triangular_or_symmetric_matrix",  # noqa

--- a/multibody/contact_solvers/icf/icf_data.cc
+++ b/multibody/contact_solvers/icf/icf_data.cc
@@ -11,16 +11,19 @@ namespace internal {
 template <typename T>
 void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
                                  int max_clique_size, int num_couplers,
-                                 std::span<const int> gain_sizes) {
+                                 std::span<const int> gain_sizes,
+                                 std::span<const int> limit_sizes) {
   Av_minus_r.Resize(1, num_velocities, 1);
 
   V_WB_alpha.Resize(num_bodies, 6, 1);
   v_alpha.Resize(1, num_velocities, 1);
 
   Gw_gain.Resize(1, max_clique_size, 1);
+  Gw_limit.Resize(1, max_clique_size, 1);
 
   coupler_constraints_data.Resize(num_couplers);
   gain_constraints_data.Resize(gain_sizes);
+  limit_constraints_data.Resize(limit_sizes);
 
   H_cc_pool.Resize(1, max_clique_size, max_clique_size);
 
@@ -37,15 +40,17 @@ IcfData<T>::~IcfData() = default;
 
 template <typename T>
 void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
-                        int num_couplers, std::span<const int> gain_sizes) {
+                        int num_couplers, std::span<const int> gain_sizes,
+                        std::span<const int> limit_sizes) {
   v_.resize(num_velocities);
   V_WB_.Resize(num_bodies, 6, 1);
   Av_.resize(num_velocities);
   gradient_.resize(num_velocities);
   coupler_constraints_data_.Resize(num_couplers);
   gain_constraints_data_.Resize(gain_sizes);
+  limit_constraints_data_.Resize(limit_sizes);
   scratch_.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-                  gain_sizes);
+                  gain_sizes, limit_sizes);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -14,6 +14,7 @@
 #include "drake/multibody/contact_solvers/icf/gain_constraints_pool.h"
 #include "drake/multibody/contact_solvers/icf/icf_data.h"
 #include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
+#include "drake/multibody/contact_solvers/icf/limit_constraints_pool.h"
 
 namespace drake {
 namespace multibody {
@@ -140,7 +141,8 @@ class IcfModel {
 
   /* Returns the total number of constraints of any type in the problem. */
   int num_constraints() const {
-    return num_coupler_constraints() + num_gain_constraints();
+    return num_coupler_constraints() + num_gain_constraints() +
+           num_limit_constraints();
   }
 
   /* Provides mutable access to the pool of all coupler constraints. */
@@ -154,12 +156,21 @@ class IcfModel {
     return gain_constraints_pool_;
   }
 
+  /* Provides mutable access to the pool of all joint limit constraints. */
+  LimitConstraintsPool<T>& limit_constraints_pool() {
+    return limit_constraints_pool_;
+  }
+
   int num_coupler_constraints() const {
     return coupler_constraints_pool_.num_constraints();
   }
 
   int num_gain_constraints() const {
     return gain_constraints_pool_.num_constraints();
+  }
+
+  int num_limit_constraints() const {
+    return limit_constraints_pool_.num_constraints();
   }
 
   /* Returns the time step δt. */
@@ -379,6 +390,7 @@ class IcfModel {
   // Fixed set of constraints.
   CouplerConstraintsPool<T> coupler_constraints_pool_;
   GainConstraintsPool<T> gain_constraints_pool_;
+  LimitConstraintsPool<T> limit_constraints_pool_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/limit_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/limit_constraints_data_pool.cc
@@ -1,0 +1,29 @@
+#include "drake/multibody/contact_solvers/icf/limit_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+template <typename T>
+LimitConstraintsDataPool<T>::~LimitConstraintsDataPool() = default;
+
+template <typename T>
+void LimitConstraintsDataPool<T>::Resize(std::span<const int> constraint_size) {
+  const int num_elements = ssize(constraint_size);
+  gamma_lower_pool_.Resize(num_elements, constraint_size);
+  G_lower_pool_.Resize(num_elements, constraint_size);
+  gamma_upper_pool_.Resize(num_elements, constraint_size);
+  G_upper_pool_.Resize(num_elements, constraint_size);
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        LimitConstraintsDataPool);

--- a/multibody/contact_solvers/icf/limit_constraints_data_pool.h
+++ b/multibody/contact_solvers/icf/limit_constraints_data_pool.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <span>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+/* Data pool for joint limit constraints (qu ≥ q ≥ ql) as defined in
+LimitConstraintsPool. This data is updated at each solver iteration, as opposed
+to the LimitConstraintsPool, which defines the constraints themselves and is
+fixed for the lifetime of the optimization problem.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class LimitConstraintsDataPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LimitConstraintsDataPool);
+
+  using VectorXView = typename EigenPool<VectorX<T>>::MatrixView;
+  using ConstVectorXView = typename EigenPool<VectorX<T>>::ConstMatrixView;
+
+  /* Constructs an empty pool. */
+  LimitConstraintsDataPool() = default;
+
+  ~LimitConstraintsDataPool();
+
+  /* Resizes the data pool to hold constraints of the given sizes.
+  @param constraint_size The size (number of velocities) for each limit
+                         constraint. */
+  void Resize(std::span<const int> constraint_size);
+
+  /* Returns the number of limit constraints this data is for. */
+  int num_constraints() const { return gamma_lower_pool_.size(); }
+
+  /* Returns the total cost ℓ(v) over all limit constraints (including both
+  lower and upper limits). See LimitConstraintsPool for details. */
+  const T& cost() const { return cost_; }
+  T& mutable_cost() { return cost_; }
+
+  /* Returns the constraint impulse γ = -∇ℓ(v) for the k-th lower limit. */
+  ConstVectorXView gamma_lower(int k) const { return gamma_lower_pool_[k]; }
+  VectorXView mutable_gamma_lower(int k) { return gamma_lower_pool_[k]; }
+
+  /* Returns the constraint impulse γ = -∇ℓ(v) for the k-th upper limit. */
+  ConstVectorXView gamma_upper(int k) const { return gamma_upper_pool_[k]; }
+  VectorXView mutable_gamma_upper(int k) { return gamma_upper_pool_[k]; }
+
+  /* Returns the Hessian G = -∂γ/∂v (diagonal) for the k-th lower limit. */
+  ConstVectorXView G_lower(int k) const { return G_lower_pool_[k]; }
+  VectorXView mutable_G_lower(int k) { return G_lower_pool_[k]; }
+
+  /* Returns the Hessian G = -∂γ/∂v (diagonal) for the k-th upper limit. */
+  ConstVectorXView G_upper(int k) const { return G_upper_pool_[k]; }
+  VectorXView mutable_G_upper(int k) { return G_upper_pool_[k]; }
+
+ private:
+  T cost_{NAN};
+  EigenPool<VectorX<T>> gamma_lower_pool_;
+  EigenPool<VectorX<T>> gamma_upper_pool_;
+  EigenPool<VectorX<T>> G_lower_pool_;  // G = -∂γ/∂v ≥ 0 is Diagonal.
+  EigenPool<VectorX<T>> G_upper_pool_;  // G = -∂γ/∂v ≥ 0 is Diagonal.
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        LimitConstraintsDataPool);

--- a/multibody/contact_solvers/icf/limit_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/limit_constraints_pool.cc
@@ -1,0 +1,216 @@
+#include "drake/multibody/contact_solvers/icf/limit_constraints_pool.h"
+
+#include <limits>
+#include <vector>
+
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+using contact_solvers::internal::BlockSparseSymmetricMatrix;
+using Eigen::VectorBlock;
+
+template <typename T>
+LimitConstraintsPool<T>::LimitConstraintsPool(const IcfModel<T>* parent_model)
+    : model_(parent_model) {
+  DRAKE_ASSERT(parent_model != nullptr);
+}
+
+template <typename T>
+LimitConstraintsPool<T>::~LimitConstraintsPool() = default;
+
+template <typename T>
+void LimitConstraintsPool<T>::Resize(std::span<const int> sizes) {
+  const int num_limit_constraints = ssize(sizes);
+  ql_.Resize(num_limit_constraints, sizes);
+  qu_.Resize(num_limit_constraints, sizes);
+  q0_.Resize(num_limit_constraints, sizes);
+  gl_hat_.Resize(num_limit_constraints, sizes);
+  gu_hat_.Resize(num_limit_constraints, sizes);
+  R_.Resize(num_limit_constraints, sizes);
+  constraint_size_.assign(sizes.begin(), sizes.end());
+  clique_.resize(num_limit_constraints);
+
+  // All constraints are disabled (i.e., infinite bounds) by default. This
+  // allows us to add a limit constraint on only one DoF in a multi-DoF
+  // clique, for example.
+  // TODO(vincekurtz): consider a setConstant method in EigenPool.
+  for (int k = 0; k < num_constraints(); ++k) {
+    ql_[k].setConstant(-std::numeric_limits<double>::infinity());
+    qu_[k].setConstant(std::numeric_limits<double>::infinity());
+    q0_[k].setConstant(0.0);
+    R_[k].setConstant(std::numeric_limits<double>::infinity());
+    gl_hat_[k].setConstant(-std::numeric_limits<double>::infinity());
+    gu_hat_[k].setConstant(-std::numeric_limits<double>::infinity());
+  }
+}
+
+template <typename T>
+void LimitConstraintsPool<T>::Set(int index, int clique, int dof, const T& q0,
+                                  const T& ql, const T& qu) {
+  DRAKE_ASSERT(0 <= index && index < num_constraints());
+  DRAKE_ASSERT(0 <= dof && dof < model().clique_size(clique));
+  DRAKE_ASSERT(ql <= q0 && q0 <= qu);
+
+  clique_[index] = clique;
+  ql_[index](dof) = ql;
+  qu_[index](dof) = qu;
+  q0_[index](dof) = q0;
+
+  // Near-rigid regularization [Castro et al., 2022].
+  constexpr double beta = 0.1;
+  constexpr double eps = beta * beta / (4 * M_PI * M_PI) * (1 + beta / M_PI);
+
+  // Approximation of W = J⋅M⁻¹⋅Jᵀ = M⁻¹ ≈ diag(M)⁻¹. The Jacobian J = Iₙ for
+  // lower limits, and J = -Iₙ for upper limits.
+  ConstVectorXView w_clique = model().clique_diagonal_mass_inverse(clique);
+  R_[index](dof) = eps * w_clique(dof);
+
+  // Eventually we will use
+  //  v̂ₗ = (qₗ − q₀) / (δt (1 + β))
+  //  v̂ᵤ = (q₀ − qᵤ) / (δt (1 + β))
+  // However, since model.time_step() may change between now and when we
+  // actually solve the problem, we precompute
+  //  ĝₗ = v̂ₗ⋅δt = (qₗ − q₀) / (1 + β)
+  //  ĝᵤ = v̂ᵤ⋅δt = (q₀ − qᵤ) / (1 + β)
+  // so that we can compute v̂ = ĝ/δt from the current time step in calls to
+  // CalcData().
+  gl_hat_[index](dof) = (ql - q0) / (1.0 + beta);
+  gu_hat_[index](dof) = (q0 - qu) / (1.0 + beta);
+}
+
+template <typename T>
+void LimitConstraintsPool<T>::CalcData(
+    const VectorX<T>& v, LimitConstraintsDataPool<T>* limit_data) const {
+  DRAKE_ASSERT(limit_data != nullptr);
+
+  const T& dt = model().time_step();
+  T& cost = limit_data->mutable_cost();
+  cost = 0;
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+    const int nv = model().clique_size(c);
+    VectorBlock<const VectorX<T>> vk = model().clique_segment(c, v);
+    VectorXView gamma_lower = limit_data->mutable_gamma_lower(k);
+    VectorXView gamma_upper = limit_data->mutable_gamma_upper(k);
+    VectorXView G_lower = limit_data->mutable_G_lower(k);
+    VectorXView G_upper = limit_data->mutable_G_upper(k);
+    for (int i = 0; i < nv; ++i) {
+      // i-th lower limit for constraint k (clique c).
+      const T vl = vk(i);
+      cost += CalcLimitData(gl_hat_[k](i) / dt, R_[k](i), vl, &gamma_lower(i),
+                            &G_lower(i));
+
+      // i-th upper limit for constraint k (clique c).
+      // N.B. The negative sign comes from the constraint velocity defined as
+      // positive when moving away from the limit. Impulses are similarly
+      // defined as positive when pushing away from the limit.
+      const T vu = -vk(i);
+      cost += CalcLimitData(gu_hat_[k](i) / dt, R_[k](i), vu, &gamma_upper(i),
+                            &G_upper(i));
+    }
+  }
+}
+
+template <typename T>
+void LimitConstraintsPool<T>::AccumulateGradient(const IcfData<T>& data,
+                                                 VectorX<T>* gradient) const {
+  DRAKE_ASSERT(gradient != nullptr);
+
+  const LimitConstraintsDataPool<T>& limit_data = data.limit_constraints_data();
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+    VectorBlock<VectorX<T>> gradient_c =
+        model().mutable_clique_segment(c, gradient);
+    ConstVectorXView gamma_lower = limit_data.gamma_lower(k);
+    ConstVectorXView gamma_upper = limit_data.gamma_upper(k);
+
+    // For this constraint vₖ = [vc; -vc], i.e. J = [I; -I]^ᵀ.
+    // Therefore ∇ℓ = γᵤ − γₗ:
+    gradient_c += gamma_upper;
+    gradient_c -= gamma_lower;
+  }
+}
+
+template <typename T>
+void LimitConstraintsPool<T>::AccumulateHessian(
+    const IcfData<T>& data,
+    BlockSparseSymmetricMatrix<MatrixX<T>>* hessian) const {
+  DRAKE_ASSERT(hessian != nullptr);
+
+  const LimitConstraintsDataPool<T>& limit_data = data.limit_constraints_data();
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+
+    const MatrixX<T> G_lower = limit_data.G_lower(k).asDiagonal();
+    const MatrixX<T> G_upper = limit_data.G_upper(k).asDiagonal();
+    hessian->AddToBlock(c, c, G_lower);
+    hessian->AddToBlock(c, c, G_upper);
+  }
+}
+
+template <typename T>
+void LimitConstraintsPool<T>::CalcCostAlongLine(
+    const LimitConstraintsDataPool<T>& limit_data, const VectorX<T>& w,
+    EigenPool<VectorX<T>>* Gw_scratch, T* dcost, T* d2cost) const {
+  DRAKE_ASSERT(Gw_scratch != nullptr);
+  DRAKE_ASSERT(dcost != nullptr);
+  DRAKE_ASSERT(d2cost != nullptr);
+  EigenPool<VectorX<T>>& Gw_pool = *Gw_scratch;
+
+  (*dcost) = 0.0;
+  (*d2cost) = 0.0;
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+    VectorBlock<const VectorX<T>> w_c = model().clique_segment(c, w);
+    Gw_pool.Resize(1, model().clique_size(c), 1);
+    VectorXView G_times_w = Gw_pool[0];
+
+    // Lower limit contribution.
+    ConstVectorXView gamma_lower = limit_data.gamma_lower(k);
+    ConstVectorXView G_lower = limit_data.G_lower(k);
+    G_times_w = G_lower.asDiagonal() * w_c;
+    (*dcost) -= w_c.dot(gamma_lower);
+    (*d2cost) += w_c.dot(G_times_w);
+
+    // Upper limit contribution.
+    ConstVectorXView gamma_upper = limit_data.gamma_upper(k);
+    ConstVectorXView G_upper = limit_data.G_upper(k);
+    G_times_w = G_upper.asDiagonal() * w_c;
+    (*dcost) += w_c.dot(gamma_upper);
+    (*d2cost) += w_c.dot(G_times_w);
+  }
+}
+
+template <typename T>
+T LimitConstraintsPool<T>::CalcLimitData(const T& v_hat, const T& R, const T& v,
+                                         T* gamma, T* G) const {
+  T cost = 0;
+  (*gamma) = 0;
+  (*G) = 0;
+
+  if (v < v_hat) {
+    const T dv = (v - v_hat);
+    cost += 0.5 * dv * dv / R;
+    (*gamma) = -dv / R;
+    (*G) = 1.0 / R;
+  }
+
+  return cost;
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        LimitConstraintsPool);

--- a/multibody/contact_solvers/icf/limit_constraints_pool.h
+++ b/multibody/contact_solvers/icf/limit_constraints_pool.h
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <span>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+#include "drake/multibody/contact_solvers/icf/limit_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+// Forward declaration to break circular dependencies.
+template <typename T>
+class IcfModel;
+
+/* A pool of joint limit constraints, qu ≥ q ≥ ql.
+
+Each limit constraint is associated with a convex cost ℓ(v) that is added to
+the overall ICF cost. The gradient of this cost ∇ℓ(v) = J'γ produces impulses
+that enforces the constraint when the convex ICF problem is solved.
+
+Each limit constraint involves all DoFs in a clique. By default, all limits are
+disabled (infinite). This allows us to handle the fairly common case (e.g., a
+robot arm on a mobile base) where many joints in a clique have limits while
+others do not.
+
+Additionally, each limit constraint enforces both the lower and upper bounds.
+The resulting impulse γ acts to push the configuration q back within the limits
+when either bound would be violated.
+
+By convention, we define velocities and impulses as positive when they move away
+from the limit. Putting together both lower and upper limits (each constraint
+enforces a two-sided limit), this produces the the Jacobian J = [Iₙ;-Iₙ], where
+Iₙ is the identity matrix of size n, the number of DoFs in the clique.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class LimitConstraintsPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LimitConstraintsPool);
+
+  using VectorXView = typename EigenPool<VectorX<T>>::MatrixView;
+  using ConstVectorXView = typename EigenPool<VectorX<T>>::ConstMatrixView;
+
+  /* Constructs an empty pool. */
+  explicit LimitConstraintsPool(const IcfModel<T>* parent_model);
+
+  ~LimitConstraintsPool();
+
+  /* Returns a reference to the parent model. */
+  const IcfModel<T>& model() const { return *model_; }
+
+  /* Returns the total number of limit constraints. Each limit constraint
+  enforces both lower and upper bounds on all DoFs in a clique. */
+  int num_constraints() const { return clique_.size(); }
+
+  /* Returns the number of generalized velocities associated with the clique of
+  each limit constraint. */
+  std::span<const int> constraint_sizes() const {
+    return std::span<const int>(constraint_size_);
+  }
+
+  /* Resizes this pool to store limit constraints of the given sizes.
+
+  Sets all constraints as infinite (i.e., disabled) by default. Constraints must
+  be explicitly enabled for each DoF by calling Set().
+
+  @param sizes The number of velocities in the clique associated with each limit
+               constraint in the pool. */
+  void Resize(std::span<const int> sizes);
+
+  /* Sets the limit constraint parameters for the given clique and DoF.
+
+  @param index The index of this limit constraint in the pool.
+  @param clique The clique to which this limit constraint applies.
+  @param dof The degree of freedom within the clique to which this limit
+             constraint applies.
+  @param q0 The initial configuration value for this DoF.
+  @param ql The lower limit for this DoF.
+  @param qu The upper limit for this DoF.
+
+  Calling this function several times with the same `index` overwrites the
+  previous constraint for that index.
+
+  @pre ql <= q0 <= qu. */
+  void Set(int index, int clique, int dof, const T& q0, const T& ql,
+           const T& qu);
+
+  /* Computes problem data as a function of the generalized velocities `v` for
+  the full plant. */
+  void CalcData(const VectorX<T>& v,
+                LimitConstraintsDataPool<T>* limit_data) const;
+
+  /* Adds the gradient contribution of this constraint, ∇ℓ = −γ, to the
+  model-wide gradient. */
+  void AccumulateGradient(const IcfData<T>& data, VectorX<T>* gradient) const;
+
+  /* Adds the contribution of this constraint to the model-wide Hessian. */
+  void AccumulateHessian(
+      const IcfData<T>& data,
+      contact_solvers::internal::BlockSparseSymmetricMatrix<MatrixX<T>>*
+          hessian) const;
+
+  /* Computes the constraint cost ℓ̃(α) = ℓ(v + α⋅w) and its first and second
+  derivatives along the line defined by the search direction `w`.
+
+  @param limit_data Constraint data computed at v + α⋅w.
+  @param w The search direction.
+  @param Gw_scratch Scratch space for intermediate values for each clique.
+  @param[out] dcost The first derivative dℓ̃ /dα on output.
+  @param[out] d2cost The second derivative d²ℓ̃ /dα² on output. */
+  void CalcCostAlongLine(const LimitConstraintsDataPool<T>& limit_data,
+                         const VectorX<T>& w, EigenPool<VectorX<T>>* Gw_scratch,
+                         T* dcost, T* d2cost) const;
+
+ private:
+  /* Computes cost, gradient, and Hessian contribution for a single limit
+  constraint.
+
+  @param v_hat The target velocity.
+  @param R Near-rigid regularization parameter.
+  @param v The current velocity.
+  @param[out] gamma The computed impulse on output.
+  @param[out] G The computed Hessian diagonal on output.
+
+  @returns The cost associated with this limit constraint. */
+  T CalcLimitData(const T& v_hat, const T& R, const T& v, T* gamma, T* G) const;
+
+  const IcfModel<T>* const model_;  // The parent model.
+
+  // We always add limit constraints per-clique. Each of the following has size
+  // num_constraints().
+  std::vector<int> clique_;           // Clique the k-th limit belongs to.
+  std::vector<int> constraint_size_;  // Clique size for the k-th constraint.
+  EigenPool<VectorX<T>> ql_;          // Lower limit.
+  EigenPool<VectorX<T>> qu_;          // Upper limit.
+  EigenPool<VectorX<T>> q0_;          // Initial configuration.
+  EigenPool<VectorX<T>> gl_hat_;  // Lower bound velocity target scaled by dt.
+  EigenPool<VectorX<T>> gu_hat_;  // Upper bound velocity target scaled by dt.
+  EigenPool<VectorX<T>> R_;       // Near-rigid regularization parameter.
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        LimitConstraintsPool);

--- a/multibody/contact_solvers/icf/test/icf_data_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_data_test.cc
@@ -20,6 +20,7 @@ GTEST_TEST(IcfData, DefaultConstructedIsEmpty) {
   EXPECT_EQ(data.V_WB().size(), 0);
   EXPECT_EQ(data.scratch().Av_minus_r.size(), 0);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), 0);
+  EXPECT_EQ(data.scratch().Gw_limit.size(), 0);
   EXPECT_EQ(data.scratch().v_alpha.size(), 0);
   EXPECT_EQ(data.scratch().Gw_gain.size(), 0);
   EXPECT_EQ(data.scratch().H_BB_pool.size(), 0);
@@ -38,9 +39,10 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   const int max_clique_size = 6;
   const int num_couplers = 2;
   const std::vector<int> gain_sizes = {3, 2};
+  const std::vector<int> limit_sizes = {5, 4, 3};
 
   data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-              gain_sizes);
+              gain_sizes, limit_sizes);
 
   // Main data elements
   EXPECT_EQ(data.num_velocities(), num_velocities);
@@ -56,10 +58,13 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
   EXPECT_EQ(data.scratch().v_alpha[0].size(), num_velocities);
   EXPECT_EQ(data.scratch().Gw_gain[0].size(), max_clique_size);
+  EXPECT_EQ(data.scratch().Gw_limit[0].size(), max_clique_size);
   EXPECT_EQ(data.scratch().coupler_constraints_data.num_constraints(),
             num_couplers);
   EXPECT_EQ(data.scratch().gain_constraints_data.num_constraints(),
             ssize(gain_sizes));
+  EXPECT_EQ(data.scratch().limit_constraints_data.num_constraints(),
+            ssize(limit_sizes));
   EXPECT_EQ(data.scratch().H_cc_pool[0].rows(), max_clique_size);
   EXPECT_EQ(data.scratch().H_cc_pool[0].cols(), max_clique_size);
   EXPECT_EQ(data.scratch().H_BB_pool[0].rows(), max_clique_size);
@@ -83,13 +88,14 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
   const int max_clique_size = 7;
   const int num_couplers = 2;
   const std::vector<int> gain_sizes = {3};
+  const std::vector<int> limit_sizes = {4};
 
   data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-              gain_sizes);
+              gain_sizes, limit_sizes);
 
   // Clearing pools changes size but shouldn't change capacity.
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
-  data.scratch().Resize(0, 0, 0, 0, gain_sizes);
+  data.scratch().Resize(0, 0, 0, 0, gain_sizes, limit_sizes);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), 0);
 
   VectorX<double> v = VectorX<double>::LinSpaced(num_velocities, 1.0, 11.0);
@@ -98,7 +104,7 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
     // cause any new allocations.
     drake::test::LimitMalloc guard;
     data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-                gain_sizes);
+                gain_sizes, limit_sizes);
     data.set_v(v);
   }
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);

--- a/multibody/contact_solvers/icf/test/icf_model_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_model_test.cc
@@ -202,6 +202,58 @@ std::vector<VectorX<T>> AddGainConstraints(IcfModel<T>* model) {
   return {K0, u0, e0, K1, u1, e1};
 }
 
+/* Adds limit constraints to the given model. The model can have 1 or 3 cliques.
+In either case, the same constraints are added to represent the same logical
+limits. */
+template <typename T>
+void AddLimitConstraints(IcfModel<T>* model) {
+  DRAKE_DEMAND(model != nullptr);
+  const bool single_clique = model->num_cliques() == 1;
+  LimitConstraintsPool<T>& limits = model->limit_constraints_pool();
+
+  const int nv = model->num_velocities();
+  const VectorX<T> q0 = VectorXd::LinSpaced(nv, -1.0, 1.0);
+
+  if (!single_clique) {
+    DRAKE_DEMAND(model->clique_size(0) == 6);
+    DRAKE_DEMAND(model->clique_size(2) == 6);
+    // Cliques 0 and 2 will have limits. We'll resize the constraint pool
+    // accordingly before adding the limit constraints.
+    std::vector<int> limited_clique_sizes = {model->clique_size(0),
+                                             model->clique_size(2)};
+    limits.Resize(limited_clique_sizes);
+
+    // Limits on clique 0.
+    limits.Set(0 /* constraint */, 0 /* clique */, 4 /* dof */, q0(2), -1.5,
+               -0.5);
+    limits.Set(0 /* constraint */, 0 /* clique */, 3 /* dof */, q0(3), -1.0,
+               0.8);
+
+    // Limits on clique 2.
+    limits.Set(1 /* constraint */, 2 /* clique */, 0 /* dof */, q0(12), -0.9,
+               1.5);
+    limits.Set(1 /* constraint */, 2 /* clique */, 2 /* dof */, q0(14), -1.0,
+               0.7);
+    limits.Set(1 /* constraint */, 2 /* clique */, 5 /* dof */, q0(17), 0.5,
+               1.5);
+  } else {
+    DRAKE_DEMAND(model->clique_size(0) == 18);
+    // All limits will be on clique 0, but the same as in the multi-clique case.
+    std::vector<int> limited_clique_sizes = {model->clique_size(0)};
+    limits.Resize(limited_clique_sizes);
+    limits.Set(0 /* constraint */, 0 /* clique */, 4 /* dof */, q0(2), -1.5,
+               -0.5);
+    limits.Set(0 /* constraint */, 0 /* clique */, 3 /* dof */, q0(3), -1.0,
+               0.8);
+    limits.Set(0 /* constraint */, 0 /* clique */, 12 /* dof */, q0(12), -0.9,
+               1.5);
+    limits.Set(0 /* constraint */, 0 /* clique */, 14 /* dof */, q0(14), -1.0,
+               0.7);
+    limits.Set(0 /* constraint */, 0 /* clique */, 17 /* dof */, q0(17), 0.5,
+               1.5);
+  }
+}
+
 /* Checks that a default constructed model is empty. */
 GTEST_TEST(IcfModel, EmptyModel) {
   IcfModel<double> model;
@@ -286,8 +338,35 @@ GTEST_TEST(IcfModel, LimitMallocOnGainConstrainedCalcData) {
   EXPECT_EQ(data.gain_constraints_data().num_constraints(), 2);
 
   const int nv = model.num_velocities();
-  const VectorXd v = VectorXd::LinSpaced(nv, -10, 10.0);
+  const VectorXd v = VectorXd::LinSpaced(nv, -10.0, 10.0);
 
+  // Computing data should not cause any new allocations.
+  {
+    drake::test::LimitMalloc guard;
+    model.CalcData(v, &data);
+  }
+}
+
+/* Checks that model.CalcData does not incur any heap allocations on a problem
+with limit constraints. */
+GTEST_TEST(IcfModel, LimitMallocOnLimitConstrainedCalcData) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddLimitConstraints(&model);
+  model.SetSparsityPattern();
+  EXPECT_EQ(model.num_cliques(), 3);
+  EXPECT_EQ(model.num_velocities(), 18);
+  EXPECT_EQ(model.num_constraints(), 2);
+  EXPECT_EQ(model.num_limit_constraints(), 2);
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  EXPECT_EQ(data.limit_constraints_data().num_constraints(), 2);
+
+  const int nv = model.num_velocities();
+  const VectorXd v = VectorXd::LinSpaced(nv, -10.0, 10.0);
+
+  // Computing data should not cause any new allocations.
   {
     drake::test::LimitMalloc guard;
     model.CalcData(v, &data);
@@ -369,13 +448,14 @@ GTEST_TEST(IcfModel, CalcGradients) {
   MakeUnconstrainedModel(&model);
   AddCouplerConstraint(&model);
   AddGainConstraints(&model);
+  AddLimitConstraints(&model);
   model.SetSparsityPattern();
   const int nv = model.num_velocities();
 
   IcfData<AutoDiffXd> data;
   model.ResizeData(&data);
   EXPECT_EQ(data.num_velocities(), nv);
-  EXPECT_EQ(model.num_constraints(), 3);
+  EXPECT_EQ(model.num_constraints(), 5);
 
   VectorXd v_values = VectorXd::LinSpaced(nv, -10, 10.0);
   VectorX<AutoDiffXd> v(nv);
@@ -396,6 +476,7 @@ GTEST_TEST(IcfModel, CalcDenseHessian) {
   MakeUnconstrainedModel(&model, true /* single cliques */);
   AddCouplerConstraint(&model);
   AddGainConstraints(&model);
+  AddLimitConstraints(&model);
   model.SetSparsityPattern();
   EXPECT_EQ(model.num_cliques(), 1);
   EXPECT_EQ(model.num_velocities(), 18);
@@ -438,6 +519,7 @@ GTEST_TEST(IcfModel, SingleVsMultipleCliques) {
   MakeUnconstrainedModel(&model_single, true);
   AddCouplerConstraint(&model_single);
   AddGainConstraints(&model_single);
+  AddLimitConstraints(&model_single);
   model_single.SetSparsityPattern();
   EXPECT_EQ(model_single.num_cliques(), 1);
   EXPECT_EQ(model_single.num_velocities(), 18);
@@ -446,6 +528,7 @@ GTEST_TEST(IcfModel, SingleVsMultipleCliques) {
   MakeUnconstrainedModel(&model_multiple, false);
   AddCouplerConstraint(&model_multiple);
   AddGainConstraints(&model_multiple);
+  AddLimitConstraints(&model_multiple);
   model_multiple.SetSparsityPattern();
   EXPECT_EQ(model_multiple.num_cliques(), 3);
   EXPECT_EQ(model_multiple.num_velocities(), 18);
@@ -493,10 +576,11 @@ GTEST_TEST(IcfModel, CalcCostAlongLine) {
   MakeUnconstrainedModel(&model);
   AddCouplerConstraint(&model);
   AddGainConstraints(&model);
+  AddLimitConstraints(&model);
   model.SetSparsityPattern();
   EXPECT_EQ(model.num_cliques(), 3);
   EXPECT_EQ(model.num_velocities(), 18);
-  EXPECT_EQ(model.num_constraints(), 3);
+  EXPECT_EQ(model.num_constraints(), 5);
 
   // Allocate data, and additional scratch.
   IcfData<AutoDiffXd> data, scratch;
@@ -554,11 +638,12 @@ GTEST_TEST(IcfModel, UpdateTimeStep) {
   MakeUnconstrainedModel(&model_original, false, 0.02);
   AddCouplerConstraint(&model_original);
   AddGainConstraints(&model_original);
+  AddLimitConstraints(&model_original);
   model_original.SetSparsityPattern();
   EXPECT_EQ(model_original.num_cliques(), 3);
   EXPECT_EQ(model_original.num_velocities(), 18);
   EXPECT_EQ(model_original.time_step(), 0.02);
-  EXPECT_EQ(model_original.num_constraints(), 3);
+  EXPECT_EQ(model_original.num_constraints(), 5);
 
   const double new_time_step = 0.003;
 
@@ -567,11 +652,12 @@ GTEST_TEST(IcfModel, UpdateTimeStep) {
   MakeUnconstrainedModel(&model_new, false, new_time_step);
   AddCouplerConstraint(&model_new);
   AddGainConstraints(&model_new);
+  AddLimitConstraints(&model_new);
   model_new.SetSparsityPattern();
   EXPECT_EQ(model_new.num_cliques(), 3);
   EXPECT_EQ(model_new.num_velocities(), 18);
   EXPECT_EQ(model_new.time_step(), new_time_step);
-  EXPECT_EQ(model_new.num_constraints(), 3);
+  EXPECT_EQ(model_new.num_constraints(), 5);
 
   // Now update the time step of the original model.
   EXPECT_NE(model_original.time_step(), new_time_step);
@@ -812,6 +898,75 @@ GTEST_TEST(IcfModel, GainConstraint) {
 
   EXPECT_TRUE(CompareMatrices(total_gradient_value, total_cost_derivatives,
                               2 * kEpsilon, MatrixCompareType::relative));
+}
+
+/* Verifies that limit constraints produce correct data. */
+GTEST_TEST(IcfModel, LimitConstraint) {
+  IcfModel<AutoDiffXd> model;
+  MakeUnconstrainedModel(&model);
+  model.SetSparsityPattern();
+  EXPECT_EQ(model.num_cliques(), 3);
+  EXPECT_EQ(model.num_velocities(), 18);
+  EXPECT_EQ(model.num_constraints(), 0);
+
+  IcfData<AutoDiffXd> data;
+  model.ResizeData(&data);
+  EXPECT_EQ(data.num_velocities(), model.num_velocities());
+  EXPECT_EQ(data.limit_constraints_data().num_constraints(), 0);
+
+  // At this point there should be no limit constraints.
+  EXPECT_EQ(model.num_limit_constraints(), 0);
+  EXPECT_EQ(model.num_constraints(), 0);
+
+  // Add a few limit constraints to the model.
+  AddLimitConstraints(&model);
+  EXPECT_EQ(model.num_limit_constraints(), 2);
+  EXPECT_EQ(model.num_constraints(), 2);
+
+  // Resize data to include limit constraints data.
+  model.ResizeData(&data);
+  EXPECT_EQ(data.limit_constraints_data().num_constraints(), 2);
+
+  const int nv = model.num_velocities();
+  const VectorX<AutoDiffXd> q0 = VectorXd::LinSpaced(nv, -1.0, 1.0);
+  VectorXd v_value = VectorXd::LinSpaced(nv, -10, 10.0);
+  VectorX<AutoDiffXd> v(nv);
+  math::InitializeAutoDiff(v_value, &v);
+  model.CalcData(v, &data);
+
+  const AutoDiffXd dt = model.time_step();
+  VectorX<AutoDiffXd> q = q0 + dt * v;
+
+  const LimitConstraintsDataPool<AutoDiffXd>& limits_data =
+      data.limit_constraints_data();
+  EXPECT_EQ(limits_data.num_constraints(), 2);
+
+  const VectorXd cost_gradient = limits_data.cost().derivatives();
+
+  // Impulses on constraint 0, clique 0.
+  const VectorX<AutoDiffXd> gamma_lower0 = limits_data.gamma_lower(0);
+  const VectorX<AutoDiffXd> gamma_upper0 = limits_data.gamma_upper(0);
+  // tau = Jᵀ⋅γ, and J = [1; -1] for limit constraints.
+  const VectorX<AutoDiffXd> tau0 = gamma_lower0 - gamma_upper0;
+
+  // Impulses on constraint 1, clique 2.
+  const VectorX<AutoDiffXd> gamma_lower1 = limits_data.gamma_lower(1);
+  const VectorX<AutoDiffXd> gamma_upper1 = limits_data.gamma_upper(1);
+  // tau = Jᵀ⋅γ, and J = [1; -1] for limit constraints.
+  const VectorX<AutoDiffXd> tau1 = gamma_lower1 - gamma_upper1;
+
+  // Assemble all clique contributions into tau by hand.
+  VectorX<AutoDiffXd> tau = VectorX<AutoDiffXd>::Zero(nv);
+  tau.segment<6>(0) = tau0;
+  tau.segment<6>(12) = tau1;
+
+  // Verify that the impulses are non-zero, e.g., at least one limit is active.
+  EXPECT_TRUE(tau.norm() > 1e-6);
+
+  // Verify that the cost gradient matches the expected impulse.
+  const VectorXd tau_value = math::ExtractValue(tau);
+  EXPECT_TRUE(CompareMatrices(cost_gradient, -tau_value, kEpsilon,
+                              MatrixCompareType::relative));
 
   // Verify contributions to Hessian.
   auto hessian = model.MakeHessian(data);


### PR DESCRIPTION
Adds joint limits to the ICF formulation. This is the next step along the ICF PR train (https://github.com/RobotLocomotion/drake/issues/23769).

For full context, see the [cenic_main](https://github.com/RobotLocomotion/drake/tree/cenic_main) dev branch, and especially the [ICF README](https://github.com/RobotLocomotion/drake/blob/cenic_main/multibody/contact_solvers/icf/README.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23876)
<!-- Reviewable:end -->
