### PR TITLE
[tools] Remove Ubuntu arch-specific rcfiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,15 +56,6 @@ if(APPLE)
       "${MINIMUM_MACOS_CODENAME}) or newer."
     )
   endif()
-else()
-  execute_process(
-    COMMAND "/usr/bin/arch"
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE UBUNTU_ARCH)
-  if(UBUNTU_ARCH STREQUAL "")
-    message(FATAL_ERROR "Could NOT query linux arch")
-  endif()
-  list(APPEND BAZELRC_IMPORTS "tools/ubuntu-arch-${UBUNTU_ARCH}.bazelrc")
 endif()
 
 # This version number should match bazel_compatibility in MODULE.bazel.

--- a/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs_user_environment.sh
@@ -31,13 +31,11 @@ fi
 
 workspace_dir="$(cd "$(dirname "${BASH_SOURCE}")/../../.." && pwd)"
 bazelrc="${workspace_dir}/gen/environment.bazelrc"
-arch=$(/usr/bin/arch)
 clang_major=$(sed -n 's/^clang-\([0-9]\+\)$/\1/p' \
   "${workspace_dir}/setup/ubuntu/source_distribution/packages-${VERSION_CODENAME}-clang.txt")
 
 mkdir -p "$(dirname "${bazelrc}")"
 cat > "${bazelrc}" <<EOF
-import %workspace%/tools/ubuntu-arch-${arch}.bazelrc
 common:clang --repo_env=CC=clang-${clang_major}
 common:clang --repo_env=CXX=clang++-${clang_major}
 build:clang --action_env=CC=clang-${clang_major}

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -121,6 +121,7 @@ build:clang --host_action_env=CXX=clang++
 
 ### A configuration that enables all optional dependencies. ###
 build:everything --@drake//tools/flags:with_gurobi=True
+build:everything --@drake//tools/workspace/gurobi:force_disable_when_not_supported=True
 build:everything --@drake//tools/flags:with_mosek=True
 build:everything --@drake//tools/flags:with_snopt=True
 # We'll also use it to test legacy AutoDiff until 2026-07-01 when this flag

--- a/tools/macos.bazelrc
+++ b/tools/macos.bazelrc
@@ -1,2 +1,0 @@
-# TODO(jwnimmer-tri) Delete this unused file from git. It only remains here as a
-# tombstone so that developers don't need to immediately re-run install_prereqs.

--- a/tools/ubuntu-arch-aarch64.bazelrc
+++ b/tools/ubuntu-arch-aarch64.bazelrc
@@ -1,4 +1,0 @@
-# Options for Ubuntu when running on arm64 as reported by `arch`.
-
-# We don't support Gurobi on arm64.
-build:everything --@drake//tools/flags:with_gurobi=False

--- a/tools/ubuntu-arch-x86_64.bazelrc
+++ b/tools/ubuntu-arch-x86_64.bazelrc
@@ -1,1 +1,0 @@
-# Options for Ubuntu when running on x86_64 as reported by `arch`.

--- a/tools/ubuntu-noble.bazelrc
+++ b/tools/ubuntu-noble.bazelrc
@@ -1,8 +1,0 @@
-# TODO(jwnimmer-tri) Delete this unused file from git. It only remains here as a
-# tombstone so that developers don't need to immediately re-run install_prereqs.
-common:clang --repo_env=CC=clang-20
-common:clang --repo_env=CXX=clang++-20
-build:clang --action_env=CC=clang-20
-build:clang --action_env=CXX=clang++-20
-build:clang --host_action_env=CC=clang-20
-build:clang --host_action_env=CXX=clang++-20

--- a/tools/ubuntu-resolute.bazelrc
+++ b/tools/ubuntu-resolute.bazelrc
@@ -1,8 +1,0 @@
-# TODO(jwnimmer-tri) Delete this unused file from git. It only remains here as a
-# tombstone so that developers don't need to immediately re-run install_prereqs.
-common:clang --repo_env=CC=clang-21
-common:clang --repo_env=CXX=clang++-21
-build:clang --action_env=CC=clang-21
-build:clang --action_env=CXX=clang++-21
-build:clang --host_action_env=CC=clang-21
-build:clang --host_action_env=CXX=clang++-21

--- a/tools/ubuntu.bazelrc
+++ b/tools/ubuntu.bazelrc
@@ -1,2 +1,0 @@
-# TODO(jwnimmer-tri) Delete this unused file from git. It only remains here as a
-# tombstone so that developers don't need to immediately re-run install_prereqs.

--- a/tools/workspace/gurobi/BUILD.bazel
+++ b/tools/workspace/gurobi/BUILD.bazel
@@ -1,11 +1,52 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+# Internal use only. When set to True, Gurobi will be diabled even when
+# --@drake//tools/flags:with_gurobi=True is set.
+bool_flag(
+    name = "force_disable_when_not_supported",
+    build_setting_default = False,
+)
+
+# Internal use only.
+config_setting(
+    name = "force_disable_when_not_supported_false",
+    flag_values = {":force_disable_when_not_supported": "False"},
+)
+
+# Internal use only. This a funny way of spelling
+#
+#   force_disable := (force_disable_when_not_supported
+#                     AND (NOT (osx OR x86_64)))
+#
+# because we actually need its negation ("NOT force_disable").
 selects.config_setting_group(
-    name = "enabled",
+    name = "dont_force_disable",
+    match_any = [
+        ":force_disable_when_not_supported_false",
+        # Drake CI installs Gurobi on all of our macOS images, but for Linux
+        # images only install on x86_64 (not aarch64). Thus, if we are either
+        # macOS or x86_64, we know we have access to Gurobi.
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+# Internal use only.
+selects.config_setting_group(
+    name = "enabled_via_flag_or_define",
     match_any = [
         ":enabled_via_flag",
         ":enabled_via_define",
+    ],
+)
+
+selects.config_setting_group(
+    name = "enabled",
+    match_all = [
+        ":enabled_via_flag_or_define",
+        ":dont_force_disable",
     ],
     visibility = [
         "//solvers:__pkg__",


### PR DESCRIPTION
We can accomplish the same thing with a config_setting, which has the advantage of not needing special rcfile bash setup logic.

This is the last in-flight change to install_prereqs_user_environment, so we'll take this opportunity to delete stale TODO'd files and force developers to re-run install_prereqs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24392)
<!-- Reviewable:end -->
