### PR TITLE
Deprecate `SpatialVector::operator<<`

### DIFF
--- a/bindings/generated_docstrings/multibody_math.h
+++ b/bindings/generated_docstrings/multibody_math.h
@@ -1552,6 +1552,13 @@ equal to V_MBo_E.Shift(p_BoBc_E).
 See also:
     Shift(), ShiftInPlace(), and ComposeWithMovingFrameVelocity().)""";
       } operator_sub;
+      // Symbol: drake::multibody::to_string
+      struct /* to_string */ {
+        // Source: drake/multibody/math/spatial_vector.h
+        const char* doc =
+R"""(Returns string representation of a SpatialVector. Especially useful
+for debugging.)""";
+      } to_string;
     } multibody;
   } drake;
 } pydrake_doc_multibody_math;

--- a/multibody/math/spatial_acceleration.h
+++ b/multibody/math/spatial_acceleration.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/math/convert_time_derivative.h"
 #include "drake/multibody/math/spatial_vector.h"
 #include "drake/multibody/math/spatial_velocity.h"
@@ -353,3 +354,6 @@ inline SpatialAcceleration<T> operator-(const SpatialAcceleration<T>& A1_E,
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::SpatialAcceleration);
+
+DRAKE_FORMATTER_AS(typename T, drake::multibody, SpatialAcceleration<T>, x,
+                   drake::multibody::to_string(x))

--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/multibody/math/spatial_vector.h"
 
 namespace drake {
@@ -244,3 +245,6 @@ inline SpatialForce<T> operator-(const SpatialForce<T>& F1_E,
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::SpatialForce);
+
+DRAKE_FORMATTER_AS(typename T, drake::multibody, SpatialForce<T>, x,
+                   drake::multibody::to_string(x))

--- a/multibody/math/spatial_momentum.h
+++ b/multibody/math/spatial_momentum.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/multibody/math/spatial_vector.h"
 
 namespace drake {
@@ -198,3 +199,6 @@ inline SpatialMomentum<T> operator-(const SpatialMomentum<T>& L1_E,
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::SpatialMomentum);
+
+DRAKE_FORMATTER_AS(typename T, drake::multibody, SpatialMomentum<T>, x,
+                   drake::multibody::to_string(x))

--- a/multibody/math/spatial_vector.h
+++ b/multibody/math/spatial_vector.h
@@ -5,12 +5,14 @@
 #endif
 
 #include <limits>
+#include <string>
 #include <tuple>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt_ostream.h"
+#include "drake/common/fmt.h"
 #include "drake/math/rotation_matrix.h"
 
 /* Note: many of the operations in the various SpatialVector-derived classes
@@ -299,26 +301,43 @@ class SpatialVector {
   CoeffsEigenType V_;
 };
 
+/// Returns string representation of a SpatialVector. Especially useful for
+/// debugging.
+/// @relates SpatialVector.
+template <template <typename> class SpatialQuantity, typename T>
+std::string to_string(const SpatialVector<SpatialQuantity, T>& V) {
+  std::string result{fmt::format("[{}", V[0])};
+  for (int i = 1; i < V.size(); ++i) {
+    result.append(fmt::format(", {}", V[i]));
+  }
+  result.append("]ᵀ");  // The "transpose" symbol.
+  return result;
+}
+
 /// Stream insertion operator to write SpatialVector objects into a
 /// `std::ostream`. Especially useful for debugging.
 /// @relates SpatialVector.
 template <template <typename> class SpatialQuantity, typename T>
-std::ostream& operator<<(std::ostream& o,
-                         const SpatialVector<SpatialQuantity, T>& V) {
-  o << "[" << fmt::to_string(V[0]);
-  for (int i = 1; i < V.size(); ++i) {
-    o << ", " << fmt::to_string(V[i]);
-  }
-  o << "]ᵀ";  // The "transpose" symbol.
-  return o;
+DRAKE_DEPRECATED(
+    "2026-07-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
+std::ostream&
+operator<<(std::ostream& o, const SpatialVector<SpatialQuantity, T>& V) {
+  return o << to_string(V);
 }
 
 }  // namespace multibody
 }  // namespace drake
 
-// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
 namespace fmt {
 template <template <typename> class SpatialQuantity, typename T>
 struct formatter<drake::multibody::SpatialVector<SpatialQuantity, T>>
-    : drake::ostream_formatter {};
+    : formatter<std::string> {
+  template <typename FormatContext>
+  auto format(const drake::multibody::SpatialVector<SpatialQuantity, T>& x,
+              FormatContext& ctx) const {
+    return formatter<std::string>::format(drake::multibody::to_string(x), ctx);
+  }
+};
 }  // namespace fmt

--- a/multibody/math/spatial_velocity.h
+++ b/multibody/math/spatial_velocity.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/multibody/math/spatial_force.h"
 #include "drake/multibody/math/spatial_momentum.h"
 #include "drake/multibody/math/spatial_vector.h"
@@ -270,3 +271,6 @@ T SpatialVelocity<T>::dot(const SpatialMomentum<T>& momentum) const {
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::SpatialVelocity);
+
+DRAKE_FORMATTER_AS(typename T, drake::multibody, SpatialVelocity<T>, x,
+                   drake::multibody::to_string(x))

--- a/multibody/math/test/spatial_algebra_test.cc
+++ b/multibody/math/test/spatial_algebra_test.cc
@@ -276,6 +276,10 @@ TYPED_TEST(SpatialQuantityTest, IsApprox) {
   EXPECT_FALSE(V.IsApprox(other, precision));
 }
 
+// TODO(2026-07-01): delete test `ShiftOperatorIntoStream` when
+// `SpatialVector::operator<<` is removed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Test the stream insertion operator to write into a stream.
 TYPED_TEST(SpatialQuantityTest, ShiftOperatorIntoStream) {
   typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
@@ -285,6 +289,15 @@ TYPED_TEST(SpatialQuantityTest, ShiftOperatorIntoStream) {
   stream << V;
   std::string expected_string = "[0, 0, 3, 1, 2, 0]ᵀ";
   EXPECT_EQ(expected_string, stream.str());
+}
+#pragma GCC diagnostic pop
+
+// Test the string representation of spatial vectors.
+TYPED_TEST(SpatialQuantityTest, ToStringFmtFormatter) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  const SpatialQuantity& V = this->V_;
+  std::string expected_string = "[0, 0, 3, 1, 2, 0]ᵀ";
+  EXPECT_EQ(fmt::to_string(V), expected_string);
 }
 
 TYPED_TEST(SpatialQuantityTest, MultiplicationAssignmentOperator) {
@@ -901,6 +914,10 @@ typedef ::testing::Types<SpatialVelocity<Expression>,      // BR
     SymbolicSpatialQuantityTypes;
 TYPED_TEST_SUITE(SymbolicSpatialQuantityTest, SymbolicSpatialQuantityTypes);
 
+// TODO(2026-07-01): delete test `ShiftOperatorIntoStream` when
+// `SpatialVector::operator<<` is removed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TYPED_TEST(SymbolicSpatialQuantityTest, ShiftOperatorIntoStream) {
   std::stringstream V_stream;
   V_stream << this->V_;
@@ -910,6 +927,14 @@ TYPED_TEST(SymbolicSpatialQuantityTest, ShiftOperatorIntoStream) {
   Q_stream << this->Q_;
   std::string Q_expected_string = "[Q(0), Q(1), Q(2), Q(3), Q(4), Q(5)]ᵀ";
   EXPECT_EQ(Q_expected_string, Q_stream.str());
+}
+#pragma GCC diagnostic pop
+
+TYPED_TEST(SymbolicSpatialQuantityTest, ToStringFmtFormatter) {
+  std::string V_expected_string = "[wx, wy, wz, vx, vy, vz]ᵀ";
+  EXPECT_EQ(fmt::to_string(this->V_), V_expected_string);
+  std::string Q_expected_string = "[Q(0), Q(1), Q(2), Q(3), Q(4), Q(5)]ᵀ";
+  EXPECT_EQ(fmt::to_string(this->Q_), Q_expected_string);
 }
 
 // Tests the dot product between spatial momentum and spatial velocity


### PR DESCRIPTION
Towards [#17742](https://github.com/RobotLocomotion/drake/issues/17742). For review please, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24195)
<!-- Reviewable:end -->
