### PR TITLE
[tools] Remove unused compiler configs

### DIFF
--- a/tools/bazel-build.rc
+++ b/tools/bazel-build.rc
@@ -108,25 +108,6 @@ build:debug --test_timeout=120,600,1800,7200
 build:linux --fission=dbg
 build:linux --features=per_object_debug_info
 
-# Options for explicitly using GCC.
-# TODO(#24359) Delete this entirely.
-common:gcc --repo_env=CC=gcc
-common:gcc --repo_env=CXX=g++
-build:gcc --action_env=CC=gcc
-build:gcc --action_env=CXX=g++
-build:gcc --host_action_env=CC=gcc
-build:gcc --host_action_env=CXX=g++
-
-# Options for explicitly using Clang.
-# Note that the drake/gen/environment.bazelrc file might override this.
-# TODO(#24359) Delete this entirely.
-common:clang --repo_env=CC=clang
-common:clang --repo_env=CXX=clang++
-build:clang --action_env=CC=clang
-build:clang --action_env=CXX=clang++
-build:clang --host_action_env=CC=clang
-build:clang --host_action_env=CXX=clang++
-
 ### A configuration that enables all optional dependencies. ###
 build:everything --@drake//tools/flags:with_gurobi=True
 build:everything --@drake//tools/workspace/gurobi:force_disable_when_not_supported=True


### PR DESCRIPTION
These were only used by drake-ci, but it no longer needs them as of https://github.com/RobotLocomotion/drake-ci/pull/419.

Closes #24359.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24402)
<!-- Reviewable:end -->
