### PR TITLE
[multibody] CENIC accepts a bare plant (no diagram)

### DIFF
--- a/bindings/generated_docstrings/multibody_cenic.h
+++ b/bindings/generated_docstrings/multibody_cenic.h
@@ -68,8 +68,9 @@ optimization problem [Castro et al., 2023] to advance the system state
 at each time step. A simple half-stepping strategy provides a
 second-order error estimate for automatic step-size selection.
 
-Because CENIC is specific to multibody systems, this integrator
-requires a system diagram with a ``MultibodyPlant`` subsystem.
+Because CENIC is specific to multibody systems, the system it's asked
+to integrate must either be a MultibodyPlant system or a Diagram that
+contains a MultibodyPlant subsystem, at any level of Diagram nesting.
 
 Running CENIC in fixed-step mode (with error-control disabled)
 recovers the "Lagged" variant of discrete-time ICF simulation from
@@ -109,10 +110,11 @@ https://arxiv.org/abs/2511.08771.)""";
 R"""(Constructs the integrator.
 
 Parameter ``system``:
-    The overall system diagram to simulate. Must include exactly one
-    continuous-time MultibodyPlant. Other (discrete-time) plants are
-    allowed in the diagram. This ``system`` is aliased by this object
-    so must remain alive longer than the integrator.
+    The overall system to simulate. Must either be a MultibodyPlant or
+    a Diagram that contains exactly one continuous-time
+    MultibodyPlant. Other (discrete-time) plants are allowed in a
+    diagram. This ``system`` is aliased by this object so must remain
+    alive longer than the integrator.
 
 Parameter ``context``:
     context for the overall system.)""";

--- a/multibody/cenic/cenic_integrator.cc
+++ b/multibody/cenic/cenic_integrator.cc
@@ -25,26 +25,19 @@ using systems::VectorBase;
 
 namespace {
 
-// Validate a diagram for CenicIntegrator, and capture the structure details
-// needed at run-time.
+// Validate a root system for CenicIntegrator, and capture the structure
+// details needed at run-time.
 template <typename T>
-class DiagramScanner : public SystemVisitor<T> {
+class SystemScanner : public SystemVisitor<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramScanner);
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemScanner);
 
-  // Validates a diagram for CenicIntegrator, and returns the structure facts.
-  // Throws if: not a diagram;
-  //            not exactly one continuous-time plant.
-  static CenicDiagramStructure<T> ScanAndValidateDiagram(
+  // Validates a system for CenicIntegrator, and returns the structure facts.
+  // Throws if: is not, or does not contain, exactly one continuous-time plant.
+  static CenicDiagramStructure<T> ScanAndValidateSystem(
       const System<T>& system) {
-    const auto* const diagram = dynamic_cast<const Diagram<T>*>(&system);
-    if (diagram == nullptr) {
-      throw std::logic_error(
-          fmt::format("CenicIntegrator must be given a Diagram, not a {}.",
-                      NiceTypeName::Get(system)));
-    }
-    DiagramScanner<T> visitor;
-    diagram->Accept(&visitor);
+    SystemScanner<T> visitor;
+    system.Accept(&visitor);
     DRAKE_DEMAND(visitor.current_path_.empty());
     if (visitor.structure_.plant == nullptr) {
       if (visitor.rejected_plant_ != nullptr) {
@@ -56,8 +49,10 @@ class DiagramScanner : public SystemVisitor<T> {
               visitor.rejected_plant_->GetSystemPathname()));
         }
       }
-      throw std::logic_error(
-          "CenicIntegrator found zero continuous-time plants in the diagram.");
+      throw std::logic_error(fmt::format(
+          "CenicIntegrator found zero continuous-time plants in the root "
+          "system. The root system was a {} named '{}'.",
+          NiceTypeName::Get(system), system.get_name()));
     }
     // TODO(rpoyner-tri): It might make sense here to "compact" the non-plant
     // paths; only keeping paths describing non-plant subtrees, rather than
@@ -83,7 +78,7 @@ class DiagramScanner : public SystemVisitor<T> {
     // flow. However, since CenicIntegrator is strongly coupled to a specific
     // class (MultibodyPlant) without any design intention to operate on any
     // other class, using the cast to find the plant needle in the diagram
-    // haystack if the best choice among the available options.
+    // haystack is the best choice among the available options.
     const auto* maybe_plant = dynamic_cast<const MultibodyPlant<T>*>(&system);
     if (maybe_plant != nullptr) {
       VisitPlant(*maybe_plant);
@@ -93,8 +88,8 @@ class DiagramScanner : public SystemVisitor<T> {
   }
 
  private:
-  DiagramScanner() = default;
-  ~DiagramScanner() override = default;
+  SystemScanner() = default;
+  ~SystemScanner() override = default;
 
   void VisitPlant(const MultibodyPlant<T>& plant) {
     if (plant.is_discrete()) {
@@ -132,14 +127,14 @@ class DiagramScanner : public SystemVisitor<T> {
 };
 
 // The Get*ByPath functions below assume that:
-// (1) their path parameters were constructed by scanning the root diagram
-//     (see DiagramScanner above),
-// (2) and that the traversed argument (`state`, `diagram`) is either the
-//     root diagram itself, or created for the root diagram.
+// (1) their path parameters were constructed by scanning the root system
+//     (see SystemScanner above),
+// (2) and that the traversed argument (`state`, `system`) is either the
+//     root system itself, or created for the root system.
 
 // Condition (1) is guaranteed by the scanner above and integrator constructor
 // below. Condition (2) is guaranteed by chains of custody leading back to the
-// root diagram (see #created_for_root_diagram comments below), and a few
+// root system (see #created_for_root_system comments below), and a few
 // explicit checks. Hence, the functions can safely traverse the data using
 // static_cast, rather than dynamic_cast.
 
@@ -164,9 +159,9 @@ ContinuousState<T>& GetMutableSubstateByPath(ContinuousState<T>& state,
 }
 
 template <typename T>
-const System<T>& GetSubsystemByPath(const Diagram<T>& diagram,
+const System<T>& GetSubsystemByPath(const System<T>& system,
                                     const SubsystemPath& path) {
-  const System<T>* cursor = &diagram;
+  const System<T>* cursor = &system;
   for (const SubsystemIndex& k : path) {
     cursor = &(static_cast<const Diagram<T>*>(cursor)->get_system(k));
   }
@@ -179,7 +174,7 @@ template <typename T>
 CenicIntegrator<T>::CenicIntegrator(const System<T>& system,
                                     Context<T>* context)
     : IntegratorBase<T>(system, context),
-      structure_(DiagramScanner<T>::ScanAndValidateDiagram(system)),
+      structure_(SystemScanner<T>::ScanAndValidateSystem(system)),
       external_systems_linearizer_(structure_.plant) {
   this->set_target_accuracy(kDefaultAccuracy);
 }
@@ -209,7 +204,7 @@ int CenicIntegrator<T>::get_error_estimate_order() const {
 
 template <typename T>
 void CenicIntegrator<T>::Scratch::Resize(const MultibodyPlant<T>& plant,
-                                         const System<T>& diagram) {
+                                         const System<T>& system) {
   const int nv = plant.num_velocities();
   const int nq = plant.num_positions();
   v_guess.resize(nv);
@@ -218,12 +213,9 @@ void CenicIntegrator<T>::Scratch::Resize(const MultibodyPlant<T>& plant,
   external_feedback_storage.Resize(nv);
 
   // Allocate intermediate states for error control.
-  x_next_full = dynamic_pointer_cast_or_throw<DiagramContinuousState<T>>(
-      diagram.AllocateTimeDerivatives());
-  x_next_half_1 = dynamic_pointer_cast_or_throw<DiagramContinuousState<T>>(
-      diagram.AllocateTimeDerivatives());
-  x_next_half_2 = dynamic_pointer_cast_or_throw<DiagramContinuousState<T>>(
-      diagram.AllocateTimeDerivatives());
+  x_next_full = system.AllocateTimeDerivatives();
+  x_next_half_1 = system.AllocateTimeDerivatives();
+  x_next_half_2 = system.AllocateTimeDerivatives();
 }
 
 template <typename T>
@@ -263,13 +255,13 @@ void CenicIntegrator<T>::DoInitialize() {
   builder_ = std::make_unique<IcfBuilder<T>>(&plant());
 
   // Allocate scratch variables.
-  // #created_for_root_diagram: This call takes the integrator's system, which
-  // is our root diagram. As a result, all of the `x_next*` states will be
-  // created for our root diagram.
+  // #created_for_root_system: This call takes the integrator's system, which
+  // is our root system. As a result, all of the `x_next*` states will be
+  // created for our root system.
   scratch_.Resize(plant(), this->get_system());
 }
 
-// Replaces the default norm (weighted infinity norm on the entire diagram
+// Replaces the default norm (weighted infinity norm on the entire root system
 // state) with an infinity norm on just plant positions. This is motivated by
 // Sec. V.E of [Kurtz and Castro, 2025].
 //
@@ -282,9 +274,9 @@ void CenicIntegrator<T>::DoInitialize() {
 template <typename T>
 T CenicIntegrator<T>::CalcStateChangeNorm(
     const ContinuousState<T>& dx_state) const {
-  // #created_for_root_diagram: CalcStateChangeNorm is a virtual call from
+  // #created_for_root_system: CalcStateChangeNorm is a virtual call from
   // IntegratorBase, with the guarantee that `dx_state` is created for the
-  // whole integrated system, which is our root diagram.
+  // whole integrated system, which is our root system.
   const VectorBase<T>& plant_q =
       GetSubstateByPath(dx_state, structure_.plant_path)
           .get_generalized_position();
@@ -361,7 +353,7 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
   // error control is enabled or not.
   VectorX<T>& v_guess = scratch_.v_guess;
   v_guess = plant().GetVelocities(plant_context);
-  systems::DiagramContinuousState<T>& x_next_full = *scratch_.x_next_full;
+  systems::ContinuousState<T>& x_next_full = *scratch_.x_next_full;
   ComputeNextContinuousState(model_at_x0_, v_guess, &x_next_full);
 
   if (this->get_fixed_step_mode()) {
@@ -379,13 +371,13 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
     // the full step, so we can reuse all of the constraints, avoiding expensive
     // geometry queries and such.
     model_at_x0_.UpdateTimeStep(0.5 * h);
-    // #created_for_root_diagram: The `x_next*` state here is an alias to the
-    // one in `scratch_`, which is always created for the root diagram.
+    // #created_for_root_system: The `x_next*` state here is an alias to the
+    // one in `scratch_`, which is always created for the root system.
     v_guess += GetSubstateByPath(x_next_full, structure_.plant_path)
                    .get_generalized_velocity()
                    .CopyToVector();
     v_guess /= 2.0;
-    systems::DiagramContinuousState<T>& x_next_half_1 = *scratch_.x_next_half_1;
+    systems::ContinuousState<T>& x_next_half_1 = *scratch_.x_next_half_1;
     ComputeNextContinuousState(model_at_x0_, v_guess, &x_next_half_1);
 
     // For the second half-step to (t + h), we need to start from (t + h/2). So
@@ -398,12 +390,12 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
     // we will reuse the linearizations of any external systems, if they exist.
     builder_->UpdateModel(plant_context, 0.5 * h, actuation_feedback,
                           external_feedback, &model_at_xh_);
-    // #created_for_root_diagram: The `x_next*` state here is the one in
-    // `scratch_`, which is always created for the root diagram.
+    // #created_for_root_system: The `x_next*` state here is the one in
+    // `scratch_`, which is always created for the root system.
     v_guess = GetSubstateByPath(*scratch_.x_next_full, structure_.plant_path)
                   .get_generalized_velocity()
                   .CopyToVector();
-    systems::DiagramContinuousState<T>& x_next_half_2 = *scratch_.x_next_half_2;
+    systems::ContinuousState<T>& x_next_half_2 = *scratch_.x_next_half_2;
     ComputeNextContinuousState(model_at_xh_, v_guess, &x_next_half_2);
 
     // Set the state to the result of the second half-step (since this is more
@@ -424,12 +416,12 @@ bool CenicIntegrator<T>::DoStep(const T& h) {
 template <typename T>
 void CenicIntegrator<T>::ComputeNextContinuousState(
     const IcfModel<T>& model, const VectorX<T>& v_guess,
-    DiagramContinuousState<T>* x_next) {
+    ContinuousState<T>* x_next) {
   DRAKE_ASSERT(x_next != nullptr);
   DRAKE_ASSERT(v_guess.size() == model.num_velocities());
   DRAKE_ASSERT(model.num_velocities() == plant().num_velocities());
-  // #created_for_root_diagram: The `x_next*` state here is an alias to the one
-  // of the states in `scratch_`, which is always created for the root diagram.
+  // #created_for_root_system: The `x_next*` state here is an alias to the one
+  // of the states in `scratch_`, which is always created for the root system.
   // Just to underscore the point, do an explicit safety check.
   this->get_system().ValidateCreatedForThisSystem(*x_next);
   const T& h = model.time_step();
@@ -469,7 +461,7 @@ void CenicIntegrator<T>::ComputeNextContinuousState(
   AdvancePlantConfiguration(h, v, &q);
 
   // Set the updated plant state, x = [q; v].
-  // #created_for_root_diagram: See explicit check above.
+  // #created_for_root_system: See explicit check above.
   ContinuousState<T>& mutable_plant_state =
       GetMutableSubstateByPath<T>(*x_next, structure_.plant_path);
   mutable_plant_state.get_mutable_generalized_position().SetFromVector(q);
@@ -480,11 +472,11 @@ void CenicIntegrator<T>::ComputeNextContinuousState(
   // While we could use a more advanced integration scheme here, the non-plant
   // dynamics are usually pretty simple (e.g., the integral term from a PID
   // controller), so forward euler is sufficient.
-  const auto& diagram = static_cast<const Diagram<T>&>(this->get_system());
+  const auto& root_system = this->get_system();
   for (const auto& path : structure_.non_plant_xc_paths) {
-    // #created_for_root_diagram: See `diagram` derivation from
+    // #created_for_root_system: See `root_system` derivation from
     // `this->get_system()` just above the for loop.
-    const System<T>& subsystem = GetSubsystemByPath(diagram, path);
+    const System<T>& subsystem = GetSubsystemByPath(root_system, path);
     const Context<T>& subcontext = subsystem.GetMyContextFromRoot(context);
 
     // TODO(vincekurtz): eliminate these heap allocations.
@@ -495,7 +487,7 @@ void CenicIntegrator<T>::ComputeNextContinuousState(
     VectorX<T> sub_xc_next = subcontext.get_continuous_state().CopyToVector();
     sub_xc_next += h * sub_xc_dot;
 
-    // #created_for_root_diagram: See explicit check above.
+    // #created_for_root_system: See explicit check above.
     GetMutableSubstateByPath(*x_next, path).SetFromVector(sub_xc_next);
   }
 }

--- a/multibody/cenic/cenic_integrator.h
+++ b/multibody/cenic/cenic_integrator.h
@@ -10,7 +10,6 @@
 #include "drake/multibody/contact_solvers/icf/icf_solver_parameters.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/integrator_base.h"
-#include "drake/systems/framework/diagram_continuous_state.h"
 
 namespace drake {
 namespace multibody {
@@ -24,7 +23,8 @@ template <typename T>
 struct CenicDiagramStructure {
   /* The plant used as the basis of the convex optimization problem. */
   const MultibodyPlant<T>* plant{};
-  /* The path to the plant from the root diagram. */
+  /* The path to the plant from the root system. An empty path means the root
+  system *is* the plant. */
   SubsystemPath plant_path;
   /* Paths to subsystems, other than the targeted plant, that have continuous
   state. */
@@ -74,8 +74,9 @@ problem [Castro et al., 2023] to advance the system state at each time step. A
 simple half-stepping strategy provides a second-order error estimate for
 automatic step-size selection.
 
-Because CENIC is specific to multibody systems, this integrator requires a
-system diagram with a `MultibodyPlant` subsystem.
+Because CENIC is specific to multibody systems, the system it's asked to
+integrate must either be a MultibodyPlant system or a Diagram that contains a
+MultibodyPlant subsystem, at any level of Diagram nesting.
 
 Running CENIC in fixed-step mode (with error-control disabled) recovers the
 "Lagged" variant of discrete-time ICF simulation from [Castro et al., 2023].
@@ -117,10 +118,11 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
   static constexpr double kDefaultAccuracy = 1e-3;
 
   /** Constructs the integrator.
-  @param system The overall system diagram to simulate. Must include exactly one
-                continuous-time MultibodyPlant. Other (discrete-time) plants are
-                allowed in the diagram. This `system` is aliased by this object
-                so must remain alive longer than the integrator.
+  @param system The overall system to simulate. Must either be a MultibodyPlant
+                or a Diagram that contains exactly one continuous-time
+                MultibodyPlant. Other (discrete-time) plants are allowed in a
+                diagram. This `system` is aliased by this object so must remain
+                alive longer than the integrator.
   @param context context for the overall system.  */
   explicit CenicIntegrator(const systems::System<T>& system,
                            systems::Context<T>* context = nullptr);
@@ -148,12 +150,13 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
  private:
   /* Preallocated scratch space. */
   struct Scratch {
-    /* Resizes the scratch space to accommodate the given plant and enclosing
-    diagram. */
+    /* Resizes scratch space to accommodate the given plant and root system. */
     void Resize(const MultibodyPlant<T>& plant,
-                const systems::System<T>& diagram);
+                const systems::System<T>& system);
 
-    /* State-sized variables, x = [q; v] for the plant (not the diagram). */
+    /* State-sized variables, x = [q; v] for the plant only. When the root
+    system is a Diagram, any non-plant continuous state will not be stored
+    here. */
     VectorX<T> v_guess;
     VectorX<T> q;
 
@@ -167,13 +170,13 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
 
     /* Intermediate states for error control, which compares a single large
     step (x_next_full_) to the result of two smaller steps (x_next_half_2_).
-    Note that these states include continuous state for the entire diagram. */
+    These states include continuous state for the entire root system. */
     /* x_{t+h}. */
-    std::unique_ptr<systems::DiagramContinuousState<T>> x_next_full;
+    std::unique_ptr<systems::ContinuousState<T>> x_next_full;
     /* x_{t+h/2}. */
-    std::unique_ptr<systems::DiagramContinuousState<T>> x_next_half_1;
+    std::unique_ptr<systems::ContinuousState<T>> x_next_half_1;
     /* x_{t+h/2+h/2}. */
-    std::unique_ptr<systems::DiagramContinuousState<T>> x_next_half_2;
+    std::unique_ptr<systems::ContinuousState<T>> x_next_half_2;
   };
 
   /* Data for PrintSimulatorStatistics(). */
@@ -193,10 +196,10 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
   void DoInitialize() final;
 
   /* @warning For `h` == 0, CENIC DoStep() executes a special case that does no
-     integration or state updates, but does reset the error estimate to all 0,
-     and always succeeds.
+  integration or state updates, but does reset the error estimate to all 0,
+  and always succeeds.
 
-    See IntegratorBase::DoStep() for full implementation requirements. */
+  See IntegratorBase::DoStep() for full implementation requirements. */
   bool DoStep(const T& h) final;
 
   /* Solves the ICF problem to compute x_{t+h}.
@@ -207,7 +210,7 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
                      plant and any external systems. */
   void ComputeNextContinuousState(
       const contact_solvers::icf::internal::IcfModel<T>& model,
-      const VectorX<T>& v_guess, systems::DiagramContinuousState<T>* x_next);
+      const VectorX<T>& v_guess, systems::ContinuousState<T>* x_next);
 
   /* Advances the plant's generalized positions, q = q₀ + h N(q₀) v, taking care
   to handle quaternion DoFs properly.

--- a/multibody/cenic/test/make_cenic_integrator_test.cc
+++ b/multibody/cenic/test/make_cenic_integrator_test.cc
@@ -54,6 +54,18 @@ GTEST_TEST(MakeCenicIntegratorTest, SuccessNested) {
   EXPECT_EQ(&dut_plant, &diagram_plant);
 }
 
+GTEST_TEST(MakeCenicIntegratorTest, SuccessUnnested) {
+  MultibodyPlant<double> plant(0.0);
+  plant.Finalize();
+
+  std::unique_ptr<IntegratorBase<double>> dut = MakeCenicIntegrator(plant);
+  auto& cenic = dynamic_cast<CenicIntegrator<double>&>(*dut);
+
+  // The CENIC plant is the same object as the offered plant.
+  const auto& dut_plant = cenic.plant();
+  EXPECT_EQ(&dut_plant, &plant);
+}
+
 GTEST_TEST(MakeCenicIntegratorTest, FailureDiscrete) {
   RobotDiagramBuilder<double> builder;
   std::unique_ptr<RobotDiagram<double>> robot_diagram = builder.Build();
@@ -62,13 +74,13 @@ GTEST_TEST(MakeCenicIntegratorTest, FailureDiscrete) {
       ".*requires.*continuous.*found.*time_step=0.001.*");
 }
 
-GTEST_TEST(MakeCenicIntegratorTest, FailureNonDiagram) {
+GTEST_TEST(MakeCenicIntegratorTest, FailureNoDiagramNoPlant) {
   ConstantVectorSource<double> system(0.0);
   DRAKE_EXPECT_THROWS_MESSAGE(MakeCenicIntegrator(system),
-                              ".*must be given a Diagram.*");
+                              ".*zero.*continuous.*");
 }
 
-GTEST_TEST(MakeCenicIntegratorTest, FailureNoPlant) {
+GTEST_TEST(MakeCenicIntegratorTest, FailureDiagramNoPlant) {
   DiagramBuilder<double> builder;
   builder.AddSystem<ConstantVectorSource>(0.0);
   std::unique_ptr<Diagram<double>> diagram = builder.Build();


### PR DESCRIPTION
Previous patches extended CENIC to accept a plant wrapped in an arbitrary number of diagram layers. This patch extends that logic in the other direction, to zero wrapping diagrams. In the process, one dynamic cast is added, and several are dropped.

It is unlikely that this new configuration will be much use to users, but it enables the possibility of adapting existing plant feature tests to test CENIC logic.

A few unrelated comment repairs are also added to this patch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24441)
<!-- Reviewable:end -->

Toward #23764.