### PR TITLE
Deprecate `VectorBase::operator<<`

### DIFF
--- a/bindings/generated_docstrings/systems_analysis.h
+++ b/bindings/generated_docstrings/systems_analysis.h
@@ -4754,9 +4754,8 @@ is advanced:
 .. code-block:: c++
 
     simulator.set_monitor([](const Context<T>& root_context) {
-      std∷cout << root_context.get_time() << " "
-                << root_context.get_continuous_state_vector()
-                << std∷endl;
+      fmt∷print("{} {}\n", root_context.get_time(),
+                            root_context.get_continuous_state_vector());
       return EventStatus∷Succeeded();
     });
 

--- a/bindings/generated_docstrings/systems_framework.h
+++ b/bindings/generated_docstrings/systems_framework.h
@@ -12893,6 +12893,13 @@ derivatives) might be discarded.)""";
           const char* doc = R"""()""";
         } ThrowConversionMismatch;
       } system_scalar_converter_internal;
+      // Symbol: drake::systems::to_string
+      struct /* to_string */ {
+        // Source: drake/systems/framework/vector_base.h
+        const char* doc =
+R"""(Returns the string representation of a VectorBase<T> as a row vector
+RowVectorX<T> e.g., "1, 2, 3". This is useful for debugging purposes.)""";
+      } to_string;
     } systems;
   } drake;
 } pydrake_doc_systems_framework;

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -424,9 +424,8 @@ class Simulator {
   /// Output time and continuous states whenever the trajectory is advanced:
   /// @code
   /// simulator.set_monitor([](const Context<T>& root_context) {
-  ///   std::cout << root_context.get_time() << " "
-  ///             << root_context.get_continuous_state_vector()
-  ///             << std::endl;
+  ///   fmt::print("{} {}\n", root_context.get_time(),
+  ///                         root_context.get_continuous_state_vector());
   ///   return EventStatus::Succeeded();
   /// });
   /// @endcode

--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -8,6 +8,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/dummy_value.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/systems/framework/vector_base.h"
 
 namespace drake {
@@ -211,3 +212,6 @@ class BasicVector : public VectorBase<T> {
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::BasicVector);
+
+DRAKE_FORMATTER_AS(typename T, drake::systems, BasicVector<T>, x,
+                   drake::systems::to_string(x))

--- a/systems/framework/leaf_context.cc
+++ b/systems/framework/leaf_context.cc
@@ -50,50 +50,57 @@ std::unique_ptr<State<T>> LeafContext<T>::DoCloneState() const {
 
 template <typename T>
 std::string LeafContext<T>::do_to_string() const {
-  std::ostringstream os;
+  std::string result;
 
-  os << this->GetSystemPathname() << " Context\n";
-  os << std::string(this->GetSystemPathname().size() + 9, '-') << "\n";
-  os << "Time: " << fmt::to_string(this->get_time()) << "\n";
+  result.append(fmt::format("{} Context\n", this->GetSystemPathname()));
+  result.append(fmt::format(
+      "{}\n", std::string(this->GetSystemPathname().size() + 9, '-')));
+  result.append(fmt::format("Time: {}\n", fmt::to_string(this->get_time())));
 
   if (this->num_continuous_states() || this->num_discrete_state_groups() ||
       this->num_abstract_states()) {
-    os << "States:\n";
+    result.append("States:\n");
     if (this->num_continuous_states()) {
-      os << "  " << this->num_continuous_states() << " continuous states\n";
-      os << "    " << this->get_continuous_state_vector() << "\n";
+      result.append(fmt::format("  {} continuous states\n",
+                                this->num_continuous_states()));
+      result.append(
+          fmt::format("    {}\n", this->get_continuous_state_vector()));
     }
     if (this->num_discrete_state_groups()) {
-      os << "  " << this->num_discrete_state_groups()
-         << " discrete state groups with\n";
+      result.append(fmt::format("  {} discrete state groups with\n",
+                                this->num_discrete_state_groups()));
       for (int i = 0; i < this->num_discrete_state_groups(); i++) {
-        os << "     " << this->get_discrete_state(i).size() << " states\n";
-        os << "       " << this->get_discrete_state(i) << "\n";
+        result.append(fmt::format("     {} states\n",
+                                  this->get_discrete_state(i).size()));
+        result.append(fmt::format("       {}\n", this->get_discrete_state(i)));
       }
     }
     if (this->num_abstract_states()) {
-      os << "  " << this->num_abstract_states() << " abstract states\n";
+      result.append(
+          fmt::format("  {} abstract states\n", this->num_abstract_states()));
     }
-    os << "\n";
+    result.append("\n");
   }
 
   if (this->num_numeric_parameter_groups() || this->num_abstract_parameters()) {
-    os << "Parameters:\n";
+    result.append("Parameters:\n");
     if (this->num_numeric_parameter_groups()) {
-      os << "  " << this->num_numeric_parameter_groups()
-         << " numeric parameter groups";
-      os << " with\n";
+      result.append(fmt::format("  {} numeric parameter groups with\n",
+                                this->num_numeric_parameter_groups()));
       for (int i = 0; i < this->num_numeric_parameter_groups(); i++) {
-        os << "     " << this->get_numeric_parameter(i).size()
-           << " parameters\n";
-        os << "       " << this->get_numeric_parameter(i) << "\n";
+        result.append(fmt::format("     {} parameters\n",
+                                  this->get_numeric_parameter(i).size()));
+        result.append(
+            fmt::format("       {}\n", this->get_numeric_parameter(i)));
       }
     }
     if (this->num_abstract_parameters()) {
-      os << "  " << this->num_abstract_parameters() << " abstract parameters\n";
+      result.append(fmt::format("  {} abstract parameters\n",
+                                this->num_abstract_parameters()));
     }
   }
-  return os.str();
+
+  return result;
 }
 
 template <typename T>

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -236,6 +236,10 @@ using DefaultScalars =
     ::testing::Types<double, AutoDiffXd, symbolic::Expression>;
 TYPED_TEST_SUITE(TypedBasicVectorTest, DefaultScalars);
 
+// TODO(2026-07-01): delete test `StringStream` when
+// `BasicVector<T>::operator<<` is removed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests ability to stream a BasicVector into a string.
 TYPED_TEST(TypedBasicVectorTest, StringStream) {
   using T = TypeParam;
@@ -247,7 +251,22 @@ TYPED_TEST(TypedBasicVectorTest, StringStream) {
       fmt::format("hello {} world", fmt_eigen(vec.value().transpose()));
   EXPECT_EQ(s.str(), expected);
 }
+#pragma GCC diagnostic pop
 
+// Tests string representation of a BasicVector.
+TYPED_TEST(TypedBasicVectorTest, ToStringFmtFormatter) {
+  using T = TypeParam;
+  BasicVector<T> vec(3);
+  vec.get_mutable_value() << 1.0, 2.2, 3.3;
+  const std::string expected =
+      fmt::format("hello {} world", fmt_eigen(vec.value().transpose()));
+  EXPECT_EQ(fmt::format("hello {} world", vec), expected);
+}
+
+// TODO(2026-07-01): delete test `ZeroLengthStringStream` block when
+// `BasicVector<T>::operator<<` is removed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests ability to stream a BasicVector of size zero into a string.
 TYPED_TEST(TypedBasicVectorTest, ZeroLengthStringStream) {
   using T = TypeParam;
@@ -257,6 +276,16 @@ TYPED_TEST(TypedBasicVectorTest, ZeroLengthStringStream) {
   const std::string expected =
       fmt::format("foo [{}] bar", fmt_eigen(vec.value().transpose()));
   EXPECT_EQ(s.str(), expected);
+}
+#pragma GCC diagnostic pop
+
+// Tests string representation of a BasicVector of size zero.
+TYPED_TEST(TypedBasicVectorTest, ZeroLengthVectorToStringFmtFormatter) {
+  using T = TypeParam;
+  BasicVector<T> vec(0);
+  const std::string expected =
+      fmt::format("foo [{}] bar", fmt_eigen(vec.value().transpose()));
+  EXPECT_EQ(fmt::format("foo [{}] bar", vec), expected);
 }
 
 // Tests the default set of bounds (empty).

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -232,6 +232,10 @@ TEST_F(ContinuousStateTest, Clone) {
   EXPECT_EQ((*vector)[2], 1.75);
 }
 
+// TODO(2026-07-01): delete test `StringStream` when
+// `BasicVector<T>::operator<<` is removed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests ability to stream a ContinuousState vector into a string.
 TEST_F(ContinuousStateTest, StringStream) {
   std::stringstream s;
@@ -240,6 +244,16 @@ TEST_F(ContinuousStateTest, StringStream) {
       fmt::format("hello {} world",
                   fmt_eigen(continuous_state_->CopyToVector().transpose()));
   EXPECT_EQ(s.str(), expected);
+}
+#pragma GCC diagnostic pop
+
+// Tests string representation of a ContinuousState vector.
+TEST_F(ContinuousStateTest, ToStringFmtFormatter) {
+  const std::string expected =
+      fmt::format("hello {} world",
+                  fmt_eigen(continuous_state_->CopyToVector().transpose()));
+  EXPECT_EQ(fmt::format("hello {} world", continuous_state_->get_vector()),
+            expected);
 }
 
 // Tests for DiagramContinuousState.

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -1,18 +1,20 @@
 #pragma once
 
 #include <initializer_list>
-#include <ostream>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
-#include <fmt/format.h>
+// TODO(2026-07-01): Remove ostream header when `operator<<` is removed.
+#include <ostream>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/common/fmt_eigen.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/unused.h"
 
@@ -270,22 +272,31 @@ class VectorBase {
   }
 };
 
+/// Returns the string representation of a VectorBase<T> as a row vector
+/// RowVectorX<T> e.g., "1, 2, 3". This is useful for debugging purposes.
+template <typename T>
+std::string to_string(const VectorBase<T>& vec) {
+  return fmt::to_string(fmt_eigen(vec.CopyToVector().transpose()));
+}
+
 /// Allows a VectorBase<T> to be streamed into a string as though it were a
 /// RowVectorX<T>. This is useful for debugging purposes.
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const VectorBase<T>& vec) {
-  os << fmt::to_string(fmt_eigen(vec.CopyToVector().transpose()));
+DRAKE_DEPRECATED(
+    "2026-07-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream&
+operator<<(std::ostream& os, const VectorBase<T>& vec) {
+  os << to_string(vec);
   return os;
 }
 
 }  // namespace systems
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
-namespace fmt {
-template <typename T>
-struct formatter<drake::systems::VectorBase<T>> : drake::ostream_formatter {};
-}  // namespace fmt
-
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::VectorBase);
+
+DRAKE_FORMATTER_AS(typename T, drake::systems, VectorBase<T>, x,
+                   drake::systems::to_string(x))


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). For review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24187)
<!-- Reviewable:end -->
