### PR TITLE
[common] Add drake::logging::level aliases

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -68,6 +68,7 @@
 // #include "drake/common/string_unordered_set.h"
 // #include "drake/common/temp_directory.h"
 // #include "drake/common/text_logging.h"
+// #include "drake/common/text_logging_level.h"
 // #include "drake/common/text_logging_spdlog.h"
 // #include "drake/common/timer.h"
 // #include "drake/common/type_safe_index.h"
@@ -3169,6 +3170,16 @@ R"""((Advanced) Retrieves the default sink for all Drake logs. This allows
 consumers of Drake to redirect Drake's text logs to locations other
 than the default of stderr.)""";
       } get_dist_sink;
+      // Symbol: drake::logging::level
+      struct /* level */ {
+      } level;
+      // Symbol: drake::logging::level_enum
+      struct /* level_enum */ {
+        // Source: drake/common/text_logging_level.h
+        const char* doc =
+R"""(The severity level associated with a log message. Specfic values are
+named like drake∷logging∷level∷info, etc.)""";
+      } level_enum;
       // Symbol: drake::logging::logger
       struct /* logger */ {
         // Source: drake/common/text_logging.h

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -112,6 +112,7 @@ drake_cc_library(
         "eigen_types.h",
         "never_destroyed.h",
         "text_logging.h",
+        "text_logging_level.h",
         # Remove with deprecation on 2026-09-01.
         "ssize.h",
     ],
@@ -1278,6 +1279,7 @@ drake_cc_googletest(
         "test/text_logging_test.cc",
         "text_logging.cc",
         "text_logging.h",
+        "text_logging_level.h",
     ],
     defines = [
         "TEXT_LOGGING_TEST_SPDLOG=0",
@@ -1298,6 +1300,7 @@ drake_cc_googletest(
         "test/text_logging_ostream_test.cc",
         "text_logging.cc",
         "text_logging.h",
+        "text_logging_level.h",
     ],
     defines = [
         "TEXT_LOGGING_TEST_SPDLOG=0",

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -100,7 +100,7 @@ GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
 // Shouldn't increment argument whether the macro expanded or not, since
 // logging is off.
 #if TEXT_LOGGING_TEST_SPDLOG
-  drake::log()->set_level(spdlog::level::off);
+  drake::log()->set_level(drake::logging::level::off);
 #endif
   DRAKE_LOGGER_TRACE("tracearg={}", ++tracearg);
   DRAKE_LOGGER_DEBUG("debugarg={}", ++debugarg);
@@ -111,7 +111,7 @@ GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
 
 // Should increment arg only if the macro expanded.
 #if TEXT_LOGGING_TEST_SPDLOG
-  drake::log()->set_level(spdlog::level::trace);
+  drake::log()->set_level(drake::logging::level::trace);
 #endif
   DRAKE_LOGGER_TRACE("tracearg={}", ++tracearg);
   DRAKE_LOGGER_DEBUG("debugarg={}", ++debugarg);
@@ -127,7 +127,7 @@ GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
 
 // Only DEBUG should increment arg since trace is not enabled.
 #if TEXT_LOGGING_TEST_SPDLOG
-  drake::log()->set_level(spdlog::level::debug);
+  drake::log()->set_level(drake::logging::level::debug);
 #endif
   DRAKE_LOGGER_TRACE("tracearg={}", ++tracearg);
   DRAKE_LOGGER_DEBUG("debugarg={}", ++debugarg);
@@ -140,6 +140,15 @@ GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
 #endif
   tracearg = 0;
   debugarg = 0;
+}
+
+GTEST_TEST(TextLoggingTest, LogLevelEnum) {
+  EXPECT_LT(drake::logging::level::trace, drake::logging::level::debug);
+  EXPECT_LT(drake::logging::level::debug, drake::logging::level::info);
+  EXPECT_LT(drake::logging::level::info, drake::logging::level::warn);
+  EXPECT_LT(drake::logging::level::warn, drake::logging::level::err);
+  EXPECT_LT(drake::logging::level::err, drake::logging::level::critical);
+  EXPECT_LT(drake::logging::level::critical, drake::logging::level::off);
 }
 
 GTEST_TEST(TextLoggingTest, SetLogLevel) {

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -63,7 +63,8 @@ Drake's linter.) */
     /* variable name to avoid potential variable name shadowing warnings. */ \
     ::drake::logging::logger* const drake_spdlog_macro_logger_alias =        \
         ::drake::log();                                                      \
-    if (drake_spdlog_macro_logger_alias->level() <= spdlog::level::trace) {  \
+    if (drake_spdlog_macro_logger_alias->level() <=                          \
+        ::drake::logging::level::trace) {                                    \
       SPDLOG_LOGGER_TRACE(drake_spdlog_macro_logger_alias, __VA_ARGS__);     \
     }                                                                        \
   } while (0)
@@ -73,7 +74,8 @@ Drake's linter.) */
     /* variable name to avoid potential variable name shadowing warnings. */ \
     ::drake::logging::logger* const drake_spdlog_macro_logger_alias =        \
         ::drake::log();                                                      \
-    if (drake_spdlog_macro_logger_alias->level() <= spdlog::level::debug) {  \
+    if (drake_spdlog_macro_logger_alias->level() <=                          \
+        ::drake::logging::level::debug) {                                    \
       SPDLOG_LOGGER_DEBUG(drake_spdlog_macro_logger_alias, __VA_ARGS__);     \
     }                                                                        \
   } while (0)
@@ -92,6 +94,7 @@ Drake's linter.) */
 #endif  // DRAKE_DOXYGEN_CXX
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/text_logging_level.h"
 
 namespace drake {
 

--- a/common/text_logging_level.h
+++ b/common/text_logging_level.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#ifdef HAVE_SPDLOG
+
+#include <spdlog/spdlog.h>
+
+namespace drake {
+namespace logging {
+
+/** The severity level associated with a log message.
+Specfic values are named like drake::logging::level::info, etc. */
+using level_enum = spdlog::level::level_enum;
+
+}  // namespace logging
+}  // namespace drake
+
+#else  // HAVE_SPDLOG
+
+namespace drake {
+namespace logging {
+
+enum class level_enum {
+  trace,
+  debug,
+  info,
+  warn,
+  err,
+  critical,
+  off,
+};
+
+}  // namespace logging
+}  // namespace drake
+
+#endif  // HAVE_SPDLOG
+
+namespace drake {
+namespace logging {
+// We need to alias the values into a namespace, so that drake::logging::level
+// maintains backwards compatibility.
+namespace level {
+/** The TRACE severity level associated with a log message. */
+constexpr auto trace = level_enum::trace;
+/** The DEBUG severity level associated with a log message. */
+constexpr auto debug = level_enum::debug;
+/** The INFO severity level associated with a log message. */
+constexpr auto info = level_enum::info;
+/** The WARNING severity level associated with a log message. */
+constexpr auto warn = level_enum::warn;
+/** The ERROR severity level associated with a log message. */
+constexpr auto err = level_enum::err;
+/** The CRITICAL severity level associated with a log message. */
+constexpr auto critical = level_enum::critical;
+/** The OFF severity level associated with a log message. */
+constexpr auto off = level_enum::off;
+}  // namespace level
+
+}  // namespace logging
+}  // namespace drake

--- a/multibody/inverse_kinematics/differential_inverse_kinematics_system.cc
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics_system.cc
@@ -472,7 +472,7 @@ void LogConstraintViolations(const MathematicalProgram& prog,
       fmt::join(infeasible_constraint_names, ", "));
 
   // Debugging information for all constraints.
-  if (log()->should_log(spdlog::level::debug)) {
+  if (log()->should_log(logging::level::debug)) {
     for (const auto& binding : prog.GetAllConstraints()) {
       const auto& constraint = binding.evaluator();
 


### PR DESCRIPTION
This provides a glidepath from `spdlog::level` to `drake::logging::level` for code that needs to manipulate log severity levels.  (Towards #24202.)

Downstream users who interact with Drake's `text_logging.h` should prefer to use the new aliases instead of spdlog levels directly.

For TRI developers, see also Anzu PR 18054.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24201)
<!-- Reviewable:end -->
