### PR TITLE
[multibody] Split out desired_state_input_test

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -479,6 +479,13 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "desired_state_input_test",
+    deps = [
+        ":desired_state_input",
+    ],
+)
+
+drake_cc_googletest(
     name = "discrete_step_memory_test",
     deps = [
         ":multibody_plant_core",

--- a/multibody/plant/test/actuated_models_test.cc
+++ b/multibody/plant/test/actuated_models_test.cc
@@ -366,34 +366,6 @@ TEST_F(ActuatedIiwaArmTest, GetActuationInputPort) {
       "num_model_instances\\(\\)' failed.");
 }
 
-/* Unit tests internal:: class to store desired states. */
-GTEST_TEST(DesiredStateInput, DesiredStateInputTest) {
-  internal::DesiredStateInput<double> xd(5);
-  const Vector3<double> q1(1.0, 2.0, 3.0);
-  const Vector3<double> v1(4.0, 5.0, 6.0);
-  xd.SetModelInstanceDesiredStates(ModelInstanceIndex(1), q1, v1);
-
-  const Vector2<double> q3(1.0, 2.0);
-  const Vector2<double> v3(3.0, 4.0);
-  xd.SetModelInstanceDesiredStates(ModelInstanceIndex(3), q3, v3);
-
-  EXPECT_EQ(xd.num_model_instances(), 5);
-  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(0)));
-  EXPECT_TRUE(xd.is_armed(ModelInstanceIndex(1)));
-  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(2)));
-  EXPECT_TRUE(xd.is_armed(ModelInstanceIndex(3)));
-  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(4)));
-
-  EXPECT_EQ(xd.positions(ModelInstanceIndex(1)), q1);
-  EXPECT_EQ(xd.velocities(ModelInstanceIndex(1)), v1);
-  EXPECT_EQ(xd.positions(ModelInstanceIndex(3)), q3);
-  EXPECT_EQ(xd.velocities(ModelInstanceIndex(3)), v3);
-
-  xd.ClearModelInstanceDesiredStates(ModelInstanceIndex(1));
-  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(1)));
-  EXPECT_TRUE(xd.is_armed(ModelInstanceIndex(3)));
-}
-
 // We verify basic port size invariants for a model in which only a subset of
 // the arm's actuators are PD controlled.
 TEST_F(ActuatedIiwaArmTest, GetDesiredStatePort) {

--- a/multibody/plant/test/desired_state_input_test.cc
+++ b/multibody/plant/test/desired_state_input_test.cc
@@ -1,0 +1,43 @@
+#include "drake/multibody/plant/desired_state_input.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+
+GTEST_TEST(DesiredStateInputTest, FullApi) {
+  DesiredStateInput<double> xd(/* num_model_instances = */ 5);
+  const Vector3d q1(1.0, 2.0, 3.0);
+  const Vector3d v1(4.0, 5.0, 6.0);
+  xd.SetModelInstanceDesiredStates(ModelInstanceIndex(1), q1, v1);
+
+  const Vector2d q3(1.0, 2.0);
+  const Vector2d v3(3.0, 4.0);
+  xd.SetModelInstanceDesiredStates(ModelInstanceIndex(3), q3, v3);
+
+  EXPECT_EQ(xd.num_model_instances(), 5);
+  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(0)));
+  EXPECT_TRUE(xd.is_armed(ModelInstanceIndex(1)));
+  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(2)));
+  EXPECT_TRUE(xd.is_armed(ModelInstanceIndex(3)));
+  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(4)));
+
+  EXPECT_EQ(xd.positions(ModelInstanceIndex(1)), q1);
+  EXPECT_EQ(xd.velocities(ModelInstanceIndex(1)), v1);
+  EXPECT_EQ(xd.positions(ModelInstanceIndex(3)), q3);
+  EXPECT_EQ(xd.velocities(ModelInstanceIndex(3)), v3);
+
+  xd.ClearModelInstanceDesiredStates(ModelInstanceIndex(1));
+  EXPECT_FALSE(xd.is_armed(ModelInstanceIndex(1)));
+  EXPECT_TRUE(xd.is_armed(ModelInstanceIndex(3)));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
The class is in its own file with its own build label. Its unit test should stand alone, too.

Towards #24107.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24120)
<!-- Reviewable:end -->
