### PR TITLE
[Jenkins] Drop support for specifying drake-ci PR by ID

### DIFF
--- a/.jenkins/Jenkinsfile-experimental
+++ b/.jenkins/Jenkinsfile-experimental
@@ -7,10 +7,7 @@
 def props = [
   parameters([
     string(name: 'ciSha', defaultValue: 'main',
-      description: 'Commit SHA or branch name. ' +
-        'For pull requests, enter branch name <code>pr/1234/head</code> ' +
-        'or <code>pr/1234/merge</code> for pull request #1234. ' +
-        'Defaults to <code>main</code>.'),
+      description: 'Commit SHA or branch name. Defaults to <code>main</code>.'),
     ]
   ),
   buildDiscarder(

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -71,9 +71,9 @@ repository from the [Jenkins UI](https://drake-jenkins.csail.mit.edu/),
 4. Click on "Pull Requests" towards the top, and select your pull request.
 5. Click on "Build with Parameters" in the left menu.
 6. (Optional) If you need to test your changes alongside a pull request or
-   branch of the ``RobotLocomotion/drake-ci`` repository, enter ``pr/XYZ/head``
-   (HEAD of pull request), ``pr/XYZ/merge`` (pull request merged with master)
-   for ``ciSha``. Otherwise, leave it set to "main."
+   branch of the ``RobotLocomotion/drake-ci`` repository, enter the git commit
+   SHA associated with the HEAD of the pull request. Otherwise, leave it set to
+   "main."
 7. Click ``Build``.
 
 The list of experimental builds includes builds that automatically run on opened


### PR DESCRIPTION
With recent updates to the Jenkins workflow this no longer works reliably. Instead, a git commit SHA should always be used (usually representing the HEAD of the PR'd branch).

Closes #24026.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24034)
<!-- Reviewable:end -->
