### PR TITLE
[multibody] Add JointActuator::set_effort_limit

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -6466,6 +6466,15 @@ property is set in the perception properties (as documented above).
 
 See mbp_geometry "the overview" for more details.)""";
         } RegisterVisualGeometry;
+        // Symbol: drake::multibody::MultibodyPlant::RemoveAllJointActuatorEffortLimits
+        struct /* RemoveAllJointActuatorEffortLimits */ {
+          // Source: drake/multibody/plant/multibody_plant.h
+          const char* doc =
+R"""(Removes the effort limits on all joint actuators. (In other words,
+sets all effort limits to +∞.) This is a convenient way to obtain a
+plant without any built-in effort limits, in case models loaded by the
+Parser have unwanted limits.)""";
+        } RemoveAllJointActuatorEffortLimits;
         // Symbol: drake::multibody::MultibodyPlant::RemoveConstraint
         struct /* RemoveConstraint */ {
           // Source: drake/multibody/plant/multibody_plant.h

--- a/bindings/generated_docstrings/multibody_tree.h
+++ b/bindings/generated_docstrings/multibody_tree.h
@@ -4315,6 +4315,12 @@ reflected_inertia.)""";
 R"""(Sets the default value for this actuator's rotor inertia. See
 reflected_inertia.)""";
         } set_default_rotor_inertia;
+        // Symbol: drake::multibody::JointActuator::set_effort_limit
+        struct /* set_effort_limit */ {
+          // Source: drake/multibody/tree/joint_actuator.h
+          const char* doc =
+R"""(Sets the actuator effort limit. (To clear the limit, set it to +∞.))""";
+        } set_effort_limit;
       } JointActuator;
       // Symbol: drake::multibody::JointActuatorIndex
       struct /* JointActuatorIndex */ {

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -267,6 +267,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.AddJointActuator.doc)
         .def("RemoveJointActuator", &Class::RemoveJointActuator,
             py::arg("actuator"), cls_doc.RemoveJointActuator.doc)
+        .def("RemoveAllJointActuatorEffortLimits",
+            &Class::RemoveAllJointActuatorEffortLimits,
+            cls_doc.RemoveAllJointActuatorEffortLimits.doc)
         .def(
             "AddFrame",
             [](Class* self, const Frame<T>& frame) {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -778,6 +778,7 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(joint_actuator.name(), str)
         self.assertIsInstance(joint_actuator.joint(), Joint)
         self.assertIsInstance(joint_actuator.effort_limit(), float)
+        joint_actuator.set_effort_limit(effort_limit=22.0)
         self.assertIsInstance(joint_actuator.default_rotor_inertia(), float)
         self.assertIsInstance(joint_actuator.default_gear_ratio(), float)
         joint_actuator.set_default_rotor_inertia(1.5)
@@ -785,6 +786,9 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(joint_actuator.default_reflected_inertia(), float)
         self.assertGreaterEqual(joint_actuator.input_start(), 0)
         self.assertEqual(joint_actuator.num_inputs(), 1)
+
+        plant = MultibodyPlant_[T](0.0)
+        plant.RemoveAllJointActuatorEffortLimits()
 
     def _test_rotational_inertia_or_unit_inertia_api(self, T, Class):
         """

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -955,6 +955,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("input_start", &Class::input_start, cls_doc.input_start.doc)
         .def("num_inputs", &Class::num_inputs, cls_doc.num_inputs.doc)
         .def("effort_limit", &Class::effort_limit, cls_doc.effort_limit.doc)
+        .def("set_effort_limit", &Class::set_effort_limit,
+            py::arg("effort_limit"), cls_doc.set_effort_limit.doc)
         .def("default_rotor_inertia", &Class::default_rotor_inertia,
             cls_doc.default_rotor_inertia.doc)
         .def("default_gear_ratio", &Class::default_gear_ratio,

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -677,6 +677,17 @@ void IcfBuilder<T>::SetActuationGainConstraints(const VectorX<T>& Ku,
     constraint_index = model->num_cliques();
   }
 
+  // Collect joint effort limits, indexed by velocity.
+  VectorX<T>& effort_limits = scratch_.effort_limits;
+  effort_limits.setConstant(kInf);
+  for (JointActuatorIndex actuator_index : plant_.GetJointActuatorIndices()) {
+    const JointActuator<T>& actuator =
+        plant_.get_joint_actuator(actuator_index);
+    const Joint<T>& joint = actuator.joint();
+    effort_limits[joint.velocity_start()] = actuator.effort_limit();
+  }
+
+  // Add constraints for cliques with actuation.
   for (int c = 0; c < model->num_cliques(); ++c) {
     if (plant_facts_.clique_nu[c] == 0) {
       continue;
@@ -684,7 +695,7 @@ void IcfBuilder<T>::SetActuationGainConstraints(const VectorX<T>& Ku,
 
     const auto Ku_c = model->clique_segment(c, Ku);
     const auto bu_c = model->clique_segment(c, bu);
-    const auto e_c = model->clique_segment(c, plant_facts_.effort_limits);
+    const auto e_c = model->clique_segment(c, effort_limits);
 
     gain_constraints.Set(constraint_index, c, Ku_c, bu_c, e_c);
     ++constraint_index;
@@ -773,7 +784,9 @@ IcfBuilder<T>::BodiesSortedByAnchorage::BodiesSortedByAnchorage(
 
 template <typename T>
 IcfBuilder<T>::Scratch::Scratch(const MultibodyPlant<T>& plant)
-    : accelerations(VectorX<T>::Zero(plant.num_velocities())), forces(plant) {
+    : effort_limits(VectorX<T>::Zero(plant.num_velocities())),
+      accelerations(VectorX<T>::Zero(plant.num_velocities())),
+      forces(plant) {
   J_V_WB.resize(6, plant.num_velocities());
 }
 
@@ -823,12 +836,8 @@ IcfBuilder<T>::PlantFacts::PlantFacts(const MultibodyPlant<T>& plant) {
     body_is_floating[b] = is_free_floating ? 1 : 0;
   }
 
-  // Iterate over actuators to find number of actuators per clique, and effort
-  // limits for each velocity.
+  // Iterate over actuators to find number of actuators per clique.
   clique_nu.assign(clique_sizes.size(), 0);
-  const int nv = plant.num_velocities();
-  effort_limits.resize(nv);
-  effort_limits.setConstant(kInf);
   for (JointActuatorIndex actuator_index : plant.GetJointActuatorIndices()) {
     const JointActuator<T>& actuator = plant.get_joint_actuator(actuator_index);
     const Joint<T>& joint = actuator.joint();
@@ -837,7 +846,6 @@ IcfBuilder<T>::PlantFacts::PlantFacts(const MultibodyPlant<T>& plant) {
     const int c = tree_to_clique[t];
     DRAKE_ASSERT(c >= 0);
     ++clique_nu[c];
-    effort_limits[dof] = actuator.effort_limit();
   }
   num_actuation_constraints = std::ranges::count_if(clique_nu, [](int k) {
     return k > 0;

--- a/multibody/contact_solvers/icf/icf_builder.h
+++ b/multibody/contact_solvers/icf/icf_builder.h
@@ -66,14 +66,12 @@ class IcfBuilder {
                            const IcfLinearFeedbackGains<T>* external_feedback,
                            IcfModel<T>* model) const;
 
-  /* Testing only access. */
-  const VectorX<T>& effort_limits() const { return plant_facts_.effort_limits; }
-
  private:
   /* Scratch workspace data to build the model. */
   struct Scratch {
     explicit Scratch(const MultibodyPlant<T>& plant);
 
+    VectorX<T> effort_limits;        // size nv
     Matrix6X<T> J_V_WB;              // size 6 x nv
     const VectorX<T> accelerations;  // size nv
     MultibodyForces<T> forces;
@@ -165,15 +163,14 @@ class IcfBuilder {
   struct PlantFacts {
     explicit PlantFacts(const MultibodyPlant<T>& plant);
 
-    std::vector<int> tree_to_clique;      // cliques are trees with nv > 0.
-    std::vector<int> clique_sizes;        // nv for each clique.
-    std::vector<int> body_jacobian_cols;  // cols of J_WB for each body.
-    std::vector<int> body_to_clique;      // clique index for each body.
-    std::vector<int> body_is_floating;    // 1 if body is floating, else 0.
-    VectorX<T> effort_limits;             // actuator limits for each velocity.
-    std::vector<int> clique_nu;           // number of actuators per clique.
-    int num_actuation_constraints{};      // count of clique_nu_[k] > 0.
-    std::vector<int> limited_clique_sizes;        // nv in each limited clique.
+    std::vector<int> tree_to_clique;        // cliques are trees with nv > 0.
+    std::vector<int> clique_sizes;          // nv for each clique.
+    std::vector<int> body_jacobian_cols;    // cols of J_WB for each body.
+    std::vector<int> body_to_clique;        // clique index for each body.
+    std::vector<int> body_is_floating;      // 1 if body is floating, else 0.
+    std::vector<int> clique_nu;             // number of actuators per clique.
+    int num_actuation_constraints{};        // count of clique_nu_[k] > 0.
+    std::vector<int> limited_clique_sizes;  // nv in each limited clique.
     std::vector<int> clique_to_limit_constraint;  // clique idx --> limit idx.
   };
   const PlantFacts plant_facts_{plant_};
@@ -194,7 +191,7 @@ class IcfBuilder {
   std::vector<geometry::ContactSurface<T>> surfaces_;
 
   // Storage for intermediate computations, often overwritten.
-  Scratch scratch_{plant_};
+  mutable Scratch scratch_{plant_};
 };
 
 }  // namespace internal

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1031,6 +1031,14 @@ void MultibodyPlant<T>::RemoveJointActuator(const JointActuator<T>& actuator) {
 }
 
 template <typename T>
+void MultibodyPlant<T>::RemoveAllJointActuatorEffortLimits() {
+  for (const JointActuatorIndex& i : GetJointActuatorIndices()) {
+    get_mutable_joint_actuator(i).set_effort_limit(
+        std::numeric_limits<double>::infinity());
+  }
+}
+
+template <typename T>
 geometry::SourceId MultibodyPlant<T>::RegisterAsSourceForSceneGraph(
     SceneGraph<T>* scene_graph) {
   DRAKE_THROW_UNLESS(scene_graph != nullptr);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1693,6 +1693,12 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @see AddJointActuator()
   void RemoveJointActuator(const JointActuator<T>& actuator);
 
+  /// Removes the effort limits on all joint actuators. (In other words, sets
+  /// all effort limits to +∞.) This is a convenient way to obtain a plant
+  /// without any built-in effort limits, in case models loaded by the Parser
+  /// have unwanted limits.
+  void RemoveAllJointActuatorEffortLimits();
+
   /// Creates a new model instance.  Returns the index for the model
   /// instance.
   ///

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3916,9 +3916,16 @@ TEST_P(KukaArmTest, StateAccess) {
     plant_->SetVelocities(context_.get(), v_block);
     plant_->SetPositionsAndVelocities(context_.get(), qv_block);
   }
+}
 
+TEST_P(KukaArmTest, EffortLimits) {
   Eigen::VectorXd effort_limits(7);
   effort_limits << 320, 320, 176, 176, 110, 40, 40;
+  EXPECT_TRUE(CompareMatrices(plant_->GetEffortLowerLimits(), -effort_limits));
+  EXPECT_TRUE(CompareMatrices(plant_->GetEffortUpperLimits(), effort_limits));
+
+  plant_->RemoveAllJointActuatorEffortLimits();
+  effort_limits.setConstant(std::numeric_limits<double>::infinity());
   EXPECT_TRUE(CompareMatrices(plant_->GetEffortLowerLimits(), -effort_limits));
   EXPECT_TRUE(CompareMatrices(plant_->GetEffortUpperLimits(), effort_limits));
 }

--- a/multibody/tree/joint_actuator.cc
+++ b/multibody/tree/joint_actuator.cc
@@ -11,15 +11,22 @@ JointActuator<T>::JointActuator(const std::string& name, const Joint<T>& joint,
                                 double effort_limit)
     : MultibodyElement<T>(joint.model_instance()),
       name_(name),
-      joint_index_(joint.index()),
-      effort_limit_(effort_limit) {
-  if (effort_limit_ <= 0.0) {
-    throw std::runtime_error("Effort limit must be strictly positive!");
-  }
+      joint_index_(joint.index()) {
+  set_effort_limit(effort_limit);
 }
 
 template <typename T>
 JointActuator<T>::~JointActuator() = default;
+
+template <typename T>
+void JointActuator<T>::set_effort_limit(double effort_limit) {
+  if (!(effort_limit > 0.0)) {
+    throw std::logic_error(fmt::format(
+        "JointActuator effort limit must be strictly positive (not {})",
+        effort_limit));
+  }
+  effort_limit_ = effort_limit;
+}
 
 template <typename T>
 void JointActuator<T>::set_controller_gains(PdControllerGains gains) {

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -153,6 +153,9 @@ class JointActuator final : public MultibodyElement<T> {
   /// Returns the actuator effort limit.
   double effort_limit() const { return effort_limit_; }
 
+  /// Sets the actuator effort limit. (To clear the limit, set it to +∞.)
+  void set_effort_limit(double effort_limit);
+
   // Don't let clang-format wrap long @image lines.
   // clang-format off
   /// @anchor reflected_inertia
@@ -414,8 +417,8 @@ class JointActuator final : public MultibodyElement<T> {
   // joint().num_velocities().
   int actuator_dof_start_{-1};
 
-  // Actuator effort limit. It must be greater than 0.
-  double effort_limit_;
+  // Actuator effort limit. It must be strictly greater than 0.
+  double effort_limit_{};
 
   // The rotor inertia for this actuator. A zero value indicates that motor
   // inertial effects are not modeled for `this` actuator.

--- a/multibody/tree/test/joint_actuator_test.cc
+++ b/multibody/tree/test/joint_actuator_test.cc
@@ -56,7 +56,7 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
           Eigen::Vector3d(0, 0, 1)));
   DRAKE_EXPECT_THROWS_MESSAGE(
       tree.AddJointActuator("act2", body2_body1, kNegativeEffortLimit),
-      "Effort limit must be strictly positive!");
+      ".*effort limit.*positive.*");
 
   // Throw if the effort limit is set to be negative.
   const Joint<double>& body3_body2 =
@@ -65,7 +65,7 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
           Eigen::Vector3d(0, 0, 1)));
   DRAKE_EXPECT_THROWS_MESSAGE(
       tree.AddJointActuator("act3", body3_body2, kZeroEffortLimit),
-      "Effort limit must be strictly positive!");
+      ".*effort limit.*positive.*");
 
   EXPECT_EQ(actuator1.input_start(), 0);  // First & only actuated dof.
   EXPECT_EQ(actuator1.num_inputs(), 1);   // Prismatic is 1 dof.
@@ -78,6 +78,8 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
 
   const auto& actuator4 =
       tree.AddJointActuator("act4", body4_world, kPositiveEffortLimit);
+  tree.get_mutable_joint_actuator(actuator4.index()).set_effort_limit(22.0);
+  EXPECT_EQ(actuator4.effort_limit(), 22.0);
 
   tree.Finalize();
 


### PR DESCRIPTION
Add MbP::RemoveAllJointActuatorEffortLimits.

These are prerequisites to enabling unconditional enforcement of effort limits (#24110).  Users who don't want the effort limits enforced will need to set them to infinity, but previously had no way to do so.

Closes #16179.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24108)
<!-- Reviewable:end -->
