### PR TITLE
Update CMake minimum required to accomodate wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,12 @@
 # -*- mode: cmake -*-
 # vi: set ft=cmake :
 
-# The minimum required CMake version should match the minimum listed in
-# doc/_pages/from_source.md, which is also the minimum installed by
-# setup/install_prereqs across all platforms.
+# The minimum required CMake version should be the minimum of the versions
+# listed in doc/_pages/from_source.md and the version used by the wheel build.
 # When this changes, drake-external-examples/drake_cmake_external/CMakeLists.txt
 # should be changed accordingly so that downstream users are synced with
 # Drake itself.
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.26)
 
 project(drake
   DESCRIPTION "Model-based design and verification for robotics"


### PR DESCRIPTION
Alma Linux 9 ships with a lower version of CMake than is otherwise the minimum supported on all our platforms (from Noble) when building from source.

Amends #24231.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24290)
<!-- Reviewable:end -->
