### PR TITLE
[common] Switch FileSource printing to stock fmt

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -3702,9 +3702,14 @@ Raises:
     // Symbol: drake::to_string
     struct /* to_string */ {
       // Source: drake/common/file_source.h
-      const char* doc_1args_source = R"""(Returns a string representation.)""";
+      const char* doc_deprecated =
+R"""((Deprecated.)
+
+Deprecated:
+    Use fmt∷to_string instead, with ``#include <fmt/std.h>``. This
+    will be removed from Drake on or after 2026-07-01.)""";
       // Source: drake/common/identifier.h
-      const char* doc_1args_constdrakeIdentifier =
+      const char* doc =
 R"""(Enables use of identifiers with to_string. It requires ADL to work.
 So, it should be invoked as: ``to_string(id);`` and should be preceded
 by ``using std∷to_string``.)""";

--- a/common/file_source.cc
+++ b/common/file_source.cc
@@ -1,23 +1,12 @@
 #include "drake/common/file_source.h"
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
-
-#include "drake/common/overloaded.h"
+#include <fmt/std.h>
 
 namespace drake {
+
 std::string to_string(const FileSource& source) {
-  // TODO(jwnimmer-tri) Once we have a new enough fmt with `std.h`, a
-  // simple `return fmt::to_string(source)` here will suffice.
-  return std::visit(overloaded{[](const std::filesystem::path& path) {
-                                 // We'll delegate to the built-in operator<<,
-                                 // which properly quotes the path.
-                                 return fmt::to_string(fmt::streamed(path));
-                               },
-                               [](const MemoryFile& file) {
-                                 return fmt::to_string(file);
-                               }},
-                    source);
+  return fmt::to_string(source);
 }
 
 }  // namespace drake

--- a/common/file_source.h
+++ b/common/file_source.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <variant>
 
-#include "drake/common/fmt.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/memory_file.h"
 
 namespace drake {
@@ -12,9 +12,8 @@ namespace drake {
 /** Represents a file. The file can be on-disk or in-memory. */
 using FileSource = std::variant<std::filesystem::path, MemoryFile>;
 
-/** Returns a string representation. */
+DRAKE_DEPRECATED("2026-07-01",
+                 "Use fmt::to_string instead, with `#include <fmt/std.h>`.")
 std::string to_string(const FileSource& source);
 
 }  // namespace drake
-
-DRAKE_FORMATTER_AS(, drake, FileSource, x, drake::to_string(x))

--- a/common/fmt.h
+++ b/common/fmt.h
@@ -163,6 +163,8 @@ Drake drops support for earlier version of fmt. */
       const Base* const self = this;                                           \
       return const_cast<Base*>(self)->format(MyTraits::Functor::call(x), ctx); \
     }                                                                          \
+    /* Disable re-quoting the return value of the EXPR (e.g., in std::map). */ \
+    void set_debug_format() = delete;                                          \
   };                                                                           \
   } /* namespace drake::internal::formatter_as */                              \
                                                                                \

--- a/common/test/file_source_test.cc
+++ b/common/test/file_source_test.cc
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <string>
 
+#include <fmt/std.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/memory_file.h"
@@ -22,12 +23,20 @@ GTEST_TEST(FileSourceTest, DefaultPath) {
 }
 
 GTEST_TEST(FileSourceTest, ToString) {
-  EXPECT_EQ(to_string(FileSource("a/b/c")), "\"a/b/c\"");
-  EXPECT_EQ(fmt::to_string(FileSource("a/b/c")), "\"a/b/c\"");
+  EXPECT_EQ(fmt::to_string(FileSource("a/b/c")), "variant(\"a/b/c\")");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(to_string(FileSource("a/b/c")), "variant(\"a/b/c\")");
+#pragma GCC diagnostic pop
 
   const MemoryFile file("012345789", ".ext", "hint");
-  EXPECT_EQ(to_string(FileSource(file)), file.to_string());
-  EXPECT_EQ(fmt::to_string(FileSource(file)), file.to_string());
+  EXPECT_EQ(fmt::to_string(FileSource(file)),
+            fmt::format("variant({})", file.to_string()));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(to_string(FileSource(file)),
+            fmt::format("variant({})", file.to_string()));
+#pragma GCC diagnostic pop
 }
 
 /* Quick and dirty struct that has a FileSource and can be serialized. */

--- a/geometry/in_memory_mesh.cc
+++ b/geometry/in_memory_mesh.cc
@@ -1,55 +1,18 @@
 #include "drake/geometry/in_memory_mesh.h"
 
-#include <algorithm>
-#include <vector>
-
 #include <fmt/format.h>
 #include <fmt/ranges.h>
-
-#include "drake/common/drake_assert.h"
-
-// Drake currently supports a wide range of fmt versions (9..11), which vary
-// heavily in terms of how they format maps (i.e., range-of-pairs) and variant.
-// When formatting the supported_files, we can't use fmt's built-in std::map
-// formatter because as of fmt 11 it forces the "debug presentation format"
-// which when combined with our DRAKE_FORMATTER_AS on FileSource ends up
-// re-quoting the formatted FileSource as if it were a string. Instead, we'll
-// use a helper struct that more directly controls the format of a map entry.
-// TODO(jwnimmer-tri) We can clean this up even further by removing
-// DRAKE_FORMATTER_AS on FileSource because variant<> is natively formattable.
-namespace drake {
-namespace {
-struct FormattableSupportingFileMapEntry {
-  std::string to_string() const {
-    DRAKE_DEMAND(key != nullptr && value != nullptr);
-    return fmt::format(
-        "{:?}: {}",  // Use '?' specifier to format the key as a string literal.
-        *key, *value);
-  }
-  const std::string* key{};
-  const FileSource* value{};
-};
-}  // namespace
-}  // namespace drake
-
-DRAKE_FORMATTER_AS(, drake, FormattableSupportingFileMapEntry, x, x.to_string())
+#include <fmt/std.h>
 
 namespace drake {
 namespace geometry {
 
 std::string InMemoryMesh::to_string() const {
-  std::vector<FormattableSupportingFileMapEntry> supporting_encoded;
-  std::transform(supporting_files.cbegin(), supporting_files.cend(),
-                 std::back_inserter(supporting_encoded),
-                 [](const auto& key_value) {
-                   return FormattableSupportingFileMapEntry{&key_value.first,
-                                                            &key_value.second};
-                 });
-  return fmt::format("InMemoryMesh(mesh_file={}{})", mesh_file,
-                     supporting_files.empty()
-                         ? std::string{}
-                         : fmt::format(", supporting_files={{{}}}",
-                                       fmt::join(supporting_encoded, ", ")));
+  return fmt::format(
+      "InMemoryMesh(mesh_file={}{})", mesh_file,
+      supporting_files.empty()
+          ? std::string{}
+          : fmt::format(", supporting_files={}", supporting_files));
 }
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/test/in_memory_mesh_test.cc
+++ b/geometry/test/in_memory_mesh_test.cc
@@ -21,14 +21,14 @@ GTEST_TEST(InMemoryMeshTest, ToString) {
   mesh.supporting_files.emplace("name", file);
   EXPECT_EQ(mesh.to_string(),
             fmt::format("InMemoryMesh(mesh_file={file}, "
-                        "supporting_files={{\"name\": {file}}})",
+                        "supporting_files={{\"name\": variant({file})}})",
                         fmt::arg("file", file_str)));
 
   mesh.supporting_files.emplace("name2", file);
   EXPECT_EQ(mesh.to_string(),
             fmt::format("InMemoryMesh(mesh_file={file}, "
-                        "supporting_files={{\"name\": {file}, "
-                        "\"name2\": {file}}})",
+                        "supporting_files={{\"name\": variant({file}), "
+                        "\"name2\": variant({file})}})",
                         fmt::arg("file", file_str)));
 }
 


### PR DESCRIPTION
This adds a `variant(...)` notation in the string output, bringing us back on par with the canonical output format for variants.

Deprecate `to_string(FileSource)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24255)
<!-- Reviewable:end -->
