### PR TITLE
[CENIC] Refactor statistics into an extensible/encapsulted design

### DIFF
--- a/bindings/generated_docstrings/multibody_cenic.h
+++ b/bindings/generated_docstrings/multibody_cenic.h
@@ -122,27 +122,6 @@ R"""(Sets the convex solver tolerances and iteration limits.)""";
           const char* doc =
 R"""(Gets the current convex solver tolerances and iteration limits.)""";
         } get_solver_parameters;
-        // Symbol: drake::multibody::CenicIntegrator::get_total_hessian_factorizations
-        struct /* get_total_hessian_factorizations */ {
-          // Source: drake/multibody/cenic/cenic_integrator.h
-          const char* doc =
-R"""(Gets the current total number of Hessian factorizations performed,
-across all time steps and solver iterations.)""";
-        } get_total_hessian_factorizations;
-        // Symbol: drake::multibody::CenicIntegrator::get_total_ls_iterations
-        struct /* get_total_ls_iterations */ {
-          // Source: drake/multibody/cenic/cenic_integrator.h
-          const char* doc =
-R"""(Gets the current total number of linesearch iterations, across all
-time steps and solver iterations.)""";
-        } get_total_ls_iterations;
-        // Symbol: drake::multibody::CenicIntegrator::get_total_solver_iterations
-        struct /* get_total_solver_iterations */ {
-          // Source: drake/multibody/cenic/cenic_integrator.h
-          const char* doc =
-R"""(Gets the current total number of solver iterations across all time
-steps.)""";
-        } get_total_solver_iterations;
         // Symbol: drake::multibody::CenicIntegrator::plant
         struct /* plant */ {
           // Source: drake/multibody/cenic/cenic_integrator.h

--- a/bindings/generated_docstrings/systems_analysis.h
+++ b/bindings/generated_docstrings/systems_analysis.h
@@ -1378,6 +1378,11 @@ Returns:
             const char* doc = R"""()""";
           } kNotConverged;
         } ConvergenceStatus;
+        // Symbol: drake::systems::ImplicitIntegrator::DoGetStatisticsSummary
+        struct /* DoGetStatisticsSummary */ {
+          // Source: drake/systems/analysis/implicit_integrator.h
+          const char* doc = R"""()""";
+        } DoGetStatisticsSummary;
         // Symbol: drake::systems::ImplicitIntegrator::DoImplicitIntegratorClone
         struct /* DoImplicitIntegratorClone */ {
           // Source: drake/systems/analysis/implicit_integrator.h
@@ -2148,6 +2153,15 @@ Returns:
 See also:
     DoStep())""";
         } DoDenseStep;
+        // Symbol: drake::systems::IntegratorBase::DoGetStatisticsSummary
+        struct /* DoGetStatisticsSummary */ {
+          // Source: drake/systems/analysis/integrator_base.h
+          const char* doc =
+R"""(Returns statistics particular to a specific integrator, in service of
+GetStatisticsSummary(). The default implementation of this function
+does nothing. If your integrator collects its own statistics, you
+should re-implement this method and return them there.)""";
+        } DoGetStatisticsSummary;
         // Symbol: drake::systems::IntegratorBase::DoInitialize
         struct /* DoInitialize */ {
           // Source: drake/systems/analysis/integrator_base.h
@@ -2219,6 +2233,15 @@ system.EvalTimeDerivatives() directly. This version of this function
 exists to allow integrators to include AutoDiff'd systems in
 derivative function evaluations.)""";
         } EvalTimeDerivatives;
+        // Symbol: drake::systems::IntegratorBase::GetStatisticsSummary
+        struct /* GetStatisticsSummary */ {
+          // Source: drake/systems/analysis/integrator_base.h
+          const char* doc =
+R"""(Returns all integrator statistics as a single collection. The data is
+organized as a list of (key, value) pairs. The types allowed by the
+``variant`` may grow over time; be sure to use ``std::visit`` for
+access.)""";
+        } GetStatisticsSummary;
         // Symbol: drake::systems::IntegratorBase::Initialize
         struct /* Initialize */ {
           // Source: drake/systems/analysis/integrator_base.h
@@ -3340,6 +3363,12 @@ Raises:
     RuntimeError if the integration scheme does not match any of
     GetIntegrationSchemes().)""";
       } IsScalarTypeSupportedByIntegrator;
+      // Symbol: drake::systems::NamedStatistic
+      struct /* NamedStatistic */ {
+        // Source: drake/systems/analysis/integrator_base.h
+        const char* doc =
+R"""(Helper type for IntegratorBase<T>::GetStatisticsSummary.)""";
+      } NamedStatistic;
       // Symbol: drake::systems::PrintSimulatorStatistics
       struct /* PrintSimulatorStatistics */ {
         // Source: drake/systems/analysis/simulator_print_stats.h

--- a/multibody/cenic/cenic_integrator.h
+++ b/multibody/cenic/cenic_integrator.h
@@ -114,20 +114,6 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
   void SetSolverParameters(
       const contact_solvers::icf::IcfSolverParameters& parameters);
 
-  /** Gets the current total number of solver iterations across all time steps.
-   */
-  int get_total_solver_iterations() const { return total_solver_iterations_; }
-
-  /** Gets the current total number of linesearch iterations, across all time
-  steps and solver iterations. */
-  int get_total_ls_iterations() const { return total_ls_iterations_; }
-
-  /** Gets the current total number of Hessian factorizations performed, across
-  all time steps and solver iterations. */
-  int get_total_hessian_factorizations() const {
-    return total_hessian_factorizations_;
-  }
-
   bool supports_error_estimation() const final;
 
   int get_error_estimate_order() const final;
@@ -150,6 +136,13 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
     contact_solvers::icf::internal::IcfLinearFeedbackGains<T> external_feedback;
   };
 
+  /* Data for PrintSimulatorStatistics(). */
+  struct Stats {
+    int total_solver_iterations{0};
+    int total_hessian_factorizations{0};
+    int total_ls_iterations{0};
+  };
+
   /* Gets a reference to the ICF builder used to set up the convex problem. */
   contact_solvers::icf::internal::IcfBuilder<T>& builder() {
     // N.B. this is not const because the builder caches geometry data when
@@ -160,6 +153,10 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
 
   T CalcStateChangeNorm(
       const systems::ContinuousState<T>& dx_state) const final;
+
+  void DoResetStatistics() final;
+
+  std::vector<systems::NamedStatistic> DoGetStatisticsSummary() const final;
 
   void DoInitialize() final;
 
@@ -212,10 +209,8 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
   // Pre-allocated scratch space for intermediate calculations.
   Scratch scratch_;
 
-  // Logging/performance tracking utilities
-  int total_solver_iterations_{0};
-  int total_ls_iterations_{0};
-  int total_hessian_factorizations_{0};
+  // Data for PrintSimulatorStatistics().
+  Stats stats_;
 
   // Intermediate states for error control, which compares a single large
   // step (x_next_full_) to the result of two smaller steps (x_next_half_2_).

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -435,9 +435,6 @@ drake_cc_library(
         ":simulator",
         "@fmt",
     ],
-    implementation_deps = [
-        "//multibody/cenic:cenic_integrator",
-    ],
 )
 
 drake_cc_library(

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -24,6 +24,13 @@ void ImplicitIntegrator<T>::DoResetStatistics() {
 }
 
 template <class T>
+std::vector<NamedStatistic> ImplicitIntegrator<T>::DoGetStatisticsSummary()
+    const {
+  // TODO(jwnimmer-tri) Add statistics here.
+  return {};
+}
+
+template <class T>
 void ImplicitIntegrator<T>::DoReset() {
   J_.resize(0, 0);
   DoResetCachedJacobianRelatedMatrices();

--- a/systems/analysis/implicit_integrator.h
+++ b/systems/analysis/implicit_integrator.h
@@ -4,6 +4,7 @@
 #include <limits>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <Eigen/LU>
 
@@ -411,6 +412,7 @@ class ImplicitIntegrator : public IntegratorBase<T> {
       const = 0;
   MatrixX<T>& get_mutable_jacobian() { return J_; }
   void DoResetStatistics() override;
+  std::vector<NamedStatistic> DoGetStatisticsSummary() const override;
   void DoReset() final;
 
   // Compute the partial derivative of the ordinary differential equations with

--- a/systems/analysis/integrator_base.cc
+++ b/systems/analysis/integrator_base.cc
@@ -11,6 +11,44 @@ template <class T>
 IntegratorBase<T>::~IntegratorBase() = default;
 
 template <class T>
+std::vector<NamedStatistic> IntegratorBase<T>::GetStatisticsSummary() const {
+  std::vector<NamedStatistic> result;
+
+  // Add our local statistics.
+  result.emplace_back("integrator_num_steps_taken", get_num_steps_taken());
+  if (!get_fixed_step_mode()) {
+    result.emplace_back(
+        "integrator_actual_initial_step_size_taken",
+        ExtractDoubleOrThrow(get_actual_initial_step_size_taken()));
+    result.emplace_back("integrator_largest_step_size_taken",
+                        ExtractDoubleOrThrow(get_largest_step_size_taken()));
+    result.emplace_back(
+        "integrator_smallest_adapted_step_size_taken",
+        ExtractDoubleOrThrow(get_smallest_adapted_step_size_taken()));
+    result.emplace_back("integrator_num_step_shrinkages_from_error_control",
+                        get_num_step_shrinkages_from_error_control());
+  }
+  result.emplace_back("integrator_num_derivative_evaluations",
+                      get_num_derivative_evaluations());
+
+  // Add subclass statistics afterward.
+  auto subclass_data = DoGetStatisticsSummary();
+  result.insert(result.end(), std::make_move_iterator(subclass_data.begin()),
+                std::make_move_iterator(subclass_data.end()));
+  subclass_data.clear();
+
+  return result;
+}
+
+template <class T>
+void IntegratorBase<T>::DoResetStatistics() {}
+
+template <class T>
+std::vector<NamedStatistic> IntegratorBase<T>::DoGetStatisticsSummary() const {
+  return {};
+}
+
+template <class T>
 bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& h_max) {
   using std::isnan;
   using std::min;


### PR DESCRIPTION
Sample output:

```console
jwnimmer@call-cps:~/jwnimmer-tri/drake$ bazel-bin/examples/multibody/clutter/clutter 
Num positions: 140
Num velocities: 120
[2026-01-29 16:06:46.017] [console] [info] Meshcat listening for connections at http://localhost:7000
Press [ENTER] to continue ...

AdvanceTo() time [sec]: 0.730681126
General stats regarding discrete updates:
Number of time steps taken (simulator stats) = 554
Simulator publishes every time step: true
Number of publishes = 556
Number of discrete updates = 0
Number of "unrestricted" updates = 0

Stats for integrator CenicIntegrator with error control:
Number of time steps taken (integrator stats) = 554
Initial time step taken =       0.01 s
Largest time step taken =        0.1 s
Smallest adapted step size = 0.00044038 s
Number of steps shrunk due to error control = 252
Number of derivative evaluations = 0
Number of steps shrunk due to convergence-based failure = 0
Number of convergence-based step failures (should match) = 0

JSON Statistics:
{
  "integrator_num_steps_taken": 554,
  "integrator_actual_initial_step_size_taken": 0.010000000000000002,
  "integrator_largest_step_size_taken": 0.10000000000000009,
  "integrator_smallest_adapted_step_size_taken": 0.00044037999923885043,
  "integrator_num_step_shrinkages_from_error_control": 252,
  "integrator_num_derivative_evaluations": 0,
  "cenic_total_solver_iterations": 17312,
  "cenic_total_hessian_factorizations": 17312,
  "cenic_total_ls_iterations": 56692
}
Press [ENTER] to quit ...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24030)
<!-- Reviewable:end -->
