### PR TITLE
Update wheels to latest MOSEK

### DIFF
--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -26,11 +26,11 @@ build --@drake//solvers:mosek_lazy_load=True
 EOF
 
 # MOSEK's published wheels declare an upper bound on their supported Python
-# version, which is currently Python < 3.14. When that changes to a larger
+# version, which is currently Python < 3.15. When that changes to a larger
 # version number, we should bump this up to match, and also grep tools/wheel
 # for other mentions of MOSEK version bounds and fix those as well.
 PYTHON_MINOR=$(/usr/local/bin/python -c "import sys; print(sys.version_info.minor)")
-if [[ ${PYTHON_MINOR} -ge 14 ]]; then
+if [[ ${PYTHON_MINOR} -ge 15 ]]; then
     cat >> /tmp/drake-wheel-build/drake-build/drake.bazelrc << EOF
 build --@drake//tools/flags:with_mosek=False
 build --@drake//solvers:mosek_lazy_load=False

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -72,10 +72,10 @@ cp -r -t ${WHEEL_DIR}/pydrake/lib \
     /tmp/drake-wheel-build/drake-dist/lib/libdrake*.so
 
 # See tools/wheel/image/build-drake.sh for details on the lack of MOSEK support
-# for Python 3.14.
+# for Python 3.15.
 PYTHON_MINOR=$(python -c "import sys; print(sys.version_info.minor)")
 MOSEK_ENABLED=1
-[ ${PYTHON_MINOR} -ge 14 ] && MOSEK_ENABLED=
+[ ${PYTHON_MINOR} -ge 15 ] && MOSEK_ENABLED=
 
 if [[ "$(uname)" == "Darwin" && -n "${MOSEK_ENABLED}" ]]; then
     # MOSEK is "sort of" third party, but is procured as part of Drake's build

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -15,10 +15,10 @@ python_required = [
     'pydot',
     'PyYAML',
     # MOSEK's published wheels declare an upper bound on their supported Python
-    # version, which is currently Python < 3.14. When that changes to a larger
+    # version, which is currently Python < 3.15. When that changes to a larger
     # version number, we should bump this up to match, and also grep tools/wheel
     # for other mentions of MOSEK version bounds and fix those as well.
-    'Mosek==11.0.24 ; python_version < "3.14"',
+    'Mosek==11.1.2 ; python_version < "3.15"',
 ]
 
 def find_data_files(*patterns):

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -53,9 +53,9 @@ build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
 EOF
 
 # See tools/wheel/image/build-drake.sh for details on the lack of MOSEK support
-# for Python 3.14.
+# for Python 3.15.
 PYTHON_MINOR=$($python_executable -c "import sys; print(sys.version_info.minor)")
-if [[ ${PYTHON_MINOR} -ge 14 ]]; then
+if [[ ${PYTHON_MINOR} -ge 15 ]]; then
     cat >> "$build_root/drake.bazelrc" << EOF
 build --@drake//tools/flags:with_mosek=False
 EOF

--- a/tools/wheel/test/tests/mosek-test.py
+++ b/tools/wheel/test/tests/mosek-test.py
@@ -11,10 +11,10 @@ solver = MosekSolver()
 assert solver.enabled()
 
 # MOSEK's published wheels declare an upper bound on their supported Python
-# version, which is currently Python < 3.14. When that changes to a larger
+# version, which is currently Python < 3.15. When that changes to a larger
 # version number, we should bump this up to match, and also grep tools/wheel
 # for other mentions of MOSEK version bounds and fix those as well.
-if sys.version_info[:2] < (3, 14):
+if sys.version_info[:2] < (3, 15):
     assert solver.available()
 else:
     assert not solver.available()


### PR DESCRIPTION
Update wheels to use MOSEK 11.1.2, which adds support for Python 3.14. Update Python version checks to enable MOSEK for Python up to 3.14. This is currently the most recent version we support, but keep the version checks since they are still present in MOSEK, and it is likely we will need these checks again when we start supporting Python 3.15.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/23996)
<!-- Reviewable:end -->
