### PR TITLE
[multibody] Add weld constraint to ICF solver

### DIFF
--- a/bindings/generated_docstrings/multibody_contact_solvers_icf.h
+++ b/bindings/generated_docstrings/multibody_contact_solvers_icf.h
@@ -29,6 +29,8 @@
 // #include "drake/multibody/contact_solvers/icf/limit_constraints_pool.h"
 // #include "drake/multibody/contact_solvers/icf/patch_constraints_data_pool.h"
 // #include "drake/multibody/contact_solvers/icf/patch_constraints_pool.h"
+// #include "drake/multibody/contact_solvers/icf/weld_constraints_data_pool.h"
+// #include "drake/multibody/contact_solvers/icf/weld_constraints_pool.h"
 
 // Symbol: pydrake_doc_multibody_contact_solvers_icf
 constexpr struct /* pydrake_doc_multibody_contact_solvers_icf */ {

--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -1,6 +1,7 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
     "//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
     "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_package_library",
@@ -25,6 +26,7 @@ drake_cc_package_library(
         ":icf_solver_parameters",
         ":limit_constraints_data_pool",
         ":patch_constraints_data_pool",
+        ":weld_constraints_data_pool",
     ],
 )
 
@@ -82,6 +84,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "weld_constraints_data_pool",
+    srcs = ["weld_constraints_data_pool.cc"],
+    hdrs = ["weld_constraints_data_pool.h"],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "icf_search_direction_data",
     hdrs = ["icf_search_direction_data.h"],
     deps = [
@@ -101,6 +113,7 @@ drake_cc_library(
         ":gain_constraints_data_pool",
         ":limit_constraints_data_pool",
         ":patch_constraints_data_pool",
+        ":weld_constraints_data_pool",
         "//common:essential",
     ],
 )
@@ -116,6 +129,7 @@ drake_cc_library(
         "//multibody/plant",
     ],
     implementation_deps = [
+        "//math:geometric_transform",
         "//multibody/plant:contact_properties",
     ],
 )
@@ -170,6 +184,7 @@ drake_cc_library(
         "icf_model.cc",
         "limit_constraints_pool.cc",
         "patch_constraints_pool.cc",
+        "weld_constraints_pool.cc",
     ],
     hdrs = [
         "coupler_constraints_pool.h",
@@ -177,6 +192,7 @@ drake_cc_library(
         "icf_model.h",
         "limit_constraints_pool.h",
         "patch_constraints_pool.h",
+        "weld_constraints_pool.h",
     ],
     deps = [
         ":coupler_constraints_data_pool",
@@ -184,8 +200,11 @@ drake_cc_library(
         ":icf_data",
         ":icf_search_direction_data",
         ":limit_constraints_data_pool",
+        ":weld_constraints_data_pool",
         "//common:default_scalars",
         "//common:essential",
+        "//math:geometric_transform",
+        "//math:vector3_util",
         "//multibody/contact_solvers:block_sparse_lower_triangular_or_symmetric_matrix",  # noqa
     ],
 )
@@ -260,6 +279,29 @@ drake_cc_googletest(
         "//common/test_utilities:limit_malloc",
         "//multibody/parsing:parser",
         "//multibody/plant:contact_properties",
+        "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
+    name = "weld_constraints_pool_test",
+    deps = [
+        ":icf_data",
+        ":icf_model",
+        ":icf_search_direction_data",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "weld_constraint_init_and_sim_test",
+    deps = [
+        "//multibody/cenic:cenic_integrator",
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//multibody/plant:multibody_plant_config_functions",
+        "//systems/analysis:simulator",
         "//systems/framework:diagram_builder",
     ],
 )

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -4,10 +4,12 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "drake/geometry/scene_graph_config.h"
 #include "drake/geometry/scene_graph_inspector.h"
+#include "drake/math/rotation_matrix.h"
 #include "drake/multibody/plant/contact_properties.h"
 #include "drake/multibody/plant/multibody_plant_icf_attorney.h"
 #include "drake/multibody/topology/graph.h"
@@ -22,6 +24,7 @@ using drake::multibody::internal::GetPointContactStiffness;
 using drake::multibody::internal::LinkJointGraph;
 using drake::multibody::internal::SpanningForest;
 using drake::multibody::internal::TreeIndex;
+using drake::multibody::internal::WeldConstraintSpec;
 
 namespace drake {
 namespace multibody {
@@ -212,6 +215,10 @@ void IcfBuilder<T>::UpdateModel(
   AllocateCouplerConstraints(model);
   SetCouplerConstraints(context, model);
 
+  // Weld constraints
+  AllocateWeldConstraints(model);
+  SetWeldConstraints(context, model);
+
   // Limit constraints
   AllocateLimitConstraints(model);
   SetLimitConstraints(context, model);
@@ -276,14 +283,15 @@ void IcfBuilder<T>::ValidatePlant() {
 
   // Revisit this condition as constraints are implemented. See issues #23759,
   // #23760, #23762, #23763.
-  if (plant_.num_constraints() - plant_.num_coupler_constraints() > 0) {
+  if (plant_.num_constraints() - plant_.num_coupler_constraints() -
+          plant_.num_weld_constraints() >
+      0) {
     throw std::logic_error(fmt::format(
         "The CENIC integrator does not yet support some constraints, but "
         "they are present in the given MultibodyPlant: {} distance "
-        "constraint(s), {} ball constraint(s), {} weld constraint(s), {} "
-        "tendon constraint(s)",
+        "constraint(s), {} ball constraint(s), {} tendon constraint(s)",
         plant_.num_distance_constraints(), plant_.num_ball_constraints(),
-        plant_.num_weld_constraints(), plant_.num_tendon_constraints()));
+        plant_.num_tendon_constraints()));
   }
 }
 
@@ -412,6 +420,87 @@ void IcfBuilder<T>::SetCouplerConstraints(const systems::Context<T>& context,
 
     couplers.Set(index, clique0, tree_dof0, tree_dof1, q0, q1, spec.gear_ratio,
                  spec.offset);
+    ++index;
+  }
+}
+
+template <typename T>
+void IcfBuilder<T>::AllocateWeldConstraints(IcfModel<T>* model) const {
+  DRAKE_ASSERT(model != nullptr);
+  const std::map<MultibodyConstraintId, WeldConstraintSpec>& specs_map =
+      plant_.get_weld_constraint_specs();
+  WeldConstraintsPool<T>& welds = model->weld_constraints_pool();
+  welds.Resize(specs_map.size());
+}
+
+template <typename T>
+void IcfBuilder<T>::SetWeldConstraints(const systems::Context<T>& context,
+                                       IcfModel<T>* model) const {
+  DRAKE_ASSERT(model != nullptr);
+  using drake::math::RigidTransform;
+  using drake::math::RotationMatrix;
+
+  const std::map<MultibodyConstraintId, WeldConstraintSpec>& specs_map =
+      plant_.get_weld_constraint_specs();
+
+  WeldConstraintsPool<T>& welds = model->weld_constraints_pool();
+
+  int index = 0;
+  for (const auto& [id, spec] : specs_map) {
+    const RigidBody<T>& body_A = plant_.get_body(spec.body_A);
+    const RigidBody<T>& body_B = plant_.get_body(spec.body_B);
+
+    // By convention in the ICF weld constraint pool, body B must not be
+    // anchored. If body A is anchored, that's fine.
+    const bool A_anchored = plant_.IsAnchored(body_A);
+    const bool B_anchored = plant_.IsAnchored(body_B);
+
+    // TODO(sherm1): Move this exception up to the plant level so
+    //  that it fails as fast as possible. Currently, the earliest this can
+    //  happen is in MbP::Finalize() after the topology has been finalized.
+    //  Note that there are lots of other potential redundancies (like adding
+    //  a weld constraint to bodies connected already by a weld joint) and
+    //  decide whether we need to do anything about them.
+    if (A_anchored && B_anchored) {
+      const std::string msg = fmt::format(
+          "Creating a weld constraint between bodies '{}' and '{}' where "
+          "both are welded to the world is not allowed.",
+          body_A.name(), body_B.name());
+      throw std::logic_error(msg);
+    }
+
+    // If B is anchored but A is not, swap roles so that the "B" body in the
+    // pool is always the dynamic one.
+    const RigidBody<T>& pool_bodyA = B_anchored ? body_B : body_A;
+    const RigidBody<T>& pool_bodyB = B_anchored ? body_A : body_B;
+    const auto& X_AP_spec = B_anchored ? spec.X_BQ : spec.X_AP;
+    const auto& X_BQ_spec = B_anchored ? spec.X_AP : spec.X_BQ;
+
+    const RigidTransform<T>& X_WA = pool_bodyA.EvalPoseInWorld(context);
+    const RigidTransform<T>& X_WB = pool_bodyB.EvalPoseInWorld(context);
+
+    // Constraint frame poses in world.
+    const RigidTransform<T> X_WP = X_WA * X_AP_spec.template cast<T>();
+    const RigidTransform<T> X_WQ = X_WB * X_BQ_spec.template cast<T>();
+
+    // Positions of P in A and Q in B, expressed in world.
+    const Vector3<T> p_AP_W =
+        X_WA.rotation() * X_AP_spec.translation().template cast<T>();
+    const Vector3<T> p_BQ_W =
+        X_WB.rotation() * X_BQ_spec.translation().template cast<T>();
+
+    // Relative translation p_PoQo in world.
+    const Vector3<T> p_PoQo_W = X_WQ.translation() - X_WP.translation();
+
+    // Relative rotation as Euler vector a_PQ = θ⋅k, expressed in world.
+    const Eigen::AngleAxis<T> aa_PQ =
+        X_WP.rotation().InvertAndCompose(X_WQ.rotation()).ToAngleAxis();
+    // a_PQ has the same components when expressed in P or Q, so we re-express
+    // in world using P's orientation.
+    const Vector3<T> a_PQ_W = X_WP.rotation() * (aa_PQ.angle() * aa_PQ.axis());
+
+    welds.Set(index, pool_bodyA.index(), pool_bodyB.index(), p_AP_W, p_BQ_W,
+              p_PoQo_W, a_PQ_W);
     ++index;
   }
 }

--- a/multibody/contact_solvers/icf/icf_builder.h
+++ b/multibody/contact_solvers/icf/icf_builder.h
@@ -118,6 +118,14 @@ class IcfBuilder {
   void SetCouplerConstraints(const systems::Context<T>& context,
                              IcfModel<T>* model) const;
 
+  /* Resizes the model to accommodate weld constraints. */
+  void AllocateWeldConstraints(IcfModel<T>* model) const;
+
+  /* Sets weld constraints in the model.
+  @pre AllocateWeldConstraints() has already been called. */
+  void SetWeldConstraints(const systems::Context<T>& context,
+                          IcfModel<T>* model) const;
+
   /* Resizes the model to accommodate limit constraints. */
   void AllocateLimitConstraints(IcfModel<T>* model) const;
 

--- a/multibody/contact_solvers/icf/icf_data.cc
+++ b/multibody/contact_solvers/icf/icf_data.cc
@@ -11,7 +11,7 @@ namespace internal {
 template <typename T>
 void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
                                  int max_clique_size, int num_couplers,
-                                 std::span<const int> gain_sizes,
+                                 int num_welds, std::span<const int> gain_sizes,
                                  std::span<const int> limit_sizes,
                                  std::span<const int> patch_sizes) {
   Av_minus_r.Resize(1, num_velocities, 1);
@@ -27,6 +27,7 @@ void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
   gain_constraints_data.Resize(gain_sizes);
   limit_constraints_data.Resize(limit_sizes);
   patch_constraints_data.Resize(patch_sizes);
+  weld_constraints_data.Resize(num_welds);
 
   H_cc_pool.Resize(1, max_clique_size, max_clique_size);
 
@@ -43,7 +44,8 @@ IcfData<T>::~IcfData() = default;
 
 template <typename T>
 void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
-                        int num_couplers, std::span<const int> gain_sizes,
+                        int num_couplers, int num_welds,
+                        std::span<const int> gain_sizes,
                         std::span<const int> limit_sizes,
                         std::span<const int> patch_sizes) {
   v_.resize(num_velocities);
@@ -54,8 +56,9 @@ void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
   gain_constraints_data_.Resize(gain_sizes);
   limit_constraints_data_.Resize(limit_sizes);
   patch_constraints_data_.Resize(patch_sizes);
+  weld_constraints_data_.Resize(num_welds);
   scratch_.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-                  gain_sizes, limit_sizes, patch_sizes);
+                  num_welds, gain_sizes, limit_sizes, patch_sizes);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_data.h
+++ b/multibody/contact_solvers/icf/icf_data.h
@@ -8,6 +8,7 @@
 #include "drake/multibody/contact_solvers/icf/gain_constraints_data_pool.h"
 #include "drake/multibody/contact_solvers/icf/limit_constraints_data_pool.h"
 #include "drake/multibody/contact_solvers/icf/patch_constraints_data_pool.h"
+#include "drake/multibody/contact_solvers/icf/weld_constraints_data_pool.h"
 
 namespace drake {
 namespace multibody {
@@ -47,7 +48,8 @@ class IcfData {
   struct Scratch {
     /* Resizes the scratch space, allocating memory as needed. */
     void Resize(int num_bodies, int num_velocities, int max_clique_size,
-                int num_couplers, std::span<const int> gain_sizes,
+                int num_couplers, int num_welds,
+                std::span<const int> gain_sizes,
                 std::span<const int> limit_sizes,
                 std::span<const int> patch_sizes);
 
@@ -78,6 +80,7 @@ class IcfData {
     GainConstraintsDataPool<T> gain_constraints_data;
     LimitConstraintsDataPool<T> limit_constraints_data;
     PatchConstraintsDataPool<T> patch_constraints_data;
+    WeldConstraintsDataPool<T> weld_constraints_data;
 
     // Scratch space for coupler constraints Hessian accumulation. Holds at most
     // one matrix of size max_clique_size() x max_clique_size().
@@ -106,12 +109,16 @@ class IcfData {
   @param num_velocities Total number of generalized velocities.
   @param max_clique_size Maximum number of velocities in any clique.
   @param num_couplers Number of coupler constraints.
+  @param num_welds Number of weld constraints.
   @param gain_sizes Number of velocities for each gain constraint.
   @param limit_sizes Number of velocities for each limit constraint.
   @param patch_sizes Number of contact pairs for each patch constraint, of size
                      equal to the number of patches. */
+  // TODO(sherm1) This argument list will get out of hand as we add more
+  //  constraint types. Consider switching to a parameter struct which would
+  //  let us use named fields at the call sites.
   void Resize(int num_bodies, int num_velocities, int max_clique_size,
-              int num_couplers, std::span<const int> gain_sizes,
+              int num_couplers, int num_welds, std::span<const int> gain_sizes,
               std::span<const int> limit_sizes,
               std::span<const int> patch_sizes);
 
@@ -184,6 +191,14 @@ class IcfData {
     return patch_constraints_data_;
   }
 
+  /* Returns the data pool for weld constraints. */
+  const WeldConstraintsDataPool<T>& weld_constraints_data() const {
+    return weld_constraints_data_;
+  }
+  WeldConstraintsDataPool<T>& mutable_weld_constraints_data() {
+    return weld_constraints_data_;
+  }
+
   /* Returns a mutable scratch space for intermediate computations. We allow
   IcfModel to write on the scratch as needed. */
   Scratch& scratch() const { return scratch_; }
@@ -201,6 +216,7 @@ class IcfData {
   GainConstraintsDataPool<T> gain_constraints_data_;
   LimitConstraintsDataPool<T> limit_constraints_data_;
   PatchConstraintsDataPool<T> patch_constraints_data_;
+  WeldConstraintsDataPool<T> weld_constraints_data_;
 
   mutable Scratch scratch_;
 };

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -18,7 +18,8 @@ IcfModel<T>::IcfModel()
       coupler_constraints_pool_(this),
       gain_constraints_pool_(this),
       limit_constraints_pool_(this),
-      patch_constraints_pool_(this) {}
+      patch_constraints_pool_(this),
+      weld_constraints_pool_(this) {}
 
 template <typename T>
 void IcfModel<T>::ResetParameters(std::unique_ptr<IcfParameters<T>> params) {
@@ -88,6 +89,7 @@ template <typename T>
 void IcfModel<T>::ResizeData(IcfData<T>* data) const {
   data->Resize(num_bodies_, num_velocities_, max_clique_size_,
                coupler_constraints_pool_.num_constraints(),
+               weld_constraints_pool_.num_constraints(),
                gain_constraints_pool_.constraint_sizes(),
                limit_constraints_pool_.constraint_sizes(),
                patch_constraints_pool_.patch_sizes());
@@ -112,6 +114,7 @@ void IcfModel<T>::CalcData(const VectorX<T>& v, IcfData<T>* data) const {
   limit_constraints_pool_.CalcData(v, &data->mutable_limit_constraints_data());
   patch_constraints_pool_.CalcData(V_WB,
                                    &data->mutable_patch_constraints_data());
+  weld_constraints_pool_.CalcData(V_WB, &data->mutable_weld_constraints_data());
 
   // Accumulate gradient contributions from constraints.
   VectorX<T>& gradient = data->mutable_gradient();
@@ -119,13 +122,15 @@ void IcfModel<T>::CalcData(const VectorX<T>& v, IcfData<T>* data) const {
   gain_constraints_pool_.AccumulateGradient(*data, &gradient);
   limit_constraints_pool_.AccumulateGradient(*data, &gradient);
   patch_constraints_pool_.AccumulateGradient(*data, &gradient);
+  weld_constraints_pool_.AccumulateGradient(*data, &gradient);
 
   // Accumulate cost contributions from constraints.
   data->set_cost(data->momentum_cost() +
                  data->coupler_constraints_data().cost() +
                  data->gain_constraints_data().cost() +
                  data->limit_constraints_data().cost() +
-                 data->patch_constraints_data().cost());
+                 data->patch_constraints_data().cost() +
+                 data->weld_constraints_data().cost());
 }
 
 template <typename T>
@@ -154,6 +159,7 @@ void IcfModel<T>::UpdateHessian(
   gain_constraints_pool_.AccumulateHessian(data, hessian);
   limit_constraints_pool_.AccumulateHessian(data, hessian);
   patch_constraints_pool_.AccumulateHessian(data, hessian);
+  weld_constraints_pool_.AccumulateHessian(data, hessian);
 }
 
 template <typename T>
@@ -262,6 +268,24 @@ T IcfModel<T>::CalcCostAlongLine(
     *d2cost_dalpha2 += constraint_d2cost;
   }
 
+  // Add weld constraints contributions:
+  {
+    T constraint_dcost, constraint_d2cost;
+
+    EigenPool<Vector6<T>>& V_WB_alpha = data.scratch().V_WB_alpha;
+    // N.B. V_WB_alpha was already computed above for patch constraints.
+
+    weld_constraints_pool_.CalcData(V_WB_alpha,
+                                    &data.scratch().weld_constraints_data);
+    weld_constraints_pool_.CalcCostAlongLine(
+        data.scratch().weld_constraints_data, search_direction.U,
+        &constraint_dcost, &constraint_d2cost);
+
+    cost += data.scratch().weld_constraints_data.cost();
+    *dcost_dalpha += constraint_dcost;
+    *d2cost_dalpha2 += constraint_d2cost;
+  }
+
   return cost;
 }
 
@@ -281,6 +305,11 @@ void IcfModel<T>::SetSparsityPattern() {
 
   // Build off-diagonal entries in the sparsity pattern.
   patch_constraints_pool_.CalcSparsityPattern(&sparsity);
+  weld_constraints_pool_.CalcSparsityPattern(&sparsity);
+
+  // Precompute the iteration-invariant weld Hessian blocks now that all
+  // constraint data and model parameters are finalized.
+  weld_constraints_pool_.PrecomputeHessianBlocks();
 
   sparsity_pattern_ = std::make_unique<BlockSparsityPattern>(
       std::move(block_sizes), std::move(sparsity));
@@ -306,6 +335,11 @@ void IcfModel<T>::UpdateTimeStep(const T& time_step) {
   r_ = Av0_ - time_step * k0();
 
   params_->time_step = time_step;
+
+  // Weld constraint regularization R depends on the time step.
+  // Recompute Hessian blocks whenever dt changes so
+  // AccumulateHessian() uses up-to-date values.
+  weld_constraints_pool_.PrecomputeHessianBlocks();
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -16,6 +16,7 @@
 #include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
 #include "drake/multibody/contact_solvers/icf/limit_constraints_pool.h"
 #include "drake/multibody/contact_solvers/icf/patch_constraints_pool.h"
+#include "drake/multibody/contact_solvers/icf/weld_constraints_pool.h"
 
 namespace drake {
 namespace multibody {
@@ -143,7 +144,8 @@ class IcfModel {
   /* Returns the total number of constraints of any type in the problem. */
   int num_constraints() const {
     return num_coupler_constraints() + num_gain_constraints() +
-           num_limit_constraints() + num_patch_constraints();
+           num_limit_constraints() + num_patch_constraints() +
+           num_weld_constraints();
   }
 
   /* Provides mutable access to the pool of all coupler constraints. */
@@ -167,6 +169,11 @@ class IcfModel {
     return patch_constraints_pool_;
   }
 
+  /* Provides mutable access to the pool of all weld constraints. */
+  WeldConstraintsPool<T>& weld_constraints_pool() {
+    return weld_constraints_pool_;
+  }
+
   int num_coupler_constraints() const {
     return coupler_constraints_pool_.num_constraints();
   }
@@ -181,6 +188,10 @@ class IcfModel {
 
   int num_patch_constraints() const {
     return patch_constraints_pool_.num_patches();
+  }
+
+  int num_weld_constraints() const {
+    return weld_constraints_pool_.num_constraints();
   }
 
   /* Returns the time step δt. */
@@ -402,6 +413,7 @@ class IcfModel {
   GainConstraintsPool<T> gain_constraints_pool_;
   LimitConstraintsPool<T> limit_constraints_pool_;
   PatchConstraintsPool<T> patch_constraints_pool_;
+  WeldConstraintsPool<T> weld_constraints_pool_;
 };
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/patch_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/patch_constraints_pool.cc
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/math/cross_product.h"
 #include "drake/multibody/contact_solvers/icf/icf_model.h"
 
 namespace drake {
@@ -15,24 +16,13 @@ namespace icf {
 namespace internal {
 
 using contact_solvers::internal::BlockSparseSymmetricMatrix;
+using math::VectorToSkewSymmetric;
 
 // Computes the soft norm ‖x‖ₛ = sqrt(xᵀx + ε²) - ε.
 template <typename T>
 T SoftNorm(const Vector3<T>& x, const T& eps) {
   using std::sqrt;
   return sqrt(x.squaredNorm() + eps * eps) - eps;
-}
-
-// Forms the skew symmetric matrix pₓ(p) such that pₓ⋅a = p×a.
-template <typename T>
-Matrix3<T> Skew(const Vector3<T>& p) {
-  // clang-format off
-    Matrix3<T> S;
-    S <<     0, -p.z(),  p.y(),
-          p.z(),     0, -p.x(),
-         -p.y(),  p.x(),     0;
-  // clang-format on
-  return S;
 }
 
 // Given spatial force F_Bo applied at B and the relative position p_AB of B
@@ -63,7 +53,7 @@ Vector6<T> ShiftSpatialForce(const Vector6<T>& F, const Vector3<T>& p) {
 // @returns The shifted second-order tensor G_Ao.
 template <typename T>
 Matrix6<T> ShiftSecondOrderTensor(const Matrix3<T>& G, const Vector3<T>& p) {
-  const Matrix3<T> px = Skew(p);
+  const Matrix3<T> px = VectorToSkewSymmetric(p);
   const Matrix3<T> pxG = px * G;
   Matrix6<T> Gp;
   Gp.template topLeftCorner<3, 3>() = -pxG * px;
@@ -80,7 +70,7 @@ Matrix6<T> ShiftFromTheRight(const Matrix6<T>& G, const Vector3<T>& p) {
   const auto Gwv = G.template topRightCorner<3, 3>();
   const auto Gvw = G.template bottomLeftCorner<3, 3>();
   const auto Gv = G.template bottomRightCorner<3, 3>();
-  const Matrix3<T> px = Skew(p);
+  const Matrix3<T> px = VectorToSkewSymmetric(p);
 
   Matrix6<T> R;
   R.template topLeftCorner<3, 3>() = Gw - Gwv * px;
@@ -98,7 +88,7 @@ Matrix6<T> ShiftFromTheLeft(const Matrix6<T>& G, const Vector3<T>& p) {
   const auto Gwv = G.template topRightCorner<3, 3>();
   const auto Gvw = G.template bottomLeftCorner<3, 3>();
   const auto Gv = G.template bottomRightCorner<3, 3>();
-  const Matrix3<T> px = Skew(p);
+  const Matrix3<T> px = VectorToSkewSymmetric(p);
 
   Matrix6<T> R;
   R.template topLeftCorner<3, 3>() = Gw + px * Gvw;

--- a/multibody/contact_solvers/icf/test/icf_builder_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_builder_test.cc
@@ -120,6 +120,69 @@ GTEST_TEST(IcfBuilder, Coupler) {
   EXPECT_EQ(pool.gear_ratio()[0], 0.8);
 }
 
+GTEST_TEST(IcfBuilder, WeldConstraint) {
+  systems::DiagramBuilder<double> diagram_builder;
+  multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};
+
+  MultibodyPlant<double>& plant =
+      multibody::AddMultibodyPlant(plant_config, &diagram_builder);
+
+  Parser(&plant, "Pendulum1").AddModelsFromString(kRobotXml, "xml");
+  Parser(&plant, "Pendulum2").AddModelsFromString(kRobotXml, "xml");
+  plant.AddWeldConstraint(plant.get_body(BodyIndex(1)), RigidTransformd(),
+                          plant.get_body(BodyIndex(2)), RigidTransformd());
+  plant.Finalize();
+
+  auto diagram = diagram_builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  const auto& plant_context = plant.GetMyContextFromRoot(*diagram_context);
+
+  const double time_step = 0.01;
+  IcfBuilder<double> builder(&plant);
+  IcfModel<double> model;
+  builder.UpdateModel(plant_context, time_step, nullptr, nullptr, &model);
+  EXPECT_EQ(model.num_cliques(), 2);
+  EXPECT_EQ(model.num_velocities(), plant.num_velocities());
+  ASSERT_EQ(model.num_weld_constraints(), 1);
+
+  // Check the weld constraint produced.
+  const auto& pool = model.weld_constraints_pool();
+  EXPECT_EQ(pool.num_constraints(), 1);
+  EXPECT_EQ(pool.body_pairs()[0].first, 1);
+  EXPECT_EQ(pool.body_pairs()[0].second, 2);
+}
+
+GTEST_TEST(IcfBuilder, NoWeldBetweenAnchoredBodies) {
+  systems::DiagramBuilder<double> diagram_builder;
+  multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};
+
+  MultibodyPlant<double>& plant =
+      multibody::AddMultibodyPlant(plant_config, &diagram_builder);
+  const auto M_B = SpatialInertia<double>::MakeUnitary();
+
+  plant.AddRigidBody("free_body", M_B);  // Need something that can move.
+  const RigidBody<double>& body1 = plant.AddRigidBody("body1", M_B);
+  const RigidBody<double>& body2 = plant.AddRigidBody("body2", M_B);
+  plant.AddJoint<WeldJoint>("weld1", plant.world_body(), RigidTransformd(),
+                            body1, RigidTransformd(), RigidTransformd());
+  plant.AddJoint<WeldJoint>("weld2", plant.world_body(), RigidTransformd(),
+                            body2, RigidTransformd(), RigidTransformd());
+  plant.AddWeldConstraint(body1, RigidTransformd(), body2, RigidTransformd());
+  plant.Finalize();
+
+  auto diagram = diagram_builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  const auto& plant_context = plant.GetMyContextFromRoot(*diagram_context);
+
+  const double time_step = 0.01;
+  IcfBuilder<double> icf_builder(&plant);
+  IcfModel<double> model;
+  DRAKE_EXPECT_THROWS_MESSAGE(icf_builder.UpdateModel(plant_context, time_step,
+                                                      nullptr, nullptr, &model),
+                              ".*weld constraint.*body1.*body2.*both are "
+                              "welded to the world.*not allowed.*");
+}
+
 // TODO(#23992): the limitation checked in this test is a regression from SAP
 // coupler constraints.
 GTEST_TEST(IcfBuilder, CouplerBad) {
@@ -306,22 +369,6 @@ GTEST_TEST(IcfBuilder, TendonConstraintUnsupported) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(IcfBuilder<double>(&plant),
                               ".*not.*support.*1 tendon constraint\\(s\\).*");
-}
-
-GTEST_TEST(IcfBuilder, WeldConstraintUnsupported) {
-  systems::DiagramBuilder<double> diagram_builder;
-  multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};
-  MultibodyPlant<double>& plant =
-      multibody::AddMultibodyPlant(plant_config, &diagram_builder);
-
-  Parser(&plant, "Pendulum").AddModelsFromString(kRobotXml, "xml");
-
-  plant.AddWeldConstraint(plant.get_body(BodyIndex(0)), RigidTransformd(),
-                          plant.get_body(BodyIndex(1)), RigidTransformd());
-  plant.Finalize();
-
-  DRAKE_EXPECT_THROWS_MESSAGE(IcfBuilder<double>(&plant),
-                              ".*not.*support.*1 weld constraint\\(s\\).*");
 }
 
 GTEST_TEST(IcfBuilder, DeformableUnsupported) {

--- a/multibody/contact_solvers/icf/test/icf_data_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_data_test.cc
@@ -39,12 +39,13 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   const int num_velocities = 12;
   const int max_clique_size = 6;
   const int num_couplers = 2;
+  const int num_welds = 3;
   const std::vector<int> gain_sizes = {3, 2};
   const std::vector<int> limit_sizes = {5, 4, 3};
   const std::vector<int> patch_sizes = {8, 6, 4, 2};
 
   data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-              gain_sizes, limit_sizes, patch_sizes);
+              num_welds, gain_sizes, limit_sizes, patch_sizes);
 
   // Main data elements
   EXPECT_EQ(data.num_velocities(), num_velocities);
@@ -70,6 +71,7 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
             ssize(limit_sizes));
   EXPECT_EQ(data.scratch().patch_constraints_data.num_constraints(),
             ssize(patch_sizes));
+  EXPECT_EQ(data.scratch().weld_constraints_data.num_constraints(), num_welds);
   EXPECT_EQ(data.scratch().H_cc_pool[0].rows(), max_clique_size);
   EXPECT_EQ(data.scratch().H_cc_pool[0].cols(), max_clique_size);
   EXPECT_EQ(data.scratch().H_BB_pool[0].rows(), max_clique_size);
@@ -92,16 +94,17 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
   const int num_velocities = 11;
   const int max_clique_size = 7;
   const int num_couplers = 2;
+  const int num_welds = 1;
   const std::vector<int> gain_sizes = {3};
   const std::vector<int> limit_sizes = {4};
   const std::vector<int> patch_sizes = {5};
 
   data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-              gain_sizes, limit_sizes, patch_sizes);
+              num_welds, gain_sizes, limit_sizes, patch_sizes);
 
   // Clearing pools changes size but shouldn't change capacity.
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
-  data.scratch().Resize(0, 0, 0, 0, gain_sizes, limit_sizes, patch_sizes);
+  data.scratch().Resize(0, 0, 0, 0, 0, gain_sizes, limit_sizes, patch_sizes);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), 0);
 
   VectorX<double> v = VectorX<double>::LinSpaced(num_velocities, 1.0, 11.0);
@@ -110,7 +113,7 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
     // cause any new allocations.
     drake::test::LimitMalloc guard;
     data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-                gain_sizes, limit_sizes, patch_sizes);
+                num_welds, gain_sizes, limit_sizes, patch_sizes);
     data.set_v(v);
   }
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);

--- a/multibody/contact_solvers/icf/test/icf_model_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_model_test.cc
@@ -307,6 +307,35 @@ void AddPatchConstraints(IcfModel<T>* model) {
   }
 }
 
+/* Adds weld constraints to the given model. Two weld constraints are added:
+one between the world (body 0) and body 1, and one between body 2 and body 3
+(cross-clique in the multi-clique case). */
+template <typename T>
+void AddWeldConstraints(IcfModel<T>* model) {
+  DRAKE_DEMAND(model != nullptr);
+
+  WeldConstraintsPool<T>& welds = model->weld_constraints_pool();
+  welds.Resize(2);
+
+  // Weld 0: world (body 0, anchored) to body 1.
+  {
+    const Vector3<T> p_AP_W(0.1, 0.0, 0.0);
+    const Vector3<T> p_BQ_W(0.0, 0.0, 0.0);
+    const Vector3<T> p_PoQo_W(0.05, 0.0, 0.0);
+    const Vector3<T> a_PQ_W(0.0, 0.0, 0.01);
+    welds.Set(0, /*bodyA=*/0, /*bodyB=*/1, p_AP_W, p_BQ_W, p_PoQo_W, a_PQ_W);
+  }
+
+  // Weld 1: body 2 to body 3 (cross-clique in multi-clique case).
+  {
+    const Vector3<T> p_AP_W(0.1, 0.2, 0.3);
+    const Vector3<T> p_BQ_W(0.0, 0.1, 0.0);
+    const Vector3<T> p_PoQo_W(0.02, -0.01, 0.03);
+    const Vector3<T> a_PQ_W(0.005, -0.003, 0.001);
+    welds.Set(1, /*bodyA=*/2, /*bodyB=*/3, p_AP_W, p_BQ_W, p_PoQo_W, a_PQ_W);
+  }
+}
+
 /* Checks that a default constructed model is empty. */
 GTEST_TEST(IcfModel, EmptyModel) {
   IcfModel<double> model;
@@ -452,6 +481,32 @@ GTEST_TEST(IcfModel, LimitMallocOnPatchConstrainedCalcData) {
   }
 }
 
+/* Checks that model.CalcData does not incur any heap allocations on a problem
+with weld constraints. */
+GTEST_TEST(IcfModel, LimitMallocOnWeldConstrainedCalcData) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddWeldConstraints(&model);
+  model.SetSparsityPattern();
+  EXPECT_EQ(model.num_cliques(), 3);
+  EXPECT_EQ(model.num_velocities(), 18);
+  EXPECT_EQ(model.num_constraints(), 2);
+  EXPECT_EQ(model.num_weld_constraints(), 2);
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  EXPECT_EQ(data.weld_constraints_data().num_constraints(), 2);
+
+  const int nv = model.num_velocities();
+  const VectorXd v = VectorXd::LinSpaced(nv, -10.0, 10.0);
+
+  // Computing data should not cause any new allocations.
+  {
+    drake::test::LimitMalloc guard;
+    model.CalcData(v, &data);
+  }
+}
+
 /* Iterates over each body to check sizes and such. */
 GTEST_TEST(IcfModel, PerBodyElements) {
   IcfModel<double> model;
@@ -529,13 +584,14 @@ GTEST_TEST(IcfModel, CalcGradients) {
   AddGainConstraints(&model);
   AddLimitConstraints(&model);
   AddPatchConstraints(&model);
+  AddWeldConstraints(&model);
   model.SetSparsityPattern();
   const int nv = model.num_velocities();
 
   IcfData<AutoDiffXd> data;
   model.ResizeData(&data);
   EXPECT_EQ(data.num_velocities(), nv);
-  EXPECT_EQ(model.num_constraints(), 8);
+  EXPECT_EQ(model.num_constraints(), 10);
 
   VectorXd v_values = VectorXd::LinSpaced(nv, -10.0, 10.0);
   VectorX<AutoDiffXd> v(nv);
@@ -558,6 +614,7 @@ GTEST_TEST(IcfModel, CalcDenseHessian) {
   AddGainConstraints(&model);
   AddLimitConstraints(&model);
   AddPatchConstraints(&model);
+  AddWeldConstraints(&model);
   model.SetSparsityPattern();
   EXPECT_EQ(model.num_cliques(), 1);
   EXPECT_EQ(model.num_velocities(), 18);
@@ -602,6 +659,7 @@ GTEST_TEST(IcfModel, SingleVsMultipleCliques) {
   AddGainConstraints(&model_single);
   AddLimitConstraints(&model_single);
   AddPatchConstraints(&model_single);
+  AddWeldConstraints(&model_single);
   model_single.SetSparsityPattern();
   EXPECT_EQ(model_single.num_cliques(), 1);
   EXPECT_EQ(model_single.num_velocities(), 18);
@@ -612,6 +670,7 @@ GTEST_TEST(IcfModel, SingleVsMultipleCliques) {
   AddGainConstraints(&model_multiple);
   AddLimitConstraints(&model_multiple);
   AddPatchConstraints(&model_multiple);
+  AddWeldConstraints(&model_multiple);
   model_multiple.SetSparsityPattern();
   EXPECT_EQ(model_multiple.num_cliques(), 3);
   EXPECT_EQ(model_multiple.num_velocities(), 18);
@@ -646,10 +705,13 @@ GTEST_TEST(IcfModel, SingleVsMultipleCliques) {
             std::vector<int>({6, 6, 6}));
 
   // Cost, gradient, and Hessian should be the same regardless of sparsity.
-  EXPECT_NEAR(data_single.cost(), data_multiple.cost(), kEpsilon);
+  // We use 100 * kEpsilon because cross-clique weld constraints accumulate
+  // slightly different round-off when the same problem is decomposed into one
+  // vs. three cliques.
+  EXPECT_NEAR(data_single.cost(), data_multiple.cost(), 100 * kEpsilon);
   EXPECT_TRUE(CompareMatrices(data_single.gradient(), data_multiple.gradient(),
-                              kEpsilon, MatrixCompareType::relative));
-  EXPECT_TRUE(CompareMatrices(H_single, H_multiple, kEpsilon,
+                              100 * kEpsilon, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(H_single, H_multiple, 100 * kEpsilon,
                               MatrixCompareType::relative));
 }
 
@@ -661,10 +723,11 @@ GTEST_TEST(IcfModel, CalcCostAlongLine) {
   AddGainConstraints(&model);
   AddLimitConstraints(&model);
   AddPatchConstraints(&model);
+  AddWeldConstraints(&model);
   model.SetSparsityPattern();
   EXPECT_EQ(model.num_cliques(), 3);
   EXPECT_EQ(model.num_velocities(), 18);
-  EXPECT_EQ(model.num_constraints(), 8);
+  EXPECT_EQ(model.num_constraints(), 10);
 
   // Allocate data, and additional scratch.
   IcfData<AutoDiffXd> data, scratch;
@@ -724,11 +787,12 @@ GTEST_TEST(IcfModel, UpdateTimeStep) {
   AddGainConstraints(&model_original);
   AddLimitConstraints(&model_original);
   AddPatchConstraints(&model_original);
+  AddWeldConstraints(&model_original);
   model_original.SetSparsityPattern();
   EXPECT_EQ(model_original.num_cliques(), 3);
   EXPECT_EQ(model_original.num_velocities(), 18);
   EXPECT_EQ(model_original.time_step(), 0.02);
-  EXPECT_EQ(model_original.num_constraints(), 8);
+  EXPECT_EQ(model_original.num_constraints(), 10);
 
   const double new_time_step = 0.003;
 
@@ -739,11 +803,12 @@ GTEST_TEST(IcfModel, UpdateTimeStep) {
   AddGainConstraints(&model_new);
   AddLimitConstraints(&model_new);
   AddPatchConstraints(&model_new);
+  AddWeldConstraints(&model_new);
   model_new.SetSparsityPattern();
   EXPECT_EQ(model_new.num_cliques(), 3);
   EXPECT_EQ(model_new.num_velocities(), 18);
   EXPECT_EQ(model_new.time_step(), new_time_step);
-  EXPECT_EQ(model_new.num_constraints(), 8);
+  EXPECT_EQ(model_new.num_constraints(), 10);
 
   // Now update the time step of the original model.
   EXPECT_NE(model_original.time_step(), new_time_step);
@@ -1060,6 +1125,101 @@ GTEST_TEST(IcfModel, LimitConstraint) {
   MatrixXd gradient_derivatives = math::ExtractGradient(data.gradient());
   EXPECT_TRUE(CompareMatrices(hessian_value, gradient_derivatives,
                               10 * kEpsilon, MatrixCompareType::relative));
+}
+
+/* Verifies that weld constraints produce correct data. */
+GTEST_TEST(IcfModel, WeldConstraint) {
+  IcfModel<AutoDiffXd> model;
+  MakeUnconstrainedModel(&model);
+  model.SetSparsityPattern();
+  EXPECT_EQ(model.num_cliques(), 3);
+  EXPECT_EQ(model.num_velocities(), 18);
+  EXPECT_EQ(model.num_constraints(), 0);
+
+  IcfData<AutoDiffXd> data;
+  model.ResizeData(&data);
+  EXPECT_EQ(data.num_velocities(), model.num_velocities());
+  EXPECT_EQ(data.weld_constraints_data().num_constraints(), 0);
+
+  // At this point there should be no weld constraints.
+  EXPECT_EQ(model.num_weld_constraints(), 0);
+  EXPECT_EQ(model.num_constraints(), 0);
+
+  // Add weld constraints.
+  AddWeldConstraints(&model);
+  EXPECT_EQ(model.num_weld_constraints(), 2);
+  EXPECT_EQ(model.num_constraints(), 2);
+
+  // Re-set sparsity since weld constraints introduce cross-clique coupling.
+  model.SetSparsityPattern();
+
+  // Resize data to include weld constraints data.
+  model.ResizeData(&data);
+  EXPECT_EQ(data.weld_constraints_data().num_constraints(), 2);
+
+  const int nv = model.num_velocities();
+  VectorXd v_value = VectorXd::LinSpaced(nv, -10, 10.0);
+  VectorX<AutoDiffXd> v(nv);
+  math::InitializeAutoDiff(v_value, &v);
+  model.CalcData(v, &data);
+
+  const WeldConstraintsDataPool<AutoDiffXd>& weld_data =
+      data.weld_constraints_data();
+  EXPECT_EQ(weld_data.num_constraints(), 2);
+
+  // The weld constraints should add positive cost (non-zero constraint error).
+  EXPECT_GT(weld_data.cost().value(), 0.0);
+
+  // Impulses should be finite and non-zero.
+  for (int k = 0; k < 2; ++k) {
+    const Vector6<AutoDiffXd>& gamma = weld_data.gamma(k);
+    EXPECT_TRUE(math::ExtractValue(gamma).allFinite());
+    EXPECT_GT(math::ExtractValue(gamma).norm(), 0.0);
+  }
+
+  // The total cost should include the weld contribution.
+  EXPECT_GT(data.cost().value(), data.momentum_cost().value());
+
+  // Verify accumulated total cost and gradients via AutoDiff.
+  const VectorXd total_cost_derivatives = data.cost().derivatives();
+  const VectorXd total_gradient_value = math::ExtractValue(data.gradient());
+  EXPECT_TRUE(CompareMatrices(total_gradient_value, total_cost_derivatives,
+                              2 * kEpsilon, MatrixCompareType::relative));
+
+  // Verify contributions to Hessian.
+  auto weld_hessian = model.MakeHessian(data);
+  MatrixXd weld_hessian_value =
+      math::ExtractValue(weld_hessian->MakeDenseMatrix());
+  MatrixXd weld_gradient_derivatives = math::ExtractGradient(data.gradient());
+  EXPECT_TRUE(CompareMatrices(weld_hessian_value, weld_gradient_derivatives,
+                              10 * kEpsilon, MatrixCompareType::relative));
+
+  // The cross-clique weld (body 2, clique 1 to body 3, clique 2) should
+  // produce non-zero off-diagonal blocks in the Hessian.
+  const double off_diag_norm = weld_hessian_value.block<6, 6>(6, 12).norm();
+  EXPECT_GT(off_diag_norm, 0.0);
+
+  // Check CalcCostAlongLine for weld constraints.
+  const VectorX<AutoDiffXd> w = VectorX<AutoDiffXd>::LinSpaced(
+      nv, 0.1, -0.2);  // Arbitrary search direction.
+  IcfSearchDirectionData<AutoDiffXd> search_data;
+
+  // Set data with constant value of v.
+  VectorX<AutoDiffXd> v_constant =
+      VectorX<AutoDiffXd>::LinSpaced(nv, -10, 10.0);
+  model.CalcData(v_constant, &data);
+  model.CalcSearchDirectionData(data, w, &search_data);
+
+  const AutoDiffXd alpha = {
+      0.35 /* arbitrary value */,
+      VectorXd::Ones(1) /* This is the independent variable */};
+  AutoDiffXd dcost, d2cost;
+  const AutoDiffXd cost =
+      model.CalcCostAlongLine(alpha, data, search_data, &dcost, &d2cost);
+
+  const double scale = std::abs(dcost.value());
+  EXPECT_NEAR(dcost.value(), cost.derivatives()[0], scale * kEpsilon);
+  EXPECT_NEAR(d2cost.value(), dcost.derivatives()[0], scale * kEpsilon);
 }
 
 }  // namespace

--- a/multibody/contact_solvers/icf/test/weld_constraint_init_and_sim_test.cc
+++ b/multibody/contact_solvers/icf/test/weld_constraint_init_and_sim_test.cc
@@ -1,0 +1,137 @@
+/* Test that CENIC is capable of resolving a weld constraint with a large
+initial error, and then is able to maintain the constraint over time under
+gravity.
+
+Setup:
+  - box1: a cube welded to the world at z=1.0 (no joint in MJCF).
+  - box2: an cube, free body (6 DOF), connected to box1 via
+    AddWeldConstraint. The constraint places box2's top face against
+    box1's bottom face. box2 starts severely displaced so the ICF constraint
+    correction required is large.
+*/
+
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/cenic/cenic_integrator.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using multibody::CenicIntegrator;
+using multibody::MultibodyPlant;
+using multibody::MultibodyPlantConfig;
+using multibody::Parser;
+using systems::DiagramBuilder;
+using systems::Simulator;
+
+// MJCF model defining two boxes and a floor.
+//
+// box1: half-extents 0.15m, welded to the world (no joint) at z=0.5.
+// box2: half-extents 0.10m, free floating body (freejoint). The weld
+//       constraint will be added programmatically below.
+// floor: half-extents 1m x 1m x 0.05m, welded to world with top face at z=0.
+constexpr char kMjcf[] = R"""(
+  <?xml version="1.0"?>
+  <mujoco model="weld_constraint_demo">
+    <worldbody>
+      <!-- box1: welded to world at z=1.0 (no joint means fixed) -->
+      <body name="box1" pos="0 0 1.0">
+        <inertial mass="2" diaginertia="0.015 0.015 0.015"/>
+        <geom type="box" size="0.15 0.15 0.15" rgba="0.5 0.5 0.5 1"/>
+      </body>
+      <!-- box2: free body, to be weld-constrained to box1 -->
+      <body name="box2" pos="0 0 0.75">
+        <joint name="box2_free" type="free"/>
+        <inertial mass="1" diaginertia="0.0067 0.0067 0.0067"/>
+        <geom type="box" size="0.1 0.1 0.1" rgba="0.9 0.4 0.1 1"/>
+      </body>
+      <!-- floor for visual context -->
+      <geom name="floor" type="box" pos="0 0 -0.05" size="1 1 0.05"
+            rgba="0.2 0.8 0.3 1"/>
+    </worldbody>
+  </mujoco>
+)""";
+
+GTEST_TEST(WeldConstraintSimulation, LargeInitialError) {
+  DiagramBuilder<double> builder;
+
+  // Continuous-time plant is required for the CENIC integrator.
+  MultibodyPlantConfig plant_config;
+  plant_config.time_step = 0.0;
+  auto [plant, scene_graph] = AddMultibodyPlant(plant_config, &builder);
+
+  Parser(&plant).AddModelsFromString(kMjcf, "xml");
+
+  const auto& box1 = plant.GetBodyByName("box1");
+  const auto& box2 = plant.GetBodyByName("box2");
+
+  // Weld constraint: frame P on box1 at the center of its bottom face (-z),
+  // frame Q on box2 at the center of its top face (+z).
+  // When satisfied, box2 hangs underneath box1:
+  //   box1 center at z=1.0, bottom face at z=0.85
+  //   box2 center at z=0.75 - initial_gap, top face at z=0.85 - initial_gap.
+  const RigidTransformd X_box1_P(Vector3d(0.0, 0.0, -0.15));
+  const RigidTransformd X_box2_Q(Vector3d(0.0, 0.0, 0.1));
+  plant.AddWeldConstraint(box1, X_box1_P, box2, X_box2_Q);
+
+  plant.Finalize();
+  auto diagram = builder.Build();
+
+  // Set initial conditions: box2's exact constrained position would be center
+  // of box2 at (0, 0, 0.75), just below box1. Here we start with box2's center
+  // at (0, 0, 0.75 - initial_gap), so CENIC must overcome the initial gap
+  // error to pull box2 up into alignment. An initial_gap of 0.5m is a very
+  // large error. This will cause CENIC to take many small steps to
+  // converge, but it should still succeed (it did not originally). The weld
+  // constraint resists gravity to hold box2 in place. Without the
+  // constraint, box2 would fall freely under gravity.
+  auto context = diagram->CreateDefaultContext();
+  auto& plant_context = plant.GetMyMutableContextFromRoot(context.get());
+  const double initial_gap = 0.5;
+  plant.SetFloatingBaseBodyPoseInWorldFrame(
+      &plant_context, box2,
+      RigidTransformd(Vector3d(0.0, 0.0, 0.75 - initial_gap)));
+
+  // Set up the simulator with the CENIC integrator.
+  auto simulator =
+      std::make_unique<Simulator<double>>(*diagram, std::move(context));
+  auto& integrator = simulator->reset_integrator<CenicIntegrator<double>>();
+  integrator.set_maximum_step_size(0.1);
+  integrator.set_fixed_step_mode(false);  // Use error control.
+  integrator.set_target_accuracy(1e-3);
+
+  simulator->Initialize();
+  simulator->AdvanceTo(0.5);
+
+  // Verify the weld constraint held: box2's center should be at z=0.75.
+  // box1 center is at z=1.0. Frame P is at z=-0.15 on box1 (world z=0.85).
+  // Frame Q is at z=+0.10 on box2, so box2 center = 0.85 - 0.10 = 0.75.
+  const auto& final_plant_context =
+      plant.GetMyContextFromRoot(simulator->get_context());
+  const Vector3d& p_WB2 =
+      plant.EvalBodyPoseInWorld(final_plant_context, box2).translation();
+  const double kTolerance = 1e-5;  // 0.01 mm tolerance.
+  const Vector3d expected_position(0.0, 0.0, 0.75);
+  const double position_error = (p_WB2 - expected_position).norm();
+  EXPECT_LE(position_error, kTolerance);
+}
+
+}  // namespace
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
@@ -1,0 +1,394 @@
+#include "drake/multibody/contact_solvers/icf/weld_constraints_pool.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/cross_product.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+#include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+namespace {
+
+constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
+
+/* Sets up a simple model with 3 bodies in separate cliques, suitable for
+testing weld constraints. Body 0 is the world (anchored), bodies 1-3 are
+dynamic with 6 DOFs each. */
+template <typename T>
+void MakeModelForWeld(IcfModel<T>* model, double time_step = 0.01) {
+  const int nv = 18;
+
+  std::unique_ptr<IcfParameters<T>> params = model->ReleaseParameters();
+  ASSERT_TRUE(params != nullptr);
+
+  params->time_step = time_step;
+  params->v0 = VectorX<T>::LinSpaced(nv, -1.0, 1.0);
+
+  // Sparse mass matrix with three cliques of size 6.
+  const Matrix6<T> A1 = 0.3 * Matrix6<T>::Identity();
+  const Matrix6<T> A2 = 2.3 * Matrix6<T>::Identity();
+  const Matrix6<T> A3 = 1.5 * Matrix6<T>::Identity();
+
+  MatrixX<T>& M0 = params->M0;
+  M0 = MatrixX<T>::Identity(nv, nv);
+  M0.template block<6, 6>(0, 0) = A1;
+  M0.template block<6, 6>(6, 6) = A2;
+  M0.template block<6, 6>(12, 12) = A3;
+
+  params->D0 = VectorX<T>::Constant(nv, 0.1);
+  params->k0 = VectorX<T>::LinSpaced(nv, -1.0, 1.0);
+
+  params->clique_sizes = {6, 6, 6};
+  params->clique_start = {0, 6, 12, nv};
+
+  // Body 0 = world (anchored), body 1 = floating, body 2 = floating,
+  // body 3 = non-floating (uses non-identity Jacobian).
+  params->body_is_floating = {0, 1, 1, 0};
+  params->body_mass = {1.0e20, 0.3, 2.3, 1.5};
+
+  // Body-to-clique mapping. World is anchored (clique = -1).
+  params->body_to_clique = {-1, 0, 1, 2};
+
+  const Matrix6<T> J_WB3 = VectorX<T>::LinSpaced(36, -1.0, 1.0).reshaped(6, 6);
+
+  params->J_WB.Resize(4, 6, 6);
+  params->J_WB[0] = Matrix6<T>::Identity();  // World (ignored).
+  params->J_WB[1] = Matrix6<T>::Identity();  // Floating body.
+  params->J_WB[2] = Matrix6<T>::Identity();  // Floating body.
+  params->J_WB[3] = J_WB3;
+
+  model->ResetParameters(std::move(params));
+}
+
+/* Verifies basic construction and accessors. */
+GTEST_TEST(WeldConstraintsPool, BasicConstruction) {
+  IcfModel<double> model;
+  MakeModelForWeld(&model);
+
+  WeldConstraintsPool<double>& welds = model.weld_constraints_pool();
+  EXPECT_EQ(welds.num_constraints(), 0);
+
+  welds.Resize(2);
+  EXPECT_EQ(welds.num_constraints(), 2);
+}
+
+/* Verifies that the weld constraint correctly computes impulses, cost,
+gradient, and Hessian for a simple case: a weld between a floating body
+(body 1) and the world (body 0, anchored). Expected values are computed
+by hand from the weld constraint formulation. */
+GTEST_TEST(WeldConstraintsPool, WeldToWorld) {
+  IcfModel<double> model;
+  MakeModelForWeld(&model);
+
+  WeldConstraintsPool<double>& welds = model.weld_constraints_pool();
+  welds.Resize(1);
+
+  // Small constraint error: P and Q are slightly offset.
+  const Vector3<double> p_AP_W(0.1, 0.0, 0.0);
+  const Vector3<double> p_BQ_W(0.0, 0.0, 0.0);
+  const Vector3<double> p_PoQo_W(0.05, 0.0, 0.0);  // Small translational err.
+  const Vector3<double> a_PQ_W(0.0, 0.0, 0.01);    // Small rotational error.
+
+  // Body 0 (anchored) = A, body 1 (floating, clique 0) = B.
+  welds.Set(0, /*bodyA=*/0, /*bodyB=*/1, p_AP_W, p_BQ_W, p_PoQo_W, a_PQ_W);
+
+  // Set the sparsity pattern (required for Hessian).
+  model.SetSparsityPattern();
+
+  // Set up data.
+  IcfData<double> data;
+  model.ResizeData(&data);
+
+  // Use v = v0 for simplicity.
+  const VectorXd& v0 = model.v0();
+  const VectorXd v = v0;
+  model.CalcData(v, &data);
+
+  // --- Hand calculation of expected weld constraint values ---
+  //
+  // Body 1 is floating in clique 0, so V_WB[1] = v0[0:6].
+  const double dt = model.time_step();
+  const double mass_B = model.body_mass(1);
+
+  // Body B spatial velocity components (body 1, floating).
+  const Vector3<double> w_WB = v0.head<3>();       // angular
+  const Vector3<double> v_WBo = v0.segment<3>(3);  // linear at Bo
+
+  // Midpoint M is halfway between P and Q.
+  // Bm is on B, coincident with M: p_BoBm = p_BQ - 0.5*p_PoQo.
+  const Vector3<double> p_BoBm_W = p_BQ_W - 0.5 * p_PoQo_W;
+  // Linear velocity of Bm: v_WBm = v_WBo + w_WB × p_BoBm.
+  const Vector3<double> v_WBm = v_WBo + w_WB.cross(p_BoBm_W);
+
+  // Body A is anchored, so vc = V_WBm (relative to zero).
+  Vector6<double> vc;
+  vc.head<3>() = w_WB;
+  vc.tail<3>() = v_WBm;
+
+  // Near-rigid regularization (from weld_constraints_pool.cc constants).
+  constexpr double kBeta = 0.1;
+  const double taud = kBeta * dt / M_PI;
+  const double dt_plus_taud = dt + taud;
+
+  // Constraint function g0 = (a_PQ, p_PoQo).
+  Vector6<double> g0;
+  g0 << a_PQ_W, p_PoQo_W;
+
+  // Bias velocity: v̂ = -g0 / (dt + τ_d).
+  const Vector6<double> v_hat = -g0 / dt_plus_taud;
+
+  // Regularization R is a uniform diagonal: R = (r_scale/mass_B) * I₆,
+  // (body A is anchored so only B contributes).
+  const double r_scale =
+      (kBeta * kBeta * dt * dt) / (4.0 * M_PI * M_PI * dt * dt_plus_taud);
+  const double R_scalar = r_scale / mass_B;
+
+  // Expected impulse: γ = R⁻¹(v̂ - vc), with R diagonal and uniform.
+  const Vector6<double> expected_gamma = (v_hat - vc) / R_scalar;
+
+  // Expected weld cost: ℓ = ½(v̂ - vc)ᵀ R⁻¹ (v̂ - vc) = ½(v̂ - vc)ᵀ γ.
+  const double expected_weld_cost = 0.5 * (v_hat - vc).dot(expected_gamma);
+
+  // Expected momentum cost for v = v0.
+  // A = M + dt*D (block diagonal), r = A*v0 - dt*k0.
+  // momentum_cost = v0ᵀ(½A v0 - r).
+  MatrixXd A_mat = model.M0();
+  A_mat.diagonal() += dt * model.D0();
+  const VectorXd Av0 = A_mat * v0;
+  const VectorXd r = Av0 - dt * model.k0();
+  const double expected_momentum_cost = v0.dot(0.5 * Av0 - r);
+  const double expected_total_cost =
+      expected_momentum_cost + expected_weld_cost;
+
+  // --- Verify computed values match hand calculation ---
+
+  const Vector6<double>& gamma = data.weld_constraints_data().gamma(0);
+  EXPECT_TRUE(CompareMatrices(gamma, expected_gamma, 4 * kEpsilon,
+                              MatrixCompareType::relative));
+
+  const double weld_cost = data.weld_constraints_data().cost();
+  EXPECT_NEAR(weld_cost, expected_weld_cost,
+              4 * kEpsilon * std::abs(expected_weld_cost));
+
+  EXPECT_NEAR(data.momentum_cost(), expected_momentum_cost,
+              4 * kEpsilon * std::abs(expected_momentum_cost));
+  EXPECT_NEAR(data.cost(), expected_total_cost,
+              4 * kEpsilon * std::abs(expected_total_cost));
+
+  // --- Hand calculation of expected Hessian block for body B (clique 0) ---
+  //
+  // The full Hessian is H = A + weld_contribution, where A = M + dt*D is block
+  // diagonal. For a weld-to-world constraint with floating body B, the weld
+  // contribution to the (c_b, c_b) block is:
+  //   H_BB = G_Bp = Φ(p_BoBm)ᵀ G Φ(p_BoBm)
+  // where G = diag(R⁻¹) and Φ(p) = [I₃, 0; -p×, I₃] is the spatial shift
+  // operator. Body B is floating so J_WB = I₆, giving H_BB = G_Bp directly.
+
+  const double R_inv = 1.0 / R_scalar;
+
+  // p_BoBm_W was already computed above for the velocity calculation.
+
+  // Skew-symmetric matrix [p_BoBm]×.
+  const Eigen::Matrix3d px = math::VectorToSkewSymmetric(p_BoBm_W);
+  const Eigen::Matrix3d I3 = Eigen::Matrix3d::Identity();
+
+  // G_Bp = Φᵀ G Φ with G = R⁻¹ I₆ (uniform scalar).
+  // G_Bp = R⁻¹ [ I₃ - p×⋅p×  p× ]
+  //            [    -p×      I₃ ]
+  Matrix6<double> expected_H_BB;
+  expected_H_BB.topLeftCorner<3, 3>() = R_inv * (I3 - px * px);
+  expected_H_BB.topRightCorner<3, 3>() = R_inv * px;
+  expected_H_BB.bottomLeftCorner<3, 3>() = -R_inv * px;
+  expected_H_BB.bottomRightCorner<3, 3>() = R_inv * I3;
+
+  // Expected Hessian block: A_clique0 + H_BB.
+  const Matrix6<double> A_clique0 = A_mat.block<6, 6>(0, 0);
+  const Matrix6<double> expected_hessian_block = A_clique0 + expected_H_BB;
+
+  // Build Hessian, verify it is finite, and check the result for bodyB.
+  const MatrixXd hessian = model.MakeHessian(data)->MakeDenseMatrix();
+  EXPECT_TRUE(hessian.allFinite());
+
+  const Matrix6<double> hessian_block_B = hessian.block<6, 6>(0, 0);
+  EXPECT_TRUE(CompareMatrices(hessian_block_B, expected_hessian_block,
+                              4 * kEpsilon, MatrixCompareType::relative));
+}
+
+/* Verifies the weld constraint between two dynamic bodies in different
+cliques (cross-clique case). Parameterized to test both clique orderings:
+  - false: bodyA=1 (clique 0), bodyB=2 (clique 1), i.e. c_b > c_a.
+  - true:  bodyA=2 (clique 1), bodyB=1 (clique 0), i.e. c_a > c_b. */
+class CrossCliqueWeldTest : public testing::TestWithParam<bool> {};
+
+TEST_P(CrossCliqueWeldTest, CrossCliqueWeld) {
+  const bool reverse_bodies = GetParam();
+
+  IcfModel<double> model;
+  MakeModelForWeld(&model);
+
+  WeldConstraintsPool<double>& welds = model.weld_constraints_pool();
+  welds.Resize(1);
+
+  // Weld between body 1 (clique 0) and body 2 (clique 1).
+  const Vector3<double> p_AP_W(0.1, 0.2, 0.3);
+  const Vector3<double> p_BQ_W(0.0, 0.1, 0.0);
+  const Vector3<double> p_PoQo_W(0.02, -0.01, 0.03);
+  const Vector3<double> a_PQ_W(0.005, -0.003, 0.001);
+
+  if (reverse_bodies) {
+    // Body 2 = A (clique 1), Body 1 = B (clique 0), i.e. c_a > c_b.
+    welds.Set(0, /*bodyA=*/2, /*bodyB=*/1, p_AP_W, p_BQ_W, p_PoQo_W, a_PQ_W);
+  } else {
+    // Body 1 = A (clique 0), Body 2 = B (clique 1), i.e. c_b > c_a.
+    welds.Set(0, /*bodyA=*/1, /*bodyB=*/2, p_AP_W, p_BQ_W, p_PoQo_W, a_PQ_W);
+  }
+
+  model.SetSparsityPattern();
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  const VectorXd v = model.v0();
+  model.CalcData(v, &data);
+
+  // Verify cost and impulse.
+  EXPECT_GT(data.weld_constraints_data().cost(), 0.0);
+  const Vector6<double>& gamma = data.weld_constraints_data().gamma(0);
+  EXPECT_TRUE(gamma.allFinite());
+  EXPECT_GT(gamma.norm(), 0.0);
+
+  // Build Hessian and verify it has off-diagonal blocks.
+  auto hessian = model.MakeHessian(data);
+  const MatrixXd H_dense = hessian->MakeDenseMatrix();
+  EXPECT_TRUE(H_dense.allFinite());
+
+  // The off-diagonal block between clique 0 and clique 1 should be non-zero.
+  const double off_diag_norm = H_dense.block<6, 6>(0, 6).norm();
+  EXPECT_GT(off_diag_norm, 0.0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    WeldConstraintsPool, CrossCliqueWeldTest, testing::Bool(),
+    [](const testing::TestParamInfo<bool>& test_param_info) {
+      return test_param_info.param ? "CliqueAGreater" : "CliqueBGreater";
+    });
+
+/* Verifies that CalcCostAlongLine produces consistent derivatives using
+AutoDiff. For each sampled α value, we verify the cost, first derivative, and
+second derivative by comparing CalcCostAlongLine outputs against the
+full-precision AutoDiff result obtained by evaluating CalcData at v + α·w. */
+GTEST_TEST(WeldConstraintsPool, CalcCostAlongLine) {
+  IcfModel<AutoDiffXd> model;
+  MakeModelForWeld(&model);
+
+  WeldConstraintsPool<AutoDiffXd>& welds = model.weld_constraints_pool();
+  welds.Resize(1);
+
+  const Vector3<AutoDiffXd> p_AP_W(0.1, 0.0, 0.0);
+  const Vector3<AutoDiffXd> p_BQ_W(0.0, 0.0, 0.0);
+  const Vector3<AutoDiffXd> p_PoQo_W(0.05, 0.0, 0.0);
+  const Vector3<AutoDiffXd> a_PQ_W(0.0, 0.0, 0.01);
+
+  welds.Set(0, 0, 1, p_AP_W, p_BQ_W, p_PoQo_W, a_PQ_W);
+
+  model.SetSparsityPattern();
+
+  const int nv = model.num_velocities();
+  IcfData<AutoDiffXd> data, scratch;
+  model.ResizeData(&data);
+  model.ResizeData(&scratch);
+
+  // Compute data at the base point v = v0.
+  const VectorX<AutoDiffXd> v = VectorXd::LinSpaced(nv, -1.0, 1.0);
+  model.CalcData(v, &data);
+
+  // Arbitrary search direction.
+  const VectorX<AutoDiffXd> w = VectorX<AutoDiffXd>::LinSpaced(nv, 0.1, 0.5);
+
+  // Precompute search direction data.
+  IcfSearchDirectionData<AutoDiffXd> search_data;
+  model.CalcSearchDirectionData(data, w, &search_data);
+
+  // Verify at several α values.
+  for (double alpha_value : {-0.45, 0.0, 0.15, 0.34, 0.93, 1.32}) {
+    // Make α the independent variable for AutoDiff.
+    const AutoDiffXd alpha = {alpha_value, VectorXd::Ones(1)};
+
+    // Compute the expected cost and its derivative w.r.t. α via AutoDiff.
+    const VectorX<AutoDiffXd> v_alpha = v + alpha * w;
+    model.CalcData(v_alpha, &scratch);
+    const double cost_expected = scratch.cost().value();
+    const double dcost_expected = scratch.cost().derivatives()[0];
+    const VectorXd w_times_H = math::ExtractGradient(scratch.gradient());
+    const double d2cost_expected = w_times_H.dot(math::ExtractValue(w));
+
+    // Compare against CalcCostAlongLine.
+    AutoDiffXd dcost, d2cost;
+    const AutoDiffXd cost =
+        model.CalcCostAlongLine(alpha, data, search_data, &dcost, &d2cost);
+    EXPECT_NEAR(cost.value(), cost_expected,
+                8 * kEpsilon * std::abs(cost_expected));
+    EXPECT_NEAR(dcost.value(), dcost_expected,
+                8 * kEpsilon * std::abs(dcost_expected));
+    EXPECT_NEAR(d2cost.value(), d2cost_expected,
+                8 * kEpsilon * std::abs(d2cost_expected));
+  }
+}
+
+/* Verifies gradient consistency using AutoDiff. */
+GTEST_TEST(WeldConstraintsPool, GradientConsistency) {
+  IcfModel<AutoDiffXd> model;
+  MakeModelForWeld(&model);
+
+  WeldConstraintsPool<AutoDiffXd>& welds = model.weld_constraints_pool();
+  welds.Resize(1);
+
+  const Vector3<AutoDiffXd> p_AP_W(0.1, 0.0, 0.0);
+  const Vector3<AutoDiffXd> p_BQ_W(0.0, 0.0, 0.0);
+  const Vector3<AutoDiffXd> p_PoQo_W(0.05, 0.0, 0.0);
+  const Vector3<AutoDiffXd> a_PQ_W(0.0, 0.0, 0.01);
+
+  welds.Set(0, 0, 1, p_AP_W, p_BQ_W, p_PoQo_W, a_PQ_W);
+
+  model.SetSparsityPattern();
+
+  const int nv = model.num_velocities();
+  IcfData<AutoDiffXd> data;
+  model.ResizeData(&data);
+
+  const VectorXd v_values = math::ExtractValue(model.v0());
+  VectorX<AutoDiffXd> v(nv);
+  math::InitializeAutoDiff(v_values, &v);
+
+  model.CalcData(v, &data);
+
+  // The AutoDiff derivatives of the cost give the full-precision gradient.
+  const VectorXd cost_derivatives = data.cost().derivatives();
+  const VectorXd gradient_value = math::ExtractValue(data.gradient());
+
+  EXPECT_TRUE(CompareMatrices(gradient_value, cost_derivatives, 100 * kEpsilon,
+                              MatrixCompareType::relative));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/icf/weld_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/weld_constraints_data_pool.cc
@@ -1,0 +1,20 @@
+#include "drake/multibody/contact_solvers/icf/weld_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+template <typename T>
+WeldConstraintsDataPool<T>::~WeldConstraintsDataPool() = default;
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        WeldConstraintsDataPool);

--- a/multibody/contact_solvers/icf/weld_constraints_data_pool.h
+++ b/multibody/contact_solvers/icf/weld_constraints_data_pool.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cmath>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+/* Stores data for weld constraints. This data is updated at each solver
+iteration, as opposed to the WeldConstraintsPool, which helps define the
+optimization problem.
+
+Each weld constraint has a 6-dimensional impulse γ = (γᵣ, γₜ) ∈ ℝ⁶, where γᵣ
+is the rotational component and γₜ is the translational component.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class WeldConstraintsDataPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(WeldConstraintsDataPool);
+
+  /* Constructs an empty pool. */
+  WeldConstraintsDataPool() = default;
+
+  ~WeldConstraintsDataPool();
+
+  /* Resizes the pool, allocating memory only as necessary. */
+  void Resize(int num_welds) { gamma_pool_.resize(num_welds); }
+
+  /* Returns the number of weld constraints this data is for. */
+  int num_constraints() const { return ssize(gamma_pool_); }
+
+  /* Returns the constraint impulse γ ∈ ℝ⁶ for the k-th constraint in the pool.
+  See WeldConstraintsPool for details. */
+  const Vector6<T>& gamma(int k) const { return gamma_pool_[k]; }
+  Vector6<T>& mutable_gamma(int k) { return gamma_pool_[k]; }
+
+  /* Returns the total constraint cost ℓ(v) for all weld constraints in the
+  pool. */
+  const T& cost() const { return cost_; }
+  T& mutable_cost() { return cost_; }
+
+ private:
+  T cost_{NAN};                         // Total cost over all weld constraints.
+  std::vector<Vector6<T>> gamma_pool_;  // Constraint impulses, size 6 each.
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        WeldConstraintsDataPool);

--- a/multibody/contact_solvers/icf/weld_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/weld_constraints_pool.cc
@@ -1,0 +1,436 @@
+#include "drake/multibody/contact_solvers/icf/weld_constraints_pool.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "drake/math/cross_product.h"
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+using contact_solvers::internal::BlockSparseSymmetricMatrix;
+using math::VectorToSkewSymmetric;
+
+namespace {
+
+// Given spatial impulse Γ_Bo applied at B and the relative position p_AB of B
+// from A, computes the spatial impulse Γ_Ao shifted to A.
+// Mathematically, Γ_Ao = Φ(p_AB)ᵀ⋅Γ_Bo, where Φ(p) is the shift operator.
+template <typename T>
+Vector6<T> ShiftSpatialImpulse(const Vector6<T>& F, const Vector3<T>& p) {
+  const auto t = F.template head<3>();
+  const auto f = F.template tail<3>();
+  Vector6<T> result;
+  result.template head<3>() = t + p.cross(f);
+  result.template tail<3>() = f;
+  return result;
+}
+
+// Near-rigid parameter β.
+constexpr double kBeta = 0.1;
+
+// Minimum time scale h_min for weld constraints.
+// For δt ≥ h_min the formula recovers the near-rigid model;
+// for δt < h_min stiffness and dissipation are capped at
+// the h_min near-rigid values.
+constexpr double kHMin = 1e-4;
+
+}  // namespace
+
+template <typename T>
+WeldConstraintsPool<T>::WeldConstraintsPool(const IcfModel<T>* parent_model)
+    : model_(parent_model) {
+  DRAKE_DEMAND(parent_model != nullptr);
+}
+
+template <typename T>
+WeldConstraintsPool<T>::~WeldConstraintsPool() = default;
+
+template <typename T>
+void WeldConstraintsPool<T>::Resize(const int num_constraints) {
+  body_pairs_.resize(num_constraints);
+  p_AP_W_.Resize(num_constraints, 3, 1);
+  p_BQ_W_.Resize(num_constraints, 3, 1);
+  p_PoQo_W_.Resize(num_constraints, 3, 1);
+  g0_.resize(num_constraints);
+  R_.resize(num_constraints);
+}
+
+template <typename T>
+void WeldConstraintsPool<T>::Set(int index, int bodyA, int bodyB,
+                                 const Vector3<T>& p_AP_W,
+                                 const Vector3<T>& p_BQ_W,
+                                 const Vector3<T>& p_PoQo_W,
+                                 const Vector3<T>& a_PQ_W) {
+  DRAKE_ASSERT(0 <= index && index < num_constraints());
+  DRAKE_ASSERT(!model().is_anchored(bodyB));
+
+  body_pairs_[index] = std::make_pair(bodyA, bodyB);
+  p_AP_W_[index] = p_AP_W;
+  p_BQ_W_[index] = p_BQ_W;
+  p_PoQo_W_[index] = p_PoQo_W;
+
+  // Constraint function g₀ = (a_PQ, p_PoQo) ∈ ℝ⁶.
+  g0_[index] = (Vector6<T>() << a_PQ_W, p_PoQo_W).finished();
+
+  // R_ is time-step-dependent and computed in PrecomputeHessianBlocks().
+}
+
+template <typename T>
+void WeldConstraintsPool<T>::CalcSparsityPattern(
+    std::vector<std::vector<int>>* sparsity) const {
+  DRAKE_ASSERT(sparsity != nullptr);
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+    if (!model().is_anchored(bodyA)) {
+      const int c_a = model().body_to_clique(bodyA);
+      const int c_b = model().body_to_clique(bodyB);
+      if (c_a == c_b) continue;  // No off-diagonal block for same-clique.
+      const int c_min = std::min(c_a, c_b);
+      const int c_max = std::max(c_a, c_b);
+      sparsity->at(c_min).push_back(c_max);
+    }
+  }
+}
+
+template <typename T>
+void WeldConstraintsPool<T>::CalcData(
+    const EigenPool<Vector6<T>>& V_WB,
+    WeldConstraintsDataPool<T>* weld_data) const {
+  DRAKE_ASSERT(weld_data != nullptr);
+
+  using std::max;
+  const T dt = model().time_step();
+  // Effective time scale for computing stiffness and dissipation.
+  const T dt_eff = max(dt, static_cast<T>(kHMin));
+  const T taud = kBeta * dt_eff / M_PI;
+  const T dt_plus_taud = dt + taud;
+
+  T& cost = weld_data->mutable_cost();
+  cost = 0;
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+
+    // Compute constraint velocity vc = V_W_AmBm at the midpoint M.
+    // M is at the midpoint of P and Q: p_WM = 0.5(p_WP + p_WQ).
+    // Am is a point on A coincident with M: p_AoAm = p_AP + 0.5*p_PQ.
+    // Bm is a point on B coincident with M: p_BoBm = p_BQ - 0.5*p_PQ.
+    const Vector3<T>& p_PoQo = p_PoQo_W_[k];
+    const Vector3<T> p_AoAm_W = p_AP_W_[k] + 0.5 * p_PoQo;
+    const Vector3<T> p_BoBm_W = p_BQ_W_[k] - 0.5 * p_PoQo;
+
+    // V_WAm = V_WA + [0; w_WA × p_AoAm] (shift to Am).
+    // V_WBm = V_WB + [0; w_WB × p_BoBm] (shift to Bm).
+    // vc = V_WBm - V_WAm.
+    const Vector6<T>& V_WB_body = V_WB[bodyB];
+    const Vector3<T>& w_WB = V_WB_body.template head<3>();
+    const Vector3<T>& v_WBo = V_WB_body.template tail<3>();
+    const Vector3<T> v_WBm = v_WBo + w_WB.cross(p_BoBm_W);
+
+    Vector6<T> vc;  // Constraint velocity V_W_AmBm.
+    if (!model().is_anchored(bodyA)) {
+      const Vector6<T>& V_WA_body = V_WB[bodyA];
+      const Vector3<T>& w_WA = V_WA_body.template head<3>();
+      const Vector3<T>& v_WAo = V_WA_body.template tail<3>();
+      const Vector3<T> v_WAm = v_WAo + w_WA.cross(p_AoAm_W);
+      vc.template head<3>() = w_WB - w_WA;
+      vc.template tail<3>() = v_WBm - v_WAm;
+    } else {
+      vc.template head<3>() = w_WB;
+      vc.template tail<3>() = v_WBm;
+    }
+
+    // v̂ = g₀/(dt + taud) where taud = β·dt_eff/π.
+    // This is bounded as dt → 0 (v̂ → g₀/taud).
+    const Vector6<T> v_hat = -g0_[k] / dt_plus_taud;
+    const Vector6<T>& R_diag = R_[k];
+
+    // γ = R⁻¹⋅(v̂ - vc), where R is diagonal.
+    const Vector6<T> gamma = (v_hat - vc).cwiseQuotient(R_diag);
+    weld_data->mutable_gamma(k) = gamma;
+
+    // cost = ½(v̂ - vc)ᵀ⋅γ
+    cost += 0.5 * (v_hat - vc).dot(gamma);
+  }
+}
+
+template <typename T>
+void WeldConstraintsPool<T>::AccumulateGradient(const IcfData<T>& data,
+                                                VectorX<T>* gradient) const {
+  DRAKE_ASSERT(gradient != nullptr);
+
+  const WeldConstraintsDataPool<T>& weld_data = data.weld_constraints_data();
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+    const int c_b = model().body_to_clique(bodyB);
+
+    // The gradient ∂ℓ/∂vc of the weld cost ℓ = ½(v̂ − vc)ᵀR⁻¹(v̂ − vc) is
+    // −R⁻¹⋅(v̂ − vc) (R is diagonal). Define γ ≜ −∂ℓ/∂vc.
+    const Vector6<T>& gamma = weld_data.gamma(k);
+
+    // The constraint Jacobian maps v → vc = V_W_AmBm, so its transpose maps
+    // constraint impulses γ → generalized impulses Jᵀγ so ∇ℓ = −Jᵀ⋅γ.
+    // For body B: the spatial impulse at Bm is +γ, shifted to Bo.
+    // Γ_Bo_W = Shift(γ, p_BoBm_W)
+    const Vector3<T>& p_PoQo = p_PoQo_W_[k];
+    const Vector3<T> p_BoBm_W = p_BQ_W_[k] - 0.5 * p_PoQo;
+    const Vector6<T> Gamma_Bo_W = ShiftSpatialImpulse(gamma, p_BoBm_W);
+
+    Eigen::VectorBlock<VectorX<T>> gradient_b =
+        model().mutable_clique_segment(c_b, gradient);
+    if (model().is_floating(bodyB)) {
+      gradient_b.noalias() -= Gamma_Bo_W;
+    } else {
+      auto J_WB = model().J_WB(bodyB);
+      gradient_b.noalias() -= J_WB.transpose() * Gamma_Bo_W;
+    }
+
+    // For body A: the spatial impulse at Am is −γ, shifted to Ao.
+    // p_AoAm_W = p_AP_W + 0.5*p_PoQo_W
+    if (!model().is_anchored(bodyA)) {
+      const int c_a = model().body_to_clique(bodyA);
+      const Vector3<T> p_AoAm_W = p_AP_W_[k] + 0.5 * p_PoQo;
+      const Vector6<T> minus_Gamma_Ao_W =
+          ShiftSpatialImpulse(Vector6<T>(-gamma), p_AoAm_W);
+
+      Eigen::VectorBlock<VectorX<T>> gradient_a =
+          model().mutable_clique_segment(c_a, gradient);
+      if (model().is_floating(bodyA)) {
+        gradient_a.noalias() -= minus_Gamma_Ao_W;
+      } else {
+        auto J_WA = model().J_WB(bodyA);
+        gradient_a.noalias() -= J_WA.transpose() * minus_Gamma_Ao_W;
+      }
+    }
+  }
+}
+
+template <typename T>
+void WeldConstraintsPool<T>::PrecomputeHessianBlocks() {
+  hessian_blocks_.resize(num_constraints());
+
+  using std::max;
+  const T dt = model().time_step();
+  // Effective time scale for computing stiffness and dissipation.
+  const T dt_eff = max(dt, static_cast<T>(kHMin));
+  const T taud = kBeta * dt_eff / M_PI;
+  // R⁻¹ = K·dt·(dt + taud) where K = 4π²/(β²·dt_eff²·w), so
+  // R_diag = w / (K·dt·(dt + taud)) = β²·dt_eff²·w / (4π²·dt·(dt + taud)).
+  const T r_scale = (kBeta * kBeta * dt_eff * dt_eff) /
+                    (4.0 * M_PI * M_PI * dt * (dt + taud));
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+    const int c_b = model().body_to_clique(bodyB);
+    const int c_a = model().body_to_clique(bodyA);  // negative if anchored.
+
+    typename WeldConstraintsPool<T>::HessianBlock& hb = hessian_blocks_[k];
+    hb.c_b = c_b;
+    hb.c_a = c_a;
+    hb.a_is_dynamic = !model().is_anchored(bodyA);
+
+    // Compute the regularization R = ε⋅W, where W ≈ J⋅diag(M)⁻¹⋅Jᵀ.
+    // For a weld constraint between two bodies, the Jacobian maps generalized
+    // velocities to the relative spatial velocity V_W_AmBm. For the diagonal
+    // approximation, we need the sum of contributions from both bodies.
+
+    // Approximate W_B = J_WB⋅diag(M_B)⁻¹⋅J_WBᵀ using body mass.
+    // For a single rigid body, this is approximately 1/mass for translational
+    // DOFs. We use a scalar approximation: w ≈ 1/m_B (+ 1/m_A if not anchored).
+    const T& mass_B = model().body_mass(bodyB);
+    T w = 1.0 / mass_B;
+    if (!model().is_anchored(bodyA)) {
+      w += 1.0 / model().body_mass(bodyA);
+    }
+
+    // For the rotational part, the Delassus approximation is more complex
+    // as it depends on the inertia tensor. We use the same scalar mass-based
+    // approximation as for translation, which is consistent with SAP's
+    // near-rigid approach where the exact value of R is not critical as long
+    // as it regularizes appropriately.
+    R_[k].setConstant(r_scale * w);
+
+    const Vector6<T>& R_diag = R_[k];
+
+    // G = diag(R⁻¹) ∈ ℝ⁶ˣ⁶
+    const Vector6<T> R_inv = R_diag.cwiseInverse();
+    Matrix6<T> G = Matrix6<T>::Zero();
+    G.diagonal() = R_inv;
+
+    // TODO(sherm1) Consider precomputing p_BoBm_W and p_AoAm_W.
+    const Vector3<T>& p_PoQo_W = p_PoQo_W_[k];
+    const Vector3<T> p_BoBm_W = p_BQ_W_[k] - 0.5 * p_PoQo_W;
+
+    // Compute G_Bp = Φ(p_BoBm)ᵀ⋅G⋅Φ(p_BoBm) where Φ(p) = [𝕀₃, 0; -pₓ, 𝕀₃].
+    const Matrix3<T> px_B = VectorToSkewSymmetric(p_BoBm_W);
+    const Matrix3<T> Gr = G.template topLeftCorner<3, 3>();
+    const Matrix3<T> Gt = G.template bottomRightCorner<3, 3>();
+    Matrix6<T> G_Bp;
+    G_Bp.template topLeftCorner<3, 3>() = Gr - px_B * Gt * px_B;
+    G_Bp.template topRightCorner<3, 3>() = px_B * Gt;
+    G_Bp.template bottomLeftCorner<3, 3>() = -Gt * px_B;
+    G_Bp.template bottomRightCorner<3, 3>() = Gt;
+
+    // Body B contribution: H_BB = J_WBᵀ⋅G_Bp⋅J_WB
+    DRAKE_ASSERT(!model().is_anchored(bodyB));
+    auto J_WB = model().J_WB(bodyB);
+    if (model().is_floating(bodyB)) {
+      hb.H_BB = G_Bp;
+    } else {
+      const int nv_b = model().clique_size(c_b);
+      Matrix6X<T> GJb(6, nv_b);
+      GJb.noalias() = G_Bp * J_WB;
+      hb.H_BB.resize(nv_b, nv_b);
+      hb.H_BB.noalias() = J_WB.transpose() * GJb;
+    }
+
+    // Body A contribution, only if not anchored.
+    if (hb.a_is_dynamic) {
+      const Vector3<T> p_AoAm_W = p_AP_W_[k] + 0.5 * p_PoQo_W;
+      auto J_WA = model().J_WB(bodyA);
+
+      // G_Ap = Φ(p_AoAm)ᵀ⋅G⋅Φ(p_AoAm) where Φ(p) = [𝕀₃, 0; -pₓ, 𝕀₃].
+      const Matrix3<T> px_A = VectorToSkewSymmetric(p_AoAm_W);
+      Matrix6<T> G_Ap;
+      G_Ap.template topLeftCorner<3, 3>() = Gr - px_A * Gt * px_A;
+      G_Ap.template topRightCorner<3, 3>() = px_A * Gt;
+      G_Ap.template bottomLeftCorner<3, 3>() = -Gt * px_A;
+      G_Ap.template bottomRightCorner<3, 3>() = Gt;
+
+      // H_AA = J_WAᵀ⋅G_Ap⋅J_WA
+      if (model().is_floating(bodyA)) {
+        hb.H_AA = G_Ap;
+      } else {
+        const int nv_a = model().clique_size(c_a);
+        Matrix6X<T> GJa(6, nv_a);
+        GJa.noalias() = G_Ap * J_WA;
+        hb.H_AA.resize(nv_a, nv_a);
+        hb.H_AA.noalias() = J_WA.transpose() * GJa;
+      }
+
+      // Let Φ_A = Φ(p_AoAm) and Φ_B = Φ(p_BoBm).
+      // Cross term: H_BA = −J_WBᵀ⋅Φ_Bᵀ⋅G⋅Φ_A⋅J_WA
+
+      // Define G_cross = −Φ_Bᵀ⋅G⋅Φ_A.
+      Matrix6<T> G_cross;
+      G_cross.template topLeftCorner<3, 3>() = -(Gr - px_B * Gt * px_A);
+      G_cross.template topRightCorner<3, 3>() = -px_B * Gt;
+      G_cross.template bottomLeftCorner<3, 3>() = Gt * px_A;
+      G_cross.template bottomRightCorner<3, 3>() = -Gt;
+
+      // Compute H_BA and store the final cross block in the correct
+      // orientation for AddToBlock.
+      const int nv_a = model().clique_size(c_a);
+      const int nv_b = model().clique_size(c_b);
+      MatrixX<T> H_BA(nv_b, nv_a);
+      {
+        Matrix6X<T> GJa(6, nv_a);
+        GJa.noalias() = G_cross * J_WA;
+        if (model().is_floating(bodyB)) {
+          H_BA = GJa;
+        } else {
+          H_BA.noalias() = J_WB.transpose() * GJa;
+        }
+      }
+
+      if (c_b > c_a) {
+        hb.cross_row = c_b;
+        hb.cross_col = c_a;
+        hb.H_cross = H_BA;
+      } else if (c_a > c_b) {
+        hb.cross_row = c_a;
+        hb.cross_col = c_b;
+        hb.H_cross = H_BA.transpose();
+      } else {
+        // c_a == c_b: both bodies in the same clique.
+        hb.cross_row = c_a;
+        hb.cross_col = c_b;
+        hb.H_cross = H_BA + H_BA.transpose();
+      }
+    }
+  }
+}
+
+template <typename T>
+void WeldConstraintsPool<T>::AccumulateHessian(
+    const IcfData<T>&, BlockSparseSymmetricMatrix<MatrixX<T>>* hessian) const {
+  DRAKE_ASSERT(hessian != nullptr);
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const typename WeldConstraintsPool<T>::HessianBlock& hb =
+        hessian_blocks_[k];
+    hessian->AddToBlock(hb.c_b, hb.c_b, hb.H_BB);
+
+    if (hb.a_is_dynamic) {
+      hessian->AddToBlock(hb.c_a, hb.c_a, hb.H_AA);
+      hessian->AddToBlock(hb.cross_row, hb.cross_col, hb.H_cross);
+    }
+  }
+}
+
+template <typename T>
+void WeldConstraintsPool<T>::CalcCostAlongLine(
+    const WeldConstraintsDataPool<T>& weld_data,
+    const EigenPool<Vector6<T>>& U_WB, T* dcost, T* d2cost) const {
+  DRAKE_ASSERT(dcost != nullptr);
+  DRAKE_ASSERT(d2cost != nullptr);
+  *dcost = 0.0;
+  *d2cost = 0.0;
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+
+    // Compute the constraint "velocity" in the search direction w.
+    // U_AmBm_W = uc (constraint velocity evaluated on w).
+    const Vector3<T>& p_PoQo = p_PoQo_W_[k];
+    const Vector3<T> p_AoAm_W = p_AP_W_[k] + 0.5 * p_PoQo;
+    const Vector3<T> p_BoBm_W = p_BQ_W_[k] - 0.5 * p_PoQo;
+
+    const Vector6<T>& U_WB_body = U_WB[bodyB];
+    const Vector3<T>& uw_WB = U_WB_body.template head<3>();
+    const Vector3<T>& uv_WBo = U_WB_body.template tail<3>();
+    const Vector3<T> uv_WBm = uv_WBo + uw_WB.cross(p_BoBm_W);
+
+    Vector6<T> uc;  // Constraint velocity in search direction.
+    if (!model().is_anchored(bodyA)) {
+      const Vector6<T>& U_WA_body = U_WB[bodyA];
+      const Vector3<T>& uw_WA = U_WA_body.template head<3>();
+      const Vector3<T>& uv_WAo = U_WA_body.template tail<3>();
+      const Vector3<T> uv_WAm = uv_WAo + uw_WA.cross(p_AoAm_W);
+      uc.template head<3>() = uw_WB - uw_WA;
+      uc.template tail<3>() = uv_WBm - uv_WAm;
+    } else {
+      uc.template head<3>() = uw_WB;
+      uc.template tail<3>() = uv_WBm;
+    }
+
+    const Vector6<T>& gamma = weld_data.gamma(k);
+    const Vector6<T>& R_diag = R_[k];
+
+    // dℓ̃/dα = −γᵀ⋅uc
+    (*dcost) -= gamma.dot(uc);
+
+    // d²ℓ̃/dα² = ucᵀ⋅R⁻¹⋅uc
+    (*d2cost) += uc.cwiseQuotient(R_diag).dot(uc);
+  }
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        WeldConstraintsPool);

--- a/multibody/contact_solvers/icf/weld_constraints_pool.h
+++ b/multibody/contact_solvers/icf/weld_constraints_pool.h
@@ -1,0 +1,180 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+#include "drake/multibody/contact_solvers/icf/weld_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+// Forward declaration to break circular dependencies.
+template <typename T>
+class IcfModel;
+
+/* A pool of weld constraints between pairs of bodies.
+
+Each weld constraint connects distinct bodies A and B, enforcing coincidence
+of a frame P on A and a frame Q on B. The constraint function is defined as
+  g = (a_PQ, p_PoQo) = 0 ∈ ℝ⁶
+where a_PQ = θ⋅k is the Euler vector for the relative rotation R_PQ, and
+p_PoQo is the relative translation between the constraint frames P and Q.
+
+Following the SAP weld constraint formulation (see sap_weld_constraint.h), we
+define the constraint velocity as the relative spatial velocity of points Am
+(fixed to A) and Bm (fixed to B) coincident at the midpoint M between P and Q:
+  vc = V_W_AmBm ∈ ℝ⁶
+and the convex cost as:
+  ℓ(vc) = ½(v̂ − vc)ᵀR⁻¹(v̂ − vc)
+where R is a 6×6 diagonal "near-rigid" regularization matrix and v̂ is a bias
+velocity computed from g₀, the constraint function evaluated at q₀.
+
+This produces spatial impulse γ ≜ −dℓ(vc)/dvc = (γᵣ, γₜ) ∈ ℝ⁶ which we use to
+apply equal and opposite impulses at Am and Bm (co-located at the midpoint M),
+ensuring conservation of angular momentum and satisfaction of Newton's third
+law. Our sign convention is such that γ is the impulse on B, so the impulse on A
+is −γ.
+
+Like patch constraints, weld constraints involve two bodies and can introduce
+cross-clique coupling (off-diagonal blocks in the Hessian) when the two bodies
+belong to different cliques.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class WeldConstraintsPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(WeldConstraintsPool);
+
+  /* Constructs an empty pool. */
+  explicit WeldConstraintsPool(const IcfModel<T>* parent_model);
+
+  ~WeldConstraintsPool();
+
+  /* Returns a reference to the parent model. */
+  const IcfModel<T>& model() const { return *model_; }
+
+  /* Returns the total number of weld constraints stored in this pool. */
+  int num_constraints() const { return ssize(body_pairs_); }
+
+  /* Resizes the constraints pool to store the given number of weld constraints.
+
+  @warning After resizing, constraints may hold invalid data until Set() is
+  called for each constraint index in [0, num_constraints()). */
+  void Resize(int num_constraints);
+
+  /* Sets the k-th weld constraint.
+
+  @param index The index of the constraint within the pool.
+  @param bodyA The index of body A in the IcfModel. May be anchored.
+  @param bodyB The index of body B in the IcfModel. Must not be anchored.
+  @param p_AP_W Position of constraint point P in body A, expressed in world.
+  @param p_BQ_W Position of constraint point Q in body B, expressed in world.
+  @param p_PoQo_W Position of Qo relative to Po, expressed in world.
+  @param a_PQ_W Euler vector a_PQ = θ⋅k for relative rotation, in world frame.
+
+  Calling this function several times with the same `index` overwrites the
+  previous constraint for that index.
+
+  @pre all indices are in range, bodyA ≠ bodyB, bodyB not anchored. */
+  void Set(int index, int bodyA, int bodyB, const Vector3<T>& p_AP_W,
+           const Vector3<T>& p_BQ_W, const Vector3<T>& p_PoQo_W,
+           const Vector3<T>& a_PQ_W);
+
+  /* Computes the sparsity pattern for the pool. Clique i is connected to
+  clique j > i iff sparsity[i] contains j. */
+  void CalcSparsityPattern(std::vector<std::vector<int>>* sparsity) const;
+
+  /* Precomputes the iteration-invariant Hessian blocks for every weld
+  constraint. Because the weld cost ℓ(vc) = ½(v̂ − vc)ᵀR⁻¹(v̂ − vc) is
+  purely quadratic in the constraint velocity, its Hessian ∂²ℓ/∂v² depends
+  only on the regularization R and the (constant) constraint Jacobians. This
+  method must be called after all Set() calls and before AccumulateHessian()
+  is used. */
+  void PrecomputeHessianBlocks();
+
+  /* Computes problem data as a function of the body spatial velocities V_WB for
+  the full IcfModel. */
+  void CalcData(const EigenPool<Vector6<T>>& V_WB,
+                WeldConstraintsDataPool<T>* weld_data) const;
+
+  /* Adds the gradient contribution of this constraint, ∇ℓ(v) = −Jᵀγ, to the
+  model-wide gradient. */
+  void AccumulateGradient(const IcfData<T>& data, VectorX<T>* gradient) const;
+
+  /* Adds the contribution of this constraint to the model-wide Hessian. */
+  void AccumulateHessian(
+      const IcfData<T>& data,
+      contact_solvers::internal::BlockSparseSymmetricMatrix<MatrixX<T>>*
+          hessian) const;
+
+  /* Computes the first and second derivatives of the constraint cost
+  ℓ̃(α) = ℓ(v + α⋅w).
+
+  @param weld_data Constraint data computed at v + α⋅w.
+  @param U_WB Body spatial velocities when generalized velocities equal w.
+         I.e., U_WB = J_WB⋅w.
+  @param[out] dcost the first derivative dℓ̃/dα on output.
+  @param[out] d2cost the second derivative d²ℓ̃/dα² on output. */
+  void CalcCostAlongLine(const WeldConstraintsDataPool<T>& weld_data,
+                         const EigenPool<Vector6<T>>& U_WB, T* dcost,
+                         T* d2cost) const;
+
+  /* Testing only access. */
+  const std::vector<std::pair<int, int>>& body_pairs() const {
+    return body_pairs_;
+  }
+
+ private:
+  const IcfModel<T>* const model_;  // The parent model.
+
+  // Body pairs involved in each weld constraint, (bodyA, bodyB).
+  // bodyB is always dynamic (not anchored).
+  std::vector<std::pair<int, int>> body_pairs_;
+
+  // Per-constraint data, all indexed by constraint index k.
+  EigenPool<Vector3<T>> p_AP_W_;    // Position of P in A, expressed in W.
+  EigenPool<Vector3<T>> p_BQ_W_;    // Position of Q in B, expressed in W.
+  EigenPool<Vector3<T>> p_PoQo_W_;  // Relative translation, expressed in W.
+
+  std::vector<Vector6<T>> g0_;  // Constraint function at start of step.
+
+  // Near-rigid regularization per constraint.
+  // R depends on the current time step δt and is computed in
+  // PrecomputeHessianBlocks(), which must be called whenever δt changes.
+  // R is a diagonal 6×6 regularization matrix: R = diag(Rᵣ, Rₜ).
+  std::vector<Vector6<T>> R_;  // The diagonal regularization matrix.
+
+  // TODO(sherm1) Consider whether this should be using EigenPools to
+  //  reduce memory use.
+  // Precomputed Hessian blocks for each weld constraint, populated by
+  // PrecomputeHessianBlocks(). These are iteration-invariant because the weld
+  // cost Hessian depends only on R and the constant constraint Jacobians.
+  struct HessianBlock {
+    int c_b{-1};         // Clique index for body B (always valid).
+    int c_a{-1};         // Clique index for body A (-1 if anchored).
+    MatrixX<T> H_BB;     // Diagonal block for body B's clique.
+    MatrixX<T> H_AA;     // Diagonal block for body A's clique (if dynamic).
+    MatrixX<T> H_cross;  // Off-diagonal (or same-clique cross) block.
+    int cross_row{-1};   // Block row index for the cross term.
+    int cross_col{-1};   // Block column index for the cross term.
+    bool a_is_dynamic{false};  // True when body A is not anchored.
+  };
+  std::vector<HessianBlock> hessian_blocks_;
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        WeldConstraintsPool);

--- a/multibody/contact_solvers/sap/sap_weld_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_weld_constraint.cc
@@ -107,7 +107,7 @@ SapWeldConstraint<T>::MakeSapHolonomicConstraintKinematics(
   // this setting, once the constraint velocity vc and cost ℓ(vc) are defined,
   // impulses follow from:
   //  γ = -dℓ/dvc
-  // and the mulitbody spatial forces modeled by this cost are inferred from the
+  // and the multibody spatial forces modeled by this cost are inferred from the
   // optimality conditions (the momentum balance), see
   // DoAccumulateSpatialImpulses().
   //
@@ -121,7 +121,7 @@ SapWeldConstraint<T>::MakeSapHolonomicConstraintKinematics(
   // rotational contribution ℓᵣ(vc)
   //   ℓₜ(vc) = 1/2||p_PQ(t) + δt⋅v_AmBm||ₜ²,  ||x||ₜ² = Rₜ||x||²
   //   ℓᵣ(vc) = 1/2||a_PQ(t) + δt⋅w_AB||ᵣ²  ,  ||x||ᵣ² = Rᵣ||x||²
-  // were a_PQ is the axis-angle vector and, Rₜ and Rᵣ the regularization
+  // where a_PQ is the axis-angle vector and, Rₜ and Rᵣ the regularization
   // parameters determined by the SAP formulation in the "near-rigid" regime,
   // see SapHolonomicConstraint.
   // We can show (see below), that this formulation is an approximation to
@@ -138,7 +138,7 @@ SapWeldConstraint<T>::MakeSapHolonomicConstraintKinematics(
   //   γₜ = -dℓ/dvcₜ = -Rₜ(p_PQ(t) + δt⋅v_AmBm)
   // We show below that:
   //  p_PQ(t+δt) = p_PQ(t) + δt⋅v_AmBm + O(dt⋅‖p_PQ‖⋅‖w_WA + w_WB‖)
-  // and therefore this models a linear spring on p_PQ(t+δt) (heavilty
+  // and therefore this models a linear spring on p_PQ(t+δt) (heavily
   // overdamped given the time scale introduced by SAP's choice of Rₜ cannot
   // be resolved by the discrete time step δt).
   //
@@ -149,8 +149,8 @@ SapWeldConstraint<T>::MakeSapHolonomicConstraintKinematics(
   //          = v_W_PQ + p_PQ_W×(w_WA + w_WB)/2
   // And therefore we arrive to the conclusion that:
   //   p_PQ(t) + δt⋅v_AmBm ≈ p_PQ(t+δt)
-  //                       = p_PQ(t) + δt⋅ᵂd(p_PQ)/t + O(δt²)
-  //                       = p_PQ(t) + O(dt⋅‖p_PQ‖⋅‖w_WA + w_WB‖)
+  //                       = p_PQ(t) + δt⋅ᵂd(p_PQ)/dt + O(δt²)
+  //                       = p_PQ(t) + O(δt⋅‖p_PQ‖⋅‖w_WA + w_WB‖)
   // and thus the cost ℓₜ(vc) penalizes a first order approximation to
   // p_PQ(t+δt).
   // We show conservation of angular momentum in DoAccumulateSpatialImpulses().
@@ -159,7 +159,7 @@ SapWeldConstraint<T>::MakeSapHolonomicConstraintKinematics(
   //   γᵣ = -dℓ/dvcᵣ = -Rᵣ(a_PQ(t) + δt⋅w_AB)
   // We show below that for small values of θ = ||a_PQ(t)||, we have that
   //  a_PQ(t) + δt⋅w_AB ≈ a_PQ(t+δt)
-  // and therefore this cost models a linear torsionial spring that oposes
+  // and therefore this cost models a linear torsional spring that opposes
   // deviations of a_PQ from zero.
   //
   // To show this we start with:


### PR DESCRIPTION
Implement weld constraints in the ICF solver, analogous to the existing SAP weld constraint. This enables the ICF solver to handle rigid attachments between bodies and can be used to model mechanisms with closed topological loops.

New files:
- weld_constraints_data_pool.h/.cc: Per-iteration data (impulses γ, cost). Note that the Hessian depends only on quantities that are fixed during iteration so those are precomputed.
- weld_constraints_pool.h/.cc: Constraint pool with Set, CalcData, AccumulateGradient, AccumulateHessian, CalcCostAlongLine, CalcSparsityPattern
- test/weld_constraints_pool_test.cc: Unit tests for weld-to-world, cross-clique, cost-along-line, and gradient consistency
- test/weld_constraint_simulation.cc: Tests that CENIC (using ICF) can overcome a large initial error and enforce the constraint during a simulation

Modified files:
- icf_data.h/.cc: Add WeldConstraintsDataPool member and num_welds param
- icf_model.h/.cc: Add WeldConstraintsPool, wire into CalcData, gradient, Hessian, cost, sparsity, and CalcCostAlongLine
- icf_builder.h/.cc: Add AllocateWeldConstraints/SetWeldConstraints, remove weld from unsupported-constraint exception
- BUILD.bazel: Add new library and test targets
- test/icf_data_test.cc: Update Resize calls for new num_welds parameter
- test/icf_builder_test.cc: Convert WeldConstraintUnsupported to WeldConstraintSupported
- test/icf_model_test.cc: Added weld constraint tests

The weld constraint uses the SAP near-rigid regularization (β=0.1) with a 6-DOF constraint g=(a_PQ, p_PoQo). Constraint velocity is evaluated at the midpoint M between frames P and Q. Cross-clique Hessian blocks are computed for two-body constraints spanning different cliques.

All 80 ICF tests pass including lint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24174)
<!-- Reviewable:end -->
