### PR TITLE
Deprecate `operator<<` for `RigidTransform` and `RollPitchYaw`

### DIFF
--- a/bindings/generated_docstrings/math.h
+++ b/bindings/generated_docstrings/math.h
@@ -5150,6 +5150,13 @@ Deprecated:
         // Source: drake/math/gradient_util.h
         const char* doc = R"""()""";
       } setSubMatrixGradient;
+      // Symbol: drake::math::to_string
+      struct /* to_string */ {
+        // Source: drake/math/roll_pitch_yaw.h
+        const char* doc =
+R"""(Represents a RollPitchYaw object as a string. Especially useful for
+debugging.)""";
+      } to_string;
       // Symbol: drake::math::transposeGrad
       struct /* transposeGrad */ {
         // Source: drake/math/gradient_util.h

--- a/math/rigid_transform.cc
+++ b/math/rigid_transform.cc
@@ -25,18 +25,28 @@ void RigidTransform<T>::ThrowInvalidMultiplyVector4(const Vector4<T>& vec_B) {
 
 template <typename T>
 std::ostream& operator<<(std::ostream& out, const RigidTransform<T>& X) {
-  const RollPitchYaw<T> rpy(X.rotation());
-  const Vector3<T>& p = X.translation();
-  out << fmt::format("{} xyz = {} {} {}", rpy, p.x(), p.y(), p.z());
-  return out;
+  return out << fmt::to_string(X);
 }
 
+template <typename T>
+std::string to_string(const RigidTransform<T>& X) {
+  const RollPitchYaw<T> rpy(X.rotation());
+  const Vector3<T>& p = X.translation();
+  return fmt::format("{} xyz = {} {} {}", rpy, p.x(), p.y(), p.z());
+}
+
+// TODO(2026-06-01): delete `operator<<` instantiation and the `#pragma`s.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // clang-format off
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
     static_cast<std::ostream&(*)(std::ostream&, const RigidTransform<T>&)>(
-        &operator<< )
+        &operator<< ),
+    static_cast<std::string(*)(const RigidTransform<T>&)>(
+        &to_string)
 ));
 // clang-format on
+#pragma GCC diagnostic pop
 
 }  // namespace math
 }  // namespace drake

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include <limits>
-
-#include <fmt/format.h>
+#include <string>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/math/rotation_matrix.h"
@@ -1023,7 +1023,15 @@ static_assert(sizeof(RigidTransform<double>) == 12 * sizeof(double),
 /// `std::ostream`. Especially useful for debugging.
 /// @relates RigidTransform
 template <typename T>
-std::ostream& operator<<(std::ostream& out, const RigidTransform<T>& X);
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream&
+operator<<(std::ostream& out, const RigidTransform<T>& X);
+
+template <typename T>
+std::string to_string(const RigidTransform<T>& X);
 
 /// Abbreviation (alias/typedef) for a RigidTransform double scalar type.
 /// @relates RigidTransform
@@ -1032,12 +1040,8 @@ using RigidTransformd = RigidTransform<double>;
 }  // namespace math
 }  // namespace drake
 
-// Format RigidTransform using its operator<<.
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename T>
-struct formatter<drake::math::RigidTransform<T>> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(typename T, drake::math, RigidTransform<T>, x,
+                   drake::math::to_string(x))
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RigidTransform);

--- a/math/roll_pitch_yaw.cc
+++ b/math/roll_pitch_yaw.cc
@@ -1,9 +1,5 @@
 #include "drake/math/roll_pitch_yaw.h"
 
-#include <string>
-
-#include <fmt/format.h>
-
 #include "drake/common/cond.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -454,6 +450,11 @@ void RollPitchYaw<T>::ThrowPitchAngleViolatesGimbalLockTolerance(
 
 template <typename T>
 std::ostream& operator<<(std::ostream& out, const RollPitchYaw<T>& rpy) {
+  return out << fmt::to_string(rpy);
+}
+
+template <typename T>
+std::string to_string(const RollPitchYaw<T>& rpy) {
   // Helper to represent an angle as a terse string.  If the angle is symbolic
   // and ends up a string that's too long, return a placeholder instead.
   auto repr = [](const T& angle) {
@@ -466,16 +467,21 @@ std::ostream& operator<<(std::ostream& out, const RollPitchYaw<T>& rpy) {
   const T& roll = rpy.roll_angle();
   const T& pitch = rpy.pitch_angle();
   const T& yaw = rpy.yaw_angle();
-  out << fmt::format("rpy = {} {} {}", repr(roll), repr(pitch), repr(yaw));
-  return out;
+  return fmt::format("rpy = {} {} {}", repr(roll), repr(pitch), repr(yaw));
 }
 
+// TODO(2026-06-01): delete `operator<<` instantiation and the `#pragma`s.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // clang-format off
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
     static_cast<std::ostream&(*)(std::ostream&, const RollPitchYaw<T>&)>(
-        &operator<< )
+        &operator<< ),
+    static_cast<std::string(*)(const RollPitchYaw<T>&)>(
+        &to_string)
 ));
 // clang-format on
+#pragma GCC diagnostic pop
 
 }  // namespace math
 }  // namespace drake

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -2,14 +2,16 @@
 
 #include <cmath>
 #include <limits>
+#include <string>
 
 #include <Eigen/Dense>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -564,7 +566,18 @@ class RollPitchYaw {
 /// `std::ostream`. Especially useful for debugging.
 /// @relates RollPitchYaw.
 template <typename T>
-std::ostream& operator<<(std::ostream& out, const RollPitchYaw<T>& rpy);
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream&
+operator<<(std::ostream& out, const RollPitchYaw<T>& rpy);
+
+/// Represents a RollPitchYaw object as a string. Especially useful for
+/// debugging.
+/// @relates RollPitchYaw.
+template <typename T>
+std::string to_string(const RollPitchYaw<T>& rpy);
 
 /// Abbreviation (alias/typedef) for a RollPitchYaw double scalar type.
 /// @relates RollPitchYaw
@@ -573,12 +586,8 @@ using RollPitchYawd = RollPitchYaw<double>;
 }  // namespace math
 }  // namespace drake
 
-// Format RollPitchYaw using its operator<<.
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename T>
-struct formatter<drake::math::RollPitchYaw<T>> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(typename T, drake::math, RollPitchYaw<T>, x,
+                   drake::math::to_string(x))
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RollPitchYaw);

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -532,6 +532,9 @@ GTEST_TEST(RollPitchYaw, SymbolicTest) {
               testing::MatchesRegex(".*inf.*(and.*inf.*){5}"));
 }
 
+// TODO(2026-06-01): delete test StreamInsertionOperator
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Test the stream insertion operator to write into a stream.
 GTEST_TEST(RollPitchYaw, StreamInsertionOperator) {
   // Test stream insertion for RollPitchYaw<double>.
@@ -564,6 +567,33 @@ GTEST_TEST(RollPitchYaw, StreamInsertionOperator) {
   streamD << rpy_symbolic_huge;
   rpy_expected_string = "rpy = <symbolic> <symbolic> <symbolic>";
   EXPECT_EQ(rpy_expected_string, streamD.str());
+}
+#pragma GCC diagnostic pop
+
+// Test the fmt formatter.
+GTEST_TEST(RollPitchYaw, ToStringFmtFormatter) {
+  // Test the fmt formatter for RollPitchYaw<double>.
+  const RollPitchYaw<double> rpy_double(0.2, 0.3, 0.4);
+  std::string rpy_expected_string = "rpy = 0.2 0.3 0.4";
+  EXPECT_EQ(fmt::to_string(rpy_double), rpy_expected_string);
+
+  // Test the fmt formatter for RollPitchYaw<AutoDiffXd>.
+  const RollPitchYaw<AutoDiffXd> rpy_autodiff(0.5, 0.6, 0.7);
+  rpy_expected_string = "rpy = 0.5 0.6 0.7";
+  EXPECT_EQ(fmt::to_string(rpy_autodiff), rpy_expected_string);
+
+  // Test the fmt formatter for RollPitchYaw<symbolic::Expression>.
+  const symbolic::Variable r("foo"), p("bar"), y("baz");
+  const RollPitchYaw<Expression> rpy_symbolic(r, p, y);
+  rpy_expected_string = "rpy = foo bar baz";
+  EXPECT_EQ(fmt::to_string(rpy_symbolic), rpy_expected_string);
+
+  // When the expression strings are very long, they will be truncated.
+  const Expression big_expr = sqrt(pow(r, 2) + pow(p, 2) + pow(y, 2));
+  const RollPitchYaw<symbolic::Expression> rpy_symbolic_huge(big_expr, big_expr,
+                                                             big_expr);
+  rpy_expected_string = "rpy = <symbolic> <symbolic> <symbolic>";
+  EXPECT_EQ(fmt::to_string(rpy_symbolic_huge), rpy_expected_string);
 }
 
 }  // namespace


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24082)
<!-- Reviewable:end -->
