### PR TITLE
[build] Apply isystem includes to externals from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,6 +429,11 @@ macro(override_module NAME)
     "${PROJECT_SOURCE_DIR}/cmake/external/workspace/conversion.bzl"
     "${local_path}/conversion.bzl"
     SYMBOLIC)
+  file(CREATE_LINK
+    "${PROJECT_SOURCE_DIR}/tools/skylark/cc.bzl"
+    "${local_path}/cc.bzl"
+    SYMBOLIC
+  )
   string(APPEND BAZEL_REPO_ENV
       " --override_module=${NAME}=${local_path}")
   string(APPEND BAZEL_REPO_ENV

--- a/cmake/external/workspace/eigen/BUILD.bazel.in
+++ b/cmake/external/workspace/eigen/BUILD.bazel.in
@@ -1,6 +1,6 @@
 # -*- bazel -*-
 
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(":cc.bzl", "cc_library")
 load(":conversion.bzl", "split_cmake_list")
 
 EIGEN_DEFINES = split_cmake_list(
@@ -18,5 +18,6 @@ cc_library(
     ),
     defines = EIGEN_DEFINES,
     includes = ["include"],
+    isystem = True,
     visibility = ["//visibility:public"],
 )

--- a/cmake/external/workspace/fmt/BUILD.bazel.in
+++ b/cmake/external/workspace/fmt/BUILD.bazel.in
@@ -1,6 +1,6 @@
 # -*- bazel -*-
 
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(":cc.bzl", "cc_library")
 load(":conversion.bzl", "split_cmake_list")
 
 _DEFINES = split_cmake_list(
@@ -19,5 +19,6 @@ cc_library(
     ),
     defines = _DEFINES,
     includes = ["include"],
+    isystem = True,
     visibility = ["//visibility:public"],
 )

--- a/cmake/external/workspace/glib/BUILD.bazel.in
+++ b/cmake/external/workspace/glib/BUILD.bazel.in
@@ -1,6 +1,6 @@
 # -*- bazel -*-
 
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(":cc.bzl", "cc_library")
 
 cc_library(
     name = "glib",
@@ -16,5 +16,6 @@ cc_library(
         allow_empty = False,
     ),
     includes = ["include"],
+    isystem = True,
     visibility = ["//visibility:public"],
 )

--- a/cmake/external/workspace/spdlog/BUILD.bazel.in
+++ b/cmake/external/workspace/spdlog/BUILD.bazel.in
@@ -1,7 +1,7 @@
 # -*- bazel -*-
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(":cc.bzl", "cc_library")
 load(":conversion.bzl", "split_cmake_list")
 
 _DEFINES = split_cmake_list(
@@ -21,6 +21,7 @@ cc_library(
     ),
     defines = _DEFINES,
     includes = ["include"],
+    isystem = True,
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
     deps = ["@fmt"],

--- a/cmake/external/workspace/zlib/BUILD.bazel.in
+++ b/cmake/external/workspace/zlib/BUILD.bazel.in
@@ -1,6 +1,6 @@
 # -*- bazel -*-
 
-load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(":cc.bzl", "cc_library")
 load(":conversion.bzl", "split_cmake_list")
 
 _DEFINES = split_cmake_list(
@@ -19,5 +19,6 @@ cc_library(
     ],
     defines = _DEFINES,
     includes = ["include"],
+    isystem = True,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Apply the changes from #23723 to the CMake builds also by changing the user-provided externals to use Drake's cc_library wrapper.

Towards #24128.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24130)
<!-- Reviewable:end -->
