### PR TITLE
Allow geometry names through RenderEngineGltfClient

### DIFF
--- a/bindings/generated_docstrings/geometry_render.h
+++ b/bindings/generated_docstrings/geometry_render.h
@@ -547,6 +547,25 @@ Warning:
     or be removed at any time, without any deprecation notice ahead of
     time.)""";
           } DoRegisterDeformableVisual;
+          // Symbol: drake::geometry::render::RenderEngine::DoRegisterNamedVisual
+          struct /* DoRegisterNamedVisual */ {
+            // Source: drake/geometry/render/render_engine.h
+            const char* doc =
+R"""(A variant of the DoRegisterVisual(). This includes an optional name
+for the geometry. If a derived class cannot meaningfully make use of
+the name, it need not implement this method. The default
+implementation is to invoke the previous overload by stripping out the
+name.
+
+This* is the method that RegisterVisual() will always call. If a
+derived engine can make use of a name, it has two options:
+
+- Implement all registration acts in this overload (and use a no-op
+implementation for the previous overload), or
+- implement DoRegisterVisual() to do the work, delegate to that method for
+the work, and then handle the name in this method as a result of a
+successful registration.)""";
+          } DoRegisterNamedVisual;
           // Symbol: drake::geometry::render::RenderEngine::DoRegisterVisual
           struct /* DoRegisterVisual */ {
             // Source: drake/geometry/render/render_engine.h
@@ -734,6 +753,13 @@ Parameter ``X_WG``:
 
 Parameter ``needs_updates``:
     If true, the geometry's pose will be updated via UpdatePoses().
+
+Parameter ``name``:
+    An optional name that can be associated with the visual. Derived
+    classes are not obliged to make use of the name (and may even
+    simply ignore it). Typically, this would be the name of the
+    geometry in the model. It is *not* load bearing and need not be
+    unique.
 
 Returns:
     True if the RenderEngine implementation accepted the shape for

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -60,6 +60,13 @@ class PyRenderEngine : public RenderEngine {
         bool, Base, DoRegisterVisual, id, shape, properties, X_WG);
   }
 
+  bool DoRegisterNamedVisual(GeometryId id, Shape const& shape,
+      PerceptionProperties const& properties, RigidTransformd const& X_WG,
+      std::string_view name) override {
+    PYBIND11_OVERLOAD(
+        bool, Base, DoRegisterNamedVisual, id, shape, properties, X_WG, name);
+  }
+
   void DoUpdateVisualPose(GeometryId id, RigidTransformd const& X_WG) override {
     PYBIND11_OVERLOAD_PURE(void, Base, DoUpdateVisualPose, id, X_WG);
   }
@@ -295,11 +302,11 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.Clone.doc)
         .def("RegisterVisual",
             static_cast<bool (Class::*)(GeometryId, Shape const&,
-                PerceptionProperties const&, RigidTransformd const&, bool)>(
-                &Class::RegisterVisual),
+                PerceptionProperties const&, RigidTransformd const&, bool,
+                std::string_view)>(&Class::RegisterVisual),
             py::arg("id"), py::arg("shape"), py::arg("properties"),
             py::arg("X_WG"), py::arg("needs_updates") = true,
-            cls_doc.RegisterVisual.doc)
+            py::arg("name") = "", cls_doc.RegisterVisual.doc)
         .def("RemoveGeometry",
             static_cast<bool (Class::*)(GeometryId)>(&Class::RemoveGeometry),
             py::arg("id"), cls_doc.RemoveGeometry.doc)

--- a/bindings/pydrake/geometry/test/render_engine_subclass_test.py
+++ b/bindings/pydrake/geometry/test/render_engine_subclass_test.py
@@ -25,13 +25,36 @@ class TestRenderEngineSubclass(unittest.TestCase):
         that don't override DoRender*Image. This test confirms that behavior
         propagates down to Python."""
 
-        class MinimalEngine(mut.RenderEngine):
-            """Minimal implementation of the RenderEngine virtual API"""
+        class LegacyEngine(mut.RenderEngine):
+            """Minimal implementation of the RenderEngine virtual API which
+            only implements DoRegisterVisual (no name)."""
 
             def UpdateViewpoint(self, X_WC):
                 pass
 
             def DoRegisterVisual(self, id, shape, properties, X_WG):
+                pass
+
+            def DoUpdateVisualPose(self, id, X_WG):
+                pass
+
+            def DoRemoveGeometry(self, id):
+                pass
+
+            def __deepcopy__(self, memo):
+                return type(self)()
+
+        class MinimalEngine(mut.RenderEngine):
+            """(Almost) Minimal implementation of the RenderEngine virtual API.
+            This implements the named-visual API instead."""
+
+            def UpdateViewpoint(self, X_WC):
+                pass
+
+            def DoRegisterVisual(self, id, shape, properties, X_WG):
+                raise RuntimeError("Minimal engine uses the name API")
+
+            def DoRegisterNamedVisual(self, id, shape, properties, X_WG, name):
                 pass
 
             def DoUpdateVisualPose(self, id, X_WG):
@@ -72,6 +95,19 @@ class TestRenderEngineSubclass(unittest.TestCase):
         depth_image = ImageDepth32F(intrinsics.width(), intrinsics.height())
         label_image = ImageLabel16I(intrinsics.width(), intrinsics.height())
 
+        legacy_engine = LegacyEngine()
+        props = mut.PerceptionProperties()
+        props.AddProperty("label", "id", mut.RenderLabel(1))
+        # Passing a name causes no problems.
+        legacy_engine.RegisterVisual(
+            id=mut.GeometryId.get_new_id(),
+            shape=mut.Sphere(1.0),
+            properties=props,
+            X_WG=RigidTransform.Identity(),
+            needs_updates=False,
+            name="ignored",
+        )
+
         color_only = ColorOnlyEngine()
         color_only.RenderColorImage(color_cam, color_image)
         with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):
@@ -79,6 +115,15 @@ class TestRenderEngineSubclass(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):
             color_only.RenderLabelImage(color_cam, label_image)
         self.assertIsInstance(color_only.Clone(), ColorOnlyEngine)
+        # Passing a name won't tickle the throw in DoRegisterVisual().
+        color_only.RegisterVisual(
+            id=mut.GeometryId.get_new_id(),
+            shape=mut.Sphere(1.0),
+            properties=props,
+            X_WG=RigidTransform.Identity(),
+            needs_updates=False,
+            name="foo",
+        )
 
         depth_only = DepthOnlyEngine()
         with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):

--- a/bindings/pydrake/geometry/test/render_test.py
+++ b/bindings/pydrake/geometry/test/render_test.py
@@ -286,6 +286,9 @@ class TestGeometryRender(unittest.TestCase):
                 DummyRenderEngine.latest_instance = self
 
             def DoRegisterVisual(self, id, shape, properties, X_WG):
+                raise RuntimeError("DummyRenderEngine registers named visuals")
+
+            def DoRegisterNamedVisual(self, id, shape, properties, X_WG, name):
                 DummyRenderEngine.latest_instance = self
                 mut.GetRenderLabelOrThrow(properties)
                 if self.force_accept or properties.HasGroup(

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -1604,7 +1604,8 @@ void GeometryState<T>::AddRenderer(
         } else {
           accepted |= render_engine->RegisterVisual(
               id, geometry.shape(), *properties,
-              RigidTransformd(geometry.X_FG()), geometry.is_dynamic());
+              RigidTransformd(geometry.X_FG()), geometry.is_dynamic(),
+              geometry.name());
         }
       }
     }
@@ -2148,7 +2149,7 @@ bool GeometryState<T>::AddRigidToCompatibleRenderersUnchecked(
   for (auto& engine : *candidate_renderers) {
     added_to_renderer =
         engine->RegisterVisual(geometry.id(), geometry.shape(), properties,
-                               X_WG, geometry.is_dynamic()) ||
+                               X_WG, geometry.is_dynamic(), geometry.name()) ||
         added_to_renderer;
   }
   return added_to_renderer;

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -61,9 +61,10 @@ bool RenderEngine::RegisterVisual(GeometryId id,
                                   const drake::geometry::Shape& shape,
                                   const PerceptionProperties& properties,
                                   const RigidTransformd& X_WG,
-                                  bool needs_updates) {
+                                  bool needs_updates, std::string_view name) {
   // TODO(SeanCurtis-TRI): Test that the id hasn't already been used.
-  const bool accepted = DoRegisterVisual(id, shape, properties, X_WG);
+  const bool accepted =
+      DoRegisterNamedVisual(id, shape, properties, X_WG, name);
   if (accepted) {
     if (needs_updates) {
       update_ids_.insert(id);
@@ -72,6 +73,13 @@ bool RenderEngine::RegisterVisual(GeometryId id,
     }
   }
   return accepted;
+}
+
+bool RenderEngine::DoRegisterNamedVisual(GeometryId id, const Shape& shape,
+                                         const PerceptionProperties& properties,
+                                         const math::RigidTransformd& X_WG,
+                                         std::string_view /* name */) {
+  return DoRegisterVisual(id, shape, properties, X_WG);
 }
 
 bool RenderEngine::RegisterDeformableVisual(

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -140,6 +140,11 @@ class RenderEngine {
    @param X_WG           The pose of the geometry relative to the world frame W.
    @param needs_updates  If true, the geometry's pose will be updated via
                          UpdatePoses().
+   @param name           An optional name that can be associated with the
+                         visual. Derived classes are not obliged to make use of
+                         the name (and may even simply ignore it). Typically,
+                         this would be the name of the geometry in the model.
+                         It is *not* load bearing and need not be unique.
    @returns True if the %RenderEngine implementation accepted the shape for
             registration.
    @throws std::exception if the shape is an unsupported type, the
@@ -151,7 +156,7 @@ class RenderEngine {
   bool RegisterVisual(GeometryId id, const Shape& shape,
                       const PerceptionProperties& properties,
                       const math::RigidTransformd& X_WG,
-                      bool needs_updates = true);
+                      bool needs_updates = true, std::string_view name = {});
 
   // TODO(xuchenhan-tri): Bring RenderMesh out of internal namespace, when doing
   // that, the invariants for a RenderMesh to be valid should be verified.
@@ -323,6 +328,25 @@ class RenderEngine {
   virtual bool DoRegisterVisual(GeometryId id, const Shape& shape,
                                 const PerceptionProperties& properties,
                                 const math::RigidTransformd& X_WG) = 0;
+
+  /** A variant of the DoRegisterVisual(). This includes an optional name for
+   the geometry. If a derived class cannot meaningfully make use of the name, it
+   need not implement this method. The default implementation is to invoke the
+   previous overload by stripping out the name.
+
+   *This* is the method that RegisterVisual() will always call. If a derived
+   engine can make use of a name, it has two options:
+
+     - Implement all registration acts in this overload (and use a no-op
+       implementation for the previous overload), or
+     - implement DoRegisterVisual() to do the work, delegate to that method for
+       the work, and then handle the name in this method as a result of a
+       successful registration.
+   */
+  virtual bool DoRegisterNamedVisual(GeometryId id, const Shape& shape,
+                                     const PerceptionProperties& properties,
+                                     const math::RigidTransformd& X_WG,
+                                     std::string_view name);
 
   /** The NVI-function for RegisterDeformableVisual(). This function defaults to
    returning false. If the derived class chooses to register this particular

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_assert.h"
@@ -44,6 +45,7 @@ using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 using geometry::internal::DummyRenderEngine;
+using geometry::internal::DummyRenderEngineWithNames;
 using math::RigidTransformd;
 using std::set;
 using std::unordered_map;
@@ -60,6 +62,8 @@ using systems::sensors::ImageRgba8U;
 // This mainline implementation:
 //    - UpdateViewpoint and DoUpdateVisualPose are no-ops.
 //    - DoRegisterVisual and DoRemoveGeometry do nothing and report such.
+//      - DoRegisterVisual is the overload without name information. For a test
+//        engine that includes names, see DummyRenderEngine.
 //    - DoClone simply returns nullptr.
 //    - Implements no rendering interfaces; invocations of
 //      MinimumEngine::Render*Image (in any variant) will throw.
@@ -218,8 +222,11 @@ GTEST_TEST(RenderEngine, DeformableGeometryRegistrationAndUpdate) {
 // configure each geometry correctly on whether it gets updated or not, and the
 // latter will confirm that the right geometries get updated.
 GTEST_TEST(RenderEngine, RigidGeometryRegistrationAndUpdate) {
+  // Create two engines. One (engine) represents the legacy behavior that
+  // ignores names. The other (engine_with_names) captures and reports names.
   // Change the default render label to something registerable.
   DummyRenderEngine engine({RenderLabel::kDontCare});
+  DummyRenderEngineWithNames engine_with_names({RenderLabel::kDontCare});
 
   // Configure parameters for registering visuals.
   PerceptionProperties skip_properties = engine.rejecting_properties();
@@ -262,11 +269,11 @@ GTEST_TEST(RenderEngine, RigidGeometryRegistrationAndUpdate) {
   // false (and other arguments do not matter).
   const GeometryId id1 = GeometryId::get_new_id();
   const bool is_dynamic = true;
-  const bool dynamic_accepted =
-      engine.RegisterVisual(id1, sphere, skip_properties, {}, is_dynamic);
+  const bool dynamic_accepted = engine.RegisterVisual(
+      id1, sphere, skip_properties, {}, is_dynamic, "dynamic");
   EXPECT_FALSE(dynamic_accepted);
-  const bool anchored_accepted =
-      engine.RegisterVisual(id1, sphere, skip_properties, {}, !is_dynamic);
+  const bool anchored_accepted = engine.RegisterVisual(
+      id1, sphere, skip_properties, {}, !is_dynamic, "anchored");
   EXPECT_FALSE(anchored_accepted);
   // Confirm nothing is updated - because nothing is registered.
   engine.UpdatePoses(X_WG_all);
@@ -276,8 +283,8 @@ GTEST_TEST(RenderEngine, RigidGeometryRegistrationAndUpdate) {
     // Case: the shape is configured for registration, but does *not* require
     // updating.
     const auto& [id, X_WG] = *(X_WG_all.begin());
-    bool accepted =
-        engine.RegisterVisual(id, sphere, add_properties, X_WG, !is_dynamic);
+    bool accepted = engine.RegisterVisual(id, sphere, add_properties, X_WG,
+                                          !is_dynamic, "anchored");
     EXPECT_TRUE(accepted);
     EXPECT_TRUE(CompareMatrices(engine.world_pose(id).GetAsMatrix34(),
                                 X_WG.GetAsMatrix34()));
@@ -285,14 +292,22 @@ GTEST_TEST(RenderEngine, RigidGeometryRegistrationAndUpdate) {
     EXPECT_EQ(engine.updated_ids().size(), 0);
     EXPECT_TRUE(CompareMatrices(engine.world_pose(id).GetAsMatrix34(),
                                 X_WG.GetAsMatrix34()));
+    // `engine` doesn't capture names.
+    EXPECT_EQ(engine.names().size(), 0);
+
+    // The same act, registered with the name-accepting engine captures names.
+    engine_with_names.RegisterVisual(id, sphere, add_properties, X_WG,
+                                     !is_dynamic, "anchored");
+    EXPECT_THAT(engine_with_names.names(),
+                ::testing::Contains(::testing::Pair(id, "anchored")));
   }
 
   {
     // Case: the shape is configured for registration *and* requires updating.
     // Configure the pose for the id so it is *not* the identity.
     const auto& [id, X_WG] = *(++(X_WG_all.begin()));
-    bool accepted =
-        engine.RegisterVisual(id, sphere, add_properties, X_WG, is_dynamic);
+    bool accepted = engine.RegisterVisual(id, sphere, add_properties, X_WG,
+                                          is_dynamic, "dynamic");
     EXPECT_TRUE(accepted);
     const Vector3d p_WG(1.5, 2.5, 3.5);
     X_WG_all[id].set_translation(p_WG);
@@ -303,6 +318,14 @@ GTEST_TEST(RenderEngine, RigidGeometryRegistrationAndUpdate) {
         CompareMatrices(engine.updated_ids().at(id).translation(), p_WG));
     EXPECT_TRUE(CompareMatrices(engine.world_pose(id).GetAsMatrix34(),
                                 X_WG_all[id].GetAsMatrix34()));
+    // `engine` doesn't capture names.
+    EXPECT_EQ(engine.names().size(), 0);
+
+    // The same act, registered with the name-accepting engine captures names.
+    engine_with_names.RegisterVisual(id, sphere, add_properties, X_WG,
+                                     is_dynamic, "dynamic");
+    EXPECT_THAT(engine_with_names.names(),
+                ::testing::Contains(::testing::Pair(id, "dynamic")));
   }
 }
 

--- a/geometry/render_gltf_client/BUILD.bazel
+++ b/geometry/render_gltf_client/BUILD.bazel
@@ -292,6 +292,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
+        "//geometry:scene_graph",
         "//systems/sensors/test_utilities:image_compare",
         "@nlohmann_internal//:nlohmann",
         "@vtk_internal//:vtkCommonMath",

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.cc
@@ -222,73 +222,6 @@ std::map<int, Matrix4<double>> FindRootNodes(const nlohmann::json& gltf) {
   return roots;
 }
 
-/* Effectively sets the world pose of the single "geometry" represented by one
- or more nodes defined in a glTF file. It achieves this by setting the
- transforms on the `root_nodes` of the glTF and *only* the root nodes. All other
- nodes should maintain their fixed poses *relative* to their root nodes. It's
- important that `root_nodes` contain *only* root nodes, such as those found by
- FindRootNodes().
-
- @param gltf         The json representing the gltf file; its contents will be
-                     modified.
- @param root_nodes   The set of nodes to set (indicated by integers in the range
-                     [0, N-1] such that the gltf contains N nodes.
- @param X_WG         The pose of the Drake geometry in the world frame.
- @param scale        The scale to apply to all the indicated nodes (i.e., S_WF).
- @param strip        If true, removes any translation, rotation, or scale
-                     properties from the targeted nodes. */
-void SetRootPoses(nlohmann::json* gltf,
-                  const std::map<int, Matrix4<double>>& root_nodes,
-                  const math::RigidTransformd& X_WG,
-                  const Vector3<double>& scale, bool strip) {
-  /* We have to do some extra work for poses. A *correct* glTF file is defined
-   in the file's frame F as y up. Drake poses things in a geometry frame G which
-   is z up. When VTK exports a glTF file, it doesn't rotate from F to G (y up
-   to z up). We can't simply apply the geometry pose X_WG to the glTF's data. We
-   need to introduce X_GF, the transform necessary to take the data from the
-   y-up glTF frame to the z-up Drake frame.
-
-   Furthermore, the transform in glTF is not a Drake RigidTransform; it is
-   an affine transform. glTF documents the transform T = X_t * X_r * S, where
-   X_t and X_r are RigidTransforms consisting of a translation and rotation,
-   respectively. S is a (possibly non-uniform) scale transform.
-
-   Therefore, the transform we need to apply to indicated nodes includes: the
-   geometry pose X_WG, the geometry scale transform determined by scale (S_WG),
-   the y-up-to-z-up transform (X_GF), and the node's transform within its file,
-   T_FN. Or, more succinctly:
-
-      T_WN = X_WG * S_WG * X_GF * T_FN, or
-      T_WN =               T_WF * T_FN.
-   */
-
-  // T_WF isn't truly T_WF at construction. We'll construct it piecemeal as
-  // we concatenate transforms on its right side as indicated above.
-  Matrix4<double> T_WF = X_WG.GetAsMatrix4();
-  // S_WG is `scale` on the diagonal. Multiplication with X_WG has the effect of
-  // scaling the corresponding columns.
-  for (int i = 0; i < 3; ++i) {
-    T_WF.block<3, 1>(0, i) *= scale(i);
-  }
-  const math::RigidTransformd X_GF(
-      math::RotationMatrixd::MakeXRotation(M_PI / 2));
-  T_WF *= X_GF.GetAsMatrix4();
-
-  if (gltf->contains("nodes")) {
-    nlohmann::json& nodes = (*gltf)["nodes"];
-    const int node_count = ssize(nodes);
-    for (const auto& [n, T_FN] : root_nodes) {
-      DRAKE_DEMAND(n >= 0 && n < node_count);
-      if (strip) {
-        nodes[n].erase("translation");
-        nodes[n].erase("position");
-        nodes[n].erase("scale");
-      }
-      nodes[n]["matrix"] = GltfMatrixFromEigenMatrix(T_WF * T_FN);
-    }
-  }
-}
-
 // TODO(SeanCurtis-TRI): This is a vague hack. It provides the right label
 // colors, but it leaves a great deal of cruft in the gltf: samplers, textures,
 // images, and, most importantly, data in the buffer. Ideally, label and depth
@@ -505,6 +438,57 @@ void RenderEngineGltfClient::ExportScene(const std::string& export_path,
       const Rgba color = RenderEngine::MakeRgbFromLabel(record.label);
       ChangeToLabelMaterials(&temp, color);
     }
+
+    // Compute T_WF: the transform from the glTF file frame F (y-up) into the
+    // world frame W, incorporating the current geometry pose X_WG, the
+    // geometry's anisotropic scale S_WG, and the y-up-to-z-up correction
+    // X_GF:
+    //
+    //   T_WF = X_WG * S_WG * X_GF,  so  T_WN = T_WF * T_FN.
+    //
+    // This consolidates what was previously computed per root node into a
+    // single matrix placed on the wrapper node.
+    Matrix4<double> T_WF = record.X_WG.GetAsMatrix4();
+    for (int i = 0; i < 3; ++i) {
+      T_WF.block<3, 1>(0, i) *= record.scale(i);
+    }
+    T_WF *=
+        math::RigidTransformd(math::RotationMatrixd::MakeXRotation(M_PI / 2))
+            .GetAsMatrix4();
+
+    // Build a wrapper node that:
+    //   (a) carries the SceneGraph geometry name, and
+    //   (b) carries the world-pose matrix T_WF, and
+    //   (c) parents all of the source glTF's root nodes as children.
+    // Each child root node retains its original file-frame transform T_FN, so
+    // the effective world transform for each descendant is T_WF * T_FN.
+    nlohmann::json wrapper;
+    wrapper["name"] = record.geometry_name;
+    wrapper["matrix"] = GltfMatrixFromEigenMatrix(T_WF);
+    nlohmann::json children_array = nlohmann::json::array();
+    for (const auto& [root_idx, unused] : record.root_nodes) {
+      children_array.push_back(root_idx);
+    }
+    wrapper["children"] = std::move(children_array);
+
+    // Add the wrapper to temp's nodes array and make it the sole root of the
+    // default scene. MergeGltf will then offset all node indices (including
+    // the wrapper's children list) to account for gltf's existing nodes.
+    if (!temp.contains("nodes")) {
+      temp["nodes"] = nlohmann::json::array();
+    }
+    const int wrapper_idx = ssize(temp["nodes"]);
+    temp["nodes"].push_back(std::move(wrapper));
+
+    const int scene_idx = temp.contains("scene") ? temp["scene"].get<int>() : 0;
+    if (!temp.contains("scenes")) {
+      temp["scenes"] = nlohmann::json::array();
+    }
+    while (ssize(temp["scenes"]) <= scene_idx) {
+      temp["scenes"].push_back(nlohmann::json::object());
+    }
+    temp["scenes"][scene_idx]["nodes"] = nlohmann::json::array({wrapper_idx});
+
     MergeGltf(&gltf, std::move(temp), record.name, &merge_record);
   }
 
@@ -529,9 +513,7 @@ void RenderEngineGltfClient::DoUpdateVisualPose(
     GeometryId id, const math::RigidTransformd& X_WG) {
   auto iter = gltfs_.find(id);
   if (iter != gltfs_.end()) {
-    GltfRecord& gltf = iter->second;
-    SetRootPoses(&gltf.contents, gltf.root_nodes, X_WG, gltf.scale,
-                 false /* strip */);
+    iter->second.X_WG = X_WG;
     return;
   }
   RenderEngineVtk::DoUpdateVisualPose(id, X_WG);
@@ -646,14 +628,18 @@ bool RenderEngineGltfClient::ImplementGltf(
   // of materials.
 
   std::map<int, Matrix4<double>> root_nodes = FindRootNodes(mesh_data);
-  SetRootPoses(&mesh_data, root_nodes, data.X_WG, mesh.scale3(), true);
 
   DRAKE_DEMAND(!gltfs_.contains(data.id));
   const MeshSource& mesh_source = mesh.source();
   const std::string gltf_name = mesh_source.description();
   gltfs_.insert({data.id,
-                 {gltf_name, std::move(mesh_data), std::move(root_nodes),
-                  mesh.scale3(), GetRenderLabelOrThrow(data.properties)}});
+                 {.name = gltf_name,
+                  .geometry_name = std::string(data.name),
+                  .contents = std::move(mesh_data),
+                  .root_nodes = std::move(root_nodes),
+                  .scale = mesh.scale3(),
+                  .X_WG = data.X_WG,
+                  .label = GetRenderLabelOrThrow(data.properties)}});
   return true;
 }
 

--- a/geometry/render_gltf_client/internal_render_engine_gltf_client.h
+++ b/geometry/render_gltf_client/internal_render_engine_gltf_client.h
@@ -12,6 +12,7 @@
 #include "drake/geometry/render_gltf_client/internal_merge_gltf.h"
 #include "drake/geometry/render_gltf_client/internal_render_client.h"
 #include "drake/geometry/render_vtk/internal_render_engine_vtk.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/systems/sensors/image.h"
 
 namespace drake {
@@ -120,15 +121,22 @@ class DRAKE_NO_EXPORT RenderEngineGltfClient
     //   If the glTF came from disk, it will be the file path, otherwise the
     //   filename hint associated with the in-memory mesh.
     std::string name;
-    // The contents of a glTF file registered as Mesh or Convex.
+    // The SceneGraph geometry name (from RegistrationData::name). Used as the
+    // name of the wrapper root node injected during ExportScene().
+    std::string geometry_name;
+    // The contents of the glTF file in its original, unposed form. Root nodes
+    // retain their file-frame transforms T_FN; world posing is deferred to
+    // ExportScene() via the wrapper node.
     nlohmann::json contents;
     // The root nodes of the gltf file represented as a mapping from the node's
-    // *local* index in the gltf to the pose of that node relative to the
+    // *local* index in the gltf to the original transform of that node in the
     // file's frame F. Note this "pose" is not necessarily a RigidTransform. It
     // can include scale. It is the node matrix stored in the gltf.
     std::map<int, Matrix4<double>> root_nodes;
     // The anisotropic scale of the mesh.
     Vector3<double> scale = Vector3<double>::Ones();
+    // The current world pose of the geometry, updated by DoUpdateVisualPose().
+    math::RigidTransformd X_WG;
     // The render label associated with the geometry.
     render::RenderLabel label;
   };

--- a/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
+++ b/geometry/render_gltf_client/test/internal_render_engine_gltf_client_test.cc
@@ -7,9 +7,12 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <common_robotics_utilities/base64_helpers.hpp>
+#include <fmt/ranges.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
@@ -30,6 +33,7 @@
 #include "drake/geometry/render_gltf_client/internal_merge_gltf.h"
 #include "drake/geometry/render_gltf_client/render_engine_gltf_client_params.h"
 #include "drake/geometry/render_gltf_client/test/internal_sample_image_data.h"
+#include "drake/geometry/scene_graph.h"
 
 // This might *seem* to be unused, but don't remove it! We rely on this to dump
 // images to the console when calling `EXPECT_EQ(Image<...>, Image<...>)`.
@@ -293,7 +297,7 @@ class RenderEngineGltfClientGltfTest : public ::testing::Test {
         Mesh(FindResourceOrThrow(
                  "drake/geometry/render_gltf_client/test/tri.obj"),
              scale_),
-        properties_, X_WG_));
+        properties_, X_WG_, /* needs_update= */ true, "tri_obj"));
     EXPECT_TRUE(engine_.has_geometry(id));
     return id;
   }
@@ -305,7 +309,7 @@ class RenderEngineGltfClientGltfTest : public ::testing::Test {
         Mesh(FindResourceOrThrow(
                  "drake/geometry/render_gltf_client/test/tri_tree.gltf"),
              scale_),
-        properties_, X_WG_));
+        properties_, X_WG_, /* needs_update= */ true, "tri_tree_gltf"));
     EXPECT_TRUE(engine_.has_geometry(id));
     return id;
   }
@@ -535,90 +539,95 @@ TEST_F(RenderEngineGltfClientGltfTest, InMemorySupportingFilesToDataUris) {
   }
 }
 
-/* Currently, our server expects us to output a z-up gltf (because (a) Drake is
- z-up and (b) VTK does not correct it). The input gltf files are y-up.
- Therefore, we have to do some special math to apply a z-up pose to a y-up
- object.
+/* Pose computation works as follows:
 
- We do this update twice: once when the geometry is registered and once
- when we call UpdatePoses(). This will check both.
+   - record.contents stores the glTF file *unmodified*. Root nodes retain their
+     original file-frame transforms T_FN (translation/rotation/scale or matrix).
+   - record.X_WG stores the current world pose and is updated cheaply by
+     DoUpdateVisualPose().
+   - At ExportScene() time, a single wrapper node is injected that:
+       (a) carries record.geometry_name as its "name",
+       (b) carries T_WF = X_WG * S_WG * X_GF as its "matrix", and
+       (c) parents all of the source glTF's root nodes as "children".
+     The effective world transform of each root node N is then T_WF * T_FN.
 
- The transform located in the gltf contents should be as follows:
-
-    T = X_t * X_r * S * R_zy * F
-
- where:
-    X_t: a transform that translates the geometry.
-    X_r: a transform that rotates the geometry.
-    S: a transform that scales the geometry (possibly non-uniformly).
-    R_zy: The rotation from y-up to z-up.
-    F: The transform (not necessarily rigid) of the root node in the file.
-
- We'll extract the matrix X out of the glTF contents, and gradually remove
- each of the T, R, S, R_zy and compare the resultant F with that stored in the
- GltfRecord. */
+ This test verifies:
+   1. record.X_WG correctly tracks the geometry's pose after registration and
+      after UpdatePoses().
+   2. record.contents root nodes are unmodified (retain original file format).
+   3. The exported wrapper node carries the expected T_WF matrix and children.
+ */
 TEST_F(RenderEngineGltfClientGltfTest, PoseComputation) {
   const GeometryId gltf_id = AddGltf();
 
-  /* Given the non-rigid transform of a node (T_WN), the rigid pose of the
-   file's frame (T_WF) and the scale factor, extract the transform of the node
-   in the file's frame (T_FN). */
-  auto extract_T_FN = [](const Matrix4<double> T_WN,
-                         const RigidTransformd& X_WF,
+  /* Compute the expected wrapper-node matrix:
+       T_WF = X_WG * S_WG * X_GF
+     where S_WG scales the columns of X_WG and X_GF is the y-up-to-z-up
+     rotation (MakeXRotation(π/2)). */
+  auto compute_T_WF = [](const RigidTransformd& X_WG,
                          const Vector3d& scale_in) -> Matrix4<double> {
-    Matrix4<double> X_t_inv = Matrix4<double>::Identity();
-    X_t_inv.block<3, 1>(0, 3) = -X_WF.translation();
-    Matrix4<double> X_R_inv = Matrix4<double>::Identity();
-    X_R_inv.block<3, 3>(0, 0) = X_WF.rotation().inverse().matrix();
-    Matrix4<double> S_inv = Matrix4<double>::Identity();
-    S_inv(0, 0) /= scale_in.x();
-    S_inv(1, 1) /= scale_in.y();
-    S_inv(2, 2) /= scale_in.z();
-    const RigidTransformd X_zy_inv(RotationMatrixd::MakeXRotation(-M_PI / 2));
-    const Matrix4<double> R_zy_inv = X_zy_inv.GetAsMatrix4();
-    return R_zy_inv * S_inv * X_R_inv * X_t_inv * T_WN;
+    Matrix4<double> T = X_WG.GetAsMatrix4();
+    for (int i = 0; i < 3; ++i) T.block<3, 1>(0, i) *= scale_in(i);
+    T *= RigidTransformd(RotationMatrixd::MakeXRotation(M_PI / 2))
+             .GetAsMatrix4();
+    return T;
   };
 
-  // Extract the transform matrix from a node's specification. Also validate
-  // that it *only* includes "matrix" and not "translation", "rotation", or
-  // "scale".
-  auto extract_T_WN = [](const json& node) {
-    EXPECT_FALSE(node.contains("translation"));
-    EXPECT_FALSE(node.contains("rotation"));
-    EXPECT_FALSE(node.contains("scale"));
-    EXPECT_TRUE(node.contains("matrix"));
-    return EigenMatrixFromGltfMatrix(node["matrix"]);
-  };
-
-  // Previous tests already showed that there's a single root node. We'll get
-  // that node's T_FN.
   const std::map<GeometryId, Tester::GltfRecord>& gltfs =
       Tester::gltfs(engine_);
   const Tester::GltfRecord& record = gltfs.at(gltf_id);
+
+  // 1a. After registration, record.X_WG should hold the initial pose.
+  EXPECT_TRUE(
+      CompareMatrices(record.X_WG.GetAsMatrix4(), X_WG_.GetAsMatrix4(), 1e-15));
+
+  // 2. Contents are unmodified: glTF-original root nodes retain their original
+  // file-frame pose. In this case, we exploit the fact that all root nodes
+  // in tri_tree.gltf have only translation components.
+  // TODO(SeanCurtis-TRI): If this proves too brittle, we'll parse the original
+  // glTF and get the node transformation data directly.
   for (const auto& [node_index, T_FN_expected] : record.root_nodes) {
     const json& root = record.contents["nodes"][node_index];
     SCOPED_TRACE(fmt::format("Node {}({})", root["name"].get<std::string>(),
                              node_index));
-    // Confirm computation of X_WN during registration.
-    const Matrix4<double> X_WN_init = extract_T_WN(root);
-    const Matrix4<double> T_FN_init = extract_T_FN(X_WN_init, X_WG_, scale_);
-    EXPECT_TRUE(CompareMatrices(T_FN_init, T_FN_expected, 1e-15));
+    EXPECT_FALSE(root.contains("matrix"));
+    EXPECT_TRUE(root.contains("translation"));
   }
 
+  // 1b. After UpdatePoses(), record.X_WG should hold the updated pose.
   const RigidTransformd X_WG_update(RollPitchYawd{M_PI * 0.5, 0, 3 * M_PI / 2},
                                     Vector3d(-3, 1, 2));
   engine_.UpdatePoses(
       std::unordered_map<GeometryId, RigidTransformd>{{gltf_id, X_WG_update}});
-  for (const auto& [node_index, T_FN_expected] : record.root_nodes) {
-    const json& root = record.contents["nodes"][node_index];
-    SCOPED_TRACE(fmt::format("Node {}({})", root["name"].get<std::string>(),
-                             node_index));
-    // Confirm computation of X_WN during UpdatePoses.
-    const Matrix4<double> T_WN_update = extract_T_WN(root);
-    const Matrix4<double> T_FN_update =
-        extract_T_FN(T_WN_update, X_WG_update, scale_);
-    EXPECT_TRUE(CompareMatrices(T_FN_update, T_FN_expected, 1e-15));
+  EXPECT_TRUE(CompareMatrices(record.X_WG.GetAsMatrix4(),
+                              X_WG_update.GetAsMatrix4(), 1e-15));
+
+  // 3. Export and verify the wrapper node carries T_WF and the right children.
+  const json exported = ExportAndReadJson("pose_test.gltf", ImageType::kColor);
+  const json* wrapper_node{};
+  for (const auto& node : exported["nodes"]) {
+    if (node.contains("name") && node["name"] == "tri_tree_gltf") {
+      wrapper_node = &node;
+      break;
+    }
   }
+  ASSERT_NE(wrapper_node, nullptr)
+      << "Wrapper node named 'tri_tree_gltf' not found in exported glTF";
+
+  ASSERT_TRUE(wrapper_node->contains("matrix"));
+  const Matrix4<double> T_WF_actual =
+      EigenMatrixFromGltfMatrix((*wrapper_node)["matrix"]);
+  const Matrix4<double> T_WF_expected = compute_T_WF(X_WG_update, scale_);
+  EXPECT_TRUE(CompareMatrices(T_WF_actual, T_WF_expected, 1e-13));
+
+  // The wrapper must parent exactly the same number of children as the source
+  // glTF had root nodes (two for tri_tree.gltf: "root_tri" and "empty_root").
+  ASSERT_TRUE(wrapper_node->contains("children"));
+  EXPECT_EQ(ssize((*wrapper_node)["children"]), ssize(record.root_nodes));
+
+  // The wrapper node itself should not reference any mesh directly; it is
+  // a pure pose/grouping node.
+  EXPECT_FALSE(wrapper_node->contains("mesh"));
 }
 
 /* ExportScene() is responsible for merging gltf geometries into the VTK-made
@@ -637,24 +646,31 @@ TEST_F(RenderEngineGltfClientGltfTest, ExportScene) {
   const json gltf_obj_only =
       ExportAndReadJson("only_obj.gltf", ImageType::kColor);
   /* We should have three nodes, the mesh and VTK's "Renderer Node" and "Camera
-   Node". */
+   Node".
+
+   Note: in VTK logic, we only get the Camera Node because we have the mesh
+   node. If we don't have at least one vtkActor in VTK proper, we won't get the
+   camera node. */
   ASSERT_EQ(gltf_obj_only["nodes"].size(), 3);
 
-  /* Now we add the gltf. It adds three nodes: "empty_root", "root_tri", and
-   "child_tri". */
+  /* Now we add the gltf. It adds *four* nodes: the three in the glTF file
+   ("empty_root", "root_tri", and "child_tri") and a novel root node based on
+   the geometry name, "tri_tree_gltf". */
   AddGltf();
 
   const json gltf_color = ExportAndReadJson("color.gltf", ImageType::kColor);
-  ASSERT_EQ(gltf_color["nodes"].size(), 6);
-  bool root_tri_present = false;
-  bool empty_root_present = false;
+
+  // These are the nodes we expect to see. We'll remove everyone we find. Note:
+  // this doesn't account for extra nodes.
+  std::set<std::string> expected_nodes{
+      "Camera Node", "Renderer Node", "tri_tree_gltf", "root_tri",
+      "empty_root",  "child_tri",     "tri_obj"};
   for (const auto& n : gltf_color["nodes"]) {
     const std::string& name = n["name"].get<std::string>();
-    root_tri_present = root_tri_present || name == "root_tri";
-    empty_root_present = empty_root_present || name == "empty_root";
+    expected_nodes.erase(name);
   }
-  EXPECT_TRUE(root_tri_present);
-  EXPECT_TRUE(empty_root_present);
+  EXPECT_EQ(expected_nodes.size(), 0)
+      << fmt::to_string(fmt::join(expected_nodes, ", "));
 
   /* Finally, let's compare label and color. */
   auto find_mat_for_node = [](const json& gltf, std::string_view node_name) {
@@ -727,6 +743,85 @@ TEST_F(RenderEngineGltfClientGltfTest, RemoveGltf) {
   const json gltf_empty = ExportAndReadJson("empty.gltf", ImageType::kColor);
   /* An empty scene has no nodes (not even renderer and camera). */
   ASSERT_EQ(gltf_empty["nodes"].size(), 0);
+}
+
+/* When geometry is registered with a specific name via RegisterVisual, those
+ names should appear as node names in the exported glTF scene. This confirms
+ that geometry names assigned in SceneGraph propagate all the way through to
+ the exported representation. */
+GTEST_TEST(RenderEngineGltfClientNamesTest, GeometryNamesInExportedScene) {
+  // 1. Instantiate a SceneGraph.
+  SceneGraph<double> scene_graph;
+  const SourceId source_id = scene_graph.RegisterSource("test");
+
+  // 2. & 3. Instantiate a RenderEngineGltfClient, keeping a raw pointer.
+  auto engine = std::make_unique<RenderEngineGltfClient>();
+  // We'll save a reference to the engine so we can (a) exercise the ExportScene
+  // functionality and (b) easily test the cloned behavior.
+  const RenderEngineGltfClient& engine_ref = *engine;
+
+  // 4. Add the render engine to SceneGraph.
+  scene_graph.AddRenderer("gltf_client", std::move(engine));
+
+  // 5. Register geometries directly on the engine with known, distinct names.
+  const RigidTransformd X_WG;
+  PerceptionProperties properties;
+  properties.AddProperty("label", "id", render::RenderLabel(1));
+
+  const GeometryId obj_id = scene_graph.RegisterAnchoredGeometry(
+      source_id, std::make_unique<GeometryInstance>(
+                     X_WG,
+                     Mesh(FindResourceOrThrow(
+                              "drake/geometry/render_gltf_client/test/tri.obj"),
+                          Vector3d::Ones()),
+                     "my_obj_geom"));
+  scene_graph.AssignRole(source_id, obj_id, properties);
+
+  const GeometryId gltf_id = scene_graph.RegisterAnchoredGeometry(
+      source_id,
+      std::make_unique<GeometryInstance>(
+          X_WG,
+          Mesh(FindResourceOrThrow(
+                   "drake/geometry/render_gltf_client/test/tri_tree.gltf"),
+               Vector3d::Ones()),
+          "my_gltf_geom"));
+  scene_graph.AssignRole(source_id, gltf_id, properties);
+
+  // 6. Export the scene.
+  const fs::path temp_dir = temp_directory();
+  const fs::path output_path = temp_dir / "names_test.gltf";
+  RenderEngineGltfClientTester::ExportScene(engine_ref, output_path,
+                                            ImageType::kColor);
+
+  // 7. Read the exported glTF and verify the known names appear as node names.
+  const json gltf = ReadJsonFile(output_path);
+  std::set<std::string> node_names;
+  for (const auto& node : gltf["nodes"]) {
+    if (node.contains("name")) {
+      node_names.insert(node["name"].get<std::string>());
+    }
+  }
+  EXPECT_THAT(node_names, ::testing::Contains("my_obj_geom"));
+  EXPECT_THAT(node_names, ::testing::Contains("my_gltf_geom"));
+
+  // 8. Verify that cloning the engine preserves the geometry names.
+  std::unique_ptr<RenderEngine> clone_base = engine_ref.Clone();
+  auto* clone = dynamic_cast<RenderEngineGltfClient*>(clone_base.get());
+  ASSERT_NE(clone, nullptr);
+
+  const fs::path clone_output_path = temp_dir / "names_test_clone.gltf";
+  RenderEngineGltfClientTester::ExportScene(*clone, clone_output_path,
+                                            ImageType::kColor);
+
+  const json clone_gltf = ReadJsonFile(clone_output_path);
+  std::set<std::string> clone_node_names;
+  for (const auto& node : clone_gltf["nodes"]) {
+    if (node.contains("name")) {
+      clone_node_names.insert(node["name"].get<std::string>());
+    }
+  }
+  EXPECT_THAT(clone_node_names, ::testing::Contains("my_obj_geom"));
+  EXPECT_THAT(clone_node_names, ::testing::Contains("my_gltf_geom"));
 }
 
 }  // namespace

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -324,11 +324,20 @@ void RenderEngineVtk::ImplementGeometry(const Sphere& sphere, void* user_data) {
                     DefineMaterial(data.properties, default_diffuse_), data);
 }
 
-bool RenderEngineVtk::DoRegisterVisual(GeometryId id, const Shape& shape,
-                                       const PerceptionProperties& properties,
-                                       const RigidTransformd& X_WG) {
+bool RenderEngineVtk::DoRegisterVisual(GeometryId, const Shape&,
+                                       const PerceptionProperties&,
+                                       const RigidTransformd&) {
+  throw std::runtime_error("RenderEngineVtk uses named visuals.");
+}
+
+bool RenderEngineVtk::DoRegisterNamedVisual(
+    GeometryId id, const Shape& shape, const PerceptionProperties& properties,
+    const RigidTransformd& X_WG, std::string_view name) {
   // Note: the user_data interface on reification requires a non-const pointer.
-  RegistrationData data{properties, X_WG, id};
+  RegistrationData data{.properties = properties,
+                        .X_WG = X_WG,
+                        .id = id,
+                        .name = std::string(name)};
   shape.Reify(this, &data);
   return data.accepted;
 }
@@ -606,6 +615,7 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
       for (const auto& source_part : source_prop.parts) {
         vtkNew<vtkActor> target_actor;
         target_actor->ShallowCopy(source_part.actor);
+        target_actor->SetObjectName(source_part.actor->GetObjectName());
         vtkNew<vtkOpenGLPolyDataMapper> target_mapper;
         target_mapper->ShallowCopy(source_part.actor->GetMapper());
         target_actor->SetMapper(target_mapper);
@@ -1075,9 +1085,10 @@ void RenderEngineVtk::ImplementPolyData(vtkPolyDataAlgorithm* source,
 
   // Adds the actor into the specified pipeline.
   PropArray props;
-  auto connect_actor = [this, &actors, &mappers, &props,
-                        &vtk_X_WG](ImageType image_type) {
+  auto connect_actor = [this, &actors, &mappers, &props, &vtk_X_WG,
+                        &data](ImageType image_type) {
     vtkSmartPointer<vtkActor>& actor = actors[image_type];
+    actor->SetObjectName(data.name);
     actor->SetMapper(mappers[image_type].Get());
     actor->SetUserTransform(vtk_X_WG);
     pipelines_[image_type]->renderer->AddActor(actor);

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -167,12 +167,20 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
     const math::RigidTransformd& X_WG;
     const GeometryId id;
     bool accepted{true};
+    std::string name;
   };
 
-  // @see RenderEngine::DoRegisterVisual().
+  // @see RenderEngine::DoRegisterVisual(). This throws; RenderEngineVtk wants
+  // to capture names; DoRegisterNamedVisual() is the true implementation.
   bool DoRegisterVisual(GeometryId id, const Shape& shape,
                         const PerceptionProperties& properties,
-                        const math::RigidTransformd& X_WG) override;
+                        const math::RigidTransformd& X_WG) final;
+
+  // @see RenderEngine::DoRegisterNamedVisual().
+  bool DoRegisterNamedVisual(GeometryId id, const Shape& shape,
+                             const PerceptionProperties& properties,
+                             const math::RigidTransformd& X_WG,
+                             std::string_view name) override;
 
   // @see RenderEngine::DoRegisterDeformableVisual().
   bool DoRegisterDeformableVisual(

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -89,6 +89,11 @@ class RenderEngineVtkTester {
     }
     return actors;
   }
+
+  // Return the full props map for the renderer.
+  static const auto& GetProps(const RenderEngineVtk& renderer) {
+    return renderer.props_;
+  }
 };
 
 namespace {
@@ -588,7 +593,7 @@ class RenderEngineVtkTest : public ::testing::Test {
       material.AddProperty("phong", "diffuse", kTerrainColor.ToRgba());
       engine->RegisterVisual(GeometryId::get_new_id(), HalfSpace(), material,
                              RigidTransformd::Identity(),
-                             false /* needs update */);
+                             false /* needs update */, "terrain");
     }
   }
 
@@ -633,7 +638,7 @@ class RenderEngineVtkTest : public ::testing::Test {
     expected_label_ = RenderLabel(12345);  // an arbitrary value.
     renderer->RegisterVisual(geometry_id_, sphere, simple_material(use_texture),
                              RigidTransformd::Identity(),
-                             true /* needs update */);
+                             true /* needs update */, "sphere");
     RigidTransformd X_WV{Vector3d{0, 0, 0.5}};
     X_WV_.clear();
     X_WV_.insert({geometry_id_, X_WV});
@@ -648,7 +653,7 @@ class RenderEngineVtkTest : public ::testing::Test {
     const GeometryId id = GeometryId::get_new_id();
     PerceptionProperties props = simple_material(false);
     renderer->RegisterVisual(id, box, props, RigidTransformd::Identity(),
-                             true /* needs update */);
+                             true /* needs update */, "box");
     // Leave the box centered on the xy plane, but raise it up for the expected
     // depth in the camera (distance from eye to near surface):
     //      expected depth = p_WC.z - length / 2 - p_WV.z;
@@ -798,7 +803,8 @@ TEST_F(RenderEngineVtkTest, MeshTest) {
     PerceptionProperties material = simple_material();
     const GeometryId id = GeometryId::get_new_id();
     renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
-                              true /* needs update */);
+                              true /* needs update */,
+                              use_texture ? "box.obj" : "box_no_mtl.obj");
     renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
         {id, RigidTransformd::Identity()}});
 
@@ -842,19 +848,19 @@ TEST_F(RenderEngineVtkTest, NonUniformScale) {
     const Vector3d unit_scale(1, 1, 1);
     ref_engine.RegisterVisual(mesh_id, Mesh(unit_mesh, unit_scale), material,
                               RigidTransformd(Vector3d(-1.5, 0, 0)),
-                              /* needs_update =*/false);
+                              false /* needs update */, "unit_mesh");
     ref_engine.RegisterVisual(convex_id, Convex(unit_mesh, unit_scale),
                               material, RigidTransformd(Vector3d(1.5, 0, 0)),
-                              /* needs_update =*/false);
+                              false /* needs update */, "unit_convex");
 
     // This should be the scale factor documented in rotated_cube_squished.obj
     const Vector3d stretch(2, 4, 8);
     scale_engine.RegisterVisual(mesh_id, Mesh(scale_mesh, stretch), material,
                                 RigidTransformd(Vector3d(-1.5, 0, 0)),
-                                /* needs_update =*/false);
+                                false /* needs update */, "scale_mesh");
     scale_engine.RegisterVisual(convex_id, Convex(scale_mesh, stretch),
                                 material, RigidTransformd(Vector3d(1.5, 0, 0)),
-                                /* needs_update =*/false);
+                                false /* needs update */, "scale_convex");
 
     ref_engine.UpdateViewpoint(X_WC);
     scale_engine.UpdateViewpoint(X_WC);
@@ -893,14 +899,15 @@ TEST_F(RenderEngineVtkTest, InMemoryMesh) {
                                     const Mesh& memory_mesh) {
     renderer_->RemoveGeometry(id);
     renderer_->RegisterVisual(id, file_mesh, props, RigidTransformd::Identity(),
-                              false);
+                              false, "file_mesh");
     ImageRgba8U file_image(kWidth, kHeight);
     Render(fmt::format("{}_file", file_prefix), nullptr, nullptr, &file_image,
            nullptr, nullptr);
 
     renderer_->RemoveGeometry(id);
     renderer_->RegisterVisual(id, memory_mesh, props,
-                              RigidTransformd::Identity(), false);
+                              RigidTransformd::Identity(), false,
+                              "memory_mesh");
     ImageRgba8U memory_image(kWidth, kHeight);
     Render(fmt::format("{}_memory", file_prefix), nullptr, nullptr,
            &memory_image, nullptr, nullptr);
@@ -967,7 +974,7 @@ TEST_F(RenderEngineVtkTest, GltfTextureSupport) {
       "drake/geometry/render/test/meshes/fully_textured_pyramid.gltf");
   renderer_->RegisterVisual(id, Mesh(filename), material,
                             RigidTransformd::Identity(),
-                            false /* needs update */);
+                            false /* needs update */, "fully_textured_pyramid");
   ImageRgba8U image(64, 64);
   const ColorRenderCamera camera(
       {"unused", {64, 64, kFovY / 2}, {0.01, 10}, {}}, FLAGS_show_window);
@@ -1013,7 +1020,8 @@ TEST_F(RenderEngineVtkTest, GltfAssetFormats) {
     // Add the i'th cube to the scene.
     const GeometryId id = GeometryId::get_new_id();
     renderer_->RegisterVisual(id, Mesh(filenames[i]), PerceptionProperties{},
-                              RigidTransformd::Identity(), true);
+                              RigidTransformd::Identity(), true,
+                              fmt::format("cube{}", i));
     renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
         {id, RigidTransformd::Identity()}});
 
@@ -1048,7 +1056,7 @@ TEST_F(RenderEngineVtkTest, GltfUnsupportedExtensionRequired) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       renderer_->RegisterVisual(id, Mesh(filename), material,
                                 RigidTransformd::Identity(),
-                                false /* needs update */),
+                                false /* needs update */, "basisu_required"),
       ".*KHR_texture_basisu is required.*");
 }
 
@@ -1111,9 +1119,9 @@ TEST_F(RenderEngineVtkTest, MultiMaterialObjects) {
     Init(X_WR, false);
     Mesh mesh(f);
     renderer_->RegisterVisual(id1, mesh, material, X_WM1,
-                              false /* needs update */);
+                              false /* needs update */, "mesh1");
     renderer_->RegisterVisual(id2, mesh, material, X_WM2,
-                              false /* needs update */);
+                              false /* needs update */, "mesh2");
 
     const std::string name =
         fmt::format("image for {}", f.extension().string());
@@ -1167,7 +1175,7 @@ TEST_F(RenderEngineVtkTest, VtkGltfBehavior) {
   material.AddProperty("label", "id", expected_label_);
   const GeometryId id = GeometryId::get_new_id();
   renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
-                            true /* needs update */);
+                            true /* needs update */, "rainbow_box");
   for (vtkActor* actor :
        RenderEngineVtkTester::GetColorActors(*renderer_, id)) {
     ASSERT_TRUE(TransformComponentsAreIdentity(actor));
@@ -1373,6 +1381,31 @@ TEST_F(RenderEngineVtkTest, SimpleClone) {
   EXPECT_NE(dynamic_cast<RenderEngineVtk*>(clone.get()), nullptr);
   PerformCenterShapeTest(static_cast<RenderEngineVtk*>(clone.get()),
                          "Simple clone");
+
+  // We also need to test the cloning of fields that don't directly affect the
+  // rendered output.
+
+  // Verify that every actor in the clone has the same ObjectName as the
+  // corresponding actor in the original renderer.
+  RenderEngineVtk* clone_vtk = static_cast<RenderEngineVtk*>(clone.get());
+  const auto& orig_props = RenderEngineVtkTester::GetProps(*renderer_);
+  const auto& clone_props = RenderEngineVtkTester::GetProps(*clone_vtk);
+  ASSERT_EQ(orig_props.size(), clone_props.size());
+  for (const auto& [id, orig_prop_array] : orig_props) {
+    ASSERT_TRUE(clone_props.count(id) > 0)
+        << "Clone missing geometry " << fmt::to_string(id);
+    const auto& clone_prop_array = clone_props.at(id);
+    for (size_t pipeline = 0; pipeline < orig_prop_array.size(); ++pipeline) {
+      const auto& orig_prop = orig_prop_array[pipeline];
+      const auto& clone_prop = clone_prop_array[pipeline];
+      ASSERT_EQ(orig_prop.parts.size(), clone_prop.parts.size());
+      for (size_t p = 0; p < orig_prop.parts.size(); ++p) {
+        EXPECT_FALSE(orig_prop.parts[p].actor->GetObjectName().empty());
+        EXPECT_EQ(orig_prop.parts[p].actor->GetObjectName(),
+                  clone_prop.parts[p].actor->GetObjectName());
+      }
+    }
+  }
 }
 
 // Tests that the cloned renderer still works, even when the original is

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -1939,9 +1939,10 @@ class ChangeShapeRenderEngine : public DummyRenderEngine {
   }
 
  protected:
-  bool DoRegisterVisual(GeometryId id, const Shape&,
-                        const PerceptionProperties&,
-                        const math::RigidTransformd&) override {
+  bool DoRegisterNamedVisual(GeometryId id, const Shape&,
+                             const PerceptionProperties&,
+                             const math::RigidTransformd&,
+                             std::string_view) override {
     registered_id_ = id;
     return true;
   }

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -104,6 +104,12 @@ class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
     return registered_geometries_.contains(id);
   }
 
+  /* A _possible_ mapping of each registered id to its name. DummyRenderEngine
+   ignores names and, as such, this map will always be empty. Derived class
+   that track names (e.g., DummyRenderEngineWithNames) will capture the names
+   and this map will be fully populated. */
+  const std::map<GeometryId, std::string>& names() const { return names_; }
+
   // These six functions (and supporting members) facilitate testing while there
   // are two APIs for specifying the camera for rendering images. They should
   // go away when the legacy "simple" intrinsics are removed.
@@ -159,7 +165,10 @@ class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
   /* Dummy implementation that registers the given `shape` if the `properties`
    contains the "in_test" group or the render engine has been forced to accept
    all geometries (via set_force_accept()). (Also counts the number of
-   successfully registered shape over the lifespan of `this` instance.) */
+   successfully registered shape over the lifespan of `this` instance.)
+   This implements the *legacy* visual registration; it ignores names and
+   provides the basis testing that legacy behavior. To test name registration,
+   use DummyRenderEngineWithNames (see below). */
   bool DoRegisterVisual(GeometryId id, const Shape&,
                         const PerceptionProperties& properties,
                         const math::RigidTransformd& X_WG) override {
@@ -249,11 +258,20 @@ class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
     return "DummyRenderEngineParams: {}";
   }
 
+  /* Registers an (id, name) pair -- derived classes that track names should
+   use this to capture the names. */
+  void RegisterName(GeometryId id, const std::string& name) {
+    names_[id] = name;
+  }
+
  private:
   // If true, the engine will accept all geometries.
   bool force_accept_{};
 
   std::unordered_set<GeometryId> registered_geometries_;
+
+  // The names associated with the geometries.
+  std::map<GeometryId, std::string> names_;
 
   // The current poses of the geometries in the world frame.
   std::map<GeometryId, math::RigidTransformd> X_WGs_;
@@ -289,6 +307,39 @@ class DummyRenderEngine : public render::RenderEngine, private ShapeReifier {
   mutable render::ColorRenderCamera color_camera_;
   mutable render::DepthRenderCamera depth_camera_;
   mutable render::ColorRenderCamera label_camera_;
+};
+
+/* A variant of DummyRenderEngine that captures names of registered visuals.*/
+class DummyRenderEngineWithNames : public DummyRenderEngine {
+ public:
+  explicit DummyRenderEngineWithNames(const render::RenderLabel& label)
+      : DummyRenderEngine(label) {}
+
+ protected:
+  /* This dummy implements named visuals; as such, we won't allow derived
+   classes to override this method anymore. Leaving it overridable might allow
+   erring downstream implementations that would simply become dead code. */
+  bool DoRegisterVisual(GeometryId id, const Shape&,
+                        const PerceptionProperties& properties,
+                        const math::RigidTransformd& X_WG) final {
+    throw std::runtime_error(
+        "DoRegisterNamedVisual is implemented instead; this should never get "
+        "invoked.");
+  }
+
+  /* Registration of a _named_ visual. The name will be captured and reported
+  in this->names(). */
+  bool DoRegisterNamedVisual(GeometryId id, const Shape& shape,
+                             const PerceptionProperties& properties,
+                             const math::RigidTransformd& X_WG,
+                             std::string_view name) override {
+    bool result =
+        DummyRenderEngine::DoRegisterVisual(id, shape, properties, X_WG);
+    if (result) {
+      RegisterName(id, std::string(name));
+    }
+    return result;
+  }
 };
 
 }  // namespace internal

--- a/tools/workspace/vtk_internal/patches/upstream/gltf_export_with_object_names.patch
+++ b/tools/workspace/vtk_internal/patches/upstream/gltf_export_with_object_names.patch
@@ -1,0 +1,27 @@
+By default, when exporting meshes/nodes to glTF files, VTK simply enumerates the
+meshes in order and assigns the same generic name to mesh and corresponding
+node. This changes the behavior so that *if* the actor has a non-empty object
+name assigned, that object name will be used instead.
+
+--- IO/Export/vtkGLTFExporter.cxx
++++ IO/Export/vtkGLTFExporter.cxx
+@@ -320,7 +320,18 @@ void WriteMesh(nlohmann::json& accessors, nlohmann::json& buffers, nlohmann::jso
+   }
+ 
+   nlohmann::json amesh;
+-  std::string meshName = "mesh" + vtk::to_string(meshes.size());
++  auto make_mesh_name = [&meshes](vtkActor* aPart) {
++    if (aPart->GetObjectName().empty())
++    {
++      return "mesh" + vtk::to_string(meshes.size());
++    }
++    else
++    {
++      return aPart->GetObjectName();
++    }
++  };
++
++  std::string meshName = make_mesh_name(aPart);
+   amesh["name"] = meshName;
+   amesh["primitives"] = prims;
+   meshes.emplace_back(amesh);

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -192,6 +192,7 @@ def vtk_internal_repository(
             # - Patch file names should begin with the name of the module being
             #   edited (e.g., patching IO/Image is named io_image_{foo}.patch).
             # - Use alphabetical order within a directory when listing patches.
+            ":patches/upstream/gltf_export_with_object_names.patch",
             ":patches/upstream/rendering_opengl2_replace_single_scattering_with_multi_scattering_in_pbr.patch",
             ":patches/upstream/utilities_x11_more_functions.patch",
             ":patches/common_core_fmt9.patch",


### PR DESCRIPTION
1. Patch VTK so its glTF export can use non-empty ObjectName values on actors.
2. Map geometry names to actor object names.
   - Requires changes to RenderEngine interface and implementations. - Introduces new NVI method to preserve legacy, unnamed behavior.
   - Make sure GeometryState passes the name when registering geometries.
   - Make sure object names get cloned.
3. RenderEngineGltfClient
   - Change how glTF files get embedded. Instead of all root nodes lying at the base, inject a geometry-level node carrying the geometry name.
   - Test confirms that nodes with the geometry names appear and are root nodes.

Resolves #24185.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24209)
<!-- Reviewable:end -->
