### PR TITLE
[wheel] Drop advertised support for macOS x86_64

### DIFF
--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -88,7 +88,7 @@ See https://drake.mit.edu/pip.html for installation instructions and caveats.
         'Topic :: Scientific/Engineering',
         'Topic :: Software Development :: Libraries :: Python Modules'],
       license='Various',
-      platforms=['linux_x86_64', 'macosx_x86_64', 'macosx_arm64'],
+      platforms=['linux_x86_64', 'macosx_arm64'],
       packages=_actually_find_packages(),
       # Add in any packaged data.
       include_package_data=True,

--- a/tools/wheel/test/tests/sanity-test.py
+++ b/tools/wheel/test/tests/sanity-test.py
@@ -21,7 +21,4 @@ prog.AddLinearConstraint(x[0] >= 1)
 prog.AddLinearConstraint(x[1] >= 1)
 prog.AddQuadraticCost(numpy.eye(2), numpy.zeros(2), x)
 solver = pydrake.all.IpoptSolver()
-if platform.system() == 'Darwin' and platform.machine() == 'x86_64':
-    assert not solver.available(), 'IPOPT is supposed to be disabled'
-else:
-    assert solver.Solve(prog, None, None).is_success(), 'IPOPT is not usable'
+assert solver.Solve(prog, None, None).is_success(), 'IPOPT is not usable'


### PR DESCRIPTION
v1.34.0 was the last release to provide macOS x86_64 wheels. Remove the reference from PyPI metadata (and a dead test case).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24052)
<!-- Reviewable:end -->
