### PR TITLE
[doc] Deprecate published docker images

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -47,7 +47,6 @@ body:
         - pip install drake
         - apt install drake
         - binary tar.gz download
-        - dockerhub
         - compiled from source code using CMake
         - compiled from source code using Bazel
   - type: textarea

--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -39,8 +39,6 @@ custom:
           url: '/apt.html'
         - page: 'Binary Download'
           url: '/from_binary.html'
-        - page: 'Docker Hub'
-          url: '/docker.html'
         - page: 'Build From Source'
           url: '/from_source.html'
       - title: 'Gallery'

--- a/doc/_pages/docker.md
+++ b/doc/_pages/docker.md
@@ -4,6 +4,15 @@ title: Installation via Docker
 
 # Docker Hub
 
+<div class="warning" markdown="1">
+**Drake's published Docker images are deprecated and will no longer receive
+updates after 2026-06-01.**
+
+For users who want to run Drake in Docker, you can fork the current Dockerfile
+and customize it your needs. Or, can switch to a simple `pip install drake`
+(or uv, etc.), or `apt install drake-dev`, etc.
+</div>
+
 Drake publishes pre-compiled binaries as Docker images on
 [Docker Hub](https://hub.docker.com/r/robotlocomotion/drake). Refer to
 [Supported Configurations](/installation.html#supported-configurations)
@@ -21,12 +30,17 @@ Drake binary releases incorporate a pre-compiled version of
 Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
 
 <div class="note" markdown="1">
-Drake's docker images do not support the Gurobi solver. To use
+Drake's Docker images do not support the Gurobi solver. To use
 Gurobi, you will need to build Drake from source following the instructions
 in [Source Installation](/from_source.html).
 </div>
 
 ## Stable Releases
+
+<div class="warning" markdown="1">
+**Drake's published Docker images are deprecated and will no longer receive
+updates after 2026-06-01.**
+</div>
 
 The latest stable image can be pulled from
 [Docker Hub](https://hub.docker.com/r/robotlocomotion/drake)
@@ -39,7 +53,7 @@ docker pull robotlocomotion/drake:X.Y.Z
 Refer to [Release Notes](/release_notes/release_notes.html) for a list of
 published X.Y.Z version numbers.
 
-The docker tags for Drake's stable releases are spelled like:
+The Docker tags for Drake's stable releases are spelled like:
 
 * ``jammy-X.Y.Z`` for the Ubuntu 22.04 image of Drake vX.Y.Z.
 * ``noble-X.Y.Z`` for the Ubuntu 24.04 image of Drake vX.Y.Z.
@@ -49,6 +63,11 @@ Refer to [Quickstart](/installation.html#quickstart) for next steps.
 
 ## Nightly Releases
 
+<div class="warning" markdown="1">
+**Drake's published Docker images are deprecated and will no longer receive
+updates after 2026-06-01.**
+</div>
+
 The latest nightly image can be pulled from
 [Docker Hub](https://hub.docker.com/r/robotlocomotion/drake)
 as follows:
@@ -57,7 +76,7 @@ as follows:
 docker pull robotlocomotion/drake:latest
 ```
 
-The docker tags for Drake's nightly releases are spelled like:
+The Docker tags for Drake's nightly releases are spelled like:
 
 * ``jammy-YYYYMMDD`` for the Ubuntu 22.04 image of Drake as of date YYYY-MM-DD.
 * ``jammy`` is a synonym for the most recent ``jammy-YYYYMMDD``.

--- a/doc/_pages/getting_help.md
+++ b/doc/_pages/getting_help.md
@@ -40,7 +40,7 @@ When reporting an issue, please consider providing the following information
 (``helper command in monospace``):
 
 * Operating system (e.g., Ubuntu Noble 24.04 or macOS Sequoia)
-* Installation method (e.g., pip, apt, binary tar.gz, docker image, or
+* Installation method (e.g., pip, apt, binary tar.gz, or
   rebuilding from source)
 * Language you are using (C++ or [Python](/python_bindings.html))
     * If using C++:

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -94,7 +94,6 @@ Stable and nightly release versions are available for each method.
 * [Pip](/pip.html) (only supports Python)
 * [APT](/apt.html) (only supports Ubuntu)
 * [Binary (`*.tar.gz`) download](/from_binary.html)
-* [Docker Hub](/docker.html)
 
 Alternatively, you can skip the pre-compiled binaries and build Drake
 following the instructions in [Source Installation](/from_source.html).

--- a/doc/_pages/issues.md
+++ b/doc/_pages/issues.md
@@ -56,7 +56,7 @@ RobotLocomotion/drake-ci
 
 <tr>
 <td><code>distribution</code></td>
-<td>Nightly binaries, monthly releases, docker, installation.</td>
+<td>Nightly binaries, monthly releases, installation.</td>
 <td>jwnimmer-tri</td>
 <td><small>
 tools/install<br>

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -314,8 +314,7 @@ the email address associated with your github account.
       ```
    2. If the current content differs from the above content, ask for help on
       slack in the ``#releases`` channel.
-5. Copy the updated tutorials from the pinned Dockerfile release
-   (in ``/opt/drake/share/drake/tutorials/...``) into the Deepnote project
+5. Copy the updated tutorials from the wheel release into the Deepnote project
    storage (``~/work/...``):
    1. Open [zzz_for_maintainers.ipynb](https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/zzz_for_maintainers-fd55235184ab44289133abc40e94a5e0).
    2. Run each cell one by one, checking for errors as you go.

--- a/tools/install/dockerhub/jammy/README.md
+++ b/tools/install/dockerhub/jammy/README.md
@@ -1,3 +1,6 @@
+Drake's published Docker images are deprecated and will no longer
+receive updates after 2026-06-01.
+
 # Docker Image for Docker Hub (Jammy)
 
 To create a Docker image similar to those hosted on

--- a/tools/install/dockerhub/noble/README.md
+++ b/tools/install/dockerhub/noble/README.md
@@ -1,3 +1,6 @@
+Drake's published Docker images are deprecated and will no longer
+receive updates after 2026-06-01.
+
 # Docker Image for Docker Hub (Noble)
 
 To create a Docker image similar to those hosted on

--- a/tools/release_engineering/dev/README.md
+++ b/tools/release_engineering/dev/README.md
@@ -11,7 +11,7 @@ other platforms are not supported.
 
     apt install aptly
 
-Follow instructions to install docker
+Follow instructions to install Docker
 https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 
 Follow instructions to install awscli
@@ -62,7 +62,7 @@ Clone the drake repository:
 
 ## Run script for Docker / S3 / GitHub
 
-The next step is to push docker images, mirror the .tar/.deb artifacts to S3,
+The next step is to push Docker images, mirror the .tar/.deb artifacts to S3,
 and push the official source code archive to GitHub.
 
 Once your machine is set-up, run the `push_release` script as described below:

--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -457,7 +457,7 @@ def main(args: List[str]) -> None:
         dest="push_docker",
         default=True,
         action=argparse.BooleanOptionalAction,
-        help="Publish docker images from staging images.",
+        help="Publish Docker images from staging images.",
     )
     parser.add_argument(
         "--tar",

--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -130,7 +130,7 @@ def _download_binaries(*, timestamp, staging, version):
     """
 
     # This is a partial inventory of our binary releases (tgz and wheel only).
-    # The apt and docker releases are handled separately.
+    # The apt and Docker releases are handled separately.
     if staging:
         assert version is not None
         assert timestamp is None

--- a/tools/wheel/test/provision.sh
+++ b/tools/wheel/test/provision.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Internal script to provision a bare docker image for testing a Drake wheel.
+# Internal script to provision a bare Docker image for testing a Drake wheel.
 
 set -eu -o pipefail
 

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -92,7 +92,7 @@ def _path_depth(path):
 
 def _docker(*args, stdout=None):
     """
-    Runs a docker command.
+    Runs a Docker command.
     The value of `stdout` is passed through to the subprocess module.
     Blocks until completion and returns a CompletedProcess instance.
     """
@@ -216,7 +216,7 @@ def _build_stage(target, args, tag_prefix, stage=None):
 
 def _target_args(target: Target, role: Role):
     """
-    Returns the docker build arguments for the specified platform target.
+    Returns the Docker build arguments for the specified platform target.
     """
     platform_name = target.platform(role).name
     platform_version = target.platform(role).version


### PR DESCRIPTION
Now that we offer easy alternatives (especially PyPI wheels, but also the apt site and binary tarball download), the docker images are no longer particularly useful.  If users want to run Drake in Docker, they can simply fire it up and do `pip install drake` (or uv, etc), or `apt install drake-dev`, or etc.  Or they can start from the current [Dockerfile](https://github.com/RobotLocomotion/drake/blob/v1.49.0/tools/install/dockerhub/noble/Dockerfile) and customize it to their needs.

(The version-numbered Docker images were actually copies of the nightly build, not the official release builds, so they were already a bit sketchy.  Instead of rewriting a bunch of code to support making them correct, it's a better trade-off to just drop it.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24048)
<!-- Reviewable:end -->
