### PR TITLE
[simulator] Deprecate publish_every_time_step

### DIFF
--- a/bindings/generated_docstrings/systems_analysis.h
+++ b/bindings/generated_docstrings/systems_analysis.h
@@ -4577,14 +4577,11 @@ single dispatcher call may handle multiple unrestricted update events.)""";
         struct /* get_publish_every_time_step */ {
           // Source: drake/systems/analysis/simulator.h
           const char* doc_deprecated =
-R"""(Returns true if the set_publish_every_time_step() option has been
-enabled. By default, returns false. (Deprecated.)
+R"""((Deprecated.)
 
 Deprecated:
-    This method is not needed once per-step events are used. Check the
-    "publish every time step" section in troubleshooting.md for
-    details on how to migrate. This will be removed from Drake on or
-    after 2026-06-01.)""";
+    See https://drake.mit.edu/troubleshooting.html#force-publishing
+    for help. This will be removed from Drake on or after 2026-06-01.)""";
         } get_publish_every_time_step;
         // Symbol: drake::systems::Simulator::get_system
         struct /* get_system */ {
@@ -4812,59 +4809,25 @@ Note:
         struct /* set_publish_at_initialization */ {
           // Source: drake/systems/analysis/simulator.h
           const char* doc_deprecated =
-R"""(Prefer using initialization or per-step publish events instead.
-
-Sets whether the simulation should trigger a forced-Publish at the end
-of Initialize(). See set_publish_every_time_step() documentation for
-more information.
-
-See also:
-    LeafSystem::DeclareInitializationPublishEvent()
-
-See also:
-    LeafSystem::DeclarePerStepPublishEvent()
-
-See also:
-    LeafSystem::DeclareForcedPublishEvent() (Deprecated.)
+R"""((Deprecated.)
 
 Deprecated:
-    If you are only issuing a publish at initialization, use
-    LeafSystem::DeclareInitializationPublishEvent() instead. Check the
-    "publish every time step" section in troubleshooting.md for
-    details on how to migrate. This will be removed from Drake on or
-    after 2026-06-01.)""";
+    This is no longer controlled by the Simulator. It must be be
+    defined in the LeafSystem instead. See
+    https://drake.mit.edu/troubleshooting.html#force-publishing for
+    help. This will be removed from Drake on or after 2026-06-01.)""";
         } set_publish_at_initialization;
         // Symbol: drake::systems::Simulator::set_publish_every_time_step
         struct /* set_publish_every_time_step */ {
           // Source: drake/systems/analysis/simulator.h
           const char* doc_deprecated =
-R"""(Prefer using per-step publish events instead.
-
-Sets whether the simulation should trigger a forced-Publish event on
-the System under simulation at the end of every trajectory-advancing
-step. Specifically, that means the System::Publish() event dispatcher
-will be invoked on each subsystem of the System and passed the current
-Context and a forced-publish Event. If a subsystem has declared a
-forced-publish event handler, that will be called. Otherwise, nothing
-will happen.
-
-Enabling this option does not cause a forced-publish to be triggered
-at initialization; if you want that you should also call
-``set_publish_at_initialization(true)``. If you want a forced-publish
-at the end of every step, you will usually also want one at the end of
-initialization, requiring both options to be enabled.
-
-See also:
-    LeafSystem::DeclarePerStepPublishEvent()
-
-See also:
-    LeafSystem::DeclareForcedPublishEvent() (Deprecated.)
+R"""((Deprecated.)
 
 Deprecated:
-    Use LeafSystem::DeclarePerStepPublishEvent() instead. Check the
-    "publish every time step" section in troubleshooting.md for
-    details on how to migrate. This will be removed from Drake on or
-    after 2026-06-01.)""";
+    This is no longer controlled by the Simulator. It must be defined
+    in the LeafSystem instead. See
+    https://drake.mit.edu/troubleshooting.html#force-publishing for
+    help. This will be removed from Drake on or after 2026-06-01.)""";
         } set_publish_every_time_step;
         // Symbol: drake::systems::Simulator::set_target_realtime_rate
         struct /* set_target_realtime_rate */ {
@@ -4928,10 +4891,10 @@ IntegratorBase.)""";
         struct /* publish_every_time_step */ {
           // Source: drake/systems/analysis/simulator_config.h
           const char* doc =
-R"""(DEPRECATED: removal date: 2026-06-01. Check "publish every time step"
-section in troubleshooting.md for details on how to migrate to system
-events. Sets Simulator::set_publish_at_initialization() in addition to
-Simulator::set_publish_every_time_step() when applied by
+R"""(DEPRECATED: removal date: 2026-06-01. See
+https://drake.mit.edu/troubleshooting.html#force-publishing for
+guidance. Sets Simulator::set_publish_at_initialization() in addition
+to Simulator::set_publish_every_time_step() when applied by
 ApplySimulatorConfig().)""";
         } publish_every_time_step;
         // Symbol: drake::systems::SimulatorConfig::start_time

--- a/bindings/generated_docstrings/systems_analysis.h
+++ b/bindings/generated_docstrings/systems_analysis.h
@@ -4576,9 +4576,15 @@ single dispatcher call may handle multiple unrestricted update events.)""";
         // Symbol: drake::systems::Simulator::get_publish_every_time_step
         struct /* get_publish_every_time_step */ {
           // Source: drake/systems/analysis/simulator.h
-          const char* doc =
+          const char* doc_deprecated =
 R"""(Returns true if the set_publish_every_time_step() option has been
-enabled. By default, returns false.)""";
+enabled. By default, returns false. (Deprecated.)
+
+Deprecated:
+    This method is not needed once per-step events are used. Check the
+    "publish every time step" section in troubleshooting.md for
+    details on how to migrate. This will be removed from Drake on or
+    after 2026-06-01.)""";
         } get_publish_every_time_step;
         // Symbol: drake::systems::Simulator::get_system
         struct /* get_system */ {
@@ -4805,9 +4811,8 @@ Note:
         // Symbol: drake::systems::Simulator::set_publish_at_initialization
         struct /* set_publish_at_initialization */ {
           // Source: drake/systems/analysis/simulator.h
-          const char* doc =
-R"""((To be deprecated) Prefer using initialization or per-step publish
-events instead.
+          const char* doc_deprecated =
+R"""(Prefer using initialization or per-step publish events instead.
 
 Sets whether the simulation should trigger a forced-Publish at the end
 of Initialize(). See set_publish_every_time_step() documentation for
@@ -4820,13 +4825,20 @@ See also:
     LeafSystem::DeclarePerStepPublishEvent()
 
 See also:
-    LeafSystem::DeclareForcedPublishEvent())""";
+    LeafSystem::DeclareForcedPublishEvent() (Deprecated.)
+
+Deprecated:
+    If you are only issuing a publish at initialization, use
+    LeafSystem::DeclareInitializationPublishEvent() instead. Check the
+    "publish every time step" section in troubleshooting.md for
+    details on how to migrate. This will be removed from Drake on or
+    after 2026-06-01.)""";
         } set_publish_at_initialization;
         // Symbol: drake::systems::Simulator::set_publish_every_time_step
         struct /* set_publish_every_time_step */ {
           // Source: drake/systems/analysis/simulator.h
-          const char* doc =
-R"""((To be deprecated) Prefer using per-step publish events instead.
+          const char* doc_deprecated =
+R"""(Prefer using per-step publish events instead.
 
 Sets whether the simulation should trigger a forced-Publish event on
 the System under simulation at the end of every trajectory-advancing
@@ -4846,7 +4858,13 @@ See also:
     LeafSystem::DeclarePerStepPublishEvent()
 
 See also:
-    LeafSystem::DeclareForcedPublishEvent())""";
+    LeafSystem::DeclareForcedPublishEvent() (Deprecated.)
+
+Deprecated:
+    Use LeafSystem::DeclarePerStepPublishEvent() instead. Check the
+    "publish every time step" section in troubleshooting.md for
+    details on how to migrate. This will be removed from Drake on or
+    after 2026-06-01.)""";
         } set_publish_every_time_step;
         // Symbol: drake::systems::Simulator::set_target_realtime_rate
         struct /* set_target_realtime_rate */ {
@@ -4910,7 +4928,9 @@ IntegratorBase.)""";
         struct /* publish_every_time_step */ {
           // Source: drake/systems/analysis/simulator_config.h
           const char* doc =
-R"""(Sets Simulator::set_publish_at_initialization() in addition to
+R"""(DEPRECATED: removal date: 2026-06-01. Check "publish every time step"
+section in troubleshooting.md for details on how to migrate to system
+events. Sets Simulator::set_publish_at_initialization() in addition to
 Simulator::set_publish_every_time_step() when applied by
 ApplySimulatorConfig().)""";
         } publish_every_time_step;

--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -59,7 +59,6 @@ def main():
     pole_pin.set_angle(context=cart_pole_context, angle=2.0)
 
     simulator = Simulator(diagram, diagram_context)
-    simulator.set_publish_every_time_step(False)
     simulator.set_target_realtime_rate(args.target_realtime_rate)
     simulator.Initialize()
     simulator.AdvanceTo(args.simulation_time)

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -391,12 +391,6 @@ Parameter ``interruptible``:
                   make_shared_ptr_from_py_object<Context<T>>(py_context));
             },
             py::arg("context"), doc.Simulator.reset_context.doc)
-        .def("set_publish_every_time_step",
-            &Simulator<T>::set_publish_every_time_step, py::arg("publish"),
-            doc.Simulator.set_publish_every_time_step.doc)
-        .def("set_publish_at_initialization",
-            &Simulator<T>::set_publish_at_initialization, py::arg("publish"),
-            doc.Simulator.set_publish_at_initialization.doc)
         .def("set_target_realtime_rate",
             &Simulator<T>::set_target_realtime_rate, py::arg("realtime_rate"),
             doc.Simulator.set_target_realtime_rate.doc)
@@ -420,7 +414,23 @@ Parameter ``interruptible``:
             doc.Simulator.get_num_unrestricted_updates.doc)
         .def("get_system", &Simulator<T>::get_system, py_rvp::reference,
             doc.Simulator.get_system.doc);
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // delete with publish_every_time_step 2026-06-01
+    cls.def("set_publish_every_time_step",
+           WrapDeprecated(
+               doc.Simulator.set_publish_every_time_step.doc_deprecated,
+               &Simulator<T>::set_publish_every_time_step),
+           py::arg("publish"),
+           doc.Simulator.set_publish_every_time_step.doc_deprecated)
+        .def("set_publish_at_initialization",
+            WrapDeprecated(
+                doc.Simulator.set_publish_at_initialization.doc_deprecated,
+                &Simulator<T>::set_publish_at_initialization),
+            py::arg("publish"),
+            doc.Simulator.set_publish_at_initialization.doc_deprecated);
+    // delete till here
+#pragma GCC diagnostic pop
     m  // BR
         .def("ApplySimulatorConfig",
             py::overload_cast<const SimulatorConfig&,

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -1,12 +1,18 @@
 import copy
 import gc
 import unittest
+
+# delete next line with publish_every_time_step 2026-06-01
+import warnings
 import weakref
 
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import Parallelism
+
+# delete next line with publish_every_time_step 2026-06-01
+from pydrake.common.deprecation import DrakeDeprecationWarning
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.math import isnan
 from pydrake.symbolic import Expression, Variable
@@ -337,8 +343,14 @@ class TestAnalysis(unittest.TestCase):
         )
         simulator.reset_context(context=simulator.get_context().Clone())
 
-        simulator.set_publish_every_time_step(publish=True)
-        simulator.set_publish_at_initialization(publish=True)
+        # delete with publish_every_time_step 2026-06-01
+        # Test will pass after deletion since the API will no longer exist.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DrakeDeprecationWarning)
+            simulator.set_publish_every_time_step(publish=True)
+            simulator.set_publish_at_initialization(publish=True)
+            self.assertEqual(len(w), 2)
+        # delete till this line
         simulator.set_target_realtime_rate(realtime_rate=0.0)
         self.assertEqual(simulator.get_target_realtime_rate(), 0.0)
         self.assertIsInstance(simulator.get_actual_realtime_rate(), float)

--- a/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
+++ b/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
@@ -63,7 +63,6 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         pole_pin.set_angle(context=cart_pole_context, angle=2.0)
 
         simulator = Simulator(diagram, diagram_context)
-        simulator.set_publish_every_time_step(False)
         simulator.AdvanceTo(0.1)
 
         visualizer.draw(vis_context)
@@ -108,7 +107,6 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         )
 
         simulator = Simulator(diagram, diagram_context)
-        simulator.set_publish_every_time_step(False)
         simulator.AdvanceTo(0.1)
 
         visualizer.draw(vis_context)
@@ -164,7 +162,6 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         )
 
         simulator = Simulator(diagram, diagram_context)
-        simulator.set_publish_every_time_step(False)
         simulator.AdvanceTo(0.1)
 
         visualizer.draw(vis_context)

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -188,9 +188,6 @@ PYBIND11_MODULE(test_util, m) {
       // Leverage simulator to call initialization events.
       // TODO(eric.cousineau): Simplify as part of #10015.
       Simulator<T> simulator(system);
-      // Do not publish at initialization because we want to track publishes
-      // from only events of trigger type `kInitialization`.
-      simulator.set_publish_at_initialization(false);
       simulator.Initialize();
     }
     {

--- a/common/drake_deprecated.h
+++ b/common/drake_deprecated.h
@@ -12,9 +12,11 @@ use of code that is permitted but discouraged. */
 
 #ifdef DRAKE_DOXYGEN_CXX
 /** Use `DRAKE_DEPRECATED("removal_date", "message")` to discourage use of
-certain APIs.  It can be used on classes, typedefs, variables, non-static data
-members, functions, arguments, enumerations, and template specializations. When
-code refers to the deprecated item, a compile time warning will be issued
+certain APIs. It can be used on classes, typedefs, functions, arguments,
+enumerations, and template specializations. It must not be used on non-static
+data members of structs or classes. Instead, add a comment on the preceding line
+noting that the data member is deprecated and stating its planned removal date.
+When code refers to the deprecated item, a compile time warning will be issued
 displaying the given message, preceded by "DRAKE DEPRECATED: ". The Doxygen API
 reference will show that the API is deprecated, along with the message.
 

--- a/doc/_pages/troubleshooting.md
+++ b/doc/_pages/troubleshooting.md
@@ -193,7 +193,7 @@ This includes
 
 These have all been deprecated (for removal on 2026-06-01). We don't expect this
 will generally impact users. This guide will help those who may rely on this
-functionality transition in to the recommended mechanisms.
+functionality transition into the recommended mechanisms.
 
 Rather than configuring an *entire* diagram to publish at initialization or
 at each time step, each `LeafSystem` articulates independently whether it has
@@ -216,7 +216,7 @@ rate.
 Note: introducing a per-step publish event implicitly includes publishing at
 initialization.
 
-There is also a deprecated `Simulator::get_publish_every_time_step()`, the
+There is also a deprecated [`Simulator::get_publish_every_time_step()`][get_publish_every_step], the
 getter for this `Simulator` parameter. This will need to be evaluated on a per-leaf-system basis.
 
 ### `SimulatorConfig::publish_every_time_step`
@@ -242,7 +242,7 @@ in the system's constructor.
 Note: if your leaf system already includes a per-step publish event, you won't
 also need an initialization publish event. Initialization is included in
 per-step events.
-<!-- 2026-06-01 End of block to delete. >
+<!-- 2026-06-01 End of block to delete. -->
 
 # PyPI (pip)
 
@@ -327,7 +327,7 @@ Note that the concurrency level passed to `make` (e.g., `make -j 2`) does not
 propagate through to affect the concurrency of most of Drake's build steps; you
 need to configure the dotfile in order to control the build concurrency.
 
-# Pydrake out of memory{#pydrake - oom }
+# Pydrake out of memory {#pydrake-oom}
 
 Pydrake programs often control C++ objects that use a lot of memory, so that
 the default behaviors for running garbage collection don't effectively control
@@ -414,6 +414,7 @@ sudo route -nv add -net 224.0.0.0/4 -interface lo0
 <!-- Links to be removed upon 2026-06-01 deprecation removal. -->
 [force_trigger]: https://drake.mit.edu/doxygen_cxx/namespacedrake_1_1systems.html#a59b7f49353f2a99b6c22d2eaae0fe9e9af8ece195be5dd5e820bdeee7ad21a4bf
 [sim_every_step]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_simulator.html#aef1dc6aeb821503379ab1dd8c6044562
+[get_publish_every_step]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_simulator.html#ae66775683e61fc461dec4f76bb8e5c7a
 [sim_init]: https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_simulator.html#ac210a235b5e0865efb51fdd27c4b58ae
 [sim_config_every_step]: https://drake.mit.edu/doxygen_cxx/structdrake_1_1systems_1_1_simulator_config.html#af1d9089360c8cd472de8f923ba7df99a
 <!-- End of links to be removed.  -->

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -125,7 +125,6 @@ void DoMain() {
 
   // Set up simulator.
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
-  simulator.set_publish_every_time_step(true);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
   simulator.AdvanceTo(FLAGS_simulation_time);

--- a/examples/hydroelastic/ball_plate/ball_plate_run_dynamics.cc
+++ b/examples/hydroelastic/ball_plate/ball_plate_run_dynamics.cc
@@ -134,7 +134,6 @@ rigid-compliant, compliant-compliant, and rigid-compliant respectively. The
 hydroelastic contact model can work with non-convex shapes accurately without
 resorting to their convex hulls. Launch meldis before running this example.
 See the README.md file for more information.)""");
-  FLAGS_simulator_publish_every_time_step = true;
   FLAGS_simulator_target_realtime_rate = 0.1;
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   return drake::examples::ball_plate::do_main();

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -196,7 +196,6 @@ int DoMain() {
   sim_config.max_step_size = FLAGS_max_time_step;
   sim_config.accuracy = FLAGS_accuracy;
   sim_config.target_realtime_rate = FLAGS_realtime_rate;
-  sim_config.publish_every_time_step = false;
 
   systems::Simulator<double> simulator(*diagram);
   ApplySimulatorConfig(sim_config, &simulator);

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -148,7 +148,6 @@ int DoMain() {
       initial_position);
 
   simulator.Initialize();
-  simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_realtime_rate);
   simulator.AdvanceTo(FLAGS_simulation_sec);
 

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -169,8 +169,6 @@ int DoMain() {
   auto sys = builder.Build();
 
   Simulator<double> simulator(*sys);
-
-  simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
 

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -119,7 +119,6 @@ int do_main() {
   if (!integrator->get_fixed_step_mode())
     integrator->set_target_accuracy(target_accuracy);
 
-  simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
   simulator.AdvanceTo(simulation_time);

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -79,8 +79,6 @@ int do_main() {
   pole_pin.set_angle(&cart_pole_context, 2.0);
 
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
-
-  simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
   simulator.AdvanceTo(FLAGS_simulation_time);

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -102,8 +102,6 @@ int do_main() {
                               Vector3<double>(FLAGS_vx0, 0.0, 0.0)));
 
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
-
-  simulator.set_publish_every_time_step(true);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
   simulator.AdvanceTo(FLAGS_simulation_time);

--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -178,7 +178,6 @@ int do_main() {
   // step integrator. This value is not used if time_step > 0 (fixed-time step).
   integrator.set_target_accuracy(FLAGS_integration_accuracy);
 
-  simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
   simulator.AdvanceTo(FLAGS_simulation_time);

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -117,7 +117,6 @@ int do_main() {
   if (!integrator->get_fixed_step_mode())
     integrator->set_target_accuracy(target_accuracy);
 
-  simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
   simulator.AdvanceTo(simulation_time);

--- a/examples/scene_graph/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/solar_system_run_dynamics.cc
@@ -47,7 +47,6 @@ int do_main() {
   systems::Simulator<double> simulator(*diagram);
 
   simulator.get_mutable_integrator().set_maximum_step_size(0.002);
-  simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(1);
   simulator.Initialize();
   simulator.AdvanceTo(FLAGS_simulation_time);

--- a/multibody/plant/test/box_test.cc
+++ b/multibody/plant/test/box_test.cc
@@ -64,7 +64,6 @@ class SlidingBoxTest : public ::testing::Test {
     plant.get_actuation_input_port().FixValue(&plant_context, applied_force_);
 
     Simulator<double> simulator(*diagram, std::move(diagram_context));
-    simulator.set_publish_every_time_step(true);
     // Implicit integration does much better than the default RK3 for this
     // system with regularized friction. Otherwise RK3 requires a very small
     // accuracy setting and it is very costly.

--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -145,7 +145,7 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
   IntegratorBase<double>& integrator = simulator.get_mutable_integrator();
   integrator.set_maximum_step_size(1e-3);  // Reasonable for this problem.
   integrator.set_target_accuracy(target_accuracy);
-  simulator.set_publish_every_time_step(true);
+
   simulator.Initialize();
 
   // Prior to simulating, dynamics output ports should be filled with zeros.

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -187,6 +187,7 @@ SimulatorStatus Simulator<T>::Initialize(const InitializeParams& params) {
     accumulated_event_status.KeepMoreSevere(
         HandlePublish(merged_events_->get_publish_events()));
 
+    // Delete the if block with publish_every_time_step 2026-06-01.
     // If requested, do a force-publish before the simulation starts.
     if (publish_at_initialization_) {
       accumulated_event_status.KeepMoreSevere(
@@ -438,12 +439,14 @@ SimulatorStatus Simulator<T>::AdvanceTo(const T& boundary_time) {
 
       accumulated_event_status.KeepMoreSevere(
           HandlePublish(merged_events_->get_publish_events()));
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      // delete with publish_every_time_step 2026-06-01
       if (get_publish_every_time_step()) {
         accumulated_event_status.KeepMoreSevere(
             HandlePublish(system_.get_forced_publish_events()));
       }
-
+#pragma GCC diagnostic pop
       // Invoke the monitor() if there is one. This is logically like a
       // Diagram-level Publish event so we handle it similarly.
       if (get_monitor())

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -562,9 +562,10 @@ class Simulator {
   /// @see LeafSystem::DeclarePerStepPublishEvent()
   /// @see LeafSystem::DeclareForcedPublishEvent()
   DRAKE_DEPRECATED("2026-06-01",
-                   "Use LeafSystem::DeclarePerStepPublishEvent() instead. "
-                   "Check the \"publish every time step\" section in "
-                   "troubleshooting.md for details on how to migrate.")
+                   "This is no longer controlled by the Simulator. It must be "
+                   "be defined in the LeafSystem instead. See "
+                   "https://drake.mit.edu/troubleshooting.html#force-publishing"
+                   " for help.");
   void set_publish_every_time_step(bool publish) {
     publish_every_time_step_ = publish;
   }
@@ -580,10 +581,10 @@ class Simulator {
   /// @see LeafSystem::DeclarePerStepPublishEvent()
   /// @see LeafSystem::DeclareForcedPublishEvent()
   DRAKE_DEPRECATED("2026-06-01",
-                   "If you are only issuing a publish at initialization, use "
-                   "LeafSystem::DeclareInitializationPublishEvent() instead. "
-                   "Check the \"publish every time step\" section in "
-                   "troubleshooting.md for details on how to migrate.")
+                   "This is no longer controlled by the Simulator. It must be "
+                   "be defined in the LeafSystem instead. See "
+                   "https://drake.mit.edu/troubleshooting.html#force-publishing"
+                   " for help.");
   void set_publish_at_initialization(bool publish) {
     publish_at_initialization_ = publish;
   }
@@ -591,9 +592,8 @@ class Simulator {
   /// Returns true if the set_publish_every_time_step() option has been
   /// enabled. By default, returns false.
   DRAKE_DEPRECATED("2026-06-01",
-                   "This method is not needed once per-step events are used. "
-                   "Check the \"publish every time step\" section in "
-                   "troubleshooting.md for details on how to migrate.")
+                   "See https://drake.mit.edu/troubleshooting.html"
+                   "#force-publishing for help.");
   bool get_publish_every_time_step() const { return publish_every_time_step_; }
 
   /// Returns a const reference to the internally-maintained Context holding the

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -13,6 +13,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/extract_double.h"
 #include "drake/common/name_value.h"
 #include "drake/systems/analysis/integrator_base.h"
@@ -543,7 +544,7 @@ class Simulator {
   /// @see set_target_realtime_rate()
   double get_actual_realtime_rate() const;
 
-  /// (To be deprecated) Prefer using per-step publish events instead.
+  /// Prefer using per-step publish events instead.
   ///
   /// Sets whether the simulation should trigger a forced-Publish event on the
   /// System under simulation at the end of every trajectory-advancing step.
@@ -560,11 +561,15 @@ class Simulator {
   ///
   /// @see LeafSystem::DeclarePerStepPublishEvent()
   /// @see LeafSystem::DeclareForcedPublishEvent()
+  DRAKE_DEPRECATED("2026-06-01",
+                   "Use LeafSystem::DeclarePerStepPublishEvent() instead. "
+                   "Check the \"publish every time step\" section in "
+                   "troubleshooting.md for details on how to migrate.")
   void set_publish_every_time_step(bool publish) {
     publish_every_time_step_ = publish;
   }
 
-  /// (To be deprecated) Prefer using initialization or per-step publish
+  /// Prefer using initialization or per-step publish
   /// events instead.
   ///
   /// Sets whether the simulation should trigger a forced-Publish at the end
@@ -574,12 +579,21 @@ class Simulator {
   /// @see LeafSystem::DeclareInitializationPublishEvent()
   /// @see LeafSystem::DeclarePerStepPublishEvent()
   /// @see LeafSystem::DeclareForcedPublishEvent()
+  DRAKE_DEPRECATED("2026-06-01",
+                   "If you are only issuing a publish at initialization, use "
+                   "LeafSystem::DeclareInitializationPublishEvent() instead. "
+                   "Check the \"publish every time step\" section in "
+                   "troubleshooting.md for details on how to migrate.")
   void set_publish_at_initialization(bool publish) {
     publish_at_initialization_ = publish;
   }
 
   /// Returns true if the set_publish_every_time_step() option has been
   /// enabled. By default, returns false.
+  DRAKE_DEPRECATED("2026-06-01",
+                   "This method is not needed once per-step events are used. "
+                   "Check the \"publish every time step\" section in "
+                   "troubleshooting.md for details on how to migrate.")
   bool get_publish_every_time_step() const { return publish_every_time_step_; }
 
   /// Returns a const reference to the internally-maintained Context holding the
@@ -872,8 +886,10 @@ class Simulator {
   // Slow down to this rate if possible (user settable).
   double target_realtime_rate_{SimulatorConfig{}.target_realtime_rate};
 
+  // delete with publish_every_time_step 2026-06-01
   bool publish_every_time_step_{SimulatorConfig{}.publish_every_time_step};
 
+  // delete with publish_every_time_step 2026-06-01
   bool publish_at_initialization_{SimulatorConfig{}.publish_every_time_step};
 
   // These are recorded at initialization or statistics reset.

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -563,9 +563,9 @@ class Simulator {
   /// @see LeafSystem::DeclareForcedPublishEvent()
   DRAKE_DEPRECATED("2026-06-01",
                    "This is no longer controlled by the Simulator. It must be "
-                   "be defined in the LeafSystem instead. See "
+                   "defined in the LeafSystem instead. See "
                    "https://drake.mit.edu/troubleshooting.html#force-publishing"
-                   " for help.");
+                   " for help.")
   void set_publish_every_time_step(bool publish) {
     publish_every_time_step_ = publish;
   }
@@ -584,7 +584,7 @@ class Simulator {
                    "This is no longer controlled by the Simulator. It must be "
                    "be defined in the LeafSystem instead. See "
                    "https://drake.mit.edu/troubleshooting.html#force-publishing"
-                   " for help.");
+                   " for help.")
   void set_publish_at_initialization(bool publish) {
     publish_at_initialization_ = publish;
   }
@@ -593,7 +593,7 @@ class Simulator {
   /// enabled. By default, returns false.
   DRAKE_DEPRECATED("2026-06-01",
                    "See https://drake.mit.edu/troubleshooting.html"
-                   "#force-publishing for help.");
+                   "#force-publishing for help.")
   bool get_publish_every_time_step() const { return publish_every_time_step_; }
 
   /// Returns a const reference to the internally-maintained Context holding the

--- a/systems/analysis/simulator_config.h
+++ b/systems/analysis/simulator_config.h
@@ -33,8 +33,8 @@ struct SimulatorConfig {
   double start_time{0.0};
   double target_realtime_rate{0.0};
   /// DEPRECATED: removal date: 2026-06-01.
-  /// Check "publish every time step" section in troubleshooting.md for details
-  /// on how to migrate to system events.
+  /// See https://drake.mit.edu/troubleshooting.html#force-publishing for
+  /// guidance.
   /// Sets Simulator::set_publish_at_initialization() in addition to
   /// Simulator::set_publish_every_time_step() when applied by
   /// ApplySimulatorConfig().

--- a/systems/analysis/simulator_config.h
+++ b/systems/analysis/simulator_config.h
@@ -6,7 +6,6 @@
 
 namespace drake {
 namespace systems {
-
 // TODO(dale.mcconachie) Update to include all configurable properties of
 // IntegratorBase. Currently, initial_step_size_target, minimum_step_size, and
 // throw_on_minimum_step_size_violation are missing.
@@ -33,11 +32,13 @@ struct SimulatorConfig {
   /// `start_time` at the beginning of the simulation.
   double start_time{0.0};
   double target_realtime_rate{0.0};
+  /// DEPRECATED: removal date: 2026-06-01.
+  /// Check "publish every time step" section in troubleshooting.md for details
+  /// on how to migrate to system events.
   /// Sets Simulator::set_publish_at_initialization() in addition to
   /// Simulator::set_publish_every_time_step() when applied by
   /// ApplySimulatorConfig().
   bool publish_every_time_step{false};
 };
-
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/simulator_config_functions.cc
+++ b/systems/analysis/simulator_config_functions.cc
@@ -224,10 +224,14 @@ void ApplySimulatorConfig(const SimulatorConfig& config,
   }
   simulator->get_mutable_context().SetTime(config.start_time);
   simulator->set_target_realtime_rate(config.target_realtime_rate);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // delete with publish_every_time_step 2026-06-01
   // It is almost always the case we want these two next flags to be either both
   // true or both false. Otherwise we could miss the first publish at t = 0.
   simulator->set_publish_at_initialization(config.publish_every_time_step);
   simulator->set_publish_every_time_step(config.publish_every_time_step);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -250,7 +254,11 @@ SimulatorConfig ExtractSimulatorConfig(const Simulator<T>& simulator) {
   result.start_time = ExtractDoubleOrThrow(simulator.get_context().get_time());
   result.target_realtime_rate =
       ExtractDoubleOrThrow(simulator.get_target_realtime_rate());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // delete with publish_every_time_step 2026-06-01
   result.publish_every_time_step = simulator.get_publish_every_time_step();
+#pragma GCC diagnostic pop
   return result;
 }
 

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -21,7 +21,7 @@ DEFINE_double(simulator_target_realtime_rate,
 DEFINE_bool(simulator_publish_every_time_step,
             drake::systems::SimulatorConfig{}.publish_every_time_step,
             "DEPRECATED: removal date: 2026-06-01. "
-            "Check \"publish every time step\" section in troubleshooting.md "
+            "See https://drake.mit.edu/troubleshooting.html#force-publishing "
             "for details on how to migrate to system events."
             "[Simulator flag] Sets whether the simulation should trigger a "
             "forced-Publish event at the end of every trajectory-advancing "

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -16,8 +16,13 @@ DEFINE_double(simulator_target_realtime_rate,
               "[Simulator flag] Desired rate relative to real time.  See "
               "documentation for Simulator::set_target_realtime_rate() for "
               "details.");
+
+// delete with publish_every_time_step 2026-06-01
 DEFINE_bool(simulator_publish_every_time_step,
             drake::systems::SimulatorConfig{}.publish_every_time_step,
+            "DEPRECATED: removal date: 2026-06-01. "
+            "Check \"publish every time step\" section in troubleshooting.md "
+            "for details on how to migrate to system events."
             "[Simulator flag] Sets whether the simulation should trigger a "
             "forced-Publish event at the end of every trajectory-advancing "
             "step. This also includes the very first publish at t = 0 (see "
@@ -97,14 +102,14 @@ template <typename T>
 std::unique_ptr<Simulator<T>> MakeSimulatorFromGflags(
     const System<T>& system, std::unique_ptr<Context<T>> context) {
   auto simulator = std::make_unique<Simulator<T>>(system, std::move(context));
+  const SimulatorConfig config{
+      FLAGS_simulator_integration_scheme, FLAGS_simulator_max_time_step,
+      FLAGS_simulator_accuracy, FLAGS_simulator_use_error_control,
+      FLAGS_simulator_start_time, FLAGS_simulator_target_realtime_rate,
+      // delete FLAGS_simulator_publish_every_time_step with
+      // publish_every_time_step feature on 2026-06-01
+      FLAGS_simulator_publish_every_time_step};
 
-  const SimulatorConfig config{FLAGS_simulator_integration_scheme,
-                               FLAGS_simulator_max_time_step,
-                               FLAGS_simulator_accuracy,
-                               FLAGS_simulator_use_error_control,
-                               FLAGS_simulator_start_time,
-                               FLAGS_simulator_target_realtime_rate,
-                               FLAGS_simulator_publish_every_time_step};
   ApplySimulatorConfig(config, simulator.get());
 
   return simulator;

--- a/systems/analysis/simulator_gflags.h
+++ b/systems/analysis/simulator_gflags.h
@@ -19,6 +19,7 @@ DECLARE_bool(simulator_use_error_control);
 
 // Declares simulator gflags.
 DECLARE_double(simulator_target_realtime_rate);
+// Delete next line with publish_every_time_step 2026-06-01
 DECLARE_bool(simulator_publish_every_time_step);
 
 namespace drake {

--- a/systems/analysis/simulator_print_stats.cc
+++ b/systems/analysis/simulator_print_stats.cc
@@ -31,8 +31,12 @@ void PrintSimulatorStatistics(const Simulator<T>& simulator) {
   fmt::print("General stats regarding discrete updates:\n");
   fmt::print("Number of time steps taken (simulator stats) = {:d}\n",
              simulator.get_num_steps_taken());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // delete with publish_every_time_step 2026-06-01
   fmt::print("Simulator publishes every time step: {}\n",
              simulator.get_publish_every_time_step());
+#pragma GCC diagnostic pop
   fmt::print("Number of publishes = {:d}\n", simulator.get_num_publishes());
   fmt::print("Number of discrete updates = {:d}\n",
              simulator.get_num_discrete_updates());

--- a/systems/analysis/test/simulator_config_functions_test.cc
+++ b/systems/analysis/test/simulator_config_functions_test.cc
@@ -80,6 +80,7 @@ TYPED_TEST(SimulatorConfigFunctionsTest, CongruenceTest) {
   EXPECT_EQ(sim_defaults.start_time, config_defaults.start_time);
   EXPECT_EQ(sim_defaults.target_realtime_rate,
             config_defaults.target_realtime_rate);
+  // delete with publish_every_time_step 2026-06-01
   EXPECT_EQ(sim_defaults.publish_every_time_step,
             config_defaults.publish_every_time_step);
 }
@@ -93,6 +94,7 @@ TYPED_TEST(SimulatorConfigFunctionsTest, RoundTripTest) {
       "use_error_control: true\n"
       "start_time: 0.5\n"
       "target_realtime_rate: 3.0\n"
+      // delete with publish_every_time_step 2026-06-01
       "publish_every_time_step: true\n";
 
   // Ensure that the string and the struct have the same fields.
@@ -114,6 +116,7 @@ TYPED_TEST(SimulatorConfigFunctionsTest, RoundTripTest) {
   EXPECT_EQ(readback.use_error_control, bespoke.use_error_control);
   EXPECT_EQ(readback.start_time, bespoke.start_time);
   EXPECT_EQ(readback.target_realtime_rate, bespoke.target_realtime_rate);
+  // delete with publish_every_time_step 2026-06-01
   EXPECT_EQ(readback.publish_every_time_step, bespoke.publish_every_time_step);
 }
 

--- a/systems/analysis/test/simulator_gflags_test.py
+++ b/systems/analysis/test/simulator_gflags_test.py
@@ -20,6 +20,7 @@ class TestSimulatorGflags(unittest.TestCase):
                 "--simulator_accuracy=1E-3",
                 "--simulator_use_error_control=true",
                 "--simulator_target_realtime_rate=1.",
+                # Delete next line with publish_every_time_step 2026-06-01
                 "--simulator_publish_every_time_step=true",
             ],
             stdout=subprocess.PIPE,

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -181,9 +181,6 @@ GTEST_TEST(SimulatorTest, DiagramWitness) {
   const double h = 1;
   Simulator<double> simulator(system);
   simulator.reset_integrator<RungeKutta2Integrator<double>>(h);
-  simulator.set_publish_at_initialization(false);
-  simulator.set_publish_every_time_step(false);
-
   simulator.get_mutable_context().SetTime(0);
   simulator.AdvanceTo(1);
 
@@ -303,13 +300,15 @@ class TwoWitnessStatelessSystem : public LeafSystem<double> {
   const double offset2_;
   std::function<void(const Context<double>&)> publish_callback_{nullptr};
 };
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// delete with publish_every_time_step 2026-06-01
 // Disables non-witness based publishing for witness function testing.
 void DisableDefaultPublishing(Simulator<double>* s) {
   s->set_publish_at_initialization(false);
   s->set_publish_every_time_step(false);
 }
-
+#pragma GCC diagnostic pop
 // Initializes the Simulator's integrator to fixed step mode for witness
 // function related tests.
 void InitFixedStepIntegratorForWitnessTesting(Simulator<double>* s, double h) {
@@ -937,9 +936,6 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   simulator.reset_integrator<ExplicitEulerIntegrator<double>>(h);
 
   simulator.set_target_realtime_rate(0.5);
-  // Request forced-publishes at every internal step.
-  simulator.set_publish_at_initialization(true);
-  simulator.set_publish_every_time_step(true);
 
   // Set the integrator and initialize the simulator.
   simulator.Initialize();
@@ -951,7 +947,6 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   EXPECT_EQ(simulator.get_num_steps_taken(), 1000);
   EXPECT_EQ(simulator.get_num_discrete_updates(), 0);
 
-  EXPECT_EQ(spring_mass.get_publish_count(), 1001);
   EXPECT_EQ(spring_mass.get_update_count(), 0);
 
   // Current time is 1. An earlier final time should fail.
@@ -1021,10 +1016,13 @@ GTEST_TEST(SimulatorTest, RealtimeRate) {
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 5.1);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// delete this test with publish_every_time_step 2026-06-01
 // Tests that if publishing every time step is disabled and publish on
 // initialization is enabled, publish only happens on initialization.
 GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
-  analysis_test::MySpringMassSystem<double> spring_mass(1.0, 1.0, 0.0);
+  analysis_test::MySpringMassSystemTemp<double> spring_mass(1.0, 1.0, 0.0);
   Simulator<double> simulator(spring_mass);  // Use default Context.
   simulator.set_publish_at_initialization(true);
   simulator.set_publish_every_time_step(false);
@@ -1038,6 +1036,88 @@ GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
   simulator.AdvanceTo(1.0);
   EXPECT_EQ(1, simulator.get_num_publishes());
 }
+
+// Delete this test with publish_every_time_step 2026-06-01
+// Try a purely continuous system with no sampling.
+GTEST_TEST(SimulatorTest, SpringMassNoSampleUsingPublishEveryTimeStep) {
+  const double kSpring = 300.0;  // N/m
+  const double kMass = 2.0;      // kg
+
+  // Set the integrator default step size.
+  const double h = 1e-3;
+
+  analysis_test::MySpringMassSystemTemp<double> spring_mass(kSpring, kMass,
+                                                            0.0);
+  Simulator<double> simulator(spring_mass);  // Use default Context.
+
+  // Set initial condition using the Simulator's internal Context.
+  spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
+
+  // Create the integrator.
+  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(h);
+
+  simulator.set_target_realtime_rate(0.5);
+  // Request forced-publishes at every internal step.
+  simulator.set_publish_at_initialization(true);
+  simulator.set_publish_every_time_step(true);
+
+  // Set the integrator and initialize the simulator.
+  simulator.Initialize();
+
+  // Simulate for 1 second.
+  simulator.AdvanceTo(1.0);
+
+  EXPECT_NEAR(simulator.get_context().get_time(), 1.0, 1e-8);
+  EXPECT_EQ(simulator.get_num_steps_taken(), 1000);
+  EXPECT_EQ(simulator.get_num_discrete_updates(), 0);
+
+  EXPECT_EQ(spring_mass.get_publish_count(), 1001);
+  EXPECT_EQ(spring_mass.get_update_count(), 0);
+
+  // Current time is 1. An earlier final time should fail.
+  EXPECT_THROW(simulator.AdvanceTo(0.5), std::runtime_error);
+}
+
+// delete this test with publish_every_time_step 2026-06-01
+// Repeat the previous test but now the continuous steps are interrupted
+// by a discrete sample every 1/30 second. The step size doesn't divide that
+// evenly so we should get some step size modification here.
+GTEST_TEST(SimulatorTest, SpringMassUsingPublishEveryTimeStep) {
+  const double kSpring = 300.0;  // N/m
+  const double kMass = 2.0;      // kg
+
+  // Set the integrator default step size.
+  const double h = 1e-3;
+
+  // Create the mass spring system and the simulator.
+  analysis_test::MySpringMassSystemTemp<double> spring_mass(kSpring, kMass,
+                                                            30.0);
+  Simulator<double> simulator(spring_mass);  // Use default Context.
+
+  // Set initial condition using the Simulator's internal context.
+  spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
+
+  // Create the integrator and initialize it.
+  auto& integrator =
+      simulator.reset_integrator<ExplicitEulerIntegrator<double>>(h);
+  integrator.Initialize();
+
+  // Set the integrator and initialize the simulator.
+  simulator.Initialize();
+
+  // Simulate to one second.
+  simulator.AdvanceTo(1.0);
+
+  EXPECT_GT(simulator.get_num_steps_taken(), 1000);
+  EXPECT_EQ(simulator.get_num_discrete_updates(), 30);
+
+  // We're calling Publish() every step, and extra steps have to be taken
+  // since the step size doesn't divide evenly into the sample rate. Shouldn't
+  // require more than one extra step per sample though.
+  EXPECT_LE(spring_mass.get_publish_count(), 1030);
+  EXPECT_EQ(spring_mass.get_update_count(), 30);
+}
+#pragma GCC diagnostic pop
 
 // Repeat the previous test but now the continuous steps are interrupted
 // by a discrete sample every 1/30 second. The step size doesn't divide that
@@ -1069,11 +1149,6 @@ GTEST_TEST(SimulatorTest, SpringMass) {
 
   EXPECT_GT(simulator.get_num_steps_taken(), 1000);
   EXPECT_EQ(simulator.get_num_discrete_updates(), 30);
-
-  // We're calling Publish() every step, and extra steps have to be taken
-  // since the step size doesn't divide evenly into the sample rate. Shouldn't
-  // require more than one extra step per sample though.
-  EXPECT_LE(spring_mass.get_publish_count(), 1030);
   EXPECT_EQ(spring_mass.get_update_count(), 30);
 }
 
@@ -1715,8 +1790,6 @@ GTEST_TEST(SimulatorTest, DiscreteUpdateAndPublish) {
   });
 
   Simulator<double> simulator(system);
-  simulator.set_publish_at_initialization(false);
-  simulator.set_publish_every_time_step(false);
   simulator.AdvanceTo(0.5);
 
   // Update occurs at 1000Hz, at the beginning of each step (there is no
@@ -1752,9 +1825,6 @@ GTEST_TEST(SimulatorTest, UpdateThenPublishThenIntegrate) {
         events[simulator.get_num_steps_taken()].push_back(kIntegrate);
       });
 
-  // Run a simulation with per-step forced-publishing enabled.
-  simulator.set_publish_at_initialization(true);
-  simulator.set_publish_every_time_step(true);
   simulator.AdvanceTo(0.5);
 
   // Verify that at least one of each event type was triggered.
@@ -2110,10 +2180,6 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
   sim.get_mutable_integrator().set_fixed_step_mode(true);
   sim.get_mutable_integrator().set_maximum_step_size(0.001);
 
-  // Disables all simulator induced publish events, so that all publish calls
-  // are initiated by sys.
-  sim.set_publish_at_initialization(false);
-  sim.set_publish_every_time_step(false);
   sim.Initialize();
   sim.AdvanceTo(0.1);
 

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -1021,7 +1021,7 @@ GTEST_TEST(SimulatorTest, RealtimeRate) {
 // delete this test with publish_every_time_step 2026-06-01
 // Tests that if publishing every time step is disabled and publish on
 // initialization is enabled, publish only happens on initialization.
-GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
+GTEST_TEST(SimulatorTest, DisablePublishEveryTimestepDeprecated) {
   analysis_test::MySpringMassSystemTemp<double> spring_mass(1.0, 1.0, 0.0);
   Simulator<double> simulator(spring_mass);  // Use default Context.
   simulator.set_publish_at_initialization(true);
@@ -1039,7 +1039,8 @@ GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
 
 // Delete this test with publish_every_time_step 2026-06-01
 // Try a purely continuous system with no sampling.
-GTEST_TEST(SimulatorTest, SpringMassNoSampleUsingPublishEveryTimeStep) {
+GTEST_TEST(SimulatorTest,
+           SpringMassNoSampleUsingPublishEveryTimeStepDeprecated) {
   const double kSpring = 300.0;  // N/m
   const double kMass = 2.0;      // kg
 
@@ -1082,7 +1083,7 @@ GTEST_TEST(SimulatorTest, SpringMassNoSampleUsingPublishEveryTimeStep) {
 // Repeat the previous test but now the continuous steps are interrupted
 // by a discrete sample every 1/30 second. The step size doesn't divide that
 // evenly so we should get some step size modification here.
-GTEST_TEST(SimulatorTest, SpringMassUsingPublishEveryTimeStep) {
+GTEST_TEST(SimulatorTest, SpringMassUsingPublishEveryTimeStepDeprecated) {
   const double kSpring = 300.0;  // N/m
   const double kMass = 2.0;      // kg
 
@@ -1119,10 +1120,10 @@ GTEST_TEST(SimulatorTest, SpringMassUsingPublishEveryTimeStep) {
 }
 #pragma GCC diagnostic pop
 
-// Repeat the previous test but now the continuous steps are interrupted
-// by a discrete sample every 1/30 second. The step size doesn't divide that
-// evenly so we should get some step size modification here.
-GTEST_TEST(SimulatorTest, SpringMass) {
+// Repeat the SpringMassNoSample test but now the continuous steps are
+// interrupted by a discrete sample every 1/30 second. The step size doesn't
+// divide that evenly so we should get some step size modification here.
+GTEST_TEST(SimulatorTest, SpringMassRegularSampling) {
   const double kSpring = 300.0;  // N/m
   const double kMass = 2.0;      // kg
 

--- a/systems/analysis/test_utilities/my_spring_mass_system.h
+++ b/systems/analysis/test_utilities/my_spring_mass_system.h
@@ -19,13 +19,47 @@ class MySpringMassSystem : public SpringMassSystem<T> {
   // Pass through to SpringMassSystem, except add events and handlers.
   MySpringMassSystem(double stiffness, double mass, double update_rate)
       : SpringMassSystem<T>(stiffness, mass, false /*no input force*/) {
-    // This forced-publish event is necessary for any simulator_test case that
-    // needs to verify that the publish_every_time_step feature works.
-    this->DeclareForcedPublishEvent(&MySpringMassSystem::CountPublishes);
-
     if (update_rate > 0.0) {
       this->DeclarePeriodicDiscreteUpdateEvent(
           1.0 / update_rate, 0.0, &MySpringMassSystem::CountDiscreteUpdates);
+    }
+  }
+
+  int get_update_count() const { return update_count_; }
+
+ private:
+  // The discrete equation update here is for the special case of zero
+  // discrete variables- in other words, this is just a counter.
+  EventStatus CountDiscreteUpdates(const Context<T>&,
+                                   DiscreteValues<T>*) const {
+    ++update_count_;
+    return EventStatus::Succeeded();
+  }
+
+  mutable int update_count_{0};
+};  // MySpringMassSystem
+
+/*
+ * A temporary class for `Simulator` tests that use deprecated
+ * publish_every_time_step feature.
+ * Delete the class with publish_every_time_step 2026-06-01
+ */
+template <class T>
+class MySpringMassSystemTemp : public SpringMassSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MySpringMassSystemTemp);
+
+  // Pass through to SpringMassSystem, except add events and handlers.
+  MySpringMassSystemTemp(double stiffness, double mass, double update_rate)
+      : SpringMassSystem<T>(stiffness, mass, false /*no input force*/) {
+    // This forced-publish event is necessary for any simulator_test case that
+    // needs to verify that the publish_every_time_step feature works.
+    this->DeclareForcedPublishEvent(&MySpringMassSystemTemp::CountPublishes);
+
+    if (update_rate > 0.0) {
+      this->DeclarePeriodicDiscreteUpdateEvent(
+          1.0 / update_rate, 0.0,
+          &MySpringMassSystemTemp::CountDiscreteUpdates);
     }
   }
 
@@ -49,7 +83,7 @@ class MySpringMassSystem : public SpringMassSystem<T> {
 
   mutable int publish_count_{0};
   mutable int update_count_{0};
-};  // MySpringMassSystem
+};  // MySpringMassSystemTemp
 
 }  // namespace analysis_test
 }  // namespace systems

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -527,6 +527,8 @@ class LeafSystem : public System<T> {
   where `MySystem` is a class derived from `LeafSystem<T>` and the method
   name is arbitrary.
 
+  <!-- Delete this warning when publish_every_time_step is deleted on
+  2026-06-01. -->
   @warning These per-step publish events are independent of the Simulator's
   optional "publish every time step" and "publish at initialization"
   features. Generally if you are declaring per-step publish events yourself
@@ -678,7 +680,8 @@ class LeafSystem : public System<T> {
   _update_ events occur during initialization. On the other hand, any
   _publish_ events, including initialization-triggered, per-step,
   and time-triggered publish events that trigger at the initial time, are
-  dispatched together during initialization.
+  dispatched together during initialization. Initialization-triggered publish
+  events will precede per-step and time-triggered publish events.
 
   Template arguments to these methods are inferred from the argument lists
   and need not be specified explicitly. */
@@ -846,6 +849,8 @@ class LeafSystem : public System<T> {
   @note It's rare that an event needs to be triggered by force. Please
   consider per-step and periodic triggered events first.
 
+  <!-- Delete this warning when publish_every_time_step is deleted on
+  2026-06-01. -->
   @warning Simulator handles forced publish events at initialization
   and on a per-step basis when its "publish at initialization" and
   "publish every time step" options are set (not recommended).

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1501,8 +1501,8 @@ class System : public SystemBase {
   // For unfortunate historical reasons the Drake Simulator needs access to
   // forced publish events to implement its optional publish_every_time_step
   // feature. Now we have PerStep events that serve the same purpose.
-  // Move this to protected with the other forced events when the Simulator
-  // feature is removed.
+  // TODO(2026-06-01): Move this to protected with the other forced events when
+  // the Simulator feature is removed.
   const EventCollection<PublishEvent<T>>& get_forced_publish_events() const {
     DRAKE_DEMAND(forced_publish_events_ != nullptr);
     return *forced_publish_events_;

--- a/systems/primitives/test/discrete_derivative_test.cc
+++ b/systems/primitives/test/discrete_derivative_test.cc
@@ -55,8 +55,6 @@ void RunFirstOrderHold(const bool suppress_initial_transient) {
   auto diagram = builder.Build();
   Simulator<double> simulator(*diagram);
   const auto& log = logger->FindLog(simulator.get_context());
-  simulator.set_publish_at_initialization(false);
-  simulator.set_publish_every_time_step(false);
   simulator.AdvanceTo(kDuration);
 
   for (int i = 0; i < log.sample_times().size(); i++) {

--- a/systems/sensors/lcm_image_array_receive_example.cc
+++ b/systems/sensors/lcm_image_array_receive_example.cc
@@ -63,8 +63,6 @@ int DoMain() {
   auto simulator = std::make_unique<systems::Simulator<double>>(
       *diagram, std::move(context));
 
-  simulator->set_publish_at_initialization(true);
-  simulator->set_publish_every_time_step(false);
   simulator->set_target_realtime_rate(1.0);
   simulator->Initialize();
   simulator->AdvanceTo(FLAGS_duration);


### PR DESCRIPTION
Towards [#20267](https://github.com/RobotLocomotion/drake/issues/20267). +@sherm1, @jwnimmer-tri for review please, thank you!

<details>

Deprecate:
1) `Simulator<T>::set_publish_at_initialization()` 
2) `Simulator<T>::set_publish_every_time_step()`
3) `Simulator<T>::get_publish_every_time_step()`
4) `SimulatorConfig{}.publish_every_time_step`
5) `simulator_publish_every_time_step` g_flag.

I modified `mkdoc.py` to print `std::make_pair("x", x.doc_deprecated),` instead of `std::make_pair("x", x.doc),` in `Serialize__fields()`. Without this modification, a build error will occur, since a deprecated variable's docstring has a `doc_deprecated` member instead of `doc`.

Search for the following deprecation date `2026-06-01` when deleting.

I already removed some references of `publish_every_time_step = false` in examples and tests, since it is initialized to false and thus won't have an effect.

</details>

---

Tips for users who need to port their code away from the deprecated API:

## Force publishing

Simulator had APIs to exercise its diagram’s [force](https://drake.mit.edu/doxygen_cxx/namespacedrake_1_1systems.html#a59b7f49353f2a99b6c22d2eaae0fe9e9af8ece195be5dd5e820bdeee7ad21a4bf) events. This includes

- [Simulator::set_publish_every_time_step()](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_simulator.html#aef1dc6aeb821503379ab1dd8c6044562)
- [SimulatorConfig::publish_every_time_step](https://drake.mit.edu/doxygen_cxx/structdrake_1_1systems_1_1_simulator_config.html#af1d9089360c8cd472de8f923ba7df99a)
- The optional command-line parameter simulator_publish_every_time_step
- [Simulator::set_publish_at_initialization()](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_simulator.html#ac210a235b5e0865efb51fdd27c4b58ae)

These have all been deprecated (for removal on 2026-06-01). We don’t expect this will generally impact users. This guide will help those who may rely on this functionality transition into the recommended mechanisms.

Rather than configuring an entire diagram to publish at initialization or at each time step, each LeafSystem articulates independently whether it has work that should be done at initialization or at each time step. This is done by declaring [events](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_event.html) in each LeafSystem’s constructor.

### Simulator::set_publish_every_time_step()

To configure a LeafSystem to publish at every time step, use [LeafSystem::DeclarePerStepPublishEvent()](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_leaf_system.html#a49a07c6bbccc4464d5d6192889c3d2e6) in the system’s constructor.

This will most likely be defined for some form of system introspection: e.g., logging system state, broadcasting state to an external process. Less likely would be visualization because an appropriate visualization rate is typically at a lower frequency than that of simulation steps. Furthermore, well articulated logging systems will typically be parameterized to control their publication rate.

Note: introducing a per-step publish event implicitly includes publishing at initialization.

There is also a deprecated [Simulator::get_publish_every_time_step()](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_simulator.html#ae66775683e61fc461dec4f76bb8e5c7a), the getter for this Simulator parameter. This will need to be evaluated on a per-leaf-system basis.

### SimulatorConfig::publish_every_time_step

This flag value was simply passed to Simulator::set_publish_every_time_step(). If you find you actually have a leaf system that may need to publish at each time step and that determination needs to be made at runtime, you’ll have to find an alternative means to configure it. You can create your own configuration struct and include it in your scene configuration yaml.

### Command-line parameter simulator_publish_every_time_step

This command-line flag simply set the value of SimulatorConfig::publish_every_time_step. Please refer to the previous section for guidance.

### Simulator::set_publish_at_initialization()

To configure a LeafSystem to publish at every time step, use [LeafSystem::DeclareInitializationPublishEvent()](https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_leaf_system.html#aab3136bba7eb6480a84309d019b28d83) in the system’s constructor.

Note: if your leaf system already includes a per-step publish event, you won’t also need an initialization publish event. Initialization is included in per-step events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23940)
<!-- Reviewable:end -->
