### PR TITLE
Remove all uses of fmt::ostream_formatter

### DIFF
--- a/bindings/generated_docstrings/multibody_inverse_kinematics.h
+++ b/bindings/generated_docstrings/multibody_inverse_kinematics.h
@@ -3993,6 +3993,11 @@ Note:
           const char* doc = R"""()""";
         } ctor;
       } UnitQuaternionConstraint;
+      // Symbol: drake::multibody::to_string
+      struct /* to_string */ {
+        // Source: drake/multibody/inverse_kinematics/differential_inverse_kinematics.h
+        const char* doc = R"""()""";
+      } to_string;
     } multibody;
   } drake;
 } pydrake_doc_multibody_inverse_kinematics;

--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -22,7 +22,8 @@
 #include <type_traits>
 
 #include <Eigen/Dense>
-#include <fmt/ostream.h>
+
+#include "drake/common/fmt.h"
 
 // clang-format off
 namespace Eigen {
@@ -554,7 +555,4 @@ inline const AutoDiffScalar<VectorXd> max(const AutoDiffScalar<VectorXd>& a,
 }  // namespace Eigen
 // clang-format on
 
-namespace fmt {
-template <>
-struct formatter<drake::AutoDiffXd> : fmt::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, Eigen, AutoDiffScalar<Eigen::VectorXd>, x, x.value())

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -34,9 +34,7 @@ When logging a third-party type whose only affordance for string output is
 `operator<<`, use fmt::streamed(); see its documentation for details. This is
 very rare (only a couple uses in Drake so far).
 
-When implementing a string output for a Drake type, eventually this page will
-demonstrate how to use fmt::formatter<T>. In the meantime, you can implement
-`operator<<` and use fmt::ostream_formatter, or else use the macro helper
+To implement a string output for a Drake type, use the macro helper
 DRAKE_FORMATTER_AS(). Grep around in Drake's existing code to find examples.
 
 @warning This file should only be included from cc files, not header files.

--- a/geometry/proximity/test/characterization_utilities.cc
+++ b/geometry/proximity/test/characterization_utilities.cc
@@ -21,37 +21,28 @@ using Eigen::Vector3d;
 using math::RigidTransform;
 using std::vector;
 
-std::ostream& operator<<(std::ostream& out, GeometryType s) {
+std::string_view to_string(GeometryType s) {
   switch (s) {
     case kBox:
-      out << "Box";
-      break;
+      return "Box";
     case kCapsule:
-      out << "Capsule";
-      break;
+      return "Capsule";
     case kConvex:
-      out << "Convex";
-      break;
+      return "Convex";
     case kCylinder:
-      out << "Cylinder";
-      break;
+      return "Cylinder";
     case kEllipsoid:
-      out << "Ellipsoid";
-      break;
+      return "Ellipsoid";
     case kHalfSpace:
-      out << "HalfSpace";
-      break;
+      return "HalfSpace";
     case kMesh:
-      out << "Mesh";
-      break;
+      return "Mesh";
     case kPoint:
-      out << "Point";
-      break;
+      return "Point";
     case kSphere:
-      out << "Sphere";
-      break;
+      return "Sphere";
   }
-  return out;
+  DRAKE_UNREACHABLE();
 }
 
 QueryInstance::QueryInstance(GeometryType shape1_in, GeometryType shape2_in,

--- a/geometry/proximity/test/characterization_utilities.h
+++ b/geometry/proximity/test/characterization_utilities.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -22,6 +23,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_export.h"
+#include "drake/common/fmt.h"
 #include "drake/common/unused.h"
 #include "drake/geometry/proximity/collision_filter.h"
 #include "drake/geometry/shape_specification.h"
@@ -78,7 +80,7 @@ enum GeometryType {
   kPoint,
   kSphere
 };
-std::ostream& operator<<(std::ostream& out, GeometryType s);
+std::string_view to_string(GeometryType s);
 
 /* This represents a single cell of the table -- an instance of invoking a
  proximity query. It explicitly calls out the two shapes and the expected
@@ -441,11 +443,7 @@ class CharacterizeResultTest : public ::testing::Test {
 }  // namespace geometry
 }  // namespace drake
 
-namespace fmt {
-template <>
-struct formatter<drake::geometry::internal::GeometryType>
-    : fmt::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::geometry::internal, GeometryType, x, to_string(x))
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class ::drake::geometry::internal::CharacterizeResultTest);

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -2798,8 +2798,7 @@ TEST_F(RenderEngineGlTest, SingleLight) {
       if (!config.target_type.empty() && l_type != config.target_type) {
         continue;
       }
-      SCOPED_TRACE(
-          fmt::format("{} - {}", fmt::streamed(l_type), config.description));
+      SCOPED_TRACE(fmt::format("{} - {}", l_type, config.description));
       LightParameter test_light = config.light;
       test_light.type = l_type;
       const RenderEngineGlParams params{.lights = {test_light}};

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -206,6 +206,10 @@ struct TestColor {
 
   bool operator!=(const TestColor& c) const { return !(*this == c); }
 
+  std::string to_string() const {
+    return fmt::format("({}, {}, {}, {})", r, g, b, a);
+  }
+
   int r{0};
   int g{0};
   int b{0};
@@ -213,8 +217,7 @@ struct TestColor {
 };
 
 std::ostream& operator<<(std::ostream& out, const TestColor& c) {
-  out << "(" << c.r << ", " << c.g << ", " << c.b << ", " << c.a << ")";
-  return out;
+  return out << c.to_string();
 }
 
 // Background (sky) and terrain colors.
@@ -786,7 +789,7 @@ TEST_F(RenderEngineVtkTest, ControlBackgroundColor) {
         .backend = FLAGS_backend,
     };
     RenderEngineVtk engine(params);
-    Render(fmt::to_string(fmt::streamed(bg)), &engine);
+    Render(bg.to_string(), &engine);
     VerifyUniformColor(bg);
   }
 }
@@ -1992,7 +1995,7 @@ TEST_F(RenderEngineVtkTest, SingleLight) {
         continue;
       }
       const std::string unambiguous_description =
-          fmt::format("{} - {}", fmt::streamed(l_type), config.description);
+          fmt::format("{} - {}", l_type, config.description);
       SCOPED_TRACE(unambiguous_description);
       LightParameter test_light = config.light;
       test_light.type = l_type;

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.cc
@@ -53,17 +53,21 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematicsImpl(
 
 }  // namespace
 
-std::ostream& operator<<(std::ostream& os,
-                         const DifferentialInverseKinematicsStatus value) {
+std::string_view to_string(const DifferentialInverseKinematicsStatus value) {
   switch (value) {
-    case (DifferentialInverseKinematicsStatus::kSolutionFound):
-      return os << "Solution found.";
-    case (DifferentialInverseKinematicsStatus::kNoSolutionFound):
-      return os << "No solution found.";
-    case (DifferentialInverseKinematicsStatus::kStuck):
-      return os << "Stuck!";
+    case DifferentialInverseKinematicsStatus::kSolutionFound:
+      return "Solution found.";
+    case DifferentialInverseKinematicsStatus::kNoSolutionFound:
+      return "No solution found.";
+    case DifferentialInverseKinematicsStatus::kStuck:
+      return "Stuck!";
   }
   DRAKE_UNREACHABLE();
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const DifferentialInverseKinematicsStatus value) {
+  return os << to_string(value);
 }
 
 const std::vector<std::shared_ptr<solvers::LinearConstraint>>&

--- a/multibody/inverse_kinematics/differential_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/differential_inverse_kinematics.h
@@ -3,17 +3,19 @@
 #include <limits>
 #include <memory>
 #include <optional>
-#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include <fmt/ostream.h>
+// Remove with deprecation 2026-07-01.
+#include <ostream>
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/fmt.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/math/spatial_algebra.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -29,6 +31,12 @@ enum class DifferentialInverseKinematicsStatus {
                      /// likely due to constraints.
 };
 
+std::string_view to_string(DifferentialInverseKinematicsStatus value);
+
+DRAKE_DEPRECATED(
+    "2026-07-01",
+    "Use fmt functions instead (e.g., fmt::format(), fmt::to_string(), "
+    "fmt::print()). Refer to GitHub issue #17742 for more information.")
 std::ostream& operator<<(std::ostream& os,
                          const DifferentialInverseKinematicsStatus value);
 
@@ -522,8 +530,5 @@ DifferentialInverseKinematicsResult DoDifferentialInverseKinematics(
 }  // namespace multibody
 }  // namespace drake
 
-namespace fmt {
-template <>
-struct formatter<drake::multibody::DifferentialInverseKinematicsStatus>
-    : fmt::ostream_formatter {};
-}  // namespace fmt
+DRAKE_FORMATTER_AS(, drake::multibody, DifferentialInverseKinematicsStatus, x,
+                   ::drake::multibody::to_string(x))

--- a/solvers/evaluator_base.h
+++ b/solvers/evaluator_base.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Deprecate `operator<<` for `DifferentialInverseKinematicsStatus`.

Towards #17742.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24252)
<!-- Reviewable:end -->
