### PR TITLE
[wheel] Add support for manylinux aarch64

### DIFF
--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -30,7 +30,13 @@ EOF
 # version number, we should bump this up to match, and also grep tools/wheel
 # for other mentions of MOSEK version bounds and fix those as well.
 PYTHON_MINOR=$(/usr/local/bin/python -c "import sys; print(sys.version_info.minor)")
-if [[ ${PYTHON_MINOR} -ge 15 ]]; then
+MOSEK_ENABLED=1
+[ ${PYTHON_MINOR} -ge 15 ] && MOSEK_ENABLED=
+
+# MOSEK is not currently supported for Linux aarch64 wheels.
+[ "$(arch)" == "aarch64" ] && MOSEK_ENABLED=
+
+if [[ -z "${MOSEK_ENABLED}" ]]; then
     cat >> /tmp/drake-wheel-build/drake-build/drake.bazelrc << EOF
 build --@drake//tools/flags:with_mosek=False
 build --@drake//solvers:mosek_lazy_load=False

--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -170,5 +170,5 @@ if [[ "$(uname)" == "Darwin" ]]; then
 else
     GLIBC_VERSION=$(ldd --version | sed -n '1{s/.* //;s/[.]/_/p}')
 
-    auditwheel repair --plat manylinux_${GLIBC_VERSION}_x86_64 dist/drake*.whl
+    auditwheel repair --plat manylinux_${GLIBC_VERSION}_$(arch) dist/drake*.whl
 fi

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -22,7 +22,9 @@ python_required = [
     # builds wheels (see tools/wheel/wheel_builder/macos.py and
     # tools/wheel/wheel_builder/linux.py), then that should be documented for
     # users accordingly.
-    'Mosek==11.1.2 ; python_version < "3.15"',
+    # Additionally, MOSEK is not supported on Linux aarch64. (Apple Silicon
+    # is spelled 'arm64', so this doesn't apply there.)
+    'Mosek==11.1.2 ; python_version < "3.15" and platform_machine != "aarch64"',
 ]
 
 def find_data_files(*patterns):

--- a/tools/wheel/test/tests/mosek-test.py
+++ b/tools/wheel/test/tests/mosek-test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import platform
 import sys
 
 from pydrake.all import MosekSolver
@@ -14,7 +15,9 @@ assert solver.enabled()
 # version, which is currently Python < 3.15. When that changes to a larger
 # version number, we should bump this up to match, and also grep tools/wheel
 # for other mentions of MOSEK version bounds and fix those as well.
-if sys.version_info[:2] < (3, 15):
+# Additionally, MOSEK is not currently supported for Linux aarch64 wheels.
+# (Apple Silicon is spelled 'arm64', so this doesn't apply there.)
+if sys.version_info[:2] < (3, 15) and platform.machine() != "aarch64":
     assert solver.available()
 else:
     assert not solver.available()

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -4,7 +4,7 @@
 import atexit
 from datetime import datetime, timezone
 import os
-import pathlib
+import platform
 import subprocess
 import sys
 import tarfile
@@ -27,11 +27,13 @@ _images_to_remove = []
 
 tag_base = "pip-drake"
 
+ARCH = platform.machine()
+
 # This is the complete set of defined targets (i.e. potential wheels). By
-# default, all targets are built, but the user may down-select from this set.
-# The platform alias is used for Docker tag names, and, when combined with the
-# Python version, must be unique.
-targets = (
+# default, all targets matching the currently running architecture are built,
+# but the user may down-select from this set. The platform alias is used for
+# Docker tag names, and, when combined with the Python version, must be unique.
+targets = {
     # NOTE: adding or removing a python version?  Please also check the
     # following locations for updates:
     # * the artifact tallies in doc/_pages/release_playbook.md (search
@@ -44,50 +46,70 @@ targets = (
     # * the Python versions supported by MOSEK, in tools/wheel/setup.py. If
     #   there is any Python version supported by Drake, but not MOSEK, a note
     #   should be added to the aforementioned installation documentation.
-    Target(
-        build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
-        test_platform=Platform("ubuntu", "22.04", "jammy"),
-        python_version_tuple=(3, 10, 16),
-        python_sha="bfb249609990220491a1b92850a07135ed0831e41738cf681d63cf01b2a8fbd1",  # noqa
+    "x86_64": (
+        Target(
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
+            test_platform=Platform("ubuntu", "22.04", "jammy"),
+            python_version_tuple=(3, 10, 16),
+            python_sha="bfb249609990220491a1b92850a07135ed0831e41738cf681d63cf01b2a8fbd1",  # noqa
+        ),
+        Target(
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
+            test_platform=Platform("ubuntu", "22.04", "jammy"),
+            python_version_tuple=(3, 11, 11),
+            python_sha="2a9920c7a0cd236de33644ed980a13cbbc21058bfdc528febb6081575ed73be3",  # noqa
+        ),
+        Target(
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
+            test_platform=Platform("ubuntu", "24.04", "noble"),
+            python_version_tuple=(3, 12, 8),
+            python_sha="c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e",  # noqa
+        ),
+        Target(
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
+            # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been
+            # released.
+            test_platform=Platform("ubuntu", "25.10", "questing"),
+            python_version_tuple=(3, 13, 0),
+            python_sha="086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d",  # noqa
+        ),
+        Target(
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
+            # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been
+            # released.
+            test_platform=Platform("ubuntu", "25.10", "questing"),
+            python_version_tuple=(3, 14, 0),
+            python_sha="2299dae542d395ce3883aca00d3c910307cd68e0b2f7336098c8e7b7eee9f3e9",  # noqa
+        ),
     ),
-    Target(
-        build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
-        test_platform=Platform("ubuntu", "22.04", "jammy"),
-        python_version_tuple=(3, 11, 11),
-        python_sha="2a9920c7a0cd236de33644ed980a13cbbc21058bfdc528febb6081575ed73be3",  # noqa
+    "aarch64": (
+        Target(
+            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
+            test_platform=Platform("ubuntu", "24.04", "noble"),
+            python_version_tuple=(3, 12, 8),
+            python_sha="c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e",  # noqa
+        ),
+        Target(
+            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
+            # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been
+            # released.
+            test_platform=Platform("ubuntu", "25.10", "questing"),
+            python_version_tuple=(3, 13, 0),
+            python_sha="086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d",  # noqa
+        ),
+        Target(
+            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
+            # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been
+            # released.
+            test_platform=Platform("ubuntu", "25.10", "questing"),
+            python_version_tuple=(3, 14, 0),
+            python_sha="2299dae542d395ce3883aca00d3c910307cd68e0b2f7336098c8e7b7eee9f3e9",  # noqa
+        ),
     ),
-    Target(
-        build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
-        test_platform=Platform("ubuntu", "24.04", "noble"),
-        python_version_tuple=(3, 12, 8),
-        python_sha="c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e",  # noqa
-    ),
-    Target(
-        build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
-        # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been released.
-        test_platform=Platform("ubuntu", "25.10", "questing"),
-        python_version_tuple=(3, 13, 0),
-        python_sha="086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d",  # noqa
-    ),
-    Target(
-        build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
-        # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been released.
-        test_platform=Platform("ubuntu", "25.10", "questing"),
-        python_version_tuple=(3, 14, 0),
-        python_sha="2299dae542d395ce3883aca00d3c910307cd68e0b2f7336098c8e7b7eee9f3e9",  # noqa
-    ),
-)
+}[ARCH]
 glibc_versions = {
     "almalinux9": "2_34",
 }
-
-
-def _path_depth(path):
-    """
-    Return the number of components (i.e. the "depth") of `path`.
-    """
-    offset = 1 if os.path.isabs(path) else 0  # Strip leading '/'.
-    return len(pathlib.Path(path).parts[offset:])
 
 
 def _docker(*args, stdout=None):
@@ -291,7 +313,7 @@ def _test_wheel(target, identifier, options):
     wheel = wheel_name(
         python_version=target.python_tag,
         wheel_version=options.version,
-        wheel_platform=f"manylinux_{glibc}_x86_64",
+        wheel_platform=f"manylinux_{glibc}_{ARCH}",
     )
 
     test_image = _tagname(target, TEST, f"test-{identifier}")


### PR DESCRIPTION
Add a host of aarch64 targets to the Linux wheel build matrix, and teach the builder to distinguish between architectures when assembling the list of targets to build, by only selecting the targets on the currently running arch.
    
Given Drake's pending removal of official support for Ubuntu Jammy, only add support for Linux aarch64 wheels starting with Python 3.12 (the version of choice on Noble). Additionally, don't support MOSEK for the new wheels, at least for now.
    
This commit only adds the ability to produce the wheel files. It does not document official support nor update release automation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24066)
<!-- Reviewable:end -->
