### PR TITLE
[tools] Disable valgrind child process tracing

### DIFF
--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -68,10 +68,6 @@ void CheckWebsocketCommand(const Meshcat& meshcat,
   std::vector<std::string> argv;
   argv.push_back(
       FindResourceOrThrow("drake/geometry/meshcat_websocket_client"));
-  // Even when this unit test is itself running under valgrind, we don't want to
-  // instrument the helper process. Our valgrind configuration recognizes this
-  // argument and skips instrumentation of the child process.
-  argv.push_back("--disable-drake-valgrind-tracing");
   argv.push_back(fmt::format("--ws_url={}", meshcat.ws_url()));
   if (send_json) {
     DRAKE_DEMAND(!send_json->empty());

--- a/geometry/test/meshcat_websocket_client.py
+++ b/geometry/test/meshcat_websocket_client.py
@@ -82,11 +82,6 @@ def main():
         description="Test utility for Meshcat websockets"
     )
     parser.add_argument(
-        "--disable-drake-valgrind-tracing",
-        action="count",
-        help="ignored by this program; see valgrind.sh for details",
-    )
-    parser.add_argument(
         "--ws_url", type=str, required=True, help="websocket URL"
     )
     parser.add_argument(

--- a/multibody/parsing/package_downloader.py
+++ b/multibody/parsing/package_downloader.py
@@ -186,12 +186,10 @@ def _wrapped_main(*, config_json):
 
 
 def _main(argv):
-    # We expect exactly three command-line arguments to this program:
+    # We expect exactly two command-line arguments to this program:
     # - The input filename containing JSON data with our *actual* arguments.
     # - The output filename we should use to report error message text.
-    # - A dummy argument that we'll ignore. (It's sometimes used by our caller
-    #    to suppress valgrind when we're called from C++ code).
-    json_filename, error_filename, _ = argv
+    json_filename, error_filename = argv
     with open(error_filename, "w", encoding="utf-8") as error_file:
         try:
             _wrapped_main(config_json=json_filename)

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -361,8 +361,8 @@ const std::string& PackageData::GetPathWithAutomaticFetching(
   const std::string downloader =
       FindResourceOrThrow("drake/multibody/parsing/package_downloader.py");
   const std::string command =
-      fmt::format("/usr/bin/python3 -E {} {} {} {}", downloader, json_filename,
-                  error_filename, "--disable-drake-valgrind-tracing");
+      fmt::format("/usr/bin/python3 -E {} {} {}", downloader, json_filename,
+                  error_filename);
   const int returncode = std::system(command.c_str());
   if (returncode != 0) {
     // Try to read the error message text from the downloader.

--- a/multibody/parsing/test/package_downloader_stress_test.py
+++ b/multibody/parsing/test/package_downloader_stress_test.py
@@ -67,7 +67,6 @@ class StressTestDownloader(unittest.TestCase):
                             "multibody/parsing/package_downloader.py",
                             kwargs,
                             error_filename,
-                            "UNUSED_ARGUMENT",
                         ]
                     )
                 )

--- a/multibody/parsing/test/package_downloader_test.py
+++ b/multibody/parsing/test/package_downloader_test.py
@@ -71,7 +71,7 @@ class TestDownloader(unittest.TestCase):
 
         # Wrap a call to main.
         try:
-            mut._main([json_filename, error_filename, "UNUSED_ARGUMENT"])
+            mut._main([json_filename, error_filename])
             returncode = 0
         except SystemExit as e:
             returncode = e.code

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -139,22 +139,18 @@ build:_ubsan --test_timeout=120,600,1800,7200
 
 ### Memcheck build. ###
 build:memcheck --config=_memcheck
-# We explicitly do not filter `sh` targets because some C++ binaries are tested
-# indirectly via those targets. Any Python code that is run through a `sh`
-# target may need `tags = ["no_memcheck"]` if it incurs CI issues.
-build:memcheck --test_lang_filters=-py
 build:memcheck --test_tag_filters=-gurobi,-mosek,-snopt,-lint,-no_memcheck,-no_valgrind_tools
 
 ### Memcheck everything build. ###
 build:memcheck_everything --config=_memcheck
 build:memcheck_everything --config=_sanitizer_everything_common
 build:memcheck_everything --test_tag_filters=-mosek,-gurobi,-no_memcheck,-no_valgrind_tools
-build:memcheck_everything --test_lang_filters=-sh,-py
 
 ### Memcheck and Memcheck everything common flags. ###
 ### NOT intended for developer use. ###
 build:_memcheck --run_under=//tools/dynamic_analysis:valgrind
 build:_memcheck --build_tests_only
+build:_memcheck --test_lang_filters=-sh,-py
 build:_memcheck --copt=-DNDEBUG                # Disable third-party asserts.
 build:_memcheck --copt=-DDRAKE_ENABLE_ASSERTS  # ... but keep Drake's asserts.
 # Slowdown factor can range from 5-100. Increase timeouts to 25x.

--- a/tools/dynamic_analysis/valgrind.sh
+++ b/tools/dynamic_analysis/valgrind.sh
@@ -19,11 +19,6 @@ export GTEST_DEATH_TEST_USE_FORK=1
 # if they're running under valgrind.
 export VALGRIND_OPTS=""
 
-# Note the "--disable-drake-valgrind-tracing" skip-by-arg option below. Any
-# subprocess launched by a test with that as a command-line argument won't
-# be instrumented by valgrind. This is useful when you want to instrument
-# a C++ unit test but not a helper program that it calls.
-
 valgrind \
     --error-exitcode=1 \
     --gen-suppressions=all \
@@ -34,8 +29,5 @@ valgrind \
     --suppressions=/usr/lib/valgrind/debian.supp \
     --suppressions=/usr/lib/valgrind/python3.supp \
     --tool=memcheck \
-    --trace-children=yes \
-    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-15,/usr/bin/clang-format-15,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
-    --trace-children-skip-by-arg=--disable-drake-valgrind-tracing \
     --track-origins=yes \
     "$@"


### PR DESCRIPTION
These days there are basically no tests that use drake_sh_test to test C++ code, and even if in the future there were acceptance tests that did so, we don't need to memcheck them; memcheck on the nearby googletest should be sufficient.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24269)
<!-- Reviewable:end -->
