### PR TITLE
[setup] Use Clang 21 on Ubuntu 26.04

### DIFF
--- a/setup/ubuntu/source_distribution/packages-resolute-clang.txt
+++ b/setup/ubuntu/source_distribution/packages-resolute-clang.txt
@@ -1,4 +1,4 @@
-clang-20
-libclang-rt-20-dev
-libomp-20-dev
-llvm-20
+clang-21
+libclang-rt-21-dev
+libomp-21-dev
+llvm-21

--- a/tools/ubuntu-resolute.bazelrc
+++ b/tools/ubuntu-resolute.bazelrc
@@ -1,8 +1,8 @@
 # Options for explicitly using Clang.
 # Keep this in sync with doc/_pages/from_source.md.
-common:clang --repo_env=CC=clang-20
-common:clang --repo_env=CXX=clang++-20
-build:clang --action_env=CC=clang-20
-build:clang --action_env=CXX=clang++-20
-build:clang --host_action_env=CC=clang-20
-build:clang --host_action_env=CXX=clang++-20
+common:clang --repo_env=CC=clang-21
+common:clang --repo_env=CXX=clang++-21
+build:clang --action_env=CC=clang-21
+build:clang --action_env=CXX=clang++-21
+build:clang --host_action_env=CC=clang-21
+build:clang --host_action_env=CXX=clang++-21


### PR DESCRIPTION
This only affects the compiler for `--config=clang`. We still use Clang 20 for python docstring generation on all Ubuntu versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24376)
<!-- Reviewable:end -->
