### PR TITLE
[multibody] CENIC accepts 0-duration step as no-op

### DIFF
--- a/bindings/generated_docstrings/multibody_cenic.h
+++ b/bindings/generated_docstrings/multibody_cenic.h
@@ -75,6 +75,20 @@ Running CENIC in fixed-step mode (with error-control disabled)
 recovers the "Lagged" variant of discrete-time ICF simulation from
 [Castro et al., 2023].
 
+Implementation notes:
+
+Warning:
+    CENIC's error control implementation is not sensitive to
+    continuous state of systems other than the plant(). See issue
+    #23921.
+
+Warning:
+    When asked to perform 0-sized integration steps, CENIC executes a
+    special case that does no integration or state updates, but does
+    reset the error estimate to all 0, and always succeeds. This is in
+    contrast to other integrator implementations in Drake. See
+    DoStep() in the implementation.
+
 References:
 
 [Castro et al., 2023] Castro A., Han X., and Masterjohn J., 2023.

--- a/multibody/cenic/cenic_integrator.cc
+++ b/multibody/cenic/cenic_integrator.cc
@@ -296,6 +296,12 @@ template <typename T>
 bool CenicIntegrator<T>::DoStep(const T& h) {
   DRAKE_DEMAND(builder_ != nullptr);
 
+  if (h == T(0)) {
+    ContinuousState<T>& err = *this->get_mutable_error_estimate();
+    err.get_mutable_vector().SetZero();
+    return true;
+  }
+
   // TODO(vincekurtz): consider delaying this to encourage cache hits
   Context<T>& context = *this->get_mutable_context();
   ContinuousState<T>& x_next = context.get_mutable_continuous_state();

--- a/multibody/cenic/cenic_integrator.h
+++ b/multibody/cenic/cenic_integrator.h
@@ -80,6 +80,17 @@ system diagram with a `MultibodyPlant` subsystem.
 Running CENIC in fixed-step mode (with error-control disabled) recovers the
 "Lagged" variant of discrete-time ICF simulation from [Castro et al., 2023].
 
+Implementation notes:
+
+@warning CENIC's error control implementation is not sensitive to continuous
+         state of systems other than the plant(). See issue #23921.
+
+@warning When asked to perform 0-sized integration steps, CENIC executes a
+         special case that does no integration or state updates, but does reset
+         the error estimate to all 0, and always succeeds. This is in contrast
+         to other integrator implementations in Drake. See DoStep() in the
+         implementation.
+
 References:
 
   [Castro et al., 2023] Castro A., Han X., and Masterjohn J., 2023. Irrotational
@@ -181,6 +192,11 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
 
   void DoInitialize() final;
 
+  /* @warning For `h` == 0, CENIC DoStep() executes a special case that does no
+     integration or state updates, but does reset the error estimate to all 0,
+     and always succeeds.
+
+    See IntegratorBase::DoStep() for full implementation requirements. */
   bool DoStep(const T& h) final;
 
   /* Solves the ICF problem to compute x_{t+h}.

--- a/multibody/cenic/test/cenic_integrator_test.cc
+++ b/multibody/cenic/test/cenic_integrator_test.cc
@@ -522,6 +522,17 @@ TEST_P(DoublePendulum, JointLimits) {
   const VectorXd q = plant_->GetPositions(*plant_context_);
   EXPECT_NEAR(q(0), 0.2, 1e-5);
   EXPECT_NEAR(q(1), 0.4, 1e-5);
+
+  // Generic integrator behavior: accept 0-duration step with no change to time
+  // or continuous state, and with error estimate updated to all 0.
+  integrator_->IntegrateWithMultipleStepsToTime(
+      simulator_->get_context().get_time());
+  EXPECT_EQ(simulator_->get_context().get_time(), 1.0);
+  const VectorXd q_after = plant_->GetPositions(*plant_context_);
+  EXPECT_EQ(q_after(0), q(0));
+  EXPECT_EQ(q_after(1), q(1));
+  VectorXd error_estimate(integrator_->get_error_estimate()->CopyToVector());
+  EXPECT_EQ(error_estimate.norm(), 0);
 }
 
 /* Checks that effort limits are enforced by the integrator. */


### PR DESCRIPTION
Toward #24304.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24338)
<!-- Reviewable:end -->
