### PR TITLE
[setup] Add dependencies to our apt package release

### DIFF
--- a/setup/ubuntu/binary_distribution/install_prereqs.sh
+++ b/setup/ubuntu/binary_distribution/install_prereqs.sh
@@ -71,12 +71,5 @@ elif ! [[ "${VERSION_CODENAME}" =~ (noble) ]]; then
   exit 2
 fi
 
-apt-get install ${maybe_yes} --no-install-recommends $(cat <<EOF
-build-essential
-cmake
-pkg-config
-EOF
-)
-
 packages=$(cat "${BASH_SOURCE%/*}/packages-${VERSION_CODENAME}.txt")
 apt-get install ${maybe_yes} --no-install-recommends ${packages}

--- a/setup/ubuntu/binary_distribution/packages-noble.txt
+++ b/setup/ubuntu/binary_distribution/packages-noble.txt
@@ -1,4 +1,6 @@
+build-essential
 ca-certificates
+cmake
 jupyter-notebook
 libblas-dev
 libegl1
@@ -13,6 +15,7 @@ libpython3.12
 libspdlog-dev
 libx11-6
 ocl-icd-libopencl1
+pkg-config
 python3
 python3-ipywidgets
 python3-matplotlib

--- a/setup/ubuntu/binary_distribution/packages-resolute.txt
+++ b/setup/ubuntu/binary_distribution/packages-resolute.txt
@@ -1,4 +1,6 @@
+build-essential
 ca-certificates
+cmake
 jupyter-notebook
 libblas-dev
 libegl1
@@ -13,6 +15,7 @@ libpython3.14
 libspdlog-dev
 libx11-6
 ocl-icd-libopencl1
+pkg-config
 python3
 python3-ipywidgets
 python3-matplotlib

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -90,10 +90,6 @@ done
 # Dependencies that are installed by the following sourced script that are
 # needed when developing with binary distributions are also needed when
 # developing with source distributions.
-#
-# Note that the list of packages in binary_distribution/packages.txt is used to
-# generate the dependencies of the drake .deb package, so does not include
-# development dependencies such as build-essential and cmake.
 
 source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
   "${binary_distribution_args[@]}"


### PR DESCRIPTION
Add `build-essential`, `cmake`, `pkg-config` as new dependencies of our apt binary package releases. Previously these were already declared as dependencies when building from source or when downloading `tar.gz` binary releases. In 5f60cdf3 (from 2018), we specifically chose to exclude them as apt binary package dependencies, because users might only want to run Drake programs instead of consume Drake as a library. However, since that time Drake has removed its programs and is only a library now, so that line of reasoning is moot. On the other hand, these days Python-only users of the Drake are common; they wouldn't need CMake, so for them these new dependencies would be spurious. However, Python-only users probably are not installing from apt, because we offer PyPI wheels now. We'll assume that the majority of apt installs are for use by downstream C++ projects, so installing build tools is reasonable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24399)
<!-- Reviewable:end -->
