### PR TITLE
Fix typo 'MultiBody' in some places

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -1767,7 +1767,7 @@ Perform introspection to find out what's in the MultibodyPlant.
 
 **** Model Instances
 
-A MultiBodyPlant may contain multiple model instances. Each model
+A MultibodyPlant may contain multiple model instances. Each model
 instance corresponds to a set of bodies and their connections
 (joints). Model instances provide methods to get or set the state of
 the set of bodies (e.g., through GetPositionsAndVelocities() and

--- a/examples/multibody/four_bar/README.md
+++ b/examples/multibody/four_bar/README.md
@@ -1,7 +1,7 @@
 # Four-Bar Linkage Example
 This planar four-bar linkage demonstrates how to use a bushing to
 approximate a closed kinematic chain. It loads an SDF model from the
-file "four_bar.sdf" into MultiBodyPlant. It handles the closed kinematic
+file "four_bar.sdf" into MultibodyPlant. It handles the closed kinematic
 chain by replacing one of the four-bar's revolute (pin) joints with a
 bushing ([drake::multibody::LinearBushingRollPitchYaw](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_linear_bushing_roll_pitch_yaw.html))
 whose force stiffness and damping values were approximated as discussed below.

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -124,7 +124,7 @@ const double kPadMinorRadius = 6e-3;   // 6 mm.
 // rigid body for a finger. The collision geometries, consisting of a set of
 // small spheres, approximates a torus attached to the finger.
 //
-// @param[in] plant the MultiBodyPlant in which to add the pads.
+// @param[in] plant the MultibodyPlant in which to add the pads.
 // @param[in] pad_offset the ring offset along the x-axis in the finger
 // coordinate frame, i.e., how far the ring protrudes from the center of the
 // finger.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -332,7 +332,7 @@ geometry.
 @anchor model_instances
                         ### Model Instances
 
-A MultiBodyPlant may contain multiple model instances. Each model instance
+A MultibodyPlant may contain multiple model instances. Each model instance
 corresponds to a
 set of bodies and their connections (joints). Model instances provide
 methods to get or set the state of the set of bodies (e.g., through


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24102)
<!-- Reviewable:end -->
