### PR TITLE
[multibody] Work around GCC 15.2 bug in supernodal_solver_test

### DIFF
--- a/multibody/contact_solvers/test/supernodal_solver_test.cc
+++ b/multibody/contact_solvers/test/supernodal_solver_test.cc
@@ -71,13 +71,15 @@ DenseBlockDiagonalPair Make9x9SpdBlockDiagonalMatrixOf3x3SpdMatrices() {
 DenseBlockDiagonalPair Make12x12SpdBlockDiagonalMatrixOf3x3SpdMatrices() {
   MatrixXd A(12, 12);
   // clang-format off
-  A << 5, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  // N.B. Using some doubles here (`.0`) instead of ints is necessary to work
+  // around a GCC 15.1/15.2 compiler bug.
+  A << 5, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0.0,
        2, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 9, 2, 2, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 2, 5, 3, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 2, 3, 8, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 4, 1, 1, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 4, 1, 1, 0, 0, 0.0,
        0, 0, 0, 0, 0, 0, 1, 4, 2, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 1, 2, 5, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 1,
@@ -590,13 +592,15 @@ TYPED_TEST(SuperNodalSolverTest, ColumnSizesDifferent) {
 
   MatrixXd G(13, 13);
   // clang-format off
-  G << 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  // N.B. Using some doubles here (`.0`) instead of ints is necessary to work
+  // around a GCC 15.1/15.2 compiler bug.
+  G << 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0,
        2, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 9, 2, 2, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 2, 5, 3, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0, 2, 3, 8, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 4, 1, 1, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 4, 1, 1, 0, 0, 0, 0.0,
        0, 0, 0, 0, 0, 0, 1, 4, 2, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 1, 2, 5, 0, 0, 0, 0,
        0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 1, 0,


### PR DESCRIPTION
Towards #23976.

We hit https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123737.  You can't have more than 128 ints in a row when comma-initializing an Eigen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24289)
<!-- Reviewable:end -->
