### PR TITLE
[doc] Clean up proprietary solver documentation

### DIFF
--- a/doc/_pages/bazel.md
+++ b/doc/_pages/bazel.md
@@ -207,29 +207,34 @@ license seats you want to use.
 
 ## Gurobi
 
-### Install on Ubuntu
+Drake supports any patch version of Gurobi 13.0. At time of writing, the most
+recent available version was 13.0.1; if using a newer patch version, the paths
+and file names below should be adjusted accordingly.
+
+The first steps are to:
 
 1. Register for an account on [https://www.gurobi.com](https://www.gurobi.com).
 2. Set up your Gurobi license file in accordance with Gurobi documentation.
 3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``.
-4. Download ``gurobi13.0.1_linux64.tar.gz``. You may need to manually edit the
+
+From there, follow the platform-specific instructions below.
+
+### Install on Ubuntu
+
+1. Download ``gurobi13.0.1_linux64.tar.gz``. You may need to manually edit the
    URL to get the correct version.
-5. Unzip it. We suggest that you use ``/opt/gurobi1301`` to simplify working
+2. Unzip it. We suggest that you use ``/opt/gurobi1301`` to simplify working
    with Drake installations.
-6. If you unzipped into a location other than ``/opt/gurobi1301``, then call
+3. If you unzipped into a location other than ``/opt/gurobi1301``, then call
    ``export GUROBI_HOME=GUROBI_UNZIP_PATH/linux64`` to set the path you used,
    where in ``GUROBI_HOME`` folder you can find ``bin`` folder.
 
-Drake supports any patch version of Gurobi 13.0. At time of writing, the most
-recent available version was 13.0.1; if using a newer patch version, the paths
-and file names above should be adjusted accordingly.
-
 ### Install on macOS
 
-1. Register for an account on [http://www.gurobi.com](http://www.gurobi.com).
-2. Set up your Gurobi license file in accordance with Gurobi documentation.
-3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``
-4. Download and install ``gurobi13.0.1_macos2_universal.pkg``.
+Download and install ``gurobi13.0.1_macos2_universal.pkg``. It should be
+installed to `/Library/gurobi1301`.
+
+### Test
 
 To confirm that your setup was successful, run a test that requires Gurobi:
 
@@ -237,7 +242,7 @@ To confirm that your setup was successful, run a test that requires Gurobi:
 
 ## MOSEK
 
-The Drake Bazel build system downloads MOSEK™ 10.0.18 automatically. No manual
+The Drake Bazel build system downloads MOSEK™ 11.1 automatically. No manual
 installation is required.  Set the location of your license file as follows:
 
   ```export MOSEKLM_LICENSE_FILE=/path/to/mosek.lic```
@@ -258,13 +263,13 @@ a private RobotLocomotion git repository.
    named ``snopt7.4.tar.gz``).
 2. ``export SNOPT_PATH=/home/username/Downloads/snopt7.4.tar.gz``
 
-Using the RobotLocomotion git repository
+### Using the RobotLocomotion git repository
 
 1. Obtain access to the private RobotLocomotion/snopt GitHub repository.
 2. [Set up SSH access to github.com](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/).
 3. ``export SNOPT_PATH=git``
 
-Test the build (for either mechanism)
+### Test the build (for either mechanism)
 
 To confirm that your setup was successful, run a test that requires SNOPT:
 

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -205,9 +205,10 @@ Adjusting closed-source (commercial) software dependencies:
   When `ON`, enables the `GurobiSolver` in the build.
   * When enabled, you must download and install Gurobi 13.0 yourself prior to
     running Drake's CMake configure script; Drake does not automatically
-    download Gurobi. If Gurobi is not installed to its standard location, you
-    must also `export GUROBI_HOME=${...GUROBI_UNZIP_PATH...}/linux64`
-    in your terminal so that `find_package(Gurobi)` will be able to find it.
+    download Gurobi. On Ubuntu, if Gurobi is not installed to its standard
+    location, you must also
+    `export GUROBI_HOME=${...GUROBI_UNZIP_PATH...}/linux64` in your terminal
+    so that `find_package(Gurobi)` will be able to find it.
 * `WITH_MOSEK` (default `OFF`).
   When `ON`, enables the `MosekSolver` in the build.
   * When enabled, Drake automatically downloads the MOSEK™ software from


### PR DESCRIPTION
Finish the Gurobi instructions on macOS by providing the path that Drake's `find_package` call defaults to. Fix an outdated reference to the MOSEK version supported by Drake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24412)
<!-- Reviewable:end -->
