### PR TITLE
Deprecate `Identifier::operator<<`

### DIFF
--- a/common/identifier.h
+++ b/common/identifier.h
@@ -1,14 +1,17 @@
 #pragma once
 
 #include <cstdint>
-#include <ostream>
 #include <string>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
+
+// Remove with deprecation 2026-05-01.
+#include <ostream>
 
 namespace drake {
 
@@ -233,7 +236,12 @@ class Identifier {
  @relates Identifier
  */
 template <typename Tag>
-std::ostream& operator<<(std::ostream& out, const Identifier<Tag>& id) {
+DRAKE_DEPRECATED(
+    "2026-05-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream&
+operator<<(std::ostream& out, const Identifier<Tag>& id) {
   out << id.get_value();
   return out;
 }
@@ -258,8 +266,4 @@ struct hash<drake::Identifier<Tag>> : public drake::DefaultHash {};
 
 }  // namespace std
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename Tag>
-struct formatter<drake::Identifier<Tag>> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(typename Tag, drake, Identifier<Tag>, x, drake::to_string(x))

--- a/common/test/identifier_test.cc
+++ b/common/test/identifier_test.cc
@@ -182,11 +182,18 @@ TEST_F(IdentifierTests, PutInSet) {
   EXPECT_TRUE(ids.contains(a1));
 }
 
-// Tests the streaming behavior.
+// Tests the streaming behavior. Remove with 2026-05-01 deprecation removal.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(IdentifierTests, StreamOperator) {
   stringstream ss;
   ss << a2_;
   EXPECT_EQ(ss.str(), "2");
+}
+#pragma GCC diagnostic pop
+
+TEST_F(IdentifierTests, FmtFormatterProducesExpectedString) {
+  EXPECT_EQ(fmt::to_string(a2_), "2");
 }
 
 // Tests the ability to convert the id to string via std::to_string.
@@ -304,8 +311,7 @@ TEST_F(IdentifierTests, InvalidStream) {
     return;
   }
   AId invalid;
-  std::stringstream ss;
-  DRAKE_EXPECT_THROWS_MESSAGE(ss << invalid, ".*is_valid.*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(fmt::to_string(invalid), ".*is_valid.*failed.*");
 }
 
 }  // namespace

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -149,23 +149,17 @@ Value& GetMutableValueOrThrow(const Key& key,
 // Specializations for missing key based on key types.
 template <>
 std::string get_missing_id_message<SourceId>(const SourceId& key) {
-  std::stringstream ss;
-  ss << "Referenced geometry source " << key << " is not registered.";
-  return ss.str();
+  return fmt::format("Referenced geometry source {} is not registered.", key);
 }
 
 template <>
 std::string get_missing_id_message<FrameId>(const FrameId& key) {
-  std::stringstream ss;
-  ss << "Referenced frame " << key << " has not been registered.";
-  return ss.str();
+  return fmt::format("Referenced frame {} has not been registered.", key);
 }
 
 template <>
 std::string get_missing_id_message<GeometryId>(const GeometryId& key) {
-  std::stringstream ss;
-  ss << "Referenced geometry " << key << " has not been registered.";
-  return ss.str();
+  return fmt::format("Referenced geometry {} has not been registered.", key);
 }
 
 //-----------------------------------------------------------------------------

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -740,7 +740,7 @@ std::string GraphOfConvexSets::GetGraphvizString(
   graphviz << "digraph GraphOfConvexSets {\n";
   graphviz << "labelloc=t;\n";
   for (const auto& [v_id, v] : vertices_) {
-    graphviz << "v" << v_id << " [label=\"" << v->name();
+    graphviz << "v" << to_string(v_id) << " [label=\"" << v->name();
     if (result) {
       if (options.show_vars) {
         std::optional<VectorXd> x = v->GetSolution(*result);
@@ -759,7 +759,8 @@ std::string GraphOfConvexSets::GetGraphvizString(
   }
   for (const auto& [e_id, e] : edges_) {
     unused(e_id);
-    graphviz << "v" << e->u().id() << " -> v" << e->v().id();
+    graphviz << "v" << to_string(e->u().id()) << " -> v"
+             << to_string(e->v().id());
     graphviz << " [label=\"" << e->name();
     if (result) {
       if (options.show_costs) {
@@ -794,7 +795,8 @@ std::string GraphOfConvexSets::GetGraphvizString(
 
   if (active_path) {
     for (const auto& e : *active_path) {
-      graphviz << "v" << e->u().id() << " -> v" << e->v().id();
+      graphviz << "v" << to_string(e->u().id()) << " -> v"
+               << to_string(e->v().id());
       graphviz << " [label=\"" << e->name() << " = active\"";
       graphviz << ", color="
                << "\"#ff0000\"";

--- a/geometry/proximity/test/collision_filter_test.cc
+++ b/geometry/proximity/test/collision_filter_test.cc
@@ -35,15 +35,16 @@ constexpr bool kCanCollide = true;
   const bool result1 = filter.CanCollideWith(id_A, id_B);
   const bool result2 = filter.CanCollideWith(id_B, id_A);
   if (result1 != result2) {
-    return ::testing::AssertionFailure()
-           << "The collision filter state for " << id_A << " and " << id_B
-           << " changed based on ordering";
+    return ::testing::AssertionFailure() << fmt::format(
+               "The collision filter state for {} and {} changed based on "
+               "ordering",
+               id_A, id_B);
   }
   if (result1 != expect_collidable) {
-    return ::testing::AssertionFailure()
-           << "For pair (" << id_A << ", " << id_B
-           << "), our expectation for can-collide was " << expect_collidable
-           << ", but the filter reported " << result1;
+    return ::testing::AssertionFailure() << fmt::format(
+               "For pair ({}, {}), our expectation for can-collide was {}, but "
+               "the filter reported {}",
+               id_A, id_B, expect_collidable, result1);
   }
   return ::testing::AssertionSuccess();
 }

--- a/geometry/render_gl/test/internal_shader_program_test.cc
+++ b/geometry/render_gl/test/internal_shader_program_test.cc
@@ -174,13 +174,13 @@ class ShaderProgramTest : public ::testing::Test {
       return ::testing::AssertionFailure()
              << "Shader programs didn't match"
              << "\n  p1:"
-             << "\n    shader id: " << p1.id_
+             << "\n    shader id: " << fmt::to_string(p1.id_)
              << "\n    OpenGl id: " << p1.gl_id_
              << "\n    projection matrix location: "
              << p1.projection_matrix_loc_
              << "\n    model view matrix location: " << p1.model_view_loc_
              << "\n    magic number: " << p1.magic_number_ << "\n  p2:"
-             << "\n    shader id: " << p2.id_
+             << "\n    shader id: " << fmt::to_string(p2.id_)
              << "\n    OpenGl id: " << p2.gl_id_
              << "\n    projection matrix location: "
              << p2.projection_matrix_loc_

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -687,7 +687,7 @@ void SceneGraph<T>::CalcPoseUpdate(const Context<T>& context, int*) const {
               "SceneGraph encountered a non-finite value (e.g., NaN or "
               "infinity) on a pose input port. It came from the input "
               "associated with source id {} and name '{}'.",
-              fmt_streamed(source_id), state.GetName(source_id)));
+              source_id, state.GetName(source_id)));
         }
         state.SetFramePoses(source_id, poses, &kinematics_data);
       }
@@ -732,7 +732,7 @@ void SceneGraph<T>::CalcConfigurationUpdate(const Context<T>& context,
               "SceneGraph encountered a non-finite value (e.g., Nan or "
               "infinity) on a deformable configuration input port. It came "
               "from the input associated with source id {} and name '{}'.",
-              fmt_streamed(source_id), state.GetName(source_id)));
+              source_id, state.GetName(source_id)));
         }
         state.SetGeometryConfiguration(source_id, configs, &kinematics_data);
       }

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -2641,7 +2641,7 @@ TEST_F(GeometryStateTest, TestCollisionCandidates) {
             if (!diff.empty()) {
               result << "\n    " << msg;
               for (const auto& p : diff) {
-                result << " (" << p.first << ", " << p.second << ")";
+                result << fmt::format(" ({}, {})", p.first, p.second);
               }
             }
           };
@@ -3141,12 +3141,11 @@ TEST_F(GeometryStateTest, AssignRolesToGeometry) {
     const bool illustration = i & 0x2;
     const bool perception = i & 0x4;
     const GeometryId id = geometries_[i];
-    EXPECT_TRUE(has_expected_roles(id, false, false, false))
-        << "Geometry " << id << " at index (" << i
-        << ") didn't start without roles";
+    EXPECT_TRUE(has_expected_roles(id, false, false, false)) << fmt::format(
+        "Geometry {} at index ({}) didn't start without roles", id, i);
     set_roles(id, proximity, perception, illustration);
     EXPECT_TRUE(has_expected_roles(id, proximity, perception, illustration))
-        << "Incorrect roles for geometry " << id << " at index (" << i << ").";
+        << fmt::format("Incorrect roles for geometry {} at index ({}).", id, i);
   }
 
   // Confirm it works on anchored geometry. Pick, arbitrarily, assigning

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -4218,10 +4218,11 @@ class BoxPenetrationTest : public ::testing::Test {
       p_Ac = expected_penetration_.p_WCb;
       p_Bc = expected_penetration_.p_WCa;
     } else {
-      GTEST_FAIL() << "Wrong geometry ids reported in contact for tangent "
-                   << shape_name(shape_type) << ". Expected " << tangent_id
-                   << " and " << box_id << ". Got " << contact.id_A << " and "
-                   << contact.id_B;
+      GTEST_FAIL() << fmt::format(
+          "Wrong geometry ids reported in contact for tangent {}. Expected {} "
+          "and {}. Got {} and {}",
+          shape_name(shape_type), tangent_id, box_id, contact.id_A,
+          contact.id_B);
     }
     EXPECT_TRUE(CompareMatrices(contact.nhat_BA_W, normal, tolerance))
         << "Against tangent " << shape_name(shape_type);

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1605,8 +1605,8 @@ GTEST_TEST(MultibodyPlantTest, FilterAdjacentBodies) {
         auto pair2 = std::make_pair(id2, id1);
         if (!expected_pairs.contains(pair1) &&
             !expected_pairs.contains(pair2)) {
-          GTEST_FAIL() << "The pair " << id1 << ", " << id2
-                       << " is not in the expected set";
+          GTEST_FAIL() << fmt::format(
+              "The pair {}, {} is not in the expected set", id1, id2);
         }
       };
       for (int i = 0; i < static_cast<int>(contacts.size()); ++i) {


### PR DESCRIPTION
Towards [17742](https://github.com/RobotLocomotion/drake/issues/17742). +@jwnimmer-tri for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23964)
<!-- Reviewable:end -->
