### PR TITLE
[cmake] Use DRAKE_CI_ENABLE_EVERYTHING to opt-in to dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,6 +623,9 @@ define_bool_option("WITH_OSQP" "OSQP")
 define_bool_option("WITH_SCS" "SCS")
 
 option(WITH_GUROBI "Build with support for Gurobi" OFF)
+if(DRAKE_CI_ENABLE_EVERYTHING)
+  set(WITH_GUROBI ON)
+endif()
 if(WITH_GUROBI)
   find_package(Gurobi 13.0 EXACT MODULE REQUIRED)
 
@@ -635,6 +638,9 @@ if(WITH_GUROBI)
 endif()
 
 option(WITH_MOSEK "Build with support for MOSEK" OFF)
+if(DRAKE_CI_ENABLE_EVERYTHING)
+  set(WITH_MOSEK ON)
+endif()
 if(WITH_MOSEK)
   string(APPEND BAZEL_CONFIG " --config=mosek")
 endif()
@@ -692,6 +698,9 @@ endif()
 set(WITH_ROBOTLOCOMOTION_SNOPT OFF CACHE BOOL
   "Build with support for SNOPT using the RobotLocomotion/snopt private GitHub repository"
 )
+if(DRAKE_CI_ENABLE_EVERYTHING)
+  set(WITH_ROBOTLOCOMOTION_SNOPT ON)
+endif()
 
 set(WITH_SNOPT OFF CACHE BOOL
   "Build with support for SNOPT using a SNOPT source archive at SNOPT_PATH"


### PR DESCRIPTION
This variable is set by drake-ci on "everything" jobs. When set, we should turn on as many off-by-default options as we can, so that we have CI coverage of the opt-in settings.

See https://github.com/RobotLocomotion/drake-ci/pull/410.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24377)
<!-- Reviewable:end -->
