### PR TITLE
Deprecate `PackageMap::operator<<`

### DIFF
--- a/bindings/generated_docstrings/multibody_parsing.h
+++ b/bindings/generated_docstrings/multibody_parsing.h
@@ -350,6 +350,11 @@ Aborts if no package named ``package_name`` exists in this PackageMap.)""";
           const char* doc =
 R"""(Returns the number of entries in this PackageMap.)""";
         } size;
+        // Symbol: drake::multibody::PackageMap::to_string
+        struct /* to_string */ {
+          // Source: drake/multibody/parsing/package_map.h
+          const char* doc = R"""()""";
+        } to_string;
       } PackageMap;
       // Symbol: drake::multibody::Parser
       struct /* Parser */ {

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -976,15 +976,20 @@ void PackageMap::AddPackageXml(const char* filename) {
   this->AddPackageXml(std::string(filename));
 }
 
+std::string PackageMap::to_string() const {
+  std::string result{"PackageMap:\n"};
+  if (size() == 0) {
+    result.append("  [EMPTY!]\n");
+  }
+  for (const auto& [package_name, data] : impl_->map()) {
+    result.append(
+        fmt::format("  - {}: {}\n", package_name, data.display_path()));
+  }
+  return result;
+}
+
 std::ostream& operator<<(std::ostream& out, const PackageMap& package_map) {
-  out << "PackageMap:\n";
-  if (package_map.size() == 0) {
-    out << "  [EMPTY!]\n";
-  }
-  for (const auto& [package_name, data] : package_map.impl_->map()) {
-    out << "  - " << package_name << ": " << data.display_path() << "\n";
-  }
-  return out;
+  return out << fmt::to_string(package_map);
 }
 
 }  // namespace multibody

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -7,7 +7,8 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/name_value.h"
 
 namespace drake {
@@ -226,8 +227,7 @@ class PackageMap final {
 
   ///@}
 
-  friend std::ostream& operator<<(std::ostream& out,
-                                  const PackageMap& package_map);
+  std::string to_string() const;
 
  private:
   /* A constructor that creates an empty map . */
@@ -248,6 +248,12 @@ class PackageMap final {
   std::unique_ptr<Impl> impl_;
 };
 
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream& operator<<(std::ostream& out, const PackageMap& package_map);
+
 namespace internal {
 
 /* (Internal use only) Parses the metadata from `tools/workspace/drake_models`
@@ -258,8 +264,4 @@ PackageMap::RemoteParams GetDrakeModelsRemoteParams();
 }  // namespace multibody
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::multibody::PackageMap> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::multibody, PackageMap, x, x.to_string())

--- a/multibody/parsing/test/package_map_remote_test.cc
+++ b/multibody/parsing/test/package_map_remote_test.cc
@@ -267,7 +267,7 @@ TEST_F(PackageMapRemoteTest, AddMapMergeFetched) {
 
   // Confirm the remote data (URLs) was still preserved, even though we already
   // had a fetched path in available during the AddMap.
-  EXPECT_THAT(fmt::to_string(fmt_streamed(dut)),
+  EXPECT_THAT(fmt::to_string(dut),
               testing::HasSubstr("package_map_test_packages/compressed.zip"));
 }
 


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24083)
<!-- Reviewable:end -->
