### PR TITLE
Remove platform-based minimum on CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,15 @@
 # -*- mode: cmake -*-
 # vi: set ft=cmake :
 
-# The minimum required CMake version should be the minimum of the versions
-# listed in doc/_pages/from_source.md and the version used by the wheel build.
-# When this changes, drake-external-examples/drake_cmake_external/CMakeLists.txt
-# should be changed accordingly so that downstream users are synced with
-# Drake itself.
-cmake_minimum_required(VERSION 3.26)
+# The upper bound here (which sets the "policy version") should match the
+# highest version tested in Drake CI, which is documented in
+# doc/_pages/from_source.md. On the other hand, the minimum version is not
+# necessarily governed by our CI test matrix or OS support matrix, rather by
+# what is strictly required by the CMake features used here. This logic is
+# similar to what governs our minimum Bazel version (see MODULE.bazel).
+# When changing this, tools/install/libdrake/drake-config.cmake.in and its
+# corresponding tests should also be updated.
+cmake_minimum_required(VERSION 3.20...4.3)
 
 project(drake
   DESCRIPTION "Model-based design and verification for robotics"

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -28,10 +28,10 @@ officially supports when building from source:
      CMakeLists.txt. -->
 <!-- The minimum Python version(s) should match those listed in both the root
      CMakeLists.txt and setup/python/pyproject.toml. -->
-<!-- The minimum CMake version across all platforms should match that listed
-     in the root CMakeLists.txt. The maximum version should match the policy
-     version listed in tools/install/libdrake/drake-config.cmake.in (and all
-     corresponding tests). -->
+<!-- The maximum CMake version across all platforms should match the upper
+     bound ("policy version") listed in both the root CMakeLists.txt and
+     tools/install/libdrake/drake-config.cmake.in (along with the related
+     libdrake tests). -->
 
 | Operating System ⁽¹⁾               | Architecture | Python ⁽²⁾ | Bazel | CMake | C/C++ Compiler ⁽³⁾           |
 |------------------------------------|--------------|------------|-------|-------|------------------------------|


### PR DESCRIPTION
Instead of basing our CMake minimum required on the minimum tested in CI across all platforms, set it based on what we know we need based on the CMake feature usage in the build. This means a "downgrade" to 3.20 (see: `cmake_path`), until a newer feature may be used to demand an update in the future.

Further, update the policy version based on the maximum version that is tested in CI, which will typically come from Homebrew on macOS and is currently 4.3.

Amends #24290.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24312)
<!-- Reviewable:end -->
