### PR TITLE
[multibody] Add caching for actuation-related plant input ports

### DIFF
--- a/multibody/plant/compliant_contact_manager.cc
+++ b/multibody/plant/compliant_contact_manager.cc
@@ -347,7 +347,7 @@ void CompliantContactManager<T>::DoCalcActuation(
   if (plant().get_discrete_contact_solver() == DiscreteContactSolver::kTamsi) {
     DRAKE_DEMAND(tamsi_driver_ != nullptr);
     // TAMSI does not model additional actuation terms as SAP does.
-    *actuation = this->AssembleActuationInput(context);
+    *actuation = this->EvalActuationInput(context);
   }
 }
 

--- a/multibody/plant/desired_state_input.cc
+++ b/multibody/plant/desired_state_input.cc
@@ -28,6 +28,14 @@ void DesiredStateInput<T>::SetModelInstanceDesiredStates(
   velocities_[model_instance] = vd;
 }
 
+template <typename T>
+void DesiredStateInput<T>::ClearModelInstanceDesiredStates(
+    ModelInstanceIndex model_instance) {
+  DRAKE_DEMAND(model_instance < num_model_instances());
+  positions_[model_instance] = std::nullopt;
+  velocities_[model_instance] = std::nullopt;
+}
+
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/desired_state_input.h
+++ b/multibody/plant/desired_state_input.h
@@ -18,7 +18,7 @@ namespace internal {
  SetModelInstanceDesiredStates(). Model instances with desired states are marked
  as "armed", see is_armed().
 
- This class is the result of MultibodyPlant::AssembleDesiredStateInput().
+ This class is the result of MultibodyPlant::EvalDesiredStateInput().
  See also @ref pd_controllers_and_ports for further details.
 
  @tparam_default_scalar */
@@ -39,12 +39,18 @@ class DesiredStateInput {
    model instance will return `true`.
    @pre model_instance < num_model_instances()
    @pre qd and vd have size equal to the number of actuators in
-   `model_instance`. MultibodyPlant::AssembleDesiredStateInput() will evaluate
-   the desired state input state ports for each model instance and store the
-   result for each model instance in a DesiredStateInput. */
+   `model_instance`. MultibodyPlant::EvalDesiredStateInput() will evaluate the
+   desired state input state ports for each model instance and store the result
+   for each model instance in a DesiredStateInput. */
   void SetModelInstanceDesiredStates(ModelInstanceIndex model_instance,
                                      const Eigen::Ref<const VectorX<T>>& qd,
                                      const Eigen::Ref<const VectorX<T>>& vd);
+
+  /* Removes `this` class's storage of the desired positions and velocities for
+   for the given `model_instance`. Subsequent calls to is_armed() for the given
+   model instance will return `false`.
+   @pre model_instance < num_model_instances() */
+  void ClearModelInstanceDesiredStates(ModelInstanceIndex model_instance);
 
   /* Returns `true` if `model_instance` is armed.
    @pre model_instance < num_model_instances() */

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -273,17 +273,17 @@ DiscreteUpdateManager<T>::EvalJointLocking(
 }
 
 template <typename T>
-VectorX<T> DiscreteUpdateManager<T>::AssembleActuationInput(
+const VectorX<T>& DiscreteUpdateManager<T>::EvalActuationInput(
     const systems::Context<T>& context) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::AssembleActuationInput(
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalActuationInput(
       plant(), context);
 }
 
 template <typename T>
-DesiredStateInput<T> DiscreteUpdateManager<T>::AssembleDesiredStateInput(
+const DesiredStateInput<T>& DiscreteUpdateManager<T>::EvalDesiredStateInput(
     const systems::Context<T>& context) const {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<
-      T>::AssembleDesiredStateInput(plant(), context);
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalDesiredStateInput(
+      plant(), context);
 }
 
 template <typename T>
@@ -341,7 +341,7 @@ void DiscreteUpdateManager<T>::CalcJointActuationForces(
   actuation_w_pd->setZero();
   actuation_wo_pd->setZero();
   if (plant().num_actuators() > 0) {
-    const VectorX<T> u = AssembleActuationInput(context);
+    const VectorX<T>& u = EvalActuationInput(context);
     for (JointActuatorIndex actuator_index :
          plant().GetJointActuatorIndices()) {
       const JointActuator<T>& actuator =

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -313,9 +313,10 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   const internal::JointLockingCacheData<T>& EvalJointLocking(
       const systems::Context<T>& context) const;
 
-  VectorX<T> AssembleActuationInput(const systems::Context<T>& context) const;
+  const VectorX<T>& EvalActuationInput(
+      const systems::Context<T>& context) const;
 
-  DesiredStateInput<T> AssembleDesiredStateInput(
+  const DesiredStateInput<T>& EvalDesiredStateInput(
       const systems::Context<T>& context) const;
 
   const std::map<MultibodyConstraintId, internal::CouplerConstraintSpec>&

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -66,26 +66,20 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     plant.AddAppliedExternalSpatialForces(context, forces);
   }
 
-  static void AddJointActuationForces(const MultibodyPlant<T>& plant,
-                                      const drake::systems::Context<T>& context,
-                                      VectorX<T>* forces) {
-    plant.AddJointActuationForces(context, forces);
-  }
-
   static void CalcForceElementsContribution(
       const MultibodyPlant<T>& plant, const drake::systems::Context<T>& context,
       MultibodyForces<T>* forces) {
     return plant.CalcForceElementsContribution(context, forces);
   }
 
-  static VectorX<T> AssembleActuationInput(const MultibodyPlant<T>& plant,
-                                           const systems::Context<T>& context) {
-    return plant.AssembleActuationInput(context);
+  static const VectorX<T>& EvalActuationInput(
+      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
+    return plant.EvalActuationInput(context);
   }
 
-  static DesiredStateInput<T> AssembleDesiredStateInput(
+  static const DesiredStateInput<T>& EvalDesiredStateInput(
       const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
-    return plant.AssembleDesiredStateInput(context);
+    return plant.EvalDesiredStateInput(context);
   }
 
   // TODO(xuchenhan-tri): Remove this when SceneGraph takes control of all

--- a/multibody/plant/sap_driver.cc
+++ b/multibody/plant/sap_driver.cc
@@ -725,12 +725,10 @@ void SapDriver<T>::AddPdControllerConstraints(
   // Do nothing if not PD controllers were specified.
   if (plant().num_actuators() == 0) return;
 
-  // TODO(amcastro-tri): makes these EvalFoo() instead to avoid heap
-  // allocations.
-  const DesiredStateInput<T> desired_states =
-      manager_->AssembleDesiredStateInput(context);
-  const VectorX<T> feed_forward_actuation =
-      manager_->AssembleActuationInput(context);
+  const DesiredStateInput<T>& desired_states =
+      manager_->EvalDesiredStateInput(context);
+  const VectorX<T>& feed_forward_actuation =
+      manager_->EvalActuationInput(context);
 
   const SpanningForest& forest = get_forest();
   for (ModelInstanceIndex model_instance_index(0);
@@ -1233,7 +1231,7 @@ void SapDriver<T>::CalcActuation(const systems::Context<T>& context,
   // PD controlled actuation values are overwritten below with values computed
   // by the SAP solver, which includes these terms implicitly and enforces
   // effort limits.
-  *actuation = manager().AssembleActuationInput(context);
+  *actuation = manager().EvalActuationInput(context);
 
   // Add contribution from PD controllers.
   const ContactProblemCache<T>& contact_problem_cache =

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -192,9 +192,8 @@ GTEST_TEST(MultibodyPlantForwardDynamics, AtlasRobot) {
     // CalcTimeDerivatives should not be allocating, but for now we have a few
     // remaining fixes before it's down to zero:
     //  2 temps in MbTS::CalcArticulatedBodyForceCache (F_B_W_, tau_).
-    //  1 temp  in MbP::AssembleActuationInput (actuation_input).
     //  2 temps in MbTS::DoCalcTimeDerivatives (xdot, qdot).
-    LimitMalloc guard({.max_num_allocations = 5});
+    LimitMalloc guard({.max_num_allocations = 4});
     EXPECT_NO_THROW(plant.CalcTimeDerivatives(*context, derivatives.get()));
   }
 


### PR DESCRIPTION
This resolves several TODOs and paves the way for future changes that will add effort limit clamping (#24110).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24111)
<!-- Reviewable:end -->
