### PR TITLE
[CENIC] Consisent implementation and documentation of external gradients

### DIFF
--- a/multibody/contact_solvers/icf/icf_external_systems_linearizer.cc
+++ b/multibody/contact_solvers/icf/icf_external_systems_linearizer.cc
@@ -59,53 +59,71 @@ std::tuple<bool, bool> IcfExternalSystemsLinearizer<T>::LinearizeExternalSystem(
   // Get references to pre-allocated variables.
   VectorX<T>& gu0 = scratch_.gu0;
   VectorX<T>& ge0 = scratch_.ge0;
+  VectorX<T>& gu_tilde0 = scratch_.gu_tilde0;
+  VectorX<T>& ge_tilde0 = scratch_.ge_tilde0;
   VectorX<T>& x_prime = scratch_.x_prime;
   VectorX<T>& gu_prime = scratch_.gu_prime;
   VectorX<T>& ge_prime = scratch_.ge_prime;
-  MatrixX<T>& N = scratch_.N;
+  MatrixX<T>& N0 = scratch_.N0;
 
   // Compute some quantities that depend on the current state, before messing
   // with the state with finite differences.
-  N = plant_.MakeVelocityToQDotMap(plant_context);
+  N0 = plant_.MakeVelocityToQDotMap(plant_context);
   if (has_actuation_forces) {
+    // gu0ᵢ is really only needed if Kuᵢ < 0.
+    // TODO(amcastro-tri): Only compute if any Kuᵢ < 0.
     CalcActuationForces(plant_context, &gu0);
   }
   if (has_external_forces) {
+    // gueᵢ is really only needed if Keᵢ < 0.
+    // TODO(amcastro-tri): Only compute if any Keᵢ < 0.
     CalcExternalForces(plant_context, &ge0);
   }
 
-  // Initialize the perturbed state x = [q; v] and outputs
-  //    gu(x) = B u(x),
-  //    ge(x) = τₑₓₜ(x).
-  const VectorX<T> x =
-      plant_context.get_continuous_state_vector().CopyToVector();
-  x_prime = x;
-
-  // We'll want to perturb q and v separately, so we'll go ahead and grab these
-  // references.
+  // Initial state.
   const int nq = plant_.num_positions();
   const int nv = plant_.num_velocities();
-  auto q = x.head(nq);
-  auto v = x.segment(nq, nv);
+  const VectorX<T> x0 =
+      plant_context.get_continuous_state_vector().CopyToVector();
+  auto v0 = x0.segment(nq, nv);
+
+  // Semi-implicit state x̃(v) at v₀, x̃₀ = x̃(v₀) = [q₀ + h⋅N₀⋅v₀; v₀]
+  VectorX<T> x_tilde0 = x0;
+  auto q_tilde0 = x_tilde0.head(nq);
+  auto v_tilde0 = x_tilde0.segment(nq, nv);
+  q_tilde0 += h * N0 * v0;
+
+  // Store x̃₀ in plant_context.
+  mutable_plant_context.SetContinuousState(x_tilde0);
+  if (has_actuation_forces) {
+    CalcActuationForces(plant_context, &gu_tilde0);
+  }
+  if (has_external_forces) {
+    CalcExternalForces(plant_context, &ge_tilde0);
+  }
+
+  // Perturbed state.
+  x_prime = x_tilde0;
   auto q_prime = x_prime.head(nq);
   auto v_prime = x_prime.segment(nq, nv);
 
-  // Compute τ = D(v − v₀) + g₀ with forward differences.
+  // Compute τ(v) = b -  K⋅(v − v₀), using forward differences.
+  // We do this separately for τᵤ(x) and τₑ(x), as needed by ICF.
   const double eps = std::sqrt(std::numeric_limits<double>::epsilon());
   for (int i = 0; i < nv; ++i) {
     // Choose a step size (the same way as how implicit_integrator.cc does it).
-    const T abs_vi = abs(v(i));
+    const T abs_vi = abs(v_tilde0(i));
     T dvi = (abs_vi <= 1) ? T{eps} : eps * abs_vi;
 
     // Ensure that v' and v differ by an exactly representable number.
-    v_prime(i) = v(i) + dvi;
-    dvi = v_prime(i) - v(i);
+    v_prime(i) = v_tilde0(i) + dvi;
+    dvi = v_prime(i) - v_tilde0(i);
 
     // Perturb q as well, using the fact that q' = q + h N dv.
     // TODO(jwnimmer-tri) This seems wasteful; the (v_prime - v) is sparse (only
     // one element is non-zero) and typically N is also sparse. Consider using
     // plant.MapVelocityToQDot or similar.
-    q_prime = q + h * N * (v_prime - v);
+    q_prime = q_tilde0 + h * N0 * (v_prime - v_tilde0);
 
     // Put x' in the context and mark the state as stale.
     mutable_plant_context.SetContinuousState(x_prime);
@@ -114,34 +132,39 @@ std::tuple<bool, bool> IcfExternalSystemsLinearizer<T>::LinearizeExternalSystem(
       // Compute the relevant matrix entries for actuation inputs:
       //   Ku = -dgu/dv
       CalcActuationForces(mutable_plant_context, &gu_prime);
-      Ku(i) = -(gu_prime(i) - gu0(i)) / dvi;
+      Ku(i) = -(gu_prime(i) - gu_tilde0(i)) / dvi;
+
+      if (Ku(i) > 0.0) {
+        // Implicit approximation.
+        bu(i) = gu_tilde0(i) + Ku(i) * v0(i);
+      } else {
+        // Explicit approximation.
+        Ku(i) = 0.0;
+        bu(i) = gu0(i);
+      }
     }
 
     if (has_external_forces) {
       // Same thing, but for external forces:
       //  Ke = -dge/dv
       CalcExternalForces(mutable_plant_context, &ge_prime);
-      Ke(i) = -(ge_prime(i) - ge0(i)) / dvi;
+      Ke(i) = -(ge_prime(i) - ge_tilde0(i)) / dvi;
+      if (Ke(i) > 0.0) {
+        // Implicit approximation.
+        be(i) = ge_tilde0(i) + Ke(i) * v0(i);
+      } else {
+        // Explicit approximation.
+        Ke(i) = 0.0;
+        be(i) = ge0(i);
+      }
     }
 
     // Reset the state for the next iteration.
-    v_prime(i) = v(i);
+    v_prime(i) = v_tilde0(i);
   }
 
   // Reset the context back to how we found it. That means v is now back to v0.
-  mutable_plant_context.SetContinuousState(x);
-  const auto& v0 = v;
-
-  // Use the diagonal projection for both K and b ensures that any non-convex
-  // portion of the dynamics is treated explicitly.
-  if (has_actuation_forces) {
-    Ku = Ku.cwiseMax(0);
-    bu = gu0 + Ku.asDiagonal() * v0;
-  }
-  if (has_external_forces) {
-    Ke = Ke.cwiseMax(0);
-    be = ge0 + Ke.asDiagonal() * v0;
-  }
+  mutable_plant_context.SetContinuousState(x0);
 
   return {has_actuation_forces, has_external_forces};
 }
@@ -154,10 +177,12 @@ IcfExternalSystemsLinearizer<T>::Scratch::Scratch(
   f_ext = std::make_unique<MultibodyForces<T>>(plant);
   gu0.resize(nv);
   ge0.resize(nv);
+  gu_tilde0.resize(nv);
+  ge_tilde0.resize(nv);
   x_prime.resize(nq + nv);
   gu_prime.resize(nv);
   ge_prime.resize(nv);
-  N.resize(nq, nv);
+  N0.resize(nq, nv);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_external_systems_linearizer.h
+++ b/multibody/contact_solvers/icf/icf_external_systems_linearizer.h
@@ -13,20 +13,53 @@ namespace contact_solvers {
 namespace icf {
 namespace internal {
 
-/* Helper class that linearizes torques dτ/dv from plant input ports using
-finite differences. The linerization is approximate because it only keeps
+/* Helper class that linearizes external generalized forces with respect to
+generalized velocities. The linerization is approximate because it only keeps
 diagonal terms and forces them to be non-negative, so that the ICF problem
 remains convex.
 
-Torques from externally connected systems are given by
-    τ = B u(x) + τₑₓₜ(x),
-which we will approximate as
-    τ ≈ clamp(-Kᵤ v + bᵤ) - Kₑ v + bₑ,
-where Kᵤ, Kₑ are diagonal and positive semi-definite.
+To enforce effort limit constraints, ICF needs to differentiate generalized
+forces due to actuation. We therefore write the total generalized forces as
+  τ(x) = τᵤ(x) + τₑ(x),
+with the generalized forces due to actuation τᵤ(x)= B⋅u(x) and all other
+external sources in τₑ(x) (these could be body forces, drag, or any other
+externally applied generalized forces). For ICF, each contribution is linearized
+separately to write
+  τᵤ(v) ≈ clamp(-Kᵤ⋅v + bᵤ; e),
+  τₑ(v) ≈ - Kₑ⋅v + bₑ,
+where Kᵤ, Kₑ are positive diagonal matrices, v the multibody generalized
+velocities and e the vector of effort limits. For clarity, from now on we
+linearize a single term τ(x), with the understanding that we do this separately
+for both τᵤ(x) and τₑ(x).
 
-Note that contributions due to controls u(x) will be clamped to effort limits,
-while contributions due to external generalized and spatial forces τₑₓₜ(x) will
-not be.
+We can derive these approximations by considering the discrete momentum balance.
+Without loss of generality, we can ignore contact and other constraints to write
+  M⋅(v−v₀) = h⋅k₀ + h⋅τ(q, v),
+  q = q₀ +h⋅v.
+It is important to note that:
+ 1. We evaluate actuation and external forces τ(q, v) implicitly for stability
+ 2. The scheme is semi-implicit in q for better stability and energy
+    conservation properties (this updates in the configurations is symplectic).
+
+We define x̃(v) = [q₀ + h⋅v; v], and approximate the external generalized forces
+as
+  τ(v) = τ(x̃(v)) ≈  τ(x̃₀) + dτ/dv(x̃₀)⋅(v − v₀),
+with x̃₀ = [q₀ + h⋅v₀; v₀].
+
+Further, we make the component-wise approximation:
+  (Implicit) τᵢ ≈  τᵢ(x̃₀) - max(0, -dτᵢ/dvᵢ)⋅(v − v₀), when dτᵢ/dvᵢ < 0 and,
+  (Explicit) τᵢ ≈  τᵢ(x₀), when dτᵢ/dvᵢ ≥ 0.
+That is, this approximation is implicit for stabilizing force terms (such as
+controllers) and explicit otherwise. Within the CENIC framework, error-control
+is able to stabilize explicit terms in the scheme when needed.
+
+In total, we write the approximations above as
+  τ(v) = b -  K⋅v,
+where K is the positive diagonal matrix with entries
+  K = max(0, -diag(dτ/dv)),
+and bias term
+  bᵢ = τᵢ(x̃₀) + Kᵢ⋅v₀ᵢ, for dτᵢ/dvᵢ(x̃₀) < 0,
+  bᵢ = τᵢ(x₀)         , otherwise.
 
 @tparam_nonsymbolic_scalar */
 template <class T>
@@ -46,8 +79,8 @@ class IcfExternalSystemsLinearizer {
     TODO(jwnimmer-tri) Explain / clarify with paper citations.
   @param[in,out] mutable_plant_context The plant context to linearize around,
     used both as input (for the current state and inputs) and to mutate during
-    differencing while computing changes in torque due to changes in state, but
-    all mutations are undone prior to returning.
+    differencing while computing changes in generalized forces due to changes in
+    state. All mutations are undone prior to returning.
   @param[out] actuation_feedback The linearization of actuation torques, valid
     iff the `has_actuation_forces` return value is true.
   @param[out] actuation_feedback The linearization of external torques, valid
@@ -67,12 +100,14 @@ class IcfExternalSystemsLinearizer {
     ~Scratch();
 
     std::unique_ptr<MultibodyForces<T>> f_ext;
-    VectorX<T> gu0;       // Actuation gu(x) = B u(x) at x₀.
-    VectorX<T> ge0;       // External forces ge(x) = τ_ext(x) at x₀.
-    VectorX<T> x_prime;   // Perturbed plant state x' for finite differences.
-    VectorX<T> gu_prime;  // Perturbed actuation gu(x') = B u(x').
-    VectorX<T> ge_prime;  // Perturbed external forces ge(x') = τ_ext(x').
-    MatrixX<T> N;         // Kinematic map q̇ = N v.
+    VectorX<T> gu0;        // Actuation gu(x) = B u(x) at x₀.
+    VectorX<T> ge0;        // External forces ge(x) = τ_ext(x) at x₀.
+    VectorX<T> gu_tilde0;  // Actuation at gu(x̃₀) at x̃₀ = x̃(v₀).
+    VectorX<T> ge_tilde0;  // External forces ge(x̃₀) at x̃₀ = x̃(v₀).
+    VectorX<T> x_prime;    // Perturbed plant state x' for finite differences.
+    VectorX<T> gu_prime;   // Perturbed actuation gu(x') = B u(x').
+    VectorX<T> ge_prime;   // Perturbed external forces ge(x') = τ_ext(x').
+    MatrixX<T> N0;         // Kinematic map (q̇ = N v) at q₀.
   };
 
   /* Computes external forces τ = τₑₓₜ(x) from the plant's spatial and
@@ -82,7 +117,7 @@ class IcfExternalSystemsLinearizer {
                           VectorX<T>* tau) const;
 
   /* Computes actuator forces τ = B u(x) from the plant's actuation input ports
-  (including the general actuation input port and any model-instance-specific
+  (including the plant-wide actuation input port and any model-instance-specific
   input ports).
   @param[out] tau Output storage for τ. */
   void CalcActuationForces(const systems::Context<T>& plant_context,


### PR DESCRIPTION
Per Slack discussion, this PR fixes the math in the computation of external gradients.

I still need to fix the unit test. It does not pass because the prviously computed bias was wrong. We need to fix it so that it computes the right bias. Pushing now though so that we can discuss.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23900)
<!-- Reviewable:end -->
