### PR TITLE
[tools] Release manager now uploads the source archive

### DIFF
--- a/.github/ISSUE_TEMPLATE/POST_RELEASE_ACTIONS.yml
+++ b/.github/ISSUE_TEMPLATE/POST_RELEASE_ACTIONS.yml
@@ -34,9 +34,9 @@ body:
         "These two steps must be completed in order. Check each box after
         completion."
       options:
-        - label: >
-            Run script to push Docker images, mirror the artifacts to S3, and
-            push the source archive to GitHub
+        - label: "Run push_docker.py script to push Docker images"
           required: false
-        - label: "Run script for Apt repository updates"
+        - label: "Run push_release.py script to mirror the artifacts to S3"
+          required: false
+        - label: "Run push_release script for Apt repository updates"
           required: false

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -159,9 +159,10 @@ the main body of the document:
       appropriate edits as follows:
       * The version number
    5. Click the box labeled "Attach binaries by dropping them here or selecting
-      them." and then choose for upload the **36** release files from
+      them." and then choose for upload the **39** release files from
       ``/tmp/drake-release/v1.N.0/...``:
-      - 9: 3 `.tar.gz` + 6 checksums
+      - 9: 3 binary `.tar.gz` + 6 checksums
+      - 3: 1 source `.tar.gz` + 2 checksums
       - 6: 2 `.deb` + 4 checksums
       - 15: 5 linux `.whl` + 10 checksums
       - 6: 2 macOS arm `.whl` + 4 checksums

--- a/tools/release_engineering/dev/README.md
+++ b/tools/release_engineering/dev/README.md
@@ -62,8 +62,7 @@ Clone the drake repository:
 
 ## Run script for GitHub / S3
 
-The next step is to push the official source code archive to GitHub and mirror
-the release artifacts to S3.
+The next step is to mirror the GitHub release artifacts to S3.
 
 Once your machine is set up, run the `push_release` script as described below:
 
@@ -73,9 +72,6 @@ The release creator will provide the version. Throughout this process, don’t
 use `v` on the version string. For example:
 
     bazel run //tools/release_engineering/dev:push_release -- 1.0.0
-
-**Note:** If there is a timeout error uploading to GitHub, double-check
-the GitHub token created above, it is likely a permissions issue.
 
 ## Run script for Docker
 
@@ -106,12 +102,7 @@ contains:
 for each supported configuration (e.g. jammy and noble) as
 `/drake-dev_<version>-1_amd64-<configuration>.deb`.
 
-3. The [GitHub release](https://github.com/RobotLocomotion/drake/releases),
-found at `https://github.com/RobotLocomotion/drake/releases/tag/v<version>`,
-contains `drake-<version>-src.tar.gz` and corresponding `.sha256` and
-`.sha512` files.
-
-4. [Dockerhub](https://hub.docker.com/r/robotlocomotion/drake/tags?ordering=last_updated&page=1)
+3. [Dockerhub](https://hub.docker.com/r/robotlocomotion/drake/tags?ordering=last_updated&page=1)
 has a plain `<version>` tag as well as a `<version>` tag for each supported
 configuration (e.g. jammy and noble).
 

--- a/tools/release_engineering/dev/push_release.py
+++ b/tools/release_engineering/dev/push_release.py
@@ -6,7 +6,6 @@ This program is only supported on Ubuntu Noble 24.04.
 """
 
 import argparse
-import hashlib
 import os
 import re
 import shutil
@@ -15,7 +14,6 @@ import sys
 import tempfile
 import textwrap
 from typing import Any, Dict, List, Optional
-import urllib.request
 
 import boto3
 import github3
@@ -25,11 +23,6 @@ from github3.repos.tag import RepoTag
 
 _GITHUB_REPO_OWNER = "RobotLocomotion"
 _GITHUB_REPO_NAME = "drake"
-_GITHUB_REPO_URI = (
-    f"https://github.com/{_GITHUB_REPO_OWNER}/{_GITHUB_REPO_NAME}"
-)
-
-_ARCHIVE_HASHES = {"sha256", "sha512"}
 
 _AWS_BUCKET = "drake-packages"
 _AWS_PREFIX = "drake/release"
@@ -92,46 +85,6 @@ class _State:
                 self._release.upload_asset(content_type, name, f)
             self._done()
 
-    def _compute_hash(self, path: str, algorithm: str) -> str:
-        """
-        Compute and return the specified hash for the specified file.
-        """
-        with open(path, "rb") as f:
-            return hashlib.file_digest(f, algorithm).hexdigest()
-
-    def _write_hashfile(
-        self, name: str, algorithm: str, local_path: str, hashfile_path: str
-    ) -> str:
-        """
-        Writes the hash of the specified file using the specified algorithm
-        to the specified path. Returns the computed hash.
-        """
-        self._begin(f"computing {algorithm} for", name)
-
-        digest = self._compute_hash(local_path, algorithm)
-        with open(hashfile_path, "wt") as f:
-            f.write(f"{digest} {name}\n")
-
-        self._done()
-        return digest
-
-    def _download_archive_github(self, name: str) -> str:
-        """
-        Downloads the source archive from the GitHub release. Returns the full
-        path to the downloaded file.
-        """
-        self._begin("downloading", name)
-
-        local_path = os.path.join(self._scratch.name, name)
-        archive_url = (
-            f"{_GITHUB_REPO_URI}/archive/refs/tags/"
-            f"v{self._options.source_version}.tar.gz"
-        )
-        assert urllib.request.urlretrieve(archive_url, local_path)
-
-        self._done()
-        return local_path
-
     def get_artifacts(self) -> List[Asset]:
         """
         Get artifacts associated with a GitHub release.
@@ -164,28 +117,6 @@ class _State:
             self._begin("pushing", artifact.name, dest)
             self._s3.upload_file(local_path, bucket, path)
             self._done()
-
-    def push_archive(self, name: str) -> None:
-        """
-        Pushes the release source archive to GitHub, along with computed
-        hashes.
-
-        If --dry-run was given, rather than actually pushing files, prints what
-        would be done.
-        """
-        local_path = self._download_archive_github(name)
-        self._upload_file_github(name, local_path)
-
-        # Calculate hashes and write hash files
-        for algorithm in _ARCHIVE_HASHES:
-            hashfile_name = f"{name}.{algorithm}"
-            hashfile_path = os.path.join(self._scratch.name, hashfile_name)
-
-            digest = self._write_hashfile(
-                name, algorithm, local_path, hashfile_path
-            )
-            print(f"{name!r} {algorithm}: {digest}")
-            self._upload_file_github(hashfile_name, hashfile_path)
 
 
 def _fatal(msg: str, result: int = 1) -> None:
@@ -246,15 +177,6 @@ def _find_tag(repo: Repository, tag: str) -> Optional[RepoTag]:
     return None
 
 
-def _push_source(state: _State) -> None:
-    """
-    Downloads the source .tar artifact and pushes it to GitHub.
-    """
-    version = state.source_version
-    dest_name = f"drake-{version}-src.tar.gz"
-    state.push_archive(dest_name)
-
-
 def _push_s3(state: _State) -> None:
     """
     Downloads GitHub release artifacts and pushes them to S3.
@@ -266,13 +188,6 @@ def _push_s3(state: _State) -> None:
 
 def main(args: List[str]) -> None:
     parser = argparse.ArgumentParser(prog="push_release", description=__doc__)
-    parser.add_argument(
-        "--source",
-        dest="push_source",
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        help="Mirror source .tar archive to GitHub.",
-    )
     parser.add_argument(
         "--s3",
         dest="push_s3",
@@ -342,8 +257,6 @@ def main(args: List[str]) -> None:
     state = _State(options, release)
 
     # Push the requested release artifacts.
-    if options.push_source:
-        _push_source(state)
     if options.push_s3:
         _push_s3(state)
 

--- a/tools/release_engineering/download_release_candidate.py
+++ b/tools/release_engineering/download_release_candidate.py
@@ -2,6 +2,9 @@ r"""
 Downloads the to-be-released binaries, verifies they are all the same version,
 and prepares to upload them per the release playbook.
 
+When running this tool, the current Drake checkout must have been merged up
+to the latest master (or at least, newer than the intended release git sha).
+
 This program is supported only on Ubuntu (not macOS).
 
 Use bazel to build the tool.
@@ -203,6 +206,44 @@ def _check_deb_versions(*, filenames, version):
         raise UserError("\n".join(version_errors))
 
 
+def _create_tar_gz(*, git_sha, tmp_dir: str, version: str):
+    """Creates a Drake tar.gz source archive of the given `git_sha`, storing it
+    in the given `tmp_dir`.
+    """
+    assert len(git_sha) == 40
+    assert version[0] == "v"
+
+    # Create the tar.gz using this program's git clone (but at the release sha,
+    # not the current revision).
+    output_name = f"drake-{version[1:]}-src.tar.gz"
+    output_path = f"{tmp_dir}/{output_name}"
+    drake_root = Path(__file__).resolve().parent.parent.parent
+    assert (drake_root / "MODULE.bazel").exists()
+    subprocess.check_call(
+        [
+            "git",
+            "archive",
+            "--format=tar.gz",
+            f"--output={output_path}",
+            f"--prefix=drake-{version[1:]}/",
+            git_sha,
+        ],
+        cwd=drake_root,
+    )
+
+    # Write checksum files.
+    _run(
+        f"sha256sum {output_name} > {output_name}.sha256",
+        shell=True,
+        cwd=tmp_dir,
+    )
+    _run(
+        f"sha512sum {output_name} > {output_name}.sha512",
+        shell=True,
+        cwd=tmp_dir,
+    )
+
+
 def _download_version(*, version):
     """Implements the --version (download) command line action."""
     if version[0] != "v":
@@ -224,6 +265,13 @@ def _download_version(*, version):
 
     _check_deb_versions(filenames=filenames, version=version)
     print("The debian binaries all have the same version.")
+
+    _create_tar_gz(
+        git_sha=git_sha,
+        tmp_dir=tmp_dir,
+        version=version,
+    )
+    print("The source archive was created successfully.")
 
     print()
     print(


### PR DESCRIPTION
The "download_release_candidate" now also creates the source archive, in addition to downloading the staging binaries.

One consequence of this change in the order of operations is that the release attachment source archive might be compressed differently (i.e., different checksum) than the auto-generated "Source code (tar.gz)" link from GitHub.  While it was nice to have them start out the same in the past, having a difference now is not really a problem, especially because the checksum of the auto-generated archive could change out from under us at any time anyway.

Towards #24036.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24192)
<!-- Reviewable:end -->
