### PR TITLE
Configure Renovate to update CMake's MODULE copy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,11 @@
     "bazelisk",
     "bazel-module"
   ],
+  "bazel-module": {
+    "managerFilePatterns": [
+      "cmake/MODULE.bazel.in"
+    ]
+  },
   "labels": [
     "priority: low",
     "release notes: fix",


### PR DESCRIPTION
Updates to `MODULE.bazel` and `cmake/MODULE.bazel.in` must match.

Testing: see changes at https://github.com/tyler-yankee/drake-renovate-clone/commit/dd27c69414bce53f2313576937090d1410ef9706 and results for `apple_support` at https://github.com/tyler-yankee/drake-renovate-clone/pull/2.

Closes #23843.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24028)
<!-- Reviewable:end -->
