### PR TITLE
[tools] Remove "no-sandbox" tag for MOSEK and Gurobi license files

### DIFF
--- a/tools/skylark/test_tags.bzl
+++ b/tools/skylark/test_tags.bzl
@@ -9,14 +9,8 @@ def gurobi_test_tags(gurobi_required = True):
 
     By default, sets gurobi_required=True, which will require that the supplied
     tag filters include "gurobi".
-
-    Gurobi checks a license file outside the workspace so tests that use Gurobi
-    must have the tag "no-sandbox".
     """
-    result = [
-        # TODO(david-german-tri): Find a better fix for the license file.
-        "no-sandbox",
-    ]
+    result = []
 
     if gurobi_required:
         result.append("gurobi")
@@ -28,17 +22,11 @@ def mosek_test_tags(mosek_required = True):
 
     By default, sets mosek_required=True, which will require that the supplied
     tag filters include "mosek".
-
-    MOSEK™ checks a license file outside the workspace, so tests that use
-    MOSEK™ must have the tag "no-sandbox".
     """
-    nominal_tags = [
-        "no-sandbox",
-    ]
     if mosek_required:
-        return nominal_tags + ["mosek"]
+        return ["mosek"]
     else:
-        return nominal_tags
+        return []
 
 def vtk_test_tags():
     """Returns test tags necessary for rendering tests. (This is called "vtk"


### PR DESCRIPTION
This was apparently necessary in the past, but is no longer needed.

(If we do ever need to worry about the license file path in the future, we should have the `repository.bzl` read the environment variable and symlink the license file into the repository, so that it's always on a well-known path from the point of view of any test that needs it.)

Towards #24381, to start to clear the deck for deleting the tags macros.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24380)
<!-- Reviewable:end -->
