### PR TITLE
[icf] Removes incorrect DRAKE_ASSERT

### DIFF
--- a/multibody/contact_solvers/icf/limit_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/limit_constraints_pool.cc
@@ -54,7 +54,7 @@ void LimitConstraintsPool<T>::Set(int index, int clique, int dof, const T& q0,
                                   const T& ql, const T& qu) {
   DRAKE_ASSERT(0 <= index && index < num_constraints());
   DRAKE_ASSERT(0 <= dof && dof < model().clique_size(clique));
-  DRAKE_ASSERT(ql <= q0 && q0 <= qu);
+  DRAKE_ASSERT(ql <= qu);
 
   clique_[index] = clique;
   ql_[index](dof) = ql;

--- a/multibody/contact_solvers/icf/limit_constraints_pool.h
+++ b/multibody/contact_solvers/icf/limit_constraints_pool.h
@@ -90,7 +90,9 @@ class LimitConstraintsPool {
   Calling this function several times with the same `index` overwrites the
   previous constraint for that index.
 
-  @pre ql <= q0 <= qu. */
+  @pre ql <= qu.
+  @note ICF regularizes limit constraints (i.e. they are slightly compliant),
+  and therefore values of q0 outside [ql, qu] are allowed. */
   void Set(int index, int clique, int dof, const T& q0, const T& ql,
            const T& qu);
 


### PR DESCRIPTION
This causes the failure of `multibody/cenic:cenic_integrator_test` in `cenic_main`.
The assert is incorrect and must be removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23911)
<!-- Reviewable:end -->
