### PR TITLE
Improve Obb-Plane/HalfSpace intersection

### DIFF
--- a/geometry/proximity/obb.cc
+++ b/geometry/proximity/obb.cc
@@ -53,40 +53,39 @@ bool Obb::HasOverlap(const Obb& obb_G, const Aabb& aabb_H,
   return internal::BoxesOverlap(aabb_H.half_width(), obb_G.half_width(), X_AO);
 }
 
-bool Obb::HasOverlap(const Obb& bv, const internal::Plane<double>& plane_P,
+bool Obb::HasOverlap(const Obb& bv_H, const internal::Plane<double>& plane_P,
                      const math::RigidTransformd& X_PH) {
-  // We want the two corners of the box that lie at the most extreme extents in
-  // the plane's normal direction. Then we can determine their heights
-  // -- if the interval of heights includes _zero_, the box overlaps.
+  /* The box doesn't overlap the plane if the box center is sufficiently far
+   from the plane to provide "clearance". If we consider the vector from the
+   "lowest" (defined relative to the normal direction) point on the box L to the
+   box origin Bo, p_LBo, the measure of that vector's projection onto the plane
+   normal, p_LBo·n_P, is exactly the clearance distance.
 
-  // The box's canonical frame B is posed in the hierarchy frame H.
-  const RigidTransformd& X_HB = bv.pose();
-  const RotationMatrixd R_PB = X_PH.rotation() * X_HB.rotation();
-  // The corner of the box that will have the *greatest* height value w.r.t.
-  // the plane measured from the box's frame's origin (Bo) but expressed in the
-  // plane's frame.
-  Vector3d p_BoCmax_P = Vector3d::Zero();
-  // We want to find the vectors Bᴹᵃˣᵢ  ∈ {Bᵢ, -Bᵢ}, such that Bᴹᵃˣᵢ ⋅ n̂ₚ is
-  // positive. The maximum box corner is a combination of those Bᴹᵃˣᵢ vectors.
+   By definition, the vector p_LBo = ±Bx·hx + ±By·hy + ±Bz·hz, where the
+   signs applied to the basis vectors depend on the relative orientation of B
+   and P. Specifically, we'd pick the signs of the basis vectors so that Bi·n_P
+   is non-negative. Fortunately, we don't need to find the actual point L; we
+   only need the measure of the projected vector. We can exploit the fact that
+   (-Bi)·n_P = -(Bi·n_P); |Bi·n_P| is equal to ±Bi·n_P where we've picked
+   the "right" sign. */
+
+  const RotationMatrixd& R_HB = bv_H.pose().rotation();
+  const RotationMatrixd R_PB = X_PH.rotation() * R_HB;
+  double half_extent_along_normal = 0.0;
+  const Vector3d& n_P = ExtractDoubleOrThrow(plane_P.normal());
   for (int i = 0; i < 3; ++i) {
-    const Vector3d& Bi_P = R_PB.col(i);
-    const Vector3d& Bi_max_P = Bi_P.dot(plane_P.normal()) > 0 ? Bi_P : -Bi_P;
-    p_BoCmax_P += Bi_max_P * bv.half_width()(i);
+    const auto& Bi_P = R_PB.col(i);
+    double extent = std::abs(Bi_P.dot(n_P)) * bv_H.half_width()(i);
+    half_extent_along_normal += extent;
   }
 
-  const Vector3d& p_HoBo_H = bv.center();
-  const Vector3d p_PoBo_P = X_PH * p_HoBo_H;
-  // Minimum corner is merely the reflection of the maximum corner across the
-  // center of the box.
-  const Vector3d p_PoCmax_P = p_PoBo_P + p_BoCmax_P;
-  const Vector3d p_PoCmin_P = p_PoBo_P - p_BoCmax_P;
-
-  const double max_height = plane_P.CalcHeight(p_PoCmax_P);
-  const double min_height = plane_P.CalcHeight(p_PoCmin_P);
-  return min_height <= 0 && 0 <= max_height;
+  const Vector3d p_PoBo_P = X_PH * bv_H.center();
+  const double box_center_height =
+      ExtractDoubleOrThrow(plane_P.CalcHeight(p_PoBo_P));
+  return std::abs(box_center_height) <= half_extent_along_normal;
 }
 
-bool Obb::HasOverlap(const Obb& bv, const HalfSpace&,
+bool Obb::HasOverlap(const Obb& bv_H, const HalfSpace&,
                      const math::RigidTransformd& X_CH) {
   /*
                                               Hy           Hx
@@ -108,52 +107,41 @@ bool Obb::HasOverlap(const Obb& bv, const HalfSpace&,
               ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  Half space
               ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
-    If any point in the bounding volume has a signed distance φ that is less
-    than or equal to zero, we consider the box to be overlapping the half space.
-    We could simply, yet inefficiently, determine this by iterating over all
-    eight vertices and evaluating the signed distance for each vertex.
+    In the picture above, L is the point of the box that is "lowest" (in the
+    opposite direction of the normal. We can project the vector from v_BoL onto
+    the half space normal Cz to get the _minimum distance_ between the box
+    center and the half space boundary for the box to be outside the half space.
 
-    However, to provide value as a culling algorithm, we need to be cheaper. So,
-    if the lowest corner (marked `L`) has a signed distance less than or equal
-    to zero, the overlapping condition is met.
+    So, |v_BoL·Cz| is the clearance distance. The signed distance of the box
+    center to the half space boundary is p_CB·Cz. The box doesn't overlap the
+    half space iff p_CB·Cz > |v_BoL·Cz|.
 
-    The point L = Bₒ + ∑ sᵢ * dᵢ * Bᵢ, where:
-      - i ∈ {x, y, z}.
-      - dᵢ is the _half_ measure of the box's dimension along axis i.
-      - sᵢ ∈ {1, -1}, such that sᵢBᵢ ⋅ Cz ≤ 0.
-
-    Since, φ(p_CL) = p_CL ⋅ Cz. If p_CL is expressed in C, then the z-component
-    of p_CL (p_CL_z), is equal to φ(p_CL). So, if p_CL_z ≤ 0, they overlap.
+    Given we're dotting everything with Cz, we only need the z-components of
+    the quantities in question.
    */
 
   // The box's canonical frame B is posed in the hierarchy frame H.
-  const RigidTransformd& X_HB = bv.pose();
+  const RigidTransformd& X_HB = bv_H.pose();
   // The z-component of the position vector from box center (Bo) to the lowest
   // corner of the box (L) expressed in the half space's canonical frame C.
   const RotationMatrixd& R_CH = X_CH.rotation();
-  const auto R_CB = (R_CH * X_HB.rotation()).matrix();
-  double p_BL_C_z = 0.0;
-  for (int i = 0; i < 3; ++i) {
-    // R_CB(2, i) is Bi_C(2) --> the z-component of Bi_C.
-    const double Bi_C_z = R_CB(2, i);
-    const double s_i = Bi_C_z > 0 ? -1 : 1;
-    p_BL_C_z += s_i * bv.half_width()(i) * Bi_C_z;
-  }
-  // Now we compute the z-component of the position vector from Co to L,
-  // expressed in Frame C.
-  //  p_CL_C = p_CB_C                   + p_BL_C
-  //         = p_CH_C + p_HB_C          + p_BL_C
-  //         = p_CH_C + (R_CH * p_HB_H) + p_BL_C
+  const auto R_CB = (R_CH * X_HB.rotation());
+  // Just taking the bottom row of R_CB operates on just the z-components.
+  const double clearance =
+      R_CB.row(2).cwiseAbs().dot(bv_H.half_width().transpose());
+
+  // Now we compute the z-component of p_CB:
+  //  p_CB_C = p_CH_C + p_HB_C
+  //         = p_CH_C + (R_CB * p_HB_H)
   // In all of these calculations, we only need the z-component. So, that means
   // we can get the z-component of p_HB_C without the full
   // R_CH * p_HB_H calculation; we can simply do Cz_H ⋅ p_HB_H.
-  const Vector3d& p_HB_H = bv.center();
+  const Vector3d& p_HB_H = bv_H.center();
   const Vector3d& Cz_H = R_CH.row(2);
   const double p_HB_C_z = Cz_H.dot(p_HB_H);
   const double p_CH_C_z = X_CH.translation()(2);
   const double p_CB_C_z = p_CH_C_z + p_HB_C_z;
-  const double p_CL_C_z = p_CB_C_z + p_BL_C_z;
-  return p_CL_C_z <= 0;
+  return p_CB_C_z <= clearance;
 }
 
 void Obb::PadBoundary() {


### PR DESCRIPTION
The old spelling, while correct, did a bunch of redundant operations. This streamlines it down to a more compact calculation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23972)
<!-- Reviewable:end -->
