### PR TITLE
[common] Resolve Warn constructor ambiguity

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -3147,10 +3147,10 @@ For example:
 
     </details>)""";
         // Symbol: drake::logging::Warn::Warn
-        struct /* Warn */ {
+        struct /* ctor */ {
           // Source: drake/common/text_logging.h
           const char* doc = R"""()""";
-        } Warn;
+        } ctor;
       } Warn;
       // Symbol: drake::logging::get_dist_sink
       struct /* get_dist_sink */ {

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -240,8 +240,12 @@ double* SanityCheck(double* data) {
 }
 </pre> */
 struct [[maybe_unused]] Warn {  // NOLINT(whitespace/braces)
+  explicit Warn(std::string_view message) { drake::log()->warn(message); }
+
   template <typename... Args>
-  Warn(fmt::format_string<Args...> pattern, Args&&... args) {
+  Warn(fmt::format_string<Args...> pattern, Args&&... args)
+    requires(sizeof...(args) > 0)
+  {
     drake::log()->warn(pattern, std::forward<Args>(args)...);
   }
 };


### PR DESCRIPTION
Apple Clang 21 fails to resolve `drake::Warn` when a temporary string is provided, attempting to match the variadic `fmt::format_string` instead of simply converting to `std::string_view`.

Towards #24276.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24281)
<!-- Reviewable:end -->
