### PR TITLE
[multibody] Clarify a gap in coupler constraint support

### DIFF
--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -392,8 +392,8 @@ void IcfBuilder<T>::SetCouplerConstraints(const systems::Context<T>& context,
     const int clique1 = tree_to_clique(tree1);
 
     if (clique0 != clique1) {
-      // TODO(#23992): this limitation is contested. It should either be
-      // removed, or escalated to MultibodyPlant.
+      // TODO(#23992): this limitation is a regression from SAP coupler
+      // constraints. It should be removed.
       throw std::logic_error(
           "IcfBuilder: Couplers are only allowed within DoFs in the same "
           "tree.");

--- a/multibody/contact_solvers/icf/test/icf_builder_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_builder_test.cc
@@ -119,9 +119,8 @@ GTEST_TEST(IcfBuilder, Coupler) {
   EXPECT_EQ(pool.gear_ratio()[0], 0.8);
 }
 
-// TODO(#23992): the limitation checked in this test is contested. Must all
-// coupler constraints live within a single topological tree? If so,
-// MultibodyPlant should to the checking.
+// TODO(#23992): the limitation checked in this test is a regression from SAP
+// coupler constraints.
 GTEST_TEST(IcfBuilder, CouplerBad) {
   systems::DiagramBuilder<double> diagram_builder;
   multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};


### PR DESCRIPTION
Towards #23992.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24112)
<!-- Reviewable:end -->
