### PR TITLE
[geometry] Remove nonsense line in cspace_free_polytope_with_mosek_test

### DIFF
--- a/geometry/optimization/test/cspace_free_polytope_with_mosek_test.cc
+++ b/geometry/optimization/test/cspace_free_polytope_with_mosek_test.cc
@@ -1256,7 +1256,6 @@ TEST_F(CIrisToyRobotTest, BinarySearch) {
   result = tester.cspace_free_polytope().BinarySearch(ignored_collision_pairs,
                                                       C, d, s_center, options);
   ASSERT_FALSE(result.has_value());
-  EXPECT_EQ(result->num_iter(), 0);
 }
 }  // namespace optimization
 }  // namespace geometry


### PR DESCRIPTION
Towards #23976.

(The `std::optional<>` is empty; we can't access its value.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24285)
<!-- Reviewable:end -->
