### PR TITLE
Deprecate `operator<<` for `SolverId` and `MixedIntegerRotationConstraintGenerator::Approach`

### DIFF
--- a/solvers/mixed_integer_rotation_constraint.cc
+++ b/solvers/mixed_integer_rotation_constraint.cc
@@ -816,7 +816,8 @@ void ComputeBoxSphereIntersectionAndHalfSpace(
 
 }  // namespace
 
-std::string to_string(MixedIntegerRotationConstraintGenerator::Approach type) {
+std::string to_string(
+    const MixedIntegerRotationConstraintGenerator::Approach& type) {
   switch (type) {
     case MixedIntegerRotationConstraintGenerator::Approach::
         kBoxSphereIntersection: {
@@ -838,8 +839,7 @@ std::string to_string(MixedIntegerRotationConstraintGenerator::Approach type) {
 std::ostream& operator<<(
     std::ostream& os,
     const MixedIntegerRotationConstraintGenerator::Approach& type) {
-  os << to_string(type);
-  return os;
+  return os << fmt::to_string(type);
 }
 
 MixedIntegerRotationConstraintGenerator::

--- a/solvers/mixed_integer_rotation_constraint.h
+++ b/solvers/mixed_integer_rotation_constraint.h
@@ -6,7 +6,8 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mixed_integer_optimization_util.h"
 
@@ -160,8 +161,13 @@ class MixedIntegerRotationConstraintGenerator {
       box_sphere_intersection_halfspace_;
 };
 
-std::string to_string(MixedIntegerRotationConstraintGenerator::Approach type);
+std::string to_string(
+    const MixedIntegerRotationConstraintGenerator::Approach& type);
 
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(
     std::ostream& os,
     const MixedIntegerRotationConstraintGenerator::Approach& type);
@@ -233,10 +239,6 @@ AddRotationMatrixBoxSphereIntersectionMilpConstraints(
 }  // namespace solvers
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<
-    drake::solvers::MixedIntegerRotationConstraintGenerator::Approach>
-    : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::solvers,
+                   MixedIntegerRotationConstraintGenerator::Approach, x,
+                   drake::solvers::to_string(x))

--- a/solvers/solver_id.cc
+++ b/solvers/solver_id.cc
@@ -37,9 +37,12 @@ bool operator!=(const SolverId& a, const SolverId& b) {
 }
 
 std::ostream& operator<<(std::ostream& os, const SolverId& self) {
+  return os << fmt::to_string(self);
+}
+
+std::string to_string(const SolverId& self) {
   // N.B. The ID is _not_ exposed to callers.
-  os << self.name();
-  return os;
+  return self.name();
 }
 
 }  // namespace solvers

--- a/solvers/solver_id.h
+++ b/solvers/solver_id.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <functional>
-#include <ostream>
 #include <string>
 
+// TODO(2026-06-01): Remove ostream header when `operator<<` is removed.
+#include <ostream>
+
 #include "drake/common/drake_copyable.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/fmt.h"
 #include "drake/common/hash.h"
 #include "drake/common/reset_after_move.h"
 
@@ -55,7 +58,14 @@ class SolverId {
 
 bool operator==(const SolverId&, const SolverId&);
 bool operator!=(const SolverId&, const SolverId&);
+
+DRAKE_DEPRECATED(
+    "2026-06-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream&, const SolverId&);
+
+std::string to_string(const SolverId&);
 
 }  // namespace solvers
 }  // namespace drake
@@ -74,8 +84,4 @@ template <>
 struct hash<drake::solvers::SolverId> : public drake::DefaultHash {};
 }  // namespace std
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <>
-struct formatter<drake::solvers::SolverId> : drake::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::solvers, SolverId, x, drake::solvers::to_string(x))

--- a/solvers/test/solver_id_test.cc
+++ b/solvers/test/solver_id_test.cc
@@ -59,6 +59,10 @@ GTEST_TEST(SolverId, WarningForVeryLongName) {
   SolverId foo{"this_solver_name_is_way_too_long"};
 }
 
+GTEST_TEST(SolverId, ToStringFmtFormatter) {
+  EXPECT_EQ(fmt::to_string(SolverId{"bar"}), "bar");
+}
+
 }  // namespace
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). For review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24132)
<!-- Reviewable:end -->
