### PR TITLE
[tools] Remove mypy_internal from new_release

### DIFF
--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -111,8 +111,6 @@ _OVERLOOK_RELEASE_REPOSITORIES = {
 _COHORTS = (
     # clarabel_cpp uses crate_universe; be sure to keep them aligned.
     {"clarabel_cpp_internal", "crate_universe"},
-    # mypy uses mypy_extensions; be sure to keep them aligned.
-    {"mypy_internal", "mypy_extensions_internal"},
     # sdformat depends on both gz libraries; be sure to keep them aligned.
     {"sdformat_internal", "gz_math_internal", "gz_utils_internal"},
     # uwebsockets depends on usockets; be sure to keep them aligned.


### PR DESCRIPTION
References to version information in `mypy_internal` and `mypy_extensions_internal` are dead as of #24019. `mypy` is now upgraded via the `venv_upgrade` mechanism.

Closes #24095.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24096)
<!-- Reviewable:end -->
