### PR TITLE
[tools] Remove limit on number of concurrent Gurobi tests

### DIFF
--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -196,7 +196,7 @@ The Drake Bazel build currently supports the following proprietary solvers:
 * MOSEK™ 11.1
 * SNOPT 7.4
 
-Important note: Running Gurobi or Mosek requires a license, which will often
+Important note: Running Gurobi or MOSEK™ requires a license, which will often
 have a maximum number of programs allowed to use the solver at once. To avoid
 hitting the concurrency limit when running `bazel test //some/package/...` or
 `bazel test //...`, use the flag `--local_test_jobs=N` set to the number of

--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -196,6 +196,12 @@ The Drake Bazel build currently supports the following proprietary solvers:
 * MOSEK™ 11.1
 * SNOPT 7.4
 
+Important note: Running Gurobi or Mosek requires a license, which will often
+have a maximum number of programs allowed to use the solver at once. To avoid
+hitting the concurrency limit when running `bazel test //some/package/...` or
+`bazel test //...`, use the flag `--local_test_jobs=N` set to the number of
+license seats you want to use.
+
 ## Gurobi
 
 ### Install on Ubuntu

--- a/tools/skylark/test_tags.bzl
+++ b/tools/skylark/test_tags.bzl
@@ -4,8 +4,6 @@
 # for any license-related needs and provide a marker so that //tools/bazel.rc
 # can selectively enable tests based on the developer's chosen configuration.
 
-load("@gurobi//:defs.bzl", "DRAKE_GUROBI_LICENSE_UNLIMITED")
-
 def gurobi_test_tags(gurobi_required = True):
     """Returns the test tags necessary for properly running Gurobi tests.
 
@@ -14,18 +12,11 @@ def gurobi_test_tags(gurobi_required = True):
 
     Gurobi checks a license file outside the workspace so tests that use Gurobi
     must have the tag "no-sandbox".
-
-    Unless DRAKE_GUROBI_LICENSE_UNLIMITED=1 is set in the shell environment
-    (e.g., in CI), we also require the tag "exclusive" to rate-limit
-    license servers with a small number of licenses.
     """
     result = [
         # TODO(david-german-tri): Find a better fix for the license file.
         "no-sandbox",
     ]
-
-    if not DRAKE_GUROBI_LICENSE_UNLIMITED:
-        result.append("exclusive")
 
     if gurobi_required:
         result.append("gurobi")

--- a/tools/workspace/gurobi/repository.bzl
+++ b/tools/workspace/gurobi/repository.bzl
@@ -66,16 +66,6 @@ def _gurobi_impl(repo_ctx):
         executable = False,
     )
 
-    # Capture whether or not Gurobi tests can run in parallel.
-    license_unlimited_int = repo_ctx.getenv("DRAKE_GUROBI_LICENSE_UNLIMITED", "0")  # noqa: E501
-    license_unlimited = bool(int(license_unlimited_int) == 1)
-    repo_ctx.file(
-        "defs.bzl",
-        content = "DRAKE_GUROBI_LICENSE_UNLIMITED = {}"
-            .format(license_unlimited),
-        executable = False,
-    )
-
 gurobi_repository = repository_rule(
     local = True,
     implementation = _gurobi_impl,


### PR DESCRIPTION
For one, there is a better way now with `--local_test_jobs`.

But also the idea was unsound anyway. Plenty of tests still use Gurobi (due to ChooseBestSolver) even though they don't add `gurobi_test_tags`. The tags were only used to label tests that fail without Gurobi.

Also the same "license seat limit" challenge applies to MOSEK as well, so it's best to have a unified approach (`--local_test_jobs`).

---

Note that CI was already using the "unlimited" option, so doesn't need to add a test job limit in response to this.

Towards #24381, to start to clear the deck for deleting the tags macros.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24382)
<!-- Reviewable:end -->
