### PR TITLE
[common] Provide scalar format strings for fmt_eigen

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -3004,7 +3004,55 @@ Note:
     enforces that nothing within Drake is allowed to use Eigen's
     ``operator<<``. Downstream code that calls into Drake is not
     required to use that option; it is only enforced by Drake's build
-    system, not by Drake's headers.)""";
+    system, not by Drake's headers.
+
+**** Format string syntax
+
+The format string specification syntax for fmt_eigen is based on
+fmtlib's [range
+format](https://fmt.dev/dev/syntax/#range-format-specifications)
+specification, recognizable by the distinctive double colon. However,
+in our current implementation of fmt_eigen we do not support the
+``"n"`` option (to remove brackets) nor the ``"s"`` nor ``"?s"``
+options (to merge a character range into a string).
+
+The so-called "range underlying spec" format string depends on the
+particular scalar type captured in the fmt_eigen instance.
+
+Examples:
+
+
+.. raw:: html
+
+    <details><summary>Click to expand C++ code...</summary>
+
+.. code-block:: c++
+
+    Eigen∷RowVector3d x{M_PI, M_SQRT2, M_E};
+    fmt∷format("{}", fmt_eigen(x));
+    // " 3.141592653589793 1.4142135623730951  2.718281828459045"
+    
+    fmt∷format("{∷.2f}", fmt_eigen(x));
+    // "3.14 1.41 2.72"
+    
+    fmt∷format("{x∷e}", fmt∷arg("x", fmt_eigen(x)));
+    // "3.141593e+00 1.414214e+00 2.718282e+00"
+
+.. raw:: html
+
+    </details>
+
+Refer to https://fmt.dev/ for syntax details, but in short:
+
+- The ``arg_id`` appears before the first colon, and specifies which argument
+should be formatted. This syntax is part of fmt, not specific to Drake.
+In the above examples we mostly leave it blank, but in the last one we give
+the argument the name ``"x"`` using ``fmt∷arg`` and then use that name in the
+format string.
+
+- The floating-point format spec appears after the second colon. This syntax is
+part of fmt, not specific to Drake. As seen in the examples, it can be used to
+change the precision or use scientific notation, etc.)""";
     } fmt_eigen;
     // Symbol: drake::fmt_floating_point
     struct /* fmt_floating_point */ {

--- a/common/fmt_eigen.h
+++ b/common/fmt_eigen.h
@@ -72,7 +72,45 @@ list. Never store it as a local variable, member field, etc.
 Drake's code is compiled using -DEIGEN_NO_IO, which enforces that nothing within
 Drake is allowed to use Eigen's `operator<<`. Downstream code that calls into
 Drake is not required to use that option; it is only enforced by Drake's build
-system, not by Drake's headers. */
+system, not by Drake's headers.
+
+### Format string syntax
+
+The format string specification syntax for fmt_eigen is based on fmtlib's
+[range format](https://fmt.dev/dev/syntax/#range-format-specifications)
+specification, recognizable by the distinctive double colon. However, in our
+current implementation of fmt_eigen we do not support the `"n"` option (to
+remove brackets) nor the `"s"` nor `"?s"` options (to merge a character range
+into a string).
+
+The so-called "range underlying spec" format string depends on the particular
+scalar type captured in the fmt_eigen instance.
+
+Examples:
+
+```
+Eigen::RowVector3d x{M_PI, M_SQRT2, M_E};
+fmt::format("{}", fmt_eigen(x));
+// " 3.141592653589793 1.4142135623730951  2.718281828459045"
+
+fmt::format("{::.2f}", fmt_eigen(x));
+// "3.14 1.41 2.72"
+
+fmt::format("{x::e}", fmt::arg("x", fmt_eigen(x)));
+// "3.141593e+00 1.414214e+00 2.718282e+00"
+```
+
+Refer to https://fmt.dev/ for syntax details, but in short:
+
+- The `arg_id` appears before the first colon, and specifies which argument
+  should be formatted. This syntax is part of fmt, not specific to Drake.
+  In the above examples we mostly leave it blank, but in the last one we give
+  the argument the name `"x"` using `fmt::arg` and then use that name in the
+  format string.
+
+- The floating-point format spec appears after the second colon. This syntax is
+  part of fmt, not specific to Drake. As seen in the examples, it can be used to
+  change the precision or use scientific notation, etc. */
 template <typename Derived>
 internal::fmt_eigen_ref<typename Derived::Scalar> fmt_eigen(
     const Eigen::MatrixBase<Derived>& matrix) {
@@ -85,8 +123,22 @@ internal::fmt_eigen_ref<typename Derived::Scalar> fmt_eigen(
 // Formatter specialization for drake::fmt_eigen.
 namespace fmt {
 template <typename Scalar>
-struct formatter<drake::internal::fmt_eigen_ref<Scalar>>
-    : formatter<std::string_view> {
+struct formatter<drake::internal::fmt_eigen_ref<Scalar>> : formatter<Scalar> {
+  constexpr auto parse(fmt::format_parse_context& ctx)
+      -> decltype(ctx.begin()) {
+    auto iter = ctx.begin();
+    auto end = ctx.end();
+    if (iter == end || *iter == '}') {
+      return iter;
+    }
+    if (*iter == ':') {
+      ++iter;
+      ctx.advance_to(iter);
+      return formatter<Scalar>::parse(ctx);
+    }
+    throw fmt::format_error("Malformed fmt_eigen format specification");
+  }
+
   template <typename FormatContext>
   auto format(const drake::internal::fmt_eigen_ref<Scalar>& ref,
               // NOLINTNEXTLINE(runtime/references) To match fmt API.
@@ -95,7 +147,6 @@ struct formatter<drake::internal::fmt_eigen_ref<Scalar>>
     // Format every matrix element in turn. We'll format them back-to-back into
     // the same buffer (while keeping track of where each one started), and then
     // in a second pass we'll slice up the buffer into string_views.
-    formatter<Scalar> element_formatter;
     std::vector<char> element_buffer;            // Slab for formatted elements.
     std::vector<size_t> element_starts;          // Indices into element_buffer.
     element_buffer.reserve(matrix.size() * 20);  // An estimate (not precise).
@@ -106,7 +157,8 @@ struct formatter<drake::internal::fmt_eigen_ref<Scalar>>
         using OutputIt = std::back_insert_iterator<std::vector<char>>;
         using OutputContext = fmt::basic_format_context<OutputIt, char>;
         OutputContext element_ctx{OutputIt(element_buffer), {}};
-        element_formatter.format(matrix(row, col), element_ctx);
+        // Use our base class Scalar formatter so its format_spec will be used.
+        formatter<Scalar>::format(matrix(row, col), element_ctx);
       }
     }
     element_starts.push_back(element_buffer.size());
@@ -121,7 +173,7 @@ struct formatter<drake::internal::fmt_eigen_ref<Scalar>>
     const std::string content =
         drake::internal::FormatMatrix(matrix.rows(), matrix.cols(), elements);
     // Copy the content into the output buffer.
-    return formatter<std::string_view>::format(content, ctx);
+    return formatter<std::string_view>{}.format(content, ctx);
   }
 };
 }  // namespace fmt

--- a/common/test/fmt_eigen_test.cc
+++ b/common/test/fmt_eigen_test.cc
@@ -31,6 +31,15 @@ DRAKE_FORMATTER_AS(, drake, BigToken, x, BigToken::to_string())
 namespace drake {
 namespace {
 
+GTEST_TEST(FmtEigenTest, DocumentationExamples) {
+  const Eigen::RowVector3d x{M_PI, M_SQRT2, M_E};
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(x)),
+            " 3.141592653589793 1.4142135623730951  2.718281828459045");
+  EXPECT_EQ(fmt::format("{::.2f}", fmt_eigen(x)), "3.14 1.41 2.72");
+  EXPECT_EQ(fmt::format("{x::e}", fmt::arg("x", fmt_eigen(x))),
+            "3.141593e+00 1.414214e+00 2.718282e+00");
+}
+
 GTEST_TEST(FmtEigenTest, Precision) {
   // This constant needs the maximum number of digits to round-trip correctly.
   const double scalar = 0.12345678901234566;
@@ -40,32 +49,48 @@ GTEST_TEST(FmtEigenTest, Precision) {
   const std::string_view baseline{"0.12345678901234566"};
   ASSERT_EQ(fmt::to_string(scalar), baseline);
 
+  // Default format.
   EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
   EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+
+  // With Scalar format string modifiers.
+  EXPECT_EQ(fmt::format("{::.2f}", fmt_eigen(value)), "0.12");
 }
 
 GTEST_TEST(FmtEigenTest, RowVector3d) {
   const Eigen::RowVector3d value{1.1, 2.2, 3.3};
 
+  // Default format.
   const std::string_view baseline{"1.1 2.2 3.3"};
   EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
   EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+
+  // With Scalar format string modifiers.
+  EXPECT_EQ(fmt::format("{::.2f}", fmt_eigen(value)), "1.10 2.20 3.30");
 }
 
 GTEST_TEST(FmtEigenTest, Vector3d) {
   const Eigen::Vector3d value{1.1, 2.2, 3.3};
 
+  // Default format.
   std::string_view baseline{"1.1\n2.2\n3.3"};
   EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
   EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+
+  // With Scalar format string modifiers.
+  EXPECT_EQ(fmt::format("{::.2f}", fmt_eigen(value)), "1.10\n2.20\n3.30");
 }
 
 GTEST_TEST(FmtEigenTest, EmptyMatrix) {
   const Eigen::MatrixXd value;
 
+  // Default format.
   const std::string_view baseline;
   EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
   EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+
+  // Scalar format string modifiers are accepeted, but no-ops.
+  EXPECT_EQ(fmt::format("{::.2f}", fmt_eigen(value)), baseline);
 }
 
 GTEST_TEST(FmtEigenTest, Matrix3d) {
@@ -76,12 +101,19 @@ GTEST_TEST(FmtEigenTest, Matrix3d) {
            3.1, 3.2, 3.3;
   // clang-format on
 
+  // Default format.
   const std::string_view baseline{
       "1.1 1.2 1.3\n"
       "2.1 2.2 2.3\n"
       "3.1 3.2 3.3"};
   EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
   EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+
+  // With Scalar format string modifiers.
+  EXPECT_EQ(fmt::format("{::.2f}", fmt_eigen(value)),
+            "1.10 1.20 1.30\n"
+            "2.10 2.20 2.30\n"
+            "3.10 3.20 3.30");
 }
 
 GTEST_TEST(FmtEigenTest, Matrix3dNeedsPadding) {
@@ -92,12 +124,19 @@ GTEST_TEST(FmtEigenTest, Matrix3dNeedsPadding) {
            3.1, 3.2, 3.3;
   // clang-format on
 
+  // Default format.
   const std::string_view baseline{
       "10.1  1.2  1.3\n"
       " 2.1  2.2  2.3\n"
       " 3.1  3.2  3.3"};
   EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
   EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+
+  // With Scalar format string modifiers.
+  EXPECT_EQ(fmt::format("{::.2f}", fmt_eigen(value)),
+            "10.10  1.20  1.30\n"
+            " 2.10  2.20  2.30\n"
+            " 3.10  3.20  3.30");
 }
 
 GTEST_TEST(FmtEigenTest, Matrix3i) {
@@ -108,12 +147,25 @@ GTEST_TEST(FmtEigenTest, Matrix3i) {
            31, 32, 33;
   // clang-format on
 
+  // Default format.
   const std::string_view baseline{
       "11 12 13\n"
       "21 22 23\n"
       "31 32 33"};
   EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
   EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+
+  // With Scalar format string modifiers.
+  EXPECT_EQ(fmt::format("value =\n"
+                        "{0}\n"
+                        "value as hex =\n"
+                        "{0::x}",
+                        fmt_eigen(value)),
+            "value =\n" + std::string{baseline} + "\n" +
+                "value as hex =\n"
+                " b  c  d\n"
+                "15 16 17\n"
+                "1f 20 21");
 }
 
 GTEST_TEST(FmtEigenTest, MatrixString) {
@@ -123,11 +175,17 @@ GTEST_TEST(FmtEigenTest, MatrixString) {
            "goodbye", "cruel", "world";
   // clang-format on
 
+  // Default format.
   const std::string_view baseline{
       "  hello   world       !\n"
       "goodbye   cruel   world"};
   EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
   EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+
+  // With Scalar format string modifiers.
+  EXPECT_EQ(fmt::format("{::?}", fmt_eigen(value)),
+            "  \"hello\"   \"world\"       \"!\"\n"
+            "\"goodbye\"   \"cruel\"   \"world\"");
 }
 
 GTEST_TEST(FmtEigenTest, AllocationsNominal) {


### PR DESCRIPTION
Towards #24263.

Printing an `Eigen::Matrix` now allows customization of the formatter settings for the underlying Scalar type (e.g., precision).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24349)
<!-- Reviewable:end -->
