### PR TITLE
Add Aabb-{plane|half space} intersection and missing bindings

### DIFF
--- a/bindings/generated_docstrings/geometry_proximity.h
+++ b/bindings/generated_docstrings/geometry_proximity.h
@@ -174,6 +174,56 @@ Parameter ``X_GH``:
 
 Returns:
     ``True`` if the boxes intersect.)""";
+          // Source: drake/geometry/proximity/aabb.h
+          const char* doc_aabb_plane =
+R"""(Checks whether bounding volume ``bv`` intersects the given plane. The
+bounding volume is centered on its canonical frame B, and B is posed
+in the corresponding hierarchy frame H. The plane is defined in frame
+P.
+
+The box and plane intersect if *any* point within the bounding volume
+has zero height (see CalcHeight()).
+
+Parameter ``bv_H``:
+    The bounding box to test.
+
+Parameter ``plane_P``:
+    The plane to test against the ``bv``. The plane is expressed in
+    frame P, therefore, to evaluate the height of a point with respect
+    to it, that point must be measured and expressed in P.
+
+Parameter ``X_PH``:
+    The relative pose between the hierarchy frame H and the plane
+    frame P.
+
+Returns:
+    ``True`` if the plane intersects the box.)""";
+          // Source: drake/geometry/proximity/aabb.h
+          const char* doc_aabb_halfspace =
+R"""(Checks whether bounding volume ``bv`` intersects the given half space.
+The bounding volume is centered on its canonical frame B, and B is
+posed in the corresponding hierarchy frame H. The half space is
+defined in its canonical frame C (such that the boundary plane of the
+half space is perpendicular to Cz and Co lies on the boundary plane).
+
+The box and halfspace intersect if *any* point within the bounding
+volume has a height less than or equal to zero.
+
+Parameter ``bv_H``:
+    The bounding box to test.
+
+Parameter ``hs_C``:
+    The half space to test against the ``bv``. The half space is
+    expressed in Frame C, therefore, to evaluate the signed distance
+    of a point with respect to it, that point must be measured and
+    expressed in C.
+
+Parameter ``X_CH``:
+    The relative pose between the hierarchy halfspace canonical frame
+    C and the box frame B.
+
+Returns:
+    ``True`` if the half space intersects the box.)""";
         } HasOverlap;
         // Symbol: drake::geometry::Aabb::center
         struct /* center */ {
@@ -737,14 +787,14 @@ Parameter ``X_GH``:
 Returns:
     ``True`` if the boxes intersect.)""";
           // Source: drake/geometry/proximity/obb.h
-          const char* doc =
-R"""((Internal use only) Checks whether bounding volume ``bv`` intersects
-the given plane. The bounding volume is centered on its canonical
-frame B, and B is posed in the corresponding hierarchy frame H. The
-plane is defined in frame P.
+          const char* doc_obb_plane =
+R"""(Checks whether bounding volume ``bv`` intersects the given plane. The
+bounding volume is centered on its canonical frame B, and B is posed
+in the corresponding hierarchy frame H. The plane is defined in frame
+P.
 
 The box and plane intersect if *any* point within the bounding volume
-has zero height (see CalcHeight()).
+has zero height.
 
 Parameter ``bv_H``:
     The bounding box to test.
@@ -767,6 +817,9 @@ The bounding volume is centered on its canonical frame B, and B is
 posed in the corresponding hierarchy frame H. The half space is
 defined in its canonical frame C (such that the boundary plane of the
 half space is perpendicular to Cz and Co lies on the boundary plane).
+
+The box and halfspace intersect if *any* point within the bounding
+volume has a height less than or equal to zero.
 
 Parameter ``bv_H``:
     The bounding box to test.

--- a/bindings/pydrake/geometry/geometry_py_bounding_box.cc
+++ b/bindings/pydrake/geometry/geometry_py_bounding_box.cc
@@ -77,6 +77,18 @@ void DefineGeometryBoundingBox(py::module m) {
       py::arg("aabb_G"), py::arg("obb_H"), py::arg("X_GH"),
       doc.Aabb.HasOverlap.doc_aabb_obb);
 
+  aabb_cls.def_static("HasOverlap",
+      py::overload_cast<const Aabb&, const HalfSpace&,
+          const math::RigidTransformd&>(&Aabb::HasOverlap),
+      py::arg("bv_H"), py::arg("hs_C"), py::arg("X_CH"),
+      doc.Aabb.HasOverlap.doc_aabb_halfspace);
+
+  aabb_cls.def_static("HasOverlap",
+      py::overload_cast<const Aabb&, const Plane<double>&,
+          const math::RigidTransformd&>(&Aabb::HasOverlap),
+      py::arg("bv_H"), py::arg("plane_P"), py::arg("X_PH"),
+      doc.Aabb.HasOverlap.doc_aabb_plane);
+
   // Obb static methods.
   obb_cls.def_static("HasOverlap",
       py::overload_cast<const Obb&, const Obb&, const math::RigidTransformd&>(
@@ -95,6 +107,12 @@ void DefineGeometryBoundingBox(py::module m) {
           const math::RigidTransformd&>(&Obb::HasOverlap),
       py::arg("bv_H"), py::arg("hs_C"), py::arg("X_CH"),
       doc.Obb.HasOverlap.doc_obb_halfspace);
+
+  obb_cls.def_static("HasOverlap",
+      py::overload_cast<const Obb&, const Plane<double>&,
+          const math::RigidTransformd&>(&Obb::HasOverlap),
+      py::arg("bv_H"), py::arg("plane_P"), py::arg("X_PH"),
+      doc.Obb.HasOverlap.doc_obb_plane);
 
   // AabbMaker and ObbMaker utility functions
   // Instead of binding the classes directly (which have lifetime issues with

--- a/bindings/pydrake/geometry/test/bounding_box_test.py
+++ b/bindings/pydrake/geometry/test/bounding_box_test.py
@@ -68,6 +68,21 @@ class TestGeometryBoundingBox(unittest.TestCase):
         transform = RigidTransform(p=[-2.0, 0.0, 0.0])
         self.assertTrue(mut.Aabb.HasOverlap(aabb1, aabb2, transform))
 
+        # Test Aabb-HalfSpace overlap.
+        half_space = mut.HalfSpace()
+        # Default half space has normal [0,0,1] and passes through origin.
+        # aabb1 is centered at origin with half_width [1,1,1], so it
+        # should overlap the half space (extends into negative z).
+        self.assertTrue(
+            mut.Aabb.HasOverlap(aabb1, half_space, identity_transform)
+        )
+
+        # Test Aabb-Plane overlap.
+        plane_normal = np.array([0.0, 0.0, 1.0])
+        point_on_plane = np.array([0.0, 0.0, 0.5])
+        plane = mut.Plane(plane_normal, point_on_plane)
+        self.assertTrue(mut.Aabb.HasOverlap(aabb1, plane, identity_transform))
+
     def test_obb_api(self):
         # Test Obb construction and basic API.
         pose = RigidTransform(p=[1.0, 2.0, 3.0])
@@ -132,6 +147,12 @@ class TestGeometryBoundingBox(unittest.TestCase):
         self.assertTrue(
             mut.Obb.HasOverlap(obb1, half_space, identity_transform)
         )
+
+        # Test Obb-Plane overlap.
+        plane_normal = np.array([0.0, 0.0, 1.0])
+        point_on_plane = np.array([0.0, 0.0, 0.5])
+        plane = mut.Plane(plane_normal, point_on_plane)
+        self.assertTrue(mut.Obb.HasOverlap(obb1, plane, identity_transform))
 
     def test_aabb_obb_cross_overlap(self):
         # Test cross-type overlap between Aabb and Obb.

--- a/geometry/proximity/aabb.h
+++ b/geometry/proximity/aabb.h
@@ -5,6 +5,8 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/plane.h"
+#include "drake/geometry/shape_specification.h"
 #include "drake/geometry/utilities.h"
 #include "drake/math/rigid_transform.h"
 
@@ -126,8 +128,45 @@ class Aabb {
   static bool HasOverlap(const Aabb& aabb_G, const Obb& obb_H,
                          const math::RigidTransformd& X_GH);
 
-  // TODO(SeanCurtis-TRI): Support collision with primitives as appropriate
-  //  (see obb.h for an example).
+  /** Checks whether bounding volume `bv` intersects the given plane. The
+   bounding volume is centered on its canonical frame B, and B is posed in the
+   corresponding hierarchy frame H. The plane is defined in frame P.
+
+   The box and plane intersect if _any_ point within the bounding volume has
+   zero height (see CalcHeight()).
+
+   @param bv_H      The bounding box to test.
+   @param plane_P   The plane to test against the `bv`. The plane is expressed
+                    in frame P, therefore, to evaluate the height of a point
+                    with respect to it, that point must be measured and
+                    expressed in P.
+   @param X_PH      The relative pose between the hierarchy frame H and the
+                    plane frame P.
+   @returns `true` if the plane intersects the box.
+   @pydrake_mkdoc_identifier{aabb_plane} */
+  static bool HasOverlap(const Aabb& bv_H, const Plane<double>& plane_P,
+                         const math::RigidTransformd& X_PH);
+
+  /** Checks whether bounding volume `bv` intersects the given half space. The
+   bounding volume is centered on its canonical frame B, and B is posed in the
+   corresponding hierarchy frame H. The half space is defined in its
+   canonical frame C (such that the boundary plane of the half space is
+   perpendicular to Cz and Co lies on the boundary plane).
+
+   The box and halfspace intersect if _any_ point within the bounding volume has
+   a height less than or equal to zero.
+
+   @param bv_H      The bounding box to test.
+   @param hs_C      The half space to test against the `bv`. The half space is
+                    expressed in Frame C, therefore, to evaluate the signed
+                    distance of a point with respect to it, that point must be
+                    measured and expressed in C.
+   @param X_CH      The relative pose between the hierarchy halfspace canonical
+                    frame C and the box frame B.
+   @returns `true` if the half space intersects the box.
+   @pydrake_mkdoc_identifier{aabb_halfspace} */
+  static bool HasOverlap(const Aabb& bv_H, const HalfSpace& hs_C,
+                         const math::RigidTransformd& X_CH);
 
   /** Compares the values of the two Aabb instances for exact equality down to
    the last bit. Assumes that the quantities are measured and expressed in

--- a/geometry/proximity/obb.h
+++ b/geometry/proximity/obb.h
@@ -98,15 +98,12 @@ class Obb {
   static bool HasOverlap(const Obb& obb_G, const Aabb& aabb_H,
                          const math::RigidTransformd& X_GH);
 
-  // TODO(xuchenhan-tri): Move Plane out of internal namespace and make this
-  //  non-internal only.
-  /** (Internal use only) Checks whether bounding volume `bv` intersects the
-   given plane. The bounding volume is centered on its canonical frame B, and B
-   is posed in the corresponding hierarchy frame H. The plane is defined in
-   frame P.
+  /** Checks whether bounding volume `bv` intersects the given plane. The
+   bounding volume is centered on its canonical frame B, and B is posed in the
+   corresponding hierarchy frame H. The plane is defined in frame P.
 
    The box and plane intersect if _any_ point within the bounding volume has
-   zero height (see CalcHeight()).
+   zero height.
 
    @param bv_H      The bounding box to test.
    @param plane_P   The plane to test against the `bv`. The plane is expressed
@@ -115,7 +112,8 @@ class Obb {
                     expressed in P.
    @param X_PH      The relative pose between the hierarchy frame H and the
                     plane frame P.
-   @returns `true` if the plane intersects the box.   */
+   @returns `true` if the plane intersects the box.
+   @pydrake_mkdoc_identifier{obb_plane} */
   static bool HasOverlap(const Obb& bv_H, const Plane<double>& plane_P,
                          const math::RigidTransformd& X_PH);
 
@@ -124,6 +122,9 @@ class Obb {
    corresponding hierarchy frame H. The half space is defined in its
    canonical frame C (such that the boundary plane of the half space is
    perpendicular to Cz and Co lies on the boundary plane).
+
+   The box and halfspace intersect if _any_ point within the bounding volume has
+   a height less than or equal to zero.
 
    @param bv_H      The bounding box to test.
    @param hs_C      The half space to test against the `bv`. The half space is

--- a/geometry/proximity/test/aabb_test.cc
+++ b/geometry/proximity/test/aabb_test.cc
@@ -9,6 +9,7 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/geometry/proximity/obb.h"
+#include "drake/geometry/proximity/plane.h"
 #include "drake/geometry/proximity/triangle_surface_mesh.h"
 
 namespace drake {
@@ -168,6 +169,110 @@ GTEST_TEST(AabbTest, TestEqual) {
   constexpr double kEps = std::numeric_limits<double>::epsilon();
   const Aabb e(p_HB + Vector3d(kEps, 0, 0), half_size);
   EXPECT_FALSE(a.Equal(e));
+}
+
+// Tests Aabb-plane intersection. The vast majority of the work is done by
+// the Plane class (tested elsewhere). We just need to confirm that the Aabb
+// describes itself in the Plane's frame correctly. To that end, we make sure
+// that the Aabb has non-trivial values for position and orientation and that
+// the transform between the hierarchy frame and plane frame is likewise
+// "interesting" (we're making sure that all the bits get used properly).
+GTEST_TEST(AabbTest, PlaneOverlap) {
+  // We'll define the problem *in* the plane's frame, but arbitrarily pose the
+  // problem in a separate frame prior to evaluation.
+  const Vector3d half_width(0.25, 2.0, 1.5);
+
+  // Box pose in the hierarchy frame H. Aabb's always have identity orientation
+  // in the *hierarchy* frame.
+  const RigidTransformd X_HB(RotationMatrixd::Identity(), Vector3d(-1, 2, 0.5));
+
+  // Hierarchy pose in the plane's frame. We're free to pick R_PH (such that
+  // R_PB ≠ I). We have to pick p_PH such that the box's corner just touches the
+  // plane.
+  const auto R_PH = RotationMatrixd::MakeFromOneVector(Vector3d(-1, 2, -2), 2);
+
+  // The "clearance" is the height the box center needs to be off the plane so
+  // that one corner is exactly touching (given its relative orientation).
+  const RotationMatrixd& R_PB = R_PH;  // R_HB = I.
+  const double clearance = R_PB.row(2).cwiseAbs().dot(half_width.transpose());
+  // The plane's normal is Pz, so only the z-value in the box origin matters.
+  const Vector3d p_PB(1.5, -0.5, clearance);
+  const Vector3d p_HB_P = R_PH * X_HB.translation();
+  const Vector3d p_PH = p_PB - p_HB_P;
+  const RigidTransformd X_PH(R_PH, p_PH);
+
+  // Express it in the world frame for computation.
+  const RigidTransformd X_WP(
+      RotationMatrixd::MakeFromOneVector(Vector3d(-1, 2, -2), 2),
+      Vector3d{3, -1, 2});
+  const Vector3d Pz_W = X_WP.rotation().col(2);
+  const Plane<double> plane_W(Pz_W, X_WP.translation());
+
+  const Aabb aabb_H(X_HB.translation(), half_width);
+
+  // Initialize X_WH such that the box corner exactly touches the plane. Then
+  // we'll perturb it in the normal direction up by epsilon (out of contact) and
+  // down again by two epsilon (into contact).
+  RigidTransformd X_WH = X_WP * X_PH;
+
+  const double kUp = 1e-6;
+  // Shift frame H up.
+  X_WH = RigidTransformd(Pz_W * kUp) * X_WH;
+  EXPECT_FALSE(Aabb::HasOverlap(aabb_H, plane_W, X_WH));
+
+  const double kDown = -2 * kUp;
+  // Shift frame H down.
+  X_WH = RigidTransformd(Pz_W * kDown) * X_WH;
+  EXPECT_TRUE(Aabb::HasOverlap(aabb_H, plane_W, X_WH));
+}
+
+GTEST_TEST(AAabbTest, HalfSpaceOverlap) {
+  const Vector3d half_width(0.25, 2.0, 1.5);
+
+  // Box pose in the hierarchy frame H. An Aabb always has identity orientation
+  // in the *hierarchy* frame.
+  const RigidTransformd X_HB(Vector3d(-1, 2, 0.5));
+
+  // Hierarchy pose in the half space's canonical frame C. We're free to pick
+  // R_CH (such that R_CB ≠ I). We have to pick p_CH such that the box's corner
+  // just touches the boundary of the half space.
+  const auto R_CH = RotationMatrixd::MakeFromOneVector(Vector3d(-1, 2, -2), 2);
+
+  // The "clearance" is the height the box center needs to be off the plane so
+  // that one corner is exactly touching (given its relative orientation).
+  const RotationMatrixd& R_CB = R_CH;  // R_HB = I.
+  const double clearance = R_CB.row(2).cwiseAbs().dot(half_width.transpose());
+  // The half space's normal is Cz, so only the z-value in the box origin
+  // matters.
+  const Vector3d p_CB(1.5, -0.5, clearance);
+  const Vector3d p_HB_C = R_CH * X_HB.translation();
+  const Vector3d p_CH = p_CB - p_HB_C;
+
+  const HalfSpace halfspace_C;
+  const Aabb aabb_H(X_HB.translation(), half_width);
+
+  // Initialize X_CH such that the box corner exactly touches the half space
+  // boundary. Then we'll perturb it in the normal direction up by epsilon (out
+  // of contact), down again by two epsilon (into contact), and down by the the
+  // box's size so that it's fully *inside* the half space, but not touching the
+  // boundary.
+  RigidTransformd X_CH(R_CH, p_CH);
+  const Vector3d Cz = Vector3d::UnitZ();
+
+  const double kUp = 1e-6;
+  // Shift frame H up.
+  X_CH = RigidTransformd(Cz * kUp) * X_CH;
+  EXPECT_FALSE(Aabb::HasOverlap(aabb_H, halfspace_C, X_CH));
+
+  const double kDown = -2 * kUp;
+  // Shift frame H down.
+  X_CH = RigidTransformd(Cz * kDown) * X_CH;
+  EXPECT_TRUE(Aabb::HasOverlap(aabb_H, halfspace_C, X_CH));
+
+  // Shift more than twice the clearance, further into penetration.
+  const double kDeep = -clearance * 2;
+  X_CH = RigidTransformd(Cz * kDeep) * X_CH;
+  EXPECT_TRUE(Aabb::HasOverlap(aabb_H, halfspace_C, X_CH));
 }
 
 /* Confirm that the AabbMaker successfully makes the expected bounding boxes.

--- a/geometry/proximity/test/obb_test.cc
+++ b/geometry/proximity/test/obb_test.cc
@@ -887,8 +887,8 @@ GTEST_TEST(ObbTest, PlaneOverlap) {
   const double clearance = R_PB.row(2).cwiseAbs().dot(half_width.transpose());
   // The plane's normal is Pz, so only the z-value in the box origin matters.
   const Vector3d p_PB(1.5, -0.5, clearance);
-  const Vector3d p_BH_P = R_PH * X_HB.translation();
-  const Vector3d p_PH = p_PB - p_BH_P;
+  const Vector3d p_HB_P = R_PH * X_HB.translation();
+  const Vector3d p_PH = p_PB - p_HB_P;
   const RigidTransformd X_PH(R_PH, p_PH);
 
   // Pose the whole problem in the world frame with some arbitrary, non-identity


### PR DESCRIPTION
The Aabb gets the two missing static functions that Obb had: Plane and HalfSpace intersection.

Finally, they are bound along with Obb's missing Plane-intersection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24001)
<!-- Reviewable:end -->
