### PR TITLE
[CENIC] Clean up integrator tests

### DIFF
--- a/multibody/cenic/BUILD.bazel
+++ b/multibody/cenic/BUILD.bazel
@@ -55,6 +55,7 @@ drake_cc_googletest(
     deps = [
         ":cenic_integrator",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:maybe_pause_for_user",
         "//geometry:meshcat_visualizer",
         "//multibody/parsing",
         "//multibody/plant",


### PR DESCRIPTION
Tightens up unit tests for the integrator itself. This gets us to 98% coverage of `cenic_integrator.cc` in kcov.

Note that this is basically a complete rewrite of the test suite: looking at the diff probably won't be particularly informative.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23916)
<!-- Reviewable:end -->
