### PR TITLE
[setup] Move libclang out of default source prereqs

### DIFF
--- a/setup/ubuntu/source_distribution/packages-noble-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-noble-test-only.txt
@@ -1,3 +1,4 @@
+libclang-20-dev
 mold
 python3-dateutil
 python3-flask

--- a/setup/ubuntu/source_distribution/packages-noble.txt
+++ b/setup/ubuntu/source_distribution/packages-noble.txt
@@ -1,5 +1,4 @@
 gfortran
-libclang-20-dev
 libgl-dev
 libglib2.0-dev
 libglx-dev

--- a/setup/ubuntu/source_distribution/packages-resolute-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-resolute-test-only.txt
@@ -1,3 +1,4 @@
+libclang-20-dev
 mold
 python3-dateutil
 python3-flask

--- a/setup/ubuntu/source_distribution/packages-resolute.txt
+++ b/setup/ubuntu/source_distribution/packages-resolute.txt
@@ -1,5 +1,4 @@
 gfortran
-libclang-20-dev
 libgl-dev
 libglib2.0-dev
 libglx-dev


### PR DESCRIPTION
Now that generated docstrings are commiteed to git, we don't need libclang at build-time, rather only a test-time (for linting).

Amends #23431.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24300)
<!-- Reviewable:end -->
