### PR TITLE
[doc] Update "common CI infra flakes"

### DIFF
--- a/doc/_pages/buildcop.md
+++ b/doc/_pages/buildcop.md
@@ -289,10 +289,8 @@ exercise changes to the CI scripts themselves.
 ## Infrastructure Flake
 
 The machinery of the CI system itself sometimes fails for reasons unrelated to
-any code change. The most common infrastructure flakes include:
-
-* Unable to obtain a Gurobi license.
-* Broken connection to a Mac build agent.
+any code change. For example, download errors from GitHub, `apt`, etc. are
+somewhat common.
 
 Infrastructure flakes will be red in Jenkins. If you believe you are looking at
 an infrastructure flake, run the build manually at HEAD. If it passes, you are


### PR DESCRIPTION
The old reference to macOS is an artifact of before that compute was moved to AWS, and Gurobi-related errors haven't been seen in a while. Stick to "download errors" (which are likely to remain for the foreseeable future) to prevent this list from bitrotting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24091)
<!-- Reviewable:end -->
