### PR TITLE
[multibody] Specify value types of MultibodyPlant output ports

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -6391,7 +6391,7 @@ Parameter ``shape``:
 
 Parameter ``name``:
     The name for the geometry. It must satisfy the requirements
-    defined in drake∷geometry∷GeometryInstance.
+    defined in geometry∷GeometryInstance.
 
 Parameter ``properties``:
     The illustration properties for this geometry.
@@ -7340,7 +7340,9 @@ Raises:
         struct /* get_body_poses_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Returns the output port of all body poses in the world frame. You can
+R"""(Reports all body poses in the world frame as an AbstractValue
+"abstract-valued" output port containing an
+``std∷vector<math∷RigidTransform<T>>`` of size num_bodies(). You can
 obtain the pose ``X_WB`` of a body B in the world frame W with:
 
 
@@ -7371,9 +7373,11 @@ Raises:
         struct /* get_body_spatial_accelerations_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Returns the output port of all body spatial accelerations in the world
-frame. You can obtain the spatial acceleration ``A_WB`` of a body B
-(for point Bo, the body's origin) in the world frame W with:
+R"""(Reports all body spatial accelerations in the world frame as an
+AbstractValue "abstract-valued" output port containing an
+``std∷vector<SpatialAcceleration<T>>`` of size num_bodies(). You can
+obtain the spatial acceleration ``A_WB`` of a body B (for point Bo,
+the body's origin) in the world frame W with:
 
 
 .. raw:: html
@@ -7409,9 +7413,11 @@ Raises:
         struct /* get_body_spatial_velocities_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Returns the output port of all body spatial velocities in the world
-frame. You can obtain the spatial velocity ``V_WB`` of a body B in the
-world frame W with:
+R"""(Reports all body spatial velocities in the world frame as an
+AbstractValue "abstract-valued" output port containing an
+``std∷vector<SpatialVelocity<T>>`` of size num_bodies(). You can
+obtain the spatial velocity ``V_WB`` of a body B in the world frame W
+with:
 
 
 .. raw:: html
@@ -7473,7 +7479,8 @@ the smallest of the two time scales ``tc`` and ``tn``.)""";
         struct /* get_contact_results_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Returns a constant reference to the port that outputs ContactResults.
+R"""(Returns an AbstractValue "abstract-valued" output port containing a
+ContactResults.
 
 In a discrete-time plant, the use_sampled_output_ports setting affects
 the output of this port. See output_port_sampling "Output port
@@ -7509,9 +7516,10 @@ CouplerConstraintSpec.)""";
         struct /* get_deformable_body_configuration_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Returns the output port for vertex positions (configurations),
-measured and expressed in the World frame, of the deformable bodies in
-``this`` plant as a GeometryConfigurationVector.)""";
+R"""(Reports vertex positions (configurations), measured and expressed in
+the world frame, of the deformable bodies in ``this`` plant as an
+AbstractValue "abstract-valued" output port containing a
+geometry∷GeometryConfigurationVector<T>.)""";
         } get_deformable_body_configuration_output_port;
         // Symbol: drake::multibody::MultibodyPlant::get_desired_state_input_port
         struct /* get_desired_state_input_port */ {
@@ -7617,8 +7625,9 @@ Raises:
         struct /* get_generalized_acceleration_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc_0args =
-R"""(Returns a constant reference to the output port for generalized
-accelerations v̇ of the model.
+R"""(Reports the generalized accelerations v̇ of the model as a
+systems∷BasicVector<T> "vector-valued" output port of size
+num_velocities().
 
 In a discrete-time plant, the use_sampled_output_ports setting affects
 the output of this port. See output_port_sampling "Output port
@@ -7632,8 +7641,10 @@ Raises:
     RuntimeError if called before Finalize().)""";
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc_1args =
-R"""(Returns a constant reference to the output port for the generalized
-accelerations v̇ᵢ ⊆ v̇ for model instance i.
+R"""(Reports the generalized accelerations v̇ᵢ for the given
+``model_instance`` i as a systems∷BasicVector<T> "vector-valued"
+output port of size num_velocities(ModelInstanceIndex) const
+"num_velocities(model_instance)".
 
 In a discrete-time plant, the use_sampled_output_ports setting affects
 the output of this port. See output_port_sampling "Output port
@@ -7653,8 +7664,10 @@ Raises:
         struct /* get_generalized_contact_forces_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Returns a constant reference to the output port of generalized contact
-forces for a specific model instance.
+R"""(Reports the generalized contact forces for the given
+``model_instance`` as a systems∷BasicVector "vector-valued" output
+port of size num_actuated_dofs(ModelInstanceIndex) const
+"num_actuated_dofs(model_instance)".
 
 In a discrete-time plant, the use_sampled_output_ports setting affects
 the output of this port. See output_port_sampling "Output port
@@ -7674,8 +7687,11 @@ Raises:
         struct /* get_geometry_pose_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Returns the output port of frames' poses to communicate with a
-SceneGraph.)""";
+R"""(Reports frames' poses of all non-world bodies in ``this`` plant as an
+AbstractValue "abstract-valued" output port containing a
+geometry∷FramePoseVector<T>. Poses are measured and expressed in the
+World frame. This port is intended to be connected to a
+geometry∷SceneGraph<T> pose input port to communicate frame poses.)""";
         } get_geometry_pose_output_port;
         // Symbol: drake::multibody::MultibodyPlant::get_geometry_query_input_port
         struct /* get_geometry_query_input_port */ {
@@ -7735,10 +7751,10 @@ Raises:
         struct /* get_net_actuation_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc_0args =
-R"""(Returns a constant reference to the output port that reports actuation
-values applied through joint actuators. This output port is a vector
-valued port. The actuation value for a particular actuator can be
-found at offset JointActuator∷input_start() in this vector. Models
+R"""(Reports the actuation values applied by joint actuators as a
+systems∷BasicVector "vector-valued" output port of size
+num_actuated_dofs(). The actuation value for a particular actuator can
+be found at offset JointActuator∷input_start() in this vector. Models
 that include PD controllers will include their contribution in this
 port, refer to mbp_actuation "Actuation" for further details.
 
@@ -7759,12 +7775,14 @@ Raises:
     RuntimeError if called before Finalize().)""";
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc_1args =
-R"""(Returns a constant reference to the output port that reports actuation
-values applied through joint actuators, for a specific model instance.
-Models that include PD controllers will include their contribution in
-this port, refer to mbp_actuation "Actuation" for further details.
-This is a vector valued port with entries ordered by monotonically
-increasing JointActuatorIndex within ``model_instance``.
+R"""(Reports the actuation values applied by joint actuators for the given
+``model_instance`` as a systems∷BasicVector "vector-valued" output
+port of size num_actuated_dofs(ModelInstanceIndex) const
+"num_actuated_dofs(model_instance)". Models that include PD
+controllers will include their contribution in this port, refer to
+mbp_actuation "Actuation" for further details. This is a vector valued
+port with entries ordered by monotonically increasing
+JointActuatorIndex within ``model_instance``.
 
 Every model instance in ``this`` plant model has a net actuation
 output port, even if zero sized (for model instance with no
@@ -7790,17 +7808,19 @@ Raises:
         struct /* get_reaction_forces_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Returns the port for joint reaction forces. A Joint models the
-kinematical relationship which characterizes the possible relative
-motion between two bodies. In Drake, a joint connects a frame ``Jp``
-on *parent* body P with a frame ``Jc`` on a *child* body C. This usage
-of the terms *parent* and *child* is just a convention and implies
-nothing about the inboard-outboard relationship between the bodies.
-Since a Joint imposes a kinematical relationship which characterizes
-the possible relative motion between frames Jp and Jc, reaction forces
-on each body are established. That is, we could cut the model at the
-joint and replace it with equivalent forces equal to these reaction
-forces in order to attain the same motions of the mechanical system.
+R"""(Reports joint reaction forces as an AbstractValue "abstract-valued"
+output port containing an ``std∷vector<SpatialForce<T>>`` of size
+num_joints(). A Joint models the kinematical relationship which
+characterizes the possible relative motion between two bodies. In
+Drake, a joint connects a frame ``Jp`` on *parent* body P with a frame
+``Jc`` on a *child* body C. This usage of the terms *parent* and
+*child* is just a convention and implies nothing about the
+inboard-outboard relationship between the bodies. Since a Joint
+imposes a kinematical relationship which characterizes the possible
+relative motion between frames Jp and Jc, reaction forces on each body
+are established. That is, we could cut the model at the joint and
+replace it with equivalent forces equal to these reaction forces in
+order to attain the same motions of the mechanical system.
 
 This output port allows to evaluate the reaction force ``F_CJc_Jc`` on
 the *child* body C, at ``Jc``, and expressed in Jc for all joints in
@@ -7851,8 +7871,9 @@ after that. Post-finalize calls will always return the same value.)""";
         struct /* get_state_output_port */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc_0args =
-R"""(Returns a constant reference to the output port for the multibody
-state x = [q, v] of the model.
+R"""(Reports the multibody state x = [q, v] of the model as a
+systems∷BasicVector<T> "vector-valued" output port of size
+num_multibody_states().
 
 Precondition:
     Finalize() was already called on ``this`` plant.
@@ -7861,8 +7882,10 @@ Raises:
     RuntimeError if called before Finalize().)""";
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc_1args =
-R"""(Returns a constant reference to the output port for the state xᵢ = [qᵢ
-vᵢ] of model instance i. (Here qᵢ ⊆ q and vᵢ ⊆ v.)
+R"""(Reports the multibody state xᵢ = [qᵢ vᵢ] for the given
+``model_instance`` i as a systems∷BasicVector<T> "vector-valued"
+output port of size num_multibody_states(ModelInstanceIndex) const
+"num_multibody_states(model_instance)". Here qᵢ ⊆ q and vᵢ ⊆ v.
 
 Precondition:
     Finalize() was already called on ``this`` plant.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -995,7 +995,9 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// or its individual model instances.
   /// @{
 
-  /// Returns the output port of all body poses in the world frame.
+  /// Reports all body poses in the world frame as an @ref AbstractValue
+  /// "abstract-valued" output port containing an
+  /// `std::vector<math::RigidTransform<T>>` of size num_bodies().
   /// You can obtain the pose `X_WB` of a body B in the world frame W with:
   /// @code
   ///   const auto& X_WB_all = plant.get_body_poses_output_port().
@@ -1010,7 +1012,9 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called pre-finalize.
   const systems::OutputPort<T>& get_body_poses_output_port() const;
 
-  /// Returns the output port of all body spatial velocities in the world frame.
+  /// Reports all body spatial velocities in the world frame as an @ref
+  /// AbstractValue "abstract-valued" output port containing an
+  /// `std::vector<SpatialVelocity<T>>` of size num_bodies().
   /// You can obtain the spatial velocity `V_WB` of a body B in the world frame
   /// W with:
   /// @code
@@ -1026,9 +1030,11 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called pre-finalize.
   const systems::OutputPort<T>& get_body_spatial_velocities_output_port() const;
 
-  /// Returns the output port of all body spatial accelerations in the world
-  /// frame. You can obtain the spatial acceleration `A_WB` of a body B (for
-  /// point Bo, the body's origin) in the world frame W with:
+  /// Reports all body spatial accelerations in the world frame as an @ref
+  /// AbstractValue "abstract-valued" output port containing an
+  /// `std::vector<SpatialAcceleration<T>>` of size num_bodies().
+  /// You can obtain the spatial acceleration `A_WB` of a body B (for point Bo,
+  /// the body's origin) in the world frame W with:
   /// @code
   ///   const auto& A_WB_all =
   ///   plant.get_body_spatial_accelerations_output_port().
@@ -1076,12 +1082,12 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const systems::InputPort<T>& get_actuation_input_port(
       ModelInstanceIndex model_instance) const;
 
-  /// Returns a constant reference to the output port that reports actuation
-  /// values applied through joint actuators. This output port is a vector
-  /// valued port. The actuation value for a particular actuator can be found at
-  /// offset JointActuator::input_start() in this vector. Models that include PD
-  /// controllers will include their contribution in this port, refer to @ref
-  /// mbp_actuation "Actuation" for further details.
+  /// Reports the actuation values applied by joint actuators as a @ref
+  /// systems::BasicVector "vector-valued" output port of size
+  /// num_actuated_dofs(). The actuation value for a particular actuator can be
+  /// found at offset JointActuator::input_start() in this vector. Models that
+  /// include PD controllers will include their contribution in this port, refer
+  /// to @ref mbp_actuation "Actuation" for further details.
   ///
   /// In a discrete-time plant, the use_sampled_output_ports setting affects the
   /// output of this port.  See @ref output_port_sampling "Output port sampling"
@@ -1095,12 +1101,15 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called before Finalize().
   const systems::OutputPort<T>& get_net_actuation_output_port() const;
 
-  /// Returns a constant reference to the output port that reports actuation
-  /// values applied through joint actuators, for a specific model instance.
-  /// Models that include PD controllers will include their contribution in this
-  /// port, refer to @ref mbp_actuation "Actuation" for further details. This is
-  /// a vector valued port with entries ordered by monotonically increasing @ref
-  /// JointActuatorIndex within `model_instance`.
+  /// Reports the actuation values applied by joint actuators for the given
+  /// `model_instance` as a @ref systems::BasicVector "vector-valued"
+  /// output port of size @ref num_actuated_dofs(ModelInstanceIndex) const
+  /// "num_actuated_dofs(model_instance)".
+  /// Models that include PD controllers
+  /// will include their contribution in this port, refer to @ref mbp_actuation
+  /// "Actuation" for further details. This is a vector valued port with entries
+  /// ordered by monotonically increasing @ref JointActuatorIndex within
+  /// `model_instance`.
   ///
   /// Every model instance in `this` plant model has a net actuation output
   /// port, even if zero sized (for model instance with no actuators).
@@ -1193,22 +1202,26 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// connection with a SceneGraph.
   const systems::InputPort<T>& get_geometry_query_input_port() const;
 
-  /// Returns a constant reference to the output port for the multibody state
-  /// x = [q, v] of the model.
+  /// Reports the multibody state x = [q, v] of the model as a @ref
+  /// systems::BasicVector<T> "vector-valued" output port of size
+  /// num_multibody_states().
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
   const systems::OutputPort<T>& get_state_output_port() const;
 
-  /// Returns a constant reference to the output port for the state
-  /// xᵢ = [qᵢ vᵢ] of model instance i. (Here qᵢ ⊆ q and vᵢ ⊆ v.)
+  /// Reports the multibody state xᵢ = [qᵢ vᵢ] for the given `model_instance` i
+  /// as a @ref systems::BasicVector<T> "vector-valued" output port of
+  /// size @ref num_multibody_states(ModelInstanceIndex) const
+  /// "num_multibody_states(model_instance)". Here qᵢ ⊆ q and vᵢ ⊆ v.
   /// @pre Finalize() was already called on `this` plant.
   /// @throws std::exception if called before Finalize().
   /// @throws std::exception if the model instance does not exist.
   const systems::OutputPort<T>& get_state_output_port(
       ModelInstanceIndex model_instance) const;
 
-  /// Returns a constant reference to the output port for generalized
-  /// accelerations v̇ of the model.
+  /// Reports the generalized accelerations v̇ of the model as a @ref
+  /// systems::BasicVector<T> "vector-valued" output port of size
+  /// num_velocities().
   ///
   /// In a discrete-time plant, the use_sampled_output_ports setting affects the
   /// output of this port.  See @ref output_port_sampling "Output port sampling"
@@ -1220,8 +1233,10 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_generalized_acceleration_output_port()
       const;
 
-  /// Returns a constant reference to the output port for the generalized
-  /// accelerations v̇ᵢ ⊆ v̇ for model instance i.
+  /// Reports the generalized accelerations v̇ᵢ for the given `model_instance` i
+  /// as a @ref systems::BasicVector<T> "vector-valued"
+  /// output port of size @ref num_velocities(ModelInstanceIndex) const
+  /// "num_velocities(model_instance)".
   ///
   /// In a discrete-time plant, the use_sampled_output_ports setting affects the
   /// output of this port.  See @ref output_port_sampling "Output port sampling"
@@ -1234,8 +1249,10 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_generalized_acceleration_output_port(
       ModelInstanceIndex model_instance) const;
 
-  /// Returns a constant reference to the output port of generalized contact
-  /// forces for a specific model instance.
+  /// Reports the generalized contact forces for the given `model_instance`
+  /// as a @ref systems::BasicVector "vector-valued" output port of size
+  /// @ref num_actuated_dofs(ModelInstanceIndex) const
+  /// "num_actuated_dofs(model_instance)".
   ///
   /// In a discrete-time plant, the use_sampled_output_ports setting affects the
   /// output of this port.  See @ref output_port_sampling "Output port sampling"
@@ -1248,7 +1265,9 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_generalized_contact_forces_output_port(
       ModelInstanceIndex model_instance) const;
 
-  /// Returns the port for joint reaction forces.
+  /// Reports joint reaction forces as an @ref AbstractValue "abstract-valued"
+  /// output port containing an `std::vector<SpatialForce<T>>` of size
+  /// num_joints().
   /// A Joint models the kinematical relationship which characterizes the
   /// possible relative motion between two bodies. In Drake, a joint connects a
   /// frame `Jp` on _parent_ body P with a frame `Jc` on a _child_ body C. This
@@ -1279,7 +1298,8 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called pre-finalize.
   const systems::OutputPort<T>& get_reaction_forces_output_port() const;
 
-  /// Returns a constant reference to the port that outputs ContactResults.
+  /// Returns an @ref AbstractValue "abstract-valued" output port containing a
+  /// @ref ContactResults.
   ///
   /// In a discrete-time plant, the use_sampled_output_ports setting affects the
   /// output of this port.  See @ref output_port_sampling "Output port sampling"
@@ -1289,13 +1309,17 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called pre-finalize, see Finalize().
   const systems::OutputPort<T>& get_contact_results_output_port() const;
 
-  /// Returns the output port of frames' poses to communicate with a
-  /// SceneGraph.
+  /// Reports frames' poses of all non-world bodies in `this` plant as an
+  /// @ref AbstractValue "abstract-valued" output port containing a
+  /// @ref geometry::FramePoseVector<T>. Poses are measured and expressed
+  /// in the World frame. This port is intended to be connected to a @ref
+  /// geometry::SceneGraph<T> pose input port to communicate frame poses.
   const systems::OutputPort<T>& get_geometry_pose_output_port() const;
 
-  /// Returns the output port for vertex positions (configurations), measured
-  /// and expressed in the World frame, of the deformable bodies in `this` plant
-  /// as a GeometryConfigurationVector.
+  /// Reports vertex positions (configurations), measured and expressed in the
+  /// world frame, of the deformable bodies in `this` plant as an @ref
+  /// AbstractValue "abstract-valued" output port containing a @ref
+  /// geometry::GeometryConfigurationVector<T>.
   const systems::OutputPort<T>& get_deformable_body_configuration_output_port()
       const;
   /// @} <!-- Input and output ports -->
@@ -2304,7 +2328,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   ///   geometry::Cylinder, etc.
   /// @param[in] name
   ///   The name for the geometry. It must satisfy the requirements defined in
-  ///   drake::geometry::GeometryInstance.
+  ///   geometry::GeometryInstance.
   /// @param[in] properties
   ///   The illustration properties for this geometry.
   /// @throws std::exception if called post-finalize.


### PR DESCRIPTION
Modified documentation for `MultibodyPlant` output ports.
Closes [#13146](https://github.com/RobotLocomotion/drake/issues/13146). +@jwnimmer-tri for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23944)
<!-- Reviewable:end -->
