### PR TITLE
Deprecate `ChebyshevBasisElement::operator<<` and `ChebyshevPolynomial::operator<<`

### DIFF
--- a/bindings/generated_docstrings/common_symbolic.h
+++ b/bindings/generated_docstrings/common_symbolic.h
@@ -2636,7 +2636,7 @@ Precondition:
       } pow;
       // Symbol: drake::symbolic::to_string
       struct /* to_string */ {
-        // Source: drake/common/symbolic/generic_polynomial.h
+        // Source: drake/common/symbolic/chebyshev_basis_element.h
         const char* doc = R"""()""";
       } to_string;
     } symbolic;

--- a/common/symbolic/chebyshev_basis_element.cc
+++ b/common/symbolic/chebyshev_basis_element.cc
@@ -241,15 +241,20 @@ std::map<ChebyshevBasisElement, double> operator*(
   return result;
 }
 
-std::ostream& operator<<(std::ostream& out, const ChebyshevBasisElement& m) {
+std::string to_string(const ChebyshevBasisElement& m) {
+  std::string result;
   if (m.var_to_degree_map().empty()) {
-    out << "T0()";
+    result.append("T0()");
   } else {
     for (const auto& [var, degree] : m.var_to_degree_map()) {
-      out << ChebyshevPolynomial(var, degree);
+      result.append(fmt::to_string(ChebyshevPolynomial(var, degree)));
     }
   }
-  return out;
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& out, const ChebyshevBasisElement& m) {
+  return out << fmt::to_string(m);
 }
 }  // namespace symbolic
 }  // namespace drake

--- a/common/symbolic/chebyshev_basis_element.h
+++ b/common/symbolic/chebyshev_basis_element.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/polynomial_basis_element.h"
@@ -131,6 +134,12 @@ class ChebyshevBasisElement : public PolynomialBasisElement {
 std::map<ChebyshevBasisElement, double> operator*(
     const ChebyshevBasisElement& a, const ChebyshevBasisElement& b);
 
+std::string to_string(const ChebyshevBasisElement& m);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream& out, const ChebyshevBasisElement& m);
 }  // namespace symbolic
 }  // namespace drake
@@ -155,9 +164,5 @@ struct NumTraits<drake::symbolic::ChebyshevBasisElement>
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::symbolic::ChebyshevBasisElement>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::symbolic, ChebyshevBasisElement, x,
+                   drake::symbolic::to_string(x))

--- a/common/symbolic/chebyshev_polynomial.cc
+++ b/common/symbolic/chebyshev_polynomial.cc
@@ -164,14 +164,18 @@ ChebyshevPolynomial::Differentiate() const {
     return derivative;
   }
 }
+std::string to_string(const ChebyshevPolynomial& p) {
+  std::string result;
+  if (p.degree() == 0) {
+    result.append("T0()");
+  } else {
+    result.append(fmt::format("T{}({})", p.degree(), p.var()));
+  }
+  return result;
+}
 
 std::ostream& operator<<(std::ostream& out, const ChebyshevPolynomial& p) {
-  if (p.degree() == 0) {
-    out << "T0()";
-  } else {
-    out << "T" << p.degree() << "(" << fmt::to_string(p.var()) << ")";
-  }
-  return out;
+  return out << fmt::to_string(p);
 }
 
 bool ChebyshevPolynomial::operator<(const ChebyshevPolynomial& other) const {

--- a/common/symbolic/chebyshev_polynomial.h
+++ b/common/symbolic/chebyshev_polynomial.h
@@ -1,16 +1,20 @@
 #pragma once
 
-#include <ostream>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/common/symbolic/polynomial.h"
+
+// Remove with deprecation 2026-06-01.
+#include <ostream>
 
 namespace drake {
 namespace symbolic {
@@ -115,6 +119,12 @@ class ChebyshevPolynomial {
   int degree_{};
 };
 
+std::string to_string(const ChebyshevPolynomial& p);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream& out, const ChebyshevPolynomial& p);
 
 /**
@@ -133,9 +143,5 @@ struct hash<drake::symbolic::ChebyshevPolynomial> : public drake::DefaultHash {
 };
 }  // namespace std
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::symbolic::ChebyshevPolynomial>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::symbolic, ChebyshevPolynomial, x,
+                   drake::symbolic::to_string(x))

--- a/common/symbolic/test/chebyshev_basis_element_test.cc
+++ b/common/symbolic/test/chebyshev_basis_element_test.cc
@@ -217,6 +217,17 @@ TEST_F(SymbolicChebyshevBasisElementTest, Integrate) {
   EXPECT_EQ(result4.at(ChebyshevBasisElement({{x_, 2}, {y_, 2}})), -1. / 4);
 }
 
+TEST_F(SymbolicChebyshevBasisElementTest, ToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(ChebyshevBasisElement()), "T0()");
+  EXPECT_EQ(fmt::to_string(ChebyshevBasisElement({{x_, 1}})), "T1(x)");
+  EXPECT_EQ(fmt::to_string(ChebyshevBasisElement({{x_, 0}})), "T0()");
+  EXPECT_EQ(fmt::to_string(ChebyshevBasisElement({{x_, 1}, {y_, 2}})),
+            "T1(x)T2(y)");
+}
+
+// Remove StringOutput test with deprecation 2026-06-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(SymbolicChebyshevBasisElementTest, StringOutput) {
   std::ostringstream os1;
   os1 << ChebyshevBasisElement();
@@ -234,6 +245,7 @@ TEST_F(SymbolicChebyshevBasisElementTest, StringOutput) {
   os4 << ChebyshevBasisElement({{x_, 1}, {y_, 2}});
   EXPECT_EQ(fmt::format("{}", os4.str()), "T1(x)T2(y)");
 }
+#pragma GCC diagnostic pop
 
 TEST_F(SymbolicChebyshevBasisElementTest, ToExpression) {
   EXPECT_PRED2(test::ExprEqual, ChebyshevBasisElement().ToExpression(),

--- a/common/symbolic/test/chebyshev_polynomial_test.cc
+++ b/common/symbolic/test/chebyshev_polynomial_test.cc
@@ -190,6 +190,15 @@ GTEST_TEST(ChebyshevPolynomialTest, UnorderedMapOfChebyshevPolynomial) {
   EXPECT_EQ(it0->second, 1);
 }
 
+GTEST_TEST(ChebyshevPolynomial, ToStringFmtFormatter) {
+  const Variable x("x");
+  EXPECT_EQ(fmt::to_string(ChebyshevPolynomial(x, 0)), "T0()");
+  EXPECT_EQ(fmt::to_string(ChebyshevPolynomial(x, 2)), "T2(x)");
+}
+
+// Remove OperatorOut test with deprecation 2026-06-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(ChebyshevPolynomial, OperatorOut) {
   const Variable x("x");
   std::ostringstream os1;
@@ -200,6 +209,7 @@ GTEST_TEST(ChebyshevPolynomial, OperatorOut) {
   os2 << ChebyshevPolynomial(x, 2);
   EXPECT_EQ(fmt::format("{}", os2.str()), "T2(x)");
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(ChebyshevPolynomialTest, ChebyshevPolynomialLess) {
   // Test operator<


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri, @SeanCurtis-TRI for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24060)
<!-- Reviewable:end -->
