### PR TITLE
[systems] Fix a long hidden test bug

### DIFF
--- a/systems/analysis/test_utilities/explicit_error_controlled_integrator_test.h
+++ b/systems/analysis/test_utilities/explicit_error_controlled_integrator_test.h
@@ -300,7 +300,7 @@ TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, SpringMassStepEC) {
   this->integrator->Reset();
   this->integrator->set_maximum_step_size(0.1);
   this->integrator->set_requested_minimum_step_size(1e-6);
-  this->integrator->set_target_accuracy(1e-3);
+  this->integrator->set_target_accuracy(1e-5);
 
   // Re-initialize the integrator.
   this->integrator->Initialize();
@@ -317,9 +317,13 @@ TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, SpringMassStepEC) {
     this->integrator->IntegrateNoFurtherThanTime(t_final, t_final, t_final);
   } while (this->context->get_time() < t_final);
 
+  // Get the final position.
+  const double x_final_ec =
+      this->context->get_continuous_state().get_vector().GetAtIndex(0);
+
   // Check the solution.
   EXPECT_NEAR(c1 * std::cos(omega * t_final) + c2 * std::sin(omega * t_final),
-              x_final, 1e-5);
+              x_final_ec, 1e-5);
 
   // Verify that integrator statistics are valid.
   EXPECT_GE(this->integrator->get_previous_integration_step_size(), 0.0);


### PR DESCRIPTION
The SpringMassStepEC abstract test case was not in fact testing error control at all; the `x_final` used to "test" the error-controlled run was in fact the still-in-scope `const` result from the fixed-step run.

Once the test was repaired, the accuracy had to be tightened to satisfy the solution check for error-controlled runs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24356)
<!-- Reviewable:end -->
