### PR TITLE
[workspace] Silence tinyobjloader_internal warnings

### DIFF
--- a/tools/workspace/tinyobjloader_internal/package.BUILD.bazel
+++ b/tools/workspace/tinyobjloader_internal/package.BUILD.bazel
@@ -15,6 +15,7 @@ cc_library_vendored(
     srcs_vendored = ["drake_src/tiny_obj_loader.cc"],
     hdrs = ["tiny_obj_loader.h"],
     hdrs_vendored = ["drake_src/tiny_obj_loader.h"],
+    copts = ["-w"],
     defines = ["TINYOBJLOADER_USE_DOUBLE=1"],
     includes = ["drake_src"],
     isystem = True,


### PR DESCRIPTION
```
INFO: From Compiling external/+internal_repositories+tinyobjloader_internal/drake_src/tiny_obj_loader.cc:
In file included from bazel-out/k8-opt/bin/external/+internal_repositories+tinyobjloader_internal/drake_src/tiny_obj_loader.cc:2:
bazel-out/k8-opt/bin/external/+internal_repositories+tinyobjloader_internal/drake_src/tiny_obj_loader.h:6458:23: warning: 'drake_vendor::tinyobj::vertex_index_t drake_vendor::tinyobj::parseRawTriple(const char**)' defined but not used [-Wunused-function]
 6458 | static vertex_index_t parseRawTriple(const char **token) {
      |                       ^~~~~~~~~~~~~~
bazel-out/k8-opt/bin/external/+internal_repositories+tinyobjloader_internal/drake_src/tiny_obj_loader.h:6404:13: warning: 'bool drake_vendor::tinyobj::parseTriple(const char**, int, int, int, vertex_index_t*, const warning_context&)' defined but not used [-Wunused-function]
 6404 | static bool parseTriple(const char **token, int vsize, int vnsize, int vtsize,
      |             ^~~~~~~~~~~
bazel-out/k8-opt/bin/external/+internal_repositories+tinyobjloader_internal/drake_src/tiny_obj_loader.h:6378:18: warning: 'drake_vendor::tinyobj::tag_sizes drake_vendor::tinyobj::parseTagTriple(const char**)' defined but not used [-Wunused-function]
 6378 | static tag_sizes parseTagTriple(const char **token) {
      |                  ^~~~~~~~~~~~~~
```

Amends #24328.

+a:@SeanCurtis-TRI for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24335)
<!-- Reviewable:end -->
