### PR TITLE
Configure Renovate to update all CMake external MODULE files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
   ],
   "bazel-module": {
     "managerFilePatterns": [
-      "cmake/MODULE.bazel.in"
+      "/^cmake/.*/?MODULE\\.bazel\\.in$/"
     ]
   },
   "labels": [


### PR DESCRIPTION
We should be keeping our `cmake/external/workspace/**/MODULE.bazel.in` files up-to-date, too.

(Found while working on #24130.)

## Testing

See https://github.com/tyler-yankee/drake-renovate-clone/commit/bfa7900a1d7bac37bc46df974886284840651ed0 for the change on my test repo, and tyler-yankee/drake-renovate-clone#3 and tyler-yankee/drake-renovate-clone#4 for the resulting changes triggered by Renovate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24131)
<!-- Reviewable:end -->
