### PR TITLE
Revert "Update drake-ros instructions to reflect current practice"

### DIFF
--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -175,12 +175,9 @@ the main body of the document:
    2. Click "Publish release".
    3. Create a new GitHub issue on the [drake](https://github.com/RobotLocomotion/drake/issues/new/choose)
       repository and select the "Post-Release Actions" template.
-   4. Update the GitHub issue on the [drake-ros](https://github.com/RobotLocomotion/drake-ros/issues/400)
+   4. Create a GitHub issue on the [drake-ros](https://github.com/RobotLocomotion/drake-ros/issues)
       repository, requesting an update of the `DRAKE_SUGGESTED_VERSION`
       constant.
-      - Change the issue name to reflect the current release version.
-      - Add a comment that includes the link to the release notes for the new
-        version.
    5. Announce on Drake Slack, ``#general``.
    6. Party on, Wayne.
 


### PR DESCRIPTION
Reverts RobotLocomotion/drake#24101.

The `drake-ros` issue cited here has been closed.

+a:@SeanCurtis-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24291)
<!-- Reviewable:end -->
