### PR TITLE
Sync minimum compiler versions in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,11 +124,11 @@ if(NOT DRAKE_CC_TOOLCHAIN_COMPILER_MAJOR)
   set(DRAKE_CC_TOOLCHAIN_COMPILER_MAJOR "0")
 endif()
 
-# The minimum compiler versions should match those listed in both
-# doc/_pages/from_source.md and tools/workspace/cc/repository.bzl.
-set(MINIMUM_APPLE_CLANG_VERSION 16)
-set(MINIMUM_CLANG_VERSION 15)
-set(MINIMUM_GNU_VERSION 11)
+# The minimum compiler versions should match those listed in
+# doc/_pages/from_source.md.
+set(MINIMUM_APPLE_CLANG_VERSION 17)
+set(MINIMUM_CLANG_VERSION 19)
+set(MINIMUM_GNU_VERSION 13)
 
 if(CMAKE_C_COMPILER_ID STREQUAL AppleClang)
   if(CMAKE_C_COMPILER_VERSION VERSION_LESS ${MINIMUM_APPLE_CLANG_VERSION})

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -24,8 +24,8 @@ officially supports when building from source:
 
 <!-- The operating system requirements should match those listed in the root
      CMakeLists.txt. -->
-<!-- The minimum compiler versions should match those listed in both the root
-     CMakeLists.txt and tools/workspace/cc/repository.bzl. -->
+<!-- The minimum compiler versions should match those listed in the root
+     CMakeLists.txt. -->
 <!-- The minimum Python version(s) should match those listed in both the root
      CMakeLists.txt and setup/python/pyproject.toml. -->
 <!-- The minimum CMake version across all platforms should match that listed


### PR DESCRIPTION
Also, remove a reference to the deprecated and now-removed `@cc` external when syncing version numbers.

The Linux bits of this are tied to #24015; Apple must have also fallen out of date sometime recently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24232)
<!-- Reviewable:end -->
