### PR TITLE
ProximityEngine gains the partial ability to cache meshes

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -1,8 +1,10 @@
 #include "drake/geometry/proximity_engine.h"
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <limits>
+#include <map>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -15,6 +17,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/string_unordered_map.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/collisions_exist_callback.h"
 #include "drake/geometry/proximity/deformable_contact_geometries.h"
@@ -61,82 +64,61 @@ class FclDynamicAABBTreeCollisionManager
     : public fcl::DynamicAABBTreeCollisionManager<double> {};
 class MapGeometryIdToFclCollisionObject
     : public unordered_map<GeometryId, unique_ptr<CollisionObjectd>> {};
+// Cache entry for a single mesh source file (independent of scale). Stores the
+// convex hull topology and unit-scale vertex positions once, then maps each
+// encountered scale factor to its own fcl::Convexd.
+struct ConvexHullCacheEntry {
+  // Vertex positions of the convex hull evaluated at unit scale (1, 1, 1).
+  shared_ptr<std::vector<Vector3d>> unit_vertices;
+  // Face topology data; identical across all scale factors.
+  shared_ptr<std::vector<int>> faces;
+  // Number of convex hull faces.
+  int num_faces{0};
+  // Sub-cache of fcl::Convexd objects keyed by (scale_x, scale_y, scale_z,
+  // margin). Scale values are validated as finite by Mesh/Convex; margin is
+  // non-negative and finite (and is validated in AddGeometry()). Two entries
+  // that differ only in margin need distinct fcl::Convexd objects because
+  // InflateAabbForHydroelasticTypesOnly() mutates the geometry's aabb_local
+  // in-place.
+  std::map<std::array<double, 4>, shared_ptr<fcl::Convexd>> scaled_hulls;
+};
 
-// Returns a copy of the given fcl collision geometry; throws an exception for
-// unsupported collision geometry types. This supplements the *missing* cloning
-// functionality in FCL. Issue has been submitted to FCL:
-// https://github.com/flexible-collision-library/fcl/issues/246
-shared_ptr<fcl::ShapeBased> CopyShapeOrThrow(
-    const fcl::CollisionGeometryd& geometry) {
-  // NOTE: Returns a shared pointer because of the FCL API in assigning
-  // collision geometry to collision objects.
-  switch (geometry.getNodeType()) {
-    case fcl::GEOM_SPHERE: {
-      const auto& sphere = dynamic_cast<const fcl::Sphered&>(geometry);
-      return make_shared<fcl::Sphered>(sphere.radius);
-    }
-    case fcl::GEOM_CYLINDER: {
-      const auto& cylinder = dynamic_cast<const fcl::Cylinderd&>(geometry);
-      return make_shared<fcl::Cylinderd>(cylinder.radius, cylinder.lz);
-    }
-    case fcl::GEOM_ELLIPSOID: {
-      const auto& ellipsoid = dynamic_cast<const fcl::Ellipsoidd&>(geometry);
-      return make_shared<fcl::Ellipsoidd>(ellipsoid.radii);
-    }
-    case fcl::GEOM_HALFSPACE:
-      // All half spaces are defined exactly the same.
-      return make_shared<fcl::Halfspaced>(0, 0, 1, 0);
-    case fcl::GEOM_BOX: {
-      const auto& box = dynamic_cast<const fcl::Boxd&>(geometry);
-      return make_shared<fcl::Boxd>(box.side);
-    }
-    case fcl::GEOM_CAPSULE: {
-      const auto& capsule = dynamic_cast<const fcl::Capsuled&>(geometry);
-      return make_shared<fcl::Capsuled>(capsule.radius, capsule.lz);
-    }
-    case fcl::GEOM_CONVEX: {
-      const auto& convex = dynamic_cast<const fcl::Convexd&>(geometry);
-      // TODO(DamrongGuoy): Change to the copy constructor Convex(other) when
-      //  we figure out why "Convex(const Convex& other) = default" created
-      //  link errors for Xenial Debug build.  For now we do deep copy of the
-      //  vertices and faces instead of simply copying the shared pointer.
-      return make_shared<fcl::Convexd>(
-          make_shared<const std::vector<Vector3d>>(convex.getVertices()),
-          convex.getFaceCount(),
-          make_shared<const std::vector<int>>(convex.getFaces()));
-    }
-    case fcl::GEOM_CONE:
-    case fcl::GEOM_PLANE:
-    case fcl::GEOM_TRIANGLE:
-      throw std::logic_error(
-          "Trying to copy fcl::CollisionGeometry of unsupported GEOM_* type");
-    default:
-      throw std::logic_error(
-          "Trying to copy fcl::CollisionGeometry of non GEOM_* type");
-  }
-}
+class MapStringToConvexHullCache
+    : public string_unordered_map<ConvexHullCacheEntry> {};
 
-// Helper function that creates a *deep* copy of the given collision object.
+// Helper function that creates a copy of the given collision object.
+// The underlying FCL collision geometry is shared with the source rather than
+// deep-copied; FCL geometry objects are treated as immutable after
+// construction.
 unique_ptr<CollisionObjectd> CopyFclObjectOrThrow(
     const CollisionObjectd& object_source) {
   const auto& shape_source = *object_source.collisionGeometry();
 
-  shared_ptr<fcl::ShapeBased> shape_copy = CopyShapeOrThrow(shape_source);
+  // Store the geometry rather than copying it. However, we have to stash away
+  // the local AABB configuration. See below for why.
+  const Vector3d local_aabb_min = shape_source.aabb_local.min_;
+  const Vector3d local_aabb_max = shape_source.aabb_local.max_;
+  const double aabb_radius = shape_source.aabb_radius;
 
-  // A copy of the geometry is passed to FCL, but CollisionObject's constructor
-  // resets that copy's local bounding box to fit the _instantiated_ shape. So
-  // we retain a pointer to the shape copy long enough after handing it off to
-  // FCL to fix it back up to its original AABB.
-  auto object_copy = make_unique<CollisionObjectd>(shape_copy);
+  shared_ptr<fcl::CollisionGeometryd> shared_geom =
+      std::const_pointer_cast<fcl::CollisionGeometryd>(
+          object_source.collisionGeometry());
 
-  // The source's local AABB may have been inflated if the underlying object is
-  // associated with a compliant hydroelastic shape with a non-zero margin;
+  auto object_copy = make_unique<CollisionObjectd>(shared_geom);
+
+  // The source's local AABB may have been inflated if the underlying object
+  // is associated with a compliant hydroelastic shape with a non-zero margin;
   // therefore the AABB that fits the shape may not be what we want. We can't
-  // tell simply by looking at the fcl object if this is the case, so, we'll
-  // simply copy the source's local AABB verbatim to preserve the effect.
-  shape_copy->aabb_local.min_ = shape_source.aabb_local.min_;
-  shape_copy->aabb_local.max_ = shape_source.aabb_local.max_;
-  shape_copy->aabb_radius = shape_source.aabb_radius;
+  // tell simply by looking at the FCL object if this is the case, so, we'll
+  // simply copy the source's local _original_ AABB verbatim to preserve the
+  // effect.
+  //
+  // Note: this has to be done *after* the collision object is created because
+  // CollisionObjectd's constructor calls computeLocalAABB() on the geometry,
+  // which would otherwise reset any inflation.
+  shared_geom->aabb_local.min_ = local_aabb_min;
+  shared_geom->aabb_local.max_ = local_aabb_max;
+  shared_geom->aabb_radius = aabb_radius;
 
   object_copy->setUserData(object_source.getUserData());
   object_copy->setTransform(object_source.getTransform());
@@ -271,7 +253,7 @@ void CullFlatten(std::vector<X>* maybes, std::vector<R>* objects) {
 
 }  // namespace
 
-// The implementation class for the fcl engine. Each of these functions
+// The implementation class for the FCL engine. Each of these functions
 // mirrors a method on the ProximityEngine (unless otherwise indicated.
 // See ProximityEngine for documentation.
 template <typename T>
@@ -284,6 +266,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     geometries_for_deformable_contact_ =
         other.geometries_for_deformable_contact_;
     mesh_sdf_data_ = other.mesh_sdf_data_;
+    convex_hull_cache_ = other.convex_hull_cache_;
+    geometry_to_hull_key_ = other.geometry_to_hull_key_;
     dynamic_tree_.clear();
     dynamic_objects_.clear();
     anchored_tree_.clear();
@@ -333,6 +317,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     engine->geometries_for_deformable_contact_ =
         this->geometries_for_deformable_contact_;
     engine->mesh_sdf_data_ = this->mesh_sdf_data_;
+    engine->convex_hull_cache_ = this->convex_hull_cache_;
+    engine->geometry_to_hull_key_ = this->geometry_to_hull_key_;
     engine->distance_tolerance_ = this->distance_tolerance_;
 
     return engine;
@@ -394,8 +380,6 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
     const double margin =
         props.GetPropertyOrDefault<double>(kHydroGroup, kMargin, 0.0);
-
-    if (margin == 0) return;  // nothing to update.
 
     CollisionObjectd* object = geometry.is_dynamic()
                                    ? dynamic_objects_[geometry.id()].get()
@@ -480,6 +464,27 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     hydroelastic_geometries_.RemoveGeometry(id);
     geometries_for_deformable_contact_.RemoveGeometry(id);
     mesh_sdf_data_.erase(id);
+
+    // Evict the convex hull cache entry for this geometry if it is the last
+    // user. The CollisionObjectd was already destroyed above (by the inner
+    // RemoveGeometry overload), so the cache entry's shared_ptr is the sole
+    // remaining owner when use_count() == 1.
+    if (auto it = geometry_to_hull_key_.find(id);
+        it != geometry_to_hull_key_.end()) {
+      const auto& [file_key, scale_key] = it->second;
+      if (auto cache_it = convex_hull_cache_.find(file_key);
+          cache_it != convex_hull_cache_.end()) {
+        auto& scaled_hulls = cache_it->second.scaled_hulls;
+        if (auto hull_it = scaled_hulls.find(scale_key);
+            hull_it != scaled_hulls.end() && hull_it->second.use_count() == 1) {
+          scaled_hulls.erase(hull_it);
+          if (scaled_hulls.empty()) {
+            convex_hull_cache_.erase(cache_it);
+          }
+        }
+      }
+      geometry_to_hull_key_.erase(it);
+    }
   }
 
   void RemoveDeformableGeometry(GeometryId id) {
@@ -620,7 +625,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   void ImplementGeometry(const Mesh& mesh, void* user_data) override {
-    // We currently represent Mesh shapes with their convex hulls in fcl.
+    // We currently represent Mesh shapes with their convex hulls in FCL.
     ImplementFromConvexHull(mesh, user_data);
     // Set up data for ComputeSignedDistanceToPoint() from non-convex meshes.
     ImplementMeshSdfData(mesh, user_data);
@@ -659,7 +664,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   /* Searches for an fcl::CollisionObject associated with the given `id`.
-   Note: this strips the const away from the collision object because fcl's
+   Note: this strips the const away from the collision object because FCL's
    API requires non-const inputs.
    @throws if the proximity engine has no geometry for the id. */
   CollisionObjectd* FindCollisionObject(GeometryId id,
@@ -1007,6 +1012,38 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     return nullptr;
   }
 
+  int convex_hull_cache_file_entries() const {
+    return ssize(convex_hull_cache_);
+  }
+
+  int convex_hull_cache_hull_entries() const {
+    int n = 0;
+    for (const auto& [_, entry] : convex_hull_cache_) {
+      n += ssize(entry.scaled_hulls);
+    }
+    return n;
+  }
+
+  bool geometry_hull_key_valid(GeometryId id) const {
+    if (!geometry_to_hull_key_.contains(id)) return false;
+
+    const auto& [file_key, scale_key] = geometry_to_hull_key_.at(id);
+    if (!convex_hull_cache_.contains(file_key)) return false;
+
+    return convex_hull_cache_.at(file_key).scaled_hulls.contains(scale_key);
+  }
+
+  bool geometry_hull_key_absent(GeometryId id) const {
+    return geometry_to_hull_key_.count(id) == 0;
+  }
+
+  bool geometry_hull_reverse_map_consistent() const {
+    for (const auto& [geometry_id, _] : geometry_to_hull_key_) {
+      if (!geometry_hull_key_valid(geometry_id)) return false;
+    }
+    return true;
+  }
+
  private:
   // Engine on one scalar can see the members of other engines.
   friend class ProximityEngineTester;
@@ -1035,7 +1072,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   // geometry's frame (its "local AABB") during construction. The hydroelastic
   // representations are larger than the specified shapes and we want to make
   // sure that the bounding volumes associated with those hydro geometries
-  // properly enclose them. So, we'll edit fcl's bounding box definition after
+  // properly enclose them. So, we'll edit FCL's bounding box definition after
   // the fact to account for the inflation.
   //
   // The fcl::CollisionObject likewise has a bounding box based on the
@@ -1049,12 +1086,12 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   // set of vertices.
   //
   // @pre `id` has a compliant hydroelastic representation.
-  // @pre `margin` > 0.
+  // @pre `margin` >= 0.
   // @pre `object != nullptr`.
   void InflateAabbForHydroelasticTypesOnly(const Shape& shape,
                                            const GeometryId id, double margin,
                                            fcl::CollisionObjectd* object) {
-    DRAKE_DEMAND(margin > 0);
+    DRAKE_DEMAND(margin >= 0);
     DRAKE_DEMAND(hydroelastic_geometries_.hydroelastic_type(id) ==
                  HydroelasticType::kCompliant);
     DRAKE_DEMAND(object != nullptr);
@@ -1069,7 +1106,10 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     DRAKE_DEMAND(g != nullptr);
 
     std::string_view shape_name = shape.type_name();
-    if (shape_name == "Mesh" || shape_name == "Convex") {
+    if (margin == 0) {
+      // No inflation needed; reset to the tight-fitting local AABB.
+      g->computeLocalAABB();
+    } else if (shape_name == "Mesh" || shape_name == "Convex") {
       // Meshes can have their vertices move an arbitrary amount, we simply need
       // to recompute the bounding box based on the *moved* vertex positions
       // defined in the hydro mesh.
@@ -1102,6 +1142,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
       unordered_map<GeometryId, unique_ptr<CollisionObjectd>>* objects) {
     const double margin =
         props.GetPropertyOrDefault<double>(kHydroGroup, kMargin, 0.0);
+    if (!(margin >= 0 && std::isfinite(margin))) {
+      throw std::logic_error("Margin must be non-negative and finite.");
+    }
     ReifyData data{nullptr, id, props, X_WG, margin};
     shape.Reify(this, &data);
 
@@ -1139,7 +1182,7 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   // Helper method called by the various ImplementGeometry overrides to
   // facilitate the logistics of creating shapes from specifications. `data`
-  // is a unique_ptr of an fcl CollisionObject that should be instantiated
+  // is a unique_ptr of an FCL CollisionObject that should be instantiated
   // with the given shape.
   void TakeShapeOwnership(const std::shared_ptr<fcl::ShapeBased>& shape,
                           void* data) {
@@ -1152,15 +1195,64 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   // from its convex hull (rather than from the actual mesh data).
   template <typename MeshType>
   void ImplementFromConvexHull(const MeshType& mesh, void* user_data) {
-    // Create fcl::Convex for the fcl bounding volume hierarchy.
-    const PolygonSurfaceMesh<double>& hull = mesh.GetConvexHull();
-    auto shared_verts = make_shared<std::vector<Vector3d>>();
-    for (int vi = 0; vi < hull.num_vertices(); ++vi) {
-      shared_verts->push_back(hull.vertex(vi));
+    // Look up (or build) the per-file cache entry for this mesh source.
+    const std::string cache_key =
+        mesh.source().GetCacheKey(/* is_convex= */ true);
+    ConvexHullCacheEntry& entry = convex_hull_cache_[cache_key];
+
+    // Populate unit-scale vertex positions and face topology on first visit.
+    // The convex hull topology is the same for all scale factors; only vertex
+    // positions differ.  We therefore store vertices at unit scale (1,1,1) and
+    // derive per-scale copies on demand.
+    const Vector3d scale = mesh.scale3();
+    const bool is_unit_scale = (scale == Vector3d::Ones());
+    if (entry.unit_vertices == nullptr) {
+      const PolygonSurfaceMesh<double>& hull = mesh.GetConvexHull();
+      auto unit_verts = make_shared<std::vector<Vector3d>>();
+      unit_verts->reserve(hull.num_vertices());
+      if (is_unit_scale) {
+        for (int vi = 0; vi < hull.num_vertices(); ++vi) {
+          unit_verts->push_back(hull.vertex(vi));
+        }
+      } else {
+        for (int vi = 0; vi < hull.num_vertices(); ++vi) {
+          unit_verts->push_back(hull.vertex(vi).array() / scale.array());
+        }
+      }
+      entry.unit_vertices = std::move(unit_verts);
+      entry.faces = make_shared<std::vector<int>>(hull.face_data());
+      entry.num_faces = hull.num_elements();
     }
-    auto shared_faces = make_shared<std::vector<int>>(hull.face_data());
-    auto fcl_convex = make_shared<fcl::Convexd>(
-        std::move(shared_verts), hull.num_elements(), std::move(shared_faces));
+
+    // Look up (or create) the fcl::Convexd for the current (scale, margin)
+    // pair. Scale values are validated as finite by Mesh/Convex; margin is
+    // non-negative. Margin is part of the key because
+    // InflateAabbForHydroelasticTypesOnly() mutates the geometry's aabb_local
+    // in-place, so two geometries with the same scale but different margins
+    // must not share an fcl::Convexd.
+    const double margin = static_cast<const ReifyData*>(user_data)->margin;
+    const std::array<double, 4> scale_key{scale[0], scale[1], scale[2], margin};
+    shared_ptr<fcl::Convexd>& fcl_convex = entry.scaled_hulls[scale_key];
+    if (fcl_convex == nullptr) {
+      // For the unit-scale case (the common case), share the unit_vertices
+      // shared_ptr directly rather than allocating and filling a second vector.
+      shared_ptr<std::vector<Vector3d>> verts_for_fcl;
+      if (is_unit_scale) {
+        verts_for_fcl = entry.unit_vertices;
+      } else {
+        verts_for_fcl = make_shared<std::vector<Vector3d>>();
+        verts_for_fcl->reserve(entry.unit_vertices->size());
+        for (const Vector3d& uv : *entry.unit_vertices) {
+          verts_for_fcl->push_back(uv.array() * scale.array());
+        }
+      }
+      fcl_convex = make_shared<fcl::Convexd>(std::move(verts_for_fcl),
+                                             entry.num_faces, entry.faces);
+    }
+
+    // Record the reverse mapping so RemoveGeometry() can evict stale entries.
+    geometry_to_hull_key_[static_cast<const ReifyData*>(user_data)->id] = {
+        cache_key, scale_key};
 
     TakeShapeOwnership(fcl_convex, user_data);
     ProcessHydroelastic(mesh, user_data);
@@ -1295,6 +1387,21 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
 
   // Data for ComputeSignedDistanceToPoint from meshes (Mesh and Convex).
   std::unordered_map<GeometryId, MeshDistanceBoundary> mesh_sdf_data_{};
+
+  // Two-level cache used by ImplementFromConvexHull().
+  //   Level 1: mesh-source cache key  →  ConvexHullCacheEntry
+  //     Stores unit-scale vertex positions and shared face topology so that
+  //     parsing each mesh file is done at most once.
+  //   Level 2 (inside ConvexHullCacheEntry): scale factor  →  fcl::Convexd
+  //     Stores one fcl::Convexd per distinct scale, sharing face topology
+  //     across all scales of the same source file.
+  MapStringToConvexHullCache convex_hull_cache_{};
+
+  // Reverse map from GeometryId to its convex hull cache key. Populated in
+  // ImplementFromConvexHull() for Mesh and Convex geometries; used by
+  // RemoveGeometry() to evict stale cache entries.
+  std::unordered_map<GeometryId, std::pair<std::string, std::array<double, 4>>>
+      geometry_to_hull_key_{};
 };
 
 template <typename T>
@@ -1565,6 +1672,31 @@ bool ProximityEngine<T>::IsFclConvexType(GeometryId id) const {
 template <typename T>
 void* ProximityEngine<T>::GetCollisionObject(GeometryId id) const {
   return impl_->GetCollisionObject(id);
+}
+
+template <typename T>
+int ProximityEngine<T>::convex_hull_cache_file_entries() const {
+  return impl_->convex_hull_cache_file_entries();
+}
+
+template <typename T>
+int ProximityEngine<T>::convex_hull_cache_hull_entries() const {
+  return impl_->convex_hull_cache_hull_entries();
+}
+
+template <typename T>
+bool ProximityEngine<T>::geometry_hull_key_valid(GeometryId id) const {
+  return impl_->geometry_hull_key_valid(id);
+}
+
+template <typename T>
+bool ProximityEngine<T>::geometry_hull_key_absent(GeometryId id) const {
+  return impl_->geometry_hull_key_absent(id);
+}
+
+template <typename T>
+bool ProximityEngine<T>::geometry_hull_reverse_map_consistent() const {
+  return impl_->geometry_hull_reverse_map_consistent();
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -43,12 +43,9 @@ namespace internal {
    - distance
    - ray-intersection
 
- Not all shape queries are fully supported. To add support for a shape:
- 1. for fcl versions of the specification, modify CopyShapeOrThrow().
- 2. add an instance of the new shape to the CopySemantics test in
-    proximity_engine_test.cc.
- 3. for penetration, test the new shape in the class BoxPenetrationTest of
-    proximity_engine_test.cc and document its configuration.
+ Not all shape queries are fully supported. If adding a shape that supports
+ point penetration, add the new shape in the BoxPenetrationTest of
+ proximity_engine_test.cc and document its configuration.
 
  <!-- TODO(SeanCurtis-TRI): Fully document the semantics of the proximity
  properties that will affect the proximity engine -- hydroelastic semantics,
@@ -383,6 +380,18 @@ class ProximityEngine {
   // pointer type. But if the return value is not null, it can be safely cast to
   // fcl::CollisionObjectd*. This is for testing only.
   void* GetCollisionObject(GeometryId id) const;
+
+  // Returns the number of top-level file entries in the convex hull cache.
+  int convex_hull_cache_file_entries() const;
+  // Returns the total number of (scale,margin) sub-entries across all file
+  // entries in the convex hull cache.
+  int convex_hull_cache_hull_entries() const;
+  // Returns true if id is in the reverse map and its key pair is valid.
+  bool geometry_hull_key_valid(GeometryId id) const;
+  // Returns true if id is absent from the reverse map.
+  bool geometry_hull_key_absent(GeometryId id) const;
+  // Returns true if every reverse-map entry points to a valid cache entry.
+  bool geometry_hull_reverse_map_consistent() const;
 };
 
 }  // namespace internal

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <limits>
 #include <memory>
+#include <ranges>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -14,6 +15,7 @@
 
 #include <fcl/fcl.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
@@ -100,6 +102,39 @@ class ProximityEngineTester {
   static const TriangleSurfaceMesh<double>* get_mesh_distance_boundary(
       const ProximityEngine<T>& engine, GeometryId id) {
     return engine.mesh_distance_boundary(id);
+  }
+
+  // Returns the number of top-level file entries in the convex hull cache.
+  static int convex_hull_cache_file_entries(
+      const ProximityEngine<double>& engine) {
+    return engine.convex_hull_cache_file_entries();
+  }
+
+  // Returns the total number of scaled_hulls sub-entries across all file
+  // entries in the convex hull cache.
+  static int convex_hull_cache_hull_entries(
+      const ProximityEngine<double>& engine) {
+    return engine.convex_hull_cache_hull_entries();
+  }
+
+  // Returns true if the given geometry id is in the reverse map AND its
+  // recorded (file_key, scale_key) refer to a valid cache entry.
+  static bool geometry_hull_key_valid(const ProximityEngine<double>& engine,
+                                      GeometryId id) {
+    return engine.geometry_hull_key_valid(id);
+  }
+
+  // Returns true if the given geometry id is absent from the reverse map.
+  static bool geometry_hull_key_absent(const ProximityEngine<double>& engine,
+                                       GeometryId id) {
+    return engine.geometry_hull_key_absent(id);
+  }
+
+  // Returns true if every entry currently in geometry_to_hull_key points to
+  // a valid (file_key, scale_key) pair in convex_hull_cache.
+  static bool geometry_hull_reverse_map_consistent(
+      const ProximityEngine<double>& engine) {
+    return engine.geometry_hull_reverse_map_consistent();
   }
 };
 
@@ -545,8 +580,351 @@ GTEST_TEST(ProximityEngineTests, ProcessVtkConvexUndefHydro) {
   }
 }
 
+// Tests that registering the same mesh source multiple times reuses the same
+// underlying fcl::Convex collision geometry object (i.e. the convex hull cache
+// is working).
+GTEST_TEST(ProximityEngineTests, ConvexHullCacheDuplicatesShareGeometry) {
+  ProximityEngine<double> engine;
+  const std::string path_a =
+      FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+  const std::string path_b =
+      FindResourceOrThrow("drake/geometry/test/non_convex_mesh.obj");
+
+  // Add the shape (dynamic vs anchored as indicated). Returns a pointer to the
+  // underlying collision geometry -- the cached quantity.
+  auto add_geometry = [&engine](const Shape& shape, bool is_dynamic = true) {
+    const GeometryId id = GeometryId::get_new_id();
+    if (is_dynamic) {
+      engine.AddDynamicGeometry(shape, {}, id);
+    } else {
+      engine.AddAnchoredGeometry(shape, {}, id);
+    }
+    const fcl::CollisionObjectd* obj =
+        ProximityEngineTester::GetCollisionObject(engine, id);
+    DRAKE_DEMAND(obj != nullptr);
+    return obj->collisionGeometry().get();
+  };
+
+  // We'll register one path as multiple geometry (some Mesh, some Convex).
+  const fcl::CollisionGeometryd* convex_a1 = add_geometry(Convex(path_a));
+  const fcl::CollisionGeometryd* convex_a2 = add_geometry(Convex(path_a));
+  const fcl::CollisionGeometryd* mesh_a1 = add_geometry(Mesh(path_a));
+  const fcl::CollisionGeometryd* mesh_a2 = add_geometry(Mesh(path_a));
+
+  // Start by confirming our reference geometry isn't null.
+  ASSERT_NE(convex_a1, nullptr);
+
+  // All of the collision objects instantiated by path_a (whether Mesh or
+  // Convex) should all share the same collision geometry.
+  EXPECT_EQ(convex_a1, convex_a2);
+  EXPECT_EQ(convex_a1, mesh_a1);
+  EXPECT_EQ(convex_a1, mesh_a2);
+
+  // We'll use a second mesh to show that not all meshes get cached the same.
+  // We'll also use the second mesh to show that anchored/dynamic doesn't
+  // matter.
+  const fcl::CollisionGeometryd* convex_b = add_geometry(Convex(path_b));
+  const fcl::CollisionGeometryd* mesh_b =
+      add_geometry(Mesh(path_b), /* is_dynamic= */ false);
+
+  // From a different path, we should get a different geometry.
+  EXPECT_NE(convex_b, nullptr);
+  EXPECT_NE(convex_a1, convex_b);
+  EXPECT_EQ(convex_b, mesh_b);
+}
+
+// Tests that the convex hull cache correctly handles multiple registrations of
+// the same mesh file with different anisotropic scale factors. The cache must
+// produce a distinct fcl::Convexd—with correctly-scaled vertex positions for
+// each unique scale, rather than reusing the hull built for the first scale
+// seen.
+//
+// Setup: three Convex instances all sourced from the same obj file (a 2m cube;
+// unit half-extents of 1m in each axis). Each has an anisotropic scale that
+// doubles exactly one axis, and each box is placed 10m along that axis from the
+// origin.
+//
+//   Instance  Position        Scale      Active half-extent  Expected distance
+//      A      (-10,  0,  0)  (2, 1, 1)   x: 2 m              8.0 m
+//      B      ( 0, -10,  0)  (1, 2, 1)   y: 2 m              8.0 m
+//      C      ( 0,  0, -10)  (1, 1, 2)   z: 2 m              8.0 m
+//
+// If the scale is wrong, things could fail in two ways: at the broadphase and
+// at the narrowphase. To test the broadphase, we introduce a query threshold
+// that is farther than the correct distance (8.0m) but closer than the distance
+// associated with an unscaled box (9.0m). If the box hasn't been scaled
+// properly, the broadphase will prune it and there will be no result for the
+// geometry.
+//
+// For the narrow phase, we simply confirm that the reported distances are all
+// as expected.
+GTEST_TEST(ProximityEngineTests, ConvexHullCacheScaleIsRespected) {
+  ProximityEngine<double> engine;
+  const std::string path =
+      FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+
+  const GeometryId id_A = GeometryId::get_new_id();
+  const GeometryId id_B = GeometryId::get_new_id();
+  const GeometryId id_C = GeometryId::get_new_id();
+
+  // Each box is placed 10m along a different axis and scaled to double only
+  // that axis' half-extent, so the distance from the origin to each box's
+  // nearest face is exactly 10 - 2 = 8 m.
+  const RigidTransformd X_WA(Vector3d(-10, 0, 0));
+  const RigidTransformd X_WB(Vector3d(0, -10, 0));
+  const RigidTransformd X_WC(Vector3d(0, 0, -10));
+
+  engine.AddAnchoredGeometry(Convex(path, Vector3d(2.0, 1.0, 1.0)), X_WA, id_A);
+  engine.AddAnchoredGeometry(Convex(path, Vector3d(1.0, 2.0, 1.0)), X_WB, id_B);
+  engine.AddAnchoredGeometry(Convex(path, Vector3d(1.0, 1.0, 2.0)), X_WC, id_C);
+
+  const std::unordered_map<GeometryId, RigidTransformd> X_WGs{
+      {id_A, X_WA}, {id_B, X_WB}, {id_C, X_WC}};
+
+  // Threshold chosen between the correct nearest-face distance (8.0 m) and the
+  // nearest distance produced by a wrong-scale (x-doubled) hull placed at
+  // y/z = -10 m (which would be 9.0 m).
+  const double threshold = 8.5;
+  const auto results =
+      engine.ComputeSignedDistanceToPoint(Vector3d::Zero(), X_WGs, threshold);
+
+  // All three geometries must appear in results with their correct distances.
+  // If any cache entry returned the wrong scale, the corresponding geometry's
+  // FCL AABB would be too far from the origin to pass the threshold and it
+  // would be missing from results.
+  ASSERT_EQ(results.size(), 3);
+  std::unordered_map<GeometryId, double> dist_by_id;
+  for (const auto& r : results) {
+    dist_by_id[r.id_G] = r.distance;
+  }
+  constexpr double kTol = 1e-14;
+  EXPECT_NEAR(dist_by_id.at(id_A), 8.0, kTol);  // confirms x-scale of Box A
+  EXPECT_NEAR(dist_by_id.at(id_B), 8.0, kTol);  // confirms y-scale of Box B
+  EXPECT_NEAR(dist_by_id.at(id_C), 8.0, kTol);  // confirms z-scale of Box C
+}
+
 // TODO(SeanCurtis-TRI): Confirm that SDF data gets computed for Mesh(vtk) and
 // all Convex().
+
+// Tests that Convex shapes sourced from the same file but registered with
+// different margins receive distinct fcl::Convexd objects (as each Convexd
+// stores a local AABB encompassing the geometry *and* its margin). The
+// declarations can't interfere with each other.
+//
+// We'll declare three convex geometries (A, B, C in that order). A and C have
+// zero margin and B has a non-zero margin. The boxes will be arrayed along an
+// axis with a gap between them slightly smaller than the non-zero margin.
+// They are arrayed in the order: A C B.
+//
+//                     ┌┄┄┄┄┄┄┄┄┄┄┄┐
+//        ┏━━━━━┓ ┏━━━━┿┓ ┏━━━━━┓  ┊
+//        ┃  A  ┃ ┃  C ┊┃ ┃  B  ┃  ┊
+//        ┗━━━━━┛ ┗━━━━┿┛ ┗━━━━━┛  ┊ <-- B with margin
+//                     └┄┄┄┄┄┄┄┄┄┄┄┘
+//
+// Failure modes we're looking to detect:
+//
+//   1. Subsequent registrations stomp on previous registrations.
+//      In this case, the overlap between B and C would be lost (C's last
+//      zero-margin registration would replace B's margin).
+//   2. Subsequent registrations don't get a new margin.
+//      In this case, the overlap between B and C would be lost (this time
+//      because B -- and C -- simply picked up the original zero-margin AABB).
+GTEST_TEST(ProximityEngineTests, ConvexHullCacheMarginIsRespected) {
+  ProximityEngine<double> engine;
+  const std::string path =
+      FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+
+  const double kResHint = 0.5;
+  const double kE = 1e8;
+  const double kMarginValue = 0.1;
+  const double kBoxExtent = 2.0;
+
+  // Spatial order A C B; registration order A B C.
+  const double kOffset = kBoxExtent + kMarginValue / 2;
+  const RigidTransformd X_WA(Vector3d(-kOffset, 0, 0));
+  const RigidTransformd X_WC(Vector3d(0, 0, 0));
+  const RigidTransformd X_WB(Vector3d(kOffset, 0, 0));
+
+  ProximityProperties props_no_margin;
+  props_no_margin.AddProperty(kHydroGroup, kMargin, 0.0);
+  AddCompliantHydroelasticProperties(kResHint, kE, &props_no_margin);
+
+  ProximityProperties props_with_margin;
+  props_with_margin.AddProperty(kHydroGroup, kMargin, kMarginValue);
+  AddCompliantHydroelasticProperties(kResHint, kE, &props_with_margin);
+
+  const GeometryId id_A = GeometryId::get_new_id();
+  const GeometryId id_B = GeometryId::get_new_id();
+  const GeometryId id_C = GeometryId::get_new_id();
+  engine.AddDynamicGeometry(Convex(path), X_WA, id_A, props_no_margin);
+  engine.AddDynamicGeometry(Convex(path), X_WB, id_B, props_with_margin);
+  engine.AddDynamicGeometry(Convex(path), X_WC, id_C, props_no_margin);
+
+  // Call UpdateWorldPoses for the three dynamic geometries. This triggers
+  // computeAABB() for B, which reads the shared geometry's aabb_local. In
+  // the bug case, C's registration reset that aabb_local and B loses its
+  // inflation here.
+  engine.UpdateWorldPoses({{id_A, X_WA}, {id_B, X_WB}, {id_C, X_WC}});
+
+  // B's inflated AABB must overlap C; A is far away and never a candidate.
+  std::vector<SortedPair<GeometryId>> candidates =
+      engine.FindCollisionCandidates();
+  auto formattable_view =
+      candidates | std::views::transform([](const SortedPair<GeometryId>& p) {
+        return fmt::format("({}, {})", p.first(), p.second());
+      });
+  EXPECT_EQ(candidates.size(), 1) << fmt::format(
+      "For A={}, B={}, C={}, we have the following candidates:\n{}", id_A, id_B,
+      id_C, fmt::join(formattable_view, ", "));
+}
+
+// Tests that updating the margin of an existing geometry (via
+// UpdateRepresentationForNewProperties()) does not corrupt the broad-phase AABB
+// of another geometry registered from the same source file but with a different
+// margin.
+//
+// We place two convex shapes near a reference sphere at the origin. With a
+// zero-valued margin, the AABBs would not overlap. With the initial non-zero
+// margin, they both overlap. We'll reduce the margin of one shape and show
+// that it no longer overlaps, but the other still does; its margin has been
+// unaffected.
+GTEST_TEST(ProximityEngineTests,
+           ConvexHullCacheMarginUpdateDoesNotCorruptSiblings) {
+  ProximityEngine<double> engine;
+  const std::string path =
+      FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+
+  const double kResHint = 0.5;
+  const double kE = 1e8;
+  const double kSmallMargin = 0.1;   // A's margin.
+  const double kLargeMargin = 0.2;   // B's margin.
+  const double kSphereRadius = 0.5;  // Reference geometry radius.
+
+  const double kBoxExtent = 2;
+  const double kOffset = kBoxExtent / 2 + kSphereRadius;
+
+  const RigidTransformd X_WA(Vector3d(-kOffset - kSmallMargin / 2, 0, 0));
+  const RigidTransformd X_WB(Vector3d(kOffset + kLargeMargin / 2, 0, 0));
+  const RigidTransformd X_WS;  // sphere at origin
+
+  ProximityProperties props_small;
+  props_small.AddProperty(kHydroGroup, kMargin, kSmallMargin);
+  AddCompliantHydroelasticProperties(kResHint, kE, &props_small);
+
+  ProximityProperties props_large;
+  props_large.AddProperty(kHydroGroup, kMargin, kLargeMargin);
+  AddCompliantHydroelasticProperties(kResHint, kE, &props_large);
+
+  const GeometryId id_A = GeometryId::get_new_id();
+  const GeometryId id_B = GeometryId::get_new_id();
+  const GeometryId id_S = GeometryId::get_new_id();
+  engine.AddDynamicGeometry(Convex(path), X_WA, id_A, props_small);
+  engine.AddDynamicGeometry(Convex(path), X_WB, id_B, props_large);
+  engine.AddAnchoredGeometry(Sphere(kSphereRadius), X_WS, id_S,
+                             ProximityProperties());
+  engine.UpdateWorldPoses({{id_A, X_WA}, {id_B, X_WB}});
+
+  // Both inflated AABBs must overlap the sphere => 2 candidates.
+  ASSERT_EQ(engine.FindCollisionCandidates().size(), 2);
+
+  // Update A to zero margin. B must be unaffected.
+  ProximityProperties props_zero;
+  props_zero.AddProperty(kHydroGroup, kMargin, 0.0);
+  AddCompliantHydroelasticProperties(kResHint, kE, &props_zero);
+  const InternalGeometry geo_A(SourceId::get_new_id(),
+                               std::make_unique<Convex>(path),
+                               FrameId::get_new_id(), id_A, "A", X_WA);
+  engine.UpdateRepresentationForNewProperties(geo_A, props_zero);
+
+  // UpdateWorldPoses triggers computeAABB() on all dynamic objects (A and B).
+  // In the bug case, B's aabb_local was reset when A's was updated (shared
+  // Convexd), so B would lose its inflation here.
+  engine.UpdateWorldPoses({{id_A, X_WA}, {id_B, X_WB}});
+
+  // A-sphere overlap is gone; B-sphere overlap must persist.
+  EXPECT_EQ(engine.FindCollisionCandidates().size(), 1);
+}
+
+// Tests that the convex hull cache is correctly evicted when geometries are
+// removed. Exercises three eviction cases in sequence using the same initial
+// population, plus a running invariant check on the reverse map.
+//
+// Initial setup (all from the same .obj, all dynamic):
+//   G1: scale (1,1,1) — sole occupant of the (1,1,1,0) sub-entry.
+//   G2: scale (2,1,1) — shares the (2,1,1,0) sub-entry with G3.
+//   G3: scale (2,1,1) — shares the (2,1,1,0) sub-entry with G2.
+//
+// This yields 2 sub-entries under 1 file entry initially.
+//
+// Removal sequence and expected outcomes:
+//   Remove G3: G2 still holds the (2,1,1,0) hull → no eviction.
+//              2 sub-entries, 1 file entry.
+//   Remove G2: cache is now sole owner of (2,1,1,0) → sub-entry evicted.
+//              1 sub-entry, 1 file entry.
+//   Remove G1: cache is sole owner of (1,1,1,0) → evicted; file entry empty →
+//              file entry also evicted.
+//              0 sub-entries, 0 file entries.
+//
+// After each removal, the reverse-map invariant is checked:
+//   a) The removed geometry is no longer in geometry_to_hull_key.
+//   b) Every remaining entry in geometry_to_hull_key has a corresponding
+//      valid pair in convex_hull_cache.
+GTEST_TEST(ProximityEngineTests, ConvexHullCacheEviction) {
+  ProximityEngine<double> engine;
+  const std::string path =
+      FindResourceOrThrow("drake/geometry/test/quad_cube.obj");
+
+  const double kResHint = 0.5;
+  const double kE = 1e8;
+
+  ProximityProperties props;
+  AddCompliantHydroelasticProperties(kResHint, kE, &props);
+
+  const Convex convex_unit(path, 1.0);
+  const Convex convex_scaled(path, Vector3d(2, 1, 1));
+
+  const GeometryId id_G1 = GeometryId::get_new_id();
+  const GeometryId id_G2 = GeometryId::get_new_id();
+  const GeometryId id_G3 = GeometryId::get_new_id();
+  engine.AddDynamicGeometry(convex_unit, {}, id_G1, props);
+  engine.AddDynamicGeometry(convex_scaled, {}, id_G2, props);
+  engine.AddDynamicGeometry(convex_scaled, {}, id_G3, props);
+
+  // Helper that checks the reverse-map invariant: every entry in
+  // geometry_to_hull_key has a corresponding valid entry in convex_hull_cache,
+  // and the given removed_id is absent.
+  auto validate_eviction = [&](GeometryId removed_id, int expected_files,
+                               int expected_hulls, const std::string& label) {
+    SCOPED_TRACE(label);
+    EXPECT_TRUE(
+        ProximityEngineTester::geometry_hull_key_absent(engine, removed_id));
+    EXPECT_TRUE(
+        ProximityEngineTester::geometry_hull_reverse_map_consistent(engine));
+    EXPECT_EQ(ProximityEngineTester::convex_hull_cache_file_entries(engine),
+              expected_files);
+    EXPECT_EQ(ProximityEngineTester::convex_hull_cache_hull_entries(engine),
+              expected_hulls);
+  };
+
+  // Confirm initial conditions.
+  int expected_files = 1;
+  int expected_hulls = 2;
+  validate_eviction(GeometryId::get_new_id(), expected_files, expected_hulls,
+                    "Fake Geometry");
+
+  // Remove G3 — G2 still holds the (2,1,1,0) hull; no eviction expected.
+  engine.RemoveGeometry(id_G3, /* is_dynamic= */ true);
+  validate_eviction(id_G3, expected_files, expected_hulls, "G3 removed");
+
+  // Remove G2 — cache is now sole owner of (2,1,1,0); sub-entry evicted.
+  engine.RemoveGeometry(id_G2, /* is_dynamic= */ true);
+  validate_eviction(id_G2, expected_files, --expected_hulls, "G2 removed");
+
+  // Remove G1 — cache is sole owner of (1,1,1,0); fully evicted.
+  engine.RemoveGeometry(id_G1, /* is_dynamic= */ true);
+  validate_eviction(id_G1, --expected_files, --expected_hulls, "G1 removed");
+}
 
 // Tests that the signed distance field (SDF) data computed for an obj correctly
 // accounts for its scale factor.
@@ -959,37 +1337,24 @@ GTEST_TEST(ProximityEngineTests, FailedParsing) {
 
 // Tests for copy/move semantics.  ---------------------------------------------
 
-// Tests the copy semantics of the ProximityEngine -- the copy is a complete,
-// deep copy. Every type of shape specification must be included in this test.
+// Tests the copy semantics of the ProximityEngine -- the copy is a complete
+// copy. Each CollisionObjectd (and its transform, user data, and AABB) is
+// individually duplicated, but the underlying fcl collision geometry is shared
+// rather than deep-copied, since FCL geometry is treated as immutable after
+// construction. As cloning makes no special effort based on geometry type, we
+// can use one or two arbitrary, representative shapes for this test.
 GTEST_TEST(ProximityEngineTests, CopySemantics) {
   ProximityEngine<double> ref_engine;
-  Sphere sphere{0.5};
-  RigidTransformd pose = RigidTransformd::Identity();
+  const RigidTransformd pose = RigidTransformd::Identity();
 
   // NOTE: The GeometryId values are all lies; the values are arbitrary but
   // do not matter in the context of this test.
-  ref_engine.AddAnchoredGeometry(sphere, pose, GeometryId::get_new_id());
+  ref_engine.AddAnchoredGeometry(Sphere{0.5}, pose, GeometryId::get_new_id());
+  ref_engine.AddDynamicGeometry(Sphere{0.5}, pose, GeometryId::get_new_id());
 
-  ref_engine.AddDynamicGeometry(sphere, pose, GeometryId::get_new_id());
-
-  Cylinder cylinder{0.1, 1.0};
-  ref_engine.AddDynamicGeometry(cylinder, pose, GeometryId::get_new_id());
-
-  Box box{0.1, 0.2, 0.3};
-  ref_engine.AddDynamicGeometry(box, pose, GeometryId::get_new_id());
-
-  Capsule capsule{0.1, 1.0};
-  ref_engine.AddDynamicGeometry(capsule, pose, GeometryId::get_new_id());
-
-  Ellipsoid ellipsoid{0.1, 0.2, 0.3};
-  ref_engine.AddDynamicGeometry(ellipsoid, pose, GeometryId::get_new_id());
-
-  HalfSpace half_space{};
-  ref_engine.AddDynamicGeometry(half_space, pose, GeometryId::get_new_id());
-
-  Convex convex{
-      drake::FindResourceOrThrow("drake/geometry/test/quad_cube.obj")};
-  ref_engine.AddDynamicGeometry(convex, pose, GeometryId::get_new_id());
+  ref_engine.AddDynamicGeometry(
+      Convex{drake::FindResourceOrThrow("drake/geometry/test/quad_cube.obj")},
+      pose, GeometryId::get_new_id());
 
   ProximityEngine<double> copy_construct(ref_engine);
   ProximityEngineTester::IsDeepCopy(copy_construct, ref_engine);


### PR DESCRIPTION
Specifically, this allows for caching the convex hulls used in FCL. This doesn't handle hydroelastic representations, derived quantities (like sdfs), or other artifacts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24293)
<!-- Reviewable:end -->
