### PR TITLE
[setup] Fix temp arch-based filename for bazelisk

### DIFF
--- a/setup/ubuntu/source_distribution/install_bazelisk.sh
+++ b/setup/ubuntu/source_distribution/install_bazelisk.sh
@@ -31,7 +31,7 @@ dpkg_install_from_wget() {
   fi
 
   # Download and verify.
-  tmpdeb="/tmp/${package}_${version}-amd64.deb"
+  tmpdeb="/tmp/${package}_${version}-$(dpkg-architecture -qDEB_HOST_ARCH).deb"
   wget -O "${tmpdeb}" "${url}"
   if echo "${checksum} ${tmpdeb}" | sha256sum -c -; then
     echo  # Blank line between checkout output and dpkg output.


### PR DESCRIPTION
This doesn't much matter, since the per-architecture URL and shasums are already correct, but it helps avoid any confusion in CI logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24395)
<!-- Reviewable:end -->
