### PR TITLE
[tools] Port rcfiles to use enable_platform_specific_config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ if(ANDROID OR CYGWIN OR IOS OR NOT UNIX)
 endif()
 
 set(BAZELRC_IMPORTS "tools/bazel.rc")
-set(UNIX_DISTRIBUTION_CODENAME)
 
 # The minimum Darwin version and codename should correspond to the minimum
 # supported macOS version listed in doc/_pages/installation.md and
@@ -57,11 +56,7 @@ if(APPLE)
       "${MINIMUM_MACOS_CODENAME}) or newer."
     )
   endif()
-
-  list(APPEND BAZELRC_IMPORTS "tools/macos.bazelrc")
 else()
-  list(APPEND BAZELRC_IMPORTS "tools/ubuntu.bazelrc")
-
   execute_process(
     COMMAND "/usr/bin/arch"
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -70,27 +65,6 @@ else()
     message(FATAL_ERROR "Could NOT query linux arch")
   endif()
   list(APPEND BAZELRC_IMPORTS "tools/ubuntu-arch-${UBUNTU_ARCH}.bazelrc")
-
-  execute_process(
-    COMMAND "bash" "-c" ". /etc/os-release && echo \${VERSION_CODENAME}"
-    RESULT_VARIABLE OS_RELEASE_RESULT
-    OUTPUT_VARIABLE UNIX_DISTRIBUTION_CODENAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  if(NOT OS_RELEASE_RESULT EQUAL 0)
-    message(WARNING "Could NOT read the /etc/os-release VERSION_CODENAME.")
-  else()
-    set(MAYBE_RC "tools/ubuntu-${UNIX_DISTRIBUTION_CODENAME}.bazelrc")
-    if(NOT EXISTS "${PROJECT_SOURCE_DIR}/${MAYBE_RC}")
-      message(WARNING "Could not find config file ${MAYBE_RC}. "
-        "This may indicate that you're using an OS or OS version that "
-        "is not officially supported, so the build configuration cannot be "
-        "fine-tuned. See https://drake.mit.edu/from_source.html for details "
-        "on officially supported platforms when building from source.")
-    else()
-      list(APPEND BAZELRC_IMPORTS "${MAYBE_RC}")
-    endif()
-  endif()
 endif()
 
 # This version number should match bazel_compatibility in MODULE.bazel.
@@ -208,32 +182,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 23)
 
-# The supported Python major/minor versions.
-# When changing any of these, see drake/tools/workspace/python/README.md.
-if(APPLE)
-  set(SUPPORTED_PYTHON_VERSION 3.14)
-else()
-  if(UNIX_DISTRIBUTION_CODENAME STREQUAL resolute)
-    set(SUPPORTED_PYTHON_VERSION 3.14)
-  else()  # UNIX_DISTRIBUTION_CODENAME := noble
-    set(SUPPORTED_PYTHON_VERSION 3.12)
-  endif()
-endif()
-
-# Next we'll very carefully choose which Python interpreter to use.
-#
-# - If the user provided the legacy spelling -DPYTHON_EXECUTABLE, shift that
-#   into -DPython_EXECUTABLE instead and continue (with a warning).
-#
-# - If the user provided -DPython_EXECUTABLE, take it at face value (and
-#   therefore error out if they gave us a broken definition).
-#
-# - Otherwise, try to find SUPPORTED_PYTHON_VERSION and use it if found.
-#
-# - Otherwise, try to find any Python 3 interpreter at all.
-#
-# In all cases, we'll warn in case the found Python is not supported.
+# Next we'll find which Python interpreter to use.
 if(PYTHON_EXECUTABLE AND NOT Python_EXECUTABLE)
+  # The user has set the legacy spelling. Warn and automatically fix it.
   set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}" CACHE FILEPATH
     "Path to the python3 executable" FORCE
   )
@@ -243,35 +194,13 @@ if(PYTHON_EXECUTABLE AND NOT Python_EXECUTABLE)
     "compatibility only.")
   unset(PYTHON_EXECUTABLE CACHE)
 endif()
-if(Python_EXECUTABLE)
-  find_package(Python 3 EXACT MODULE REQUIRED
-    COMPONENTS Development Interpreter
-  )
-else()
-  find_package(Python ${SUPPORTED_PYTHON_VERSION} EXACT MODULE
-    COMPONENTS Development Interpreter
-  )
-  if(NOT Python_FOUND)
-    find_package(Python 3 EXACT MODULE REQUIRED
-      COMPONENTS Development Interpreter
-    )
-  endif()
-endif()
+find_package(Python 3.12 MODULE REQUIRED
+  COMPONENTS Development Interpreter
+)
 if(NOT Python_INTERPRETER_ID STREQUAL Python)
   message(WARNING
     "Python interpreter ${Python_INTERPRETER_ID} is NOT supported. Python "
     "code in project drake_install may fail at runtime."
-  )
-endif()
-set(PYTHON_VERSION_MAJOR_MINOR
-  "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}"
-)
-if(NOT PYTHON_VERSION_MAJOR_MINOR VERSION_EQUAL SUPPORTED_PYTHON_VERSION)
-  message(WARNING
-    "The found Python version ${PYTHON_VERSION_MAJOR_MINOR} differs from "
-    "Drake's preferred version ${SUPPORTED_PYTHON_VERSION} on this platform. "
-    "You may experience compatibility problems that are outside the scope of "
-    "Drake's continuous integration test suites."
   )
 endif()
 

--- a/cmake/MODULE.bazel.in
+++ b/cmake/MODULE.bazel.in
@@ -12,7 +12,7 @@ local_path_override(
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 
 python.toolchain(
-    python_version = "@PYTHON_VERSION_MAJOR_MINOR@",
+    python_version = "@Python_VERSION_MAJOR@.@Python_VERSION_MINOR@",
     is_default = True,
 )
 

--- a/setup/mac/source_distribution/install_prereqs_user_environment.sh
+++ b/setup/mac/source_distribution/install_prereqs_user_environment.sh
@@ -18,7 +18,6 @@ bazelrc="${workspace_dir}/gen/environment.bazelrc"
 
 mkdir -p "$(dirname "${bazelrc}")"
 cat > "${bazelrc}" <<EOF
-import %workspace%/tools/macos.bazelrc
 EOF
 
 # Prefetch the bazelisk download of bazel.

--- a/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
@@ -32,12 +32,18 @@ fi
 workspace_dir="$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)"
 bazelrc="${workspace_dir}/gen/environment.bazelrc"
 arch=$(/usr/bin/arch)
+clang_major=$(sed -n 's/^clang-\([0-9]\+\)$/\1/p' \
+  "${workspace_dir}/setup/ubuntu/source_distribution/packages-${VERSION_CODENAME}-clang.txt")
 
 mkdir -p "$(dirname "${bazelrc}")"
 cat > "${bazelrc}" <<EOF
-import %workspace%/tools/ubuntu.bazelrc
 import %workspace%/tools/ubuntu-arch-${arch}.bazelrc
-import %workspace%/tools/ubuntu-${VERSION_CODENAME}.bazelrc
+common:clang --repo_env=CC=clang-${clang_major}
+common:clang --repo_env=CXX=clang++-${clang_major}
+build:clang --action_env=CC=clang-${clang_major}
+build:clang --action_env=CXX=clang++-${clang_major}
+build:clang --host_action_env=CC=clang-${clang_major}
+build:clang --host_action_env=CXX=clang++-${clang_major}
 EOF
 
 # Prefetch the bazelisk download of bazel.

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -41,6 +41,18 @@ build --java_runtime_version=remotejdk_11
 build --cxxopt=-std=c++23
 build --host_cxxopt=-std=c++23
 
+# Configure ${PATH} for actions.
+# N.B. Ensure this is consistent with `execute.bzl`.
+build:linux --action_env=PATH=/usr/bin:/bin
+build:macos --action_env=PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
+# Disable python imports from ~/.local (pip -U) during build and test.
+# https://github.com/bazelbuild/bazel/issues/4939
+# https://github.com/RobotLocomotion/drake/issues/8475
+# TODO(jwnimmer-tri) Try to enable this on macOS as well.
+build:linux --action_env=PYTHONNOUSERSITE=1
+build:linux --test_env=PYTHONNOUSERSITE=1
+
 # Suppress warnings from module externals.
 build --per_file_copt=external/libx11./.*@-w
 build --per_file_copt=external/libxcb./.*@-w
@@ -90,6 +102,28 @@ build:openmp --linkopt=-fopenmp
 build:debug --compilation_mode=dbg
 # Provide a performance cushion for debug builds, 2x the default timeouts.
 build:debug --test_timeout=120,600,1800,7200
+# Enable split debug symbols (Linux only).
+build:linux --fission=dbg
+build:linux --features=per_object_debug_info
+
+# Options for explicitly using GCC.
+# TODO(#24359) Delete this entirely.
+common:gcc --repo_env=CC=gcc
+common:gcc --repo_env=CXX=g++
+build:gcc --action_env=CC=gcc
+build:gcc --action_env=CXX=g++
+build:gcc --host_action_env=CC=gcc
+build:gcc --host_action_env=CXX=g++
+
+# Options for explicitly using Clang.
+# Note that the drake/gen/environment.bazelrc file might override this.
+# TODO(#24359) Delete this entirely.
+common:clang --repo_env=CC=clang
+common:clang --repo_env=CXX=clang++
+build:clang --action_env=CC=clang
+build:clang --action_env=CXX=clang++
+build:clang --host_action_env=CC=clang
+build:clang --host_action_env=CXX=clang++
 
 ### A configuration that enables all optional dependencies. ###
 build:everything --test_tag_filters=-no_everything

--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -1,13 +1,2 @@
-# Common options for macOS.
-
-# N.B. Ensure this is consistent with `execute.bzl`.
-build --action_env=PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin
-
-# Options for explicitly using Clang.
-# TODO(#24359) Delete this entirely.
-common:clang --repo_env=CC=clang
-common:clang --repo_env=CXX=clang++
-build:clang --action_env=CC=clang
-build:clang --action_env=CXX=clang++
-build:clang --host_action_env=CC=clang
-build:clang --host_action_env=CXX=clang++
+# TODO(jwnimmer-tri) Delete this unused file from git. It only remains here as a
+# tombstone so that developers don't need to immediately re-run install_prereqs.

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -1,5 +1,5 @@
-# Options for explicitly using Clang.
-# Keep this in sync with doc/_pages/from_source.md.
+# TODO(jwnimmer-tri) Delete this unused file from git. It only remains here as a
+# tombstone so that developers don't need to immediately re-run install_prereqs.
 common:clang --repo_env=CC=clang-20
 common:clang --repo_env=CXX=clang++-20
 build:clang --action_env=CC=clang-20

--- a/tools/ubuntu-resolute.bazelrc
+++ b/tools/ubuntu-resolute.bazelrc
@@ -1,5 +1,5 @@
-# Options for explicitly using Clang.
-# Keep this in sync with doc/_pages/from_source.md.
+# TODO(jwnimmer-tri) Delete this unused file from git. It only remains here as a
+# tombstone so that developers don't need to immediately re-run install_prereqs.
 common:clang --repo_env=CC=clang-21
 common:clang --repo_env=CXX=clang++-21
 build:clang --action_env=CC=clang-21

--- a/tools/ubuntu.bazelrc
+++ b/tools/ubuntu.bazelrc
@@ -1,22 +1,2 @@
-# Common options for Ubuntu, no matter the version.
-
-build --fission=dbg
-build --features=per_object_debug_info
-
-# Configure ${PATH} for actions.
-# N.B. Ensure this is consistent with `execute.bzl`.
-build --action_env=PATH=/usr/bin:/bin
-
-# Disable python imports from ~/.local (pip -U) during build and test.
-# https://github.com/bazelbuild/bazel/issues/4939
-# https://github.com/RobotLocomotion/drake/issues/8475
-build --action_env=PYTHONNOUSERSITE=1
-build --test_env=PYTHONNOUSERSITE=1
-
-# Options for explicitly using GCC.
-common:gcc --repo_env=CC=gcc
-common:gcc --repo_env=CXX=g++
-build:gcc --action_env=CC=gcc
-build:gcc --action_env=CXX=g++
-build:gcc --host_action_env=CC=gcc
-build:gcc --host_action_env=CXX=g++
+# TODO(jwnimmer-tri) Delete this unused file from git. It only remains here as a
+# tombstone so that developers don't need to immediately re-run install_prereqs.

--- a/tools/workspace/python/README.md
+++ b/tools/workspace/python/README.md
@@ -1,7 +1,7 @@
 When changing the set of supported Python versions (or the default Python
 version on macOS), the following files need attention:
 
-- `drake/CMakeLists.txt` near `SUPPORTED_PYTHON_VERSION`,
+- `drake/CMakeLists.txt` near `find_package(Python <min_version> ...)`,
 - `drake/MODULE.bazel` near `PYTHON_VERSIONS`,
 - `drake/doc/_pages/installation.md` in the support matrix column for `Python`,
 - `drake/doc/_pages/from_source.md` in the support matrix column for `Python`,


### PR DESCRIPTION
This reduces our dependence on special rcfile bash setup logic, especially for CMake builds from source.

Switch Ubuntu `--config=clang` to use the `packages.txt` files as the source of truth for the preferred version number for developers, instead of a separate per-codename rcfile.

(I also have a follow-up PR in the wings to remove the arch-specific rcfiles, waiting on #24384.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24391)
<!-- Reviewable:end -->
