### PR TITLE
[tools] Move clang-specific setting into skylark instead of bazelrc

### DIFF
--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -12,9 +12,6 @@ build:tsan_everything --copt=-Wno-macro-redefined
 build:ubsan --copt=-Wno-macro-redefined
 build:ubsan_everything --copt=-Wno-macro-redefined
 
-# https://github.com/RobotLocomotion/drake/issues/22204
-build --copt=-fno-assume-unique-vtables
-
 # Options for explicitly using Clang.
 common:clang --repo_env=CC=clang
 common:clang --repo_env=CXX=clang++

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -46,6 +46,8 @@ CLANG_FLAGS = CXX_FLAGS + [
     "-Werror=return-stack-address",
     "-Werror=sign-compare",
     "-Werror=unqualified-std-cast-call",
+    # https://github.com/RobotLocomotion/drake/issues/22204
+    "-fno-assume-unique-vtables",
 ]
 
 # The APPLECLANG_FLAGS will be enabled for all C++ rules in the project when

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -6,11 +6,5 @@ build:clang --action_env=CC=clang-20
 build:clang --action_env=CXX=clang++-20
 build:clang --host_action_env=CC=clang-20
 build:clang --host_action_env=CXX=clang++-20
-# https://github.com/RobotLocomotion/drake/issues/22204
-# TODO(jwnimmer-tri) Ideally, our drake_cc.bzl logic for compiler-specific flags
-# should take over this option so we can ensure it's being used even in CMake
-# installs of Drake from source (if and only if Clang >= 17 is being used).
-build:clang --copt=-fno-assume-unique-vtables
-build:clang --host_copt=-fno-assume-unique-vtables
 
 build --define=UBUNTU_VERSION=24.04

--- a/tools/ubuntu-resolute.bazelrc
+++ b/tools/ubuntu-resolute.bazelrc
@@ -6,11 +6,5 @@ build:clang --action_env=CC=clang-20
 build:clang --action_env=CXX=clang++-20
 build:clang --host_action_env=CC=clang-20
 build:clang --host_action_env=CXX=clang++-20
-# https://github.com/RobotLocomotion/drake/issues/22204
-# TODO(jwnimmer-tri) Ideally, our drake_cc.bzl logic for compiler-specific flags
-# should take over this option so we can ensure it's being used even in CMake
-# installs of Drake from source (if and only if Clang >= 17 is being used).
-build:clang --copt=-fno-assume-unique-vtables
-build:clang --host_copt=-fno-assume-unique-vtables
 
 build --define=UBUNTU_VERSION=26.04


### PR DESCRIPTION
This ensures it is enabled exactly when necessary, including in CMake source builds on Ubuntu.

This is possible now because our minimum supported Clang is new enough on all platforms to always have this option available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24358)
<!-- Reviewable:end -->
