### PR TITLE
[systems] Fix MultilayerPerceptron vector-indexing contract violation

### DIFF
--- a/systems/primitives/multilayer_perceptron.cc
+++ b/systems/primitives/multilayer_perceptron.cc
@@ -145,8 +145,8 @@ MultilayerPerceptron<T>::MultilayerPerceptron(
                                 &MultilayerPerceptron<T>::CalcOutput);
 
   num_parameters_ = 0;
-  weight_indices_.reserve(num_weights_);
-  bias_indices_.reserve(num_weights_);
+  weight_indices_.resize(num_weights_);
+  bias_indices_.resize(num_weights_);
   for (int i = 0; i < num_weights_; ++i) {
     weight_indices_[i] = num_parameters_;
     num_parameters_ += layers_[i + 1] * layers_[i];


### PR DESCRIPTION
Towards #23976.

This failure is already detected by the (forthcoming) Ubuntu 26.04 CI, so doesn't need any new unit test cases here.

(The code is actually operationally correct -- that's why none of our sanitizers flagged it.  But formally we're not supposed to access reserved memory without setting a proper size.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24283)
<!-- Reviewable:end -->
