### PR TITLE
[pydrake] Fix CoulombFriction pickling test

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1073,12 +1073,14 @@ class TestPlant(unittest.TestCase):
     def test_friction_api(self, T):
         CoulombFriction = CoulombFriction_[T]
         CoulombFriction()
-        CoulombFriction(static_friction=0.7, dynamic_friction=0.6)
+        dut = CoulombFriction(static_friction=0.7, dynamic_friction=0.6)
+        self.assertIsInstance(dut.static_friction(), T)
+        self.assertIsInstance(dut.dynamic_friction(), T)
         copy.copy(CoulombFriction())
         assert_pickle(
             self,
-            CoulombFriction,
-            lambda x: [x.static_friction, x.dynamic_friction],
+            dut,
+            lambda x: [x.static_friction(), x.dynamic_friction()],
             T=T,
         )
 


### PR DESCRIPTION
It was testing pickling the class object (not an instance of the class) and the value_to_compare was using bound methods, not values.

Noticed during #23903.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24430)
<!-- Reviewable:end -->
