### PR TITLE
Support int and size_t in DRAKE_THROW_UNLESS

### DIFF
--- a/common/drake_assert.cc
+++ b/common/drake_assert.cc
@@ -93,12 +93,15 @@ void AssertionFailed(const char* condition, const char* func, const char* file,
 template <typename T>
 std::string StringifyErrorDetailValue(const T& value)
   requires(std::is_same_v<T, float> || std::is_same_v<T, double> ||
+           std::is_same_v<T, int> || std::is_same_v<T, std::size_t> ||
            std::is_same_v<T, std::string> ||
            std::is_same_v<T, std::string_view> ||
            std::is_same_v<T, const char*>)
 {
   if constexpr (std::is_floating_point_v<T>) {
     return fmt_floating_point(value);
+  } else if constexpr (std::is_integral_v<T>) {
+    return fmt::to_string(value);
   } else {
     return fmt_debug_string(value);
   }
@@ -110,6 +113,8 @@ template std::string StringifyErrorDetailValue<std::string>(const std::string&);
 template std::string StringifyErrorDetailValue<std::string_view>(
     const std::string_view&);
 template std::string StringifyErrorDetailValue<char const*>(char const* const&);
+template std::string StringifyErrorDetailValue<int>(const int&);
+template std::string StringifyErrorDetailValue<std::size_t>(const std::size_t&);
 
 }  // namespace internal
 }  // namespace drake

--- a/common/drake_assert.h
+++ b/common/drake_assert.h
@@ -72,7 +72,7 @@
 /// Provides a convenient wrapper to throw an exception when a condition is
 /// unmet.  This is similar to an assertion, but uses exceptions instead of
 /// `::abort()`, and cannot be disabled.
-///
+#define DRAKE_THROW_UNLESS(condition, ...)
 /// Evaluates `condition` and iff the value is false will throw an exception
 /// with a message showing at least the condition text, function name, file, and
 /// line.
@@ -98,10 +98,10 @@
 /// expressions are specified, this will most likely produce a compiler error
 /// referencing "ENCODE_EACH".
 ///
-/// Not all value expression types are supported. This shouldn't be interpreted
-/// as *the* definitive list. If yours isn't supported, feel free to submit a PR
-/// to add it (reaching out for help as appropriate).
-#define DRAKE_THROW_UNLESS(condition, ...)
+/// Not all value expression types are supported. The currently supported set
+/// shouldn't be considered *the* definitive set. If yours isn't supported, feel
+/// free to submit a PR to add it (reaching out for help as appropriate).
+#define DRAKE_DEREF(ptr)
 /// Derferences a pointer, with null checking. If the provided pointer is null,
 /// throws an exception. Otherwise, returns a reference to the object being
 /// pointed to.
@@ -128,7 +128,6 @@
 /// arrays (&x[0]).
 ///
 /// @endcode
-#define DRAKE_DEREF(ptr)
 #else  //  DRAKE_DOXYGEN_CXX
 
 // Users should NOT set these; only this header should set them.
@@ -254,6 +253,7 @@ namespace internal {
 template <typename T>
 std::string StringifyErrorDetailValue(const T& value)
   requires(std::is_same_v<T, float> || std::is_same_v<T, double> ||
+           std::is_same_v<T, int> || std::is_same_v<T, std::size_t> ||
            std::is_same_v<T, std::string> ||
            std::is_same_v<T, std::string_view> ||
            std::is_same_v<T, const char*>);

--- a/common/test/drake_throw_test.cc
+++ b/common/test/drake_throw_test.cc
@@ -25,9 +25,9 @@ GTEST_TEST(DrakeThrowTest, BasicTest) {
 GTEST_TEST(DrakeThrowTest, ThrowWithValues) {
   // Create a collection of lvalues.
   const double a = 1.5;
-  const double b = 2.5;
+  const int b = 2;
   const double c = 3.5;
-  const double d = 4.5;
+  const std::size_t d = 4;
   // Ensure it works with up to four values with a true-valued condition.
   DRAKE_EXPECT_NO_THROW(DRAKE_THROW_UNLESS(true, a));
   DRAKE_EXPECT_NO_THROW(DRAKE_THROW_UNLESS(true, a, b));
@@ -56,10 +56,9 @@ GTEST_TEST(DrakeThrowTest, ThrowWithValues) {
   };
 
   DRAKE_EXPECT_THROWS_MESSAGE(do_throw(1), ".*a = 1.5.");
-  DRAKE_EXPECT_THROWS_MESSAGE(do_throw(2), ".*a = 1.5, b = 2.5.");
-  DRAKE_EXPECT_THROWS_MESSAGE(do_throw(3), ".*a = 1.5, b = 2.5, c = 3.5.");
-  DRAKE_EXPECT_THROWS_MESSAGE(do_throw(4),
-                              ".*a = 1.5, b = 2.5, c = 3.5, d = 4.5.");
+  DRAKE_EXPECT_THROWS_MESSAGE(do_throw(2), ".*a = 1.5, b = 2.");
+  DRAKE_EXPECT_THROWS_MESSAGE(do_throw(3), ".*a = 1.5, b = 2, c = 3.5.");
+  DRAKE_EXPECT_THROWS_MESSAGE(do_throw(4), ".*a = 1.5, b = 2, c = 3.5, d = 4.");
 }
 
 // Confirms that the overload defined in fmt_eigen.h plays properly with the


### PR DESCRIPTION
Also correct a documentation error; docs were associated with the wrong macro.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24011)
<!-- Reviewable:end -->
