### PR TITLE
[build] Specify platform-specific C++ standard for installed Drake

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -35,6 +35,26 @@ load(":header_lint.bzl", "cc_check_allowed_headers")
 
 package(default_visibility = ["//visibility:private"])
 
+# Keep this in sync with the platform-specific `--cxxopt` ranges in tools/*.
+config_setting(
+    name = "cxx20",
+    values = {
+        "cxxopt": "-std=c++20",
+    },
+)
+
+generate_file(
+    name = "cxx_standard.cmake",
+    content = select({
+        ":cxx20": (
+            "set(DRAKE_CXX_STANDARD cxx_std_20)"
+        ),
+        "//conditions:default": (
+            "set(DRAKE_CXX_STANDARD cxx_std_23)"
+        ),
+    }),
+)
+
 generate_file(
     name = "drake_install_java.cmake",
     content = select({
@@ -179,6 +199,7 @@ cmake_configure_file(
         ":bazel_eigen_defines.cmake",
         ":bazel_fmt_defines.cmake",
         ":bazel_spdlog_defines.cmake",
+        ":cxx_standard.cmake",
         ":drake_install_java.cmake",
         ":libdrake_was_linked_shared.cmake",
         ":python_version.cmake",

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -50,6 +50,8 @@ if(@DRAKE_INSTALL_JAVA@)
   list(APPEND _expectedTargets drake::drake-lcmtypes-java)
 endif()
 
+set(_drake_interface_compile_features @DRAKE_CXX_STANDARD@)
+
 set(_targetsDefined)
 set(_targetsNotDefined)
 
@@ -90,7 +92,7 @@ set_target_properties(drake::drake PROPERTIES
   IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/${_drake_library_name}"
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include"
   INTERFACE_LINK_LIBRARIES "${_drake_interface_libraries}"
-  INTERFACE_COMPILE_FEATURES "cxx_std_20"
+  INTERFACE_COMPILE_FEATURES "${_drake_interface_compile_features}"
   INTERFACE_COMPILE_DEFINITIONS "${_drake_interface_compile_definitions}"
 )
 if(@LIBDRAKE_WAS_LINKED_SHARED@)

--- a/tools/install/libdrake/test/find_package_drake_install_test.py
+++ b/tools/install/libdrake/test/find_package_drake_install_test.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import textwrap
 import unittest
 
@@ -24,6 +25,11 @@ class FindPackageDrakeInstallTest(unittest.TestCase):
             f.write(textwrap.dedent(cc_content_drake))
 
         cmake_prefix_path = install_test_helper.get_install_dir()
+        # Keep this in sync with the platform-specific `--cxxopt` ranges in
+        # tools/*.
+        drake_cxx_std = "cxx_std_23"
+        if sys.version_info[0:2] <= (3, 10):
+            drake_cxx_std = "cxx_std_20"
 
         cmake_content = f"""
             cmake_minimum_required(VERSION 3.9...4.2)
@@ -38,6 +44,24 @@ class FindPackageDrakeInstallTest(unittest.TestCase):
             if(NOT drake_type STREQUAL "SHARED_LIBRARY")
                 message(FATAL_ERROR "drake::drake is ${{drake_type}}, but expected SHARED_LIBRARY.")
             endif()
+
+            # Check that by linking against drake::drake, main_drake gets the
+            # correct CXX standard. Since INTERFACE_COMPILE_FEATURES aren't
+            # propagated until generate time, we generate a file that has the
+            # query result, and then check that file at build time.
+            set(cxx_std_out ${{CMAKE_CURRENT_BINARY_DIR}}/cxx_std_check.txt)
+            file(GENERATE
+                OUTPUT ${{cxx_std_out}}
+                CONTENT $<IN_LIST:{drake_cxx_std},$<TARGET_PROPERTY:main_drake,COMPILE_FEATURES>>
+            )
+            set(val_out ${{CMAKE_CURRENT_BINARY_DIR}}/validation.stamp)
+            add_custom_command(
+                OUTPUT ${{val_out}}
+                COMMAND grep "1" ${{cxx_std_out}}
+                COMMAND ${{CMAKE_COMMAND}} -E touch ${{val_out}}
+                DEPENDS ${{cxx_std_out}}
+            )
+            add_custom_target(check_cxx_std ALL DEPENDS ${{val_out}})
         """
 
         cmake_filename = os.path.join(cmake_source_dir, "CMakeLists.txt")


### PR DESCRIPTION
At https://drake.mit.edu/installation.html we note:

> The following table shows the configurations that must be used when compiling your own C++ code against Drake’s C++ code using one of Drake’s pre-compiled binaries:  
...   
Any other configuration not listed here will lead to undefined behavior (as a violation of the C++ One-Definition Rule).

with various C++ standards according to the version of Ubuntu/macOS.

The `drake::drake` CMake target's [`INTERFACE_COMPILE_FEATURES`](https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_COMPILE_FEATURES.html) should convey this information.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24183)
<!-- Reviewable:end -->
