### PR TITLE
Add p_BQ as a free variable in PositionConstraint

### DIFF
--- a/bindings/generated_docstrings/multibody_inverse_kinematics.h
+++ b/bindings/generated_docstrings/multibody_inverse_kinematics.h
@@ -3761,7 +3761,23 @@ gradient of the constraint is computed from autodiff.)""";
         const char* doc =
 R"""(Constrains the position of a point Q, rigidly attached to a frame B,
 to be within a bounding box measured and expressed in frame A. Namely
-p_AQ_lower <= p_AQ <= p_AQ_upper.)""";
+p_AQ_lower <= p_AQ <= p_AQ_upper.
+
+Note that p_BQ may or may not be a decision variable. Common use cases
+include: 1. We want a specified point Q on the frame B to be within a
+bounding box. In this case, p_BQ is specified and not a decision
+variable. 2. We want some point Q on the frame B to be within a
+bounding box, but we don't know the exact position of Q on the frame
+B. For example, we want some point on the robot palm to touch a table,
+but we don't care which point on the robot palm. In this case, p_BQ is
+a decision variable, and we need an additional constraint to say "Q is
+on the surface of the robot palm".
+
+When p_BQ is a decision variable (i.e., it is *not* specified in the
+ctor), the constraint is evaluated on the vector x = [q, p_BQ]. When
+p_BQ is not a decision variable (i.e. it *is* specified
+non-`nullopt`in the ctor), the constraint is evaluated on the vector x
+= q.)""";
         // Symbol: drake::multibody::PositionConstraint::PositionConstraint
         struct /* ctor */ {
           // Source: drake/multibody/inverse_kinematics/position_constraint.h
@@ -3788,7 +3804,8 @@ Parameter ``frameB``:
 
 Parameter ``p_BQ``:
     The position of the point Q, rigidly attached to frame B, measured
-    and expressed in frame B.
+    and expressed in frame B. If set to nullopt, then p_BQ is also a
+    decision variable.
 
 Parameter ``plant_context``:
     The Context that has been allocated for this ``plant``. We will
@@ -3843,7 +3860,8 @@ Parameter ``frameB``:
 
 Parameter ``p_BQ``:
     The position of the point Q, rigidly attached to frame B, measured
-    and expressed in frame B.
+    and expressed in frame B. If set to nullopt, then p_BQ is also a
+    decision variable.
 
 Parameter ``plant_context``:
     The Context that has been allocated for this ``plant``. We will

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -661,7 +661,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
                           const Frame<double>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+                          std::optional<Eigen::Vector3d> p_BQ,
                           systems::Context<double>* plant_context) {
           return std::make_unique<Class>(plant, frameA, p_AQ_lower, p_AQ_upper,
               frameB, p_BQ, plant_context);
@@ -679,7 +679,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
                           const Frame<double>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+                          std::optional<Eigen::Vector3d> p_BQ,
                           systems::Context<double>* plant_context) {
           return std::make_unique<Class>(plant, frameAbar, X_AbarA, p_AQ_lower,
               p_AQ_upper, frameB, p_BQ, plant_context);
@@ -696,7 +696,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
                           const Frame<AutoDiffXd>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+                          std::optional<Eigen::Vector3d> p_BQ,
                           systems::Context<AutoDiffXd>* plant_context) {
           return std::make_unique<Class>(plant, frameA, p_AQ_lower, p_AQ_upper,
               frameB, p_BQ, plant_context);
@@ -714,7 +714,7 @@ PYBIND11_MODULE(inverse_kinematics, m) {
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
                           const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
                           const Frame<AutoDiffXd>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+                          std::optional<Eigen::Vector3d> p_BQ,
                           systems::Context<AutoDiffXd>* plant_context) {
           return std::make_unique<Class>(plant, frameAbar, X_AbarA, p_AQ_lower,
               p_AQ_upper, frameB, p_BQ, plant_context);

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -867,6 +867,23 @@ class TestConstraints(unittest.TestCase):
         constraint.UpdateUpperBound(new_ub=np.array([10.0, 0.5, 2.0]))
         constraint.set_bounds(new_lb=[-1, -2, -2.0], new_ub=[1.0, 2.0, 3.0])
 
+        # Construct without specifying p_BQ's value. p_BQ is a decision
+        # variable.
+        constraint = ik.PositionConstraint(
+            plant=variables.plant,
+            frameAbar=variables.body1_frame,
+            X_AbarA=RigidTransform([-0.1, -0.2, -0.3]),
+            p_AQ_lower=[-0.1, -0.2, -0.3],
+            p_AQ_upper=[-0.05, -0.12, -0.28],
+            frameB=variables.body2_frame,
+            p_BQ=None,
+            plant_context=variables.plant_context,
+        )
+        self.assertIsInstance(constraint, mp.Constraint)
+        self.assertEqual(
+            constraint.num_vars(), variables.plant.num_positions() + 3
+        )
+
     @check_type_variables
     def test_position_cost(self, variables):
         cost = ik.PositionCost(

--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/inverse_kinematics/position_constraint.h"
 
+#include <utility>
+
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/inverse_kinematics/kinematic_evaluator_utilities.h"
 
@@ -8,79 +10,51 @@ using drake::multibody::internal::UpdateContextConfiguration;
 
 namespace drake {
 namespace multibody {
-
 PositionConstraint::~PositionConstraint() = default;
 
+// Double version. No frameAbar.
 PositionConstraint::PositionConstraint(
     const MultibodyPlant<double>* const plant, const Frame<double>& frameA,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-    const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+    const Frame<double>& frameB, std::optional<Eigen::Vector3d> p_BQ,
     systems::Context<double>* plant_context)
     : PositionConstraint(plant, frameA, std::nullopt, p_AQ_lower, p_AQ_upper,
-                         frameB, p_BQ, plant_context) {}
+                         frameB, std::move(p_BQ), plant_context) {}
 
+// Double version.
 PositionConstraint::PositionConstraint(
     const MultibodyPlant<double>* const plant, const Frame<double>& frameAbar,
     const std::optional<math::RigidTransformd>& X_AbarA,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-    const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+    const Frame<double>& frameB, std::optional<Eigen::Vector3d> p_BQ,
     systems::Context<double>* plant_context)
-    : solvers::Constraint(3, RefFromPtrOrThrow(plant).num_positions(),
-                          p_AQ_lower, p_AQ_upper),
-      plant_double_(plant),
-      frameAbar_index_(frameAbar.index()),
-      X_AAbar_{X_AbarA.has_value() ? X_AbarA.value().inverse()
-                                   : math::RigidTransformd::Identity()},
-      frameB_index_(frameB.index()),
-      p_BQ_{p_BQ},
-      context_double_{plant_context},
-      plant_autodiff_(nullptr),
-      context_autodiff_(nullptr) {
-  if (plant == nullptr) {
-    throw std::invalid_argument("PositionConstraint(): plant is nullptr.");
-  }
-  if (plant_context == nullptr) {
-    throw std::invalid_argument(
-        "PositionConstraint(): plant_context is nullptr.");
-  }
-}
+    : PositionConstraint(plant, frameAbar, X_AbarA, p_AQ_lower, p_AQ_upper,
+                         frameB, std::move(p_BQ), plant_context, 0) {}
 
+// Autodiff version.
 PositionConstraint::PositionConstraint(
     const MultibodyPlant<AutoDiffXd>* const plant,
     const Frame<AutoDiffXd>& frameAbar,
     const std::optional<math::RigidTransformd>& X_AbarA,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-    const Frame<AutoDiffXd>& frameB,
-    const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+    const Frame<AutoDiffXd>& frameB, std::optional<Eigen::Vector3d> p_BQ,
     systems::Context<AutoDiffXd>* plant_context)
-    : solvers::Constraint(3, RefFromPtrOrThrow(plant).num_positions(),
-                          p_AQ_lower, p_AQ_upper),
-      plant_double_(nullptr),
-      frameAbar_index_(frameAbar.index()),
-      X_AAbar_{X_AbarA.has_value() ? X_AbarA.value().inverse()
-                                   : math::RigidTransformd::Identity()},
-      frameB_index_(frameB.index()),
-      p_BQ_{p_BQ},
-      context_double_{nullptr},
-      plant_autodiff_(plant),
-      context_autodiff_(plant_context) {
-  if (plant_context == nullptr)
-    throw std::invalid_argument("plant_context is nullptr.");
-}
+    : PositionConstraint(plant, frameAbar, X_AbarA, p_AQ_lower, p_AQ_upper,
+                         frameB, std::move(p_BQ), plant_context, 0) {}
 
+// AutoDiff version. No frameAbar.
 PositionConstraint::PositionConstraint(
     const MultibodyPlant<AutoDiffXd>* const plant,
     const Frame<AutoDiffXd>& frameA,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-    const Frame<AutoDiffXd>& frameB,
-    const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
+    const Frame<AutoDiffXd>& frameB, std::optional<Eigen::Vector3d> p_BQ,
     systems::Context<AutoDiffXd>* plant_context)
     : PositionConstraint(plant, frameA, std::nullopt, p_AQ_lower, p_AQ_upper,
-                         frameB, p_BQ, plant_context) {}
+                         frameB, std::move(p_BQ), plant_context, 0) {}
 
 namespace {
 
@@ -89,34 +63,79 @@ void EvalConstraintGradient(
     const MultibodyPlant<double>& plant, const Frame<double>& frameAbar,
     const math::RigidTransformd& X_AAbar, const Frame<double>& frameB,
     const Eigen::Vector3d& p_AQ, const Eigen::Vector3d& p_BQ,
-    const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd* y) {
+    bool p_BQ_is_decision_variable, const Eigen::Ref<const AutoDiffVecXd>& x,
+    AutoDiffVecXd* y) {
   Eigen::Matrix3Xd Jq_V_AbarBq(3, plant.num_positions());
   plant.CalcJacobianTranslationalVelocity(context, JacobianWrtVariable::kQDot,
                                           frameB, p_BQ, frameAbar, frameAbar,
                                           &Jq_V_AbarBq);
-  *y =
-      math::InitializeAutoDiff(p_AQ, X_AAbar.rotation().matrix() * Jq_V_AbarBq *
-                                         math::ExtractGradient(x));
+  if (p_BQ_is_decision_variable) {
+    // dy/dq = R_AAbar * Jq_V_AbarBq
+    // dy/dp_BQ = R_AAbar * R_AbarB
+    Eigen::Matrix3Xd dydx(3, x.size());
+    dydx.leftCols(plant.num_positions()) =
+        X_AAbar.rotation().matrix() * Jq_V_AbarBq;
+    const math::RigidTransformd X_AbarB =
+        plant.CalcRelativeTransform(context, frameAbar, frameB);
+    dydx.rightCols<3>() =
+        X_AAbar.rotation().matrix() * X_AbarB.rotation().matrix();
+    const Eigen::Matrix3Xd gradient = dydx * math::ExtractGradient(x);
+    *y = math::InitializeAutoDiff(p_AQ, gradient);
+  } else {
+    *y = math::InitializeAutoDiff(
+        p_AQ,
+        X_AAbar.rotation().matrix() * Jq_V_AbarBq * math::ExtractGradient(x));
+  }
 }
 
+// The supported template are
+// T = double, S = double
+// T = double, S = AutoDiffXd
+// T = AutoDiffXd, S = AutoDiffXd
 template <typename T, typename S>
 void DoEvalGeneric(const MultibodyPlant<T>& plant, systems::Context<T>* context,
                    const FrameIndex frameAbar_index,
                    const math::RigidTransformd& X_AAbar,
-                   const FrameIndex frameB_index, const Eigen::Vector3d& p_BQ,
+                   const FrameIndex frameB_index,
+                   const std::optional<Eigen::Vector3d>& p_BQ,
                    const Eigen::Ref<const VectorX<S>>& x, VectorX<S>* y) {
   y->resize(3);
-  UpdateContextConfiguration(context, plant, x);
+  Vector3<T> p_BQ_T;
+  Eigen::Vector3d p_BQ_value;
+  const bool p_BQ_is_decision_variable = !p_BQ.has_value();
+  if (p_BQ_is_decision_variable) {
+    const VectorX<S> q = x.head(plant.num_positions());
+    UpdateContextConfiguration(context, plant, q);
+    if constexpr (std::is_same_v<S, double>) {
+      p_BQ_value = x.template tail<3>();
+    } else {
+      // x is AutoDiffXd
+      p_BQ_value(0) = x(plant.num_positions()).value();
+      p_BQ_value(1) = x(plant.num_positions() + 1).value();
+      p_BQ_value(2) = x(plant.num_positions() + 2).value();
+    }
+    if constexpr (std::is_same_v<T, S>) {
+      p_BQ_T = x.template tail<3>();
+    } else {
+      // S != T --> T is double. Assign double to double.
+      p_BQ_T = p_BQ_value;
+    }
+  } else {
+    p_BQ_value = p_BQ.value();
+    p_BQ_T = p_BQ_value;
+    UpdateContextConfiguration(context, plant, x);
+  }
+
   const Frame<T>& frameAbar = plant.get_frame(frameAbar_index);
   const Frame<T>& frameB = plant.get_frame(frameB_index);
   Vector3<T> p_AbarQ;
-  plant.CalcPointsPositions(*context, frameB, p_BQ.cast<T>(), frameAbar,
-                            &p_AbarQ);
+  plant.CalcPointsPositions(*context, frameB, p_BQ_T, frameAbar, &p_AbarQ);
   if constexpr (std::is_same_v<T, S>) {
     *y = X_AAbar.cast<S>() * p_AbarQ;
   } else {
     EvalConstraintGradient(*context, plant, frameAbar, X_AAbar, frameB,
-                           X_AAbar * p_AbarQ, p_BQ, x, y);
+                           X_AAbar * p_AbarQ, p_BQ_value,
+                           p_BQ_is_decision_variable, x, y);
   }
 }
 
@@ -142,6 +161,57 @@ void PositionConstraint::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
   } else {
     DoEvalGeneric(*plant_autodiff_, context_autodiff_, frameAbar_index_,
                   X_AAbar_, frameB_index_, p_BQ_, x, y);
+  }
+}
+namespace {
+
+template <typename T, typename U>
+const MultibodyPlant<T>* MaybeMatchScalar(const MultibodyPlant<U>* instance) {
+  if constexpr (std::is_same_v<T, U>) {
+    return instance;
+  } else {
+    return nullptr;
+  }
+}
+
+template <typename T, typename U>
+systems::Context<T>* MaybeMatchScalar(systems::Context<U>* instance) {
+  if constexpr (std::is_same_v<T, U>) {
+    return instance;
+  } else {
+    return nullptr;
+  }
+}
+
+}  // namespace
+
+template <typename T>
+PositionConstraint::PositionConstraint(
+    const MultibodyPlant<T>* plant, const Frame<T>& frameAbar,
+    const std::optional<math::RigidTransformd>& X_AbarA,
+    const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
+    const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper, const Frame<T>& frameB,
+    const std::optional<Eigen::Vector3d>& p_BQ,
+    systems::Context<T>* plant_context, int)
+    : solvers::Constraint(
+          3,
+          RefFromPtrOrThrow(plant).num_positions() + (p_BQ.has_value() ? 0 : 3),
+          p_AQ_lower, p_AQ_upper),
+      plant_double_(MaybeMatchScalar<double>(plant)),
+      frameAbar_index_(frameAbar.index()),
+      X_AAbar_{X_AbarA.has_value() ? X_AbarA.value().inverse()
+                                   : math::RigidTransformd::Identity()},
+      frameB_index_(frameB.index()),
+      p_BQ_{p_BQ},
+      context_double_{MaybeMatchScalar<double>(plant_context)},
+      plant_autodiff_(MaybeMatchScalar<AutoDiffXd>(plant)),
+      context_autodiff_(MaybeMatchScalar<AutoDiffXd>(plant_context)) {
+  if (plant == nullptr) {
+    throw std::invalid_argument("PositionConstraint(): plant is nullptr.");
+  }
+  if (plant_context == nullptr) {
+    throw std::invalid_argument(
+        "PositionConstraint(): plant_context is nullptr.");
   }
 }
 


### PR DESCRIPTION
The users can search over the point p_BQ as a decision variable, expressed in the frame B.

Resolves #22793

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23967)
<!-- Reviewable:end -->
