### PR TITLE
Update dependency buildifier_prebuilt to v8.5.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -198,7 +198,7 @@ use_repo(maven, "drake_maven_internal")
 
 bazel_dep(
     name = "buildifier_prebuilt",
-    version = "8.2.1.2",
+    version = "8.5.1",
     dev_dependency = True,
 )
 bazel_dep(

--- a/tools/lint/buildifier-tables.json
+++ b/tools/lint/buildifier-tables.json
@@ -25,6 +25,29 @@
     "install_files.files": true
   },
   "NamePriority": {
+    "cc_library_vendored.srcs_vendored": -90,
+    "generate_vendor_patch.srcs_vendored": -90,
+    "cc_library_vendored.hdrs_vendored": -87,
+
+    "check_lists_consistency.files": -9,
+    "check_lists_consistency.glob_include": -8,
+    "check_lists_consistency.glob_exclude": -7,
+
+    "coin_cc_library.config_h": -95,
+    "coin_cc_library.config_h_public": -94,
+    "coin_cc_library.config_h_private": -93,
+    "coin_cc_library.autoconf_defines": -92,
+    "coin_cc_library.autoconf_undefines": -91,
+    "coin_cc_library.config_private_defines": -91,
+    "coin_cc_library.hdrs_public": -87,
+    "coin_cc_library.includes_public": -87,
+    "coin_cc_library.hdrs_private": -86,
+    "coin_cc_library.includes_private": -86,
+    "coin_cc_library.vendor_tool_args": -2,
+    "coin_cc_library.output_vendoring_patch": -1,
+
+    "cmake_configure_file.strict": -1,
+
     "drake_cc_library.implementation_deps": 5,
     "drake_cc_library_linux_only.implementation_deps": 5,
     "drake_cc_optional_library.implementation_deps": 5,

--- a/tools/workspace/ccd_internal/package.BUILD.bazel
+++ b/tools/workspace/ccd_internal/package.BUILD.bazel
@@ -28,7 +28,10 @@ cmake_configure_file(
 # Group the headers exported by this library.
 cc_library(
     name = "hdrs",
-    hdrs = [":config"] + glob(["src/ccd/*.h"], allow_empty = False),
+    hdrs = [":config"] + glob(
+        ["src/ccd/*.h"],
+        allow_empty = False,
+    ),
     defines = ["CCD_STATIC_DEFINE"],
     includes = ["src"],
     isystem = True,
@@ -37,7 +40,13 @@ cc_library(
 # Compile the code (using both its exported headers and its private headers).
 cc_library(
     name = "compiled",
-    srcs = glob(["src/*.c", "src/*.h"], allow_empty = False),
+    srcs = glob(
+        [
+            "src/*.c",
+            "src/*.h",
+        ],
+        allow_empty = False,
+    ),
     copts = [
         "-Wno-all",
         "-fvisibility=hidden",
@@ -59,11 +68,11 @@ cc_linkonly_library(
 cc_library(
     name = "ccd",
     linkstatic = True,
+    visibility = ["//visibility:public"],
     deps = [
         ":archive",
         ":hdrs",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(

--- a/tools/workspace/clarabel_cpp_internal/package.BUILD.bazel
+++ b/tools/workspace/clarabel_cpp_internal/package.BUILD.bazel
@@ -17,7 +17,10 @@ exports_files([
     "rust_wrapper/Cargo.toml",
 ])
 
-_HDRS = glob(["include/**"], allow_empty = False)
+_HDRS = glob(
+    ["include/**"],
+    allow_empty = False,
+)
 
 cc_library_vendored(
     name = "hdrs",
@@ -36,11 +39,14 @@ cc_library_vendored(
 
 rust_static_library(
     name = "clarabel_cpp_rust_wrapper",
-    edition = "2021",
-    srcs = glob(["rust_wrapper/src/**/*.rs"], allow_empty = False),
+    srcs = glob(
+        ["rust_wrapper/src/**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = ["sdp"],
-    deps = all_crate_deps(),
+    edition = "2021",
     proc_macro_deps = all_crate_deps(proc_macro = True),
+    deps = all_crate_deps(),
 )
 
 cc_wrap_static_archive_hidden(
@@ -52,14 +58,14 @@ cc_wrap_static_archive_hidden(
 cc_library(
     name = "clarabel_cpp",
     linkstatic = True,
+    visibility = ["//visibility:public"],
     deps = [
-        ":hdrs",
         ":clarabel_cpp_rust_wrapper_hidden",
+        ":hdrs",
         "@blas",
         "@eigen",
         "@lapack",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(

--- a/tools/workspace/clp_internal/package.BUILD.bazel
+++ b/tools/workspace/clp_internal/package.BUILD.bazel
@@ -20,17 +20,18 @@ _HDRS = glob(
         "Clp/src/*.h",
         "Clp/src/*.hpp",
     ],
+    allow_empty = False,
     exclude = [
         "**/config*",
         "**/*Config.h",
     ],
-    allow_empty = False,
 )
 
 _SRCS = glob(
     [
         "Clp/src/*.cpp",
     ],
+    allow_empty = False,
     exclude = [
         # We only want libClp, not libClpSolver nor the main program.
         "**/MyEventHandler*",
@@ -51,7 +52,6 @@ _SRCS = glob(
         # We treat COIN_HAS_WSMP as OFF.
         "**/ClpCholeskyWssmp*",
     ],
-    allow_empty = False,
 )
 
 _AUTOCONF_DEFINES = [
@@ -138,17 +138,17 @@ coin_cc_library(
     autoconf_defines = _AUTOCONF_DEFINES,
     autoconf_undefines = _AUTOCONF_UNDEFINES,
     config_private_defines = _CONFIG_PRIVATE_DEFINES,
+    srcs = _SRCS,
     hdrs_public = _HDRS,
     includes_public = _INCLUDES,
     hdrs_private = _HDRS,
     includes_private = _INCLUDES,
-    srcs = _SRCS,
     vendor_tool_args = ["--no-inline-namespace"],
     output_vendoring_patch = "drake_clp.patch",
+    visibility = ["//visibility:public"],
     deps = [
         "@coinutils_internal//:coinutils",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(
@@ -159,10 +159,10 @@ install(
         ":drake_clp.patch",
         "@drake//tools/workspace/clp_internal:patches",
     ],
+    doc_strip_prefix = ["patches"],
     allowed_externals = [
         "@drake//tools/workspace/clp_internal:patches",
     ],
-    doc_strip_prefix = ["patches"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/coinutils_internal/package.BUILD.bazel
+++ b/tools/workspace/coinutils_internal/package.BUILD.bazel
@@ -17,11 +17,11 @@ _HDRS = glob(
         "CoinUtils/src/*.hpp",
         "CoinUtils/src/*.h",
     ],
+    allow_empty = False,
     exclude = [
         "**/config*",
         "**/*Config.h",
     ],
-    allow_empty = False,
 )
 
 _SRCS = glob(
@@ -126,18 +126,18 @@ coin_cc_library(
     autoconf_defines = _AUTOCONF_DEFINES,
     autoconf_undefines = _AUTOCONF_UNDEFINES,
     config_private_defines = _CONFIG_PRIVATE_DEFINES,
+    srcs = _SRCS,
     hdrs_public = _HDRS,
     includes_public = _INCLUDES,
     hdrs_private = _HDRS,
     includes_private = _INCLUDES,
-    srcs = _SRCS,
     vendor_tool_args = ["--no-inline-namespace"],
     output_vendoring_patch = "drake_coinutils.patch",
+    visibility = ["//visibility:public"],
     deps = [
         "@blas",
         "@lapack",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(

--- a/tools/workspace/common_robotics_utilities_internal/package.BUILD.bazel
+++ b/tools/workspace/common_robotics_utilities_internal/package.BUILD.bazel
@@ -51,16 +51,16 @@ cc_library(
         "include/common_robotics_utilities/voxel_grid_common.hpp",
         "include/common_robotics_utilities/zlib_helpers.hpp",
     ],
+    copts = COPTS,
     includes = ["include"],
     isystem = True,
-    copts = COPTS,
+    linkopts = [
+        "-pthread",
+    ],
     linkstatic = True,
     deps = [
         "@eigen",
         "@zlib",
-    ],
-    linkopts = [
-        "-pthread",
     ],
 )
 
@@ -108,18 +108,18 @@ cc_test(
 # N.B. This test uses two threads even when OpenMP is not available.
 cc_test(
     name = "parallelism_test",
+    timeout = "moderate",
     srcs = ["test/parallelism_test.cpp"],
     copts = COPTS,
     env = {"OMP_NUM_THREADS": "2"},
+    flaky = True,
+    shard_count = 4,
     tags = [
         "cpu:2",
         "no_kcov",
         # Some of these tests take too long under valgrind for CI.
         "no_memcheck",
     ],
-    flaky = True,
-    shard_count = 4,
-    timeout = "moderate",
     deps = [
         ":common_robotics_utilities",
         "@googletest//:gtest",

--- a/tools/workspace/csdp_internal/package.BUILD.bazel
+++ b/tools/workspace/csdp_internal/package.BUILD.bazel
@@ -65,12 +65,12 @@ cc_library(
     includes = ["includes"],
     isystem = True,
     linkstatic = 1,
+    visibility = ["//visibility:public"],
     deps = [
         "@blas",
         "@drake//solvers:csdp_solver_error_handling",
         "@lapack",
     ],
-    visibility = ["//visibility:public"],
 )
 
 # We do not install the header file (its a private dependency), but we still

--- a/tools/workspace/curl_internal/package.BUILD.bazel
+++ b/tools/workspace/curl_internal/package.BUILD.bazel
@@ -247,25 +247,25 @@ cmake_configure_file(
     name = "configure_file",
     src = "lib/curl_config-cmake.h.in",
     out = "lib/curl_config.h",
+    strict = True,
     defines = CMAKE_DEFINES,
     undefines = CMAKE_UNDEFINES,
-    strict = True,
 )
 
 # Compile the library.
 cc_library(
     name = "libcurl",
-    hdrs = _HDRS + [":lib/curl_config.h"],
     srcs = _SRCS,
+    hdrs = _HDRS + [":lib/curl_config.h"],
+    copts = _COPTS,
     includes = _INCLUDES,
     isystem = True,
-    copts = _COPTS,
     linkopts = _LINKOPTS,
     linkstatic = 1,
+    visibility = ["//visibility:public"],
     deps = [
         "@zlib",
     ],
-    visibility = ["//visibility:public"],
 )
 
 # Install the license notice.

--- a/tools/workspace/dm_control_internal/package.BUILD.bazel
+++ b/tools/workspace/dm_control_internal/package.BUILD.bazel
@@ -4,10 +4,13 @@ package(default_visibility = ["//visibility:private"])
 
 exports_files(
     # Keep this list alpha-sorted.
-    srcs = glob([
-        "dm_control/suite/*.xml",
-        "dm_control/suite/common/*.xml",
-    ] + ["LICENSE"], allow_empty = False),
+    srcs = glob(
+        [
+            "dm_control/suite/*.xml",
+            "dm_control/suite/common/*.xml",
+        ] + ["LICENSE"],
+        allow_empty = False,
+    ),
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/doxygen_internal/package.BUILD.bazel
+++ b/tools/workspace/doxygen_internal/package.BUILD.bazel
@@ -1,3 +1,6 @@
 # -*- bazel -*-
 
-exports_files(["doxygen", "drake_repository_metadata.json"])
+exports_files([
+    "doxygen",
+    "drake_repository_metadata.json",
+])

--- a/tools/workspace/drake_models/package.BUILD.bazel
+++ b/tools/workspace/drake_models/package.BUILD.bazel
@@ -44,17 +44,21 @@ filegroup(
 # to take its place, so that our Bazel install rules can still find it. We'll
 # fill it with dummy data. To guard against shipping a Drake release with the
 # dummy data, the package_map_remote_test checks the content of the json file.
-HAS_METADATA = len(glob(["drake_repository_metadata.json"], allow_empty = True)) > 0
+HAS_METADATA = len(glob(
+    ["drake_repository_metadata.json"],
+    allow_empty = True,
+)) > 0
 
 HAS_METADATA and exports_files(["drake_repository_metadata.json"])
+
 HAS_METADATA or genrule(
     name = "_gen_dummy_metadata",
     outs = ["drake_repository_metadata.json"],
     cmd = "echo '{}' > $@".format(
         json.encode(dict(
-            urls = [],
             sha256 = "",
             strip_prefix = "",
+            urls = [],
         )),
     ),
 )

--- a/tools/workspace/fcl_internal/package.BUILD.bazel
+++ b/tools/workspace/fcl_internal/package.BUILD.bazel
@@ -58,10 +58,10 @@ _HDRS_GLOB = glob(
     include = [
         "include/**/*.h",
     ],
+    allow_empty = False,
     exclude = [
         "**/octree/**",
     ],
-    allow_empty = False,
 )
 
 # To minimize the build footprint, only build the fraction of FCL that is
@@ -70,6 +70,7 @@ _SRCS = glob(
     include = [
         "src/**/*.cpp",
     ],
+    allow_empty = False,
     exclude = [
         # We use none of this code.
         "**/*conservative_advancement*.cpp",
@@ -84,7 +85,6 @@ _SRCS = glob(
         "src/math/*.cpp",
         "src/math/detail/*.cpp",
     ],
-    allow_empty = False,
 ) + [
     "src/broadphase/broadphase_collision_manager.cpp",
     "src/broadphase/broadphase_dynamic_AABB_tree.cpp",

--- a/tools/workspace/github3_py_internal/package.BUILD.bazel
+++ b/tools/workspace/github3_py_internal/package.BUILD.bazel
@@ -10,9 +10,12 @@ package(
 
 py_library(
     name = "github3_py",
-    srcs = glob([
-        "src/github3/**",
-    ], allow_empty = False),
+    srcs = glob(
+        [
+            "src/github3/**",
+        ],
+        allow_empty = False,
+    ),
     imports = [
         "src",
     ],

--- a/tools/workspace/gklib_internal/package.BUILD.bazel
+++ b/tools/workspace/gklib_internal/package.BUILD.bazel
@@ -9,10 +9,14 @@ package(default_visibility = ["//visibility:private"])
 
 cc_library(
     name = "gklib",
-    srcs = glob(["src/*.c"], allow_empty = False),
-    hdrs = glob(["include/*.h"], allow_empty = False),
-    includes = ["include"],
-    isystem = True,
+    srcs = glob(
+        ["src/*.c"],
+        allow_empty = False,
+    ),
+    hdrs = glob(
+        ["include/*.h"],
+        allow_empty = False,
+    ),
     copts = [
         # We don't allow Drake externals to use OpenMP until we wire up "max
         # parallelism" governance to a drake::Parallellism public API option.
@@ -20,6 +24,8 @@ cc_library(
         "-fvisibility=hidden",
         "-w",
     ],
+    includes = ["include"],
+    isystem = True,
     linkstatic = True,
     visibility = ["//visibility:public"],
 )

--- a/tools/workspace/gz_math_internal/package.BUILD.bazel
+++ b/tools/workspace/gz_math_internal/package.BUILD.bazel
@@ -257,9 +257,9 @@ cc_library_vendored(
         for x in _HDRS
     ],
     copts = ["-w"],
-    linkstatic = True,
     includes = ["drake_hdr"],
     isystem = True,
+    linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [
         "@gz_utils_internal//:gz_utils",

--- a/tools/workspace/gz_utils_internal/package.BUILD.bazel
+++ b/tools/workspace/gz_utils_internal/package.BUILD.bazel
@@ -95,20 +95,20 @@ _HDRS = _MOST_PUBLIC_HDRS + [
 
 cc_library_vendored(
     name = "gz_utils",
-    hdrs = _HDRS,
-    hdrs_vendored = [
-        x.replace("include/gz/", "drake_hdr/gz/")
-        for x in _HDRS
-    ],
     srcs = _SRCS,
     srcs_vendored = [
         x.replace("src/", "drake_src/")
         for x in _SRCS
     ],
+    hdrs = _HDRS,
+    hdrs_vendored = [
+        x.replace("include/gz/", "drake_hdr/gz/")
+        for x in _HDRS
+    ],
     copts = ["-w"],
-    linkstatic = True,
     includes = ["drake_hdr"],
     isystem = True,
+    linkstatic = True,
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/implib_so_internal/package.BUILD.bazel
+++ b/tools/workspace/implib_so_internal/package.BUILD.bazel
@@ -5,7 +5,10 @@ load("@drake//tools/skylark:py.bzl", "py_binary")
 py_binary(
     name = "gen",
     srcs = ["implib-gen.py"],
-    data = glob(["arch/**"], allow_empty = False),
+    data = glob(
+        ["arch/**"],
+        allow_empty = False,
+    ),
     main = "implib-gen.py",
     python_version = "PY3",
     srcs_version = "PY3",

--- a/tools/workspace/ipopt_internal/package.BUILD.bazel
+++ b/tools/workspace/ipopt_internal/package.BUILD.bazel
@@ -242,13 +242,17 @@ _INCLUDES_PRIVATE = depset([paths.dirname(x) for x in _SRCS]).to_list()
 
 # All of the headers that live in the same directories as the sources (except
 # for the config headers which we need to handle separately, below).
-_HDRS_PRIVATE = glob([
-    x + "/*.h*"
-    for x in _INCLUDES_PRIVATE
-], exclude = [
-    "src/Common/config*",
-    "src/Common/IpoptConfig.h",
-], allow_empty = False)
+_HDRS_PRIVATE = glob(
+    [
+        x + "/*.h*"
+        for x in _INCLUDES_PRIVATE
+    ],
+    allow_empty = False,
+    exclude = [
+        "src/Common/config*",
+        "src/Common/IpoptConfig.h",
+    ],
+)
 
 _AUTOCONF_DEFINES = [
     "IPOPT_VERSION=\"drake_vendor\"",
@@ -351,19 +355,19 @@ coin_cc_library(
     autoconf_defines = _AUTOCONF_DEFINES,
     autoconf_undefines = _AUTOCONF_UNDEFINES,
     config_private_defines = _CONFIG_PRIVATE_DEFINES,
+    srcs = _SRCS,
     hdrs_public = _HDRS_PUBLIC,
     includes_public = _INCLUDES_PUBLIC,
     hdrs_private = _HDRS_PRIVATE,
     includes_private = _INCLUDES_PRIVATE,
-    srcs = _SRCS,
     vendor_tool_args = ["--no-inline-namespace"],
     output_vendoring_patch = "drake_ipopt.patch",
+    visibility = ["//visibility:public"],
     deps = [
         "@blas",
         "@lapack",
         "@spral_internal//:spral",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(

--- a/tools/workspace/lapack_internal/package.BUILD.bazel
+++ b/tools/workspace/lapack_internal/package.BUILD.bazel
@@ -95,13 +95,13 @@ LAPACK_ALL_SRCS = depset(
 # The next two need special attention since they are actual Fortran modules.
 
 fortran_module(
-    src = "SRC/la_constants.f90",
     name = "la_constants",
+    src = "SRC/la_constants.f90",
 )
 
 fortran_module(
-    src = "SRC/la_xisnan.F90",
     name = "la_xisnan",
+    src = "SRC/la_xisnan.F90",
     uses = ["la_constants"],
 )
 
@@ -123,11 +123,11 @@ fortran_library(
         x[3:] if x.startswith("../") else "SRC/" + x
         for x in LAPACK_MOST_SRCS
     ],
-    linkstatic = True,
     _input_mods = [
         "la_constants.mod",
         "la_xisnan.mod",
     ],
+    linkstatic = True,
     deps = [
         ":la_constants",
         ":la_xisnan",

--- a/tools/workspace/libpng_internal/package.BUILD.bazel
+++ b/tools/workspace/libpng_internal/package.BUILD.bazel
@@ -69,13 +69,11 @@ genrule(
 
 cc_library(
     name = "libpng",
-    hdrs = _PUBLIC_HDRS,
     srcs = _SRCS + _PRIVATE_HDRS + select({
         ":build_intel": _SRCS_INTEL,
         "//conditions:default": [],
     }),
-    includes = ["."],
-    isystem = True,
+    hdrs = _PUBLIC_HDRS,
     copts = [
         "-fvisibility=hidden",
         "-w",
@@ -97,12 +95,14 @@ cc_library(
             "-DPNG_INTEL_SSE_IMPLEMENTATION=0",
         ],
     }),
+    includes = ["."],
+    isystem = True,
     linkopts = ["-lm"],
     linkstatic = True,
+    visibility = ["//visibility:public"],
     deps = [
         "@zlib",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(

--- a/tools/workspace/libtiff_internal/package.BUILD.bazel
+++ b/tools/workspace/libtiff_internal/package.BUILD.bazel
@@ -69,6 +69,7 @@ cmake_configure_files(
         "HAVE_SYS_TYPES_H=1",
         "HAVE_UNISTD_H=1",
     ],
+    strict = True,
     undefines = [
         # Drake only supports 64-bit, little-endian hardware.
         "WORDS_BIGENDIAN",
@@ -120,7 +121,6 @@ cmake_configure_files(
         # Ignore stray @VAR@ in comments.
         "VAR",
     ],
-    strict = True,
 )
 
 _PUBLIC_HDRS = [
@@ -152,19 +152,19 @@ _SRCS = glob(
 
 cc_library(
     name = "libtiff",
-    hdrs = _PUBLIC_HDRS,
     srcs = _SRCS + _PRIVATE_HDRS,
-    includes = ["libtiff"],
-    isystem = True,
+    hdrs = _PUBLIC_HDRS,
     copts = [
         "-fvisibility=hidden",
         "-w",
     ],
+    includes = ["libtiff"],
+    isystem = True,
     linkstatic = True,
+    visibility = ["//visibility:public"],
     deps = [
         "@zlib",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(

--- a/tools/workspace/libzip_internal/package.BUILD.bazel
+++ b/tools/workspace/libzip_internal/package.BUILD.bazel
@@ -251,11 +251,11 @@ cc_library(
         "-w",
     ],
     includes = ["lib"],
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
     deps = [
         "@zlib",
     ],
-    linkstatic = 1,
-    visibility = ["//visibility:public"],
 )
 
 # Install the license file.

--- a/tools/workspace/metis_internal/package.BUILD.bazel
+++ b/tools/workspace/metis_internal/package.BUILD.bazel
@@ -9,10 +9,14 @@ package(default_visibility = ["//visibility:private"])
 
 cc_library(
     name = "metis",
-    srcs = glob(["libmetis/*.c"], allow_empty = False),
-    hdrs = glob(["libmetis/*.h"], allow_empty = False) + ["include/metis.h"],
-    includes = ["include"],
-    isystem = True,
+    srcs = glob(
+        ["libmetis/*.c"],
+        allow_empty = False,
+    ),
+    hdrs = glob(
+        ["libmetis/*.h"],
+        allow_empty = False,
+    ) + ["include/metis.h"],
     copts = [
         # We don't allow Drake externals to use OpenMP until we wire up "max
         # parallelism" governance to a drake::Parallellism public API option.
@@ -20,11 +24,13 @@ cc_library(
         "-fvisibility=hidden",
         "-w",
     ],
+    includes = ["include"],
+    isystem = True,
     linkstatic = True,
+    visibility = ["//visibility:public"],
     deps = [
         "@gklib_internal//:gklib",
     ],
-    visibility = ["//visibility:public"],
 )
 
 # Install the license file.

--- a/tools/workspace/mosek/package.BUILD.bazel
+++ b/tools/workspace/mosek/package.BUILD.bazel
@@ -12,27 +12,34 @@ package(default_visibility = ["//visibility:private"])
 
 # Find the TBB shared library with the major.minor-style version number.
 # This will be the spelling with the actual object code.
-_TBB_MAJMIN_GLOB = glob([
-    # This is the spelling for linux64x86.
-    "bin/libtbb.so.*.*",
-    # This is the spelling for linuxaarch64.
-    "bin/libtbb_debug.so.*.*",
-    # This is the spelling for osxaarch64 and osx64x86.
-    "bin/libtbb.*.*.dylib",
-], allow_empty = True)
+_TBB_MAJMIN_GLOB = glob(
+    [
+        # This is the spelling for linux64x86.
+        "bin/libtbb.so.*.*",
+        # This is the spelling for linuxaarch64.
+        "bin/libtbb_debug.so.*.*",
+        # This is the spelling for osxaarch64 and osx64x86.
+        "bin/libtbb.*.*.dylib",
+    ],
+    allow_empty = True,
+)
 
 len(_TBB_MAJMIN_GLOB) == 1 or fail("Glob failure: " + str(glob(["**"])))
 
 # Find the TBB shared library with the major-only-style version number.
 # This will be the spelling that's a symlink to the major.minor spelling.
-_TBB_MAJ_GLOB = glob([
-    # This is the spelling for linux64x86.
-    "bin/libtbb.so.*",
-    # This is the spelling for linuxaarch64.
-    "bin/libtbb_debug.so.*",
-    # This is the spelling for osxaarch64 and osx64x86.
-    "bin/libtbb.*.dylib",
-], exclude = _TBB_MAJMIN_GLOB, allow_empty = True)
+_TBB_MAJ_GLOB = glob(
+    [
+        # This is the spelling for linux64x86.
+        "bin/libtbb.so.*",
+        # This is the spelling for linuxaarch64.
+        "bin/libtbb_debug.so.*",
+        # This is the spelling for osxaarch64 and osx64x86.
+        "bin/libtbb.*.dylib",
+    ],
+    allow_empty = True,
+    exclude = _TBB_MAJMIN_GLOB,
+)
 
 len(_TBB_MAJ_GLOB) == 1 or fail("Glob failure: " + str(glob(["**"])))
 
@@ -49,27 +56,30 @@ cc_import(
 
 cc_library(
     name = "tbb",
+    linkopts = ["-pthread"],
+    visibility = ["//visibility:public"],
     deps = [
         ":import_tbb_maj",
         ":import_tbb_majmin",
     ],
-    linkopts = ["-pthread"],
-    visibility = ["//visibility:public"],
 )
 
 # Find the mosek shared library with the major.minor-style version number.
-_MOSEK_MAJMIN_GLOB = glob([
-    "bin/libmosek64.so.*.*",
-    "bin/libmosek64.*.*.dylib",
-], allow_empty = True)
+_MOSEK_MAJMIN_GLOB = glob(
+    [
+        "bin/libmosek64.so.*.*",
+        "bin/libmosek64.*.*.dylib",
+    ],
+    allow_empty = True,
+)
 
 len(_MOSEK_MAJMIN_GLOB) == 1 or fail("Glob failure: " + str(glob(["**"])))
 
 cc_import(
     name = "import_mosek",
     shared_library = _MOSEK_MAJMIN_GLOB[0],
-    deps = [":tbb"],
     visibility = ["//visibility:private"],
+    deps = [":tbb"],
 )
 
 _MOSEK_SO_NAME = paths.basename(_MOSEK_MAJMIN_GLOB[0])
@@ -92,10 +102,10 @@ cc_library(
     srcs = _IMPLIB_SRCS + [
         "@drake//tools/workspace/mosek:drake_dlopen_mosek.cc",
     ],
+    linkstatic = True,
     deps = [
         "@drake//common:find_resource",
     ],
-    linkstatic = True,
 )
 
 config_setting(
@@ -107,11 +117,11 @@ cc_library(
     name = "mosek",
     hdrs = ["h/mosek.h"],
     includes = ["h"],
+    visibility = ["//visibility:public"],
     deps = select({
         ":lazy_load": [":implib_mosek"],
         "//conditions:default": [":import_mosek"],
     }),
-    visibility = ["//visibility:public"],
 )
 
 install_files(
@@ -146,12 +156,12 @@ install(
 
 install(
     name = "install",
+    visibility = ["//visibility:public"],
     deps = [
         ":install_licenses",
         ":install_mosek_libraries",
         ":install_tbb_libraries",
     ],
-    visibility = ["//visibility:public"],
 )
 
 exports_files(["drake_repository_metadata.json"])

--- a/tools/workspace/mpmath_py_internal/package.BUILD.bazel
+++ b/tools/workspace/mpmath_py_internal/package.BUILD.bazel
@@ -10,9 +10,12 @@ package(
 
 py_library(
     name = "mpmath_py",
-    srcs = glob([
-        "mpmath/**/*.py",
-    ], allow_empty = False),
+    srcs = glob(
+        [
+            "mpmath/**/*.py",
+        ],
+        allow_empty = False,
+    ),
     imports = ["."],
 )
 

--- a/tools/workspace/msgpack_internal/package.BUILD.bazel
+++ b/tools/workspace/msgpack_internal/package.BUILD.bazel
@@ -22,24 +22,28 @@ cc_library(
 # The upstream headers that we'll use.
 _HDRS = [
     "include/msgpack.hpp",
-] + glob([
-    "include/msgpack/**/*.h",
-    "include/msgpack/**/*.hpp",
-], exclude = _HDRS_NO_VENDOR, allow_empty = False)
+] + glob(
+    [
+        "include/msgpack/**/*.h",
+        "include/msgpack/**/*.hpp",
+    ],
+    allow_empty = False,
+    exclude = _HDRS_NO_VENDOR,
+)
 
 cc_library_vendored(
     name = "msgpack",
     hdrs = _HDRS,
-    defines = ["MSGPACK_NO_BOOST"],
     hdrs_vendored = [
         x.replace("include/", "drake_hdr/")
         for x in _HDRS
     ],
+    defines = ["MSGPACK_NO_BOOST"],
     includes = ["drake_hdr"],
     isystem = True,
     linkstatic = 1,
-    deps = [":hdrs_no_vendor"],
     visibility = ["//visibility:public"],
+    deps = [":hdrs_no_vendor"],
 )
 
 install(

--- a/tools/workspace/nanoflann_internal/package.BUILD.bazel
+++ b/tools/workspace/nanoflann_internal/package.BUILD.bazel
@@ -10,9 +10,9 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "nanoflann",
     hdrs = ["include/nanoflann.hpp"],
-    strip_include_prefix = "include",
     isystem = True,
     linkstatic = 1,
+    strip_include_prefix = "include",
 )
 
 # Install the license file.

--- a/tools/workspace/nlohmann_internal/package.BUILD.bazel
+++ b/tools/workspace/nlohmann_internal/package.BUILD.bazel
@@ -13,8 +13,6 @@ cc_library(
         "single_include/nlohmann/json.hpp",
         "single_include/nlohmann/json_fwd.hpp",
     ],
-    strip_include_prefix = "single_include",
-    isystem = True,
     defines = [
         # The nlohmann/json code has logic that tries to infer whether or not
         # the compiler toolchain supports the spaceship operator (<=>).
@@ -25,7 +23,9 @@ cc_library(
         # spaceship support so we can just force it to be off; problem solved.
         "JSON_HAS_THREE_WAY_COMPARISON=0",
     ],
+    isystem = True,
     linkstatic = 1,
+    strip_include_prefix = "single_include",
 )
 
 # Install the license file.

--- a/tools/workspace/nlopt_internal/package.BUILD.bazel
+++ b/tools/workspace/nlopt_internal/package.BUILD.bazel
@@ -74,8 +74,14 @@ cc_library(
     name = "util",
     srcs = _SRCS_UTIL_CABI,
     hdrs = _HDRS_UTIL_CABI,
-    copts = ["-w", "-fvisibility=hidden"],
-    includes = ["src/api", "src/util"],
+    copts = [
+        "-w",
+        "-fvisibility=hidden",
+    ],
+    includes = [
+        "src/api",
+        "src/util",
+    ],
     isystem = True,
     linkstatic = True,
     deps = [
@@ -131,7 +137,10 @@ cc_library(
     name = "algs",
     srcs = _SRCS_ALGS_CABI,
     hdrs = _HDRS_ALGS_CABI,
-    copts = ["-w", "-fvisibility=hidden"],
+    copts = [
+        "-w",
+        "-fvisibility=hidden",
+    ],
     includes = [
         "src/algs/auglag",
         "src/algs/bobyqa",
@@ -202,7 +211,10 @@ cc_library(
     name = "stogo",
     srcs = _SRCS_STOGO_CABI,
     hdrs = _HDRS_STOGO_CABI,
-    copts = ["-w", "-fvisibility=hidden"],
+    copts = [
+        "-w",
+        "-fvisibility=hidden",
+    ],
     includes = ["src/algs/stogo"],
     isystem = True,
     linkstatic = True,
@@ -253,7 +265,10 @@ cc_library(
     name = "ags",
     srcs = _SRCS_AGS_CABI,
     hdrs = _HDRS_AGS_CABI,
-    copts = ["-w", "-fvisibility=hidden"],
+    copts = [
+        "-w",
+        "-fvisibility=hidden",
+    ],
     includes = ["src/algs/ags"],
     isystem = True,
     linkstatic = True,
@@ -282,7 +297,10 @@ cc_library(
     name = "api",
     srcs = _SRCS_API,
     hdrs = _HDRS_API,
-    copts = ["-w", "-fvisibility=hidden"],
+    copts = [
+        "-w",
+        "-fvisibility=hidden",
+    ],
     includes = ["src/api"],
     linkstatic = True,
     deps = [
@@ -303,6 +321,7 @@ _ALL_SRCS = (
     _SRCS_AGS_CPPABI +
     _SRCS_API
 )
+
 _ALL_HDRS = (
     _HDRS_UTIL_CABI +
     _HDRS_ALGS_CABI +
@@ -391,18 +410,21 @@ install(
     targets = [":nlopt"],
     docs = [
         "AUTHORS",
-    ] + glob([
-        "src/**/COPYING",
-        "src/**/COPYRIGHT",
-        "src/**/README",
-        "src/**/README.orig",
-    ], exclude = [
-        # These are disabled upstream by default.
-        "src/algs/cquad/**",
-        "src/algs/subplex/**",
-        # This is disabled in Drake specifically due to LGPL.
-        "src/algs/luksan/**",
-    ]),
+    ] + glob(
+        [
+            "src/**/COPYING",
+            "src/**/COPYRIGHT",
+            "src/**/README",
+            "src/**/README.orig",
+        ],
+        exclude = [
+            # These are disabled upstream by default.
+            "src/algs/cquad/**",
+            "src/algs/subplex/**",
+            # This is disabled in Drake specifically due to LGPL.
+            "src/algs/luksan/**",
+        ],
+    ),
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/onetbb_internal/package.BUILD.bazel
+++ b/tools/workspace/onetbb_internal/package.BUILD.bazel
@@ -20,19 +20,19 @@ cc_library(
         "include",
         "include/oneapi",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "@mosek//:tbb",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(
     name = "install",
     docs = ["LICENSE.txt"],
+    visibility = ["//visibility:public"],
     deps = [
         "@mosek//:install_tbb_libraries",
     ],
-    visibility = ["//visibility:public"],
 )
 
 exports_files(["drake_repository_metadata.json"])

--- a/tools/workspace/osqp_internal/package.BUILD.bazel
+++ b/tools/workspace/osqp_internal/package.BUILD.bazel
@@ -113,21 +113,21 @@ OSQPLIB_SOURCES = [
 
 cc_library(
     name = "osqp",
-    hdrs = OSQP_HEADERS_PUBLIC,
     srcs = OSQP_HEADERS_PRIVATE + OSQPLIB_SOURCES,
-    includes = [
-        "include/private",
-        "include/public",
-        "algebra/builtin",
-        "algebra/_common",
-        "algebra/_common/lin_sys/qdldl",
-    ],
-    isystem = True,
+    hdrs = OSQP_HEADERS_PUBLIC,
     copts = [
         "-fvisibility=hidden",
         "-w",
         "-Werror=incompatible-pointer-types",
     ],
+    includes = [
+        "algebra/_common",
+        "algebra/_common/lin_sys/qdldl",
+        "algebra/builtin",
+        "include/private",
+        "include/public",
+    ],
+    isystem = True,
     linkstatic = 1,
     deps = [
         "@qdldl_internal//:qdldl",

--- a/tools/workspace/poisson_disk_sampling_internal/package.BUILD.bazel
+++ b/tools/workspace/poisson_disk_sampling_internal/package.BUILD.bazel
@@ -22,15 +22,15 @@ copy_file(
 
 cc_library(
     name = "poisson_disk_sampling",
-    hdrs = ["include/thinks/tph_poisson.h"],
     srcs = [":implementation"],
-    strip_include_prefix = "include/thinks",
-    isystem = True,
-    linkstatic = 1,
+    hdrs = ["include/thinks/tph_poisson.h"],
     copts = [
         "-fvisibility=hidden",
         "-DTPH_POISSON_IMPLEMENTATION",
     ],
+    isystem = True,
+    linkstatic = 1,
+    strip_include_prefix = "include/thinks",
 )
 
 install(

--- a/tools/workspace/pybind11/package.BUILD.bazel
+++ b/tools/workspace/pybind11/package.BUILD.bazel
@@ -64,9 +64,9 @@ cc_library(
     includes = ["include"],
     isystem = True,
     deps = [
-        "@eigen",
         "@drake//tools/workspace/python:cc_headers",
         "@drake//tools/workspace/python:cc_libs",
+        "@eigen",
     ],
 )
 

--- a/tools/workspace/qdldl_internal/package.BUILD.bazel
+++ b/tools/workspace/qdldl_internal/package.BUILD.bazel
@@ -17,6 +17,7 @@ cmake_configure_file(
     name = "configure_file_types",
     src = "configure/qdldl_types.h.in",
     out = "include/qdldl_types.h",
+    strict = True,
     # https://github.com/osqp/qdldl/blob/v0.1.6/README.md#custom-types-for-integer-floats-and-booleans
     defines = [
         "QDLDL_BOOL_TYPE=unsigned char",
@@ -31,7 +32,6 @@ cmake_configure_file(
         # Match this to QDLDL_INT_TYPE above.
         "QDLDL_INT_TYPE_MAX=INT_MAX",
     ],
-    strict = True,
     visibility = ["//visibility:private"],
 )
 
@@ -39,24 +39,24 @@ cmake_configure_file(
     name = "configure_file_version",
     src = "configure/qdldl_version.h.in",
     out = "include/qdldl_version.h",
+    strict = True,
     defines = [
         "QDLDL_VERSION_MAJOR=0",
         "QDLDL_VERSION_MINOR=0",
         "QDLDL_VERSION_PATCH=0",
     ],
-    strict = True,
     visibility = ["//visibility:private"],
 )
 
 cc_library(
     name = "qdldl",
+    srcs = [
+        "src/qdldl.c",
+    ],
     hdrs = [
         "include/qdldl.h",
         ":include/qdldl_types.h",
         ":include/qdldl_version.h",
-    ],
-    srcs = [
-        "src/qdldl.c",
     ],
     copts = [
         "-fvisibility=hidden",

--- a/tools/workspace/qhull_internal/package.BUILD.bazel
+++ b/tools/workspace/qhull_internal/package.BUILD.bazel
@@ -57,6 +57,7 @@ _SRCS_CPP = [
 
 cc_library(
     name = "qhull_r",
+    srcs = _SRCS_C,
     hdrs = _HDRS_C,
     copts = [
         "-fvisibility=hidden",
@@ -64,7 +65,6 @@ cc_library(
     ],
     includes = ["src"],
     isystem = True,
-    srcs = _SRCS_C,
     linkstatic = 1,
 )
 
@@ -80,13 +80,13 @@ _SRCS_CPP_VENDORED = [
 
 cc_library_vendored(
     name = "qhull",
-    hdrs = _HDRS_CPP,
-    hdrs_vendored = _HDRS_CPP_VENDORED,
-    includes = ["drake_hdr"],
-    isystem = True,
     srcs = _SRCS_CPP,
     srcs_vendored = _SRCS_CPP_VENDORED,
+    hdrs = _HDRS_CPP,
+    hdrs_vendored = _HDRS_CPP_VENDORED,
     copts = ["-w"],
+    includes = ["drake_hdr"],
+    isystem = True,
     linkstatic = 1,
     visibility = ["//visibility:public"],
     deps = [":qhull_r"],
@@ -115,10 +115,10 @@ install(
         ":drake_qhull.patch",
         "@drake//tools/workspace/qhull_internal:patches",
     ],
+    doc_strip_prefix = ["patches"],
     allowed_externals = [
         "@drake//tools/workspace/qhull_internal:patches",
     ],
-    doc_strip_prefix = ["patches"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/ros_xacro_internal/package.BUILD.bazel
+++ b/tools/workspace/ros_xacro_internal/package.BUILD.bazel
@@ -15,11 +15,14 @@ generate_file(
 
 py_binary(
     name = "xacro_bin",
-    main = "ros_xacro_main.py",
-    srcs = ["ros_xacro_main.py"] + glob([
-        "xacro/**/*.py",
-    ], allow_empty = False),
+    srcs = ["ros_xacro_main.py"] + glob(
+        [
+            "xacro/**/*.py",
+        ],
+        allow_empty = False,
+    ),
     imports = ["."],
+    main = "ros_xacro_main.py",
     python_version = "PY3",
     srcs_version = "PY3",
 )

--- a/tools/workspace/scs_internal/package.BUILD.bazel
+++ b/tools/workspace/scs_internal/package.BUILD.bazel
@@ -18,16 +18,24 @@ cc_library(
     srcs = glob([
         "src/*.c",
     ]) + [
-        "linsys/csparse.h",
-        "linsys/csparse.c",
-        "linsys/scs_matrix.h",
-        "linsys/scs_matrix.c",
         "linsys/cpu/direct/private.c",
         "linsys/cpu/direct/private.h",
+        "linsys/csparse.c",
+        "linsys/csparse.h",
+        "linsys/scs_matrix.c",
+        "linsys/scs_matrix.h",
     ],
     hdrs = glob([
         "include/*.h",
     ]),
+    copts = [
+        "-fvisibility=hidden",
+        "-w",
+        "-Werror=incompatible-pointer-types",
+        # We don't allow Drake externals to use OpenMP until we wire up "max
+        # parallelism" governance to a drake::Parallellism public API option.
+        "-fno-openmp",
+    ],
     defines = [
         "USE_LAPACK=1",
         # Keep the default primitive size of `double` and `int`.  Don't define
@@ -39,19 +47,11 @@ cc_library(
         "linsys",
     ],
     isystem = True,
-    copts = [
-        "-fvisibility=hidden",
-        "-w",
-        "-Werror=incompatible-pointer-types",
-        # We don't allow Drake externals to use OpenMP until we wire up "max
-        # parallelism" governance to a drake::Parallellism public API option.
-        "-fno-openmp",
-    ],
-    linkstatic = 1,
     linkopts = select({
         ":linux": ["-lrt"],
         "//conditions:default": [],
     }),
+    linkstatic = 1,
     deps = [
         "@blas",
         "@lapack",

--- a/tools/workspace/sdformat_internal/package.BUILD.bazel
+++ b/tools/workspace/sdformat_internal/package.BUILD.bazel
@@ -29,6 +29,7 @@ cmake_configure_file(
     name = "config",
     src = "include/sdf/config.hh.in",
     out = "include/sdf/config.hh",
+    strict = True,
     cmakelists = ["CMakeLists.txt"],
     defines = [
         "PROJECT_NAME=SDFormat",
@@ -44,7 +45,6 @@ cmake_configure_file(
         # some or all of our console.patch file.
         "SDFORMAT_DISABLE_CONSOLE_LOGFILE",
     ],
-    strict = True,
     visibility = ["//visibility:private"],
 )
 
@@ -262,10 +262,13 @@ cc_library_vendored(
         x.replace("include/sdf/", "drake_hdr/sdf/")
         for x in _HDRS
     ],
+    copts = ["-w"],
+    defines = [
+        "SDFORMAT_STATIC_DEFINE",
+        "SDFORMAT_DISABLE_CONSOLE_LOGFILE",
+    ],
     includes = ["drake_hdr"],
     isystem = True,
-    copts = ["-w"],
-    defines = ["SDFORMAT_STATIC_DEFINE", "SDFORMAT_DISABLE_CONSOLE_LOGFILE"],
     linkstatic = 1,
     visibility = ["//visibility:public"],
     deps = [
@@ -300,10 +303,10 @@ check_lists_consistency(
 
 install(
     name = "install",
-    visibility = ["//visibility:public"],
     docs = [
         "LICENSE",
     ],
+    visibility = ["//visibility:public"],
 )
 
 exports_files(["drake_repository_metadata.json"])

--- a/tools/workspace/snopt/package.BUILD.bazel
+++ b/tools/workspace/snopt/package.BUILD.bazel
@@ -54,9 +54,6 @@ cc_library(
         "interfaces/include/snopt.h",
         "interfaces/include/snopt_cwrap.h",
     ],
-    includes = [
-        "interfaces/include",
-    ],
     copts = [
         "-w",
         # Hide symbols per note (2) above.  The snopt_cwrap.c file isn't
@@ -64,6 +61,9 @@ cc_library(
         # but perhaps keeping these functions obscured helps serve the overall
         # goal of obscuring the calls into the SNOPT object code even more.
         "-fvisibility=hidden",
+    ],
+    includes = [
+        "interfaces/include",
     ],
     # Link statically per note (1) above.
     linkstatic = 1,

--- a/tools/workspace/spral_internal/package.BUILD.bazel
+++ b/tools/workspace/spral_internal/package.BUILD.bazel
@@ -20,18 +20,18 @@ _COPTS = [
 cc_library(
     name = "compat",
     hdrs = ["src/compat.hxx"],
+    copts = _COPTS,
     includes = ["src"],
     isystem = True,
-    copts = _COPTS,
     linkstatic = True,
 )
 
 cc_library(
     name = "contrib",
     hdrs = ["src/ssids/contrib.h"],
+    copts = _COPTS,
     includes = ["src"],
     isystem = True,
-    copts = _COPTS,
     linkstatic = True,
     deps = [
         ":spral_ssids_contrib",
@@ -40,16 +40,22 @@ cc_library(
 
 cc_library(
     name = "cpu_kernels",
-    srcs = glob(["src/ssids/cpu/**/*.cxx"], allow_empty = False) + [
+    srcs = glob(
+        ["src/ssids/cpu/**/*.cxx"],
+        allow_empty = False,
+    ) + [
         # SPRAL has modules where C calls Fortran calls C. The only way we can
         # denote that to a single-pass linker is by listing the object code as
         # a source file.
         "src/ssids/contrib_free.f90.pic.o",
     ],
-    hdrs = glob(["src/ssids/cpu/**/*.hxx"], allow_empty = False),
+    hdrs = glob(
+        ["src/ssids/cpu/**/*.hxx"],
+        allow_empty = False,
+    ),
+    copts = _COPTS + ["-fvisibility=hidden"],
     includes = ["src"],
     isystem = True,
-    copts = _COPTS + ["-fvisibility=hidden"],
     linkstatic = True,
     deps = [
         ":contrib",
@@ -67,9 +73,9 @@ cc_library(
     hdrs = [
         "src/hw_topology/guess_topology.hxx",
     ],
+    copts = _COPTS,
     includes = ["src"],
     isystem = True,
-    copts = _COPTS,
     linkstatic = True,
     deps = [
         ":compat",
@@ -80,21 +86,21 @@ cc_library(
     name = "omp",
     srcs = ["src/omp.cxx"],
     hdrs = ["src/omp.hxx"],
+    copts = _COPTS,
     includes = ["src"],
     isystem = True,
-    copts = _COPTS,
     linkstatic = True,
 )
 
 cc_library(
     name = "profile",
     hdrs = ["src/ssids/profile.hxx"],
+    copts = _COPTS,
     # Note that there is a profile.cxx upstream, but we don't compile it here.
     # The patches/no_fortran_profiling.patch removes the Fortran callers, so
     # we can omit it (so that it doesn't leak global symbols into our library).
     includes = ["src"],
     isystem = True,
-    copts = _COPTS,
     deps = [
         ":guess_topology",
         ":omp",
@@ -105,14 +111,14 @@ cc_library(
 # file, refer to the upstream Makefile.am at "# Fortran 90 dependencies".
 
 fortran_module(
-    src = "src/blas_iface.f90",
     name = "spral_blas_iface",
+    src = "src/blas_iface.f90",
     deps = ["@blas"],
 )
 
 fortran_module(
-    src = "src/core_analyse.f90",
     name = "spral_core_analyse",
+    src = "src/core_analyse.f90",
 )
 
 fortran_module(
@@ -351,15 +357,15 @@ fortran_module(
 cc_library(
     name = "spral",
     hdrs = ["include/spral_ssids.h"],
+    copts = _COPTS,
     includes = ["include"],
     isystem = True,
-    copts = _COPTS,
     linkstatic = True,
+    visibility = ["//visibility:public"],
     deps = [
         # TODO(jwnimer-tri) Prune away the transitive hdrs here.
         ":spral_ssids_ciface",
     ],
-    visibility = ["//visibility:public"],
 )
 
 install(

--- a/tools/workspace/stable_baselines3_internal/package.BUILD.bazel
+++ b/tools/workspace/stable_baselines3_internal/package.BUILD.bazel
@@ -8,9 +8,9 @@ licenses(["notice"])  # MIT
 py_library(
     name = "stable_baselines3",
     srcs = glob(["**/*.py"]),
-    deps = ["@gymnasium_py_internal//:gymnasium_py"],
     data = glob(["**/version.txt"]),
     visibility = ["//visibility:public"],
+    deps = ["@gymnasium_py_internal//:gymnasium_py"],
 )
 
 exports_files(["drake_repository_metadata.json"])

--- a/tools/workspace/stduuid_internal/package.BUILD.bazel
+++ b/tools/workspace/stduuid_internal/package.BUILD.bazel
@@ -10,9 +10,9 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "stduuid",
     hdrs = ["include/uuid.h"],
-    strip_include_prefix = "include",
     isystem = True,
     linkstatic = 1,
+    strip_include_prefix = "include",
 )
 
 # Install the license file.

--- a/tools/workspace/suitesparse_internal/package.BUILD.bazel
+++ b/tools/workspace/suitesparse_internal/package.BUILD.bazel
@@ -11,10 +11,10 @@ cc_library(
     name = "config",
     srcs = ["SuiteSparse_config/SuiteSparse_config.c"],
     hdrs = ["SuiteSparse_config/SuiteSparse_config.h"],
-    strip_include_prefix = "SuiteSparse_config",
-    isystem = True,
     copts = ["-fvisibility=hidden"],
+    isystem = True,
     linkstatic = True,
+    strip_include_prefix = "SuiteSparse_config",
     visibility = ["//visibility:public"],
 )
 
@@ -22,12 +22,12 @@ cc_library(
 cc_library(
     name = "amd_hdrs",
     hdrs = [
-        "AMD/Include/amd_internal.h",
         "AMD/Include/amd.h",
+        "AMD/Include/amd_internal.h",
     ],
-    strip_include_prefix = "AMD/Include",
     isystem = True,
     linkstatic = True,
+    strip_include_prefix = "AMD/Include",
     deps = [
         ":config",
     ],
@@ -36,8 +36,8 @@ cc_library(
 # The libamd sources are compiled twice, once as 32-bit and once as 64-bit.
 _AMD_SRCS = glob(
     ["AMD/Source/amd_*.c"],
-    exclude = ["AMD/Source/amd_l*.c"],
     allow_empty = False,
+    exclude = ["AMD/Source/amd_l*.c"],
 )
 
 cc_library(
@@ -45,8 +45,8 @@ cc_library(
     srcs = _AMD_SRCS,
     copts = ["-fvisibility=hidden"],
     linkstatic = True,
-    deps = [":amd_hdrs"],
     visibility = ["//visibility:public"],
+    deps = [":amd_hdrs"],
 )
 
 # N.B. Most of SuiteSparse is GPL/LGPL licensed. Do NOT add any of those

--- a/tools/workspace/sympy_py_internal/package.BUILD.bazel
+++ b/tools/workspace/sympy_py_internal/package.BUILD.bazel
@@ -10,14 +10,21 @@ package(
 
 py_library(
     name = "sympy_py",
-    srcs = glob([
-        "sympy/**/*.py",
-    ], allow_empty = False),
-    data = glob([
-        "sympy/**",
-    ], exclude = [
-        "sympy/**/*.py",
-    ], allow_empty = False),
+    srcs = glob(
+        [
+            "sympy/**/*.py",
+        ],
+        allow_empty = False,
+    ),
+    data = glob(
+        [
+            "sympy/**",
+        ],
+        allow_empty = False,
+        exclude = [
+            "sympy/**/*.py",
+        ],
+    ),
     imports = ["."],
 )
 

--- a/tools/workspace/tinyxml2_internal/package.BUILD.bazel
+++ b/tools/workspace/tinyxml2_internal/package.BUILD.bazel
@@ -9,8 +9,8 @@ package(default_visibility = ["//visibility:private"])
 
 cc_library(
     name = "tinyxml2",
-    hdrs = ["tinyxml2.h"],
     srcs = ["tinyxml2.cpp"],
+    hdrs = ["tinyxml2.h"],
     includes = ["."],
     isystem = True,
     linkstatic = 1,

--- a/tools/workspace/uritemplate_py_internal/package.BUILD.bazel
+++ b/tools/workspace/uritemplate_py_internal/package.BUILD.bazel
@@ -11,7 +11,10 @@ package(
 
 py_library(
     name = "uritemplate_py",
-    srcs = glob(["uritemplate/**/*.py"], allow_empty = False),
+    srcs = glob(
+        ["uritemplate/**/*.py"],
+        allow_empty = False,
+    ),
     imports = ["."],
 )
 

--- a/tools/workspace/usockets_internal/package.BUILD.bazel
+++ b/tools/workspace/usockets_internal/package.BUILD.bazel
@@ -9,20 +9,20 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "usockets",
-    hdrs = ["src/libusockets.h"],
     srcs = glob([
         "src/*.c",
         "src/eventing/*.c",
         "src/crypto/*.c",
         "src/**/*.h",
     ]),
-    includes = ["src"],
-    isystem = True,
+    hdrs = ["src/libusockets.h"],
     copts = [
         "-DLIBUS_NO_SSL",
         "-fvisibility=hidden",
         "-w",
     ],
+    includes = ["src"],
+    isystem = True,
     linkstatic = 1,
 )
 

--- a/tools/workspace/uwebsockets_internal/package.BUILD.bazel
+++ b/tools/workspace/uwebsockets_internal/package.BUILD.bazel
@@ -14,12 +14,12 @@ cc_library(
     hdrs = glob(["src/*.h"]),
     includes = ["src"],
     isystem = True,
+    linkopts = ["-pthread"],
+    linkstatic = 1,
     deps = [
         "@usockets_internal//:usockets",
         "@zlib",
     ],
-    linkopts = ["-pthread"],
-    linkstatic = 1,
 )
 
 # Install the license file.

--- a/tools/workspace/voxelized_geometry_tools_internal/package.BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools_internal/package.BUILD.bazel
@@ -45,14 +45,14 @@ cc_library(
     ],
     includes = ["include"],
     isystem = True,
+    linkopts = [
+        "-pthread",
+    ],
     linkstatic = True,
     deps = [
         "@common_robotics_utilities_internal//:common_robotics_utilities",
         "@eigen",
         "@zlib",
-    ],
-    linkopts = [
-        "-pthread",
     ],
 )
 
@@ -115,9 +115,9 @@ cc_library(
     isystem = True,
     linkstatic = True,
     deps = [
-        ":voxelized_geometry_tools",
         ":cuda_voxelization_helpers",
         ":opencl_voxelization_helpers",
+        ":voxelized_geometry_tools",
         "@common_robotics_utilities_internal//:common_robotics_utilities",
         "@eigen",
         "@zlib",
@@ -134,10 +134,10 @@ cc_test(
         "no_kcov",
     ],
     deps = [
-        ":voxelized_geometry_tools",
         ":cuda_voxelization_helpers",
         ":opencl_voxelization_helpers",
         ":pointcloud_voxelization",
+        ":voxelized_geometry_tools",
         "@common_robotics_utilities_internal//:common_robotics_utilities",
         "@googletest//:gtest",
     ],
@@ -191,10 +191,10 @@ cc_test(
     srcs = ["test/voxel_raycasting_test.cpp"],
     tags = ["no_kcov"],
     deps = [
-        ":voxelized_geometry_tools",
         ":cuda_voxelization_helpers",
         ":opencl_voxelization_helpers",
         ":pointcloud_voxelization",
+        ":voxelized_geometry_tools",
         "@common_robotics_utilities_internal//:common_robotics_utilities",
         "@googletest//:gtest",
     ],

--- a/tools/workspace/vtk_internal/package.BUILD.bazel
+++ b/tools/workspace/vtk_internal/package.BUILD.bazel
@@ -37,8 +37,8 @@ exports_files(
 # to improve the error messages in case of a mis-configured build.
 cc_library(
     name = "_on_macos_you_must_not_have_forcepic_in_your_bazelrc_file_see_drake_issue_20217",  # noqa
-    linkstatic = True,
     features = ["-supports_pic"],
+    linkstatic = True,
     tags = ["manual"],
 )
 
@@ -69,11 +69,11 @@ cc_binary(
     srcs = [
         "Rendering/OpenGL2/vtkProbeOpenGLVersion.cxx",
     ],
+    linkstatic = True,
     deps = [
         ":vtkRenderingOpenGL2",
         "@drake//tools/workspace/vtk_internal:vtk_opengl_init",
     ],
-    linkstatic = True,
 )
 
 # Install any license notices.

--- a/tools/workspace/xmlrunner_py_internal/package.BUILD.bazel
+++ b/tools/workspace/xmlrunner_py_internal/package.BUILD.bazel
@@ -10,7 +10,10 @@ package(
 
 py_library(
     name = "xmlrunner_py",
-    srcs = glob(["xmlrunner/**"], allow_empty = False),
+    srcs = glob(
+        ["xmlrunner/**"],
+        allow_empty = False,
+    ),
     imports = ["."],
 )
 

--- a/tools/workspace/yaml_cpp_internal/package.BUILD.bazel
+++ b/tools/workspace/yaml_cpp_internal/package.BUILD.bazel
@@ -6,19 +6,25 @@ load("@drake//tools/workspace:vendor_cxx.bzl", "cc_library_vendored")
 licenses(["notice"])  # MIT
 
 # The upstream headers that we'll use.
-_HDRS = glob([
-    "include/yaml-cpp/*.h",
-    "include/yaml-cpp/node/*.h",
-    "include/yaml-cpp/node/detail/*.h",
-], allow_empty = False)
+_HDRS = glob(
+    [
+        "include/yaml-cpp/*.h",
+        "include/yaml-cpp/node/*.h",
+        "include/yaml-cpp/node/detail/*.h",
+    ],
+    allow_empty = False,
+)
 
 # The upstream sources that we'll use.
 _SRCS = [
     "src/contrib/dragonbox.h",
-] + glob([
-    "src/*.cpp",
-    "src/*.h",
-], allow_empty = False)
+] + glob(
+    [
+        "src/*.cpp",
+        "src/*.h",
+    ],
+    allow_empty = False,
+)
 
 cc_library_vendored(
     name = "yaml_cpp",


### PR DESCRIPTION
The upgraded tool now has more to say about `package.BUILD.bazel` files, so many of them end up being adjusted here as well.  We also need to add more fine-tuning to our tables file so that e.g. `srcs` and `srcs_vendored` remain adjacent when calling our custom `cc_library_vendored` rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24318)
<!-- Reviewable:end -->
