### PR TITLE
[ad] Store partials in custom vector

### DIFF
--- a/common/ad/auto_diff.h
+++ b/common/ad/auto_diff.h
@@ -67,16 +67,11 @@ class AutoDiff {
   Instead of mutating the derivatives after construction, it's generally
   preferable to set them directly in the constructor if possible.
 
-  Do not presume any specific C++ type for the the return value. It will act
-  like a mutable Eigen column-vector expression (e.g., Eigen::Block<VectorXd>)
-  that also allows for assignment and resizing, but we reserve the right to
-  change the return type for efficiency down the road.
-
   @note This function name is kept for compatibility with Eigen::AutoDiffScalar
   but it does NOT run in constant-time even though its name is lowercase.
   Calling this function often needs to finalize the derivatives prior to
   returning the reference, so is O(N) in the size of the derivatives. */
-  Eigen::VectorXd& derivatives() { return partials_.GetRawStorageMutable(); }
+  DerivativesMutableXpr derivatives() { return partials_.MakeMutableXpr(); }
 
   /// @name Internal use only
   //@{

--- a/common/ad/internal/derivatives_xpr.cc
+++ b/common/ad/internal/derivatives_xpr.cc
@@ -1,5 +1,6 @@
 #include "drake/common/ad/internal/derivatives_xpr.h"
 
+#include "drake/common/ad/internal/partials.h"
 #include "drake/common/drake_assert.h"
 
 namespace drake {
@@ -13,6 +14,49 @@ DerivativesConstXpr::DerivativesConstXpr(double coeff, const double* data,
           coeff * Eigen::Map<const Eigen::VectorXd, /* Options = */ 0, Stride>(
                       data, size, Stride(0, stride))) {
   DRAKE_DEMAND(size == 0 || data != nullptr);
+}
+
+DerivativesMutableXpr::DerivativesMutableXpr(internal::Partials* backreference,
+                                             double* data, int size)
+    : Eigen::Map<Eigen::VectorXd>(data, size), backreference_{backreference} {
+  DRAKE_DEMAND(size == 0 || data != nullptr);
+  DRAKE_DEMAND(backreference_ != nullptr);
+}
+
+DerivativesMutableXpr DerivativesMutableXpr::resize(Eigen::Index rows,
+                                                    Eigen::Index cols) {
+  DRAKE_THROW_UNLESS(rows >= 0);
+  DRAKE_THROW_UNLESS(cols == 1);
+  return SetFrom(Eigen::VectorXd::Zero(rows));
+}
+
+DerivativesMutableXpr DerivativesMutableXpr::conservativeResize(
+    Eigen::Index rows, Eigen::Index cols) {
+  DRAKE_THROW_UNLESS(rows >= 0);
+  DRAKE_THROW_UNLESS(cols == 1);
+
+  if (rows != size()) {
+    const int old_size = size();
+    Eigen::VectorXd new_value(rows);
+    for (int i = 0; i < old_size; ++i) {
+      if (i >= rows) {
+        break;
+      }
+      new_value[i] = coeff(i);
+    }
+    for (int i = old_size; i < rows; ++i) {
+      new_value[i] = 0.0;
+    }
+    SetFrom(new_value);
+  }
+
+  return *this;
+}
+
+DerivativesMutableXpr DerivativesMutableXpr::SetFrom(
+    const Eigen::Ref<const Eigen::VectorXd>& other) {
+  DRAKE_DEMAND(backreference_ != nullptr);
+  return backreference_->SetFrom(other);
 }
 
 }  // namespace ad

--- a/common/ad/internal/derivatives_xpr.h
+++ b/common/ad/internal/derivatives_xpr.h
@@ -57,5 +57,63 @@ class DerivativesConstXpr final : public internal::DerivativesConstXprBase {
                                int stride);
 };
 
+/** The return type for AutoDiff::derivatives() when the AutoDiff is mutable.
+
+The underlying type is `Eigen::Map<Eigen::VectorXd>` which includes all of the
+usual functions for element access and arithmetic.
+
+@note Unlike a typical Map, this class also provides the capability to resize()
+the underlying data as well as assign through from a vector of different size.
+
+@warning After resizing or assigning to this object, `this` is no longer valid.
+Always use those functions' return value as the ongoing means of access. */
+class DerivativesMutableXpr final : public Eigen::Map<Eigen::VectorXd> {
+ public:
+  /** This class is copyable and copy-assignable. */
+  DerivativesMutableXpr(const DerivativesMutableXpr&) = default;
+  DerivativesMutableXpr operator=(const DerivativesMutableXpr& other) {
+    return SetFrom(other);
+  }
+
+  /** Sets the AutoDiff::derivatives() to a new value and returns a new Xpr.
+  @warning After calling this object, `this` is no longer valid. Always use the
+  return value as the ongoing means of access, or call AutoDiff::derivatives()
+  again to obtain a new reference. */
+  template <typename Derived>
+  DerivativesMutableXpr operator=(const DenseBase<Derived>& other) {
+    return SetFrom(other);
+  }
+
+  /** Like MatrixBase::resize(), discards any existing data and resizes the
+  derivatives vector.
+  @note The signature and defaults match MatrixBase::resize().
+  @warning After calling this object, `this` is no longer valid. Always use the
+  return value as the ongoing means of access.
+  @pre rows >= 0
+  @throws std::exception when cols != 1 */
+  DerivativesMutableXpr resize(Eigen::Index rows, Eigen::Index cols = 1);
+
+  /** Like MatrixBase::conservativeResize(), changes the size() of this while
+  keeping existing data intact. New values are filled with zeros.
+  @note The signature and defaults match MatrixBase::conservativeResize().
+  @warning After calling this object, `this` is no longer valid. Always use the
+  return value as the ongoing means of access.
+  @pre rows >= 0
+  @throws std::exception when cols != 1 */
+  DerivativesMutableXpr conservativeResize(Eigen::Index rows,
+                                           Eigen::Index cols = 1);
+
+ private:
+  // We can only be constructed by class Partials.
+  friend internal::Partials;
+  explicit DerivativesMutableXpr(internal::Partials* backreference,
+                                 double* data, int size);
+
+  // Implementation of operator=.
+  DerivativesMutableXpr SetFrom(const Eigen::Ref<const Eigen::VectorXd>& other);
+
+  internal::Partials* backreference_{};
+};
+
 }  // namespace ad
 }  // namespace drake

--- a/common/ad/internal/partials.cc
+++ b/common/ad/internal/partials.cc
@@ -1,5 +1,6 @@
 #include "drake/common/ad/internal/partials.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <stdexcept>
@@ -28,20 +29,62 @@ int IndexToInt(Eigen::Index index) {
 
 }  // namespace
 
+StorageVec StorageVec::Allocate(int size) {
+  DRAKE_ASSERT(0 <= size && size <= INT32_MAX);
+  StorageVec result;
+  if (size > 0) {
+    result.size_ = size;
+    result.data_ = new double[size];
+  }
+  return result;
+}
+
+StorageVec::StorageVec(const StorageVec& other) noexcept {
+  DRAKE_ASSERT(0 <= other.size_ && other.size_ <= INT32_MAX);
+  StorageVec result;
+  if (other.size_ > 0) {
+    size_ = other.size_;
+    data_ = new double[size_];
+    std::copy(other.data_, other.data_ + size_, data_);
+  }
+}
+
+StorageVec& StorageVec::operator=(const StorageVec& other) noexcept {
+  DRAKE_ASSERT(0 <= other.size_ && other.size_ <= INT32_MAX);
+  if (this != &other) {
+    if (size_ == other.size_) {
+      std::copy(other.data_, other.data_ + other.size_, data_);
+    } else {
+      delete data_;
+      size_ = other.size_;
+      if (size_ > 0) {
+        data_ = new double[size_];
+        std::copy(other.data_, other.data_ + other.size_, data_);
+      } else {
+        data_ = nullptr;
+      }
+    }
+  }
+  return *this;
+}
+
+StorageVec::~StorageVec() {
+  delete data_;
+}
+
 Partials::Partials(Eigen::Index size, Eigen::Index offset)
-    : coeff_{1.0}, storage_{VectorXd::Zero(IndexToInt(size))} {
+    : coeff_{1.0}, storage_{StorageVec::Allocate(IndexToInt(size))} {
   if (IndexToInt(offset) >= size) {
     throw std::out_of_range(fmt::format(
         "AutoDiff offset {} must be strictly less than size {}", offset, size));
   }
-  storage_[offset] = 1.0;
+  mutable_storage_view().setZero();
+  mutable_storage_view()[offset] = 1.0;
 }
 
 Partials::Partials(const Eigen::Ref<const VectorXd>& value)
-    : coeff_{1.0}, storage_{value} {
-  // Called for its side-effect of throwing on too-large sizes. (Unfortunately,
-  // it's unrealistic to unit test this because it requires a >16 GiB value.)
-  IndexToInt(value.size());
+    : coeff_{1.0}, storage_{StorageVec::Allocate(IndexToInt(value.size()))} {
+  mutable_storage_view() = value;
 }
 
 void Partials::MatchSizeOf(const Partials& other) {
@@ -50,7 +93,8 @@ void Partials::MatchSizeOf(const Partials& other) {
     return;
   }
   if (size() == 0) {
-    storage_ = VectorXd::Zero(other.size());
+    storage_ = StorageVec::Allocate(other.size());
+    mutable_storage_view().setZero();
     coeff_ = 1.0;
     return;
   }
@@ -58,7 +102,7 @@ void Partials::MatchSizeOf(const Partials& other) {
 }
 
 void Partials::SetZero() {
-  storage_.setZero();
+  mutable_storage_view().setZero();
   // The `coeff_` here could be set to nearly any number (especially 0.0), but
   // we'll stick with 1.0 as the "canonical" spelling of "unscaled storage".
   // That might open the door to future optimizations (e.g., skipping extra
@@ -76,9 +120,9 @@ void Partials::Mul(double factor) {
     // value is zero or NaN, then we'll leave it alone.
     const double total_factor = coeff_ * factor;  // This will be non-finite.
     for (int i = 0; i < size(); ++i) {
-      const double x = storage_[i];
+      const double x = storage_.data()[i];
       if ((x < 0) || (x > 0)) {
-        storage_[i] = x * total_factor;
+        storage_.mutable_data()[i] = x * total_factor;
       }
     }
     coeff_ = 1.0;
@@ -94,9 +138,9 @@ void Partials::Div(double factor) {
     // value is zero or NaN, then we'll leave it alone.
     const double total_factor = coeff_ / factor;
     for (int i = 0; i < size(); ++i) {
-      const double x = storage_[i];
+      const double x = storage_.data()[i];
       if ((x < 0) || (x > 0)) {
-        storage_[i] = x * total_factor;
+        storage_.mutable_data()[i] = x * total_factor;
       }
     }
     coeff_ = 1.0;
@@ -129,20 +173,20 @@ void Partials::AddScaled(double scale, const Partials& other) {
   if (std::isfinite(scale)) [[likely]] {
     // N.B. Using a single Eigen expression for the following line is crucial
     // for performance. It compiles this better than a hand-written for-loop.
-    storage_.noalias() =
-        coeff_ * storage_ + (scale * other.coeff_) * other.storage_;
+    mutable_storage_view().noalias() =
+        coeff_ * storage_view() + (scale * other.coeff_) * other.storage_view();
     coeff_ = 1.0;
     return;
   }
 
   // Unlikely: non-finite scale; zero partials in `other` must not be scaled.
   for (int i = 0; i < size(); ++i) {
-    const double this_datum = coeff_ * storage_[i];
-    const double other_datum = other.coeff_ * other.storage_[i];
+    const double this_datum = coeff_ * storage_.data()[i];
+    const double other_datum = other.coeff_ * other.storage_.data()[i];
     if ((other_datum < 0) || (other_datum > 0)) {
-      storage_[i] = this_datum + other_datum * scale;
+      storage_.mutable_data()[i] = this_datum + other_datum * scale;
     } else {
-      storage_[i] = this_datum;
+      storage_.mutable_data()[i] = this_datum;
     }
   }
   coeff_ = 1.0;
@@ -152,12 +196,13 @@ DerivativesConstXpr Partials::make_const_xpr() const {
   return DerivativesConstXpr{coeff_, storage_.data(), size(), /* stride = */ 1};
 }
 
-VectorXd& Partials::GetRawStorageMutable() {
+DerivativesMutableXpr Partials::MakeMutableXpr() {
   if (coeff_ != 1.0) {
-    storage_ *= coeff_;
+    mutable_storage_view() *= coeff_;
     coeff_ = 1.0;
   }
-  return storage_;
+
+  return DerivativesMutableXpr{this, storage_.mutable_data(), size()};
 }
 
 void Partials::ThrowIfDifferentSize(const Partials& other) {
@@ -171,6 +216,16 @@ void Partials::ThrowIfDifferentSize(const Partials& other) {
         size(), other.size()));
   }
 }
+
+DerivativesMutableXpr Partials::SetFrom(
+    const Eigen::Ref<const VectorXd>& other) {
+  *this = Partials(other);
+  return MakeMutableXpr();
+}
+
+// We want sizeof(AutoDiff) to be <= 32 bytes. Setting aside the 8 bytes for
+// the value, that leaves 24 bytes available for the Partials.
+static_assert(sizeof(Partials) <= 24);
 
 }  // namespace internal
 }  // namespace ad

--- a/common/ad/internal/partials.h
+++ b/common/ad/internal/partials.h
@@ -8,6 +8,60 @@ namespace drake {
 namespace ad {
 namespace internal {
 
+/* Heap storage for an array of doubles, for use by the Partials class later in
+this file. The storage can be empty (null).
+
+Note that this class is not directly unit tested; instead, it's test coverage
+comes from partial_test indirectly. */
+class StorageVec {
+ public:
+  /* Allocates new storage of the given size, but does not initialize it.
+  If the size is zero, the storage will be empty (null). */
+  static StorageVec Allocate(int size);
+
+  /* Creates empty (null) storage. */
+  StorageVec() = default;
+
+  /* Steals the storage from `other`. */
+  StorageVec(StorageVec&& other) noexcept {
+    size_ = other.size_;
+    data_ = other.data_;
+    other.size_ = 0;
+    other.data_ = nullptr;
+  }
+
+  /* Steals the storage from `other`. */
+  StorageVec& operator=(StorageVec&& other) noexcept {
+    if (this != &other) {
+      delete data_;
+      size_ = other.size_;
+      data_ = other.data_;
+      other.size_ = 0;
+      other.data_ = nullptr;
+    }
+    return *this;
+  }
+
+  /* Copies the storage from `other`. */
+  StorageVec(const StorageVec& other) noexcept;
+
+  /* Copies the storage from `other`. */
+  StorageVec& operator=(const StorageVec& other) noexcept;
+
+  ~StorageVec();
+
+  /* Returns the size. */
+  int size() const { return size_; }
+
+  /* Returns the double array storage (or null, when empty). */
+  const double* data() const { return data_; }
+  double* mutable_data() { return data_; }
+
+ private:
+  int size_{0};
+  double* data_{nullptr};
+};
+
 /* A vector of partial derivatives, optimized for use with Drake's AutoDiff.
 
 Partials are dynamically sized, and can have size() == 0.
@@ -82,12 +136,30 @@ class Partials {
   /* Returns an Eigen-compatible view into this vector. */
   ad::DerivativesConstXpr make_const_xpr() const;
 
-  /* Returns the underlying storage vector (mutable). This may involve O(size)
-  multiplications. */
-  Eigen::VectorXd& GetRawStorageMutable();
+  /* Returns an Eigen-compatible mutable view into this vector, including
+  resizing. This runs in linear time O(size). */
+  ad::DerivativesMutableXpr MakeMutableXpr();
 
  private:
   void ThrowIfDifferentSize(const Partials& other);
+
+  /* Returns a const Eigen view of the current storage (i.e., without scaling
+  by the `coeff_`). */
+  Eigen::Map<const Eigen::VectorXd> storage_view() const {
+    return Eigen::Map<const Eigen::VectorXd>(storage_.data(), storage_.size());
+  }
+
+  /* Returns a mutable Eigen view of the current storage (i.e., without scaling
+  by the `coeff_`). */
+  Eigen::Map<Eigen::VectorXd> mutable_storage_view() {
+    return Eigen::Map<Eigen::VectorXd>(storage_.mutable_data(),
+                                       storage_.size());
+  }
+
+  // Our MutableXpr type is allowed to set us via a backreference.
+  friend ad::DerivativesMutableXpr;
+  ad::DerivativesMutableXpr SetFrom(
+      const Eigen::Ref<const Eigen::VectorXd>& other);
 
   // Our effective value is `coeff_ * storage_`; we store them separately so
   // that re-scaling is fast (we can just scale the coeff).
@@ -100,7 +172,7 @@ class Partials {
   // contract of "any zero values will remain zero, even if the factor is ±∞ or
   // NaN" per our class overview.
   double coeff_{0.0};
-  Eigen::VectorXd storage_;
+  StorageVec storage_;
 };
 
 }  // namespace internal

--- a/common/ad/test/partials_heap_test.cc
+++ b/common/ad/test/partials_heap_test.cc
@@ -14,31 +14,39 @@ using test::LimitMalloc;
 // An empty fixture for later expansion.
 class PartialsHeapTest : public ::testing::Test {};
 
-// Neither the constructor nor GetRawStorageMutable allocate when size() == 0.
-TEST_F(PartialsHeapTest, GetRawStorageMutableEmpty) {
+// Neither the constructor nor MakeMutableXpr allocate when size() == 0.
+TEST_F(PartialsHeapTest, MakeMutableXprEmpty) {
   LimitMalloc guard;
   Partials empty;
-  empty.GetRawStorageMutable();
-  empty.GetRawStorageMutable();
+  empty.MakeMutableXpr();
+  empty.MakeMutableXpr();
 }
 
-// Between the full-degree `value` constructor and GetRawStorageMutable, at
+// Between the full-degree `value` constructor and MakeMutableXpr, at
 // most one allocation (for the returned storage) is allowed.
-TEST_F(PartialsHeapTest, GetRawStorageMutableGeneric) {
+TEST_F(PartialsHeapTest, MakeMutableXprGeneric) {
   const Eigen::Vector3d value{1.0, 2.0, 3.0};
   LimitMalloc guard({1});
   Partials full(value);
-  full.GetRawStorageMutable();
-  full.GetRawStorageMutable();
+  full.MakeMutableXpr();
+  full.MakeMutableXpr();
 }
 
-// Between the unit-vector constructor and GetRawStorageMutable, at
+// Between the unit-vector constructor and MakeMutableXpr, at
 // most one allocation (for the returned storage) is allowed.
-TEST_F(PartialsHeapTest, GetRawStorageMutableUnit) {
+TEST_F(PartialsHeapTest, MakeMutableXprUnit) {
   LimitMalloc guard({1});
   Partials unit(10, 0);
-  unit.GetRawStorageMutable();
-  unit.GetRawStorageMutable();
+  unit.MakeMutableXpr();
+  unit.MakeMutableXpr();
+}
+
+// Copy-assignment of equal sizes doesn't allocate.
+TEST_F(PartialsHeapTest, CopyAssign) {
+  Partials foo(Eigen::Vector3d{1.0, 2.0, 3.0});
+  const Partials bar(Eigen::Vector3d{4.0, 5.0, 6.0});
+  LimitMalloc guard;
+  foo = bar;
 }
 
 }  // namespace

--- a/common/ad/test/partials_test.cc
+++ b/common/ad/test/partials_test.cc
@@ -1,5 +1,6 @@
 #include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -280,7 +281,7 @@ TEST_F(PartialsTest, AddScaledEquivalenceToEigen) {
       Twins result(*this);
       if (prescale) {
         // Force the partials into canonical form.
-        result.partials.GetRawStorageMutable();
+        result.partials.MakeMutableXpr();
       }
       result.partials.AddScaled(scale, other.partials);
       result.twin.noalias() += scale * other.twin;
@@ -391,40 +392,91 @@ TEST_F(PartialsTest, AddScaledDifferentSizes) {
                               ".*different sizes.*");
 }
 
+TEST_F(PartialsTest, Resizing) {
+  Partials dut;
+  EXPECT_EQ(dut.make_const_xpr().size(), 0);
+
+  // Assign a larger vector.
+  dut.MakeMutableXpr() = Vector4d::Unit(1);
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(1)));
+
+  // Resize smaller, preserving the existing data.
+  dut.MakeMutableXpr().conservativeResize(2);
+  EXPECT_EQ(dut.size(), 2);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d::Unit(1)));
+
+  // Resize larger, preserving the existing data.
+  dut.MakeMutableXpr().conservativeResize(4);
+  EXPECT_EQ(dut.size(), 4);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(1)));
+
+  // Resize smaller, not preserving any existing data.
+  dut.MakeMutableXpr().resize(1);
+  EXPECT_EQ(dut.size(), 1);
+}
+
+// We need to indirect self-move-assign through this function; doing it
+// directly in the test code generates a compiler warning.
+void MoveAssign(Partials* target, Partials* donor) {
+  *target = std::move(*donor);
+}
+
+TEST_F(PartialsTest, MutableAssignmentSelf) {
+  Partials dut{2, 1};
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d::Unit(1)));
+
+  MoveAssign(&dut, &dut);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d::Unit(1)));
+}
+
+TEST_F(PartialsTest, MutableAssignmentEmpty) {
+  Partials dut{2, 1};
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d::Unit(1)));
+
+  Partials empty;
+  dut = empty;
+  EXPECT_EQ(dut.make_const_xpr().size(), 0);
+
+  dut = Partials{2, 1};
+  dut = std::move(empty);
+  EXPECT_EQ(dut.make_const_xpr().size(), 0);
+}
+
+TEST_F(PartialsTest, MutableAssignmentEqualSize) {
+  Partials dut{2, 1};
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d::Unit(1)));
+
+  Partials other{2, 0};
+  dut = other;
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d::Unit(0)));
+}
+
 TEST_F(PartialsTest, MutableAssignmentFromDefaultCtor) {
   Partials dut;
-  EXPECT_EQ(dut.GetRawStorageMutable().size(), 0);
+  EXPECT_EQ(dut.make_const_xpr().size(), 0);
 
-  dut.GetRawStorageMutable() = Vector4d::Unit(3);
+  dut.MakeMutableXpr() = Vector4d::Unit(1);
   EXPECT_EQ(dut.size(), 4);
-  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(3)));
-
-  dut.GetRawStorageMutable().resize(1);
-  EXPECT_EQ(dut.size(), 1);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(1)));
 }
 
 TEST_F(PartialsTest, MutableAssignmentFromUnitCtor) {
   Partials dut{2, 1};
-  EXPECT_TRUE(CompareMatrices(dut.GetRawStorageMutable(), Vector2d::Unit(1)));
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d::Unit(1)));
 
-  dut.GetRawStorageMutable() = Vector4d::Unit(3);
+  dut.MakeMutableXpr() = Vector4d::Unit(1);
   EXPECT_EQ(dut.size(), 4);
-  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(3)));
-
-  dut.GetRawStorageMutable().resize(1);
-  EXPECT_EQ(dut.size(), 1);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(1)));
 }
 
 TEST_F(PartialsTest, MutableAssignmentFromFullCtor) {
   Partials dut{Vector2d{1.0, 2.0}};
-  EXPECT_TRUE(CompareMatrices(dut.GetRawStorageMutable(), Vector2d{1.0, 2.0}));
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector2d{1.0, 2.0}));
 
-  dut.GetRawStorageMutable() = Vector4d::Unit(3);
+  dut.MakeMutableXpr() = Vector4d::Unit(1);
   EXPECT_EQ(dut.size(), 4);
-  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(3)));
-
-  dut.GetRawStorageMutable().resize(1);
-  EXPECT_EQ(dut.size(), 1);
+  EXPECT_TRUE(CompareMatrices(dut.make_const_xpr(), Vector4d::Unit(1)));
 }
 
 }  // namespace

--- a/common/yaml/test/yaml_performance_test.cc
+++ b/common/yaml/test/yaml_performance_test.cc
@@ -30,7 +30,9 @@ namespace ad {
 template <typename Archive>
 void Serialize(Archive* a, drake::ad::AutoDiff* x) {
   a->Visit(drake::MakeNameValue("value", &(x->value())));
-  a->Visit(drake::MakeNameValue("derivatives", &(x->derivatives())));
+  Eigen::VectorXd derivatives = x->derivatives();
+  a->Visit(drake::MakeNameValue("derivatives", &derivatives));
+  x->derivatives() = derivatives;
 }
 }  // namespace ad
 }  // namespace drake


### PR DESCRIPTION
Towards #17492 and #23820.

This is a non-functional refactoring to prepare for future changes that optimize storage layout, e.g., sparsity, COW, batching, etc. None of those optimizations are possible with `VectorXd` storage.
    
In particular, note that the storage size is now represented by an `int` instead of an `Eigen::Index`. This gives us 4 more unused bytes in the struct that we'll be able to repurpose for new fields in the future (e.g., sparsity).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23902)
<!-- Reviewable:end -->
