### PR TITLE
Deprecate `drake::Polynomial::operator<<`

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -1608,6 +1608,11 @@ not reflect any sort of mathematical total order.)""";
           // Source: drake/common/polynomial.h
           const char* doc = R"""()""";
         } terms;
+        // Symbol: drake::Polynomial::Monomial::to_string
+        struct /* to_string */ {
+          // Source: drake/common/polynomial.h
+          const char* doc = R"""()""";
+        } to_string;
       } Monomial;
       // Symbol: drake::Polynomial::Polynomial<T>
       struct /* ctor */ {
@@ -1791,6 +1796,11 @@ R"""(Returns true if this is a univariate polynomial)""";
 R"""(A comparison to allow std::lexicographical_compare on this class; does
 not reflect any sort of mathematical total order.)""";
       } operator_lt;
+      // Symbol: drake::Polynomial::to_string
+      struct /* to_string */ {
+        // Source: drake/common/polynomial.h
+        const char* doc = R"""()""";
+      } to_string;
     } Polynomial;
     // Symbol: drake::Polynomiald
     struct /* Polynomiald */ {

--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -850,6 +850,43 @@ Polynomial<T> Polynomial<T>::FromExpression(const Expression& e) {
   return FromExpressionVisitor<T>{}.Visit(e);
 }
 
+template <typename T>
+std::string Polynomial<T>::Monomial::to_string() const {
+  std::string result;
+  bool print_star = false;
+  if (coefficient != 1 || terms.empty()) {
+    result.append(fmt::format("({})", coefficient));
+    print_star = true;
+  }
+  for (const Term& term : terms) {
+    if (print_star) {
+      result.append("*");
+    } else {
+      print_star = true;
+    }
+    result.append(IdToVariableName(term.var));
+    if (term.power != 1) {
+      result.append(fmt::format("^{}", term.power));
+    }
+  }
+  return result;
+}
+
+template <typename T>
+std::string Polynomial<T>::to_string() const {
+  if (monomials_.empty()) {
+    return "0";
+  }
+  std::string result;
+  typename std::vector<Monomial>::const_iterator iter = monomials_.begin();
+  result.append((*iter).to_string());
+  for (++iter; iter != monomials_.end(); ++iter) {
+    result.append("+");
+    result.append((*iter).to_string());
+  }
+  return result;
+}
+
 // template class Polynomial<std::complex<double>>;
 // doesn't work yet because the roots solver can't handle it
 


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri, for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24070)
<!-- Reviewable:end -->
