### PR TITLE
Deprecate `RationalFunction::operator<<`

### DIFF
--- a/common/symbolic/rational_function.cc
+++ b/common/symbolic/rational_function.cc
@@ -42,8 +42,11 @@ Formula RationalFunction::operator!=(const RationalFunction& f) const {
 }
 
 std::ostream& operator<<(std::ostream& os, const RationalFunction& f) {
-  os << fmt::format("({}) / ({})", f.numerator(), f.denominator());
-  return os;
+  return os << fmt::to_string(f);
+}
+
+std::string to_string(const RationalFunction& f) {
+  return fmt::format("({}) / ({})", f.numerator(), f.denominator());
 }
 
 void RationalFunction::CheckIndeterminates() const {
@@ -52,21 +55,24 @@ void RationalFunction::CheckIndeterminates() const {
   const Variables vars2{intersect(numerator_.decision_variables(),
                                   denominator_.indeterminates())};
   if (!vars1.empty() || !vars2.empty()) {
-    std::ostringstream oss;
-    oss << "RationalFunction " << *this << " is invalid.\n";
+    std::string err_msg{
+        fmt::format("RationalFunction {} is invalid.\n", *this)};
     if (!vars1.empty()) {
-      oss << "The following variable(s) "
-             "are used as indeterminates in the numerator and decision "
-             "variables in the denominator at the same time:\n"
-          << vars1 << ".\n";
+      err_msg.append(fmt::format(
+          "The following variable(s) are used as indeterminates in the "
+          "numerator and decision variables in the denominator at the same "
+          "time:\n{}.\n",
+          vars1));
     }
     if (!vars2.empty()) {
-      oss << "The following variable(s) "
-             "are used as decision variables in the numerator and "
-             "indeterminates variables in the denominator at the same time:\n"
-          << vars2 << ".\n";
+      err_msg.append(
+          fmt::format("The following variable(s) "
+                      "are used as decision variables in the numerator and "
+                      "indeterminates variables in the denominator at the same "
+                      "time:\n{}.\n",
+                      vars2));
     }
-    throw std::logic_error(oss.str());
+    throw std::logic_error(err_msg);
   }
 }
 

--- a/common/symbolic/rational_function.h
+++ b/common/symbolic/rational_function.h
@@ -1,9 +1,13 @@
 #pragma once
 
-#include <ostream>
+#include <string>
 
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/symbolic/polynomial.h"
+
+// Remove with deprecation 2026-06-01.
+#include <ostream>
 
 namespace drake {
 namespace symbolic {
@@ -134,8 +138,6 @@ class RationalFunction {
    */
   Formula operator!=(const RationalFunction& f) const;
 
-  friend std::ostream& operator<<(std::ostream&, const RationalFunction& f);
-
   /// Returns an equivalent symbolic expression of this rational function.
   [[nodiscard]] Expression ToExpression() const;
 
@@ -204,6 +206,14 @@ RationalFunction operator/(RationalFunction f, double c);
 RationalFunction operator/(double c, const RationalFunction& f);
 RationalFunction operator/(const Monomial& m, RationalFunction f);
 RationalFunction operator/(RationalFunction f, const Monomial& m);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream& operator<<(std::ostream&, const RationalFunction& f);
+
+std::string to_string(const RationalFunction& f);
 
 /**
  * Returns the rational function @p f raised to @p n.
@@ -327,9 +337,5 @@ EIGEN_STRONG_INLINE bool not_equal_strict(
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::symbolic::RationalFunction> : drake::ostream_formatter {
-};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::symbolic, RationalFunction, x,
+                   drake::symbolic::to_string(x))

--- a/common/symbolic/test/rational_function_test.cc
+++ b/common/symbolic/test/rational_function_test.cc
@@ -385,6 +385,14 @@ TEST_F(SymbolicRationalFunctionTest, SetIndetermiantes) {
   EXPECT_EQ(f.denominator().indeterminates(), var_xy_);
 }
 
+TEST_F(SymbolicRationalFunctionTest, ToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(RationalFunction{}), "(0) / (1*1)");
+  EXPECT_EQ(fmt::to_string(RationalFunction{p1_, polynomial_one_}),
+            "(1*y + 2*x^2) / (1*1)");
+  EXPECT_EQ(fmt::to_string(RationalFunction{p1_, p2_}),
+            "(1*y + 2*x^2) / (2*y + 1*x^2)");
+}
+
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri, @SeanCurtis-TRI for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24056)
<!-- Reviewable:end -->
