### PR TITLE
[tools] Consolidate packaging settings into CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,7 +638,7 @@ if(WITH_GUROBI)
 endif()
 
 option(WITH_MOSEK "Build with support for MOSEK" OFF)
-if(DRAKE_CI_ENABLE_EVERYTHING)
+if(DRAKE_CI_ENABLE_EVERYTHING OR DRAKE_CI_ENABLE_PACKAGING)
   set(WITH_MOSEK ON)
 endif()
 if(WITH_MOSEK)
@@ -703,7 +703,7 @@ endif()
 set(WITH_ROBOTLOCOMOTION_SNOPT OFF CACHE BOOL
   "Build with support for SNOPT using the RobotLocomotion/snopt private GitHub repository"
 )
-if(DRAKE_CI_ENABLE_EVERYTHING)
+if(DRAKE_CI_ENABLE_EVERYTHING OR DRAKE_CI_ENABLE_PACKAGING)
   set(WITH_ROBOTLOCOMOTION_SNOPT ON)
 endif()
 
@@ -765,10 +765,6 @@ if(DRAKE_USE_EIGEN_LEGACY_AUTODIFF)
   string(APPEND BAZEL_CONFIG " --@drake//tools/flags:use_eigen_legacy_autodiff=True")
 else()
   string(APPEND BAZEL_CONFIG " --@drake//tools/flags:use_eigen_legacy_autodiff=False")
-endif()
-
-if(DRAKE_CI_ENABLE_PACKAGING)
-  string(APPEND BAZEL_CONFIG " --config=packaging")
 endif()
 
 if(BUILD_TYPE_LOWER STREQUAL debug)

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -109,9 +109,6 @@ build:everything --@drake//tools/flags:use_eigen_legacy_autodiff=False
 # -- If Gurobi is optional, set gurobi_required=False.
 build:gurobi --@drake//tools/flags:with_gurobi=True
 build:everything --@drake//tools/flags:with_gurobi=True
-# N.B. The build:packaging configuration does NOT use Gurobi (yet).
-# See https://github.com/RobotLocomotion/drake/issues/10804.
-build:packaging --test_tag_filters=-gurobi
 
 ### A configuration that enables MOSEK™. ###
 # -- To use this config, the MOSEKLM_LICENSE_FILE environment variable must be
@@ -121,7 +118,6 @@ build:packaging --test_tag_filters=-gurobi
 # -- "mosek_test_tags()" from //tools/skylark:test_tags.bzl.
 # -- If MOSEK™ is optional, set mosek_required=False.
 build:mosek --@drake//tools/flags:with_mosek=True
-build:packaging --@drake//tools/flags:with_mosek=True
 build:everything --@drake//tools/flags:with_mosek=True
 
 ### A configuration that enables SNOPT. ###
@@ -132,5 +128,4 @@ build:everything --@drake//tools/flags:with_mosek=True
 # -- To run tests that require SNOPT, also specify a set of test_tag_filters
 # -- that does not exclude the "snopt" tag.
 build:snopt --@drake//tools/flags:with_snopt=True
-build:packaging --@drake//tools/flags:with_snopt=True
 build:everything --@drake//tools/flags:with_snopt=True

--- a/tools/ubuntu.bazelrc
+++ b/tools/ubuntu.bazelrc
@@ -13,11 +13,6 @@ build --action_env=PATH=/usr/bin:/bin
 build --action_env=PYTHONNOUSERSITE=1
 build --test_env=PYTHONNOUSERSITE=1
 
-# (Re-)enable OpenMP in Ubuntu packaging builds. OpenMP is on by default in our
-# drake/CMakeLists.txt but drake-ci is defectively forcing it off again; this is
-# a hack to make sure it's still on until drake-ci gets fixed.
-build:packaging --config=openmp
-
 # Options for explicitly using GCC.
 common:gcc --repo_env=CC=gcc
 common:gcc --repo_env=CXX=g++


### PR DESCRIPTION
Our packaging jobs use CMake as an entry point, so having half of the settings in CMake and half in Bazel doesn't make sense. We'll use drake/CMakeLists.txt as the source of truth.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24386)
<!-- Reviewable:end -->
