### PR TITLE
[analysis] Overload Simulator::reset_integrator to take an integrator

### DIFF
--- a/bindings/generated_docstrings/systems_analysis.h
+++ b/bindings/generated_docstrings/systems_analysis.h
@@ -4649,7 +4649,7 @@ Note:
     System&, Context*); this constructor is usually associated with
     error-controlled integrators.)""";
           // Source: drake/systems/analysis/simulator.h
-          const char* doc_1args =
+          const char* doc_1args_constT =
 R"""(Resets the integrator with a new one using factory construction and a
 maximum step size argument (which is required for constructing
 fixed-step integrators).
@@ -4676,6 +4676,16 @@ Note:
     System&, const T&, Context*); this constructor is usually
     associated with fixed-step integrators (i.e., integrators which do
     not support error estimation).)""";
+          // Source: drake/systems/analysis/simulator.h
+          const char* doc_1args_integrator =
+R"""((Advanced) Resets the integrator to the given object.
+
+See also:
+    argument-less version of reset_integrator() for note about
+    initialization.
+
+Precondition:
+    integrator->get_system() is the same object as this->get_system().)""";
         } reset_integrator;
         // Symbol: drake::systems::Simulator::set_monitor
         struct /* set_monitor */ {

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -67,6 +67,18 @@ Simulator<T>::Simulator(const System<T>* system,
 }
 
 template <typename T>
+IntegratorBase<T>& Simulator<T>::reset_integrator(
+    std::unique_ptr<IntegratorBase<T>> integrator) {
+  DRAKE_THROW_UNLESS(integrator != nullptr);
+  DRAKE_THROW_UNLESS(&integrator->get_system() == &this->get_system());
+  integrator->reset_context(&this->get_mutable_context());
+  IntegratorBase<T>* result = integrator.get();
+  integrator_ = std::move(integrator);
+  initialization_done_ = false;
+  return *result;
+}
+
+template <typename T>
 SimulatorStatus Simulator<T>::Initialize(const InitializeParams& params) {
   // TODO(sherm1) Modify Context to satisfy constraints.
   // TODO(sherm1) Invoke System's initial conditions computation.

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -707,7 +707,7 @@ class Simulator {
   ///       constructor is usually associated with fixed-step integrators (i.e.,
   ///       integrators which do not support error estimation).
   template <class Integrator>
-  Integrator& reset_integrator(const T max_step_size) {
+  Integrator& reset_integrator(const T& max_step_size) {
     static_assert(
         std::is_constructible_v<Integrator, const System<T>&, double,
                                 Context<T>*>,
@@ -719,6 +719,13 @@ class Simulator {
     initialization_done_ = false;
     return *static_cast<Integrator*>(integrator_.get());
   }
+
+  /// (Advanced) Resets the integrator to the given object.
+  /// @see argument-less version of reset_integrator() for note about
+  ///      initialization.
+  /// @pre integrator->get_system() is the same object as this->get_system().
+  IntegratorBase<T>& reset_integrator(
+      std::unique_ptr<IntegratorBase<T>> integrator);
 
   /// Gets the length of the interval used for witness function time isolation.
   /// The length of the interval is computed differently, depending on context,

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -984,10 +984,14 @@ GTEST_TEST(SimulatorTest, ResetIntegratorTest) {
   // Simulate for 1/2 second.
   simulator.AdvanceTo(0.5);
 
-  // Reset the integrator.
-  simulator.reset_integrator<RungeKutta2Integrator<double>>(h);
+  // Confirm that the step size `h` was obeyed.
+  EXPECT_EQ(simulator.get_num_steps_taken(), 500);
 
-  // Simulate to 1 second..
+  // Reset the integrator with the advanced spelling.
+  simulator.reset_integrator(
+      std::make_unique<RungeKutta2Integrator<double>>(spring_mass, h));
+
+  // Simulate to 1 second.
   simulator.AdvanceTo(1.0);
 
   EXPECT_NEAR(context.get_time(), 1.0, 1e-8);


### PR DESCRIPTION
Previously, only integrators with a public constructor with a very precise signature were allowed, and were constructed in-situ. Now, any (uniquely owned) integrator object can be passed in.

(This goes towards CENIC support.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23896)
<!-- Reviewable:end -->
