### PR TITLE
Deprecate `GenericPolynomial<T>::operator<<`

### DIFF
--- a/bindings/generated_docstrings/common_symbolic.h
+++ b/bindings/generated_docstrings/common_symbolic.h
@@ -2636,7 +2636,7 @@ Precondition:
       } pow;
       // Symbol: drake::symbolic::to_string
       struct /* to_string */ {
-        // Source: drake/common/symbolic/polynomial.h
+        // Source: drake/common/symbolic/generic_polynomial.h
         const char* doc = R"""()""";
       } to_string;
     } symbolic;

--- a/common/symbolic/generic_polynomial.h
+++ b/common/symbolic/generic_polynomial.h
@@ -1,17 +1,20 @@
 #pragma once
 
 #include <map>
-#include <ostream>
+#include <string>
 
 #include <Eigen/Core>
-#include <fmt/format.h>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/symbolic/chebyshev_basis_element.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/monomial_basis_element.h"
 #include "drake/common/symbolic/polynomial_basis_element.h"
+
+// Remove with deprecation 2026-05-01.
+#include <ostream>
 
 namespace drake {
 namespace symbolic {
@@ -503,20 +506,15 @@ GenericPolynomialEnable<BasisElement> pow(
 }
 
 template <typename BasisElement>
-std::ostream& operator<<(std::ostream& os,
-                         const GenericPolynomial<BasisElement>& p) {
-  const typename GenericPolynomial<BasisElement>::MapType& map{
-      p.basis_element_to_coefficient_map()};
-  if (map.empty()) {
-    return os << 0;
-  }
-  auto it = map.begin();
-  os << it->second << "*" << it->first;
-  for (++it; it != map.end(); ++it) {
-    os << " + " << it->second << "*" << it->first;
-  }
-  return os;
-}
+std::string to_string(const GenericPolynomial<BasisElement>& p);
+
+template <typename BasisElement>
+DRAKE_DEPRECATED(
+    "2026-05-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream&
+operator<<(std::ostream& os, const GenericPolynomial<BasisElement>& p);
 
 extern template class GenericPolynomial<MonomialBasisElement>;
 extern template class GenericPolynomial<ChebyshevBasisElement>;
@@ -565,9 +563,6 @@ struct NumTraits<
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename BasisElement>
-struct formatter<drake::symbolic::GenericPolynomial<BasisElement>>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(typename BasisElement, drake::symbolic,
+                   GenericPolynomial<BasisElement>, x,
+                   drake::symbolic::to_string(x))

--- a/common/symbolic/test/generic_polynomial_test.cc
+++ b/common/symbolic/test/generic_polynomial_test.cc
@@ -1834,6 +1834,22 @@ TEST_F(SymbolicGenericPolynomialTest, SetIndeterminates) {
   }
 }
 
+/*
+ * `GenericPolynomial` is basis element agnostic and relies on `fmt::format()`
+ * for basis element stringification. Therefore, we'll only test against one
+ * specific basis element type to confirm `GenericPolynomial`'s specific
+ * stringification logic.
+ */
+TEST_F(SymbolicGenericPolynomialTest, UsingChebyshevBasisToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(GenericPolynomial<ChebyshevBasisElement>{}), "0");
+  EXPECT_EQ(
+      fmt::to_string(GenericPolynomial<ChebyshevBasisElement>{Expression(1.)}),
+      "1*T0()");
+  EXPECT_EQ(fmt::to_string(GenericPolynomial<ChebyshevBasisElement>{
+                12 * pow(var_x_, 3) + 8 * pow(var_x_, 2) - 7 * var_x_ - 1}),
+            "3*T0() + 2*T1(x) + 4*T2(x) + 3*T3(x)");
+}
+
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24027)
<!-- Reviewable:end -->
