### PR TITLE
[wheel] Use PEP508 environment markers for platform-specific requirements

### DIFF
--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -14,14 +14,12 @@ python_required = [
     'numpy',
     'pydot',
     'PyYAML',
+    # MOSEK's published wheels declare an upper bound on their supported Python
+    # version, which is currently Python < 3.14. When that changes to a larger
+    # version number, we should bump this up to match, and also grep tools/wheel
+    # for other mentions of MOSEK version bounds and fix those as well.
+    'Mosek==11.0.24 ; python_version < "3.14"',
 ]
-
-# MOSEK's published wheels declare an upper bound on their supported Python
-# version, which is currently Python < 3.14. When that changes to a larger
-# version number, we should bump this up to match, and also grep tools/wheel
-# for other mentions of MOSEK version bounds and fix those as well.
-python_required.append('Mosek==11.0.24 ; python_version < "3.14"')
-
 
 def find_data_files(*patterns):
     result = []


### PR DESCRIPTION
use PEP508 environment markers for platform-specific requirements

so that tools like uv, poetry etc - which create cross-platform solutions - can get the right answer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23934)
<!-- Reviewable:end -->
