### PR TITLE
[icf] Add patch constraints

### DIFF
--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_package_library(
         ":icf_model",
         ":icf_search_direction_data",
         ":limit_constraints_data_pool",
+        ":patch_constraints_data_pool",
     ],
 )
 
@@ -65,6 +66,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "patch_constraints_data_pool",
+    srcs = ["patch_constraints_data_pool.cc"],
+    hdrs = ["patch_constraints_data_pool.h"],
+    deps = [
+        ":eigen_pool",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "icf_search_direction_data",
     hdrs = ["icf_search_direction_data.h"],
     deps = [
@@ -83,6 +95,7 @@ drake_cc_library(
         ":eigen_pool",
         ":gain_constraints_data_pool",
         ":limit_constraints_data_pool",
+        ":patch_constraints_data_pool",
         "//common:essential",
     ],
 )
@@ -94,12 +107,14 @@ drake_cc_library(
         "gain_constraints_pool.cc",
         "icf_model.cc",
         "limit_constraints_pool.cc",
+        "patch_constraints_pool.cc",
     ],
     hdrs = [
         "coupler_constraints_pool.h",
         "gain_constraints_pool.h",
         "icf_model.h",
         "limit_constraints_pool.h",
+        "patch_constraints_pool.h",
     ],
     deps = [
         ":coupler_constraints_data_pool",

--- a/multibody/contact_solvers/icf/icf_data.cc
+++ b/multibody/contact_solvers/icf/icf_data.cc
@@ -12,10 +12,12 @@ template <typename T>
 void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
                                  int max_clique_size, int num_couplers,
                                  std::span<const int> gain_sizes,
-                                 std::span<const int> limit_sizes) {
+                                 std::span<const int> limit_sizes,
+                                 std::span<const int> patch_sizes) {
   Av_minus_r.Resize(1, num_velocities, 1);
 
   V_WB_alpha.Resize(num_bodies, 6, 1);
+  U_AbB_W.Resize(ssize(patch_sizes), 6, 1);
   v_alpha.Resize(1, num_velocities, 1);
 
   Gw_gain.Resize(1, max_clique_size, 1);
@@ -24,6 +26,7 @@ void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
   coupler_constraints_data.Resize(num_couplers);
   gain_constraints_data.Resize(gain_sizes);
   limit_constraints_data.Resize(limit_sizes);
+  patch_constraints_data.Resize(patch_sizes);
 
   H_cc_pool.Resize(1, max_clique_size, max_clique_size);
 
@@ -41,7 +44,8 @@ IcfData<T>::~IcfData() = default;
 template <typename T>
 void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
                         int num_couplers, std::span<const int> gain_sizes,
-                        std::span<const int> limit_sizes) {
+                        std::span<const int> limit_sizes,
+                        std::span<const int> patch_sizes) {
   v_.resize(num_velocities);
   V_WB_.Resize(num_bodies, 6, 1);
   Av_.resize(num_velocities);
@@ -49,8 +53,9 @@ void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
   coupler_constraints_data_.Resize(num_couplers);
   gain_constraints_data_.Resize(gain_sizes);
   limit_constraints_data_.Resize(limit_sizes);
+  patch_constraints_data_.Resize(patch_sizes);
   scratch_.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-                  gain_sizes, limit_sizes);
+                  gain_sizes, limit_sizes, patch_sizes);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -17,7 +17,8 @@ IcfModel<T>::IcfModel()
     : params_{std::make_unique<IcfParameters<T>>()},
       coupler_constraints_pool_(this),
       gain_constraints_pool_(this),
-      limit_constraints_pool_(this) {}
+      limit_constraints_pool_(this),
+      patch_constraints_pool_(this) {}
 
 template <typename T>
 void IcfModel<T>::ResetParameters(std::unique_ptr<IcfParameters<T>> params) {
@@ -88,7 +89,8 @@ void IcfModel<T>::ResizeData(IcfData<T>* data) const {
   data->Resize(num_bodies_, num_velocities_, max_clique_size_,
                coupler_constraints_pool_.num_constraints(),
                gain_constraints_pool_.constraint_sizes(),
-               limit_constraints_pool_.constraint_sizes());
+               limit_constraints_pool_.constraint_sizes(),
+               patch_constraints_pool_.patch_sizes());
 }
 
 template <typename T>
@@ -108,18 +110,22 @@ void IcfModel<T>::CalcData(const VectorX<T>& v, IcfData<T>* data) const {
                                      &data->mutable_coupler_constraints_data());
   gain_constraints_pool_.CalcData(v, &data->mutable_gain_constraints_data());
   limit_constraints_pool_.CalcData(v, &data->mutable_limit_constraints_data());
+  patch_constraints_pool_.CalcData(V_WB,
+                                   &data->mutable_patch_constraints_data());
 
   // Accumulate gradient contributions from constraints.
   VectorX<T>& gradient = data->mutable_gradient();
   coupler_constraints_pool_.AccumulateGradient(*data, &gradient);
   gain_constraints_pool_.AccumulateGradient(*data, &gradient);
   limit_constraints_pool_.AccumulateGradient(*data, &gradient);
+  patch_constraints_pool_.AccumulateGradient(*data, &gradient);
 
   // Accumulate cost contributions from constraints.
   data->set_cost(data->momentum_cost() +
                  data->coupler_constraints_data().cost() +
                  data->gain_constraints_data().cost() +
-                 data->limit_constraints_data().cost());
+                 data->limit_constraints_data().cost() +
+                 data->patch_constraints_data().cost());
 }
 
 template <typename T>
@@ -147,6 +153,7 @@ void IcfModel<T>::UpdateHessian(
   coupler_constraints_pool_.AccumulateHessian(data, hessian);
   gain_constraints_pool_.AccumulateHessian(data, hessian);
   limit_constraints_pool_.AccumulateHessian(data, hessian);
+  patch_constraints_pool_.AccumulateHessian(data, hessian);
 }
 
 template <typename T>
@@ -181,9 +188,6 @@ T IcfModel<T>::CalcCostAlongLine(
   const T& a = search_direction.a;
   const T& b = search_direction.b;
   const T& c = search_direction.c;
-
-  EigenPool<Vector6<T>>& V_WB_alpha = data.scratch().V_WB_alpha;
-  DRAKE_ASSERT(V_WB_alpha.size() == num_bodies_);
 
   VectorXView v_alpha = data.scratch().v_alpha[0];
   DRAKE_ASSERT(v_alpha.size() == num_velocities_);
@@ -239,6 +243,25 @@ T IcfModel<T>::CalcCostAlongLine(
     *d2cost_dalpha2 += constraint_d2cost;
   }
 
+  // Add patch constraints contributions:
+  {
+    T constraint_dcost, constraint_d2cost;
+
+    EigenPool<Vector6<T>>& V_WB_alpha = data.scratch().V_WB_alpha;
+    DRAKE_ASSERT(V_WB_alpha.size() == num_bodies_);
+
+    CalcBodySpatialVelocities(v_alpha, &V_WB_alpha);
+    patch_constraints_pool_.CalcData(V_WB_alpha,
+                                     &data.scratch().patch_constraints_data);
+    patch_constraints_pool_.CalcCostAlongLine(
+        data.scratch().patch_constraints_data, search_direction.U,
+        &data.scratch().U_AbB_W, &constraint_dcost, &constraint_d2cost);
+
+    cost += data.scratch().patch_constraints_data.cost();
+    *dcost_dalpha += constraint_dcost;
+    *d2cost_dalpha2 += constraint_d2cost;
+  }
+
   return cost;
 }
 
@@ -255,6 +278,9 @@ void IcfModel<T>::SetSparsityPattern() {
   for (int i = 0; i < num_cliques_; ++i) {
     sparsity[i].emplace_back(i);
   }
+
+  // Build off-diagonal entries in the sparsity pattern.
+  patch_constraints_pool_.CalcSparsityPattern(&sparsity);
 
   sparsity_pattern_ = std::make_unique<BlockSparsityPattern>(
       std::move(block_sizes), std::move(sparsity));

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -15,6 +15,7 @@
 #include "drake/multibody/contact_solvers/icf/icf_data.h"
 #include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
 #include "drake/multibody/contact_solvers/icf/limit_constraints_pool.h"
+#include "drake/multibody/contact_solvers/icf/patch_constraints_pool.h"
 
 namespace drake {
 namespace multibody {
@@ -142,7 +143,7 @@ class IcfModel {
   /* Returns the total number of constraints of any type in the problem. */
   int num_constraints() const {
     return num_coupler_constraints() + num_gain_constraints() +
-           num_limit_constraints();
+           num_limit_constraints() + num_patch_constraints();
   }
 
   /* Provides mutable access to the pool of all coupler constraints. */
@@ -161,6 +162,11 @@ class IcfModel {
     return limit_constraints_pool_;
   }
 
+  /* Provides mutable access to the pool of all patch (contact) constraints. */
+  PatchConstraintsPool<T>& patch_constraints_pool() {
+    return patch_constraints_pool_;
+  }
+
   int num_coupler_constraints() const {
     return coupler_constraints_pool_.num_constraints();
   }
@@ -171,6 +177,10 @@ class IcfModel {
 
   int num_limit_constraints() const {
     return limit_constraints_pool_.num_constraints();
+  }
+
+  int num_patch_constraints() const {
+    return patch_constraints_pool_.num_patches();
   }
 
   /* Returns the time step δt. */
@@ -391,6 +401,7 @@ class IcfModel {
   CouplerConstraintsPool<T> coupler_constraints_pool_;
   GainConstraintsPool<T> gain_constraints_pool_;
   LimitConstraintsPool<T> limit_constraints_pool_;
+  PatchConstraintsPool<T> patch_constraints_pool_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/patch_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/patch_constraints_data_pool.cc
@@ -1,0 +1,34 @@
+#include "drake/multibody/contact_solvers/icf/patch_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+template <typename T>
+PatchConstraintsDataPool<T>::~PatchConstraintsDataPool() = default;
+
+template <typename T>
+void PatchConstraintsDataPool<T>::Resize(std::span<const int> patch_sizes) {
+  num_patches_ = ssize(patch_sizes);
+  num_pairs_ = std::accumulate(patch_sizes.begin(), patch_sizes.end(), 0);
+
+  // Data per patch.
+  cost_pool_.resize(num_patches_);
+  G_Bp_pool_.Resize(num_patches_, 6, 6);
+  Gamma_Bo_W_.Resize(num_patches_, 6, 1);
+
+  // Data per pair.
+  v_AcBc_W_.Resize(num_pairs_, 3, 1);
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        PatchConstraintsDataPool);

--- a/multibody/contact_solvers/icf/patch_constraints_data_pool.h
+++ b/multibody/contact_solvers/icf/patch_constraints_data_pool.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <numeric>
+#include <span>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+/* Data pool for contact constraints. This data is updated at each solver
+iteration, as opposed to the PatchConstraintsPool, which defines the
+constraints themselves and is fixed for the lifetime of the optimization
+problem.
+
+Per-patch data holds num_patches() elements. Per-pair data is indexed by global
+pair index, and holds num_pairs() >= num_patches() elements. See
+PatchConstraintsPool for further indexing details.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class PatchConstraintsDataPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PatchConstraintsDataPool);
+
+  /* Constructs an empty pool. */
+  PatchConstraintsDataPool() = default;
+
+  ~PatchConstraintsDataPool();
+
+  /* Returns the number of patches in the pool. */
+  int num_patches() const { return num_patches_; }
+
+  /* Returns the total number of contact pairs among all patches. */
+  int num_pairs() const { return num_pairs_; }
+
+  /* Returns the number of constraints (patches) in the pool. */
+  int num_constraints() const { return num_patches_; }
+
+  /* Resizes the data pool to hold constraints of the given sizes.
+  @param patch_size Number of contact pairs for the k-th patch. */
+  void Resize(std::span<const int> patch_sizes);
+
+  /* Returns the Hessian block for each patch. */
+  const EigenPool<Matrix6<T>>& G_Bp_pool() const { return G_Bp_pool_; }
+  EigenPool<Matrix6<T>>& mutable_G_Bp_pool() { return G_Bp_pool_; }
+
+  /* Returns contact velocities for each pair. */
+  const EigenPool<Vector3<T>>& v_AcBc_W_pool() const { return v_AcBc_W_; }
+  EigenPool<Vector3<T>>& mutable_v_AcBc_W_pool() { return v_AcBc_W_; }
+
+  /* Returns constraint impulses (gradients) for each patch. */
+  const EigenPool<Vector6<T>>& Gamma_Bo_W_pool() const { return Gamma_Bo_W_; }
+  EigenPool<Vector6<T>>& mutable_Gamma_Bo_W_pool() { return Gamma_Bo_W_; }
+
+  /* Returns the cost contribution for each patch. */
+  const std::vector<T>& cost_pool() const { return cost_pool_; }
+  std::vector<T>& mutable_cost_pool() { return cost_pool_; }
+
+  /* Returns the total cost over all patches. */
+  const T& cost() const { return cost_; }
+  T& mutable_cost() { return cost_; }
+
+ private:
+  int num_patches_{0};
+  int num_pairs_{0};
+  T cost_{NAN};
+
+  // Data per patch.
+  std::vector<T> cost_pool_;
+  EigenPool<Matrix6<T>> G_Bp_pool_;   // Constraint Hessian for patch p.
+  EigenPool<Vector6<T>> Gamma_Bo_W_;  // Spatial impulse on body B.
+
+  // Data per patch and per pair.
+  EigenPool<Vector3<T>> v_AcBc_W_;  // Contact velocity.
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        PatchConstraintsDataPool);

--- a/multibody/contact_solvers/icf/patch_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/patch_constraints_pool.cc
@@ -1,0 +1,725 @@
+#include "multibody/contact_solvers/icf/patch_constraints_pool.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+using contact_solvers::internal::BlockSparseSymmetricMatrix;
+
+// Computes the soft norm ‖x‖ₛ = sqrt(xᵀx + ε²) - ε.
+template <typename T>
+T SoftNorm(const Vector3<T>& x, const T& eps) {
+  using std::sqrt;
+  return sqrt(x.squaredNorm() + eps * eps) - eps;
+}
+
+// Forms the skew symmetric matrix pₓ(p) such that pₓ⋅a = p×a.
+template <typename T>
+Matrix3<T> Skew(const Vector3<T>& p) {
+  // clang-format off
+    Matrix3<T> S;
+    S <<     0, -p.z(),  p.y(),
+          p.z(),     0, -p.x(),
+         -p.y(),  p.x(),     0;
+  // clang-format on
+  return S;
+}
+
+// Given spatial force F_Bo applied at B and the relative position p_AB of B
+// from A, computes the spatial force F_Ao shifted to A. Mathematically, F_Ao =
+// ϕ(p_AB)ᵀ⋅F_Bo, where ϕ(p) = [-pₓ; 𝕀₃]. All quantities must be expressed in
+// the same common frame.
+//
+// @param F The spatial force F_Bo.
+// @param p The relative position p_AB.
+// @returns The shifted spatial force F_Ao.
+template <typename T>
+Vector6<T> ShiftSpatialForce(const Vector6<T>& F, const Vector3<T>& p) {
+  const auto t = F.template head<3>();
+  const auto f = F.template tail<3>();
+  Vector6<T> result;
+  result.template head<3>() = t + p.cross(f);
+  result.template tail<3>() = f;
+  return result;
+}
+
+// Shifts a second-order tensor G_Bo computed about B to tensor G_Ao computed
+// about A, given the relative position p_AB of B from A. Mathematically, G_Ao =
+// ϕ(p_AB)ᵀ⋅G_Bo⋅ϕ(p_AB), where ϕ(p) = [-pₓ; 𝕀₃]. All quantities must be
+// expressed in the same common frame.
+//
+// @param G The second-order tensor G_Bo.
+// @param p The relative position p_AB.
+// @returns The shifted second-order tensor G_Ao.
+template <typename T>
+Matrix6<T> ShiftSecondOrderTensor(const Matrix3<T>& G, const Vector3<T>& p) {
+  const Matrix3<T> px = Skew(p);
+  const Matrix3<T> pxG = px * G;
+  Matrix6<T> Gp;
+  Gp.template topLeftCorner<3, 3>() = -pxG * px;
+  Gp.template topRightCorner<3, 3>() = pxG;
+  Gp.template bottomLeftCorner<3, 3>() = pxG.transpose();
+  Gp.template bottomRightCorner<3, 3>() = G;
+  return Gp;
+}
+
+// Returns G⋅Φ(p), where Φ(p) = [𝕀₃, 0; -pₓ, 𝕀₃].
+template <typename T>
+Matrix6<T> ShiftFromTheRight(const Matrix6<T>& G, const Vector3<T>& p) {
+  const auto Gw = G.template topLeftCorner<3, 3>();
+  const auto Gwv = G.template topRightCorner<3, 3>();
+  const auto Gvw = G.template bottomLeftCorner<3, 3>();
+  const auto Gv = G.template bottomRightCorner<3, 3>();
+  const Matrix3<T> px = Skew(p);
+
+  Matrix6<T> R;
+  R.template topLeftCorner<3, 3>() = Gw - Gwv * px;
+  R.template topRightCorner<3, 3>() = Gwv;
+  R.template bottomLeftCorner<3, 3>() = Gvw - Gv * px;
+  R.template bottomRightCorner<3, 3>() = Gv;
+
+  return R;
+}
+
+// Returns Φ(p)ᵀ⋅G, where Φ(p) = [𝕀₃, 0; -pₓ, 𝕀₃]
+template <typename T>
+Matrix6<T> ShiftFromTheLeft(const Matrix6<T>& G, const Vector3<T>& p) {
+  const auto Gw = G.template topLeftCorner<3, 3>();
+  const auto Gwv = G.template topRightCorner<3, 3>();
+  const auto Gvw = G.template bottomLeftCorner<3, 3>();
+  const auto Gv = G.template bottomRightCorner<3, 3>();
+  const Matrix3<T> px = Skew(p);
+
+  Matrix6<T> R;
+  R.template topLeftCorner<3, 3>() = Gw + px * Gvw;
+  R.template topRightCorner<3, 3>() = Gwv + px * Gv;
+  R.template bottomLeftCorner<3, 3>() = Gvw;
+  R.template bottomRightCorner<3, 3>() = Gv;
+
+  return R;
+}
+
+/* Computes the normal impulse and derivative associated with an individual
+contact using a discrete Hunt-Crossley model. The normal impulse is
+
+  γₙ(vₙ) = δt⋅(k⋅(-ϕ₀ − δt⋅vₙ))₊⋅(1 - d⋅vₙ)₊
+         = δt⋅(fₑ₀ - δt⋅k⋅vₙ)₊⋅(1 - d⋅vₙ)₊,
+
+where (x)₊ = max(0, x), vₙ is the normal contact velocity, ϕ₀ is the initial
+signed distance, fₑ₀ = -k⋅ϕ₀ is the previous-step elastic force contribution, k
+is the contact stiffness, d is the dissipation coefficient, and δt is the time
+step.
+
+@param dt Time step δt.
+@param vn Normal contact velocity vₙ.
+@param fe0 Previous time step normal force elastic contribution fₑ₀.
+@param k Contact stiffness.
+@param d Dissipation coefficient.
+
+@returns A pair with the normal impulse γₙ and its derivative dγₙ/dvₙ. */
+template <typename T>
+std::pair<T, T> CalcDiscreteHuntCrossleyImpulseAndDerivative(
+    const T& dt, const T& vn, const T& fe0, const T& k, const T& d) {
+  // Elastic force contribution.
+  const T fe = fe0 - dt * k * vn;
+
+  // Quick exit if either of the terms is non-positive.
+  if (fe <= 0.0) {
+    return std::make_pair(0.0, 0.0);
+  }
+  const T damping = 1.0 - d * vn;
+  if (damping <= 0.0) {
+    return std::make_pair(0.0, 0.0);
+  }
+
+  // Normal impulse γₙ.
+  const T gn = dt * fe * damping;
+
+  // Derivative dγₙ/dvₙ = -δt⋅[k⋅δt⋅(1 - d⋅vₙ) + d⋅(fₑ₀ - δt⋅k⋅vₙ)].
+  const T dgn_dvn = -dt * (k * dt * damping + d * fe);
+
+  return std::make_pair(gn, dgn_dvn);
+}
+
+/* Computes the antiderivative N(vₙ) of the normal impulse associated with an
+individual contact using a discrete Hunt-Crossley model.
+
+The anti-derivative N(vₙ) is defined such that dN/dvₙ = γₙ(vₙ) and is used to
+define the constraint cost ℓ_c(v).
+
+@param dt Time step δt.
+@param vn Normal contact velocity vₙ.
+@param fe0 Previous time step normal force elastic contribution fₑ₀.
+@param k Contact stiffness.
+@param d Dissipation coefficient.
+
+@returns The anti-derivative N(vₙ).
+*/
+template <typename T>
+T CalcDiscreteHuntCrossleyAntiderivative(const T& dt, const T& vn, const T& fe0,
+                                         const T& k, const T& d) {
+  using std::min;
+
+  // The discrete impulse is modeled as:
+  //   γₙ(v) = δt⋅(fₑ₀ - δt⋅k⋅v)₊⋅(1 - d⋅v)₊.
+  // We see that γₙ(v) = 0 for v ≥ v̂, with v̂ = min(vx, vd) and:
+  //  vx = -ϕ₀/δt = fₑ₀/(δt⋅k),
+  //  vd = 1/d.
+  // Then for v < v̂, γₙ(v) is positive and we can verify that:
+  //   N⁺(v) = δt⋅[v⋅(fₑ₀ + 1/2⋅Δf)-d⋅v²/2⋅(fₑ₀ + 2/3⋅Δf)],
+  // is its antiderivative with Δf = -δt⋅k⋅v.
+  // Since γₙ(v) = 0 for v ≥ v̂, then N(v) must be constant for v ≥ v̂.
+  // Therefore we define it as:
+  //   N(v) = N⁺(min(vn, v̂)).
+
+  // We define the "dissipation" velocity vd at which the dissipation term
+  // vanishes using a small tolerance so that vd goes to a very large number in
+  // the limit to d = 0.
+  const T vd = 1.0 / (d + 1.0e-20);
+
+  // Similarly, we define vx as the velocity at which the elastic term goes
+  // to zero. We use a small tolerance so that it goes to a very large
+  // number in the limit of k = 0 (e.g., from discrete hydroelastics).
+  const T vx = fe0 / dt / (k + 1.0e-20);
+
+  // With the tolerances above in vd and vx, we can define a v̂ that goes to a
+  // large number in the limit of either d = 0 or k = 0.
+  const T v_hat = min(vx, vd);
+
+  // Clamp vn to v̂.
+  const T vn_clamped = min(vn, v_hat);
+
+  // From the derivation above, N(v) = N⁺(vn_clamped).
+  const T& v = vn_clamped;  // Alias to shorten notation.
+  const T df = -dt * k * v;
+  const T N = dt * (v * (fe0 + 1.0 / 2.0 * df) -
+                    d * v * v / 2.0 * (fe0 + 2.0 / 3.0 * df));
+
+  return N;
+}
+
+template <typename T>
+PatchConstraintsPool<T>::PatchConstraintsPool(const IcfModel<T>* parent_model)
+    : model_(parent_model) {
+  DRAKE_ASSERT(parent_model != nullptr);
+}
+
+template <typename T>
+PatchConstraintsPool<T>::~PatchConstraintsPool() = default;
+
+template <typename T>
+void PatchConstraintsPool<T>::Resize(std::span<const int> num_pairs_per_patch) {
+  num_pairs_.assign(num_pairs_per_patch.begin(), num_pairs_per_patch.end());
+
+  const int num_patches = num_pairs_.size();
+  const int num_pairs =
+      std::accumulate(num_pairs_.begin(), num_pairs_.end(), 0);
+
+  // Per-patch data.
+  num_cliques_.resize(num_patches);
+  bodies_.resize(num_patches);
+  p_AB_W_.Resize(num_patches, 3, 1);
+  dissipation_.resize(num_patches);
+  static_friction_.resize(num_patches);
+  dynamic_friction_.resize(num_patches);
+  Rt_.resize(num_patches);
+
+  // Per-pair data.
+  p_BC_W_.Resize(num_pairs, 3, 1);
+  normal_W_.Resize(num_pairs, 3, 1);
+  stiffness_.resize(num_pairs);
+  fe0_.resize(num_pairs);
+  fn0_.resize(num_pairs);
+  net_friction_.resize(num_pairs);
+
+  // Start indexes for each patch.
+  pair_data_start_.resize(num_patches);
+  int previous_total = 0;
+  for (int i = 0; i < num_patches; ++i) {
+    pair_data_start_[i] = previous_total;
+    previous_total += num_pairs_[i];
+  }
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::SetPatch(int patch_index, int bodyA, int bodyB,
+                                       const T& dissipation,
+                                       const T& static_friction,
+                                       const T& dynamic_friction,
+                                       const Vector3<T>& p_AB_W) {
+  DRAKE_ASSERT(0 <= patch_index && patch_index < num_patches());
+  DRAKE_ASSERT(bodyA != bodyB);               // Same body never makes sense.
+  DRAKE_ASSERT(!model().is_anchored(bodyB));  // B is never anchored.
+
+  bodies_[patch_index] =
+      std::make_pair(bodyB, bodyA);  // Dynamic body B always first.
+  dissipation_[patch_index] = dissipation;
+  static_friction_[patch_index] = static_friction;
+  dynamic_friction_[patch_index] = dynamic_friction;
+  p_AB_W_[patch_index] = p_AB_W;
+
+  const int num_cliques =
+      (model().is_anchored(bodyA) || model().is_anchored(bodyB)) ? 1 : 2;
+  num_cliques_[patch_index] = num_cliques;
+
+  // Compute per-patch regularization of friction. We use a "spherical body
+  // approximation" for the estimation of the Delassus operator. A sphere has
+  // gyration radius of g = 5/2 R (with R the radius). A contact will happen
+  // at distance R from the CoM.
+  // Thus the Delassus operator will be:
+  //   W = 1/m⋅[I₃   0
+  //           [ 0   R²/g²]
+  // It's RMS norm will be w = sqrt(7)/m ≈ 2.65/m.
+  T w = 2.65 / model().body_mass(bodies_[patch_index].first);
+  if (num_cliques == 2) {
+    w += 2.65 / model().body_mass(bodies_[patch_index].second);
+  }
+  Rt_[patch_index] = sigma_ * w;
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::SetPair(const int patch_index,
+                                      const int pair_index,
+                                      const Vector3<T>& p_BoC_W,
+                                      const Vector3<T>& normal_W, const T& fe0,
+                                      const T& stiffness) {
+  using std::max;
+  DRAKE_ASSERT(0 <= patch_index && patch_index < num_patches());
+  DRAKE_ASSERT(0 <= pair_index && pair_index < num_pairs_[patch_index]);
+  const int i = patch_pair_index(patch_index, pair_index);
+
+  p_BC_W_[i] = p_BoC_W;
+  normal_W_[i] = normal_W;
+  fe0_[i] = fe0;
+  stiffness_[i] = stiffness;
+
+  // Pre-computed quantities.
+  const int num_cliques = num_cliques_[patch_index];
+
+  // First clique.
+  const Vector6<T>& V_WB = model().V_WB0(bodies_[patch_index].first);
+  const auto w_WB = V_WB.template head<3>();
+  const auto v_WB = V_WB.template tail<3>();
+  Vector3<T> v_AcBc_W = v_WB + w_WB.cross(p_BoC_W);
+
+  // Second clique.
+  if (num_cliques == 2) {
+    const Vector6<T>& V_WA = model().V_WB0(bodies_[patch_index].second);
+    const Vector3<T> p_AC_W = p_AB_W_[patch_index] + p_BoC_W;
+    const auto w_WA = V_WA.template head<3>();
+    const auto v_WA = V_WA.template tail<3>();
+    v_AcBc_W -= (v_WA + w_WA.cross(p_AC_W));
+  }
+
+  // N.B. the normal impulse is n₀ = (δt⋅fₑ₀))₊(1−dvₙ₀)₊, where (·)₊ = max(0,·).
+  // However, model.time_step() may change between when the constraint is set
+  // and when the problem is solved. Thus we only store the normal force fₙ₀ =
+  // (fₑ₀)₊(1−dvₙ₀)₊ here and compute the impulse n₀ = δt⋅fₙ₀ later in
+  // CalcData().
+  const T& d = dissipation_[patch_index];
+  const T vn0 = v_AcBc_W.dot(normal_W);
+  const T damping = max(0.0, 1.0 - d * vn0);
+  const T fn0 = max(0.0, fe0) * damping;
+  fn0_[i] = fn0;
+
+  // Coefficient of friction is determined based on previous velocity. This
+  // allows us to consider a Streibeck-like curve while maintaining a convex
+  // formulation.
+  const T vt0 = (v_AcBc_W - vn0 * normal_W).norm();
+  const T s = vt0 / stiction_tolerance_;
+  const T& mu_s = static_friction_[patch_index];
+  const T& mu_d = dynamic_friction_[patch_index];
+
+  auto sigmoid = [](const T& x) -> T {
+    return x / sqrt(1 + x * x);
+  };
+
+  const T mu =
+      (mu_s - mu_d) * 0.5 * (1 - (sigmoid(s - 10) / sigmoid(10))) + mu_d;
+  net_friction_[i] = mu;
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::CalcSparsityPattern(
+    std::vector<std::vector<int>>* sparsity) const {
+  DRAKE_ASSERT(sparsity != nullptr);
+  for (int p = 0; p < num_patches(); ++p) {
+    // We only need to add to the sparsity if body_a is not anchored.
+    const int body_a = bodies_[p].second;
+    if (!model().is_anchored(body_a)) {
+      const int body_b = bodies_[p].first;
+      DRAKE_ASSERT(!model().is_anchored(body_b));  // Body B is never anchored.
+      const int c_a = model().body_to_clique(body_a);
+      const int c_b = model().body_to_clique(body_b);
+      if (c_a == c_b) continue;  // we do not add diagonal blocks here.
+      const int c_min = std::min(c_a, c_b);
+      const int c_max = std::max(c_a, c_b);
+      sparsity->at(c_min).push_back(c_max);  // j > i blocks.
+    }
+  }
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::CalcData(
+    const EigenPool<Vector6<T>>& V_WB,
+    PatchConstraintsDataPool<T>* patch_data) const {
+  DRAKE_ASSERT(patch_data != nullptr);
+  CalcContactVelocities(V_WB, &patch_data->mutable_v_AcBc_W_pool());
+  CalcPatchQuantities(
+      patch_data->mutable_v_AcBc_W_pool(), &patch_data->mutable_cost_pool(),
+      &patch_data->mutable_Gamma_Bo_W_pool(), &patch_data->mutable_G_Bp_pool());
+  patch_data->mutable_cost() = std::accumulate(
+      patch_data->cost_pool().begin(), patch_data->cost_pool().end(), T(0.0));
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::AccumulateGradient(const IcfData<T>& data,
+                                                 VectorX<T>* gradient) const {
+  DRAKE_ASSERT(gradient != nullptr);
+  const PatchConstraintsDataPool<T>& patch_data = data.patch_constraints_data();
+  const EigenPool<Vector6<T>>& Gamma_Bo_W_pool = patch_data.Gamma_Bo_W_pool();
+
+  for (int p = 0; p < num_patches(); ++p) {
+    const int body_a = bodies_[p].second;
+    const int body_b = bodies_[p].first;
+    const int c_b = model().body_to_clique(body_b);
+    const int c_a = model().body_to_clique(body_a);  // negative if anchored.
+
+    // First clique, body B.
+    DRAKE_ASSERT(!model().is_anchored(body_b));  // Body B is never anchored.
+
+    const Vector6<T>& Gamma_Bo_W = Gamma_Bo_W_pool[p];
+
+    Eigen::VectorBlock<VectorX<T>> gradient_b =
+        model().mutable_clique_segment(c_b, gradient);
+    if (model().is_floating(body_b)) {
+      gradient_b.noalias() -= Gamma_Bo_W;
+    } else {
+      ConstJacobianView J_WB = model().J_WB(body_b);
+      gradient_b.noalias() -= J_WB.transpose() * Gamma_Bo_W;
+    }
+
+    // Second clique, for body A, only contributes if not anchored.
+    if (!model().is_anchored(body_a)) {
+      const Vector3<T>& p_AB_W = p_AB_W_[p];
+      const Vector6<T> minus_Gamma_Ao_W = ShiftSpatialForce(Gamma_Bo_W, p_AB_W);
+      Eigen::VectorBlock<VectorX<T>> gradient_a =
+          model().mutable_clique_segment(c_a, gradient);
+
+      if (model().is_floating(body_a)) {
+        gradient_a.noalias() += minus_Gamma_Ao_W;
+      } else {
+        ConstJacobianView J_WA = model().J_WB(body_a);
+        gradient_a.noalias() += J_WA.transpose() * minus_Gamma_Ao_W;
+      }
+    }
+  }
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::AccumulateHessian(
+    const IcfData<T>& data,
+    BlockSparseSymmetricMatrix<MatrixX<T>>* hessian) const {
+  DRAKE_ASSERT(hessian != nullptr);
+
+  const PatchConstraintsDataPool<T>& patch_data = data.patch_constraints_data();
+
+  auto& H_BB_pool = data.scratch().H_BB_pool;
+  auto& H_AA_pool = data.scratch().H_AA_pool;
+  auto& H_AB_pool = data.scratch().H_AB_pool;
+  auto& H_BA_pool = data.scratch().H_BA_pool;
+  auto& GJa_pool = data.scratch().GJa_pool;
+  auto& GJb_pool = data.scratch().GJb_pool;
+
+  const EigenPool<Matrix6<T>>& G_Bp_pool = patch_data.G_Bp_pool();
+
+  for (int p = 0; p < num_patches(); ++p) {
+    const int body_a = bodies_[p].second;
+    const int body_b = bodies_[p].first;
+    const int c_b = model().body_to_clique(body_b);
+    const int c_a = model().body_to_clique(body_a);  // negative if anchored.
+    const int nv_b = model().clique_size(c_b);
+    const int nv_a = model().clique_size(c_a);  // zero if anchored.
+
+    // First clique, body B.
+    DRAKE_ASSERT(!model().is_anchored(body_b));  // Body B is never anchored.
+
+    // Accumulate Hessian.
+    H_BB_pool.Resize(1, nv_b, nv_b);
+    auto H_BB = H_BB_pool[0];
+
+    const Matrix6<T>& G_Bp = G_Bp_pool[p];
+    ConstJacobianView J_WB = model().J_WB(body_b);
+    if (model().is_floating(body_b)) {
+      H_BB.noalias() = G_Bp;
+    } else {
+      GJb_pool.Resize(1, 6, nv_b);
+      auto GJb = GJb_pool[0];
+      GJb.noalias() = G_Bp * J_WB;
+      H_BB.noalias() = J_WB.transpose() * GJb;
+    }
+    hessian->AddToBlock(c_b, c_b, H_BB);
+
+    // Second clique, for body A, only contributes if not anchored.
+    if (!model().is_anchored(body_a)) {
+      GJa_pool.Resize(1, 6, nv_a);
+      auto GJa = GJa_pool[0];
+
+      const Vector3<T>& p_AB_W = p_AB_W_[p];
+      ConstJacobianView J_WA = model().J_WB(body_a);
+
+      // Accumulate (upper triangular) Hessian.
+      H_AA_pool.Resize(1, nv_a, nv_a);
+      auto H_AA = H_AA_pool[0];
+      const Matrix6<T> G_Phi = ShiftFromTheRight(G_Bp, p_AB_W);  // = Gₚ⋅Φ
+      const Matrix6<T> G_Ap = ShiftFromTheLeft(G_Phi, p_AB_W);   // = Φᵀ⋅Gₚ⋅Φ
+
+      // When c_a != c_b, we only write the lower triangular portion.
+      // If c_a == c_b, we must compute both terms.
+      GJa.noalias() = G_Phi * J_WA;
+      H_BA_pool.Resize(1, nv_b, nv_a);
+      auto H_BA = H_BA_pool[0];
+      if (model().is_floating(body_b)) {
+        H_BA.noalias() = -GJa;
+      } else {
+        H_BA.noalias() = -J_WB.transpose() * GJa;
+      }
+      if (c_b > c_a) {
+        hessian->AddToBlock(c_b, c_a, H_BA);
+      }
+      if (c_a > c_b) {
+        // N.B. Doing:
+        // AddToBlock(c_a, c_b, H_BA.transpose()) allocates temp memory!!!.
+        H_AB_pool.Resize(1, nv_a, nv_b);
+        auto H_AB = H_AB_pool[0];
+        H_AB = H_BA.transpose();
+        hessian->AddToBlock(c_a, c_b, H_AB);
+      }
+      if (c_b == c_a) {
+        // We must add both. Additionally, AddToBlock assumes symmetric blocks
+        // for diagonal blocks.
+        H_BB.noalias() = H_BA + H_BA.transpose();  // Re-use H_BB.
+        hessian->AddToBlock(c_a, c_b, H_BB);
+      }
+
+      if (model().is_floating(body_a)) {
+        H_AA.noalias() = G_Ap;
+      } else {
+        GJa.noalias() = G_Ap * J_WA;
+        H_AA.noalias() = J_WA.transpose() * GJa;
+      }
+      hessian->AddToBlock(c_a, c_a, H_AA);
+    }
+  }
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::CalcCostAlongLine(
+    const PatchConstraintsDataPool<T>& patch_data,
+    const EigenPool<Vector6<T>>& U_WB_pool,
+    EigenPool<Vector6<T>>* U_AbB_W_pool_ptr, T* dcost, T* d2cost) const {
+  DRAKE_ASSERT(U_AbB_W_pool_ptr != nullptr);
+  DRAKE_ASSERT(dcost != nullptr);
+  DRAKE_ASSERT(d2cost != nullptr);
+  auto& U_AbB_W_pool = *U_AbB_W_pool_ptr;
+  DRAKE_ASSERT(U_AbB_W_pool.size() == num_patches());
+  CalcConstraintVelocities(U_WB_pool, &U_AbB_W_pool);
+
+  const auto& Gamma_pool = patch_data.Gamma_Bo_W_pool();
+  const EigenPool<Matrix6<T>>& G_Bp_pool = patch_data.G_Bp_pool();
+  *dcost = 0;
+  *d2cost = 0;
+  Vector6<T> dGamma;
+  for (int p = 0; p < num_patches(); ++p) {
+    // N.B. All this is contiguous, so we could use a single dot product.
+    const Vector6<T>& U = U_AbB_W_pool[p];
+    const Vector6<T>& Gamma = Gamma_pool[p];
+    const Matrix6<T>& G = G_Bp_pool[p];
+    *dcost -= U.dot(Gamma);  // -= Uᵀ⋅Γ
+
+    dGamma = G * U;
+    *d2cost += U.dot(dGamma);  // += Uᵀ⋅Gₚ⋅U
+  }
+}
+
+template <typename T>
+T PatchConstraintsPool<T>::CalcLaggedHuntCrossleyModel(
+    int p, int k, const Vector3<T>& v_AcBc_W, Vector3<T>* gamma_Bc_W,
+    Matrix3<T>* G) const {
+  using std::max;
+  const int pk = patch_pair_index(p, k);
+  const Vector3<T>& normal_W = normal_W_[pk];
+  const T& dt = model().time_step();
+
+  const T& mu = net_friction_[pk];
+  const T& d = dissipation_[p];
+  const T& stiffness = stiffness_[pk];
+  const T& n0 = fn0_[pk] * dt;
+  const T& fe0 = fe0_[pk];
+
+  // Regularization for the stiction tolerance
+  const T sap_stiction_tolerance = mu * Rt_[p] * n0;
+  const T vs = max(stiction_tolerance_, sap_stiction_tolerance);
+
+  // Normal velocity. Positive when bodies move apart.
+  const T vn = v_AcBc_W.dot(normal_W);
+  const Vector3<T> vt_AcBc_W = v_AcBc_W - vn * normal_W;
+  const T vt_soft = SoftNorm(vt_AcBc_W, vs);
+  const Vector3<T> t_hat_W = vt_AcBc_W / (vt_soft + vs);
+
+  // Normal impulse γₙ(vₙ), derivative dγₙ/dvₙ, and antiderivative N(vₙ).
+  const auto [gn, dgn_dvn] =
+      CalcDiscreteHuntCrossleyImpulseAndDerivative(dt, vn, fe0, stiffness, d);
+  const T N = CalcDiscreteHuntCrossleyAntiderivative(dt, vn, fe0, stiffness, d);
+
+  // Constraint cost and impulse (negative gradient), including both friction
+  // and normal force contributions.
+  const T cost = mu * vt_soft * n0 - N;
+  *gamma_Bc_W = -mu * t_hat_W * n0 + gn * normal_W;
+
+  // Pn is a SPD projection matrix with eigenvalues {1, 0, 0}.
+  const Matrix3<T> Pn = normal_W * normal_W.transpose();
+
+  // Pt is SPD with eigenvalues {‖t̂‖², 0, 0}. Note that since ‖t̂‖² < 1, Pt is
+  // not a projection matrix.
+  const Matrix3<T> Pt = t_hat_W * t_hat_W.transpose();
+
+  // M = Pperp(t) * Pperp(n) is SPD with eigenvalues {1 - ‖t̂‖², 0, 1}, all
+  // positive since ‖t̂‖ < 1.
+  const Matrix3<T> M = Matrix3<T>::Identity() - Pt - Pn;
+
+  // Constraint Hessian, including both friction and normal force contributions.
+  *G = mu * n0 / (vt_soft + vs) * M - dgn_dvn * Pn;
+
+  return cost;
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::CalcConstraintVelocities(
+    const EigenPool<Vector6<T>>& V_WB_pool,
+    EigenPool<Vector6<T>>* V_AbB_W_pool) const {
+  DRAKE_ASSERT(V_WB_pool.size() == model().num_bodies());
+  DRAKE_ASSERT(V_AbB_W_pool->size() == num_patches());
+
+  for (int p = 0; p < num_patches(); ++p) {
+    const int num_cliques = num_cliques_[p];
+
+    const int bodyB = bodies_[p].first;
+    // If A is anchored, bodyA, will reference a zero velocity that won't
+    // get used.
+    const int bodyA = bodies_[p].second;
+    const Vector6<T>& V_WB = V_WB_pool[bodyB];
+    const Vector6<T>& V_WA = V_WB_pool[bodyA];
+
+    Vector6<T>& V_AbB_W = (*V_AbB_W_pool)[p];
+    V_AbB_W = V_WB;
+
+    if (num_cliques == 2) {
+      const Vector3<T>& p_AB_W = p_AB_W_[p];
+
+      const auto w_WA = V_WA.template head<3>();
+      const auto v_WA = V_WA.template tail<3>();
+      auto w_AbB_W = V_AbB_W.template head<3>();
+      auto v_AbB_W = V_AbB_W.template tail<3>();
+
+      w_AbB_W -= w_WA;
+      v_AbB_W -= (v_WA + w_WA.cross(p_AB_W));
+    }
+  }
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::CalcContactVelocities(
+    const EigenPool<Vector6<T>>& V_WB_pool,
+    EigenPool<Vector3<T>>* v_AcBc_W_pool) const {
+  for (int p = 0; p < num_patches(); ++p) {
+    const int num_cliques = num_cliques_[p];
+    const int num_pairs = num_pairs_[p];
+
+    const int bodyB = bodies_[p].first;
+    // If A is anchored, bodyA = 0, will reference a zero velocity that won't
+    // get used.
+    const int bodyA = bodies_[p].second;
+    const Vector6<T>& V_WB = V_WB_pool[bodyB];
+    const Vector6<T>& V_WA = V_WB_pool[bodyA];
+
+    for (int k = 0; k < num_pairs; ++k) {
+      const int pk = patch_pair_index(p, k);
+      Vector3<T>& v_AcBc_W = (*v_AcBc_W_pool)[pk];
+
+      // First clique, always corresponding to body B.
+      const Vector3<T>& p_BC_W = p_BC_W_[pk];
+      const auto w_WB = V_WB.template head<3>();
+      const auto v_WB = V_WB.template tail<3>();
+      v_AcBc_W = v_WB + w_WB.cross(p_BC_W);
+
+      // Second clique. Always corresponding to body A.
+      if (num_cliques == 2) {
+        const Vector3<T> p_AC_W = p_AB_W_[p] + p_BC_W_[pk];
+        const auto w_WA = V_WA.template head<3>();
+        const auto v_WA = V_WA.template tail<3>();
+        v_AcBc_W -= (v_WA + w_WA.cross(p_AC_W));
+      }
+    }
+  }
+}
+
+template <typename T>
+void PatchConstraintsPool<T>::CalcPatchQuantities(
+    const EigenPool<Vector3<T>>& v_AcBc_W_pool, std::vector<T>* cost_pool,
+    EigenPool<Vector6<T>>* spatial_impulses_pool,
+    EigenPool<Matrix6<T>>* patch_hessians_pool) const {
+  EigenPool<Vector6<T>>& Gamma_Bo_W_pool = *spatial_impulses_pool;
+  EigenPool<Matrix6<T>>& G_Bp_pool = *patch_hessians_pool;
+
+  Gamma_Bo_W_pool.SetZero();
+  G_Bp_pool.SetZero();
+
+  for (int p = 0; p < num_patches(); ++p) {
+    const int num_pairs = num_pairs_[p];
+
+    // Accumulate impulses on the patch for the first clique only. This is
+    // always body B.
+    Vector6<T>& Gamma_Bo_W = Gamma_Bo_W_pool[p];
+    Matrix6<T>& G_Bp = G_Bp_pool[p];
+
+    cost_pool->at(p) = 0.0;
+    for (int k = 0; k < num_pairs; ++k) {
+      const int pk = patch_pair_index(p, k);
+      const Vector3<T>& v_AcBc_W = v_AcBc_W_pool[pk];
+
+      Vector3<T> gamma_Bc_W;
+      Matrix3<T> Gk;
+      cost_pool->at(p) +=
+          CalcLaggedHuntCrossleyModel(p, k, v_AcBc_W, &gamma_Bc_W, &Gk);
+
+      // Shift from Ck to B and accumulate.
+      const Vector3<T>& p_BC_W = p_BC_W_[pk];
+      Gamma_Bo_W.template head<3>() += p_BC_W.cross(gamma_Bc_W);
+      Gamma_Bo_W.template tail<3>() += gamma_Bc_W;
+
+      // Accumulate onto the path Hessian Gp.
+      G_Bp += ShiftSecondOrderTensor(Gk, p_BC_W);
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::contact_solvers::icf::internal::
+        PatchConstraintsPool);

--- a/multibody/contact_solvers/icf/patch_constraints_pool.h
+++ b/multibody/contact_solvers/icf/patch_constraints_pool.h
@@ -1,0 +1,269 @@
+#pragma once
+
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+#include "drake/multibody/contact_solvers/icf/patch_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+// Forward declaration to break circular dependencies.
+template <typename T>
+class IcfModel;
+
+/* A pool of contact constraints organized by patches. Each patch involves two
+bodies A and B, with one or more contact pairs per patch. We can think of each
+patch as corresponding to a physical "contact surface" between the two bodies.
+
+Each constraint (patch) adds a cost term ℓ(v) to the overall ICF cost. The
+gradient of this cost term is ∇ℓ = -Jᵀγ, where J = J_AbB is the Jacobian for the
+relative spatial velocity of body B with respect to the spatial velocity of body
+A shifted to B's center. That is, V_AbB_W = J⋅v, with v the generalized
+velocities of the model. With this Jacobian definition, impulses γ correspond to
+the spatial impulse on body B, expressed in the world frame.
+
+This constraint type includes several optimizations for speeding up contact-rich
+simulations:
+
+  - All spatial quantities (relative contact velocities, normals, tangents,
+    spatial velocities, etc.) are expressed in the world frame. This allows us
+    to avoid expensive intermediate frame computations and reduce FLOP counts.
+
+  - Computations are optimized for the common case of a single clique (a moving
+    body interacts with an anchored body). The two-clique case (two moving
+    bodies) is handled by shifting single-body quantities, allowing reuse of
+    expensive-to-compute spatial quantities.
+
+  - Contact pairs between the same two bodies are grouped into a single patch
+    constraint. This improves memory locality by allowing the solver to process
+    an entire patch with a coherent access pattern, reducing cache misses and
+    allowing us to load per-body-pair data only once.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class PatchConstraintsPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PatchConstraintsPool);
+
+  using JacobianView = typename EigenPool<Matrix6X<T>>::MatrixView;
+  using ConstJacobianView = typename EigenPool<Matrix6X<T>>::ConstMatrixView;
+
+  /* Constructs an empty pool. */
+  explicit PatchConstraintsPool(const IcfModel<T>* parent_model);
+
+  ~PatchConstraintsPool();
+
+  /* Returns a reference to the parent model. */
+  const IcfModel<T>& model() const { return *model_; }
+
+  /* Returns the number of patches (pairs of contacting bodies) in the pool. */
+  int num_patches() const { return ssize(num_pairs_); }
+
+  /* Returns the number of pairs in the given patch. */
+  int num_pairs(int patch_index) const {
+    DRAKE_ASSERT(0 <= patch_index && patch_index < num_patches());
+    return num_pairs_[patch_index];
+  }
+
+  /* Returns the number of pairs in each patch. */
+  std::span<const int> patch_sizes() const {
+    return std::span<const int>(num_pairs_);
+  }
+
+  /* Returns the total number of pairs across all patches. */
+  int total_num_pairs() const { return ssize(fe0_); }
+
+  /* Returns the number of constraints in the pool. We introduce one constraint
+  for each patch. */
+  int num_constraints() const { return num_patches(); }
+
+  /* Sets the stiction tolerance used for friction regularization.
+
+  This is a velocity, in m/s. Objects in stiction may slide tangentially at
+  velocities up to this value. Additionally, we transition smoothly from static
+  to dynamic friction coefficients at around 10× this velocity. See
+  [Kurtz and Castro, 2025] for details. */
+  void set_stiction_tolerance(double stiction_tolerance) {
+    DRAKE_DEMAND(stiction_tolerance > 0.0);
+    stiction_tolerance_ = stiction_tolerance;
+  }
+
+  /* Resizes this constraint pool to store the given patches and pairs.
+
+  @param num_pairs_per_patch Number of contact pairs for each patch.
+
+  @warning After resizing, constraints may hold invalid data until SetPatch()
+  and SetPair() are called for each patch and pair. */
+  void Resize(std::span<const int> num_pairs_per_patch);
+
+  /* Sets the contact patch between bodies A and B.
+
+  @param patch_index The index of the patch within the pool.
+  @param bodyA The index of body A (may be anchored).
+  @param bodyB The index of body B (must be dynamic).
+  @param dissipation The Hunt & Crossley dissipation coefficient for the patch.
+  @param static_friction The static friction coefficient for the patch.
+  @param dynamic_friction The dynamic friction coefficient for the patch.
+  @param p_AB_W The position of body B relative to body A.
+
+  @pre B is always dynamic (not anchored). */
+  void SetPatch(int patch_index, int bodyA, int bodyB, const T& dissipation,
+                const T& static_friction, const T& dynamic_friction,
+                const Vector3<T>& p_AB_W);
+
+  /* Sets the contact pair data for the given patch and pair index.
+
+  @param patch_index The index of the patch within the pool.
+  @param pair_index The index of the contact pair within the patch.
+  @param p_BoC_W The position of the contact point C relative to body B.
+  @param normal_W Contact normal, from A into B by convention.
+  @param fn0 The previous-step normal contact force (lagged for convexity.)
+  @param stiffness Contact stiffness, in N/m. See [Masterjohn et al., 2022].
+
+  @note As required by SetPatch(), body B is always dynamic (not anchored).
+        Therefore we provide the position of the contact point relative to B
+        and, if needed, the position relative to A is inferred from p_AB_W
+        provided to SetPatch().
+
+  [Masterjohn et al., 2022] Masterjohn, J., Guoy, D., Shepherd, J. and Castro,
+  A., 2022. Velocity level approximation of pressure field contact patches. IEEE
+  Robotics and Automation Letters, 7(4), pp.11593-11600. */
+  void SetPair(const int patch_index, const int pair_index,
+               const Vector3<T>& p_BoC_W, const Vector3<T>& normal_W,
+               const T& fn0, const T& stiffness);
+
+  /* Computes the sparsity pattern for the pool. That is, cliques i is connected
+  to clique j > i iff sparsity[i] contains j. */
+  void CalcSparsityPattern(std::vector<std::vector<int>>* sparsity) const;
+
+  /* Computes constraint data for each patch, given the body spatial velocities
+  V_WB. */
+  void CalcData(const EigenPool<Vector6<T>>& V_WB,
+                PatchConstraintsDataPool<T>* patch_data) const;
+
+  /* Adds the gradient contribution of the patch constraints, ∇ℓ = −Jᵀ⋅γ, to the
+  overall gradient. */
+  void AccumulateGradient(const IcfData<T>& data, VectorX<T>* gradient) const;
+
+  /* Adds the Hessian contribution of the patch constraints to the overall
+  Hessian. */
+  void AccumulateHessian(
+      const IcfData<T>& data,
+      contact_solvers::internal::BlockSparseSymmetricMatrix<MatrixX<T>>*
+          hessian) const;
+
+  /* Computes the first and second derivatives of the constraint cost
+  ℓ̃(α) = ℓ(v + α⋅w).
+
+  @param patch_data The pre-computed patch constraint data at v + α⋅w.
+  @param U_WB Body spatial velocity when the generalized velocities equal w.
+         I.e., U_WB = J⋅w.
+  @param U_AbB_W_pool Scratch space for patch spatial velocities.
+  @param[out] dcost the first derivative dℓ̃ /dα on output.
+  @param[out] d2cost the second derivative d²ℓ̃ /dα² on output. */
+  void CalcCostAlongLine(const PatchConstraintsDataPool<T>& patch_data,
+                         const EigenPool<Vector6<T>>& U_WB_pool,
+                         EigenPool<Vector6<T>>* U_AbB_W_pool, T* dcost,
+                         T* d2cost) const;
+
+ private:
+  /* Returns the index into data per patch and per contact pair.
+  @param p Patch index p < num_pairs().
+  @param k Pair index k < num_pairs(p). */
+  int patch_pair_index(int p, int k) const { return pair_data_start_[p] + k; }
+
+  /* Computes cost, gradient, and Hessian contributions for the given pair.
+
+  @param p Patch index.
+  @param k Pair index within patch.
+  @param v_AcBc_W Relative contact point velocity.
+  @param[out] gamma_Bc_W Contact spatial impulse on body B
+  @param[out] G Contact spatial Hessian for the pair. */
+  T CalcLaggedHuntCrossleyModel(int p, int k, const Vector3<T>& v_AcBc_W,
+                                Vector3<T>* gamma_Bc_W, Matrix3<T>* G) const;
+
+  /* Computes relative spatial velocities V_AbB_W for each patch, given body
+  spatial velocities V_WB. When A is anchored, V_WA = 0 and V_AbB_W = V_WB. */
+  void CalcConstraintVelocities(const EigenPool<Vector6<T>>& V_WB_pool,
+                                EigenPool<Vector6<T>>* V_AbB_W_pool) const;
+
+  /* Computes contact velocities for each contact pair from body spatial
+  velocities V_WB. */
+  void CalcContactVelocities(const EigenPool<Vector6<T>>& V_WB_pool,
+                             EigenPool<Vector3<T>>* v_AcBc_W_pool) const;
+
+  /* Computes cost, gradient, and Hessian contributions for each patch. */
+  void CalcPatchQuantities(const EigenPool<Vector3<T>>& v_AcBc_W_pool,
+                           std::vector<T>* cost_pool,
+                           EigenPool<Vector6<T>>* spatial_impulses_pool,
+                           EigenPool<Matrix6<T>>* patch_hessians_pool) const;
+
+  // The parent model.
+  const IcfModel<T>* const model_;
+
+  // The stiction tolerance vₛ (m/s) for regularized friction.
+  double stiction_tolerance_{1.0e-4};
+
+  // SAP regularization parameter σ. Each frictional contact is regularized by
+  // εₛ = max(vₛ, μ⋅σ⋅wₜ⋅n₀), where vₛ is the stiction tolerance, μ is the
+  // friction coefficient, wₜ is the Delassus operator approximation, and n₀ is
+  // the normal impulse from the previous time step. See the ICF paper [Castro
+  // et al., 2025] for further details.
+  double sigma_{1.0e-3};
+
+  // Data per patch. Indexed by patch index p < num_patches().
+  std::vector<int> num_pairs_;    // Number of pairs per patch.
+  std::vector<int> num_cliques_;  // Number of cliques (one or two).
+  std::vector<T> Rt_;             // Friction regularization Rₜ = σ⋅wₜ
+
+  // Bodies involved in each patch. The first is always body B, which always
+  // corresponds to a valid (positive) clique. The second is always body A,
+  // which might correspond to an anchored body with invalid (negative) clique.
+  std::vector<std::pair<int, int>> bodies_;
+
+  EigenPool<Vector3<T>> p_AB_W_;  // Position of body B relative to A.
+  std::vector<T> dissipation_;    // Hunt & Crossley dissipation.
+
+  // Friction coefficients per patch.
+  std::vector<T> static_friction_;
+  std::vector<T> dynamic_friction_;
+
+  // Starting index for each patch. Holds the global pair index of the first
+  // pair in each patch, of size num_patches().
+  std::vector<int> pair_data_start_;
+
+  // Data per pair. Indexed by patch_pair_index(p, k).
+  EigenPool<Vector3<T>> p_BC_W_;    // Position of contact point from body B.
+  EigenPool<Vector3<T>> normal_W_;  // Contact normals.
+  std::vector<T> stiffness_;        // Linear stiffness, N/m.
+  // Elastic component of the normal force at the previous step, in N.
+  std::vector<T> fe0_;
+  // Normal force (elastic and damping) at the previous step, in N.
+  std::vector<T> fn0_;
+
+  // The net friction coefficient for each pair. Computed by interpolating
+  // between static and dynamic coefficients based on the relative contact
+  // velocity of this pair at the previous time step.
+  std::vector<T> net_friction_;
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::contact_solvers::icf::internal::
+        PatchConstraintsPool);


### PR DESCRIPTION
Adds contact constraints to the ICF formulation. This is the next step along the ICF PR train (https://github.com/RobotLocomotion/drake/issues/23769).

For full context, see the [cenic_main](https://github.com/RobotLocomotion/drake/tree/cenic_main) dev branch, and especially the [ICF README](https://github.com/RobotLocomotion/drake/blob/cenic_main/multibody/contact_solvers/icf/README.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23885)
<!-- Reviewable:end -->
