### PR TITLE
Fix constraint tolerance type truncation error in the RaySampler

### DIFF
--- a/planning/iris/iris_np2.cc
+++ b/planning/iris/iris_np2.cc
@@ -211,7 +211,7 @@ bool CheckTerminationConditions(int iteration_num, double delta_volume,
 bool RaySamplerProcess(const SceneGraphCollisionChecker& checker,
                        const VectorXd& ellipsoid_center,
                        const HPolyhedron& current_polytope,
-                       const IrisNp2Options& options, int constraints_tol,
+                       const IrisNp2Options& options, double constraints_tol,
                        VectorXd* particle) {
   DRAKE_THROW_UNLESS(particle != nullptr);
 


### PR DESCRIPTION
This type truncation was causing the constraint tolerance to be zero, causing IrisNp2 to break when using the ray sampler.

+@rhjiang for feature review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24241)
<!-- Reviewable:end -->
