### PR TITLE
[build] Provide a wrapper debug build configuration

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -670,7 +670,7 @@ If you need to debug further while using Bazel, it is suggested to use
 ```
     # Terminal 1 - Host process.
     cd drake
-    bazel run -c dbg \
+    bazel run --config=debug \
         --run_under='gdbserver localhost:9999' \
         //bindings/pydrake/systems:py/lifetime_test -- \
         --trace=user

--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -30,7 +30,7 @@ build --notrim_test_configuration
 build --action_env=CCACHE_DISABLE=1
 
 # Transcriptions of CMake configs into their equivalent Bazel flags.
-build:Debug --compilation_mode=dbg --fission=no
+build:Debug --config=debug --fission=no
 build:MinSizeRel --compilation_mode=opt --copt=-Os --host_copt=-Os
 build:Release --compilation_mode=opt
 build:RelWithDebInfo --compilation_mode=opt --fission=no --copt=-g --host_copt=-g

--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -116,14 +116,14 @@ bazel build common:polynomial                        # Build libpolynomial.
 bazel build common:all                               # Build everything in common but NOT its children.
 
 bazel test common:polynomial_test                    # Run one test.
-bazel test -c dbg common:polynomial_test             # Run one test in debug mode.
+bazel test --config=debug common:polynomial_test       # Run one test in debug mode.
 bazel test --config=memcheck common:polynomial_test  # Run one test under memcheck (valgrind).
 bazel test --config=fastmemcheck common:all          # Run common's tests under memcheck, with minimal recompiling.
 bazel test --config=kcov common:polynomial_test      # Run one test under kcov (see instructions below).
-bazel build -c dbg common:polynomial_test && \
+bazel build --config=debug common:polynomial_test && \
   gdb bazel-bin/common/polynomial_test               # Run one test under gdb.
 
-bazel test -c dbg --config=clang --config=asan common:polynomial_test  # Run one test under AddressSanitizer.
+bazel test --config=debug --config=clang --config=asan common:polynomial_test  # Run one test under AddressSanitizer.
 
 bazel test --config lint //...                       # Only run style checks; don't build or test anything else.
 ```

--- a/examples/cubic_polynomial/backward_reachability.cc
+++ b/examples/cubic_polynomial/backward_reachability.cc
@@ -200,8 +200,8 @@ void ComputeBackwardReachableSet() {
   // Serialize the result and generate Python plots.  In particular, plot the
   // true indicator function of B and w (its polynomial outer-approximation).
   // Execute:
-  //    > bazel run //examples/cubic_polynomial:backward_reachability -c dbg
-  //         --config mosek
+  //    > bazel run //examples/cubic_polynomial:backward_reachability
+  //         --config debug --config mosek
   //    > bazel run //common/proto:call_python_client_cli
   const int N{1000};
   Eigen::VectorXd x_val(N), w_val(N), v_val(N), ground_val(N);

--- a/multibody/contact_solvers/test/newton_with_bisection_test.cc
+++ b/multibody/contact_solvers/test/newton_with_bisection_test.cc
@@ -233,8 +233,9 @@ std::vector<RootFindingTestData> GenerateTestCases() {
 // Test parametrized on different root finding cases.
 // To see debug information printed out by DoNewtonWithBisectionFallback, run
 // with:
-//   bazel run -c dbg multibody/contact_solvers:newton_with_bisection_test --
-//   --spdlog_level debug
+//   bazel run --config=debug
+//    multibody/contact_solvers:newton_with_bisection_test --
+//    --spdlog_level debug
 struct RootFindingTest : public testing::TestWithParam<RootFindingTestData> {};
 
 TEST_P(RootFindingTest, VerifyExpectedResults) {

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -77,6 +77,11 @@ build --test_env=LCM_DEFAULT_URL=memq://
 # Prevent matplotlib from showing windows (#11029).
 build --test_env=MPLBACKEND=Template
 
+### A wrapper configuration for debug builds. ###
+build:debug --compilation_mode=dbg
+# Provide a performance cushion for debug builds, 2x the default timeouts.
+build:debug --test_timeout=120,600,1800,7200
+
 ### A configuration that enables all optional dependencies. ###
 build:everything --test_tag_filters=-no_everything
 # We'll also use it to test our custom AutoDiff until 2026-04-01 when this flag

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -171,7 +171,7 @@ build:_memcheck --define=USING_MEMCHECK=ON
 # not alter the compile flags.  Thus, the already-cached compilation results
 # from a `bazel build` or `bazel test` can be reused.  This is useful to scan a
 # local build for memory errors quickly.  For more specific error reporting
-# when errors are found, try `-c dbg --config fastmemcheck` or `--config
+# when errors are found, try `--config=debug --config fastmemcheck` or `--config
 # memcheck` to recompile with line numbers and lower optimization levels.
 #
 build:fastmemcheck --run_under=//tools/dynamic_analysis:valgrind

--- a/tools/dynamic_analysis/dump_limit_malloc_stacks
+++ b/tools/dynamic_analysis/dump_limit_malloc_stacks
@@ -8,7 +8,7 @@
 #
 # Example:
 #
-#  $ bazel build -c dbg //common/test_utilities:limit_malloc_manual_test
+#  $ bazel build --config=debug //common/test_utilities:limit_malloc_manual_test
 #  $ tools/dynamic_analysis/dump_limit_malloc_stacks \
 #      bazel-bin/common/test_utilities/limit_malloc_manual_test \
 #      |& tee stacks.out


### PR DESCRIPTION
We need to extend test timeouts on debug builds, and Bazel provides no way of conditionally applying flags based on `--compilation_mode`. Instead, we'll instruct developers (and CI) to use `--config=debug`, and put our test timeouts under there.

Reapplies #24144. Towards #24124. See also RobotLocomotion/drake-ci#390.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24177)
<!-- Reviewable:end -->
