### PR TITLE
[setup] Use Python 3.14 on Resolute

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-resolute.txt
+++ b/setup/ubuntu/binary_distribution/packages-resolute.txt
@@ -8,7 +8,7 @@ libglx0
 libgomp1
 liblapack3
 libopengl0
-libpython3.13
+libpython3.14
 libspdlog-dev
 libx11-6
 ocl-icd-libopencl1


### PR DESCRIPTION
Addresses https://drake-jenkins.csail.mit.edu/view/Linux%20Resolute%20Unprovisioned/job/linux-resolute-unprovisioned-clang-bazel-nightly-everything-release/7/ and other related failures.

Our CMake logic says we should be on 3.14 on this platform:

https://github.com/RobotLocomotion/drake/blob/e53ec4da3c250428b9ee7dcb6c7e165e5e94f4da/CMakeLists.txt#L224

but our `install_prereqs` doesn't match.

Towards #23976.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24307)
<!-- Reviewable:end -->
