### PR TITLE
[geometry] Rewrite memoization for thread-safety and C++20

### DIFF
--- a/bindings/generated_docstrings/geometry.h
+++ b/bindings/generated_docstrings/geometry.h
@@ -29,6 +29,7 @@
 // #include "drake/geometry/internal_frame.h"
 // #include "drake/geometry/internal_geometry.h"
 // #include "drake/geometry/kinematics_vector.h"
+// #include "drake/geometry/lazy_shared.h"
 // #include "drake/geometry/make_mesh_for_deformable.h"
 // #include "drake/geometry/mesh_deformation_interpolator.h"
 // #include "drake/geometry/mesh_source.h"

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -46,6 +46,7 @@ drake_cc_package_library(
         ":internal_frame",
         ":internal_geometry",
         ":kinematics_vector",
+        ":lazy_shared",
         ":make_mesh_for_deformable",
         ":mesh_deformation_interpolator",
         ":mesh_source",
@@ -302,6 +303,14 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "lazy_shared",
+    hdrs = ["lazy_shared.h"],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "poisson_disk",
     srcs = ["poisson_disk.cc"],
     hdrs = ["poisson_disk.h"],
@@ -438,6 +447,7 @@ drake_cc_library(
         ":geometry_ids",
         ":geometry_roles",
         ":internal_frame",
+        ":lazy_shared",
         ":make_mesh_for_deformable",
         ":shape_specification",
         "//common:copyable_unique_ptr",
@@ -472,6 +482,7 @@ drake_cc_library(
     srcs = ["shape_specification.cc"],
     hdrs = ["shape_specification.h"],
     deps = [
+        ":lazy_shared",
         ":mesh_source",
         "//common:essential",
         "//geometry/proximity:polygon_surface_mesh",
@@ -1064,6 +1075,13 @@ drake_cc_googletest(
     name = "in_memory_mesh_test",
     deps = [
         ":in_memory_mesh",
+    ],
+)
+
+drake_cc_googletest(
+    name = "lazy_shared_test",
+    deps = [
+        ":lazy_shared",
     ],
 )
 

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -74,24 +74,9 @@ const GeometryProperties* InternalGeometry::properties(Role role) const {
 }
 
 const std::optional<Obb>& InternalGeometry::GetObb() const {
-  // TODO(jwnimmer-tri) Once we drop support for Jammy (i.e., once we can use
-  // GCC >= 12 as our minimum), then we should respell these atomics to use the
-  // C++20 syntax and remove the warning suppressions here and below. (We need
-  // the warning suppression because newer Clang complains.)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  std::shared_ptr<std::optional<Obb>> check = std::atomic_load(&obb_);
-#pragma GCC diagnostic pop
-  if (check == nullptr) {
-    // Note: This approach means that multiple threads *may* redundantly compute
-    // the OBB; but only the first one will set the OBB.
-    auto new_obb = std::make_shared<std::optional<Obb>>(CalcObb(*shape_spec_));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    std::atomic_compare_exchange_strong(&obb_, &check, new_obb);
-#pragma GCC diagnostic pop
-  }
-  return *obb_;
+  return obb_.GetOrMake([this]() {
+    return std::make_shared<std::optional<Obb>>(CalcObb(*shape_spec_));
+  });
 }
 
 }  // namespace internal

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -12,6 +12,7 @@
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/internal_frame.h"
+#include "drake/geometry/lazy_shared.h"
 #include "drake/geometry/proximity/obb.h"
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
@@ -281,9 +282,7 @@ class InternalGeometry {
   // frame, G. It's a nullptr if the geometry is rigid.
   copyable_unique_ptr<VolumeMesh<double>> reference_mesh_;
 
-  // Allows the deferred computation of the OBB on an otherwise const
-  // InternalGeometry.
-  mutable std::shared_ptr<std::optional<Obb>> obb_{nullptr};
+  LazyShared<std::optional<Obb>> obb_;
 };
 
 }  // namespace internal

--- a/geometry/lazy_shared.h
+++ b/geometry/lazy_shared.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// LLVM libc++ doesn't support std::atomic<std::shared_ptr<T>>, so will need a
+// different implementation; https://github.com/llvm/llvm-project/issues/99980.
+#ifdef __cpp_lib_atomic_shared_ptr
+
+// This is the implementation targeted at libstdc++ (GCC).
+
+/* Wrapper that stores a T, with the ability to initalize it on first use ("lazy
+evaluation") in a thread-safe way.
+
+In case multiple threads call GetOrMake() concurrently, this class allows for
+benign races where the factory function might be called twice but only one
+winner is retained. (Implementing at-most-once instead of at-least-once would
+be slower in the common case of no thread contention.)
+
+Once this object has been initialized via call to GetOrMake(), any copies of it
+(via copy-construction or copy-assignment) will share the same underlying
+instance of `T` using reference counting (ala shared_ptr).
+
+Moving from an initialized object (via move-construction or move-assignement)
+will reset the moved-from object back to empty. */
+template <typename T>
+class LazyShared {
+ public:
+  /* Constructs an empty object. */
+  LazyShared() = default;
+
+  /* Copy construction shares ownership of existing data.
+  See class overview for details. */
+  LazyShared(const LazyShared& other) : data_(other.data_.load()) {}
+
+  /* Move construction transfers ownership of existing data.
+  See class overview for details. */
+  LazyShared(LazyShared&& other) noexcept
+      : data_(other.data_.exchange(nullptr)) {}
+
+  /* Copy assignment shares ownership of existing data.
+  See class overview for details. */
+  LazyShared& operator=(const LazyShared& other) {
+    if (this != &other) {
+      data_.store(other.data_.load());
+    }
+    return *this;
+  }
+
+  /* Move assignment transfers ownership of existing data.
+  See class overview for details. */
+  LazyShared& operator=(LazyShared&& other) noexcept {
+    if (this != &other) {
+      data_.store(other.data_.exchange(nullptr));
+    }
+    return *this;
+  }
+
+  ~LazyShared() = default;
+
+  /* If this object already has a value (e.g., if GetOrMake() has previously
+  been called on this object), then returns the stored result. Otherwise, calls
+  factory(), stores the result into this, and returns it. The `factory` function
+  should return a `shared_ptr<const T>` (or something convertible to a
+  `shared_ptr<const T>`), and should not have side-effects since it might be
+  called twice. */
+  template <typename Factory>
+  const T& GetOrMake(Factory&& factory) const
+    requires(std::is_invocable_r_v<std::shared_ptr<const T>, Factory>)
+  {
+    std::shared_ptr<const T> result = data_.load();
+    if (result == nullptr) {
+      std::shared_ptr<const T> candidate = factory();
+      DRAKE_DEMAND(candidate != nullptr);
+      if (data_.compare_exchange_strong(/* expected = */ result,
+                                        /* desired = */ candidate)) {
+        // The `candidate` was stored into `data_`; it's what we should return.
+        result = std::move(candidate);
+      } else {
+        // The compare_exchange_strong overwrote `result` with the (non-null)
+        // value computed by some other thread.
+      }
+    }
+    return *result;
+  }
+
+ private:
+  mutable std::atomic<std::shared_ptr<const T>> data_;
+};
+
+#else  // __cpp_lib_atomic_shared_ptr
+
+// This is the implementation targeted at libc++ (LLVM). It is exactly the same
+// logic as the other implementation above, but uses the deprecated atomic
+// operation functions, instead of the std::atomic template class. Refer to the
+// other implementation above for comments and explanation.
+
+template <typename T>
+class LazyShared {
+ public:
+  LazyShared() = default;
+  LazyShared(const LazyShared& other) : data_(std::atomic_load(&other.data_)) {}
+  LazyShared(LazyShared&& other) noexcept
+      : data_(std::atomic_exchange(&other.data_, std::shared_ptr<const T>())) {}
+  LazyShared& operator=(const LazyShared& other) {
+    if (this != &other) {
+      std::atomic_store(&data_, std::atomic_load(&other.data_));
+    }
+    return *this;
+  }
+  LazyShared& operator=(LazyShared&& other) noexcept {
+    if (this != &other) {
+      std::atomic_store(&data_, std::atomic_exchange(
+                                    &other.data_, std::shared_ptr<const T>()));
+    }
+    return *this;
+  }
+  ~LazyShared() = default;
+  template <typename Factory>
+  const T& GetOrMake(Factory&& factory) const
+    requires(std::is_invocable_r_v<std::shared_ptr<const T>, Factory>)
+  {
+    std::shared_ptr<const T> result = std::atomic_load(&data_);
+    if (result == nullptr) {
+      std::shared_ptr<const T> candidate = factory();
+      DRAKE_DEMAND(candidate != nullptr);
+      if (std::atomic_compare_exchange_strong(&data_, &result, candidate)) {
+        result = std::move(candidate);
+      }
+    }
+    return *result;
+  }
+
+ private:
+  mutable std::shared_ptr<const T> data_;
+};
+
+#endif  // __cpp_lib_atomic_shared_ptr
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -36,35 +36,6 @@ namespace drake {
 namespace geometry {
 namespace {
 
-// Computes a convex hull and assigns it to the given shared pointer in a
-// thread-safe manner. Only does work if the shared_ptr is null (i.e., there is
-// no convex hull yet). Used by Mesh::GetConvexHull() and
-// Convex::GetConvexHull(). Note: the correctness of this function is tested in
-// shape_specification_thread_test.cc.
-void ComputeConvexHullAsNecessary(
-    std::shared_ptr<PolygonSurfaceMesh<double>>* hull_ptr,
-    const MeshSource& mesh_source, const Vector3<double>& scale) {
-  // TODO(jwnimmer-tri) Once we drop support for Jammy (i.e., once we can use
-  // GCC >= 12 as our minimum), then we should respell these atomics to use the
-  // C++20 syntax and remove the warning suppressions here and below. (We need
-  // the warning supression because newer Clang complains.)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  std::shared_ptr<PolygonSurfaceMesh<double>> check =
-      std::atomic_load(hull_ptr);
-#pragma GCC diagnostic pop
-  if (check == nullptr) {
-    // Note: This approach means that multiple threads *may* redundantly compute
-    // the convex hull; but only the first one will set the hull.
-    auto new_hull = std::make_shared<PolygonSurfaceMesh<double>>(
-        internal::MakeConvexHull(mesh_source, scale));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    std::atomic_compare_exchange_strong(hull_ptr, &check, new_hull);
-#pragma GCC diagnostic pop
-  }
-}
-
 // Support for Mesh and Convex do_to_string(). It does the hard work of
 // converting the MeshSource into the appropriate parameter name and value
 // representation and then packages it into the full Mesh string representation.
@@ -181,8 +152,10 @@ double Convex::scale() const {
 }
 
 const PolygonSurfaceMesh<double>& Convex::GetConvexHull() const {
-  ComputeConvexHullAsNecessary(&hull_, source_, scale_);
-  return *hull_;
+  return hull_.GetOrMake([this]() {
+    return std::make_shared<PolygonSurfaceMesh<double>>(
+        internal::MakeConvexHull(source_, scale_));
+  });
 }
 
 std::string Convex::do_to_string() const {
@@ -283,8 +256,10 @@ double Mesh::scale() const {
 }
 
 const PolygonSurfaceMesh<double>& Mesh::GetConvexHull() const {
-  ComputeConvexHullAsNecessary(&hull_, source_, scale_);
-  return *hull_;
+  return hull_.GetOrMake([this]() {
+    return std::make_shared<PolygonSurfaceMesh<double>>(
+        internal::MakeConvexHull(source_, scale_));
+  });
 }
 
 std::string Mesh::do_to_string() const {

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/lazy_shared.h"
 #include "drake/geometry/mesh_source.h"
 #include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/math/rigid_transform.h"
@@ -362,8 +363,7 @@ class Convex final : public Shape {
 
   MeshSource source_;
   Vector3<double> scale_;
-  // Allows the deferred computation of the hull on an otherwise const Convex.
-  mutable std::shared_ptr<PolygonSurfaceMesh<double>> hull_{nullptr};
+  internal::LazyShared<PolygonSurfaceMesh<double>> hull_;
 };
 
 /** Definition of a cylinder. It is centered in its canonical frame with the
@@ -617,8 +617,7 @@ class Mesh final : public Shape {
   // NOTE: Cannot be const to support default copy/move semantics.
   MeshSource source_;
   Vector3<double> scale_;
-  // Allows the deferred computation of the hull on an otherwise const Mesh.
-  mutable std::shared_ptr<PolygonSurfaceMesh<double>> hull_{nullptr};
+  internal::LazyShared<PolygonSurfaceMesh<double>> hull_;
 };
 
 // TODO(russt): Rename this to `Cone` if/when it is supported by more of the

--- a/geometry/test/lazy_shared_test.cc
+++ b/geometry/test/lazy_shared_test.cc
@@ -1,0 +1,95 @@
+#include "drake/geometry/lazy_shared.h"
+
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+GTEST_TEST(LazySharedTest, LifecycleNull) {
+  LazyShared<int> empty;
+  LazyShared<int> copied(empty);
+  LazyShared<int> copy_assigned;
+  copy_assigned = empty;
+  LazyShared<int> moved(LazyShared<int>{});
+  LazyShared<int> move_assigned;
+  move_assigned = LazyShared<int>{};
+
+  // Any time GetOrMake() takes the "Make" branch, this `counter` will
+  // increment. The value returned by GetOrMake() will be a snapshot of the
+  // `counter` at the time that particular object's value was made. Therefore,
+  // by checking the return value of GetOrMake() we can know whether objects
+  // were created fresh or shared from somewhere else.
+  int counter = 0;
+  auto factory = [&]() {
+    return std::make_unique<int>(++counter);
+  };
+
+  // None of the objects are related to each other.
+  EXPECT_EQ(empty.GetOrMake(factory), 1);
+  EXPECT_EQ(empty.GetOrMake(factory), 1);
+  EXPECT_EQ(copied.GetOrMake(factory), 2);
+  EXPECT_EQ(copied.GetOrMake(factory), 2);
+  EXPECT_EQ(copy_assigned.GetOrMake(factory), 3);
+  EXPECT_EQ(copy_assigned.GetOrMake(factory), 3);
+  EXPECT_EQ(moved.GetOrMake(factory), 4);
+  EXPECT_EQ(moved.GetOrMake(factory), 4);
+  EXPECT_EQ(move_assigned.GetOrMake(factory), 5);
+  EXPECT_EQ(move_assigned.GetOrMake(factory), 5);
+}
+
+GTEST_TEST(LazySharedTest, LifecycleNonNull) {
+  // Any time GetOrMake() takes the "Make" branch, this `counter` will
+  // increment. The value returned by GetOrMake() will be a snapshot of the
+  // `counter` at the time that particular object's value was made. Therefore,
+  // by checking the return value of GetOrMake() we can know whether objects
+  // were created fresh or shared from somewhere else.
+  int counter = 0;
+  auto factory = [&]() {
+    return std::make_unique<int>(++counter);
+  };
+
+  LazyShared<int> dut;
+  EXPECT_EQ(dut.GetOrMake(factory), 1);
+  EXPECT_EQ(dut.GetOrMake(factory), 1);
+
+  // Copying retains the shared object.
+  LazyShared<int> copied(dut);
+  EXPECT_EQ(copied.GetOrMake(factory), 1);
+  EXPECT_EQ(copied.GetOrMake(factory), 1);
+  EXPECT_EQ(dut.GetOrMake(factory), 1);
+
+  // Copy-assignment retains the shared object.
+  LazyShared<int> copy_assigned;
+  copy_assigned = dut;
+  EXPECT_EQ(copy_assigned.GetOrMake(factory), 1);
+  EXPECT_EQ(copy_assigned.GetOrMake(factory), 1);
+  EXPECT_EQ(copied.GetOrMake(factory), 1);
+  EXPECT_EQ(dut.GetOrMake(factory), 1);
+
+  // Moving transfers the shared object.
+  LazyShared<int> moved(std::move(copied));
+  EXPECT_EQ(moved.GetOrMake(factory), 1);
+  EXPECT_EQ(moved.GetOrMake(factory), 1);
+  EXPECT_EQ(copied.GetOrMake(factory), 2);
+  EXPECT_EQ(copied.GetOrMake(factory), 2);
+  EXPECT_EQ(dut.GetOrMake(factory), 1);
+
+  // Move-assignment transfers the shared object.
+  LazyShared<int> move_assigned;
+  move_assigned = std::move(copy_assigned);
+  EXPECT_EQ(move_assigned.GetOrMake(factory), 1);
+  EXPECT_EQ(move_assigned.GetOrMake(factory), 1);
+  EXPECT_EQ(copy_assigned.GetOrMake(factory), 3);
+  EXPECT_EQ(copy_assigned.GetOrMake(factory), 3);
+  EXPECT_EQ(dut.GetOrMake(factory), 1);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Context:

With GCC's libstdc++ (e.g., on Ubuntu), the free functions like `std::atomic_compare_exchange_strong` are deprecated for removal in C++26, and generate warnings when used today.  The replacement `std::atomic<std::shared_ptr<T>>` is available.

With LLVM's libc++ (e.g., on macOS), the `std::atomic<std::shared_ptr<T>>` is not available (https://github.com/llvm/llvm-project/issues/99980) and the free functions are _not_ deprecated.

So, we need to maintain two different implementations of this logic, which means factoring it out into a reusable helper class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24265)
<!-- Reviewable:end -->
