### PR TITLE
[common] Widen symbolic::Variable::Id to 128 bits + random entropy

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -1749,7 +1749,7 @@ not reflect any sort of mathematical total order.)""";
 R"""(When FromExpression converts a symbolic∷Variable to a Polynomial∷Term,
 it uses this mapping function to project the symbolic∷Variable∷Id to a
 Polynomial∷VarType. Note that the mapping is non-injective (i.e.,
-degenerate) because an Id is 64 bits but a VarType is only 32 bits.)""";
+degenerate) because an Id is 128 bits but a VarType is only 32 bits.)""";
       } VariableIdToVarType;
       // Symbol: drake::Polynomial::VariableNameToId
       struct /* VariableNameToId */ {

--- a/bindings/generated_docstrings/common_symbolic_expression.h
+++ b/bindings/generated_docstrings/common_symbolic_expression.h
@@ -1478,7 +1478,17 @@ Note:
         // Symbol: drake::symbolic::Variable::Id
         struct /* Id */ {
           // Source: drake/common/symbolic/expression/variable.h
-          const char* doc = R"""(Identifier for a symbolic variable.)""";
+          const char* doc =
+R"""(Identifier for a symbolic variable. Variable equality is defined by
+whether their Ids are equal (i.e., ignoring Variable names). Ids are
+akin to `UUIDs
+<https://en.wikipedia.org/wiki/Universally_unique_identifier>`_
+because Ids contain a large number of random bits so are unique not
+only within a single process, but also across multiple runs of
+programs over time. On the other hand, we also guarantee that all Ids
+created within a single process have consistent behavior in their
+comparison (``operator<``) and hashing operators, so that any single
+program is still run-to-run consistent.)""";
           // Symbol: drake::symbolic::Variable::Id::Id
           struct /* ctor */ {
             // Source: drake/common/symbolic/expression/variable.h
@@ -1496,11 +1506,6 @@ R"""(Constructs a "dummy" id, not associated with any variable.)""";
             const char* doc =
 R"""(Returns a string representation of this Id.)""";
           } to_string;
-          // Symbol: drake::symbolic::Variable::Id::value
-          struct /* value */ {
-            // Source: drake/common/symbolic/expression/variable.h
-            const char* doc = R"""()""";
-          } value;
         } Id;
         // Symbol: drake::symbolic::Variable::Type
         struct /* Type */ {

--- a/bindings/pydrake/symbolic/test/symbolic_test.py
+++ b/bindings/pydrake/symbolic/test/symbolic_test.py
@@ -2031,9 +2031,7 @@ class TestExtractVariablesFromExpression(unittest.TestCase):
 
 
 class TestDecomposeAffineExpression(unittest.TestCase):
-    def test(self):
-        x = sym.Variable("x")
-        y = sym.Variable("y")
+    def test_basic(self):
         e = 2 * x + 3 * y + 4
         variables, map_var_to_index = sym.ExtractVariablesFromExpression(e)
         coeffs, constant_term = sym.DecomposeAffineExpression(
@@ -2043,6 +2041,22 @@ class TestDecomposeAffineExpression(unittest.TestCase):
         self.assertEqual(coeffs.shape, (2,))
         self.assertEqual(coeffs[map_var_to_index[x.get_id()]], 2)
         self.assertEqual(coeffs[map_var_to_index[y.get_id()]], 3)
+
+    def test_invalid_variable_id(self):
+        # For reference, first check a valid call with just a single variable.
+        e = sym.Expression(x)
+        _, var_to_index = sym.ExtractVariablesFromExpression(e)
+        self.assertEqual(len(var_to_index), 1)
+        (variable_id,) = var_to_index.keys()
+        sym.DecomposeAffineExpression(e, {variable_id: 0})
+
+        # Now corrupt the variable ID to check that it's detected during type-
+        # casting. The ID's `type` is stored in bits 64..71 of the 128-bit
+        # value, and must be a valid enum in the range [0..7]; adding 8 makes it
+        # invalid.
+        variable_id += 8 << 64
+        with self.assertRaisesRegex(ValueError, "Ill-formed Variable::Id"):
+            sym.DecomposeAffineExpression(e, {variable_id: 0})
 
 
 class TestDecomposeAffineExpressions(unittest.TestCase):

--- a/bindings/pydrake/symbolic_types_pybind.h
+++ b/bindings/pydrake/symbolic_types_pybind.h
@@ -27,9 +27,18 @@ namespace symbolic {
 class VariableIdPythonAttorney {
  public:
   VariableIdPythonAttorney() = delete;
-  static Variable::Id Construct(uint64_t value) {
+  static uint64_t hi(const Variable::Id& id) { return id.hi_; }
+  static uint64_t lo(const Variable::Id& id) { return id.lo_; }
+  static Variable::Id Construct(uint64_t hi, uint64_t lo) {
+    // We need to maintain Id's invariant that the low byte of hi_ is the
+    // Variable::Type, by rejecting out-of-bounds types.
+    const uint8_t var_type = static_cast<uint8_t>(hi);
+    if (var_type > static_cast<uint8_t>(Variable::Type::RANDOM_EXPONENTIAL)) {
+      throw std::domain_error("Ill-formed Variable::Id");
+    }
     Variable::Id result;
-    result.value_ = value;
+    result.hi_ = hi;
+    result.lo_ = lo;
     return result;
   }
 };
@@ -50,24 +59,30 @@ struct type_caster<drake::symbolic::Variable::Id> {
       return false;
     }
 
-    pybind11::int_ integer;
+    pybind11::int_ concat;
     try {
-      integer = pybind11::cast<pybind11::int_>(src);
+      concat = pybind11::cast<pybind11::int_>(src);
     } catch (...) {
       return false;
     }
 
+    const pybind11::object hi_py = concat >> pybind11::int_(64);
+    const pybind11::object lo_py = concat & pybind11::int_(~uint64_t{});
+    const uint64_t hi = hi_py.cast<uint64_t>();
+    const uint64_t lo = lo_py.cast<uint64_t>();
     // N.B. "value" is a magic variable declared by pybind11 where we're
     // supposed to put the loaded result.
-    value = Attorney::Construct(integer.cast<uint64_t>());
+    value = Attorney::Construct(hi, lo);
 
     return true;
   }
 
   static handle cast(drake::symbolic::Variable::Id src,
       return_value_policy /* policy */, handle /* parent */) {
-    pybind11::int_ value{src.value()};
-    return value.release();
+    const pybind11::int_ hi_py{Attorney::hi(src)};
+    const pybind11::int_ lo_py{Attorney::lo(src)};
+    pybind11::object concat = (hi_py << pybind11::int_(64)) + lo_py;
+    return concat.release();
   }
 };
 }  // namespace detail

--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -693,7 +693,14 @@ void Polynomial<T>::MakeMonomialsUnique(void) {
 template <typename T>
 Polynomial<T>::VarType Polynomial<T>::VariableIdToVarType(
     const symbolic::Variable::Id& id) {
-  return static_cast<Polynomial<T>::VarType>(id.value());
+  // To convert an Id to a VarType, we want to extract the non-random portion of
+  // the Id. That is exactly the data it feeds into its hash_append function.
+  uint32_t hashed_data{};
+  auto hasher = [&hashed_data](const uint32_t* data, size_t /* size = 4 */) {
+    hashed_data = *data;
+  };
+  hash_append(hasher, id);
+  return static_cast<Polynomial<T>::VarType>(hashed_data);
 }
 
 namespace {

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -417,7 +417,7 @@ class Polynomial {
   /** When FromExpression converts a symbolic::Variable to a Polynomial::Term,
    * it uses this mapping function to project the symbolic::Variable::Id to a
    * Polynomial::VarType. Note that the mapping is non-injective (i.e.,
-   * degenerate) because an Id is 64 bits but a VarType is only 32 bits.
+   * degenerate) because an Id is 128 bits but a VarType is only 32 bits.
    */
   static VarType VariableIdToVarType(const drake::symbolic::Variable::Id& id);
 

--- a/common/symbolic/expression/test/variable_test.cc
+++ b/common/symbolic/expression/test/variable_test.cc
@@ -54,6 +54,26 @@ class VariableTest : public ::testing::Test {
   }
 };
 
+TEST_F(VariableTest, IdComparison) {
+  const Variable::Id x = x_.get_id();
+  const Variable::Id y = y_.get_id();
+  const Variable::Id z = z_.get_id();
+
+  // ID equality and inequality.
+  EXPECT_EQ(x, x);
+  EXPECT_NE(x, y);
+
+  // IDs compare in the order they were created.
+  EXPECT_LT(x, y);
+  EXPECT_LT(y, z);
+  EXPECT_GT(z, y);
+  EXPECT_GT(y, x);
+
+  // The dummy is bottom.
+  EXPECT_LT(Variable::Id(), x);
+  EXPECT_GT(x, Variable::Id());
+}
+
 // Tests that default constructor and EIGEN_INITIALIZE_MATRICES_BY_ZERO
 // constructor both create the same value.
 TEST_F(VariableTest, DefaultConstructors) {
@@ -117,6 +137,7 @@ TEST_F(VariableTest, Move) {
   // The moved-from object matches a default-constructed Variable.
   const Variable expected;
   EXPECT_EQ(x.get_id(), expected.get_id());
+  EXPECT_TRUE(x.is_dummy());
   EXPECT_EQ(get_std_hash(x), get_std_hash(expected));
   EXPECT_EQ(x.get_name(), expected.get_name());
 }
@@ -192,12 +213,13 @@ TEST_F(VariableTest, VariableTypeFmtFormatter) {
 
 TEST_F(VariableTest, VariableIdFmtFormatter) {
   // The dummy ID is all-zero.
-  EXPECT_EQ(fmt::to_string(Variable::Id()), "0x0000000000000000");
+  EXPECT_EQ(fmt::to_string(Variable::Id()),
+            "0x00000000000000000000000000000000");
 
-  // A normal ID is a 64-bit hexidecimal number starting with "0x...".
+  // A normal ID is a 128-bit hexadecimal number starting with "0x...".
   const std::string x_str = fmt::to_string(x_.get_id());
   EXPECT_EQ(x_str.substr(0, 2), "0x");
-  EXPECT_EQ(x_str.length(), 2 + 64 / 4);
+  EXPECT_EQ(x_str.length(), 2 + 128 / 4);
 }
 
 // This test checks whether Variable is compatible with std::unordered_set.

--- a/common/symbolic/expression/variable.cc
+++ b/common/symbolic/expression/variable.cc
@@ -5,6 +5,8 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
+#include <random>
 #include <string>
 #include <utility>
 
@@ -20,28 +22,55 @@ namespace drake {
 namespace symbolic {
 
 Variable::Id Variable::Id::Create(Type type) {
+  static std::once_flag flag;
+  static uint64_t global_hi_tare = 0;
+  static uint64_t global_lo_tare = 0;
+  std::call_once(flag, []() {
+    // We need to draw actual physical entropy from a random_device, so that
+    // variable IDs differ from one run of a process to the next.
+    std::random_device device;
+    std::mt19937_64 generator(device());
+
+    // Draw a random 56-bit number, in the upper bits of a 64-bit word. (We
+    // leave the lower 8 bits as zero, to be used for the Variable::Type.)
+    using distribution = std::uniform_int_distribution<uint64_t>;
+    distribution rand56(0, (uint64_t{1} << 56) - 1);
+    global_hi_tare = rand56(generator) << 8;
+    DRAKE_ASSERT((global_hi_tare << 56) == 0);
+
+    // Draw a random 32-bit number, in the upper bits of a 64-bit word. (We
+    // leave the lower 32 bits as zero, to be used for a consistent hash code
+    // based on the serial number.)
+    distribution rand32(0, (uint64_t{1} << 32) - 1);
+    global_lo_tare = rand32(generator) << 32;
+    DRAKE_ASSERT((global_lo_tare << 32) == 0);
+  });
+
   // Each variable created gets a serial number counting up from 1.
   // (Zero is reserved for the default-constructed Id.)
   static atomic<uint64_t> counter(0);
   const uint64_t serial_number = ++counter;
 
   Id result;
-  // We store the Type enum in the upper byte (8 bits) of value_ (64 bits).
+  // We store the Type enum in the lower byte of hi_.
   static_assert(sizeof(Type) == 1);
-  result.value_ = (static_cast<uint64_t>(type) << (64 - 8)) + serial_number;
+  result.hi_ = global_hi_tare + static_cast<uint64_t>(type);
+  // Once the serial number reaches 2^32, it will leak into the "random" part
+  // of lo_ (the upper 32 bits), but that is not a problem. We still guarantee
+  // that lo_ is unique across all variables created by this program.
+  result.lo_ = global_lo_tare + serial_number;
   return result;
 }
 
 std::string Variable::Id::to_string() const {
-  // Our string repsentation is 18 characters: "0x" followed by 16 hex digits to
-  // cover all 64 bits (padded with leading zeros as necessary).
-  return fmt::format("{:#018x}", value_);
+  // Our string representation is 18+16 characters: "0x" followed by 16+16 hex
+  // digits to cover all 128 bits (padded with leading zeros as necessary).
+  return fmt::format("{:#018x}{:016x}", hi_, lo_);
 }
 
 Variable::Variable(string name, const Type type)
-    : id_{Id::Create(type)}, name_{make_shared<const string>(std::move(name))} {
-  DRAKE_ASSERT(get_id().value() > 0);
-}
+    : id_{Id::Create(type)},
+      name_{make_shared<const string>(std::move(name))} {}
 
 string Variable::get_name() const {
   return name_ != nullptr ? *name_ : string{"𝑥"};

--- a/common/symbolic/expression/variable.h
+++ b/common/symbolic/expression/variable.h
@@ -51,7 +51,14 @@ class Variable {
                          ///< exponential distribution with λ=1.
   };
 
-  /** Identifier for a symbolic variable. */
+  /** Identifier for a symbolic variable. Variable equality is defined by
+  whether their Ids are equal (i.e., ignoring Variable names). Ids are akin to
+  [UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier) because
+  Ids contain a large number of random bits so are unique not only within a
+  single process, but also across multiple runs of programs over time. On the
+  other hand, we also guarantee that all Ids created within a single process
+  have consistent behavior in their comparison (`operator<`) and hashing
+  operators, so that any single program is still run-to-run consistent. */
   class Id {
    public:
     DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Id);
@@ -67,16 +74,15 @@ class Variable {
     // NOLINTNEXTLINE(runtime/references) Per hash_append convention.
     friend void hash_append(HashAlgorithm& hasher, const Id& item) noexcept {
       using drake::hash_append;
-      hash_append(hasher, item.value());
+      // To maintain consistent hash iteration order across repeated runs of a
+      // program, we must only hash the non-random part of our state. The low
+      // 32 bits of lo_ don't contain any randomness. (We could also hash our
+      // get_type(), but it doesn't add a meaningful amount of entropy.)
+      hash_append(hasher, static_cast<uint32_t>(item.lo_));
     }
 
     /** Returns a string representation of this Id. */
     std::string to_string() const;
-
-#if !defined(DRAKE_DOXYGEN_CXX)
-    /* (Internal use only) Returns this Id as a bare integer. */
-    uint64_t value() const { return value_; }
-#endif
 
    private:
     friend class Variable;
@@ -85,14 +91,60 @@ class Variable {
     static Id Create(Type type);
 
     Type get_type() const {
-      // We store the Type enum in the upper byte (8 bits) of value_ (64 bits).
-      return static_cast<Type>(value_ >> (64 - 8));
+      // We store the Type enum in the lower byte of hi_.
+      return static_cast<Type>(static_cast<uint8_t>(hi_));
     }
 
-    bool is_default() const { return value_ == 0; }
+    bool is_default() const { return lo_ == 0 && hi_ == 0; }
 
-    // We store the Type enum in the upper byte of value_.
-    uint64_t value_{};
+    // Id represents three pieces of information:
+    // - type: the Variable::Type;
+    // - serial number: a counter incremented for each new Variable created
+    //     within this process; the first Variable created is serial number 1,
+    //     the second Variable is serial number 2, etc.;
+    // - nonce: a random value that's initialized once per process the first
+    //     time it's needed; all variables created within the process are based
+    //     on the same nonce; this helps distinguish variables created by one
+    //     process from those created by another process when saving them to
+    //     disk.
+    //
+    // For efficiency, we pack these three pieces into two member fields:
+    // - the 8-bit type is stored in the low byte of hi_;
+    // - the 64-bit serial number is stored in lo_, summed with the nonce in the
+    //   upper 4 bytes; to recover the serial number we would need to subtract
+    //   the nonce from lo_, but in practice we never need the serial number by
+    //   itself;
+    // - the 88-bit nonce is stored as:
+    //   - 56 bits in the upper 7 bytes of hi_ and
+    //   - 32 bits added to the upper 4 bytes of lo_.
+    //
+    // Why 88 bits for the nonce? Like a UUID, we need enough bits to avoid
+    // birthday collisions. Using only 56 or 64 bits ends up with too high a
+    // chance of collision. Using 88 bits is a balance between having enough
+    // entropy while still allowing for consistency of our sort ordering and
+    // hash code.
+    //
+    // Why not pack both the type and serial number into single 64-bit word,
+    // leaving the other 64-bit word exclusively for nonce data? That would
+    // put at risk the `type` changing if the serial number got too large.
+    //
+    // Note that if the serial number's value exceeds 32 bits, it will end up
+    // affecting bits of lo_ where the nonce is stored. This is not a problem;
+    // in effect it's just a slightly difference random nonce. Ids are still
+    // distinct from each other in all ways that matter.
+    //
+    // Note that the lower 4 bytes of `lo_` store the serial number mod 2^32,
+    // which can therefore provide a run-to-run stable hash key when an Id is
+    // used in unordered containers, without being affected by the random nonce.
+    // This is important for reproducibility.
+    //
+    // Because nearly all variables have same type (`CONTINUOUS`) and the nonce
+    // is invariant within one process, hi_ will typically contain exactly the
+    // same value across all Variables in this process, and therefore it's
+    // important to declare lo_ first and hi_ second so that the entropy-bearing
+    // member field (lo_) is the first one to be compared by operator<=>.
+    uint64_t lo_{};
+    uint64_t hi_{};
   };
 
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Variable);
@@ -118,7 +170,7 @@ class Variable {
 
   /** Checks if this is the variable created by the default constructor. */
   [[nodiscard]] bool is_dummy() const { return get_id().is_default(); }
-  [[nodiscard]] Id get_id() const { return id_; }
+  [[nodiscard]] const Id& get_id() const { return id_; }
   [[nodiscard]] Type get_type() const { return get_id().get_type(); }
   [[nodiscard]] std::string get_name() const;
   [[nodiscard]] std::string to_string() const;


### PR DESCRIPTION
This allows the Id to be saved and re-loaded into a new process while retaining its meaning.

Towards #20673.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24331)
<!-- Reviewable:end -->
