### PR TITLE
[tools] Add reference to wheel S3 backups

### DIFF
--- a/tools/release_engineering/dev/README.md
+++ b/tools/release_engineering/dev/README.md
@@ -94,6 +94,10 @@ contains:
     * Binaries: A set of `drake-<version>-[...].tar.gz` files for each supported
     configuration (e.g. jammy, noble, and mac). In addition, there should be
     `.sha256` and `.sha512` files for each `.tar.gz` file.
+    * Wheels: A set of `drake-<version>-[...].whl` files for each supported
+    configuration (Python version and platform; e.g., cp3{10-14}-manylinux and
+    cp3{13-14}-macosx). In addition, there should be `.sha256` and `.sha512`
+    files for each `.whl` file.
     * Source: A `drake-<version>-src.tar.gz` file and corresponding `.sha256`
     and `.sha512` files.
 


### PR DESCRIPTION
Amend #24062. Wheels (and corresponding shasums) are being backed up to S3 for each release starting from v1.50.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24119)
<!-- Reviewable:end -->
