### PR TITLE
[icf] Add convex solver

### DIFF
--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -18,6 +18,8 @@ drake_cc_package_library(
         ":icf_data",
         ":icf_model",
         ":icf_search_direction_data",
+        ":icf_solver",
+        ":icf_solver_parameters",
         ":limit_constraints_data_pool",
         ":patch_constraints_data_pool",
     ],
@@ -101,6 +103,28 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "icf_solver_parameters",
+    hdrs = ["icf_solver_parameters.h"],
+    deps = ["//common:name_value"],
+)
+
+drake_cc_library(
+    name = "icf_solver",
+    srcs = ["icf_solver.cc"],
+    hdrs = ["icf_solver.h"],
+    deps = [
+        ":icf_data",
+        ":icf_model",
+        ":icf_search_direction_data",
+        ":icf_solver_parameters",
+        "//common:essential",
+        "//common:name_value",
+        "//multibody/contact_solvers:block_sparse_cholesky_solver",
+        "//multibody/contact_solvers:newton_with_bisection",
+    ],
+)
+
+drake_cc_library(
     name = "icf_model",
     srcs = [
         "coupler_constraints_pool.cc",
@@ -153,6 +177,16 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:limit_malloc",
         "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "icf_solver_test",
+    deps = [
+        ":icf_data",
+        ":icf_model",
+        ":icf_solver",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/contact_solvers/icf/README.md
+++ b/multibody/contact_solvers/icf/README.md
@@ -50,7 +50,7 @@ where $N(q_n)$ is the kinematic map such that $\dot{q} = N(q)v$.
 
 In addition to contact, ICF can support other constraint types (e.g., joint
 limits, couplers, etc.) via appropriately designed convex potentials. For full
-details, see [Castro et al., 2023] and [Kurtz et al., 2025].
+details, see [Castro et al., 2023] and [Kurtz and Castro, 2025].
 
 ## About this Implementation
 
@@ -71,7 +71,7 @@ Key components and how they talk to each other:
      decision variables $v$.
    - `IcfData`: Holds all variable data that changes during the optimization
      process, e.g., $v$ and derived quantities.
-   - TODO(#23769): `IcfSolver`: Solves the convex problem itself, e.g., does
+   - `IcfSolver`: Solves the convex problem itself, e.g., does
      Newton iterations.
    - TODO(#23769): `IcfBuilder`: Constructs the optimization problem. The
      builder is the only component that knows about `MultibodyPlant`.
@@ -79,10 +79,10 @@ Key components and how they talk to each other:
 Other components:
 
    - Constraint pools (`CouplerConstraintsPool`, `GainConstraintsPool`,
-     `LimitConstraintsPool`, TODO(#23769): `PatchConstraintsPool`) are part of
+     `LimitConstraintsPool`, `PatchConstraintsPool`) are part of
      `IcfModel`, and hold constraints of various types.
    - Similarly, constraint data pools (`CouplerConstraintsDataPool`,
-     `GainConstraintsDataPool`, `LimitConstraintsDataPool`, TODO(#23769):
+     `GainConstraintsDataPool`, `LimitConstraintsDataPool`,
      `PatchConstraintsDataPool`) are part of `IcfData`, and hold data that
      change with $v$ for the corresponding constraints.
    - The underlying `EigenPool` datatype is used to store constraint quantities
@@ -92,8 +92,17 @@ Other components:
 ## References:
 
 [Castro et al., 2023] Castro A., Han X., and Masterjohn J., 2023. Irrotational
-Contact Fields. https://arxiv.org/abs/2312.03908
+Contact Fields. https://arxiv.org/abs/2312.03908.
 
-[Kurtz et al., 2025] Kurtz V. and Castro A., 2025. CENIC: Convex
+[Hairer and Wanner, 1996] Hairer E. and Wanner G., 1996. Solving Ordinary
+Differential Equations II: Stiff and Differential-Algebraic Problems. Springer
+Series in Computational Mathematics, Vol. 14. Springer-Verlag, Berlin, 2nd
+edition.
+
+[Kurtz and Castro, 2025] Kurtz V. and Castro A., 2025. CENIC: Convex
 Error-controlled Numerical Integration for Contact.
-https://arxiv.org/abs/2511.08771
+https://arxiv.org/abs/2511.08771.
+
+[Masterjohn et al., 2022] Masterjohn, J., Guoy, D., Shepherd, J. and Castro,
+A., 2022. Velocity level approximation of pressure field contact patches. IEEE
+Robotics and Automation Letters, 7(4), pp.11593-11600.

--- a/multibody/contact_solvers/icf/icf_solver.cc
+++ b/multibody/contact_solvers/icf/icf_solver.cc
@@ -1,0 +1,375 @@
+#include "drake/multibody/contact_solvers/icf/icf_solver.h"
+
+#include <algorithm>
+#include <limits>
+
+#include "drake/common/text_logging.h"
+#include "drake/multibody/contact_solvers/newton_with_bisection.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+using contact_solvers::internal::BlockSparseCholeskySolver;
+using contact_solvers::internal::BlockSparsityPattern;
+using contact_solvers::internal::Bracket;
+using contact_solvers::internal::DoNewtonWithBisectionFallback;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+void IcfSolverStats::Clear() {
+  num_iterations = 0;
+  num_factorizations = 0;
+  cost.clear();
+  gradient_norm.clear();
+  ls_iterations.clear();
+  alpha.clear();
+  step_norm.clear();
+}
+
+void IcfSolverStats::Reserve(int max_iterations) {
+  cost.reserve(max_iterations);
+  gradient_norm.reserve(max_iterations);
+  ls_iterations.reserve(max_iterations);
+  alpha.reserve(max_iterations);
+  step_norm.reserve(max_iterations);
+}
+
+IcfSolver::~IcfSolver() = default;
+
+bool IcfSolver::SolveWithGuess(const IcfModel<double>& model,
+                               const double tolerance, IcfData<double>* data) {
+  using std::clamp;
+  DRAKE_ASSERT(data != nullptr);
+  DRAKE_ASSERT(tolerance > 0);
+  DRAKE_ASSERT(model.num_velocities() > 0);
+  DRAKE_ASSERT(model.num_velocities() == data->num_velocities());
+
+  // Retrieve scratch space for decision variables vₖ and search direction wₖ.
+  VectorXd& v = decision_variables_;
+  VectorXd& dv = search_direction_;  // Also stores Δvₖ = αₖ⋅wₖ.
+  v.resize(model.num_velocities());
+  dv.resize(model.num_velocities());
+
+  // Set the initial guess as stored in data.
+  v = data->v();
+
+  // Convergence tolerances are scaled by D = diag(M)⁻⁰ᐧ⁵, so that all
+  // entries of g̃ = D⋅g and ṽ = D⁻¹⋅v have the same units [Castro et al., 2021].
+  //
+  // Convergence is achieved when either the (normalized) gradient is small
+  //   ‖D⋅gₖ‖ ≤ ε max(1, ‖D⋅r‖),
+  // or the (normalized) step size is sufficiently small,
+  //   η ‖D⁻¹⋅Δvₖ‖ ≤ ε max(1, ‖D⋅r‖).
+  // where η = θ / (1 − θ), θ = ‖D⁻¹⋅Δvₖ‖ / ‖D⁻¹⋅Δvₖ₋₁‖, as per [Hairer and
+  // Wanner, 1996].
+  const VectorXd& D = model.scale_factor();
+  const double scale = std::max(1.0, (D.asDiagonal() * model.r()).norm());
+  const double epsilon = std::max(tolerance, parameters_.min_tolerance);
+  const double scaled_tolerance = epsilon * scale;
+
+  double alpha{NAN};     // Linesearch parameter α.
+  int ls_iterations{0};  // Count of linesearch iterations taken.
+  double eta = 1.0;      // Convergence scaling factor η.
+  stats_.Clear();
+
+  if (parameters_.print_solver_stats) {
+    drake::log()->info("IcfSolver starting convex solve:");
+  }
+  for (int k = 0; k < parameters_.max_iterations; ++k) {
+    // Compute the cost and gradient.
+    model.CalcData(v, data);
+    const double grad_norm = (D.asDiagonal() * data->gradient()).norm();
+
+    // Gradient-based convergence check. Allows for early exit if v is already
+    // close enough to the solution.
+    if (grad_norm < scaled_tolerance) {
+      if (parameters_.print_solver_stats && k == 0) {
+        // This ensures that we get a printout even when the initial guess is
+        // good enough that no iterations are performed.
+        drake::log()->info("  k: {}, cost: {:.6f}, gradient: {:e}", k,
+                           data->cost(), grad_norm);
+      }
+      return true;
+    }
+
+    // Step-size-based convergence check. This is only valid after the first
+    // iteration has been completed, since we need the step size ‖D⁻¹⋅Δvₖ‖
+    if (k > 0) {
+      // For k = 1, we have η = 1, so this is equivalent to ‖D⁻¹⋅Δvₖ‖ < tol.
+      // Otherwise we use η = θ/(1−θ) as set below (see [Hairer and Wanner,
+      // 1996], p.120).
+      if (eta * stats_.step_norm.back() < scaled_tolerance) {
+        return true;
+      }
+    }
+
+    // Choose whether to re-compute the Hessian factorization using Equation
+    // IV.8.11 of [Hairer and Wanner, 1996]. This essentially predicts whether
+    // we'll converge in the next few iterations, assuming linear convergence.
+    if (k > 1) {
+      const double dvk = stats_.step_norm[k - 1];    // ‖D⁻¹⋅Δvₖ‖
+      const double dvkm1 = stats_.step_norm[k - 2];  // ‖D⁻¹⋅Δvₖ₋₁‖
+
+      // Convergence rate estimate θ = ‖D⁻¹⋅Δvₖ‖ / ‖D⁻¹⋅Δvₖ₋₁‖. Note that unlike
+      // in the Newton-Raphson steps discussed in [Hairer and Wanner, 1996], it
+      // is possible that θ ≥ 1 without divergence, thanks to linesearch.
+      // Therefore we clamp θ to be slightly less than 1.0 to avoid division by
+      // zero when computing η = θ/(1−θ).
+      const double theta = clamp(dvk / dvkm1, 0.0, 0.9999);
+      eta = theta / (1.0 - theta);
+
+      // Predict the residual after a total of k_max iterations, assuming
+      // linear convergence at the current rate θ.
+      const int k_max = parameters_.hessian_reuse_target_iterations;
+      const double anticipated_residual =
+          std::pow(theta, k_max - k) / (1 - theta) * dvk;
+
+      if (anticipated_residual > scaled_tolerance) {
+        // We likely won't converge in time at this (linear) rate, so we should
+        // recompute the Hessian in hopes of faster (quadratic) convergence.
+        hessian_factorization_is_fresh_enough_ = false;
+      }
+    }
+
+    // For iterations other than the first, we know the sparsity pattern is
+    // unchanged, so we can reuse it without checking. The sparsity pattern is
+    // often but not always the same between solves, so we need to perform the
+    // full check when k = 0.
+    bool reuse_sparsity_pattern = (k > 0) || !SparsityPatternChanged(model);
+
+    // We reuse the previous hessian when all of the following hold:
+    //   1. Reuse is enabled in the solver parameters.
+    //   2. The sparsity pattern is unchanged from the last time the Hessian was
+    //      computed.
+    //   3. The "anticipated residual" heuristics indicate that we'll converge
+    //      in time under a linear convergence assumption.
+    bool reuse_hessian = parameters_.enable_hessian_reuse &&
+                         reuse_sparsity_pattern &&
+                         hessian_factorization_is_fresh_enough_;
+
+    // Compute the search direction wₖ = -Hₖ⁻¹⋅gₖ.
+    ComputeSearchDirection(model, *data, &dv, reuse_hessian,
+                           reuse_sparsity_pattern);
+
+    // If the sparsity pattern changed, store it for future checks.
+    if (!reuse_sparsity_pattern) {
+      previous_sparsity_pattern_ =
+          std::make_unique<BlockSparsityPattern>(model.sparsity_pattern());
+    }
+
+    // Compute the optimal step size αₖ = min_α ℓ(vₖ + α⋅wₖ).
+    std::tie(alpha, ls_iterations) = PerformExactLineSearch(model, *data, dv);
+
+    // Update the decision variables (velocities), vₖ₊₁ = vₖ + αₖ⋅wₖ.
+    dv *= alpha;  // Store Δvₖ = αₖ⋅wₖ for recording the step size later.
+    v += dv;
+
+    // Finalize solver stats now that we've finished the iteration.
+    stats_.num_iterations++;
+    stats_.cost.push_back(data->cost());
+    stats_.gradient_norm.push_back(grad_norm);
+    stats_.ls_iterations.push_back(ls_iterations);
+    stats_.alpha.push_back(alpha);
+    const double step_norm = (D.cwiseInverse().asDiagonal() * dv).norm();
+    stats_.step_norm.push_back(step_norm);
+
+    if (parameters_.print_solver_stats) {
+      drake::log()->info(
+          "  k: {}, cost: {:.6f}, gradient: {:e}, step: {:e}, ls_iterations: "
+          "{}, alpha: {:.6f}",
+          k, data->cost(), grad_norm, step_norm, ls_iterations, alpha);
+    }
+  }
+
+  return false;  // Failed to converge.
+}
+
+void IcfSolver::SetParameters(const IcfSolverParameters& parameters) {
+  parameters_ = parameters;
+  stats_.Reserve(parameters_.max_iterations);
+}
+
+std::pair<double, int> IcfSolver::PerformExactLineSearch(
+    const IcfModel<double>& model, const IcfData<double>& data,
+    const VectorXd& w) {
+  const double alpha_max = parameters_.alpha_max;
+
+  // Set up prerequisites for efficiently computing ℓ̃(α) and its derivatives.
+  IcfSearchDirectionData<double>& search_data = search_direction_data_;
+  model.CalcSearchDirectionData(data, w, &search_data);
+
+  // First we'll evaluate ∂ℓ̃/∂α at α = 0. This should be strictly negative,
+  // since the Hessian is positive definite. This is cheap since we already have
+  // the gradient at α = 0 cached from solving for the search direction earlier.
+  const double ell0 = data.cost();              // Cost ℓ̃(0).
+  const double dell0 = data.gradient().dot(w);  // Derivative ∂ℓ̃/∂α at α = 0.
+  // The derivative along the linesearch direction, ∂ℓ̃/∂α, should be negative at
+  // at α = 0 since the Hessian is positive definite.
+  DRAKE_THROW_UNLESS(dell0 < 0, dell0);
+
+  // First and second derivatives of ℓ̃(α).
+  double dell{NAN};   // First derivative ∂ℓ̃/∂α.
+  double d2ell{NAN};  // Second derivative ∂²ℓ̃/∂α².
+
+  // Next we'll evaluate ℓ̃, ∂ℓ̃/∂α, and ∂²ℓ̃/∂α² at α = α_max. If the cost is
+  // still decreasing here, we just accept α_max to take the largest step
+  // possible.
+  const double ell =
+      model.CalcCostAlongLine(alpha_max, data, search_data, &dell, &d2ell);
+  if (dell <= std::numeric_limits<double>::epsilon()) {
+    return std::make_pair(alpha_max, 0);
+  }
+
+  // TODO(vincekurtz): consider adding a check to enable full Newton steps when
+  // tolerances are very close to machine epsilon, as in SapSolver. We'll need
+  // to be mindful of the fact that the cost can be negative in the pooled ICF
+  // formulation.
+
+  // Set the initial guess for linesearch based on a cubic hermite spline
+  // between α = 0 and α = α_max. This spline takes the form
+  // p(t) = a t³ + b t² + c t + d, where
+  //   p(0) = ℓ(0),
+  //   p(1) = ℓ(α_max),
+  //   p'(0) = α_max⋅ℓ'(0),
+  //   p'(1) = α_max⋅ℓ'(α_max).
+  // We can then find the analytical minimum in [0, α_max] by setting p'(t) = 0
+  // and use that to establish an initial guess for linesearch.
+  const double a = 2 * (ell0 - ell) + dell0 * alpha_max + dell * alpha_max;
+  const double b = -3 * (ell0 - ell) - 2 * dell0 * alpha_max - dell * alpha_max;
+  const double c = dell0 * alpha_max;
+  // This will throw if a solution to p'(t) = 0 cannot be found in (0, 1). We
+  // know that such a solution must exist because p(t) is a cubic with p'(0) < 0
+  // and p'(1) > 0.
+  const double alpha_guess =
+      alpha_max * SolveQuadraticInUnitInterval(3 * a, 2 * b, c);
+
+  // We've exhausted all of the early exit conditions, so now we move on to the
+  // Newton method with bisection fallback. To do so, we define an anonymous
+  // function that computes the value and gradient of f(α) = −ℓ̃'(α)/ℓ̃'₀, where
+  // ℓ̃'(α) = ∂ℓ̃/∂α and ℓ̃'₀ = ℓ̃'(0). Normalizing in this way reduces
+  // round-off errors, ensuring f(0) = -1.
+  const double dell_scale = -dell0;
+  auto cost_and_gradient = [&model, &data, &search_data,
+                            &dell_scale](double x) {
+    double dell_dalpha;
+    double d2ell_dalpha2;
+    model.CalcCostAlongLine(x, data, search_data, &dell_dalpha, &d2ell_dalpha2);
+    return std::make_pair(dell_dalpha / dell_scale, d2ell_dalpha2 / dell_scale);
+  };
+
+  // The initial bracket is [0, α_max], since we already know that ℓ̃'(0) < 0 and
+  // ℓ̃'(α_max) > 0. Values at the endpoints of the bracket are f(0) = -1 (by
+  // definition) and f(α_max) = dell / dell_scale, because we just set dell =
+  // ℓ̃'(α_max) above.
+  const Bracket bracket(0.0, -1.0, alpha_max, dell / dell_scale);
+
+  // Finally, solve for f(α) = 0 using Newton with bisection fallback.
+  return DoNewtonWithBisectionFallback(
+      cost_and_gradient, bracket, alpha_guess, parameters_.linesearch_tolerance,
+      parameters_.linesearch_tolerance, parameters_.max_linesearch_iterations);
+}
+
+double IcfSolver::SolveQuadraticInUnitInterval(const double a, const double b,
+                                               const double c) {
+  using std::abs;
+  using std::clamp;
+  using std::sqrt;
+
+  // Sign function that returns 1 for positive numbers, -1 for
+  // negative numbers, and 0 for zero.
+  auto sign = [](const double x) {
+    return (x > 0) - (x < 0);
+  };
+
+  double s;
+  if (abs(a) < std::numeric_limits<double>::epsilon()) {
+    // If a ≈ 0, just solve b x + c = 0. b must be non-zero, otherwise this
+    // quadratic would be constant and our precondition of "exactly one root in
+    // (0, 1)" would be violated.
+    s = -c / b;
+  } else {
+    // Use the numerically stable root-finding method described here:
+    // https://math.stackexchange.com/questions/866331/.
+    const double discriminant = b * b - 4 * a * c;
+    DRAKE_DEMAND(discriminant >= 0);  // Must have a real root.
+    s = -b - sign(b) * sqrt(discriminant);
+    s /= 2 * a;
+    // If the first root is outside [0, 1], try the second root.
+    if (s < 0.0 || s > 1.0) {
+      s = c / (a * s);
+    }
+  }
+
+  // The solution must be in [0, 1], modulo some numerical slop.
+  constexpr double slop = 1e-8;
+  DRAKE_THROW_UNLESS(s >= -slop && s <= 1.0 + slop, s);
+
+  return clamp(s, 0.0, 1.0);  // Ensure s ∈ [0, 1].
+}
+
+void IcfSolver::ComputeSearchDirection(const IcfModel<double>& model,
+                                       const IcfData<double>& data, VectorXd* w,
+                                       bool reuse_factorization,
+                                       bool reuse_sparsity_pattern) {
+  DRAKE_ASSERT(w != nullptr);
+
+  if (parameters_.use_dense_algebra) {
+    if (!reuse_factorization) {
+      // Compute and factorize the dense Hessian.
+      // N.B. Dense algebra is just for testing and debugging, so we don't mind
+      // this expensive heap allocation.
+      const MatrixXd H = model.MakeHessian(data)->MakeDenseMatrix();
+      dense_hessian_factorization_ = H.ldlt();
+      stats_.num_factorizations++;
+
+      // The factorization is now fresh, so we should try to reuse it next time.
+      hessian_factorization_is_fresh_enough_ = true;
+    }
+
+    // Compute the search direction w = -H⁻¹⋅g with dense algebra.
+    *w = dense_hessian_factorization_.solve(-data.gradient());
+
+  } else {  // Use sparse algebra.
+    if (!reuse_factorization) {
+      if (reuse_sparsity_pattern) {
+        // Compute the sparse Hessian, reusing the existing sparsity pattern.
+        model.UpdateHessian(data, hessian_.get());
+        hessian_factorization_.UpdateMatrix(*hessian_);
+      } else {
+        // Compute the sparse Hessian from scratch.
+        hessian_ = model.MakeHessian(data);
+        hessian_factorization_.SetMatrix(*hessian_);
+      }
+
+      // Perform a sparse Cholesky factorization of the Hessian.
+      DRAKE_THROW_UNLESS(hessian_factorization_.Factor());
+      stats_.num_factorizations++;
+
+      // The factorization is now fresh, so we should try to reuse it next time.
+      hessian_factorization_is_fresh_enough_ = true;
+    }
+
+    // Compute the search direction w = -H⁻¹⋅g with sparse algebra.
+    *w = -data.gradient();
+    hessian_factorization_.SolveInPlace(w);
+  }
+}
+
+bool IcfSolver::SparsityPatternChanged(const IcfModel<double>& model) const {
+  if (previous_sparsity_pattern_ == nullptr) {
+    return true;  // No previous sparsity pattern to compare against.
+  }
+  return (model.sparsity_pattern().neighbors() !=
+          previous_sparsity_pattern_->neighbors()) ||
+         (model.sparsity_pattern().block_sizes() !=
+          previous_sparsity_pattern_->block_sizes());
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/icf/icf_solver.h
+++ b/multibody/contact_solvers/icf/icf_solver.h
@@ -1,0 +1,219 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/multibody/contact_solvers/block_sparse_cholesky_solver.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+#include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
+#include "drake/multibody/contact_solvers/icf/icf_solver_parameters.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+/* Statistics to track during the optimization process.
+
+For quantities that are recorded at each iteration, we count k = 0 as the first
+iteration so vectors have size() == num_iterations. If the solver exits
+early (e.g., the initial guess solves the problem to tolerances), then we have
+`num_iterations = 0` and vector elements are empty. */
+struct IcfSolverStats {
+  /* Resets the stats to start a new solve. */
+  void Clear();
+
+  /* Reserves space for the vectors to avoid reallocations. */
+  void Reserve(int max_iterations);
+
+  /* The number of solver iterations. */
+  int num_iterations{0};
+
+  /* The total number of Hessian factorizations. */
+  int num_factorizations{0};
+
+  /* The cost ℓ(vₖ) at each iteration. */
+  std::vector<double> cost;
+
+  /* The gradient norm ||∇ℓ(vₖ)|| at each iteration. */
+  std::vector<double> gradient_norm;
+
+  /* The number of linesearch iterations performed at each solver iteration. */
+  std::vector<int> ls_iterations;
+
+  /* The linesearch parameter α at each iteration. */
+  std::vector<double> alpha;
+
+  /* The step size ||Δvₖ|| at each iteration. */
+  std::vector<double> step_norm;
+};
+
+/* A solver for convex Irrotational Contact Fields (ICF) problems,
+
+    min_v ℓ(v; q₀, v₀, h)
+
+where (q₀, v₀) is the initial state, h is the time step, and ℓ(v) is the
+convex cost.
+
+This solver uses a Newton method with exact linesearch to find the
+optimal next-step velocities v. That is, at each iteration k, we compute the
+search direction wₖ by solving the linear system
+
+    Hₖ⋅wₖ = -gₖ
+
+where Hₖ = ∇²ℓ(vₖ) is the Hessian at vₖ and gₖ = ∇ℓ(vₖ) is the gradient. We then
+perform an exact linesearch to find the optimal step size αₖ that minimizes
+
+    min_α ℓ̃(α) = ℓ(vₖ + α⋅wₖ),  α ∈ [0, α_max]
+
+and update the decision variables
+
+    vₖ₊₁ = vₖ + Δvₖ,
+    Δvₖ = αₖ⋅wₖ.
+
+This process repeats until convergence. Convergence is achieved when either the
+(normalized) gradient is sufficiently small,
+
+    ‖D⋅gₖ‖ ≤ ε max(1, ‖D⋅r‖),
+
+or the (normalized) step size is sufficiently small,
+
+    η ‖D⁻¹⋅Δvₖ‖ ≤ ε max(1, ‖D⋅r‖),
+
+with convergence tolerance ε, η = θ / (1 − θ), and θ = ‖D⁻¹⋅Δvₖ‖ / ‖D⁻¹⋅Δvₖ₋₁‖
+as per [Hairer and Wanner, 1996]. Norms are scaled by D = diag(M)⁻⁰ᐧ⁵, so that
+all entries of g̃ = D⋅g and ṽ = D⁻¹⋅v share the same units [Castro et al., 2023].
+
+Additionally, this solver supports optional Hessian reuse to avoid the cost of
+recomputing and refactoring the Hessian at each iteration. Since ℓ(v) is convex,
+any positive definite approximation of Hₖ can be used to compute the search
+direction, and the problem will still be guaranteed to converge (albeit more
+slowly). Hessian reuse takes advantage of this fact by reusing Hₖ from a
+previous iteration (or even a previous solve) when convergence is sufficiently
+fast. The solver monitors convergence and automatically recomputes the Hessian
+only when necessary to regain fast (Newton-like) convergence.
+
+The ICF formulation was first described in [Castro et al., 2023]. This
+implementation follows the details described in [Kurtz and Castro, 2025]. The
+Hessian reuse strategy is described in Section VI.C of [Kurtz and Castro, 2025]
+and is an adaptation of techniques from [Hairer and Wanner, 1996], chapter IV.8.
+
+See IcfSolverParameters and icf/README.md for further details. */
+class IcfSolver {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IcfSolver);
+
+  /* Instantiates a solver with default parameters. */
+  IcfSolver() { stats_.Reserve(parameters_.max_iterations); }
+
+  ~IcfSolver();
+
+  /* Solves the convex problem to compute next-step velocities, argmin ℓ(v).
+
+  @param model The ICF model defining the optimization problem.
+  @param tolerance The convergence tolerance ε to be used for this solve. See
+                   the class documentation for convergence criteria details.
+  @param[in, out] data The ICF data structure to be updated with the solution.
+                       To begin, stores the initial guess for velocities v.
+
+  @return true if and only if the optimizer converged to tolerance ε.
+  @pre The model and data must compatible, e.g., via model.ResizeData(&data).
+  @pre The model must be non-empty, e.g., model.num_velocities() > 0. */
+  bool SolveWithGuess(const IcfModel<double>& model, const double tolerance,
+                      IcfData<double>* data);
+
+  /* Returns solver statistics from the most recent solve. */
+  const IcfSolverStats& stats() const { return stats_; }
+
+  /* Sets solver parameters, reallocating space for statistics as needed. */
+  void SetParameters(const IcfSolverParameters& parameters);
+
+  /* Returns the current set of solver parameters. */
+  const IcfSolverParameters& get_parameters() const { return parameters_; }
+
+ private:
+  /* Solves min_α ℓ̃(α) = ℓ(v + α⋅w) using a 1D Newton method with bisection
+  fallback. The initial guess is generated using cubic spline interpolation.
+
+  @param model The ICF model, used to evaluate ℓ̃(α) and its derivatives.
+  @param data The ICF data at the current iterate v.
+  @param w The search direction.
+
+  @returns A pair containing the optimal linesearch parameter α and the number
+  of linesearch iterations taken. */
+  std::pair<double, int> PerformExactLineSearch(const IcfModel<double>& model,
+                                                const IcfData<double>& data,
+                                                const Eigen::VectorXd& w);
+
+  /* Returns the root of the quadratic equation ax² + bx + c = 0, x ∈ (0, 1).
+  @pre The equation in question must have one exactly real root in (0, 1),
+       otherwise this function will abort. */
+  static double SolveQuadraticInUnitInterval(const double a, const double b,
+                                             const double c);
+
+  /* Solves for the Newton search direction w = −H⁻¹⋅g, with flags for several
+  levels of Hessian reuse.
+
+  @param model The ICF model, used to compute the Hessian H.
+  @param data The ICF data at the current iterate v.
+  @param[out] w The computed search direction.
+  @param reuse_factorization If true, reuse the exact same factorization of H as
+                             in the previous iteration. Do not compute the new
+                             Hessian at all. This is the fastest option, but
+                             gives a lower-quality search direction.
+
+  @param reuse_sparsity_pattern If true, recompute H and its factorization, but
+                                reuse the stored sparsity pattern. This gives an
+                                exact Newton step, but avoids some allocations.
+
+  @note If both `reuse_sparsity_pattern` and `reuse_factorization1 are `false`,
+  computes H from scratch and factors it anew. The `reuse_factorization` flag
+  takes precedence over `reuse_sparsity_pattern`. */
+  void ComputeSearchDirection(const IcfModel<double>& model,
+                              const IcfData<double>& data, Eigen::VectorXd* w,
+                              bool reuse_factorization = false,
+                              bool reuse_sparsity_pattern = false);
+
+  /* Indicates whether the model's sparsity pattern has changed since the last
+  time the Hessian was computed. */
+  bool SparsityPatternChanged(const IcfModel<double>& model) const;
+
+  // Stored Hessian and factorization objects. Allows for Hessian reuse between
+  // iterations and between subsequent solves.
+  std::unique_ptr<
+      contact_solvers::internal::BlockSparseSymmetricMatrix<Eigen::MatrixXd>>
+      hessian_;
+  contact_solvers::internal::BlockSparseCholeskySolver<Eigen::MatrixXd>
+      hessian_factorization_;
+  Eigen::LDLT<Eigen::MatrixXd> dense_hessian_factorization_;
+
+  // Data used during linesearch.
+  IcfSearchDirectionData<double> search_direction_data_;
+
+  // Track the sparsity pattern for triggering Hessian reuse.
+  std::unique_ptr<contact_solvers::internal::BlockSparsityPattern>
+      previous_sparsity_pattern_;
+
+  // Flag for Hessian factorization re-use (changes between iterations).
+  bool hessian_factorization_is_fresh_enough_{false};
+
+  // Iteration limits, tolerances, and other parameters.
+  IcfSolverParameters parameters_;
+
+  // Statistics for logging and tracking convergence.
+  IcfSolverStats stats_;
+
+  // Pre-allocated decision variables v and search direction w.
+  Eigen::VectorXd decision_variables_;
+  Eigen::VectorXd search_direction_;
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/icf/icf_solver_parameters.h
+++ b/multibody/contact_solvers/icf/icf_solver_parameters.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "drake/common/name_value.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+
+/** (Advanced) Parameters to configure the Irrotational Contact Fields (ICF)
+convex solver.
+
+For details, see
+
+  [Kurtz and Castro, 2025] Kurtz V. and Castro A., 2025. CENIC: Convex
+  Error-controlled Numerical Integration for Contact.
+  https://arxiv.org/abs/2511.08771.
+
+  [Hairer and Wanner, 1996] Hairer E. and Wanner G., 1996. Solving Ordinary
+  Differential Equations II: Stiff and Differential-Algebraic Problems. Springer
+  Series in Computational Mathematics, Vol. 14. Springer-Verlag, Berlin, 2nd
+  edition. */
+struct IcfSolverParameters {
+  /** Passes this object to an Archive.
+  Refer to @ref yaml_serialization "YAML Serialization" for background. */
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(max_iterations));
+    a->Visit(DRAKE_NVP(min_tolerance));
+    a->Visit(DRAKE_NVP(enable_hessian_reuse));
+    a->Visit(DRAKE_NVP(hessian_reuse_target_iterations));
+    a->Visit(DRAKE_NVP(use_dense_algebra));
+    a->Visit(DRAKE_NVP(max_linesearch_iterations));
+    a->Visit(DRAKE_NVP(linesearch_tolerance));
+    a->Visit(DRAKE_NVP(alpha_max));
+    a->Visit(DRAKE_NVP(print_solver_stats));
+  }
+
+  /** Maximum number of Newton iterations. */
+  int max_iterations{100};
+
+  /** Minimum tolerance ε for the convergence conditions
+
+    ‖D⋅∇ℓ‖ ≤ ε max(1, ‖D⋅r‖),
+    η ‖D⁻¹⋅Δv‖ ≤ ε max(1, ‖D⋅r‖),
+
+  as detailed in Section VI.B of [Kurtz and Castro, 2025].
+
+  This provides a lower bound on the actual tolerance used, which is specified
+  explicitly when calling the solver. For instance, CENIC passes an adaptive
+  tolerance based on the desired accuracy to the ICF solver, see Section VI.B of
+  [Kurtz and Castro, 2025]. */
+  double min_tolerance{1e-8};
+
+  /** Whether hessian reuse between iterations and time steps is enabled. */
+  bool enable_hessian_reuse{false};
+
+  /** Target maximum number of iterations for Hessian reuse. The solver
+  effectively estimates the number of iterations to convergence. If the estimate
+  is larger than this target, the Hessian will be recomputed to regain faster
+  Newton-style convergence. See [Hairer and Wanner, 1996], Ch. IV.8. */
+  int hessian_reuse_target_iterations{10};
+
+  /** Dense algebra (LDLT) for solving for the search direction H⁻¹⋅g. This is
+  primarily useful for debugging and testing: sparse algebra is generally much
+  faster. */
+  bool use_dense_algebra{false};
+
+  /** Maximum iterations for exact linesearch. */
+  int max_linesearch_iterations{100};
+
+  /** Convergence tolerance for exact linesearch. */
+  double linesearch_tolerance{1e-8};
+
+  /** Maximum step length for exact linesearch. */
+  double alpha_max{1.0};
+
+  /** Whether to print stats to the console at each iteration. */
+  bool print_solver_stats{false};
+};
+
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/icf/patch_constraints_pool.h
+++ b/multibody/contact_solvers/icf/patch_constraints_pool.h
@@ -134,11 +134,7 @@ class PatchConstraintsPool {
   @note As required by SetPatch(), body B is always dynamic (not anchored).
         Therefore we provide the position of the contact point relative to B
         and, if needed, the position relative to A is inferred from p_AB_W
-        provided to SetPatch().
-
-  [Masterjohn et al., 2022] Masterjohn, J., Guoy, D., Shepherd, J. and Castro,
-  A., 2022. Velocity level approximation of pressure field contact patches. IEEE
-  Robotics and Automation Letters, 7(4), pp.11593-11600. */
+        provided to SetPatch(). */
   void SetPair(const int patch_index, const int pair_index,
                const Vector3<T>& p_BoC_W, const Vector3<T>& normal_W,
                const T& fn0, const T& stiffness);
@@ -219,7 +215,7 @@ class PatchConstraintsPool {
   // εₛ = max(vₛ, μ⋅σ⋅wₜ⋅n₀), where vₛ is the stiction tolerance, μ is the
   // friction coefficient, wₜ is the Delassus operator approximation, and n₀ is
   // the normal impulse from the previous time step. See the ICF paper [Castro
-  // et al., 2025] for further details.
+  // et al., 2023] for further details.
   double sigma_{1.0e-3};
 
   // Data per patch. Indexed by patch index p < num_patches().

--- a/multibody/contact_solvers/icf/test/icf_solver_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_solver_test.cc
@@ -1,0 +1,277 @@
+#include "drake/multibody/contact_solvers/icf/icf_solver.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+namespace {
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+constexpr double kConvergenceTolerance = 1e-8;
+
+class IcfSolverTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Create a simple model with two cliques.
+    const int nv = 12;
+
+    std::unique_ptr<IcfParameters<double>> params = model_.ReleaseParameters();
+    params->time_step = 0.01;
+    params->v0 = VectorXd::LinSpaced(nv, -1.0, 1.0);
+    params->M0 = MatrixXd::Identity(nv, nv);
+    params->M0.block<6, 6>(0, 0) = 0.9 * Matrix6<double>::Identity();
+    params->M0.block<6, 6>(6, 6) = 1.7 * Matrix6<double>::Identity();
+    params->D0 = VectorXd::Constant(nv, 0.1);
+    params->k0 = VectorXd::LinSpaced(nv, -1.0, 1.0);
+    params->clique_sizes = {6, 6};
+    params->clique_start = {0, 6, nv};
+    params->body_is_floating = {0, 0};
+    params->body_mass = {0.2, 1.8};
+    params->J_WB.Resize(2, 6, 6);
+    params->J_WB[0] = VectorXd::LinSpaced(36, -1.0, 1.0).reshaped(6, 6);
+    params->J_WB[1] = 3.4 * Matrix6<double>::Identity();
+    params->body_to_clique = {0, 1};
+    model_.ResetParameters(std::move(params));
+
+    // Add a basic contact (patch) constraint with one pair and one patch.
+    const double dissipation = 12.1;
+    const double stiffness = 1.0e8;
+    const double friction = 0.7;
+    const Vector3<double> p_AB_W(-0.1, 0.3, -0.2);
+    const Vector3<double> nhat_AB_W(0.0, 0.0, -1.0);
+    const Vector3<double> p_BC_W = -0.5 * p_AB_W;
+    const double fn0 = 10.5;
+
+    PatchConstraintsPool<double>& patches = model_.patch_constraints_pool();
+    const std::vector<int> num_pairs_per_patch = {1};
+    patches.Resize(num_pairs_per_patch);
+    patches.SetPatch(0 /* patch index */, 0 /* body A */, 1 /* body B */,
+                     dissipation, friction, friction, p_AB_W);
+    patches.SetPair(0 /* patch index */, 0 /* pair index */, p_BC_W, nhat_AB_W,
+                    fn0, stiffness);
+
+    // Make sure the data matches the model.
+    model_.SetSparsityPattern();
+    model_.ResizeData(&data_);
+
+    // Set an arbitrary initial guess.
+    data_.set_v(VectorXd::LinSpaced(nv, -0.5, 2.4));
+  }
+
+  IcfSolver solver_;
+  IcfModel<double> model_;
+  IcfData<double> data_;
+};
+
+/* For an unconstrained problem, the solver should converge in a single
+iteration with no linesearch required. */
+TEST_F(IcfSolverTest, UnconstrainedProblem) {
+  // Remove patch constraints to recover an unconstrained problem.
+  const std::vector<int> empty;
+  model_.patch_constraints_pool().Resize(empty);
+  model_.SetSparsityPattern();
+  model_.ResizeData(&data_);
+
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  const IcfSolverStats& stats = solver_.stats();
+
+  EXPECT_GT(stats.step_norm[0], 0.0);
+  EXPECT_EQ(stats.num_iterations, 1);
+  EXPECT_EQ(stats.ls_iterations[0], 0);
+}
+
+/* Solves a typical problem with patch constraints.*/
+TEST_F(IcfSolverTest, Convergence) {
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  const IcfSolverStats& stats = solver_.stats();
+
+  // The problem should be difficult enough that it takes quite a few
+  // iterations (and linesearch iterations) to converge.
+  EXPECT_GE(stats.num_iterations, 5);
+  const int total_ls_iterations = std::accumulate(stats.ls_iterations.begin(),
+                                                  stats.ls_iterations.end(), 0);
+  EXPECT_GE(total_ls_iterations, stats.num_iterations);
+
+  // Check the sizes of the recorded stats.
+  EXPECT_EQ(stats.cost.size(), stats.num_iterations);
+  EXPECT_EQ(stats.gradient_norm.size(), stats.num_iterations);
+  EXPECT_EQ(stats.ls_iterations.size(), stats.num_iterations);
+  EXPECT_EQ(stats.alpha.size(), stats.num_iterations);
+  EXPECT_EQ(stats.step_norm.size(), stats.num_iterations);
+
+  // Cost and gradient norm should decrease at each iteration.
+  for (int k = 1; k < stats.num_iterations; ++k) {
+    EXPECT_LT(stats.cost[k], stats.cost[k - 1]);
+    EXPECT_LT(stats.gradient_norm[k], stats.gradient_norm[k - 1]);
+  }
+}
+
+/* Verifies that dense and sparse algebra produce the same result. */
+TEST_F(IcfSolverTest, DenseVsSparseAlgebra) {
+  const VectorXd v_guess = data_.v();
+
+  // Solve with sparse algebra.
+  EXPECT_FALSE(solver_.get_parameters().use_dense_algebra);
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  const IcfSolverStats sparse_stats = solver_.stats();
+  const VectorXd sparse_solution = data_.v();
+
+  // Solve with dense algebra.
+  IcfSolverParameters solver_params;
+  solver_params.use_dense_algebra = true;
+  solver_.SetParameters(solver_params);
+  EXPECT_TRUE(solver_.get_parameters().use_dense_algebra);
+  data_.set_v(v_guess);  // Reset the initial guess.
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  const IcfSolverStats dense_stats = solver_.stats();
+  const VectorXd dense_solution = data_.v();
+
+  // Both approaches should take the same number of iterations.
+  EXPECT_EQ(dense_stats.num_iterations, sparse_stats.num_iterations);
+
+  // The solutions should be the same, up to the convergence tolerance.
+  EXPECT_TRUE(CompareMatrices(dense_solution, sparse_solution,
+                              kConvergenceTolerance,
+                              MatrixCompareType::relative));
+}
+
+/* Verifies that Hessian reuse performs as expected. */
+TEST_F(IcfSolverTest, HessianReuse) {
+  const VectorXd v_guess = data_.v();
+  IcfSolverParameters solver_params = solver_.get_parameters();
+
+  // Solve without Hessian reuse.
+  solver_params.enable_hessian_reuse = false;
+  solver_.SetParameters(solver_params);
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  const IcfSolverStats no_reuse_stats = solver_.stats();
+  const VectorXd no_reuse_solution = data_.v();
+
+  // Solve with Hessian reuse.
+  solver_params.enable_hessian_reuse = true;
+  solver_.SetParameters(solver_params);
+  data_.set_v(v_guess);  // Reset the initial guess.
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  const IcfSolverStats reuse_stats = solver_.stats();
+  const VectorXd reuse_solution = data_.v();
+
+  // Without reuse, we perform a factorization at every iteration.
+  EXPECT_EQ(no_reuse_stats.num_factorizations, no_reuse_stats.num_iterations);
+
+  // With reuse, we should perform fewer factorizations than iterations.
+  // However, we should have forced at least two factorizations total: one at
+  // the first time step, and at least one other when convergence stalled.
+  EXPECT_LT(reuse_stats.num_factorizations, reuse_stats.num_iterations);
+  EXPECT_GE(reuse_stats.num_factorizations, 2);
+
+  // Solutions should be the same, up to the convergence tolerance used.
+  EXPECT_TRUE(CompareMatrices(reuse_solution, no_reuse_solution,
+                              kConvergenceTolerance,
+                              MatrixCompareType::relative));
+}
+
+/* Verifies that no iterations are performed if the initial guess solves the
+problem to the requested tolerance. */
+TEST_F(IcfSolverTest, EarlyExit) {
+  // Solve the problem once, writing the solution to data_.
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  EXPECT_GT(solver_.stats().num_iterations, 5);
+
+  // Solve the problem again, with the solution as the initial guess (already
+  // stored in data_).
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  EXPECT_EQ(solver_.stats().num_iterations, 0);
+}
+
+/* Verifies that the solver runs properly with printouts enabled. */
+TEST_F(IcfSolverTest, PrintStatsSmokeTest) {
+  IcfSolverParameters solver_params = solver_.get_parameters();
+  solver_params.print_solver_stats = true;
+  solver_.SetParameters(solver_params);
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+}
+
+/* Checks that the solver works with several reasonable linesearch step size
+limits. */
+TEST_F(IcfSolverTest, LinesearchStepSizeLimits) {
+  const VectorXd v_guess = data_.v();
+  IcfSolverParameters solver_params = solver_.get_parameters();
+
+  // Test several values for alpha_max.
+  const std::vector<double> alpha_max_values = {0.5, 1.0, 1.5};
+  for (const double alpha_max : alpha_max_values) {
+    solver_params.alpha_max = alpha_max;
+    solver_.SetParameters(solver_params);
+    data_.set_v(v_guess);
+    EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  }
+}
+
+/* Checks that we can converge to different tolerances. */
+TEST_F(IcfSolverTest, ConvergenceTolerances) {
+  const VectorXd v_guess = data_.v();
+
+  // Solve with a very loose tolerance.
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, 1e-1, &data_));
+  const int loose_tolerance_iterations = solver_.stats().num_iterations;
+
+  // Solve with a tight tolerance, from the same initial guess.
+  data_.set_v(v_guess);
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, 1e-6, &data_));
+  const int tight_tolerance_iterations = solver_.stats().num_iterations;
+
+  EXPECT_LT(loose_tolerance_iterations, tight_tolerance_iterations);
+}
+
+/* Verify that the solver returns false if it fails to converge. */
+TEST_F(IcfSolverTest, ConvergenceFailure) {
+  IcfSolverParameters solver_params = solver_.get_parameters();
+  solver_params.max_iterations = 2;  // Too low for this problem.
+  solver_.SetParameters(solver_params);
+  EXPECT_FALSE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+}
+
+/* Checks that the solver matches the analytical solution for a simple
+unconstrained problem. */
+TEST_F(IcfSolverTest, AnalyticalSolution) {
+  // Solve a simple problem with a clear analytical solution.
+  const std::vector<int> empty;
+  model_.patch_constraints_pool().Resize(empty);
+  model_.SetSparsityPattern();
+  model_.ResizeData(&data_);
+  EXPECT_TRUE(solver_.SolveWithGuess(model_, kConvergenceTolerance, &data_));
+  const VectorXd solution = data_.v();
+
+  // Compute the analytical solution, (M0 + h D0) (v - v0) + h k0 = 0.
+  const MatrixXd M0 = model_.params().M0;
+  const VectorXd D0 = model_.params().D0;
+  const VectorXd v0 = model_.params().v0;
+  const VectorXd k0 = model_.params().k0;
+  const double h = model_.params().time_step;
+  const MatrixXd A = M0 + h * D0.asDiagonal().toDenseMatrix();
+  const VectorXd analytical_solution = v0 - A.ldlt().solve(h * k0);
+
+  EXPECT_TRUE(CompareMatrices(solution, analytical_solution,
+                              kConvergenceTolerance,
+                              MatrixCompareType::relative));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Adds the convex solver for solving ICF problems. This is the next step along the ICF PR train (https://github.com/RobotLocomotion/drake/issues/23769).

For full context, see the [cenic_main](https://github.com/RobotLocomotion/drake/tree/cenic_main) dev branch and the [ICF README](https://github.com/RobotLocomotion/drake/blob/master/multibody/contact_solvers/icf/README.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23908)
<!-- Reviewable:end -->
