### PR TITLE
[multibody] Deprecate the TAMSI solver

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -1342,7 +1342,7 @@ arises.)""";
       // Symbol: drake::multibody::DiscreteContactApproximation
       struct /* DiscreteContactApproximation */ {
         // Source: drake/multibody/plant/multibody_plant.h
-        const char* doc =
+        const char* doc_deprecated =
 R"""(The type of the contact approximation used for a discrete
 MultibodyPlant model.
 
@@ -1394,7 +1394,11 @@ References
   https://arxiv.org/abs/2110.10107.
 - [Castro et al., 2023] Castro A., Han X., and Masterjohn J., 2023. A Theory
   of Irrotational Contact Fields. Available online at
-  https://arxiv.org/abs/2312.03908)""";
+  https://arxiv.org/abs/2312.03908 (Deprecated.)
+
+Deprecated:
+    The TAMSI solver is deprecated for removal. This will be removed
+    from Drake on or after 2026-09-01.)""";
         // Symbol: drake::multibody::DiscreteContactApproximation::kLagged
         struct /* kLagged */ {
           // Source: drake/multibody/plant/multibody_plant.h
@@ -1424,7 +1428,7 @@ R"""(TAMSI solver approximation, see [Castro et al., 2019].)""";
       // Symbol: drake::multibody::DiscreteContactSolver
       struct /* DiscreteContactSolver */ {
         // Source: drake/multibody/plant/multibody_plant.h
-        const char* doc =
+        const char* doc_deprecated =
 R"""(The type of the contact solver used for a discrete MultibodyPlant
 model.
 
@@ -1444,7 +1448,11 @@ References
   https://arxiv.org/abs/1909.05700.
 - [Castro et al., 2022] Castro A., Permenter F. and Han X., 2022. An
   Unconstrained Convex Formulation of Compliant Contact. Available online at
-  https://arxiv.org/abs/2110.10107.)""";
+  https://arxiv.org/abs/2110.10107. (Deprecated.)
+
+Deprecated:
+    The TAMSI solver is deprecated for removal. This will be removed
+    from Drake on or after 2026-09-01.)""";
         // Symbol: drake::multibody::DiscreteContactSolver::kSap
         struct /* kSap */ {
           // Source: drake/multibody/plant/multibody_plant.h

--- a/bindings/pydrake/examples/gym/envs/cart_pole.py
+++ b/bindings/pydrake/examples/gym/envs/cart_pole.py
@@ -52,10 +52,8 @@ sim_time_step = 0.01
 gym_time_step = 0.05
 controller_time_step = 0.01
 gym_time_limit = 5
-drake_contact_models = ["point", "hydroelastic_with_fallback"]
-contact_model = drake_contact_models[0]
-drake_contact_approximations = ["sap", "tamsi", "similar", "lagged"]
-contact_approximation = drake_contact_approximations[0]
+contact_model = "point"
+discrete_contact_approximation = "lagged"
 
 
 def AddAgent(plant=None, builder=None):
@@ -80,7 +78,7 @@ def make_sim(
     multibody_plant_config = MultibodyPlantConfig(
         time_step=sim_time_step,
         contact_model=contact_model,
-        discrete_contact_approximation=contact_approximation,
+        discrete_contact_approximation=discrete_contact_approximation,
     )
 
     plant, scene_graph = AddMultibodyPlant(multibody_plant_config, builder)

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1733,18 +1733,36 @@ PYBIND11_MODULE(plant, m) {
   }
 
   {
+    // Note that due to a bug in the docstring generation, the TAMSI deprecation
+    // warning ends up being attached to the enum class overview doc, instead of
+    // the kTamsi enum field. This is fine, but does make the 'doc_deprecated'
+    // uses below slightly confusing on first glance.
     using Class = DiscreteContactSolver;
     constexpr auto& cls_doc = doc.DiscreteContactSolver;
-    py::enum_<Class>(m, "DiscreteContactSolver", cls_doc.doc)
-        .value("kTamsi", Class::kTamsi, cls_doc.kTamsi.doc)
-        .value("kSap", Class::kSap, cls_doc.kSap.doc);
+    py::enum_<Class> cls(m, "DiscreteContactSolver", cls_doc.doc_deprecated);
+    // Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.value("kTamsi", Class::kTamsi, cls_doc.kTamsi.doc);
+#pragma GCC diagnostic pop
+    cls.value("kSap", Class::kSap, cls_doc.kSap.doc);
   }
 
   {
+    // Note that due to a bug in the docstring generation, the TAMSI deprecation
+    // warning ends up being attached to the enum class overview doc, instead of
+    // the kTamsi enum field. This is fine, but does make the 'doc_deprecated'
+    // uses below slightly confusing on first glance.
     using Class = DiscreteContactApproximation;
     constexpr auto& cls_doc = doc.DiscreteContactApproximation;
-    py::enum_<Class>(m, "DiscreteContactApproximation", cls_doc.doc)
-        .value("kTamsi", Class::kTamsi, cls_doc.kTamsi.doc)
+    py::enum_<Class> cls(
+        m, "DiscreteContactApproximation", cls_doc.doc_deprecated);
+    // Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.value("kTamsi", Class::kTamsi, cls_doc.kTamsi.doc);
+#pragma GCC diagnostic pop
+    cls  // BR
         .value("kSap", Class::kSap, cls_doc.kSap.doc)
         .value("kSimilar", Class::kSimilar, cls_doc.kSimilar.doc)
         .value("kLagged", Class::kLagged, cls_doc.kLagged.doc);

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -20,10 +20,9 @@ DEFINE_double(
     mbp_discrete_update_period, 0.01,
     "The fixed-time step period (in seconds) of discrete updates for the "
     "multibody plant modeled as a discrete system. Strictly positive. "
-    "Set to zero for a continuous plant model. When using TAMSI, a smaller "
-    "time step of 1.0e-3 is recommended.");
+    "Set to zero for a continuous plant model.");
 DEFINE_string(contact_approximation, "sap",
-              "Discrete contact approximation. Options are: 'tamsi', 'sap', "
+              "Discrete contact approximation. Options are: 'sap', "
               "'similar', 'lagged'");
 
 namespace drake {

--- a/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
+++ b/examples/hydroelastic/spatula_slip_control/spatula_slip_control.cc
@@ -18,7 +18,7 @@
 #include "drake/visualization/visualization_config_functions.h"
 
 // Parameters for squeezing the spatula.
-DEFINE_double(gripper_force, 1,
+DEFINE_double(gripper_force, 1.5,
               "The baseline force to be applied by the gripper. [N].");
 DEFINE_double(amplitude, 5,
               "The amplitude of the oscillations "
@@ -39,8 +39,8 @@ DEFINE_string(contact_model, "hydroelastic",
 DEFINE_string(contact_surface_representation, "polygon",
               "Contact-surface representation for hydroelastics. "
               "Options are: 'triangle' or 'polygon'.");
-DEFINE_string(contact_approximation, "tamsi",
-              "Discrete contact approximation. Options are: 'tamsi', "
+DEFINE_string(contact_approximation, "lagged",
+              "Discrete contact approximation. Options are: "
               "'sap', 'similar', 'lagged'");
 
 // Simulator settings.

--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -61,8 +61,8 @@ DEFINE_bool(is_inclined_plane_half_space, true,
 DEFINE_string(
     bodyB_type, "sphere",
     "Valid body types are 'sphere', 'block', or 'block_with_4Spheres'");
-DEFINE_string(contact_approximation, "tamsi",
-              "Discrete contact approximation. Options are: 'tamsi', "
+DEFINE_string(contact_approximation, "lagged",
+              "Discrete contact approximation. Options are: "
               "'sap', 'similar', 'lagged'");
 
 using drake::multibody::MultibodyPlant;

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -105,16 +105,13 @@ DEFINE_double(frequency, 2.0,
               "carried out by the gripper. [Hz].");
 
 DEFINE_string(contact_approximation, "sap",
-              "Discrete contact approximation. Options are: 'tamsi', 'sap', "
+              "Discrete contact approximation. Options are: 'sap', "
               "'similar', 'lagged'");
 
-DEFINE_double(
-    coupler_gear_ratio, -1.0,
-    "When using SAP, the left finger's position qₗ is constrained to qₗ = "
-    "ρ⋅qᵣ, where qᵣ is the right finger's position and ρ is this "
-    "coupler_gear_ration parameter (dimensionless). If TAMSI used, "
-    "then the right finger is locked, only the left finger moves and this "
-    "parameter is ignored.");
+DEFINE_double(coupler_gear_ratio, -1.0,
+              "The left finger's position qₗ is constrained to qₗ = "
+              "ρ⋅qᵣ, where qᵣ is the right finger's position and ρ is this "
+              "coupler_gear_ration parameter (dimensionless).");
 
 // The pad was measured as a torus with the following major and minor radii.
 const double kPadMajorRadius = 14e-3;  // 14 mm.
@@ -230,12 +227,8 @@ int do_main() {
   const PrismaticJoint<double>& right_slider =
       plant.GetJointByName<PrismaticJoint>("right_slider");
 
-  // TAMSI does not support general constraints. If using TAMSI, we simplify the
-  // model to have the right finger locked.
-  if (FLAGS_contact_approximation != "tamsi") {
-    plant.AddCouplerConstraint(left_slider, right_slider,
-                               FLAGS_coupler_gear_ratio);
-  }
+  plant.AddCouplerConstraint(left_slider, right_slider,
+                             FLAGS_coupler_gear_ratio);
 
   // Now the model is complete.
   plant.Finalize();
@@ -288,13 +281,10 @@ int do_main() {
   const double f0 = mass * a0;           // Force amplitude, Newton.
   fmt::print("Acceleration amplitude = {:8.4f} m/s²\n", a0);
 
-  // The actuation force that must be applied in order to attain a given grip
-  // force depends on how the gripper is modeled.
-  // When we model the gripper as having the right finger locked and only the
-  // actuated left finger moves, it is clear that the actuation force directly
-  // balances the grip force (as done when usint the TAMSI solver).
+  // Consider the actuation force that must be applied in order to attain a
+  // given grip force.
   // When we model the gripper with two moving fingers coupled to move together
-  // with a constraint, the relationship is not as obvious. We can think of the
+  // with a constraint, the relationship is not obvious. We can think of the
   // constrained mechanism as a system of pulleys and therefore we'd need to
   // consider a free-body diagram to find the relationship between forces. A
   // much simpler approach however is to consider virtual displacements. When
@@ -310,9 +300,7 @@ int do_main() {
   // twice as much force as the grip force. This makes sense if we consider a
   // system of pulleys for this mechanism.
   const double grip_actuation_force =
-      FLAGS_contact_approximation == "tamsi"
-          ? FLAGS_grip_force
-          : (1.0 - FLAGS_coupler_gear_ratio) * FLAGS_grip_force;
+      (1.0 - FLAGS_coupler_gear_ratio) * FLAGS_grip_force;
 
   // Notice we are using the same Sine source to:
   //   1. Generate a harmonic forcing of the gripper with amplitude f0 and
@@ -361,14 +349,6 @@ int do_main() {
   // around this initial position.
   translate_joint.set_translation(&plant_context, 0.0);
   translate_joint.set_translation_rate(&plant_context, v0);
-
-  if (FLAGS_contact_approximation == "tamsi") {
-    drake::log()->warn(
-        "contact_approximation = 'tamsi'. Since TAMSI does not support coupler "
-        "constraints to model the coupling of the fingers, this simple example "
-        "locks the right finger and only the left finger is allowed to move.");
-    right_slider.Lock(&plant_context);
-  }
 
   // Set up simulator.
   auto simulator =

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1127,6 +1127,9 @@ static constexpr char kMimicModel[] = R"""(
       </joint>
     </model>)""";
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(SdfParserTest, MimicNoSap) {
   plant_.set_discrete_contact_approximation(
       DiscreteContactApproximation::kTamsi);
@@ -1139,6 +1142,7 @@ TEST_F(SdfParserTest, MimicNoSap) {
           "with a discrete time step and using "
           "DiscreteContactSolver::kSap..*or.*continuous.*CENIC.*"));
 }
+#pragma GCC diagnostic pop
 
 TEST_F(SdfParserTestContinuous, MimicContinuous) {
   // Feature support in continuous plants depends on integrator selection, so

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -423,6 +423,9 @@ static constexpr char kMimicModel[] = R"""(
       </joint>
     </robot>)""";
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(UrdfParserTest, MimicNoSap) {
   // Currently the <mimic> tag is only supported by SAP. Setting the solver
   // to TAMSI should be a warning.
@@ -442,6 +445,7 @@ TEST_F(UrdfParserTestContinuous, MimicContinuous) {
   // can't be checked at parsing time.
   EXPECT_NE(AddModelFromUrdfString(kMimicModel, ""), std::nullopt);
 }
+#pragma GCC diagnostic pop
 
 TEST_F(UrdfParserTest, MimicNoJoint) {
   // Currently the <mimic> tag is only supported by SAP.

--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -31,6 +31,12 @@ using drake::systems::Context;
 namespace drake {
 namespace multibody {
 namespace internal {
+namespace {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+constexpr auto kDiscreteContactSolverTamsi = DiscreteContactSolver::kTamsi;
+#pragma GCC diagnostic pop
+}  // namespace
 
 template <typename T>
 AccelerationsDueNonConstraintForcesCache<
@@ -204,7 +210,7 @@ void CompliantContactManager<T>::DoCalcContactSolverResults(
     }
   }
 
-  if (plant().get_discrete_contact_solver() == DiscreteContactSolver::kTamsi) {
+  if (plant().get_discrete_contact_solver() == kDiscreteContactSolverTamsi) {
     DRAKE_DEMAND(tamsi_driver_ != nullptr);
     tamsi_driver_->CalcContactSolverResults(context, contact_results);
   }
@@ -268,7 +274,7 @@ void CompliantContactManager<T>::DoExtractModelInfo() {
             std::make_unique<SapDriver<T>>(this, near_rigid_threshold);
       }
       break;
-    case DiscreteContactSolver::kTamsi:
+    case kDiscreteContactSolverTamsi:
       // N.B. We do allow discrete updates with TAMSI when T =
       // symbolic::Expression, but only when there is no contact.
       tamsi_driver_ = std::make_unique<TamsiDriver<T>>(this);
@@ -305,7 +311,7 @@ void CompliantContactManager<T>::DoCalcDiscreteUpdateMultibodyForces(
   // Thus far only TAMSI and SAP are supported. Verify this is true.
   DRAKE_DEMAND(
       plant().get_discrete_contact_solver() == DiscreteContactSolver::kSap ||
-      plant().get_discrete_contact_solver() == DiscreteContactSolver::kTamsi);
+      plant().get_discrete_contact_solver() == kDiscreteContactSolverTamsi);
 
   // Delegate to specific solver driver.
   if (plant().get_discrete_contact_solver() == DiscreteContactSolver::kSap) {
@@ -319,7 +325,7 @@ void CompliantContactManager<T>::DoCalcDiscreteUpdateMultibodyForces(
     }
   }
 
-  if (plant().get_discrete_contact_solver() == DiscreteContactSolver::kTamsi) {
+  if (plant().get_discrete_contact_solver() == kDiscreteContactSolverTamsi) {
     DRAKE_DEMAND(tamsi_driver_ != nullptr);
     tamsi_driver_->CalcDiscreteUpdateMultibodyForces(context, forces);
   }
@@ -331,7 +337,7 @@ void CompliantContactManager<T>::DoCalcActuation(
   // Thus far only TAMSI and SAP are supported. Verify this is true.
   DRAKE_DEMAND(
       plant().get_discrete_contact_solver() == DiscreteContactSolver::kSap ||
-      plant().get_discrete_contact_solver() == DiscreteContactSolver::kTamsi);
+      plant().get_discrete_contact_solver() == kDiscreteContactSolverTamsi);
 
   if (plant().get_discrete_contact_solver() == DiscreteContactSolver::kSap) {
     if constexpr (std::is_same_v<T, symbolic::Expression>) {
@@ -344,7 +350,7 @@ void CompliantContactManager<T>::DoCalcActuation(
     }
   }
 
-  if (plant().get_discrete_contact_solver() == DiscreteContactSolver::kTamsi) {
+  if (plant().get_discrete_contact_solver() == kDiscreteContactSolverTamsi) {
     DRAKE_DEMAND(tamsi_driver_ != nullptr);
     // TAMSI does not model additional actuation terms as SAP does.
     *actuation = this->EvalActuationInput(context);

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -250,6 +250,13 @@ struct JointLimitsPenaltyParametersEstimator {
 
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+constexpr auto kDiscreteContactSolverTamsi = DiscreteContactSolver::kTamsi;
+constexpr auto kDiscreteContactApproximationTamsi =
+    DiscreteContactApproximation::kTamsi;
+#pragma GCC diagnostic push
+
 // Hack to fully qualify frame names, pending resolution of #9128. Used by
 // geometry registration routines. When this hack is removed, also undo the
 // de-hacking step within internal_geometry_names.cc. Note that unlike the
@@ -495,7 +502,7 @@ MultibodyConstraintId MultibodyPlant<T>::AddCouplerConstraint(
 
   if (is_discrete()) {
     switch (get_discrete_contact_solver()) {
-      case DiscreteContactSolver::kTamsi:
+      case kDiscreteContactSolverTamsi:
         // TAMSI does not support coupler constraints.
         throw std::runtime_error(
             "Currently this MultibodyPlant is set to use the TAMSI solver. "
@@ -539,7 +546,7 @@ MultibodyConstraintId MultibodyPlant<T>::AddDistanceConstraint(
 
   if (is_discrete()) {
     switch (get_discrete_contact_solver()) {
-      case DiscreteContactSolver::kTamsi:
+      case kDiscreteContactSolverTamsi:
         // TAMSI does not support distance constraints.
         throw std::runtime_error(
             "Currently this MultibodyPlant is set to use the TAMSI solver. "
@@ -650,7 +657,7 @@ MultibodyConstraintId MultibodyPlant<T>::AddBallConstraint(
 
   if (is_discrete()) {
     switch (get_discrete_contact_solver()) {
-      case DiscreteContactSolver::kTamsi:
+      case kDiscreteContactSolverTamsi:
         // TAMSI does not support ball constraints.
         throw std::runtime_error(
             "Currently this MultibodyPlant is set to use the TAMSI solver. "
@@ -693,7 +700,7 @@ MultibodyConstraintId MultibodyPlant<T>::AddWeldConstraint(
 
   if (is_discrete()) {
     switch (get_discrete_contact_solver()) {
-      case DiscreteContactSolver::kTamsi:
+      case kDiscreteContactSolverTamsi:
         // TAMSI does not support weld constraints.
         throw std::runtime_error(
             "Currently this MultibodyPlant is set to use the TAMSI solver. "
@@ -739,7 +746,7 @@ MultibodyConstraintId MultibodyPlant<T>::AddTendonConstraint(
 
   if (is_discrete()) {
     switch (get_discrete_contact_solver()) {
-      case DiscreteContactSolver::kTamsi:
+      case kDiscreteContactSolverTamsi:
         // TAMSI does not support tendon constraints.
         throw std::runtime_error(
             "Currently this MultibodyPlant is set to use the TAMSI solver. "
@@ -878,8 +885,8 @@ void MultibodyPlant<T>::set_contact_model(ContactModel model) {
 template <typename T>
 DiscreteContactSolver MultibodyPlant<T>::get_discrete_contact_solver() const {
   // Only the TAMSI approximation uses the TAMSI solver.
-  if (discrete_contact_approximation_ == DiscreteContactApproximation::kTamsi)
-    return DiscreteContactSolver::kTamsi;
+  if (discrete_contact_approximation_ == kDiscreteContactApproximationTamsi)
+    return kDiscreteContactSolverTamsi;
   // All other approximations use the SAP solver.
   return DiscreteContactSolver::kSap;
 }
@@ -890,7 +897,7 @@ void MultibodyPlant<T>::set_discrete_contact_approximation(
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_THROW_UNLESS(is_discrete());
 
-  if (approximation == DiscreteContactApproximation::kTamsi &&
+  if (approximation == kDiscreteContactApproximationTamsi &&
       num_constraints() > 0) {
     throw std::runtime_error(fmt::format(
         "You selected TAMSI as the contact approximation, but you have "

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -174,7 +174,8 @@ enum class ContactModel {
 ///   https://arxiv.org/abs/2110.10107.
 enum class DiscreteContactSolver {
   /// TAMSI solver, see [Castro et al., 2019].
-  kTamsi,
+  kTamsi DRAKE_DEPRECATED("2026-09-01",
+                          "The TAMSI solver is deprecated for removal."),
   /// SAP solver, see [Castro et al., 2022].
   kSap,
 };
@@ -231,7 +232,8 @@ enum class DiscreteContactSolver {
 ///   https://arxiv.org/abs/2312.03908
 enum class DiscreteContactApproximation {
   /// TAMSI solver approximation, see [Castro et al., 2019].
-  kTamsi,
+  kTamsi DRAKE_DEPRECATED("2026-09-01",
+                          "The TAMSI solver is deprecated for removal."),
   /// SAP solver model approximation, see [Castro et al., 2022].
   kSap,
   /// Similarity approximation found in [Castro et al., 2023].

--- a/multibody/plant/multibody_plant_config_functions.cc
+++ b/multibody/plant/multibody_plant_config_functions.cc
@@ -6,6 +6,9 @@
 
 #include "drake/common/drake_assert.h"
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#include "drake/common/text_logging.h"
+
 namespace drake {
 namespace multibody {
 
@@ -79,8 +82,11 @@ constexpr const char* EnumToChars(ContactModel enum_value) {
 // as well as in the list of kDiscreteContactApproximations below.
 constexpr const char* EnumToChars(DiscreteContactApproximation enum_value) {
   switch (enum_value) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     case DiscreteContactApproximation::kTamsi:
       return "tamsi";
+#pragma GCC diagnostic pop
     case DiscreteContactApproximation::kSap:
       return "sap";
     case DiscreteContactApproximation::kSimilar:
@@ -121,6 +127,8 @@ constexpr std::array<NamedEnum<ContactModel>, 3> kContactModels{{
     {ContactModel::kHydroelasticWithFallback},
 }};
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 constexpr std::array<NamedEnum<DiscreteContactApproximation>, 4>
     kDiscreteContactApproximations{{
         {DiscreteContactApproximation::kTamsi},
@@ -128,6 +136,7 @@ constexpr std::array<NamedEnum<DiscreteContactApproximation>, 4>
         {DiscreteContactApproximation::kSimilar},
         {DiscreteContactApproximation::kLagged},
     }};
+#pragma GCC diagnostic pop
 
 constexpr std::array<NamedEnum<ContactRep>, 2> kContactReps{{
     {ContactRep::kTriangle},
@@ -157,6 +166,11 @@ std::string GetStringFromContactModel(ContactModel contact_model) {
 
 DiscreteContactApproximation GetDiscreteContactApproximationFromString(
     std::string_view discrete_contact_approximation) {
+  if (discrete_contact_approximation == "tamsi") {
+    static const logging::Warn log_once(
+        "DRAKE_DEPRECATED: The TAMSI solver is deprecated, and will be removed "
+        "from Drake on or after 2026-09-01.");
+  }
   for (const auto& [value, name] : kDiscreteContactApproximations) {
     if (name == discrete_contact_approximation) {
       return value;

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -205,8 +205,11 @@ template <typename T>
 std::vector<RotationMatrix<T>> SapDriver<T>::AddContactConstraints(
     const systems::Context<T>& context, SapContactProblem<T>* problem) const {
   DRAKE_DEMAND(problem != nullptr);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DRAKE_DEMAND(plant().get_discrete_contact_approximation() !=
                DiscreteContactApproximation::kTamsi);
+#pragma GCC diagnostic pop
 
   // Parameters used by SAP to estimate regularization, see [Castro et al.,
   // 2021].

--- a/multibody/plant/test/compliant_contact_manager_scalar_conversion_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_scalar_conversion_test.cc
@@ -12,10 +12,19 @@
 namespace drake {
 namespace multibody {
 namespace internal {
+namespace {
 
 using drake::systems::Context;
 using drake::systems::Simulator;
 using Eigen::VectorXd;
+
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+constexpr auto kDiscreteContactSolverTamsi = DiscreteContactSolver::kTamsi;
+constexpr auto kDiscreteContactApproximationTamsi =
+    DiscreteContactApproximation::kTamsi;
+#pragma GCC diagnostic push
 
 template <typename T>
 class CompliantContactManagerScalarConversionTest : public ::testing::Test {};
@@ -65,9 +74,9 @@ std::unique_ptr<MultibodyPlant<T>> MakePlant(
   // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
   // arbitrarily choose two model approximations to accomplish this.
   switch (solver_type) {
-    case DiscreteContactSolver::kTamsi:
+    case kDiscreteContactSolverTamsi:
       plant->set_discrete_contact_approximation(
-          DiscreteContactApproximation::kTamsi);
+          kDiscreteContactApproximationTamsi);
       break;
     case DiscreteContactSolver::kSap:
       plant->set_discrete_contact_approximation(
@@ -116,9 +125,9 @@ GTEST_TEST(ScalarConvertAndSimulateTest, PlantWithSap) {
 
 GTEST_TEST(ScalarConvertAndSimulateTest, PlantWithTamsi) {
   TestPlantConversionAndSimulate<double, AutoDiffXd>(
-      DiscreteContactSolver::kTamsi);
+      kDiscreteContactSolverTamsi);
   TestPlantConversionAndSimulate<AutoDiffXd, double>(
-      DiscreteContactSolver::kTamsi);
+      kDiscreteContactSolverTamsi);
 }
 
 template <typename T, typename U>
@@ -133,17 +142,18 @@ void TestPlantConversion(DiscreteContactSolver solver_type) {
 GTEST_TEST(ScalarConvertTest, ConversionToAndFromSymbolic) {
   // Conversion from double to symbolic.
   TestPlantConversion<double, symbolic::Expression>(
-      DiscreteContactSolver::kTamsi);
+      kDiscreteContactSolverTamsi);
   TestPlantConversion<double, symbolic::Expression>(
       DiscreteContactSolver::kSap);
 
   // Conversion from symbolic to double.
   TestPlantConversion<symbolic::Expression, double>(
-      DiscreteContactSolver::kTamsi);
+      kDiscreteContactSolverTamsi);
   TestPlantConversion<symbolic::Expression, double>(
       DiscreteContactSolver::kSap);
 }
 
+}  // namespace
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/test/compliant_contact_manager_test.cc
+++ b/multibody/plant/test/compliant_contact_manager_test.cc
@@ -55,8 +55,6 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-constexpr double kEps = std::numeric_limits<double>::epsilon();
-
 // Friend class used to provide access to a selection of private functions in
 // SapDriver for testing purposes.
 // TODO(amcastro-tri): Consider how to split SapDriver tests from
@@ -79,6 +77,16 @@ class SapDriverTest {
                                     contact_results);
   }
 };
+
+namespace {
+
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+constexpr auto kDiscreteContactSolverTamsi = DiscreteContactSolver::kTamsi;
+#pragma GCC diagnostic push
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
 
 // Tests that in SetDiscreteUpdateManager, a non-empty DeformableModel will
 // cause a DeformableDriver to be instantiated in the manager.
@@ -686,7 +694,7 @@ TEST_P(RigidBodyOnCompliantGround, VerifyContactResultsBodyInSlip) {
   // projections onto the friction cone are accurate to machine epsilon and
   // therefore no error is expected.
   const double kRelativeSlipTolerance =
-      config.contact_solver == DiscreteContactSolver::kTamsi ? 2.0e-6 : 0.0;
+      config.contact_solver == kDiscreteContactSolverTamsi ? 2.0e-6 : 0.0;
 
   if (config.point_contact) {
     // Test point contact.
@@ -751,15 +759,15 @@ std::vector<ContactTestConfig> MakeTestCases() {
        .contact_solver = DiscreteContactSolver::kSap},
       {.description = "HydroelasticContactWithFallback_TAMSI",
        .point_contact = false,
-       .contact_solver = DiscreteContactSolver::kTamsi},
+       .contact_solver = kDiscreteContactSolverTamsi},
       {.description = "HydroelasticContactOnly_TAMSI",
        .point_contact = false,
        // We verify that the test passes with hydroelastic only.
        .contact_model = ContactModel::kHydroelastic,
-       .contact_solver = DiscreteContactSolver::kTamsi},
+       .contact_solver = kDiscreteContactSolverTamsi},
       {.description = "PointContact_TAMSI",
        .point_contact = true,
-       .contact_solver = DiscreteContactSolver::kTamsi},
+       .contact_solver = kDiscreteContactSolverTamsi},
   };
 }
 
@@ -768,6 +776,7 @@ INSTANTIATE_TEST_SUITE_P(CompliantContactManagerTests,
                          testing::ValuesIn(MakeTestCases()),
                          testing::PrintToStringParamName());
 
+}  // namespace
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -562,6 +562,9 @@ TEST_F(DeformableModelTest, NonEmptyClone) {
             deformable_model_ptr_->HasConstraint(body_id));
 }
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 /* An empty DeformableModel doesn't get in the way of a TAMSI plant. */
 TEST_F(DeformableModelTest, EmptyDeformableModelWorksWithTamsi) {
   plant_->set_discrete_contact_approximation(
@@ -569,6 +572,7 @@ TEST_F(DeformableModelTest, EmptyDeformableModelWorksWithTamsi) {
   EXPECT_TRUE(deformable_model_ptr_->is_empty());
   EXPECT_NO_THROW(plant_->Finalize());
 }
+#pragma GCC diagnostic push
 
 /* If a DeformableModel is not empty, we require the owning plant to use the SAP
  solver. */

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -52,6 +52,14 @@ const double kTimestep = 0.01;
 const double kElbowPosition = 0.3;
 const double kArmLength = 0.1;
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+constexpr auto kDiscreteContactSolverTamsi = DiscreteContactSolver::kTamsi;
+constexpr auto kDiscreteContactApproximationTamsi =
+    DiscreteContactApproximation::kTamsi;
+#pragma GCC diagnostic push
+
 // Set up a plant with 2 trees, one tree having a single floating body, the
 // second tree a serial chain of two bodies attached to each other and world by
 // revolute joints.
@@ -299,12 +307,12 @@ INSTANTIATE_TEST_SUITE_P(IndexPermutations, JointLockingTest,
                          ::testing::Values(0, 1));
 
 struct TrajectoryTestConfig {
-  DiscreteContactSolver solver{DiscreteContactSolver::kTamsi};
+  DiscreteContactSolver solver{kDiscreteContactSolverTamsi};
 };
 
 std::ostream& operator<<(std::ostream& out, DiscreteContactSolver solver) {
   switch (solver) {
-    case DiscreteContactSolver::kTamsi: {
+    case kDiscreteContactSolverTamsi: {
       out << "TAMSI";
       break;
     }
@@ -347,9 +355,9 @@ class TrajectoryTest : public ::testing::TestWithParam<TrajectoryTestConfig> {
     // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
     // arbitrarily choose two model approximations to accomplish this.
     switch (solver) {
-      case DiscreteContactSolver::kTamsi:
+      case kDiscreteContactSolverTamsi:
         plant->set_discrete_contact_approximation(
-            DiscreteContactApproximation::kTamsi);
+            kDiscreteContactApproximationTamsi);
         break;
       case DiscreteContactSolver::kSap:
         plant->set_discrete_contact_approximation(
@@ -482,7 +490,7 @@ TEST_P(TrajectoryTest, CompareWeldAndLocked) {
 // Test joint locking with TAMSI and SAP.
 std::vector<TrajectoryTestConfig> MakeTrajectoryTestCases() {
   return std::vector<TrajectoryTestConfig>{
-      {.solver = DiscreteContactSolver::kTamsi},
+      {.solver = kDiscreteContactSolverTamsi},
       {.solver = DiscreteContactSolver::kSap},
   };
 }
@@ -493,7 +501,7 @@ INSTANTIATE_TEST_SUITE_P(JointLockingTests, TrajectoryTest,
 
 struct FilteredContactResultsConfig {
   ContactModel contact_model{ContactModel::kPoint};
-  std::optional<DiscreteContactSolver> solver{DiscreteContactSolver::kTamsi};
+  std::optional<DiscreteContactSolver> solver{kDiscreteContactSolverTamsi};
 };
 
 std::ostream& operator<<(std::ostream& out,
@@ -524,9 +532,9 @@ class FilteredContactResultsTest
       // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
       // arbitrarily choose two model approximations to accomplish this.
       switch (*config.solver) {
-        case DiscreteContactSolver::kTamsi:
+        case kDiscreteContactSolverTamsi:
           plant_->set_discrete_contact_approximation(
-              DiscreteContactApproximation::kTamsi);
+              kDiscreteContactApproximationTamsi);
           break;
         case DiscreteContactSolver::kSap:
           plant_->set_discrete_contact_approximation(
@@ -706,9 +714,9 @@ MakeFilteredContactResultsTestCases() {
       {.contact_model = ContactModel::kPoint, .solver = std::nullopt},
       {.contact_model = ContactModel::kHydroelastic, .solver = std::nullopt},
       {.contact_model = ContactModel::kPoint,
-       .solver = DiscreteContactSolver::kTamsi},
+       .solver = kDiscreteContactSolverTamsi},
       {.contact_model = ContactModel::kHydroelastic,
-       .solver = DiscreteContactSolver::kTamsi},
+       .solver = kDiscreteContactSolverTamsi},
       {.contact_model = ContactModel::kPoint,
        .solver = DiscreteContactSolver::kSap},
       {.contact_model = ContactModel::kHydroelastic,

--- a/multibody/plant/test/make_discrete_update_manager_test.cc
+++ b/multibody/plant/test/make_discrete_update_manager_test.cc
@@ -32,6 +32,9 @@ GTEST_TEST(MakeDiscreteUpdateManagerTest, Sap) {
           symbolic_manager));
 }
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(MakeDiscreteUpdateManagerTest, Tamsi) {
   std::unique_ptr<DiscreteUpdateManager<double>> double_manager =
       MakeDiscreteUpdateManager<double>(DiscreteContactSolver::kTamsi);
@@ -50,6 +53,7 @@ GTEST_TEST(MakeDiscreteUpdateManagerTest, Tamsi) {
       is_dynamic_castable<CompliantContactManager<symbolic::Expression>>(
           symbolic_manager));
 }
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace internal

--- a/multibody/plant/test/multibody_plant_config_functions_test.cc
+++ b/multibody/plant/test/multibody_plant_config_functions_test.cc
@@ -150,11 +150,16 @@ GTEST_TEST(MultibodyPlantConfigFunctionsTest, DiscreteContactApproximation) {
   // Test for valid approximations.
   std::vector<std::pair<const char*, DiscreteContactApproximation>>
       known_values{
-          std::pair("tamsi", DiscreteContactApproximation::kTamsi),
           std::pair("sap", DiscreteContactApproximation::kSap),
           std::pair("similar", DiscreteContactApproximation::kSimilar),
           std::pair("lagged", DiscreteContactApproximation::kLagged),
       };
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  known_values.push_back(
+      std::pair("tamsi", DiscreteContactApproximation::kTamsi));
+#pragma GCC diagnostic pop
   for (const auto& [name, value] : known_values) {
     EXPECT_EQ(GetDiscreteContactApproximationFromString(name), value);
     EXPECT_EQ(GetStringFromDiscreteContactApproximation(value), name);

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -73,6 +73,14 @@ class MultibodyPlantTester {
 
 namespace {
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+constexpr auto kDiscreteContactSolverTamsi = DiscreteContactSolver::kTamsi;
+constexpr auto kDiscreteContactApproximationTamsi =
+    DiscreteContactApproximation::kTamsi;
+#pragma GCC diagnostic push
+
 struct LadderTestConfig {
   // This is a gtest test suffix; no underscores or spaces.
   std::string description;
@@ -82,7 +90,7 @@ struct LadderTestConfig {
   // point contact if `false`.
   bool hydro_geometry{true};
   // Discrete solver used in the update.
-  DiscreteContactSolver contact_solver{DiscreteContactSolver::kTamsi};
+  DiscreteContactSolver contact_solver{kDiscreteContactSolverTamsi};
   // The ladder is split into two pieces. We join them together using different
   // methods to verify the correctness of reaction forces on a variety of
   // constrained configurations.
@@ -153,9 +161,9 @@ class LadderTest : public ::testing::TestWithParam<LadderTestConfig> {
       // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
       // arbitrarily choose two model approximations to accomplish this.
       switch (config.contact_solver) {
-        case DiscreteContactSolver::kTamsi:
+        case kDiscreteContactSolverTamsi:
           plant_->set_discrete_contact_approximation(
-              DiscreteContactApproximation::kTamsi);
+              kDiscreteContactApproximationTamsi);
           break;
         case DiscreteContactSolver::kSap:
           plant_->set_discrete_contact_approximation(
@@ -610,22 +618,22 @@ std::vector<LadderTestConfig> MakeTestCases() {
       {.description = "WeldJointDiscretePointTamsi",
        .time_step = 2.0e-2,
        .hydro_geometry = false,
-       .contact_solver = DiscreteContactSolver::kTamsi,
+       .contact_solver = kDiscreteContactSolverTamsi,
        .weld_method = LadderTestConfig::WeldMethod::kWeldJoint},
       {.description = "RevoluteJointWithLimitsDiscretePointTamsi",
        .time_step = 1.0e-2,  // N.B. TAMSI goes unstable if using a larger step.
        .hydro_geometry = false,
-       .contact_solver = DiscreteContactSolver::kTamsi,
+       .contact_solver = kDiscreteContactSolverTamsi,
        .weld_method = LadderTestConfig::WeldMethod::kRevoluteJointWithLimits},
       {.description = "WeldJointDiscreteHydroelasticTamsi",
        .time_step = 2.0e-2,
        .hydro_geometry = true,
-       .contact_solver = DiscreteContactSolver::kTamsi,
+       .contact_solver = kDiscreteContactSolverTamsi,
        .weld_method = LadderTestConfig::WeldMethod::kWeldJoint},
       {.description = "RevoluteJointWithLimitsDiscreteHydroelasticTamsi",
        .time_step = 1.0e-2,  // N.B. TAMSI goes unstable if using a larger step.
        .hydro_geometry = true,
-       .contact_solver = DiscreteContactSolver::kTamsi,
+       .contact_solver = kDiscreteContactSolverTamsi,
        .weld_method = LadderTestConfig::WeldMethod::kRevoluteJointWithLimits},
 
       // Discrete SAP solver tests.

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -324,11 +324,18 @@ std::string ParamInfoToString(
   return s.str();
 }
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+constexpr auto kDiscreteContactApproximationTamsi =
+    DiscreteContactApproximation::kTamsi;
+#pragma GCC diagnostic push
+
 // Helper to make all parameter permutations for DiscretePlantTest.
 auto MakeAllPermutations() {
   return ::testing::Combine(
       ::testing::Values(DiscreteContactApproximation::kSimilar,
-                        DiscreteContactApproximation::kTamsi),
+                        kDiscreteContactApproximationTamsi),
       ::testing::Values(ContactModel::kPoint,
                         ContactModel::kHydroelasticWithFallback),
       ::testing::Values(RobotModelConfig::ContactConfig::kNoGeometry,

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -5379,11 +5379,15 @@ TEST_P(MultibodyPlantConstraintTestTimeStepParam, ConstraintActiveStatus) {
   MultibodyConstraintId tendon_id = plant_.AddTendonConstraint(
       {world_A.index()}, {1.0}, {2.0}, {-3.0}, {4.0}, {5.0}, {6.0});
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   if (plant_.is_discrete()) {
     DRAKE_EXPECT_THROWS_MESSAGE(plant_.set_discrete_contact_approximation(
                                     DiscreteContactApproximation::kTamsi),
                                 ".*TAMSI does not support constraints.*");
   }
+#pragma GCC diagnostic pop
 
   plant_.Finalize();
 
@@ -6327,6 +6331,10 @@ GTEST_TEST(MultibodyPlantTest, RenameModelInstance) {
                               ".*finalized.*");
 }
 
+// Rework this test on 2026-09-01 per TAMSI deprecation. The only test logic we
+// still need is to check for a post-Finalize call to change the approximation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Verify the proper coordination of discrete contact approximations with their
 // corresponding solvers.
 GTEST_TEST(MultibodyPlantTests, DiscreteContactApproximation) {
@@ -6369,6 +6377,7 @@ GTEST_TEST(MultibodyPlantTests, DiscreteContactApproximation) {
           DiscreteContactApproximation::kTamsi),
       "Post-finalize calls to '.*' are not allowed; .*");
 }
+#pragma GCC diagnostic pop
 
 INSTANTIATE_TEST_SUITE_P(ContinousAndDiscreteRemodeling,
                          MultibodyPlantRemodelingParam,

--- a/multibody/plant/test/sap_driver_ball_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_ball_constraints_test.cc
@@ -300,6 +300,9 @@ GTEST_TEST(BallConstraintTests, FinalizedConstraint) {
           *context));
 }
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
   MultibodyPlant<double> plant{0.1};
   plant.set_discrete_contact_approximation(
@@ -312,6 +315,7 @@ GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
                                                       bodyB, Vector3d{0, 0, 0}),
                               ".*TAMSI does not support ball constraints.*");
 }
+#pragma GCC diagnostic push
 
 GTEST_TEST(BallConstraintTests, FailOnContinuous) {
   MultibodyPlant<double> plant{0.0};

--- a/multibody/plant/test/sap_driver_distance_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_distance_constraints_test.cc
@@ -352,6 +352,9 @@ GTEST_TEST(DistanceConstraintsTests, DistanceConstraintParams) {
   }
 }
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(DistanceConstraintTests, FailOnTAMSI) {
   MultibodyPlant<double> plant{0.1};
   plant.set_discrete_contact_approximation(
@@ -365,6 +368,7 @@ GTEST_TEST(DistanceConstraintTests, FailOnTAMSI) {
                                   Vector3d{0, 0, 0}, 1 /* distance */),
       ".*TAMSI does not support distance constraints.*");
 }
+#pragma GCC diagnostic push
 
 GTEST_TEST(DistanceConstraintTests, FailOnContinuous) {
   MultibodyPlant<double> plant{0.0};

--- a/multibody/plant/test/sap_driver_tendon_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_tendon_constraints_test.cc
@@ -361,6 +361,9 @@ class SimplePlant : public ::testing::Test {
   double valid_damping_{5};
 };
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(SimplePlant, FailOnTAMSI) {
   MakePlant();
   plant_->set_discrete_contact_approximation(
@@ -371,6 +374,7 @@ TEST_F(SimplePlant, FailOnTAMSI) {
                                   {}, {}, {}),
       ".*TAMSI does not support tendon constraints.*");
 }
+#pragma GCC diagnostic pop
 
 TEST_F(SimplePlant, FailOnContinuous) {
   MakePlant(0.0);  // Continuous plant.

--- a/multibody/plant/test/sap_driver_weld_constraints_test.cc
+++ b/multibody/plant/test/sap_driver_weld_constraints_test.cc
@@ -330,6 +330,9 @@ GTEST_TEST(WeldConstraintsTests, VerifyIdMapping) {
   EXPECT_THROW(plant.get_ball_constraint_specs(weld_id), std::exception);
 }
 
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
   MultibodyPlant<double> plant{0.1};
   plant.set_discrete_contact_approximation(
@@ -342,6 +345,7 @@ GTEST_TEST(BallConstraintTests, FailOnTAMSI) {
                                                       bodyB, RigidTransformd()),
                               ".*TAMSI does not support weld constraints.*");
 }
+#pragma GCC diagnostic pop
 
 GTEST_TEST(WeldConstraintTests, FailOnContinuous) {
   MultibodyPlant<double> plant{0.0};

--- a/multibody/plant/test_utilities/rigid_body_on_compliant_ground.h
+++ b/multibody/plant/test_utilities/rigid_body_on_compliant_ground.h
@@ -44,8 +44,12 @@ struct ContactTestConfig {
   // testing of cases using the hydroelastic contact model, whether point
   // contact is used or not.
   ContactModel contact_model{ContactModel::kHydroelasticWithFallback};
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // Option that allows to exercise the TAMSI and SAP solver code paths
   DiscreteContactSolver contact_solver{DiscreteContactSolver::kTamsi};
+#pragma GCC diagnostic pop
 };
 
 // This provides the suffix for each test parameter: the test config
@@ -76,6 +80,9 @@ class RigidBodyOnCompliantGround
     DiagramBuilder<double> builder;
     auto items = AddMultibodyPlantSceneGraph(&builder, kTimeStep_);
     plant_ = &items.plant;
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
     // arbitrarily choose two model approximations to accomplish this.
     switch (config.contact_solver) {
@@ -88,6 +95,7 @@ class RigidBodyOnCompliantGround
             DiscreteContactApproximation::kSap);
         break;
     }
+#pragma GCC diagnostic pop
 
     // We change the default gravity magnitude so that numbers are simpler to
     // work with.

--- a/multibody/test_utilities/robot_model.cc
+++ b/multibody/test_utilities/robot_model.cc
@@ -20,10 +20,14 @@ std::ostream& operator<<(std::ostream& out, const RobotModelConfig& c) {
       out << "Sap";
       break;
     }
+// Remove on 2026-09-01 per TAMSI deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     case DiscreteContactApproximation::kTamsi: {
       out << "Tamsi";
       break;
     }
+#pragma GCC diagnostic pop
   }
 
   switch (c.contact_model) {


### PR DESCRIPTION
There are much better alternatives now (SAP, CENIC) and supporting this incomplete solver (doesn't support constraints, etc.) is a drag on development velocity.  Trying to document and test which modeling features work and don't work in various plant configurations is a huge pain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24089)
<!-- Reviewable:end -->
