### PR TITLE
[setup] Promote ca-certificates to binary prereqs (from build)

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-noble.txt
+++ b/setup/ubuntu/binary_distribution/packages-noble.txt
@@ -1,3 +1,4 @@
+ca-certificates
 jupyter-notebook
 libblas-dev
 libegl1

--- a/setup/ubuntu/binary_distribution/packages-resolute.txt
+++ b/setup/ubuntu/binary_distribution/packages-resolute.txt
@@ -1,3 +1,4 @@
+ca-certificates
 jupyter-notebook
 libblas-dev
 libegl1

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -90,7 +90,6 @@ if [[ "${with_update}" -eq 1 && "${binary_distribution_called_update:-0}" -ne 1 
 fi
 
 apt-get install ${maybe_yes} --no-install-recommends $(cat <<EOF
-ca-certificates
 wget
 EOF
 )


### PR DESCRIPTION
PackageMap needs it to download https archives (e.g., drake_models).

+a:@rpoyner-tri for both reviews, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24398)
<!-- Reviewable:end -->
