### PR TITLE
[CENIC] Reject unimplemented constraints at IcfBuilder

### DIFF
--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -76,6 +76,8 @@ template <typename T>
 IcfBuilder<T>::IcfBuilder(const MultibodyPlant<T>& plant,
                           const systems::Context<T>& context)
     : plant_(&plant), scratch_(plant) {
+  ValidatePlant();
+
   using std::isinf;
   const int nv = plant.num_velocities();
 
@@ -367,6 +369,21 @@ void IcfBuilder<T>::UpdateModel(
     // N.B. actuation constraint indices in the pool depend on whether external
     // or not external forces are present in the model.
     SetActuationGainConstraints(Ku, bu, external_feedback != nullptr, model);
+  }
+}
+
+template <typename T>
+void IcfBuilder<T>::ValidatePlant() {
+  // Revisit this condition as constraints are implemented. See issues #23759,
+  // #23760, #23762, #23763.
+  if (plant_->num_constraints() - plant_->num_coupler_constraints() > 0) {
+    throw std::runtime_error(fmt::format(
+        "The CENIC integrator does not yet support some constraints, but "
+        "they are present in the given MultibodyPlant: {} distance "
+        "constraint(s), {} ball constraint(s), {} weld constraint(s), {} "
+        "tendon constraint(s)",
+        plant_->num_distance_constraints(), plant_->num_ball_constraints(),
+        plant_->num_weld_constraints(), plant_->num_tendon_constraints()));
   }
 }
 

--- a/multibody/contact_solvers/icf/icf_builder.h
+++ b/multibody/contact_solvers/icf/icf_builder.h
@@ -75,6 +75,9 @@ class IcfBuilder {
     MultibodyForces<T> forces;
   };
 
+  /* Throws if the plant provided at construction is not compatible with ICF. */
+  void ValidatePlant();
+
   /* Computes geometry data and store it internally for later use. */
   void CalcGeometryContactData(const systems::Context<T>& context);
 


### PR DESCRIPTION
- MultibodyPlant: allow constraints on continuous plants
  - remove related obsolete tests

- IcfBuilder: validate plant at construction time
  - add tests for rejection of unimplemented constraints

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23898)
<!-- Reviewable:end -->
