### PR TITLE
Fix potential segmentation fault in the IrisNp2 RaySampler

### DIFF
--- a/planning/iris/iris_np2.cc
+++ b/planning/iris/iris_np2.cc
@@ -159,6 +159,9 @@ void CheckInitialConditions(const SceneGraphCollisionChecker& checker,
   DRAKE_THROW_UNLESS(options.ray_sampler_options.ray_search_num_steps >= 1);
   DRAKE_THROW_UNLESS(
       options.ray_sampler_options.num_particles_to_walk_towards >= 1);
+  DRAKE_THROW_UNLESS(
+      options.ray_sampler_options.num_particles_to_walk_towards <=
+      options.sampled_iris_options.num_particles);
 }
 
 /* Check for certain conditions at the end of the separating hyperplanes step,
@@ -727,8 +730,14 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
       int num_prog_successes = 0;
       constexpr double kSolverFailRateWarning = 0.1;
 
-      // TODO(cohnt): Comment on why there's two possible sets of particles to
-      // work on.
+      // If we use kRaySampler with
+      // ray_sampler_options.only_walk_toward_collisions == false, then we
+      // process the first
+      // ray_sampler_options.num_particles_to_walk_towards particles. Otherwise,
+      // we process all particles that are in-collision (or violate a
+      // user-defined constraint). If we use kGreedySampler or kRaySampler with
+      // ray_sampler_options.only_walk_toward_collisions == true, then we only
+      // process particles in collision.
       bool process_collisions_only =
           sampling_strategy == IrisNp2SamplingStrategy::kGreedySampler ||
           options.ray_sampler_options.only_walk_toward_collisions;
@@ -741,6 +750,9 @@ HPolyhedron IrisNp2(const SceneGraphCollisionChecker& checker,
 
       for (int particle_index = 0;
            particle_index < num_particles_to_walk_toward; ++particle_index) {
+        // We use DRAKE_ASSERT here, since CheckInitialConditions should already
+        // ensure particle_index < ssize(particles_to_work_on).
+        DRAKE_ASSERT(particle_index < ssize(particles_to_work_on));
         auto& particle = particles_to_work_on[particle_index];
         if (num_hyperplanes_added >=
             options.sampled_iris_options.max_separating_planes_per_iteration) {

--- a/planning/iris/test/iris_np2_test.cc
+++ b/planning/iris/test/iris_np2_test.cc
@@ -131,6 +131,14 @@ TEST_F(JointLimits1D, UnsupportedOptions) {
       ".*num_particles_to_walk_towards.*");
   options.ray_sampler_options.num_particles_to_walk_towards = 1;
 
+  options.ray_sampler_options.num_particles_to_walk_towards = 1e4;
+  options.sampled_iris_options.num_particles = 1e2;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      IrisNp2(*scene_graph_checker, starting_ellipsoid_, domain_, options),
+      ".*num_particles_to_walk_towards.*num_particles.*");
+  options.ray_sampler_options.num_particles_to_walk_towards = 1;
+  options.sampled_iris_options.num_particles = 1e3;
+
   options.sampling_strategy = "another sampling strategy";
   DRAKE_EXPECT_THROWS_MESSAGE(
       IrisNp2(*scene_graph_checker, starting_ellipsoid_, domain_, options),


### PR DESCRIPTION
There was no check that the number of particles used by the algorithm is larger than the number expected by the RaySampler, leading to a potential memory error.

- [x] Waiting for #24243 to merge before starting review, since the two PRs are connected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24272)
<!-- Reviewable:end -->
