### PR TITLE
[tools] Fix release source archive shasum

### DIFF
--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -221,21 +221,7 @@ class _State:
         Compute and return the specified hash for the specified file.
         """
         with open(path, "rb") as f:
-            if hasattr(hashlib, "file_digest"):
-                return hashlib.file_digest(f, algorithm)
-
-            else:
-                digest = hashlib.new(algorithm)
-                buf = bytearray(256 * 1024)
-                view = memoryview(buf)
-
-                while True:
-                    size = f.readinto(buf)
-                    if size == 0:
-                        break
-                    digest.update(view[:size])
-
-                return digest.hexdigest()
+            return hashlib.file_digest(f, algorithm).hexdigest()
 
     def _write_hashfile(
         self, name: str, algorithm: str, local_path: str, hashfile_path: str


### PR DESCRIPTION
Write the SHA-256 itself, instead of the `hashlib` object.

Towards #23941.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23942)
<!-- Reviewable:end -->
