### PR TITLE
[common] Fix default precision of fmt_eigen floating point

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1146,6 +1146,7 @@ drake_cc_googletest(
     name = "fmt_eigen_test",
     deps = [
         ":essential",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/common/fmt_eigen.cc
+++ b/common/fmt_eigen.cc
@@ -1,35 +1,32 @@
-// TODO(jwnimmer-tri) Write our own formatting logic instead of using Eigen IO,
-// and add customization flags for how to display the matrix data.
-#undef EIGEN_NO_IO
 #include "drake/common/fmt_eigen.h"
 
-#include <limits>
-#include <sstream>
+#include <algorithm>
+
+#include <fmt/ranges.h>
 
 namespace drake {
 namespace internal {
 
-template <typename T>
-using FormatterEigenRef =
-    Eigen::Ref<const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>;
+std::string FormatMatrix(const Eigen::Index rows, const Eigen::Index cols,
+                         const std::span<std::string_view> elements) {
+  if (rows <= 0 || cols <= 0) {
+    return std::string{};
+  }
 
-template <typename Scalar>
-std::string FormatEigenMatrix(const FormatterEigenRef<Scalar>& matrix)
-  requires std::is_same_v<Scalar, double> || std::is_same_v<Scalar, float> ||
-           std::is_same_v<Scalar, std::string>
-{  // NOLINT(whitespace/braces)
-  std::stringstream stream;
-  // We'll print our matrix data using as much precision as we can, so that
-  // console log output and/or error messages paint the full picture. Sadly,
-  // the ostream family of floating-point formatters doesn't know how to do
-  // "shortest round-trip precision". If we set the precision to max_digits,
-  // then simple numbers like "1.1" print as "1.1000000000000001"; instead,
-  // we'll use max_digits - 1 to avoid that problem, with the risk of losing
-  // the last ulps in the printout in case we needed that last digit. This
-  // will all be fixed once we stop using Eigen IO.
-  stream.precision(std::numeric_limits<double>::max_digits10 - 1);
-  stream << matrix;
-  return stream.str();
+  const size_t max_element_size =
+      std::ranges::max(elements, {}, &std::string_view::size).size();
+  std::string result;
+  result.reserve(rows * cols * (max_element_size + 1));
+  for (Eigen::Index row = 0; row < rows; ++row) {
+    if (row > 0) {
+      result.push_back('\n');
+    }
+    const std::span<std::string_view> row_elements =
+        elements.subspan(row * cols, cols);
+    fmt::format_to(std::back_inserter(result), "{0:>{1}}",
+                   fmt::join(row_elements, " "), max_element_size);
+  }
+  return result;
 }
 
 template <typename Scalar>
@@ -40,12 +37,6 @@ std::string StringifyErrorDetailValue(const fmt_eigen_ref<Scalar>& value)
 }
 
 // Explicitly instantiate for the allowed scalar types in our header.
-template std::string FormatEigenMatrix<double>(
-    const FormatterEigenRef<double>& matrix);
-template std::string FormatEigenMatrix<float>(
-    const FormatterEigenRef<float>& matrix);
-template std::string FormatEigenMatrix<std::string>(
-    const FormatterEigenRef<std::string>& matrix);
 template std::string StringifyErrorDetailValue<double>(
     const fmt_eigen_ref<double>& value);
 template std::string StringifyErrorDetailValue<float>(

--- a/common/fmt_eigen.h
+++ b/common/fmt_eigen.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <Eigen/Core>
 
@@ -18,14 +20,12 @@ struct fmt_eigen_ref {
       matrix;
 };
 
-/* Returns the string formatting of the given matrix.
-@tparam Scalar must be either double, float, or string */
-template <typename Scalar>
-std::string FormatEigenMatrix(
-    const Eigen::Ref<
-        const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>>& matrix)
-  requires std::is_same_v<Scalar, double> || std::is_same_v<Scalar, float> ||
-           std::is_same_v<Scalar, std::string>;
+/* Returns the string formatting of the given matrix elements (i.e., padded by
+whitespace and/or newlines into a tabular layout). The elements are provided
+in row-major order.
+@pre rows * cols == ssize(elements) */
+std::string FormatMatrix(Eigen::Index rows, Eigen::Index cols,
+                         std::span<std::string_view> elements);
 
 /* Type trait for supporting the use of fmt_eigen(x) in DRAKE_THROW_UNLESS. This
 is the set of scalar types that are supported (have been explicitly instantiated
@@ -92,18 +92,36 @@ struct formatter<drake::internal::fmt_eigen_ref<Scalar>>
               // NOLINTNEXTLINE(runtime/references) To match fmt API.
               FormatContext& ctx) const -> decltype(ctx.out()) {
     const auto& matrix = ref.matrix;
-    if constexpr (std::is_same_v<Scalar, double> ||
-                  std::is_same_v<Scalar, float>) {
-      return formatter<std::string_view>{}.format(
-          drake::internal::FormatEigenMatrix<Scalar>(matrix), ctx);
-    } else {
-      return formatter<std::string_view>{}.format(
-          drake::internal::FormatEigenMatrix<std::string>(
-              matrix.unaryExpr([](const auto& element) -> std::string {
-                return fmt::to_string(element);
-              })),
-          ctx);
+    // Format every matrix element in turn. We'll format them back-to-back into
+    // the same buffer (while keeping track of where each one started), and then
+    // in a second pass we'll slice up the buffer into string_views.
+    formatter<Scalar> element_formatter;
+    std::vector<char> element_buffer;            // Slab for formatted elements.
+    std::vector<size_t> element_starts;          // Indices into element_buffer.
+    element_buffer.reserve(matrix.size() * 20);  // An estimate (not precise).
+    element_starts.reserve(matrix.size() + 1);   // Exact allocation (precise).
+    for (Eigen::Index row = 0; row < matrix.rows(); ++row) {
+      for (Eigen::Index col = 0; col < matrix.cols(); ++col) {
+        element_starts.push_back(element_buffer.size());
+        using OutputIt = std::back_insert_iterator<std::vector<char>>;
+        using OutputContext = fmt::basic_format_context<OutputIt, char>;
+        OutputContext element_ctx{OutputIt(element_buffer), {}};
+        element_formatter.format(matrix(row, col), element_ctx);
+      }
     }
+    element_starts.push_back(element_buffer.size());
+    std::vector<std::string_view> elements;
+    elements.reserve(matrix.size());
+    for (Eigen::Index i = 0; i < matrix.size(); ++i) {
+      const size_t begin = element_starts[i];
+      const size_t end = element_starts[i + 1];
+      elements.push_back(std::string_view{&element_buffer[begin], end - begin});
+    }
+    // Combine the element strings with whitespace.
+    const std::string content =
+        drake::internal::FormatMatrix(matrix.rows(), matrix.cols(), elements);
+    // Copy the content into the output buffer.
+    return formatter<std::string_view>::format(content, ctx);
   }
 };
 }  // namespace fmt

--- a/common/test/fmt_eigen_test.cc
+++ b/common/test/fmt_eigen_test.cc
@@ -5,27 +5,67 @@
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/limit_malloc.h"
+
 namespace drake {
 namespace {
 
-// TODO(jwnimer-tri) The expected values below are what Eigen prints for us by
-// default. In the future, we might decide to use some different formatting.
-// In that case, it's fine to update the test goals here to reflect those
-// updated defaults.
+/* The implementation of fmt_eigen reserves 20 characters to format each scalar
+in an Eigen::Matrix. If the formatted size exceeds that, everything still works,
+but it will cause a re-allocation (using exponential growth). This scalar type
+allows probing that in a LimitMalloc test case, because its formated size is 30
+characters per scalar. */
+struct BigToken {
+  static std::string_view to_string() {
+    return "0123456789"
+           "0123456789"
+           "0123456789";
+  }
+};
+
+}  // namespace
+}  // namespace drake
+
+DRAKE_FORMATTER_AS(, drake, BigToken, x, BigToken::to_string())
+
+namespace drake {
+namespace {
+
+GTEST_TEST(FmtEigenTest, Precision) {
+  // This constant needs the maximum number of digits to round-trip correctly.
+  const double scalar = 0.12345678901234566;
+  const Eigen::VectorXd value = Eigen::VectorXd::Constant(1, scalar);
+
+  // Sanity check the scalar formatting without fmt_eigen.
+  const std::string_view baseline{"0.12345678901234566"};
+  ASSERT_EQ(fmt::to_string(scalar), baseline);
+
+  EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+}
 
 GTEST_TEST(FmtEigenTest, RowVector3d) {
   const Eigen::RowVector3d value{1.1, 2.2, 3.3};
-  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), "1.1 2.2 3.3");
+
+  const std::string_view baseline{"1.1 2.2 3.3"};
+  EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
 }
 
 GTEST_TEST(FmtEigenTest, Vector3d) {
   const Eigen::Vector3d value{1.1, 2.2, 3.3};
-  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), "1.1\n2.2\n3.3");
+
+  std::string_view baseline{"1.1\n2.2\n3.3"};
+  EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
 }
 
 GTEST_TEST(FmtEigenTest, EmptyMatrix) {
   const Eigen::MatrixXd value;
-  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), "");
+
+  const std::string_view baseline;
+  EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
 }
 
 GTEST_TEST(FmtEigenTest, Matrix3d) {
@@ -35,10 +75,13 @@ GTEST_TEST(FmtEigenTest, Matrix3d) {
            2.1, 2.2, 2.3,
            3.1, 3.2, 3.3;
   // clang-format on
-  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)),
-            "1.1 1.2 1.3\n"
-            "2.1 2.2 2.3\n"
-            "3.1 3.2 3.3");
+
+  const std::string_view baseline{
+      "1.1 1.2 1.3\n"
+      "2.1 2.2 2.3\n"
+      "3.1 3.2 3.3"};
+  EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
 }
 
 GTEST_TEST(FmtEigenTest, Matrix3dNeedsPadding) {
@@ -48,10 +91,13 @@ GTEST_TEST(FmtEigenTest, Matrix3dNeedsPadding) {
            2.1, 2.2, 2.3,
            3.1, 3.2, 3.3;
   // clang-format on
-  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)),
-            "10.1  1.2  1.3\n"
-            " 2.1  2.2  2.3\n"
-            " 3.1  3.2  3.3");
+
+  const std::string_view baseline{
+      "10.1  1.2  1.3\n"
+      " 2.1  2.2  2.3\n"
+      " 3.1  3.2  3.3"};
+  EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
 }
 
 GTEST_TEST(FmtEigenTest, Matrix3i) {
@@ -61,10 +107,13 @@ GTEST_TEST(FmtEigenTest, Matrix3i) {
            21, 22, 23,
            31, 32, 33;
   // clang-format on
-  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)),
-            "11 12 13\n"
-            "21 22 23\n"
-            "31 32 33");
+
+  const std::string_view baseline{
+      "11 12 13\n"
+      "21 22 23\n"
+      "31 32 33"};
+  EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
 }
 
 GTEST_TEST(FmtEigenTest, MatrixString) {
@@ -73,9 +122,44 @@ GTEST_TEST(FmtEigenTest, MatrixString) {
   value << "hello", "world", "!",
            "goodbye", "cruel", "world";
   // clang-format on
-  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)),
-            "  hello   world       !\n"
-            "goodbye   cruel   world");
+
+  const std::string_view baseline{
+      "  hello   world       !\n"
+      "goodbye   cruel   world"};
+  EXPECT_EQ(fmt::to_string(fmt_eigen(value)), baseline);
+  EXPECT_EQ(fmt::format("{}", fmt_eigen(value)), baseline);
+}
+
+GTEST_TEST(FmtEigenTest, AllocationsNominal) {
+  Eigen::RowVectorXd value(6);
+  value << 1.1, 2.2, 3.3, 4.4, 5.5, 6.6;
+  std::string formatted;
+  {
+    // We expect exactly 5 allocations:
+    // • 3 vector reservations in the header,
+    // • 1 string return value of FormatMatrix,
+    // • 1 string copy within fmt.
+    test::LimitMalloc guard({.max_num_allocations = 5});
+    formatted = fmt::to_string(fmt_eigen(value));
+  }
+  EXPECT_EQ(formatted, "1.1 2.2 3.3 4.4 5.5 6.6");
+}
+
+GTEST_TEST(FmtEigenTest, AllocationsOverflow) {
+  const Eigen::RowVector3<BigToken> value;
+  std::string formatted;
+  {
+    // We expect exactly 6 allocations:
+    // • 3 vector reservations in the header,
+    //   ◦ 1 vector reallocation (element_buffer reservation was insufficient)
+    // • 1 string return value of FormatMatrix,
+    // • 1 string copy within fmt.
+    test::LimitMalloc guard({.max_num_allocations = 6});
+    formatted = fmt::to_string(fmt_eigen(value));
+  }
+  EXPECT_EQ(formatted, std::string{BigToken::to_string()} + " " +
+                           std::string{BigToken::to_string()} + " " +
+                           std::string{BigToken::to_string()});
 }
 
 // Regression against the set of supported Scalar types.


### PR DESCRIPTION
Towards #24263.

We want shortest-round-trip by default.  (Previously, we might fail to print the least-significant digit.)

Also add test cases for `fmt::to_string` in addition to `fmt::format`. The codepaths inside fmt differ slightly between the two, so we should test them both.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24351)
<!-- Reviewable:end -->
