### PR TITLE
[CENIC] Clean up 4-arg UpdateModel()

### DIFF
--- a/multibody/cenic/cenic_integrator.cc
+++ b/multibody/cenic/cenic_integrator.cc
@@ -173,8 +173,8 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
     // The last time we updated the model, we used the initial state (q₀, v₀),
     // so all we need to update is the time step and the external system
     // linearization.
-    builder().UpdateModel(h, actuation_feedback, external_feedback,
-                          &model_at_x0_);
+    builder().UpdateTimeStep(h, actuation_feedback, external_feedback,
+                             &model_at_x0_);
   } else {
     time_at_last_solve_ = t0;
     // Build the full model around (q₀, v₀, h).
@@ -202,7 +202,7 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
     // initial guess. Note that this solve starts from the same initial state as
     // the full step, so we can reuse all of the constraints, avoiding expensive
     // geometry queries and such.
-    builder().UpdateModel(0.5 * h, &model_at_x0_);
+    builder().UpdateTimeStep(0.5 * h, &model_at_x0_);
     v_guess += x_next_full_->get_substate(plant_subsystem_index_)
                    .get_generalized_velocity()
                    .CopyToVector();

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -163,12 +163,14 @@ IcfBuilder<T>::IcfBuilder(const MultibodyPlant<T>& plant,
     ++clique_nu_[c];
     effort_limits_[dof] = actuator.effort_limit();
   }
+  num_actuation_constraints_ = std::ranges::count_if(clique_nu_, [](int k) {
+    return k > 0;
+  });
 
   // Iterate over joints to find cliques with at least one 1-DoF joint with
   // finite limits. Each of these cliques will require a limit constraint.
   limited_clique_sizes_.clear();
   clique_to_limit_constraint_.assign(clique_sizes_.size(), -1);
-  limit_constraint_to_clique_.clear();
   for (JointIndex joint_index : plant.GetJointIndices()) {
     const Joint<T>& joint = plant.get_joint(joint_index);
 
@@ -190,7 +192,6 @@ IcfBuilder<T>::IcfBuilder(const MultibodyPlant<T>& plant,
     const int clique = tree_to_clique(tree_index);
     const int clique_nv = clique_sizes_[clique];
     limited_clique_sizes_.push_back(clique_nv);
-    limit_constraint_to_clique_.push_back(clique);
     clique_to_limit_constraint_[clique] = limited_clique_sizes_.size() - 1;
   }
 
@@ -333,13 +334,14 @@ void IcfBuilder<T>::UpdateModel(
 }
 
 template <typename T>
-void IcfBuilder<T>::UpdateModel(const T& time_step, IcfModel<T>* model) const {
+void IcfBuilder<T>::UpdateTimeStep(const T& time_step,
+                                   IcfModel<T>* model) const {
   DRAKE_ASSERT(model != nullptr);
   model->UpdateTimeStep(time_step);
 }
 
 template <typename T>
-void IcfBuilder<T>::UpdateModel(
+void IcfBuilder<T>::UpdateTimeStep(
     const T& time_step, const IcfLinearFeedbackGains<T>* actuation_feedback,
     const IcfLinearFeedbackGains<T>* external_feedback,
     IcfModel<T>* model) const {
@@ -348,22 +350,23 @@ void IcfBuilder<T>::UpdateModel(
   model->UpdateTimeStep(time_step);
 
   // N.B. external forces must come first, followed by actuation.
-#if 0
-  // This DRAKE_DEMAND is not correct. We only add gain constraints for cliques
-  // that are actuated (see line 685), so it's sometimes the case that the 0 <
-  // gain_constraints.num_constraints() < model->num_cliques().
+
+  bool has_actuation_feedback = actuation_feedback != nullptr;
+  bool has_external_feedback = external_feedback != nullptr;
+  int external_constraints = model->num_cliques() * has_external_feedback;
+  int actuation_constraints =
+      num_actuation_constraints_ * has_actuation_feedback;
   auto& gain_constraints = model->gain_constraints_pool();
+  DRAKE_DEMAND(gain_constraints.num_constraints() >= external_constraints);
   DRAKE_DEMAND(gain_constraints.num_constraints() ==
-               model->num_cliques() *
-                   ((external_feedback != nullptr ? 1 : 0) +
-                    (actuation_feedback != nullptr ? 1 : 0)));
-#endif
-  if (external_feedback != nullptr) {
+               external_constraints + actuation_constraints);
+
+  if (has_external_feedback) {
     const VectorX<T>& Ke = external_feedback->K;
     const VectorX<T>& be = external_feedback->b;
     SetExternalGainConstraints(Ke, be, model);
   }
-  if (actuation_feedback != nullptr) {
+  if (has_actuation_feedback) {
     const VectorX<T>& Ku = actuation_feedback->K;
     const VectorX<T>& bu = actuation_feedback->b;
     // N.B. actuation constraint indices in the pool depend on whether external

--- a/multibody/contact_solvers/icf/icf_builder.h
+++ b/multibody/contact_solvers/icf/icf_builder.h
@@ -54,16 +54,16 @@ class IcfBuilder {
   }
 
   /* Updates only the time step δt. All other model data remains unchanged. */
-  void UpdateModel(const T& time_step, IcfModel<T>* model) const;
+  void UpdateTimeStep(const T& time_step, IcfModel<T>* model) const;
 
   /* Updates only the time step δt and feedback gains. All other model data
   remains unchanged.
   @pre The existence (i.e., nullness) of the two feedbacks values must match the
   existence of the most recent prior call to UpdateModel(). */
-  void UpdateModel(const T& time_step,
-                   const IcfLinearFeedbackGains<T>* actuation_feedback,
-                   const IcfLinearFeedbackGains<T>* external_feedback,
-                   IcfModel<T>* model) const;
+  void UpdateTimeStep(const T& time_step,
+                      const IcfLinearFeedbackGains<T>* actuation_feedback,
+                      const IcfLinearFeedbackGains<T>* external_feedback,
+                      IcfModel<T>* model) const;
 
  private:
   /* Scratch workspace data to build the model. */
@@ -150,10 +150,10 @@ class IcfBuilder {
   std::vector<T> body_mass_;             // mass of each body.
   VectorX<T> effort_limits_;             // actuator limits for each velocity.
   std::vector<int> clique_nu_;           // number of actuators per clique.
+  int num_actuation_constraints_{};      // count of clique_nu_[k] > 0.
 
   std::vector<int> limited_clique_sizes_;        // nv in each limited clique.
-  std::vector<int> clique_to_limit_constraint_;  // clique idx <--> limit idx.
-  std::vector<int> limit_constraint_to_clique_;
+  std::vector<int> clique_to_limit_constraint_;  // clique idx --> limit idx.
 
   // Internal storage for geometry query results.
   std::vector<geometry::PenetrationAsPointPair<T>> point_pairs_;

--- a/multibody/contact_solvers/icf/test/icf_builder_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_builder_test.cc
@@ -84,11 +84,71 @@ GTEST_TEST(IcfBuilder, UpdateTimeStepOnly) {
   EXPECT_EQ(model.num_limit_constraints(), 1);
   EXPECT_EQ(model.time_step(), time_step);
 
-  builder.UpdateModel(time_step * 2, &model);
+  builder.UpdateTimeStep(time_step * 2, &model);
   EXPECT_EQ(model.num_cliques(), 1);
   EXPECT_EQ(model.num_velocities(), plant.num_velocities());
   EXPECT_EQ(model.num_limit_constraints(), 1);
   EXPECT_EQ(model.time_step(), time_step * 2);
+}
+
+GTEST_TEST(IcfBuilder, RetryStep) {
+  systems::DiagramBuilder<double> diagram_builder{};
+  multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};
+
+  MultibodyPlant<double>& plant =
+      multibody::AddMultibodyPlant(plant_config, &diagram_builder);
+
+  Parser(&plant, "Pendulum").AddModelsFromString(robot_xml, "xml");
+  plant.AddJointActuator("elbow", plant.GetJointByName("joint2"));
+  plant.Finalize();
+  EXPECT_EQ(plant.num_velocities(), 2);
+
+  auto diagram = diagram_builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  auto& plant_context = plant.GetMyContextFromRoot(*diagram_context);
+
+  IcfLinearFeedbackGains<double> no_feedback;
+  no_feedback.K.setConstant(plant.num_velocities(), 0.01);
+  no_feedback.b.setConstant(plant.num_velocities(), 0.02);
+  const double time_step = 0.01;
+  IcfBuilder<double> builder(plant, plant_context);
+  IcfModel<double> model;
+  VectorX<double> v;
+  v.setConstant(plant.num_velocities(), 0.03);
+
+  // Run a long step (pretending it failed error bounds) and then a "retry
+  // step", for all combinations of feedback parameters. The retry step should
+  // be equivalent to having done a full step of the same duration.
+  for (int k = 0; k < 4; ++k) {
+    IcfLinearFeedbackGains<double>* actuation_feedback =
+        (k & 1) ? &no_feedback : nullptr;
+    IcfLinearFeedbackGains<double>* external_feedback =
+        (k & 2) ? &no_feedback : nullptr;
+
+    // Do a long step to populate all internals.
+    builder.UpdateModel(plant_context, 2 * time_step, actuation_feedback,
+                        external_feedback, &model);
+    // Do the "Retry step."
+    builder.UpdateTimeStep(time_step, actuation_feedback, external_feedback,
+                           &model);
+    IcfData<double> data1;
+    model.ResizeData(&data1);
+    model.CalcData(v, &data1);
+
+    // Do an equivalent step to produce the expected values.
+    builder.UpdateModel(plant_context, time_step, actuation_feedback,
+                        external_feedback, &model);
+    IcfData<double> data2;
+    model.ResizeData(&data2);
+    model.CalcData(v, &data2);
+
+    // Resulting data should match.
+    EXPECT_EQ(data1.v(), data2.v());
+    EXPECT_EQ(data1.Av(), data2.Av());
+    EXPECT_EQ(data1.momentum_cost(), data2.momentum_cost());
+    EXPECT_EQ(data1.cost(), data2.cost());
+    EXPECT_EQ(data1.gradient(), data2.gradient());
+  }
 }
 
 GTEST_TEST(IcfBuilder, BallConstraintUnsupported) {


### PR DESCRIPTION
- actually count the actuation constraints so we can correctly check the "has same feedbacks" precondition.
- add vague proof-of-life unit tests for 4-arg UpdateModel.
- remove unused limit_constraint_to_clique_ index conversion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23919)
<!-- Reviewable:end -->
