### PR TITLE
Deprecate `MonomialBasisElement::operator<<`

### DIFF
--- a/common/symbolic/monomial_basis_element.cc
+++ b/common/symbolic/monomial_basis_element.cc
@@ -116,31 +116,33 @@ Expression MonomialBasisElement::DoToExpression() const {
   return ExpressionMulFactory{1.0, base_to_exponent_map}.GetExpression();
 }
 
-std::ostream& operator<<(std::ostream& out, const MonomialBasisElement& m) {
+std::string to_string(const MonomialBasisElement& m) {
   if (m.var_to_degree_map().empty()) {
-    return out << 1;
+    return "1";
   }
   auto it = m.var_to_degree_map().begin();
-  out << fmt::to_string(it->first);
+  std::string result{fmt::to_string(it->first)};
   if (it->second > 1) {
-    out << "^" << it->second;
+    result.append(fmt::format("^{}", it->second));
   }
   for (++it; it != m.var_to_degree_map().end(); ++it) {
-    out << " * ";
-    out << fmt::to_string(it->first);
+    result.append(fmt::format(" * {}", it->first));
     if (it->second > 1) {
-      out << "^" << it->second;
+      result.append(fmt::format("^{}", it->second));
     }
   }
-  return out;
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& out, const MonomialBasisElement& m) {
+  return out << fmt::to_string(m);
 }
 
 MonomialBasisElement& MonomialBasisElement::pow_in_place(const int p) {
   if (p < 0) {
-    std::ostringstream oss;
-    oss << "MonomialBasisElement::pow(int p) is called with a negative p = "
-        << p;
-    throw std::runtime_error(oss.str());
+    throw std::runtime_error(fmt::format(
+        "MonomialBasisElement::pow(int p) is called with a negative p = {}",
+        p));
   }
   if (p == 0) {
     int* total_degree = get_mutable_total_degree();

--- a/common/symbolic/monomial_basis_element.h
+++ b/common/symbolic/monomial_basis_element.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <utility>
 
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/chebyshev_basis_element.h"
 #include "drake/common/symbolic/polynomial_basis_element.h"
@@ -182,6 +184,12 @@ class MonomialBasisElement : public PolynomialBasisElement {
   [[nodiscard]] Expression DoToExpression() const override;
 };
 
+std::string to_string(const MonomialBasisElement& m);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream& out, const MonomialBasisElement& m);
 
 /** Returns a multiplication of two monomials, @p m1 and @p m2.
@@ -240,9 +248,5 @@ EIGEN_DEVICE_FUNC inline drake::symbolic::Expression cast(
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::symbolic::MonomialBasisElement>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::symbolic, MonomialBasisElement, x,
+                   drake::symbolic::to_string(x))

--- a/common/symbolic/test/monomial_basis_element_test.cc
+++ b/common/symbolic/test/monomial_basis_element_test.cc
@@ -677,5 +677,16 @@ TEST_F(MonomialBasisElementTest, MergeBasisElementInPlace) {
   EXPECT_EQ(basis_element1.var_to_degree_map().at(var_z_), 2);
   EXPECT_EQ(basis_element1.total_degree(), 9);
 }
+
+TEST_F(MonomialBasisElementTest, ToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(MonomialBasisElement{}), "1");
+  EXPECT_EQ(fmt::to_string(MonomialBasisElement{{{var_x_, 1}}}), "x");
+  EXPECT_EQ(fmt::to_string(MonomialBasisElement{{{var_x_, 2}}}), "x^2");
+  EXPECT_EQ(fmt::to_string(MonomialBasisElement{{{var_x_, 1}, {var_z_, 3}}}),
+            "z^3 * x");
+  EXPECT_EQ(fmt::to_string(
+                MonomialBasisElement{{{var_x_, 2}, {var_z_, 3}, {var_y_, 5}}}),
+            "z^3 * y^5 * x^2");
+}
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri, @SeanCurtis-TRI for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24032)
<!-- Reviewable:end -->
