### PR TITLE
Clean up PenetrationAsPointPair tests

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -1349,9 +1349,11 @@ drake_cc_library(
     hdrs = ["test/fcl_utilities.h"],
     visibility = ["//visibility:private"],
     deps = [
+        ":polygon_surface_mesh",
         ":proximity_utilities",
         "//geometry:geometry_ids",
         "//geometry:shape_specification",
+        "//math:geometric_transform",
         "@fcl_internal//:fcl",
     ],
 )
@@ -1734,8 +1736,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "penetration_as_point_pair_callback_test",
+    data = [
+        "//geometry:test_obj_files",
+    ],
     deps = [
+        ":fcl_utilities",
         ":penetration_as_point_pair_callback",
+        "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//math:autodiff",

--- a/geometry/proximity/test/fcl_utilities.cc
+++ b/geometry/proximity/test/fcl_utilities.cc
@@ -1,20 +1,37 @@
 #include "drake/geometry/proximity/test/fcl_utilities.h"
 
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/proximity/polygon_surface_mesh.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-std::unique_ptr<fcl::CollisionObjectd> MakeFclObject(const Shape& shape,
-                                                     GeometryId id,
-                                                     bool is_dynamic) {
+namespace {
+
+std::shared_ptr<fcl::Convexd> MakeConvex(const Convex& convex) {
+  const PolygonSurfaceMesh<double>& hull = convex.GetConvexHull();
+  auto vertices = std::make_shared<std::vector<Vector3d>>();
+  vertices->reserve(hull.num_vertices());
+  for (int i = 0; i < hull.num_vertices(); ++i) {
+    vertices->push_back(hull.vertex(i));
+  }
+  auto faces = std::make_shared<std::vector<int>>(hull.face_data());
+  return std::make_shared<fcl::Convexd>(std::move(vertices),
+                                        hull.num_elements(), std::move(faces));
+}
+
+}  // namespace
+
+std::unique_ptr<fcl::CollisionObjectd> MakeFclObject(
+    const Shape& shape, GeometryId id, bool is_dynamic,
+    const math::RigidTransformd& X_WG) {
   struct FclObjectMaker final : public ShapeReifier {
     using ShapeReifier::ImplementGeometry;
-    void ImplementGeometry(const Sphere& sphere, void* data) override {
-      *static_cast<std::shared_ptr<fcl::CollisionGeometryd>*>(data) =
-          std::make_shared<fcl::Sphered>(sphere.radius());
-    }
     void ImplementGeometry(const Box& box, void* data) override {
       *static_cast<std::shared_ptr<fcl::CollisionGeometryd>*>(data) =
           std::make_shared<fcl::Boxd>(box.size());
@@ -22,6 +39,10 @@ std::unique_ptr<fcl::CollisionObjectd> MakeFclObject(const Shape& shape,
     void ImplementGeometry(const Capsule& capsule, void* data) override {
       *static_cast<std::shared_ptr<fcl::CollisionGeometryd>*>(data) =
           std::make_shared<fcl::Capsuled>(capsule.radius(), capsule.length());
+    }
+    void ImplementGeometry(const Convex& convex, void* data) override {
+      *static_cast<std::shared_ptr<fcl::CollisionGeometryd>*>(data) =
+          MakeConvex(convex);
     }
     void ImplementGeometry(const Cylinder& cylinder, void* data) override {
       *static_cast<std::shared_ptr<fcl::CollisionGeometryd>*>(data) =
@@ -32,12 +53,17 @@ std::unique_ptr<fcl::CollisionObjectd> MakeFclObject(const Shape& shape,
       *static_cast<std::shared_ptr<fcl::CollisionGeometryd>*>(data) =
           std::make_shared<fcl::Halfspaced>(0, 0, 1, 0);
     }
+    void ImplementGeometry(const Sphere& sphere, void* data) override {
+      *static_cast<std::shared_ptr<fcl::CollisionGeometryd>*>(data) =
+          std::make_shared<fcl::Sphered>(sphere.radius());
+    }
   };
   FclObjectMaker maker;
   std::shared_ptr<fcl::CollisionGeometryd> fcl_geometry;
   shape.Reify(&maker, &fcl_geometry);
   auto object = std::make_unique<fcl::CollisionObjectd>(fcl_geometry);
   EncodedData(id, is_dynamic).write_to(object.get());
+  object->setTransform(X_WG.GetAsIsometry3());
   return object;
 }
 

--- a/geometry/proximity/test/fcl_utilities.h
+++ b/geometry/proximity/test/fcl_utilities.h
@@ -6,6 +6,7 @@
 
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
@@ -13,10 +14,11 @@ namespace internal {
 
 // Creates an fcl::CollisionObjectd for a given Drake Shape, stamping the
 // geometry id into the FCL object's user data (as required by
-// the various Callback types).
-std::unique_ptr<fcl::CollisionObjectd> MakeFclObject(const Shape& shape,
-                                                     GeometryId id,
-                                                     bool is_dynamic);
+// the various Callback types) and setting the fcl object's pose to the given
+// pose.
+std::unique_ptr<fcl::CollisionObjectd> MakeFclObject(
+    const Shape& shape, GeometryId id, bool is_dynamic,
+    const math::RigidTransformd& X_WG = math::RigidTransformd::Identity());
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
@@ -11,9 +11,11 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"
+#include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
+#include "drake/geometry/proximity/test/fcl_utilities.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/rigid_transform.h"
@@ -25,6 +27,7 @@ namespace internal {
 namespace penetration_as_point_pair {
 namespace {
 
+using Eigen::AngleAxisd;
 using Eigen::Vector3d;
 using fcl::CollisionObjectd;
 using fcl::Sphered;
@@ -33,6 +36,7 @@ using math::RigidTransformd;
 using math::RotationMatrix;
 using math::RotationMatrixd;
 using std::make_shared;
+using std::unordered_map;
 using std::vector;
 using symbolic::Expression;
 
@@ -530,6 +534,453 @@ TEST_F(PenetrationAsPointPairCallbackTest, UnsupportedHalfSpaceHalfSpace) {
                               hs2_id);
   UnsupportedGeometry<AutoDiffXd>(this->halfspace_, halfspace2,
                                   this->id_halfspace_, hs2_id);
+}
+
+// This is a one-off test. Exposed in issue #10577. A point penetration pair
+// was returned for a zero-depth contact. This reproduces the geometry that
+// manifested the error. The reproduction isn't *exact*; it's been reduced to
+// a simpler configuration. Specifically, the important characteristics are:
+//   - both box and cylinder are ill aspected (one dimension is several orders
+//     of magnitude smaller than the other two),
+//   - the cylinder is placed away from the center of the box face,
+//   - the box is rotated 90 degrees around it's z-axis -- note swapping box
+//     dimensions with an identity rotation did *not* produce equivalent
+//     results, and
+//   - FCL uses GJK/EPA to solve box-cylinder collision (this is beyond control
+//     of this test).
+//
+// Libccd upgraded how it handles degenerate simplices. The upshot of that is
+// FCL would still return the same penetration depth, but instead of returning
+// a gibberish normal, it returns a zero vector. We want to make sure we don't
+// report zero-penetration as penetration, even in these numerically,
+// ill-conditioned scenarios. So, we address it up to a tolerance.
+TEST_F(PenetrationAsPointPairCallbackTest, Issue10577Regression_Osculation) {
+  GeometryId id_A = GeometryId::get_new_id();
+  GeometryId id_B = GeometryId::get_new_id();
+
+  // Original translations were p_WA = (-0.145, -0.63, 0.2425) and
+  // p_WB = (0, -0.6, 0.251), respectively.
+  RigidTransformd X_WA(Eigen::AngleAxisd{M_PI_2, Vector3d::UnitZ()},
+                       Vector3d{-0.25, 0, 0});
+  RigidTransformd X_WB(Vector3d{0, 0, 0.0085});
+  std::unique_ptr<CollisionObjectd> box =
+      MakeFclObject(Box(0.49, 0.63, 0.015), id_A, /* is_dynamic= */ true, X_WA);
+  std::unique_ptr<CollisionObjectd> cylinder =
+      MakeFclObject(Cylinder(0.08, 0.002), id_B, /* is_dynamic= */ true, X_WB);
+  const unordered_map<GeometryId, RigidTransformd> X_WG{{id_A, X_WA},
+                                                        {id_B, X_WB}};
+
+  vector<PenetrationAsPointPair<double>> pairs;
+  CallbackData<double> callback_data(&collision_filter_, &X_WG, &pairs);
+  Callback<double>(box.get(), cylinder.get(), &callback_data);
+  EXPECT_EQ(pairs.size(), 0);
+}
+
+// Robust Box-Primitive tests. Tests collision of the box with other primitives
+// in a uniform framework. These tests parallel tests located in fcl.
+//
+// All of the tests below here are using the callback to exercise the black box.
+// They exist because of FCL; FCL's unit tests were sporadic at best and these
+// tests revealed errors/properties of FCL that weren't otherwise apparent.
+// Ultimately, these tests don't belong here. But they can be re-used when we
+// replace FCL with Drake's own implementations.
+//
+// This performs a very specific test. It collides a rotated box with a
+// surface that is tangent to the z = 0 plane. The box is a cube with unit size.
+// The goal is to transform the box such that:
+//   1. the corner of the box C, located at p_BoC_B = (-0.5, -0.5, -0.5),
+//      transformed by the box's pose X_WB, ends up at the position
+//      p_WC = (0, 0, -kDepth), i.e., p_WC = X_WB * p_BoC_B, and
+//   2. all other corners are transformed to lie above the z = 0 plane.
+//
+// In this configuration, the corner C becomes the unique point of deepest
+// penetration in the interior of the half space.
+//
+// It is approximately *this* picture
+//        ┆  ╱╲
+//        ┆ ╱  ╲
+//        ┆╱    ╲
+//       ╱┆╲    ╱
+//      ╱ ┆ ╲  ╱
+//     ╱  ┆  ╲╱
+//     ╲  ┆  ╱
+//      ╲ ┆ ╱
+//  _____╲┆╱_____    ╱____ With small penetration depth of d
+//  ░░░░░░┆░░░░░░    ╲
+//  ░░░░░░┆░░░░░░
+//  ░░░Tangent░░░
+//  ░░░░shape░░░░
+//  ░░interior░░░
+//  ░░░░░░┆░░░░░░
+//
+// We can use this against various *convex* shapes to determine uniformity of
+// behavior. As long as the convex tangent shape *touches* the z = 0 plane at
+// (0, 0, 0), and the shape is *large* compared to the penetration depth, then
+// we should get a fixed, known contact. Specifically, if we assume the tangent
+// shape is A and the box is B, then
+//   - the normal is (0, 0, -1) from box into the plane,
+//   - the penetration depth is the specified depth used to configure the
+//     position of the box, and
+//   - the contact position is (0, 0, -depth / 2).
+//
+// Every convex shape type can be used as the tangent shape as follows:
+//   - plane: simply define the z = 0 plane.
+//   - box: define a box whose top face lies on the z = 0 and encloses the
+//     origin.
+//   - sphere: place the sphere at (0, 0 -radius).
+//   - cylinder: There are two valid configurations (radius & length >> depth).
+//     - Place a "standing" cylinder at (0, 0, -length/2).
+//     - Rotate the cylinder so that its length axis is parallel with the z = 0
+//       plane and then displace downward (0, 0, -radius). Described as "prone".
+//   - capsule: There are two valid configurations (radius & length >> depth).
+//     - Place a "standing" capsule at (0, 0, -length/2 - radius).
+//     - Rotate the capsule so that its length axis is parallel with the z = 0
+//       plane and then displace downward (0, 0, -radius). Described as "prone".
+//
+// Note: there are an infinite number of orientations that satisfy the
+// configuration described above. They should *all* provide the same collision
+// results. We provide two representative orientations to illustrate issues
+// with the underlying functionality -- the *quality* of the answer depends on
+// the orientation of the box. When the problem listed in Drake issue 7656 is
+// resolved, all tests should resolve to the same answer with the same tight
+// precision.
+// TODO(SeanCurtis-TRI): Add other shapes as they become available.
+class BoxPenetrationTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    // Confirm all of the constants are consistent (in case someone tweaks them
+    // later). In this case, tangent geometry must be much larger than the
+    // depth.
+    EXPECT_GT(kRadius, kDepth * 100);
+    EXPECT_GT(kLength, kDepth * 100);
+
+    // Confirm that the poses of the box satisfy the conditions described above.
+    for (auto func : {X_WB_1, X_WB_2}) {
+      const math::RigidTransformd X_WB = func(p_BoC_B_, p_WC_);
+      // Confirm that p_BoC_B transforms to p_WC.
+      const Vector3d p_WC_test = X_WB * p_BoC_B_;
+      EXPECT_TRUE(CompareMatrices(p_WC_test, p_WC_, 1e-15,
+                                  MatrixCompareType::absolute));
+
+      // Confirm that *all* other points map to values where z > 0.
+      for (double x : {-0.5, 0.5}) {
+        for (double y : {-0.5, 0.5}) {
+          for (double z : {-0.5, 0.5}) {
+            const Vector3d p_BoC_B{x, y, z};
+            if (p_BoC_B.isApprox(p_BoC_B_)) continue;
+            const Vector3d p_WC = X_WB * p_BoC_B;
+            EXPECT_GT(p_WC(2), 0);
+          }
+        }
+      }
+    }
+
+    // Configure the expected penetration characterization.
+    expected_penetration_.p_WCa << 0, 0, 0;       // Tangent plane
+    expected_penetration_.p_WCb = p_WC_;          // Cube
+    expected_penetration_.nhat_BA_W << 0, 0, -1;  // From cube into plane
+    expected_penetration_.depth = kDepth;
+    // NOTE: The ids are set by the individual calling tests.
+  }
+
+  enum TangentShape {
+    TangentPlane,
+    TangentSphere,
+    TangentBox,
+    TangentStandingCylinder,
+    TangentProneCylinder,
+    TangentConvex,
+    TangentStandingCapsule,
+    TangentProneCapsule
+  };
+
+  // The test that produces *bad* results based on the box orientation. Not
+  // called "bad" because when FCL is fixed, they'll both be good.
+  void TestCollision1(TangentShape shape_type, double tolerance) {
+    TestCollision(shape_type, tolerance, X_WB_1(p_BoC_B_, p_WC_));
+  }
+
+  // The test that produces *good* results based on the box orientation. Not
+  // called "good" because when FCL is fixed, they'll both be good.
+  void TestCollision2(TangentShape shape_type, double tolerance) {
+    TestCollision(shape_type, tolerance, X_WB_2(p_BoC_B_, p_WC_));
+  }
+
+ private:
+  // Perform the collision test against the indicated shape and confirm the
+  // results to the given tolerance.
+  void TestCollision(TangentShape shape_type, double tolerance,
+                     const math::RigidTransformd& X_WB) {
+    const GeometryId tangent_id = GeometryId::get_new_id();
+    const RigidTransformd X_WA = shape_pose(shape_type);
+    std::unique_ptr<CollisionObjectd> tangent_object = MakeFclObject(
+        shape(shape_type), tangent_id, /* is_dynamic= */ true, X_WA);
+
+    const GeometryId box_id = GeometryId::get_new_id();
+    std::unique_ptr<CollisionObjectd> box_object =
+        MakeFclObject(box_, box_id, /* is_dynamic= */ true, X_WB);
+
+    // Note: we need a CollisionFilter for the callback data, but we don't need
+    // to populate it, because we're not actually filtering anything.
+    CollisionFilter collision_filter;
+    const unordered_map<GeometryId, RigidTransformd> X_WGs{{tangent_id, X_WA},
+                                                           {box_id, X_WB}};
+    vector<PenetrationAsPointPair<double>> results;
+    CallbackData<double> callback_data(&collision_filter, &X_WGs, &results);
+    Callback<double>(tangent_object.get(), box_object.get(), &callback_data);
+
+    ASSERT_EQ(results.size(), 1u)
+        << "Against tangent " << shape_name(shape_type);
+
+    const PenetrationAsPointPair<double>& contact = results[0];
+    Vector3d normal;
+    Vector3d p_Ac;
+    Vector3d p_Bc;
+    if (contact.id_A == tangent_id && contact.id_B == box_id) {
+      // The documented encoding of expected_penetration_.
+      normal = expected_penetration_.nhat_BA_W;
+      p_Ac = expected_penetration_.p_WCa;
+      p_Bc = expected_penetration_.p_WCb;
+    } else if (contact.id_A == box_id && contact.id_B == tangent_id) {
+      // The reversed encoding of expected_penetration_.
+      normal = -expected_penetration_.nhat_BA_W;
+      p_Ac = expected_penetration_.p_WCb;
+      p_Bc = expected_penetration_.p_WCa;
+    } else {
+      GTEST_FAIL() << fmt::format(
+          "Wrong geometry ids reported in contact for tangent {}. Expected {} "
+          "and {}. Got {} and {}",
+          shape_name(shape_type), tangent_id, box_id, contact.id_A,
+          contact.id_B);
+    }
+    EXPECT_TRUE(CompareMatrices(contact.nhat_BA_W, normal, tolerance))
+        << "Against tangent " << shape_name(shape_type);
+    EXPECT_TRUE(CompareMatrices(contact.p_WCa, p_Ac, tolerance))
+        << "Against tangent " << shape_name(shape_type);
+    EXPECT_TRUE(CompareMatrices(contact.p_WCb, p_Bc, tolerance))
+        << "Against tangent " << shape_name(shape_type);
+    EXPECT_NEAR(contact.depth, expected_penetration_.depth, tolerance)
+        << "Against tangent " << shape_name(shape_type);
+  }
+
+  // The expected collision result -- assumes that A is the tangent object and
+  // B is the colliding box.
+  PenetrationAsPointPair<double> expected_penetration_;
+
+  // Produces the X_WB that produces high-quality answers.
+  static math::RigidTransformd X_WB_2(const Vector3d& p_BoC_B,
+                                      const Vector3d& p_WC) {
+    // Compute the pose of the colliding box.
+    // a. Orient the box so that the corner p_BoC_B = (-0.5, -0.5, -0.5) lies in
+    //    the most -z extent. With only rotation, p_BoC_B != p_WC.
+    const math::RotationMatrixd R_WB(
+        AngleAxisd(std::atan(M_SQRT2), Vector3d(M_SQRT1_2, -M_SQRT1_2, 0)));
+
+    // b. Translate it so that the rotated corner p_BoC_W lies at
+    //    (0, 0, -d).
+    const Vector3d p_BoC_W = R_WB * p_BoC_B;
+    const Vector3d p_WB = p_WC - p_BoC_W;
+    return math::RigidTransformd(R_WB, p_WB);
+  }
+
+  // Produces the X_WB that produces low-quality answers.
+  static math::RigidTransformd X_WB_1(const Vector3d& p_BoC_B,
+                                      const Vector3d& p_WC) {
+    // Compute the pose of the colliding box.
+    // a. Orient the box so that the corner p_BoC_B = (-0.5, -0.5, -0.5) lies in
+    //    the most -z extent. With only rotation, p_BoC_B != p_WC.
+    const math::RotationMatrixd R_WB(AngleAxisd(-M_PI_4, Vector3d::UnitY()) *
+                                     AngleAxisd(M_PI_4, Vector3d::UnitX()));
+
+    // b. Translate it so that the rotated corner p_BoC_W lies at
+    //    (0, 0, -d).
+    const Vector3d p_BoC_W = R_WB * p_BoC_B;
+    const Vector3d p_WB = p_WC - p_BoC_W;
+    return math::RigidTransformd(R_WB, p_WB);
+  }
+
+  // Map enumeration to string for error messages.
+  static const char* shape_name(TangentShape shape) {
+    switch (shape) {
+      case TangentPlane:
+        return "plane";
+      case TangentSphere:
+        return "sphere";
+      case TangentBox:
+        return "box";
+      case TangentStandingCylinder:
+        return "standing cylinder";
+      case TangentProneCylinder:
+        return "prone cylinder";
+      case TangentConvex:
+        return "convex";
+      case TangentStandingCapsule:
+        return "standing capsule";
+      case TangentProneCapsule:
+        return "prone capsule";
+    }
+    return "undefined shape";
+  }
+
+  // Map enumeration to the configured shapes.
+  const Shape& shape(TangentShape shape) {
+    switch (shape) {
+      case TangentPlane:
+        return tangent_plane_;
+      case TangentSphere:
+        return tangent_sphere_;
+      case TangentBox:
+        return tangent_box_;
+      case TangentStandingCylinder:
+      case TangentProneCylinder:
+        return tangent_cylinder_;
+      case TangentConvex:
+        return tangent_convex_;
+      case TangentStandingCapsule:
+      case TangentProneCapsule:
+        return tangent_capsule_;
+    }
+    // GCC considers this function ill-formed - no apparent return value. This
+    // exception alleviates its concern.
+    throw std::logic_error(
+        "Trying to acquire shape for unknown shape enumerated value: " +
+        std::to_string(shape));
+  }
+
+  // Map enumeration to tangent pose.
+  RigidTransformd shape_pose(TangentShape shape) {
+    RigidTransformd pose = RigidTransformd::Identity();
+    switch (shape) {
+      case TangentPlane:
+        break;  // leave it at the identity
+      case TangentSphere:
+        pose.set_translation({0, 0, -kRadius});
+        break;
+      case TangentBox:
+      // The tangent convex is a cube of the same size as the tangent box.
+      // That is why we give them the same pose.
+      case TangentConvex:
+      case TangentStandingCylinder:
+        pose.set_translation({0, 0, -kLength / 2});
+        break;
+      case TangentStandingCapsule:
+        pose.set_translation({0, 0, -kLength / 2 - kRadius});
+        break;
+      case TangentProneCylinder:
+      case TangentProneCapsule:
+        pose = RigidTransformd(AngleAxisd{M_PI_2, Vector3d::UnitX()},
+                               Vector3d{0, 0, -kRadius});
+        break;
+    }
+    return pose;
+  }
+
+  // Test constants. Geometric measures must be much larger than depth. The test
+  // enforces a ratio of at least 100. Using these in a GTEST precludes the
+  // possibility of being constexpr initialized; GTEST takes references.
+  static const double kDepth;
+  static const double kRadius;
+  static const double kLength;
+
+  // The various geometries used in the collision test.
+  const Box box_{1, 1, 1};
+  const Sphere tangent_sphere_{kRadius};
+  const Box tangent_box_{kLength, kLength, kLength};
+  const HalfSpace tangent_plane_;  // Default construct the z = 0 plane.
+  const Cylinder tangent_cylinder_{kRadius, kLength};
+  // We scale the convex shape by 5.0 to match the tangent_box_ of size 10.0.
+  // The file "quad_cube.obj" contains the cube of size 2.0.
+  const Convex tangent_convex_{
+      drake::FindResourceOrThrow("drake/geometry/test/quad_cube.obj"), 5.0};
+  const Capsule tangent_capsule_{kRadius, kLength};
+
+  const Vector3d p_WC_{0, 0, -kDepth};
+  const Vector3d p_BoC_B_{-0.5, -0.5, -0.5};
+};
+
+// See documentation. All geometry constants must be >= kDepth * 100.
+const double BoxPenetrationTest::kDepth = 1e-3;
+const double BoxPenetrationTest::kRadius = 1;
+const double BoxPenetrationTest::kLength = 10;
+
+TEST_F(BoxPenetrationTest, TangentPlane1) {
+  TestCollision1(TangentPlane, 1e-12);
+}
+
+TEST_F(BoxPenetrationTest, TangentPlane2) {
+  TestCollision2(TangentPlane, 1e-12);
+}
+
+TEST_F(BoxPenetrationTest, TangentBox1) {
+  TestCollision1(TangentBox, 1e-12);
+}
+
+TEST_F(BoxPenetrationTest, TangentBox2) {
+  TestCollision2(TangentBox, 1e-12);
+}
+
+TEST_F(BoxPenetrationTest, TangentSphere1) {
+  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
+  // collision result from being more precise. Largely due to normal
+  // calculation. See related Drake issue 7656.
+  TestCollision1(TangentSphere, 1e-1);
+}
+
+TEST_F(BoxPenetrationTest, TangentSphere2) {
+  TestCollision2(TangentSphere, 1e-12);
+}
+
+TEST_F(BoxPenetrationTest, TangentStandingCylinder1) {
+  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
+  // collision result from being more precise. See related Drake issue 7656.
+  TestCollision1(TangentStandingCylinder, 1e-3);
+}
+
+TEST_F(BoxPenetrationTest, TangentStandingCylinder2) {
+  TestCollision2(TangentStandingCylinder, 1e-12);
+}
+
+TEST_F(BoxPenetrationTest, TangentProneCylinder1) {
+  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
+  // collision result from being more precise. Largely due to normal
+  // calculation. See related Drake issue 7656.
+  TestCollision1(TangentProneCylinder, 1e-1);
+}
+
+TEST_F(BoxPenetrationTest, TangentProneCylinder2) {
+  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
+  // collision result from being more precise. In this case, the largest error
+  // is in the position of the contact points. See related Drake issue 7656.
+  TestCollision2(TangentProneCylinder, 1e-4);
+}
+
+TEST_F(BoxPenetrationTest, TangentConvex1) {
+  // TODO(DamrongGuoy): We should check why we cannot use a smaller tolerance.
+  TestCollision1(TangentConvex, 1e-3);
+}
+
+TEST_F(BoxPenetrationTest, TangentConvex2) {
+  // TODO(DamrongGuoy): We should check why we cannot use a smaller tolerance.
+  TestCollision2(TangentConvex, 1e-3);
+}
+
+TEST_F(BoxPenetrationTest, TangentStandingCapsule1) {
+  // TODO(tehbelinda): We should check why we cannot use a smaller tolerance.
+  TestCollision1(TangentStandingCapsule, 1e-1);
+}
+
+TEST_F(BoxPenetrationTest, TangentStandingCapsule2) {
+  TestCollision2(TangentStandingCapsule, 1e-12);
+}
+
+TEST_F(BoxPenetrationTest, TangentProneCapsule1) {
+  // TODO(tehbelinda): We should check why we cannot use a smaller tolerance.
+  TestCollision1(TangentProneCapsule, 1e-1);
+}
+
+TEST_F(BoxPenetrationTest, TangentProneCapsule2) {
+  // TODO(tehbelinda): We should check why we cannot use a smaller tolerance.
+  TestCollision2(TangentProneCapsule, 1e-4);
 }
 
 }  // namespace

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <limits>
 #include <memory>
 #include <ranges>
@@ -14,7 +15,6 @@
 #include <vector>
 
 #include <fcl/fcl.h>
-#include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
@@ -1734,46 +1734,146 @@ GTEST_TEST(SignedDistanceToPointBroadphaseTest, MultipleThreshold) {
   EXPECT_EQ(2, results.size());
 }
 
-// Penetration tests -- testing data flow; not testing the value of the query.
+// Test harness for testing the ProximityEngine's spatial query functions.
+// The tests will examine ProximityEngine's bookkeeping responsibilities for
+// each of the spatial query APIs -- the mathematics and correctness of the
+// values is deferred to callback implementation tests.
+class ProximityEngineQueryTest : public ::testing::Test {
+ protected:
+  // Adds the given shape as a *dynamic* geometry at the given (optional)
+  // position to the test's engine, registering the pose with the global pose
+  // lookup table.
+  GeometryId AddDynamic(const Shape& shape,
+                        const Vector3d& p_WG = Vector3d::Zero()) {
+    const GeometryId id = GeometryId::get_new_id();
+    const RigidTransformd X_WG(p_WG);
+    X_WGs_.insert({id, X_WG});
+    engine_.AddDynamicGeometry(shape, X_WG, id);
+    return id;
+  }
+  // Adds the given shape as an *anchored* geometry at the given (optional)
+  // position to the test's engine, registering the pose with the global pose
+  // lookup table.
+  GeometryId AddAnchored(const Shape& shape,
+                         const Vector3d& p_WG = Vector3d::Zero()) {
+    const GeometryId id = GeometryId::get_new_id();
+    const RigidTransformd X_WG(p_WG);
+    X_WGs_.insert({id, X_WG});
+    engine_.AddAnchoredGeometry(shape, X_WG, id);
+    return id;
+  }
 
-// A scene with no geometry reports no penetrations.
-GTEST_TEST(ProximityEngineTests, PenetrationOnEmptyScene) {
-  ProximityEngine<double> engine;
+  // Wrapper for declaring a collision filter between all of the listed ids.
+  // If `is_temporary` is `true`, a FilterId will be returned that can
+  // subsequently be removed via the RemoveDeclaration() API.
+  std::optional<FilterId> ExcludeCollisionsWithin(
+      std::initializer_list<GeometryId> ids, bool is_temporary = false) {
+    // Note: we *pass* an empty GeometrySet to ExcludeWithin because,
+    // ultimately the extract_ids lambda function will return the actual ids.
+    // It's just a simplifying trick for the test.
+    if (is_temporary) {
+      return engine_.collision_filter().ApplyTransient(
+          CollisionFilterDeclaration().ExcludeWithin(GeometrySet()),
+          [&ids](const GeometrySet&, CollisionFilterScope) {
+            return std::unordered_set<GeometryId>{ids};
+          });
+    }
+    engine_.collision_filter().Apply(
+        CollisionFilterDeclaration().ExcludeWithin(GeometrySet()),
+        [&ids](const GeometrySet&, CollisionFilterScope) {
+          return std::unordered_set<GeometryId>{ids};
+        });
+    return std::nullopt;
+  }
 
-  auto results = engine.ComputePointPairPenetration({});
-  EXPECT_EQ(results.size(), 0);
-}
+  ProximityEngine<double> engine_;
+  unordered_map<GeometryId, RigidTransform<double>> X_WGs_;
+};
 
-// A scene with a single anchored geometry reports no penetrations.
-GTEST_TEST(ProximityEngineTests, PenetrationSingleAnchored) {
-  ProximityEngine<double> engine;
+/* ComputePointPairPenetration() responsibilities:
+  1. Report results for colliding dynamic-dynamic geometry pairs.
+  2. Report *no* results for colliding anchored-anchored geometry pairs.
+  3. Report results for colliding anchored-dynamic geometry pairs.
+  4. Respect collision filter.
+  5. Results are always ordered.
+  6. AutoDiff derivatives pass through successfully.
+  7. It should also allow Callback exceptions to propagate through; we won't
+     test this directly -- Drake standard practices and the clear absence of a
+     catch block is sufficient evidence
 
-  Sphere sphere{0.5};
-  RigidTransformd pose = RigidTransformd::Identity();
-  const GeometryId id = GeometryId::get_new_id();
-  engine.AddAnchoredGeometry(sphere, pose, id);
-  auto results = engine.ComputePointPairPenetration({{id, pose}});
-  EXPECT_EQ(results.size(), 0);
-}
+  Note: the sequence of this test is important -- state accumulates and each
+  assertion is reliant on the successful execution of the previous assertion. */
+TEST_F(ProximityEngineQueryTest, ComputePointPairPenetration) {
+  auto eval_dut = [this]() {
+    engine_.UpdateWorldPoses(X_WGs_);
+    return engine_.ComputePointPairPenetration(X_WGs_);
+  };
 
-// Tests that anchored geometry aren't collided against each other -- even if
-// they actually *are* in penetration.
-GTEST_TEST(ProximityEngineTests, PenetrationMultipleAnchored) {
-  ProximityEngine<double> engine;
+  // Empty engines happily produce no results.
+  EXPECT_TRUE(eval_dut().empty());
 
-  const double radius = 0.5;
-  Sphere sphere{radius};
-  const GeometryId id1 = GeometryId::get_new_id();
-  std::unordered_map<GeometryId, RigidTransformd> X_WGs;
-  X_WGs.emplace(id1, RigidTransformd::Identity());
-  const GeometryId id2 = GeometryId::get_new_id();
-  RigidTransformd pose = RigidTransformd::Identity();
-  engine.AddAnchoredGeometry(sphere, pose, GeometryId::get_new_id());
-  pose.set_translation({1.8 * radius, 0, 0});
-  X_WGs.emplace(id2, pose);
-  engine.AddAnchoredGeometry(sphere, pose, GeometryId::get_new_id());
-  auto results = engine.ComputePointPairPenetration(X_WGs);
-  EXPECT_EQ(results.size(), 0);
+  const Sphere sphere{0.5};
+  // Two spheres with centers 0.9 apart collide (2 * 0.5 = 1.0 > 0.9).
+  const double d = 0.9;
+
+  // Each cluster is placed far apart to prevent cross-cluster collisions.
+
+  // Responsibility 1: colliding dynamic-dynamic pair IS reported.
+  const GeometryId id_A = AddDynamic(sphere, {0, 0, 0});
+  const GeometryId id_B = AddDynamic(sphere, {d, 0, 0});
+
+  // Responsibility 2: colliding anchored-anchored pair is NOT reported.
+  AddAnchored(sphere, {0, 100, 0});
+  AddAnchored(sphere, {d, 100, 0});
+
+  // Responsibility 3: colliding dynamic-anchored pair IS reported.
+  const GeometryId id_C = AddDynamic(sphere, {0, 200, 0});
+  const GeometryId id_D = AddAnchored(sphere, {d, 200, 0});
+
+  // Responsibility 4: filtered dynamic-dynamic pair is NOT reported.
+  const GeometryId id_G = AddDynamic(sphere, {0, 300, 0});
+  const GeometryId id_H = AddDynamic(sphere, {d, 300, 0});
+  ExcludeCollisionsWithin({id_G, id_H});
+
+  const std::vector<PenetrationAsPointPair<double>> results = eval_dut();
+
+  // Helper to extract the sorted id pairs from a result.
+  auto ids_of = [](const PenetrationAsPointPair<double>& p) {
+    return std::make_pair(p.id_A, p.id_B);
+  };
+
+  // (1) & (3) each contribute one pair; (2) and (4) contribute none.
+  ASSERT_EQ(results.size(), 2);
+  // We know that ids order by creation order; we'll exploit that.
+  EXPECT_EQ(ids_of(results[0]), std::pair(id_A, id_B));
+  EXPECT_EQ(ids_of(results[1]), std::pair(id_C, id_D));
+
+  // (5) - results are stable (ordered) across repeated calls.
+  const std::vector<PenetrationAsPointPair<double>> results2 = eval_dut();
+  ASSERT_EQ(results2.size(), 2);
+  EXPECT_EQ(ids_of(results2[0]), ids_of(results[0]));
+  EXPECT_EQ(ids_of(results2[1]), ids_of(results[1]));
+
+  // (6) - AutoDiff derivatives pass through successfully.
+  const auto ad_engine = engine_.ToScalarType<AutoDiffXd>();
+  unordered_map<GeometryId, RigidTransform<AutoDiffXd>> X_WGs_ad;
+  for (const auto& [id, X_WG] : X_WGs_) {
+    X_WGs_ad[id] = X_WG.cast<AutoDiffXd>();
+  }
+  // Seed id_C's translation with derivatives.
+  X_WGs_ad[id_C] = RigidTransform<AutoDiffXd>{
+      math::InitializeAutoDiff(X_WGs_.at(id_C).translation())};
+
+  ad_engine->UpdateWorldPoses(X_WGs_ad);
+  const std::vector<PenetrationAsPointPair<AutoDiffXd>> ad_results =
+      ad_engine->ComputePointPairPenetration(X_WGs_ad);
+  // Still get two results.
+  ASSERT_EQ(ad_results.size(), 2);
+  // Confirm derivatives on the second result -- not empty and not zero.
+  const auto& result = ad_results[1];
+  const auto& derivs = result.depth.derivatives();
+  ASSERT_EQ(derivs.size(), 3);
+  EXPECT_FALSE(derivs.isZero());
 }
 
 // Utility test for evaluating the following "ResultOrdering" test. It produces
@@ -1823,34 +1923,6 @@ unordered_map<GeometryId, RigidTransformd> MakeCollidingRing(double radius,
     poses[GeometryId::get_new_id()] = RigidTransformd(p_WSo);
   }
   return poses;
-}
-
-// Confirms that the ComputePointPairPenetration() computation returns the
-// same results twice in a row. This test is explicitly required because it is
-// known that updating the pose in the FCL tree can lead to erratic ordering.
-GTEST_TEST(ProximityEngineTests, PenetrationAsPointPairResultOrdering) {
-  ProximityEngine<double> engine;
-
-  const double r = 0.5;
-  // For radius = 0.5, we find 4 spheres is sufficient to expose the old bug.
-  unordered_map<GeometryId, RigidTransformd> poses = MakeCollidingRing(r, 4);
-
-  const Sphere sphere{r};
-  for (const auto& pair : poses) {
-    engine.AddDynamicGeometry(sphere, {}, pair.first);
-  }
-  engine.UpdateWorldPoses(poses);
-  const auto results1 = engine.ComputePointPairPenetration(poses);
-  ASSERT_EQ(results1.size(), poses.size());
-
-  engine.UpdateWorldPoses(poses);
-  const auto results2 = engine.ComputePointPairPenetration(poses);
-  ASSERT_EQ(results1.size(), poses.size());
-
-  for (size_t i = 0; i < poses.size(); ++i) {
-    EXPECT_EQ(results1[i].id_A, results2[i].id_A);
-    EXPECT_EQ(results1[i].id_B, results2[i].id_B);
-  }
 }
 
 // Confirms that the FindCollisionCandidates() computation returns the
@@ -2024,429 +2096,36 @@ TEST_F(ProximityEngineHydroWithFallback,
   }
 }
 
-// These tests validate collisions/distance between spheres. This does *not*
-// test against other geometry types because we assume FCL works. This merely
-// confirms that the ProximityEngine functions provide the correct mapping.
-
-// Common class for evaluating a simple penetration case between two spheres.
-// This tests that collisions that are expected are reported between
-//   1. dynamic-anchored
-//   2. dynamic-dynamic
-// It uses spheres to confirm that the collision results are as expected.
-// These are the only sphere-sphere tests because the assumption is that if you
-// can get *any* sphere-sphere collision test right, you can get all of them
-// right.
-// NOTE: FCL does not document the case where two spheres have coincident
-// centers; therefore it is not tested here.
-class SimplePenetrationTest : public ::testing::Test {
- protected:
-  // Moves the dynamic sphere to either a penetrating or non-penetrating
-  // position. The sphere is indicated by its `id` which belongs to the given
-  // `source_id`. If `is_colliding` is true, the sphere is placed in a colliding
-  // configuration.
-  //
-  // Non-colliding state
-  //       y           x = free_x_
-  //        │          │
-  //       *│*         o o
-  //    *   │   *   o       o
-  //   *    │    * o         o
-  // ──*────┼────*─o─────────o───────── x
-  //   *    │    * o         o
-  //    *   │   *   o       o
-  //       *│*         o o
-  //
-  // Colliding state
-  //       y       x = colliding_x_
-  //        │      │
-  //       *│*    o o
-  //    *   │  o*      o
-  //   *    │ o  *      o
-  // ──*────┼─o──*──────o────────────── x
-  //   *    │ o  *      o
-  //    *   │  o*      o
-  //       *│*    o o
-
-  // Updates a pose in X_WGs_ to be colliding or non-colliding. Then updates the
-  // position of all dynamic geometries.
-  void MoveDynamicSphere(GeometryId id, bool is_colliding,
-                         ProximityEngine<double>* engine = nullptr) {
-    engine = engine == nullptr ? &engine_ : engine;
-
-    DRAKE_DEMAND(engine->num_geometries() == static_cast<int>(X_WGs_.size()));
-
-    const double x_pos = is_colliding ? colliding_x_ : free_x_;
-    X_WGs_[id].set_translation({x_pos, 0, 0});
-
-    engine->UpdateWorldPoses(X_WGs_);
-  }
-
-  // Poses have been defined as doubles; get them in the required scalar type.
-  template <typename T>
-  unordered_map<GeometryId, RigidTransform<T>> GetTypedPoses() const {
-    unordered_map<GeometryId, RigidTransform<T>> typed_X_WG;
-    for (const auto& id_pose_pair : X_WGs_) {
-      const GeometryId id = id_pose_pair.first;
-      const RigidTransformd& X_WG = id_pose_pair.second;
-      typed_X_WG[id] = X_WG.cast<T>();
-    }
-    return typed_X_WG;
-  }
-
-  // Compute penetration and confirm that a single penetration with the expected
-  // properties was found. Provide the geometry ids of the sphere located at
-  // the origin and the sphere positioned to be in collision.
-  template <typename T>
-  void ExpectPenetration(GeometryId origin_sphere, GeometryId colliding_sphere,
-                         ProximityEngine<T>* engine) {
-    std::vector<PenetrationAsPointPair<T>> penetration_results =
-        engine->ComputePointPairPenetration(GetTypedPoses<T>());
-    ASSERT_EQ(penetration_results.size(), 1);
-    const PenetrationAsPointPair<T>& penetration = penetration_results[0];
-
-    std::vector<SignedDistancePair<T>> distance_results =
-        engine->ComputeSignedDistancePairwiseClosestPoints(GetTypedPoses<T>(),
-                                                           kInf);
-    ASSERT_EQ(distance_results.size(), 1);
-    const SignedDistancePair<T>& distance = distance_results[0];
-
-    // There are no guarantees as to the ordering of which element is A and
-    // which is B. This test enforces an order for validation.
-
-    // First confirm membership
-    EXPECT_TRUE((penetration.id_A == origin_sphere &&
-                 penetration.id_B == colliding_sphere) ||
-                (penetration.id_A == colliding_sphere &&
-                 penetration.id_B == origin_sphere));
-
-    EXPECT_TRUE(
-        (distance.id_A == origin_sphere && distance.id_B == colliding_sphere) ||
-        (distance.id_A == colliding_sphere && distance.id_B == origin_sphere));
-
-    // Assume A => origin_sphere and b => colliding_sphere
-    // NOTE: In this current version, penetration is only reported in double.
-    PenetrationAsPointPair<double> expected;
-    // This implicitly tests the *ordering* of the two reported ids. It must
-    // always be in *this* order.
-    bool origin_is_A = origin_sphere < colliding_sphere;
-    expected.id_A = origin_is_A ? origin_sphere : colliding_sphere;
-    expected.id_B = origin_is_A ? colliding_sphere : origin_sphere;
-    expected.depth = 2 * radius_ - colliding_x_;
-    // Contact point on the origin_sphere.
-    Vector3<double> p_WCo{radius_, 0, 0};
-    // Contact point on the colliding_sphere.
-    Vector3<double> p_WCc{colliding_x_ - radius_, 0, 0};
-    expected.p_WCa = origin_is_A ? p_WCo : p_WCc;
-    expected.p_WCb = origin_is_A ? p_WCc : p_WCo;
-    Vector3<double> norm_into_B = Vector3<double>::UnitX();
-    expected.nhat_BA_W = origin_is_A ? -norm_into_B : norm_into_B;
-
-    EXPECT_EQ(penetration.id_A, expected.id_A);
-    EXPECT_EQ(penetration.id_B, expected.id_B);
-    EXPECT_EQ(penetration.depth, expected.depth);
-    EXPECT_TRUE(CompareMatrices(penetration.p_WCa, expected.p_WCa, 1e-13,
-                                MatrixCompareType::absolute));
-    EXPECT_TRUE(CompareMatrices(penetration.p_WCb, expected.p_WCb, 1e-13,
-                                MatrixCompareType::absolute));
-    EXPECT_TRUE(CompareMatrices(penetration.nhat_BA_W, expected.nhat_BA_W,
-                                1e-13, MatrixCompareType::absolute));
-
-    // Should return the penetration depth here.
-    SignedDistancePair<T> expected_distance;
-    expected_distance.distance = -expected.depth;
-    expected_distance.id_A = origin_sphere;
-    expected_distance.id_B = colliding_sphere;
-    expected_distance.p_ACa = Eigen::Vector3d(radius_, 0, 0);
-    expected_distance.p_BCb = Eigen::Vector3d(-radius_, 0, 0);
-    if (expected_distance.id_B < expected_distance.id_A) {
-      std::swap(expected_distance.id_A, expected_distance.id_B);
-      std::swap(expected_distance.p_ACa, expected_distance.p_BCb);
-    }
-    EXPECT_LT(distance.id_A, distance.id_B);
-    CompareSignedDistancePair(distance, expected_distance,
-                              std::numeric_limits<double>::epsilon());
-  }
-
-  // The two spheres collides, but are ignored due to the setting in the
-  // collision filter.
-  template <typename T>
-  void ExpectIgnoredPenetration(GeometryId origin_sphere,
-                                GeometryId colliding_sphere,
-                                ProximityEngine<T>* engine) {
-    std::vector<PenetrationAsPointPair<T>> penetration_results =
-        engine->ComputePointPairPenetration(GetTypedPoses<T>());
-    EXPECT_EQ(penetration_results.size(), 0);
-
-    std::vector<SignedDistancePair<T>> distance_results =
-        engine->ComputeSignedDistancePairwiseClosestPoints(GetTypedPoses<T>(),
-                                                           kInf);
-    ASSERT_EQ(distance_results.size(), 0);
-  }
-
-  // Compute penetration and confirm that none were found.
-  template <typename T>
-  void ExpectNoPenetration(GeometryId origin_sphere,
-                           GeometryId colliding_sphere,
-                           ProximityEngine<T>* engine) {
-    std::vector<PenetrationAsPointPair<double>> penetration_results =
-        engine->ComputePointPairPenetration(GetTypedPoses<T>());
-    EXPECT_EQ(penetration_results.size(), 0);
-
-    std::vector<SignedDistancePair<double>> distance_results =
-        engine->ComputeSignedDistancePairwiseClosestPoints(X_WGs_, kInf);
-    ASSERT_EQ(distance_results.size(), 1);
-    SignedDistancePair<double> distance = distance_results[0];
-
-    // There are no guarantees as to the ordering of which element is A and
-    // which is B. This test enforces an order for validation.
-    EXPECT_TRUE(
-        (distance.id_A == origin_sphere && distance.id_B == colliding_sphere) ||
-        (distance.id_A == colliding_sphere && distance.id_B == origin_sphere));
-
-    bool origin_is_A = origin_sphere < colliding_sphere;
-    SignedDistancePair<double> expected_distance;
-    expected_distance.id_A = origin_is_A ? origin_sphere : colliding_sphere;
-    expected_distance.id_B = origin_is_A ? colliding_sphere : origin_sphere;
-    expected_distance.distance = free_x_ - 2 * radius_;
-    // Contact point on the origin_sphere.
-    Vector3<double> p_OCo{radius_, 0, 0};
-    // Contact point on the colliding_sphere.
-    Vector3<double> p_CCc{-radius_, 0, 0};
-    expected_distance.p_ACa = origin_is_A ? p_OCo : p_CCc;
-    expected_distance.p_BCb = origin_is_A ? p_CCc : p_OCo;
-
-    CompareSignedDistancePair(distance, expected_distance,
-                              std::numeric_limits<double>::epsilon());
-  }
-
-  ProximityEngine<double> engine_;
-  unordered_map<GeometryId, RigidTransformd> X_WGs_;
-  const double radius_{0.5};
-  const Sphere sphere_{radius_};
-  const double free_x_{2.5 * radius_};
-  const double colliding_x_{1.5 * radius_};
-};
-
-// Tests collision between dynamic and anchored sphere. One case colliding, one
-// case *not* colliding.
-TEST_F(SimplePenetrationTest, PenetrationDynamicAndAnchored) {
-  // Set up anchored geometry.
-  RigidTransformd pose = RigidTransformd::Identity();
-  const GeometryId anchored_id = GeometryId::get_new_id();
-  engine_.AddAnchoredGeometry(sphere_, pose, anchored_id);
-
-  // Set up dynamic geometry.
-  const GeometryId dynamic_id = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, dynamic_id);
-  EXPECT_EQ(engine_.num_geometries(), 2);
-
-  X_WGs_[anchored_id] = pose;
-  X_WGs_[dynamic_id] = RigidTransformd::Identity();
-
-  // Non-colliding case.
-  MoveDynamicSphere(dynamic_id, false /* not colliding */);
-  ExpectNoPenetration(anchored_id, dynamic_id, &engine_);
-
-  // Colliding case.
-  MoveDynamicSphere(dynamic_id, true /* colliding */);
-  ExpectPenetration(anchored_id, dynamic_id, &engine_);
-
-  // Test colliding case on copy.
-  ProximityEngine<double> copy_engine(engine_);
-  ExpectPenetration(anchored_id, dynamic_id, &copy_engine);
-
-  // Test scalar-converted engines.
-  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine =
-      engine_.ToScalarType<AutoDiffXd>();
-  ExpectPenetration(anchored_id, dynamic_id, ad_engine.get());
-  std::unique_ptr<ProximityEngine<Expression>> sym_engine =
-      engine_.ToScalarType<Expression>();
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      ExpectPenetration(anchored_id, dynamic_id, sym_engine.get()),
-      ".*are not supported for scalar type drake::symbolic::Expression.*");
-}
-
-// Performs the same collision test between two dynamic spheres which belong to
-// the same source.
-TEST_F(SimplePenetrationTest, PenetrationDynamicAndDynamicSingleSource) {
-  const GeometryId origin_id = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, origin_id);
-
-  GeometryId collide_id = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, collide_id);
-  EXPECT_EQ(engine_.num_geometries(), 2);
-
-  X_WGs_[origin_id] = RigidTransformd::Identity();
-  X_WGs_[collide_id] = RigidTransformd::Identity();
-
-  // Non-colliding case.
-  MoveDynamicSphere(collide_id, false /* not colliding */);
-  ExpectNoPenetration(origin_id, collide_id, &engine_);
-
-  // Colliding case.
-  MoveDynamicSphere(collide_id, true /* colliding */);
-  ExpectPenetration(origin_id, collide_id, &engine_);
-
-  // Test colliding case on copy.
-  ProximityEngine<double> copy_engine(engine_);
-  ExpectPenetration(origin_id, collide_id, &copy_engine);
-
-  // Test scalar-converted engines.
-  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine =
-      engine_.ToScalarType<AutoDiffXd>();
-  ExpectPenetration(origin_id, collide_id, ad_engine.get());
-  std::unique_ptr<ProximityEngine<Expression>> sym_engine =
-      engine_.ToScalarType<Expression>();
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      ExpectPenetration(origin_id, collide_id, sym_engine.get()),
-      ".*are not supported for scalar type drake::symbolic::Expression.*");
-}
-
-// Tests if collisions exist between dynamic and anchored sphere. One case
-// colliding, one case *not* colliding.
-TEST_F(SimplePenetrationTest, HasCollisionsDynamicAndAnchored) {
-  // Set up anchored geometry.
-  const RigidTransformd pose = RigidTransformd::Identity();
-  const GeometryId anchored_id = GeometryId::get_new_id();
-  engine_.AddAnchoredGeometry(sphere_, pose, anchored_id);
-
-  // Set up dynamic geometry.
-  const GeometryId dynamic_id = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, dynamic_id);
-  EXPECT_EQ(engine_.num_geometries(), 2);
-
-  X_WGs_[anchored_id] = pose;
-  X_WGs_[dynamic_id] = RigidTransformd::Identity();
-
-  // Non-colliding case.
-  MoveDynamicSphere(dynamic_id, false /* not colliding */);
-  EXPECT_FALSE(engine_.HasCollisions());
-
-  // Colliding case.
-  MoveDynamicSphere(dynamic_id, true /* colliding */);
-  EXPECT_TRUE(engine_.HasCollisions());
-
-  // Test colliding case on copy.
-  ProximityEngine<double> copy_engine(engine_);
-  EXPECT_TRUE(copy_engine.HasCollisions());
-
-  // Test scalar-converted engines.
-  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine =
-      engine_.ToScalarType<AutoDiffXd>();
-  EXPECT_TRUE(ad_engine->HasCollisions());
-  std::unique_ptr<ProximityEngine<Expression>> sym_engine =
-      engine_.ToScalarType<Expression>();
-  EXPECT_TRUE(sym_engine->HasCollisions());
-}
-
-// Performs the same collision test between two dynamic spheres which belong to
-// the same source.
-TEST_F(SimplePenetrationTest, HasCollisionsDynamicAndDynamicSingleSource) {
-  const GeometryId origin_id = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, origin_id);
-
-  GeometryId collide_id = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, collide_id);
-  EXPECT_EQ(engine_.num_geometries(), 2);
-
-  X_WGs_[origin_id] = RigidTransformd::Identity();
-  X_WGs_[collide_id] = RigidTransformd::Identity();
-
-  // Non-colliding case.
-  MoveDynamicSphere(collide_id, false /* not colliding */);
-  EXPECT_FALSE(engine_.HasCollisions());
-
-  // Colliding case.
-  MoveDynamicSphere(collide_id, true /* colliding */);
-  EXPECT_TRUE(engine_.HasCollisions());
-
-  // Test colliding case on copy.
-  ProximityEngine<double> copy_engine(engine_);
-  EXPECT_TRUE(copy_engine.HasCollisions());
-
-  // Test scalar-converted engines.
-  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine =
-      engine_.ToScalarType<AutoDiffXd>();
-  EXPECT_TRUE(ad_engine->HasCollisions());
-  std::unique_ptr<ProximityEngine<Expression>> sym_engine =
-      engine_.ToScalarType<Expression>();
-  EXPECT_TRUE(sym_engine->HasCollisions());
-}
-
 // There was a bug (23406). If anchored geometries existed but they were not
 // in collision with dynamic geometries, collisions between dynamics geometries
 // would be ignored and the HasCollisions() query would return a lie. This is
 // a test against that bug coming back.
-TEST_F(SimplePenetrationTest, HasCollisionsAnchoredInterference) {
+GTEST_TEST(ProximityEngineTests, HasCollisionsAnchoredInterference) {
+  ProximityEngine<double> engine;
+  const Sphere sphere{0.5};
+  unordered_map<GeometryId, RigidTransformd> X_WGs_;
+
   const GeometryId dynamic_id_1 = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, dynamic_id_1);
+  engine.AddDynamicGeometry(sphere, {}, dynamic_id_1);
 
   const GeometryId dynamic_id_2 = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, dynamic_id_2);
-  EXPECT_EQ(engine_.num_geometries(), 2);
+  engine.AddDynamicGeometry(sphere, {}, dynamic_id_2);
+  EXPECT_EQ(engine.num_geometries(), 2);
 
   X_WGs_[dynamic_id_1] = RigidTransformd::Identity();
   X_WGs_[dynamic_id_2] = RigidTransformd::Identity();
 
-  EXPECT_TRUE(engine_.HasCollisions());
+  EXPECT_TRUE(engine.HasCollisions());
 
   // The anchored geometry must be non-colliding, but close enough that its
   // bounding box overlaps.
   const Vector3d p_WA =
-      Vector3d(1, 1, 0).normalized() * (sphere_.radius() * 2.1);
+      Vector3d(1, 1, 0).normalized() * (sphere.radius() * 2.1);
   const GeometryId anchored_id = GeometryId::get_new_id();
-  engine_.AddAnchoredGeometry(sphere_, RigidTransformd(p_WA), anchored_id);
-  EXPECT_EQ(engine_.num_geometries(), 3);
+  engine.AddAnchoredGeometry(sphere, RigidTransformd(p_WA), anchored_id);
+  EXPECT_EQ(engine.num_geometries(), 3);
   // We still have collisions (original code would report false).
-  EXPECT_TRUE(engine_.HasCollisions());
-}
-
-// Performs the same collision test where the geometries have been filtered.
-TEST_F(SimplePenetrationTest, WithCollisionFilters) {
-  GeometryId origin_id = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, origin_id);
-
-  GeometryId collide_id = GeometryId::get_new_id();
-  engine_.AddDynamicGeometry(sphere_, {}, collide_id);
-  ASSERT_EQ(engine_.num_geometries(), 2);
-
-  X_WGs_[origin_id] = RigidTransformd::Identity();
-  X_WGs_[collide_id] = RigidTransformd::Identity();
-
-  ASSERT_TRUE(engine_.collision_filter().CanCollideWith(origin_id, collide_id));
-
-  // I know the GeometrySet only has id_A and id_B, so I'll construct the
-  // extracted set by hand.
-  auto extract_ids = [origin_id, collide_id](const GeometrySet&,
-                                             CollisionFilterScope) {
-    return std::unordered_set<GeometryId>{origin_id, collide_id};
-  };
-  engine_.collision_filter().Apply(CollisionFilterDeclaration().ExcludeWithin(
-                                       GeometrySet{origin_id, collide_id}),
-                                   extract_ids, false /* is_invariant */);
-
-  EXPECT_FALSE(
-      engine_.collision_filter().CanCollideWith(origin_id, collide_id));
-
-  // Non-colliding case.
-  MoveDynamicSphere(collide_id, false /* not colliding */);
-  ExpectIgnoredPenetration(origin_id, collide_id, &engine_);
-
-  // Colliding case.
-  MoveDynamicSphere(collide_id, true /* colliding */);
-  ExpectIgnoredPenetration(origin_id, collide_id, &engine_);
-
-  // Test colliding case on copy.
-  ProximityEngine<double> copy_engine(engine_);
-  ExpectIgnoredPenetration(origin_id, collide_id, &copy_engine);
-
-  // Test scalar-converted engines.
-  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine =
-      engine_.ToScalarType<AutoDiffXd>();
-  ExpectIgnoredPenetration(origin_id, collide_id, ad_engine.get());
-  std::unique_ptr<ProximityEngine<Expression>> sym_engine =
-      engine_.ToScalarType<Expression>();
-  ExpectIgnoredPenetration(origin_id, collide_id, sym_engine.get());
+  EXPECT_TRUE(engine.HasCollisions());
 }
 
 // Confirms that non-positive thresholds produce the right value. Creates three
@@ -2500,129 +2179,6 @@ GTEST_TEST(ProximityEngineTests, PairwiseSignedDistanceNonPositiveThreshold) {
   EXPECT_EQ(results_barely_out.size(), 0u);
 }
 
-// Given a sphere S and box B. The box's height and depth are large (much larger
-// than the diameter of the sphere), but the box's *width* is *less* than the
-// sphere diameter. The sphere will contact it such that it's penetration is
-// along the "width" axis.
-//
-// The sphere will start in a non-colliding state and subsequently move in the
-// width direction. As long as the sphere's center is on the same side of the
-// box's "origin", the contact normal direction should remain unchanged. But as
-// soon as it crosses the origin, the contact normal should flip directions.
-//
-// Non-colliding state - no collision reported.
-//       y
-//      ┇ │ ┇       ←  movement of sphere
-//      ┃ │ ┃       o o
-//      ┃ │ ┃    o       o
-//      ┃ │ ┃   o         o
-// ─────╂─┼─╂───o────c────o───────── x
-//      ┃ │ ┃   o         o
-//      ┃ │ ┃    o       o
-//      ┃ │ ┃       o o            `c' marks the sphere center
-//      ┇ │ ┇
-//
-// Sphere's center is just to the right of the box's origin.
-// From the first contact up to this point, the contact normal should point to
-// the left (into the box). The direction is based on how PenetrationAsPointPair
-// defines the normal direction -- from geometry B into geometry A. Based on
-// how the geometries are defined, this means from the sphere, into the box.
-//       y
-//      ┇ │ ┇       ←  movement of sphere
-//      ┃ o o
-//     o┃ │ ┃  o
-//    o ┃ │ ┃   o
-// ───o─╂─┼c╂───o─────────────── x
-//    o ┃ │ ┃   o
-//     o┃ │ ┃  o
-//      ┃ o o
-//      ┇ │ ┇
-//
-// Discontinuous colliding state - crossed the origin; contact normal flips to
-// the right.
-//       y
-//        ┇ │ ┇       ←  movement of sphere
-//        o o ┃
-//     o  ┃ │ ┃o
-//    o   ┃ │ ┃ o
-// ───o───╂c┼─╂─o─────────────── x
-//    o   ┃ │ ┃ o
-//     o  ┃ │ ┃o
-//        o o ┃
-//        ┇ │ ┇
-//
-// Note: this test is in direct response to a very *particular* observed bug
-// in simulation which pointed to errors in FCL. This is provided as a
-// regression test once FCL is patched. The original failure condition has been
-// reproduced with this simplified version of the original problem. Note:
-// passing this test does not guarantee general correctness of box-sphere
-// collision; only that this particular bug is gone.
-
-// Supporting structure for the query.
-struct SpherePunchData {
-  const std::string description;
-  const Vector3d sphere_pose;
-  const int contact_count;
-  // This is the contact normal pointing *into* the box.
-  const Vector3d contact_normal;
-  const double depth;
-};
-
-GTEST_TEST(ProximityEngineCollisionTest, SpherePunchThroughBox) {
-  ProximityEngine<double> engine;
-  const double radius = 0.5;
-  const double w = radius;  // Box width smaller than diameter.
-  const double half_w = w / 2;
-  const double h = 10 * radius;  // Box height much larger than sphere.
-  const double d = 10 * radius;  // Box depth much larger than sphere.
-  const double eps = std::numeric_limits<double>::epsilon();
-  const GeometryId box_id = GeometryId::get_new_id();
-  engine.AddDynamicGeometry(Box{w, h, d}, {}, box_id);
-  const GeometryId sphere_id = GeometryId::get_new_id();
-  engine.AddDynamicGeometry(Sphere{radius}, {}, sphere_id);
-
-  unordered_map<GeometryId, RigidTransformd> poses{
-      {box_id, RigidTransformd::Identity()},
-      {sphere_id, RigidTransformd::Identity()}};
-  // clang-format off
-  std::vector<SpherePunchData> test_data{
-      // In non-penetration, contact_normal and depth values don't matter; they
-      // are not tested.
-      {"non-penetration",
-       {radius + half_w + 0.1, 0.0, 0.0}, 0, {0.0, 0.0, 0.0}, -1.0},
-      {"shallow penetration -- sphere center outside of box",
-       {radius + 0.75 * half_w, 0.0, 0.0}, 1, {-1.0, 0.0, 0.0}, 0.25 * half_w},
-      {"deep penetration -- sphere contacts opposite side of the box",
-       {radius - half_w, 0.0, 0.0}, 1, {-1.0, 0.0, 0.0}, w},
-      {"sphere's origin is just to the right of the box center",
-       {eps, 0.0, 0.0}, 1, {-1.0, 0.0, 0.0}, radius + half_w - eps},
-      {"sphere's center has crossed the box's origin - flipped normal",
-       {-eps, 0.0, 0.0}, 1, {1.0, 0.0, 0.0}, radius + half_w - eps}};
-  // clang-format on
-  for (const auto& test : test_data) {
-    poses[sphere_id].set_translation(test.sphere_pose);
-    engine.UpdateWorldPoses(poses);
-    std::vector<PenetrationAsPointPair<double>> results =
-        engine.ComputePointPairPenetration(poses);
-
-    ASSERT_EQ(static_cast<int>(results.size()), test.contact_count)
-        << "Failed for the " << test.description << " case";
-    if (test.contact_count == 1) {
-      const PenetrationAsPointPair<double>& penetration = results[0];
-      // Normal direction is predicated on the sphere being geometry B.
-      ASSERT_EQ(penetration.id_A, box_id);
-      ASSERT_EQ(penetration.id_B, sphere_id);
-      EXPECT_TRUE(CompareMatrices(penetration.nhat_BA_W, test.contact_normal,
-                                  eps, MatrixCompareType::absolute))
-          << "Failed for the " << test.description << " case";
-      // For this simple, axis-aligned test (where all the values are nicely
-      // powers of 2), I should expect perfect answers.
-      EXPECT_EQ(penetration.depth - test.depth, 0)
-          << "Failed for the " << test.description << " case";
-    }
-  }
-}
-
 // TODO(SeanCurtis-TRI): All of the FCL-based queries should have *limited*
 //  testing in proximity engine. They should only test the following:
 //  Successful evaluation between two dynamic shapes and between a dynamic
@@ -2635,464 +2191,16 @@ GTEST_TEST(ProximityEngineCollisionTest, SpherePunchThroughBox) {
 //  create a set of tests that can be evaluated on each of the FCL-based queries
 //  that performs those two tests.
 
-// TODO(SeanCurtis-TRI): Remove these geometric tests from here and put them
-//  in their own test. We're keeping them, ultimately, so that we can use these
-//  tests for our own implementation of shape-shape point-intersection
-//  algorithms. In the short-term, these tests should be expressed directly
-//  in terms of the penetration_as_point_pair::Callback and moved to that set
-//  of tests.
-
-// Robust Box-Primitive tests. Tests collision of the box with other primitives
-// in a uniform framework. These tests parallel tests located in fcl.
-//
-// All of the tests below here are using the callback to exercise the black box.
-// They exist because of FCL; FCL's unit tests were sporadic at best and these
-// tests revealed errors/properties of FCL that weren't otherwise apparent.
-// Ultimately, these tests don't belong here. But they can be re-used when we
-// replace FCL with Drake's own implementations.
-//
-// This performs a very specific test. It collides a rotated box with a
-// surface that is tangent to the z = 0 plane. The box is a cube with unit size.
-// The goal is to transform the box such that:
-//   1. the corner of the box C, located at p_BoC_B = (-0.5, -0.5, -0.5),
-//      transformed by the box's pose X_WB, ends up at the position
-//      p_WC = (0, 0, -kDepth), i.e., p_WC = X_WB * p_BoC_B, and
-//   2. all other corners are transformed to lie above the z = 0 plane.
-//
-// In this configuration, the corner C becomes the unique point of deepest
-// penetration in the interior of the half space.
-//
-// It is approximately *this* picture
-//        ┆  ╱╲
-//        ┆ ╱  ╲
-//        ┆╱    ╲
-//       ╱┆╲    ╱
-//      ╱ ┆ ╲  ╱
-//     ╱  ┆  ╲╱
-//     ╲  ┆  ╱
-//      ╲ ┆ ╱
-//  _____╲┆╱_____    ╱____ With small penetration depth of d
-//  ░░░░░░┆░░░░░░    ╲
-//  ░░░░░░┆░░░░░░
-//  ░░░Tangent░░░
-//  ░░░░shape░░░░
-//  ░░interior░░░
-//  ░░░░░░┆░░░░░░
-//
-// We can use this against various *convex* shapes to determine uniformity of
-// behavior. As long as the convex tangent shape *touches* the z = 0 plane at
-// (0, 0, 0), and the shape is *large* compared to the penetration depth, then
-// we should get a fixed, known contact. Specifically, if we assume the tangent
-// shape is A and the box is B, then
-//   - the normal is (0, 0, -1) from box into the plane,
-//   - the penetration depth is the specified depth used to configure the
-//     position of the box, and
-//   - the contact position is (0, 0, -depth / 2).
-//
-// Every convex shape type can be used as the tangent shape as follows:
-//   - plane: simply define the z = 0 plane.
-//   - box: define a box whose top face lies on the z = 0 and encloses the
-//     origin.
-//   - sphere: place the sphere at (0, 0 -radius).
-//   - cylinder: There are two valid configurations (radius & length >> depth).
-//     - Place a "standing" cylinder at (0, 0, -length/2).
-//     - Rotate the cylinder so that its length axis is parallel with the z = 0
-//       plane and then displace downward (0, 0, -radius). Described as "prone".
-//   - capsule: There are two valid configurations (radius & length >> depth).
-//     - Place a "standing" capsule at (0, 0, -length/2 - radius).
-//     - Rotate the capsule so that its length axis is parallel with the z = 0
-//       plane and then displace downward (0, 0, -radius). Described as "prone".
-//
-// Note: there are an infinite number of orientations that satisfy the
-// configuration described above. They should *all* provide the same collision
-// results. We provide two representative orientations to illustrate issues
-// with the underlying functionality -- the *quality* of the answer depends on
-// the orientation of the box. When the problem listed in Drake issue 7656 is
-// resolved, all tests should resolve to the same answer with the same tight
-// precision.
-// TODO(SeanCurtis-TRI): Add other shapes as they become available.
-class BoxPenetrationTest : public ::testing::Test {
- protected:
-  void SetUp() {
-    // Confirm all of the constants are consistent (in case someone tweaks them
-    // later). In this case, tangent geometry must be much larger than the
-    // depth.
-    EXPECT_GT(kRadius, kDepth * 100);
-    EXPECT_GT(kLength, kDepth * 100);
-
-    // Confirm that the poses of the box satisfy the conditions described above.
-    for (auto func : {X_WB_1, X_WB_2}) {
-      const math::RigidTransformd X_WB = func(p_BoC_B_, p_WC_);
-      // Confirm that p_BoC_B transforms to p_WC.
-      const Vector3d p_WC_test = X_WB * p_BoC_B_;
-      EXPECT_TRUE(CompareMatrices(p_WC_test, p_WC_, 1e-15,
-                                  MatrixCompareType::absolute));
-
-      // Confirm that *all* other points map to values where z > 0.
-      for (double x : {-0.5, 0.5}) {
-        for (double y : {-0.5, 0.5}) {
-          for (double z : {-0.5, 0.5}) {
-            const Vector3d p_BoC_B{x, y, z};
-            if (p_BoC_B.isApprox(p_BoC_B_)) continue;
-            const Vector3d p_WC = X_WB * p_BoC_B;
-            EXPECT_GT(p_WC(2), 0);
-          }
-        }
-      }
-    }
-
-    // Configure the expected penetration characterization.
-    expected_penetration_.p_WCa << 0, 0, 0;       // Tangent plane
-    expected_penetration_.p_WCb = p_WC_;          // Cube
-    expected_penetration_.nhat_BA_W << 0, 0, -1;  // From cube into plane
-    expected_penetration_.depth = kDepth;
-    // NOTE: The ids are set by the individual calling tests.
-  }
-
-  enum TangentShape {
-    TangentPlane,
-    TangentSphere,
-    TangentBox,
-    TangentStandingCylinder,
-    TangentProneCylinder,
-    TangentConvex,
-    TangentStandingCapsule,
-    TangentProneCapsule
-  };
-
-  // The test that produces *bad* results based on the box orientation. Not
-  // called "bad" because when FCL is fixed, they'll both be good.
-  void TestCollision1(TangentShape shape_type, double tolerance) {
-    TestCollision(shape_type, tolerance, X_WB_1(p_BoC_B_, p_WC_));
-  }
-
-  // The test that produces *good* results based on the box orientation. Not
-  // called "good" because when FCL is fixed, they'll both be good.
-  void TestCollision2(TangentShape shape_type, double tolerance) {
-    TestCollision(shape_type, tolerance, X_WB_2(p_BoC_B_, p_WC_));
-  }
-
- private:
-  // Perform the collision test against the indicated shape and confirm the
-  // results to the given tolerance.
-  void TestCollision(TangentShape shape_type, double tolerance,
-                     const math::RigidTransformd& X_WB) {
-    const GeometryId tangent_id = GeometryId::get_new_id();
-    engine_.AddDynamicGeometry(shape(shape_type), {}, tangent_id);
-
-    const GeometryId box_id = GeometryId::get_new_id();
-    engine_.AddDynamicGeometry(box_, {}, box_id);
-
-    // Confirm that there are no other geometries interfering.
-    ASSERT_EQ(engine_.num_dynamic(), 2);
-
-    // Update the poses of the geometry.
-    unordered_map<GeometryId, RigidTransformd> poses{
-        {tangent_id, shape_pose(shape_type)}, {box_id, X_WB}};
-    engine_.UpdateWorldPoses(poses);
-    std::vector<PenetrationAsPointPair<double>> results =
-        engine_.ComputePointPairPenetration(poses);
-
-    ASSERT_EQ(results.size(), 1u)
-        << "Against tangent " << shape_name(shape_type);
-
-    const PenetrationAsPointPair<double>& contact = results[0];
-    Vector3d normal;
-    Vector3d p_Ac;
-    Vector3d p_Bc;
-    if (contact.id_A == tangent_id && contact.id_B == box_id) {
-      // The documented encoding of expected_penetration_.
-      normal = expected_penetration_.nhat_BA_W;
-      p_Ac = expected_penetration_.p_WCa;
-      p_Bc = expected_penetration_.p_WCb;
-    } else if (contact.id_A == box_id && contact.id_B == tangent_id) {
-      // The reversed encoding of expected_penetration_.
-      normal = -expected_penetration_.nhat_BA_W;
-      p_Ac = expected_penetration_.p_WCb;
-      p_Bc = expected_penetration_.p_WCa;
-    } else {
-      GTEST_FAIL() << fmt::format(
-          "Wrong geometry ids reported in contact for tangent {}. Expected {} "
-          "and {}. Got {} and {}",
-          shape_name(shape_type), tangent_id, box_id, contact.id_A,
-          contact.id_B);
-    }
-    EXPECT_TRUE(CompareMatrices(contact.nhat_BA_W, normal, tolerance))
-        << "Against tangent " << shape_name(shape_type);
-    EXPECT_TRUE(CompareMatrices(contact.p_WCa, p_Ac, tolerance))
-        << "Against tangent " << shape_name(shape_type);
-    EXPECT_TRUE(CompareMatrices(contact.p_WCb, p_Bc, tolerance))
-        << "Against tangent " << shape_name(shape_type);
-    EXPECT_NEAR(contact.depth, expected_penetration_.depth, tolerance)
-        << "Against tangent " << shape_name(shape_type);
-  }
-
-  // The expected collision result -- assumes that A is the tangent object and
-  // B is the colliding box.
-  PenetrationAsPointPair<double> expected_penetration_;
-
-  // Produces the X_WB that produces high-quality answers.
-  static math::RigidTransformd X_WB_2(const Vector3d& p_BoC_B,
-                                      const Vector3d& p_WC) {
-    // Compute the pose of the colliding box.
-    // a. Orient the box so that the corner p_BoC_B = (-0.5, -0.5, -0.5) lies in
-    //    the most -z extent. With only rotation, p_BoC_B != p_WC.
-    const math::RotationMatrixd R_WB(
-        AngleAxisd(std::atan(M_SQRT2), Vector3d(M_SQRT1_2, -M_SQRT1_2, 0)));
-
-    // b. Translate it so that the rotated corner p_BoC_W lies at
-    //    (0, 0, -d).
-    const Vector3d p_BoC_W = R_WB * p_BoC_B;
-    const Vector3d p_WB = p_WC - p_BoC_W;
-    return math::RigidTransformd(R_WB, p_WB);
-  }
-
-  // Produces the X_WB that produces low-quality answers.
-  static math::RigidTransformd X_WB_1(const Vector3d& p_BoC_B,
-                                      const Vector3d& p_WC) {
-    // Compute the pose of the colliding box.
-    // a. Orient the box so that the corner p_BoC_B = (-0.5, -0.5, -0.5) lies in
-    //    the most -z extent. With only rotation, p_BoC_B != p_WC.
-    const math::RotationMatrixd R_WB(AngleAxisd(-M_PI_4, Vector3d::UnitY()) *
-                                     AngleAxisd(M_PI_4, Vector3d::UnitX()));
-
-    // b. Translate it so that the rotated corner p_BoC_W lies at
-    //    (0, 0, -d).
-    const Vector3d p_BoC_W = R_WB * p_BoC_B;
-    const Vector3d p_WB = p_WC - p_BoC_W;
-    return math::RigidTransformd(R_WB, p_WB);
-  }
-
-  // Map enumeration to string for error messages.
-  static const char* shape_name(TangentShape shape) {
-    switch (shape) {
-      case TangentPlane:
-        return "plane";
-      case TangentSphere:
-        return "sphere";
-      case TangentBox:
-        return "box";
-      case TangentStandingCylinder:
-        return "standing cylinder";
-      case TangentProneCylinder:
-        return "prone cylinder";
-      case TangentConvex:
-        return "convex";
-      case TangentStandingCapsule:
-        return "standing capsule";
-      case TangentProneCapsule:
-        return "prone capsule";
-    }
-    return "undefined shape";
-  }
-
-  // Map enumeration to the configured shapes.
-  const Shape& shape(TangentShape shape) {
-    switch (shape) {
-      case TangentPlane:
-        return tangent_plane_;
-      case TangentSphere:
-        return tangent_sphere_;
-      case TangentBox:
-        return tangent_box_;
-      case TangentStandingCylinder:
-      case TangentProneCylinder:
-        return tangent_cylinder_;
-      case TangentConvex:
-        return tangent_convex_;
-      case TangentStandingCapsule:
-      case TangentProneCapsule:
-        return tangent_capsule_;
-    }
-    // GCC considers this function ill-formed - no apparent return value. This
-    // exception alleviates its concern.
-    throw std::logic_error(
-        "Trying to acquire shape for unknown shape enumerated value: " +
-        std::to_string(shape));
-  }
-
-  // Map enumeration to tangent pose.
-  RigidTransformd shape_pose(TangentShape shape) {
-    RigidTransformd pose = RigidTransformd::Identity();
-    switch (shape) {
-      case TangentPlane:
-        break;  // leave it at the identity
-      case TangentSphere:
-        pose.set_translation({0, 0, -kRadius});
-        break;
-      case TangentBox:
-      // The tangent convex is a cube of the same size as the tangent box.
-      // That is why we give them the same pose.
-      case TangentConvex:
-      case TangentStandingCylinder:
-        pose.set_translation({0, 0, -kLength / 2});
-        break;
-      case TangentStandingCapsule:
-        pose.set_translation({0, 0, -kLength / 2 - kRadius});
-        break;
-      case TangentProneCylinder:
-      case TangentProneCapsule:
-        pose = RigidTransformd(AngleAxisd{M_PI_2, Vector3d::UnitX()},
-                               Vector3d{0, 0, -kRadius});
-        break;
-    }
-    return pose;
-  }
-
-  // Test constants. Geometric measures must be much larger than depth. The test
-  // enforces a ratio of at least 100. Using these in a GTEST precludes the
-  // possibility of being constexpr initialized; GTEST takes references.
-  static const double kDepth;
-  static const double kRadius;
-  static const double kLength;
-
-  ProximityEngine<double> engine_;
-
-  // The various geometries used in the collision test.
-  const Box box_{1, 1, 1};
-  const Sphere tangent_sphere_{kRadius};
-  const Box tangent_box_{kLength, kLength, kLength};
-  const HalfSpace tangent_plane_;  // Default construct the z = 0 plane.
-  const Cylinder tangent_cylinder_{kRadius, kLength};
-  // We scale the convex shape by 5.0 to match the tangent_box_ of size 10.0.
-  // The file "quad_cube.obj" contains the cube of size 2.0.
-  const Convex tangent_convex_{
-      drake::FindResourceOrThrow("drake/geometry/test/quad_cube.obj"), 5.0};
-  const Capsule tangent_capsule_{kRadius, kLength};
-
-  const Vector3d p_WC_{0, 0, -kDepth};
-  const Vector3d p_BoC_B_{-0.5, -0.5, -0.5};
-};
-
-// See documentation. All geometry constants must be >= kDepth * 100.
-const double BoxPenetrationTest::kDepth = 1e-3;
-const double BoxPenetrationTest::kRadius = 1;
-const double BoxPenetrationTest::kLength = 10;
-
-TEST_F(BoxPenetrationTest, TangentPlane1) {
-  TestCollision1(TangentPlane, 1e-12);
-}
-
-TEST_F(BoxPenetrationTest, TangentPlane2) {
-  TestCollision2(TangentPlane, 1e-12);
-}
-
-TEST_F(BoxPenetrationTest, TangentBox1) {
-  TestCollision1(TangentBox, 1e-12);
-}
-
-TEST_F(BoxPenetrationTest, TangentBox2) {
-  TestCollision2(TangentBox, 1e-12);
-}
-
-TEST_F(BoxPenetrationTest, TangentSphere1) {
-  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
-  // collision result from being more precise. Largely due to normal
-  // calculation. See related Drake issue 7656.
-  TestCollision1(TangentSphere, 1e-1);
-}
-
-TEST_F(BoxPenetrationTest, TangentSphere2) {
-  TestCollision2(TangentSphere, 1e-12);
-}
-
-TEST_F(BoxPenetrationTest, TangentStandingCylinder1) {
-  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
-  // collision result from being more precise. See related Drake issue 7656.
-  TestCollision1(TangentStandingCylinder, 1e-3);
-}
-
-TEST_F(BoxPenetrationTest, TangentStandingCylinder2) {
-  TestCollision2(TangentStandingCylinder, 1e-12);
-}
-
-TEST_F(BoxPenetrationTest, TangentProneCylinder1) {
-  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
-  // collision result from being more precise. Largely due to normal
-  // calculation. See related Drake issue 7656.
-  TestCollision1(TangentProneCylinder, 1e-1);
-}
-
-TEST_F(BoxPenetrationTest, TangentProneCylinder2) {
-  // TODO(SeanCurtis-TRI): There are underlying fcl issues that prevent the
-  // collision result from being more precise. In this case, the largest error
-  // is in the position of the contact points. See related Drake issue 7656.
-  TestCollision2(TangentProneCylinder, 1e-4);
-}
-
-TEST_F(BoxPenetrationTest, TangentConvex1) {
-  // TODO(DamrongGuoy): We should check why we cannot use a smaller tolerance.
-  TestCollision1(TangentConvex, 1e-3);
-}
-
-TEST_F(BoxPenetrationTest, TangentConvex2) {
-  // TODO(DamrongGuoy): We should check why we cannot use a smaller tolerance.
-  TestCollision2(TangentConvex, 1e-3);
-}
-
-TEST_F(BoxPenetrationTest, TangentStandingCapsule1) {
-  // TODO(tehbelinda): We should check why we cannot use a smaller tolerance.
-  TestCollision1(TangentStandingCapsule, 1e-1);
-}
-
-TEST_F(BoxPenetrationTest, TangentStandingCapsule2) {
-  TestCollision2(TangentStandingCapsule, 1e-12);
-}
-
-TEST_F(BoxPenetrationTest, TangentProneCapsule1) {
-  // TODO(tehbelinda): We should check why we cannot use a smaller tolerance.
-  TestCollision1(TangentProneCapsule, 1e-1);
-}
-
-TEST_F(BoxPenetrationTest, TangentProneCapsule2) {
-  // TODO(tehbelinda): We should check why we cannot use a smaller tolerance.
-  TestCollision2(TangentProneCapsule, 1e-4);
-}
-
-// This is a one-off test. Exposed in issue #10577. A point penetration pair
-// was returned for a zero-depth contact. This reproduces the geometry that
-// manifested the error. The reproduction isn't *exact*; it's been simplified to
-// a simpler configuration. Specifically, the important characteristics are:
-//   - both box and cylinder are ill aspected (one dimension is several orders
-//     of magnitude smaller than the other two),
-//   - the cylinder is placed away from the center of the box face,
-//   - the box is rotated 90 degrees around it's z-axis -- note swapping box
-//     dimensions with an identity rotation did *not* produce equivalent
-//     results, and
-//   - FCL uses GJK/EPA to solve box-cylinder collision (this is beyond control
-//     of this test).
-//
-// Libccd upgraded how it handles degenerate simplices. The upshot of that is
-// FCL would still return the same penetration depth, but instead of returning
-// a gibberish normal, it returns a zero vector. We want to make sure we don't
-// report zero-penetration as penetration, even in these numerically,
-// ill-conditioned scenarios. So, we address it up to a tolerance.
-GTEST_TEST(ProximityEngineTests, Issue10577Regression_Osculation) {
-  ProximityEngine<double> engine;
-  GeometryId id_A = GeometryId::get_new_id();
-  GeometryId id_B = GeometryId::get_new_id();
-  engine.AddDynamicGeometry(Box(0.49, 0.63, 0.015), {}, id_A);
-  engine.AddDynamicGeometry(Cylinder(0.08, 0.002), {}, id_B);
-
-  // Original translation was p_WA = (-0.145, -0.63, 0.2425) and
-  // p_WB = (0, -0.6, 0.251), respectively.
-  RigidTransformd X_WA(Eigen::AngleAxisd{M_PI_2, Vector3d::UnitZ()},
-                       Vector3d{-0.25, 0, 0});
-  RigidTransformd X_WB(Vector3d{0, 0, 0.0085});
-  const unordered_map<GeometryId, RigidTransformd> X_WG{{id_A, X_WA},
-                                                        {id_B, X_WB}};
-  engine.UpdateWorldPoses(X_WG);
-  std::vector<GeometryId> geometry_map{id_A, id_B};
-  auto pairs = engine.ComputePointPairPenetration(X_WG);
-  EXPECT_EQ(pairs.size(), 0);
-}
-
 // When anchored geometry is added to the proximity engine, the broadphase
 // algorithm needs to be properly updated, otherwise it assumes all of the
 // anchored geometry has the identity transformation. This test confirms that
 // this configuration occurs; the dynamic sphere and anchored sphere are
 // configured away from the origin in collision. Without proper broadphase
-// initialization for the anchored geometry, no collision is reported.
+// initialization for the anchored geometry, no collision is reported. We
+// also confirm that it gets initialized properly when cloned.
+//
+// This test uses HasCollisions() to exercise the broadphase, but it is not
+// a test on HasCollisions() logic (that is tested elsewhere).
 GTEST_TEST(ProximityEngineTests, AnchoredBroadPhaseInitialization) {
   ProximityEngine<double> engine;
   GeometryId id_D = GeometryId::get_new_id();
@@ -3107,15 +2215,13 @@ GTEST_TEST(ProximityEngineTests, AnchoredBroadPhaseInitialization) {
   std::unordered_map<GeometryId, math::RigidTransform<double>> X_WGs{
       {id_A, X_WA}, {id_D, X_WD}};
   engine.UpdateWorldPoses(X_WGs);
-  auto pairs = engine.ComputePointPairPenetration(X_WGs);
 
-  EXPECT_EQ(pairs.size(), 1);
+  EXPECT_TRUE(engine.HasCollisions());
 
   // Confirm that it survives copying.
   ProximityEngine<double> engine_copy(engine);
   engine_copy.UpdateWorldPoses({{id_D, X_WD}});
-  auto pairs_copy = engine_copy.ComputePointPairPenetration(X_WGs);
-  EXPECT_EQ(pairs_copy.size(), 1);
+  EXPECT_TRUE(engine_copy.HasCollisions());
 }
 
 // Basic smoke test for the autodiffibility of the signed distance computation.
@@ -3291,25 +2397,6 @@ GTEST_TEST(ProximityEngineTests,
       engine.ComputeSignedDistancePairwiseClosestPoints(X_WGs, kInf),
       "Signed distance queries between shapes 'Box' and 'Box' are not "
       "supported for scalar type drake::AutoDiffXd.*");
-}
-
-// Tests that an unsupported geometry causes the engine to throw.
-GTEST_TEST(ProximityEngineTests, ExpressionUnsupported) {
-  ProximityEngine<Expression> engine;
-
-  // Add two geometries that can't be queried.
-  const GeometryId id1 = GeometryId::get_new_id();
-  const GeometryId id2 = GeometryId::get_new_id();
-  engine.AddDynamicGeometry(Box(1, 2, 3), {}, id1);
-  engine.AddDynamicGeometry(Box(2, 4, 6), {}, id2);
-
-  const unordered_map<GeometryId, RigidTransform<Expression>> X_WGs{
-      {id1, RigidTransform<Expression>::Identity()},
-      {id2, RigidTransform<Expression>::Identity()}};
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      engine.ComputePointPairPenetration(X_WGs),
-      "Penetration queries between shapes 'Box' and 'Box' are not supported "
-      "for scalar type drake::symbolic::Expression.*");
 }
 
 // Test fixture for deformable contact.


### PR DESCRIPTION
Clean up PenetrationAsPointPair tests

1. Move valuable tests from proximity_engine_test into their rightful
   home penetration_as_point_pair_callback_test.cc
    - (ProximityEngineTests, Issue10577Regression_Osculation)
    - (BoxPenetrationTest, *)
1. Delete redundant tests (tests that duplicate tests on the Callback or
   are simply bitrotted):
    - The SimplePenetrationTest test harness.
    - (SimplePenetrationTest, PenetrationDynamicAndAnchored)
    - (SimplePenetrationTest, PenetrationDynamicAndDynamicSingleSource)
    - (SimplePenetrationTest, HasCollisionsDynamicAndAnchored)
    - (SimplePenetrationTest, HasCollisionsDynamicAndDynamicSingleSource)
    - (SimplePenetrationTest, WithCollisionFilters)
    - (ProximityEngineTests, ExpressionUnsupported)
    - (ProximityEngineCollisionTest, SpherePunchThroughBox) (an anacrhonism)
2. Respell (SimplePenetrationTest, HasCollisionsAnchoredInterference)
   - This had nothing to do with SimplePenetrationTest. It has been
     elevated to ProximityEngineTests.
3. Reframing existing tests
   - Clarify (ProximityEngineTests, AnchoredBroadPhaseInitialization) and
    use a cheaper query.
4. Create a single test for ProximityEngine's unique responsibilites for
   calls to ComputePointPairPenetration().
   Created: (ProximityEngineTests, ComputePointPairPenetration)
   Removed the tests that individually exercised aspects of the overall
   test:
      - (ProximityEngineTests, PenetrationSingleAnchored)
      - (ProximityEngineTests, PenetrationMultipleAnchored)
      - (ProximityEngineTests, PenetrationAsPointPairResultOrdering)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24394)
<!-- Reviewable:end -->
