### PR TITLE
[tools] Install Python importlib metadata

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -195,6 +195,25 @@ install_cmake_config(
     versioned = False,
 )
 
+cmake_configure_file(
+    name = "site_packages_metadata_expand",
+    src = "site-packages-METADATA.in",
+    out = "METADATA",
+    atonly = True,
+    cmakelists = [
+        ":stamp_version.cmake",
+    ],
+)
+
+# Publish a dist-info/METADATA file to report our version number to non-wheel
+# builds. Wheel builds have their own mechanism to handle this, and end up
+# discarding (ignoring) this file entirely.
+install(
+    name = "install_site_packages_metadata",
+    data = [":METADATA"],
+    data_dest = "lib/python@PYTHON_VERSION@/site-packages/drake.dist-info",
+)
+
 # Verify that extra include paths are not leaking into our interface deps.
 cc_check_allowed_headers(
     name = "allowed_headers_lint",
@@ -298,8 +317,9 @@ install(
     install_tests = [
         "test/drake_python_dir_install_test.py",
         "test/find_package_drake_install_test.py",
-        "test/snopt_visibility_install_test.py",
+        "test/metadata_install_test.py",
         "test/rpath_install_test.py",
+        "test/snopt_visibility_install_test.py",
     ],
     hdrs = [":libdrake_headers"],
     hdr_dest = "include/drake",
@@ -308,6 +328,7 @@ install(
     deps = [
         ":install_cmake_config",
         ":install_libdrake",
+        ":install_site_packages_metadata",
     ],
 )
 
@@ -436,5 +457,9 @@ add_lint_tests(
     python_lint_extra_srcs = [
         "build_components_refresh.py",
         "test/drake_python_dir_install_test.py",
+        "test/find_package_drake_install_test.py",
+        "test/metadata_install_test.py",
+        "test/rpath_install_test.py",
+        "test/snopt_visibility_install_test.py",
     ],
 )

--- a/tools/install/libdrake/site-packages-METADATA.in
+++ b/tools/install/libdrake/site-packages-METADATA.in
@@ -1,0 +1,6 @@
+Metadata-Version: 1.0
+Name: drake
+Version: @DRAKE_VERSION@
+Summary: Model-based design and verification for robotics
+Author-email: drake-users@mit.edu
+License: Various

--- a/tools/install/libdrake/test/find_package_drake_install_test.py
+++ b/tools/install/libdrake/test/find_package_drake_install_test.py
@@ -36,7 +36,9 @@ class FindPackageDrakeInstallTest(unittest.TestCase):
             # Check that the imported drake::drake is a shared library.
             get_target_property(drake_type drake::drake TYPE)
             if(NOT drake_type STREQUAL "SHARED_LIBRARY")
-                message(FATAL_ERROR "drake::drake is ${{drake_type}}, but expected SHARED_LIBRARY.")
+                message(FATAL_ERROR "drake::drake is ${{drake_type}}, "
+                  "but expected SHARED_LIBRARY."
+                )
             endif()
         """
 
@@ -47,10 +49,9 @@ class FindPackageDrakeInstallTest(unittest.TestCase):
 
         cmake_binary_dir = install_test_helper.create_temporary_dir("build")
 
-        subprocess.check_call(["cmake", cmake_source_dir],
-                              cwd=cmake_binary_dir)
+        subprocess.check_call(["cmake", cmake_source_dir], cwd=cmake_binary_dir)
         subprocess.check_call("make", cwd=cmake_binary_dir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tools/install/libdrake/test/metadata_install_test.py
+++ b/tools/install/libdrake/test/metadata_install_test.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+
+import install_test_helper
+
+
+class MetadataTest(unittest.TestCase):
+    def test_importlib_metadata(self):
+        """Checks that installed pydrake can report its version number."""
+        # Override PYTHONPATH to only use the installed `pydrake` module.
+        install_dir = install_test_helper.get_install_dir()
+        tool_env = dict(os.environ)
+        tool_env["PYTHONPATH"] = (
+            install_test_helper.get_python_site_packages_dir(install_dir)
+        )
+
+        # Run importlib against the installed `pydrake` module.
+        version = install_test_helper.check_output(
+            [
+                install_test_helper.get_python_executable(),
+                "-c",
+                "import importlib.metadata;\
+               print(importlib.metadata.version('drake'))",
+            ],
+            env=tool_env,
+        ).strip()
+
+        # On "Packaging" builds have a version number; here, we expect the
+        # sentinel value (as opposed to crashing with PackageNotFoundError).
+        self.assertEqual(version, "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/install/libdrake/test/rpath_install_test.py
+++ b/tools/install/libdrake/test/rpath_install_test.py
@@ -16,7 +16,6 @@ def has_prefix(path, prefixes):
 
 
 class RpathTest(unittest.TestCase):
-
     def test_rpaths(self):
         """Confirms that libdrake.so does not link to any non-system libraries
         that are not correctly RPATH'd.
@@ -24,9 +23,8 @@ class RpathTest(unittest.TestCase):
 
         # The shared library to be tested.
         libdrake = os.path.join(
-            install_test_helper.get_install_dir(),
-            "lib/libdrake.so"
-            )
+            install_test_helper.get_install_dir(), "lib/libdrake.so"
+        )
         self.assertTrue(os.path.exists(libdrake))
 
         libs_checked = 0
@@ -44,8 +42,10 @@ class RpathTest(unittest.TestCase):
             ]
             for lib in otool.linked_libraries(libdrake):
                 libs_checked += 1
-                self.assertTrue(has_prefix(lib.path, allowed_prefixes),
-                                msg=f"{lib.path} has a disallowed prefix")
+                self.assertTrue(
+                    has_prefix(lib.path, allowed_prefixes),
+                    msg=f"{lib.path} has a disallowed prefix",
+                )
         else:
             allowed_prefixes = [
                 "/lib/",
@@ -54,8 +54,7 @@ class RpathTest(unittest.TestCase):
                 "/usr/lib64/",
                 os.path.dirname(libdrake),
             ]
-            output = subprocess.check_output(
-                ['ldd', libdrake], encoding="utf8")
+            output = subprocess.check_output(["ldd", libdrake], encoding="utf8")
 
             for line in output.splitlines():
                 # Output is e.g.:
@@ -66,18 +65,19 @@ class RpathTest(unittest.TestCase):
                 # We ignore anything that isn't a resolved library. Since we're
                 # checking the start of the string, we don't need to separate
                 # the resolved path from the offset address.
-                m = re.match('.* => (.*)$', line.strip())
+                m = re.match(".* => (.*)$", line.strip())
                 if m is not None:
                     (resolved,) = m.groups()
                     libs_checked += 1
 
-                    self.assertNotEqual(resolved, "not found",
-                                        msg=line.strip())
-                    self.assertTrue(has_prefix(resolved, allowed_prefixes),
-                                    msg=f"{resolved} has a disallowed prefix")
+                    self.assertNotEqual(resolved, "not found", msg=line.strip())
+                    self.assertTrue(
+                        has_prefix(resolved, allowed_prefixes),
+                        msg=f"{resolved} has a disallowed prefix",
+                    )
 
         self.assertGreater(libs_checked, 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tools/install/libdrake/test/snopt_visibility_install_test.py
+++ b/tools/install/libdrake/test/snopt_visibility_install_test.py
@@ -7,7 +7,6 @@ import install_test_helper
 
 
 class SnoptVisibilityTest(unittest.TestCase):
-
     def test_visibility(self):
         """Confirm that SNOPT's symbols are not exported in the installed
         libdrake.so.  See comments in //tools/workspace/snopt/... for details.
@@ -15,9 +14,8 @@ class SnoptVisibilityTest(unittest.TestCase):
 
         # The shared library to be tested.
         libdrake = os.path.join(
-            install_test_helper.get_install_dir(),
-            "lib/libdrake.so"
-            )
+            install_test_helper.get_install_dir(), "lib/libdrake.so"
+        )
         self.assertTrue(os.path.exists(libdrake))
 
         # Dump the symbol names to an output string.
@@ -40,5 +38,5 @@ class SnoptVisibilityTest(unittest.TestCase):
             self.assertNotIn(" _sn", line)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tools/wheel/test/tests/metadata_test.py
+++ b/tools/wheel/test/tests/metadata_test.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import importlib.metadata
+
+version = importlib.metadata.version("drake")
+assert isinstance(version, str), repr(version)


### PR DESCRIPTION
Relates to #14509.

This allows `importlib.metadata.version("drake")` to report the version number in binary releases, like we already do for pip wheel releases.

Also fix nearby lack of linting and the accumulated lint.

---

Using https://drake.mit.edu/from_binary.html instructions ...

Demonstration of failure in latest stable release:

```console
jwnimmer@call-cps:~/tmp$ curl -fsSLO https://github.com/RobotLocomotion/drake/releases/download/v1.51.1/drake-1.51.1-noble.tar.gz
jwnimmer@call-cps:~/tmp$ mkdir -p env
jwnimmer@call-cps:~/tmp$ tar -xvzf drake-1.51.1-noble.tar.gz -C env --strip-components=1
...
jwnimmer@call-cps:~/tmp$ python3 -m venv env --system-site-packages
jwnimmer@call-cps:~/tmp$ env/bin/python -c 'import importlib.metadata; print(importlib.metadata.version("drake"))'
Traceback (most recent call last):
  File "/usr/lib/python3.12/importlib/metadata/__init__.py", line 397, in from_name
    return next(cls.discover(name=name))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.12/importlib/metadata/__init__.py", line 889, in version
    return distribution(distribution_name).version
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/metadata/__init__.py", line 862, in distribution
    return Distribution.from_name(distribution_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/metadata/__init__.py", line 399, in from_name
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: No package metadata was found for drake
```

Demonstration of success from this PR's packaging build:

```console
jwnimmer@call-cps:~/tmp$ curl -fsSLO https://drake-packages.csail.mit.edu/drake/experimental/drake-0.0.20260403.183714%2Bgitf9ee0338-noble.tar.gz
jwnimmer@call-cps:~/tmp$ mkdir -p env
jwnimmer@call-cps:~/tmp$ tar -xvzf drake-0.0.20260403.183714%2Bgitf9ee0338-noble.tar.gz -C env --strip-components=1
...
jwnimmer@call-cps:~/tmp$ python3 -m venv env --system-site-packages
jwnimmer@call-cps:~/tmp$ env/bin/python -c 'import importlib.metadata; print(importlib.metadata.version("drake"))'
0.0.20260403.183714+gitf9ee0338
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24342)
<!-- Reviewable:end -->
