### PR TITLE
Give RenderEngineVtk the ability to share geometry from objs

### DIFF
--- a/bindings/generated_docstrings/geometry_render.h
+++ b/bindings/generated_docstrings/geometry_render.h
@@ -13,6 +13,7 @@
 #endif
 
 // #include "drake/geometry/render/light_parameter.h"
+// #include "drake/geometry/render/mesh_source_cache_key.h"
 // #include "drake/geometry/render/render_camera.h"
 // #include "drake/geometry/render/render_engine.h"
 // #include "drake/geometry/render/render_label.h"

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":light_parameter",
+        ":mesh_source_cache_key",
         ":render_camera",
         ":render_engine",
         ":render_label",
@@ -96,6 +97,16 @@ drake_cc_library(
     ],
     implementation_deps = [
         "@tinyobjloader_internal//:tinyobjloader",
+    ],
+)
+
+drake_cc_library(
+    name = "mesh_source_cache_key",
+    srcs = ["mesh_source_cache_key.cc"],
+    hdrs = ["mesh_source_cache_key.h"],
+    deps = [
+        "//common:essential",
+        "//geometry:mesh_source",
     ],
 )
 
@@ -206,6 +217,17 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//geometry:geometry_roles",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_source_cache_key_test",
+    deps = [
+        ":mesh_source_cache_key",
+        "//common:memory_file",
+        "//common:temp_directory",
+        "//geometry:in_memory_mesh",
+        "//geometry:mesh_source",
     ],
 )
 

--- a/geometry/render/mesh_source_cache_key.cc
+++ b/geometry/render/mesh_source_cache_key.cc
@@ -1,0 +1,67 @@
+#include "drake/geometry/render/mesh_source_cache_key.h"
+
+#include <filesystem>
+
+#include "drake/common/fmt.h"
+
+namespace fs = std::filesystem;
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+std::string GetMeshSourceCacheKey(const MeshSource& mesh_source,
+                                  bool is_convex) {
+  std::string prefix;
+  // TODO(SeanCurtis-TRI): This uses the sha of the core mesh file to identify
+  // a unique mesh. However, there is a weird, adversarial case:
+  //
+  //  - User loads a geometry from foo.mesh that references foo.bin.
+  //    - the data for foo.mesh and foo.bin gets processed and loaded into
+  //      the cache.
+  //  - The hash of foo.mesh serves as its unique key.
+  //  - User then changes contents of foo.bin.
+  //  - User loads another geometry with foo.mesh (which has now appreciably
+  //    changed because foo.bin is different).
+  //  - The cache will believe it is the same file as before, even though the
+  //    geometry has changed and not load the new version, using the old
+  //    instead.
+  //
+  // For example, if a user runs a simulation, rendering images out, resets
+  // the simulation with changes to the foo.bin file (e.g. material properties
+  // in a .mtl file), with the intent of creating a visual variant of the
+  // previous simulation, the geometry in the second pass will not have
+  // changed appearance.
+  //
+  // This problem applies to both on-disk and in-memory meshes. For on-disk
+  // meshes, the problem is worse because it strictly uses the mesh file name
+  // as cache id and therefore won't even detect changes in the core mesh file
+  // (let alone any of the supporting files).
+  //
+  // To address this we'll have to have a key predicated on the contents on
+  // the whole file *ecosystem* so that we can detect if any part of the file
+  // family is unique, creating, in some sense, a unique geometry.
+  if (mesh_source.is_in_memory()) {
+    prefix = mesh_source.in_memory().mesh_file.sha256().to_string();
+  } else {
+    DRAKE_DEMAND(mesh_source.is_path());
+    std::error_code path_error;
+    const fs::path canonical_path =
+        fs::canonical(mesh_source.path(), path_error);
+    if (path_error) {
+      throw std::runtime_error(
+          fmt::format("Unable to access mesh file '{}': {}",
+                      mesh_source.path().string(), path_error.message()));
+    }
+    prefix = canonical_path.string();
+  }
+  // Note: We're using "?" as a separator. It isn't valid for filenames,
+  // so using it guarantees we won't collide with potential file names.
+  return prefix + (is_convex ? "?convex" : "");
+}
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/mesh_source_cache_key.h
+++ b/geometry/render/mesh_source_cache_key.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+
+#include "drake/geometry/mesh_source.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+/* Returns a unique cache key for the given mesh source.
+
+The key uniquely identifies the mesh data. For on-disk meshes, it uses the
+canonicalized file path. For in-memory meshes, it uses the SHA256 hash of
+the mesh file contents.
+
+@param mesh_source   The mesh source to generate a key for.
+@param is_convex     Whether the mesh is being used as a convex shape. This
+                     affects the key because convex shapes undergo additional
+                     processing (convex hull computation).
+@returns A string suitable for use as a cache key.
+@throws std::runtime_error if the mesh source path cannot be canonicalized. */
+std::string GetMeshSourceCacheKey(const MeshSource& mesh_source,
+                                  bool is_convex);
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -178,7 +178,8 @@ class RenderEngine {
    @returns True if the %RenderEngine implementation accepted the geometry for
             registration. */
   bool RegisterDeformableVisual(
-      GeometryId id, const std::vector<internal::RenderMesh>& render_meshes,
+      GeometryId id,
+      const std::vector<geometry::internal::RenderMesh>& render_meshes,
       const PerceptionProperties& properties);
 
   //@}
@@ -358,7 +359,8 @@ class RenderEngine {
 
    @experimental */
   virtual bool DoRegisterDeformableVisual(
-      GeometryId id, const std::vector<internal::RenderMesh>& render_meshes,
+      GeometryId id,
+      const std::vector<geometry::internal::RenderMesh>& render_meshes,
       const PerceptionProperties& properties);
 
   /** The NVI-function for updating the pose of a rigid render geometry

--- a/geometry/render/test/mesh_source_cache_key_test.cc
+++ b/geometry/render/test/mesh_source_cache_key_test.cc
@@ -1,0 +1,126 @@
+#include "drake/geometry/render/mesh_source_cache_key.h"
+
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/memory_file.h"
+#include "drake/common/temp_directory.h"
+#include "drake/geometry/in_memory_mesh.h"
+#include "drake/geometry/mesh_source.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+namespace {
+
+namespace fs = std::filesystem;
+
+// Two OBJ content strings used throughout these tests. They are
+// geometrically distinct so their SHA256 hashes differ.
+constexpr char kObjContent[] =
+    "v 0 0 0\nv 1 0 0\nv 0 1 0\nvn 0 0 1\nf 1//1 2//1 3//1\n";
+constexpr char kObjContentAlt[] =
+    "v 1 0 0\nv 0 1 0\nv 0 0 1\nvn 1 0 0\nf 1//1 2//1 3//1\n";
+
+// Writes content to path and returns path.
+fs::path WriteFile(const fs::path& path, std::string_view content) {
+  std::ofstream f(path);
+  f << content;
+  return path;
+}
+
+InMemoryMesh MakeMemoryMesh(const std::string& contents) {
+  // All memory sources have the same name and description so we can show only
+  // the contents alone is sufficient to distinguish.
+  return InMemoryMesh(MemoryFile(contents, ".obj", "common_name.obj"));
+}
+
+/* Test fixture that writes the shared on-disk files and in-memory MemoryFiles
+once for the entire test suite (via SetUpTestSuite). */
+class GetMeshSourceCacheKeyTest : public ::testing::Test {
+ public:
+  static void SetUpTestSuite() {
+    // Place the physical files on disk in support of the declared mesh sources.
+    WriteFile(file_source_a_.path(), kObjContent);
+    WriteFile(file_source_b_.path(), kObjContent);
+  }
+
+ protected:
+  // Shared on-disk resources (one temp dir, written once).
+  static const fs::path dir_;
+  static const MeshSource file_source_a_;
+  static const MeshSource file_source_b_;
+
+  // Shared in-memory resources.
+  static const MeshSource mem_source_a_;
+  static const MeshSource mem_source_b_;
+};
+
+const fs::path GetMeshSourceCacheKeyTest::dir_(temp_directory());
+const MeshSource GetMeshSourceCacheKeyTest::file_source_a_(dir_ / "mesh_a.obj");
+const MeshSource GetMeshSourceCacheKeyTest::file_source_b_(dir_ / "mesh_b.obj");
+// In-memory meshes used by in-memory tests. They intentionally match in every
+// way except for the content, to make sure only the content matters.
+const MeshSource GetMeshSourceCacheKeyTest::mem_source_a_(
+    MakeMemoryMesh(kObjContent));
+const MeshSource GetMeshSourceCacheKeyTest::mem_source_b_(
+    MakeMemoryMesh(kObjContentAlt));
+
+// The same file used for mesh and convex produce different keys.
+TEST_F(GetMeshSourceCacheKeyTest, OnDiskMeshVsConvex) {
+  const std::string mesh_key = GetMeshSourceCacheKey(file_source_a_, false);
+  const std::string convex_key = GetMeshSourceCacheKey(file_source_a_, true);
+
+  EXPECT_NE(mesh_key, convex_key);
+}
+
+// Two physically different files produce different keys (even if their contents
+// are identical).
+TEST_F(GetMeshSourceCacheKeyTest, OnDiskDifferentPaths) {
+  const std::string key_a = GetMeshSourceCacheKey(file_source_a_, false);
+  const std::string key_b = GetMeshSourceCacheKey(file_source_b_, false);
+
+  EXPECT_NE(key_a, key_b);
+}
+
+// A symlink to a file resolves to the same canonical key as the real path.
+TEST_F(GetMeshSourceCacheKeyTest, OnDiskSymlinkCanonicalizesToSameKey) {
+  const std::string real_key = GetMeshSourceCacheKey(file_source_a_, false);
+  fs::path link = dir_ / "link.obj";
+  fs::create_symlink(file_source_a_.path(), link);
+  const std::string link_key = GetMeshSourceCacheKey(MeshSource(link), false);
+
+  EXPECT_EQ(real_key, link_key);
+}
+
+// A non-existent path throws std::runtime_error.
+TEST_F(GetMeshSourceCacheKeyTest, OnDiskNonExistentPathThrows) {
+  EXPECT_THROW(
+      GetMeshSourceCacheKey(MeshSource(fs::path("/no/such/file.obj")), false),
+      std::runtime_error);
+}
+
+// The same contents used for mesh and convex produce different keys.
+TEST_F(GetMeshSourceCacheKeyTest, InMemoryMeshVsConvex) {
+  const std::string mesh_key = GetMeshSourceCacheKey(mem_source_a_, false);
+  const std::string convex_key = GetMeshSourceCacheKey(mem_source_a_, true);
+
+  EXPECT_NE(mesh_key, convex_key);
+}
+
+// Two in-memory meshes with different content produce different keys.
+TEST_F(GetMeshSourceCacheKeyTest, InMemoryDifferentContentDifferentKey) {
+  EXPECT_NE(GetMeshSourceCacheKey(mem_source_a_, false),
+            GetMeshSourceCacheKey(mem_source_b_, false));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render_gl/BUILD.bazel
+++ b/geometry/render_gl/BUILD.bazel
@@ -144,6 +144,7 @@ drake_cc_optional_library(
         "//common:string_container",
         "//common/yaml:yaml_io",
         "//geometry/proximity:polygon_to_triangle_mesh",
+        "//geometry/render:mesh_source_cache_key",
         "//geometry/render:render_engine",
         "//geometry/render:render_mesh",
         "//systems/sensors:image",

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -19,6 +19,7 @@
 #include "drake/common/unused.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
+#include "drake/geometry/render/mesh_source_cache_key.h"
 
 namespace drake {
 namespace geometry {
@@ -47,6 +48,7 @@ using render::LightParameter;
 using render::RenderCameraCore;
 using render::RenderEngine;
 using render::RenderLabel;
+using render::internal::GetMeshSourceCacheKey;
 using std::make_shared;
 using std::make_unique;
 using std::map;
@@ -664,62 +666,6 @@ void main() {
 })""";
 };
 
-// Given a filename (e.g., of a mesh), this produces a string that we use in
-// our maps to guarantee we only load the file once.
-std::string GetPathKey(const MeshSource& mesh_source, bool is_convex) {
-  std::string prefix;
-  if (mesh_source.is_in_memory()) {
-    // TODO(SeanCurtis-TRI): This uses the sha of the core mesh file to identify
-    // a unique mesh. However, there is a weird, adversarial case:
-    //
-    //  - User loads a geometry from foo.mesh that references foo.bin.
-    //    - the data for foo.mesh and foo.bin gets processed and loaded into
-    //      the cache.
-    //  - The hash of foo.mesh serves as its unique key.
-    //  - User then changes contents of foo.bin.
-    //  - User loads another geometry with foo.mesh (which has now appreciably
-    //    changed because foo.bin is different).
-    //  - The cache will believe it is the same file as before, even though the
-    //    geometry has changed and not load the new version, using the old
-    //    instead.
-    //
-    // For example, if a user runs a simulation, rendering images out, resets
-    // the simulation with changes to the foo.bin file (e.g. material properties
-    // in a .mtl file), with the intent of creating a visual variant of the
-    // previous simulation, the geometry in the second pass will not have
-    // changed appearance.
-    //
-    // This problem applies to both on-disk and in-memory meshes. For on-disk
-    // meshes, the problem is worse because it strictly uses the mesh file name
-    // as cache id and therefore won't even detect changes in the core mesh file
-    // (let alone any of the supporting files).
-    //
-    // To address this we'll have to have a key predicated on the contents on
-    // the whole file *ecosystem* so that we can detect if any part of the file
-    // family is unique, creating, in some sense, a unique geometry.
-    //
-    // The urgency is low for now because if someone is doing multiple passes
-    // to create render variations, they're probably using the higher-fidelity
-    // RenderEngineVtk. As we improve the fidelity of RenderEngineGl, we'll
-    // want to shore up this hole.
-    prefix = mesh_source.in_memory().mesh_file.sha256().to_string() +
-             (is_convex ? "?convex" : "");
-  } else {
-    DRAKE_DEMAND(mesh_source.is_path());
-    prefix = mesh_source.path().string();
-    std::error_code path_error;
-    const fs::path path = fs::canonical(mesh_source.path(), path_error);
-    if (path_error) {
-      throw std::runtime_error(
-          fmt::format("RenderEngineGl: unable to access the file {}; {}",
-                      prefix, path_error.message()));
-    }
-  }
-  // Note: We're using "?". It isn't valid for filenames, so using it in the
-  // key guarantees we won't collide with potential file names.
-  return prefix + (is_convex ? "?convex" : "");
-}
-
 // We want to make sure the lights are as clean as possible. So, we'll
 // re-normalize unit vectors (where possible). We're not testing for "bad"
 // values because those values which *might* be considered "bad" can be used
@@ -889,7 +835,7 @@ void RenderEngineGl::ImplementMeshesForSource(void* user_data,
                                               const Vector3<double>& scale,
                                               const MeshSource& mesh_source,
                                               bool is_convex) {
-  const std::string file_key = GetPathKey(mesh_source, is_convex);
+  const std::string file_key = GetMeshSourceCacheKey(mesh_source, is_convex);
   // If mesh_source is in memory, we want to pass an *empty* filename to
   // MaybeMakeMeshFallbackmaterial() to avoid looking for foo.png.
   const fs::path filename =
@@ -1334,7 +1280,8 @@ int RenderEngineGl::GetBox() {
 
 void RenderEngineGl::CacheConvexHullMesh(const Convex& convex,
                                          const RegistrationData& data) {
-  const std::string file_key = GetPathKey(convex.source(), /*is_convex=*/true);
+  const std::string file_key =
+      GetMeshSourceCacheKey(convex.source(), /*is_convex=*/true);
 
   if (!meshes_.contains(file_key)) {
     const bool unscaled = (convex.scale3().array() == 1.0).all();
@@ -2187,7 +2134,8 @@ void RenderEngineGl::CacheFileMeshesMaybe(const MeshSource& mesh_source,
     return;
   }
 
-  const std::string file_key = GetPathKey(mesh_source, /* is_convex= */ false);
+  const std::string file_key =
+      GetMeshSourceCacheKey(mesh_source, /*is_convex=*/false);
 
   if (!meshes_.contains(file_key)) {
     vector<RenderGlMesh> file_meshes;

--- a/geometry/render_vtk/BUILD.bazel
+++ b/geometry/render_vtk/BUILD.bazel
@@ -105,6 +105,7 @@ drake_cc_optional_library(
         "//common/yaml:yaml_io",
         "//geometry:vtk_gltf_uri_loader",
         "//geometry/proximity:polygon_to_triangle_mesh",
+        "//geometry/render:mesh_source_cache_key",
         "//geometry/render:render_engine",
         "//geometry/render:render_mesh",
         "//geometry/render/shaders:depth_shaders",

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -49,6 +49,7 @@
 #include "drake/common/text_logging.h"
 #include "drake/common/yaml/yaml_io.h"
 #include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
+#include "drake/geometry/render/mesh_source_cache_key.h"
 #include "drake/geometry/render/shaders/depth_shaders.h"
 #include "drake/geometry/render_vtk/internal_make_render_window.h"
 #include "drake/geometry/render_vtk/internal_render_engine_vtk_base.h"
@@ -81,6 +82,7 @@ using render::LightParameter;
 using render::RenderCameraCore;
 using render::RenderEngine;
 using render::RenderLabel;
+using render::internal::GetMeshSourceCacheKey;
 using std::make_unique;
 using systems::sensors::CameraInfo;
 using systems::sensors::ImageDepth32F;
@@ -261,18 +263,35 @@ void RenderEngineVtk::ImplementGeometry(const Capsule& capsule,
 
 void RenderEngineVtk::ImplementGeometry(const Convex& convex, void* user_data) {
   auto& data = *static_cast<RegistrationData*>(user_data);
-  const TriangleSurfaceMesh<double> tri_hull =
-      geometry::internal::MakeTriangleFromPolygonMesh(convex.GetConvexHull());
-  RenderMesh render_mesh =
-      geometry::internal::MakeFacetedRenderMeshFromTriangleSurfaceMesh(
-          tri_hull, data.properties);
-  if (!render_mesh.material.has_value()) {
-    render_mesh.material = MakeDiffuseMaterial(default_diffuse_);
+
+  const std::string cache_key =
+      GetMeshSourceCacheKey(convex.source(), /*is_convex=*/true);
+
+  if (!mesh_cache_.contains(cache_key)) {
+    // Compute the hull from the *unscaled* source so the cached VTK geometry
+    // is independent of any particular instance's scale. If the current
+    // convex already has unit scale its hull is already unscaled; otherwise
+    // we re-instantiate from the source to get the unscaled hull, matching
+    // the strategy used by RenderEngineGl::CacheConvexHullMesh.
+    const bool unit_scale = (convex.scale3().array() == 1.0).all();
+    const TriangleSurfaceMesh<double> tri_hull =
+        geometry::internal::MakeTriangleFromPolygonMesh(
+            unit_scale ? convex.GetConvexHull()
+                       : Convex(convex.source()).GetConvexHull());
+    // Pass empty properties so that no material is baked into the cached
+    // geometry; material is always resolved per-instance (convex hulls never
+    // have file-defined materials).
+    RenderMesh render_mesh =
+        geometry::internal::MakeFacetedRenderMeshFromTriangleSurfaceMesh(
+            tri_hull, PerceptionProperties{});
+    CachedMesh cached;
+    cached.parts.push_back(
+        {.material = std::nullopt,
+         .vtk_source = CreateVtkMesh(std::move(render_mesh))});
+    mesh_cache_[cache_key] = std::move(cached);
   }
-  // We don't use convex.scale3() because it's already built in to the convex
-  // hull.
-  const Vector3d kUnitScale(1, 1, 1);
-  ImplementRenderMesh(std::move(render_mesh), kUnitScale, data);
+
+  ImplementCachedMesh(mesh_cache_.at(cache_key), convex.scale3(), data);
 }
 
 void RenderEngineVtk::ImplementGeometry(const Cylinder& cylinder,
@@ -606,6 +625,11 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
       use_pbr_materials_(other.use_pbr_materials_) {
   InitializePipelines();
 
+  // Shallow-copy the mesh cache: the vtkSmartPointers inside are reference-
+  // counted, so this clone shares the same vtkPolyDataAlgorithm sources as
+  // the original without duplicating any vertex data.
+  mesh_cache_ = other.mesh_cache_;
+
   for (const auto& [id, source_props] : other.props_) {
     PropArray target_props;
     for (int i = 0; i < kNumPipelines; ++i) {
@@ -671,11 +695,36 @@ void RenderEngineVtk::ImplementRenderMesh(RenderMesh&& mesh,
 
 bool RenderEngineVtk::ImplementObj(const Mesh& mesh,
                                    const RegistrationData& data) {
-  std::vector<RenderMesh> meshes = LoadRenderMeshesFromObj(
-      mesh.source(), data.properties, default_diffuse_, diagnostic_);
-  for (auto& render_mesh : meshes) {
-    ImplementRenderMesh(std::move(render_mesh), mesh.scale3(), data);
+  const std::string cache_key =
+      GetMeshSourceCacheKey(mesh.source(), /*is_convex=*/false);
+
+  if (!mesh_cache_.contains(cache_key)) {
+    // On cache miss: parse the OBJ file and immediately convert each part into
+    // a vtkPolyDataAlgorithm. Subsequent registrations of the same mesh will
+    // share these VTK sources, so vertex data is allocated and uploaded to the
+    // GPU only once.
+    std::vector<RenderMesh> render_meshes = LoadRenderMeshesFromObj(
+        mesh.source(), data.properties, default_diffuse_, diagnostic_);
+    CachedMesh cached;
+    for (RenderMesh& render_mesh : render_meshes) {
+      // Only cache materials that originated from the OBJ/MTL file itself
+      // (signalled by from_mesh_file == true). Fallback materials derived
+      // from perception properties or the engine default are per-instance
+      // and must be re-derived at each registration, so we store nullopt for
+      // those cases.
+      std::optional<RenderMaterial> file_material;
+      if (render_mesh.material.has_value() &&
+          render_mesh.material->from_mesh_file) {
+        file_material = render_mesh.material;
+      }
+      cached.parts.push_back(
+          {.material = file_material,
+           .vtk_source = CreateVtkMesh(std::move(render_mesh))});
+    }
+    mesh_cache_[cache_key] = std::move(cached);
   }
+
+  ImplementCachedMesh(mesh_cache_.at(cache_key), mesh.scale3(), data);
   return true;
 }
 
@@ -1304,6 +1353,33 @@ void RenderEngineVtk::UpdateWindow(const DepthRenderCamera& camera,
   // Never show window for depth camera; it is a meaningless operation as the
   // raw depth rasterization is not human consummable.
   UpdateWindow(camera.core(), false, p, "");
+}
+
+void RenderEngineVtk::ImplementCachedMesh(const CachedMesh& cached,
+                                          const Vector3d& scale,
+                                          const RegistrationData& data) {
+  const bool unit_scale = (scale.array() == 1).all();
+  for (const CachedMesh::Part& part : cached.parts) {
+    // File-defined materials (OBJ/MTL) always win. When none was present
+    // (nullopt -- either no MTL, or a convex hull), resolve per-instance via
+    // DefineMaterial so that phong/diffuse properties and the engine default
+    // are both honoured.
+    const RenderMaterial material =
+        part.material.has_value()
+            ? *part.material
+            : DefineMaterial(data.properties, default_diffuse_);
+    if (unit_scale) {
+      ImplementPolyData(part.vtk_source.GetPointer(), material, data);
+    } else {
+      vtkNew<vtkTransform> transform;
+      transform->Scale(scale.x(), scale.y(), scale.z());
+      vtkNew<vtkTransformPolyDataFilter> transform_filter;
+      transform_filter->SetInputConnection(part.vtk_source->GetOutputPort());
+      transform_filter->SetTransform(transform.GetPointer());
+      transform_filter->Update();
+      ImplementPolyData(transform_filter.GetPointer(), material, data);
+    }
+  }
 }
 
 }  // namespace internal

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -271,6 +271,32 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
   // @pre actor is not null.
   static void SetDepthShader(vtkActor* actor);
 
+  // Stores cached mesh data to avoid redundant re-parsing and re-instantiation
+  // of geometry when the same mesh is registered multiple times.
+  //
+  // Each `Part` holds the VTK geometry source (a vtkPolyDataAlgorithm) and
+  // the resolved material for one OBJ sub-mesh. Multiple geometry
+  // registrations that reference the same OBJ file share these sources,
+  // so VTK only allocates and uploads the vertex data once.
+  struct CachedMesh {
+    struct Part {
+      // The material from the OBJ/MTL file (RenderMaterial::from_mesh_file ==
+      // true), or nullopt when the file defined no material. When nullopt, the
+      // per-instance material is resolved at registration time via
+      // DefineMaterial() so that phong/diffuse perception properties and the
+      // engine default_diffuse are both honoured correctly for each instance.
+      std::optional<geometry::internal::RenderMaterial> material;
+      vtkSmartPointer<vtkPolyDataAlgorithm> vtk_source;
+    };
+    std::vector<Part> parts;
+  };
+
+  // Instantiates the parts of a CachedMesh. Materials and scale factors are
+  // resolved on a per-instance basis.
+  void ImplementCachedMesh(const CachedMesh& cached,
+                           const Eigen::Vector3d& scale,
+                           const RegistrationData& data);
+
   // A geometry is modeled with one or more "parts". A part maps to the actor
   // representing it in VTK and an optional transform mapping the actor's frame
   // A to the Drake geometry frame G. This mapping can include scaling terms.
@@ -332,6 +358,12 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
   // The collection of per-geometry actors -- one actor per pipeline (color,
   // depth, and label) -- keyed by the geometry's GeometryId.
   std::unordered_map<GeometryId, PropArray> props_;
+
+  // Cache mapping mesh source keys to parsed/rendered mesh data. The key is
+  // computed from GetMeshSourceCacheKey() to uniquely identify a mesh source.
+  // This eliminates redundant re-parsing and re-rendering when the same mesh
+  // is registered multiple times.
+  std::unordered_map<std::string, CachedMesh> mesh_cache_;
 
   // Lights can be defined in the engine parameters. If no lights are defined,
   // we use the fallback_lights. Otherwise, we use the parameter lights.

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 // To ease build system upkeep, we annotate VTK includes with their deps.
+#include <vtkMapper.h>         // vtkRenderingCore
 #include <vtkOpenGLTexture.h>  // vtkRenderingOpenGL2
 #include <vtkPNGReader.h>      // vtkIOImage
 #include <vtkProperty.h>       // vtkRenderingCore
@@ -94,6 +95,22 @@ class RenderEngineVtkTester {
   // Return the full props map for the renderer.
   static const auto& GetProps(const RenderEngineVtk& renderer) {
     return renderer.props_;
+  }
+
+  // Returns the upstream vtkAlgorithm feeding the color-pipeline mapper for
+  // the first part of the given geometry. For unit-scale registrations this
+  // is the DrakeObjSource directly; for scaled registrations it is the
+  // vtkTransformPolyDataFilter that wraps the source.
+  static vtkAlgorithm* GetColorMapperSource(const RenderEngineVtk& renderer,
+                                            GeometryId id) {
+    vtkActor* actor = renderer.props_.at(id).at(0).parts.at(0).actor.Get();
+    DRAKE_DEMAND(actor != nullptr);
+    return actor->GetMapper()->GetInputAlgorithm(0, 0);
+  }
+
+  // Returns the number of entries currently in the mesh cache.
+  static int GetMeshCacheSize(const RenderEngineVtk& renderer) {
+    return static_cast<int>(renderer.mesh_cache_.size());
   }
 };
 
@@ -3330,6 +3347,155 @@ TEST_F(RenderEngineVtkTest, WholeImageVerticalAspectRatio) {
   CompareImages(color,
                 "drake/geometry/render_vtk/test/whole_image_custom_color.png",
                 /* tolerance = */ 2);
+}
+
+// ---------------------------------------------------------------------------
+// Mesh-cache source-sharing tests
+//
+// These tests verify that registering the same OBJ file multiple times results
+// in exactly one cache entry and that all registrations share the same
+// underlying vtkPolyDataAlgorithm source (i.e. vertex data is not duplicated).
+// ---------------------------------------------------------------------------
+//
+// Registers the same no-MTL OBJ three times and confirms that:
+//   (a) the mesh cache has exactly one entry, and
+//   (b) every registration's color-pipeline mapper feeds from the same upstream
+//       vtkAlgorithm pointer.
+//
+// Note: registering as Mesh and Convex will produce different cache entries.
+TEST_F(RenderEngineVtkTest, ObjMeshSourceSharing) {
+  const RenderEngineVtkParams params{.backend = FLAGS_backend};
+  RenderEngineVtk engine(params);
+
+  const std::string obj_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box_no_mtl.obj");
+
+  // Each registration uses a distinct diffuse color to demonstrate that the
+  // geometry source is shared even when per-instance materials differ.
+  auto make_props = [](const Rgba& color) {
+    PerceptionProperties props;
+    props.AddProperty("label", "id", RenderLabel::kDontCare);
+    props.AddProperty("phong", "diffuse", color);
+    return props;
+  };
+
+  const GeometryId mesh_id1 = GeometryId::get_new_id();
+  const GeometryId mesh_id2 = GeometryId::get_new_id();
+  const GeometryId mesh_id3 = GeometryId::get_new_id();
+  engine.RegisterVisual(mesh_id1, Mesh(obj_path), make_props(Rgba(1, 0, 0)),
+                        RigidTransformd::Identity());
+  engine.RegisterVisual(mesh_id2, Mesh(obj_path), make_props(Rgba(0, 1, 0)),
+                        RigidTransformd::Identity());
+  engine.RegisterVisual(mesh_id3, Mesh(obj_path), make_props(Rgba(0, 0, 1)),
+                        RigidTransformd::Identity());
+
+  // Register the same source file as Convex three times with distinct colors.
+  // These get a separate cache entry (the is_convex flag is part of the key).
+  const GeometryId convex_id1 = GeometryId::get_new_id();
+  const GeometryId convex_id2 = GeometryId::get_new_id();
+  const GeometryId convex_id3 = GeometryId::get_new_id();
+  engine.RegisterVisual(convex_id1, Convex(obj_path), make_props(Rgba(1, 0, 0)),
+                        RigidTransformd::Identity());
+  engine.RegisterVisual(convex_id2, Convex(obj_path), make_props(Rgba(0, 1, 0)),
+                        RigidTransformd::Identity());
+  engine.RegisterVisual(convex_id3, Convex(obj_path), make_props(Rgba(0, 0, 1)),
+                        RigidTransformd::Identity());
+
+  // Two cache entries: one for Mesh, one for Convex (different cache keys).
+  EXPECT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 2);
+
+  // All three Mesh mappers feed from the same upstream source.
+  vtkAlgorithm* mesh_src1 =
+      RenderEngineVtkTester::GetColorMapperSource(engine, mesh_id1);
+  vtkAlgorithm* mesh_src2 =
+      RenderEngineVtkTester::GetColorMapperSource(engine, mesh_id2);
+  vtkAlgorithm* mesh_src3 =
+      RenderEngineVtkTester::GetColorMapperSource(engine, mesh_id3);
+  ASSERT_NE(mesh_src1, nullptr);
+  EXPECT_EQ(mesh_src1, mesh_src2);
+  EXPECT_EQ(mesh_src2, mesh_src3);
+
+  // All three Convex mappers feed from the same upstream source.
+  vtkAlgorithm* convex_src1 =
+      RenderEngineVtkTester::GetColorMapperSource(engine, convex_id1);
+  vtkAlgorithm* convex_src2 =
+      RenderEngineVtkTester::GetColorMapperSource(engine, convex_id2);
+  vtkAlgorithm* convex_src3 =
+      RenderEngineVtkTester::GetColorMapperSource(engine, convex_id3);
+  ASSERT_NE(convex_src1, nullptr);
+  EXPECT_EQ(convex_src1, convex_src2);
+  EXPECT_EQ(convex_src2, convex_src3);
+
+  // Mesh and Convex of the same file use different cached sources (hull vs
+  // full mesh geometry).
+  EXPECT_NE(mesh_src1, convex_src1);
+}
+
+// Same as above but with an OBJ that carries its own MTL material. The VTK
+// geometry source should still be shared across registrations.
+TEST_F(RenderEngineVtkTest, ObjWithMtlSourceSharing) {
+  const RenderEngineVtkParams params{.backend = FLAGS_backend};
+  RenderEngineVtk engine(params);
+
+  const std::string obj_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.obj");
+
+  PerceptionProperties props;
+  props.AddProperty("label", "id", RenderLabel::kDontCare);
+
+  const GeometryId id1 = GeometryId::get_new_id();
+  const GeometryId id2 = GeometryId::get_new_id();
+  const GeometryId id3 = GeometryId::get_new_id();
+  engine.RegisterVisual(id1, Mesh(obj_path), props,
+                        RigidTransformd::Identity());
+  engine.RegisterVisual(id2, Mesh(obj_path), props,
+                        RigidTransformd::Identity());
+  engine.RegisterVisual(id3, Mesh(obj_path), props,
+                        RigidTransformd::Identity());
+
+  EXPECT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 1);
+
+  vtkAlgorithm* src1 = RenderEngineVtkTester::GetColorMapperSource(engine, id1);
+  vtkAlgorithm* src2 = RenderEngineVtkTester::GetColorMapperSource(engine, id2);
+  vtkAlgorithm* src3 = RenderEngineVtkTester::GetColorMapperSource(engine, id3);
+  ASSERT_NE(src1, nullptr);
+  EXPECT_EQ(src1, src2);
+  EXPECT_EQ(src2, src3);
+}
+
+// Registers two *different* OBJ files and confirms they produce independent
+// cache entries with distinct upstream sources.
+TEST_F(RenderEngineVtkTest, DifferentObjsDontShare) {
+  const RenderEngineVtkParams params{.backend = FLAGS_backend};
+  RenderEngineVtk engine(params);
+
+  const std::string obj_path_a =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box_no_mtl.obj");
+  const std::string obj_path_b =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.obj");
+
+  PerceptionProperties props;
+  props.AddProperty("label", "id", RenderLabel::kDontCare);
+
+  const GeometryId id_a = GeometryId::get_new_id();
+  const GeometryId id_b = GeometryId::get_new_id();
+  engine.RegisterVisual(id_a, Mesh(obj_path_a), props,
+                        RigidTransformd::Identity());
+  engine.RegisterVisual(id_b, Mesh(obj_path_b), props,
+                        RigidTransformd::Identity());
+
+  // Two distinct files → two distinct cache entries.
+  EXPECT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 2);
+
+  // The two sources must be different objects.
+  vtkAlgorithm* src_a =
+      RenderEngineVtkTester::GetColorMapperSource(engine, id_a);
+  // rainbow_box.obj has multiple parts; grab the first one.
+  vtkAlgorithm* src_b =
+      RenderEngineVtkTester::GetColorMapperSource(engine, id_b);
+  ASSERT_NE(src_a, nullptr);
+  ASSERT_NE(src_b, nullptr);
+  EXPECT_NE(src_a, src_b);
 }
 
 }  // namespace


### PR DESCRIPTION
1. Refactor the mesh cache key logic from RenderEngineGl and share it.
2. RenderEngineVtk now has a "mesh" cache representing the parsed obj data (geometry and material).
   - The geometry is represented by a vtkPolyDataAlgorithm. This gets shared across instances.

relates #23995.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24235)
<!-- Reviewable:end -->
