### PR TITLE
Revert "Deprecate `VectorBase::operator<<` (#24187)"

### DIFF
--- a/bindings/generated_docstrings/systems_analysis.h
+++ b/bindings/generated_docstrings/systems_analysis.h
@@ -4754,8 +4754,9 @@ is advanced:
 .. code-block:: c++
 
     simulator.set_monitor([](const Context<T>& root_context) {
-      fmt∷print("{} {}\n", root_context.get_time(),
-                            root_context.get_continuous_state_vector());
+      std∷cout << root_context.get_time() << " "
+                << root_context.get_continuous_state_vector()
+                << std∷endl;
       return EventStatus∷Succeeded();
     });
 

--- a/bindings/generated_docstrings/systems_framework.h
+++ b/bindings/generated_docstrings/systems_framework.h
@@ -12893,13 +12893,6 @@ derivatives) might be discarded.)""";
           const char* doc = R"""()""";
         } ThrowConversionMismatch;
       } system_scalar_converter_internal;
-      // Symbol: drake::systems::to_string
-      struct /* to_string */ {
-        // Source: drake/systems/framework/vector_base.h
-        const char* doc =
-R"""(Returns the string representation of a VectorBase<T> as a row vector
-RowVectorX<T> e.g., "1, 2, 3". This is useful for debugging purposes.)""";
-      } to_string;
     } systems;
   } drake;
 } pydrake_doc_systems_framework;

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -424,8 +424,9 @@ class Simulator {
   /// Output time and continuous states whenever the trajectory is advanced:
   /// @code
   /// simulator.set_monitor([](const Context<T>& root_context) {
-  ///   fmt::print("{} {}\n", root_context.get_time(),
-  ///                         root_context.get_continuous_state_vector());
+  ///   std::cout << root_context.get_time() << " "
+  ///             << root_context.get_continuous_state_vector()
+  ///             << std::endl;
   ///   return EventStatus::Succeeded();
   /// });
   /// @endcode

--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -8,7 +8,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/dummy_value.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt.h"
 #include "drake/systems/framework/vector_base.h"
 
 namespace drake {
@@ -212,6 +211,3 @@ class BasicVector : public VectorBase<T> {
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::BasicVector);
-
-DRAKE_FORMATTER_AS(typename T, drake::systems, BasicVector<T>, x,
-                   drake::systems::to_string(x))

--- a/systems/framework/leaf_context.cc
+++ b/systems/framework/leaf_context.cc
@@ -50,57 +50,50 @@ std::unique_ptr<State<T>> LeafContext<T>::DoCloneState() const {
 
 template <typename T>
 std::string LeafContext<T>::do_to_string() const {
-  std::string result;
+  std::ostringstream os;
 
-  result.append(fmt::format("{} Context\n", this->GetSystemPathname()));
-  result.append(fmt::format(
-      "{}\n", std::string(this->GetSystemPathname().size() + 9, '-')));
-  result.append(fmt::format("Time: {}\n", fmt::to_string(this->get_time())));
+  os << this->GetSystemPathname() << " Context\n";
+  os << std::string(this->GetSystemPathname().size() + 9, '-') << "\n";
+  os << "Time: " << fmt::to_string(this->get_time()) << "\n";
 
   if (this->num_continuous_states() || this->num_discrete_state_groups() ||
       this->num_abstract_states()) {
-    result.append("States:\n");
+    os << "States:\n";
     if (this->num_continuous_states()) {
-      result.append(fmt::format("  {} continuous states\n",
-                                this->num_continuous_states()));
-      result.append(
-          fmt::format("    {}\n", this->get_continuous_state_vector()));
+      os << "  " << this->num_continuous_states() << " continuous states\n";
+      os << "    " << this->get_continuous_state_vector() << "\n";
     }
     if (this->num_discrete_state_groups()) {
-      result.append(fmt::format("  {} discrete state groups with\n",
-                                this->num_discrete_state_groups()));
+      os << "  " << this->num_discrete_state_groups()
+         << " discrete state groups with\n";
       for (int i = 0; i < this->num_discrete_state_groups(); i++) {
-        result.append(fmt::format("     {} states\n",
-                                  this->get_discrete_state(i).size()));
-        result.append(fmt::format("       {}\n", this->get_discrete_state(i)));
+        os << "     " << this->get_discrete_state(i).size() << " states\n";
+        os << "       " << this->get_discrete_state(i) << "\n";
       }
     }
     if (this->num_abstract_states()) {
-      result.append(
-          fmt::format("  {} abstract states\n", this->num_abstract_states()));
+      os << "  " << this->num_abstract_states() << " abstract states\n";
     }
-    result.append("\n");
+    os << "\n";
   }
 
   if (this->num_numeric_parameter_groups() || this->num_abstract_parameters()) {
-    result.append("Parameters:\n");
+    os << "Parameters:\n";
     if (this->num_numeric_parameter_groups()) {
-      result.append(fmt::format("  {} numeric parameter groups with\n",
-                                this->num_numeric_parameter_groups()));
+      os << "  " << this->num_numeric_parameter_groups()
+         << " numeric parameter groups";
+      os << " with\n";
       for (int i = 0; i < this->num_numeric_parameter_groups(); i++) {
-        result.append(fmt::format("     {} parameters\n",
-                                  this->get_numeric_parameter(i).size()));
-        result.append(
-            fmt::format("       {}\n", this->get_numeric_parameter(i)));
+        os << "     " << this->get_numeric_parameter(i).size()
+           << " parameters\n";
+        os << "       " << this->get_numeric_parameter(i) << "\n";
       }
     }
     if (this->num_abstract_parameters()) {
-      result.append(fmt::format("  {} abstract parameters\n",
-                                this->num_abstract_parameters()));
+      os << "  " << this->num_abstract_parameters() << " abstract parameters\n";
     }
   }
-
-  return result;
+  return os.str();
 }
 
 template <typename T>

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -236,10 +236,6 @@ using DefaultScalars =
     ::testing::Types<double, AutoDiffXd, symbolic::Expression>;
 TYPED_TEST_SUITE(TypedBasicVectorTest, DefaultScalars);
 
-// TODO(2026-07-01): delete test `StringStream` when
-// `BasicVector<T>::operator<<` is removed.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests ability to stream a BasicVector into a string.
 TYPED_TEST(TypedBasicVectorTest, StringStream) {
   using T = TypeParam;
@@ -251,22 +247,7 @@ TYPED_TEST(TypedBasicVectorTest, StringStream) {
       fmt::format("hello {} world", fmt_eigen(vec.value().transpose()));
   EXPECT_EQ(s.str(), expected);
 }
-#pragma GCC diagnostic pop
 
-// Tests string representation of a BasicVector.
-TYPED_TEST(TypedBasicVectorTest, ToStringFmtFormatter) {
-  using T = TypeParam;
-  BasicVector<T> vec(3);
-  vec.get_mutable_value() << 1.0, 2.2, 3.3;
-  const std::string expected =
-      fmt::format("hello {} world", fmt_eigen(vec.value().transpose()));
-  EXPECT_EQ(fmt::format("hello {} world", vec), expected);
-}
-
-// TODO(2026-07-01): delete test `ZeroLengthStringStream` block when
-// `BasicVector<T>::operator<<` is removed.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests ability to stream a BasicVector of size zero into a string.
 TYPED_TEST(TypedBasicVectorTest, ZeroLengthStringStream) {
   using T = TypeParam;
@@ -276,16 +257,6 @@ TYPED_TEST(TypedBasicVectorTest, ZeroLengthStringStream) {
   const std::string expected =
       fmt::format("foo [{}] bar", fmt_eigen(vec.value().transpose()));
   EXPECT_EQ(s.str(), expected);
-}
-#pragma GCC diagnostic pop
-
-// Tests string representation of a BasicVector of size zero.
-TYPED_TEST(TypedBasicVectorTest, ZeroLengthVectorToStringFmtFormatter) {
-  using T = TypeParam;
-  BasicVector<T> vec(0);
-  const std::string expected =
-      fmt::format("foo [{}] bar", fmt_eigen(vec.value().transpose()));
-  EXPECT_EQ(fmt::format("foo [{}] bar", vec), expected);
 }
 
 // Tests the default set of bounds (empty).

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -232,10 +232,6 @@ TEST_F(ContinuousStateTest, Clone) {
   EXPECT_EQ((*vector)[2], 1.75);
 }
 
-// TODO(2026-07-01): delete test `StringStream` when
-// `BasicVector<T>::operator<<` is removed.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Tests ability to stream a ContinuousState vector into a string.
 TEST_F(ContinuousStateTest, StringStream) {
   std::stringstream s;
@@ -244,16 +240,6 @@ TEST_F(ContinuousStateTest, StringStream) {
       fmt::format("hello {} world",
                   fmt_eigen(continuous_state_->CopyToVector().transpose()));
   EXPECT_EQ(s.str(), expected);
-}
-#pragma GCC diagnostic pop
-
-// Tests string representation of a ContinuousState vector.
-TEST_F(ContinuousStateTest, ToStringFmtFormatter) {
-  const std::string expected =
-      fmt::format("hello {} world",
-                  fmt_eigen(continuous_state_->CopyToVector().transpose()));
-  EXPECT_EQ(fmt::format("hello {} world", continuous_state_->get_vector()),
-            expected);
 }
 
 // Tests for DiagramContinuousState.

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -1,20 +1,18 @@
 #pragma once
 
 #include <initializer_list>
+#include <ostream>
 #include <stdexcept>
-#include <string>
 #include <utility>
 
-// TODO(2026-07-01): Remove ostream header when `operator<<` is removed.
-#include <ostream>
+#include <fmt/format.h>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt.h"
 #include "drake/common/fmt_eigen.h"
+#include "drake/common/fmt_ostream.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/unused.h"
 
@@ -272,31 +270,22 @@ class VectorBase {
   }
 };
 
-/// Returns the string representation of a VectorBase<T> as a row vector
-/// RowVectorX<T> e.g., "1, 2, 3". This is useful for debugging purposes.
-template <typename T>
-std::string to_string(const VectorBase<T>& vec) {
-  return fmt::to_string(fmt_eigen(vec.CopyToVector().transpose()));
-}
-
 /// Allows a VectorBase<T> to be streamed into a string as though it were a
 /// RowVectorX<T>. This is useful for debugging purposes.
 template <typename T>
-DRAKE_DEPRECATED(
-    "2026-07-01",
-    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
-    "fmt::print()). Refer to GitHub issue #17742 for more information.")
-std::ostream&
-operator<<(std::ostream& os, const VectorBase<T>& vec) {
-  os << to_string(vec);
+std::ostream& operator<<(std::ostream& os, const VectorBase<T>& vec) {
+  os << fmt::to_string(fmt_eigen(vec.CopyToVector().transpose()));
   return os;
 }
 
 }  // namespace systems
 }  // namespace drake
 
+// TODO(jwnimmer-tri) Add a real formatter and deprecate the operator<<.
+namespace fmt {
+template <typename T>
+struct formatter<drake::systems::VectorBase<T>> : drake::ostream_formatter {};
+}  // namespace fmt
+
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::VectorBase);
-
-DRAKE_FORMATTER_AS(typename T, drake::systems, VectorBase<T>, x,
-                   drake::systems::to_string(x))


### PR DESCRIPTION
This reverts commit 7ae0c24544620f314d97f0f2481677c5fa65d3ce.

 Dear @j4yyousi ,

 The on-call build cop believes that your PR #24187 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
  * https://drake-jenkins.csail.mit.edu/job/linux-jammy-gcc-bazel-nightly-everything-debug/751/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24197)
<!-- Reviewable:end -->
