### PR TITLE
[common] Upgrade minimum fmt and spdlog baseline

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -3008,24 +3008,12 @@ Template parameter ``T``:
     // Symbol: drake::fmt_runtime
     struct /* fmt_runtime */ {
       // Source: drake/common/fmt.h
-      const char* doc =
-R"""(When using fmt >= 8, this is an alias for <a
-href="https://fmt.dev/latest/api.html#compile-time-format-string-checks">fmt∷runtime</a>.
-When using fmt < 8, this is a no-op.)""";
+      const char* doc = R"""()""";
     } fmt_runtime;
     // Symbol: drake::fmt_streamed
     struct /* fmt_streamed */ {
       // Source: drake/common/fmt_ostream.h
-      const char* doc =
-R"""(When using fmt >= 9, this is an alias for <a
-href="https://fmt.dev/latest/api.html#ostream-api">fmt∷streamed</a>.
-When using fmt < 9, this uses a polyfill instead.
-
-Within Drake, the nominal use for ``fmt∷streamed`` is when formatting
-third-party types that provide ``operator<<`` support but not
-``fmt∷formatter<T>`` support. Once we stop using
-``FMT_DEPRECATED_OSTREAM=1``, compilation errors will help you
-understand where you are required to use this wrapper.)""";
+      const char* doc = R"""()""";
     } fmt_streamed;
     // Symbol: drake::hash_append
     struct /* hash_append */ {
@@ -3413,6 +3401,11 @@ R"""(Determines whether ``x > y`` using ``operator<``.)""";
       const char* doc =
 R"""(Determines whether ``x >= y`` using ``operator<``.)""";
     } operator_ge;
+    // Symbol: drake::ostream_formatter
+    struct /* ostream_formatter */ {
+      // Source: drake/common/fmt_ostream.h
+      const char* doc = R"""()""";
+    } ostream_formatter;
     // Symbol: drake::pow
     struct /* pow */ {
       // Source: drake/common/polynomial.h

--- a/bindings/pydrake/common/text_logging_pybind.cc
+++ b/bindings/pydrake/common/text_logging_pybind.cc
@@ -1,12 +1,12 @@
 #include "drake/bindings/pydrake/common/text_logging_pybind.h"
 
-#ifdef HAVE_SPDLOG
-
 #include <atomic>
 #include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>
+
+#ifdef HAVE_SPDLOG
 
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/dist_sink.h>
@@ -108,10 +108,8 @@ class pylogging_sink final
         return 50;
       case Enum::off:
         break;
-#if SPDLOG_VERSION >= 10600
       case Enum::n_levels:
         break;
-#endif
     }
     DRAKE_UNREACHABLE();
   }

--- a/bindings/pydrake/math/math_py_monolith.cc
+++ b/bindings/pydrake/math/math_py_monolith.cc
@@ -15,7 +15,6 @@
 #include "drake/bindings/pydrake/math_operators_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/math/barycentric.h"
 #include "drake/math/bspline_basis.h"
 #include "drake/math/compute_numerical_gradient.h"
@@ -655,7 +654,7 @@ void DoScalarIndependentDefinitions(py::module m) {
               // In the future, we should enhance this to display all of the
               // information.
               return fmt::format("<NumericalGradientOption({})>",
-                  fmt_streamed(py::repr(method)));
+                  std::string(py::repr(method)));
             });
   }
 

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -176,8 +176,8 @@ void DoScalarIndependentDefinitions(py::module m) {
           py::str py_namespace = std::string{self.get_namespace()};
           py::str py_element = std::string{self.get_element()};
           return fmt::format("ScopedName({}, {})",
-              fmt_streamed(py::repr(py_namespace)),
-              fmt_streamed(py::repr(py_element)));
+              std::string(py::repr(py_namespace)),
+              std::string(py::repr(py_element)));
         });
     DefCopyAndDeepCopy(&cls);
   }

--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -22,8 +22,7 @@
 #include <type_traits>
 
 #include <Eigen/Dense>
-
-#include "drake/common/fmt_ostream.h"
+#include <fmt/ostream.h>
 
 // clang-format off
 namespace Eigen {
@@ -557,5 +556,5 @@ inline const AutoDiffScalar<VectorXd> max(const AutoDiffScalar<VectorXd>& a,
 
 namespace fmt {
 template <>
-struct formatter<drake::AutoDiffXd> : drake::ostream_formatter {};
+struct formatter<drake::AutoDiffXd> : fmt::ostream_formatter {};
 }  // namespace fmt

--- a/common/file_source.cc
+++ b/common/file_source.cc
@@ -1,8 +1,8 @@
 #include "drake/common/file_source.h"
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/overloaded.h"
 
 namespace drake {
@@ -12,7 +12,7 @@ std::string to_string(const FileSource& source) {
   return std::visit(overloaded{[](const std::filesystem::path& path) {
                                  // We'll delegate to the built-in operator<<,
                                  // which properly quotes the path.
-                                 return fmt::to_string(fmt_streamed(path));
+                                 return fmt::to_string(fmt::streamed(path));
                                },
                                [](const MemoryFile& file) {
                                  return fmt::to_string(file);

--- a/common/fmt.cc
+++ b/common/fmt.cc
@@ -13,48 +13,8 @@ std::string fmt_floating_point(T x)
   return result;
 }
 
-// We can simplify this after we drop support for Ubuntu 22.04 Jammy.
 std::string fmt_debug_string(std::string_view x) {
-#if FMT_VERSION >= 90000
   return fmt::format("{:?}", x);
-#else
-  std::string result;
-  result.reserve(x.size() + 2);
-  result.push_back('"');
-  for (const char ch : x) {
-    // Check for characters with a custom escape sequence.
-    if (ch == '\n') {
-      result.push_back('\\');
-      result.push_back('n');
-      continue;
-    }
-    if (ch == '\r') {
-      result.push_back('\\');
-      result.push_back('r');
-      continue;
-    }
-    if (ch == '\t') {
-      result.push_back('\\');
-      result.push_back('t');
-      continue;
-    }
-    // Check for characters that require a leading backslash.
-    if (ch == '"' || ch == '\\') {
-      result.push_back('\\');
-      result.push_back(ch);
-      continue;
-    }
-    // Check for any other non-printable characters.
-    if (ch < 0x20 || ch >= 0x7F) {
-      result.append(fmt::format("\\x{:02x}", static_cast<int>(ch)));
-      continue;
-    }
-    // Normal character.
-    result.push_back(ch);
-  }
-  result.push_back('"');
-  return result;
-#endif
 }
 
 template std::string fmt_floating_point<float>(float);

--- a/common/fmt.h
+++ b/common/fmt.h
@@ -14,25 +14,12 @@
 
 namespace drake {
 
-#if FMT_VERSION >= 80000 || defined(DRAKE_DOXYGEN_CXX)
-/** When using fmt >= 8, this is an alias for
-<a
-href="https://fmt.dev/latest/api.html#compile-time-format-string-checks">fmt::runtime</a>.
-When using fmt < 8, this is a no-op. */
+[[deprecated(
+    "\nDRAKE DEPRECATED: Use fmt::runtime instead.\n"
+    "The deprecated code will be removed from Drake on or after 2026-07-01.")]]
 inline auto fmt_runtime(std::string_view s) {
   return fmt::runtime(s);
 }
-/** When using fmt >= 8, this is defined to be `const` to indicate that the
-`fmt::formatter<T>::format(...)` function should be object-const.
-When using fmt < 8, the function signature was incorrect (lacking the const),
-so this macro will be empty. */
-#define DRAKE_FMT8_CONST const
-#else  // FMT_VERSION
-inline auto fmt_runtime(std::string_view s) {
-  return s;
-}
-#define DRAKE_FMT8_CONST
-#endif  // FMT_VERSION
 
 /** Returns `fmt::to_string(x)` but always with at least one digit after the
 decimal point. Different versions of fmt disagree on whether to omit the
@@ -167,7 +154,7 @@ Drake drops support for earlier version of fmt. */
     /* Shadow our base class member function template of the same name. */     \
     template <typename FormatContext>                                          \
     auto format(const typename MyTraits::InputType& x,                         \
-                FormatContext& ctx) DRAKE_FMT8_CONST {                         \
+                FormatContext& ctx) const {                                    \
       /* Call the base class member function after laundering the object   */  \
       /* through the user's provided format_as function. Older versions of */  \
       /* fmt have const-correctness bugs, which we can fix with some good  */  \
@@ -185,3 +172,7 @@ Drake drops support for earlier version of fmt. */
   struct formatter<NAMESPACE::TYPE>                                            \
       : drake::internal::formatter_as::Formatter<NAMESPACE::TYPE> {};          \
   } /* namespace fmt */
+
+// DRAKE DEPRECATED: This macro is deprecated and will be removed from Drake on
+// or after 2026-07-01.
+#define DRAKE_FMT8_CONST const

--- a/common/fmt_eigen.h
+++ b/common/fmt_eigen.h
@@ -90,7 +90,7 @@ struct formatter<drake::internal::fmt_eigen_ref<Scalar>>
   template <typename FormatContext>
   auto format(const drake::internal::fmt_eigen_ref<Scalar>& ref,
               // NOLINTNEXTLINE(runtime/references) To match fmt API.
-              FormatContext& ctx) DRAKE_FMT8_CONST -> decltype(ctx.out()) {
+              FormatContext& ctx) const -> decltype(ctx.out()) {
     const auto& matrix = ref.matrix;
     if constexpr (std::is_same_v<Scalar, double> ||
                   std::is_same_v<Scalar, float>) {

--- a/common/fmt_ostream.h
+++ b/common/fmt_ostream.h
@@ -1,75 +1,23 @@
 #pragma once
 
-#include <sstream>
-#include <string_view>
-
 #include <fmt/ostream.h>
 
 #include "drake/common/fmt.h"
 
 namespace drake {
 
-// Compatibility shim for fmt::streamed.
-#if FMT_VERSION >= 90000 || defined(DRAKE_DOXYGEN_CXX)
-/** When using fmt >= 9, this is an alias for
-<a href="https://fmt.dev/latest/api.html#ostream-api">fmt::streamed</a>.
-When using fmt < 9, this uses a polyfill instead.
-
-Within Drake, the nominal use for `fmt::streamed` is when formatting third-party
-types that provide `operator<<` support but not `fmt::formatter<T>` support.
-Once we stop using `FMT_DEPRECATED_OSTREAM=1`, compilation errors will help you
-understand where you are required to use this wrapper. */
 template <typename T>
+[[deprecated(
+    "\nDRAKE DEPRECATED: Use fmt::streamed instead.\n"
+    "The deprecated code will be removed from Drake on or after 2026-07-01.")]]
 auto fmt_streamed(const T& ref) {
   return fmt::streamed(ref);
 }
-#else   // FMT_VERSION
-namespace internal {
-template <typename T>
-struct streamed_ref {
-  const T& ref;
-};
-}  // namespace internal
-template <typename T>
-internal::streamed_ref<T> fmt_streamed(const T& ref) {
-  return {ref};
-}
-#endif  // FMT_VERSION
 
-// Compatibility shim for fmt::ostream_formatter.
-#if FMT_VERSION >= 90000
-using fmt::ostream_formatter;
-#else   // FMT_VERSION
-/** When using fmt >= 9, this is an alias for fmt::ostream_formatter.
-When using fmt < 9, this uses a polyfill instead. */
-struct ostream_formatter : fmt::formatter<std::string_view> {
-  template <typename T, typename FormatContext>
-  auto format(const T& value,
-              // NOLINTNEXTLINE(runtime/references) To match fmt API.
-              FormatContext& ctx) DRAKE_FMT8_CONST {
-    std::ostringstream output;
-    output << value;
-    output.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-    return fmt::formatter<std::string_view>::format(output.str(), ctx);
-  }
-};
-#endif  // FMT_VERSION
+using ostream_formatter
+    [[deprecated("\nDRAKE DEPRECATED: Use fmt::ostream_formatter instead.\n"
+                 "The deprecated code will be removed from Drake on or after "
+                 "2026-07-01.")]]  // BR
+    = fmt::ostream_formatter;
 
 }  // namespace drake
-
-// Formatter specialization for drake::fmt_streamed.
-#ifndef DRAKE_DOXYGEN_CXX
-#if FMT_VERSION < 90000
-namespace fmt {
-template <typename T>
-struct formatter<drake::internal::streamed_ref<T>> : drake::ostream_formatter {
-  template <typename FormatContext>
-  auto format(drake::internal::streamed_ref<T> tag,
-              // NOLINTNEXTLINE(runtime/references) To match fmt API.
-              FormatContext& ctx) DRAKE_FMT8_CONST {
-    return ostream_formatter::format(tag.ref, ctx);
-  }
-};
-}  // namespace fmt
-#endif  // FMT_VERSION
-#endif  // DRAKE_DOXYGEN_CXX

--- a/common/symbolic/chebyshev_basis_element.h
+++ b/common/symbolic/chebyshev_basis_element.h
@@ -7,7 +7,6 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/fmt.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/hash.h"
 #include "drake/common/symbolic/polynomial_basis_element.h"
 

--- a/common/test/fmt_ostream_test.cc
+++ b/common/test/fmt_ostream_test.cc
@@ -2,6 +2,10 @@
 
 #include <gtest/gtest.h>
 
+// Remove this entire file on 2026-07-01 per deprecation.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 // Sample code that shows how to shim Drake code that defines an operator<< to
 // interface with fmt >= 9 semantics. The ostream_formatter is intended to be a
 // porting shim for #17742 and will probably be deleted eventually, once all
@@ -56,3 +60,5 @@ GTEST_TEST(FmtOstreamTest, ThirdPartyOstreamShim) {
 
 }  // namespace
 }  // namespace drake
+
+#pragma GCC diagnostic pop

--- a/common/test/text_logging_ostream_test.cc
+++ b/common/test/text_logging_ostream_test.cc
@@ -4,6 +4,7 @@
 
 #include <ostream>
 
+#include <fmt/ostream.h>
 #include <gtest/gtest.h>
 
 // The BUILD.bazel rules must supply this flag.  This test code is compiled and
@@ -25,8 +26,6 @@
 #endif
 // clang-format on
 
-#include "drake/common/fmt_ostream.h"
-
 namespace {
 
 class Streamable {
@@ -37,26 +36,26 @@ class Streamable {
   }
 };
 
-using drake::fmt_streamed;
-
 // Call each API function and macro to ensure that all of them compile.
 // These should all compile and run both with and without spdlog.
 GTEST_TEST(TextLoggingTest, SmokeTestStreamable) {
   Streamable obj;
   drake::log()->trace("drake::log()->trace test: {} {}", "OK",
-                      fmt_streamed(obj));
+                      fmt::streamed(obj));
   drake::log()->debug("drake::log()->debug test: {} {}", "OK",
-                      fmt_streamed(obj));
-  drake::log()->info("drake::log()->info test: {} {}", "OK", fmt_streamed(obj));
-  drake::log()->warn("drake::log()->warn test: {} {}", "OK", fmt_streamed(obj));
+                      fmt::streamed(obj));
+  drake::log()->info("drake::log()->info test: {} {}", "OK",
+                     fmt::streamed(obj));
+  drake::log()->warn("drake::log()->warn test: {} {}", "OK",
+                     fmt::streamed(obj));
   drake::log()->error("drake::log()->error test: {} {}", "OK",
-                      fmt_streamed(obj));
+                      fmt::streamed(obj));
   drake::log()->critical("drake::log()->critical test: {} {}", "OK",
-                         fmt_streamed(obj));
+                         fmt::streamed(obj));
   DRAKE_LOGGER_TRACE("DRAKE_LOGGER_TRACE macro test: {}, {}", "OK",
-                     fmt_streamed(obj));
+                     fmt::streamed(obj));
   DRAKE_LOGGER_DEBUG("DRAKE_LOGGER_DEBUG macro test: {}, {}", "OK",
-                     fmt_streamed(obj));
+                     fmt::streamed(obj));
 }
 
 }  // namespace

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -31,12 +31,12 @@ with fmt_eigen(); see its documentation for details. This holds true whether it
 be for logging, error messages, etc.
 
 When logging a third-party type whose only affordance for string output is
-`operator<<`, use fmt_streamed(); see its documentation for details. This is
+`operator<<`, use fmt::streamed(); see its documentation for details. This is
 very rare (only a couple uses in Drake so far).
 
 When implementing a string output for a Drake type, eventually this page will
 demonstrate how to use fmt::formatter<T>. In the meantime, you can implement
-`operator<<` and use drake::ostream_formatter, or else use the macro helper
+`operator<<` and use fmt::ostream_formatter, or else use the macro helper
 DRAKE_FORMATTER_AS(). Grep around in Drake's existing code to find examples.
 
 @warning This file should only be included from cc files, not header files.

--- a/geometry/in_memory_mesh.cc
+++ b/geometry/in_memory_mesh.cc
@@ -8,31 +8,22 @@
 
 #include "drake/common/drake_assert.h"
 
-// Drake currently supports a wide range of fmt versions (8..11), which vary
+// Drake currently supports a wide range of fmt versions (9..11), which vary
 // heavily in terms of how they format maps (i.e., range-of-pairs) and variant.
 // When formatting the supported_files, we can't use fmt's built-in std::map
 // formatter because as of fmt 11 it forces the "debug presentation format"
 // which when combined with our DRAKE_FORMATTER_AS on FileSource ends up
 // re-quoting the formatted FileSource as if it were a string. Instead, we'll
 // use a helper struct that more directly controls the format of a map entry.
-// Once we drop Jammy and fmt8, we can clean this up even further by removing
-// DRAKE_FORMATTER_AS on FileSource since variant<> will be natively formattable
-// in that version.
+// TODO(jwnimmer-tri) We can clean this up even further by removing
+// DRAKE_FORMATTER_AS on FileSource because variant<> is natively formattable.
 namespace drake {
 namespace {
 struct FormattableSupportingFileMapEntry {
   std::string to_string() const {
     DRAKE_DEMAND(key != nullptr && value != nullptr);
     return fmt::format(
-#if FMT_VERSION >= 90000
         "{:?}: {}",  // Use '?' specifier to format the key as a string literal.
-#else
-        // TODO(jwnimmer-tri) On Ubuntu Jammy we use fmt8 which does not offer
-        // the capability to represent strings as literals, so we'll just toss
-        // quotes around and call it a day. Most filenames won't have quotes in
-        // them anyway.
-        "\"{}\": {}",
-#endif
         *key, *value);
   }
   const std::string* key{};

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -782,7 +782,7 @@ class Meshcat::Impl {
     // values) through to fmt to allow any fmt-specific exception to percolate.
     // Then, confirm that the user's pattern started with a valid protocol.
     const std::string url =
-        fmt::format(fmt_runtime(params.web_url_pattern),
+        fmt::format(fmt::runtime(params.web_url_pattern),
                     fmt::arg("host", "foo"), fmt::arg("port", 1));
     if (url.substr(0, 4) != "http") {
       throw std::logic_error("The web_url_pattern must be http:// or https://");
@@ -879,7 +879,7 @@ class Meshcat::Impl {
     const std::string& host = params_.host;
     const bool is_localhost = host.empty() || host == "*";
     const std::string display_host = is_localhost ? "localhost" : host;
-    return fmt::format(fmt_runtime(params_.web_url_pattern),
+    return fmt::format(fmt::runtime(params_.web_url_pattern),
                        fmt::arg("host", display_host), fmt::arg("port", port_));
   }
 

--- a/geometry/optimization/vpolytope.cc
+++ b/geometry/optimization/vpolytope.cc
@@ -10,6 +10,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <libqhullcpp/Qhull.h>
 #include <libqhullcpp/QhullVertexSet.h>

--- a/geometry/proximity/make_convex_hull_mesh_impl.cc
+++ b/geometry/proximity/make_convex_hull_mesh_impl.cc
@@ -22,7 +22,6 @@
 #include "drake/common/diagnostic_policy.h"
 #include "drake/common/find_resource.h"
 #include "drake/common/fmt_eigen.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/proximity/vtk_to_volume_mesh.h"
 #include "drake/geometry/read_gltf_to_memory.h"

--- a/geometry/proximity/test/characterization_utilities.h
+++ b/geometry/proximity/test/characterization_utilities.h
@@ -17,11 +17,11 @@
 #include <vector>
 
 #include <fcl/fcl.h>
+#include <fmt/ostream.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_export.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/unused.h"
 #include "drake/geometry/proximity/collision_filter.h"
 #include "drake/geometry/shape_specification.h"
@@ -444,7 +444,7 @@ class CharacterizeResultTest : public ::testing::Test {
 namespace fmt {
 template <>
 struct formatter<drake::geometry::internal::GeometryType>
-    : drake::ostream_formatter {};
+    : fmt::ostream_formatter {};
 }  // namespace fmt
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/ostream.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -2798,7 +2799,7 @@ TEST_F(RenderEngineGlTest, SingleLight) {
         continue;
       }
       SCOPED_TRACE(
-          fmt::format("{} - {}", fmt_streamed(l_type), config.description));
+          fmt::format("{} - {}", fmt::streamed(l_type), config.description));
       LightParameter test_light = config.light;
       test_light.type = l_type;
       const RenderEngineGlParams params{.lights = {test_light}};

--- a/geometry/render_gltf_client/internal_http_service_curl.cc
+++ b/geometry/render_gltf_client/internal_http_service_curl.cc
@@ -11,9 +11,9 @@
 
 #include <curl/curl.h>
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
@@ -85,7 +85,7 @@ std::string CurlInfoTypeAsString(curl_infotype type) {
   } else if (type == CURLINFO_END) {
     return "CURLINFO_END";
   }
-  return fmt::format("UNKNOWN_CURLINFO_TYPE={}", fmt_streamed(type));
+  return fmt::format("UNKNOWN_CURLINFO_TYPE={}", fmt::streamed(type));
 }
 
 /* Removes leading / trailing whitespace from `message` before logging.  Curl

--- a/geometry/render_gltf_client/internal_merge_gltf.cc
+++ b/geometry/render_gltf_client/internal_merge_gltf.cc
@@ -7,9 +7,9 @@
 #include <utility>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/text_logging.h"
 
 // For more explanation of the glTF fun and games:
@@ -136,7 +136,7 @@ void MergeTrees(json* j1, json&& j2, const string& blob_name,
             "Error in merging '{}.{}.{}'; two glTF files have different "
             "values. '{}' defines it as {}, but '{}' defines it as {}.",
             to_string(container_type), blob_name, key, j1_name,
-            fmt_streamed((*j1)[key]), j2_name, fmt_streamed(value)));
+            fmt::streamed((*j1)[key]), j2_name, fmt::streamed(value)));
       }
     }
   }

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -15,6 +15,7 @@
 
 #include <Eigen/Dense>
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
@@ -763,7 +764,7 @@ TEST_F(RenderEngineVtkTest, ControlBackgroundColor) {
         .backend = FLAGS_backend,
     };
     RenderEngineVtk engine(params);
-    Render(fmt::to_string(fmt_streamed(bg)), &engine);
+    Render(fmt::to_string(fmt::streamed(bg)), &engine);
     VerifyUniformColor(bg);
   }
 }
@@ -1941,7 +1942,7 @@ TEST_F(RenderEngineVtkTest, SingleLight) {
         continue;
       }
       const std::string unambiguous_description =
-          fmt::format("{} - {}", fmt_streamed(l_type), config.description);
+          fmt::format("{} - {}", fmt::streamed(l_type), config.description);
       SCOPED_TRACE(unambiguous_description);
       LightParameter test_light = config.light;
       test_light.type = l_type;

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -7,7 +7,6 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/geometry/mesh_source.h"
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/math/rigid_transform.h"

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.h
@@ -9,10 +9,11 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/ostream.h>
+
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/math/spatial_algebra.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -524,5 +525,5 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
 namespace fmt {
 template <>
 struct formatter<drake::multibody::DifferentialInverseKinematicsStatus>
-    : drake::ostream_formatter {};
+    : fmt::ostream_formatter {};
 }  // namespace fmt

--- a/multibody/parsing/test/detail_sdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_sdf_geometry_test.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include <fmt/ostream.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sdf/Root.hh>
@@ -81,7 +82,7 @@ sdf::SDFPtr ReadString(const std::string& input) {
   const bool success = sdf::readString(input, config, result, errors);
   if (!success) {
     for (const auto& error : errors) {
-      drake::log()->error("Parse error: {}", fmt_streamed(error));
+      drake::log()->error("Parse error: {}", fmt::streamed(error));
     }
     // Note that we don't throw here, we just spam the console.  This is not
     // great, but it matches the pre-existing behavior which wants this helper

--- a/solvers/evaluator_base.h
+++ b/solvers/evaluator_base.h
@@ -14,7 +14,6 @@
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic/expression.h"
 #include "drake/math/autodiff.h"

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -9,9 +9,9 @@
 
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
+#include <fmt/ostream.h>
 #include <mosek.h>
 
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/scoped_singleton.h"
 #include "drake/common/text_logging.h"
 #include "drake/solvers/mathematical_program.h"
@@ -55,7 +55,7 @@ class MosekSolver::License {
           fmt::format("Could not acquire MOSEK license: {}. See "
                       "https://docs.mosek.com/11.1/capi/"
                       "response-codes.html#mosek.rescode for details.",
-                      fmt_streamed(rescode)));
+                      fmt::streamed(rescode)));
     }
   }
 

--- a/solvers/mosek_solver_internal.cc
+++ b/solvers/mosek_solver_internal.cc
@@ -6,7 +6,8 @@
 #include <cstdio>
 #include <limits>
 
-#include "drake/common/fmt_ostream.h"
+#include <fmt/ostream.h>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/common/parallelism.h"
 #include "drake/math/quadratic_form.h"
@@ -1625,7 +1626,7 @@ void ThrowForInvalidOption(MSKrescodee rescode, const std::string& option,
         "https://docs.mosek.com/{version}/pythonapi/param-groups.html "
         "for allowable values in python.",
         fmt::arg("option", option), fmt::arg("value", val),
-        fmt::arg("code", fmt_streamed(rescode)),
+        fmt::arg("code", fmt::streamed(rescode)),
         fmt::arg("version", mosek_version)));
   }
 }
@@ -1665,7 +1666,7 @@ void MosekSolverProgram::UpdateOptions(
       if (rescode != MSK_RES_OK) {
         throw std::runtime_error(fmt::format(
             "MosekSolver(): kPrintToConsole=1 failed with response code {}",
-            fmt_streamed(rescode)));
+            fmt::streamed(rescode)));
       }
       *is_printing = true;
     }
@@ -1676,7 +1677,7 @@ void MosekSolverProgram::UpdateOptions(
       if (rescode != MSK_RES_OK) {
         throw std::runtime_error(fmt::format(
             "MosekSolver(): kPrintToFile={} failed with response code {}",
-            common.print_file_name, fmt_streamed(rescode)));
+            common.print_file_name, fmt::streamed(rescode)));
       }
       *is_printing = true;
     }

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -15,7 +15,6 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/fmt.h"
 #include "drake/common/fmt_eigen.h"
-#include "drake/common/fmt_ostream.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/unused.h"
 

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -198,7 +198,7 @@ std::string ImageWriter::MakeFileName(const std::string& format,
 
   int64_t u_time = static_cast<int64_t>(time * 1e6 + 0.5);
   int m_time = static_cast<int>(time * 1e3 + 0.5);
-  return fmt::format(fmt_runtime(format), fmt::arg("port_name", port_name),
+  return fmt::format(fmt::runtime(format), fmt::arg("port_name", port_name),
                      fmt::arg("image_type", labels_.at(pixel_type)),
                      fmt::arg("time_double", time),
                      fmt::arg("time_usec", u_time),


### PR DESCRIPTION
Deprecate now-unnecessary aliases:
- `DRAKE_FMT8_CONST`
- `drake::ostream_formatter`
- `drake::fmt_runtime`
- `drake::fmt_streamed`

Relates #24015.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24223)
<!-- Reviewable:end -->
