### PR TITLE
[common] Variable::Id is an object not a size_t

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -1475,7 +1475,8 @@ Precondition:
         // Source: drake/common/polynomial.h
         const char* doc =
 R"""(Constructs a Polynomial representing the symbolic expression ``e``.
-Note that the ID of a variable is preserved in this translation.
+The mapping from symbolic∷Variable∷Id to Polynomial∷VarType is
+governed by VariableIdToVarType().
 
 Raises:
     RuntimeError if ``e`` is not polynomial-convertible.
@@ -1741,6 +1742,15 @@ not reflect any sort of mathematical total order.)""";
         // Source: drake/common/polynomial.h
         const char* doc = R"""()""";
       } VarType;
+      // Symbol: drake::Polynomial::VariableIdToVarType
+      struct /* VariableIdToVarType */ {
+        // Source: drake/common/polynomial.h
+        const char* doc =
+R"""(When FromExpression converts a symbolic∷Variable to a Polynomial∷Term,
+it uses this mapping function to project the symbolic∷Variable∷Id to a
+Polynomial∷VarType. Note that the mapping is non-injective (i.e.,
+degenerate) because an Id is 64 bits but a VarType is only 32 bits.)""";
+      } VariableIdToVarType;
       // Symbol: drake::Polynomial::VariableNameToId
       struct /* VariableNameToId */ {
         // Source: drake/common/polynomial.h

--- a/bindings/generated_docstrings/common_symbolic_expression.h
+++ b/bindings/generated_docstrings/common_symbolic_expression.h
@@ -1478,7 +1478,29 @@ Note:
         // Symbol: drake::symbolic::Variable::Id
         struct /* Id */ {
           // Source: drake/common/symbolic/expression/variable.h
-          const char* doc = R"""()""";
+          const char* doc = R"""(Identifier for a symbolic variable.)""";
+          // Symbol: drake::symbolic::Variable::Id::Id
+          struct /* ctor */ {
+            // Source: drake/common/symbolic/expression/variable.h
+            const char* doc =
+R"""(Constructs a "dummy" id, not associated with any variable.)""";
+          } ctor;
+          // Symbol: drake::symbolic::Variable::Id::operator<=>
+          struct /* operator_le_ */ {
+            // Source: drake/common/symbolic/expression/variable.h
+            const char* doc = R"""(Default comparison operators.)""";
+          } operator_le_;
+          // Symbol: drake::symbolic::Variable::Id::to_string
+          struct /* to_string */ {
+            // Source: drake/common/symbolic/expression/variable.h
+            const char* doc =
+R"""(Returns a string representation of this Id.)""";
+          } to_string;
+          // Symbol: drake::symbolic::Variable::Id::value
+          struct /* value */ {
+            // Source: drake/common/symbolic/expression/variable.h
+            const char* doc = R"""()""";
+          } value;
         } Id;
         // Symbol: drake::symbolic::Variable::Type
         struct /* Type */ {

--- a/bindings/pydrake/symbolic_types_pybind.h
+++ b/bindings/pydrake/symbolic_types_pybind.h
@@ -20,3 +20,55 @@ DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
     drake::symbolic::RationalFunction)
 DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(  // NOLINT
     drake::symbolic::Variable)
+
+namespace drake {
+namespace symbolic {
+/* Internal use only. */
+class VariableIdPythonAttorney {
+ public:
+  VariableIdPythonAttorney() = delete;
+  static Variable::Id Construct(uint64_t value) {
+    Variable::Id result;
+    result.value_ = value;
+    return result;
+  }
+};
+}  // namespace symbolic
+}  // namespace drake
+
+namespace pybind11 {
+namespace detail {
+template <>
+struct type_caster<drake::symbolic::Variable::Id> {
+ public:
+  using Attorney = drake::symbolic::VariableIdPythonAttorney;
+
+  PYBIND11_TYPE_CASTER(drake::symbolic::Variable::Id, _("int"));
+
+  bool load(handle src, bool /* convert */) {
+    if (!src) {
+      return false;
+    }
+
+    pybind11::int_ integer;
+    try {
+      integer = pybind11::cast<pybind11::int_>(src);
+    } catch (...) {
+      return false;
+    }
+
+    // N.B. "value" is a magic variable declared by pybind11 where we're
+    // supposed to put the loaded result.
+    value = Attorney::Construct(integer.cast<uint64_t>());
+
+    return true;
+  }
+
+  static handle cast(drake::symbolic::Variable::Id src,
+      return_value_policy /* policy */, handle /* parent */) {
+    pybind11::int_ value{src.value()};
+    return value.release();
+  }
+};
+}  // namespace detail
+}  // namespace pybind11

--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -690,6 +690,12 @@ void Polynomial<T>::MakeMonomialsUnique(void) {
   }
 }
 
+template <typename T>
+Polynomial<T>::VarType Polynomial<T>::VariableIdToVarType(
+    const symbolic::Variable::Id& id) {
+  return static_cast<Polynomial<T>::VarType>(id.value());
+}
+
 namespace {
 
 using symbolic::Expression;
@@ -744,8 +750,8 @@ class FromExpressionVisitor {
   }
 
   static Polynomial<T> VisitVariable(const Expression& e) {
-    return Polynomial<T>{1.0, static_cast<Polynomial<double>::VarType>(
-                                  get_variable(e).get_id())};
+    return Polynomial<T>{
+        1.0, Polynomial<T>::VariableIdToVarType(get_variable(e).get_id())};
   }
 
   static Polynomial<T> VisitConstant(const Expression& e) {

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -406,12 +406,20 @@ class Polynomial {
       const ToleranceType& tol_type = ToleranceType::kAbsolute) const;
 
   /** Constructs a Polynomial representing the symbolic expression `e`.
-   * Note that the ID of a variable is preserved in this translation.
+   * The mapping from symbolic::Variable::Id to Polynomial::VarType is governed
+   * by VariableIdToVarType().
    *
    * @throws std::exception if `e` is not polynomial-convertible.
    * @pre e.is_polynomial() is true.
    */
   static Polynomial<T> FromExpression(const drake::symbolic::Expression& e);
+
+  /** When FromExpression converts a symbolic::Variable to a Polynomial::Term,
+   * it uses this mapping function to project the symbolic::Variable::Id to a
+   * Polynomial::VarType. Note that the mapping is non-injective (i.e.,
+   * degenerate) because an Id is 64 bits but a VarType is only 32 bits.
+   */
+  static VarType VariableIdToVarType(const drake::symbolic::Variable::Id& id);
 
   std::string to_string() const;
 

--- a/common/symbolic/expression/test/variable_test.cc
+++ b/common/symbolic/expression/test/variable_test.cc
@@ -67,12 +67,12 @@ TEST_F(VariableTest, DefaultConstructors) {
   // change the name as we develop; the API doesn't promise any particular name.
   EXPECT_EQ(v_default.get_name(), "𝑥");
   EXPECT_EQ(v_default.get_type(), Variable::Type::CONTINUOUS);
-  EXPECT_EQ(v_default.get_id(), 0);
+  EXPECT_EQ(v_default.get_id(), Variable::Id());
 
   const Variable copy(v_default);
   EXPECT_EQ(copy.get_name(), "𝑥");
   EXPECT_EQ(copy.get_type(), Variable::Type::CONTINUOUS);
-  EXPECT_EQ(copy.get_id(), 0);
+  EXPECT_EQ(copy.get_id(), Variable::Id());
 }
 
 TEST_F(VariableTest, GetId) {
@@ -91,7 +91,7 @@ TEST_F(VariableTest, GetName) {
 
 TEST_F(VariableTest, Copy) {
   const Variable x{"x"};
-  const size_t x_id{x.get_id()};
+  const Variable::Id x_id{x.get_id()};
   const size_t x_hash{get_std_hash(x)};
   const std::string x_name{x.get_name()};
 
@@ -104,7 +104,7 @@ TEST_F(VariableTest, Copy) {
 
 TEST_F(VariableTest, Move) {
   Variable x{"x"};
-  const size_t x_id{x.get_id()};
+  const Variable::Id x_id{x.get_id()};
   const size_t x_hash{get_std_hash(x)};
   const std::string x_name{x.get_name()};
 
@@ -188,6 +188,16 @@ TEST_F(VariableTest, VariableTypeFmtFormatter) {
   EXPECT_EQ(fmt::to_string(Variable::Type::RANDOM_GAUSSIAN), "Random Gaussian");
   EXPECT_EQ(fmt::to_string(Variable::Type::RANDOM_EXPONENTIAL),
             "Random Exponential");
+}
+
+TEST_F(VariableTest, VariableIdFmtFormatter) {
+  // The dummy ID is all-zero.
+  EXPECT_EQ(fmt::to_string(Variable::Id()), "0x0000000000000000");
+
+  // A normal ID is a 64-bit hexidecimal number starting with "0x...".
+  const std::string x_str = fmt::to_string(x_.get_id());
+  EXPECT_EQ(x_str.substr(0, 2), "0x");
+  EXPECT_EQ(x_str.length(), 2 + 64 / 4);
 }
 
 // This test checks whether Variable is compatible with std::unordered_set.

--- a/common/symbolic/expression/variable.cc
+++ b/common/symbolic/expression/variable.cc
@@ -19,26 +19,28 @@ using std::string;
 namespace drake {
 namespace symbolic {
 
-namespace {
-/* Produces a unique ID for a variable. */
-size_t get_next_id(const Variable::Type type) {
-  static_assert(std::is_same_v<Variable::Id, size_t>);
-  // Note that id 0 is reserved for anonymous variable which is created by the
-  // default constructor, Variable(). As a result, we have an invariant
-  // "get_next_id() > 0".
-  static never_destroyed<atomic<size_t>> next_id(1);
-  const size_t counter = next_id.access()++;
-  // We'll assume that size_t is at least 8 bytes wide, so that we can pack the
-  // counter into the lower 7 bytes of `id_` and the `Type` into the upper byte.
-  static_assert(sizeof(size_t) >= 8);
-  return counter | (static_cast<size_t>(type) << (7 * 8));
+Variable::Id Variable::Id::Create(Type type) {
+  // Each variable created gets a serial number counting up from 1.
+  // (Zero is reserved for the default-constructed Id.)
+  static atomic<uint64_t> counter(0);
+  const uint64_t serial_number = ++counter;
+
+  Id result;
+  // We store the Type enum in the upper byte (8 bits) of value_ (64 bits).
+  static_assert(sizeof(Type) == 1);
+  result.value_ = (static_cast<uint64_t>(type) << (64 - 8)) + serial_number;
+  return result;
 }
-}  // namespace
+
+std::string Variable::Id::to_string() const {
+  // Our string repsentation is 18 characters: "0x" followed by 16 hex digits to
+  // cover all 64 bits (padded with leading zeros as necessary).
+  return fmt::format("{:#018x}", value_);
+}
 
 Variable::Variable(string name, const Type type)
-    : id_{get_next_id(type)},
-      name_{make_shared<const string>(std::move(name))} {
-  DRAKE_ASSERT(id_ > 0);
+    : id_{Id::Create(type)}, name_{make_shared<const string>(std::move(name))} {
+  DRAKE_ASSERT(get_id().value() > 0);
 }
 
 string Variable::get_name() const {

--- a/common/symbolic/expression/variable.h
+++ b/common/symbolic/expression/variable.h
@@ -5,6 +5,7 @@
 #endif
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -36,8 +37,6 @@ namespace symbolic {
  */
 class Variable {
  public:
-  typedef size_t Id;
-
   /** Supported types of symbolic variables. */
   enum class Type : uint8_t {
     CONTINUOUS,       ///< A CONTINUOUS variable takes a `double` value.
@@ -50,6 +49,50 @@ class Variable {
                       ///< mean-zero, unit-variance normal.
     RANDOM_EXPONENTIAL,  ///< A random variable whose value will be drawn from
                          ///< exponential distribution with λ=1.
+  };
+
+  /** Identifier for a symbolic variable. */
+  class Id {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Id);
+
+    /** Constructs a "dummy" id, not associated with any variable. */
+    Id() = default;
+
+    /** Default comparison operators. */
+    auto operator<=>(const Id&) const = default;
+
+    /** Implements the @ref hash_append concept. */
+    template <class HashAlgorithm>
+    // NOLINTNEXTLINE(runtime/references) Per hash_append convention.
+    friend void hash_append(HashAlgorithm& hasher, const Id& item) noexcept {
+      using drake::hash_append;
+      hash_append(hasher, item.value());
+    }
+
+    /** Returns a string representation of this Id. */
+    std::string to_string() const;
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+    /* (Internal use only) Returns this Id as a bare integer. */
+    uint64_t value() const { return value_; }
+#endif
+
+   private:
+    friend class Variable;
+    friend class VariableIdPythonAttorney;
+
+    static Id Create(Type type);
+
+    Type get_type() const {
+      // We store the Type enum in the upper byte (8 bits) of value_ (64 bits).
+      return static_cast<Type>(value_ >> (64 - 8));
+    }
+
+    bool is_default() const { return value_ == 0; }
+
+    // We store the Type enum in the upper byte of value_.
+    uint64_t value_{};
   };
 
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Variable);
@@ -74,13 +117,9 @@ class Variable {
   ~Variable() = default;
 
   /** Checks if this is the variable created by the default constructor. */
-  [[nodiscard]] bool is_dummy() const { return get_id() == 0; }
+  [[nodiscard]] bool is_dummy() const { return get_id().is_default(); }
   [[nodiscard]] Id get_id() const { return id_; }
-  [[nodiscard]] Type get_type() const {
-    // We store the 1-byte Type enum in the upper byte of id_.
-    // See get_next_id() in the cc file for more details.
-    return static_cast<Type>(Id{id_} >> (7 * 8));
-  }
+  [[nodiscard]] Type get_type() const { return get_id().get_type(); }
   [[nodiscard]] std::string get_name() const;
   [[nodiscard]] std::string to_string() const;
 
@@ -100,7 +139,7 @@ class Variable {
   friend void hash_append(HashAlgorithm& hasher,
                           const Variable& item) noexcept {
     using drake::hash_append;
-    hash_append(hasher, Id{item.id_});
+    hash_append(hasher, item.get_id());
     // We do not send the name_ to the hasher, because the id_ is already unique
     // across all instances, so two Variable instances with matching id_ will
     // always have identical names.
@@ -332,6 +371,10 @@ Eigen::Matrix<Variable, rows, 1> MakeVectorIntegerVariable(
 
 namespace std {
 
+/* Provides std::hash<drake::symbolic::Variable::Id>. */
+template <>
+struct hash<drake::symbolic::Variable::Id> : public drake::DefaultHash {};
+
 /* Provides std::hash<drake::symbolic::Variable>. */
 template <>
 struct hash<drake::symbolic::Variable> : public drake::DefaultHash {};
@@ -385,6 +428,7 @@ CheckStructuralEquality(const DerivedA& m1, const DerivedB& m2) {
 }  // namespace symbolic
 }  // namespace drake
 
+DRAKE_FORMATTER_AS(, drake::symbolic, Variable::Id, x, x.to_string())
 DRAKE_FORMATTER_AS(, drake::symbolic, Variable, x, x.to_string())
 DRAKE_FORMATTER_AS(, drake::symbolic, Variable::Type, x,
                    drake::symbolic::to_string(x))

--- a/common/test/polynomial_test.cc
+++ b/common/test/polynomial_test.cc
@@ -531,7 +531,9 @@ GTEST_TEST(PolynomialTest, FromExpression) {
   const Variable z{"z"};
   Environment env{{x, 1.0}, {y, 2.0}, {z, 3.0}};
   const map<Polynomiald::VarType, double> eval_point{
-      {x.get_id(), env[x]}, {y.get_id(), env[y]}, {z.get_id(), env[z]}};
+      {Polynomiald::VariableIdToVarType(x.get_id()), env[x]},
+      {Polynomiald::VariableIdToVarType(y.get_id()), env[y]},
+      {Polynomiald::VariableIdToVarType(z.get_id()), env[z]}};
 
   const Expression e0{42.0};
   const Expression e1{pow(x, 2)};

--- a/solvers/create_cost.cc
+++ b/solvers/create_cost.cc
@@ -79,19 +79,21 @@ Binding<PolynomialCost> ParsePolynomialCost(const symbolic::Expression& e) {
         "polynomial expression.\n",
         e));
   }
-  const symbolic::Variables& vars = e.GetVariables();
+  const symbolic::Variables& symbolic_vars = e.GetVariables();
   const Polynomiald polynomial = Polynomiald::FromExpression(e);
-  vector<Polynomiald::VarType> polynomial_vars(vars.size());
-  VectorXDecisionVariable var_vec(vars.size());
+  vector<Polynomiald::VarType> polynomial_vars(symbolic_vars.size());
+  VectorXDecisionVariable symbolic_vars_vec(symbolic_vars.size());
   int polynomial_var_count = 0;
-  for (const auto& var : vars) {
-    polynomial_vars[polynomial_var_count] = var.get_id();
-    var_vec[polynomial_var_count] = var;
+  for (const auto& symbolic_var : symbolic_vars) {
+    const Polynomiald::VarType polynomial_var =
+        Polynomiald::VariableIdToVarType(symbolic_var.get_id());
+    polynomial_vars[polynomial_var_count] = polynomial_var;
+    symbolic_vars_vec[polynomial_var_count] = symbolic_var;
     ++polynomial_var_count;
   }
   return CreateBinding(make_shared<PolynomialCost>(
                            Vector1<Polynomiald>(polynomial), polynomial_vars),
-                       var_vec);
+                       symbolic_vars_vec);
 }
 
 Binding<L2NormCost> ParseL2NormCost(const symbolic::Expression& e,

--- a/solvers/test/mathematical_program_test.cc
+++ b/solvers/test/mathematical_program_test.cc
@@ -3591,38 +3591,49 @@ GTEST_TEST(TestMathematicalProgram, AddL1NormCostInEpigraphForm_Rectangular) {
   EXPECT_FALSE(linear_constraint.evaluator()->CheckSatisfied(vars, kTol));
 }
 
+using MapPolynomialVarTypeToSymbolicVariable =
+    map<Polynomial<double>::VarType, Variable>;
+
 // Helper function for ArePolynomialIsomorphic.
 //
-// Transforms a monomial into an isomorphic one up to a given map (Variable::Id
-// → Variable). Consider an example where monomial is "x³y⁴" and var_id_to_var
-// is {x.get_id() ↦ z, y.get_id() ↦ w}. We have transform(x³y⁴, {x.get_id() ↦ z,
-// y.get_id() ↦ w}) = z³w⁴.
+// Transforms a monomial into an isomorphic one up to a given map
+// (Polynomiald::VarType → symbolic::Variable). Consider an example where
+// monomial is "x³y⁴" and polynomial_var_to_symbolic_var is {x ↦ z, y ↦ w}. We
+// have transform(x³y⁴, {x ↦ z, y ↦ w}) = z³w⁴.
 //
-// @pre `var_id_to_var` is 1-1.
-// @pre The domain of `var_id_to_var` includes all variables in `monomial`.
-// @pre `var_id_to_var` should be chain-free. Formally, for all variable v in
-// the image of var_id_to_var, its ID, id(v) should not be in the domain of
-// var_id_to_var. For example, {x.get_id() -> y, y.get_id() -> z} is not
-// allowed.
+// @pre `polynomial_var_to_symbolic_var` is 1-1.
+//
+// @pre The domain of `polynomial_var_to_symbolic_var` includes all variables in
+// `monomial`.
+//
+// @pre `polynomial_var_to_symbolic_var` should be chain-free. Formally, for all
+// variable v in the image of polynomial_var_to_symbolic_var, v should not be in
+// the domain of polynomial_var_to_symbolic_var. For example, {x ↦ y, y ↦ z} is
+// not allowed.
 symbolic::Monomial transform(const symbolic::Monomial& monomial,
-                             const map<Variable::Id, Variable>& var_id_to_var) {
-  // var_id_to_var should be chain-free.
-  for (const pair<const Variable::Id, Variable>& p : var_id_to_var) {
-    const Variable& var{p.second};
-    DRAKE_DEMAND(var_id_to_var.find(var.get_id()) == var_id_to_var.end());
+                             const MapPolynomialVarTypeToSymbolicVariable&
+                                 polynomial_var_to_symbolic_var) {
+  // polynomial_var_to_symbolic_var should be chain-free.
+  for (const auto& [_, symbolic_var] : polynomial_var_to_symbolic_var) {
+    const Polynomial<double>::VarType as_polynomial_var =
+        Polynomial<double>::VariableIdToVarType(symbolic_var.get_id());
+    DRAKE_DEMAND(!polynomial_var_to_symbolic_var.contains(as_polynomial_var));
   }
   map<Variable, int> new_powers;
-  for (const pair<Variable, int> p : monomial.get_powers()) {
-    const Variable& var_in_monomial{p.first};
-    const int exponent{p.second};
-    const auto it = var_id_to_var.find(var_in_monomial.get_id());
+  for (const auto& [symbolic_var_in_monomial, exponent] :
+       monomial.get_powers()) {
+    const Polynomial<double>::VarType polynomial_var_in_monomial =
+        Polynomial<double>::VariableIdToVarType(
+            symbolic_var_in_monomial.get_id());
+    const auto iter =
+        polynomial_var_to_symbolic_var.find(polynomial_var_in_monomial);
 
-    // There should be a mapping for the ID in var_id_to_var.
-    DRAKE_DEMAND(it != var_id_to_var.end());
-    const Variable new_var{it->second};
+    // There should be a mapping for the ID in polynomial_var_to_symbolic_var.
+    DRAKE_DEMAND(iter != polynomial_var_to_symbolic_var.end());
+    const Variable new_var{iter->second};
 
-    // var_id_to_var should be 1-1.
-    DRAKE_DEMAND(new_powers.find(new_var) == new_powers.end());
+    // polynomial_var_to_symbolic_var should be 1-1.
+    DRAKE_DEMAND(!new_powers.contains(new_var));
     new_powers.emplace(new_var, exponent);
   }
   return symbolic::Monomial{new_powers};
@@ -3631,20 +3642,24 @@ symbolic::Monomial transform(const symbolic::Monomial& monomial,
 // Helper function for ArePolynomialIsomorphic.
 //
 // Transforms a Polynomial into an isomorphic one up to a given map
-// (Variable::Id → Variable). Consider an example where poly = x³y⁴ + 2x² and
-// var_id_to_var is {x.get_id() ↦ z, y.get_id() ↦ w}. We have transform(poly,
-// var_id_to_var) = z³w⁴ + 2z².
+// (Polynomiald::VarType → symbolic::Variable). Consider an example where poly =
+// x³y⁴ + 2x² and polynomial_var_to_symbolic_var is {x ↦ z, y ↦ w}. We have
+// transform(poly, polynomial_var_to_symbolic_var) = z³w⁴ + 2z².
 //
-// @pre `var_id_to_var` is 1-1.
-// @pre The domain of `var_id_to_var` includes all variables in `m`.
-// @pre `var_id_to_var` should be chain-free.
-symbolic::Polynomial transform(
-    const symbolic::Polynomial& poly,
-    const map<Variable::Id, Variable>& var_id_to_var) {
+// @pre `polynomial_var_to_symbolic_var` is 1-1.
+//
+// @pre The domain of `polynomial_var_to_symbolic_var` includes all variables in
+// `m`.
+//
+// @pre `polynomial_var_to_symbolic_var` should be chain-free.
+symbolic::Polynomial transform(const symbolic::Polynomial& poly,
+                               const MapPolynomialVarTypeToSymbolicVariable&
+                                   polynomial_var_to_symbolic_var) {
   symbolic::Polynomial::MapType new_map;
   for (const pair<const symbolic::Monomial, symbolic::Expression>& p :
        poly.monomial_to_coefficient_map()) {
-    new_map.emplace(transform(p.first, var_id_to_var), p.second);
+    new_map.emplace(transform(p.first, polynomial_var_to_symbolic_var),
+                    p.second);
   }
   return symbolic::Polynomial{new_map};
 }
@@ -3652,15 +3667,19 @@ symbolic::Polynomial transform(
 // Helper function for CheckAddedPolynomialCost.
 //
 // Checks if two Polynomial `p1` and `p2` are isomorphic with respect to a
-// bijection `var_id_to_var`.
+// bijection `polynomial_var_to_symbolic_var`.
 //
-// @pre `var_id_to_var` is 1-1.
-// @pre The domain of `var_id_to_var` includes all variables in `m`.
-// @pre `var_id_to_var` should be chain-free.
+// @pre `polynomial_var_to_symbolic_var` is 1-1.
+//
+// @pre The domain of `polynomial_var_to_symbolic_var` includes all variables in
+// `m`.
+//
+// @pre `polynomial_var_to_symbolic_var` should be chain-free.
 bool ArePolynomialIsomorphic(const symbolic::Polynomial& p1,
                              const symbolic::Polynomial& p2,
-                             const map<Variable::Id, Variable>& var_id_to_var) {
-  return transform(p1, var_id_to_var).EqualTo(p2);
+                             const MapPolynomialVarTypeToSymbolicVariable&
+                                 polynomial_var_to_symbolic_var) {
+  return transform(p1, polynomial_var_to_symbolic_var).EqualTo(p2);
 }
 
 void CheckAddedPolynomialCost(MathematicalProgram* prog, const Expression& e) {
@@ -3671,17 +3690,17 @@ void CheckAddedPolynomialCost(MathematicalProgram* prog, const Expression& e) {
   // Now reconstruct the symbolic expression from `binding`.
   const auto polynomial = binding.evaluator()->polynomials()(0);
 
-  // var_id_to_var : Variable::Id → Variable. It keeps the relation between a
-  // variable in a Polynomial<double> and symbolic::Monomial.
+  // polynomial_var_to_symbolic_var : Polynomiald::VarType → Variable. It keeps
+  // the relation between a variable in a Polynomiald and symbolic::Monomial.
   symbolic::Polynomial poly_expected;
-  map<Variable::Id, Variable> var_id_to_var;
+  MapPolynomialVarTypeToSymbolicVariable polynomial_var_to_symbolic_var;
   for (const Polynomial<double>::Monomial& m : polynomial.GetMonomials()) {
     map<Variable, int> map_var_to_power;
     for (const Polynomial<double>::Term& term : m.terms) {
-      auto it = var_id_to_var.find(term.var);
-      if (it == var_id_to_var.end()) {
+      auto it = polynomial_var_to_symbolic_var.find(term.var);
+      if (it == polynomial_var_to_symbolic_var.end()) {
         Variable var{std::to_string(term.var)};
-        var_id_to_var.emplace_hint(it, term.var, var);
+        polynomial_var_to_symbolic_var.emplace_hint(it, term.var, var);
         map_var_to_power.emplace(var, term.power);
       } else {
         map_var_to_power.emplace(it->second, term.power);
@@ -3690,9 +3709,10 @@ void CheckAddedPolynomialCost(MathematicalProgram* prog, const Expression& e) {
     poly_expected += symbolic::Monomial(map_var_to_power) * m.coefficient;
   }
   // Checks if the two polynomials, `poly` and `poly_expected` are isomorphic
-  // with respect to `var_id_to_var`.
+  // with respect to `polynomial_var_to_symbolic_var`.
   const symbolic::Polynomial poly{e};
-  EXPECT_TRUE(ArePolynomialIsomorphic(poly, poly_expected, var_id_to_var));
+  EXPECT_TRUE(ArePolynomialIsomorphic(poly, poly_expected,
+                                      polynomial_var_to_symbolic_var));
 }
 
 GTEST_TEST(TestMathematicalProgram, TestAddPolynomialCost) {


### PR DESCRIPTION
It was already abstracted away as a typedef, but that left the door open to accidentally abusing its integer nature. We replace it with a real class now to prevent future mis-use, and to allow for changing its representation down the road.

For the Python bindings, the original typedef was never bound, so for backwards compatibility we'll define a type_caster back to int rather than binding the Id class.

Towards #24331, but I think we should still tighten our belt even if we decide not to add more bits to the Id.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24333)
<!-- Reviewable:end -->
