### PR TITLE
Fix mixed_integer_rotation_constraint_corner_test conditions

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -48,6 +48,14 @@ selects.config_setting_group(
     ],
 )
 
+selects.config_setting_group(
+    name = "gurobi_and_mosek_enabled",
+    match_all = [
+        "//tools/workspace/gurobi:enabled",
+        "//tools/workspace/mosek:enabled",
+    ],
+)
+
 drake_cc_package_library(
     name = "solvers",
     visibility = ["//visibility:public"],
@@ -1761,7 +1769,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mixed_integer_rotation_constraint_corner_test",
     timeout = "long",
-    opt_in_condition = ":gurobi_or_mosek_enabled",
+    opt_in_condition = ":gurobi_and_mosek_enabled",
     # This test is quite long, so split it into 4 processes for better latency.
     shard_count = 4,
     use_default_main = False,


### PR DESCRIPTION
Amends 8bd54673. Prior to that commit, the selection condition based on tags for tests marked as "gurobi + mosek" was "and" not "or". On Linux aarch64, this test doesn't pass when only MOSEK is available.  We'll change the condition back to "and" to restore the status quo for that one test.

The other nearby test programs that changed from "and" to "or" seem to be just fine with only MOSEK, so we'll leave their filter alone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24397)
<!-- Reviewable:end -->
