### PR TITLE
Deprecate `Fields::operator<<`

### DIFF
--- a/bindings/generated_docstrings/perception.h
+++ b/bindings/generated_docstrings/perception.h
@@ -803,6 +803,12 @@ R"""(Makes operator| compatible for ``BaseField`` + ``DescriptorType``.
 See also:
     Fields::operator|= for preconditions.)""";
         } operator_bor;
+        // Symbol: drake::perception::pc_flags::to_string
+        struct /* to_string */ {
+          // Source: drake/perception/point_cloud_flags.h
+          const char* doc =
+R"""(Provides a human-readable description of ``fields``.)""";
+        } to_string;
       } pc_flags;
     } perception;
   } drake;

--- a/perception/point_cloud_flags.cc
+++ b/perception/point_cloud_flags.cc
@@ -1,49 +1,34 @@
 #include "drake/perception/point_cloud_flags.h"
 
-#include <sstream>
 #include <vector>
+
+#include "fmt/ranges.h"
 
 namespace drake {
 namespace perception {
 
-namespace {
-
-// Utility for `ToString`.
-// TODO(eric.cousineau): Move to `drake/common`, consider using `infix_iterator`
-// per Soonho's suggestion: https://codereview.stackexchange.com/a/13209
-std::ostream& join(std::ostream& os, const std::vector<std::string>& elements,
-                   const std::string& delim) {
-  for (size_t i = 0; i < elements.size(); ++i) {
-    os << elements[i];
-    if (i + 1 < elements.size()) {
-      os << delim;
-    }
-  }
-  return os;
-}
-
-}  // namespace
-
 namespace pc_flags {
 
 std::ostream& operator<<(std::ostream& os, const Fields& fields) {
+  return os << fmt::to_string(fields);
+}
+
+std::string to_string(const Fields& fields) {
   DRAKE_DEMAND(internal::kMaxBitInUse == kRGBs);
   std::vector<std::string> values;
   if (fields.contains(kXYZs)) {
-    values.push_back("kXYZs");
+    values.emplace_back("kXYZs");
   }
   if (fields.contains(kNormals)) {
-    values.push_back("kNormals");
+    values.emplace_back("kNormals");
   }
   if (fields.contains(kRGBs)) {
-    values.push_back("kRGBs");
+    values.emplace_back("kRGBs");
   }
   if (fields.has_descriptor()) {
-    values.push_back(fields.descriptor_type().name());
+    values.emplace_back(fields.descriptor_type().name());
   }
-  os << "(";
-  join(os, values, " | ");
-  return os << ")";
+  return fmt::format("({})", fmt::join(values, " | "));
 }
 
 }  // namespace pc_flags

--- a/perception/point_cloud_flags.h
+++ b/perception/point_cloud_flags.h
@@ -1,12 +1,15 @@
 #pragma once
 
-#include <ostream>
 #include <stdexcept>
 #include <string>
 
+// TODO(2026-06-01): Remove ostream header when `operator<<` is removed.
+#include <ostream>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 
 namespace drake {
 namespace perception {
@@ -156,14 +159,21 @@ class Fields {
 
   bool operator!=(const Fields& rhs) const { return !(*this == rhs); }
 
-  /// Provides human-readable output.
-  friend std::ostream& operator<<(std::ostream& os, const Fields& rhs);
-
  private:
   // TODO(eric.cousineau): Use `optional` to avoid the need for `none` objects?
   BaseFieldT base_fields_{kNone};
   DescriptorType descriptor_type_{kDescriptorNone};
 };
+
+/// Provides a human-readable description of `fields`.
+std::string to_string(const Fields& fields);
+
+/// Provides human-readable output.
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream& operator<<(std::ostream& os, const Fields& rhs);
 
 // Do not use implicit conversion because it becomes ambiguous.
 /// Makes operator| compatible for `BaseField` + `DescriptorType`.
@@ -186,9 +196,6 @@ inline Fields operator|(const DescriptorType& lhs, const Fields& rhs) {
 }  // namespace perception
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::perception::pc_flags::Fields>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::perception::pc_flags, DescriptorType, x, x.name())
+DRAKE_FORMATTER_AS(, drake::perception::pc_flags, Fields, x,
+                   drake::perception::pc_flags::to_string(x))

--- a/perception/test/point_cloud_flags_test.cc
+++ b/perception/test/point_cloud_flags_test.cc
@@ -1,5 +1,6 @@
 #include "drake/perception/point_cloud_flags.h"
 
+// TODO(2026-06-01): Remove sstream header when `Formatting` is removed.
 #include <sstream>
 #include <stdexcept>
 
@@ -14,6 +15,9 @@ namespace pcf = pc_flags;
 
 namespace {
 
+// TODO(2026-06-01): Delete test `Formatting`.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 GTEST_TEST(PointCloudFlagsTest, Formatting) {
   // Check human-friendly formatting.
   {
@@ -27,6 +31,19 @@ GTEST_TEST(PointCloudFlagsTest, Formatting) {
     os << (pcf::kXYZs | pcf::kRGBs | pcf::kDescriptorCurvature);
     EXPECT_EQ("(kXYZs | kRGBs | kDescriptorCurvature)", os.str());
   }
+}
+#pragma GCC diagnostic pop
+
+GTEST_TEST(PointCloudFlagsTest, DescriptorTypeToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(pcf::kDescriptorNone), "kDescriptorNone");
+}
+
+GTEST_TEST(PointCloudFlagsTest, FieldsToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(pcf::Fields(pcf::kDescriptorNone)), "()");
+  EXPECT_EQ(fmt::to_string(pcf::kXYZs | pcf::kDescriptorNone), "(kXYZs)");
+  EXPECT_EQ(fmt::to_string(pcf::kXYZs | pcf::kNormals | pcf::kRGBs |
+                           pcf::kDescriptorCurvature),
+            "(kXYZs | kNormals | kRGBs | kDescriptorCurvature)");
 }
 
 GTEST_TEST(PointCloudFlagsTest, Basic) {


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). @jwnimmer-tri for review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24093)
<!-- Reviewable:end -->
