### PR TITLE
[lcm] Remove use of glib

### DIFF
--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -90,7 +90,6 @@ drake_cc_library(
         "//tools/workspace/lcm_internal:flag_with_lcm_runtime_true": [
             "//common:network_policy",
             "//tools/workspace/lcm_internal:shared_library",
-            "@glib//glib",
         ],
         "//conditions:default": [],
     }),

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -6,7 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include <glib.h>
 #include <lcm/lcm.h>
 
 #include "drake/common/drake_assert.h"
@@ -135,11 +134,33 @@ namespace {
 
 // Given a literal string, escape it to be safe to use in an LCM channel regex.
 // For example ".foo" should be escaped to "\.foo" so that it only matches the
-// exact literal string, not "xfoo".
+// exact literal string, not "xfoo". LCM uses the PCRE regex syntax, which
+// states that any non-alpha-numeric character may be escaped to mean its
+// literal value by prefixing a backslash before the character:
+// https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions#Consistent_escaping_rules
 std::string ConvertLiteralStringToLcmRegex(const std::string& literal) {
-  char* const result_cstr = g_regex_escape_string(literal.c_str(), -1);
-  const std::string result{result_cstr};
-  g_free(result_cstr);
+  std::string result;
+  for (size_t i = 0; i < literal.size(); /* step size varies */) {
+    const int8_t ch = literal[i];
+    // Alpha-numeric characters should not be escaped -- escaping them could
+    // actually give them a special meaning.
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') ||
+        (ch >= '0' && ch <= '9')) {
+      result.push_back(literal[i++]);
+      continue;
+    }
+    // Everything else can be safely escaped, but if it's a multi-byte UTF-8
+    // codepoint then we need to be sure to escape the codepoint, not each
+    // individual byte.
+    result.push_back('\\');
+    const int num_bytes = (ch & 0b10000000) == 0            ? 1
+                          : (ch & 0b11100000) == 0b11000000 ? 2
+                          : (ch & 0b11110000) == 0b11100000 ? 3
+                                                            : 4;
+    for (int j = 0; j < num_bytes; ++j) {
+      result.push_back(literal[i++]);
+    }
+  }
   return result;
 }
 

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -216,10 +216,11 @@ TEST_F(DrakeLcmTest, SubscribeAllTest2) {
   EXPECT_EQ(total, 1);
 }
 
-// Tests DrakeLcm's round-trip ability using DrakeLcmInterface's sugar,
-// without any native LCM APIs.
+// Tests DrakeLcm's round-trip ability using DrakeLcmInterface's sugar, without
+// any native LCM APIs. Uses a unicode character in the channel name to verify
+// UTF-8 compatibility.
 TEST_F(DrakeLcmTest, AcceptanceTest) {
-  const std::string channel_name = "DrakeLcmTest.AcceptanceTest";
+  const std::string channel_name = "DrakeLcmTest☃AcceptanceTest";
   Subscriber<lcmt_drake_signal> subscriber(dut_.get(), channel_name);
   LoopUntilDone(&subscriber.message(), 20 /* retries */, [&]() {
     Publish(dut_.get(), channel_name, message_);


### PR DESCRIPTION
Linking glib properly in all build configurations is a tall hill to climb. Instead, we can replace the one function we need by hand.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24171)
<!-- Reviewable:end -->
