### PR TITLE
Deprecate `operator<<` for `ProgramAttribute`, `ProgramAttributes`, and `ProgramType`

### DIFF
--- a/solvers/program_attribute.cc
+++ b/solvers/program_attribute.cc
@@ -2,10 +2,10 @@
 
 #include <algorithm>
 #include <deque>
-#include <sstream>
 #include <vector>
 
-#include <fmt/format.h>
+// TODO(2026-06-01): Remove sstream header when `operator<<` is removed.
+#include <sstream>
 
 namespace drake {
 namespace solvers {
@@ -103,31 +103,28 @@ std::string to_string(const ProgramAttribute& attr) {
 }
 
 std::ostream& operator<<(std::ostream& os, const ProgramAttribute& attr) {
-  os << to_string(attr);
-  return os;
+  return os << fmt::to_string(attr);
 }
 
 std::string to_string(const ProgramAttributes& attrs) {
-  std::ostringstream result;
-  result << attrs;
-  return result.str();
+  std::deque<ProgramAttribute> sorted(attrs.begin(), attrs.end());
+  std::ranges::sort(sorted.begin(), sorted.end());
+  std::string result{"{ProgramAttributes: "};
+  if (sorted.empty()) {
+    result.append("empty");
+  } else {
+    result.append(fmt::to_string(sorted.front()));
+    sorted.pop_front();
+    for (const auto& attr : sorted) {
+      result.append(fmt::format(", {}", attr));
+    }
+  }
+  result.append("}");
+  return result;
 }
 
 std::ostream& operator<<(std::ostream& os, const ProgramAttributes& attrs) {
-  std::deque<ProgramAttribute> sorted(attrs.begin(), attrs.end());
-  std::sort(sorted.begin(), sorted.end());
-  os << "{ProgramAttributes: ";
-  if (sorted.empty()) {
-    os << "empty";
-  } else {
-    os << sorted.front();
-    sorted.pop_front();
-    for (const auto& attr : sorted) {
-      os << ", " << attr;
-    }
-  }
-  os << "}";
-  return os;
+  return os << fmt::to_string(attrs);
 }
 
 std::string to_string(const ProgramType& program_type) {
@@ -165,8 +162,7 @@ std::string to_string(const ProgramType& program_type) {
 }
 
 std::ostream& operator<<(std::ostream& os, const ProgramType& program_type) {
-  os << to_string(program_type);
-  return os;
+  return os << fmt::to_string(program_type);
 }
 
 }  // namespace solvers

--- a/solvers/program_attribute.h
+++ b/solvers/program_attribute.h
@@ -1,10 +1,12 @@
 #pragma once
 
+// TODO(2026-06-01): Remove ostream header when `operator<<` is removed.
 #include <ostream>
 #include <string>
 #include <unordered_set>
 
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -53,8 +55,19 @@ bool AreRequiredAttributesSupported(const ProgramAttributes& required,
                                     std::string* unsupported_message = nullptr);
 
 std::string to_string(const ProgramAttribute&);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream&, const ProgramAttribute&);
+
 std::string to_string(const ProgramAttributes&);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream&, const ProgramAttributes&);
 
 /**
@@ -95,18 +108,19 @@ enum class ProgramType {
 };
 
 std::string to_string(const ProgramType&);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream&, const ProgramType&);
+
 }  // namespace solvers
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::solvers::ProgramAttribute> : drake::ostream_formatter {
-};
-template <>
-struct formatter<drake::solvers::ProgramAttributes> : drake::ostream_formatter {
-};
-template <>
-struct formatter<drake::solvers::ProgramType> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::solvers, ProgramAttribute, x,
+                   drake::solvers::to_string(x))
+DRAKE_FORMATTER_AS(, drake::solvers, ProgramAttributes, x,
+                   drake::solvers::to_string(x))
+DRAKE_FORMATTER_AS(, drake::solvers, ProgramType, x,
+                   drake::solvers::to_string(x))

--- a/solvers/test/program_attribute_test.cc
+++ b/solvers/test/program_attribute_test.cc
@@ -11,20 +11,59 @@ namespace solvers {
 namespace test {
 namespace {
 
-GTEST_TEST(ProgramAttributeTest, ToString) {
+// TODO(2026-06-01): Delete test `StreamInsertionOperator`.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(ProgramAttributeTest, StreamInsertionOperator) {
   const ProgramAttributes attrs{ProgramAttribute::kGenericCost,
                                 ProgramAttribute::kGenericConstraint};
-
-  EXPECT_EQ(to_string(ProgramAttribute::kGenericCost), "GenericCost");
-  EXPECT_EQ(to_string(attrs),
-            "{ProgramAttributes: GenericCost, GenericConstraint}");
-
   std::ostringstream os;
   os << ProgramAttribute::kGenericCost;
   EXPECT_EQ(os.str(), "GenericCost");
   os = std::ostringstream{};
   os << attrs;
   EXPECT_EQ(os.str(), "{ProgramAttributes: GenericCost, GenericConstraint}");
+}
+#pragma GCC diagnostic pop
+
+GTEST_TEST(ProgramAttributeTest, ProgramAttributeToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kGenericCost), "GenericCost");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kGenericConstraint),
+            "GenericConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kQuadraticCost), "QuadraticCost");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kQuadraticConstraint),
+            "QuadraticConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kLinearCost), "LinearCost");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kLinearConstraint),
+            "LinearConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kLinearEqualityConstraint),
+            "LinearEqualityConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kLinearComplementarityConstraint),
+            "LinearComplementarityConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kLorentzConeConstraint),
+            "LorentzConeConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kRotatedLorentzConeConstraint),
+            "RotatedLorentzConeConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kPositiveSemidefiniteConstraint),
+            "PositiveSemidefiniteConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kExponentialConeConstraint),
+            "ExponentialConeConstraint");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kL2NormCost), "L2NormCost");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kBinaryVariable),
+            "BinaryVariable");
+  EXPECT_EQ(fmt::to_string(ProgramAttribute::kCallback), "Callback");
+}
+
+GTEST_TEST(ProgramAttributeTest, ProgramAttributesToStringFmtFormatter) {
+  const ProgramAttributes attrs{
+      ProgramAttribute::kGenericCost,   ProgramAttribute::kGenericConstraint,
+      ProgramAttribute::kQuadraticCost, ProgramAttribute::kQuadraticConstraint,
+      ProgramAttribute::kLinearCost,    ProgramAttribute::kLinearConstraint};
+  EXPECT_EQ(fmt::to_string(ProgramAttributes()), "{ProgramAttributes: empty}");
+  EXPECT_EQ(
+      fmt::to_string(attrs),
+      "{ProgramAttributes: GenericCost, GenericConstraint, "
+      "QuadraticCost, QuadraticConstraint, LinearCost, LinearConstraint}");
 }
 
 GTEST_TEST(ProgramAttributeTest, Supported) {
@@ -68,7 +107,7 @@ GTEST_TEST(ProgramAttributeTest, Supported) {
     const auto& supported = std::get<1>(one_case);
     const auto& expected_message = std::get<2>(one_case);
     const bool expected_is_supported = expected_message.empty();
-    SCOPED_TRACE(to_string(required) + " vs " + to_string(supported));
+    SCOPED_TRACE(fmt::to_string(required) + " vs " + fmt::to_string(supported));
 
     const bool is_supported_1 =
         AreRequiredAttributesSupported(required, supported);
@@ -82,25 +121,28 @@ GTEST_TEST(ProgramAttributeTest, Supported) {
   }
 }
 
-GTEST_TEST(ProgramTypeTest, tostring) {
-  EXPECT_EQ(to_string(ProgramType::kLP), "linear programming");
-  EXPECT_EQ(to_string(ProgramType::kQP), "quadratic programming");
-  EXPECT_EQ(to_string(ProgramType::kSOCP), "second order cone programming");
-  EXPECT_EQ(to_string(ProgramType::kSDP), "semidefinite programming");
-  EXPECT_EQ(to_string(ProgramType::kGP), "geometric programming");
-  EXPECT_EQ(to_string(ProgramType::kCGP), "conic geometric programming");
-  EXPECT_EQ(to_string(ProgramType::kMILP), "mixed-integer linear programming");
-  EXPECT_EQ(to_string(ProgramType::kMIQP),
+GTEST_TEST(ProgramTypeTest, ProgramTypeToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(ProgramType::kLP), "linear programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kQP), "quadratic programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kSOCP),
+            "second order cone programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kSDP), "semidefinite programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kGP), "geometric programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kCGP), "conic geometric programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kMILP),
+            "mixed-integer linear programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kMIQP),
             "mixed-integer quadratic programming");
-  EXPECT_EQ(to_string(ProgramType::kMISOCP),
+  EXPECT_EQ(fmt::to_string(ProgramType::kMISOCP),
             "mixed-integer second order cone programming");
-  EXPECT_EQ(to_string(ProgramType::kMISDP),
+  EXPECT_EQ(fmt::to_string(ProgramType::kMISDP),
             "mixed-integer semidefinite programming");
-  EXPECT_EQ(to_string(ProgramType::kQuadraticCostConicConstraint),
+  EXPECT_EQ(fmt::to_string(ProgramType::kQuadraticCostConicConstraint),
             "conic-constrained quadratic programming");
-  EXPECT_EQ(to_string(ProgramType::kNLP), "nonlinear programming");
-  EXPECT_EQ(to_string(ProgramType::kLCP), "linear complementarity programming");
-  EXPECT_EQ(to_string(ProgramType::kUnknown),
+  EXPECT_EQ(fmt::to_string(ProgramType::kNLP), "nonlinear programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kLCP),
+            "linear complementarity programming");
+  EXPECT_EQ(fmt::to_string(ProgramType::kUnknown),
             "uncategorized mathematical programming type");
 }
 


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24105)
<!-- Reviewable:end -->
