### PR TITLE
[tools] Adjust sanitizer configs for OpenMP

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -111,6 +111,9 @@ build:_tsan --run_under=//tools/dynamic_analysis:tsan
 # timeouts to 5x.
 # See https://clang.llvm.org/docs/ThreadSanitizer.html
 build:_tsan --test_timeout=300,1500,4500,18000
+# Configuring TSan to interop with OpenMP is difficult, so we'll turn it off.
+build:_tsan --copt=-fno-openmp
+build:_tsan --linkopt=-fno-openmp
 
 ### UBSan build. ###
 build:ubsan --config=_ubsan

--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -169,3 +169,11 @@
    fun:start_thread
    fun:clone
 }
+
+{
+   OpenMP
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   obj:/usr/lib/llvm-*/lib/libomp.so.5
+}


### PR DESCRIPTION
OpenMP is on by default, we need to interop with sanitizers:
- For Memcheck, add a supression for the omp runtime library.
- For TSan, disable OpenMP; Ubuntu's LLVM build isn't compatible.

Amends 256e37250669bcfdd4f493d66ca82daefef932f4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24389)
<!-- Reviewable:end -->
