### PR TITLE
[workspace] Update dependency MOSEK to 11.1.2

### DIFF
--- a/bindings/generated_docstrings/solvers.h
+++ b/bindings/generated_docstrings/solvers.h
@@ -4961,7 +4961,7 @@ Lorentz cone. When solving the optimization problem using conic
 solvers (like Mosek, Gurobi, SCS, etc), it is numerically preferable
 to impose the convex quadratic constraint as rotated Lorentz cone
 constraint. See
-https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation
+https://docs.mosek.com/11.1/capi/prob-def-quadratic.html#a-recommendation
 
 Raises:
     exception if this quadratic constraint is not convex (Q is not
@@ -4992,7 +4992,7 @@ R"""(Adds quadratic constraint lb ≤ .5 xᵀQx + bᵀx ≤ ub Notice that if yo
 quadratic constraint is convex, and you intend to solve the problem
 with a convex solver (like Mosek), then it is better to reformulate it
 with a second order cone constraint. See
-https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation
+https://docs.mosek.com/11.1/capi/prob-def-quadratic.html#a-recommendation
 for an explanation.
 
 Parameter ``vars``:
@@ -5014,7 +5014,7 @@ a quadratic expression. Notice that if your quadratic constraint is
 convex, and you intend to solve the problem with a convex solver (like
 Mosek), then it is better to reformulate it with a second order cone
 constraint. See
-https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation
+https://docs.mosek.com/11.1/capi/prob-def-quadratic.html#a-recommendation
 for an explanation.)""";
         } AddQuadraticConstraint;
         // Symbol: drake::solvers::MathematicalProgram::AddQuadraticCost
@@ -6727,7 +6727,7 @@ solver such as SCS, MOSEK™, CSDP, etc, the dual solution to the
 (rotated) Lorentz cone constraint doesn't have the "shadow price"
 interpretation, but should lie in the dual cone, and satisfy the KKT
 condition. For more information, refer to
-https://docs.mosek.com/11.0/capi/prob-def-conic.html#duality-for-conic-optimization
+https://docs.mosek.com/11.1/capi/prob-def-conic.html#duality-for-conic-optimization
 as an explanation.
 
 The interpretation for the dual variable to conic constraint x ∈ K can
@@ -8538,20 +8538,20 @@ Note:
     subsequent iterations.) If the specified integer solution is
     infeasible or incomplete, MOSEK™ will simply ignore it. For more
     details, check
-    https://docs.mosek.com/11.0/capi/tutorial-mio-shared.html?highlight=initial
+    https://docs.mosek.com/11.1/capi/tutorial-mio-shared.html?highlight=initial
 
 MOSEK™ supports many solver parameters. You can refer to the full list
 of parameters in
-https://docs.mosek.com/11.0/capi/param-groups.html#doc-param-groups.
+https://docs.mosek.com/11.1/capi/param-groups.html#doc-param-groups.
 On top of these parameters, we also provide the following additional
 parameters
 
 - "writedata"
    set to a file name so that MOSEK™ solver will write the
    optimization model to this file. check
-   https://docs.mosek.com/11.0/capi/solver-io.html#saving-a-problem-to-a-file
+   https://docs.mosek.com/11.1/capi/solver-io.html#saving-a-problem-to-a-file
    for more details. The supported file extensions are listed in
-   https://docs.mosek.com/11.0/capi/supported-file-formats.html#doc-shared-file-formats.
+   https://docs.mosek.com/11.1/capi/supported-file-formats.html#doc-shared-file-formats.
    Set this parameter to "" if you don't want to write to a file. Default is
    not to write to a file.)""";
         // Symbol: drake::solvers::MosekSolver::AcquireLicense
@@ -8627,14 +8627,14 @@ obtain the details.)""";
           const char* doc =
 R"""(The MOSEK™ optimization time. Please refer to MSK_DINF_OPTIMIZER_TIME
 in
-https://docs.mosek.com/11.0/capi/constants.html?highlight=msk_dinf_optimizer_time)""";
+https://docs.mosek.com/11.1/capi/constants.html?highlight=msk_dinf_optimizer_time)""";
         } optimizer_time;
         // Symbol: drake::solvers::MosekSolverDetails::rescode
         struct /* rescode */ {
           // Source: drake/solvers/mosek_solver.h
           const char* doc =
 R"""(The response code returned from MOSEK™ solver. Check
-https://docs.mosek.com/11.0/capi/response-codes.html for the meaning
+https://docs.mosek.com/11.1/capi/response-codes.html for the meaning
 on the response code.)""";
         } rescode;
         // Symbol: drake::solvers::MosekSolverDetails::solution_status
@@ -8642,8 +8642,8 @@ on the response code.)""";
           // Source: drake/solvers/mosek_solver.h
           const char* doc =
 R"""(The solution status after solving the problem. Check
-https://docs.mosek.com/11.0/capi/accessing-solution.html and
-https://docs.mosek.com/11.0/capi/constants.html#mosek.solsta for the
+https://docs.mosek.com/11.1/capi/accessing-solution.html and
+https://docs.mosek.com/11.1/capi/constants.html#mosek.solsta for the
 meaning on the solution status.)""";
         } solution_status;
       } MosekSolverDetails;
@@ -10609,7 +10609,7 @@ SCS code on github master might be more up-to-date than the version
 used in Drake.
 
 "MOSEK™" -- Parameter name and values as specified in Mosek Reference
-https://docs.mosek.com/11.0/capi/parameters.html
+https://docs.mosek.com/11.1/capi/parameters.html
 
 "OSQP" -- Parameter name and values as specified in OSQP Reference
 https://osqp.org/docs/interfaces/solver_settings.html#solver-settings

--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -193,7 +193,7 @@ bazel build //tools/lint:buildifier
 The Drake Bazel build currently supports the following proprietary solvers:
 
 * Gurobi 12.0
-* MOSEK™ 10.0
+* MOSEK™ 11.1
 * SNOPT 7.4
 
 ## Gurobi 12.0

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2064,7 +2064,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/11.1/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
@@ -2076,7 +2076,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/11.1/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @param vars x in the documentation above.
    @param hessian_type Whether the Hessian is positive semidefinite, negative
@@ -2098,7 +2098,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/11.1/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    @param vars x in the documentation above.
    @param hessian_type Whether the Hessian is positive semidefinite, negative
@@ -2120,7 +2120,7 @@ class MathematicalProgram {
    Notice that if your quadratic constraint is convex, and you intend to solve
    the problem with a convex solver (like Mosek), then it is better to
    reformulate it with a second order cone constraint. See
-   https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation for
+   https://docs.mosek.com/11.1/capi/prob-def-quadratic.html#a-recommendation for
    an explanation.
    */
   Binding<QuadraticConstraint> AddQuadraticConstraint(
@@ -2547,7 +2547,7 @@ class MathematicalProgram {
    * cone. When solving the optimization problem using conic solvers (like
    * Mosek, Gurobi, SCS, etc), it is numerically preferable to impose the
    * convex quadratic constraint as rotated Lorentz cone constraint. See
-   * https://docs.mosek.com/11.0/capi/prob-def-quadratic.html#a-recommendation
+   * https://docs.mosek.com/11.1/capi/prob-def-quadratic.html#a-recommendation
    * @throw exception if this quadratic constraint is not convex (Q is not
    * positive semidefinite)
    * @param Q The Hessian of the quadratic constraint. Should be positive

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -315,7 +315,7 @@ class MathematicalProgramResult final {
    *    solution to the (rotated) Lorentz cone constraint doesn't have the
    *    "shadow price" interpretation, but should lie in the dual cone, and
    *    satisfy the KKT condition. For more information, refer to
-   *    https://docs.mosek.com/11.0/capi/prob-def-conic.html#duality-for-conic-optimization
+   *    https://docs.mosek.com/11.1/capi/prob-def-conic.html#duality-for-conic-optimization
    *    as an explanation.
    *
    * The interpretation for the dual variable to conic constraint x ∈ K can be

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -52,7 +52,7 @@ class MosekSolver::License {
     if (rescode != MSK_RES_OK) {
       throw std::runtime_error(
           fmt::format("Could not acquire MOSEK license: {}. See "
-                      "https://docs.mosek.com/11.0/capi/"
+                      "https://docs.mosek.com/11.1/capi/"
                       "response-codes.html#mosek.rescode for details.",
                       fmt_streamed(rescode)));
     }
@@ -258,7 +258,7 @@ void MosekSolver::DoSolve2(const MathematicalProgram& prog,
 
   // Since Mosek 10, it allows setting the initial guess for both continuous and
   // integer/binary variables. See
-  // https://docs.mosek.com/11.0/rmosek/tutorial-mio-shared.html#specifying-an-initial-solution
+  // https://docs.mosek.com/11.1/rmosek/tutorial-mio-shared.html#specifying-an-initial-solution
   // for more details.
   if (initial_guess.array().isFinite().any()) {
     DRAKE_ASSERT(initial_guess.size() == prog.num_vars());
@@ -284,7 +284,7 @@ void MosekSolver::DoSolve2(const MathematicalProgram& prog,
     MSKrescodee trmcode;  // termination code
     rescode = MSK_optimizetrm(impl.task(), &trmcode);
     // Refer to
-    // https://docs.mosek.com/11.0/capi/debugging-tutorials.html#debugging-tutorials
+    // https://docs.mosek.com/11.1/capi/debugging-tutorials.html#debugging-tutorials
     // on printing the solution summary.
     if (is_printing) {
       if (rescode == MSK_RES_OK) {

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -18,15 +18,15 @@ namespace solvers {
  */
 struct MosekSolverDetails {
   /// The MOSEK™ optimization time. Please refer to MSK_DINF_OPTIMIZER_TIME in
-  /// https://docs.mosek.com/11.0/capi/constants.html?highlight=msk_dinf_optimizer_time
+  /// https://docs.mosek.com/11.1/capi/constants.html?highlight=msk_dinf_optimizer_time
   double optimizer_time{};
   /// The response code returned from MOSEK™ solver. Check
-  /// https://docs.mosek.com/11.0/capi/response-codes.html for the meaning on
+  /// https://docs.mosek.com/11.1/capi/response-codes.html for the meaning on
   /// the response code.
   int rescode{};
   /// The solution status after solving the problem. Check
-  /// https://docs.mosek.com/11.0/capi/accessing-solution.html and
-  /// https://docs.mosek.com/11.0/capi/constants.html#mosek.solsta for the
+  /// https://docs.mosek.com/11.1/capi/accessing-solution.html and
+  /// https://docs.mosek.com/11.1/capi/constants.html#mosek.solsta for the
   /// meaning on the solution status.
   int solution_status{};
 };
@@ -54,19 +54,19 @@ struct MosekSolverDetails {
  * (MOSEK™ might change the values of the integer/binary variables in the
  * subsequent iterations.) If the specified integer solution is infeasible or
  * incomplete, MOSEK™ will simply ignore it. For more details, check
- * https://docs.mosek.com/11.0/capi/tutorial-mio-shared.html?highlight=initial
+ * https://docs.mosek.com/11.1/capi/tutorial-mio-shared.html?highlight=initial
  *
  * MOSEK™ supports many solver parameters. You can refer to the full list of
  * parameters in
- * https://docs.mosek.com/11.0/capi/param-groups.html#doc-param-groups. On top
+ * https://docs.mosek.com/11.1/capi/param-groups.html#doc-param-groups. On top
  * of these parameters, we also provide the following additional parameters
  *
  * - "writedata"
  *    set to a file name so that MOSEK™ solver will write the
  *    optimization model to this file. check
- *    https://docs.mosek.com/11.0/capi/solver-io.html#saving-a-problem-to-a-file
+ *    https://docs.mosek.com/11.1/capi/solver-io.html#saving-a-problem-to-a-file
  *    for more details. The supported file extensions are listed in
- *    https://docs.mosek.com/11.0/capi/supported-file-formats.html#doc-shared-file-formats.
+ *    https://docs.mosek.com/11.1/capi/supported-file-formats.html#doc-shared-file-formats.
  *    Set this parameter to "" if you don't want to write to a file. Default is
  *    not to write to a file.
  */

--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -53,7 +53,7 @@ MosekSolverProgram::MosekSolverProgram(const MathematicalProgram& prog,
     : map_decision_var_to_mosek_var_{prog} {
   // Create the optimization task.
   // task is initialized as a null pointer, same as in Mosek's documentation
-  // https://docs.mosek.com/11.0/capi/design.html#hello-world-in-mosek
+  // https://docs.mosek.com/11.1/capi/design.html#hello-world-in-mosek
   task_ = nullptr;
   MSK_maketask(env, 0,
                map_decision_var_to_mosek_var_
@@ -735,7 +735,7 @@ MSKrescodee MosekSolverProgram::AddQuadraticConstraints(
     }
 
     // Pre-allocate the size for the Q matrix according to
-    // https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.putqcon
+    // https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.putqcon
     rescode = MSK_putmaxnumqnz(task_, qcsubi.size());
     if (rescode != MSK_RES_OK) {
       return rescode;
@@ -953,7 +953,7 @@ MSKrescodee MosekSolverProgram::AddLinearMatrixInequalityConstraint(
     std::unordered_map<Binding<LinearMatrixInequalityConstraint>, MSKint64t>*
         acc_indices) {
   // Use Mosek's "affine cone constraint". See
-  // https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html#example-sdo-lmi-linear-matrix-inequalities-and-the-vectorized-semidefinite-domain
+  // https://docs.mosek.com/11.1/capi/tutorial-sdo-shared.html#example-sdo-lmi-linear-matrix-inequalities-and-the-vectorized-semidefinite-domain
   // for more details.
   DRAKE_ASSERT(acc_indices != nullptr);
   MSKrescodee rescode = MSK_RES_OK;
@@ -1632,8 +1632,8 @@ void ThrowForInvalidOption(MSKrescodee rescode, const std::string& option,
 
 // This function is used to print information for each iteration to the console,
 // it will show PRSTATUS, PFEAS, DFEAS, etc. For more information, check out
-// https://docs.mosek.com/11.0/capi/solver-io.html. This printstr is copied
-// directly from https://docs.mosek.com/11.0/capi/solver-io.html#stream-logging.
+// https://docs.mosek.com/11.1/capi/solver-io.html. This printstr is copied
+// directly from https://docs.mosek.com/11.1/capi/solver-io.html#stream-logging.
 void MSKAPI printstr(void*, const char str[]) {
   printf("%s", str);
 }
@@ -1649,7 +1649,7 @@ void MosekSolverProgram::UpdateOptions(
   // Copy all remaining options into our `task_`.
   options->Respell([&](const auto& common, auto* respelled) {
     // This is a convenient place to configure printing (i.e., logging); see
-    // https://docs.mosek.com/11.0/capi/solver-io.html#stream-logging.
+    // https://docs.mosek.com/11.1/capi/solver-io.html#stream-logging.
     // Printing to console vs file are mutually exclusive; if the user has
     // requested both, then we must throw an error BEFORE we create the log
     // file; otherwise we might create it but never close it.
@@ -1734,7 +1734,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   if (which_sol == MSK_SOL_ITG) {
     // Mosek cannot return dual solution if the solution type is MSK_SOL_ITG
     // (which stands for mixed integer optimizer), see
-    // https://docs.mosek.com/11.0/capi/accessing-solution.html#available-solutions
+    // https://docs.mosek.com/11.1/capi/accessing-solution.html#available-solutions
     return rescode;
   }
   int num_mosek_vars{0};
@@ -1744,7 +1744,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   }
   // Mosek dual variables for variable lower bounds (slx) and upper bounds
   // (sux). Refer to
-  // https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
+  // https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
   // for more explanation.
   std::vector<MSKrealt> slx(num_mosek_vars);
   std::vector<MSKrealt> sux(num_mosek_vars);
@@ -1763,7 +1763,7 @@ MSKrescodee MosekSolverProgram::SetDualSolution(
   }
   // Mosek dual variables for linear constraints lower bounds (slc) and upper
   // bounds (suc). Refer to
-  // https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
+  // https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
   // for more explanation.
   std::vector<MSKrealt> slc(num_linear_constraints);
   std::vector<MSKrealt> suc(num_linear_constraints);

--- a/solvers/mosek_solver_internal.h
+++ b/solvers/mosek_solver_internal.h
@@ -20,10 +20,10 @@ namespace drake {
 namespace solvers {
 namespace internal {
 // Mosek treats psd matrix variables in a special manner.
-// Check https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html for more
+// Check https://docs.mosek.com/11.1/capi/tutorial-sdo-shared.html for more
 // details. To summarize, Mosek stores a positive semidefinite (psd) matrix
 // variable as a "bar var" (as called in Mosek's API, for example
-// https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html). Inside Mosek, it
+// https://docs.mosek.com/11.1/capi/tutorial-sdo-shared.html). Inside Mosek, it
 // accesses each of the psd matrix variable with a unique ID. Moreover, the
 // Mosek user cannot access the entries of the psd matrix variable individually;
 // instead, the user can only access the matrix X̅ as a whole. To impose
@@ -79,7 +79,7 @@ class MatrixVariableEntry {
 
 // Mosek stores dual variable in different categories, called slc, suc, slx, sux
 // and snx. Refer to
-// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
+// https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getsolution
 // for more information.
 enum class DualVarType {
   kLinearConstraint,  ///< Corresponds to Mosek's slc and suc.
@@ -177,9 +177,9 @@ class MosekSolverProgram {
   // expression format
   // ∑ⱼ fᵢⱼ xⱼ + ∑ⱼ<F̅ᵢⱼ, X̅ⱼ>
   // Please refer to
-  // https://docs.mosek.com/11.0/capi/tutorial-acc-optimizer.html for an
+  // https://docs.mosek.com/11.1/capi/tutorial-acc-optimizer.html for an
   // introduction on Mosek affine expression, and
-  // https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html for the affine
+  // https://docs.mosek.com/11.1/capi/tutorial-sdo-shared.html for the affine
   // expression with matrix variables.
   // F̅ᵢⱼ is a weighted sum of the symmetric matrix E stored inside Mosek.
   // bar_F[i][j] stores the indices of E and the weights of E.
@@ -538,13 +538,13 @@ MSKrescodee MosekSolverProgram::AddConeConstraints(
 }
 
 // @param slx Mosek dual variables for variable lower bound. See
-// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getslx
+// https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getslx
 // @param sux Mosek dual variables for variable upper bound. See
-// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsux
+// https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getsux
 // @param slc Mosek dual variables for linear constraint lower bound. See
-// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getslc
+// https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getslc
 // @param suc Mosek dual variables for linear constraint upper bound. See
-// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsuc
+// https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getsuc
 void SetVariableBoundsDualSolution(
     const std::vector<Binding<BoundingBoxConstraint>>& bb_constraints,
     const std::vector<Binding<PositiveSemidefiniteConstraint>>& psd_constraints,
@@ -589,10 +589,10 @@ void SetLinearConstraintDualSolution(
 
 // @param slc Mosek dual variables for linear and quadratic constraint lower
 // bound. See
-// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getslc
+// https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getslc
 // @param suc Mosek dual variables for linear and quadratic constraint upper
 // bound. See
-// https://docs.mosek.com/11.0/capi/alphabetic-functionalities.html#mosek.task.getsuc
+// https://docs.mosek.com/11.1/capi/alphabetic-functionalities.html#mosek.task.getsuc
 void SetQuadraticConstraintDualSolution(
     const std::vector<Binding<QuadraticConstraint>>& constraints,
     const std::vector<MSKrealt>& slc, const std::vector<MSKrealt>& suc,
@@ -605,7 +605,7 @@ void SetQuadraticConstraintDualSolution(
  * @param bindings The constraint for which the dual solution will be set.
  * @param task The Mosek task.
  * @param whichsol The solution type. See
- * https://docs.mosek.com/11.0/capi/constants.html#mosek.soltype
+ * https://docs.mosek.com/11.1/capi/constants.html#mosek.soltype
  * @param acc_indices Maps each constraint to the affine cone constraint
  * indices.
  * @param[out] result The dual solution in `result` will be set.

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -45,7 +45,7 @@ that the SCS code on github master might be more up-to-date than the version
 used in Drake.
 
 "MOSEK™" -- Parameter name and values as specified in Mosek Reference
-https://docs.mosek.com/11.0/capi/parameters.html
+https://docs.mosek.com/11.1/capi/parameters.html
 
 "OSQP" -- Parameter name and values as specified in OSQP Reference
 https://osqp.org/docs/interfaces/solver_settings.html#solver-settings

--- a/solvers/test/linear_program_examples.h
+++ b/solvers/test/linear_program_examples.h
@@ -79,7 +79,7 @@ class LinearProgram1 : public OptimizationProgram {
 };
 
 // Test a simple linear programming problem
-// Adapted from https://docs.mosek.com/11.0/capi/tutorial-lo-shared.html
+// Adapted from https://docs.mosek.com/11.1/capi/tutorial-lo-shared.html
 // min -3x0 - x1 - 5x2 - x3
 // s.t     3x0 +  x1 + 2x2        = 30
 //   15 <= 2x0 +  x1 + 3x2 +  x3 <= inf

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -47,7 +47,7 @@ TEST_F(UnboundedLinearProgramTest0, Test) {
         result.get_solver_details<MosekSolver>();
     EXPECT_EQ(mosek_solver_details.rescode, 0);
     // This problem status is defined in
-    // https://docs.mosek.com/11.0/capi/constants.html#mosek.prosta
+    // https://docs.mosek.com/11.1/capi/constants.html#mosek.prosta
     const int MSK_SOL_STA_DUAL_INFEAS_CER = 6;
     EXPECT_EQ(mosek_solver_details.solution_status,
               MSK_SOL_STA_DUAL_INFEAS_CER);
@@ -328,7 +328,7 @@ GTEST_TEST(MosekTest, SolverOptionsTest) {
   mosek_solver.Solve(prog, {}, solver_options, &result);
   EXPECT_FALSE(result.is_success());
   // This response code is defined in
-  // https://docs.mosek.com/11.0/capi/response-codes.html#mosek.rescode
+  // https://docs.mosek.com/11.1/capi/response-codes.html#mosek.rescode
   const int MSK_RES_ERR_HUGE_C{1375};
   EXPECT_EQ(result.get_solver_details<MosekSolver>().rescode,
             MSK_RES_ERR_HUGE_C);

--- a/solvers/test/semidefinite_program_examples.h
+++ b/solvers/test/semidefinite_program_examples.h
@@ -70,7 +70,7 @@ void SolveEigenvalueProblem(const SolverInterface& solver,
                             double tol, bool check_dual);
 
 /// Solve an SDP with a second order cone constraint. This example is taken from
-/// https://docs.mosek.com/11.0/capi/tutorial-sdo-shared.html
+/// https://docs.mosek.com/11.1/capi/tutorial-sdo-shared.html
 void SolveSDPwithSecondOrderConeExample1(const SolverInterface& solver,
                                          double tol);
 

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -26,11 +26,11 @@ build --@drake//solvers:mosek_lazy_load=True
 EOF
 
 # MOSEK's published wheels declare an upper bound on their supported Python
-# version, which is currently Python < 3.14. When that changes to a larger
+# version, which is currently Python < 3.15. When that changes to a larger
 # version number, we should bump this up to match, and also grep tools/wheel
 # for other mentions of MOSEK version bounds and fix those as well.
 PYTHON_MINOR=$(/usr/local/bin/python -c "import sys; print(sys.version_info.minor)")
-if [[ ${PYTHON_MINOR} -ge 14 ]]; then
+if [[ ${PYTHON_MINOR} -ge 15 ]]; then
     cat >> /tmp/drake-wheel-build/drake-build/drake.bazelrc << EOF
 build --@drake//tools/flags:with_mosek=False
 build --@drake//solvers:mosek_lazy_load=False

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -71,11 +71,13 @@ cp -r -t ${WHEEL_DIR}/pydrake \
 cp -r -t ${WHEEL_DIR}/pydrake/lib \
     /tmp/drake-wheel-build/drake-dist/lib/libdrake*.so
 
-# See tools/wheel/image/build-drake.sh for details on the lack of MOSEK support
-# for Python 3.14.
+# MOSEK's published wheels declare an upper bound on their supported Python
+# version, which is currently Python < 3.15. When that changes to a larger
+# version number, we should bump this up to match, and also grep tools/wheel
+# for other mentions of MOSEK version bounds and fix those as well.
 PYTHON_MINOR=$(python -c "import sys; print(sys.version_info.minor)")
 MOSEK_ENABLED=1
-[ ${PYTHON_MINOR} -ge 14 ] && MOSEK_ENABLED=
+[ ${PYTHON_MINOR} -ge 15 ] && MOSEK_ENABLED=
 
 if [[ "$(uname)" == "Darwin" && -n "${MOSEK_ENABLED}" ]]; then
     # MOSEK is "sort of" third party, but is procured as part of Drake's build

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -15,10 +15,10 @@ python_required = [
     'pydot',
     'PyYAML',
     # MOSEK's published wheels declare an upper bound on their supported Python
-    # version, which is currently Python < 3.14. When that changes to a larger
+    # version, which is currently Python < 3.15. When that changes to a larger
     # version number, we should bump this up to match, and also grep tools/wheel
     # for other mentions of MOSEK version bounds and fix those as well.
-    'Mosek==11.0.24 ; python_version < "3.14"',
+    'Mosek==11.1.2 ; python_version < "3.15"',
 ]
 
 def find_data_files(*patterns):

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -52,10 +52,12 @@ build --config=packaging
 build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
 EOF
 
-# See tools/wheel/image/build-drake.sh for details on the lack of MOSEK support
-# for Python 3.14.
+# MOSEK's published wheels declare an upper bound on their supported Python
+# version, which is currently Python < 3.15. When that changes to a larger
+# version number, we should bump this up to match, and also grep tools/wheel
+# for other mentions of MOSEK version bounds and fix those as well.
 PYTHON_MINOR=$($python_executable -c "import sys; print(sys.version_info.minor)")
-if [[ ${PYTHON_MINOR} -ge 14 ]]; then
+if [[ ${PYTHON_MINOR} -ge 15 ]]; then
     cat >> "$build_root/drake.bazelrc" << EOF
 build --@drake//tools/flags:with_mosek=False
 EOF

--- a/tools/wheel/test/tests/mosek-test.py
+++ b/tools/wheel/test/tests/mosek-test.py
@@ -11,10 +11,10 @@ solver = MosekSolver()
 assert solver.enabled()
 
 # MOSEK's published wheels declare an upper bound on their supported Python
-# version, which is currently Python < 3.14. When that changes to a larger
+# version, which is currently Python < 3.15. When that changes to a larger
 # version number, we should bump this up to match, and also grep tools/wheel
 # for other mentions of MOSEK version bounds and fix those as well.
-if sys.version_info[:2] < (3, 14):
+if sys.version_info[:2] < (3, 15):
     assert solver.available()
 else:
     assert not solver.available()

--- a/tools/workspace/mosek/LICENSE.third_party
+++ b/tools/workspace/mosek/LICENSE.third_party
@@ -9,7 +9,7 @@ https://docs.mosek.com/latest/licensing/license-agreement-info.html
 3.1 MOSEK end-user license agreement
 
 Before using the MOSEK software, please read the license agreement available in
-the distribution at <MSKHOME>/mosek/11.0/mosek-eula.pdf or on the MOSEK website
+the distribution at <MSKHOME>/mosek/11.1/mosek-eula.pdf or on the MOSEK website
 https://mosek.com/products/license-agreement. By using MOSEK you agree to the
 terms of that license agreement.
 

--- a/tools/workspace/mosek/repository.bzl
+++ b/tools/workspace/mosek/repository.bzl
@@ -13,11 +13,11 @@ def mosek_repository(
         # - tools/dynamic_analysis/tsan.supp may also need updating
         # - LICENSE.third_party may also need updating to match
         #   https://docs.mosek.com/latest/licensing/license-agreement-info.html
-        version = "11.0.24",
+        version = "11.1.2",
         sha256 = {
-            "mosektoolslinuxaarch64.tar.bz2": "68e94abb10087bf38dd4b378cc51a412dc1f94171ef50dff9075a4c1bf909bb6",  # noqa
-            "mosektoolslinux64x86.tar.bz2": "f058e4bec5cde899cf5193f7ac966a923a256c335466a0678604068a51404362",  # noqa
-            "mosektoolsosxaarch64.tar.bz2": "b0bd9232e45597d098b9464eb6302b17cf0f3bd5679e06bce1e74c046604da34",  # noqa
+            "mosektoolslinuxaarch64.tar.bz2": "59bec3262d3654d6754a89ea0a787f039ac90ca37f2093d2c6fd883672350ec8",  # noqa
+            "mosektoolslinux64x86.tar.bz2": "61416cc09c9354e6e90fb65a48c97dc4d86d5e0634ac0380a9c4e7ffbd73bf00",  # noqa
+            "mosektoolsosxaarch64.tar.bz2": "e09457a0ff2a74f701f366474bd135ae7f4d3caf08ef32b5666f2b5c1ced4b97",  # noqa
         },
         mirrors = mirrors,
     )


### PR DESCRIPTION
MOSEK 11.1.2 supports Python 3.14, so our Python 3.14 wheels can depend on it.

Closes #23853.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23983)
<!-- Reviewable:end -->
