### PR TITLE
Deprecate `ChebyshevBasisElement::operator<<`

### DIFF
--- a/bindings/generated_docstrings/common_symbolic.h
+++ b/bindings/generated_docstrings/common_symbolic.h
@@ -2636,7 +2636,7 @@ Precondition:
       } pow;
       // Symbol: drake::symbolic::to_string
       struct /* to_string */ {
-        // Source: drake/common/symbolic/generic_polynomial.h
+        // Source: drake/common/symbolic/chebyshev_basis_element.h
         const char* doc = R"""()""";
       } to_string;
     } symbolic;

--- a/common/symbolic/chebyshev_basis_element.cc
+++ b/common/symbolic/chebyshev_basis_element.cc
@@ -241,15 +241,20 @@ std::map<ChebyshevBasisElement, double> operator*(
   return result;
 }
 
-std::ostream& operator<<(std::ostream& out, const ChebyshevBasisElement& m) {
+std::string to_string(const ChebyshevBasisElement& m) {
+  std::string result;
   if (m.var_to_degree_map().empty()) {
-    out << "T0()";
+    result.append("T0()");
   } else {
     for (const auto& [var, degree] : m.var_to_degree_map()) {
-      out << ChebyshevPolynomial(var, degree);
+      result.append(fmt::to_string(ChebyshevPolynomial(var, degree)));
     }
   }
-  return out;
+  return result;
+}
+
+std::ostream& operator<<(std::ostream& out, const ChebyshevBasisElement& m) {
+  return out << fmt::to_string(m);
 }
 }  // namespace symbolic
 }  // namespace drake

--- a/common/symbolic/chebyshev_basis_element.h
+++ b/common/symbolic/chebyshev_basis_element.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/polynomial_basis_element.h"
 
@@ -131,6 +133,12 @@ class ChebyshevBasisElement : public PolynomialBasisElement {
 std::map<ChebyshevBasisElement, double> operator*(
     const ChebyshevBasisElement& a, const ChebyshevBasisElement& b);
 
+std::string to_string(const ChebyshevBasisElement& m);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream& out, const ChebyshevBasisElement& m);
 }  // namespace symbolic
 }  // namespace drake
@@ -155,9 +163,5 @@ struct NumTraits<drake::symbolic::ChebyshevBasisElement>
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::symbolic::ChebyshevBasisElement>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::symbolic, ChebyshevBasisElement, x,
+                   drake::symbolic::to_string(x))

--- a/common/symbolic/test/chebyshev_basis_element_test.cc
+++ b/common/symbolic/test/chebyshev_basis_element_test.cc
@@ -217,6 +217,17 @@ TEST_F(SymbolicChebyshevBasisElementTest, Integrate) {
   EXPECT_EQ(result4.at(ChebyshevBasisElement({{x_, 2}, {y_, 2}})), -1. / 4);
 }
 
+TEST_F(SymbolicChebyshevBasisElementTest, ToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(ChebyshevBasisElement()), "T0()");
+  EXPECT_EQ(fmt::to_string(ChebyshevBasisElement({{x_, 1}})), "T1(x)");
+  EXPECT_EQ(fmt::to_string(ChebyshevBasisElement({{x_, 0}})), "T0()");
+  EXPECT_EQ(fmt::to_string(ChebyshevBasisElement({{x_, 1}, {y_, 2}})),
+            "T1(x)T2(y)");
+}
+
+// Remove StringOutput test with deprecation 2026-06-01.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(SymbolicChebyshevBasisElementTest, StringOutput) {
   std::ostringstream os1;
   os1 << ChebyshevBasisElement();
@@ -234,6 +245,7 @@ TEST_F(SymbolicChebyshevBasisElementTest, StringOutput) {
   os4 << ChebyshevBasisElement({{x_, 1}, {y_, 2}});
   EXPECT_EQ(fmt::format("{}", os4.str()), "T1(x)T2(y)");
 }
+#pragma GCC diagnostic pop
 
 TEST_F(SymbolicChebyshevBasisElementTest, ToExpression) {
   EXPECT_PRED2(test::ExprEqual, ChebyshevBasisElement().ToExpression(),


### PR DESCRIPTION
THIS PR IS NOT FOR REVIEW. It's for testing [linux-jammy-gcc-bazel-experimental-release](https://drake-jenkins.csail.mit.edu/job/linux-jammy-gcc-bazel-experimental-release/job/PR-24065/2/display/redirect) build.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24065)
<!-- Reviewable:end -->
