### PR TITLE
Update CMake minimum required to 3.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # When this changes, drake-external-examples/drake_cmake_external/CMakeLists.txt
 # should be changed accordingly so that downstream users are synced with
 # Drake itself.
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 project(drake
   DESCRIPTION "Model-based design and verification for robotics"

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -29,8 +29,8 @@ officially supports when building from source:
 <!-- The minimum Python version(s) should match those listed in both the root
      CMakeLists.txt and setup/python/pyproject.toml. -->
 <!-- The minimum CMake version across all platforms should match that listed
-     in the root CMakeLists.txt, and the version range should match that
-     listed in tools/install/libdrake/drake-config.cmake.in (and all
+     in the root CMakeLists.txt. The maximum version should match the policy
+     version listed in tools/install/libdrake/drake-config.cmake.in (and all
      corresponding tests). -->
 
 | Operating System ⁽¹⁾               | Architecture | Python ⁽²⁾ | Bazel | CMake | C/C++ Compiler ⁽³⁾           | Java       |


### PR DESCRIPTION
This coincides with Drake's new minimum supported CMake version on Ubuntu Noble.

While we're at it, fix a comment pertaining to updating the policy version in Drake's package config file.

Towards #24015.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24231)
<!-- Reviewable:end -->
