### PR TITLE
[wheel] Build Drake on Alma Linux with GCC 14 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,12 +706,12 @@ if(WITH_ROBOTLOCOMOTION_SNOPT AND WITH_SNOPT)
   )
 endif()
 
-if(WITH_ROBOTLOCOMOTION_SNOPT OR WITH_SNOPT)
+if(WITH_IPOPT OR WITH_ROBOTLOCOMOTION_SNOPT OR WITH_SNOPT)
   enable_language(Fortran)
 
   if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
     if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS ${MINIMUM_GNU_VERSION})
-      message(FATAL_ERROR
+      message(WARNING
         "Compilation with gfortran ${CMAKE_Fortran_COMPILER_VERSION} is NOT "
         "supported"
       )
@@ -723,8 +723,12 @@ if(WITH_ROBOTLOCOMOTION_SNOPT OR WITH_SNOPT)
     )
   endif()
 
-  string(APPEND BAZEL_CONFIG " --config=snopt")
+  string(APPEND BAZEL_REPO_ENV
+    " --repo_env=FC=${CMAKE_Fortran_COMPILER}")
+endif()
 
+if(WITH_ROBOTLOCOMOTION_SNOPT OR WITH_SNOPT)
+  string(APPEND BAZEL_CONFIG " --config=snopt")
   if(WITH_ROBOTLOCOMOTION_SNOPT)
     string(APPEND BAZEL_REPO_ENV " --repo_env=SNOPT_PATH=git")
   else()

--- a/common/network_policy.cc
+++ b/common/network_policy.cc
@@ -45,11 +45,7 @@ bool IsNetworkingAllowed(std::string_view component) {
   // to be congruent with their Drake version pin.
   bool match = false;
   for (auto subrange : env_view | std::views::split(':')) {
-    // Note: rather than simply string_view(subrange), we have to jump through
-    // hoops to maintain compatibility with our antiquated wheel construction.
-    const std::string_view token{
-        &*subrange.begin(),
-        static_cast<size_t>(std::ranges::distance(subrange))};
+    const std::string_view token{subrange};
     if (token == "none") {
       static const logging::Warn log_once(
           "Setting DRAKE_ALLOW_NETWORK={} combines 'none' with non-none "

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -104,7 +104,7 @@ can be specified by the user to be parsed by Drake's CMake and passed to the
 Bazel build.
 
 * [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
-* [`CMAKE_(C|CXX)_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html)
+* [`CMAKE_(C|CXX|Fortran)_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html)
 * [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)
 
 Building and installing Drake also requires a working installation of Python.

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -43,7 +43,8 @@ build --@drake//solvers:mosek_lazy_load=False
 EOF
 fi
 
-# Install Drake using our wheel-build-specific Python interpreter.
+# Install Drake using our wheel-build-specific Python interpreter and
+# C/CXX/Fortran compilers.
 # N.B. When you change anything here, also fix wheel/macos/build-wheel.sh.
 cmake ../drake-src \
     -DWITH_USER_EIGEN=OFF \
@@ -56,5 +57,8 @@ cmake ../drake-src \
     -DDRAKE_VERSION_OVERRIDE="${DRAKE_VERSION}" \
     -DDRAKE_GIT_SHA_OVERRIDE="${DRAKE_GIT_SHA}" \
     -DCMAKE_INSTALL_PREFIX=/tmp/drake-wheel-build/drake-dist \
-    -DPython_EXECUTABLE=/usr/local/bin/python
+    -DPython_EXECUTABLE=/usr/local/bin/python \
+    -DCMAKE_C_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/gcc \
+    -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++ \
+    -DCMAKE_Fortran_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/gfortran
 make install

--- a/tools/wheel/image/packages-almalinux
+++ b/tools/wheel/image/packages-almalinux
@@ -1,7 +1,9 @@
 # Core compilers.
-gcc
-gcc-c++
-gcc-gfortran
+# N.B. When you change anything here, also fix wheel/image/build-drake.sh and
+# wheel/licenses/gcc/copyright.
+gcc-toolset-14-gcc
+gcc-toolset-14-gcc-c++
+gcc-toolset-14-gcc-gfortran
 nasm
 
 # Clang (for mkdoc).

--- a/tools/wheel/licenses/gcc/copyright
+++ b/tools/wheel/licenses/gcc/copyright
@@ -13,7 +13,7 @@ Debian packaging is done by the Debian GCC Maintainers
   ftp://sourceware.org/pub/newlib/     (for newlib)
   git://git.savannah.gnu.org/gm2.git   (for Modula-2)
 
-The current gcc-11 source package is taken from the SVN gcc-11-branch.
+The current gcc-14 source package is taken from the git gcc-14-branch.
 
 Changes: See changelog.Debian.gz
 
@@ -22,16 +22,16 @@ library, and documentation as follows:
 
 Language       Compiler package  Library package    Documentation
 ---------------------------------------------------------------------------
-Ada            gnat-11          libgnat-11          gnat-11-doc
-BRIG           gccbrig-11       libhsail-rt0
-C              gcc-11                              gcc-11-doc
-C++            g++-11           libstdc++6         libstdc++6-11-doc
-D              gdc-11
-Fortran 95     gfortran-11      libgfortran5       gfortran-11-doc
-Go             gccgo-11         libgo0
-Objective C    gobjc-11         libobjc4
-Objective C++  gobjc++-11
-Modula-2       gm2-11           libgm2
+Ada            gnat-14          libgnat-14          gnat-14-doc
+C              gcc-14                              gcc-14-doc
+C++            g++-14           libstdc++6         libstdc++6-14-doc
+D              gdc-14
+Fortran 95     gfortran-14      libgfortran5       gfortran-14-doc
+Go             gccgo-14         libgo0
+Objective C    gobjc-14         libobjc4
+Objective C++  gobjc++-14
+Modula-2       gm2-14           libgm2
+Rust           gccrs-14
 
 For some language run-time libraries, Debian provides source files,
 development files, debugging symbols and libraries containing position-
@@ -39,22 +39,22 @@ independent code in separate packages:
 
 Language  Sources      Development   Debugging            Position-Independent
 ------------------------------------------------------------------------------
-C++                                  libstdc++6-11-dbg  libstdc++6-11-pic
-D         libphobos-11-dev
+C++                                  libstdc++6-14-dbg  libstdc++6-14-pic
+D         libphobos-14-dev
 
 Additional packages include:
 
 All languages:
 libgcc1, libgcc2, libgcc4       GCC intrinsics (platform-dependent)
-gcc-11-base                    Base files common to all compilers
-gcc-11-soft-float              Software floating point (ARM only)
-gcc-11-source                  The sources with patches
+gcc-14-base                    Base files common to all compilers
+gcc-14-soft-float              Software floating point (ARM only)
+gcc-14-source                  The sources with patches
 
 Ada:
-libgnat-util11-dev, libgnat-util11   GNAT version library
+libgnat-util14-dev, libgnat-util14   GNAT version library
 
 C:
-cpp-11, cpp-11-doc            GNU C Preprocessor
+cpp-14, cpp-14-doc            GNU C Preprocessor
 libssp0-dev, libssp0            GCC stack smashing protection library
 libquadmath0                    Math routines for the __float128 type
 fixincludes                     Fix non-ANSI header files
@@ -77,10 +77,7 @@ packages are identical to the ones for the lib packages.
 COPYRIGHT STATEMENTS AND LICENSING TERMS
 
 
-GCC is Copyright (C) 1986, 1987, 1988, 1989, 1990, 1991, 1992, 1993, 1994,
-1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
-2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
-Free Software Foundation, Inc.
+GCC is Copyright (C) 1986-2024 Free Software Foundation, Inc.
 
 GCC is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free
@@ -110,13 +107,15 @@ Runtime Library Exception (included in this file):
    gcc/tsystem.h, gcc/typeclass.h).
  - libatomic
  - libdecnumber
+ - libgm2
  - libgomp
+ - libgrust
  - libitm
  - libssp
  - libstdc++-v3
  - libobjc
  - libgfortran
- - The libgnat-11 Ada support library and libgnat-util11 library.
+ - The libgnat-14 Ada support library and libgnat-util14 library.
  - Various config files in gcc/config/ used in runtime libraries.
  - libvtv
 
@@ -214,7 +213,7 @@ THE SOFTWARE.
 
 The libffi library is licensed under the following terms:
 
-    libffi - Copyright (c) 1996-2003  Red Hat, Inc.
+    libffi - Copyright (c) 1996-2011  Red Hat, Inc.
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the
@@ -315,22 +314,24 @@ presumption that third-party software is unaffected by the copyleft
 requirements of the license of GCC.
 
 
-libquadmath/*.[hc]:
+libquadmath/
+  Copyright (C) 1992-2018 Free Software Foundation, Inc.
 
-   Copyright (C) 2010 Free Software Foundation, Inc.
-   Written by Francois-Xavier Coudert  <fxcoudert@gcc.gnu.org>
-   Written by Tobias Burnus  <burnus@net-b.de>
+  Written by Francois-Xavier Coudert  <fxcoudert@gcc.gnu.org>
+  Written by Tobias Burnus  <burnus@net-b.de>
+  Contributions by Ulrich Drepper <drepper@gnu.ai.mit.edu>
+  Conversion to long double by Jakub Jelinek <jj@ultra.linux.cz>
 
-This file is part of the libiberty library.
-Libiberty is free software; you can redistribute it and/or
-modify it under the terms of the GNU Library General Public
-License as published by the Free Software Foundation; either
-version 2 of the License, or (at your option) any later version.
+  This file is part of the libquadmath library.
+  Libquadmath is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
 
-Libiberty is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Library General Public License for more details.
+  Libiberty is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
 
 libquadmath/math:
 
@@ -348,90 +349,108 @@ atanq.c, expm1q.c, j0q.c, j1q.c, log1pq.c, logq.c:
     Lesser General Public License for more details.
 
 coshq.c, erfq.c, jnq.c, lgammaq.c, powq.c, roundq.c:
-   Changes for 128-bit __float128 are
-   Copyright (C) 2001 Stephen L. Moshier <moshier@na-net.ornl.gov>
-   and are incorporated herein by permission of the author.  The author
-   reserves the right to distribute this material elsewhere under different
-   copying permissions.  These modifications are distributed here under
-   the following terms:
+  Changes for 128-bit __float128 are
+  Copyright (C) 2001 Stephen L. Moshier <moshier@na-net.ornl.gov>
+  and are incorporated herein by permission of the author.  The author
+  reserves the right to distribute this material elsewhere under different
+  copying permissions.  These modifications are distributed here under
+  the following terms:
 
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
 
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
-ldexpq.c:
-   * Conversion to long double by Ulrich Drepper,
-   * Cygnus Support, drepper@cygnus.com.
+libquadmath/math/
 
 cosq_kernel.c, expq.c, sincos_table.c, sincosq.c, sincosq_kernel.c,
 sinq_kernel.c, truncq.c:
-   Copyright (C) 1997, 1999 Free Software Foundation, Inc.
+  Copyright (C) 1997, 1999 Free Software Foundation, Inc.
 
-   The GNU C Library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public
-   License as published by the Free Software Foundation; either
-   version 2.1 of the License, or (at your option) any later version.
+  The GNU C Library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
 
-   The GNU C Library is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Lesser General Public License for more details.
+  The GNU C Library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
-isinfq.c:
- * Written by J.T. Conklin <jtc@netbsd.org>.
- * Change for long double by Jakub Jelinek <jj@ultra.linux.cz>
- * Public domain.
+libquadmath/math/isinfq.c:
+  Written by J.T. Conklin <jtc@netbsd.org>.
+  Change for long double by Jakub Jelinek <jj@ultra.linux.cz>
+  Public domain.
 
-llroundq.c, lroundq.c, tgammaq.c:
-   Copyright (C) 1997, 1999, 2002, 2004 Free Software Foundation, Inc.
-   This file is part of the GNU C Library.
-   Contributed by Ulrich Drepper <drepper@cygnus.com>, 1997 and
-                  Jakub Jelinek <jj@ultra.linux.cz>, 1999.
+libquadmath/math/
+  llroundq.c, lroundq.c, tgammaq.c:
 
-   The GNU C Library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public
-   License as published by the Free Software Foundation; either
-   version 2.1 of the License, or (at your option) any later version.
+  Copyright (C) 1997, 1999, 2002, 2004 Free Software Foundation, Inc.
+  This file is part of the GNU C Library.
+  Contributed by Ulrich Drepper <drepper@cygnus.com>, 1997 and
+                 Jakub Jelinek <jj@ultra.linux.cz>, 1999.
 
-   The GNU C Library is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Lesser General Public License for more details.
+  The GNU C Library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
 
-log10q.c:
-   Cephes Math Library Release 2.2:  January, 1991
-   Copyright 1984, 1991 by Stephen L. Moshier
-   Adapted for glibc November, 2001
+  The GNU C Library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
+libquadmath/math/log10q.c:
+  Cephes Math Library Release 2.2:  January, 1991
+  Copyright 1984, 1991 by Stephen L. Moshier
+  Adapted for glibc November, 2001
 
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
 
-remaining files:
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
- * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
- *
- * Developed at SunPro, a Sun Microsystems, Inc. business.
- * Permission to use, copy, modify, and distribute this
- * software is freely granted, provided that this notice
- * is preserved.
+libquadmath/math/
+  acoshq.c, acosq.c, asinhq.c, asinq.c, atan2q.c, atanhq.c, ceilq.c,
+  copysignq.c, coshq.c, cosq.c, erfq.c, fabsq.c, finiteq.c, floorq.c,
+  fmodq.c, frexpq.c, hypotq.c, ilogbq.c, isnanq.c, jnq.c, ldexpq.c,
+  logbq.c, modfq.c, nearbyintq.c, nextafterq.c, powq.c, remainderq.c,
+  rem_pio2q.c, rintq.c, scalblnq.c, scalbnq.c, sinhq.c, sinq.c,
+  tanhq.c, tanq.c, tanq_kernel.c:
+
+  Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+  .
+  Developed at SunPro, a Sun Microsystems, Inc. business.
+  Permission to use, copy, modify, and distribute this
+  software is freely granted, provided that this notice
+  is preserved.
+
+libquadmath/math/
+  acosq.c, asinq.c, coshq.c, erfq.c, jnq.c, powq.c, sinhq.c, tanq_kernel.c:
+
+  In addition to the Sun Microsystems copyright:
+
+  Long double expansions are
+  Copyright (C) 2001 Stephen L. Moshier <moshier@na-net.ornl.gov>
+  and are incorporated herein by permission of the author.  The author
+  reserves the right to distribute this material elsewhere under different
+  copying permissions.  These modifications are distributed here under
+  the LGPL 2.1 or later.
 
 
 gcc/go/gofrontend, libgo:
 
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright (c) 2009-2023 The Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -461,8 +480,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 D:
-gdc-11                         GNU D Compiler
-libphobos-11-dev               D standard runtime library
+gdc-14                         GNU D Compiler
+libphobos-14-dev               D standard runtime library
 
 The D source package is made up of the following components.
 
@@ -471,21 +490,21 @@ The D front-end for GCC:
 
 Copyright (C) 2004-2007 David Friedman
 Modified by Vincenzo Ampolo, Michael Parrot, Iain Buclaw, (C) 2009, 2010
+Copyright (C) 2015-2024 Free Software Foundation, Inc.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
+the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 
 On Debian GNU/Linux systems, the complete text of the GNU General
 Public License is in `/usr/share/common-licenses/GPL', version 2 of this
-license in `/usr/share/common-licenses/GPL-2'.
-
+license in `/usr/share/common-licenses/GPL-3'.
 
 The DMD Compiler implementation of the D programming language:
  - d/dmd/*
 
-Copyright (c) 1999-2010 by Digital Mars
+Copyright (C) 1999-2023 by The D Language Foundation, All Rights Reserved
 All Rights Reserved
 written by Walter Bright
 http://www.digitalmars.com
@@ -498,9 +517,9 @@ license in `/usr/share/common-licenses/Artistic'.
 
 
 The Zlib data compression library:
- - d/phobos/etc/c/zlib/*
+ - zlib/*
 
- (C) 1995-2004 Jean-loup Gailly and Mark Adler
+ (C) 1995-2016 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -520,13 +539,14 @@ The Zlib data compression library:
 
 
 The Phobos standard runtime library:
- - d/phobos/*
+ - libphobos/*
 
 Unless otherwise marked within the file, each file in the source
 is under the following licenses:
 
-Copyright (C) 2004-2005 by Digital Mars, www.digitalmars.com
+Copyright (C) 2004-2022 by Digital Mars, www.digitalmars.com
 Written by Walter Bright
+Copyright (C) 2018-2023, The D Language Foundation
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages
@@ -550,55 +570,6 @@ By plainly marking modifications, something along the lines of adding to each
 file that has been changed a "Modified by Foo Bar" line
 underneath the "Written by" line would be adequate.
 
-The libhsail-rt library is licensed under the following terms:
-
-   Copyright (C) 2015-2017 Free Software Foundation, Inc.
-   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
-   for General Processor Tech.
-
-   Permission is hereby granted, free of charge, to any person obtaining a
-   copy of this software and associated documentation files
-   (the "Software"), to deal in the Software without restriction, including
-   without limitation the rights to use, copy, modify, merge, publish,
-   distribute, sublicense, and/or sell copies of the Software, and to
-   permit persons to whom the Software is furnished to do so, subject to
-   the following conditions:
-
-   The above copyright notice and this permission notice shall be included
-   in all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-   USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-libhsail-rt/rt/fp16.c is licensed under the following terms:
-
-   Copyright (C) 2008-2017 Free Software Foundation, Inc.
-   Contributed by CodeSourcery.
-
-   This file is free software; you can redistribute it and/or modify it
-   under the terms of the GNU General Public License as published by the
-   Free Software Foundation; either version 3, or (at your option) any
-   later version.
-
-   This file is distributed in the hope that it will be useful, but
-   WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   General Public License for more details.
-
-   Under Section 7 of GPL version 3, you are granted additional
-   permissions described in the GCC Runtime Library Exception, version
-   3.1, as published by the Free Software Foundation.
-
-   You should have received a copy of the GNU General Public License and
-   a copy of the GCC Runtime Library Exception along with this program;
-   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
-   <http://www.gnu.org/licenses/>.
-
 gcc/m2:
 gcc/m2/gm2-libiberty:
 gcc/m2/mc-boot/:
@@ -619,8 +590,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 
 gcc/m2/**/*.texi:
-Copyright (C) 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
-2011, 2012, 2012, 2013 Free Software Foundation, Inc.
+Copyright (C) 2000-2024 Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -632,7 +602,7 @@ gcc/m2/gm2-libs:
 gcc/m2/gm2-libs-min:
 gcc/m2/gm2-libs-pim:
 gcc/m2/gm2-libs-ch:
-Copyright (C) 2002-2019 Free Software Foundation, Inc.
+Copyright (C) 2002-2024 Free Software Foundation, Inc.
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -661,14 +631,14 @@ Copyright ISO/IEC (International Organization for Standardization
 and International Electrotechnical Commission) 1996, 1997, 1998,
 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010
 
-Copyright (C) 2001-2019 Free Software Foundation, Inc.
+Copyright (C) 2001-2024 Free Software Foundation, Inc.
 mix of GPL-3.0 and LGPL-2.1/3
 
-Copyright (C) 2001-2019 Free Software Foundation, Inc.
+Copyright (C) 2001-2024 Free Software Foundation, Inc.
 mix of GPL-3.0 and LGPL-2.1/3
 
 gcc/m2/examples:
-Copyright (C) 2005-2015 Free Software Foundation, Inc.
+Copyright (C) 2005-2024 Free Software Foundation, Inc.
 Mix of LGPL-2.1 and GPL-3.0.
 
 gcc/m2/images:
@@ -683,7 +653,7 @@ gcc/m2/el/gm2-mode.el:
 ;; file named COPYING.  Among other things, the copyright notice
 ;; and this notice must be preserved on all copies.
 
-Copyright (C) 2001-2018 Free Software Foundation, Inc.
+Copyright (C) 2001-2024 Free Software Foundation, Inc.
 Contributed by Gaius Mulley <gaius@glam.ac.uk>.
 Mix of GPL-3 and LGPL-2.1.
 
@@ -698,7 +668,7 @@ libgm2/libpim/:
 libgm2/liblog/:
 libgm2/libcor/:
 libgm2/libmin/:
-Copyright (C) 2002-2019 Free Software Foundation, Inc.
+Copyright (C) 2002-2024 Free Software Foundation, Inc.
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/tools/workspace/gfortran_internal/repository.bzl
+++ b/tools/workspace/gfortran_internal/repository.bzl
@@ -2,7 +2,8 @@ load("//tools/workspace:execute.bzl", "execute_or_fail", "which")
 
 def _gfortran_impl(repo_ctx):
     # Find the compiler.
-    compiler = which(repo_ctx, "gfortran")
+    fc_env = repo_ctx.os.environ.get("FC") or "gfortran"
+    compiler = which(repo_ctx, fc_env)
     if not compiler:
         fail("Could not find gfortran")
     compiler = str(compiler)
@@ -42,6 +43,9 @@ gfortran_internal_repository = repository_rule(
         Locate gfortran and alias it to `:compiler`; locate libgfortran
         and alias it to `:runtime`.
     """,
+    environ = [
+        "FC",
+    ],
     local = True,
     configure = True,
     implementation = _gfortran_impl,


### PR DESCRIPTION
Install GCC 14 from the alternative 'toolset' package over the GCC that ships with Alma Linux to improve parity between wheel builds and other flavors.

To support this, allow specifying a particular Fortran compiler through the CMake interface to Drake's gfortran rules.

Remove the hack introduced in #24239 since we now have a newer compiler that can grok the original C++23-based implementation.

Closes #24238.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24249)
<!-- Reviewable:end -->
