### PR TITLE
Deprecate `operator<<` for `RotationalInertia` and `SpatialInertia`

### DIFF
--- a/bindings/generated_docstrings/multibody_tree.h
+++ b/bindings/generated_docstrings/multibody_tree.h
@@ -11895,6 +11895,15 @@ if they were "welded" together.)""";
 R"""(Returns the model instance which contains all tree elements with no
 explicit model instance specified.)""";
       } default_model_instance;
+      // Symbol: drake::multibody::to_string
+      struct /* to_string */ {
+        // Source: drake/multibody/tree/rotational_inertia.h
+        const char* doc_1args_constRotationalInertia =
+R"""(Returns the string representation of a RotationalInertia object.)""";
+        // Source: drake/multibody/tree/spatial_inertia.h
+        const char* doc_1args_constSpatialInertia =
+R"""(Returns the string representation of a SpatialInertia object.)""";
+      } to_string;
       // Symbol: drake::multibody::world_frame_index
       struct /* world_frame_index */ {
         // Source: drake/multibody/tree/multibody_tree_indexes.h

--- a/multibody/tree/rotational_inertia.cc
+++ b/multibody/tree/rotational_inertia.cc
@@ -378,13 +378,15 @@ void RotationalInertia<T>::ThrowIfNotPhysicallyValidImpl(
   }
 }
 
-// TODO(Mitiguy) Consider using this code (or code similar to this) to write
-//  most/all Drake matrices and consolidate other usages to use this.
-// TODO(jwnimmer-tri) Obeying the formatting choices from `out` (via `copyfmt`
-//  is a defect; we should always display full round-trip precision.  We should
-//  not re-use this pattern elsewhere.
 template <typename T>
 std::ostream& operator<<(std::ostream& out, const RotationalInertia<T>& I) {
+  return out << fmt::to_string(I);
+}
+
+// TODO(Mitiguy) Consider using this code (or code similar to this) to write
+//  most/all Drake matrices and consolidate other usages to use this.
+template <typename T>
+std::string to_string(const RotationalInertia<T>& I) {
   int width = 0;
   // Computes largest width so that we can align columns for a prettier format.
   // Idea taken from: Eigen::internal::print_matrix() in Eigen/src/Core/IO.h
@@ -394,28 +396,32 @@ std::ostream& operator<<(std::ostream& out, const RotationalInertia<T>& I) {
       width = std::max<int>(width, static_cast<int>(element.length()));
     }
   }
-
+  std::string result;
   // Outputs to stream.
   for (int i = 0; i < I.rows(); ++i) {
-    out << "[";
-    if (width) out.width(width);
-    out << fmt::to_string(I(i, 0));
+    result.append("[");
+    result.append(fmt::format("{:>{}}", I(i, 0), width));
     for (int j = 1; j < I.cols(); ++j) {
-      out << "  ";
-      if (width) out.width(width);
-      out << fmt::to_string(I(i, j));
+      result.append("  ");
+      result.append(fmt::format("{:>{}}", I(i, j), width));
     }
-    out << "]\n";
+    result.append("]\n");
   }
-  return out;
+  return result;
 }
 
+// TODO(2026-06-01): delete `operator<<` instantiation and the `#pragma`s.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // clang-format off
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     (static_cast<std::ostream& (*)(std::ostream&, const RotationalInertia<T>&)>(
-        &operator<< )  // clang-format would remove space lint requires
+        &operator<< ),  // clang-format would remove space lint requires
+    static_cast<std::string(*)(const RotationalInertia<T>&)>(
+        &to_string)
 ));
 // clang-format on
+#pragma GCC diagnostic pop
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -5,11 +5,13 @@
 #include <limits>
 #include <memory>
 #include <optional>
-#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
+
+// TODO(2026-06-01): remove ostream header
+#include <ostream>
 
 #include <Eigen/Eigenvalues>
 
@@ -17,8 +19,9 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt.h"
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
@@ -1072,17 +1075,23 @@ class RotationalInertia {
 /// Writes an instance of RotationalInertia into a std::ostream.
 /// @relates RotationalInertia
 template <typename T>
-std::ostream& operator<<(std::ostream& out, const RotationalInertia<T>& I);
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream&
+operator<<(std::ostream& out, const RotationalInertia<T>& I);
+
+/// Returns the string representation of a RotationalInertia object.
+/// @relates RotationalInertia
+template <typename T>
+std::string to_string(const RotationalInertia<T>& I);
 
 }  // namespace multibody
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename T>
-struct formatter<drake::multibody::RotationalInertia<T>>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(typename T, drake::multibody, RotationalInertia<T>, x,
+                   drake::multibody::to_string(x))
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::RotationalInertia);

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -4,16 +4,19 @@
 #include <exception>
 #include <limits>
 #include <optional>
-#include <ostream>
 #include <string>
 #include <utility>
+
+// TODO(2026-06-01): remove ostream header
+#include <ostream>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt.h"
 #include "drake/math/cross_product.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
@@ -1023,17 +1026,23 @@ class SpatialInertia {
 /// Writes an instance of SpatialInertia into a std::ostream.
 /// @relates SpatialInertia
 template <typename T>
-std::ostream& operator<<(std::ostream& out, const SpatialInertia<T>& M);
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream&
+operator<<(std::ostream& out, const SpatialInertia<T>& M);
+
+/// Returns the string representation of a SpatialInertia object.
+/// @relates SpatialInertia
+template <typename T>
+std::string to_string(const SpatialInertia<T>& M);
 
 }  // namespace multibody
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename T>
-struct formatter<drake::multibody::SpatialInertia<T>>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(typename T, drake::multibody, SpatialInertia<T>, x,
+                   drake::multibody::to_string(x))
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::SpatialInertia);

--- a/multibody/tree/test/geometry_spatial_inertia_test.cc
+++ b/multibody/tree/test/geometry_spatial_inertia_test.cc
@@ -38,27 +38,30 @@ constexpr double kTol = std::numeric_limits<double>::epsilon();
   const Vector3<double> p_BoBcm_B = M_expected.get_com();
   const UnitInertia<double> G_BBo_B = M_expected.get_unit_inertia();
   if (std::abs(mass - dut.get_mass()) > tolerance) {
-    return ::testing::AssertionFailure()
-           << "Expected equal masses\n"
-           << "  expected:   " << mass << "\n"
-           << "  tested:     " << dut.get_mass() << "\n"
-           << "  difference: " << std::abs(mass - dut.get_mass()) << "\n"
-           << "  is greater than tolerance: " << tolerance << "\n";
+    return ::testing::AssertionFailure() << fmt::format(
+               "Expected equal masses\n"
+               "  expected:   {}\n"
+               "  tested:     {}\n"
+               "  difference: {}\n"
+               "  is greater than tolerance: {}\n",
+               mass, dut.get_mass(), std::abs(mass - dut.get_mass()),
+               tolerance);
   }
   ::testing::AssertionResult result =
       CompareMatrices(dut.get_com(), p_BoBcm_B, tolerance);
   if (!result) return result;
   if (!dut.get_unit_inertia().IsNearlyEqualTo(G_BBo_B, tolerance)) {
-    return ::testing::AssertionFailure()
-           << "Expected equal unit inertias\n"
-           << "  expected\n"
-           << G_BBo_B << "\n"
-           << "  tested\n"
-           << dut.get_unit_inertia() << "\n"
-           << "  with tolerance: " << tolerance << "\n"
-           << "(with mass: " << dut.get_mass() << "\n"
-           << " and com: "
-           << fmt::to_string(fmt_eigen(dut.get_com().transpose())) << "\n";
+    return ::testing::AssertionFailure() << fmt::format(
+               "Expected equal unit inertias\n"
+               "  expected\n"
+               "{}\n"
+               "  tested\n"
+               "{}\n"
+               "  with tolerance: {}\n"
+               "  with mass: {}\n"
+               "  and com: {}\n",
+               G_BBo_B, dut.get_unit_inertia(), tolerance, dut.get_mass(),
+               fmt_eigen(dut.get_com().transpose()));
   }
   return ::testing::AssertionSuccess();
 }

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -884,16 +884,30 @@ GTEST_TEST(RotationalInertia, OperatorPlusEqual) {
   EXPECT_EQ(Ia_over_a.get_products(), p / a);
 }
 
+// TODO(2026-06-01): delete test ShiftOperator.
 // Test the shift operator to write into a stream.
 GTEST_TEST(RotationalInertia, ShiftOperator) {
   std::stringstream stream;
   RotationalInertia<double> I(1, 2.718, 3.14);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   stream << I;
+#pragma GCC diagnostic pop
   std::string expected_string =
       "[    1      0      0]\n"
       "[    0  2.718      0]\n"
       "[    0      0   3.14]\n";
   EXPECT_EQ(expected_string, stream.str());
+}
+
+// Verify the output string from RotationalInertia's fmt formatter.
+GTEST_TEST(RotationalInertia, ToStringFmtFormatter) {
+  RotationalInertia<double> I(1, 2.718, 3.14);
+  std::string expected_string =
+      "[    1      0      0]\n"
+      "[    0  2.718      0]\n"
+      "[    0      0   3.14]\n";
+  EXPECT_EQ(fmt::to_string(I), expected_string);
 }
 
 // Tests that we can correctly cast a RotationalInertia<double> to a

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -758,6 +758,7 @@ GTEST_TEST(SpatialInertia, CastToAutoDiff) {
   ASSERT_EQ(com_gradient.size(), 0);
 }
 
+// TODO(2026-06-01): delete test ShiftOperator.
 // Test the shift operator to write into a stream.
 GTEST_TEST(SpatialInertia, ShiftOperator) {
   const double mass = 2.5;
@@ -769,7 +770,10 @@ GTEST_TEST(SpatialInertia, ShiftOperator) {
   SpatialInertia<double> M(mass, com, G);
 
   std::stringstream stream;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   stream << M;
+#pragma GCC diagnostic pop
   std::string expected_string =
       "\n"
       " mass = 2.5\n"
@@ -779,6 +783,26 @@ GTEST_TEST(SpatialInertia, ShiftOperator) {
       "[ 0.25   5.75    0.5]\n"
       "[-0.25    0.5      6]\n";
   EXPECT_EQ(expected_string, stream.str());
+}
+
+// Verify the output string from SpatialInertia's fmt formatter.
+GTEST_TEST(SpatialInertia, ToStringFmtFormatter) {
+  const double mass = 2.5;
+  const Vector3d com(0.1, -0.2, 0.3);
+  const Vector3d m(2.0, 2.3, 2.4);         // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);        // p for products.
+  UnitInertia<double> G(m(0), m(1), m(2),  /* moments of inertia */
+                        p(0), p(1), p(2)); /* products of inertia */
+  SpatialInertia<double> M(mass, com, G);
+  std::string expected_string =
+      "\n"
+      " mass = 2.5\n"
+      " Center of mass = [0.1  -0.2  0.3]\n"
+      " Inertia about point P, I_BP =\n"
+      "[    5   0.25  -0.25]\n"
+      "[ 0.25   5.75    0.5]\n"
+      "[-0.25    0.5      6]\n";
+  EXPECT_EQ(fmt::to_string(M), expected_string);
 }
 
 // Verifies the correctness of:

--- a/multibody/tree/test/unit_inertia_test.cc
+++ b/multibody/tree/test/unit_inertia_test.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/tree/unit_inertia.h"
 
 #include <limits>
+#include <string>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -1076,6 +1077,15 @@ GTEST_TEST(UnitInertia, CatastrophicCancellationForPointInertias) {
   // inertia. Therefore, we verify here that CouldBePhysicallyValid() correctly
   // reports a physical inertia.
   EXPECT_TRUE(Gtilde_BBo_W.CouldBePhysicallyValid());
+}
+
+GTEST_TEST(UnitInertia, ToStringFmtFormatter) {
+  UnitInertia<double> I(1, 2.718, 3.14);
+  std::string expected_string =
+      "[    1      0      0]\n"
+      "[    0  2.718      0]\n"
+      "[    0      0   3.14]\n";
+  EXPECT_EQ(fmt::to_string(I), expected_string);
 }
 
 }  // namespace

--- a/multibody/tree/unit_inertia.cc
+++ b/multibody/tree/unit_inertia.cc
@@ -291,6 +291,14 @@ UnitInertia<T>::CalcPrincipalHalfLengthsAndAxesForEquivalentShape(
   return std::pair(Vector3<double>(lmax, lmed, lmin), R_EA);
 }
 
+template <typename T>
+std::string to_string(const UnitInertia<T>& I) {
+  return fmt::to_string(static_cast<const RotationalInertia<T>&>(I));
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    (static_cast<std::string (*)(const UnitInertia<T>&)>(&to_string)));
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/rotational_inertia.h"
 
@@ -469,8 +470,14 @@ class UnitInertia : public RotationalInertia<T> {
   //@}
 };
 
+template <typename T>
+std::string to_string(const UnitInertia<T>& I);
+
 }  // namespace multibody
 }  // namespace drake
+
+DRAKE_FORMATTER_AS(typename T, drake::multibody, UnitInertia<T>, x,
+                   drake::multibody::to_string(x))
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::UnitInertia);


### PR DESCRIPTION
Also add an explicit fmt formatter for `UnitInertia`. Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24088)
<!-- Reviewable:end -->
