### PR TITLE
[tools] Rewrite library_lint to not use genquery

### DIFF
--- a/tools/lint/library_lint.bzl
+++ b/tools/lint/library_lint.bzl
@@ -9,24 +9,17 @@ def library_lint(
     been used correctly, reports a lint (test) error if not.  (To understand
     proper use of drake_cc_package_library, consult its API documentation.)
 
-    Note that //examples/... packages are excluded from some checks, because
-    they should generally not use drake_cc_package_library.
+    Note that //examples/... packages are skipped, because they should not use
+    drake_cc_package_library.
     """
     if existing_rules == None:
         existing_rules = native.existing_rules().values()
+    if native.package_name().split("/")[0] == "examples":
+        return
     package_name = "//" + native.package_name()  # e.g., "//systems/framework"
     short_package_name = package_name.split("/")[-1]  # e.g., "framework"
 
-    # We use a python helper script to report lint errors.  As we find possible
-    # lint problems, we will append arguments here that will be passed along to
-    # the helper.
-    library_lint_reporter_args = [
-        "--package-name",
-        package_name,
-    ]
-    library_lint_reporter_data = []
-
-    # Within the current package, find all cc_library rules, and the (at most)
+    # Within the current package, find all cc_library rules and the (at most)
     # one package_library rule.
     cc_library_rules = []
     package_library_rule = None
@@ -39,101 +32,52 @@ def library_lint(
         if one_rule["name"].startswith("_"):
             continue
 
-        # Found a cc_library.
-        cc_library_rules.append(one_rule)
-
-        # Is it a package_library?
+        # Categorize this cc_library as a package library or not.
         if "drake_cc_package_library" in one_rule["tags"]:
-            not package_library_rule or fail("Two package libraries?")
+            # Found a package_library.
+            if package_library_rule != None:
+                fail("Two package libraries?!")
+            if one_rule["name"] != short_package_name:
+                fail("Wrong package_library name?!")
             package_library_rule = one_rule
         elif one_rule["name"] == short_package_name:
-            # Failure to use drake_cc_package_library is a lint error, except
-            # in examples folders because their libraries are never installed.
             if "nolint" in one_rule["tags"]:
                 continue
-            if not package_name.startswith("//examples"):
-                library_lint_reporter_args += ["--untagged-package-library"]
+            fail("Use drake_cc_package_library when declaring a library for " +
+                 "the entire directory")
+        else:
+            # Found a cc_library.
+            cc_library_rules.append(one_rule)
 
-    # If there is no C++ code in this package, then we're done.
-    if not cc_library_rules:
+    # If there is no package library, then we're done.
+    if package_library_rule == None:
         return
 
-    # Sanity check the package_library_rule name.
-    if package_library_rule and (
-        package_library_rule["name"] != short_package_name
-    ):
-        fail("drake_cc_package_library should not allow wrong-names?!")
+    # Compute exactly what the deps of the drake_cc_package_library should be.
+    correct_deps = []
+    for cc_library in cc_library_rules:
+        # Skip items that have opted-out of the package_library.
+        if _TAG_EXCLUDE_FROM_PACKAGE in cc_library["tags"]:
+            continue
 
-    # Unless the package_library rule exists and is testonly, then we should
-    # exclude testonly cc_library targets from the scope we're going to insist
-    # that it covers.
-    exclude_testonly = not (package_library_rule or {}).get("testonly", False)
+        # Skip testonly libraries if the package is non-testonly.
+        if not package_library_rule["testonly"]:
+            if cc_library.get("testonly", False):
+                continue
 
-    # We are going to run genquery over all of this package's cc_library rules.
-    scope = [
-        package_name + ":" + one_rule["name"]
-        for one_rule in cc_library_rules
-    ]
-    all_libraries = " + ".join(scope)
+        correct_deps.append(":{}".format(cc_library["name"]))
 
-    # This expression computes the exact result for what we want the deps of
-    # the drake_cc_package_library to be.
-    correct_deps_expression = " ".join([
-        # Start with all this package's cc_library rules.
-        "({})".format(all_libraries),
-        # Remove items that have opted-out of the package_library.
-        "except attr(tags, '{}', {})".format(
-            _TAG_EXCLUDE_FROM_PACKAGE,
-            all_libraries,
-        ),
-        # Maybe remove libraries tagged testonly = 1.
-        "except attr(testonly, 1, {})".format(
-            all_libraries,
-        ) if exclude_testonly else "",
-    ])
+    # Extract what the deps of the drake_cc_package_library currently are.
+    current_deps = package_library_rule["deps"]
 
-    # Find libraries that are deps of the package_library but shouldn't be.
-    extra_deps_expression = "deps({}, 1) except ({})".format(
-        package_name + ":" + short_package_name,
-        correct_deps_expression,
-    )
-
-    # Find libraries that should be deps of the package_library but aren't.
-    # Note that our library_lint_reporter.py tool filters out some false
-    # positives from this report.
-    missing_deps_expression = "({}) except deps({}, 1) ".format(
-        correct_deps_expression,
-        package_name + ":" + short_package_name,
-    )
-
-    # If there was a package_library rule, ensure its deps are comprehensive.
-    if package_library_rule:
-        native.genquery(
-            name = "library_lint_missing_deps",
-            expression = missing_deps_expression,
-            scope = scope,
-            testonly = 1,
-            tags = ["lint", "library_lint"],
-            visibility = ["//visibility:private"],
-        )
-        native.genquery(
-            name = "library_lint_extra_deps",
-            expression = extra_deps_expression,
-            scope = scope,
-            testonly = 1,
-            tags = ["lint", "library_lint"],
-            visibility = ["//visibility:private"],
-        )
-        library_lint_reporter_data += [
-            ":library_lint_missing_deps",
-            ":library_lint_extra_deps",
-        ]
-        library_lint_reporter_args += [
-            "--missing-deps",
-            "$(location :library_lint_missing_deps)",
-            "--extra-deps",
-            "$(location :library_lint_extra_deps)",
-        ]
+    # Compute the lint errors.
+    reporter_args = ["--package-name", package_name]
+    for item in correct_deps:
+        if item not in current_deps:
+            reporter_args += ["--missing", item]
+    for item in current_deps:
+        if item not in correct_deps:
+            reporter_args += ["--extra", item]
 
     # Report all of the library_lint results.
     py_test_isolated(
@@ -141,7 +85,6 @@ def library_lint(
         size = "small",
         srcs = ["@drake//tools/lint:library_lint_reporter"],
         main = "@drake//tools/lint:library_lint_reporter.py",
-        args = library_lint_reporter_args,
-        data = library_lint_reporter_data,
+        args = reporter_args,
         tags = ["lint", "library_lint"],
     )

--- a/tools/lint/library_lint_reporter.py
+++ b/tools/lint/library_lint_reporter.py
@@ -19,49 +19,25 @@ def main():
         help="Required name of package, e.g., //common/test_utilities",
     )
     parser.add_argument(
-        "--missing-deps",
-        metavar="FILE",
+        "--missing",
+        metavar="LABEL",
         type=str,
-        help=(
-            "Filename containing list of labels that are missing. "
-            "It is a lint error when this file is non-empty."
-        ),
+        action="append",
+        help="One label that is missing from the package library.",
     )
     parser.add_argument(
-        "--extra-deps",
-        metavar="FILE",
+        "--extra",
+        metavar="LABEL",
         type=str,
-        help=(
-            "Filename containing list of labels that are extra. "
-            "It is a lint error when this file is non-empty."
-        ),
-    )
-    parser.add_argument(
-        "--untagged-package-library",
-        action="store_true",
-        default=False,
-        help=(
-            "A cc_library exists with the short_package_name but it "
-            "does not use drake_cc_package_library"
-        ),
+        action="append",
+        help="One label that is extra in the package library.",
     )
     args = parser.parse_args()
     build_file_name = args.package_name[2:] + "/BUILD.bazel"
-    short_package_name = args.package_name.split("/")[-1]
 
     return_code = 0
 
-    if args.untagged_package_library:
-        print(
-            f"ERROR: The package {args.package_name} has a "
-            f'cc_library(name = ":{short_package_name}") '
-            "declared without using drake_cc_package_library()."
-        )
-        return_code = 1
-
-    with open(args.missing_deps or "/dev/null") as opened:
-        missing_deps = opened.readlines()
-    if missing_deps:
+    if args.missing:
         print(
             f"ERROR: Missing deps in {args.package_name}'s "
             "drake_cc_package_library."
@@ -70,8 +46,8 @@ def main():
             f"note: In the {build_file_name} rule for "
             "drake_cc_package_library, add the following lines to the deps:"
         )
-        for dep in sorted(missing_deps):
-            print(f'        ":{dep.strip().split(":")[-1]}",')
+        for dep in sorted(args.missing):
+            print(f'        "{dep}",')
         print(
             "note: Alternatively, if some of these libraries should not be "
             "added to the drake_cc_package_library, you may tag them with "
@@ -80,17 +56,7 @@ def main():
         )
         return_code = 1
 
-    with open(args.extra_deps or "/dev/null") as opened:
-        extra_deps = opened.readlines()
-    extra_deps = [
-        # Filter out false positives.  All C++ code is OK to depend on these.
-        item
-        for item in extra_deps
-        if not (
-            item.startswith("//tools/cc_toolchain:") or "@bazel_tools//" in item
-        )
-    ]
-    if extra_deps:
+    if args.extra:
         print(
             f"ERROR: Extra deps in {args.package_name}'s "
             "drake_cc_package_library."
@@ -100,8 +66,8 @@ def main():
             "drake_cc_package_library, remove the following lines from the "
             "deps:"
         )
-        for dep in sorted(extra_deps):
-            print(f'        "{dep.strip()}",')
+        for dep in sorted(args.extra):
+            print(f'        "{dep}",')
         return_code = 1
 
     return return_code

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -708,7 +708,8 @@ def drake_cc_package_library(
     confirm that all of the drake_cc_library targets have been listed as deps.
 
     Within Drake, by convention, every package (i.e., directory) that has any
-    C++ code should call this macro to create a library for its package.
+    C++ code should call this macro to create a library for its package,
+    except for code in `//examples/...`.
 
     The name must be the same as the final element of the current package.
     This rule does not accept srcs, hdrs, etc. -- only deps.
@@ -717,6 +718,9 @@ def drake_cc_package_library(
     The visibility must be explicitly provided, not relying on the BUILD file
     default.  Setting to "//visibility:public" is strongly recommended.
     """
+    if native.package_name().split("/")[0] == "examples":
+        fail("Do not use drake_cc_package_library for examples")
+
     _check_package_library_name(name)
     if not visibility:
         fail(("//{}:{} must provide a visibility setting; " +


### PR DESCRIPTION
A genquery is expensive to analyze and causes us to fetch more unused externals than necessary. Replacing it with simple string matching on deps is sufficient for this linter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24188)
<!-- Reviewable:end -->
