### PR TITLE
Give RenderEngineVtk an image cache

### DIFF
--- a/geometry/render_gltf_client/test/integration_test.py
+++ b/geometry/render_gltf_client/test/integration_test.py
@@ -172,7 +172,15 @@ class TestIntegration(unittest.TestCase):
             for k, v in entry.items():
                 # Replace the index with the actual referenced data structure.
                 if k in TestIntegration._REPLACED.keys():
-                    entry[k] = gltf[TestIntegration._REPLACED[k]][v]
+                    try:
+                        entry[k] = gltf[TestIntegration._REPLACED[k]][v]
+                    except TypeError:
+                        # If 'v' cannot be used to index into the array, it
+                        # means that we've already replaced it. This is the
+                        # case where a single accessor is referenced multiple
+                        # times; the first time changed the accessor, later
+                        # visits won't need to traverse downwards.
+                        continue
                 TestIntegration._traverse_and_mutate(gltf, entry[k])
         elif entry_type is list:
             # If the list contains only numeric numbers, round floating values

--- a/geometry/render_gltf_client/test/test_color_scene.gltf
+++ b/geometry/render_gltf_client/test/test_color_scene.gltf
@@ -97,7 +97,7 @@
          "type": "SCALAR"
       },
       {
-         "bufferView": 11,
+         "bufferView": 10,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 2601,
@@ -114,7 +114,7 @@
          "type": "VEC3"
       },
       {
-         "bufferView": 12,
+         "bufferView": 11,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 2601,
@@ -122,46 +122,46 @@
          "type": "VEC2"
       },
       {
-         "bufferView": 13,
+         "bufferView": 12,
          "byteOffset": 0,
          "componentType": 5125,
          "count": 15000,
          "type": "SCALAR"
       },
       {
+         "bufferView": 13,
+         "byteOffset": 0,
+         "componentType": 5126,
+         "count": 200,
+         "max": [
+            0.049901336431503296,
+            0.05000000074505806,
+            0.05000000074505806
+         ],
+         "min": [
+            -0.049901336431503296,
+            -0.05000000074505806,
+            -0.05000000074505806
+         ],
+         "type": "VEC3"
+      },
+      {
          "bufferView": 14,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 200,
-         "max": [
-            0.049901336431503296,
-            0.05000000074505806,
-            0.05000000074505806
-         ],
-         "min": [
-            -0.049901336431503296,
-            -0.05000000074505806,
-            -0.05000000074505806
-         ],
-         "type": "VEC3"
+         "normalized": false,
+         "type": "VEC2"
       },
       {
          "bufferView": 15,
          "byteOffset": 0,
-         "componentType": 5126,
-         "count": 200,
-         "normalized": false,
-         "type": "VEC2"
-      },
-      {
-         "bufferView": 16,
-         "byteOffset": 0,
          "componentType": 5125,
          "count": 588,
          "type": "SCALAR"
       },
       {
-         "bufferView": 18,
+         "bufferView": 16,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 200,
@@ -178,7 +178,7 @@
          "type": "VEC3"
       },
       {
-         "bufferView": 19,
+         "bufferView": 17,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 200,
@@ -186,14 +186,14 @@
          "type": "VEC2"
       },
       {
-         "bufferView": 20,
+         "bufferView": 18,
          "byteOffset": 0,
          "componentType": 5125,
          "count": 588,
          "type": "SCALAR"
       },
       {
-         "bufferView": 21,
+         "bufferView": 19,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 4902,
@@ -210,7 +210,7 @@
          "type": "VEC3"
       },
       {
-         "bufferView": 22,
+         "bufferView": 20,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 4902,
@@ -218,7 +218,39 @@
          "type": "VEC2"
       },
       {
+         "bufferView": 21,
+         "byteOffset": 0,
+         "componentType": 5125,
+         "count": 28800,
+         "type": "SCALAR"
+      },
+      {
+         "bufferView": 22,
+         "byteOffset": 0,
+         "componentType": 5126,
+         "count": 4902,
+         "max": [
+            0.049901336431503296,
+            0.05000000074505806,
+            0.10000000149011612
+         ],
+         "min": [
+            -0.049901336431503296,
+            -0.05000000074505806,
+            -0.10000000149011612
+         ],
+         "type": "VEC3"
+      },
+      {
          "bufferView": 23,
+         "byteOffset": 0,
+         "componentType": 5126,
+         "count": 4902,
+         "normalized": false,
+         "type": "VEC2"
+      },
+      {
+         "bufferView": 24,
          "byteOffset": 0,
          "componentType": 5125,
          "count": 28800,
@@ -228,16 +260,16 @@
          "bufferView": 25,
          "byteOffset": 0,
          "componentType": 5126,
-         "count": 4902,
+         "count": 24,
          "max": [
-            0.049901336431503296,
-            0.05000000074505806,
-            0.10000000149011612
+            0.05,
+            0.0375,
+            0.025
          ],
          "min": [
-            -0.049901336431503296,
-            -0.05000000074505806,
-            -0.10000000149011612
+            -0.05,
+            -0.0375,
+            -0.025
          ],
          "type": "VEC3"
       },
@@ -245,7 +277,7 @@
          "bufferView": 26,
          "byteOffset": 0,
          "componentType": 5126,
-         "count": 4902,
+         "count": 24,
          "normalized": false,
          "type": "VEC2"
       },
@@ -253,7 +285,7 @@
          "bufferView": 27,
          "byteOffset": 0,
          "componentType": 5125,
-         "count": 28800,
+         "count": 36,
          "type": "SCALAR"
       },
       {
@@ -289,39 +321,7 @@
          "type": "SCALAR"
       },
       {
-         "bufferView": 32,
-         "byteOffset": 0,
-         "componentType": 5126,
-         "count": 24,
-         "max": [
-            0.05,
-            0.0375,
-            0.025
-         ],
-         "min": [
-            -0.05,
-            -0.0375,
-            -0.025
-         ],
-         "type": "VEC3"
-      },
-      {
-         "bufferView": 33,
-         "byteOffset": 0,
-         "componentType": 5126,
-         "count": 24,
-         "normalized": false,
-         "type": "VEC2"
-      },
-      {
-         "bufferView": 34,
-         "byteOffset": 0,
-         "componentType": 5125,
-         "count": 36,
-         "type": "SCALAR"
-      },
-      {
-         "bufferView": 35,
+         "bufferView": 31,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 8423,
@@ -338,7 +338,7 @@
          "type": "VEC3"
       },
       {
-         "bufferView": 36,
+         "bufferView": 32,
          "byteOffset": 0,
          "componentType": 5126,
          "count": 8423,
@@ -346,7 +346,7 @@
          "type": "VEC2"
       },
       {
-         "bufferView": 37,
+         "bufferView": 33,
          "byteOffset": 0,
          "componentType": 5125,
          "count": 49152,
@@ -420,109 +420,109 @@
       },
       {
          "buffer": 10,
-         "byteLength": 1123,
-         "byteOffset": 0,
-         "target": 34962
-      },
-      {
-         "buffer": 11,
          "byteLength": 31212,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 12,
+         "buffer": 11,
          "byteLength": 20808,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 13,
+         "buffer": 12,
          "byteLength": 60000,
          "byteOffset": 0,
          "target": 34963
       },
       {
-         "buffer": 14,
+         "buffer": 13,
          "byteLength": 2400,
+         "byteOffset": 0,
+         "target": 34962
+      },
+      {
+         "buffer": 14,
+         "byteLength": 1600,
          "byteOffset": 0,
          "target": 34962
       },
       {
          "buffer": 15,
-         "byteLength": 1600,
-         "byteOffset": 0,
-         "target": 34962
-      },
-      {
-         "buffer": 16,
          "byteLength": 2352,
          "byteOffset": 0,
          "target": 34963
       },
       {
-         "buffer": 17,
-         "byteLength": 1123,
-         "byteOffset": 0,
-         "target": 34962
-      },
-      {
-         "buffer": 18,
+         "buffer": 16,
          "byteLength": 2400,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 19,
+         "buffer": 17,
          "byteLength": 1600,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 20,
+         "buffer": 18,
          "byteLength": 2352,
          "byteOffset": 0,
          "target": 34963
       },
       {
-         "buffer": 21,
+         "buffer": 19,
          "byteLength": 58824,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 22,
+         "buffer": 20,
          "byteLength": 39216,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 23,
+         "buffer": 21,
          "byteLength": 115200,
          "byteOffset": 0,
          "target": 34963
       },
       {
-         "buffer": 24,
-         "byteLength": 1123,
-         "byteOffset": 0,
-         "target": 34962
-      },
-      {
-         "buffer": 25,
+         "buffer": 22,
          "byteLength": 58824,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 26,
+         "buffer": 23,
          "byteLength": 39216,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 27,
+         "buffer": 24,
          "byteLength": 115200,
+         "byteOffset": 0,
+         "target": 34963
+      },
+      {
+         "buffer": 25,
+         "byteLength": 288,
+         "byteOffset": 0,
+         "target": 34962
+      },
+      {
+         "buffer": 26,
+         "byteLength": 192,
+         "byteOffset": 0,
+         "target": 34962
+      },
+      {
+         "buffer": 27,
+         "byteLength": 144,
          "byteOffset": 0,
          "target": 34963
       },
@@ -546,48 +546,24 @@
       },
       {
          "buffer": 31,
-         "byteLength": 1123,
-         "byteOffset": 0,
-         "target": 34962
-      },
-      {
-         "buffer": 32,
-         "byteLength": 288,
-         "byteOffset": 0,
-         "target": 34962
-      },
-      {
-         "buffer": 33,
-         "byteLength": 192,
-         "byteOffset": 0,
-         "target": 34962
-      },
-      {
-         "buffer": 34,
-         "byteLength": 144,
-         "byteOffset": 0,
-         "target": 34963
-      },
-      {
-         "buffer": 35,
          "byteLength": 101076,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 36,
+         "buffer": 32,
          "byteLength": 67384,
          "byteOffset": 0,
          "target": 34962
       },
       {
-         "buffer": 37,
+         "buffer": 33,
          "byteLength": 196608,
          "byteOffset": 0,
          "target": 34963
       },
       {
-         "buffer": 38,
+         "buffer": 34,
          "byteLength": 9081569,
          "byteOffset": 0,
          "target": 34962
@@ -610,23 +586,7 @@
          "mimeType": "image/png"
       },
       {
-         "bufferView": 10,
-         "mimeType": "image/png"
-      },
-      {
-         "bufferView": 17,
-         "mimeType": "image/png"
-      },
-      {
-         "bufferView": 24,
-         "mimeType": "image/png"
-      },
-      {
-         "bufferView": 31,
-         "mimeType": "image/png"
-      },
-      {
-         "bufferView": 38,
+         "bufferView": 34,
          "mimeType": "image/png"
       }
    ],
@@ -747,14 +707,10 @@
          "pbrMetallicRoughness": {
             "baseColorFactor": [
                1.0,
-               1.0,
-               1.0,
+               0.25,
+               0.25,
                1.0
             ],
-            "baseColorTexture": {
-               "index": 4,
-               "texCoord": 0
-            },
             "metallicFactor": 0.0,
             "roughnessFactor": 1.0
          }
@@ -763,10 +719,14 @@
          "pbrMetallicRoughness": {
             "baseColorFactor": [
                1.0,
-               0.25,
-               0.25,
+               1.0,
+               1.0,
                1.0
             ],
+            "baseColorTexture": {
+               "index": 4,
+               "texCoord": 0
+            },
             "metallicFactor": 0.0,
             "roughnessFactor": 1.0
          }
@@ -790,7 +750,7 @@
    ],
    "meshes": [
       {
-         "name": "mesh0",
+         "name": "example_scene::textured_sphere_visual",
          "primitives": [
             {
                "attributes": {
@@ -804,7 +764,7 @@
          ]
       },
       {
-         "name": "mesh1",
+         "name": "example_scene::rgba_sphere_visual",
          "primitives": [
             {
                "attributes": {
@@ -818,7 +778,7 @@
          ]
       },
       {
-         "name": "mesh2",
+         "name": "example_scene::textured_ellipsoid_visual",
          "primitives": [
             {
                "attributes": {
@@ -832,7 +792,7 @@
          ]
       },
       {
-         "name": "mesh3",
+         "name": "example_scene::rgba_ellipsoid_visual",
          "primitives": [
             {
                "attributes": {
@@ -846,7 +806,7 @@
          ]
       },
       {
-         "name": "mesh4",
+         "name": "example_scene::textured_cylinder_visual",
          "primitives": [
             {
                "attributes": {
@@ -860,7 +820,7 @@
          ]
       },
       {
-         "name": "mesh5",
+         "name": "example_scene::rgba_cylinder_visual",
          "primitives": [
             {
                "attributes": {
@@ -874,7 +834,7 @@
          ]
       },
       {
-         "name": "mesh6",
+         "name": "example_scene::textured_capsule_visual",
          "primitives": [
             {
                "attributes": {
@@ -888,7 +848,7 @@
          ]
       },
       {
-         "name": "mesh7",
+         "name": "example_scene::rgba_capsule_visual",
          "primitives": [
             {
                "attributes": {
@@ -902,7 +862,7 @@
          ]
       },
       {
-         "name": "mesh8",
+         "name": "example_scene::rgba_box_visual",
          "primitives": [
             {
                "attributes": {
@@ -916,7 +876,7 @@
          ]
       },
       {
-         "name": "mesh9",
+         "name": "example_scene::textured_box_visual",
          "primitives": [
             {
                "attributes": {
@@ -930,7 +890,7 @@
          ]
       },
       {
-         "name": "mesh10",
+         "name": "example_scene::mustard_bottle::base_link_mustard",
          "primitives": [
             {
                "attributes": {
@@ -965,7 +925,7 @@
             1.0
          ],
          "mesh": 0,
-         "name": "mesh0"
+         "name": "example_scene::textured_sphere_visual"
       },
       {
          "matrix": [
@@ -987,7 +947,7 @@
             1.0
          ],
          "mesh": 1,
-         "name": "mesh1"
+         "name": "example_scene::rgba_sphere_visual"
       },
       {
          "matrix": [
@@ -1009,7 +969,7 @@
             1.0
          ],
          "mesh": 2,
-         "name": "mesh2"
+         "name": "example_scene::textured_ellipsoid_visual"
       },
       {
          "matrix": [
@@ -1031,7 +991,7 @@
             1.0
          ],
          "mesh": 3,
-         "name": "mesh3"
+         "name": "example_scene::rgba_ellipsoid_visual"
       },
       {
          "matrix": [
@@ -1053,7 +1013,7 @@
             1.0
          ],
          "mesh": 4,
-         "name": "mesh4"
+         "name": "example_scene::textured_cylinder_visual"
       },
       {
          "matrix": [
@@ -1075,7 +1035,7 @@
             1.0
          ],
          "mesh": 5,
-         "name": "mesh5"
+         "name": "example_scene::rgba_cylinder_visual"
       },
       {
          "matrix": [
@@ -1097,7 +1057,7 @@
             1.0
          ],
          "mesh": 6,
-         "name": "mesh6"
+         "name": "example_scene::textured_capsule_visual"
       },
       {
          "matrix": [
@@ -1119,29 +1079,7 @@
             1.0
          ],
          "mesh": 7,
-         "name": "mesh7"
-      },
-      {
-         "matrix": [
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-            0.0,
-            0.4,
-            0.25,
-            0.0,
-            1.0
-         ],
-         "mesh": 8,
-         "name": "mesh8"
+         "name": "example_scene::rgba_capsule_visual"
       },
       {
          "matrix": [
@@ -1162,8 +1100,30 @@
             0.0,
             1.0
          ],
+         "mesh": 8,
+         "name": "example_scene::rgba_box_visual"
+      },
+      {
+         "matrix": [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.4,
+            0.25,
+            0.0,
+            1.0
+         ],
          "mesh": 9,
-         "name": "mesh9"
+         "name": "example_scene::textured_box_visual"
       },
       {
          "matrix": [
@@ -1185,7 +1145,7 @@
             1.0
          ],
          "mesh": 10,
-         "name": "mesh10"
+         "name": "example_scene::mustard_bottle::base_link_mustard"
       },
       {
          "camera": 0,
@@ -1281,23 +1241,23 @@
       },
       {
          "sampler": 1,
-         "source": 1
+         "source": 0
       },
       {
          "sampler": 2,
-         "source": 2
+         "source": 0
       },
       {
          "sampler": 3,
-         "source": 3
+         "source": 0
       },
       {
          "sampler": 4,
-         "source": 4
+         "source": 0
       },
       {
          "sampler": 5,
-         "source": 5
+         "source": 1
       }
    ]
 }

--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -433,6 +433,28 @@ bool RenderEngineVtk::DoRemoveGeometry(GeometryId id) {
 
   if (iter != props_.end()) {
     PropArray& pipe_props = iter->second;
+    // Decrement the use counts for every texture named by this geometry's
+    // parts. There are two thread-safety questions here: is manipulating this
+    // cache threadsafe? What happens inside VTK?
+    //
+    // Manipulating this cache is *not* threadsafe. We rely on Drake's practice
+    // of one-thread-per-Context (an individual RenderEngineVtk lives in each
+    // Context).
+    //
+    // VTK reference counting *is* threadsafe. So, two contexts can evict cache
+    // entries in parallel safely (each reducing VTK's internal ref count on the
+    // shared vtkTexture).
+    for (const auto& part : pipe_props[ImageType::kColor].parts) {
+      if (part.texture_key.has_value()) {
+        const std::string& key = *part.texture_key;
+        auto texture_iter = texture_cache_.find(key);
+        // If the texture key is defined, it better be in the cache.
+        DRAKE_DEMAND(texture_iter != texture_cache_.end());
+        if (--texture_iter->second.use_count == 0) {
+          texture_cache_.erase(texture_iter);
+        }
+      }
+    }
     for (int i = 0; i < kNumPipelines; ++i) {
       for (const auto& part : pipe_props[i].parts) {
         pipelines_[i]->renderer->RemoveActor(part.actor);
@@ -627,6 +649,15 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
   // the original without duplicating any vertex data.
   mesh_cache_ = other.mesh_cache_;
 
+  // Cloning the cache is subtle. The cache _data_ is a vtkTexture. That data is
+  // shared across cloned RenderEngineVtk instances. It has an internal VTK
+  // reference count across all uses (including VTK's internal uses). Drake's
+  // reference counting (use_count in CachedTexture) only counts the uses of the
+  // texture in _this_ RenderEngineVtk instance. So, while VTK's internal
+  // reference count increases with each engine clone, the cloned engine has the
+  // same *local* reference count as its source.
+  texture_cache_ = other.texture_cache_;
+
   for (const auto& [id, source_props] : other.props_) {
     PropArray target_props;
     for (int i = 0; i < kNumPipelines; ++i) {
@@ -645,7 +676,9 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
           SetDepthShader(target_actor);
         }
         target_prop.parts.push_back(
-            Part{.actor = std::move(target_actor), .T_GA = source_part.T_GA});
+            Part{.actor = std::move(target_actor),
+                 .T_GA = source_part.T_GA,
+                 .texture_key = source_part.texture_key});
       }
     }
     props_.insert({id, std::move(target_props)});
@@ -1160,52 +1193,97 @@ void RenderEngineVtk::ImplementPolyData(vtkPolyDataAlgorithm* source,
   if (use_pbr_materials_) {
     color_actor->GetProperty()->SetInterpolationToPBR();
   }
+  // When this part uses a cached texture we record the key here so that
+  // DoRemoveGeometry can decrement the per-key use-count when the geometry
+  // is later unregistered.
+  std::optional<std::string> active_texture_key;
   if (!IsEmpty(material.diffuse_map)) {
     // Parsing via VTK should never require an image to be flipped.
     DRAKE_DEMAND(material.flip_y == false);
 
-    vtkNew<vtkPNGReader> texture_reader;
-    const std::string description = std::visit<std::string>(
-        overloaded{
-            [](const auto&) -> std::string {
-              throw std::runtime_error(
-                  "RenderEngineVtk: diffuse map must be on-disk or in-memory");
-            },
-            [reader = texture_reader.Get()](const std::filesystem::path& path) {
-              reader->SetFileName(path.c_str());
-              return path.string();
-            },
-            [reader = texture_reader.Get()](const MemoryFile& file) {
-              const std::string& contents = file.contents();
-              vtkNew<vtkMemoryResourceStream> stream;
-              stream->SetBuffer(contents.c_str(), contents.size());
-              reader->SetStream(stream);
-              return file.filename_hint();
-            }},
-        material.diffuse_map);
-    texture_reader->Update();
-    if (texture_reader->GetOutput()->GetScalarType() != VTK_UNSIGNED_CHAR) {
-      log()->warn(
-          "Texture map '{}' has an unsupported bit depth, casting it to uchar "
-          "channels.",
-          description);
-    }
-
-    vtkNew<vtkImageCast> caster;
-    caster->SetOutputScalarType(VTK_UNSIGNED_CHAR);
-    caster->SetInputConnection(texture_reader->GetOutputPort());
-    caster->Update();
-    DRAKE_DEMAND(caster->GetOutput() != nullptr);
-
-    vtkNew<vtkOpenGLTexture> texture;
-    texture->SetInputConnection(caster->GetOutputPort());
     // TODO(SeanCurtis-TRI): It doesn't seem like the scale is used to actually
     // *scale* the image.
     const Vector2d uv_scale = data.properties.GetPropertyOrDefault(
         "phong", "diffuse_scale", Vector2d{1, 1});
     const bool need_repeat = uv_scale[0] > 1 || uv_scale[1] > 1;
-    texture->SetRepeat(need_repeat);
-    texture->InterpolateOn();
+
+    // Build a cache key from the image identity plus the per-texture flags
+    // configurable from input.
+    const std::string texture_key = std::visit<std::string>(
+        overloaded{
+            [](const auto&) -> std::string {
+              throw std::runtime_error(
+                  "RenderEngineVtk: diffuse map must be on-disk or in-memory");
+            },
+            [](const std::filesystem::path& path) {
+              return MemoryFile::Make(path).sha256().to_string();
+            },
+            [](const MemoryFile& file) {
+              return file.sha256().to_string();
+            }},
+        material.diffuse_map);
+    // TODO(SeanCurtis-TRI): We could reduce image decoding by saving the image
+    // source and feeding it into vtkTextures with different parameters.
+
+    // Tweak the key based on the texture parameters we actually configure.
+    // Unfortunately, every tweak of vtkTexture parameters will require a new
+    // instance of the texture data; so we'll need to modify the key to
+    // encompass every texture parameter we end up setting.
+    const std::string full_key =
+        texture_key + fmt::format("?need_repeat={}", need_repeat);
+    active_texture_key = full_key;
+
+    vtkSmartPointer<vtkTexture> texture;
+    auto cache_iter = texture_cache_.find(full_key);
+    if (cache_iter != texture_cache_.end()) {
+      // Cache hit: reuse the existing vtkTexture to avoid redundant file I/O
+      // and duplicate GPU texture uploads.
+      texture = cache_iter->second.texture;
+    } else {
+      // Cache miss: parse the image and build a new vtkTexture.
+      vtkNew<vtkPNGReader> texture_reader;
+      const std::string description = std::visit<std::string>(
+          overloaded{[](const auto&) -> std::string {
+                       throw std::runtime_error(
+                           "RenderEngineVtk: diffuse map must be on-disk or "
+                           "in-memory");
+                     },
+                     [reader = texture_reader.Get()](
+                         const std::filesystem::path& path) {
+                       reader->SetFileName(path.c_str());
+                       return path.string();
+                     },
+                     [reader = texture_reader.Get()](const MemoryFile& file) {
+                       const std::string& contents = file.contents();
+                       vtkNew<vtkMemoryResourceStream> stream;
+                       stream->SetBuffer(contents.c_str(), contents.size());
+                       reader->SetStream(stream);
+                       return file.filename_hint();
+                     }},
+          material.diffuse_map);
+      texture_reader->Update();
+      if (texture_reader->GetOutput()->GetScalarType() != VTK_UNSIGNED_CHAR) {
+        log()->warn(
+            "Texture map '{}' has an unsupported bit depth, casting it to "
+            "uchar channels.",
+            description);
+      }
+
+      vtkNew<vtkImageCast> caster;
+      caster->SetOutputScalarType(VTK_UNSIGNED_CHAR);
+      caster->SetInputConnection(texture_reader->GetOutputPort());
+      caster->Update();
+      DRAKE_DEMAND(caster->GetOutput() != nullptr);
+
+      vtkNew<vtkOpenGLTexture> new_texture;
+      new_texture->SetInputConnection(caster->GetOutputPort());
+      new_texture->SetRepeat(need_repeat);
+      new_texture->InterpolateOn();
+
+      texture_cache_[full_key].texture = new_texture;
+      texture = new_texture;
+    }
+
     if (use_pbr_materials_) {
       texture->SetUseSRGBColorSpace(true);
       color_actor->GetProperty()->SetBaseColorTexture(texture);
@@ -1221,6 +1299,12 @@ void RenderEngineVtk::ImplementPolyData(vtkPolyDataAlgorithm* source,
   color_actor->GetProperty()->SetOpacity(diffuse.a());
 
   connect_actor(ImageType::kColor);
+  // If a cached texture was applied, record its key in the color Part and
+  // bump the use-count so DoRemoveGeometry knows when to evict.
+  if (active_texture_key.has_value()) {
+    props[ImageType::kColor].parts.back().texture_key = active_texture_key;
+    ++texture_cache_[*active_texture_key].use_count;
+  }
 
   // Depth actor; always gets wired in with no additional work.
   connect_actor(ImageType::kDepth);

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -17,12 +18,14 @@
 #include <vtkRenderer.h>             // vtkRenderingCore
 #include <vtkShaderProgram.h>        // vtkRenderingOpenGL2
 #include <vtkSmartPointer.h>         // vtkCommonCore
+#include <vtkTexture.h>              // vtkRenderingCore
 #include <vtkWindowToImageFilter.h>  // vtkRenderingCore
 
 #include "drake/common/diagnostic_policy.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_export.h"
 #include "drake/common/reset_on_copy.h"
+#include "drake/common/string_unordered_map.h"
 #include "drake/geometry/render/render_engine.h"
 #include "drake/geometry/render/render_label.h"
 #include "drake/geometry/render/render_material.h"
@@ -303,9 +306,16 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
   // If T_GA = I, then `T_GA` is set to nullptr. Otherwise, posing the actor
   // using geometry's world pose X_WG should set the transform to
   // T_WA = X_WG * T_GA.
+  //
+  // For the color-pipeline parts that carry a texture, `texture_key` records
+  // the key into `texture_cache_` so that DoRemoveGeometry can perform
+  // correct reference-count-based eviction.
   struct Part {
     vtkSmartPointer<vtkActor> actor;
     vtkSmartPointer<vtkMatrix4x4> T_GA;
+    // Non-null only for color-pipeline parts whose texture came from
+    // texture_cache_.
+    std::optional<std::string> texture_key;
   };
 
   // Some geometries are represented by multiple parts (such as when importing
@@ -363,7 +373,38 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
   // computed from MeshSource::GetCacheKey() to uniquely identify a mesh source.
   // This eliminates redundant re-parsing and re-rendering when the same mesh
   // is registered multiple times.
-  std::unordered_map<std::string, CachedMesh> mesh_cache_;
+  string_unordered_map<CachedMesh> mesh_cache_;
+
+  // The texture cache entry. We track the instantiated VTK texture along with
+  // our own reference count.
+  struct CachedTexture {
+    // The loaded texture object, shared across all geometry registrations that
+    // reference the same image data and texture parameters. Erasing this
+    // vtkSmartPointer removes our contribution to the texture's VTK reference
+    // count, but does not guarantee immediate destruction because VTK holds
+    // additional internal references (e.g. through actor bookkeeping). The
+    // texture will be destroyed only once all VTK-internal references are also
+    // released. The cache therefore ensures we never hold a texture alive
+    // longer than necessary, without making any stronger claim about timing.
+    vtkSmartPointer<vtkTexture> texture;
+
+    // Number of color-pipeline Part instances *in this engine instance* that
+    // currently hold a texture_key pointing at this entry. We cannot rely on
+    // the usage counter on the vtkSmartPointer because VTK internals will
+    // typically hold additional references. So, we count Drake's usages and
+    // delete the cache entry when Drake's usage count reaches zero.
+    int use_count{};
+  };
+
+  // Cache mapping texture keys to loaded vtkTexture objects. The key is based
+  // on a hash of the image data (whether the image was specified as a path or a
+  // MemoryFile). While it requires us to read the bytes from disk with every
+  // reference, a cached image will still avoid decoding the image and maximize
+  // reuse on the GPU.
+  // The full image key contains the hash plus various suffixes to capture
+  // varying per-texture parameters (OpenGl requires different texture objects
+  // for different parameter combinations).
+  string_unordered_map<CachedTexture> texture_cache_;
 
   // Lights can be defined in the engine parameters. If no lights are defined,
   // we use the fallback_lights. Otherwise, we use the parameter lights.

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -112,6 +112,24 @@ class RenderEngineVtkTester {
   static int GetMeshCacheSize(const RenderEngineVtk& renderer) {
     return static_cast<int>(renderer.mesh_cache_.size());
   }
+
+  // Returns the number of entries currently in the texture cache.
+  static int GetTextureCacheSize(const RenderEngineVtk& renderer) {
+    return static_cast<int>(renderer.texture_cache_.size());
+  }
+
+  // Returns the vtkTexture from the first color-pipeline part of `id` that
+  // actually has a texture attached. Robustly searches against meshes that may
+  // have multiple parts.
+  static vtkTexture* GetFirstTexture(const RenderEngineVtk& renderer,
+                                     GeometryId id) {
+    for (const auto& part : renderer.props_.at(id).at(0).parts) {
+      if (vtkTexture* tex = part.actor.Get()->GetTexture(); tex != nullptr) {
+        return tex;
+      }
+    }
+    return nullptr;
+  }
 };
 
 namespace {
@@ -333,6 +351,32 @@ RigidTransformd PoseCamera(const Vector3d& p_WC, const Vector3d& p_WT,
       RotationMatrixd::MakeFromOrthonormalColumns(v_WCx, v_WCy, v_WCz), p_WC);
 }
 
+template <typename ImageType>
+::testing::AssertionResult ImagesAreSimilar(const ImageType& test_image,
+                                            const ImageType& ref_image,
+                                            double tolerance,
+                                            double conformity = 0.995) {
+  using T = typename ImageType::T;
+  DRAKE_DEMAND(ref_image.size() == test_image.size());
+  Eigen::Map<const VectorX<T>> data_expected(ref_image.at(0, 0),
+                                             ref_image.size());
+  Eigen::Map<const VectorX<T>> data_actual(test_image.at(0, 0),
+                                           test_image.size());
+  const Eigen::ArrayXd differences = (data_expected.template cast<double>() -
+                                      data_actual.template cast<double>())
+                                         .array()
+                                         .abs();
+  const int num_acceptable = (differences <= tolerance).count();
+  const double conformity_actual =
+      num_acceptable / static_cast<double>(ref_image.size());
+  return conformity_actual >= conformity
+             ? ::testing::AssertionSuccess()
+             : ::testing::AssertionFailure()
+                   << "Images differ:\n"
+                   << "  observed conformity = " << conformity_actual << "\n"
+                   << "  required conformity = " << conformity;
+}
+
 // Compares the test image against a reference image.
 //
 // The bytes of `test_image` are compared with the bytes of `ref_image`.
@@ -353,18 +397,7 @@ RigidTransformd PoseCamera(const Vector3d& p_WC, const Vector3d& p_WT,
 template <typename ImageType>
 void CompareImages(const ImageType& test_image, const ImageType& ref_image,
                    double tolerance, double conformity = 0.995) {
-  using T = typename ImageType::T;
-  ASSERT_EQ(ref_image.size(), test_image.size());
-  Eigen::Map<const VectorX<T>> data_expected(ref_image.at(0, 0),
-                                             ref_image.size());
-  Eigen::Map<const VectorX<T>> data_actual(test_image.at(0, 0),
-                                           test_image.size());
-  const Eigen::ArrayXd differences = (data_expected.template cast<double>() -
-                                      data_actual.template cast<double>())
-                                         .array()
-                                         .abs();
-  const int num_acceptable = (differences <= tolerance).count();
-  EXPECT_GE(num_acceptable / static_cast<float>(ref_image.size()), conformity);
+  EXPECT_TRUE(ImagesAreSimilar(test_image, ref_image, tolerance, conformity));
 }
 
 // Compares the test image against a reference image named by its file path.
@@ -3499,6 +3532,192 @@ TEST_F(RenderEngineVtkTest, DifferentObjsDontShare) {
   ASSERT_NE(src_a, nullptr);
   ASSERT_NE(src_b, nullptr);
   EXPECT_NE(src_a, src_b);
+}
+
+// ---------------------------------------------------------------------------
+// Texture-cache source-sharing tests
+//
+// These tests verify that registering the same image file multiple times
+// results in exactly one cache entry and that all registrations share the same
+// underlying vtkTexture object.
+// ---------------------------------------------------------------------------
+
+vtkTexture* RegisterAndGetTexture(RenderEngineVtk* engine, const Shape& shape,
+                                  const PerceptionProperties& props) {
+  DRAKE_DEMAND(engine != nullptr);
+  const RigidTransformd I = RigidTransformd::Identity();
+  const GeometryId id = GeometryId::get_new_id();
+  engine->RegisterVisual(id, shape, props, I);
+  return RenderEngineVtkTester::GetFirstTexture(*engine, id);
+}
+
+// Examines cache correctness for an image that resides *on disk*. Also, by
+// using a Sphere, we're showing that the cache isn't limited to Meshes.
+TEST_F(RenderEngineVtkTest, TextureSharingPathBased) {
+  const RenderEngineVtkParams params{.backend = FLAGS_backend};
+  RenderEngineVtk engine(params);
+
+  const std::string png_a =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
+  const std::string png_b =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/checker.png");
+
+  auto make_props = [](const std::string& png_path) {
+    PerceptionProperties props;
+    props.AddProperty("label", "id", RenderLabel::kDontCare);
+    props.AddProperty("phong", "diffuse_map", png_path);
+    return props;
+  };
+
+  vtkTexture* tex_a_1 =
+      RegisterAndGetTexture(&engine, Sphere(0.5), make_props(png_a));
+  vtkTexture* tex_b_1 =
+      RegisterAndGetTexture(&engine, Sphere(0.5), make_props(png_b));
+  vtkTexture* tex_a_2 =
+      RegisterAndGetTexture(&engine, Sphere(0.5), make_props(png_a));
+  vtkTexture* tex_b_2 =
+      RegisterAndGetTexture(&engine, Sphere(0.5), make_props(png_b));
+
+  // We registered two unique images.
+  EXPECT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 2);
+
+  // Textures for png_a should be the same.
+  ASSERT_NE(tex_a_1, nullptr);
+  EXPECT_EQ(tex_a_1, tex_a_2);
+  // Texture for png_b should be the same.
+  ASSERT_NE(tex_b_1, nullptr);
+  EXPECT_EQ(tex_b_1, tex_b_2);
+  // Textures for png_a should be different from png_b.
+  EXPECT_NE(tex_a_1, tex_b_1);
+}
+
+// Examines cache correctness for an image that is in memory. In-memory images
+// are only supported with MeshSources.
+TEST_F(RenderEngineVtkTest, TextureSharingWithMemoryFile) {
+  const RenderEngineVtkParams params{.backend = FLAGS_backend};
+  RenderEngineVtk engine(params);
+
+  const auto obj_data = MemoryFile::Make(
+      FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.obj"));
+  const auto mtl_data = MemoryFile::Make(
+      FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.mtl"));
+  const auto png_data_a = MemoryFile::Make(FindResourceOrThrow(
+      "drake/geometry/render/test/meshes/rainbow_stripes.png"));
+  const auto png_data_b = MemoryFile::Make(
+      FindResourceOrThrow("drake/geometry/render/test/meshes/checker.png"));
+
+  // We need to build a fresh and *different* mesh each time. If the mesh is
+  // identical, the mesh caching will immediately detect a cache hit and not
+  // even consider the referenced texture (not exercising the cache at all).
+  // So, we take a common obj and slightly perturb it so it is recognized as a
+  // different mesh that happens to reference the same texture image. This will
+  // exercise the texture cache.
+  int i = 0;
+  auto make_mesh = [&](const MemoryFile& png_data) {
+    return Mesh(InMemoryMesh{
+        MemoryFile(fmt::format("# {}\n", ++i) + obj_data.contents(),
+                   obj_data.extension(), obj_data.filename_hint()),
+        {{"rainbow_box.mtl", mtl_data}, {"rainbow_stripes.png", png_data}}});
+  };
+
+  PerceptionProperties props;
+  props.AddProperty("label", "id", RenderLabel::kDontCare);
+
+  vtkTexture* tex_a_1 =
+      RegisterAndGetTexture(&engine, make_mesh(png_data_a), props);
+  vtkTexture* tex_b_1 =
+      RegisterAndGetTexture(&engine, make_mesh(png_data_b), props);
+  vtkTexture* tex_a_2 =
+      RegisterAndGetTexture(&engine, make_mesh(png_data_a), props);
+  vtkTexture* tex_b_2 =
+      RegisterAndGetTexture(&engine, make_mesh(png_data_b), props);
+
+  // We registered two unique images.
+  EXPECT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 2);
+
+  // Textures for png_a should be the same.
+  ASSERT_NE(tex_a_1, nullptr);
+  EXPECT_EQ(tex_a_1, tex_a_2);
+  // Texture for png_b should be the same.
+  ASSERT_NE(tex_b_1, nullptr);
+  EXPECT_EQ(tex_b_1, tex_b_2);
+  // Textures for png_a should be different from png_b.
+  EXPECT_NE(tex_a_1, tex_b_1);
+}
+
+// Registers two geometries that share the same texture. Removing the first
+// geometry must *not* evict the texture (it is still in use). Only after the
+// second geometry is removed should the cache entry be evicted.
+TEST_F(RenderEngineVtkTest, TextureCacheEviction) {
+  const RenderEngineVtkParams params{.backend = FLAGS_backend};
+  RenderEngineVtk engine(params);
+
+  const std::string png_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
+  PerceptionProperties props;
+  props.AddProperty("label", "id", RenderLabel::kDontCare);
+  props.AddProperty("phong", "diffuse_map", png_path);
+
+  const GeometryId id1 = GeometryId::get_new_id();
+  const GeometryId id2 = GeometryId::get_new_id();
+  engine.RegisterVisual(id1, Sphere(0.5), props, RigidTransformd::Identity());
+  engine.RegisterVisual(id2, Sphere(1.5), props, RigidTransformd::Identity());
+  ASSERT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 1);
+
+  // Removing the first user must not disturb the cache.
+  engine.RemoveGeometry(id1);
+  EXPECT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 1);
+
+  // Removing the final user must evict the now-unreferenced texture.
+  engine.RemoveGeometry(id2);
+  EXPECT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 0);
+}
+
+// Confirms that cloned engines' caches are not harmed by eviction from another
+// engine.
+TEST_F(RenderEngineVtkTest, TextureCacheEvictionAcrossClones) {
+  const RenderEngineVtkParams params{.backend = FLAGS_backend};
+  RenderEngineVtk engine(params);
+
+  const std::string png_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
+  PerceptionProperties props;
+  props.AddProperty("label", "id", RenderLabel::kDontCare);
+  props.AddProperty("phong", "diffuse_map", png_path);
+
+  const GeometryId id = GeometryId::get_new_id();
+  engine.RegisterVisual(id, Sphere(0.5), props, RigidTransformd::Identity());
+  ASSERT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 1);
+
+  std::unique_ptr<RenderEngine> clone_base = engine.Clone();
+  auto* clone_ptr = dynamic_cast<RenderEngineVtk*>(clone_base.get());
+  ASSERT_NE(clone_ptr, nullptr);
+  ASSERT_EQ(RenderEngineVtkTester::GetTextureCacheSize(*clone_ptr), 1);
+
+  // Now render a reference image from each engine.
+  const ColorRenderCamera color_camera(depth_camera_.core(), FLAGS_show_window);
+
+  // Originally, the images should match.
+  ImageRgba8U source_image_ref(color_);
+  engine.RenderColorImage(color_camera, &source_image_ref);
+  ImageRgba8U clone_image_ref(color_);
+  clone_ptr->RenderColorImage(color_camera, &clone_image_ref);
+  ASSERT_TRUE(ImagesAreSimilar(source_image_ref, clone_image_ref, 1e-5, 1.0));
+
+  // Removing the geometry (and texture) from the original engine.
+  engine.RemoveGeometry(id);
+  ASSERT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 0);
+
+  // Rendering each image; the source engine has a different image, the cloned
+  // is unchanged.
+  ImageRgba8U source_image_dut(color_);
+  engine.RenderColorImage(color_camera, &source_image_dut);
+  ImageRgba8U clone_image_dut(color_);
+  clone_ptr->RenderColorImage(color_camera, &clone_image_dut);
+
+  ASSERT_FALSE(
+      ImagesAreSimilar(source_image_ref, source_image_dut, 1e-5, 0.75));
+  ASSERT_TRUE(ImagesAreSimilar(source_image_ref, clone_image_dut, 1e-5, 1.0));
 }
 
 }  // namespace


### PR DESCRIPTION
VTK now shares textures across instances. The images get cache keys similar to how meshes do.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24274)
<!-- Reviewable:end -->
