### PR TITLE
Revert "Update dependency rules_rust to v0.69.0"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(name = "rules_java", version = "9.6.1")
 bazel_dep(name = "rules_jvm_external", version = "6.9")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_python", version = "1.9.0")  # Keep this in sync with cmake/MODULE.bazel.in.  # noqa
-bazel_dep(name = "rules_rust", version = "0.69.0")
+bazel_dep(name = "rules_rust", version = "0.68.1")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
 # Configure the C++ toolchain.

--- a/tools/workspace/crate_universe/lock/details/BUILD.amd-0.2.2.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.amd-0.2.2.bazel
@@ -82,7 +82,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.autocfg-1.5.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.autocfg-1.5.0.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.blas-0.22.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.blas-0.22.0.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.blas-sys-0.7.1.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.blas-sys-0.7.1.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.bumpalo-3.20.2.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.bumpalo-3.20.2.bazel
@@ -88,7 +88,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.cfg-if-1.0.4.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.cfg-if-1.0.4.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.clarabel-0.11.1.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.clarabel-0.11.1.bazel
@@ -97,7 +97,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.darling-0.14.4.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.darling-0.14.4.bazel
@@ -89,7 +89,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.darling_core-0.14.4.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.darling_core-0.14.4.bazel
@@ -86,7 +86,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.darling_macro-0.14.4.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.darling_macro-0.14.4.bazel
@@ -82,7 +82,6 @@ rust_proc_macro(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.derive_builder-0.11.2.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.derive_builder-0.11.2.bazel
@@ -92,7 +92,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.derive_builder_core-0.11.2.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.derive_builder_core-0.11.2.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.derive_builder_macro-0.11.2.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.derive_builder_macro-0.11.2.bazel
@@ -85,7 +85,6 @@ rust_proc_macro(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.either-1.15.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.either-1.15.0.bazel
@@ -89,7 +89,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.enum_dispatch-0.3.13.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.enum_dispatch-0.3.13.bazel
@@ -85,7 +85,6 @@ rust_proc_macro(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.equivalent-1.0.2.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.equivalent-1.0.2.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.fnv-1.0.7.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.fnv-1.0.7.bazel
@@ -89,7 +89,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.hashbrown-0.16.1.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.hashbrown-0.16.1.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.ident_case-1.0.1.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.ident_case-1.0.1.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.indexmap-2.13.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.indexmap-2.13.0.bazel
@@ -89,7 +89,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.itertools-0.11.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.itertools-0.11.0.bazel
@@ -90,7 +90,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.itoa-1.0.17.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.itoa-1.0.17.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.js-sys-0.3.91.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.js-sys-0.3.91.bazel
@@ -90,7 +90,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.lapack-0.19.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.lapack-0.19.0.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.lapack-sys-0.14.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.lapack-sys-0.14.0.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.lazy_static-1.5.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.lazy_static-1.5.0.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.libc-0.2.182.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.libc-0.2.182.bazel
@@ -93,7 +93,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.memchr-2.8.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.memchr-2.8.0.bazel
@@ -89,7 +89,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.num-complex-0.4.6.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.num-complex-0.4.6.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.num-traits-0.2.19.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.num-traits-0.2.19.bazel
@@ -94,7 +94,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.once_cell-1.21.3.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.once_cell-1.21.3.bazel
@@ -178,7 +178,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.paste-1.0.15.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.paste-1.0.15.bazel
@@ -89,7 +89,6 @@ rust_proc_macro(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.proc-macro2-1.0.106.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.proc-macro2-1.0.106.bazel
@@ -93,7 +93,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.quote-1.0.45.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.quote-1.0.45.bazel
@@ -93,7 +93,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.rustversion-1.0.22.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.rustversion-1.0.22.bazel
@@ -89,7 +89,6 @@ rust_proc_macro(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.serde-1.0.228.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.serde-1.0.228.bazel
@@ -98,7 +98,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.serde-big-array-0.5.1.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.serde-big-array-0.5.1.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.serde_core-1.0.228.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.serde_core-1.0.228.bazel
@@ -93,7 +93,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.serde_derive-1.0.228.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.serde_derive-1.0.228.bazel
@@ -88,7 +88,6 @@ rust_proc_macro(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.serde_json-1.0.149.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.serde_json-1.0.149.bazel
@@ -94,7 +94,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.strsim-0.10.0.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.strsim-0.10.0.bazel
@@ -82,7 +82,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.syn-1.0.109.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.syn-1.0.109.bazel
@@ -100,7 +100,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.syn-2.0.117.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.syn-2.0.117.bazel
@@ -97,7 +97,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.thiserror-1.0.69.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.thiserror-1.0.69.bazel
@@ -92,7 +92,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.thiserror-impl-1.0.69.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.thiserror-impl-1.0.69.bazel
@@ -85,7 +85,6 @@ rust_proc_macro(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.unicode-ident-1.0.24.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.unicode-ident-1.0.24.bazel
@@ -86,7 +86,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.wasm-bindgen-0.2.114.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.wasm-bindgen-0.2.114.bazel
@@ -95,7 +95,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.wasm-bindgen-macro-0.2.114.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.wasm-bindgen-macro-0.2.114.bazel
@@ -85,7 +85,6 @@ rust_proc_macro(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.wasm-bindgen-macro-support-0.2.114.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.wasm-bindgen-macro-support-0.2.114.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.wasm-bindgen-shared-0.2.114.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.wasm-bindgen-shared-0.2.114.bazel
@@ -89,7 +89,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.web-time-0.2.4.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.web-time-0.2.4.bazel
@@ -85,7 +85,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/BUILD.zmij-1.0.21.bazel
+++ b/tools/workspace/crate_universe/lock/details/BUILD.zmij-1.0.21.bazel
@@ -86,7 +86,6 @@ rust_library(
         "@rules_rust//rust/platform:aarch64-unknown-nto-qnx710": [],
         "@rules_rust//rust/platform:aarch64-unknown-uefi": [],
         "@rules_rust//rust/platform:arm-unknown-linux-gnueabi": [],
-        "@rules_rust//rust/platform:arm-unknown-linux-musleabi": [],
         "@rules_rust//rust/platform:armv7-linux-androideabi": [],
         "@rules_rust//rust/platform:armv7-unknown-linux-gnueabi": [],
         "@rules_rust//rust/platform:i686-apple-darwin": [],

--- a/tools/workspace/crate_universe/lock/details/defs.bzl
+++ b/tools/workspace/crate_universe/lock/details/defs.bzl
@@ -373,7 +373,6 @@ _CONDITIONS = {
     "aarch64-unknown-nto-qnx710": ["@rules_rust//rust/platform:aarch64-unknown-nto-qnx710"],
     "aarch64-unknown-uefi": ["@rules_rust//rust/platform:aarch64-unknown-uefi"],
     "arm-unknown-linux-gnueabi": ["@rules_rust//rust/platform:arm-unknown-linux-gnueabi"],
-    "arm-unknown-linux-musleabi": ["@rules_rust//rust/platform:arm-unknown-linux-musleabi"],
     "armv7-linux-androideabi": ["@rules_rust//rust/platform:armv7-linux-androideabi"],
     "armv7-unknown-linux-gnueabi": ["@rules_rust//rust/platform:armv7-unknown-linux-gnueabi"],
     "cfg(all(target_family = \"wasm\", not(any(target_os = \"emscripten\", target_os = \"wasi\"))))": ["@rules_rust//rust/platform:wasm32-unknown-unknown"],


### PR DESCRIPTION
This reverts commit 299253806a2f427f4e30c37055d643649ae0cccf.

Towards #24213.  (Fixes the problem, but not closing the issue until the fix has been released to PyPI.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24212)
<!-- Reviewable:end -->
