### PR TITLE
Cenic joint locking dev

### DIFF
--- a/multibody/cenic/cenic_integrator.cc
+++ b/multibody/cenic/cenic_integrator.cc
@@ -240,8 +240,6 @@ template <typename T>
 void CenicIntegrator<T>::DoInitialize() {
   using std::isnan;
 
-  ValidatePlantContext();
-
   // Set the initial time step and accuracy.
   if (isnan(this->get_initial_step_size_target())) {
     if (isnan(this->get_maximum_step_size())) {
@@ -534,21 +532,6 @@ void CenicIntegrator<T>::AdvancePlantConfiguration(const T& h,
   const internal::SpanningForest& forest = GetInternalTree(plant()).forest();
   for (int quaternion_start : forest.quaternion_starts()) {
     q->template segment<4>(quaternion_start).normalize();
-  }
-}
-
-template <typename T>
-void CenicIntegrator<T>::ValidatePlantContext() {
-  // Revisit this condition when joint locking support is implemented. See
-  // #23764.
-  const auto& plant_context = plant().GetMyContextFromRoot(this->get_context());
-  for (const JointIndex& j : plant().GetJointIndices()) {
-    if (plant().get_joint(j).is_locked(plant_context)) {
-      throw std::runtime_error(
-          fmt::format("The CENIC integrator does not yet support joint "
-                      "locking, but at least joint {} is locked",
-                      j));
-    }
   }
 }
 

--- a/multibody/cenic/cenic_integrator.cc
+++ b/multibody/cenic/cenic_integrator.cc
@@ -38,13 +38,15 @@ class DiagramScanner : public SystemVisitor<T> {
   static CenicDiagramStructure<T> ScanAndValidateDiagram(
       const System<T>& system) {
     const auto* const diagram = dynamic_cast<const Diagram<T>*>(&system);
-    if (diagram == nullptr) {
+    const auto* maybe_plant = dynamic_cast<const MultibodyPlant<T>*>(&system);
+    if (diagram == nullptr && maybe_plant == nullptr) {
       throw std::logic_error(
-          fmt::format("CenicIntegrator must be given a Diagram, not a {}.",
+          fmt::format("CenicIntegrator must be given a Diagram or a "
+                      "MultibodyPlant, not a {}.",
                       NiceTypeName::Get(system)));
     }
     DiagramScanner<T> visitor;
-    diagram->Accept(&visitor);
+    system.Accept(&visitor);
     DRAKE_DEMAND(visitor.current_path_.empty());
     if (visitor.structure_.plant == nullptr) {
       if (visitor.rejected_plant_ != nullptr) {
@@ -164,9 +166,9 @@ ContinuousState<T>& GetMutableSubstateByPath(ContinuousState<T>& state,
 }
 
 template <typename T>
-const System<T>& GetSubsystemByPath(const Diagram<T>& diagram,
+const System<T>& GetSubsystemByPath(const System<T>& system,
                                     const SubsystemPath& path) {
-  const System<T>* cursor = &diagram;
+  const System<T>* cursor = &system;
   for (const SubsystemIndex& k : path) {
     cursor = &(static_cast<const Diagram<T>*>(cursor)->get_system(k));
   }
@@ -218,12 +220,9 @@ void CenicIntegrator<T>::Scratch::Resize(const MultibodyPlant<T>& plant,
   external_feedback_storage.Resize(nv);
 
   // Allocate intermediate states for error control.
-  x_next_full = dynamic_pointer_cast_or_throw<DiagramContinuousState<T>>(
-      diagram.AllocateTimeDerivatives());
-  x_next_half_1 = dynamic_pointer_cast_or_throw<DiagramContinuousState<T>>(
-      diagram.AllocateTimeDerivatives());
-  x_next_half_2 = dynamic_pointer_cast_or_throw<DiagramContinuousState<T>>(
-      diagram.AllocateTimeDerivatives());
+  x_next_full = diagram.AllocateTimeDerivatives();
+  x_next_half_1 = diagram.AllocateTimeDerivatives();
+  x_next_half_2 = diagram.AllocateTimeDerivatives();
 }
 
 template <typename T>
@@ -361,7 +360,7 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
   // error control is enabled or not.
   VectorX<T>& v_guess = scratch_.v_guess;
   v_guess = plant().GetVelocities(plant_context);
-  systems::DiagramContinuousState<T>& x_next_full = *scratch_.x_next_full;
+  systems::ContinuousState<T>& x_next_full = *scratch_.x_next_full;
   ComputeNextContinuousState(model_at_x0_, v_guess, &x_next_full);
 
   if (this->get_fixed_step_mode()) {
@@ -385,7 +384,7 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
                    .get_generalized_velocity()
                    .CopyToVector();
     v_guess /= 2.0;
-    systems::DiagramContinuousState<T>& x_next_half_1 = *scratch_.x_next_half_1;
+    systems::ContinuousState<T>& x_next_half_1 = *scratch_.x_next_half_1;
     ComputeNextContinuousState(model_at_x0_, v_guess, &x_next_half_1);
 
     // For the second half-step to (t + h), we need to start from (t + h/2). So
@@ -403,7 +402,7 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
     v_guess = GetSubstateByPath(*scratch_.x_next_full, structure_.plant_path)
                   .get_generalized_velocity()
                   .CopyToVector();
-    systems::DiagramContinuousState<T>& x_next_half_2 = *scratch_.x_next_half_2;
+    systems::ContinuousState<T>& x_next_half_2 = *scratch_.x_next_half_2;
     ComputeNextContinuousState(model_at_xh_, v_guess, &x_next_half_2);
 
     // Set the state to the result of the second half-step (since this is more
@@ -424,7 +423,7 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
 template <typename T>
 void CenicIntegrator<T>::ComputeNextContinuousState(
     const IcfModel<T>& model, const VectorX<T>& v_guess,
-    DiagramContinuousState<T>* x_next) {
+    ContinuousState<T>* x_next) {
   DRAKE_ASSERT(x_next != nullptr);
   DRAKE_ASSERT(v_guess.size() == model.num_velocities());
   DRAKE_ASSERT(model.num_velocities() == plant().num_velocities());
@@ -480,11 +479,11 @@ void CenicIntegrator<T>::ComputeNextContinuousState(
   // While we could use a more advanced integration scheme here, the non-plant
   // dynamics are usually pretty simple (e.g., the integral term from a PID
   // controller), so forward euler is sufficient.
-  const auto& diagram = static_cast<const Diagram<T>&>(this->get_system());
+  const auto& root_system = this->get_system();
   for (const auto& path : structure_.non_plant_xc_paths) {
-    // #created_for_root_diagram: See `diagram` derivation from
+    // #created_for_root_diagram: See `root_system` derivation from
     // `this->get_system()` just above the for loop.
-    const System<T>& subsystem = GetSubsystemByPath(diagram, path);
+    const System<T>& subsystem = GetSubsystemByPath(root_system, path);
     const Context<T>& subcontext = subsystem.GetMyContextFromRoot(context);
 
     // TODO(vincekurtz): eliminate these heap allocations.

--- a/multibody/cenic/cenic_integrator.cc
+++ b/multibody/cenic/cenic_integrator.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/cenic/cenic_integrator.h"
 
 #include "drake/common/text_logging.h"
+#include "drake/multibody/plant/slicing_and_indexing.h"
 #include "drake/systems/framework/system_visitor.h"
 
 namespace drake {
@@ -12,6 +13,7 @@ using contact_solvers::icf::internal::IcfLinearFeedbackGains;
 using contact_solvers::icf::internal::IcfModel;
 using internal::CenicDiagramStructure;
 using internal::SubsystemPath;
+using multibody::internal::ExpandRows;
 using systems::Context;
 using systems::ContinuousState;
 using systems::Diagram;
@@ -426,6 +428,7 @@ void CenicIntegrator<T>::ComputeNextContinuousState(
   // of the states in `scratch_`, which is always created for the root system.
   // Just to underscore the point, do an explicit safety check.
   this->get_system().ValidateCreatedForThisSystem(*x_next);
+
   const T& h = model.time_step();
   const Context<T>& context = this->get_context();
 
@@ -438,12 +441,26 @@ void CenicIntegrator<T>::ComputeNextContinuousState(
 
   // Solve the optimization problem for next-step velocities,
   // v = min ℓ(v; q₀, v₀, h).
-  model.ResizeData(&data_);
-  data_.set_v(v_guess);
+  bool solved{};
   if constexpr (!std::is_same_v<T, double>) {
     throw std::runtime_error(
         "CenicIntegrator: ICF solver only supports T = double.");
-  } else if (!solver_.SolveWithGuess(model, tolerance, &data_)) {
+  } else if (model.is_reducible()) {
+    model.ReduceInto(&reduced_model_, &mapping_);
+    reduced_model_.ResizeData(&data_);
+    const auto& indices = mapping_.velocity_subsequence.inverse_permutation();
+    data_.set_v(v_guess(indices));
+    reduced_model_.SetSparsityPattern();
+    solved = solver_.SolveWithGuess(reduced_model_, tolerance, &data_);
+    if (solved) {
+      data_.set_v(ExpandRows(data_.v(), model.num_velocities(), indices));
+    }
+  } else {
+    model.ResizeData(&data_);
+    data_.set_v(v_guess);
+    solved = solver_.SolveWithGuess(model, tolerance, &data_);
+  }
+  if (!solved) {
     // Somehow, the "guaranteed convergence" promise has been violated. Either
     // the problem is not correctly formulated, or there is a bug.
     throw std::runtime_error("CenicIntegrator: optimization failed.");

--- a/multibody/cenic/cenic_integrator.h
+++ b/multibody/cenic/cenic_integrator.h
@@ -253,6 +253,10 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
 
   /* Data for PrintSimulatorStatistics(). */
   Stats stats_;
+
+  /* Reduced-problem data for joint locking. */
+  contact_solvers::icf::internal::IcfModel<T> reduced_model_;
+  contact_solvers::icf::internal::ReducedMapping mapping_;
 };
 
 }  // namespace multibody

--- a/multibody/cenic/cenic_integrator.h
+++ b/multibody/cenic/cenic_integrator.h
@@ -223,9 +223,6 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
   void AdvancePlantConfiguration(const T& h, const VectorX<T>& v,
                                  VectorX<T>* q) const;
 
-  /* Throws if the plant context is not compatible with CENIC. */
-  void ValidatePlantContext();
-
   /* Locations of plant and non-plant continuous state. Note that the contained
   `plant` pointer is guaranteed to be non-null by the CenicIntegrator
   constructor .*/

--- a/multibody/cenic/cenic_integrator.h
+++ b/multibody/cenic/cenic_integrator.h
@@ -169,11 +169,11 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
     step (x_next_full_) to the result of two smaller steps (x_next_half_2_).
     Note that these states include continuous state for the entire diagram. */
     /* x_{t+h}. */
-    std::unique_ptr<systems::DiagramContinuousState<T>> x_next_full;
+    std::unique_ptr<systems::ContinuousState<T>> x_next_full;
     /* x_{t+h/2}. */
-    std::unique_ptr<systems::DiagramContinuousState<T>> x_next_half_1;
+    std::unique_ptr<systems::ContinuousState<T>> x_next_half_1;
     /* x_{t+h/2+h/2}. */
-    std::unique_ptr<systems::DiagramContinuousState<T>> x_next_half_2;
+    std::unique_ptr<systems::ContinuousState<T>> x_next_half_2;
   };
 
   /* Data for PrintSimulatorStatistics(). */
@@ -207,7 +207,7 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
                      plant and any external systems. */
   void ComputeNextContinuousState(
       const contact_solvers::icf::internal::IcfModel<T>& model,
-      const VectorX<T>& v_guess, systems::DiagramContinuousState<T>* x_next);
+      const VectorX<T>& v_guess, systems::ContinuousState<T>* x_next);
 
   /* Advances the plant's generalized positions, q = q₀ + h N(q₀) v, taking care
   to handle quaternion DoFs properly.

--- a/multibody/cenic/test/cenic_integrator_generic_integrator_test.cc
+++ b/multibody/cenic/test/cenic_integrator_generic_integrator_test.cc
@@ -38,11 +38,6 @@ struct IntegratorTestFactory<CenicIntegrator<double>> {
       return std::unexpected(
           "TODO(#23921, #24304): CENIC cannot yet pass this test.");
     }
-    if (test_info->name() == std::string("TrivialFixedStepJointsLocked") ||
-        test_info->name() ==
-            std::string("TrivialErrorControlledStepJointsLocked")) {
-      return std::unexpected("TODO(#23764): CENIC cannot yet pass this test.");
-    }
 
     IntegratorTestArticles<SpecificSystem> result;
     DiagramBuilder<double> builder;

--- a/multibody/cenic/test/cenic_integrator_test.cc
+++ b/multibody/cenic/test/cenic_integrator_test.cc
@@ -71,34 +71,6 @@ constexpr char kBallOnTableMjcf[] = R"""(
   </mujoco>
   )""";
 
-GTEST_TEST(CenicIntegratorTest, JointLockingUnsupported) {
-  DiagramBuilder<double> diagram_builder;
-  auto* plant = diagram_builder.AddSystem<MultibodyPlant<double>>(0.0);
-
-  Parser(plant).AddModelsFromString(kDoublePendulumMjcf, "xml");
-  // Remove a joint to exercise non-contiguous joint indexing.
-  plant->RemoveJoint(plant->get_joint(JointIndex(0)));
-
-  plant->Finalize();
-  auto diagram = diagram_builder.Build();
-  auto diagram_context = diagram->CreateDefaultContext();
-  auto& plant_context =
-      plant->GetMyMutableContextFromRoot(diagram_context.get());
-  CenicIntegrator<double> dut(*diagram);
-  dut.set_maximum_step_size(0.1);
-  dut.reset_context(diagram_context.get());
-
-  // Bug regression check: don't accidentally throw by mistakenly iterating
-  // over stale joint indices.
-  EXPECT_NO_THROW(dut.Initialize());
-
-  plant->get_joint(JointIndex(1)).Lock(&plant_context);
-
-  // Actual joint locking check: now something is locked, refuse to give wrong
-  // answers, and explain that joint locking is the problem.
-  DRAKE_EXPECT_THROWS_MESSAGE(dut.Initialize(), ".*joint 1.*locked.*");
-}
-
 // TestParam uses tuple for compatibility with ::testing::Combine.
 // get<0>() is nesting depth for the plant and scene graph.
 // get<1>() is nesting depth for external systems.

--- a/multibody/cenic/test/make_cenic_integrator_test.cc
+++ b/multibody/cenic/test/make_cenic_integrator_test.cc
@@ -54,6 +54,18 @@ GTEST_TEST(MakeCenicIntegratorTest, SuccessNested) {
   EXPECT_EQ(&dut_plant, &diagram_plant);
 }
 
+GTEST_TEST(MakeCenicIntegratorTest, SuccessUnnested) {
+  MultibodyPlant<double> plant(0.0);
+  plant.Finalize();
+
+  std::unique_ptr<IntegratorBase<double>> dut = MakeCenicIntegrator(plant);
+  auto& cenic = dynamic_cast<CenicIntegrator<double>&>(*dut);
+
+  // The CENIC plant is the same object as the offered plant.
+  const auto& dut_plant = cenic.plant();
+  EXPECT_EQ(&dut_plant, &plant);
+}
+
 GTEST_TEST(MakeCenicIntegratorTest, FailureDiscrete) {
   RobotDiagramBuilder<double> builder;
   std::unique_ptr<RobotDiagram<double>> robot_diagram = builder.Build();

--- a/multibody/contact_solvers/icf/coupler_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/coupler_constraints_pool.cc
@@ -12,6 +12,13 @@ namespace internal {
 
 using contact_solvers::internal::BlockSparseSymmetricMatrix;
 
+namespace {
+// Returns true if the index is present (not removed by reduction).
+bool have(int index) {
+  return index >= 0;
+}
+}  // namespace
+
 template <typename T>
 CouplerConstraintsPool<T>::CouplerConstraintsPool(
     const IcfModel<T>* parent_model)
@@ -83,8 +90,9 @@ void CouplerConstraintsPool<T>::CalcData(
     const T v_hat = g_hat_[k] / model().time_step();
     const T& R = R_[k];
 
-    const T vi = vk(i);
-    const T vj = vk(j);
+    // If a dof is locked, its velocity is prescribed to be exactly 0.
+    const T vi = have(i) ? vk(i) : T(0.0);
+    const T vj = have(j) ? vk(j) : T(0.0);
     const T vc = vi - rho * vj;  // Constraint velocity.
 
     const T gamma = -(vc - v_hat) / R;
@@ -115,8 +123,12 @@ void CouplerConstraintsPool<T>::AccumulateGradient(const IcfData<T>& data,
     //                            ↑      ↑
     //                            i      j
     const T& gamma = coupler_data.gamma(k);
-    gradient_c(i) -= gamma;
-    gradient_c(j) += rho * gamma;
+    if (have(i)) {
+      gradient_c(i) -= gamma;
+    }
+    if (have(j)) {
+      gradient_c(j) += rho * gamma;
+    }
   }
 }
 
@@ -138,10 +150,18 @@ void CouplerConstraintsPool<T>::AccumulateHessian(
     typename EigenPool<MatrixX<T>>::MatrixView Hc = H_cc_pool[0];
     Hc.setZero();
 
-    // clang-format off
-    Hc(i, i) += 1.0 / R;  Hc(i, j) -= rho / R;
-    Hc(j, i) -= rho / R;  Hc(j, j) += rho * rho / R;
-    // clang-format on
+    // On-diagonal entries, if the relevant dof exists.
+    if (have(i)) {
+      Hc(i, i) += 1.0 / R;
+    }
+    if (have(j)) {
+      Hc(j, j) += rho * rho / R;
+    }
+    // Off-diagonal entries, if both dofs exist.
+    if (have(i) && have(j)) {
+      Hc(i, j) -= rho / R;
+      Hc(j, i) -= rho / R;
+    }
 
     hessian->AddToBlock(c, c, Hc);
   }
@@ -164,8 +184,8 @@ void CouplerConstraintsPool<T>::CalcCostAlongLine(
     const T& gamma = coupler_data.gamma(k);
     auto w_c = model().clique_segment(c, w);
 
-    const T wi = w_c(i);
-    const T wj = w_c(j);
+    const T wi = have(i) ? w_c(i) : T(0.0);
+    const T wj = have(j) ? w_c(j) : T(0.0);
     const T vw = wi - rho * wj;  // "Constraint velocity" evaluated on w.
 
     (*dcost) -= gamma * vw;
@@ -174,10 +194,45 @@ void CouplerConstraintsPool<T>::CalcCostAlongLine(
 }
 
 template <typename T>
-void CouplerConstraintsPool<T>::ReduceInto(const ReducedMapping&,
-                                           CouplerConstraintsPool<T>*) const {
-  // TODO(#23764): implement.
-  DRAKE_THROW_UNLESS(num_constraints() == 0);
+void CouplerConstraintsPool<T>::ReduceInto(
+    const ReducedMapping& mapping,
+    CouplerConstraintsPool<T>* reduced_pool) const {
+  // Make sure the pool is (over) allocated.
+  reduced_pool->Resize(num_constraints());
+
+  reduced_pool->constraint_to_clique_.clear();
+  reduced_pool->dofs_.clear();
+  reduced_pool->gear_ratio_.clear();
+  reduced_pool->g_hat_.clear();
+  reduced_pool->R_.clear();
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = constraint_to_clique_[k];
+    if (!mapping.clique_subsequence.participates(c)) {
+      // Entire clique is locked; remove the constraint.
+      continue;
+    }
+    const auto& [i, j] = dofs_[k];
+    const auto& dof_subsequence = mapping.clique_dof_subsequences[c];
+    const bool have_i = dof_subsequence.participates(i);
+    const bool have_j = dof_subsequence.participates(j);
+    if (!have_i && !have_j) {
+      // Both dofs are locked; remove the constraint.
+      continue;
+    }
+
+    const int r_c = mapping.clique_subsequence.permuted_index(c);
+    // Communicate partial constraint model via negative indices. See `have()`
+    // above.
+    const int r_i = have_i ? dof_subsequence.permuted_index(i) : -1;
+    const int r_j = have_j ? dof_subsequence.permuted_index(j) : -1;
+
+    // Fill in the reduced constraint.
+    reduced_pool->constraint_to_clique_.push_back(r_c);
+    reduced_pool->dofs_.emplace_back(r_i, r_j);
+    reduced_pool->gear_ratio_.push_back(gear_ratio_[k]);
+    reduced_pool->g_hat_.push_back(g_hat_[k]);
+    reduced_pool->R_.push_back(R_[k]);
+  }
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/coupler_constraints_pool.h
+++ b/multibody/contact_solvers/icf/coupler_constraints_pool.h
@@ -104,6 +104,8 @@ class CouplerConstraintsPool {
   }
   const std::vector<std::pair<int, int>>& dofs() const { return dofs_; }
   const std::vector<T>& gear_ratio() const { return gear_ratio_; }
+  const std::vector<T>& g_hat() const { return g_hat_; }
+  const std::vector<T>& R() const { return R_; }
 
  private:
   const IcfModel<T>* const model_;  // The parent model.
@@ -111,7 +113,9 @@ class CouplerConstraintsPool {
   // Clique for the k-th constraint, of size num_constraints().
   std::vector<int> constraint_to_clique_;
 
-  // DOFs (i, j) for the k-th constraint, of size num_constraints().
+  // DOFs (i, j) for the k-th constraint, of size num_constraints(). In a
+  // reduced pool (made by ReduceInto()), either DOF can be absent, represented
+  // by a -1 value. Both DOFs cannot be absent.
   std::vector<std::pair<int, int>> dofs_;
 
   // Gear ratio ρ per constraint, of size num_constraints().

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -296,17 +296,8 @@ void IcfBuilder<T>::ValidatePlant() {
 }
 
 template <typename T>
-void IcfBuilder<T>::ValidateContext(const systems::Context<T>& context) {
-  // Revisit this condition when joint locking support is implemented. See
-  // #23764.
-  for (const JointIndex& j : plant_.GetJointIndices()) {
-    if (plant_.get_joint(j).is_locked(context)) {
-      throw std::runtime_error(
-          fmt::format("The CENIC integrator does not yet support joint "
-                      "locking, but at least joint {} is locked",
-                      j));
-    }
-  }
+void IcfBuilder<T>::ValidateContext(const systems::Context<T>&) {
+  // Nothing to complain about.
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -422,14 +422,11 @@ class IcfModel {
   smaller than the full problem. Use `is_reducible()` to check that the
   parameters describe a smaller problem.
 
-  TODO(#23764): constraints are not yet supported here.
-
   @param[out] reduced_model the reduced model.
   @param[out] mapping the reduction, as partial permutations.
 
   @pre reduced_model != nullptr.
   @pre mapping != nullptr.
-  @throws std::exception if there are any unsupported constraints.
   @post sparsity is uninitialized; call SetSparsity() when needed.
   */
   void ReduceInto(IcfModel<T>* reduced_model, ReducedMapping* mapping) const;

--- a/multibody/contact_solvers/icf/limit_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/limit_constraints_pool.cc
@@ -34,6 +34,7 @@ void LimitConstraintsPool<T>::Resize(std::span<const int> sizes) {
   R_.Resize(num_limit_constraints, sizes);
   constraint_size_.assign(sizes.begin(), sizes.end());
   clique_.resize(num_limit_constraints);
+  dof_.resize(num_limit_constraints);
 
   // All constraints are disabled (i.e., infinite bounds) by default. This
   // allows us to add a limit constraint on only one DoF in a multi-DoF
@@ -57,6 +58,7 @@ void LimitConstraintsPool<T>::Set(int index, int clique, int dof, const T& q0,
   DRAKE_ASSERT(ql <= qu);
 
   clique_[index] = clique;
+  dof_[index] = dof;
   ql_[index](dof) = ql;
   qu_[index](dof) = qu;
   q0_[index](dof) = q0;
@@ -189,6 +191,49 @@ void LimitConstraintsPool<T>::CalcCostAlongLine(
 }
 
 template <typename T>
+void LimitConstraintsPool<T>::ReduceInto(
+    const ReducedMapping& mapping,
+    LimitConstraintsPool<T>* reduced_pool) const {
+  // Make sure the pool is (over) allocated.
+  reduced_pool->Resize(constraint_sizes());
+
+  reduced_pool->clique_.clear();
+  reduced_pool->dof_.clear();
+  reduced_pool->constraint_size_.clear();
+  reduced_pool->ql_.Clear();
+  reduced_pool->qu_.Clear();
+  reduced_pool->q0_.Clear();
+  reduced_pool->gl_hat_.Clear();
+  reduced_pool->gu_hat_.Clear();
+  reduced_pool->R_.Clear();
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int c = clique_[k];
+    if (!mapping.clique_subsequence.participates(c)) {
+      continue;
+    }
+    const auto& dof_subsequence = mapping.clique_dof_subsequences[c];
+    if (!dof_subsequence.participates(dof_[k])) {
+      continue;
+    }
+    const auto& indices = dof_subsequence.inverse_permutation();
+    const int r_c = mapping.clique_subsequence.permuted_index(c);
+    const int r_dof = dof_subsequence.permuted_index(dof_[k]);
+    const int r_c_size = dof_subsequence.permuted_domain_size();
+
+    // Fill in the reduced constraint.
+    reduced_pool->clique_.push_back(r_c);
+    reduced_pool->dof_.push_back(r_dof);
+    reduced_pool->constraint_size_.push_back(r_c_size);
+    reduced_pool->ql_.Add(r_c_size, 1) = ql_[k](indices);
+    reduced_pool->qu_.Add(r_c_size, 1) = qu_[k](indices);
+    reduced_pool->q0_.Add(r_c_size, 1) = q0_[k](indices);
+    reduced_pool->gl_hat_.Add(r_c_size, 1) = gl_hat_[k](indices);
+    reduced_pool->gu_hat_.Add(r_c_size, 1) = gu_hat_[k](indices);
+    reduced_pool->R_.Add(r_c_size, 1) = R_[k](indices);
+  }
+}
+
+template <typename T>
 T LimitConstraintsPool<T>::CalcLimitData(const T& v_hat, const T& R, const T& v,
                                          T* gamma, T* G) const {
   T cost = 0;
@@ -203,13 +248,6 @@ T LimitConstraintsPool<T>::CalcLimitData(const T& v_hat, const T& R, const T& v,
   }
 
   return cost;
-}
-
-template <typename T>
-void LimitConstraintsPool<T>::ReduceInto(const ReducedMapping&,
-                                         LimitConstraintsPool<T>*) const {
-  // TODO(#23764): implement.
-  DRAKE_THROW_UNLESS(num_constraints() == 0);
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/limit_constraints_pool.h
+++ b/multibody/contact_solvers/icf/limit_constraints_pool.h
@@ -121,10 +121,14 @@ class LimitConstraintsPool {
 
   /* Testing only access. */
   const std::vector<int>& clique() const { return clique_; }
+  const std::vector<int>& dof() const { return dof_; }
   const std::vector<int>& constraint_size() const { return constraint_size_; }
   const EigenPool<VectorX<T>>& ql() const { return ql_; }
   const EigenPool<VectorX<T>>& qu() const { return qu_; }
   const EigenPool<VectorX<T>>& q0() const { return q0_; }
+  const EigenPool<VectorX<T>>& gl_hat() const { return gl_hat_; }
+  const EigenPool<VectorX<T>>& gu_hat() const { return gu_hat_; }
+  const EigenPool<VectorX<T>>& R() const { return R_; }
 
  private:
   /* Computes cost, gradient, and Hessian contribution for a single limit
@@ -144,6 +148,7 @@ class LimitConstraintsPool {
   // We always add limit constraints per-clique. Each of the following has size
   // num_constraints().
   std::vector<int> clique_;           // Clique the k-th limit belongs to.
+  std::vector<int> dof_;              // Clique-local dof for the k-th limit.
   std::vector<int> constraint_size_;  // Clique size for the k-th constraint.
   EigenPool<VectorX<T>> ql_;          // Lower limit.
   EigenPool<VectorX<T>> qu_;          // Upper limit.

--- a/multibody/contact_solvers/icf/patch_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/patch_constraints_pool.cc
@@ -262,19 +262,7 @@ void PatchConstraintsPool<T>::SetPatch(int patch_index, int bodyA, int bodyB,
       (model().is_anchored(bodyA) || model().is_anchored(bodyB)) ? 1 : 2;
   num_cliques_[patch_index] = num_cliques;
 
-  // Compute per-patch regularization of friction. We use a "spherical body
-  // approximation" for the estimation of the Delassus operator. A sphere has
-  // gyration radius of g = 5/2 R (with R the radius). A contact will happen
-  // at distance R from the CoM.
-  // Thus the Delassus operator will be:
-  //   W = 1/m⋅[I₃   0
-  //           [ 0   R²/g²]
-  // It's RMS norm will be w = sqrt(7)/m ≈ 2.65/m.
-  T w = 2.65 / model().body_mass(bodies_[patch_index].first);
-  if (num_cliques == 2) {
-    w += 2.65 / model().body_mass(bodies_[patch_index].second);
-  }
-  Rt_[patch_index] = sigma_ * w;
+  Rt_[patch_index] = CalcRt(patch_index);
 }
 
 template <typename T>
@@ -543,10 +531,88 @@ void PatchConstraintsPool<T>::CalcCostAlongLine(
 }
 
 template <typename T>
-void PatchConstraintsPool<T>::ReduceInto(const ReducedMapping&,
-                                         PatchConstraintsPool<T>*) const {
-  // TODO(#23764): implement.
-  DRAKE_THROW_UNLESS(num_constraints() == 0);
+void PatchConstraintsPool<T>::ReduceInto(
+    const ReducedMapping& mapping,
+    PatchConstraintsPool<T>* reduced_pool) const {
+  // Make sure the pool is (over) allocated.
+  reduced_pool->Resize(patch_sizes());
+
+  reduced_pool->stiction_tolerance_ = stiction_tolerance_;
+
+  reduced_pool->num_pairs_.clear();
+  reduced_pool->num_cliques_.clear();
+  reduced_pool->Rt_.clear();
+  reduced_pool->bodies_.clear();
+  reduced_pool->p_AB_W_.Clear();
+  reduced_pool->dissipation_.clear();
+  reduced_pool->static_friction_.clear();
+  reduced_pool->dynamic_friction_.clear();
+  reduced_pool->pair_data_start_.clear();
+  reduced_pool->p_BC_W_.Clear();
+  reduced_pool->normal_W_.Clear();
+  reduced_pool->stiffness_.clear();
+  reduced_pool->fe0_.clear();
+  reduced_pool->fn0_.clear();
+  reduced_pool->net_friction_.clear();
+  int pair_data_cursor{0};
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int body_a = bodies_[k].second;
+    const int body_b = bodies_[k].first;
+    const int c_b = model().body_to_clique(body_b);
+    const int c_a = model().body_to_clique(body_a);  // negative if anchored.
+    const bool have_r_c_b = mapping.clique_subsequence.participates(c_b);
+    const bool have_r_c_a =
+        (c_a >= 0 && mapping.clique_subsequence.participates(c_a));
+    const int r_num_cliques = have_r_c_b + have_r_c_a;
+    if (r_num_cliques == 0) {
+      continue;
+    }
+    // At this point, we could have a num_cliques==1 case where body_b is
+    // locked (no clique), and body_a is not. This will require flipping the
+    // patch and pairs.
+    bool need_flip = (r_num_cliques == 1 && have_r_c_a);
+    const int r_n = reduced_pool->num_constraints();
+
+    // Fill in the reduced constraint.
+    reduced_pool->num_cliques_.push_back(r_num_cliques);
+    reduced_pool->dissipation_.push_back(dissipation_[k]);
+    reduced_pool->static_friction_.push_back(static_friction_[k]);
+    reduced_pool->dynamic_friction_.push_back(dynamic_friction_[k]);
+    reduced_pool->num_pairs_.push_back(num_pairs_[k]);
+    if (need_flip) {
+      reduced_pool->bodies_.emplace_back(body_a, body_b);
+      reduced_pool->p_AB_W_.Add(3, 1) = -p_AB_W_[k];
+    } else {
+      reduced_pool->bodies_.push_back(bodies_[k]);
+      reduced_pool->p_AB_W_.Add(3, 1) = p_AB_W_[k];
+    }
+    if (r_num_cliques == num_cliques_[k]) {
+      reduced_pool->Rt_.push_back(Rt_[k]);
+    } else {
+      // A body (clique) dropped out; recalculate Rt.
+      reduced_pool->Rt_.push_back(reduced_pool->CalcRt(r_n));
+    }
+
+    // Adapt the reduced per pair indexing.
+    reduced_pool->pair_data_start_.push_back(pair_data_cursor);
+    pair_data_cursor += num_pairs(k);
+
+    // Fill in the per pair constraint data.
+    for (int q = 0; q < num_pairs(k); ++q) {
+      const int from = patch_pair_index(k, q);
+      reduced_pool->stiffness_.push_back(stiffness_[from]);
+      reduced_pool->fe0_.push_back(fe0_[from]);
+      reduced_pool->fn0_.push_back(fn0_[from]);
+      reduced_pool->net_friction_.push_back(net_friction_[from]);
+      if (need_flip) {
+        reduced_pool->p_BC_W_.Add(3, 1) = p_AB_W_[k] + p_BC_W_[from];
+        reduced_pool->normal_W_.Add(3, 1) = -normal_W_[from];
+      } else {
+        reduced_pool->p_BC_W_.Add(3, 1) = p_BC_W_[from];
+        reduced_pool->normal_W_.Add(3, 1) = normal_W_[from];
+      }
+    }
+  }
 }
 
 template <typename T>
@@ -709,6 +775,31 @@ void PatchConstraintsPool<T>::CalcPatchQuantities(
       G_Bp += ShiftSecondOrderTensor(Gk, p_BC_W);
     }
   }
+}
+
+template <typename T>
+T PatchConstraintsPool<T>::CalcRt(int patch_index) const {
+  // Compute per-patch regularization of friction. We use a "spherical body
+  // approximation" for the estimation of the Delassus operator. A sphere has
+  // gyration radius of g = 5/2 R (with R the radius). A contact will happen
+  // at distance R from the CoM.
+  // Thus the Delassus operator will be:
+  //   W = 1/m⋅[I₃   0
+  //           [ 0   R²/g²]
+  // Its RMS norm will be w = sqrt(7)/m ≈ 2.65/m.
+  T w = 2.65 / model().body_mass(bodies_[patch_index].first);
+  if (num_cliques_[patch_index] == 2) {
+    w += 2.65 / model().body_mass(bodies_[patch_index].second);
+  }
+
+  // SAP regularization parameter σ. Each frictional contact is regularized by
+  // εₛ = max(vₛ, μ⋅σ⋅wₜ⋅n₀), where vₛ is the stiction tolerance, μ is the
+  // friction coefficient, wₜ is the Delassus operator approximation, and n₀ is
+  // the normal impulse from the previous time step. See the ICF paper [Castro
+  // et al., 2023] for further details.
+  static constexpr double kSigma{1.0e-3};
+
+  return kSigma * w;
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/patch_constraints_pool.h
+++ b/multibody/contact_solvers/icf/patch_constraints_pool.h
@@ -169,14 +169,30 @@ class PatchConstraintsPool {
                          T* d2cost) const;
 
   /* Testing only access. */
-  const std::vector<std::pair<int, int>>& bodies() { return bodies_; }
+  double stiction_tolerance() const { return stiction_tolerance_; }
+  const std::vector<std::pair<int, int>>& bodies() const { return bodies_; }
+  const std::vector<int>& num_cliques() const { return num_cliques_; }
+  const std::vector<T>& dissipation() const { return dissipation_; }
+  const std::vector<T>& static_friction() const { return static_friction_; }
+  const std::vector<T>& dynamic_friction() const { return dynamic_friction_; }
+  const EigenPool<Vector3<T>>& p_AB_W() const { return p_AB_W_; }
+  const std::vector<T>& Rt() const { return Rt_; }
 
- private:
   /* Returns the index into data per patch and per contact pair.
+  Testing only access.
+
   @param p Patch index p < num_pairs().
   @param k Pair index k < num_pairs(p). */
   int patch_pair_index(int p, int k) const { return pair_data_start_[p] + k; }
+  /* Testing only access. */
+  const EigenPool<Vector3<T>>& p_BC_W() const { return p_BC_W_; }
+  const EigenPool<Vector3<T>>& normal_W() const { return normal_W_; }
+  const std::vector<T>& stiffness() const { return stiffness_; }
+  const std::vector<T>& fe0() const { return fe0_; }
+  const std::vector<T>& fn0() const { return fn0_; }
+  const std::vector<T>& net_friction() const { return net_friction_; }
 
+ private:
   /* Computes cost, gradient, and Hessian contributions for the given pair.
 
   @param p Patch index.
@@ -203,18 +219,14 @@ class PatchConstraintsPool {
                            EigenPool<Vector6<T>>* spatial_impulses_pool,
                            EigenPool<Matrix6<T>>* patch_hessians_pool) const;
 
+  /* Computes friction regularization Rₜ = σ⋅wₜ for a patch. */
+  T CalcRt(int p) const;
+
   // The parent model.
   const IcfModel<T>* const model_;
 
   // The stiction tolerance vₛ (m/s) for regularized friction.
   double stiction_tolerance_{1.0e-4};
-
-  // SAP regularization parameter σ. Each frictional contact is regularized by
-  // εₛ = max(vₛ, μ⋅σ⋅wₜ⋅n₀), where vₛ is the stiction tolerance, μ is the
-  // friction coefficient, wₜ is the Delassus operator approximation, and n₀ is
-  // the normal impulse from the previous time step. See the ICF paper [Castro
-  // et al., 2023] for further details.
-  double sigma_{1.0e-3};
 
   // Data per patch. Indexed by patch index p < num_patches().
   std::vector<int> num_pairs_;    // Number of pairs per patch.

--- a/multibody/contact_solvers/icf/test/coupler_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/coupler_constraints_pool_test.cc
@@ -1,16 +1,23 @@
 #include "drake/multibody/contact_solvers/icf/coupler_constraints_pool.h"
 
 #include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/limit_malloc.h"
 #include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
 #include "drake/multibody/contact_solvers/icf/icf_data.h"
 #include "drake/multibody/contact_solvers/icf/icf_model.h"
 #include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
 #include "drake/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.h"
+#include "drake/multibody/plant/slicing_and_indexing.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
@@ -22,7 +29,17 @@ namespace icf {
 namespace internal {
 namespace {
 
+using multibody::internal::SelectRows;
+
 constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
+
+// Undo the floating body annotation that conflicts with coupler constraint
+// configuration.
+void UndoFloatingBodyAnnotation(IcfModel<double>* model) {
+  std::unique_ptr<IcfParameters<double>> params = model->ReleaseParameters();
+  params->body_is_floating = {0, 0, 0, 0};
+  model->ResetParameters(std::move(params));
+}
 
 /* Checks that model.CalcData does not incur any heap allocations on a problem
 with coupler constraints. */
@@ -46,6 +63,29 @@ GTEST_TEST(CouplerConstraintsPool, LimitMallocOnCalcData) {
   {
     drake::test::LimitMalloc guard;
     model.CalcData(v, &data);
+  }
+}
+
+/* Checks that pool.ReduceInto does not incur any heap allocations on a
+problem with coupler constraints. */
+GTEST_TEST(CouplerConstraintsPool, LimitMallocOnReduceInto) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddCouplerConstraint(&model);
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+
+  // Do a not-smaller reduction to allocate memory in the reduced model.
+  MakeModelReducible(&model, /* dofs_to_remove = */ {});
+  model.ReduceInto(&reduced_model, &mapping);
+
+  // Given prior allocation of a big enough model, the constraint pool
+  // reduction does not allocate.
+  {
+    drake::test::LimitMalloc guard;
+    model.coupler_constraints_pool().ReduceInto(
+        mapping, &reduced_model.coupler_constraints_pool());
   }
 }
 
@@ -147,6 +187,204 @@ GTEST_TEST(CouplerConstraintsPool, Data) {
   const double scale = std::abs(dcost.value());
   EXPECT_NEAR(dcost.value(), cost.derivatives()[0], scale * kEpsilon);
   EXPECT_NEAR(d2cost.value(), dcost.derivatives()[0], scale * kEpsilon);
+}
+
+/* Verifies that reducing the coupler constraint pool produces correct data. */
+GTEST_TEST(CouplerConstraintsPool, Reduce) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  UndoFloatingBodyAnnotation(&model);
+  AddCouplerConstraint(&model);
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  const int nv = model.num_velocities();
+  const VectorXd v = VectorXd::LinSpaced(nv, -10, 10.0);
+  // Require all velocities are non-zero.
+  ASSERT_TRUE((v.array() != 0).all());
+  model.CalcData(v, &data);
+
+  auto check_reduced = [&](const std::vector<int>& locked_dofs) {
+    SCOPED_TRACE(fmt::format("locked_dofs [{}]", fmt::join(locked_dofs, ", ")));
+    IcfModel<double> reduced_model;
+    ReducedMapping mapping;
+    MakeModelReducible(&model, locked_dofs);
+    model.ReduceInto(&reduced_model, &mapping);
+    const bool have_i = mapping.velocity_subsequence.participates(7);
+    const bool have_j = mapping.velocity_subsequence.participates(9);
+    const int expected_constraints = (have_i || have_j);
+    ASSERT_EQ(reduced_model.num_coupler_constraints(), expected_constraints);
+    if (expected_constraints == 0) {
+      return;
+    }
+
+    // Check the data transmitted by pool.ReduceInto().
+    const auto& full_pool = model.coupler_constraints_pool();
+    const auto& reduced_pool = reduced_model.coupler_constraints_pool();
+    const int full_clique = full_pool.constraint_to_clique()[0];
+    const int reduced_clique = reduced_pool.constraint_to_clique()[0];
+    EXPECT_EQ(mapping.clique_subsequence.permuted_index(full_clique),
+              reduced_clique);
+    const int f_i = full_pool.dofs()[0].first;
+    const int f_j = full_pool.dofs()[0].second;
+    const int r_i = reduced_pool.dofs()[0].first;
+    const int r_j = reduced_pool.dofs()[0].second;
+    const auto& clique_mapping = mapping.clique_dof_subsequences[full_clique];
+    if (have_i) {
+      EXPECT_EQ(clique_mapping.permuted_index(f_i), r_i);
+    }
+    if (have_j) {
+      EXPECT_EQ(clique_mapping.permuted_index(f_j), r_j);
+    }
+    EXPECT_EQ(full_pool.gear_ratio()[0], reduced_pool.gear_ratio()[0]);
+    EXPECT_EQ(full_pool.g_hat()[0], reduced_pool.g_hat()[0]);
+    EXPECT_EQ(full_pool.R()[0], reduced_pool.R()[0]);
+
+    // Check the downstream calculations.
+    IcfData<double> reduced_data;
+    reduced_model.ResizeData(&reduced_data);
+    const auto reduced_velocity =
+        SelectRows(v, mapping.velocity_subsequence.inverse_permutation());
+    reduced_model.CalcData(reduced_velocity, &reduced_data);
+    const auto& full_data_pool = data.coupler_constraints_data();
+    const auto& reduced_data_pool = reduced_data.coupler_constraints_data();
+
+    // Check the data pool.
+    if (have_i && have_j) {
+      // Fully participating reduced constraint data matches the data from the
+      // full problem.
+      EXPECT_EQ(reduced_data_pool.gamma(0), full_data_pool.gamma(0));
+      EXPECT_EQ(reduced_data_pool.cost(), full_data_pool.cost());
+    } else {
+      // Under the handcrafted test conditions, partially participating reduced
+      // constraint data does *not* match the data from the full problem. These
+      // checks assume that velocities of locked dofs were non-zero in the full
+      // problem.
+      EXPECT_NE(reduced_data_pool.gamma(0), full_data_pool.gamma(0));
+      EXPECT_NE(reduced_data_pool.cost(), full_data_pool.cost());
+
+      const auto clique_v =
+          reduced_model.clique_segment(reduced_clique, reduced_velocity);
+      const auto expected_vc =
+          (have_i ? clique_v(r_i)
+                  : -reduced_pool.gear_ratio()[0] * clique_v(r_j));
+      const auto v_hat = reduced_pool.g_hat()[0] / reduced_model.time_step();
+      const auto expected_gamma = (v_hat - expected_vc) / reduced_pool.R()[0];
+      EXPECT_NEAR(reduced_data_pool.gamma(0), expected_gamma, 1e-15);
+    }
+
+    // Check gradient contribution.
+    VectorXd full_gradient = VectorXd::Zero(model.num_velocities());
+    full_pool.AccumulateGradient(data, &full_gradient);
+    const auto full_clique_gradient =
+        model.clique_segment(full_clique, full_gradient);
+    VectorXd reduced_gradient = VectorXd::Zero(reduced_model.num_velocities());
+    reduced_pool.AccumulateGradient(reduced_data, &reduced_gradient);
+    const auto reduced_clique_gradient =
+        reduced_model.clique_segment(reduced_clique, reduced_gradient);
+    if (have_i && have_j) {
+      // Fully participating reduced constraint data matches the data from the
+      // full problem.
+      EXPECT_EQ(reduced_clique_gradient(r_i), full_clique_gradient(f_i));
+      EXPECT_EQ(reduced_clique_gradient(r_j), full_clique_gradient(f_j));
+    } else if (have_i) {
+      EXPECT_EQ(reduced_clique_gradient(r_i), -reduced_data_pool.gamma(0));
+    } else if (have_j) {
+      EXPECT_EQ(reduced_clique_gradient(r_j),
+                reduced_pool.gear_ratio()[0] * reduced_data_pool.gamma(0));
+    }
+
+    // Check Hessian contribution.
+    reduced_model.SetSparsityPattern();
+    contact_solvers::internal::BlockSparseSymmetricMatrix<MatrixX<double>>
+        hessian(reduced_model.sparsity_pattern());
+    reduced_pool.AccumulateHessian(reduced_data, &hessian);
+    if (hessian.HasBlock(reduced_clique, reduced_clique)) {
+      const auto& block = hessian.diagonal_block(reduced_clique);
+      const double R = reduced_pool.R()[0];
+      const double rho = reduced_pool.gear_ratio()[0];
+      if (have_i && have_j) {
+        EXPECT_EQ(block(r_i, r_j), -rho / R);
+        EXPECT_EQ(block(r_i, r_j), block(r_j, r_i));
+      }
+      if (have_i) {
+        EXPECT_EQ(block(r_i, r_i), 1.0 / R);
+      }
+      if (have_j) {
+        EXPECT_EQ(block(r_j, r_j), rho * rho / R);
+      }
+    }
+
+    // Check cost along line.
+    const VectorXd w =
+        VectorXd::LinSpaced(nv, 0.1, -0.2);  // Arbitrary search direction.
+    double dcost{}, d2cost{};
+    full_pool.CalcCostAlongLine(full_data_pool, w, &dcost, &d2cost);
+
+    const auto& reduced_w =
+        SelectRows(w, mapping.velocity_subsequence.inverse_permutation());
+    double reduced_dcost{}, reduced_d2cost{};
+    reduced_pool.CalcCostAlongLine(reduced_data_pool, reduced_w, &reduced_dcost,
+                                   &reduced_d2cost);
+    if (have_i && have_j) {
+      EXPECT_EQ(reduced_dcost, dcost);
+      EXPECT_EQ(reduced_d2cost, d2cost);
+    } else {
+      // Partially participating reduced constraint data does *not* match the
+      // data from the full problem. These checks assume that velocities of
+      // locked dofs were non-zero in the full problem.
+      EXPECT_NE(reduced_dcost, dcost);
+      EXPECT_NE(reduced_d2cost, d2cost);
+
+      const auto clique_w =
+          reduced_model.clique_segment(reduced_clique, reduced_w);
+      const auto expected_vw =
+          (have_i ? clique_w(r_i)
+                  : -reduced_pool.gear_ratio()[0] * clique_w(r_j));
+      const auto expected_dcost = -reduced_data_pool.gamma(0) * expected_vw;
+      const auto expected_d2cost =
+          expected_vw * expected_vw / reduced_pool.R()[0];
+      EXPECT_NEAR(reduced_dcost, expected_dcost, 1e-12);
+      EXPECT_NEAR(reduced_d2cost, expected_d2cost, 1e-15);
+    }
+  };
+
+  // Reduce by none; essentially, just copy.
+  const std::vector<int> none_locked;
+  check_reduced(none_locked);
+
+  // Lock some arbitrary dofs.
+  const std::vector<int> arbitrary_locked = {0, 17};
+  check_reduced(arbitrary_locked);
+
+  // Lock one constraint dof.
+  const std::vector<int> constraint_dof_i_locked = {7};
+  check_reduced(constraint_dof_i_locked);
+
+  // Lock other constraint dof.
+  const std::vector<int> constraint_dof_j_locked = {9};
+  check_reduced(constraint_dof_j_locked);
+
+  // Lock both constraint dofs.
+  const std::vector<int> constraint_dofs_both_locked = {7, 9};
+  check_reduced(constraint_dofs_both_locked);
+
+  // Lock other dofs in constraint clique.
+  const std::vector<int> other_dofs_locked = {6, 8};
+  check_reduced(other_dofs_locked);
+
+  // Lock an entire arbitrary clique.
+  const std::vector<int> clique0_locked = {0, 1, 2, 3, 4, 5};
+  check_reduced(clique0_locked);
+
+  // Lock the entire constrained clique.
+  const std::vector<int> clique1_locked = {6, 7, 8, 9, 10, 11};
+  check_reduced(clique1_locked);
+
+  // Lock everything.
+  std::vector<int> all_locked(model.num_velocities());
+  std::iota(all_locked.begin(), all_locked.end(), 0);
+  check_reduced(all_locked);
 }
 
 }  // namespace

--- a/multibody/contact_solvers/icf/test/limit_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/limit_constraints_pool_test.cc
@@ -1,7 +1,10 @@
 #include "drake/multibody/contact_solvers/icf/limit_constraints_pool.h"
 
 #include <limits>
+#include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
@@ -46,6 +49,30 @@ GTEST_TEST(LimitConstraintsPool, LimitMallocOnCalcData) {
   {
     drake::test::LimitMalloc guard;
     model.CalcData(v, &data);
+  }
+}
+
+/* Checks that pool.ReduceInto does not incur any heap allocations on a
+problem with limit constraints. */
+GTEST_TEST(LimitConstraintsPool, LimitMallocOnReduceInto) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddLimitConstraints(&model);
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+
+  // Do a not-smaller reduction to allocate memory in the reduced model.
+  MakeModelReducible(&model, {});
+  model.ReduceInto(&reduced_model, &mapping);
+
+  // Given prior allocation of a big enough model, the constraint pool
+  // reduction does not allocate.
+  {
+    // TODO(#23912): consider reducing these allocations.
+    drake::test::LimitMalloc guard({24});
+    model.limit_constraints_pool().ReduceInto(
+        mapping, &reduced_model.limit_constraints_pool());
   }
 }
 
@@ -124,6 +151,97 @@ GTEST_TEST(LimitConstraintsPool, Data) {
   MatrixXd gradient_derivatives = math::ExtractGradient(data.gradient());
   EXPECT_TRUE(CompareMatrices(hessian_value, gradient_derivatives,
                               10 * kEpsilon, MatrixCompareType::relative));
+}
+
+/* Verifies that reducing the limit constraint pool produces correct data. */
+GTEST_TEST(LimitConstraintsPool, Reduce) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddLimitConstraints(&model);
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  const int nv = model.num_velocities();
+  const VectorXd v = VectorXd::LinSpaced(nv, -10, 10.0);
+  model.CalcData(v, &data);
+  const auto& full_pool = model.limit_constraints_pool();
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+
+  auto check_reduced = [&](const std::vector<int>& locked_dofs) {
+    SCOPED_TRACE(fmt::format("locked_dofs [{}]", fmt::join(locked_dofs, ", ")));
+    MakeModelReducible(&model, locked_dofs);
+    model.ReduceInto(&reduced_model, &mapping);
+    const auto& reduced_pool = reduced_model.limit_constraints_pool();
+    int reduced_constraint_cursor{0};
+    for (int k = 0; k < full_pool.num_constraints(); ++k) {
+      SCOPED_TRACE(fmt::format("full constraint {} vs. reduced constraint {}",
+                               k, reduced_constraint_cursor));
+      int full_clique = full_pool.clique()[k];
+      if (!mapping.clique_subsequence.participates(full_clique)) {
+        continue;
+      }
+      const auto& dof_subsequence =
+          mapping.clique_dof_subsequences[full_clique];
+      int full_dof = full_pool.dof()[k];
+      if (!dof_subsequence.participates(full_dof)) {
+        continue;
+      }
+
+      // Check the data transmitted by pool.ReduceInto().
+      const auto& indices = dof_subsequence.inverse_permutation();
+      int reduced_clique = reduced_pool.clique()[reduced_constraint_cursor];
+      EXPECT_EQ(reduced_clique,
+                mapping.clique_subsequence.permuted_index(full_clique));
+      int reduced_dof = reduced_pool.dof()[reduced_constraint_cursor];
+      EXPECT_EQ(reduced_dof, dof_subsequence.permuted_index(full_dof));
+      EXPECT_EQ(reduced_pool.constraint_size()[reduced_constraint_cursor],
+                dof_subsequence.permuted_domain_size());
+      EXPECT_TRUE(CompareMatrices(reduced_pool.ql()[reduced_constraint_cursor],
+                                  full_pool.ql()[k](indices)));
+      EXPECT_TRUE(CompareMatrices(reduced_pool.qu()[reduced_constraint_cursor],
+                                  full_pool.qu()[k](indices)));
+      EXPECT_TRUE(CompareMatrices(reduced_pool.q0()[reduced_constraint_cursor],
+                                  full_pool.q0()[k](indices)));
+      EXPECT_TRUE(
+          CompareMatrices(reduced_pool.gl_hat()[reduced_constraint_cursor],
+                          full_pool.gl_hat()[k](indices)));
+      EXPECT_TRUE(
+          CompareMatrices(reduced_pool.gu_hat()[reduced_constraint_cursor],
+                          full_pool.gu_hat()[k](indices)));
+      EXPECT_TRUE(CompareMatrices(reduced_pool.R()[reduced_constraint_cursor],
+                                  full_pool.R()[k](indices)));
+
+      ++reduced_constraint_cursor;
+    }
+    EXPECT_EQ(reduced_model.num_limit_constraints(), reduced_constraint_cursor);
+  };
+
+  // Reduce by none; essentially, just copy.
+  const std::vector<int> none_locked;
+  check_reduced(none_locked);
+
+  // Lock some arbitrary dofs.
+  const std::vector<int> arbitrary_locked = {0, 17};
+  check_reduced(arbitrary_locked);
+
+  // Lock a constrained clique.
+  const std::vector<int> clique0_locked = {0, 1, 2, 3, 4, 5};
+  check_reduced(clique0_locked);
+
+  // Lock an unconstrained clique.
+  const std::vector<int> clique1_locked = {6, 7, 8, 9, 10, 11};
+  check_reduced(clique1_locked);
+
+  // Lock other constrained clique.
+  const std::vector<int> clique2_locked = {12, 13, 14, 15, 16, 17};
+  check_reduced(clique2_locked);
+
+  // Lock everything.
+  std::vector<int> all_locked(model.num_velocities());
+  std::iota(all_locked.begin(), all_locked.end(), 0);
+  check_reduced(all_locked);
 }
 
 }  // namespace

--- a/multibody/contact_solvers/icf/test/patch_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/patch_constraints_pool_test.cc
@@ -1,5 +1,9 @@
 #include "drake/multibody/contact_solvers/icf/patch_constraints_pool.h"
 
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/limit_malloc.h"
@@ -40,6 +44,147 @@ GTEST_TEST(PatchConstraintsPool, LimitMallocOnCalcData) {
     drake::test::LimitMalloc guard;
     model.CalcData(v, &data);
   }
+}
+
+/* Checks that pool.ReduceInto does not incur any heap allocations on a
+problem with patch constraints. */
+GTEST_TEST(PatchConstraintsPool, LimitMallocOnReduceInto) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddPatchConstraints(&model);
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+
+  // Do a not-smaller reduction to allocate memory in the reduced model.
+  MakeModelReducible(&model, {});
+  model.ReduceInto(&reduced_model, &mapping);
+
+  // Given prior allocation of a big enough model, the constraint pool
+  // reduction does not allocate.
+  {
+    drake::test::LimitMalloc guard;
+    model.patch_constraints_pool().ReduceInto(
+        mapping, &reduced_model.patch_constraints_pool());
+  }
+}
+
+/* Verifies that reducing the patch constraint pool produces correct data. */
+GTEST_TEST(PatchConstraintsPool, Reduce) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddPatchConstraints(&model);
+  model.patch_constraints_pool().set_stiction_tolerance(1.1e-4);
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  const int nv = model.num_velocities();
+  const VectorXd v = VectorXd::LinSpaced(nv, -10, 10.0);
+  model.CalcData(v, &data);
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+
+  auto check_reduced = [&](const std::vector<int>& locked_dofs) {
+    SCOPED_TRACE(fmt::format("locked_dofs [{}]", fmt::join(locked_dofs, ", ")));
+    MakeModelReducible(&model, locked_dofs);
+    model.ReduceInto(&reduced_model, &mapping);
+
+    // Check the data transmitted by pool.ReduceInto().
+    const auto& full_pool = model.patch_constraints_pool();
+    const auto& reduced_pool = reduced_model.patch_constraints_pool();
+    EXPECT_EQ(full_pool.stiction_tolerance(),
+              reduced_pool.stiction_tolerance());
+
+    int r_k{0};  // Reduced constraints cursor.
+    for (int k = 0; k < full_pool.num_constraints(); ++k) {
+      SCOPED_TRACE(
+          fmt::format("full constraint {} vs. reduced constraint {}", k, r_k));
+      const auto& [b, a] = full_pool.bodies()[k];
+      const int clique_b = model.params().body_to_clique[b];
+      const int clique_a = model.params().body_to_clique[a];
+      const bool have_b = mapping.clique_subsequence.participates(clique_b);
+      const bool have_a =
+          clique_a >= 0 && mapping.clique_subsequence.participates(clique_a);
+      if (!(have_a || have_b)) {
+        continue;
+      }
+      EXPECT_EQ(reduced_pool.num_cliques()[r_k], have_a + have_b);
+      EXPECT_EQ(reduced_pool.dissipation()[r_k], full_pool.dissipation()[k]);
+      EXPECT_EQ(reduced_pool.static_friction()[r_k],
+                full_pool.static_friction()[k]);
+      EXPECT_EQ(reduced_pool.dynamic_friction()[r_k],
+                full_pool.dynamic_friction()[k]);
+      const bool is_flipped = have_a && !have_b;
+      const auto& [r_b, r_a] = reduced_pool.bodies()[r_k];
+      SCOPED_TRACE(fmt::format("flipped? {} have a? {} have b? {}", is_flipped,
+                               have_a, have_b));
+      if (is_flipped) {
+        EXPECT_EQ(b, r_a);
+        EXPECT_EQ(a, r_b);
+        EXPECT_EQ(reduced_pool.p_AB_W()[r_k], -full_pool.p_AB_W()[k]);
+      } else {
+        EXPECT_EQ(b, r_b);
+        EXPECT_EQ(a, r_a);
+        EXPECT_EQ(reduced_pool.p_AB_W()[r_k], full_pool.p_AB_W()[k]);
+      }
+      const bool Rt_changed = (reduced_pool.Rt()[r_k] != full_pool.Rt()[k]);
+      const bool cliques_changed =
+          (reduced_pool.num_cliques()[r_k] != full_pool.num_cliques()[k]);
+      // TODO(rpoyner-tri): maybe test Rt in more detail.
+      EXPECT_EQ(Rt_changed, cliques_changed);
+
+      // This check relies on there being one pair per patch.
+      EXPECT_EQ(reduced_pool.patch_pair_index(r_k, 0), r_k);
+
+      EXPECT_EQ(reduced_pool.num_pairs(r_k), full_pool.num_pairs(k));
+      for (int p = 0; p < full_pool.num_pairs(k); ++p) {
+        const int f_p = full_pool.patch_pair_index(k, p);
+        const int r_p = reduced_pool.patch_pair_index(r_k, p);
+        EXPECT_EQ(reduced_pool.stiffness()[r_p], full_pool.stiffness()[f_p]);
+        EXPECT_EQ(reduced_pool.fe0()[r_p], full_pool.fe0()[f_p]);
+        EXPECT_EQ(reduced_pool.fn0()[r_p], full_pool.fn0()[f_p]);
+        EXPECT_EQ(reduced_pool.net_friction()[r_p],
+                  full_pool.net_friction()[f_p]);
+        if (is_flipped) {
+          EXPECT_EQ(reduced_pool.normal_W()[r_p], -full_pool.normal_W()[f_p]);
+          // In the flipped case, reduced p_BC_W is the same as full p_AC_W.
+          EXPECT_EQ(reduced_pool.p_BC_W()[r_p],
+                    full_pool.p_AB_W()[k] + full_pool.p_BC_W()[f_p]);
+        } else {
+          EXPECT_EQ(reduced_pool.normal_W()[r_p], full_pool.normal_W()[f_p]);
+          EXPECT_EQ(reduced_pool.p_BC_W()[r_p], full_pool.p_BC_W()[f_p]);
+        }
+      }
+      ++r_k;
+    }
+    EXPECT_EQ(r_k, reduced_pool.num_constraints());
+  };
+
+  // Reduce by none; essentially, just copy.
+  const std::vector<int> none_locked;
+  check_reduced(none_locked);
+
+  // Lock some arbitrary dofs.
+  const std::vector<int> arbitrary_locked = {0, 17};
+  check_reduced(arbitrary_locked);
+
+  // Lock clique 0.
+  const std::vector<int> clique0_locked = {0, 1, 2, 3, 4, 5};
+  check_reduced(clique0_locked);
+
+  // Lock clique 1.
+  const std::vector<int> clique1_locked = {6, 7, 8, 9, 10, 11};
+  check_reduced(clique1_locked);
+
+  // Lock clique 2.
+  const std::vector<int> clique2_locked = {12, 13, 14, 15, 16, 17};
+  check_reduced(clique2_locked);
+
+  // Lock everything.
+  std::vector<int> all_locked(model.num_velocities());
+  std::iota(all_locked.begin(), all_locked.end(), 0);
+  check_reduced(all_locked);
 }
 
 }  // namespace

--- a/multibody/contact_solvers/icf/test/two_spheres_test.cc
+++ b/multibody/contact_solvers/icf/test/two_spheres_test.cc
@@ -136,7 +136,7 @@ TEST_P(TwoSpheres, MakeData) {
     // TODO(amcastro-tri): Fix this function to not allocate. You'll need a
     // pre-allocated workspace for this function.
     drake::test::LimitMalloc guard({
-        .max_num_allocations = 352,
+        .max_num_allocations = kDrakeAssertIsArmed ? 352 : 339,
         .min_num_allocations = 0,
         .ignore_realloc_noops = true,
     });

--- a/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
@@ -3,7 +3,10 @@
 #include <limits>
 #include <memory>
 #include <utility>
+#include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
@@ -50,6 +53,29 @@ GTEST_TEST(WeldConstraintsPool, LimitMallocOnCalcData) {
   {
     drake::test::LimitMalloc guard;
     model.CalcData(v, &data);
+  }
+}
+
+/* Checks that pool.ReduceInto does not incur any heap allocations on a
+problem with weld constraints. */
+GTEST_TEST(WeldConstraintsPool, LimitMallocOnReduceInto) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddWeldConstraints(&model);
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+
+  // Do a not-smaller reduction to allocate memory in the reduced model.
+  MakeModelReducible(&model, {});
+  model.ReduceInto(&reduced_model, &mapping);
+
+  // Given prior allocation of a big enough model, the constraint pool
+  // reduction does not allocate.
+  {
+    drake::test::LimitMalloc guard;
+    model.weld_constraints_pool().ReduceInto(
+        mapping, &reduced_model.weld_constraints_pool());
   }
 }
 
@@ -514,6 +540,94 @@ GTEST_TEST(WeldConstraintsPool, GradientConsistency) {
 
   EXPECT_TRUE(CompareMatrices(gradient_value, cost_derivatives, 100 * kEpsilon,
                               MatrixCompareType::relative));
+}
+
+/* Verifies that reducing the weld constraint pool produces correct data. */
+GTEST_TEST(WeldConstraintsPool, Reduce) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddWeldConstraints(&model);
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  const int nv = model.num_velocities();
+  const VectorXd v = VectorXd::LinSpaced(nv, -10, 10.0);
+  model.CalcData(v, &data);
+
+  auto check_reduced = [&](const std::vector<int>& locked_dofs) {
+    SCOPED_TRACE(fmt::format("locked_dofs [{}]", fmt::join(locked_dofs, ", ")));
+    MakeModelReducible(&model, locked_dofs);
+    IcfModel<double> reduced_model;
+    ReducedMapping mapping;
+    model.ReduceInto(&reduced_model, &mapping);
+
+    // Check the data transmitted by pool.ReduceInto().
+    const auto& full_pool = model.weld_constraints_pool();
+    const auto& reduced_pool = reduced_model.weld_constraints_pool();
+
+    int r_k{0};  // Reduced constraints cursor.
+    for (int k = 0; k < full_pool.num_constraints(); ++k) {
+      SCOPED_TRACE(
+          fmt::format("full constraint {} vs. reduced constraint {}", k, r_k));
+      const auto& [a, b] = full_pool.body_pairs()[k];
+      const int clique_b = model.params().body_to_clique[b];
+      const int clique_a = model.params().body_to_clique[a];
+      const bool have_b = mapping.clique_subsequence.participates(clique_b);
+      const bool have_a =
+          clique_a >= 0 && mapping.clique_subsequence.participates(clique_a);
+      if (!(have_a || have_b)) {
+        continue;
+      }
+      const bool is_flipped = have_a && !have_b;
+      const auto& [r_a, r_b] = reduced_pool.body_pairs()[r_k];
+      SCOPED_TRACE(fmt::format("flipped? {} have a? {} have b? {}", is_flipped,
+                               have_a, have_b));
+      if (is_flipped) {
+        EXPECT_EQ(r_a, b);
+        EXPECT_EQ(r_b, a);
+        EXPECT_EQ(reduced_pool.p_AP_W()[r_k], full_pool.p_BQ_W()[k]);
+        EXPECT_EQ(reduced_pool.p_BQ_W()[r_k], full_pool.p_AP_W()[k]);
+        EXPECT_EQ(reduced_pool.p_PoQo_W()[r_k], -full_pool.p_PoQo_W()[k]);
+        EXPECT_EQ(reduced_pool.g0()[r_k], -full_pool.g0()[k]);
+      } else {
+        EXPECT_EQ(r_a, a);
+        EXPECT_EQ(r_b, b);
+        EXPECT_EQ(reduced_pool.p_AP_W()[r_k], full_pool.p_AP_W()[k]);
+        EXPECT_EQ(reduced_pool.p_BQ_W()[r_k], full_pool.p_BQ_W()[k]);
+        EXPECT_EQ(reduced_pool.p_PoQo_W()[r_k], full_pool.p_PoQo_W()[k]);
+        EXPECT_EQ(reduced_pool.g0()[r_k], full_pool.g0()[k]);
+      }
+      ++r_k;
+    }
+    EXPECT_EQ(ssize(reduced_pool.R()), r_k);
+    EXPECT_EQ(reduced_pool.hessian_blocks_size(), r_k);
+    EXPECT_EQ(reduced_pool.num_constraints(), r_k);
+  };
+
+  // Reduce by none; essentially, just copy.
+  const std::vector<int> none_locked;
+  check_reduced(none_locked);
+
+  // Lock some arbitrary dofs.
+  const std::vector<int> arbitrary_locked = {0, 17};
+  check_reduced(arbitrary_locked);
+
+  // Lock clique 0.
+  const std::vector<int> clique0_locked = {0, 1, 2, 3, 4, 5};
+  check_reduced(clique0_locked);
+
+  // Lock clique 1.
+  const std::vector<int> clique1_locked = {6, 7, 8, 9, 10, 11};
+  check_reduced(clique1_locked);
+
+  // Lock clique 2.
+  const std::vector<int> clique2_locked = {12, 13, 14, 15, 16, 17};
+  check_reduced(clique2_locked);
+
+  // Lock everything.
+  std::vector<int> all_locked(model.num_velocities());
+  std::iota(all_locked.begin(), all_locked.end(), 0);
+  check_reduced(all_locked);
 }
 
 }  // namespace

--- a/multibody/contact_solvers/icf/weld_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/weld_constraints_pool.cc
@@ -56,8 +56,8 @@ void WeldConstraintsPool<T>::Resize(const int num_constraints) {
   p_AP_W_.Resize(num_constraints, 3, 1);
   p_BQ_W_.Resize(num_constraints, 3, 1);
   p_PoQo_W_.Resize(num_constraints, 3, 1);
-  g0_.resize(num_constraints);
-  R_.resize(num_constraints);
+  g0_.Resize(num_constraints, 6, 1);
+  R_.Resize(num_constraints, 6, 1);
 }
 
 template <typename T>
@@ -426,10 +426,56 @@ void WeldConstraintsPool<T>::CalcCostAlongLine(
 }
 
 template <typename T>
-void WeldConstraintsPool<T>::ReduceInto(const ReducedMapping&,
-                                        WeldConstraintsPool<T>*) const {
-  // TODO(#23764): implement.
-  DRAKE_THROW_UNLESS(num_constraints() == 0);
+void WeldConstraintsPool<T>::ReduceInto(
+    const ReducedMapping& mapping, WeldConstraintsPool<T>* reduced_pool) const {
+  // Make sure the pool is (over) allocated.
+  reduced_pool->Resize(num_constraints());
+
+  reduced_pool->body_pairs_.clear();
+  reduced_pool->p_AP_W_.Clear();
+  reduced_pool->p_BQ_W_.Clear();
+  reduced_pool->p_PoQo_W_.Clear();
+  reduced_pool->g0_.Clear();
+  int reduced_size{0};
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int body_a = body_pairs_[k].first;
+    const int body_b = body_pairs_[k].second;
+    const int c_b = model().body_to_clique(body_b);
+    const int c_a = model().body_to_clique(body_a);  // negative if anchored.
+    const bool have_r_c_b = mapping.clique_subsequence.participates(c_b);
+    const bool have_r_c_a =
+        (c_a >= 0 && mapping.clique_subsequence.participates(c_a));
+    const int r_num_cliques = have_r_c_b + have_r_c_a;
+    if (r_num_cliques == 0) {
+      continue;
+    }
+    // At this point, we could have a num_cliques==1 case where body_b is
+    // locked (no clique), and body_a is not. This will require flipping the
+    // direction of the weld constraint.
+    bool need_flip = (r_num_cliques == 1 && have_r_c_a);
+
+    // Fill in the reduced constraint.
+    if (need_flip) {
+      reduced_pool->body_pairs_.emplace_back(body_b, body_a);
+      reduced_pool->p_AP_W_.Add(3, 1) = p_BQ_W_[k];
+      reduced_pool->p_BQ_W_.Add(3, 1) = p_AP_W_[k];
+      reduced_pool->p_PoQo_W_.Add(3, 1) = -p_PoQo_W_[k];
+      reduced_pool->g0_.Add(6, 1) = -g0_[k];
+    } else {
+      reduced_pool->body_pairs_.push_back(body_pairs_[k]);
+      reduced_pool->p_AP_W_.Add(3, 1) = p_AP_W_[k];
+      reduced_pool->p_BQ_W_.Add(3, 1) = p_BQ_W_[k];
+      reduced_pool->p_PoQo_W_.Add(3, 1) = p_PoQo_W_[k];
+      reduced_pool->g0_.Add(6, 1) = g0_[k];
+    }
+
+    // Track the reduced pool size.
+    ++reduced_size;
+  }
+  // R_ and HessianBlock will be set by PrecomputeHessianBlocks(). Set the
+  // arrays to the correct size.
+  reduced_pool->R_.Resize(reduced_size, 6, 1);
+  reduced_pool->hessian_blocks_.resize(reduced_size);
 }
 
 }  // namespace internal

--- a/multibody/contact_solvers/icf/weld_constraints_pool.h
+++ b/multibody/contact_solvers/icf/weld_constraints_pool.h
@@ -127,6 +127,12 @@ class WeldConstraintsPool {
   const std::vector<std::pair<int, int>>& body_pairs() const {
     return body_pairs_;
   }
+  const EigenPool<Vector3<T>>& p_AP_W() const { return p_AP_W_; }
+  const EigenPool<Vector3<T>>& p_BQ_W() const { return p_BQ_W_; }
+  const EigenPool<Vector3<T>>& p_PoQo_W() const { return p_PoQo_W_; }
+  const EigenPool<Vector6<T>>& g0() const { return g0_; }
+  const EigenPool<Vector6<T>>& R() const { return R_; }
+  int hessian_blocks_size() const { return ssize(hessian_blocks_); }
 
  private:
   const IcfModel<T>* const model_;  // The parent model.
@@ -140,13 +146,13 @@ class WeldConstraintsPool {
   EigenPool<Vector3<T>> p_BQ_W_;    // Position of Q in B, expressed in W.
   EigenPool<Vector3<T>> p_PoQo_W_;  // Relative translation, expressed in W.
 
-  std::vector<Vector6<T>> g0_;  // Constraint function at start of step.
+  EigenPool<Vector6<T>> g0_;  // Constraint function at start of step.
 
   // Near-rigid regularization per constraint.
   // R depends on the current time step δt and is computed in
   // PrecomputeHessianBlocks(), which must be called whenever δt changes.
   // R is a diagonal 6×6 regularization matrix: R = diag(Rᵣ, Rₜ).
-  std::vector<Vector6<T>> R_;  // The diagonal regularization matrix.
+  EigenPool<Vector6<T>> R_;  // The diagonal regularization matrix.
 
   // TODO(sherm1) Consider whether this should be using EigenPools to
   //  reduce memory use.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -1144,6 +1144,7 @@ drake_cc_googletest(
         ":multibody_plant_config_functions",
         ":plant",
         "//systems/analysis:simulator",
+        "//systems/analysis:simulator_config_functions",
     ],
 )
 

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -17,6 +17,7 @@
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/spatial_inertia.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/analysis/simulator_config_functions.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -27,6 +28,7 @@ using math::RigidTransformd;
 using math::RotationMatrix;
 using systems::Context;
 using systems::Simulator;
+using systems::SimulatorConfig;
 
 namespace multibody {
 
@@ -48,9 +50,15 @@ class MultibodyPlantTester {
 
 namespace {
 
+const bool kIsDiscrete = false;  // XXX make me a test param.
 const double kTimestep = 0.01;
 const double kElbowPosition = 0.3;
 const double kArmLength = 0.1;
+const SimulatorConfig cenic_config{"cenic", 0.1, 1e-3, true, 0.0, 0.0, false};
+
+constexpr double plant_timestep() {
+  return kIsDiscrete ? kTimestep : 0.0;
+};
 
 // Remove on 2026-09-01 per TAMSI deprecation.
 #pragma GCC diagnostic push
@@ -66,7 +74,7 @@ constexpr auto kDiscreteContactApproximationTamsi =
 class JointLockingTest : public ::testing::TestWithParam<int> {
  public:
   void SetUp() {
-    plant_ = std::make_unique<MultibodyPlant<double>>(kTimestep);
+    plant_ = std::make_unique<MultibodyPlant<double>>(plant_timestep());
 
     // Each permutation of adding trees (children of world body) to the plant.
     switch (GetParam()) {
@@ -351,18 +359,20 @@ class TrajectoryTest : public ::testing::TestWithParam<TrajectoryTestConfig> {
   std::unique_ptr<MultibodyPlant<double>> MakeDoublePendulumPlant(
       bool weld_elbow, DiscreteContactSolver solver) {
     std::unique_ptr<MultibodyPlant<double>> plant;
-    plant = std::make_unique<MultibodyPlant<double>>(kTimestep);
-    // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
-    // arbitrarily choose two model approximations to accomplish this.
-    switch (solver) {
-      case kDiscreteContactSolverTamsi:
-        plant->set_discrete_contact_approximation(
-            kDiscreteContactApproximationTamsi);
-        break;
-      case DiscreteContactSolver::kSap:
-        plant->set_discrete_contact_approximation(
-            DiscreteContactApproximation::kSap);
-        break;
+    plant = std::make_unique<MultibodyPlant<double>>(plant_timestep());
+    if (plant->is_discrete()) {
+      // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
+      // arbitrarily choose two model approximations to accomplish this.
+      switch (solver) {
+        case kDiscreteContactSolverTamsi:
+          plant->set_discrete_contact_approximation(
+              kDiscreteContactApproximationTamsi);
+          break;
+        case DiscreteContactSolver::kSap:
+          plant->set_discrete_contact_approximation(
+              DiscreteContactApproximation::kSap);
+          break;
+      }
     }
 
     const RigidBody<double>& body1 =
@@ -425,8 +435,10 @@ TEST_P(TrajectoryTest, CompareWeldAndLocked) {
 
   auto simulator_welded = std::make_unique<Simulator<double>>(
       *plant_welded_, std::move(context_welded));
+  ApplySimulatorConfig(cenic_config, simulator_welded.get());
   auto simulator_locked = std::make_unique<Simulator<double>>(
       *plant_locked_, std::move(context_locked));
+  ApplySimulatorConfig(cenic_config, simulator_locked.get());
   simulator_welded->Initialize();
   simulator_locked->Initialize();
 

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -411,10 +411,6 @@ class TrajectoryTest : public ::testing::TestWithParam<TrajectoryTestConfig> {
 // accelerations, velocities and positions match to a given accuracy at each
 // time step.
 TEST_P(TrajectoryTest, CompareWeldAndLocked) {
-  if (!GetParam().solver.has_value()) {
-    GTEST_SKIP() << "CENIC joint locking not supported; see #23764.";
-  }
-
   // Allow 2 digits of precision loss to account for roundoff differences among
   // the various code paths. This value was determined empirically by observing
   // the maximum error among the trajectories.

--- a/multibody/plant/test/joint_locking_test.cc
+++ b/multibody/plant/test/joint_locking_test.cc
@@ -17,6 +17,7 @@
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/spatial_inertia.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/analysis/simulator_config_functions.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
@@ -27,6 +28,7 @@ using math::RigidTransformd;
 using math::RotationMatrix;
 using systems::Context;
 using systems::Simulator;
+using systems::SimulatorConfig;
 
 namespace multibody {
 
@@ -51,6 +53,7 @@ namespace {
 const double kTimestep = 0.01;
 const double kElbowPosition = 0.3;
 const double kArmLength = 0.1;
+const SimulatorConfig kCenicConfig{"cenic", 0.1, 1e-3, true, 0.0, 0.0};
 
 // Remove on 2026-09-01 per TAMSI deprecation.
 #pragma GCC diagnostic push
@@ -307,7 +310,7 @@ INSTANTIATE_TEST_SUITE_P(IndexPermutations, JointLockingTest,
                          ::testing::Values(0, 1));
 
 struct TrajectoryTestConfig {
-  DiscreteContactSolver solver{kDiscreteContactSolverTamsi};
+  std::optional<DiscreteContactSolver> solver{kDiscreteContactSolverTamsi};
 };
 
 std::ostream& operator<<(std::ostream& out, DiscreteContactSolver solver) {
@@ -325,7 +328,10 @@ std::ostream& operator<<(std::ostream& out, DiscreteContactSolver solver) {
 }
 
 std::ostream& operator<<(std::ostream& out, const TrajectoryTestConfig& c) {
-  return out << c.solver;
+  if (c.solver.has_value()) {
+    return out << *c.solver;
+  }
+  return out << "continuous";
 }
 
 // Fixture to construct two plants. Each containing a single double pendulum.
@@ -349,20 +355,23 @@ class TrajectoryTest : public ::testing::TestWithParam<TrajectoryTestConfig> {
   // corresponding to the configuration (0, kElbowPosition) in the model with
   // two joints.
   std::unique_ptr<MultibodyPlant<double>> MakeDoublePendulumPlant(
-      bool weld_elbow, DiscreteContactSolver solver) {
+      bool weld_elbow, std::optional<DiscreteContactSolver> solver) {
     std::unique_ptr<MultibodyPlant<double>> plant;
-    plant = std::make_unique<MultibodyPlant<double>>(kTimestep);
-    // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
-    // arbitrarily choose two model approximations to accomplish this.
-    switch (solver) {
-      case kDiscreteContactSolverTamsi:
-        plant->set_discrete_contact_approximation(
-            kDiscreteContactApproximationTamsi);
-        break;
-      case DiscreteContactSolver::kSap:
-        plant->set_discrete_contact_approximation(
-            DiscreteContactApproximation::kSap);
-        break;
+    const double plant_timestep = solver.has_value() ? kTimestep : 0.0;
+    plant = std::make_unique<MultibodyPlant<double>>(plant_timestep);
+    if (plant->is_discrete()) {
+      // N.B. We want to exercise the TAMSI and SAP code paths. Therefore we
+      // arbitrarily choose two model approximations to accomplish this.
+      switch (*solver) {
+        case kDiscreteContactSolverTamsi:
+          plant->set_discrete_contact_approximation(
+              kDiscreteContactApproximationTamsi);
+          break;
+        case DiscreteContactSolver::kSap:
+          plant->set_discrete_contact_approximation(
+              DiscreteContactApproximation::kSap);
+          break;
+      }
     }
 
     const RigidBody<double>& body1 =
@@ -402,9 +411,13 @@ class TrajectoryTest : public ::testing::TestWithParam<TrajectoryTestConfig> {
 // accelerations, velocities and positions match to a given accuracy at each
 // time step.
 TEST_P(TrajectoryTest, CompareWeldAndLocked) {
-  // Allow 2 digits of precision loss to account for roundoff differences
-  // between the two code paths. This value was determined empircally by
-  // observing the maximum error between the two trajectories.
+  if (!GetParam().solver.has_value()) {
+    GTEST_SKIP() << "CENIC joint locking not supported; see #23764.";
+  }
+
+  // Allow 2 digits of precision loss to account for roundoff differences among
+  // the various code paths. This value was determined empirically by observing
+  // the maximum error among the trajectories.
   const double kEps = 1e2 * std::numeric_limits<double>::epsilon();
   const int kNumTimesteps = 10;
 
@@ -425,8 +438,14 @@ TEST_P(TrajectoryTest, CompareWeldAndLocked) {
 
   auto simulator_welded = std::make_unique<Simulator<double>>(
       *plant_welded_, std::move(context_welded));
+  if (!plant_welded_->is_discrete()) {
+    ApplySimulatorConfig(kCenicConfig, simulator_welded.get());
+  }
   auto simulator_locked = std::make_unique<Simulator<double>>(
       *plant_locked_, std::move(context_locked));
+  if (!plant_locked_->is_discrete()) {
+    ApplySimulatorConfig(kCenicConfig, simulator_locked.get());
+  }
   simulator_welded->Initialize();
   simulator_locked->Initialize();
 
@@ -490,6 +509,7 @@ TEST_P(TrajectoryTest, CompareWeldAndLocked) {
 // Test joint locking with TAMSI and SAP.
 std::vector<TrajectoryTestConfig> MakeTrajectoryTestCases() {
   return std::vector<TrajectoryTestConfig>{
+      {.solver = std::nullopt},
       {.solver = kDiscreteContactSolverTamsi},
       {.solver = DiscreteContactSolver::kSap},
   };


### PR DESCRIPTION
There's a small provocation in here. I noticed that the diagram handling inside CenicIntegrator could pretty easily generalize from "plant inside 1 or more diagrams" to "plant inside 0 diagrams". This is not a tremendously useful configuration for users, but might turn out to be very helpful for adapting existing test suites of plant-centric features.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24387)
<!-- Reviewable:end -->
