### PR TITLE
Deprecate `drake::symbolic::Monomial::operator<<`

### DIFF
--- a/bindings/generated_docstrings/common_symbolic.h
+++ b/bindings/generated_docstrings/common_symbolic.h
@@ -1326,6 +1326,12 @@ R"""(Returns this monomial raised to ``p``.
 Raises:
     RuntimeError if ``p`` is negative.)""";
         } pow_in_place;
+        // Symbol: drake::symbolic::Monomial::to_string
+        struct /* to_string */ {
+          // Source: drake/common/symbolic/monomial.h
+          const char* doc =
+R"""(Returns the string representation of this monomial.)""";
+        } to_string;
         // Symbol: drake::symbolic::Monomial::total_degree
         struct /* total_degree */ {
           // Source: drake/common/symbolic/monomial.h

--- a/common/symbolic/decompose.cc
+++ b/common/symbolic/decompose.cc
@@ -265,12 +265,10 @@ void DecomposeQuadraticPolynomial(
     const double coefficient = get_constant_value(p.second);
     const symbolic::Monomial& p_monomial = p.first;
     if (p_monomial.total_degree() > 2) {
-      ostringstream oss;
-      oss << p.first
-          << " has order higher than 2 and it cannot be handled by "
-             "DecomposeQuadraticPolynomial."
-          << std::endl;
-      throw runtime_error(oss.str());
+      throw runtime_error(
+          fmt::format("{} has order higher than 2 and it cannot be handled by "
+                      "DecomposeQuadraticPolynomial.\n",
+                      p.first));
     }
     const auto& monomial_powers = p_monomial.get_powers();
     if (monomial_powers.size() == 2) {

--- a/common/symbolic/monomial.cc
+++ b/common/symbolic/monomial.cc
@@ -6,6 +6,7 @@
 #include <map>
 #include <numeric>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 #include <fmt/format.h>
@@ -23,9 +24,9 @@ using std::logic_error;
 using std::make_pair;
 using std::map;
 using std::ostream;
-using std::ostringstream;
 using std::pair;
 using std::runtime_error;
+using std::string;
 
 namespace {
 // Computes the total degree of a monomial. This method is used in a
@@ -187,13 +188,10 @@ double Monomial::Evaluate(const Environment& env) const {
         const Variable& var{p.first};
         const auto it = env.find(var);
         if (it == env.end()) {
-          ostringstream oss;
-          oss << "Monomial " << *this
-              << " cannot be evaluated with the given "
-                 "environment which does not provide an entry "
-                 "for variable = "
-              << fmt::to_string(var) << ".";
-          throw runtime_error(oss.str());
+          throw runtime_error(fmt::format(
+              "Monomial {} cannot be evaluated with the given environment "
+              "which does not provide an entry for variable = {}.",
+              *this, var));
         } else {
           const double base{it->second};
           const int exponent{p.second};
@@ -265,9 +263,8 @@ Monomial& Monomial::operator*=(const Monomial& m) {
 
 Monomial& Monomial::pow_in_place(const int p) {
   if (p < 0) {
-    ostringstream oss;
-    oss << "Monomial::pow(int p) is called with a negative p = " << p;
-    throw runtime_error(oss.str());
+    throw runtime_error(fmt::format(
+        "Monomial::pow(int p) is called with a negative p = {}", p));
   }
   if (p == 0) {
     total_degree_ = 0;
@@ -282,23 +279,27 @@ Monomial& Monomial::pow_in_place(const int p) {
   return *this;
 }
 
-ostream& operator<<(ostream& out, const Monomial& m) {
-  if (m.powers_.empty()) {
-    return out << 1;
+string Monomial::to_string() const {
+  if (powers_.empty()) {
+    return fmt::to_string(1);
   }
-  auto it = m.powers_.begin();
-  out << fmt::to_string(it->first);
+  string result;
+  auto it = powers_.begin();
+  result.append(fmt::to_string(it->first));
   if (it->second > 1) {
-    out << "^" << it->second;
+    result.append(fmt::format("^{}", it->second));
   }
-  for (++it; it != m.powers_.end(); ++it) {
-    out << " * ";
-    out << fmt::to_string(it->first);
+  for (++it; it != powers_.end(); ++it) {
+    result.append(fmt::format(" * {}", it->first));
     if (it->second > 1) {
-      out << "^" << it->second;
+      result.append(fmt::format("^{}", it->second));
     }
   }
-  return out;
+  return result;
+}
+
+ostream& operator<<(ostream& out, const Monomial& m) {
+  return out << fmt::to_string(m);
 }
 
 Monomial operator*(Monomial m1, const Monomial& m2) {

--- a/common/symbolic/monomial.h
+++ b/common/symbolic/monomial.h
@@ -2,15 +2,19 @@
 
 #include <cstddef>
 #include <map>
-#include <ostream>
+#include <string>
 #include <utility>
 
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/expression.h"
+
+// Remove with deprecation 2026-05-01.
+#include <ostream>
 
 // Some of our Eigen template specializations live in polynomial.h, so we
 // must only have been included from that file.  This helps prevent us from
@@ -137,12 +141,18 @@ class Monomial {
     hash_append(hasher, item.powers_);
   }
 
+  /** Returns the string representation of this monomial. */
+  std::string to_string() const;
+
  private:
   int total_degree_{0};
   std::map<Variable, int> powers_;
-  friend std::ostream& operator<<(std::ostream& out, const Monomial& m);
 };
 
+DRAKE_DEPRECATED(
+    "2026-05-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream& out, const Monomial& m);
 
 /** Returns a multiplication of two monomials, `m1` and `m2`. */
@@ -182,10 +192,5 @@ EIGEN_DEVICE_FUNC inline drake::symbolic::Expression cast(
 }  // namespace internal
 }  // namespace Eigen
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::symbolic::Monomial> : drake::ostream_formatter {};
-}  // namespace fmt
-
+DRAKE_FORMATTER_AS(, drake::symbolic, Monomial, x, x.to_string())
 #endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/common/symbolic/polynomial.cc
+++ b/common/symbolic/polynomial.cc
@@ -1112,7 +1112,7 @@ void Polynomial::CheckInvariant() const {
       oss << "Polynomial " << *this
           << " does not satisfy the invariant because the coefficient of the "
              "monomial "
-          << monomial << " is 0.\n";
+          << fmt::to_string(monomial) << " is 0.\n";
       throw runtime_error(oss.str());
     }
   }
@@ -1270,9 +1270,9 @@ ostream& operator<<(ostream& os, const Polynomial& p) {
     return os << 0;
   }
   auto it = map.begin();
-  os << it->second << "*" << it->first;
+  os << it->second << "*" << fmt::to_string(it->first);
   for (++it; it != map.end(); ++it) {
-    os << " + " << it->second << "*" << it->first;
+    os << " + " << it->second << "*" << fmt::to_string(it->first);
   }
   return os;
 }

--- a/common/symbolic/replace_bilinear_terms.cc
+++ b/common/symbolic/replace_bilinear_terms.cc
@@ -55,10 +55,8 @@ Expression ReplaceBilinearTerms(
       monomial_map.emplace(var_power.first.get_id(), var_power.second);
     }
     if (monomial_degree > 2) {
-      ostringstream oss;
-      oss << "The term " << p.first
-          << " has degree larger than 2 on the variables";
-      throw runtime_error(oss.str());
+      throw runtime_error(fmt::format(
+          "The term {} has degree larger than 2 on the variables", p.first));
     } else if (monomial_degree < 2) {
       // Only linear or constant terms, do not need to replace the variables.
       poly.AddProduct(p.second, p.first);
@@ -92,11 +90,10 @@ Expression ReplaceBilinearTerms(
           it_y_idx == y_to_index_map.end()) {
         // This error would happen, if we ask
         // ReplaceBilinearTerms(x(i) * x(j), x, y, W).
-        ostringstream oss;
-        oss << "Term " << p.first
-            << " is bilinear, but x and y does not have "
-               "the corresponding variables.";
-        throw runtime_error(oss.str());
+        throw runtime_error(
+            fmt::format("Term {} is bilinear, but x and y does not have the "
+                        "corresponding variables.",
+                        p.first));
       }
       // w_xy_expr is the symbolic expression representing the bilinear term x *
       // y.

--- a/common/symbolic/test/monomial_test.cc
+++ b/common/symbolic/test/monomial_test.cc
@@ -183,6 +183,18 @@ TEST_F(MonomialTest, GetVariables) {
   EXPECT_EQ(m3.GetVariables(), Variables({var_x_, var_y_, var_z_}));
 }
 
+TEST_F(MonomialTest, MonomialToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(Monomial{}), "1");
+  EXPECT_EQ(fmt::to_string(Monomial{{{var_x_, 1}}}), "x");
+  EXPECT_EQ(fmt::to_string(Monomial{{{var_x_, 2}}}), "x^2");
+  // Variable print order depends on Variable ID (hence on Variable creation
+  // order). z is defined first so it gets printed first, y second, and so on.
+  EXPECT_EQ(fmt::to_string(Monomial{{{var_x_, 1}, {var_z_, 3}}}), "z^3 * x");
+  EXPECT_EQ(fmt::to_string(Monomial{{{var_x_, 2}, {var_z_, 3}}}), "z^3 * x^2");
+  EXPECT_EQ(fmt::to_string(Monomial{{{var_x_, 2}, {var_z_, 3}, {var_y_, 5}}}),
+            "z^3 * y^5 * x^2");
+}
+
 // Checks we can have an Eigen matrix of Monomials without compilation
 // errors. No assertions in the test.
 TEST_F(MonomialTest, EigenMatrixOfMonomials) {

--- a/common/test_utilities/symbolic_test_util.h
+++ b/common/test_utilities/symbolic_test_util.h
@@ -183,9 +183,9 @@ template <typename F>
   const symbolic::Polynomial::MapType& map = diff.monomial_to_coefficient_map();
   for (const auto& p : map) {
     if (std::abs(get_constant_value(p.second)) > tol) {
-      return ::testing::AssertionFailure()
-             << "The coefficient for " << p.first << " is " << p.second
-             << ", exceed tolerance " << tol << "\n";
+      return ::testing::AssertionFailure() << fmt::format(
+                 "The coefficient for {} is {}, exceed tolerance {}\n", p.first,
+                 p.second, tol);
     }
   }
   return ::testing::AssertionSuccess();

--- a/systems/sensors/test_utilities/image_compare.cc
+++ b/systems/sensors/test_utilities/image_compare.cc
@@ -23,8 +23,7 @@ template <PixelType kPixelType>
 void PrintTo(const Image<kPixelType>& image, std::ostream* os) {
   const int width = image.width();
   const int height = image.height();
-  fmt::print((*os), "Image<k{}>(width={}, height={})", kPixelType, width,
-             height);
+  fmt::print(*os, "Image<k{}>(width={}, height={})", kPixelType, width, height);
   const int size = width * height;
   // When there are no pixels, don't bother printing the "Channel ..." titles.
   // If there are way too many pixels (more than fit on one screen), omit all


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). 
Hi @jwnimmer-tri, Can you please review and trigger Jenkins? Thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23981)
<!-- Reviewable:end -->
