### PR TITLE
[doc] Switch from StackOverflow to GitHub discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -1,12 +1,12 @@
 name: Bug Report
-description: File a bug report.  (Please do not post questions this way; see below for StackOverflow links.)
+description: File a bug report.  (Please do not post questions this way; see below for a link to "Questions".)
 labels: ["type: bug"]
 body:
   - type: markdown
     attributes:
       value:
         Thanks for taking the time to fill out this bug report!
-        The `#drake` posts on [StackOverflow](https://stackoverflow.com/questions/tagged/drake)
+        Prior [discussions](https://github.com/RobotLocomotion/drake/discussions)
         also might help you find a solution.
   - type: textarea
     id: what-happened


### PR DESCRIPTION
A few cross-references were missed in the prior commit.  (Amends #23915).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23969)
<!-- Reviewable:end -->
