### PR TITLE
[tools] Strip 'releases/' from update commit messages

### DIFF
--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -544,7 +544,7 @@ def _do_upgrade(temp_dir, gh, local_drake_checkout, workspace_name, metadata):
         if _smells_like_a_git_commit(new_commit):
             message = f"Update dependency {workspace_name} to latest commit"
         else:
-            release = new_commit.lstrip("v")
+            release = new_commit.lstrip("releases/").lstrip("v")
             message = f"Update dependency {workspace_name} to {release}"
     else:
         # This is a scripted upgrade of multiple packages, so we'll omit


### PR DESCRIPTION
The coin-or repositories which Drake depends on (Clp, CoinUtils, Csdp, Ipopt) spell their releases this way, bloating our commit message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24341)
<!-- Reviewable:end -->
