### PR TITLE
[setup] Add lld as a build-dep on Ubuntu Noble

### DIFF
--- a/setup/ubuntu/packages-noble-build.txt
+++ b/setup/ubuntu/packages-noble-build.txt
@@ -4,6 +4,7 @@ libglib2.0-dev
 libglx-dev
 liblapack-dev
 libopengl-dev
+lld
 ocl-icd-opencl-dev
 opencl-headers
 patch

--- a/tools/bazel-developer.rc
+++ b/tools/bazel-developer.rc
@@ -23,6 +23,11 @@ build --@drake//tools/cc_toolchain:error_severity=error
 # //tools/cc_toolchain:use_mold_linker for more details.
 build --@drake//tools/cc_toolchain:allow_mold_linker=true
 
+# Developer builds on Linux use -fuse-ld=lld (per @rules_cc) so we need to dial
+# back its default per-process thread count of 16 down to something less likely
+# to overload the system.
+build:linux --linkopt=-Wl,--threads=2
+
 # Developer builds on Linux should have OpenMP enabled by default, to match the
 # end-user default in drake/CMakeLists.txt.
 build:linux --config=openmp

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -139,7 +139,6 @@ BASE_LINKOPTS = select({
     "@drake//tools/cc_toolchain:use_mold_linker": [
         "-fuse-ld=mold",
         "-Wl,--compress-debug-sections=zlib",
-        "-Wl,--thread-count=2",
     ],
     "//conditions:default": [],
 })


### PR DESCRIPTION
Without lld installed, rules_cc defaults to using ld.gold, which is deprecated and produces warnings when linking Rust code. With lld installed, rules_cc uses it (no matter if the selected compiler is GCC or Clang).

See #24278 for the (earlier) Ubuntu Resolute version of this same change.

Note that on Noble, `lld` is a symlink to `lld-18`, i.e., LLVM 18's linker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24442)
<!-- Reviewable:end -->
