### PR TITLE
[doc] Document experimental support for Ubuntu on aarch64

### DIFF
--- a/doc/_pages/apt.md
+++ b/doc/_pages/apt.md
@@ -51,7 +51,7 @@ wget -qO- https://drake-apt.csail.mit.edu/drake.asc | gpg --dearmor - \
 Add the Drake repository to your APT sources list:
 
 ```bash
-echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/$(lsb_release -cs) $(lsb_release -cs) main" \
+echo "deb [arch=$(dpkg-architecture -qDEB_HOST_ARCH)] https://drake-apt.csail.mit.edu/$(lsb_release -cs) $(lsb_release -cs) main" \
   | sudo tee /etc/apt/sources.list.d/drake.list >/dev/null
 ```
 
@@ -75,22 +75,29 @@ Refer to [Quickstart](/installation.html#quickstart) for next steps.
 ## Nightly Releases
 
 Unsigned nightly apt packages of Drake for Ubuntu 22.04 (Jammy) and
-Ubuntu 24.04 (Noble) are available to download at:
+Ubuntu 24.04 (Noble) ⁽¹⁾ are available to download at:
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-jammy.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-jammy.deb)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-noble.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-noble.deb)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_arm64-noble.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_arm64-noble.deb)
 
 Older packages for specific dates are available by replacing ``latest``
 with date YYYYMMDD preceded with ``0.0.``. For example,
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20250301-1_amd64-jammy.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20250301-1_amd64-jammy.deb)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20250301-1_amd64-noble.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20250301-1_amd64-noble.deb)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20250301-1_arm64-noble.deb](https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_0.0.20250301-1_arm64-noble.deb)
 
 Nightly packages are retained for 56 days from their date of creation.
 
-To install a nightly apt package, download the archive and install it directly:
+To install a nightly apt package, download the archive and install it directly.
+For example, when using Ubuntu 24.04 (Noble) on amd64:
 
 ```bash
 wget https://drake-packages.csail.mit.edu/drake/nightly/drake-dev_latest-1_amd64-noble.deb
 sudo apt-get install --no-install-recommends ./drake-dev_latest-1_amd64-noble.deb
 ```
+
+⁽¹⁾ Drake's support for Ubuntu arm64 APT packages is currently experimental.
+Packages are only available on a nightly basis, not for stable releases. Follow
+[#13514](https://github.com/RobotLocomotion/drake/issues/13514) for updates.

--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -119,11 +119,12 @@ Refer to [Quickstart](/installation.html#quickstart) for next steps.
 
 ## Nightly Releases
 
-Binary packages of Drake for Ubuntu 22.04 (Jammy), Ubuntu 24.04 (Noble), and
-Mac are generated nightly and are available to download at:
+Binary packages of Drake for Ubuntu 22.04 (Jammy), Ubuntu 24.04 (Noble) ⁽¹⁾,
+and Mac are generated nightly and are available to download at:
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-jammy.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble-aarch64.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble-aarch64.tar.gz)
 * https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz
 
 Older packages for specific dates are available by replacing ``latest``
@@ -131,6 +132,7 @@ with date YYYYMMDD preceded by ``0.0.``. For example,
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-jammy.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-jammy.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble-aarch64.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble-aarch64.tar.gz)
 * https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-mac-arm64.tar.gz
 
 As with stable releases, users of macOS must download using a command-line tool
@@ -141,3 +143,9 @@ See the "Stable Releases" section above for a sample command line.
 Nightly archives are retained for 56 days from their date of creation.
 
 The installation instructions are identical to stable releases as shown above.
+
+⁽¹⁾ Drake's support for Ubuntu aarch64 binary packages is currently
+experimental. Packages are only available on a nightly basis, not for stable
+releases. Additionally, packages will only be available for Ubuntu 24.04
+(Noble) and future versions. Follow
+[#13514](https://github.com/RobotLocomotion/drake/issues/13514) for updates.

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -36,7 +36,7 @@ officially supports when building from source:
 | Operating System ⁽¹⁾               | Architecture | Python ⁽²⁾ | Bazel | CMake | C/C++ Compiler ⁽³⁾           | Java       |
 |------------------------------------|--------------|------------|-------|-------|------------------------------|------------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10       | 9.0   | 3.22  | GCC 11 (default) or Clang 15 | OpenJDK 11 |
-| Ubuntu 24.04 LTS (Noble Numbat)    | x86_64       | 3.12       | 9.0   | 3.28  | GCC 13 (default) or Clang 19 | OpenJDK 21 |
+| Ubuntu 24.04 LTS (Noble Numbat)    | x86_64 ⁽⁴⁾   | 3.12       | 9.0   | 3.28  | GCC 13 (default) or Clang 19 | OpenJDK 21 |
 | macOS Sequoia (15)                 | arm64        | 3.14       | 9.0   | 4.2   | Apple LLVM 17 (Xcode 26.2)   | OpenJDK 23 |
 | macOS Tahoe (26)                   | arm64        | 3.14       | 9.0   | 4.2   | Apple LLVM 17 (Xcode 26.2)   | OpenJDK 23 |
 
@@ -44,10 +44,9 @@ officially supports when building from source:
 notice regressions, so if it doesn't work for you then please file a bug report.
 
 Unofficially, Drake is also likely to be compatible with newer versions of
-Ubuntu or macOS than what are listed, or with Ubuntu running on arm64, or
-with other versions of Python or Java. However, these are not supported
-so if it doesn't work for you then please file a pull request with the fix,
-not a bug report.
+Ubuntu or macOS than what are listed, or with other versions of Python or Java.
+However, these are not supported so if it doesn't work for you then please file
+a pull request with the fix, not a bug report.
 
 All else being equal, we would recommend developers use Ubuntu 24.04 (Noble).
 
@@ -58,6 +57,10 @@ maybe require extra setup. See the
 ⁽²⁾ CPython is the only Python implementation supported.
 
 ⁽³⁾ Drake requires a compiler running in C++20 (or greater) mode.
+
+⁽⁴⁾ On an experimental basis, Drake also supports aarch64 on Ubuntu 24.04
+(Noble). Follow [#13514](https://github.com/RobotLocomotion/drake/issues/13514)
+for updates.
 
 # Building with CMake
 

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -22,7 +22,7 @@ officially supports:
 | Operating System ⁽¹⁾               | Architecture | Python ⁽²⁾ ⁽³⁾ | End of life ⁽⁴⁾ |
 |------------------------------------|--------------|----------------|-----------------|
 | Ubuntu 22.04 LTS (Jammy Jellyfish) | x86_64       | 3.10           | March 2026      |
-| Ubuntu 24.04 LTS (Noble Numbat)    | x86_64       | 3.12           | March 2028      |
+| Ubuntu 24.04 LTS (Noble Numbat)    | x86_64 ⁽⁵⁾   | 3.12           | March 2028      |
 | macOS Sequoia (15)                 | arm64        | 3.14           | October 2026    |
 | macOS Tahoe (26)                   | arm64        | 3.14           | October 2027    |
 
@@ -30,9 +30,9 @@ officially supports:
 notice regressions, so if it doesn't work for you then please file a bug report.
 
 Unofficially, Drake is also likely to be compatible with newer versions of
-Ubuntu or macOS than what are listed, or with Ubuntu 24.04 running on arm64, or
-with other versions of Python. However, these are not supported so if it doesn't
-work for you then please file a pull request with the fix, not a bug report.
+Ubuntu or macOS than what are listed, or with other versions of Python. However,
+these are not supported so if it doesn't work for you then please file a pull
+request with the fix, not a bug report.
 
 ⁽¹⁾ Drake features that perform image rendering (e.g., camera simulation)
 maybe require extra setup. See the
@@ -52,6 +52,14 @@ timeline for changing which Python versions are supported.
 
 ⁽⁴⁾ These end-of-life dates are estimates.
 Refer to [OS Support](/stable.html#os-support) for details.
+
+⁽⁵⁾ Nightly binaries for Ubuntu 24.04 (Noble) on aarch64 are available for all
+[binary installation methods](#choose-an-installation-method). Drake's support
+for Ubuntu on aarch64 is currently experimental, and binaries are not available
+for stable releases. Follow
+[#13514](https://github.com/RobotLocomotion/drake/issues/13514) for updates.
+If you encounter installation issues with the experimental nightly binaries,
+please post to the issue.
 
 The following table shows the configurations that *must* be used when
 compiling your own C++ code against Drake's C++ code using one of


### PR DESCRIPTION
Drake now publishes nightly binaries and runs a small subset of continuous integration for Ubuntu on aarch64. However, binaries are not yet available for stable releases.

Towards #13514. Closes #24021, closes #24020.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24085)
<!-- Reviewable:end -->
