### PR TITLE
[icf] Remove unused Clear() from coupler pool

### DIFF
--- a/multibody/contact_solvers/icf/coupler_constraints_data_pool.h
+++ b/multibody/contact_solvers/icf/coupler_constraints_data_pool.h
@@ -29,7 +29,7 @@ class CouplerConstraintsDataPool {
   /* Resizes the pool, allocating memory only as necessary. */
   void Resize(int num_couplers) { gamma_pool_.resize(num_couplers); }
 
-  /* Returns the number of gain constraints this data is for. */
+  /* Returns the number of coupler constraints this data is for. */
   int num_constraints() const { return ssize(gamma_pool_); }
 
   /* Returns the constraint impulse γ = -∇ℓ(v) for the k-th constraint in the

--- a/multibody/contact_solvers/icf/coupler_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/coupler_constraints_pool.cc
@@ -23,15 +23,6 @@ template <typename T>
 CouplerConstraintsPool<T>::~CouplerConstraintsPool() = default;
 
 template <typename T>
-void CouplerConstraintsPool<T>::Clear() {
-  constraint_to_clique_.clear();
-  dofs_.clear();
-  gear_ratio_.clear();
-  g_hat_.clear();
-  R_.clear();
-}
-
-template <typename T>
 void CouplerConstraintsPool<T>::Resize(const int num_constraints) {
   constraint_to_clique_.resize(num_constraints);
   dofs_.resize(num_constraints);

--- a/multibody/contact_solvers/icf/coupler_constraints_pool.h
+++ b/multibody/contact_solvers/icf/coupler_constraints_pool.h
@@ -49,9 +49,6 @@ class CouplerConstraintsPool {
   /* Returns the total number of constraints stored in this pool. */
   int num_constraints() const { return constraint_to_clique_.size(); }
 
-  /* Removes all constraints from this pool while keeping memory allocated. */
-  void Clear();
-
   /* Resizes the constraints pool to store the given number of constraints.
 
   @warning After resizing, constraints may hold invalid data until Set() is


### PR DESCRIPTION
In #23874 we realized that the `Clear()` helper function we've been using is totally unnecessary. It's not used in the actual ICF solver, and we can just use `Resize(0)` in unit tests. This removes that unused `Clear` function from `CouplerConstraintsPool`.

Also fixes a little typo in the coupler constraints pool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23886)
<!-- Reviewable:end -->
