### PR TITLE
[wheel] Decouple wheel settings from from packaging builds

### DIFF
--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -13,14 +13,12 @@ cd /tmp/drake-wheel-build/drake-build
 # Store downloads in the build cache to speed up rebuilds.
 export BAZELISK_HOME=/var/cache/bazel/bazelisk
 
-# Add wheel-specific bazel options.
+# Add wheel-specific settings that are not available via CMake options.
 # N.B. When you change anything here, also fix wheel/macos/build-wheel.sh.
 cat > /tmp/drake-wheel-build/drake-build/drake.bazelrc << EOF
 build --disk_cache=/var/cache/bazel/disk_cache
 build --repository_cache=/var/cache/bazel/repository_cache
 build --repo_env=DRAKE_WHEEL=1
-build --repo_env=SNOPT_PATH=${SNOPT_PATH}
-build --config=packaging
 # Enable MOSEK lazy loading. Right now this is only done for Linux builds.
 build --@drake//solvers:mosek_lazy_load=True
 EOF
@@ -30,23 +28,20 @@ EOF
 # version number, we should bump this up to match, and also grep tools/wheel
 # for other mentions of MOSEK version bounds and fix those as well.
 PYTHON_MINOR=$(/usr/local/bin/python -c "import sys; print(sys.version_info.minor)")
-MOSEK_ENABLED=1
-[ ${PYTHON_MINOR} -ge 15 ] && MOSEK_ENABLED=
+WITH_MOSEK=ON
+[ ${PYTHON_MINOR} -ge 15 ] && WITH_MOSEK=OFF
 
 # MOSEK is not currently supported for Linux aarch64 wheels.
-[ "$(arch)" == "aarch64" ] && MOSEK_ENABLED=
-
-if [[ -z "${MOSEK_ENABLED}" ]]; then
-    cat >> /tmp/drake-wheel-build/drake-build/drake.bazelrc << EOF
-build --@drake//tools/flags:with_mosek=False
-build --@drake//solvers:mosek_lazy_load=False
-EOF
-fi
+[ "$(arch)" == "aarch64" ] && WITH_MOSEK=OFF
 
 # Install Drake using our wheel-build-specific Python interpreter and
 # C/CXX/Fortran compilers.
 # N.B. When you change anything here, also fix wheel/macos/build-wheel.sh.
 cmake ../drake-src \
+    -DWITH_OPENMP=ON \
+    -DWITH_MOSEK="${WITH_MOSEK}" \
+    -DWITH_SNOPT=ON \
+    -DSNOPT_PATH="${SNOPT_PATH}" \
     -DWITH_USER_EIGEN=OFF \
     -DWITH_USER_FMT=OFF \
     -DWITH_USER_SPDLOG=OFF \

--- a/tools/wheel/macos/build-wheel.sh
+++ b/tools/wheel/macos/build-wheel.sh
@@ -40,14 +40,12 @@ readonly build_root="/tmp/drake-wheel-build/drake-build"
 mkdir -p "$build_root"
 cd "$build_root"
 
-# Add wheel-specific bazel options.
+# Add wheel-specific settings that are not available via CMake options.
 # N.B. When you change anything here, also fix wheel/image/build-drake.sh.
 cat > "$build_root/drake.bazelrc" << EOF
 build --disk_cache=$HOME/.cache/drake-wheel-build/bazel/disk_cache
 build --repository_cache=$HOME/.cache/drake-wheel-build/bazel/repository_cache
 build --repo_env=DRAKE_WHEEL=1
-build --repo_env=SNOPT_PATH=${SNOPT_PATH}
-build --config=packaging
 # See tools/wheel/wheel_builder/macos.py for more on this env variable.
 build --macos_minimum_os="${MACOSX_DEPLOYMENT_TARGET}"
 EOF
@@ -56,16 +54,18 @@ EOF
 # version, which is currently Python < 3.15. When that changes to a larger
 # version number, we should bump this up to match, and also grep tools/wheel
 # for other mentions of MOSEK version bounds and fix those as well.
+WITH_MOSEK=ON
 PYTHON_MINOR=$($python_executable -c "import sys; print(sys.version_info.minor)")
 if [[ ${PYTHON_MINOR} -ge 15 ]]; then
-    cat >> "$build_root/drake.bazelrc" << EOF
-build --@drake//tools/flags:with_mosek=False
-EOF
+  WITH_MOSEK=OFF
 fi
 
 # Install Drake.
 # N.B. When you change anything here, also fix wheel/image/build-drake.sh.
 cmake "$git_root" \
+    -DWITH_MOSEK="${WITH_MOSEK}" \
+    -DWITH_SNOPT=ON \
+    -DSNOPT_PATH="${SNOPT_PATH}" \
     -DWITH_USER_EIGEN=OFF \
     -DWITH_USER_FMT=OFF \
     -DWITH_USER_SPDLOG=OFF \


### PR DESCRIPTION
In the early days of our wheel build, it inherited exactly the same config settings as our packaging build. These days, quite a bit is different (e.g., wheel builds don't use OS dependencies anymore, MOSEK is Python-version-dependent, etc.).

At this point it makes the most sense to decouple them entirely, so that changing the packaging settings won't accidentally damage the wheel settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24375)
<!-- Reviewable:end -->
