### PR TITLE
Extends removal date on deprecated floating base API

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -5140,7 +5140,7 @@ R"""((Deprecated.)
 
 Deprecated:
     Use GetDefaultFloatingBaseBodyPose() instead. This will be removed
-    from Drake on or after 2026-01-01.)""";
+    from Drake on or after 2026-06-01.)""";
         } GetDefaultFreeBodyPose;
         // Symbol: drake::multibody::MultibodyPlant::GetDefaultPositions
         struct /* GetDefaultPositions */ {
@@ -5701,7 +5701,7 @@ R"""((Deprecated.)
 
 Deprecated:
     Use GetUniqueFloatingBaseBodyOrThrow() instead. This will be
-    removed from Drake on or after 2026-01-01.)""";
+    removed from Drake on or after 2026-06-01.)""";
         } GetUniqueFreeBaseBodyOrThrow;
         // Symbol: drake::multibody::MultibodyPlant::GetVelocities
         struct /* GetVelocities */ {
@@ -5972,7 +5972,7 @@ R"""((Deprecated.)
 
 Deprecated:
     Use HasUniqueFloatingBaseBody() instead. This will be removed from
-    Drake on or after 2026-01-01.)""";
+    Drake on or after 2026-06-01.)""";
         } HasUniqueFreeBaseBody;
         // Symbol: drake::multibody::MultibodyPlant::IsAnchored
         struct /* IsAnchored */ {
@@ -6610,7 +6610,7 @@ R"""((Deprecated.)
 
 Deprecated:
     Use SetDefaultFloatingBaseBodyPose() instead. This will be removed
-    from Drake on or after 2026-01-01.)""";
+    from Drake on or after 2026-06-01.)""";
         } SetDefaultFreeBodyPose;
         // Symbol: drake::multibody::MultibodyPlant::SetDefaultPositions
         struct /* SetDefaultPositions */ {
@@ -6784,7 +6784,7 @@ R"""((Deprecated.)
 
 Deprecated:
     Use SetFloatingBaseBodyPoseInAnchoredFrame() instead. This will be
-    removed from Drake on or after 2026-01-01.)""";
+    removed from Drake on or after 2026-06-01.)""";
         } SetFreeBodyPoseInAnchoredFrame;
         // Symbol: drake::multibody::MultibodyPlant::SetFreeBodyPoseInWorldFrame
         struct /* SetFreeBodyPoseInWorldFrame */ {
@@ -6794,7 +6794,7 @@ R"""((Deprecated.)
 
 Deprecated:
     Use SetFloatingBaseBodyPoseInWorldFrame() instead. This will be
-    removed from Drake on or after 2026-01-01.)""";
+    removed from Drake on or after 2026-06-01.)""";
         } SetFreeBodyPoseInWorldFrame;
         // Symbol: drake::multibody::MultibodyPlant::SetFreeBodyRandomAnglesDistribution
         struct /* SetFreeBodyRandomAnglesDistribution */ {

--- a/bindings/generated_docstrings/multibody_tree.h
+++ b/bindings/generated_docstrings/multibody_tree.h
@@ -7617,7 +7617,7 @@ R"""((Deprecated.)
 
 Deprecated:
     Use is_floating_base_body() instead. This will be removed from
-    Drake on or after 2026-01-01.)""";
+    Drake on or after 2026-06-01.)""";
         } is_floating;
         // Symbol: drake::multibody::RigidBody::is_floating_base_body
         struct /* is_floating_base_body */ {

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -606,11 +606,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     const char* X_PB_parameter_name_deprecated =
         "X_PB parameter name for SetFreeBodyPose() is deprecated and will be "
-        "removed 2026-01-01. Use X_JpJc instead.";
+        "removed 2026-06-01. Use X_JpJc instead.";
     const char* V_PB_parameter_name_deprecated =
         "The parameter order and V_PB parameter name for "
         "SetFreeBodySpatialVelocity() are deprecated and will be removed "
-        "2026-01-01. Use context, body, V_JpJc instead.";
+        "2026-06-01. Use context, body, V_JpJc instead.";
     cls  // BR
         .def("SetDefaultFreeBodyPose",
             WrapDeprecated(cls_doc.SetDefaultFreeBodyPose.doc_deprecated,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3670,7 +3670,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
                                                                     angles);
   }
 
-  DRAKE_DEPRECATED("2026-01-01",
+  DRAKE_DEPRECATED("2026-06-01",
                    "Use SetFloatingBaseBodyPoseInWorldFrame() instead.")
   void SetFreeBodyPoseInWorldFrame(systems::Context<T>* context,
                                    const RigidBody<T>& body,
@@ -3678,7 +3678,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     SetFloatingBaseBodyPoseInWorldFrame(context, body, X_WB);
   }
 
-  DRAKE_DEPRECATED("2026-01-01",
+  DRAKE_DEPRECATED("2026-06-01",
                    "Use SetFloatingBaseBodyPoseInAnchoredFrame() instead.")
   void SetFreeBodyPoseInAnchoredFrame(
       systems::Context<T>* context, const Frame<T>& frame_F,
@@ -3686,28 +3686,28 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     SetFloatingBaseBodyPoseInAnchoredFrame(context, frame_F, body, X_FB);
   }
 
-  DRAKE_DEPRECATED("2026-01-01",
+  DRAKE_DEPRECATED("2026-06-01",
                    "Use GetUniqueFloatingBaseBodyOrThrow() instead.")
   const RigidBody<T>& GetUniqueFreeBaseBodyOrThrow(
       ModelInstanceIndex model_instance) const {
     return GetUniqueFloatingBaseBodyOrThrow(model_instance);
   }
 
-  DRAKE_DEPRECATED("2026-01-01",
+  DRAKE_DEPRECATED("2026-06-01",
                    "Use SetDefaultFloatingBaseBodyPose() instead.")
   void SetDefaultFreeBodyPose(const RigidBody<T>& body,
                               const math::RigidTransform<double>& X_PB) {
     SetDefaultFloatingBaseBodyPose(body, X_PB);
   }
 
-  DRAKE_DEPRECATED("2026-01-01",
+  DRAKE_DEPRECATED("2026-06-01",
                    "Use GetDefaultFloatingBaseBodyPose() instead.")
   math::RigidTransform<double> GetDefaultFreeBodyPose(
       const RigidBody<T>& body) const {
     return GetDefaultFloatingBaseBodyPose(body);
   }
 
-  DRAKE_DEPRECATED("2026-01-01", "Use HasUniqueFloatingBaseBody() instead.")
+  DRAKE_DEPRECATED("2026-06-01", "Use HasUniqueFloatingBaseBody() instead.")
   bool HasUniqueFreeBaseBody(ModelInstanceIndex model_instance) const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     return internal_tree().HasUniqueFloatingBaseBodyImpl(model_instance);

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -310,7 +310,7 @@ class RigidBody : public MultibodyElement<T> {
     return is_floating_base_body_;
   }
 
-  DRAKE_DEPRECATED("2026-01-01", "Use is_floating_base_body() instead.")
+  DRAKE_DEPRECATED("2026-06-01", "Use is_floating_base_body() instead.")
   bool is_floating() const { return is_floating_base_body(); }
 
   /// (Advanced) If `true`, this body's generalized position coordinates q


### PR DESCRIPTION
Per discussion in #23897 these popular APIs should have a longer deprecation period. This PR extends the drop dead date from 2026-01-01 to 2026-06-01 making the total deprecation period 8 months rather than 3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23901)
<!-- Reviewable:end -->
