### PR TITLE
[systems] Fix GCC 15 warnings

### DIFF
--- a/systems/framework/diagram_state.h
+++ b/systems/framework/diagram_state.h
@@ -19,7 +19,7 @@ class DiagramState : public State<T> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramState);
 
   /// Constructs a DiagramState consisting of @p size substates.
-  explicit DiagramState<T>(int size);
+  explicit DiagramState(int size);
 
   /// Sets the substate at @p index to @p substate, or aborts if @p index is
   /// out of bounds. Does not take ownership of @p substate, which must live


### PR DESCRIPTION
Towards #23976.  (I have tested this locally in docker.)

```
bazel-out/k8-opt/bin/systems/framework/_virtual_includes/diagram_state/drake/systems/framework/diagram_state.h:22:27: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   22 |   explicit DiagramState<T>(int size);
      |                           ^
bazel-out/k8-opt/bin/systems/framework/_virtual_includes/diagram_state/drake/systems/framework/diagram_state.h:22:27: note: remove the '< >'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23987)
<!-- Reviewable:end -->
