### PR TITLE
Add fmt formatter for `TypeSafeIndex` and deprecate `operator<<` for `LoadYamlOptions` and `yaml::Node`

### DIFF
--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -338,6 +338,15 @@ GTEST_TEST(TypeSafeIndex, ToString) {
                                        "Converting to an int.+");
 }
 
+GTEST_TEST(TypeSafeIndex, ToStringFmtFormatter) {
+  AIndex index(87);
+  EXPECT_EQ(fmt::to_string(index), "87");
+
+  AIndex invalid;
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(fmt::to_string(invalid),
+                                       "Converting to an int.+");
+}
+
 // Verifies that it is not possible to convert between two different
 // index types.
 GTEST_TEST(TypeSafeIndex, ConversionNotAllowedBetweenDifferentTypes) {

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -5,7 +5,7 @@
 #include <typeinfo>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -578,8 +578,5 @@ template <typename Tag>
 struct hash<drake::TypeSafeIndex<Tag>> : public drake::DefaultHash {};
 }  // namespace std
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename Tag>
-struct formatter<drake::TypeSafeIndex<Tag>> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(typename Tag, drake, TypeSafeIndex<Tag>, x,
+                   std::to_string(int{x}))

--- a/common/yaml/test/yaml_io_test.cc
+++ b/common/yaml/test/yaml_io_test.cc
@@ -198,6 +198,15 @@ GTEST_TEST(YamlIoTest, SaveFileBad) {
                               ".* could not open .*/no_such_dir/.*");
 }
 
+GTEST_TEST(YamlIoTest, LoadYamlOptionsToStringFmtFormatter) {
+  LoadYamlOptions options = {.allow_yaml_with_no_cpp = true,
+                             .allow_cpp_with_no_yaml = false,
+                             .retain_map_defaults = true};
+  EXPECT_EQ(fmt::to_string(options),
+            "{.allow_yaml_with_no_cpp = true, "
+            ".allow_cpp_with_no_yaml = false, "
+            ".retain_map_defaults = true}");
+}
 }  // namespace
 }  // namespace test
 }  // namespace yaml

--- a/common/yaml/test/yaml_node_test.cc
+++ b/common/yaml/test/yaml_node_test.cc
@@ -334,8 +334,8 @@ TEST_P(YamlNodeParamaterizedTest, Visiting) {
   DRAKE_UNREACHABLE();
 }
 
-// Check debug printing using operator<<.
-TEST_P(YamlNodeParamaterizedTest, ToString) {
+// Check debug printing using fmt.
+TEST_P(YamlNodeParamaterizedTest, ToStringFmtFormatter) {
   Node dut = MakeNonEmptyDut();
 
   // Confirm that the code is being run by checking for a notable
@@ -355,11 +355,11 @@ TEST_P(YamlNodeParamaterizedTest, ToString) {
       break;
     }
   }
-  EXPECT_THAT(fmt::format("{}", dut), testing::HasSubstr(needle));
+  EXPECT_THAT(fmt::to_string(dut), testing::HasSubstr(needle));
 
   // Confirm that tags are represented somehow.
   dut.SetTag("MyTag");
-  EXPECT_THAT(fmt::format("{}", dut), testing::HasSubstr("MyTag"));
+  EXPECT_THAT(fmt::to_string(dut), testing::HasSubstr("MyTag"));
 }
 
 INSTANTIATE_TEST_SUITE_P(Suite, YamlNodeParamaterizedTest,

--- a/common/yaml/yaml_io_options.cc
+++ b/common/yaml/yaml_io_options.cc
@@ -3,10 +3,17 @@
 namespace drake {
 namespace yaml {
 
+std::string to_string(const LoadYamlOptions& options) {
+  return fmt::format(
+      "{{.allow_yaml_with_no_cpp = {}, "
+      ".allow_cpp_with_no_yaml = {}, "
+      ".retain_map_defaults = {}}}",
+      options.allow_yaml_with_no_cpp, options.allow_cpp_with_no_yaml,
+      options.retain_map_defaults);
+}
+
 std::ostream& operator<<(std::ostream& os, const LoadYamlOptions& x) {
-  return os << "{.allow_yaml_with_no_cpp = " << x.allow_yaml_with_no_cpp
-            << ", .allow_cpp_with_no_yaml = " << x.allow_cpp_with_no_yaml
-            << ", .retain_map_defaults = " << x.retain_map_defaults << "}";
+  return os << fmt::to_string(x);
 }
 
 }  // namespace yaml

--- a/common/yaml/yaml_io_options.h
+++ b/common/yaml/yaml_io_options.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <string>
+// Remove ostream with deprecation 2026-06-01.
 #include <ostream>
 
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 
 namespace drake {
 namespace yaml {
@@ -10,8 +13,6 @@ namespace yaml {
 /** Configuration for LoadYamlFile() and LoadYamlString() to govern when certain
 conditions are errors or not. Refer to the member fields for details. */
 struct LoadYamlOptions {
-  friend std::ostream& operator<<(std::ostream&, const LoadYamlOptions&);
-
   /** Allows yaml Maps to have extra key-value pairs that are not Visited by the
   Serializable being parsed into. In other words, the Serializable types provide
   an incomplete schema for the YAML data. This allows for parsing only a subset
@@ -30,11 +31,15 @@ struct LoadYamlOptions {
   bool retain_map_defaults{false};
 };
 
+std::string to_string(const LoadYamlOptions& options);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream& operator<<(std::ostream&, const LoadYamlOptions&);
+
 }  // namespace yaml
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::yaml::LoadYamlOptions> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::yaml, LoadYamlOptions, x, drake::yaml::to_string(x))

--- a/common/yaml/yaml_node.cc
+++ b/common/yaml/yaml_node.cc
@@ -309,40 +309,41 @@ void Node::Remove(std::string_view key) {
       data_);
 }
 
-std::ostream& operator<<(std::ostream& os, const Node& node) {
+std::string to_string(const Node& node) {
+  std::string result;
   if (!node.GetTag().empty()) {
-    os << "!<" << node.GetTag() << "> ";
+    result.append(fmt::format("!<{}> ", node.GetTag()));
   }
   node.Visit(overloaded{
       [&](const Node::ScalarData& data) {
-        os << '"' << data.scalar << '"';
+        result.append(fmt::format("\"{}\"", data.scalar));
       },
       [&](const Node::SequenceData& data) {
-        os << "[";
+        result.append("[");
         bool first = true;
         for (const auto& child : data.sequence) {
           if (!first) {
-            os << ", ";
+            result.append(", ");
           }
           first = false;
-          os << child;
+          result.append(fmt::format("{}", child));
         }
-        os << "]";
+        result.append("]");
       },
       [&](const Node::MappingData& data) {
-        os << "{";
+        result.append("{");
         bool first = true;
         for (const auto& [key, child] : data.mapping) {
           if (!first) {
-            os << ", ";
+            result.append(", ");
           }
           first = false;
-          os << '"' << key << '"' << ": " << child;
+          result.append(fmt::format("\"{}\": {}", key, child));
         }
-        os << "}";
+        result.append("}");
       },
   });
-  return os;
+  return result;
 }
 
 }  // namespace internal

--- a/common/yaml/yaml_node.h
+++ b/common/yaml/yaml_node.h
@@ -2,7 +2,6 @@
 
 #include <map>
 #include <optional>
-#include <ostream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -10,7 +9,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt.h"
 #include "drake/common/string_map.h"
 
 // Note that even though this file contains "class Node", the file is named
@@ -287,10 +286,6 @@ class Node final {
     friend bool operator==(const MappingData&, const MappingData&);
   };
 
-  /* Displays the given node using flow style.  Intended only for debugging,
-  not serialization. */
-  friend std::ostream& operator<<(std::ostream&, const Node&);
-
  private:
   /* No-op for use only by the public "Make..." functions. */
   Node();
@@ -315,14 +310,15 @@ class Node final {
   std::optional<std::string> filename_;
 };
 
+/* Displays the given node using flow style. Intended only for debugging,
+not serialization. */
+std::string to_string(const Node& node);
+
 }  // namespace internal
 }  // namespace yaml
 }  // namespace drake
 
 #ifndef DRAKE_DOXYGEN_CXX
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::yaml::internal::Node> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::yaml::internal, Node, x,
+                   drake::yaml::internal::to_string(x))
 #endif


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri, for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24075)
<!-- Reviewable:end -->
