### PR TITLE
Support user-provided zlib on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,21 @@ function(symlink_external_repository_libs NAME TARGET)
 
   function(_create_links lib_dir location)
     cmake_path(GET location FILENAME basename)
-    file(CREATE_LINK "${location}" "${lib_dir}/${basename}" SYMBOLIC)
+    cmake_path(GET basename EXTENSION ext)
+    if (ext STREQUAL ".tbd")
+      # rules_cc doesn't allow the .tbd linker script extension on macOS (in
+      # neither cc_library's `srcs` nor cc_import's `shared_library`
+      # arguments), so we must trick the rule by providing a symlink with the
+      # .dylib extension here. We could alternatively consider using the
+      # `additional_linker_inputs` argument, but that introduces a lot more
+      # logic for compatibility with Linux, or when the found library on macOS
+      # doesn't use a .tbd linker script.
+      cmake_path(GET basename STEM stem)
+      file(CREATE_LINK "${location}" "${lib_dir}/${stem}.dylib" SYMBOLIC)
+      return()
+    else()
+      file(CREATE_LINK "${location}" "${lib_dir}/${basename}" SYMBOLIC)
+    endif()
     # Link the SONAME spelling in case of shared libraries.
     # If the basename does not match this pattern, this part is all a no-op.
     if(ARG_USE_SO_MINOR_VERSION)
@@ -567,26 +581,11 @@ endif()
 
 option(WITH_USER_ZLIB "Use user-provided ZLIB" ${DEFAULT_WITH_USER_LIBS})
 
-if(APPLE)
-  # TODO(jwnimmer-tri) Unfortunately we can't use find_package() here because
-  # symlink_external_repository_libs() is not compatible with the `zlib.tbd`
-  # linker script that CMake finds on macOS. We should work on fixing that
-  # routine, and then remove this APPLE-specific logic. When doing so, don't
-  # forget to fix our doc/_pages/from_source.md documentation at the same time.
-  if(WITH_USER_ZLIB)
-    string(APPEND BAZEL_REPO_ENV
-        " --@drake//tools/flags:zlib_repo=hardcoded")
-  else()
-    string(APPEND BAZEL_REPO_ENV
-        " --@drake//tools/flags:zlib_repo=source")
-  endif()
-else()
-  if(WITH_USER_ZLIB)
-    find_package(ZLIB REQUIRED)
-    symlink_external_repository_includes(zlib ZLIB::ZLIB)
-    symlink_external_repository_libs(zlib ZLIB::ZLIB)
-    override_module(zlib)
-  endif()
+if(WITH_USER_ZLIB)
+  find_package(ZLIB REQUIRED)
+  symlink_external_repository_includes(zlib ZLIB::ZLIB)
+  symlink_external_repository_libs(zlib ZLIB::ZLIB)
+  override_module(zlib)
 endif()
 
 set(BAZEL_CONFIG)

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -163,8 +163,6 @@ Adjusting open-source dependencies:
   * This option is only available if pkg-config is at least version 1.0.
 * `WITH_USER_ZLIB` (default `ON`). When `ON`, uses `find_package(ZLIB)` to
   locate a user-provided `ZLIB::ZLIB` library instead of building from source.
-  * Caveat: on macOS, for now this hardcodes `-lz`
-    instead of calling `find_package`.
 * `WITH_CLARABEL` (default `ON`). When `ON`, enables the `ClarabelSolver`
   in the build. See `ClarabelSolver::available()` to retrieve this setting at
   runtime.


### PR DESCRIPTION
Note that Homebrew zlib, which installs to `/opt/homebrew/opt/zlib`, does _not_ provide a `zlib.tbd` linker script, but Xcode/system zlib, which with Xcode 26.3 installs to `/Applications/Xcode-26.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/`, _does_ provide `zlib.tbd`. This means our logic on macOS must be compatible with both, which it is as written.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24254)
<!-- Reviewable:end -->
