### PR TITLE
[setup] Add --user-environment-only option to install_prereqs

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -7,15 +7,22 @@ set -euxo pipefail
 
 binary_distribution_args=(--without-python-dependencies)
 source_distribution_args=()
+user_environment_only=0
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
     --developer)
       source_distribution_args+=(--developer)
       ;;
+    --user-environment-only)
+      user_environment_only=1
+      ;;
     # Do NOT call brew update during execution of this script.
     --without-update)
       binary_distribution_args+=(--without-update)
+      ;;
+    # Ignored for compatibility with Ubuntu.
+    -y)
       ;;
     *)
       echo 'Invalid command line argument' >&2
@@ -24,21 +31,23 @@ while [ "${1:-}" != "" ]; do
   shift
 done
 
-# Dependencies that are installed by the following sourced script that are
-# needed when developing with binary distributions are also needed when
-# developing with source distributions.
+if [[ ${user_environment_only} -eq 0 ]]; then
+  # Dependencies that are installed by the following sourced script that are
+  # needed when developing with binary distributions are also needed when
+  # developing with source distributions.
 
-# N.B. We need `${var:-}` here because mac's older version of bash does
-# not seem to be able to cope with an empty array.
+  # N.B. We need `${var:-}` here because mac's older version of bash does
+  # not seem to be able to cope with an empty array.
 
-source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
-  "${binary_distribution_args[@]:-}"
+  source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
+    "${binary_distribution_args[@]:-}"
 
-# The following additional dependencies are only needed when developing with
-# source distributions.
+  # The following additional dependencies are only needed when developing with
+  # source distributions.
 
-source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
-  "${source_distribution_args[@]:-}"
+  source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
+    "${source_distribution_args[@]:-}"
+fi
 
 # The preceding only needs to be run once per machine. The following sourced
 # script should be run once per user who develops with source distributions.

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -28,12 +28,16 @@ trap at_exit EXIT
 binary_distribution_args=()
 source_distribution_args=()
 prefetch_bazel=0
+user_environment_only=0
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
     --developer)
       source_distribution_args+=(--developer)
       prefetch_bazel=1
+      ;;
+    --user-environment-only)
+      user_environment_only=1
       ;;
     # Do NOT call apt-get update during execution of this script.
     --without-update)
@@ -50,17 +54,19 @@ while [ "${1:-}" != "" ]; do
   shift
 done
 
-# Dependencies that are installed by the following sourced script that are
-# needed when developing with binary distributions are also needed when
-# developing with source distributions.
+if [[ ${user_environment_only} -eq 0 ]]; then
+  # Dependencies that are installed by the following sourced script that are
+  # needed when developing with binary distributions are also needed when
+  # developing with source distributions.
 
-source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
-  "${binary_distribution_args[@]}"
+  source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
+    "${binary_distribution_args[@]}"
 
-# The following additional dependencies are only needed when developing with
-# source distributions.
-source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
-  "${source_distribution_args[@]}"
+  # The following additional dependencies are only needed when developing with
+  # source distributions.
+  source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" \
+    "${source_distribution_args[@]}"
+fi
 
 # Configure user environment, executing as user if we're under `sudo`.
 user_env_script="${BASH_SOURCE%/*}/source_distribution/install_prereqs_user_environment.sh"


### PR DESCRIPTION
This is needed by CI for Provisioned jobs.

Towards #22055.

FYI Once more progress has been made (i.e., rewrite in Python), I intend to add more documentation / `--help` around the still-supported command line flags beyond `--developer`.  But in `bash`, it's too much work. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24433)
<!-- Reviewable:end -->
