### PR TITLE
[pydrake] Bind symbolic.Variable default constructor

### DIFF
--- a/bindings/pydrake/symbolic/symbolic_py_monolith.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_monolith.cc
@@ -58,7 +58,8 @@ void DefineSymbolicMonolith(py::module m) {
       .value("RANDOM_EXPONENTIAL", Variable::Type::RANDOM_EXPONENTIAL,
           var_doc.Type.RANDOM_EXPONENTIAL.doc);
 
-  var_cls
+  var_cls  // BR
+      .def(py::init<>(), var_doc.ctor.doc_0args)
       .def(py::init<const string&, Variable::Type>(), py::arg("name"),
           py::arg("type") = Variable::Type::CONTINUOUS, var_doc.ctor.doc_2args)
       .def("is_dummy", &Variable::is_dummy, var_doc.is_dummy.doc)

--- a/bindings/pydrake/symbolic/test/symbolic_test.py
+++ b/bindings/pydrake/symbolic/test/symbolic_test.py
@@ -22,6 +22,7 @@ import pydrake.symbolic as sym
 # overloads from `pydrake.math`.
 
 # Define global variables to make the tests less verbose.
+dummy = sym.Variable()
 x = sym.Variable("x")
 y = sym.Variable("y")
 z = sym.Variable("z")
@@ -38,7 +39,12 @@ boolean = sym.Variable(name="boolean", type=sym.Variable.Type.BOOLEAN)
 
 class TestSymbolicVariable(unittest.TestCase):
     def test_is_dummy(self):
+        self.assertTrue(dummy.is_dummy())
         self.assertFalse(a.is_dummy())
+
+    def test_id(self):
+        self.assertEqual(dummy.get_id(), 0)
+        self.assertNotEqual(a.get_id(), 0)
 
     def test_get_name(self):
         self.assertEqual(a.get_name(), "a")


### PR DESCRIPTION
Towards #20673.

(In particular the extra unit testing will be nice to confirm how IDs work.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24330)
<!-- Reviewable:end -->
