### PR TITLE
[build] Remove Werror=old-style-cast

### DIFF
--- a/common/symbolic/expression/formula.h
+++ b/common/symbolic/expression/formula.h
@@ -539,13 +539,10 @@ struct RelationalOpTraits {
   static constexpr int Cols = Eigen::internal::min_size_prefer_fixed(
       DerivedA::ColsAtCompileTime, DerivedB::ColsAtCompileTime);
 #else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
   static constexpr int Rows = EIGEN_SIZE_MIN_PREFER_FIXED(
       (DerivedA::RowsAtCompileTime), (DerivedB::RowsAtCompileTime));
   static constexpr int Cols = EIGEN_SIZE_MIN_PREFER_FIXED(
       (DerivedA::ColsAtCompileTime), (DerivedB::ColsAtCompileTime));
-#pragma GCC diagnostic pop
 #endif  // EIGEN_VERSION_AT_LEAST
   using ReturnType = Eigen::Array<Formula, Rows, Cols>;
 };

--- a/common/test/hwy_dynamic_test.cc
+++ b/common/test/hwy_dynamic_test.cc
@@ -1,16 +1,13 @@
+#include "drake/common/hwy_dynamic.h"
+
 #include <string>
 #include <utility>
 
+#include "hwy/tests/hwy_gtest.h"
 #include <Eigen/Dense>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#include "hwy/tests/hwy_gtest.h"
-#pragma GCC diagnostic pop
-
-#include "drake/common/hwy_dynamic.h"
 #include "drake/common/test/hwy_dynamic_test_array_mul.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 

--- a/common/test/hwy_dynamic_test_array_mul.cc
+++ b/common/test/hwy_dynamic_test_array_mul.cc
@@ -5,11 +5,8 @@
 // This is the magic juju that compiles our impl functions for multiple CPUs.
 #undef HWY_TARGET_INCLUDE
 #define HWY_TARGET_INCLUDE "common/test/hwy_dynamic_test_array_mul.cc"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include "hwy/foreach_target.h"
 #include "hwy/highway.h"
-#pragma GCC diagnostic pop
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/hwy_dynamic_impl.h"

--- a/geometry/proximity/boxes_overlap.cc
+++ b/geometry/proximity/boxes_overlap.cc
@@ -3,11 +3,8 @@
 // This is the magic juju that compiles our impl functions for multiple CPUs.
 #undef HWY_TARGET_INCLUDE
 #define HWY_TARGET_INCLUDE "geometry/proximity/boxes_overlap.cc"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include "hwy/foreach_target.h"
 #include "hwy/highway.h"
-#pragma GCC diagnostic pop
 
 #include "drake/common/hwy_dynamic_impl.h"
 

--- a/geometry/proximity/test/boxes_overlap_test.cc
+++ b/geometry/proximity/test/boxes_overlap_test.cc
@@ -3,11 +3,7 @@
 #include <memory>
 #include <string>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include "hwy/tests/hwy_gtest.h"
-#pragma GCC diagnostic pop
-
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/math/fast_pose_composition_functions.cc
+++ b/math/fast_pose_composition_functions.cc
@@ -8,11 +8,8 @@
 // This is the magic juju that compiles our impl functions for multiple CPUs.
 #undef HWY_TARGET_INCLUDE
 #define HWY_TARGET_INCLUDE "math/fast_pose_composition_functions.cc"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include "hwy/foreach_target.h"
 #include "hwy/highway.h"
-#pragma GCC diagnostic pop
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/hwy_dynamic_impl.h"

--- a/math/test/fast_pose_composition_functions_test.cc
+++ b/math/test/fast_pose_composition_functions_test.cc
@@ -3,11 +3,7 @@
 #include <string>
 #include <tuple>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include "hwy/tests/hwy_gtest.h"
-#pragma GCC diagnostic pop
-
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 

--- a/multibody/benchmarks/chaotic_babyboot/MG/BUILD.bazel
+++ b/multibody/benchmarks/chaotic_babyboot/MG/BUILD.bazel
@@ -21,7 +21,6 @@ drake_cc_library(
         "MG_chaotic_babyboot_auto_generated.h",
     ],
     copts = [
-        "-Wno-old-style-cast",
         "-Wno-unused-parameter",
     ],
     deps = [

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -24,7 +24,6 @@ CXX_FLAGS = [
     "-Werror=deprecated-declarations",
     "-Werror=ignored-qualifiers",
     "-Werror=missing-declarations",
-    "-Werror=old-style-cast",
     "-Werror=overloaded-virtual",
     "-Werror=shadow",
     "-Werror=unused-result",


### PR DESCRIPTION
`cpplint` will still flag violations of this on first-party Drake code (`readability/casting`); meanwhile, the compiler no longer flags violations in Drake dependencies.

Towards #24128.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24138)
<!-- Reviewable:end -->
