### PR TITLE
[common] Fix GCC 15 compilation errors in tests

### DIFF
--- a/common/symbolic/expression/test/expression_cell_test.cc
+++ b/common/symbolic/expression/test/expression_cell_test.cc
@@ -13,6 +13,7 @@ namespace symbolic {
 namespace {
 
 using test::ExprEqual;
+using test::ExprToDoubleMapEqual;
 using test::FormulaEqual;
 
 // Provides common variables and expressions that are used by the following
@@ -59,8 +60,9 @@ TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
 
   EXPECT_EQ(to_addition(e_add_).get_constant(),
             get_constant_in_addition(e_add_));
-  EXPECT_EQ(to_addition(e_add_).get_expr_to_coeff_map(),
-            get_expr_to_coeff_map_in_addition(e_add_));
+  EXPECT_PRED2(ExprToDoubleMapEqual,
+               to_addition(e_add_).get_expr_to_coeff_map(),
+               get_expr_to_coeff_map_in_addition(e_add_));
 
   EXPECT_EQ(to_multiplication(e_mul_).get_constant(),
             get_constant_in_multiplication(e_mul_));
@@ -127,8 +129,9 @@ TEST_F(SymbolicExpressionCellTest, CastFunctionsNonConst) {
 
   EXPECT_EQ(to_addition(Expression{e_add_}).get_constant(),
             get_constant_in_addition(e_add_));
-  EXPECT_EQ(to_addition(Expression{e_add_}).get_expr_to_coeff_map(),
-            get_expr_to_coeff_map_in_addition(e_add_));
+  EXPECT_PRED2(ExprToDoubleMapEqual,
+               to_addition(Expression{e_add_}).get_expr_to_coeff_map(),
+               get_expr_to_coeff_map_in_addition(e_add_));
 
   EXPECT_EQ(to_multiplication(Expression{e_mul_}).get_constant(),
             get_constant_in_multiplication(e_mul_));

--- a/common/symbolic/test/monomial_basis_element_test.cc
+++ b/common/symbolic/test/monomial_basis_element_test.cc
@@ -247,10 +247,10 @@ TEST_F(MonomialBasisElementTest, MonomialWithZeroExponent) {
   MonomialBasisElement m1({{var_y_, 2}});
   MonomialBasisElement m2({{var_x_, 0}, {var_y_, 2}});
   EXPECT_EQ(m1, m2);
-  EXPECT_EQ(m2.var_to_degree_map().size(), 1);
-  std::map<Variable, int> power_expected;
-  power_expected.emplace(var_y_, 2);
-  EXPECT_EQ(m2.var_to_degree_map(), power_expected);
+  ASSERT_EQ(m2.var_to_degree_map().size(), 1);
+  const auto& [base, exp] = *m2.var_to_degree_map().begin();
+  EXPECT_EQ(base, var_y_);
+  EXPECT_EQ(exp, 2);
 }
 
 // This test shows that we can have a std::unordered_map whose key is of

--- a/common/symbolic/test/monomial_test.cc
+++ b/common/symbolic/test/monomial_test.cc
@@ -222,10 +222,10 @@ TEST_F(MonomialTest, MonomialWithZeroExponent) {
   Monomial m1({{var_y_, 2}});
   Monomial m2({{var_x_, 0}, {var_y_, 2}});
   EXPECT_EQ(m1, m2);
-  EXPECT_EQ(m2.get_powers().size(), 1);
-  std::map<Variable, int> power_expected;
-  power_expected.emplace(var_y_, 2);
-  EXPECT_EQ(m2.get_powers(), power_expected);
+  ASSERT_EQ(m2.get_powers().size(), 1);
+  const auto& [base, exp] = *m2.get_powers().begin();
+  EXPECT_EQ(base, var_y_);
+  EXPECT_EQ(exp, 2);
 }
 
 TEST_F(MonomialTest, MonomialBasisX0) {

--- a/common/symbolic/test/polynomial_test.cc
+++ b/common/symbolic/test/polynomial_test.cc
@@ -25,6 +25,7 @@ using std::vector;
 
 using test::ExprEqual;
 using test::PolyEqual;
+using test::PolynomialMapTypeEqual;
 
 class SymbolicPolynomialTest : public ::testing::Test {
  protected:
@@ -103,7 +104,7 @@ TEST_F(SymbolicPolynomialTest, ConstructFromMapType1) {
   map.emplace(Monomial{var_x_}, -2.0 * a_);          // x ↦ -2a
   map.emplace(Monomial{{{var_y_, 3.0}}}, 4.0 * b_);  // y³ ↦ 4b
   const Polynomial p{map};                           // p = -2ax + 4by³
-  EXPECT_EQ(p.monomial_to_coefficient_map(), map);
+  EXPECT_PRED2(PolynomialMapTypeEqual, p.monomial_to_coefficient_map(), map);
   EXPECT_EQ(p.ToExpression(), -2 * a_ * x_ + 4 * b_ * pow(y_, 3));
   EXPECT_EQ(p.decision_variables(), Variables({var_a_, var_b_}));
   EXPECT_EQ(p.indeterminates(), Variables({var_x_, var_y_}));
@@ -114,7 +115,8 @@ TEST_F(SymbolicPolynomialTest, ConstructFromMapType2) {
   for (int i = 0; i < monomials_.size(); ++i) {
     p_map.emplace(monomials_[i], 1);
   }
-  EXPECT_EQ(Polynomial{p_map}.monomial_to_coefficient_map(), p_map);
+  EXPECT_PRED2(PolynomialMapTypeEqual,
+               Polynomial{p_map}.monomial_to_coefficient_map(), p_map);
 }
 
 TEST_F(SymbolicPolynomialTest, ConstructFromMapType3) {
@@ -167,32 +169,32 @@ TEST_F(SymbolicPolynomialTest, ConstructFromExpression) {
 
 TEST_F(SymbolicPolynomialTest, ConstructorFromExpressionAndIndeterminates1) {
   const Polynomial p1{1.0, var_xyz_};  // p₁ = 1.0,
-  EXPECT_EQ(p1.monomial_to_coefficient_map(),
-            Polynomial::MapType({{Monomial{}, Expression(1.0)}}));
+  EXPECT_PRED2(PolynomialMapTypeEqual, p1.monomial_to_coefficient_map(),
+               Polynomial::MapType({{Monomial{}, Expression(1.0)}}));
   // p₂ = ax + by + cz + 10
   const Polynomial p2{a_ * x_ + b_ * y_ + c_ * z_ + 10, var_xyz_};
-  EXPECT_EQ(p2.monomial_to_coefficient_map(),
-            Polynomial::MapType({{Monomial{var_x_}, a_},
-                                 {Monomial{var_y_}, b_},
-                                 {Monomial{var_z_}, c_},
-                                 {Monomial{}, 10}}));
+  EXPECT_PRED2(PolynomialMapTypeEqual, p2.monomial_to_coefficient_map(),
+               Polynomial::MapType({{Monomial{var_x_}, a_},
+                                    {Monomial{var_y_}, b_},
+                                    {Monomial{var_z_}, c_},
+                                    {Monomial{}, 10}}));
   // p₃ = 3ab²*x²y -bc*z³
   const Polynomial p3{
       3 * a_ * pow(b_, 2) * pow(x_, 2) * y_ - b_ * c_ * pow(z_, 3), var_xyz_};
-  EXPECT_EQ(p3.monomial_to_coefficient_map(),
-            Polynomial::MapType(
-                // x²y ↦ 3ab²
-                {{Monomial{{{var_x_, 2}, {var_y_, 1}}}, 3 * a_ * pow(b_, 2)},
-                 // z³ ↦ -bc
-                 {Monomial{{{var_z_, 3}}}, -b_ * c_}}));
+  EXPECT_PRED2(PolynomialMapTypeEqual, p3.monomial_to_coefficient_map(),
+               Polynomial::MapType(
+                   // x²y ↦ 3ab²
+                   {{Monomial{{{var_x_, 2}, {var_y_, 1}}}, 3 * a_ * pow(b_, 2)},
+                    // z³ ↦ -bc
+                    {Monomial{{{var_z_, 3}}}, -b_ * c_}}));
 
   // p₄ = 3ab²*x²y - bc*x³
   const Polynomial p4{
       3 * a_ * pow(b_, 2) * pow(x_, 2) * y_ - b_ * c_ * pow(x_, 3), var_xyz_};
-  EXPECT_EQ(p4.monomial_to_coefficient_map(),
-            Polynomial::MapType(
-                {{Monomial{{{var_x_, 2}, {var_y_, 1}}}, 3 * a_ * pow(b_, 2)},
-                 {Monomial{{{var_x_, 3}}}, -b_ * c_}}));
+  EXPECT_PRED2(PolynomialMapTypeEqual, p4.monomial_to_coefficient_map(),
+               Polynomial::MapType(
+                   {{Monomial{{{var_x_, 2}, {var_y_, 1}}}, 3 * a_ * pow(b_, 2)},
+                    {Monomial{{{var_x_, 3}}}, -b_ * c_}}));
 }
 
 TEST_F(SymbolicPolynomialTest, ConstructorFromExpressionAndIndeterminates2) {
@@ -582,7 +584,8 @@ TEST_F(SymbolicPolynomialTest, MultiplicationPolynomialPolynomial2) {
   Polynomial::MapType product_map_expected{};
   product_map_expected.emplace(Monomial(), 1);
   product_map_expected.emplace(Monomial(var_x_, 2), -1);
-  EXPECT_EQ(product_map_expected, (p1 * p2).monomial_to_coefficient_map());
+  EXPECT_PRED2(PolynomialMapTypeEqual, product_map_expected,
+               (p1 * p2).monomial_to_coefficient_map());
 }
 
 TEST_F(SymbolicPolynomialTest, MultiplicationPolynomialExpression) {
@@ -953,7 +956,8 @@ TEST_F(SymbolicPolynomialTest, ConstructNonPolynomialCoefficients) {
     const Expression& e{item.first};
     const Polynomial p{e, indeterminates_};
     const Polynomial::MapType& expected_map{item.second};
-    EXPECT_EQ(p.monomial_to_coefficient_map(), expected_map);
+    EXPECT_PRED2(PolynomialMapTypeEqual, p.monomial_to_coefficient_map(),
+                 expected_map);
   }
 }
 

--- a/common/test_utilities/symbolic_test_util.h
+++ b/common/test_utilities/symbolic_test_util.h
@@ -22,6 +22,7 @@
 /// ASSERT_PRED2(ExprEqual, e1, e2);
 /// @endcode
 #include <algorithm>
+#include <map>
 #include <tuple>
 #include <vector>
 
@@ -74,6 +75,16 @@ namespace test {
 [[nodiscard]] inline bool ExprNotLess(const Expression& e1,
                                       const Expression& e2) {
   return !ExprLess(e1, e2);
+}
+
+[[nodiscard]] inline bool ExprToDoubleMapEqual(
+    const std::map<drake::symbolic::Expression, double>& m1,
+    const std::map<drake::symbolic::Expression, double>& m2) {
+  return std::equal(m1.begin(), m1.end(), m2.begin(), m2.end(),
+                    [](const auto& pair1, const auto& pair2) {
+                      return ExprEqual(pair1.first, pair2.first) &&
+                             (pair1.second == pair2.second);
+                    });
 }
 
 template <typename BasisElement>
@@ -190,6 +201,16 @@ template <typename F>
   }
   return ::testing::AssertionSuccess();
 }
+
+[[nodiscard]] inline bool PolynomialMapTypeEqual(
+    const Polynomial::MapType& m1, const Polynomial::MapType& m2) {
+  return std::equal(m1.begin(), m1.end(), m2.begin(), m2.end(),
+                    [](const auto& pair1, const auto& pair2) {
+                      return (pair1.first == pair2.first) &&
+                             ExprEqual(pair1.second, pair2.second);
+                    });
+}
+
 }  // namespace test
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
Towards #23976.  (I have tested this locally in docker.)

In the newer stdlib of GCC 15, the `std::pair<T, U>::operator==` requires that both T and U's own `operator==` return bool, not bool-convertible.  Therefore, if either one is an `Expression`, we can't rely on the built-in `map<T, U>::operator==` in unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23986)
<!-- Reviewable:end -->
