### PR TITLE
RenderEngineVtk mesh cache able to evict

### DIFF
--- a/geometry/render_vtk/internal_render_engine_vtk.cc
+++ b/geometry/render_vtk/internal_render_engine_vtk.cc
@@ -288,7 +288,7 @@ void RenderEngineVtk::ImplementGeometry(const Convex& convex, void* user_data) {
     mesh_cache_[cache_key] = std::move(cached);
   }
 
-  ImplementCachedMesh(mesh_cache_.at(cache_key), convex.scale3(), data);
+  ImplementCachedMesh(cache_key, convex.scale3(), data);
 }
 
 void RenderEngineVtk::ImplementGeometry(const Cylinder& cylinder,
@@ -461,6 +461,18 @@ bool RenderEngineVtk::DoRemoveGeometry(GeometryId id) {
       }
     }
     props_.erase(iter);
+    if (auto key_iter = geometry_mesh_keys_.find(id);
+        key_iter != geometry_mesh_keys_.end()) {
+      const std::string& key = key_iter->second;
+      auto cache_iter = mesh_cache_.find(key);
+      // If we had a key for this geometry, it must be in the cache.
+      DRAKE_DEMAND(cache_iter != mesh_cache_.end());
+      CachedMesh& cached = cache_iter->second;
+      if (--cached.use_count == 0) {
+        mesh_cache_.erase(key);
+      }
+      geometry_mesh_keys_.erase(key_iter);
+    }
     return true;
   }
 
@@ -648,6 +660,7 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
   // counted, so this clone shares the same vtkPolyDataAlgorithm sources as
   // the original without duplicating any vertex data.
   mesh_cache_ = other.mesh_cache_;
+  geometry_mesh_keys_ = other.geometry_mesh_keys_;
 
   // Cloning the cache is subtle. The cache _data_ is a vtkTexture. That data is
   // shared across cloned RenderEngineVtk instances. It has an internal VTK
@@ -753,7 +766,7 @@ bool RenderEngineVtk::ImplementObj(const Mesh& mesh,
     mesh_cache_[cache_key] = std::move(cached);
   }
 
-  ImplementCachedMesh(mesh_cache_.at(cache_key), mesh.scale3(), data);
+  ImplementCachedMesh(cache_key, mesh.scale3(), data);
   return true;
 }
 
@@ -1435,10 +1448,13 @@ void RenderEngineVtk::UpdateWindow(const DepthRenderCamera& camera,
   UpdateWindow(camera.core(), false, p, "");
 }
 
-void RenderEngineVtk::ImplementCachedMesh(const CachedMesh& cached,
+void RenderEngineVtk::ImplementCachedMesh(const std::string& cache_key,
                                           const Vector3d& scale,
                                           const RegistrationData& data) {
   const bool unit_scale = (scale.array() == 1).all();
+  const CachedMesh& cached = mesh_cache_.at(cache_key);
+  geometry_mesh_keys_[data.id] = cache_key;
+  ++mesh_cache_.at(cache_key).use_count;
   for (const CachedMesh::Part& part : cached.parts) {
     // File-defined materials (OBJ/MTL) always win. When none was present
     // (nullopt -- either no MTL, or a convex hull), resolve per-instance via

--- a/geometry/render_vtk/internal_render_engine_vtk.h
+++ b/geometry/render_vtk/internal_render_engine_vtk.h
@@ -292,11 +292,14 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
       vtkSmartPointer<vtkPolyDataAlgorithm> vtk_source;
     };
     std::vector<Part> parts;
+    // The number of registered Drake geometries in _this_ engine that reference
+    // this cache entry. When this count reaches zero the entry is evicted.
+    int use_count{0};
   };
 
   // Instantiates the parts of a CachedMesh. Materials and scale factors are
   // resolved on a per-instance basis.
-  void ImplementCachedMesh(const CachedMesh& cached,
+  void ImplementCachedMesh(const std::string& cache_key,
                            const Eigen::Vector3d& scale,
                            const RegistrationData& data);
 
@@ -405,6 +408,12 @@ class DRAKE_NO_EXPORT RenderEngineVtk : public render::RenderEngine,
   // varying per-texture parameters (OpenGl requires different texture objects
   // for different parameter combinations).
   string_unordered_map<CachedTexture> texture_cache_;
+
+  // Maps each geometry that was registered through the mesh cache to its
+  // cache key. Used by DoRemoveGeometry() to decrement use_count and evict
+  // entries whose count reaches zero. Geometries not using the cache
+  // (primitives, glTF, deformables) are never inserted here.
+  std::unordered_map<GeometryId, std::string> geometry_mesh_keys_;
 
   // Lights can be defined in the engine parameters. If no lights are defined,
   // we use the fallback_lights. Otherwise, we use the parameter lights.

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -130,6 +130,11 @@ class RenderEngineVtkTester {
     }
     return nullptr;
   }
+
+  // Returns the number of entries in the geometry-to-cache-key map.
+  static int GetGeometryMeshKeysSize(const RenderEngineVtk& renderer) {
+    return static_cast<int>(renderer.geometry_mesh_keys_.size());
+  }
 };
 
 namespace {
@@ -1070,7 +1075,7 @@ TEST_F(RenderEngineVtkTest, GltfAssetFormats) {
   Init(X_WC_, true);
 
   std::array<ImageRgba8U, kCount> images;
-  for (int i = 0; i < ssize(filenames); ++i) {
+  for (int i = 0; i < std::ssize(filenames); ++i) {
     // Add the i'th cube to the scene.
     const GeometryId id = GeometryId::get_new_id();
     renderer_->RegisterVisual(id, Mesh(filenames[i]), PerceptionProperties{},
@@ -3534,6 +3539,48 @@ TEST_F(RenderEngineVtkTest, DifferentObjsDontShare) {
   EXPECT_NE(src_a, src_b);
 }
 
+// When multiple geometries share one cache entry, the entry survives until the
+// *last* geometry is removed.
+TEST_F(RenderEngineVtkTest, MeshCacheNotEvictedUntilLastRemove) {
+  const RenderEngineVtkParams params{.backend = FLAGS_backend};
+  RenderEngineVtk engine(params);
+
+  const std::string obj_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box_no_mtl.obj");
+  PerceptionProperties props;
+  props.AddProperty("label", "id", RenderLabel::kDontCare);
+
+  const GeometryId id1 = GeometryId::get_new_id();
+  const GeometryId id2 = GeometryId::get_new_id();
+  const GeometryId id3 = GeometryId::get_new_id();
+
+  Mesh mesh(obj_path);
+  Convex convex(obj_path);
+
+  // Run it once through Mesh and once for Convex, to show both are handled the
+  // same.
+  for (const Shape* shape_ptr : std::vector<Shape*>{&mesh, &convex}) {
+    SCOPED_TRACE(shape_ptr->type_name());
+    engine.RegisterVisual(id1, *shape_ptr, props, RigidTransformd::Identity());
+    engine.RegisterVisual(id2, *shape_ptr, props, RigidTransformd::Identity());
+    engine.RegisterVisual(id3, *shape_ptr, props, RigidTransformd::Identity());
+    ASSERT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 1);
+    ASSERT_EQ(RenderEngineVtkTester::GetGeometryMeshKeysSize(engine), 3);
+
+    engine.RemoveGeometry(id1);
+    EXPECT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 1);
+    EXPECT_EQ(RenderEngineVtkTester::GetGeometryMeshKeysSize(engine), 2);
+
+    engine.RemoveGeometry(id2);
+    EXPECT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 1);
+    EXPECT_EQ(RenderEngineVtkTester::GetGeometryMeshKeysSize(engine), 1);
+
+    engine.RemoveGeometry(id3);
+    EXPECT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 0);
+    EXPECT_EQ(RenderEngineVtkTester::GetGeometryMeshKeysSize(engine), 0);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Texture-cache source-sharing tests
 //
@@ -3673,51 +3720,78 @@ TEST_F(RenderEngineVtkTest, TextureCacheEviction) {
   EXPECT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 0);
 }
 
-// Confirms that cloned engines' caches are not harmed by eviction from another
-// engine.
-TEST_F(RenderEngineVtkTest, TextureCacheEvictionAcrossClones) {
+// Confirms that cloned engines' texture and mesh caches are not harmed by
+// eviction from another engine. Uses rendering as proof that the underlying VTK
+// objects remain valid in the clone after the source engine evicts them.
+TEST_F(RenderEngineVtkTest, CacheEvictionAcrossClones) {
   const RenderEngineVtkParams params{.backend = FLAGS_backend};
   RenderEngineVtk engine(params);
 
   const std::string png_path =
       FindResourceOrThrow("drake/geometry/render/test/meshes/box.png");
-  PerceptionProperties props;
-  props.AddProperty("label", "id", RenderLabel::kDontCare);
-  props.AddProperty("phong", "diffuse_map", png_path);
+  const std::string obj_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box_no_mtl.obj");
 
-  const GeometryId id = GeometryId::get_new_id();
-  engine.RegisterVisual(id, Sphere(0.5), props, RigidTransformd::Identity());
+  PerceptionProperties tex_props;
+  tex_props.AddProperty("label", "id", RenderLabel::kDontCare);
+  tex_props.AddProperty("phong", "diffuse_map", png_path);
+
+  PerceptionProperties mesh_props;
+  mesh_props.AddProperty("label", "id", RenderLabel::kDontCare);
+
+  // The textured sphere will exercise the texture cache.
+  const GeometryId sphere_id = GeometryId::get_new_id();
+  engine.RegisterVisual(sphere_id, Sphere(0.5), tex_props,
+                        RigidTransformd::Identity());
+  // The untextured box will exercise the mesh cache.
+  const GeometryId mesh_id = GeometryId::get_new_id();
+  engine.RegisterVisual(mesh_id, Mesh(obj_path), mesh_props,
+                        RigidTransformd::Identity());
   ASSERT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 1);
+  ASSERT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 1);
 
   std::unique_ptr<RenderEngine> clone_base = engine.Clone();
   auto* clone_ptr = dynamic_cast<RenderEngineVtk*>(clone_base.get());
   ASSERT_NE(clone_ptr, nullptr);
   ASSERT_EQ(RenderEngineVtkTester::GetTextureCacheSize(*clone_ptr), 1);
+  ASSERT_EQ(RenderEngineVtkTester::GetMeshCacheSize(*clone_ptr), 1);
 
-  // Now render a reference image from each engine.
+  // Now render a reference image from each engine; they must match perfectly.
   const ColorRenderCamera color_camera(depth_camera_.core(), FLAGS_show_window);
 
-  // Originally, the images should match.
-  ImageRgba8U source_image_ref(color_);
-  engine.RenderColorImage(color_camera, &source_image_ref);
-  ImageRgba8U clone_image_ref(color_);
-  clone_ptr->RenderColorImage(color_camera, &clone_image_ref);
-  ASSERT_TRUE(ImagesAreSimilar(source_image_ref, clone_image_ref, 1e-5, 1.0));
+  ImageRgba8U source_ref(color_);
+  engine.RenderColorImage(color_camera, &source_ref);
+  ImageRgba8U clone_ref(color_);
+  clone_ptr->RenderColorImage(color_camera, &clone_ref);
+  ASSERT_TRUE(ImagesAreSimilar(source_ref, clone_ref, 1e-5, 1.0));
 
-  // Removing the geometry (and texture) from the original engine.
-  engine.RemoveGeometry(id);
+  // Remove geometries from the source engine one at a time, rendering the
+  // source after each removal. This proves each object was individually visible
+  // so a failure in either cached VTK object would be detectable.
+
+  // Remove the textured sphere (texture cache eviction).
+  engine.RemoveGeometry(sphere_id);
   ASSERT_EQ(RenderEngineVtkTester::GetTextureCacheSize(engine), 0);
+  ASSERT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 1);
+  ImageRgba8U source_no_sphere(color_);
+  engine.RenderColorImage(color_camera, &source_no_sphere);
+  // Even with low conformity, the images won't match.
+  ASSERT_FALSE(ImagesAreSimilar(source_ref, source_no_sphere, 1e-5, 0.5));
 
-  // Rendering each image; the source engine has a different image, the cloned
-  // is unchanged.
-  ImageRgba8U source_image_dut(color_);
-  engine.RenderColorImage(color_camera, &source_image_dut);
-  ImageRgba8U clone_image_dut(color_);
-  clone_ptr->RenderColorImage(color_camera, &clone_image_dut);
+  // Remove the OBJ mesh (mesh cache eviction).
+  engine.RemoveGeometry(mesh_id);
+  ASSERT_EQ(RenderEngineVtkTester::GetMeshCacheSize(engine), 0);
+  ImageRgba8U source_no_mesh(color_);
+  engine.RenderColorImage(color_camera, &source_no_mesh);
+  ASSERT_FALSE(ImagesAreSimilar(source_no_sphere, source_no_mesh, 1e-5, 0.5));
+  ASSERT_FALSE(ImagesAreSimilar(source_ref, source_no_mesh, 1e-5, 0.5));
 
-  ASSERT_FALSE(
-      ImagesAreSimilar(source_image_ref, source_image_dut, 1e-5, 0.75));
-  ASSERT_TRUE(ImagesAreSimilar(source_image_ref, clone_image_dut, 1e-5, 1.0));
+  // The clone's caches are intact and its render matches the original.
+  ASSERT_EQ(RenderEngineVtkTester::GetTextureCacheSize(*clone_ptr), 1);
+  ASSERT_EQ(RenderEngineVtkTester::GetMeshCacheSize(*clone_ptr), 1);
+  ImageRgba8U clone_dut(color_);
+  clone_ptr->RenderColorImage(color_camera, &clone_dut);
+  ASSERT_TRUE(ImagesAreSimilar(clone_ref, clone_dut, 1e-5, 1.0));
 }
 
 }  // namespace


### PR DESCRIPTION
When geometries get removed, the engine's mesh cache has the opportunity to remove the cached geometry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24319)
<!-- Reviewable:end -->
