### PR TITLE
[setup] Add lld as a build dep on Resolute

### DIFF
--- a/setup/ubuntu/source_distribution/packages-resolute.txt
+++ b/setup/ubuntu/source_distribution/packages-resolute.txt
@@ -5,6 +5,7 @@ libglib2.0-dev
 libglx-dev
 liblapack-dev
 libopengl-dev
+lld
 ocl-icd-opencl-dev
 opencl-headers
 patch


### PR DESCRIPTION
When using GCC the default ld linker isn't sufficient for Drake; we need either lld or gold, and since gold is deprecated we'll use lld now.  (On Noble, binutils installed `gold` by default; on Resolute, it doesn't anymore because gold is deprecated.)

Towards #23976.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24278)
<!-- Reviewable:end -->
