### PR TITLE
Swap the dense collision matrix in collision filter for a sparse matrix

### DIFF
--- a/common/test_utilities/limit_malloc.cc
+++ b/common/test_utilities/limit_malloc.cc
@@ -51,15 +51,6 @@ namespace drake {
 namespace test {
 namespace {
 
-// LimitMalloc does not work properly with some configurations. Check this
-// predicate and disarm to avoid erroneous results.
-bool IsSupportedConfiguration() {
-  static const bool is_supported{DRAKE_INSTALL_HEAP_HOOKS &&
-                                 !std::getenv("LSAN_OPTIONS") &&
-                                 !std::getenv("VALGRIND_OPTS")};
-  return is_supported;
-}
-
 // This variable is used as an early short-circuit for our malloc hooks.  When
 // false, we execute as minimal code footprint as possible.  This keeps dl_init
 // happy when its invoke malloc and we can't yet execute our C++ code.
@@ -181,7 +172,7 @@ class ActiveMonitor {
 };
 
 void Monitor::ObserveAllocation() {
-  if (!IsSupportedConfiguration()) {
+  if (!LimitMalloc::IsSupportedConfiguration()) {
     return;
   }
 
@@ -246,6 +237,13 @@ const LimitMallocParams& LimitMalloc::params() const {
   return ActiveMonitor::load()->params();
 }
 
+bool LimitMalloc::IsSupportedConfiguration() {
+  static const bool is_supported{DRAKE_INSTALL_HEAP_HOOKS &&
+                                 !std::getenv("LSAN_OPTIONS") &&
+                                 !std::getenv("VALGRIND_OPTS")};
+  return is_supported;
+}
+
 LimitMalloc::~LimitMalloc() {
   // Copy out the monitor's data before we delete it.
   const int observed = num_allocations();
@@ -290,7 +288,7 @@ void* realloc(void* ptr, size_t size) {
 }
 
 static void EvaluateMinNumAllocations(int observed, int min_num_allocations) {
-  if (!drake::test::IsSupportedConfiguration()) {
+  if (!drake::test::LimitMalloc::IsSupportedConfiguration()) {
     return;
   }
 

--- a/common/test_utilities/limit_malloc.h
+++ b/common/test_utilities/limit_malloc.h
@@ -68,6 +68,11 @@ class LimitMalloc final {
   /// Returns the parameters structure used to construct this object.
   const LimitMallocParams& params() const;
 
+  /// If the current configuration is supported (return true), LimitMalloc will
+  /// behave as advertised. If not (return false), the APIs are no-ops. Tests
+  /// that use this class need to take this change in behavior into account.
+  static bool IsSupportedConfiguration();
+
   // We write this out by hand, to avoid depending on Drake *at all*.
   /// @name Does not allow copy, move, or assignment
   //@{

--- a/common/test_utilities/test/limit_malloc_test.cc
+++ b/common/test_utilities/test/limit_malloc_test.cc
@@ -246,6 +246,17 @@ GTEST_TEST(LimitReallocDeathTest, ChangingSizeTest) {
   free(dummy);
 }
 
+GTEST_TEST(LimitMallocTest, IsSupportedConiguration) {
+  LimitMalloc guard({.max_num_allocations = -1});
+  CallMalloc();
+  if (LimitMalloc::IsSupportedConfiguration()) {
+    EXPECT_EQ(guard.num_allocations(), 1);
+  } else {
+    // When LimitMalloc isn't supported, it won't count.
+    EXPECT_EQ(guard.num_allocations(), 0);
+  }
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace drake

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -186,7 +186,7 @@ drake_cc_library(
     hdrs = ["collision_filter.h"],
     deps = [
         "//common:essential",
-        "//common:unused",
+        "//common:sorted_pair",
         "//geometry:collision_filter_declaration",
         "//geometry:geometry_ids",
     ],
@@ -1184,6 +1184,14 @@ drake_cc_googletest(
     name = "collision_filter_test",
     deps = [
         ":collision_filter",
+    ],
+)
+
+drake_cc_googletest(
+    name = "collision_filter_memory_test",
+    deps = [
+        ":collision_filter",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/geometry/proximity/collision_filter.cc
+++ b/geometry/proximity/collision_filter.cc
@@ -1,25 +1,15 @@
 #include "drake/geometry/proximity/collision_filter.h"
 
+#include <algorithm>
+
 #include "drake/common/drake_assert.h"
-#include "drake/common/unused.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-using std::unordered_set;
+CollisionFilter::CollisionFilter() = default;
 
-CollisionFilter::CollisionFilter() {
-  /* The filter history always has at least one entry -- entry[0] is the
-   persistent base. We associate it with a filter id that can never be
-   accessed via ApplyTransient() so that it can't accidentally be removed. */
-  filter_history_.emplace_back(FilterState{}, FilterId::get_new_id());
-}
-
-// TODO(SeanCurtis-TRI): Multiple calls to Apply will lead to multiple
-//  constructions of std::unordered_set from GeometrySet (as opposed to
-//  re-using a single set). If this is a performance issue, revisit this so
-//  that I can operate on multiple filter states *per statement*.
 void CollisionFilter::Apply(const CollisionFilterDeclaration& declaration,
                             const CollisionFilter::ExtractIds& extract_ids,
                             bool is_invariant) {
@@ -28,284 +18,268 @@ void CollisionFilter::Apply(const CollisionFilterDeclaration& declaration,
         "You cannot attempt to modify the persistent collision filter "
         "configuration when there are active, transient filter declarations");
   }
-  // TODO(SeanCurtis-TRI): We're using a brute-force approach to update the
-  //  cached composite state and the persistent state. We assume it's cheaper
-  //  to "apply" the declaration twice than to apply once and copy. If this
-  //  introduces too much cost during configuration, we have a couple of options
-  //    - Find out if copying is faster.
-  //    - In the case where there is *only* persistent state, don't use the
-  //      copy as the persistent state *is* its own composite state.
-  /* Keep current configuration and persistent base in sync. */
-  Apply(declaration, extract_ids, is_invariant, &filter_state_);
-  Apply(declaration, extract_ids, is_invariant,
-        &filter_history_[0].filter_state);
+  ApplyDeclarationToState(declaration, extract_ids, is_invariant,
+                          &persistent_base_);
+  /* Keep the cached composite and the persistent base in sync. We *could*
+   simply copy the persistent base to the filter state, but we assume that the
+   application of a declaration is a generally cheaper operation than a
+   wholesale copy. */
+  ApplyDeclarationToState(declaration, extract_ids, is_invariant,
+                          &filter_state_);
 }
 
 FilterId CollisionFilter::ApplyTransient(
     const CollisionFilterDeclaration& declaration,
     const CollisionFilter::ExtractIds& extract_ids) {
-  /* By its very definition, transient declarations *cannot* be invariant. They
-   are never used by the system to implement invariants and users cannot declare
-   a filter to be invariant. */
-  const bool is_invariant = false;
+  /* Transient declarations are never invariant. */
+  using Statement = CollisionFilterDeclaration::Statement;
+  using Op = CollisionFilterDeclaration::StatementOp;
+  const CollisionFilterScope scope = declaration.scope();
 
-  /* Using the same brute-force approach as in Apply(), we need to apply the
-   declaration to our cached, composite result (filter_state_). Then we need
-   to add it to the history by:
+  /* Resolve every statement's GeometrySet to explicit GeometryId vectors now,
+   while we have the extract_ids callback. The resolved statements are stored
+   compactly in the StateDelta and replayed cheaply in RebuildComposite()
+   without needing the callback again. */
+  std::vector<ResolvedStatement> resolved;
+  resolved.reserve(declaration.statements().size());
+  for (const Statement& statement : declaration.statements()) {
+    ResolvedStatement rs;
+    rs.operation = statement.operation;
+    const std::unordered_set<GeometryId> ids_A =
+        extract_ids(statement.set_A, scope);
+    rs.set_A.assign(ids_A.begin(), ids_A.end());
+    if (statement.operation == Op::kExcludeBetween ||
+        statement.operation == Op::kAllowBetween) {
+      const std::unordered_set<GeometryId> ids_B =
+          extract_ids(statement.set_B, scope);
+      rs.set_B.assign(ids_B.begin(), ids_B.end());
+    }
+    resolved.push_back(std::move(rs));
+  }
 
-     1. Creating a new FilterState instance (with all the registered geometry
-        in final_state_).
-     2. Apply the declaration to that new state in the history. */
-  // TODO(SeanCurtis-TRI): The brute force approach introduces several costs.
-  //  In addition to the cost of converting GeometrySet --> set<GeometryId>
-  //  twice, we are instantiating a full FilterState for what might be a small
-  //  declaration and applying the declaration twice. If this cost is too high,
-  //  even for out-of-the-loop configuration, revisit how we represent the
-  //  history and maintain the composite copy.
-  Apply(declaration, extract_ids, is_invariant, &filter_state_);
-  filter_history_.emplace_back(
-      InitializeTransientState(filter_state_, kUndefined),
-      FilterId::get_new_id());
-  Apply(declaration, extract_ids, is_invariant,
-        &filter_history_.back().filter_state);
-  return filter_history_.back().id;
+  const FilterId new_id = FilterId::get_new_id();
+  StateDelta delta{std::move(resolved), new_id};
+
+  /* Apply to the cached composite first, then store the delta. */
+  ApplyStatements(delta, &filter_state_);
+  transient_history_.push_back(std::move(delta));
+  return new_id;
 }
 
 bool CollisionFilter::IsActive(FilterId id) const {
-  for (const auto& delta : filter_history_) {
+  for (const StateDelta& delta : transient_history_) {
     if (id == delta.id) return true;
   }
   return false;
 }
 
 bool CollisionFilter::RemoveDeclaration(FilterId id) {
-  /* We skip the first entry, that is always the persistent base and can't be
-   removed. */
-  for (auto it = filter_history_.begin() + 1; it != filter_history_.end();
+  for (auto it = transient_history_.begin(); it != transient_history_.end();
        ++it) {
     if (it->id != id) continue;
 
-    /* We found a declaration to remove. We simply pop it out, relying on the
-     std::vector to use move semantics to slide the subsequent entries down.
-     Then we just copy the persistent base and "replay" the transient
-     declarations. */
-    filter_history_.erase(it);
-    filter_state_ = filter_history_[0].filter_state;
-    for (size_t i = 1; i < filter_history_.size(); ++i) {
-      const FilterState& state = filter_history_[i].filter_state;
-      /* Note: If the filtered state in transient declarations was sparse, this
-       application algorithm would directly benefit. It only requires that the
-       persistent state has all of the required pairs. See the TODO in
-       AddGeometry() for more discussion. */
-      for (const auto& [source_id, source_map] : state) {
-        for (const auto& [pair_id, pair_relation] : source_map) {
-          if (pair_relation != kUndefined) {
-            if (filter_state_[source_id][pair_id] != kInvariantFilter) {
-              filter_state_[source_id][pair_id] = pair_relation;
-            }
-          }
-        }
-      }
-    }
+    /* Remove the target delta, then rebuild the composite from the persistent
+     base plus the remaining transient deltas. Because multiple deltas can
+     touch the same pair, we cannot simply invert the removed delta in place --
+     we must replay from scratch to get the correct result. */
+    transient_history_.erase(it);
+    RebuildComposite();
     return true;
   }
   return false;
 }
 
 void CollisionFilter::Flatten() {
-  if (filter_history_.size() > 1) {
-    filter_history_.resize(1);
-    filter_history_[0].filter_state = filter_state_;
+  if (!transient_history_.empty()) {
+    /* The composite already reflects all transient deltas applied, so just
+     promote it to the persistent base and clear the history. */
+    persistent_base_ = filter_state_;
+    transient_history_.clear();
   }
 }
 
 void CollisionFilter::AddGeometry(GeometryId new_id) {
-  /* Current and persistent configurations should simply add the id with
-   unfiltered status. */
-  AddGeometry(new_id, &filter_state_, kUnfiltered);
-  AddGeometry(new_id, &filter_history_[0].filter_state, kUnfiltered);
-  // TODO(SeanCurtis): Can I skip this work by allowing delta filter state to be
-  //  incomplete? If each transient delta *only* contains explicitly declared
-  //  changes, iterating through it would be faster. More complex, but faster.
-  /* Active transient history should add the id with undefined status. */
-  for (size_t i = 1; i < filter_history_.size(); ++i) {
-    AddGeometry(new_id, &filter_history_[i].filter_state, kUndefined);
-  }
+  DRAKE_DEMAND(!geometries_.contains(new_id));
+  geometries_.insert(new_id);
+  /* No pair entries are needed: the sparse representation stores only filtered
+   pairs, and new geometry is unfiltered by default. Transient deltas store
+   only resolved GeometryId sets, so they also require no update. */
 }
 
 void CollisionFilter::RemoveGeometry(GeometryId remove_id) {
-  /* Simply remove the geometry from everything. */
-  RemoveGeometry(remove_id, &filter_state_);
-  for (auto& delta : filter_history_) {
-    RemoveGeometry(remove_id, &delta.filter_state);
+  DRAKE_DEMAND(geometries_.contains(remove_id));
+  geometries_.erase(remove_id);
+
+  RemovePairsFor(remove_id, &filter_state_);
+  RemovePairsFor(remove_id, &persistent_base_);
+
+  /* Purge the removed id from all resolved statement sets in transient history
+   so that future replays do not reference a geometry that no longer exists. */
+  for (StateDelta& delta : transient_history_) {
+    for (ResolvedStatement& statement : delta.statements) {
+      std::erase(statement.set_A, remove_id);
+      std::erase(statement.set_B, remove_id);
+    }
+  }
+
+  /* Rebuild composite from the updated persistent base + purged transients. */
+  if (has_transient_history()) {
+    RebuildComposite();
   }
 }
 
 bool CollisionFilter::CanCollideWith(GeometryId id_A, GeometryId id_B) const {
   if (id_A == id_B) return false;
-  if (id_A < id_B) {
-    return filter_state_.at(id_A).at(id_B) == kUnfiltered;
-  } else {
-    return filter_state_.at(id_B).at(id_A) == kUnfiltered;
-  }
+  const PairKey key(id_A, id_B);
+  return !filter_state_.filtered.contains(key) &&
+         !filter_state_.invariant.contains(key);
 }
 
-void CollisionFilter::AddFiltersBetween(
-    const GeometrySet& set_A, const GeometrySet& set_B,
-    const CollisionFilter::ExtractIds& extract_ids, CollisionFilterScope scope,
-    bool is_invariant, FilterState* state_out) {
-  const std::unordered_set<GeometryId> ids_A = extract_ids(set_A, scope);
-  const std::unordered_set<GeometryId>& ids_B =
-      &set_A == &set_B ? ids_A : extract_ids(set_B, scope);
-  for (GeometryId id_A : ids_A) {
-    for (GeometryId id_B : ids_B) {
-      AddFilteredPair(id_A, id_B, is_invariant, state_out);
-    }
-  }
-}
-
-void CollisionFilter::RemoveFiltersBetween(
-    const GeometrySet& set_A, const GeometrySet& set_B,
-    const CollisionFilter::ExtractIds& extract_ids, CollisionFilterScope scope,
-    FilterState* state_out) {
-  const std::unordered_set<GeometryId> ids_A = extract_ids(set_A, scope);
-  const std::unordered_set<GeometryId>& ids_B =
-      &set_A == &set_B ? ids_A : extract_ids(set_B, scope);
-  for (GeometryId id_A : ids_A) {
-    for (GeometryId id_B : ids_B) {
-      RemoveFilteredPair(id_A, id_B, state_out);
-    }
-  }
-}
-
-void CollisionFilter::AddFilteredPair(GeometryId id_A, GeometryId id_B,
-                                      bool is_invariant,
-                                      FilterState* state_out) {
-  FilterState& filter_state = *state_out;
-  DRAKE_DEMAND(filter_state.contains(id_A) && filter_state.contains(id_B));
-
-  if (id_A == id_B) return;
-  PairRelationship& pair_relation =
-      id_A < id_B ? filter_state[id_A][id_B] : filter_state[id_B][id_A];
-  if (pair_relation == kInvariantFilter) return;
-  pair_relation = is_invariant ? kInvariantFilter : kFiltered;
-}
-
-void CollisionFilter::RemoveFilteredPair(GeometryId id_A, GeometryId id_B,
-                                         FilterState* state_out) {
-  FilterState& filter_state = *state_out;
-  DRAKE_DEMAND(filter_state.contains(id_A) && filter_state.contains(id_B));
-  if (id_A == id_B) return;
-  PairRelationship& pair_relation =
-      id_A < id_B ? filter_state[id_A][id_B] : filter_state[id_B][id_A];
-  if (pair_relation == kInvariantFilter) return;
-  pair_relation = kUnfiltered;
-}
-
-bool CollisionFilter::operator==(const CollisionFilter& other) const {
+bool CollisionFilter::IsEquivalent(const CollisionFilter& other) const {
   if (this == &other) return true;
-  if (filter_state_.size() != other.filter_state_.size()) return false;
-  for (const auto& [this_id, this_map] : filter_state_) {
-    if (!other.HasGeometry(this_id)) return false;
-    for (const auto& [this_pair_id, can_collide] : this_map) {
-      unused(can_collide);
-      if (!other.HasGeometry(this_pair_id)) return false;
-      if (CanCollideWith(this_id, this_pair_id) !=
-          other.CanCollideWith(this_id, this_pair_id)) {
-        return false;
-      }
-    }
+  if (geometries_ != other.geometries_) return false;
+  /* Two filters are equal iff CanCollideWith() agrees on every pair. A pair is
+   blocked iff it is in filtered OR invariant, so we check that every blocked
+   pair in either filter is also blocked in the other. */
+  auto is_blocked = [](const FilterState& fs, const PairKey& k) {
+    return fs.filtered.contains(k) || fs.invariant.contains(k);
+  };
+  for (const PairKey& key : filter_state_.filtered) {
+    if (!is_blocked(other.filter_state_, key)) return false;
+  }
+  for (const PairKey& key : filter_state_.invariant) {
+    if (!is_blocked(other.filter_state_, key)) return false;
+  }
+  for (const PairKey& key : other.filter_state_.filtered) {
+    if (!is_blocked(filter_state_, key)) return false;
+  }
+  for (const PairKey& key : other.filter_state_.invariant) {
+    if (!is_blocked(filter_state_, key)) return false;
   }
   return true;
 }
 
 CollisionFilter CollisionFilter::MakeClearCopy() const {
-  auto clear_state = CollisionFilter::InitializeTransientState(
-      filter_state_, CollisionFilter::kUnfiltered);
-  CollisionFilter new_filter;
-  new_filter.filter_state_ = clear_state;
-  new_filter.filter_history_[0].filter_state = clear_state;
-  return new_filter;
+  CollisionFilter copy;
+  copy.geometries_ = geometries_;
+  /* filtered and invariant sets are intentionally left empty. */
+  return copy;
 }
 
-void CollisionFilter::Apply(const CollisionFilterDeclaration& declaration,
-                            const CollisionFilter::ExtractIds& extract_ids,
-                            bool is_invariant, FilterState* filter_state) {
-  using Operation = CollisionFilterDeclaration::StatementOp;
+void CollisionFilter::AddPairsBetween(const std::vector<GeometryId>& set_A,
+                                      const std::vector<GeometryId>& set_B,
+                                      bool is_invariant, FilterState* state) {
+  for (GeometryId id_A : set_A) {
+    for (GeometryId id_B : set_B) {
+      if (id_A == id_B) continue;
+      const PairKey key(id_A, id_B);
+      /* Never downgrade an invariant pair. */
+      if (state->invariant.contains(key)) continue;
+      if (is_invariant) {
+        state->filtered.erase(key);
+        state->invariant.insert(key);
+      } else {
+        state->filtered.insert(key);
+      }
+    }
+  }
+}
+
+void CollisionFilter::RemovePairsBetween(const std::vector<GeometryId>& set_A,
+                                         const std::vector<GeometryId>& set_B,
+                                         FilterState* state) {
+  for (GeometryId id_A : set_A) {
+    for (GeometryId id_B : set_B) {
+      if (id_A == id_B) continue;
+      const PairKey key(id_A, id_B);
+      state->filtered.erase(key);
+    }
+  }
+}
+
+void CollisionFilter::RemovePairsFor(GeometryId id, FilterState* state) {
+  auto pair_has_id = [id](const PairKey& k) {
+    return k.first() == id || k.second() == id;
+  };
+  std::erase_if(state->filtered, pair_has_id);
+  std::erase_if(state->invariant, pair_has_id);
+}
+
+void CollisionFilter::ApplyStatement(const ResolvedStatement& statement,
+                                     FilterState* state) {
+  using Op = CollisionFilterDeclaration::StatementOp;
+  switch (statement.operation) {
+    case Op::kExcludeBetween:
+      AddPairsBetween(statement.set_A, statement.set_B, /*is_invariant=*/false,
+                      state);
+      break;
+    case Op::kExcludeWithin:
+      AddPairsBetween(statement.set_A, statement.set_A, /*is_invariant=*/false,
+                      state);
+      break;
+    case Op::kAllowBetween:
+      RemovePairsBetween(statement.set_A, statement.set_B, state);
+      break;
+    case Op::kAllowWithin:
+      RemovePairsBetween(statement.set_A, statement.set_A, state);
+      break;
+  }
+}
+
+void CollisionFilter::ApplyStatements(const StateDelta& delta,
+                                      FilterState* state) {
+  for (const ResolvedStatement& statement : delta.statements) {
+    ApplyStatement(statement, state);
+  }
+}
+
+void CollisionFilter::ApplyDeclarationToState(
+    const CollisionFilterDeclaration& declaration,
+    const CollisionFilter::ExtractIds& extract_ids, bool is_invariant,
+    FilterState* state) {
+  using Statement = CollisionFilterDeclaration::Statement;
+  using Op = CollisionFilterDeclaration::StatementOp;
   const CollisionFilterScope scope = declaration.scope();
-  for (const auto& statement : declaration.statements()) {
+  for (const Statement& statement : declaration.statements()) {
+    const std::unordered_set<GeometryId> ids_A_set =
+        extract_ids(statement.set_A, scope);
+    const std::vector<GeometryId> ids_A(ids_A_set.begin(), ids_A_set.end());
+
     switch (statement.operation) {
-      case Operation::kAllowBetween:
-        // Note: GeometryState should never be declaring is_invariant is true
-        // while removing collision filters.
+      case Op::kExcludeBetween: {
+        const std::unordered_set<GeometryId> ids_B_set =
+            extract_ids(statement.set_B, scope);
+        const std::vector<GeometryId> ids_B(ids_B_set.begin(), ids_B_set.end());
+        AddPairsBetween(ids_A, ids_B, is_invariant, state);
+        break;
+      }
+      case Op::kExcludeWithin:
+        AddPairsBetween(ids_A, ids_A, is_invariant, state);
+        break;
+      case Op::kAllowBetween: {
         DRAKE_DEMAND(!is_invariant);
-        RemoveFiltersBetween(statement.set_A, statement.set_B, extract_ids,
-                             scope, filter_state);
+        const std::unordered_set<GeometryId> ids_B_set =
+            extract_ids(statement.set_B, scope);
+        const std::vector<GeometryId> ids_B(ids_B_set.begin(), ids_B_set.end());
+        RemovePairsBetween(ids_A, ids_B, state);
         break;
-      case Operation::kAllowWithin:
+      }
+      case Op::kAllowWithin:
         DRAKE_DEMAND(!is_invariant);
-        RemoveFiltersBetween(statement.set_A, statement.set_A, extract_ids,
-                             scope, filter_state);
-        break;
-      case Operation::kExcludeWithin:
-        AddFiltersBetween(statement.set_A, statement.set_A, extract_ids, scope,
-                          is_invariant, filter_state);
-        break;
-      case Operation::kExcludeBetween:
-        AddFiltersBetween(statement.set_A, statement.set_B, extract_ids, scope,
-                          is_invariant, filter_state);
+        RemovePairsBetween(ids_A, ids_A, state);
         break;
     }
   }
 }
 
-void CollisionFilter::AddGeometry(GeometryId new_id,
-                                  FilterState* filter_state_out,
-                                  PairRelationship relationship) {
-  FilterState& filter_state = *filter_state_out;
-  DRAKE_DEMAND(!filter_state.contains(new_id));
-  GeometryMap& new_map = filter_state[new_id] = {};
-  for (auto& [other_id, other_map] : filter_state) {
-    /* Whichever id is *smaller* tracks the relationship with the other.
-     That relationship defaults to unfiltered (i.e., "can collide").
-
-     Note: we're iterating over filter_state_ and assigning to either new_map
-     or other_map. This doesn't invalidate the implicit iterator of the range
-     operator. We never change the *keys* of filter_state_ in this loop, only
-     its values. And we don't do any iteration in the new_map or other_map
-     so don't depend on their iterators. */
-    if (other_id < new_id) {
-      other_map[new_id] = relationship;
-    } else {
-      new_map[other_id] = relationship;
-    }
+void CollisionFilter::RebuildComposite() {
+  /* Start from the persistent base and replay all transient deltas in order. */
+  filter_state_ = persistent_base_;
+  for (const StateDelta& delta : transient_history_) {
+    ApplyStatements(delta, &filter_state_);
   }
 }
 
-void CollisionFilter::RemoveGeometry(GeometryId remove_id,
-                                     FilterState* filter_state_out) {
-  FilterState& filter_state = *filter_state_out;
-  DRAKE_DEMAND(filter_state.contains(remove_id));
-  filter_state.erase(remove_id);
-  for (auto& [other_id, other_map] : filter_state) {
-    /* remove_id will only be found in maps belonging to geometries with ids
-     that are smaller than remove_id. Those that are larger were deleted when we
-     removed remove_id's entry. */
-    if (other_id < remove_id) {
-      other_map.erase(remove_id);
-    }
-  }
-}
-
-CollisionFilter::FilterState CollisionFilter::InitializeTransientState(
-    const FilterState& reference, PairRelationship default_relationship) {
-  FilterState new_state;
-  for (const auto& [id, _] : reference) {
-    unused(_);
-    AddGeometry(id, &new_state, default_relationship);
-  }
-  return new_state;
-}
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/collision_filter.h
+++ b/geometry/proximity/collision_filter.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <functional>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "drake/common/sorted_pair.h"
 #include "drake/geometry/collision_filter_declaration.h"
 #include "drake/geometry/geometry_ids.h"
 
@@ -80,10 +80,7 @@ class CollisionFilter {
                           const ExtractIds& extract_ids);
 
   /* Reports true if there are any active transient declarations.  */
-  bool has_transient_history() const {
-    /* Remember: filter_history_[0] is the persistent state. */
-    return filter_history_.size() > 1;
-  }
+  bool has_transient_history() const { return !transient_history_.empty(); }
 
   /* Reports if the given filter id is part of the active, transient history. */
   bool IsActive(FilterId id) const;
@@ -113,20 +110,15 @@ class CollisionFilter {
    @pre `id_A` and `id_B` are both part of this filter system. */
   bool CanCollideWith(GeometryId id_A, GeometryId id_B) const;
 
-  /* Reports if two collision filters are configured the same. They are
-   considered the same if the two filter systems report the same results for
-   all calls to `CanCollideWith()`. This implies they have the same geometries
-   registered, and equivalent filter state for each pair. */
-  bool operator==(const CollisionFilter& other) const;
-
-  /* Reports if two collision filters are configured differently.  See
-   operator==() for what this means. */
-  bool operator!=(const CollisionFilter& other) const {
-    return !(*this == other);
-  }
+  /* Reports if two collision filters are "equivalent" -- in that they are
+   defined over the same set of geometry ids and report the same pairs as being
+   filtered (or not). This says nothing about how the two filters are
+   articulated (e.g., different declarations of invariance, transient versus
+   permanent declarations, etc.). */
+  bool IsEquivalent(const CollisionFilter& other) const;
 
   /* Reports if the given `id` has been added to this filter system. */
-  bool HasGeometry(GeometryId id) const { return filter_state_.contains(id); }
+  bool HasGeometry(GeometryId id) const { return geometries_.contains(id); }
 
  private:
   friend class CollisionFilterTest;
@@ -135,130 +127,108 @@ class CollisionFilter {
    of the registered geometry but no collision filters. */
   CollisionFilter MakeClearCopy() const;
 
-  /* The collision filter state between a pair of geometries. */
-  enum PairRelationship {
-    kUndefined,        // No relationship has been defined; used for transient
-                       // declarations.
-    kUnfiltered,       // No filter has been declared.
-    kFiltered,         // A user-declared filter exists, the user can remove it.
-    kInvariantFilter,  // The filter supports a SceneGraph filter invariant and
-                       // cannot be removed by the user.
+  /* The representation of a pair of geometry ids in a hash set. The presence of
+   this key in a FilteredPairs set implies filtering of the pair. */
+  using PairKey = SortedPair<GeometryId>;
+
+  using FilteredPairs = std::unordered_set<PairKey>;
+
+  /* Sparse representation of the collision filter state. Only filtered pairs
+   are stored; an absent pair is unfiltered by default.
+
+   The `filtered` and `invariant` sets are always disjoint: a pair is in at
+   most one of them. Membership in either set means CanCollideWith returns
+   false. The distinction is that `invariant` pairs cannot be removed by the
+   user via Allow*() declarations. */
+  struct FilterState {
+    /* User-removable filtered pairs. */
+    FilteredPairs filtered;
+    /* SceneGraph-invariant filtered pairs (cannot be removed by Allow*). */
+    FilteredPairs invariant;
   };
 
-  /* The "filter state" is a 2d table. For N registered geometries, it is
-   an NxN table where cell (i, j) reports the filter status of the ith and jth
-   geometries (although i and j are actually GeometryIds).
+  /* A resolved statement: the GeometrySets of the original declaration have
+   been expanded to explicit vectors of GeometryIds at the time the transient
+   was applied. Storing resolved IDs means the extract_ids callback is not
+   needed at replay time.
 
-   Because a pair's filter status is symmetric (e.g., (a, b) and (b, a) are
-   equivalent), we only encode a triangular portion of the table. We have two
-   types that work together to define the table: GeometryMap and FilterState.
+   For Within operations, set_B is empty and the cross product is set_A × set_A.
+   For Between operations, the cross product is set_A × set_B.
 
-   FilterState maps a GeometryId to the filter relationship with all other
-   registered geometries with *greater* GeometryId values. That set of
-   geometries is contained in a GeometryMap, where each entry on that "row"
-   is the key-value pair (other_id, filter_pair_state).
-
-   So, given a FilterState instance (filter_state) and two GeometryIds, a and b,
-   we could set the filtered state as (assuming a < b):
-
-      filter_state[a][b] = kFiltered;
-
-   As a concrete example, if we've registered GeometryId values 10, 20, 30, 40,
-   the filter state would have keys {10, 20, 30, 40} which each maps to a
-   corresponding GeometryMap as illustrated below.
-     10 -> {(20, PairRelationship), (30, PairRelationship),
-            (40, PairRelationship)}
-     20 -> {(30, PairRelationship), (40, PairRelationship)}
-     30 -> {(40, PairRelationship)}
-     40 -> {} */
-  using GeometryMap = std::unordered_map<GeometryId, PairRelationship>;
-
-  using FilterState = std::unordered_map<GeometryId, GeometryMap>;
-
-  /* Applies the given declaration to an arbitrary `filter_state`. */
-  static void Apply(const CollisionFilterDeclaration& declaration,
-                    const ExtractIds& extract_ids, bool is_invariant,
-                    FilterState* filter_state);
-
-  /* Adds the geometry with the given `id` to the given filter state with the
-   given initial_state for all pairs including the new id. */
-  static void AddGeometry(GeometryId id, FilterState* filter_state_out,
-                          PairRelationship relationship);
-
-  /* Removes the geometry with the given `id` from the given filter state. */
-  static void RemoveGeometry(GeometryId id, FilterState* filter_state_out);
-
-  /* Declares pairs (`id_A`, `id_B`) `∀ id_A ∈ set_A*, id_B ∈ set_B*` to be
-   filtered, where `set_A*` and `set_B*` are the geometry ids in `set_A` and
-   `set_B`, respectively, consistent with the given `scope`. For each
-   pair, if they are already filtered, no discernible change is made.
-
-   The filtered pair can be made "invariant" such that subsequent calls to
-   RemoveFiltersBetween will not remove the filter. This is intended to support
-   SceneGraph invariants that geometries affixed to the same frame are filtered
-   or pairs of anchored geometries are likewise filtered. GeometryState is
-   responsible for determining invariance when adding filters.
-
-   @pre All ids in `id_A` and `id_B` are part of this filter system.  */
-  static void AddFiltersBetween(const GeometrySet& set_A,
-                                const GeometrySet& set_B,
-                                const ExtractIds& extract_ids,
-                                CollisionFilterScope scope, bool is_invariant,
-                                FilterState* state_out);
-
-  /* Declares pairs (`id_A`, `id_B`) `∀ id_A ∈ set_A*, id_B ∈ set_B*` to be
-   unfiltered (if the filter isn't invariant) where `set_A*` and `set_B*` are
-   the geometry ids in `set_A` and `set_B`, respectively, consistent with the
-   given `scope`. For each pair, if they are already unfiltered, no discernible
-   change is made.
-
-   @pre All ids `id_A` and `id_B` are part of the system.  */
-  static void RemoveFiltersBetween(const GeometrySet& set_A,
-                                   const GeometrySet& set_B,
-                                   const ExtractIds& extract_ids,
-                                   CollisionFilterScope scope,
-                                   FilterState* state_out);
-
-  /* Atomic operation in support of AddFiltersBetween().  */
-  static void AddFilteredPair(GeometryId id_A, GeometryId id_B,
-                              bool is_invariant, FilterState* state_out);
-
-  /* Atomic operation in support of RemoveFilterBetween().  */
-  static void RemoveFilteredPair(GeometryId id_A, GeometryId id_B,
-                                 FilterState* state_out);
-
-  /* Instantiates a FilterState such that all known pairs have given
-   default relationship. */
-  static FilterState InitializeTransientState(
-      const FilterState& reference, PairRelationship default_relationship);
-
-  /* The filter state of all pairs of geometry.
-
-   This is neither the persistent base configuration nor the history. It is
-   the cached result of the base with all transient declarations applied. We
-   store this composite result in order to make collision filter lookups as
-   fast as possible. The implication is that when we update the history, we
-   must *also* update this so that it always reflects the final configuration.
+   Note: Although the geometry ids are stored in vectors, they are _not_ ordered
+   and not duplicated. No operation on these sets should depend on the ordering.
    */
-  FilterState filter_state_;
+  struct ResolvedStatement {
+    using Operation = CollisionFilterDeclaration::StatementOp;
+    Operation operation{};
+    std::vector<GeometryId> set_A;
+    std::vector<GeometryId> set_B;
+  };
 
-  /* The underlying data for transient history: the assigned filter id and
-   the filter state instance which represents the applied transient declaration.
-   The filter state has been initialized with all registered geometry and
-   *no* collision filters and has the transient declaration applied directly
-   to it. In other words, any geometry pair that isn't explicitly accounted
-   for in the declaration is marked with PairRelationship::kUndefined. */
+  /* A transient declaration stored as its resolved statements. */
   struct StateDelta {
-    /* Default constructor to support resize of vector<StateDelta>. */
     StateDelta() = default;
+    StateDelta(std::vector<ResolvedStatement> statements_in, FilterId id_in)
+        : statements(std::move(statements_in)), id(id_in) {}
 
-    StateDelta(FilterState state, FilterId id_in)
-        : filter_state(std::move(state)), id(id_in) {}
-
-    FilterState filter_state;
+    std::vector<ResolvedStatement> statements;
     FilterId id{};
   };
-  std::vector<StateDelta> filter_history_;
+
+  /* Applies the resolved statements in `delta` to `state`. Used when first
+   applying a transient and when replaying history in RebuildComposite(). */
+  static void ApplyStatements(const StateDelta& delta, FilterState* state);
+
+  /* Applies a single resolved statement to `state`. */
+  static void ApplyStatement(const ResolvedStatement& statement,
+                             FilterState* state);
+
+  /* For each pair (a, b) with a ∈ set_A, b ∈ set_B (a ≠ b), adds the pair
+   to `state->filtered` or `state->invariant` depending on `is_invariant`.
+   Pairs already in `invariant` are never downgraded. */
+  static void AddPairsBetween(const std::vector<GeometryId>& set_A,
+                              const std::vector<GeometryId>& set_B,
+                              bool is_invariant, FilterState* state);
+
+  /* For each pair (a, b) with a ∈ set_A, b ∈ set_B (a ≠ b), removes the pair
+   from `state->filtered`. Pairs in `state->invariant` are not affected. */
+  static void RemovePairsBetween(const std::vector<GeometryId>& set_A,
+                                 const std::vector<GeometryId>& set_B,
+                                 FilterState* state);
+
+  /* Removes all entries in `state->filtered` and `state->invariant` that
+   involve `id`. Called when a geometry is unregistered. */
+  static void RemovePairsFor(GeometryId id, FilterState* state);
+
+  /* Applies the given declaration (using the extract_ids callback) to `state`.
+   Used by the public Apply(). */
+  static void ApplyDeclarationToState(
+      const CollisionFilterDeclaration& declaration,
+      const ExtractIds& extract_ids, bool is_invariant, FilterState* state);
+
+  /* Rebuilds filter_state_ from persistent_base_ plus all entries in
+   transient_history_ replayed in order. Called after RemoveDeclaration() or
+   RemoveGeometry() when transient history is active. */
+  void RebuildComposite();
+
+  /* The cached composite filter state: persistent_base_ with all transient
+   declarations applied in order. CanCollideWith() reads only from this, keeping
+   query cost at O(1) regardless of history depth. */
+  FilterState filter_state_;
+
+  /* The persistent base configuration. Apply() modifies this (and keeps
+   filter_state_ in sync). Transient declarations do not touch this directly. */
+  FilterState persistent_base_;
+
+  /* The set of geometry IDs registered with this filter system. Geometry
+   add/remove is never part of a transient declaration, so this is owned
+   directly by CollisionFilter. */
+  std::unordered_set<GeometryId> geometries_;
+
+  /* The ordered list of active transient declarations. Each entry stores
+   resolved statements (not a full NxN copy), so memory per entry is O(|A|+|B|)
+   rather than O(N²). */
+  std::vector<StateDelta> transient_history_;
 };
 
 }  // namespace internal

--- a/geometry/proximity/test/collision_filter_memory_test.cc
+++ b/geometry/proximity/test/collision_filter_memory_test.cc
@@ -1,0 +1,106 @@
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/limit_malloc.h"
+#include "drake/geometry/proximity/collision_filter.h"
+
+namespace drake {
+namespace geometry {
+
+class GeometrySetTester {
+ public:
+  static std::unordered_set<GeometryId> geometries(const GeometrySet& s,
+                                                   CollisionFilterScope) {
+    return s.geometries();
+  }
+};
+
+namespace internal {
+namespace {
+
+using drake::test::LimitMalloc;
+using drake::test::LimitMallocParams;
+
+/* CollisionFilter is, conceptually, a matrix reporting the pairwise filter
+ status between all geometry pairs. Implemented directly, we would expect the
+ matrix size to grow quadratically with the number of geometries.
+
+ CollisionFilter is specifically designed to avoid O(N^2) memory growth. This
+ test verifies that the footprint has linear growth.
+
+ It does so by counting the memory allocations performed. See implementation for
+ more details. */
+GTEST_TEST(CollisionFilterMemoryTest, MemoryGrowth) {
+  if (!LimitMalloc::IsSupportedConfiguration()) {
+    GTEST_SKIP() << "This test is not supported on this platform.";
+  }
+  constexpr int num_geometries = 10000;
+
+  CollisionFilter filter;
+  std::vector<GeometryId> ids;
+  LimitMallocParams unlimited;
+
+  {
+    LimitMalloc guard(unlimited);
+
+    for (int i = 0; i < num_geometries; ++i) {
+      ids.push_back(GeometryId::get_new_id());
+      filter.AddGeometry(ids.back());
+    }
+
+    /* If we generally allow CollisionFilter to make 10 allocations per
+     added geometry, that will still be far below O(N^2). */
+    ASSERT_GT(guard.num_allocations(), 0);
+    ASSERT_LT(guard.num_allocations(), 10 * num_geometries);
+  }
+
+  // Adds N unique pairs to the collision filter.
+  int a = 0;
+  int b = 1;
+  auto add_n_pairs = [&a, &b, &ids, &filter](int n) {
+    int i = 0;
+    for (; a < num_geometries; ++a) {
+      b = b >= num_geometries ? a + 1 : b;
+      for (; b < num_geometries; ++b) {
+        filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
+                         GeometrySet({ids[a], ids[b]})),
+                     &GeometrySetTester::geometries);
+        if (++i >= n) {
+          return;
+        }
+      }
+    }
+    // We want to know if we've requested added pairs that couldn't be added.
+    DRAKE_UNREACHABLE();
+  };
+
+  const int N = 10000;
+  int first_n_allocations = 0;
+  int second_n_allocations = 0;
+  {
+    LimitMalloc guard(unlimited);
+    add_n_pairs(N);
+    first_n_allocations = guard.num_allocations();
+  }
+  ASSERT_GT(first_n_allocations, 0);
+
+  {
+    LimitMalloc guard(unlimited);
+    add_n_pairs(N);
+    second_n_allocations = guard.num_allocations();
+  }
+
+  /* To be linear, the amount of work in allocating the second set of N should
+   be approximately the same as the first set of N. We'll provide generous
+   bounds to accommodate STL's memory allocation strategies but, nevertheless,
+   lie far away from O(N^2) patterns. */
+  EXPECT_GT(second_n_allocations, 0.5 * first_n_allocations);
+  EXPECT_LT(second_n_allocations, 2 * first_n_allocations);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/collision_filter_test.cc
+++ b/geometry/proximity/test/collision_filter_test.cc
@@ -275,7 +275,7 @@ TEST_F(CollisionFilterTest, TransientDeclarations) {
           Decl().ExcludeWithin(GeometrySet({pair.first, pair.second})),
           this->get_extract_ids_functor(), !invariant);
     }
-    if (temp_filter != f) return ::testing::AssertionFailure();
+    if (!temp_filter.IsEquivalent(f)) return ::testing::AssertionFailure();
     return ::testing::AssertionSuccess();
   };
 
@@ -350,7 +350,7 @@ TEST_F(CollisionFilterTest, TransientDeclarations) {
   /* Prop. D.2: Removing last declaration returns to previous state:
     P(D, E), (B, C), (B, E), (C, D) */
   EXPECT_TRUE(filter.RemoveDeclaration(id2));
-  ASSERT_TRUE(filter == filter_as_of_id1);
+  ASSERT_TRUE(filter.IsEquivalent(filter_as_of_id1));
 
   /* Re-apply the declaration (add_2_clear_2) to become:
     P(D, E), (A, B), (A, C), (C, D) */
@@ -417,10 +417,8 @@ TEST_F(CollisionFilterTest, TransientDeclarations) {
   ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
 }
 
-/* In this test, we're confirming the logic of operator== and operator!=. As
- such, we explicitly call those operators so we don't rely on gtest's
- implementation details. */
-TEST_F(CollisionFilterTest, Equality) {
+/* In this test, we're confirming the logic of IsEquivalent(). */
+TEST_F(CollisionFilterTest, Equivalency) {
   const GeometryId id_A = GeometryId::get_new_id();
   const GeometryId id_B = GeometryId::get_new_id();
   const GeometryId id_C = GeometryId::get_new_id();
@@ -429,60 +427,51 @@ TEST_F(CollisionFilterTest, Equality) {
   CollisionFilter filters2;
 
   /* Filters with no registered geometries are equal. */
-  EXPECT_EQ(filters1, filters2);
+  EXPECT_TRUE(filters1.IsEquivalent(filters2));
 
   /* Filters with different registered geometries are unequal. */
   /* Disjoint sets of geometries. */
   filters1.AddGeometry(id_A);
   filters2.AddGeometry(id_B);
-  EXPECT_FALSE(filters1 == filters2);
-  EXPECT_TRUE(filters1 != filters2);
+  EXPECT_FALSE(filters1.IsEquivalent(filters2));
   /* Sets have non-zero intersection, but are still not equal. */
   filters1.AddGeometry(id_C);
   filters2.AddGeometry(id_C);
-  EXPECT_FALSE(filters1 == filters2);
-  EXPECT_TRUE(filters1 != filters2);
+  EXPECT_FALSE(filters1.IsEquivalent(filters2));
   /* Sets have equal, non-empty sets of registered geometry and *no* filters. */
   filters1.AddGeometry(id_B);
   filters2.AddGeometry(id_A);
-  EXPECT_TRUE(filters1 == filters2);
-  EXPECT_FALSE(filters1 != filters2);
+  EXPECT_TRUE(filters1.IsEquivalent(filters2));
 
   /* Various forms of matched/mismatched filters. The correctness of this test
    depends on the order; do not re-order these operations. */
   filters1.Apply(
       CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_A, id_B})),
       this->get_extract_ids_functor());
-  EXPECT_FALSE(filters1 == filters2);
-  EXPECT_TRUE(filters1 != filters2);
+  EXPECT_FALSE(filters1.IsEquivalent(filters2));
   filters2.Apply(
       CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_A, id_B})),
       this->get_extract_ids_functor());
-  EXPECT_TRUE(filters1 == filters2);
-  EXPECT_FALSE(filters1 != filters2);
+  EXPECT_TRUE(filters1.IsEquivalent(filters2));
   filters1.Apply(
       CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_A, id_C})),
       this->get_extract_ids_functor());
-  EXPECT_FALSE(filters1 == filters2);
-  EXPECT_TRUE(filters1 != filters2);
+  EXPECT_FALSE(filters1.IsEquivalent(filters2));
   filters2.Apply(
       CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_B, id_C})),
       this->get_extract_ids_functor());
-  EXPECT_FALSE(filters1 == filters2);
-  EXPECT_TRUE(filters1 != filters2);
+  EXPECT_FALSE(filters1.IsEquivalent(filters2));
   filters1.Apply(
       CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_B, id_C})),
       this->get_extract_ids_functor());
   filters2.Apply(
       CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_A, id_C})),
       this->get_extract_ids_functor());
-  EXPECT_TRUE(filters1 == filters2);
-  EXPECT_FALSE(filters1 != filters2);
+  EXPECT_TRUE(filters1.IsEquivalent(filters2));
   filters1.Apply(
       CollisionFilterDeclaration().AllowWithin(GeometrySet({id_A, id_C})),
       this->get_extract_ids_functor());
-  EXPECT_FALSE(filters1 == filters2);
-  EXPECT_TRUE(filters1 != filters2);
+  EXPECT_FALSE(filters1.IsEquivalent(filters2));
 
   /* Neither set has filters between (A, *). The first simply doesn't have A,
    the second has A, but no filters. They should *not* be considered equal. */
@@ -490,8 +479,7 @@ TEST_F(CollisionFilterTest, Equality) {
   filters2.Apply(CollisionFilterDeclaration().AllowBetween(
                      GeometrySet(id_A), GeometrySet({id_B, id_C})),
                  this->get_extract_ids_functor());
-  EXPECT_FALSE(filters1 == filters2);
-  EXPECT_TRUE(filters1 != filters2);
+  EXPECT_FALSE(filters1.IsEquivalent(filters2));
 }
 
 }  // namespace internal

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -946,7 +946,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
                               other.anchored_objects_)) {
         return false;
       }
-      if (this->collision_filter_ != other.collision_filter_) return false;
+      if (!this->collision_filter_.IsEquivalent(other.collision_filter_)) {
+        return false;
+      }
       return true;
     }
     return false;


### PR DESCRIPTION
Rather than storing all O(N^2) pairwise relationships, we'll only store filtered information sparsely.

This also, mildly changes how we handle transient filter changes. We resolve the members of a declaration upon receipt, but we resolve the pairs during application (as generation of pairs is O(1)).

Resolves #24246

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24248)
<!-- Reviewable:end -->
