### PR TITLE
[ad] Remove extra argument to unit vector constructor

### DIFF
--- a/common/ad/internal/partials.cc
+++ b/common/ad/internal/partials.cc
@@ -28,13 +28,13 @@ int IndexToInt(Eigen::Index index) {
 
 }  // namespace
 
-Partials::Partials(Eigen::Index size, Eigen::Index offset, double coeff)
+Partials::Partials(Eigen::Index size, Eigen::Index offset)
     : derivatives_{VectorXd::Zero(IndexToInt(size))} {
   if (IndexToInt(offset) >= size) {
     throw std::out_of_range(fmt::format(
         "AutoDiff offset {} must be strictly less than size {}", offset, size));
   }
-  derivatives_[offset] = coeff;
+  derivatives_[offset] = 1.0;
 }
 
 Partials::Partials(const Eigen::Ref<const VectorXd>& value)

--- a/common/ad/internal/partials.h
+++ b/common/ad/internal/partials.h
@@ -39,7 +39,7 @@ class Partials {
   /* Constructs a single partial derivative of `coeff` at the given `offset` in
   a vector of `size` otherwise-zero derivatives.
   @throws std::exception if offset >= size */
-  Partials(Eigen::Index size, Eigen::Index offset, double coeff = 1.0);
+  Partials(Eigen::Index size, Eigen::Index offset);
 
   /* Constructs a vector with a copy of the given value. */
   explicit Partials(const Eigen::Ref<const Eigen::VectorXd>& value);

--- a/common/ad/test/partials_test.cc
+++ b/common/ad/test/partials_test.cc
@@ -33,18 +33,6 @@ TEST_F(PartialsTest, UnitCtor2Arg) {
   EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(2)));
 }
 
-TEST_F(PartialsTest, UnitCtor3Arg) {
-  const Partials dut{4, 2, -1.0};
-  EXPECT_EQ(dut.size(), 4);
-  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), -Vector4d::Unit(2)));
-}
-
-TEST_F(PartialsTest, UnitCtorZeroCoeff) {
-  const Partials dut{4, 2, 0.0};
-  EXPECT_EQ(dut.size(), 4);
-  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Zero()));
-}
-
 TEST_F(PartialsTest, UnitCtorInsanelyLarge) {
   const Eigen::Index terabyte = Eigen::Index{1} << 40;
   DRAKE_EXPECT_THROWS_MESSAGE(Partials(terabyte, 0), ".*too large.*");


### PR DESCRIPTION
Noticed during #19628 that it's confusing and not actually used anywhere.

+assignee:@sherm1 for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23899)
<!-- Reviewable:end -->
