### PR TITLE
[wheel] Optionally test and install wheels using uv

### DIFF
--- a/tools/wheel/test/Dockerfile
+++ b/tools/wheel/test/Dockerfile
@@ -1,9 +1,10 @@
-ARG PLATFORM=ubuntu:20.04
+ARG PLATFORM=ubuntu:24.04
 
 FROM ${PLATFORM}
 
 ARG PYTHON=3
+ARG PYTHON_MANAGER=pip
 
 ADD provision.sh /image/
 
-RUN /image/provision.sh ${PYTHON}
+RUN /image/provision.sh ${PYTHON} ${PYTHON_MANAGER}

--- a/tools/wheel/test/install-wheel.sh
+++ b/tools/wheel/test/install-wheel.sh
@@ -14,11 +14,25 @@
 
 set -eu -o pipefail
 
-if [[ -z "$1" ]]; then
-    echo "Usage: $0 <wheel>" >&2
+WHEEL="${1:-}"
+PYTHON_MANAGER="${2:-pip}"
+
+if [[ -z "${WHEEL}" ]]; then
+    echo "Usage: $0 <wheel> [{pip,uv}]" >&2
     exit 1
 fi
 
 . /tmp/drake-wheel-test/python/bin/activate
 
-pip install "$1"
+case "${PYTHON_MANAGER}" in
+    pip)
+        pip install "${WHEEL}"
+        ;;
+    uv)
+        ${HOME}/.local/bin/uv pip install "${WHEEL}"
+        ;;
+    *)
+        echo "Unknown virtual environment manager '${PYTHON_MANAGER}'" >&2
+        exit 1
+        ;;
+esac

--- a/tools/wheel/test/provision.sh
+++ b/tools/wheel/test/provision.sh
@@ -4,29 +4,47 @@
 
 set -eu -o pipefail
 
-readonly PYTHON=python${1:-3}
+readonly PYTHON_VERSION="${1:-3}"
+readonly PYTHON_MANAGER="${2:-pip}"
+
+readonly PYTHON="python${PYTHON_VERSION}"
+readonly VENV="/tmp/drake-wheel-test/python"
 
 . /etc/os-release
-case "$ID" in
-  ubuntu)
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get -y update
-    apt-get -y install --no-install-recommends \
-        lib${PYTHON}-dev ${PYTHON}-venv \
-        python3-venv \
-        libx11-6 libsm6 libxt6 libglib2.0-0
-    ;;
-  amzn)
-    dnf install -y ${PYTHON}
-    ;;
-  *)
-    echo "Unknown distro '$ID'" >&2
-    exit 1
-    ;;
-esac
 
-${PYTHON} -m venv /tmp/drake-wheel-test/python
+if [[ "${ID}" == "ubuntu" && "${PYTHON_MANAGER}" == "pip" ]]; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get -y update
+  # Install system prerequisites required by Drake's wheel, only on Ubuntu.
+  apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
 
-. /tmp/drake-wheel-test/python/bin/activate
+  # Install Python and set up the virtual environment.
+  apt-get -y install --no-install-recommends \
+    lib${PYTHON}-dev ${PYTHON}-venv \
+    python3-venv \
+  ${PYTHON} -m venv ${VENV}
+  . ${VENV}/bin/activate
+  pip install --upgrade pip
+elif [[ "${ID}" == "ubuntu" && "${PYTHON_MANAGER}" == "uv" ]]; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get -y update
+  # Install system prerequisites required by Drake's wheel, only on Ubuntu.
+  apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
 
-pip install --upgrade pip
+  # Install uv and set up the virtual environment.
+  apt-get -y install --no-install-recommends \
+    ca-certificates gzip tar wget
+  wget -qO- https://astral.sh/uv/install.sh | sh
+  ${HOME}/.local/bin/uv venv ${VENV} --python ${PYTHON_VERSION}
+elif [[ "${ID}" == "amzn" && "${PYTHON_MANAGER}" == "pip" ]]; then
+  dnf update -y --releasever=latest
+
+  # Install Python and set up the virtual environment.
+  dnf install -y ${PYTHON}
+  ${PYTHON} -m venv ${VENV}
+  . ${VENV}/bin/activate
+  pip install --upgrade pip
+else
+  echo "Unsupported distro '${ID}' and/or manager '${PYTHON_MANAGER}'" >&2
+  exit 1
+fi

--- a/tools/wheel/test/provision.sh
+++ b/tools/wheel/test/provision.sh
@@ -12,39 +12,50 @@ readonly VENV="/tmp/drake-wheel-test/python"
 
 . /etc/os-release
 
-if [[ "${ID}" == "ubuntu" && "${PYTHON_MANAGER}" == "pip" ]]; then
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get -y update
-  # Install system prerequisites required by Drake's wheel, only on Ubuntu.
-  apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
+case "${ID}" in
+  ubuntu)
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get -y update
+    # Install system prerequisites required by Drake's wheel, only on Ubuntu.
+    apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
 
-  # Install Python and set up the virtual environment.
-  apt-get -y install --no-install-recommends \
-    lib${PYTHON}-dev ${PYTHON}-venv \
-    python3-venv \
-  ${PYTHON} -m venv ${VENV}
-  . ${VENV}/bin/activate
-  pip install --upgrade pip
-elif [[ "${ID}" == "ubuntu" && "${PYTHON_MANAGER}" == "uv" ]]; then
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get -y update
-  # Install system prerequisites required by Drake's wheel, only on Ubuntu.
-  apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
+    # Install Python and set up the virtual environment.
+    case "${PYTHON_MANAGER}" in
+      pip)
+        apt-get -y install --no-install-recommends \
+          lib${PYTHON}-dev ${PYTHON}-venv \
+          python3-venv
+        ${PYTHON} -m venv ${VENV}
+        ;;
+      uv)
+        apt-get -y install --no-install-recommends \
+          ca-certificates gzip tar wget
+        wget -qO- https://astral.sh/uv/install.sh | sh
+        ${HOME}/.local/bin/uv venv ${VENV} --python ${PYTHON_VERSION}
+        ;;
+      *)
+        echo "Unsupported manager '${PYTHON_MANAGER}'" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  amzn)
+    dnf update -y --releasever=latest
 
-  # Install uv and set up the virtual environment.
-  apt-get -y install --no-install-recommends \
-    ca-certificates gzip tar wget
-  wget -qO- https://astral.sh/uv/install.sh | sh
-  ${HOME}/.local/bin/uv venv ${VENV} --python ${PYTHON_VERSION}
-elif [[ "${ID}" == "amzn" && "${PYTHON_MANAGER}" == "pip" ]]; then
-  dnf update -y --releasever=latest
-
-  # Install Python and set up the virtual environment.
-  dnf install -y ${PYTHON}
-  ${PYTHON} -m venv ${VENV}
-  . ${VENV}/bin/activate
-  pip install --upgrade pip
-else
-  echo "Unsupported distro '${ID}' and/or manager '${PYTHON_MANAGER}'" >&2
-  exit 1
-fi
+    # Install Python and set up the virtual environment.
+    case "${PYTHON_MANAGER}" in
+      pip)
+        dnf install -y ${PYTHON}
+        ${PYTHON} -m venv ${VENV}
+        ;;
+      *)
+        echo "Unsupported manager '${PYTHON_MANAGER}'" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "Unsupported distro '${ID}'" >&2
+    exit 1
+    ;;
+esac

--- a/tools/wheel/test/provision.sh
+++ b/tools/wheel/test/provision.sh
@@ -12,39 +12,50 @@ readonly VENV="/tmp/drake-wheel-test/python"
 
 . /etc/os-release
 
-if [[ "${ID}" == "ubuntu" && "${PYTHON_MANAGER}" == "pip" ]]; then
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get -y update
-  # Install system prerequisites required by Drake's wheel, only on Ubuntu.
-  apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
+case "${ID}" in
+  ubuntu)
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get -y update
+    # Install system prerequisites required by Drake's wheel, only on Ubuntu.
+    apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
 
-  # Install Python and set up the virtual environment.
-  apt-get -y install --no-install-recommends \
-    lib${PYTHON}-dev ${PYTHON}-venv \
-    python3-venv \
-  ${PYTHON} -m venv ${VENV}
-  . ${VENV}/bin/activate
-  pip install --upgrade pip
-elif [[ "${ID}" == "ubuntu" && "${PYTHON_MANAGER}" == "uv" ]]; then
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get -y update
-  # Install system prerequisites required by Drake's wheel, only on Ubuntu.
-  apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
+    # Install Python and set up the virtual environment.
+    case "${PYTHON_MANAGER}" in
+      pip)
+        apt-get -y install --no-install-recommends \
+          lib${PYTHON}-dev ${PYTHON}-venv \
+          python3-venv
+        ${PYTHON} -m venv ${VENV}
+        ;;
+      uv)
+        apt-get -y install --no-install-recommends \
+          ca-certificates gzip tar wget
+        wget -qO- https://astral.sh/uv/install.sh | sh
+        ${HOME}/.local/bin/uv venv ${VENV} --python ${PYTHON_VERSION}
+        ;;
+      *)
+        echo "Unsupported Python manager '${PYTHON_MANAGER}'" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  amzn)
+    dnf update -y
 
-  # Install uv and set up the virtual environment.
-  apt-get -y install --no-install-recommends \
-    ca-certificates gzip tar wget
-  wget -qO- https://astral.sh/uv/install.sh | sh
-  ${HOME}/.local/bin/uv venv ${VENV} --python ${PYTHON_VERSION}
-elif [[ "${ID}" == "amzn" && "${PYTHON_MANAGER}" == "pip" ]]; then
-  dnf update -y --releasever=latest
-
-  # Install Python and set up the virtual environment.
-  dnf install -y ${PYTHON}
-  ${PYTHON} -m venv ${VENV}
-  . ${VENV}/bin/activate
-  pip install --upgrade pip
-else
-  echo "Unsupported distro '${ID}' and/or manager '${PYTHON_MANAGER}'" >&2
-  exit 1
-fi
+    # Install Python and set up the virtual environment.
+    case "${PYTHON_MANAGER}" in
+      pip)
+        dnf install -y ${PYTHON}
+        ${PYTHON} -m venv ${VENV}
+        ;;
+      *)
+        echo "Unsupported Python manager '${PYTHON_MANAGER}'" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "Unsupported distro '${ID}'" >&2
+    exit 1
+    ;;
+esac

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -19,7 +19,7 @@ from .common import (
     wheel_name,
     wheelhouse,
 )
-from .linux_types import BUILD, TEST, Platform, Role, Target
+from .linux_types import BUILD, TEST, Platform, PythonManager, Role, Target
 
 # Artifacts that need to be cleaned up. DO NOT MODIFY outside of this file.
 _files_to_remove = []
@@ -52,6 +52,8 @@ targets = {
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble"),
+                # TODO(tyler-yankee) Add testing for Ubuntu 26.04 (with uv)
+                # once it's been released.
             ),
             python_version_tuple=(3, 12, 8),
             python_sha="c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e",  # noqa
@@ -60,9 +62,9 @@ targets = {
             build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
-                # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been
-                # released.
-                Platform("ubuntu", "25.10", "questing"),
+                Platform("ubuntu", "24.04", "noble", PythonManager.UV),
+                # TODO(tyler-yankee) Add testing for Ubuntu 26.04 (with uv)
+                # once it's been released.
             ),
             python_version_tuple=(3, 13, 0),
             python_sha="086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d",  # noqa
@@ -71,9 +73,9 @@ targets = {
             build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
-                # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been
-                # released.
-                Platform("ubuntu", "25.10", "questing"),
+                Platform("ubuntu", "24.04", "noble", PythonManager.UV),
+                # TODO(tyler-yankee) Add testing for Ubuntu 26.04 once it's
+                # been released.
             ),
             python_version_tuple=(3, 14, 0),
             python_sha="2299dae542d395ce3883aca00d3c910307cd68e0b2f7336098c8e7b7eee9f3e9",  # noqa
@@ -85,6 +87,8 @@ targets = {
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble"),
+                # TODO(tyler-yankee) Add testing for Ubuntu 26.04 (with uv)
+                # once it's been released.
             ),
             python_version_tuple=(3, 12, 8),
             python_sha="c909157bb25ec114e5869124cc2a9c4a4d4c1e957ca4ff553f1edc692101154e",  # noqa
@@ -93,9 +97,9 @@ targets = {
             build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
-                # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been
-                # released.
-                Platform("ubuntu", "25.10", "questing"),
+                Platform("ubuntu", "24.04", "noble", PythonManager.UV),
+                # TODO(tyler-yankee) Add testing for Ubuntu 26.04 (with uv)
+                # once it's been released.
             ),
             python_version_tuple=(3, 13, 0),
             python_sha="086de5882e3cb310d4dca48457522e2e48018ecd43da9cdf827f6a0759efb07d",  # noqa
@@ -104,9 +108,9 @@ targets = {
             build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
-                # TODO(jwnimmer-tri) Switch testing to 26.04 once it's been
-                # released.
-                Platform("ubuntu", "25.10", "questing"),
+                Platform("ubuntu", "24.04", "noble", PythonManager.UV),
+                # TODO(tyler-yankee) Add testing for Ubuntu 26.04 once it's
+                # been released.
             ),
             python_version_tuple=(3, 14, 0),
             python_sha="2299dae542d395ce3883aca00d3c910307cd68e0b2f7336098c8e7b7eee9f3e9",  # noqa
@@ -252,6 +256,7 @@ def _target_args(target: Target, role: Role, test_index: int | None = None):
     """
     platform_name = target.platform(role, test_index).name
     platform_version = target.platform(role, test_index).version
+    python_manager = target.platform(role, test_index).python_manager
     python_version = target.python_version
 
     if role == BUILD and target.python_sha is not None:
@@ -262,6 +267,7 @@ def _target_args(target: Target, role: Role, test_index: int | None = None):
     else:
         python_args = [
             "--build-arg", f"PYTHON={python_version}",
+            "--build-arg", f"PYTHON_MANAGER={python_manager.value}",
         ]  # fmt: skip
 
     return [
@@ -348,12 +354,16 @@ def _test_wheel(target, identifier, options):
             _images_to_remove.append(base_image)
 
         # Install the wheel.
-        install_script = "/test/install-wheel.sh"
+        install_command = [
+            "/test/install-wheel.sh",
+            os.path.join(wheelhouse, wheel),
+            test_platform.python_manager.value,
+        ]  # fmt: skip
         _docker(
             "run", "-t", f"--name={test_container}",
             f"-v{test_dir}:/test",
             f"-v{options.output_dir}:{wheelhouse}",
-            base_image, install_script, os.path.join(wheelhouse, wheel),
+            base_image, *install_command,
         )  # fmt: skip
 
         # Tag the container with the wheel installed.

--- a/tools/wheel/wheel_builder/linux_types.py
+++ b/tools/wheel/wheel_builder/linux_types.py
@@ -2,6 +2,14 @@
 # //tools/wheel:builder for the user interface.
 
 from dataclasses import dataclass
+from enum import Enum
+
+
+class PythonManager(Enum):
+    _value_: str
+
+    PIP = "pip"
+    UV = "uv"
 
 
 @dataclass
@@ -14,6 +22,7 @@ class Platform:
     name: str
     version: str
     alias: str
+    python_manager: PythonManager = PythonManager.PIP
 
 
 @dataclass


### PR DESCRIPTION
Teach the wheel builder about `uv` as an alternative to installing host-system Python and `pip`-installing the built Drake wheel used for testing.

We now no longer strictly need Ubuntu 25.10 (or any non-LTS versions moving forward, unless otherwise desired) as a test platform. Instead, test on Ubuntu 24.04 using `uv` to obtain the necessary Python version.

This change is partially motivated by an upcoming "gap" in our test matrix, whereby neither Ubuntu 24.04 nor 26.04 (see #23976) will ship Python 3.13. However, it's also a beneficial standalone change, as installing Drake with `uv` is a common use case that we should validate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24419)
<!-- Reviewable:end -->
