### PR TITLE
[github] Automatically flag stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+---
+name: stale
+on:
+  schedule:
+    - cron: '30 1 * * *'
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-close: -1
+          days-before-issue-stale: -1
+          days-before-pr-close: 30
+          days-before-pr-stale: 180
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-label: 'status: stale'
+          stale-pr-message: >
+            Thank you for your contribution. This pull request has been open for
+            180 days without activity and so is considered stale. It will be
+            automatically closed in 30 days unless you comment or remove the
+            "status: stale" label.


### PR DESCRIPTION
They'll get a biff after 6 months and then auto-close after another month without activity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24400)
<!-- Reviewable:end -->
