### PR TITLE
[mpm] Fix GridData<AutoDiffXd>::operator==

### DIFF
--- a/multibody/mpm/grid_data.h
+++ b/multibody/mpm/grid_data.h
@@ -85,6 +85,8 @@ class IndexOrFlag {
     return value_;
   }
 
+  bool operator==(const IndexOrFlag&) const = default;
+
  private:
   /* Note that the enum values are not arbitrary; kInactive must be -1 as in the
    class documentation. */
@@ -116,7 +118,12 @@ struct GridData {
 
   /* Returns true iff `this` GridData is bit-wise equal to `other`. */
   bool operator==(const GridData<T>& other) const {
-    return std::memcmp(this, &other, sizeof(GridData<T>)) == 0;
+    if constexpr (std::is_floating_point_v<T>) {
+      return std::memcmp(this, &other, sizeof(GridData<T>)) == 0;
+    } else {
+      return std::tie(v, m, scratch, index_or_flag) ==
+             std::tie(other.v, other.m, other.scratch, other.index_or_flag);
+    }
   }
 
   /* Returns true iff `this` GridData is inactive. A grid node inactive when

--- a/multibody/mpm/test/grid_data_test.cc
+++ b/multibody/mpm/test/grid_data_test.cc
@@ -75,7 +75,7 @@ TYPED_TEST(IndexOrFlagTest, StateTransition) {
   EXPECT_FALSE(another_dut.is_inactive());
 }
 
-using FloatingPointTypes = ::testing::Types<float, double>;
+using FloatingPointTypes = ::testing::Types<float, double, AutoDiffXd>;
 
 template <typename T>
 class GridDataTest : public ::testing::Test {};
@@ -100,16 +100,22 @@ TYPED_TEST(GridDataTest, Reset) {
 
 TYPED_TEST(GridDataTest, Equality) {
   using T = TypeParam;
+
+  T one{1.0};
+  if constexpr (std::is_same_v<T, AutoDiffXd>) {
+    one = AutoDiffXd(1.0, 1, 0);
+  }
+
   GridData<T> data1;
   data1.index_or_flag.set_index(123);
-  data1.scratch = Vector3<T>::Ones();
-  data1.v = Vector3<T>::Ones();
+  data1.scratch = Vector3<T>::Constant(one);
+  data1.v = Vector3<T>::Constant(one);
   data1.m = 1;
 
   GridData<T> data2;
   data2.index_or_flag.set_index(123);
-  data2.scratch = Vector3<T>::Ones();
-  data2.v = Vector3<T>::Ones();
+  data2.scratch = Vector3<T>::Constant(one);
+  data2.v = Vector3<T>::Constant(one);
   data2.m = 1;
 
   EXPECT_EQ(data1, data2);


### PR DESCRIPTION
AutoDiffXd values cannot be compared using `memcmp`.

Towards #23820.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23892)
<!-- Reviewable:end -->
