### PR TITLE
[multibody] Name changes in support of composites to come

### DIFF
--- a/bindings/generated_docstrings/multibody_math.h
+++ b/bindings/generated_docstrings/multibody_math.h
@@ -1005,6 +1005,13 @@ Returns:
     elements of ``this`` and ``other`` are equal within
     translational_tolerance.)""";
         } IsNearlyEqualWithinAbsoluteTolerance;
+        // Symbol: drake::multibody::SpatialVector::NaN
+        struct /* NaN */ {
+          // Source: drake/multibody/math/spatial_vector.h
+          const char* doc =
+R"""(Factory to create a *NaN* spatial vector, i.e., a SpatialVector whose
+rotational and translational components are all NaN.)""";
+        } NaN;
         // Symbol: drake::multibody::SpatialVector::SetNaN
         struct /* SetNaN */ {
           // Source: drake/multibody/math/spatial_vector.h

--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -186,32 +186,6 @@ This method must be called pre-Finalize.
 Raises:
     RuntimeError if ``plant`` is finalized or if time_step is changed.)""";
       } ApplyMultibodyPlantConfig;
-      // Symbol: drake::multibody::BaseBodyJointType
-      struct /* BaseBodyJointType */ {
-        // Source: drake/multibody/plant/multibody_plant.h
-        const char* doc =
-R"""(The kind of joint to be used to connect base bodies to world at
-Finalize(). See mbp_working_with_free_bodies "Working with free
-bodies" for definitions and discussion.
-
-See also:
-    SetBaseBodyJointType() for details.)""";
-        // Symbol: drake::multibody::BaseBodyJointType::kQuaternionFloatingJoint
-        struct /* kQuaternionFloatingJoint */ {
-          // Source: drake/multibody/plant/multibody_plant.h
-          const char* doc = R"""(6 dofs, unrestricted orientation.)""";
-        } kQuaternionFloatingJoint;
-        // Symbol: drake::multibody::BaseBodyJointType::kRpyFloatingJoint
-        struct /* kRpyFloatingJoint */ {
-          // Source: drake/multibody/plant/multibody_plant.h
-          const char* doc = R"""(6 dofs using 3 angles; has singularity.)""";
-        } kRpyFloatingJoint;
-        // Symbol: drake::multibody::BaseBodyJointType::kWeldJoint
-        struct /* kWeldJoint */ {
-          // Source: drake/multibody/plant/multibody_plant.h
-          const char* doc = R"""(0 dofs, fixed to World.)""";
-        } kWeldJoint;
-      } BaseBodyJointType;
       // Symbol: drake::multibody::CalcContactFrictionFromSurfaceProperties
       struct /* CalcContactFrictionFromSurfaceProperties */ {
         // Source: drake/multibody/plant/coulomb_friction.h
@@ -4968,7 +4942,7 @@ be used by Finalize(); post-finalize it returns the joint type that
 *was* used if there were any base bodies in need of a joint.
 
 See also:
-    SetBaseBodyJointType())""";
+    SetBaseBodyJointType(), Finalize())""";
         } GetBaseBodyJointType;
         // Symbol: drake::multibody::MultibodyPlant::GetBodiesKinematicallyAffectedBy
         struct /* GetBodiesKinematicallyAffectedBy */ {
@@ -6625,7 +6599,10 @@ Parameter ``model_instance``:
     is to be applied.
 
 Raises:
-    RuntimeError if called after Finalize().)""";
+    RuntimeError if called after Finalize().
+
+See also:
+    GetBaseBodyJointType(), Finalize())""";
         } SetBaseBodyJointType;
         // Symbol: drake::multibody::MultibodyPlant::SetConstraintActiveStatus
         struct /* SetConstraintActiveStatus */ {

--- a/bindings/generated_docstrings/multibody_tree.h
+++ b/bindings/generated_docstrings/multibody_tree.h
@@ -589,6 +589,32 @@ representation.)""";
           const char* doc = R"""()""";
         } type_name;
       } BallRpyJoint;
+      // Symbol: drake::multibody::BaseBodyJointType
+      struct /* BaseBodyJointType */ {
+        // Source: drake/multibody/tree/multibody_tree.h
+        const char* doc =
+R"""(The kind of joint to be used to connect base bodies to world at
+Finalize(). See mbp_working_with_free_bodies "Working with free
+bodies" for definitions and discussion.
+
+See also:
+    SetBaseBodyJointType() for details.)""";
+        // Symbol: drake::multibody::BaseBodyJointType::kQuaternionFloatingJoint
+        struct /* kQuaternionFloatingJoint */ {
+          // Source: drake/multibody/tree/multibody_tree.h
+          const char* doc = R"""(6 dofs, unrestricted orientation.)""";
+        } kQuaternionFloatingJoint;
+        // Symbol: drake::multibody::BaseBodyJointType::kRpyFloatingJoint
+        struct /* kRpyFloatingJoint */ {
+          // Source: drake/multibody/tree/multibody_tree.h
+          const char* doc = R"""(6 dofs using 3 angles; has singularity.)""";
+        } kRpyFloatingJoint;
+        // Symbol: drake::multibody::BaseBodyJointType::kWeldJoint
+        struct /* kWeldJoint */ {
+          // Source: drake/multibody/tree/multibody_tree.h
+          const char* doc = R"""(0 dofs, fixed to World.)""";
+        } kWeldJoint;
+      } BaseBodyJointType;
       // Symbol: drake::multibody::BodyIndex
       struct /* BodyIndex */ {
         // Source: drake/multibody/tree/multibody_tree_indexes.h
@@ -2113,30 +2139,39 @@ plant.)""";
         // Source: drake/multibody/tree/frame.h
         const char* doc =
 R"""(%Frame is an abstract class representing a *material frame* (also
-called a *physical frame*) of its underlying RigidBody. The Frame's
-origin is a material point of its RigidBody, and its axes have fixed
-directions in that body. A Frame's pose (position and orientation)
-with respect to its RigidBodyFrame may be parameterized, but is fixed
-(not time or state dependent) once parameters have been set.
+called a *physical frame*) of its underlying RigidBody (Link). The
+Frame's origin is a material point of its RigidBody, and its axes have
+fixed directions in that body. A Frame's pose (position and
+orientation) with respect to its RigidBodyFrame (LinkFrame) may be
+parameterized, but is fixed (not time or state dependent) once
+parameters have been set.
 
 An important characteristic of a Frame is that forces or torques
-applied to a Frame are applied to the Frame's underlying RigidBody.
+applied to a Frame are applied to the Frame's underlying body.
 Force-producing elements like joints, actuators, and constraints
 usually employ two Frames, with one Frame connected to one body and
 the other connected to a different body. Every Frame F can report the
-RigidBody B to which it is attached and its pose X_BF with respect to
-B's RigidBodyFrame.
+Link (RigidBody) L to which it is attached and its pose X_LF with
+respect to L's LinkFrame (RigidBodyFrame).
 
 A Frame's pose in World (or relative to other frames) is always
 calculated starting with its pose relative to its underlying
-RigidBodyFrame. Subclasses derived from Frame differ in how kinematic
+LinkFrame. Subclasses derived from Frame differ in how kinematic
 calculations are performed. For example, the angular velocity of a
-FixedOffsetFrame or RigidBodyFrame is identical to the angular
-velocity of its underlying body, whereas the translational velocity of
-a FixedOffsetFrame differs from that of a RigidBodyFrame.
+FixedOffsetFrame or LinkFrame (RigidBodyFrame) is identical to the
+angular velocity of its underlying body, whereas the translational
+velocity of a FixedOffsetFrame differs from that of a LinkFrame.
 
 Frame provides methods for obtaining its current orientation,
-position, motion, etc. from a Context passed to those methods.)""";
+position, motion, etc. from a Context passed to those methods.
+
+Note:
+    For historical reasons, many of the method names here use "Body"
+    to mean "Link". The distinction matters when we form composite
+    bodies, which consist of multiple links welded together. Those
+    composites form a single *rigid body* in the physics sense. Frames
+    only know about their Links, not how they may have been combined
+    into a composite body.)""";
         // Symbol: drake::multibody::Frame::CalcAngularVelocity
         struct /* CalcAngularVelocity */ {
           // Source: drake/multibody/tree/frame.h
@@ -2169,23 +2204,23 @@ See also:
           // Source: drake/multibody/tree/frame.h
           const char* doc =
 R"""(Given the offset pose ``X_FQ`` of a frame Q in ``this`` frame F, this
-method computes the pose ``X_BQ`` of frame Q in the body frame B to
-which this frame is attached. In other words, if the pose of ``this``
-frame F in the body frame B is ``X_BF``, this method computes the pose
-``X_BQ`` of frame Q in the body frame B as ``X_BQ = X_BF * X_FQ``. In
-particular, if ``this`` **is** the body frame B, i.e. ``X_BF`` is the
-identity transformation, this method directly returns ``X_FQ``.
-Specific frame subclasses can override this method to provide faster
-implementations if needed.)""";
+method computes the pose ``X_LQ`` of frame Q in the link frame L of
+the Link (RigidBody) to which this frame is attached. In other words,
+if the pose of ``this`` frame F in the link frame L is ``X_LF``, this
+method computes the pose ``X_LQ`` of frame Q in the link frame L as
+``X_LQ = X_LF * X_FQ``. In particular, if ``this`` **is** the link
+frame L, i.e. ``X_LF`` is identically the identity transform, this
+method directly returns ``X_FQ``. Specific frame subclasses can
+override this method to provide faster implementations if needed.)""";
         } CalcOffsetPoseInBody;
         // Symbol: drake::multibody::Frame::CalcOffsetRotationMatrixInBody
         struct /* CalcOffsetRotationMatrixInBody */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Calculates and returns the rotation matrix ``R_BQ`` that relates body
-frame B to frame Q via ``this`` intermediate frame F, i.e., ``R_BQ =
-R_BF * R_FQ`` (B is the body frame to which ``this`` frame F is
-attached).
+R"""(Calculates and returns the rotation matrix ``R_LQ`` that relates link
+frame L to frame Q via ``this`` intermediate frame F, i.e., ``R_LQ =
+R_LF * R_FQ`` (L is the link frame of the Link (RigidBody) to which
+``this`` frame F is attached).
 
 Parameter ``R_FQ``:
     rotation matrix that relates frame F to frame Q.)""";
@@ -2205,11 +2240,11 @@ See also:
         struct /* CalcPoseInBodyFrame */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Returns the pose ``X_BF`` of ``this`` frame F in the body frame B
-associated with this frame. In particular, if ``this`` **is** the body
-frame B, this method directly returns the identity transformation.
-Note that this ONLY depends on the Parameters in the context; it does
-not depend on time, input, state, etc.)""";
+R"""(Returns the pose ``X_LF`` of ``this`` frame F in the LinkFrame
+(RigidBodyFrame) L of this Frame's Link (RigidBody). In particular, if
+``this`` **is** the link frame L, this method directly returns the
+identity transformation. Note that this ONLY depends on the Parameters
+in the context; it does not depend on time, input, state, etc.)""";
         } CalcPoseInBodyFrame;
         // Symbol: drake::multibody::Frame::CalcPoseInWorld
         struct /* CalcPoseInWorld */ {
@@ -2221,13 +2256,13 @@ world frame W as a function of the state of the model stored in
 
 Note:
     RigidBody∷EvalPoseInWorld() provides a more efficient way to
-    obtain the pose for a body frame.)""";
+    obtain the pose for a RigidBodyFrame (LinkFrame).)""";
         } CalcPoseInWorld;
         // Symbol: drake::multibody::Frame::CalcRelativeSpatialAcceleration
         struct /* CalcRelativeSpatialAcceleration */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Calculates ``this`` frame C's spatial acceleration relative to another
+R"""(Calculates ``this`` frame F's spatial acceleration relative to another
 frame B, measured in a frame M, expressed in a frame E.
 
 Parameter ``context``:
@@ -2243,14 +2278,14 @@ Parameter ``expressed_in_frame``:
     which is frame E.
 
 Returns:
-    A_M_BC_E = A_MC_E - A_MB_E, frame C's spatial acceleration
+    A_M_BF_E = A_MF_E - A_MB_E, frame F's spatial acceleration
     relative to frame B, measured in frame M, expressed in frame E.
 
-In general, A_M_BC = DtW(V_M_BC), the time-derivative in frame M of
-frame C's spatial velocity relative to frame B. The rotational part of
-the returned quantity is α_MC_E - α_MB_E = DtM(ω_BC)_E. Note: For 3D
-analysis, DtM(ω_BC) ≠ α_BC. The translational part of the returned
-quantity is a_M_BoCo_E (Co's translational acceleration relative to
+In general, A_M_BF = DtW(V_M_BF), the time-derivative in frame M of
+frame F's spatial velocity relative to frame B. The rotational part of
+the returned quantity is α_MF_E - α_MB_E = DtM(ω_BF)_E. Note: For 3D
+analysis, DtM(ω_BF) ≠ α_BF. The translational part of the returned
+quantity is a_M_BoFo_E (Fo's translational acceleration relative to
 Bo, measured in frame M, expressed in frame E).
 
 
@@ -2260,20 +2295,20 @@ Bo, measured in frame M, expressed in frame E).
 
 .. code-block:: c++
 
-    α_MC_E - α_MB_E = DtM(ω_MC)_E - DtM(ω_MB)_E = DtM(ω_BC)_E
-     a_M_BoCo_E = a_MCo_E - a_MBo_E = DtM(v_MCo) - DtM(v_MBo) = Dt²M(p_BoCo)_E
+    α_MF_E - α_MB_E = DtM(ω_MF)_E - DtM(ω_MB)_E = DtM(ω_BF)_E
+     a_M_BoFo_E = a_MFo_E - a_MBo_E = DtM(v_MFo) - DtM(v_MBo) = Dt²M(p_BoFo)_E
 
 .. raw:: html
 
     </details>
 
-where Dt²M(p_BoCo)_E is the 2ⁿᵈ time-derivative in frame M of p_BoCo
-(the position vector from Bo to Co), and this result is expressed in
+where Dt²M(p_BoFo)_E is the 2ⁿᵈ time-derivative in frame M of p_BoFo
+(the position vector from Bo to Fo), and this result is expressed in
 frame E.
 
 Note:
     The calculation of the 2ⁿᵈ time-derivative of the distance between
-    Bo and Co can be done with relative translational acceleration,
+    Bo and Fo can be done with relative translational acceleration,
     but this calculation does not depend on the measured-in-frame,
     hence in this case, consider
     CalcRelativeSpatialAccelerationInWorld() since it is faster.
@@ -2286,7 +2321,7 @@ See also:
         struct /* CalcRelativeSpatialAccelerationInWorld */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Calculates ``this`` frame C's spatial acceleration relative to another
+R"""(Calculates ``this`` frame F's spatial acceleration relative to another
 frame B, measured and expressed in the world frame W.
 
 Parameter ``context``:
@@ -2296,14 +2331,14 @@ Parameter ``other_frame``:
     which is frame B.
 
 Returns:
-    A_W_BC_W = A_WC_W - A_WB_W, frame C's spatial acceleration
+    A_W_BF_W = A_WF_W - A_WB_W, frame F's spatial acceleration
     relative to frame B, measured and expressed in the world frame W.
 
-In general, A_W_BC = DtW(V_W_BC), the time-derivative in the world
-frame W of frame C's spatial velocity relative to frame B. The
-rotational part of the returned quantity is α_WC_W - α_WB_W =
-DtW(ω_BC)_W. For 3D analysis, DtW(ω_BC) ≠ α_BC. The translational part
-of the returned quantity is a_W_BoCo_W (Co's translational
+In general, A_W_BF = DtW(V_W_BF), the time-derivative in the world
+frame W of frame F's spatial velocity relative to frame B. The
+rotational part of the returned quantity is α_WF_W - α_WB_W =
+DtW(ω_BF)_W. For 3D analysis, DtW(ω_BF) ≠ α_BF. The translational part
+of the returned quantity is a_W_BoFo_W (Fo's translational
 acceleration relative to Bo, measured and expressed in world frame W).
 
 
@@ -2313,15 +2348,15 @@ acceleration relative to Bo, measured and expressed in world frame W).
 
 .. code-block:: c++
 
-    α_WC_W - α_WB_W = DtW(ω_WC)_W - DtW(ω_WB)_W = DtW(ω_BC)_W
-     a_W_BoCo_W = a_WCo_W - a_WBo_W = DtW(v_WCo) - DtW(v_WBo) = Dt²W(p_BoCo)_W
+    α_WF_W - α_WB_W = DtW(ω_WF)_W - DtW(ω_WB)_W = DtW(ω_BF)_W
+     a_W_BoFo_W = a_WFo_W - a_WBo_W = DtW(v_WFo) - DtW(v_WBo) = Dt²W(p_BoFo)_W
 
 .. raw:: html
 
     </details>
 
-where Dt²W(p_BoCo)_W is the 2ⁿᵈ time-derivative in frame W of p_BoCo
-(the position vector from Bo to Co), and this result is expressed in
+where Dt²W(p_BoFo)_W is the 2ⁿᵈ time-derivative in frame W of p_BoFo
+(the position vector from Bo to Fo), and this result is expressed in
 frame W.
 
 Note:
@@ -2337,7 +2372,7 @@ See also:
         struct /* CalcRelativeSpatialVelocity */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Calculates ``this`` frame C's spatial velocity relative to another
+R"""(Calculates ``this`` frame F's spatial velocity relative to another
 frame B, measured in a frame M, expressed in a frame E.
 
 Parameter ``context``:
@@ -2353,11 +2388,11 @@ Parameter ``expressed_in_frame``:
     which is frame E.
 
 Returns:
-    V_M_BC_E = V_MC_E - V_MB_E, frame C's spatial velocity relative to
+    V_M_BF_E = V_MF_E - V_MB_E, frame F's spatial velocity relative to
     frame B, measured in frame M, expressed in frame E. The rotational
-    part of the returned quantity is ω_BC_E (C's angular velocity
+    part of the returned quantity is ω_BF_E (F's angular velocity
     measured in B and expressed in E). The translational part is
-    v_M_BoCo_E (Co's translational velocity relative to Bo, measured
+    v_M_BoFo_E (Fo's translational velocity relative to Bo, measured
     in M, and expressed in E).
 
 
@@ -2367,25 +2402,25 @@ Returns:
 
 .. code-block:: c++
 
-    ω_BC_E = ω_MC_E - ω_MB_E
-     v_M_BoCo_E = v_MCo_E - v_MBo_E = DtM(p_BoCo)
+    ω_BF_E = ω_MF_E - ω_MB_E
+     v_M_BoFo_E = v_MFo_E - v_MBo_E = DtM(p_BoFo)
 
 .. raw:: html
 
     </details>
 
-where DtM(p_BoCo) is the time-derivative in frame M of p_BoCo
-(position vector from Bo to Co), and this vector is expressed in frame
+where DtM(p_BoFo) is the time-derivative in frame M of p_BoFo
+(position vector from Bo to Fo), and this vector is expressed in frame
 E.
 
 Note:
     The method CalcSpatialVelocity() is more efficient and coherent if
     any of ``this``, other_frame, or measured_in_frame are the same.
-    Also, the value of V_M_BoCo does not depend on the
-    measured_in_frame if Bo and Co are coincident (i.e., p_BoCo = 0),
+    Also, the value of V_M_BoFo does not depend on the
+    measured_in_frame if Bo and Fo are coincident (i.e., p_BoFo = 0),
     in which case consider the more efficient method
     CalcRelativeSpatialVelocityInWorld(). Lastly, the calculation of
-    elongation between Bo and Co can be done with relative
+    elongation between Bo and Fo can be done with relative
     translational velocity, but elongation does not depend on the
     measured-in-frame (hence consider
     CalcRelativeSpatialVelocityInWorld()).
@@ -2398,7 +2433,7 @@ See also:
         struct /* CalcRelativeSpatialVelocityInWorld */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Calculates ``this`` frame C's spatial velocity relative to another
+R"""(Calculates ``this`` frame F's spatial velocity relative to another
 frame B, measured and expressed in the world frame W.
 
 Parameter ``context``:
@@ -2408,11 +2443,11 @@ Parameter ``other_frame``:
     which is frame B.
 
 Returns:
-    V_W_BC_W = V_WC_W - V_WB_W, frame C's spatial velocity relative to
+    V_W_BF_W = V_WF_W - V_WB_W, frame F's spatial velocity relative to
     frame B, measured and expressed in the world frame W. The
-    rotational part of the returned quantity is ω_BC_W (C's angular
+    rotational part of the returned quantity is ω_BF_W (F's angular
     velocity measured in B and expressed in W). The translational part
-    is v_W_BoCo_W (Co's translational velocity relative to Bo,
+    is v_W_BoFo_W (Fo's translational velocity relative to Bo,
     measured and expressed in world frame W).
 
 
@@ -2422,15 +2457,15 @@ Returns:
 
 .. code-block:: c++
 
-    ω_BC_W  = ω_WC_W - ω_WB_W
-     v_W_BoCo_W = v_WCo_W - v_WBo_W = DtW(p_BoCo)
+    ω_BF_W  = ω_WF_W - ω_WB_W
+     v_W_BoFo_W = v_WFo_W - v_WBo_W = DtW(p_BoFo)
 
 .. raw:: html
 
     </details>
 
-where DtW(p_BoCo) is the time-derivative in frame W of p_BoCo
-(position vector from Bo to Co), and this vector is expressed in frame
+where DtW(p_BoFo) is the time-derivative in frame W of p_BoFo
+(position vector from Bo to Fo), and this vector is expressed in frame
 W.
 
 Note:
@@ -2453,12 +2488,12 @@ R"""(Calculates and returns the rotation matrix ``R_MF`` that relates
         struct /* CalcRotationMatrixInBodyFrame */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Returns the rotation matrix ``R_BF`` that relates body frame B to
-``this`` frame F (B is the body frame to which ``this`` frame F is
-attached).
+R"""(Returns the rotation matrix ``R_LF`` that relates link frame L to
+``this`` frame F (L is the LinkFrame of the Link (RigidBody) to which
+``this`` frame F is attached).
 
 Note:
-    If ``this`` is B, this method returns the identity RotationMatrix.
+    If ``this`` is L, this method returns the identity RotationMatrix.
     Note that this ONLY depends on the Parameters in the context; it
     does not depend on time, input, state, etc.)""";
         } CalcRotationMatrixInBodyFrame;
@@ -2594,8 +2629,8 @@ Returns:
 
 Note:
     RigidBody∷EvalSpatialVelocityInWorld() provides a more efficient
-    way to obtain a body frame's spatial velocity measured in the
-    world frame.
+    way to obtain a RigidBodyFrame (LinkFrame) spatial velocity
+    measured in the world frame.
 
 See also:
     CalcSpatialVelocity(), CalcRelativeSpatialVelocityInWorld(), and
@@ -2682,19 +2717,19 @@ See also:
         struct /* EvalPoseInBodyFrame */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Returns a reference to the body-relative pose X_BF giving the pose of
-this Frame with respect to its body's RigidBodyFrame. This may depend
-on parameters in the Context but not on time or state. The first time
-this is called after a parameter change will precalculate offset poses
-for all Frames into the Context's cache; subsequent calls on any Frame
-are very fast.)""";
+R"""(Returns a reference to the link-relative pose X_LF giving the pose of
+this Frame with respect to its link's LinkFrame (RigidBodyFrame). This
+may depend on parameters in the Context but not on time or state. The
+first time this is called after a parameter change will precalculate
+offset poses for all Frames into the Context's cache; subsequent calls
+on any Frame are very fast.)""";
         } EvalPoseInBodyFrame;
         // Symbol: drake::multibody::Frame::Frame<T>
         struct /* ctor */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
 R"""(Only derived classes can use this constructor. It creates a Frame
-object attached to ``body`` and puts the frame in the body's model
+object attached to ``link`` and puts the frame in the link's model
 instance.)""";
         } ctor;
         // Symbol: drake::multibody::Frame::GetFixedOffsetPoseInBody
@@ -2702,8 +2737,8 @@ instance.)""";
           // Source: drake/multibody/tree/frame.h
           const char* doc =
 R"""(Variant of CalcOffsetPoseInBody() that given the offset pose ``X_FQ``
-of a frame Q in ``this`` frame F, returns the pose ``X_BQ`` of frame Q
-in the body frame B to which this frame is attached.
+of a frame Q in ``this`` frame F, returns the pose ``X_LQ`` of frame Q
+in the link frame L to which this frame is attached.
 
 Raises:
     RuntimeError if called on a Frame that does not have a fixed
@@ -2713,8 +2748,8 @@ Raises:
         struct /* GetFixedPoseInBodyFrame */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Variant of CalcPoseInBodyFrame() that returns the fixed pose ``X_BF``
-of ``this`` frame F in the body frame B associated with this frame.
+R"""(Variant of CalcPoseInBodyFrame() that returns the fixed pose ``X_LF``
+of ``this`` frame F in the link frame L associated with this frame.
 
 Raises:
     RuntimeError if called on a Frame that does not have a fixed
@@ -2724,33 +2759,31 @@ Raises:
         struct /* GetFixedRotationMatrixInBody */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Calculates and returns the rotation matrix ``R_BQ`` that relates body
-frame B to frame Q via ``this`` intermediate frame F, i.e., ``R_BQ =
-R_BF * R_FQ`` (B is the body frame to which ``this`` frame F is
-attached).
+R"""(Calculates and returns the rotation matrix ``R_LQ`` that relates link
+frame L to frame Q via ``this`` intermediate frame F, i.e., ``R_LQ =
+R_LF * R_FQ`` (L is the link frame of the Link (RigidBody) to which
+``this`` frame F is attached).
 
 Parameter ``R_FQ``:
     rotation matrix that relates frame F to frame Q.
 
 Raises:
     RuntimeError if ``this`` frame F is a Frame that does not have a
-    fixed offset in the body frame B (i.e., ``R_BF`` is not constant).)""";
+    fixed offset in the link frame L (i.e., ``R_LF`` is not constant).)""";
         } GetFixedRotationMatrixInBody;
         // Symbol: drake::multibody::Frame::GetFixedRotationMatrixInBodyFrame
         struct /* GetFixedRotationMatrixInBodyFrame */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Returns the rotation matrix ``R_BF`` that relates body frame B to
-``this`` frame F (B is the body frame to which ``this`` frame F is
-attached).
+R"""(Returns the rotation matrix ``R_LF`` that relates link frame L to
+``this`` frame F (L is the LinkFrame of the Link (RigidBody) to which
+``this`` frame F is attached).
 
 Raises:
     RuntimeError if ``this`` frame F is a Frame that does not have a
-    fixed offset in the body frame B (i.e., ``R_BF`` is not constant).
-    Frame sub-classes that have a constant ``R_BF`` must override this
-    method. An example of a frame sub-class not implementing this
-    method would be that of a frame on a soft body, for which its pose
-    in the body frame depends on the state of deformation of the body.)""";
+    fixed offset in the link frame L (i.e., ``R_LF`` is not constant).
+    Frame sub-classes that have a constant ``R_LF`` must override this
+    method.)""";
         } GetFixedRotationMatrixInBodyFrame;
         // Symbol: drake::multibody::Frame::ShallowClone
         struct /* ShallowClone */ {
@@ -2764,21 +2797,23 @@ any MbT (so the assigned index, if any, is discarded).)""";
         struct /* body */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Returns a const reference to the body associated to this Frame.)""";
+R"""(Returns a const reference to the RigidBody (Link) to which this Frame
+is attached (synonym for link()).)""";
         } body;
         // Symbol: drake::multibody::Frame::get_X_BF
         struct /* get_X_BF */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
 R"""((Internal use only) Given an already up-to-date frame body pose cache,
-extract X_BF for this Frame from it.
+extract X_BF for this Frame from it. Note that X_BF is F's pose on its
+mobilized body B which might not be the same as its link L.
 
 Note:
     Be sure you have called MultibodyTreeSystem∷EvalFrameBodyPoses()
     since the last parameter change; we can't check here.
 
 Returns ``X_BF``:
-    pose of this frame in its body's frame)""";
+    pose of this frame in its Mobod's frame)""";
         } get_X_BF;
         // Symbol: drake::multibody::Frame::get_X_FB
         struct /* get_X_FB */ {
@@ -2792,15 +2827,22 @@ Note:
     since the last parameter change; we can't check here.
 
 Returns ``X_FB``:
-    inverse of this frame's pose in its body's frame)""";
+    inverse of this frame's pose in its Mobod's frame)""";
         } get_X_FB;
-        // Symbol: drake::multibody::Frame::get_body_pose_index_in_cache
-        struct /* get_body_pose_index_in_cache */ {
+        // Symbol: drake::multibody::Frame::get_X_LF
+        struct /* get_X_LF */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""((Internal use only) Retrieve this Frame's body pose index in the
-cache.)""";
-        } get_body_pose_index_in_cache;
+R"""((Internal use only) Given an already up-to-date frame body pose cache,
+extract X_LF for this Frame from it.
+
+Note:
+    Be sure you have called MultibodyTreeSystem∷EvalFrameBodyPoses()
+    since the last parameter change; we can't check here.
+
+Returns ``X_LF``:
+    pose of this frame in its Link's frame)""";
+        } get_X_LF;
         // Symbol: drake::multibody::Frame::index
         struct /* index */ {
           // Source: drake/multibody/tree/frame.h
@@ -2819,20 +2861,35 @@ Note:
     since the last parameter change; we can't check here.
 
 See also:
-    get_X_BF())""";
+    get_X_BF(), get_X_FB())""";
         } is_X_BF_identity;
         // Symbol: drake::multibody::Frame::is_body_frame
         struct /* is_body_frame */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
-R"""(Returns true if ``this`` is the body frame.)""";
+R"""(Returns true if ``this`` is the RigidBodyFrame (LinkFrame) of the
+associated RigidBody (Link). This is a synonym for is_link_frame().)""";
         } is_body_frame;
+        // Symbol: drake::multibody::Frame::is_link_frame
+        struct /* is_link_frame */ {
+          // Source: drake/multibody/tree/frame.h
+          const char* doc =
+R"""(Returns true if ``this`` is the LinkFrame (RigidBodyFrame) of the
+associated Link (RigidBody). This is a synonym for is_body_frame().)""";
+        } is_link_frame;
         // Symbol: drake::multibody::Frame::is_world_frame
         struct /* is_world_frame */ {
           // Source: drake/multibody/tree/frame.h
           const char* doc =
 R"""(Returns true if ``this`` is the world frame.)""";
         } is_world_frame;
+        // Symbol: drake::multibody::Frame::link
+        struct /* link */ {
+          // Source: drake/multibody/tree/frame.h
+          const char* doc =
+R"""(Returns a const reference to the Link (RigidBody) to which this Frame
+is attached (synonym for body()).)""";
+        } link;
         // Symbol: drake::multibody::Frame::name
         struct /* name */ {
           // Source: drake/multibody/tree/frame.h
@@ -2850,26 +2907,6 @@ Raises:
     RuntimeError if this element is not associated with a
     MultibodyPlant.)""";
         } scoped_name;
-        // Symbol: drake::multibody::Frame::set_body_pose_index_in_cache
-        struct /* set_body_pose_index_in_cache */ {
-          // Source: drake/multibody/tree/frame.h
-          const char* doc =
-R"""((Internal use only) A Frame's pose-in-parent X_PF can be
-parameterized, the parent's pose may also be parameterized, and so on.
-Thus the calculation of this frame's pose in its body (X_BF) can be
-expensive. There is a cache entry that holds the calculated X_BF,
-evaluated whenever parameters change. This allows us to grab X_BF as a
-const reference rather than having to extract and reformat parameters,
-and compose with parent and ancestor poses at runtime.
-
-At the time parameters are allocated we assign a slot in the body pose
-cache entry to each Frame and record its index using this function.
-(The index for a RigidBodyFrame will refer to an identity transform.)
-Note that the body pose index is not necessarily the same as the Frame
-index because all RigidBodyFrames can share an entry. (Of course if
-you know you are working with a RigidBodyFrame you don't need to ask
-about its body pose!))""";
-        } set_body_pose_index_in_cache;
       } Frame;
       // Symbol: drake::multibody::FrameIndex
       struct /* FrameIndex */ {
@@ -4979,8 +5016,8 @@ to choose torque stiffness and damping constants" for more details.)""";
         // Source: drake/multibody/tree/linear_spring_damper.h
         const char* doc =
 R"""(This ForceElement models a spring-damper attached between two points
-on two different bodies. Given a point P on a body A and a point Q on
-a body B with positions p_AP and p_BQ, respectively, this
+on two different bodies (links). Given a point P on a body A and a
+point Q on a body B with positions p_AP and p_BQ, respectively, this
 spring-damper applies equal and opposite forces on bodies A and B
 according to:
 
@@ -5115,6 +5152,17 @@ body frame B.)""";
           const char* doc = R"""()""";
         } stiffness;
       } LinearSpringDamper;
+      // Symbol: drake::multibody::LinkIndex
+      struct /* LinkIndex */ {
+        // Source: drake/multibody/tree/multibody_tree_indexes.h
+        const char* doc = R"""(This is a synonym for BodyIndex.)""";
+      } LinkIndex;
+      // Symbol: drake::multibody::LinkOrdinal
+      struct /* LinkOrdinal */ {
+        // Source: drake/multibody/tree/multibody_tree_indexes.h
+        const char* doc =
+R"""(Type used to identify links by ordinal within a multibody plant.)""";
+      } LinkOrdinal;
       // Symbol: drake::multibody::ModelInstanceIndex
       struct /* ModelInstanceIndex */ {
         // Source: drake/multibody/tree/multibody_tree_indexes.h
@@ -7322,7 +7370,7 @@ Raises:
         struct /* body_frame */ {
           // Source: drake/multibody/tree/rigid_body.h
           const char* doc =
-R"""(Returns a const reference to the associated BodyFrame.)""";
+R"""((Compatibility) A synonym for link_frame().)""";
         } body_frame;
         // Symbol: drake::multibody::RigidBody::default_com
         struct /* default_com */ {
@@ -7660,6 +7708,13 @@ generally Joint∷is_locked() is preferable otherwise.
 Returns:
     true if the body is locked, false otherwise.)""";
         } is_locked;
+        // Symbol: drake::multibody::RigidBody::link_frame
+        struct /* link_frame */ {
+          // Source: drake/multibody/tree/rigid_body.h
+          const char* doc =
+R"""(Returns a const reference to the associated LinkFrame
+(RigidBodyFrame).)""";
+        } link_frame;
         // Symbol: drake::multibody::RigidBody::mobod_index
         struct /* mobod_index */ {
           // Source: drake/multibody/tree/rigid_body.h
@@ -7676,6 +7731,14 @@ the index into all associated quantities.)""";
 R"""(Gets the ``name`` associated with this rigid body. The name will never
 be empty.)""";
         } name;
+        // Symbol: drake::multibody::RigidBody::ordinal
+        struct /* ordinal */ {
+          // Source: drake/multibody/tree/rigid_body.h
+          const char* doc =
+R"""((Internal use only) Returns this Link's (RigidBody's) unique ordinal.
+Currently identical to the index but will differ when we permit
+removal of Links as we do for Joints.)""";
+        } ordinal;
         // Symbol: drake::multibody::RigidBody::scoped_name
         struct /* scoped_name */ {
           // Source: drake/multibody/tree/rigid_body.h

--- a/bindings/generated_docstrings/multibody_tree.h
+++ b/bindings/generated_docstrings/multibody_tree.h
@@ -589,6 +589,32 @@ representation.)""";
           const char* doc = R"""()""";
         } type_name;
       } BallRpyJoint;
+      // Symbol: drake::multibody::BaseBodyJointType
+      struct /* BaseBodyJointType */ {
+        // Source: drake/multibody/tree/multibody_tree.h
+        const char* doc =
+R"""(The kind of joint to be used to connect base bodies to world at
+Finalize(). See mbp_working_with_free_bodies "Working with free
+bodies" for definitions and discussion.
+
+See also:
+    SetBaseBodyJointType() for details.)""";
+        // Symbol: drake::multibody::BaseBodyJointType::kQuaternionFloatingJoint
+        struct /* kQuaternionFloatingJoint */ {
+          // Source: drake/multibody/tree/multibody_tree.h
+          const char* doc = R"""(6 dofs, unrestricted orientation.)""";
+        } kQuaternionFloatingJoint;
+        // Symbol: drake::multibody::BaseBodyJointType::kRpyFloatingJoint
+        struct /* kRpyFloatingJoint */ {
+          // Source: drake/multibody/tree/multibody_tree.h
+          const char* doc = R"""(6 dofs using 3 angles; has singularity.)""";
+        } kRpyFloatingJoint;
+        // Symbol: drake::multibody::BaseBodyJointType::kWeldJoint
+        struct /* kWeldJoint */ {
+          // Source: drake/multibody/tree/multibody_tree.h
+          const char* doc = R"""(0 dofs, fixed to World.)""";
+        } kWeldJoint;
+      } BaseBodyJointType;
       // Symbol: drake::multibody::BodyIndex
       struct /* BodyIndex */ {
         // Source: drake/multibody/tree/multibody_tree_indexes.h
@@ -2778,7 +2804,7 @@ Note:
     since the last parameter change; we can't check here.
 
 Returns ``X_BF``:
-    pose of this frame in its body's frame)""";
+    pose of this frame in its Mobod's frame)""";
         } get_X_BF;
         // Symbol: drake::multibody::Frame::get_X_FB
         struct /* get_X_FB */ {
@@ -5115,6 +5141,17 @@ body frame B.)""";
           const char* doc = R"""()""";
         } stiffness;
       } LinearSpringDamper;
+      // Symbol: drake::multibody::LinkIndex
+      struct /* LinkIndex */ {
+        // Source: drake/multibody/tree/multibody_tree_indexes.h
+        const char* doc = R"""(This is a synonym for BodyIndex.)""";
+      } LinkIndex;
+      // Symbol: drake::multibody::LinkOrdinal
+      struct /* LinkOrdinal */ {
+        // Source: drake/multibody/tree/multibody_tree_indexes.h
+        const char* doc =
+R"""(Type used to identify links by ordinal within a multibody plant.)""";
+      } LinkOrdinal;
       // Symbol: drake::multibody::ModelInstanceIndex
       struct /* ModelInstanceIndex */ {
         // Source: drake/multibody/tree/multibody_tree_indexes.h
@@ -7676,6 +7713,14 @@ the index into all associated quantities.)""";
 R"""(Gets the ``name`` associated with this rigid body. The name will never
 be empty.)""";
         } name;
+        // Symbol: drake::multibody::RigidBody::ordinal
+        struct /* ordinal */ {
+          // Source: drake/multibody/tree/rigid_body.h
+          const char* doc =
+R"""((Internal use only) Returns this Link's (RigidBody's) unique ordinal.
+Currently identical to the index but will differ when we permit
+removal of Links as we do for Joints.)""";
+        } ordinal;
         // Symbol: drake::multibody::RigidBody::scoped_name
         struct /* scoped_name */ {
           // Source: drake/multibody/tree/rigid_body.h

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -156,6 +156,7 @@ drake_pybind_library(
     name = "plant_py",
     cc_deps = [
         "//bindings/generated_docstrings:multibody_plant",
+        "//bindings/generated_docstrings:multibody_tree",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "drake/bindings/generated_docstrings/multibody_plant.h"
+#include "drake/bindings/generated_docstrings/multibody_tree.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
@@ -1776,8 +1777,11 @@ PYBIND11_MODULE(plant, m) {
   }
 
   {
+    // This enum comes from a MultibodyTree header but for historical
+    // reasons we've bound it in plant.
     using Class = BaseBodyJointType;
-    constexpr auto& cls_doc = doc.BaseBodyJointType;
+    constexpr auto& tree_doc = pydrake_doc_multibody_tree.drake.multibody;
+    constexpr auto& cls_doc = tree_doc.BaseBodyJointType;
     py::enum_<Class> cls(m, "BaseBodyJointType", cls_doc.doc);
     cls.value("kQuaternionFloatingJoint", Class::kQuaternionFloatingJoint,
            cls_doc.kQuaternionFloatingJoint.doc)

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1776,17 +1776,6 @@ PYBIND11_MODULE(plant, m) {
   }
 
   {
-    using Class = BaseBodyJointType;
-    constexpr auto& cls_doc = doc.BaseBodyJointType;
-    py::enum_<Class> cls(m, "BaseBodyJointType", cls_doc.doc);
-    cls.value("kQuaternionFloatingJoint", Class::kQuaternionFloatingJoint,
-           cls_doc.kQuaternionFloatingJoint.doc)
-        .value("kRpyFloatingJoint", Class::kRpyFloatingJoint,
-            cls_doc.kRpyFloatingJoint.doc)
-        .value("kWeldJoint", Class::kWeldJoint, cls_doc.kWeldJoint.doc);
-  }
-
-  {
     using Class = MultibodyPlantConfig;
     constexpr auto& cls_doc = doc.MultibodyPlantConfig;
     py::class_<Class> cls(m, "MultibodyPlantConfig", cls_doc.doc);

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -59,7 +59,6 @@ from pydrake.multibody.plant import (
     AddMultibodyPlant,
     AddMultibodyPlantSceneGraph,
     ApplyMultibodyPlantConfig,
-    BaseBodyJointType,
     CalcContactFrictionFromSurfaceProperties,
     ConnectContactResultsToDrakeVisualizer,
     ContactModel,
@@ -81,6 +80,7 @@ from pydrake.multibody.plant import (
 )
 from pydrake.multibody.tree import (
     BallRpyJoint_,
+    BaseBodyJointType,
     Body_,  # dispreferred alias for RigidBody_
     BodyIndex,
     CalcSpatialInertia,

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -149,6 +149,17 @@ void DoScalarIndependentDefinitions(py::module m) {
   }
 
   {
+    using Enum = BaseBodyJointType;
+    constexpr auto& cls_doc = doc.BaseBodyJointType;
+    py::enum_<Enum> cls(m, "BaseBodyJointType", cls_doc.doc);
+    cls.value("kQuaternionFloatingJoint", Enum::kQuaternionFloatingJoint,
+           cls_doc.kQuaternionFloatingJoint.doc)
+        .value("kRpyFloatingJoint", Enum::kRpyFloatingJoint,
+            cls_doc.kRpyFloatingJoint.doc)
+        .value("kWeldJoint", Enum::kWeldJoint, cls_doc.kWeldJoint.doc);
+  }
+
+  {
     using Class = ScopedName;
     constexpr auto& cls_doc = doc.ScopedName;
     py::class_<Class> cls(m, "ScopedName", cls_doc.doc);

--- a/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
+++ b/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
@@ -85,7 +85,7 @@ class DrakeKukaIIwaRobot {
         MakeKukaIiwaModel<T>(false /* finalized model */,
                              gravity /* acceleration of gravity */));
 
-    linkN_ = &tree().world_body();
+    linkN_ = &tree().world_link();
 
     // Get this robot's seven links.
     linkA_ = &tree().GetRigidBodyByName("iiwa_link_1");
@@ -111,7 +111,7 @@ class DrakeKukaIIwaRobot {
 
   /// This method gets the number of rigid bodies in this robot.
   /// @returns the number of rigid bodies in this robot.
-  int get_number_of_rigid_bodies() const { return tree().num_bodies(); }
+  int get_number_of_rigid_bodies() const { return tree().num_links(); }
 
   /// This method calculates kinematic properties of the end-effector (herein
   /// denoted as rigid body G) of a 7-DOF KUKA LBR iiwa robot (14 kg payload).
@@ -145,7 +145,7 @@ class DrakeKukaIIwaRobot {
     const SpatialVelocity<T>& V_NG_N = vc.get_V_WB(linkG_->mobod_index());
 
     // Retrieve end-effector spatial acceleration from acceleration cache.
-    std::vector<SpatialAcceleration<T>> A_WB(tree().num_bodies());
+    std::vector<SpatialAcceleration<T>> A_WB(tree().num_links());
     // TODO(eric.cousineau): For this model, the end effector's BodyIndex
     // matches its MobodIndex, thus we're not really checking the difference
     // between MultibodyPlant and MultibodyTree's ordering.

--- a/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
+++ b/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
@@ -85,16 +85,16 @@ class DrakeKukaIIwaRobot {
         MakeKukaIiwaModel<T>(false /* finalized model */,
                              gravity /* acceleration of gravity */));
 
-    linkN_ = &tree().world_body();
+    linkN_ = &tree().world_link();
 
     // Get this robot's seven links.
-    linkA_ = &tree().GetRigidBodyByName("iiwa_link_1");
-    linkB_ = &tree().GetRigidBodyByName("iiwa_link_2");
-    linkC_ = &tree().GetRigidBodyByName("iiwa_link_3");
-    linkD_ = &tree().GetRigidBodyByName("iiwa_link_4");
-    linkE_ = &tree().GetRigidBodyByName("iiwa_link_5");
-    linkF_ = &tree().GetRigidBodyByName("iiwa_link_6");
-    linkG_ = &tree().GetRigidBodyByName("iiwa_link_7");
+    linkA_ = &tree().GetLinkByName("iiwa_link_1");
+    linkB_ = &tree().GetLinkByName("iiwa_link_2");
+    linkC_ = &tree().GetLinkByName("iiwa_link_3");
+    linkD_ = &tree().GetLinkByName("iiwa_link_4");
+    linkE_ = &tree().GetLinkByName("iiwa_link_5");
+    linkF_ = &tree().GetLinkByName("iiwa_link_6");
+    linkG_ = &tree().GetLinkByName("iiwa_link_7");
 
     // Get this robot's seven joints.
     NA_joint_ = &tree().template GetJointByName<RevoluteJoint>("iiwa_joint_1");
@@ -111,7 +111,7 @@ class DrakeKukaIIwaRobot {
 
   /// This method gets the number of rigid bodies in this robot.
   /// @returns the number of rigid bodies in this robot.
-  int get_number_of_rigid_bodies() const { return tree().num_bodies(); }
+  int get_number_of_rigid_bodies() const { return tree().num_links(); }
 
   /// This method calculates kinematic properties of the end-effector (herein
   /// denoted as rigid body G) of a 7-DOF KUKA LBR iiwa robot (14 kg payload).
@@ -145,7 +145,7 @@ class DrakeKukaIIwaRobot {
     const SpatialVelocity<T>& V_NG_N = vc.get_V_WB(linkG_->mobod_index());
 
     // Retrieve end-effector spatial acceleration from acceleration cache.
-    std::vector<SpatialAcceleration<T>> A_WB(tree().num_bodies());
+    std::vector<SpatialAcceleration<T>> A_WB(tree().num_links());
     // TODO(eric.cousineau): For this model, the end effector's BodyIndex
     // matches its MobodIndex, thus we're not really checking the difference
     // between MultibodyPlant and MultibodyTree's ordering.

--- a/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.cc
+++ b/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.cc
@@ -91,7 +91,7 @@ KukaIiwaModelBuilder<T>::Build() const {
   // angles and a position vector. Alternately, frame An is regarded as
   // coincident with linkA.
   const Joint<T>* joint{nullptr};
-  const RigidBody<T>& linkN = model->world_body();
+  const RigidBody<T>& linkN = model->world_link();
   joint = &AddRevoluteJointFromSpaceXYZAnglesAndXYZ(
       "iiwa_joint_1", linkN, joint_1_rpy_, joint_1_xyz_, linkA,
       Eigen::Vector3d::UnitZ(), model.get());

--- a/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.cc
+++ b/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.cc
@@ -75,13 +75,13 @@ KukaIiwaModelBuilder<T>::Build() const {
                                                      I_GGcm_G_);
 
   // Add this robot's seven links.
-  const RigidBody<T>& linkA = model->AddRigidBody("iiwa_link_1", M_AAo_A);
-  const RigidBody<T>& linkB = model->AddRigidBody("iiwa_link_2", M_BBo_B);
-  const RigidBody<T>& linkC = model->AddRigidBody("iiwa_link_3", M_CCo_C);
-  const RigidBody<T>& linkD = model->AddRigidBody("iiwa_link_4", M_DDo_D);
-  const RigidBody<T>& linkE = model->AddRigidBody("iiwa_link_5", M_EEo_E);
-  const RigidBody<T>& linkF = model->AddRigidBody("iiwa_link_6", M_FFo_F);
-  const RigidBody<T>& linkG = model->AddRigidBody("iiwa_link_7", M_GGo_G);
+  const Link<T>& linkA = model->AddLink("iiwa_link_1", M_AAo_A);
+  const Link<T>& linkB = model->AddLink("iiwa_link_2", M_BBo_B);
+  const Link<T>& linkC = model->AddLink("iiwa_link_3", M_CCo_C);
+  const Link<T>& linkD = model->AddLink("iiwa_link_4", M_DDo_D);
+  const Link<T>& linkE = model->AddLink("iiwa_link_5", M_EEo_E);
+  const Link<T>& linkF = model->AddLink("iiwa_link_6", M_FFo_F);
+  const Link<T>& linkG = model->AddLink("iiwa_link_7", M_GGo_G);
 
   // Create a revolute joint between linkN (Newtonian frame/world) and linkA
   // using two joint-frames, namely "Na" and "An".  The "inboard frame" Na is
@@ -91,7 +91,7 @@ KukaIiwaModelBuilder<T>::Build() const {
   // angles and a position vector. Alternately, frame An is regarded as
   // coincident with linkA.
   const Joint<T>* joint{nullptr};
-  const RigidBody<T>& linkN = model->world_body();
+  const Link<T>& linkN = model->world_link();
   joint = &AddRevoluteJointFromSpaceXYZAnglesAndXYZ(
       "iiwa_joint_1", linkN, joint_1_rpy_, joint_1_xyz_, linkA,
       Eigen::Vector3d::UnitZ(), model.get());
@@ -109,7 +109,7 @@ KukaIiwaModelBuilder<T>::Build() const {
       Eigen::Vector3d::UnitZ(), model.get());
   model->AddJointActuator("iiwa_actuator_3", *joint);
 
-  // Create a revolute joint between linkB and linkC.
+  // Create a revolute joint between linkC and linkD.
   joint = &AddRevoluteJointFromSpaceXYZAnglesAndXYZ(
       "iiwa_joint_4", linkC, joint_4_rpy_, joint_4_xyz_, linkD,
       Eigen::Vector3d::UnitZ(), model.get());

--- a/multibody/math/spatial_vector.h
+++ b/multibody/math/spatial_vector.h
@@ -291,6 +291,14 @@ class SpatialVector {
   /// rotational and translational components are both zero.
   static SpatialQuantity Zero() { return SpatialQuantity{}.SetZero(); }
 
+  /// Factory to create a _NaN_ spatial vector, i.e., a %SpatialVector whose
+  /// rotational and translational components are all NaN.
+  static SpatialQuantity NaN() {
+    SpatialQuantity quantity;
+    quantity.SetNaN();
+    return quantity;
+  }
+
  private:
   // Helper method to return a mutable reference to the derived spatial
   // quantity.

--- a/multibody/math/test/spatial_algebra_test.cc
+++ b/multibody/math/test/spatial_algebra_test.cc
@@ -110,6 +110,27 @@ TYPED_TEST(SpatialQuantityTest, ZeroFactory) {
   EXPECT_TRUE(V.translational() == Vector3<T>::Zero());
 }
 
+// Construction of a "NaN" spatial vector.
+TYPED_TEST(SpatialQuantityTest, NaNFactory) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  typedef typename TestFixture::ScalarType T;
+  SpatialQuantity V = SpatialQuantity::NaN();
+  auto is_nan = [](const T& x) -> bool {
+    if constexpr (std::is_same_v<T, Expression>) {
+      return symbolic::is_nan(x);
+    }
+    if constexpr (std::is_same_v<T, AutoDiffXd>) {
+      return std::isnan(x.value());
+    }
+    if constexpr (std::is_same_v<T, double>) {
+      return std::isnan(x);
+    }
+  };
+  for (int i = 0; i < V.size(); ++i) {
+    EXPECT_TRUE(is_nan(V[i]));
+  }
+}
+
 // Tests:
 // - Construction from a Eigen expressions.
 // - SetZero() method.

--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -210,7 +210,7 @@ TEST_F(IiwaToppraTest, JointTorqueLimit) {
   auto s_path = result.value();
 
   // This tolerance was tuned to work with the given gridpoints.
-  const double tol = 1e-14;
+  const double tol = 1e-13;
   Eigen::MatrixXd M(7, 7);
   Eigen::VectorXd Cv(7);
   Eigen::VectorXd G(7);

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -333,7 +333,7 @@ template <typename T>
 void DeformableModel<T>::SetParallelism(Parallelism parallelism) {
   parallelism_ = parallelism;
   const std::vector<DeformableBodyIndex>& body_indices =
-      deformable_bodies_.indices();
+      deformable_bodies_.valid_indices();
   for (const DeformableBodyIndex& index : body_indices) {
     deformable_bodies_.get_mutable_element(index).set_parallelism(parallelism);
   }
@@ -346,7 +346,8 @@ void DeformableModel<T>::SetDefaultState(const systems::Context<T>& context,
     DRAKE_DEMAND(is_empty());
     return;
   } else {
-    for (const DeformableBodyIndex& index : deformable_bodies_.indices()) {
+    for (const DeformableBodyIndex& index :
+         deformable_bodies_.valid_indices()) {
       const DeformableBody<T>& body = deformable_bodies_.get_element(index);
       body.SetDefaultState(context, state);
     }
@@ -372,7 +373,8 @@ std::unique_ptr<PhysicalModel<double>> DeformableModel<T>::CloneToDouble(
 
     /* Copy over deformable_bodies_. */
     result->deformable_bodies_.ResizeToMatch(deformable_bodies_);
-    for (const DeformableBodyIndex& index : deformable_bodies_.indices()) {
+    for (const DeformableBodyIndex& index :
+         deformable_bodies_.valid_indices()) {
       const DeformableBody<T>& body = deformable_bodies_.get_element(index);
       result->deformable_bodies_.Add(body.CloneToDouble());
     }
@@ -430,7 +432,7 @@ void DeformableModel<T>::DoDeclareSystemResources() {
 
     /* Declare discrete states and parameters. */
     const std::vector<DeformableBodyIndex>& body_indices =
-        deformable_bodies_.indices();
+        deformable_bodies_.valid_indices();
     for (const DeformableBodyIndex& index : body_indices) {
       DeformableBody<T>& body = deformable_bodies_.get_mutable_element(index);
       body.DeclareDiscreteState(static_cast<internal::MultibodyTreeSystem<T>*>(
@@ -482,7 +484,7 @@ void DeformableModel<T>::CopyVertexPositions(const systems::Context<T>& context,
       output->get_mutable_value<geometry::GeometryConfigurationVector<T>>();
   output_value.clear();
   const std::vector<DeformableBodyIndex>& body_indices =
-      deformable_bodies_.indices();
+      deformable_bodies_.valid_indices();
   for (const DeformableBodyIndex& index : body_indices) {
     const DeformableBody<T>& body = deformable_bodies_.get_element(index);
     const GeometryId geometry_id = body.geometry_id();

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1224,8 +1224,8 @@ std::vector<BodyIndex> MultibodyPlant<T>::GetBodiesKinematicallyAffectedBy(
                       __func__, joint));
     }
   }
-  const std::set<BodyIndex> links =
-      internal_tree().GetBodiesKinematicallyAffectedBy(joint_indexes);
+  const std::set<LinkIndex> links =
+      internal_tree().GetLinksKinematicallyAffectedBy(joint_indexes);
   // TODO(sherm1) Change the return type to set to avoid this copy.
   return std::vector<BodyIndex>(links.cbegin(), links.cend());
 }
@@ -1350,7 +1350,7 @@ void MultibodyPlant<T>::CalcSpatialAccelerationsFromVdot(
     // Make sure there aren't any inactives for now.
     DRAKE_DEMAND(ssize(mobod.follower_link_ordinals()) == 1);
     const BodyIndex active_link_index =
-        forest.links(mobod.link_ordinal()).index();
+        forest.links(mobod.active_link_ordinal()).index();
     (*A_WB_array)[active_link_index] = A_WB_array_mobod[mobod.index()];
   }
 }
@@ -1418,43 +1418,13 @@ template <typename T>
 void MultibodyPlant<T>::SetBaseBodyJointType(
     BaseBodyJointType joint_type,
     std::optional<ModelInstanceIndex> model_instance) {
-  std::optional<internal::ForestBuildingOptions> options;
-  switch (joint_type) {
-    case BaseBodyJointType::kQuaternionFloatingJoint:
-      options = internal::ForestBuildingOptions::kDefault;
-      break;
-    case BaseBodyJointType::kRpyFloatingJoint:
-      options = internal::ForestBuildingOptions::kUseRpyFloatingJoints;
-      break;
-    case BaseBodyJointType::kWeldJoint:
-      options = internal::ForestBuildingOptions::kUseFixedBase;
-      break;
-  }
-  DRAKE_DEMAND(options.has_value());
-  DRAKE_THROW_UNLESS(!is_finalized());
-  internal::LinkJointGraph& graph = mutable_tree().mutable_graph();
-  if (model_instance.has_value()) {
-    graph.SetForestBuildingOptions(*model_instance, *options);
-  } else {
-    graph.SetGlobalForestBuildingOptions(*options);
-  }
+  mutable_tree().SetBaseBodyJointType(joint_type, model_instance);
 }
 
 template <typename T>
 BaseBodyJointType MultibodyPlant<T>::GetBaseBodyJointType(
     std::optional<ModelInstanceIndex> model_instance) const {
-  const internal::LinkJointGraph& graph = internal_tree().graph();
-  const internal::ForestBuildingOptions options =
-      model_instance.has_value()
-          ? graph.get_forest_building_options_in_use(*model_instance)
-          : graph.get_global_forest_building_options();
-  if (static_cast<bool>(options &
-                        internal::ForestBuildingOptions::kUseRpyFloatingJoints))
-    return BaseBodyJointType::kRpyFloatingJoint;
-  if (static_cast<bool>(options &
-                        internal::ForestBuildingOptions::kUseFixedBase))
-    return BaseBodyJointType::kWeldJoint;
-  return BaseBodyJointType::kQuaternionFloatingJoint;
+  return internal_tree().GetBaseBodyJointType(model_instance);
 }
 
 template <typename T>
@@ -2690,7 +2660,7 @@ void MultibodyPlant<T>::AddAppliedExternalSpatialForces(
         HasNaN(spatial_force.translational())) {
       throw std::runtime_error(fmt::format(
           "Spatial force applied on body {} contains NaN.",
-          internal_tree().get_body(external_spatial_force.body_index).name()));
+          internal_tree().get_link(external_spatial_force.body_index).name()));
     }
   };
   // Loop over all forces.
@@ -4060,13 +4030,13 @@ void MultibodyPlant<T>::DeclareSceneGraphPorts() {
 template <typename T>
 void MultibodyPlant<T>::CalcBodyPosesOutput(
     const Context<T>& context,
-    std::vector<math::RigidTransform<T>>* outupt) const {
+    std::vector<math::RigidTransform<T>>* output) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   this->ValidateContext(context);
-  outupt->resize(num_bodies());
+  output->resize(num_bodies());
   for (BodyIndex body_index(0); body_index < this->num_bodies(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
-    outupt->at(body_index) = EvalBodyPoseInWorld(context, body);
+    output->at(body_index) = EvalBodyPoseInWorld(context, body);
   }
 }
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1350,7 +1350,7 @@ void MultibodyPlant<T>::CalcSpatialAccelerationsFromVdot(
     // Make sure there aren't any inactives for now.
     DRAKE_DEMAND(ssize(mobod.follower_link_ordinals()) == 1);
     const BodyIndex active_link_index =
-        forest.links(mobod.link_ordinal()).index();
+        forest.links(mobod.active_link_ordinal()).index();
     (*A_WB_array)[active_link_index] = A_WB_array_mobod[mobod.index()];
   }
 }
@@ -1418,43 +1418,13 @@ template <typename T>
 void MultibodyPlant<T>::SetBaseBodyJointType(
     BaseBodyJointType joint_type,
     std::optional<ModelInstanceIndex> model_instance) {
-  std::optional<internal::ForestBuildingOptions> options;
-  switch (joint_type) {
-    case BaseBodyJointType::kQuaternionFloatingJoint:
-      options = internal::ForestBuildingOptions::kDefault;
-      break;
-    case BaseBodyJointType::kRpyFloatingJoint:
-      options = internal::ForestBuildingOptions::kUseRpyFloatingJoints;
-      break;
-    case BaseBodyJointType::kWeldJoint:
-      options = internal::ForestBuildingOptions::kUseFixedBase;
-      break;
-  }
-  DRAKE_DEMAND(options.has_value());
-  DRAKE_THROW_UNLESS(!is_finalized());
-  internal::LinkJointGraph& graph = mutable_tree().mutable_graph();
-  if (model_instance.has_value()) {
-    graph.SetForestBuildingOptions(*model_instance, *options);
-  } else {
-    graph.SetGlobalForestBuildingOptions(*options);
-  }
+  mutable_tree().SetBaseBodyJointType(joint_type, model_instance);
 }
 
 template <typename T>
 BaseBodyJointType MultibodyPlant<T>::GetBaseBodyJointType(
     std::optional<ModelInstanceIndex> model_instance) const {
-  const internal::LinkJointGraph& graph = internal_tree().graph();
-  const internal::ForestBuildingOptions options =
-      model_instance.has_value()
-          ? graph.get_forest_building_options_in_use(*model_instance)
-          : graph.get_global_forest_building_options();
-  if (static_cast<bool>(options &
-                        internal::ForestBuildingOptions::kUseRpyFloatingJoints))
-    return BaseBodyJointType::kRpyFloatingJoint;
-  if (static_cast<bool>(options &
-                        internal::ForestBuildingOptions::kUseFixedBase))
-    return BaseBodyJointType::kWeldJoint;
-  return BaseBodyJointType::kQuaternionFloatingJoint;
+  return internal_tree().GetBaseBodyJointType(model_instance);
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -245,16 +245,6 @@ enum class DiscreteContactApproximation {
   kLagged,
 };
 
-/// The kind of joint to be used to connect base bodies to world at Finalize().
-/// See @ref mbp_working_with_free_bodies "Working with free bodies"
-/// for definitions and discussion.
-/// @see SetBaseBodyJointType() for details.
-enum class BaseBodyJointType {
-  kQuaternionFloatingJoint,  ///< 6 dofs, unrestricted orientation.
-  kRpyFloatingJoint,         ///< 6 dofs using 3 angles; has singularity.
-  kWeldJoint,                ///< 0 dofs, fixed to World.
-};
-
 /// @cond
 // Helper macro to throw an exception within methods that should not be called
 // post-finalize.
@@ -1267,6 +1257,10 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_generalized_contact_forces_output_port(
       ModelInstanceIndex model_instance) const;
 
+  // TODO(sherm1) Modify the next comment to explain that unmodeled joints will
+  //  have NaN reaction force entries here. (Joints can be unmodeled because
+  //  they were removed or because they are internal to a composite body.)
+
   /// Reports joint reaction forces as an @ref AbstractValue "abstract-valued"
   /// output port containing an `std::vector<SpatialForce<T>>` of size
   /// num_joints().
@@ -1424,9 +1418,9 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
       const std::string& name, ModelInstanceIndex model_instance,
       const SpatialInertia<double>& M_BBo_B = SpatialInertia<double>::Zero()) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    // Add the actual rigid body to the model.
+    // Add the actual RigidBody (Link) to the model.
     const RigidBody<T>& body =
-        this->mutable_tree().AddRigidBody(name, model_instance, M_BBo_B);
+        this->mutable_tree().AddLink(name, model_instance, M_BBo_B);
     // Each entry of visual_geometries_, ordered by body index, contains a
     // std::vector of geometry ids for that body. The emplace_back() below
     // resizes visual_geometries_ to store the geometry ids for the body we
@@ -1766,6 +1760,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @param[in] model_instance (optional) the index of the model instance to
   ///   which `joint_type` is to be applied.
   /// @throws std::exception if called after Finalize().
+  /// @see GetBaseBodyJointType(), Finalize()
   void SetBaseBodyJointType(
       BaseBodyJointType joint_type,
       std::optional<ModelInstanceIndex> model_instance = {});
@@ -1778,7 +1773,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// This can be called any time -- pre-finalize it returns the joint type
   /// that will be used by Finalize(); post-finalize it returns the joint type
   /// that _was_ used if there were any base bodies in need of a joint.
-  /// @see SetBaseBodyJointType()
+  /// @see SetBaseBodyJointType(), Finalize()
   BaseBodyJointType GetBaseBodyJointType(
       std::optional<ModelInstanceIndex> model_instance = {}) const;
 
@@ -2476,7 +2471,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const RigidBody<T>* GetBodyFromFrameId(geometry::FrameId frame_id) const {
     const auto it = frame_id_to_body_index_.find(frame_id);
     if (it == frame_id_to_body_index_.end()) return nullptr;
-    return &internal_tree().get_body(it->second);
+    return &internal_tree().get_link(it->second);
   }
 
   /// If the body with `body_index` belongs to the called plant, it returns
@@ -2499,7 +2494,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     const auto it = body_index_to_frame_id_.find(body_index);
     if (it == body_index_to_frame_id_.end()) {
       throw std::logic_error("Body '" +
-                             internal_tree().get_body(body_index).name() +
+                             internal_tree().get_link(body_index).name() +
                              "' does not have geometry registered with it.");
     }
     return it->second;
@@ -3764,7 +3759,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const math::RigidTransform<T>& EvalBodyPoseInWorld(
       const systems::Context<T>& context, const RigidBody<T>& body_B) const {
     this->ValidateContext(context);
-    return internal_tree().EvalBodyPoseInWorld(context, body_B);
+    return internal_tree().EvalLinkPoseInWorld(context, body_B);
   }
 
   /// Evaluates V_WB, body B's spatial velocity in the world frame W.
@@ -3777,7 +3772,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const SpatialVelocity<T>& EvalBodySpatialVelocityInWorld(
       const systems::Context<T>& context, const RigidBody<T>& body_B) const {
     this->ValidateContext(context);
-    return internal_tree().EvalBodySpatialVelocityInWorld(context, body_B);
+    return internal_tree().EvalLinkSpatialVelocityInWorld(context, body_B);
   }
 
   /// Evaluates A_WB, body B's spatial acceleration in the world frame W.
@@ -5195,7 +5190,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to the *world* body.
   const RigidBody<T>& world_body() const {
-    return internal_tree().world_body();
+    return internal_tree().world_link();
   }
 
   /// Returns a constant reference to the *world* frame.
@@ -5206,18 +5201,18 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// Returns the number of RigidBody elements in the model, including the
   /// "world" RigidBody, which is always part of the model.
   /// @see AddRigidBody().
-  int num_bodies() const { return internal_tree().num_bodies(); }
+  int num_bodies() const { return internal_tree().num_links(); }
 
   /// Returns `true` if plant has a rigid body with unique index `body_index`.
   bool has_body(BodyIndex body_index) const {
-    return internal_tree().has_body(body_index);
+    return internal_tree().has_link(body_index);
   }
 
   /// Returns a constant reference to the body with unique index `body_index`.
   /// @throws std::exception if `body_index` does not correspond to a body in
   /// this model.
   const RigidBody<T>& get_body(BodyIndex body_index) const {
-    return internal_tree().get_body(body_index);
+    return internal_tree().get_link(body_index);
   }
 
   /// Returns `true` if @p body is anchored (i.e. the kinematic path between
@@ -5234,13 +5229,13 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if the body name occurs in multiple model
   /// instances.
   bool HasBodyNamed(std::string_view name) const {
-    return internal_tree().HasBodyNamed(name);
+    return internal_tree().HasLinkNamed(name);
   }
 
   /// @returns The total number of bodies (across all model instances) with the
   /// given name.
   int NumBodiesWithName(std::string_view name) const {
-    return internal_tree().NumBodiesWithName(name);
+    return internal_tree().NumLinksWithName(name);
   }
 
   /// @returns `true` if a body named `name` was added to the %MultibodyPlant
@@ -5250,7 +5245,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if @p model_instance is not valid for this model.
   bool HasBodyNamed(std::string_view name,
                     ModelInstanceIndex model_instance) const {
-    return internal_tree().HasBodyNamed(name, model_instance);
+    return internal_tree().HasLinkNamed(name, model_instance);
   }
 
   /// Returns a constant reference to a body that is identified
@@ -5261,7 +5256,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @see HasBodyNamed() to query if there exists a body in `this`
   /// %MultibodyPlant with a given specified name.
   const RigidBody<T>& GetBodyByName(std::string_view name) const {
-    return internal_tree().GetRigidBodyByName(name);
+    return internal_tree().GetLinkByName(name);
   }
 
   /// Returns a constant reference to the body that is uniquely identified
@@ -5271,13 +5266,13 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// %MultibodyPlant with a given specified name.
   const RigidBody<T>& GetBodyByName(std::string_view name,
                                     ModelInstanceIndex model_instance) const {
-    return internal_tree().GetRigidBodyByName(name, model_instance);
+    return internal_tree().GetLinkByName(name, model_instance);
   }
 
   /// Returns a list of body indices associated with `model_instance`.
   std::vector<BodyIndex> GetBodyIndices(
       ModelInstanceIndex model_instance) const {
-    return internal_tree().GetBodyIndices(model_instance);
+    return internal_tree().GetLinkIndices(model_instance);
   }
 
   /// Returns a constant reference to a rigid body that is identified
@@ -5289,7 +5284,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @see HasBodyNamed() to query if there exists a body in `this` model with a
   /// given specified name.
   const RigidBody<T>& GetRigidBodyByName(std::string_view name) const {
-    return internal_tree().GetRigidBodyByName(name);
+    return internal_tree().GetLinkByName(name);
   }
 
   /// Returns a constant reference to the rigid body that is uniquely identified
@@ -5302,7 +5297,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// given specified name.
   const RigidBody<T>& GetRigidBodyByName(
       std::string_view name, ModelInstanceIndex model_instance) const {
-    return internal_tree().GetRigidBodyByName(name, model_instance);
+    return internal_tree().GetLinkByName(name, model_instance);
   }
 
   /// Returns all bodies that are transitively welded, or rigidly affixed, to

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -245,16 +245,6 @@ enum class DiscreteContactApproximation {
   kLagged,
 };
 
-/// The kind of joint to be used to connect base bodies to world at Finalize().
-/// See @ref mbp_working_with_free_bodies "Working with free bodies"
-/// for definitions and discussion.
-/// @see SetBaseBodyJointType() for details.
-enum class BaseBodyJointType {
-  kQuaternionFloatingJoint,  ///< 6 dofs, unrestricted orientation.
-  kRpyFloatingJoint,         ///< 6 dofs using 3 angles; has singularity.
-  kWeldJoint,                ///< 0 dofs, fixed to World.
-};
-
 /// @cond
 // Helper macro to throw an exception within methods that should not be called
 // post-finalize.
@@ -1267,6 +1257,10 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   const systems::OutputPort<T>& get_generalized_contact_forces_output_port(
       ModelInstanceIndex model_instance) const;
 
+  // TODO(sherm1) Modify the next comment to explain that unmodeled joints will
+  //  have NaN reaction force entries here. (Joints can be unmodeled because
+  //  they were removed or because they are internal to a composite body.)
+
   /// Reports joint reaction forces as an @ref AbstractValue "abstract-valued"
   /// output port containing an `std::vector<SpatialForce<T>>` of size
   /// num_joints().
@@ -1766,6 +1760,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @param[in] model_instance (optional) the index of the model instance to
   ///   which `joint_type` is to be applied.
   /// @throws std::exception if called after Finalize().
+  /// @see GetBaseBodyJointType(), Finalize()
   void SetBaseBodyJointType(
       BaseBodyJointType joint_type,
       std::optional<ModelInstanceIndex> model_instance = {});
@@ -1778,7 +1773,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// This can be called any time -- pre-finalize it returns the joint type
   /// that will be used by Finalize(); post-finalize it returns the joint type
   /// that _was_ used if there were any base bodies in need of a joint.
-  /// @see SetBaseBodyJointType()
+  /// @see SetBaseBodyJointType(), Finalize()
   BaseBodyJointType GetBaseBodyJointType(
       std::optional<ModelInstanceIndex> model_instance = {}) const;
 
@@ -5195,7 +5190,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to the *world* body.
   const RigidBody<T>& world_body() const {
-    return internal_tree().world_body();
+    return internal_tree().world_link();
   }
 
   /// Returns a constant reference to the *world* frame.
@@ -5206,7 +5201,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// Returns the number of RigidBody elements in the model, including the
   /// "world" RigidBody, which is always part of the model.
   /// @see AddRigidBody().
-  int num_bodies() const { return internal_tree().num_bodies(); }
+  int num_bodies() const { return internal_tree().num_links(); }
 
   /// Returns `true` if plant has a rigid body with unique index `body_index`.
   bool has_body(BodyIndex body_index) const {

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -116,8 +116,8 @@ class KukaIiwaModelForwardDynamicsTests : public test::KukaIiwaModelTests {
     plant_->CalcMassMatrixViaInverseDynamics(*context_, &M);
     const double kappa = 1.0 / M.llt().rcond();
 
-    // Compare expected results against actual vdot.
-    const double kRelativeTolerance = kappa * kEpsilon;
+    // Compare expected results against actual vdot (with a little slop).
+    const double kRelativeTolerance = 2 * kappa * kEpsilon;
     EXPECT_TRUE(CompareMatrices(vdot, vdot_expected, kRelativeTolerance,
                                 MatrixCompareType::relative));
   }
@@ -189,6 +189,14 @@ GTEST_TEST(MultibodyPlantForwardDynamics, AtlasRobot) {
       .FixValue(context.get(), VectorX<double>::Zero(num_actuators));
   auto derivatives = plant.AllocateTimeDerivatives();
   {
+    // Make sure to get global and parameter-change heap allocations done
+    // before we check CalcTimeDerivatives() heap use.
+
+    // Initialization of Highway may use heap on the first call.
+    const math::RotationMatrix<double> R_AB, R_BC;  // Both identity.
+    EXPECT_TRUE((R_AB * R_BC).IsExactlyIdentity());
+    plant.EvalFrameBodyPoses(*context);  // Updated when parameters change.
+
     // CalcTimeDerivatives should not be allocating, but for now we have a few
     // remaining fixes before it's down to zero:
     //  2 temps in MbTS::CalcArticulatedBodyForceCache (F_B_W_, tau_).

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3080,7 +3080,7 @@ TEST_F(SplitPendulum, GetMultibodyPlantFromElement) {
   struct MyMBSystem : public internal::MultibodyTreeSystem<double> {
     MyMBSystem() {
       rigid_body =
-          &mutable_tree().AddRigidBody("Body", SpatialInertia<double>::NaN());
+          &mutable_tree().AddLink("Body", SpatialInertia<double>::NaN());
       Finalize();
     }
     const RigidBody<double>* rigid_body{};

--- a/multibody/rational/rational_forward_kinematics.cc
+++ b/multibody/rational/rational_forward_kinematics.cc
@@ -245,12 +245,12 @@ RationalForwardKinematics::CalcChildBodyPoseAsMultilinearPolynomial(
 
   internal::MobodIndex mobilizer_index;
   bool is_order_reversed{};
-  if (parent_mobod.inboard().is_valid() &&
-      parent_mobod.inboard() == child_mobod_index) {
+  if (parent_mobod.inboard_mobod().is_valid() &&
+      parent_mobod.inboard_mobod() == child_mobod_index) {
     is_order_reversed = true;
     mobilizer_index = parent_mobod_index;
-  } else if (child_mobod.inboard().is_valid() &&
-             child_mobod.inboard() == parent_mobod_index) {
+  } else if (child_mobod.inboard_mobod().is_valid() &&
+             child_mobod.inboard_mobod() == parent_mobod_index) {
     is_order_reversed = false;
     mobilizer_index = child_mobod_index;
   } else {

--- a/multibody/rational/rational_forward_kinematics_internal.cc
+++ b/multibody/rational/rational_forward_kinematics_internal.cc
@@ -46,16 +46,17 @@ std::vector<BodyIndex> FindPath(const MultibodyPlant<double>& plant,
         forest.mobods(current_link.mobod_index());
     if (current != world_index()) {
       const SpanningForest::Mobod& parent_mobod =
-          forest.mobods(current_mobod.inboard());
+          forest.mobods(current_mobod.inboard_mobod());
       const BodyIndex parent =
-          tree.forest().links(parent_mobod.link_ordinal()).index();
+          tree.forest().links(parent_mobod.active_link_ordinal()).index();
       visit_edge(current, parent);
     }
-    for (const MobodIndex& child_mobod_index : current_mobod.outboards()) {
+    for (const MobodIndex& child_mobod_index :
+         current_mobod.outboard_mobods()) {
       const SpanningForest::Mobod& child_mobod =
           forest.mobods(child_mobod_index);
       const BodyIndex child =
-          tree.forest().links(child_mobod.link_ordinal()).index();
+          tree.forest().links(child_mobod.active_link_ordinal()).index();
       visit_edge(current, child);
     }
   }
@@ -86,7 +87,8 @@ std::vector<MobodIndex> FindMobilizersOnPath(
     const LinkJointGraph::Link& link_i = forest.link_by_index(path[i]);
     const LinkJointGraph::Link& link_ip1 = forest.link_by_index(path[i + 1]);
     const SpanningForest::Mobod& mobod_i = forest.mobods(link_i.mobod_index());
-    if (!mobod_i.is_world() && mobod_i.inboard() == link_ip1.mobod_index()) {
+    if (!mobod_i.is_world() &&
+        mobod_i.inboard_mobod() == link_ip1.mobod_index()) {
       // path[i] is the child of path[i+1] in MultibodyTreeTopology, they are
       // connected by path[i]'s inboard mobilizer.
       mobilizers_on_path.push_back(link_i.mobod_index());

--- a/multibody/rational/test/rational_forward_kinematics_test.cc
+++ b/multibody/rational/test/rational_forward_kinematics_test.cc
@@ -45,7 +45,7 @@ void CheckBodyKinematics(const RationalForwardKinematics& dut,
 
   const internal::MultibodyTree<double>& tree =
       internal::GetInternalTree(dut.plant());
-  tree.CalcAllBodyPosesInWorld(*context, &X_WB_expected);
+  tree.CalcAllLinkPosesInWorld(*context, &X_WB_expected);
 
   symbolic::Environment env;
   for (int i = 0; i < s_val.rows(); ++i) {

--- a/multibody/topology/link_joint_graph.cc
+++ b/multibody/topology/link_joint_graph.cc
@@ -739,10 +739,10 @@ std::vector<LinkIndex> LinkJointGraph::FindPathFromWorld(
   const SpanningForest::Mobod* mobod =
       &forest().mobods()[link_to_mobod(link_index)];
   std::vector<LinkIndex> path(mobod->level() + 1);
-  while (mobod->inboard().is_valid()) {
-    const Link& link = links(mobod->link_ordinal());
+  while (mobod->inboard_mobod().is_valid()) {
+    const Link& link = links(mobod->active_link_ordinal());
     path[mobod->level()] = link.index();  // Active Link if optimized assembly.
-    mobod = &forest().mobods(mobod->inboard());
+    mobod = &forest().mobods(mobod->inboard_mobod());
   }
   DRAKE_DEMAND(mobod->is_world());
   path[0] = LinkIndex(0);
@@ -755,7 +755,7 @@ LinkIndex LinkJointGraph::FindFirstCommonAncestor(LinkIndex link1_index,
   const MobodIndex mobod_ancestor = forest().FindFirstCommonAncestor(
       link_to_mobod(link1_index), link_to_mobod(link2_index));
   const Link& ancestor_link =
-      links(forest().mobod_to_link_ordinal(mobod_ancestor));
+      links(forest().mobod_to_active_link_ordinal(mobod_ancestor));
   return ancestor_link.index();
 }
 

--- a/multibody/topology/link_joint_graph_debug.cc
+++ b/multibody/topology/link_joint_graph_debug.cc
@@ -97,9 +97,9 @@ std::string LinkJointGraph::GenerateGraphvizString(
     if (show_as_modeled && joint.mobod_index().is_valid()) {
       const SpanningForest::Mobod& mobod = forest().mobods(joint.mobod_index());
       if (mobod.is_reversed()) {
-        revised_parent_ordinal = mobod.link_ordinal();
+        revised_parent_ordinal = mobod.active_link_ordinal();
       } else {
-        revised_child_ordinal = mobod.link_ordinal();
+        revised_child_ordinal = mobod.active_link_ordinal();
       }
     }
 

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -13,18 +13,16 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-using LinkIndex = BodyIndex;
-
 class SpanningForest;
-
-using LinkOrdinal = TypeSafeIndex<class LinkOrdinalTag>;
 
 using JointTraitsIndex = TypeSafeIndex<class JointTraitsTag>;
 using WeldedLinksAssemblyIndex = TypeSafeIndex<class WeldedLinksAssemblyTag>;
 using LoopConstraintIndex = TypeSafeIndex<class LoopConstraintTag>;
 
-/* Link properties that can affect how the forest model gets built. Or-ing
-these also produces a LinkFlags object. */
+/* Link properties that can affect how the forest model gets built. This enum
+is emulating a bit mask; "and" and "or" operators are provided which return
+a LinkFlags object. Be careful with ordinary equality and assignment
+operators. */
 enum class LinkFlags : uint32_t {
   kDefault = 0,
   kStatic = 1 << 0,          ///< Implicitly welded to World.
@@ -33,16 +31,20 @@ enum class LinkFlags : uint32_t {
   kShadow = 1 << 3           ///< Link is a shadow (internal use only).
 };
 
-/* Joint properties that can affect how the SpanningForest gets built. Or-ing
-these also produces a JointFlags object. */
+/* Joint properties that can affect how the SpanningForest gets built. This enum
+is emulating a bit mask; "and" and "or" operators are provided which return
+a JointFlags object. Be careful with ordinary equality and assignment
+operators. */
 enum class JointFlags : uint32_t {
   kDefault = 0,
   kMustBeModeled = 1 << 0  ///< Model explicitly even if ignorable weld.
 };
 
-/* Options for how to build the SpanningForest. Or-ing these also produces a
-ForestBuildingOptions object. These can be provided as per-model instance
-options to locally override global options. */
+/* Options for how to build the SpanningForest. These can be provided as
+per-model instance options to locally override global options. This enum
+is emulating a bit mask; "and", "or", and "not" operators are provided which
+return a ForestBuildingOptions object. Be careful with ordinary equality and
+assignment operators. */
 enum class ForestBuildingOptions : uint32_t {
   kDefault = 0,
   kStatic = 1 << 0,                ///< Weld all links to World.
@@ -82,6 +84,9 @@ inline ForestBuildingOptions operator&(ForestBuildingOptions left,
                                        ForestBuildingOptions right) {
   return static_cast<ForestBuildingOptions>(static_cast<unsigned>(left) &
                                             static_cast<unsigned>(right));
+}
+inline ForestBuildingOptions operator~(ForestBuildingOptions options) {
+  return static_cast<ForestBuildingOptions>(~static_cast<unsigned>(options));
 }
 
 }  // namespace internal

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -13,11 +13,7 @@ namespace multibody {
 // TODO(sherm1) Promote from internal once API has stabilized: issue #11307.
 namespace internal {
 
-using LinkIndex = BodyIndex;
-
 class SpanningForest;
-
-using LinkOrdinal = TypeSafeIndex<class LinkOrdinalTag>;
 
 using JointTraitsIndex = TypeSafeIndex<class JointTraitsTag>;
 using WeldedLinksAssemblyIndex = TypeSafeIndex<class WeldedLinksAssemblyTag>;
@@ -82,6 +78,9 @@ inline ForestBuildingOptions operator&(ForestBuildingOptions left,
                                        ForestBuildingOptions right) {
   return static_cast<ForestBuildingOptions>(static_cast<unsigned>(left) &
                                             static_cast<unsigned>(right));
+}
+inline ForestBuildingOptions operator~(ForestBuildingOptions options) {
+  return static_cast<ForestBuildingOptions>(~static_cast<unsigned>(options));
 }
 
 }  // namespace internal

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -354,17 +354,16 @@ class SpanningForest {
     return graph().get_forest_building_options_in_use(index);
   }
 
-  /* Returns the Link that is represented by the given Mobod. This could be
-  one of the Links from the original graph or an added shadow Link. If this
-  Mobod represents a WeldedLinksAssembly, the Link returned here is the
-  "active" Link, that is, the one whose mobilizer is used to move the whole
-  Assembly. Cost is O(1) and very fast.
+  /* Returns the Link that is represented by the given Mobod, or the active
+  link if given a composite mobod. This could be one of the Links from the
+  original graph or an added shadow Link. An active link is the one whose
+  mobilizer is used to move the whole mobod. Cost is O(1) and very fast.
   @pre mobod_index is in range */
-  inline LinkOrdinal mobod_to_link_ordinal(MobodIndex mobod_index) const;
+  inline LinkOrdinal mobod_to_active_link_ordinal(MobodIndex mobod_index) const;
 
-  /* Returns all the Links mobilized by this Mobod. The "active" Link returned
-  by mobod_to_link() comes first, then any other Links in the same Assembly.
-  O(1), very fast.
+  /* Returns all the Links mobilized by this Mobod. The active link returned
+  by mobod_to_active_link() comes first, then any other links in the same
+  composite mobod. O(1), very fast.
   @pre mobod_index is in range  */
   inline const std::vector<LinkOrdinal>& mobod_to_link_ordinals(
       MobodIndex mobod_index) const;

--- a/multibody/topology/spanning_forest_inlines.h
+++ b/multibody/topology/spanning_forest_inlines.h
@@ -23,9 +23,9 @@ inline int SpanningForest::num_mobods() const {
   return std::ssize(mobods());
 }
 
-inline LinkOrdinal SpanningForest::mobod_to_link_ordinal(
+inline LinkOrdinal SpanningForest::mobod_to_active_link_ordinal(
     MobodIndex mobod_index) const {
-  return mobods(mobod_index).link_ordinal();
+  return mobods(mobod_index).active_link_ordinal();
 }
 
 inline const std::vector<LinkOrdinal>& SpanningForest::mobod_to_link_ordinals(

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -120,7 +120,7 @@ class BodyNode : public MultibodyElement<T> {
   // MultibodyTree::Finalize() method call.
   void add_child_node(const BodyNode<T>* child) { children_.push_back(child); }
 
-  MobodIndex inboard_mobod_index() const { return mobod().inboard(); }
+  MobodIndex inboard_mobod_index() const { return mobod().inboard_mobod(); }
 
   // Returns a constant reference to the body B associated with this node.
   const RigidBody<T>& body() const {

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -120,7 +120,7 @@ class BodyNode : public MultibodyElement<T> {
   // MultibodyTree::Finalize() method call.
   void add_child_node(const BodyNode<T>* child) { children_.push_back(child); }
 
-  MobodIndex inboard_mobod_index() const { return mobod().inboard(); }
+  MobodIndex inboard_mobod_index() const { return mobod().inboard_mobod(); }
 
   // Returns a constant reference to the body B associated with this node.
   const RigidBody<T>& body() const {
@@ -135,7 +135,7 @@ class BodyNode : public MultibodyElement<T> {
   const RigidBody<T>& parent_body() const {
     DRAKE_ASSERT(get_parent_body_index().is_valid());
     DRAKE_ASSERT(this->has_parent_tree());
-    return this->get_parent_tree().get_body(get_parent_body_index());
+    return this->get_parent_tree().get_link(get_parent_body_index());
   }
 
   // Returns a const pointer to the parent (inboard) body node or nullptr if
@@ -227,8 +227,10 @@ class BodyNode : public MultibodyElement<T> {
   //   An already updated position kinematics cache in sync with positions.
   // @param[out] H_PB_W_cache
   //   The cache entry being calculated; just this node's H_PB is updated.
-
-  // @note `H_PB_W` is only a function of this node's generalized positions q.
+  //
+  // @note Although `H_PB_P` would be a function of only this node's generalized
+  //   positions qₘ, the output value is expressed in World so requires more
+  //   kinematics data.
   //
   // @pre The position kinematics cache `pc` was already updated to be in sync
   // with positions by MultibodyTree::CalcPositionKinematicsCache().

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -113,6 +113,10 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcPositionKinematicsCache_BaseToTip(
       break;
   }
 
+  // TODO(sherm1) Calculate X_WL for composites. Currently we don't make
+  //  composites so X_WL = X_WB if L is the link on B.
+  pc->SetX_WL(mobilizer_->mobod().active_link_ordinal(), X_WB);
+
   // Compute shift vector p_PoBo_W from the parent origin to the body origin.
   const Vector3<T>& p_PoBo_P = X_PB.translation();
   const math::RotationMatrix<T>& R_WP = X_WP.rotation();
@@ -122,6 +126,12 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcPositionKinematicsCache_BaseToTip(
 // TODO(sherm1) Consider combining this with VelocityCache computation
 //  so that we don't have to make a separate pass. Or better, get rid of this
 //  computation altogether by working in better frames.
+
+// Hinge matrix for this node. H_PB_W ∈ ℝ⁶ˣⁿᵐ with nm ∈ [0; 6] the number of
+// mobilities for this node. Therefore, the return is a Matrix<6,kNv> since the
+// number of columns depends on the mobilizer type. It is returned as an
+// Eigen::Map to the memory allocated in the std::vector H_PB_W_cache so that we
+// can work with H_PB_W as with any other Eigen matrix object.
 template <typename T, class ConcreteMobilizer>
 void BodyNodeImpl<T, ConcreteMobilizer>::
     CalcAcrossNodeJacobianWrtVExpressedInWorld(
@@ -197,13 +207,6 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
   DRAKE_ASSERT(mobod_index() != world_mobod_index());
   DRAKE_ASSERT(vc != nullptr);
 
-  // Hinge matrix for this node. H_PB_W ∈ ℝ⁶ˣⁿᵐ with nm ∈ [0; 6] the
-  // number of mobilities for this node. Therefore, the return is a
-  // Matrix<6,kNv> since the number of columns depends on the mobilizer type.
-  // It is returned as an Eigen::Map to the memory allocated in the
-  // std::vector H_PB_W_cache so that we can work with H_PB_W as with any
-  // other Eigen matrix object.
-
   // As a guideline for developers, a summary of the computations performed in
   // this method is provided:
   // Notation:
@@ -248,15 +251,15 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
   // Jain (2010)) where p_MoBo_F = 0 and thus V_PB_W = V_FM_W.
 
   // Generalized coordinates local to this node's mobilizer.
-  const T* q_ptr = get_q(positions);
-  const T* v_ptr = get_v(velocities);
+  const T* q_B = get_q(positions);
+  const T* v_B = get_v(velocities);
 
   // =========================================================================
   // Computation of V_PB_W in Eq. (1). See summary at the top of this method.
 
   // Update V_FM using the operator V_FM = H_FM * vm:
   SpatialVelocity<T>& V_FM = get_mutable_V_FM(vc);
-  V_FM = mobilizer_->calc_V_FM(q_ptr, v_ptr);
+  V_FM = mobilizer_->calc_V_FM(q_B, v_B);
 
   // Compute V_PB_W = R_WF * V_FM.Shift(p_MoBo_F), Eq. (4).
   // Side note to developers: in operator form for rigid bodies this would be
@@ -269,7 +272,7 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
     // Hinge matrix for this node. H_PB_W ∈ ℝ⁶ˣⁿᵛ with nv ∈ [0; 6] the
     // number of mobilities for this node.
     const auto H_PB_W = get_H(H_PB_W_cache);  // 6 x kNv fixed-size Map.
-    const Eigen::Map<const VVector<T>> v(v_ptr);
+    const Eigen::Map<const VVector<T>> v(v_B);
     V_PB_W.get_coeffs() = H_PB_W * v;
   } else {
     V_PB_W.get_coeffs().setZero();
@@ -289,7 +292,12 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcVelocityKinematicsCache_BaseToTip(
   // =========================================================================
   // Update velocity V_WB of this node's body B in the world frame. Using the
   // recursive Eq. (1). See summary at the top of this method.
-  get_mutable_V_WB(vc) = V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W);
+  SpatialVelocity<T>& V_WB = get_mutable_V_WB(vc);
+  V_WB = V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W);
+
+  // TODO(sherm1) Calculate V_WL for composites. Currently we don't make
+  //  composites so V_WL = V_WB if L is the link on B.
+  vc->SetV_WL(mobilizer_->mobod().active_link_ordinal(), V_WB);
 }
 
 // As a guideline for developers, a summary of the computations performed in
@@ -824,7 +832,7 @@ void BodyNodeImpl<T, ConcreteMobilizer>::
 
   // Get the spatial acceleration of the parent.
   const SpatialAcceleration<T>& A_WP =
-      ac->get_A_WB(mobilizer_->mobod().inboard());
+      ac->get_A_WB(mobilizer_->mobod().inboard_mobod());
 
   // Shift vector p_PoBo_W from the parent origin to the body origin.
   const Vector3<T>& p_PoBo_W = get_p_PoBo_W(pc);

--- a/multibody/tree/deformable_body.cc
+++ b/multibody/tree/deformable_body.cc
@@ -64,7 +64,7 @@ MultibodyConstraintId DeformableBody<T>::AddFixedConstraint(
     const RigidBody<T>& body_B, const math::RigidTransform<double>& X_BA,
     const geometry::Shape& shape_G, const math::RigidTransform<double>& X_BG) {
   DRAKE_THROW_UNLESS(this->has_parent_tree());
-  if (&this->get_parent_tree().get_body(body_B.index()) != &body_B) {
+  if (&this->get_parent_tree().get_link(body_B.index()) != &body_B) {
     throw std::logic_error(fmt::format(
         "AddFixedConstraint(): The rigid body with name {} is not registered "
         "with the MultibodyPlant owning the deformable model.",

--- a/multibody/tree/element_collection.cc
+++ b/multibody/tree/element_collection.cc
@@ -174,9 +174,12 @@ template class ElementCollection<double, ModelInstance, ModelInstanceIndex>;
 template class ElementCollection<AutoDiffXd, ModelInstance, ModelInstanceIndex>;
 template class ElementCollection<Expression, ModelInstance, ModelInstanceIndex>;
 
-template class ElementCollection<double, RigidBody, BodyIndex>;
-template class ElementCollection<AutoDiffXd, RigidBody, BodyIndex>;
-template class ElementCollection<Expression, RigidBody, BodyIndex>;
+// `links_` in MultibodyTree uses `Link` (a template alias for RigidBody).
+// GCC substitutes through aliases, but Clang preserves the alias name in
+// mangled symbols, so we must instantiate with `Link` to match both compilers.
+template class ElementCollection<double, Link, LinkIndex>;
+template class ElementCollection<AutoDiffXd, Link, LinkIndex>;
+template class ElementCollection<Expression, Link, LinkIndex>;
 
 template class ElementCollection<double, DeformableBody, DeformableBodyIndex>;
 template class ElementCollection<AutoDiffXd, DeformableBody,

--- a/multibody/tree/element_collection.h
+++ b/multibody/tree/element_collection.h
@@ -39,7 +39,7 @@ types like FixedOffsetFrame *are* directly owned by this collection.
   - Joint
   - JointActuator
   - ModelInstance
-  - RigidBody
+  - RigidBody (Link)
   - DeformableBody
 @tparam Index The corresponding index type for the given Element type. */
 template <typename T, template <typename> class Element, typename Index>
@@ -51,6 +51,12 @@ class ElementCollection final {
 
   /* Returns the total number of (non-null) elements. */
   int num_elements() const { return ssize(indices_packed_); }
+
+  /* Returns the total number of indices ever allocated (including the ones
+  that might be invalid now). This is the size that should be used for any array
+  that is to be addressed by index. next_index() will return this value as the
+  next unused index. */
+  int num_indices() const { return ssize(elements_by_index_); }
 
   /* Returns a read-only view of the (non-null) elements. The result is only
   guaranteed to remain valid until the next call to any non-const member
@@ -96,7 +102,7 @@ class ElementCollection final {
   /* Returns a reference to the list of currently-valid indices. The result is
   only guaranteed to remain valid until the next call to any non-const member
   function. */
-  const std::vector<Index>& indices() const { return indices_packed_; }
+  const std::vector<Index>& valid_indices() const { return indices_packed_; }
 
   /* Returns a reference to the name lookup dictionary. The result is only
   guaranteed to remain valid until the next call to any non-const member
@@ -107,7 +113,7 @@ class ElementCollection final {
 
   /* Returns the index that is one beyond the current maximum, i.e., the index
   that can be used for the next element passed to Add(). */
-  Index next_index() const { return Index{ssize(elements_by_index_)}; }
+  Index next_index() const { return Index{num_indices()}; }
 
   /* Adds a new element. If the element->index() equals the next_index(), then
   the element will be appended to the end (and next_index() will increment).

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -22,30 +22,40 @@ std::string DeprecateWhenEmptyName(std::string name, std::string_view type);
 template <typename T>
 class RigidBody;
 
+template <typename T>
+using Link = RigidBody<T>;
+
 /// %Frame is an abstract class representing a _material frame_ (also called a
-/// _physical frame_) of its underlying RigidBody. The %Frame's origin is a
-/// material point of its RigidBody, and its axes have fixed directions
+/// _physical frame_) of its underlying RigidBody (Link). The %Frame's origin
+/// is a material point of its RigidBody, and its axes have fixed directions
 /// in that body. A %Frame's pose (position and orientation) with respect to its
-/// RigidBodyFrame may be parameterized, but is fixed (not time or state
-/// dependent) once parameters have been set.
+/// RigidBodyFrame (LinkFrame) may be parameterized, but is fixed (not time or
+/// state dependent) once parameters have been set.
 ///
 /// An important characteristic of a %Frame is that forces or torques applied to
-/// a %Frame are applied to the %Frame's underlying RigidBody. Force-producing
+/// a %Frame are applied to the %Frame's underlying body. Force-producing
 /// elements like joints, actuators, and constraints usually employ two %Frames,
 /// with one %Frame connected to one body and the other connected to a different
-/// body. Every %Frame F can report the RigidBody B to which it is attached and
-/// its pose X_BF with respect to B's RigidBodyFrame.
+/// body. Every %Frame F can report the Link (RigidBody) L to which it is
+/// attached and its pose X_LF with respect to L's LinkFrame (RigidBodyFrame).
 ///
 /// A %Frame's pose in World (or relative to other frames) is always calculated
-/// starting with its pose relative to its underlying RigidBodyFrame.
+/// starting with its pose relative to its underlying LinkFrame.
 /// Subclasses derived from %Frame differ in how kinematic calculations are
 /// performed. For example, the angular velocity of a FixedOffsetFrame or
-/// RigidBodyFrame is identical to the angular velocity of its underlying body,
+/// LinkFrame (RigidBodyFrame) is identical to the angular velocity of its
+/// underlying body,
 /// whereas the translational velocity of a FixedOffsetFrame differs from that
-/// of a RigidBodyFrame.
+/// of a LinkFrame.
 ///
 /// %Frame provides methods for obtaining its current orientation, position,
 /// motion, etc. from a Context passed to those methods.
+///
+/// @note For historical reasons, many of the method names here use "Body" to
+/// mean "Link". The distinction matters when we form composite bodies, which
+/// consist of multiple links welded together. Those composites form a single
+/// _rigid body_ in the physics sense. Frames only know about their Links, not
+/// how they may have been combined into a composite body.
 ///
 /// @tparam_default_scalar
 template <typename T>
@@ -58,15 +68,25 @@ class Frame : public MultibodyElement<T> {
   /// Returns this element's unique index.
   FrameIndex index() const { return this->template index_impl<FrameIndex>(); }
 
-  /// Returns a const reference to the body associated to this %Frame.
-  const RigidBody<T>& body() const { return body_; }
+  /// Returns a const reference to the RigidBody (Link) to which this %Frame is
+  /// attached (synonym for link()).
+  const RigidBody<T>& body() const { return link(); }
+
+  /// Returns a const reference to the Link (RigidBody) to which this %Frame is
+  /// attached (synonym for body()).
+  const Link<T>& link() const { return link_; }
 
   /// Returns true if `this` is the world frame.
   bool is_world_frame() const { return this->index() == world_frame_index(); }
 
-  /// Returns true if `this` is the body frame.
-  bool is_body_frame() const {
-    return this->index() == body_.body_frame().index();
+  /// Returns true if `this` is the RigidBodyFrame (LinkFrame) of the
+  /// associated RigidBody (Link). This is a synonym for is_link_frame().
+  bool is_body_frame() const { return is_link_frame(); }
+
+  /// Returns true if `this` is the LinkFrame (RigidBodyFrame) of the
+  /// associated Link (RigidBody). This is a synonym for is_body_frame().
+  bool is_link_frame() const {
+    return this->index() == link().link_frame().index();
   }
 
   /// Returns the name of this frame. The name will never be empty.
@@ -78,33 +98,33 @@ class Frame : public MultibodyElement<T> {
   /// MultibodyPlant.
   ScopedName scoped_name() const;
 
-  /// Returns a reference to the body-relative pose X_BF giving the pose of this
-  /// Frame with respect to its body's RigidBodyFrame. This may depend on
-  /// parameters in the Context but not on time or state. The first time this is
-  /// called after a parameter change will precalculate offset poses for all
-  /// %Frames into the Context's cache; subsequent calls on any %Frame are very
-  /// fast.
+  /// Returns a reference to the link-relative pose X_LF giving the pose of this
+  /// %Frame with respect to its link's LinkFrame (RigidBodyFrame). This may
+  /// depend on parameters in the Context but not on time or state. The first
+  /// time this is called after a parameter change will precalculate offset
+  /// poses for all %Frames into the Context's cache; subsequent calls on any
+  /// %Frame are very fast.
   const math::RigidTransform<T>& EvalPoseInBodyFrame(
       const systems::Context<T>& context) const {
     const internal::FrameBodyPoseCache<T>& frame_body_poses =
         this->GetParentTreeSystem().EvalFrameBodyPoses(context);
-    return get_X_BF(frame_body_poses);
+    return get_X_LF(frame_body_poses);
   }
 
-  /// Returns the pose `X_BF` of `this` frame F in the body frame B associated
-  /// with this frame.
-  /// In particular, if `this` **is** the body frame B, this method directly
-  /// returns the identity transformation.
-  /// Note that this ONLY depends on the Parameters in the context; it does
-  /// not depend on time, input, state, etc.
+  /// Returns the pose `X_LF` of `this` frame F in the LinkFrame
+  /// (RigidBodyFrame) L of this %Frame's Link (RigidBody). In particular, if
+  /// `this` **is** the link frame L, this method directly returns the
+  /// identity transformation. Note that this ONLY depends on the Parameters
+  /// in the context; it does not depend on time, input, state, etc.
   math::RigidTransform<T> CalcPoseInBodyFrame(
       const systems::Context<T>& context) const {
     return DoCalcPoseInBodyFrame(context.get_parameters());
   }
 
-  /// Returns the rotation matrix `R_BF` that relates body frame B to `this`
-  /// frame F (B is the body frame to which `this` frame F is attached).
-  /// @note If `this` is B, this method returns the identity RotationMatrix.
+  /// Returns the rotation matrix `R_LF` that relates link frame L to `this`
+  /// frame F (L is the LinkFrame of the Link (RigidBody) to which `this`
+  /// frame F is  attached).
+  /// @note If `this` is L, this method returns the identity RotationMatrix.
   /// Note that this ONLY depends on the Parameters in the context; it does
   /// not depend on time, input, state, etc.
   math::RotationMatrix<T> CalcRotationMatrixInBodyFrame(
@@ -112,15 +132,12 @@ class Frame : public MultibodyElement<T> {
     return DoCalcRotationMatrixInBodyFrame(context.get_parameters());
   }
 
-  /// Variant of CalcPoseInBodyFrame() that returns the fixed pose `X_BF` of
-  /// `this` frame F in the body frame B associated with this frame.
+  /// Variant of CalcPoseInBodyFrame() that returns the fixed pose `X_LF` of
+  /// `this` frame F in the link frame L associated with this frame.
   /// @throws std::exception if called on a %Frame that does not have a
   /// fixed offset in the body frame.
-  // %Frame sub-classes that can represent the fixed pose of `this` frame F in
-  // a body frame B, must override this method.
-  // An example of a frame sub-class not implementing this method would be that
-  // of a frame on a soft body, for which its pose in the body frame depends
-  // on the state of deformation of the body.
+  // Frame sub-classes that can represent the fixed pose of `this` frame F in
+  // a link frame L, must override this method.
   virtual math::RigidTransform<T> GetFixedPoseInBodyFrame() const {
     throw std::logic_error(
         "Attempting to retrieve a fixed pose from a frame of type '" +
@@ -128,14 +145,12 @@ class Frame : public MultibodyElement<T> {
         "', which does not support this operation.");
   }
 
-  /// Returns the rotation matrix `R_BF` that relates body frame B to `this`
-  /// frame F (B is the body frame to which `this` frame F is attached).
+  /// Returns the rotation matrix `R_LF` that relates link frame L to `this`
+  /// frame F (L is the LinkFrame of the Link (RigidBody) to which `this`
+  /// frame F is attached).
   /// @throws std::exception if `this` frame F is a %Frame that does not have
-  /// a fixed offset in the body frame B (i.e., `R_BF` is not constant).
-  /// %Frame sub-classes that have a constant `R_BF` must override this method.
-  /// An example of a frame sub-class not implementing this method would be that
-  /// of a frame on a soft body, for which its pose in the body frame depends
-  /// on the state of deformation of the body.
+  /// a fixed offset in the link frame L (i.e., `R_LF` is not constant).
+  /// %Frame sub-classes that have a constant `R_LF` must override this method.
   virtual math::RotationMatrix<T> GetFixedRotationMatrixInBodyFrame() const {
     throw std::logic_error(
         "Unable to retrieve a fixed rotation matrix from a frame of type '" +
@@ -143,21 +158,21 @@ class Frame : public MultibodyElement<T> {
         "', which does not support this method.");
   }
 
-  // TODO(jwnimmer-tri) These next four functions only exist so that BodyFrame
-  // can override their NVI body to be a simple copy instead of ComposeXX or
-  // ComposeRR against an identity. It is not at all clear to me that this
-  // implementation complexity is buying us any measurable speedup at runtime.
+  // TODO(jwnimmer-tri) These next four functions only exist so that
+  //  RigidBodyFrame can override their NVI body to be a simple copy instead of
+  //  ComposeXX or ComposeRR against an identity. It is not at all clear to me
+  //  that this implementation complexity is buying us any measurable speedup at
+  //  runtime.
 
   /// Given the offset pose `X_FQ` of a frame Q in `this` frame F, this method
-  /// computes the pose `X_BQ` of frame Q in the body frame B to which this
-  /// frame is attached.
-  /// In other words, if the pose of `this` frame F in the body frame B is
-  /// `X_BF`, this method computes the pose `X_BQ` of frame Q in the body frame
-  /// B as `X_BQ = X_BF * X_FQ`.
-  /// In particular, if `this` **is** the body frame B, i.e. `X_BF` is the
-  /// identity transformation, this method directly returns `X_FQ`.
-  /// Specific frame subclasses can override this method to provide faster
-  /// implementations if needed.
+  /// computes the pose `X_LQ` of frame Q in the link frame L of the Link
+  /// (RigidBody) to which this frame is attached. In other words, if the
+  /// pose of `this` frame F in the link frame L is `X_LF`, this method
+  /// computes the pose `X_LQ` of frame Q in the link frame L as
+  /// `X_LQ = X_LF * X_FQ`. In particular, if `this` **is** the link frame L,
+  /// i.e. `X_LF` is identically the identity transform, this method directly
+  /// returns `X_FQ`. Specific frame subclasses can override this method to
+  /// provide faster implementations if needed.
   math::RigidTransform<T> CalcOffsetPoseInBody(
       const systems::Context<T>& context,
       const math::RigidTransform<T>& X_FQ) const {
@@ -173,9 +188,10 @@ class Frame : public MultibodyElement<T> {
   }
 #endif
 
-  /// Calculates and returns the rotation matrix `R_BQ` that relates body frame
-  /// B to frame Q via `this` intermediate frame F, i.e., `R_BQ = R_BF * R_FQ`
-  /// (B is the body frame to which `this` frame F is attached).
+  /// Calculates and returns the rotation matrix `R_LQ` that relates link frame
+  /// L to frame Q via `this` intermediate frame F, i.e., `R_LQ = R_LF * R_FQ`
+  /// (L is the link frame of the Link (RigidBody) to which `this` frame F is
+  /// attached).
   /// @param[in] R_FQ rotation matrix that relates frame F to frame Q.
   math::RotationMatrix<T> CalcOffsetRotationMatrixInBody(
       const systems::Context<T>& context,
@@ -193,8 +209,8 @@ class Frame : public MultibodyElement<T> {
 #endif
 
   /// Variant of CalcOffsetPoseInBody() that given the offset pose `X_FQ` of a
-  /// frame Q in `this` frame F, returns the pose `X_BQ` of frame Q in the body
-  /// frame B to which this frame is attached.
+  /// frame Q in `this` frame F, returns the pose `X_LQ` of frame Q in the link
+  /// frame L to which this frame is attached.
   /// @throws std::exception if called on a %Frame that does not have a
   /// fixed offset in the body frame.
   virtual math::RigidTransform<T> GetFixedOffsetPoseInBody(
@@ -202,12 +218,13 @@ class Frame : public MultibodyElement<T> {
     return GetFixedPoseInBodyFrame() * X_FQ;
   }
 
-  /// Calculates and returns the rotation matrix `R_BQ` that relates body frame
-  /// B to frame Q via `this` intermediate frame F, i.e., `R_BQ = R_BF * R_FQ`
-  /// (B is the body frame to which `this` frame F is attached).
+  /// Calculates and returns the rotation matrix `R_LQ` that relates link frame
+  /// L to frame Q via `this` intermediate frame F, i.e., `R_LQ = R_LF * R_FQ`
+  /// (L is the link frame of the Link (RigidBody) to which `this` frame F is
+  /// attached).
   /// @param[in] R_FQ rotation matrix that relates frame F to frame Q.
   /// @throws std::exception if `this` frame F is a %Frame that does not have
-  /// a fixed offset in the body frame B (i.e., `R_BF` is not constant).
+  /// a fixed offset in the link frame L (i.e., `R_LF` is not constant).
   virtual math::RotationMatrix<T> GetFixedRotationMatrixInBody(
       const math::RotationMatrix<T>& R_FQ) const {
     return GetFixedRotationMatrixInBodyFrame() * R_FQ;
@@ -216,7 +233,7 @@ class Frame : public MultibodyElement<T> {
   /// Computes and returns the pose `X_WF` of `this` frame F in the world
   /// frame W as a function of the state of the model stored in `context`.
   /// @note RigidBody::EvalPoseInWorld() provides a more efficient way to obtain
-  /// the pose for a body frame.
+  /// the pose for a RigidBodyFrame (LinkFrame).
   math::RigidTransform<T> CalcPoseInWorld(
       const systems::Context<T>& context) const {
     DRAKE_THROW_UNLESS(this->has_parent_tree());
@@ -261,10 +278,8 @@ class Frame : public MultibodyElement<T> {
   /// velocity ω measured in a frame M and expressed in a frame E).
   const Vector3<T>& EvalAngularVelocityInWorld(
       const systems::Context<T>& context) const {
-    // TODO(Mitiguy) The calculation below assumes "this" frame is attached to a
-    //  rigid body (not a soft body). Modify if soft bodies are possible.
-    const SpatialVelocity<T>& V_WB = body().EvalSpatialVelocityInWorld(context);
-    const Vector3<T>& w_WF_W = V_WB.rotational();
+    const SpatialVelocity<T>& V_WL = link().EvalSpatialVelocityInWorld(context);
+    const Vector3<T>& w_WF_W = V_WL.rotational();
     return w_WF_W;
   }
 
@@ -292,7 +307,8 @@ class Frame : public MultibodyElement<T> {
   /// frame W). The translational part is v_WFo_W (translational velocity v of
   /// frame F's origin point Fo, measured and expressed in the world frame W).
   /// @note RigidBody::EvalSpatialVelocityInWorld() provides a more efficient
-  /// way to obtain a body frame's spatial velocity measured in the world frame.
+  /// way to obtain a RigidBodyFrame (LinkFrame) spatial velocity measured in
+  /// the world  frame.
   /// @see CalcSpatialVelocity(), CalcRelativeSpatialVelocityInWorld(), and
   /// CalcSpatialAccelerationInWorld().
   SpatialVelocity<T> CalcSpatialVelocityInWorld(
@@ -314,20 +330,20 @@ class Frame : public MultibodyElement<T> {
                                          const Frame<T>& frame_M,
                                          const Frame<T>& frame_E) const;
 
-  /// Calculates `this` frame C's spatial velocity relative to another frame B,
+  /// Calculates `this` frame F's spatial velocity relative to another frame B,
   /// measured and expressed in the world frame W.
   /// @param[in] context contains the state of the multibody system.
   /// @param[in] other_frame which is frame B.
-  /// @return V_W_BC_W = V_WC_W - V_WB_W, frame C's spatial velocity relative to
+  /// @return V_W_BF_W = V_WF_W - V_WB_W, frame F's spatial velocity relative to
   /// frame B, measured and expressed in the world frame W. The rotational part
-  /// of the returned quantity is ω_BC_W (C's angular velocity measured in B and
-  /// expressed in W). The translational part is v_W_BoCo_W (Co's translational
+  /// of the returned quantity is ω_BF_W (F's angular velocity measured in B and
+  /// expressed in W). The translational part is v_W_BoFo_W (Fo's translational
   /// velocity relative to Bo, measured and expressed in world frame W). <pre>
-  ///     ω_BC_W  = ω_WC_W - ω_WB_W
-  ///  v_W_BoCo_W = v_WCo_W - v_WBo_W = DtW(p_BoCo)
+  ///     ω_BF_W  = ω_WF_W - ω_WB_W
+  ///  v_W_BoFo_W = v_WFo_W - v_WBo_W = DtW(p_BoFo)
   /// </pre>
-  /// where DtW(p_BoCo) is the time-derivative in frame W of p_BoCo (position
-  /// vector from Bo to Co), and this vector is expressed in frame W.
+  /// where DtW(p_BoFo) is the time-derivative in frame W of p_BoFo (position
+  /// vector from Bo to Fo), and this vector is expressed in frame W.
   /// @note The method CalcSpatialVelocityInWorld() is more efficient and
   /// coherent if any of `this`, other_frame, or the world frame W are the same.
   /// @see CalcSpatialVelocityInWorld() and CalcRelativeSpatialVelocity().
@@ -336,32 +352,32 @@ class Frame : public MultibodyElement<T> {
     const Frame<T>& frame_B = other_frame;
     const SpatialVelocity<T> V_WB_W =
         frame_B.CalcSpatialVelocityInWorld(context);
-    const SpatialVelocity<T> V_WC_W = CalcSpatialVelocityInWorld(context);
-    return V_WC_W - V_WB_W;
+    const SpatialVelocity<T> V_WF_W = CalcSpatialVelocityInWorld(context);
+    return V_WF_W - V_WB_W;
   }
 
-  /// Calculates `this` frame C's spatial velocity relative to another frame B,
+  /// Calculates `this` frame F's spatial velocity relative to another frame B,
   /// measured in a frame M, expressed in a frame E.
   /// @param[in] context contains the state of the multibody system.
   /// @param[in] other_frame which is frame B.
   /// @param[in] measured_in_frame which is frame M.
   /// @param[in] expressed_in_frame which is frame E.
-  /// @return V_M_BC_E = V_MC_E - V_MB_E, frame C's spatial velocity relative to
+  /// @return V_M_BF_E = V_MF_E - V_MB_E, frame F's spatial velocity relative to
   /// frame B, measured in frame M, expressed in frame E. The rotational part
-  /// of the returned quantity is ω_BC_E (C's angular velocity measured in B and
-  /// expressed in E). The translational part is v_M_BoCo_E (Co's translational
+  /// of the returned quantity is ω_BF_E (F's angular velocity measured in B and
+  /// expressed in E). The translational part is v_M_BoFo_E (Fo's translational
   /// velocity relative to Bo, measured in M, and expressed in E). <pre>
-  ///  ω_BC_E = ω_MC_E - ω_MB_E
-  ///  v_M_BoCo_E = v_MCo_E - v_MBo_E = DtM(p_BoCo)
+  ///  ω_BF_E = ω_MF_E - ω_MB_E
+  ///  v_M_BoFo_E = v_MFo_E - v_MBo_E = DtM(p_BoFo)
   /// </pre>
-  /// where DtM(p_BoCo) is the time-derivative in frame M of p_BoCo (position
-  /// vector from Bo to Co), and this vector is expressed in frame E.
+  /// where DtM(p_BoFo) is the time-derivative in frame M of p_BoFo (position
+  /// vector from Bo to Fo), and this vector is expressed in frame E.
   /// @note The method CalcSpatialVelocity() is more efficient and coherent
   /// if any of `this`, other_frame, or measured_in_frame are the same.
-  /// Also, the value of V_M_BoCo does not depend on the measured_in_frame if
-  /// Bo and Co are coincident (i.e., p_BoCo = 0), in which case consider the
+  /// Also, the value of V_M_BoFo does not depend on the measured_in_frame if
+  /// Bo and Fo are coincident (i.e., p_BoFo = 0), in which case consider the
   /// more efficient method CalcRelativeSpatialVelocityInWorld().
-  /// Lastly, the calculation of elongation between Bo and Co can be done with
+  /// Lastly, the calculation of elongation between Bo and Fo can be done with
   /// relative translational velocity, but elongation does not depend on the
   /// measured-in-frame (hence consider CalcRelativeSpatialVelocityInWorld()).
   /// @see CalcSpatialVelocityInWorld(), CalcSpatialVelocity(), and
@@ -375,9 +391,9 @@ class Frame : public MultibodyElement<T> {
     const Frame<T>& frame_E = expressed_in_frame;
     const SpatialVelocity<T> V_MB_E =
         frame_B.CalcSpatialVelocity(context, frame_M, frame_E);
-    const SpatialVelocity<T> V_MC_E =
+    const SpatialVelocity<T> V_MF_E =
         CalcSpatialVelocity(context, frame_M, frame_E);
-    return V_MC_E - V_MB_E;
+    return V_MF_E - V_MB_E;
   }
 
   /// Calculates `this` frame F's spatial acceleration measured and expressed in
@@ -420,24 +436,24 @@ class Frame : public MultibodyElement<T> {
       const systems::Context<T>& context, const Frame<T>& measured_in_frame,
       const Frame<T>& expressed_in_frame) const;
 
-  /// Calculates `this` frame C's spatial acceleration relative to another
+  /// Calculates `this` frame F's spatial acceleration relative to another
   /// frame B, measured and expressed in the world frame W.
   /// @param[in] context contains the state of the multibody system.
   /// @param[in] other_frame which is frame B.
-  /// @return A_W_BC_W = A_WC_W - A_WB_W, frame C's spatial acceleration
+  /// @return A_W_BF_W = A_WF_W - A_WB_W, frame F's spatial acceleration
   /// relative to frame B, measured and expressed in the world frame W.
   ///
-  /// In general, A_W_BC = DtW(V_W_BC), the time-derivative in the world frame W
-  /// of frame C's spatial velocity relative to frame B. The rotational part of
-  /// the returned quantity is α_WC_W - α_WB_W = DtW(ω_BC)_W. For 3D analysis,
-  /// DtW(ω_BC) ≠ α_BC. The translational part of the returned quantity is
-  /// a_W_BoCo_W (Co's translational acceleration relative to Bo, measured and
+  /// In general, A_W_BF = DtW(V_W_BF), the time-derivative in the world frame W
+  /// of frame F's spatial velocity relative to frame B. The rotational part of
+  /// the returned quantity is α_WF_W - α_WB_W = DtW(ω_BF)_W. For 3D analysis,
+  /// DtW(ω_BF) ≠ α_BF. The translational part of the returned quantity is
+  /// a_W_BoFo_W (Fo's translational acceleration relative to Bo, measured and
   /// expressed in world frame W). <pre>
-  ///  α_WC_W - α_WB_W = DtW(ω_WC)_W - DtW(ω_WB)_W = DtW(ω_BC)_W
-  ///  a_W_BoCo_W = a_WCo_W - a_WBo_W = DtW(v_WCo) - DtW(v_WBo) = Dt²W(p_BoCo)_W
+  ///  α_WF_W - α_WB_W = DtW(ω_WF)_W - DtW(ω_WB)_W = DtW(ω_BF)_W
+  ///  a_W_BoFo_W = a_WFo_W - a_WBo_W = DtW(v_WFo) - DtW(v_WBo) = Dt²W(p_BoFo)_W
   /// </pre>
-  /// where Dt²W(p_BoCo)_W is the 2ⁿᵈ time-derivative in frame W of p_BoCo (the
-  /// position vector from Bo to Co), and this result is expressed in frame W.
+  /// where Dt²W(p_BoFo)_W is the 2ⁿᵈ time-derivative in frame W of p_BoFo (the
+  /// position vector from Bo to Fo), and this result is expressed in frame W.
   /// @note The method CalcSpatialAccelerationInWorld() is more efficient and
   /// coherent if any of `this`, other_frame, or the world frame W are the same.
   /// @see CalcSpatialAccelerationInWorld(), CalcRelativeSpatialAcceleration().
@@ -446,33 +462,33 @@ class Frame : public MultibodyElement<T> {
     const Frame<T>& frame_B = other_frame;
     const SpatialAcceleration<T> A_WB_W =
         frame_B.CalcSpatialAccelerationInWorld(context);
-    const SpatialAcceleration<T> A_WC_W =
+    const SpatialAcceleration<T> A_WF_W =
         CalcSpatialAccelerationInWorld(context);
-    return A_WC_W - A_WB_W;
+    return A_WF_W - A_WB_W;
   }
 
-  /// Calculates `this` frame C's spatial acceleration relative to another
+  /// Calculates `this` frame F's spatial acceleration relative to another
   /// frame B, measured in a frame M, expressed in a frame E.
   /// @param[in] context contains the state of the multibody system.
   /// @param[in] other_frame which is frame B.
   /// @param[in] measured_in_frame which is frame M.
   /// @param[in] expressed_in_frame which is frame E.
-  /// @return A_M_BC_E = A_MC_E - A_MB_E, frame C's spatial acceleration
+  /// @return A_M_BF_E = A_MF_E - A_MB_E, frame F's spatial acceleration
   /// relative to frame B, measured in frame M, expressed in frame E.
   ///
-  /// In general, A_M_BC = DtW(V_M_BC), the time-derivative in frame M of
-  /// frame C's spatial velocity relative to frame B. The rotational part of the
-  /// returned quantity is α_MC_E - α_MB_E = DtM(ω_BC)_E. Note: For 3D analysis,
-  /// DtM(ω_BC) ≠ α_BC. The translational part of the returned quantity is
-  /// a_M_BoCo_E (Co's translational acceleration relative to Bo, measured in
+  /// In general, A_M_BF = DtW(V_M_BF), the time-derivative in frame M of
+  /// frame F's spatial velocity relative to frame B. The rotational part of the
+  /// returned quantity is α_MF_E - α_MB_E = DtM(ω_BF)_E. Note: For 3D analysis,
+  /// DtM(ω_BF) ≠ α_BF. The translational part of the returned quantity is
+  /// a_M_BoFo_E (Fo's translational acceleration relative to Bo, measured in
   /// frame M, expressed in frame E). <pre>
-  ///  α_MC_E - α_MB_E = DtM(ω_MC)_E - DtM(ω_MB)_E = DtM(ω_BC)_E
-  ///  a_M_BoCo_E = a_MCo_E - a_MBo_E = DtM(v_MCo) - DtM(v_MBo) = Dt²M(p_BoCo)_E
+  ///  α_MF_E - α_MB_E = DtM(ω_MF)_E - DtM(ω_MB)_E = DtM(ω_BF)_E
+  ///  a_M_BoFo_E = a_MFo_E - a_MBo_E = DtM(v_MFo) - DtM(v_MBo) = Dt²M(p_BoFo)_E
   /// </pre>
-  /// where Dt²M(p_BoCo)_E is the 2ⁿᵈ time-derivative in frame M of p_BoCo (the
-  /// position vector from Bo to Co), and this result is expressed in frame E.
+  /// where Dt²M(p_BoFo)_E is the 2ⁿᵈ time-derivative in frame M of p_BoFo (the
+  /// position vector from Bo to Fo), and this result is expressed in frame E.
   /// @note The calculation of the 2ⁿᵈ time-derivative of the distance between
-  /// Bo and Co can be done with relative translational acceleration, but this
+  /// Bo and Fo can be done with relative translational acceleration, but this
   /// calculation does not depend on the measured-in-frame, hence in this case,
   /// consider CalcRelativeSpatialAccelerationInWorld() since it is faster.
   /// @see CalcSpatialAccelerationInWorld(), CalcSpatialAcceleration(), and
@@ -486,9 +502,9 @@ class Frame : public MultibodyElement<T> {
     const Frame<T>& frame_E = expressed_in_frame;
     const SpatialAcceleration<T> A_MB_E =
         frame_B.CalcSpatialAcceleration(context, frame_M, frame_E);
-    const SpatialAcceleration<T> A_MC_E =
+    const SpatialAcceleration<T> A_MF_E =
         CalcSpatialAcceleration(context, frame_M, frame_E);
-    return A_MC_E - A_MB_E;
+    return A_MF_E - A_MB_E;
   }
 
   /// (Advanced) NVI to DoCloneToScalar() templated on the scalar type of the
@@ -511,46 +527,47 @@ class Frame : public MultibodyElement<T> {
   /// @name Internal use only
   /// These functions work directly with the frame body pose cache entry.
   //@{
-  /// (Internal use only) A %Frame's pose-in-parent X_PF can be parameterized,
-  /// the parent's pose may also be parameterized, and so on. Thus the
-  /// calculation of this frame's pose in its body (X_BF) can be expensive.
-  /// There is a cache entry that holds the calculated X_BF, evaluated
-  /// whenever parameters change. This allows us to grab X_BF as a const
-  /// reference rather than having to extract and reformat parameters, and
+  /// (Internal use only) A %Frame's pose-in-parent-frame X_PF can be
+  /// parameterized, the parent frame's pose may also be parameterized, and so
+  /// on. Thus the calculation of this frame's pose in its link frame (X_LF) can
+  /// be expensive. There is a cache entry that holds the calculated X_LF,
+  /// evaluated whenever parameters change. This allows us to grab X_LF as a
+  /// const reference rather than having to extract and reformat parameters, and
   /// compose with parent and ancestor poses at runtime.
   ///
-  /// At the time parameters are allocated we assign a slot in the body pose
-  /// cache entry to each %Frame and record its index using this function. (The
-  /// index for a RigidBodyFrame will refer to an identity transform.) Note that
-  /// the body pose index is not necessarily the same as the %Frame index
-  /// because all RigidBodyFrames can share an entry. (Of course if you know you
-  /// are working with a RigidBodyFrame you don't need to ask about its body
-  /// pose!)
-  void set_body_pose_index_in_cache(int body_pose_index) {
-    body_pose_index_in_cache_ = body_pose_index;
-  }
-
-  /// (Internal use only) Retrieve this %Frame's body pose index in the cache.
-  int get_body_pose_index_in_cache() const { return body_pose_index_in_cache_; }
+  /// When we are optimizing assemblies using composite Mobods, the pose of
+  /// a frame on its Mobod (X_BF) can differ from its pose on its Link (X_LF).
+  /// Most multibody computations need X_BF, but X_LF is available also.
 
   /// (Internal use only) Given an already up-to-date frame body pose cache,
-  /// extract X_BF for this %Frame from it.
+  /// extract X_LF for this %Frame from it.
   /// @note Be sure you have called MultibodyTreeSystem::EvalFrameBodyPoses()
   ///       since the last parameter change; we can't check here.
-  /// @retval X_BF pose of this frame in its body's frame
+  /// @retval X_LF pose of this frame in its Link's frame
+  const math::RigidTransform<T>& get_X_LF(
+      const internal::FrameBodyPoseCache<T>& frame_body_poses) const {
+    return frame_body_poses.get_X_LF(index());
+  }
+
+  /// (Internal use only) Given an already up-to-date frame body pose cache,
+  /// extract X_BF for this %Frame from it. Note that X_BF is F's pose on its
+  /// mobilized body B which might not be the same as its link L.
+  /// @note Be sure you have called MultibodyTreeSystem::EvalFrameBodyPoses()
+  ///       since the last parameter change; we can't check here.
+  /// @retval X_BF pose of this frame in its Mobod's frame
   const math::RigidTransform<T>& get_X_BF(
       const internal::FrameBodyPoseCache<T>& frame_body_poses) const {
-    return frame_body_poses.get_X_BF(body_pose_index_in_cache_);
+    return frame_body_poses.get_X_BF(index());
   }
 
   /// (Internal use only) Given an already up-to-date frame body pose cache,
   /// extract X_FB (=X_BF⁻¹) for this %Frame from it.
   /// @note Be sure you have called MultibodyTreeSystem::EvalFrameBodyPoses()
   ///       since the last parameter change; we can't check here.
-  /// @retval X_FB inverse of this frame's pose in its body's frame
+  /// @retval X_FB inverse of this frame's pose in its Mobod's frame
   const math::RigidTransform<T>& get_X_FB(
       const internal::FrameBodyPoseCache<T>& frame_body_poses) const {
-    return frame_body_poses.get_X_FB(body_pose_index_in_cache_);
+    return frame_body_poses.get_X_FB(index());
   }
 
   /// (Internal use only) Given an already up-to-date frame body pose cache,
@@ -558,22 +575,22 @@ class Frame : public MultibodyElement<T> {
   /// precomputed in the cache so is very fast to check.
   /// @note Be sure you have called MultibodyTreeSystem::EvalFrameBodyPoses()
   ///       since the last parameter change; we can't check here.
-  /// @see get_X_BF()
+  /// @see get_X_BF(), get_X_FB()
   bool is_X_BF_identity(
       const internal::FrameBodyPoseCache<T>& frame_body_poses) const {
-    return frame_body_poses.is_X_BF_identity(body_pose_index_in_cache_);
+    return frame_body_poses.is_X_BF_identity(index());
   }
   //@}
 
  protected:
   /// Only derived classes can use this constructor. It creates a %Frame
-  /// object attached to `body` and puts the frame in the body's model
+  /// object attached to `link` and puts the frame in the link's model
   /// instance.
-  explicit Frame(const std::string& name, const RigidBody<T>& body,
+  explicit Frame(const std::string& name, const Link<T>& link,
                  std::optional<ModelInstanceIndex> model_instance = {})
-      : MultibodyElement<T>(model_instance.value_or(body.model_instance())),
+      : MultibodyElement<T>(model_instance.value_or(link.model_instance())),
         name_(internal::DeprecateWhenEmptyName(name, "Frame")),
-        body_(body) {}
+        link_(link) {}
 
   /// Called by DoDeclareParameters(). Derived classes may choose to override
   /// to declare their sub-class specific parameters.
@@ -652,10 +669,8 @@ class Frame : public MultibodyElement<T> {
 
   const std::string name_;
 
-  // The body associated with this frame.
-  const RigidBody<T>& body_;
-
-  int body_pose_index_in_cache_{-1};
+  // The link to which this frame is attached.
+  const Link<T>& link_;
 };
 
 }  // namespace multibody

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -537,7 +537,7 @@ class Frame : public MultibodyElement<T> {
   /// extract X_BF for this %Frame from it.
   /// @note Be sure you have called MultibodyTreeSystem::EvalFrameBodyPoses()
   ///       since the last parameter change; we can't check here.
-  /// @retval X_BF pose of this frame in its body's frame
+  /// @retval X_BF pose of this frame in its Mobod's frame
   const math::RigidTransform<T>& get_X_BF(
       const internal::FrameBodyPoseCache<T>& frame_body_poses) const {
     return frame_body_poses.get_X_BF(body_pose_index_in_cache_);

--- a/multibody/tree/frame_body_pose_cache.h
+++ b/multibody/tree/frame_body_pose_cache.h
@@ -13,82 +13,145 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-/* This class is one of the cache entries in the Context. It holds the
-precalculated body-relative poses X_BF of every Frame F. Since FixedOffsetFrame
-body poses are parameterized, and given with respect to a parent frame P which
-may itself be a parameterized FixedOffsetFrame, we need to precalculate X_BF
-once the parameters have been set so that we don't have to do that calculation
-repeatedly at runtime. We also precalculate the inverse X_FB since that
-is often needed as well, and record whether X_BF (and of course X_FB) is the
-identity transform, for use in runtime optimizations.
+/* This class is one of the cache entries in the Context. It can be filled in
+once parameters have known values (and must be recalculated when parameters
+change). It holds the following items.
 
-Every Frame is allocated one slot here and the index of that slot (which we
-refer to as `body_pose_index` in this class) is stored in the Frame object for
-fast retrieval (the indices are assigned in Finalize()). Since RigidBodyFrames
-have identity poses by definition, they all share a single entry (the 0th) here
-to permit getting the body pose of any Frame efficiently in cases where you
-don't know what kind of Frame you have. Of course if you know you are working
-with RigidBodyFrames you don't have to use this cache.
+Frame & Link poses
+------------------
+ - the link-relative pose X_LF of every Frame F on the Link to which it is
+   fixed. FixedOffsetFrame link poses are parameterized, and given with
+   respect to a parent frame P which may itself be a parameterized
+   FixedOffsetFrame. We need to precalculate X_LF so that we don't have to do
+   that calculation repeatedly at runtime.
+ - the pose X_BL of each link's frame L on its Mobod frame B. Note that frame B
+   is always the link frame of the mobod's active (most inboard) link. X_BL is
+   necessarily identity unless B is a composite mobod and L is not the active
+   link.
+ - since a frame is fixed to its link L, and L is fixed to its mobod B, we
+   can calculate each frame's mobod-relative pose X_BF (= X_BL*X_LF). This
+   can only differ from X_LF when mobod B is composite and L is not the active
+   link of B.
+ - the inverse X_FB since that is often needed as well.
+ - whether X_BF (and of course X_FB) is the identity transform, for use in
+   runtime optimizations.
+
+Mass properties
+---------------
+ - the SpatialInertia M_LLo_L of every link L about its link origin Lo,
+   expressed in L. Since mass properties can be parameterized, we need to
+   precalculate these inertias so that we don't have to do that repeatedly at
+   runtime.
+ - the SpatialInertia M_BBo_B of every mobod B about its body origin Bo,
+   expressed in B. This differs from M_LLo_L when B is a composite mobod.
+
 @tparam_default_scalar */
 template <typename T>
 class FrameBodyPoseCache {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FrameBodyPoseCache);
 
-  explicit FrameBodyPoseCache(int num_mobods,
-                              int num_frame_body_pose_slots_needed)
-      : X_BF_pool_(num_frame_body_pose_slots_needed),
-        X_FB_pool_(num_frame_body_pose_slots_needed),
-        is_X_BF_identity_(num_frame_body_pose_slots_needed),
+  explicit FrameBodyPoseCache(int num_links, int num_frames, int num_mobods)
+      : X_LF_pool_(num_frames, math::RigidTransform<T>::Identity()),
+        X_BF_pool_(num_frames, math::RigidTransform<T>::Identity()),
+        X_FB_pool_(num_frames, math::RigidTransform<T>::Identity()),
+        is_X_BF_identity_(num_frames, true),
+        X_BL_pool_(num_links, math::RigidTransform<T>::Identity()),
+        is_X_BL_identity_(num_links, true),
+        M_LLo_L_pool_(num_links, SpatialInertia<T>::NaN()),
         M_BBo_B_pool_(num_mobods, SpatialInertia<T>::NaN()) {
-    DRAKE_DEMAND(num_frame_body_pose_slots_needed > 0);
-
-    // All RigidBodyFrames share this body pose.
-    X_BF_pool_[0] = X_FB_pool_[0] = math::RigidTransform<T>::Identity();
-    is_X_BF_identity_[0] = true;
+    // Initially all transforms are identity, mass props are NaN.
   }
 
-  const math::RigidTransform<T>& get_X_BF(int body_pose_index) const {
+  const math::RigidTransform<T>& get_X_LF(FrameIndex index) const {
+    DRAKE_ASSERT(0 <= index && index < ssize(X_LF_pool_));
+    return X_LF_pool_[index];
+  }
+
+  const math::RigidTransform<T>& get_X_BF(FrameIndex index) const {
     // This method must be very fast in Release.
-    DRAKE_ASSERT(0 <= body_pose_index && body_pose_index < ssize(X_BF_pool_));
-    return X_BF_pool_[body_pose_index];
+    DRAKE_ASSERT(0 <= index && index < ssize(X_BF_pool_));
+    return X_BF_pool_[index];
   }
 
-  const math::RigidTransform<T>& get_X_FB(int body_pose_index) const {
+  const math::RigidTransform<T>& get_X_FB(FrameIndex index) const {
     // This method must be very fast in Release.
-    DRAKE_ASSERT(0 <= body_pose_index && body_pose_index < ssize(X_FB_pool_));
-    return X_FB_pool_[body_pose_index];
+    DRAKE_ASSERT(0 <= index && index < ssize(X_FB_pool_));
+    return X_FB_pool_[index];
   }
 
-  // Returns true if F is a body frame or is coincident with a body frame,
-  // unless T is symbolic, in which case we always return false. This should be
-  // used only for performance optimization, so that a false negative
-  // harmlessly leads to treating X_BF as a general transform.
-  bool is_X_BF_identity(int body_pose_index) const {
+  // We're given a frame F that is fixed to some link L, and L is fixed to
+  // some mobod B. Denote B's active link as L₀. By definition, L₀'s
+  // LinkFrame is also mobilized body B's body frame.
+  //
+  // This method returns true if
+  // (1) F is B's body frame (that is, F is L's LinkFrame and L≡L₀), or
+  // (2) T is nonsymbolic and F is currently coincident B's body frame.
+  //
+  // This should be used only for performance optimization, so that a false
+  // negative harmlessly leads to treating X_BF as a general transform.
+  bool is_X_BF_identity(FrameIndex index) const {
     // This method must be very fast in Release.
-    DRAKE_ASSERT(0 <= body_pose_index &&
-                 body_pose_index < ssize(is_X_BF_identity_));
-    return static_cast<bool>(is_X_BF_identity_[body_pose_index]);
+    DRAKE_ASSERT(0 <= index && index < ssize(is_X_BF_identity_));
+    return static_cast<bool>(is_X_BF_identity_[index]);
   }
 
-  const SpatialInertia<T>& get_M_BBo_B(MobodIndex index) const {
+  const math::RigidTransform<T>& get_X_BL(LinkOrdinal ordinal) const {
     // This method must be very fast in Release.
-    DRAKE_ASSERT(0 <= index && index < ssize(M_BBo_B_pool_));
-    return M_BBo_B_pool_[index];
+    DRAKE_ASSERT(0 <= ordinal && ordinal < ssize(X_BL_pool_));
+    return X_BL_pool_[ordinal];
   }
 
-  void SetX_BF(int body_pose_index, const math::RigidTransform<T>& X_BF) {
+  bool is_X_BL_identity(LinkOrdinal ordinal) const {
+    // This method must be very fast in Release.
+    DRAKE_ASSERT(0 <= ordinal && ordinal < ssize(is_X_BL_identity_));
+    return static_cast<bool>(is_X_BL_identity_[ordinal]);
+  }
+
+  const SpatialInertia<T>& get_M_LLo_L(LinkOrdinal ordinal) const {
+    DRAKE_ASSERT(0 <= ordinal && ordinal < ssize(M_LLo_L_pool_));
+    return M_LLo_L_pool_[ordinal];
+  }
+
+  const SpatialInertia<T>& get_M_BBo_B(MobodIndex ordinal) const {
+    // This method must be very fast in Release.
+    DRAKE_ASSERT(0 <= ordinal && ordinal < ssize(M_BBo_B_pool_));
+    return M_BBo_B_pool_[ordinal];
+  }
+
+  void SetX_LF(FrameIndex index, const math::RigidTransform<T>& X_LF) {
     // This method is only called when parameters change.
-    DRAKE_DEMAND(0 <= body_pose_index && body_pose_index < ssize(X_BF_pool_));
-    // RigidBodyFrames use pose index 0; we already know X_BF is identity.
-    if (body_pose_index == 0) return;
-    X_BF_pool_[body_pose_index] = X_BF;
-    X_FB_pool_[body_pose_index] = X_BF.inverse();
+    DRAKE_DEMAND(0 <= index && index < ssize(X_LF_pool_));
+    X_LF_pool_[index] = X_LF;
+  }
+
+  void SetX_BF(FrameIndex index, const math::RigidTransform<T>& X_BF) {
+    // This method is only called when parameters change.
+    DRAKE_DEMAND(0 <= index && index < ssize(X_BF_pool_));
+    X_BF_pool_[index] = X_BF;
+    X_FB_pool_[index] = X_BF.inverse();
     if constexpr (scalar_predicate<T>::is_bool) {
-      is_X_BF_identity_[body_pose_index] = X_BF.IsExactlyIdentity();
+      is_X_BF_identity_[index] = X_BF.IsExactlyIdentity();
     } else {
-      is_X_BF_identity_[body_pose_index] = static_cast<uint8_t>(false);
+      is_X_BF_identity_[index] = static_cast<uint8_t>(false);
     }
+  }
+
+  void SetX_BL(LinkOrdinal ordinal, const math::RigidTransform<T>& X_BL) {
+    // This method is only called when parameters change.
+    DRAKE_DEMAND(0 <= ordinal && ordinal < ssize(X_BL_pool_));
+    X_BL_pool_[ordinal] = X_BL;
+    if constexpr (scalar_predicate<T>::is_bool) {
+      is_X_BL_identity_[ordinal] = X_BL.IsExactlyIdentity();
+    } else {
+      is_X_BL_identity_[ordinal] = static_cast<uint8_t>(false);
+    }
+  }
+
+  void SetM_LLo_L(LinkOrdinal ordinal, const SpatialInertia<T>& M_LLo_L) {
+    // This method is only called when parameters change.
+    DRAKE_DEMAND(0 <= ordinal && ordinal < ssize(M_LLo_L_pool_));
+    M_LLo_L_pool_[ordinal] = M_LLo_L;
   }
 
   void SetM_BBo_B(MobodIndex index, const SpatialInertia<T>& M_BBo_B) {
@@ -100,13 +163,18 @@ class FrameBodyPoseCache {
  private:
   // Sizes are set on construction.
 
-  // These are indexed by Frame::get_body_pose_index_in_cache().
+  // These are indexed by FrameIndex.
+  std::vector<math::RigidTransform<T>> X_LF_pool_;
   std::vector<math::RigidTransform<T>> X_BF_pool_;
   std::vector<math::RigidTransform<T>> X_FB_pool_;
   std::vector<uint8_t> is_X_BF_identity_;  // fast vector<bool> equivalent
 
-  // Spatial inertia of mobilized body B, about its body origin Bo, expressed
-  // in B. These are indexed by MobodIndex.
+  // These are indexed by LinkOrdinal.
+  std::vector<math::RigidTransform<T>> X_BL_pool_;
+  std::vector<uint8_t> is_X_BL_identity_;
+  std::vector<SpatialInertia<T>> M_LLo_L_pool_;
+
+  // This is indexed by MobodIndex.
   std::vector<SpatialInertia<T>> M_BBo_B_pool_;
 };
 

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -1005,8 +1005,9 @@ class Joint : public MultibodyElement<T> {
 
   In the case of revolute, prismatic, and screw joints we have an axis â whose
   components are the same in Jp and Jc. However, for maximum speed, the
-  available mobilizers are specialized to rotate only about a coordinate axis.
-  TODO(sherm1) Make that happen.
+  available mobilizers for revolute and prismatic are specialized to rotate
+  about or translate along a coordinate axis.
+
   As an example, if the mobilizer rotates around z, we want new frames F and M
   with Fz=Mz=â, Fo=Jpo, Mo=Jco. We also want F==M when Jp==Jc, i.e. at the joint
   zero position so that the coordinate q will mean the same thing using F and M

--- a/multibody/tree/linear_spring_damper.cc
+++ b/multibody/tree/linear_spring_damper.cc
@@ -144,12 +144,12 @@ template <typename ToScalar>
 std::unique_ptr<ForceElement<ToScalar>>
 LinearSpringDamper<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
-  const RigidBody<ToScalar>& bodyA_clone = tree_clone.get_body(bodyA().index());
-  const RigidBody<ToScalar>& bodyB_clone = tree_clone.get_body(bodyB().index());
+  const Link<ToScalar>& linkA_clone = tree_clone.get_link(bodyA().index());
+  const Link<ToScalar>& linkB_clone = tree_clone.get_link(bodyB().index());
 
   // Make the LinearSpringDamper<T> clone.
   auto spring_damper_clone = std::make_unique<LinearSpringDamper<ToScalar>>(
-      bodyA_clone, p_AP(), bodyB_clone, p_BQ(), free_length(), stiffness(),
+      linkA_clone, p_AP(), linkB_clone, p_BQ(), free_length(), stiffness(),
       damping());
 
   return spring_damper_clone;

--- a/multibody/tree/linear_spring_damper.h
+++ b/multibody/tree/linear_spring_damper.h
@@ -14,7 +14,7 @@ template <typename T>
 class RigidBody;
 
 /// This %ForceElement models a spring-damper attached between two points on
-/// two different bodies.
+/// two different bodies (links).
 /// Given a point P on a body A and a point Q on a body B with positions
 /// p_AP and p_BQ, respectively, this spring-damper applies equal and
 /// opposite forces on bodies A and B according to: <pre>

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -220,8 +220,11 @@ class MultibodyElement {
   // Give unit tests access to the tree.
   friend class MultibodyElementTester;
 
+  // Index and ordinal are given the same numerical value here. The ordinal
+  // can be overridden with set_ordinal().
   void set_parent_tree(const internal::MultibodyTree<T>* tree, int64_t index) {
     index_ = index;
+    ordinal_ = index;
     parent_tree_ = tree;
   }
 

--- a/multibody/tree/multibody_forces.cc
+++ b/multibody/tree/multibody_forces.cc
@@ -7,7 +7,7 @@ namespace multibody {
 
 template <typename T>
 MultibodyForces<T>::MultibodyForces(const internal::MultibodyTree<T>& model)
-    : MultibodyForces(model.num_bodies(), model.num_velocities()) {
+    : MultibodyForces(model.num_links(), model.num_velocities()) {
   DRAKE_DEMAND(model.is_finalized());
 }
 
@@ -42,7 +42,7 @@ template <typename T>
 bool MultibodyForces<T>::CheckHasRightSizeForModel(
     const internal::MultibodyTree<T>& model) const {
   return model.num_velocities() == num_velocities() &&
-         model.num_bodies() == num_bodies();
+         model.num_links() == num_bodies();
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -56,8 +56,8 @@ MultibodyTree<T>::MultibodyTree() {
   // correct.
   DRAKE_DEMAND(world_instance == world_model_instance());
 
-  world_rigid_body_ = &AddRigidBody("world", world_model_instance(),
-                                    SpatialInertia<double>::NaN());
+  world_link_ =
+      &AddLink("world", world_model_instance(), SpatialInertia<double>::NaN());
 
   // `default_model_instance()` hardcodes the returned index.  Make sure it's
   // correct.
@@ -95,35 +95,36 @@ template <typename T>
 MultibodyTree<T>::~MultibodyTree() = default;
 
 template <typename T>
-const RigidBody<T>& MultibodyTree<T>::AddRigidBody(
+const Link<T>& MultibodyTree<T>::AddLink(
     const std::string& name, ModelInstanceIndex model_instance,
-    const SpatialInertia<double>& M_BBo_B) {
+    const SpatialInertia<double>& M_LLo_L) {
   if (model_instance >= num_model_instances()) {
     throw std::logic_error("Invalid model instance specified.");
   }
 
-  if (HasBodyNamed(name, model_instance)) {
+  if (HasLinkNamed(name, model_instance)) {
     throw std::logic_error(fmt::format(
         "Model instance '{}' already contains a body named '{}'. Body names "
         "must be unique within a given model.",
         model_instances_.get_element(model_instance).name(), name));
   }
 
-  const RigidBody<T>& body = this->AddRigidBodyImpl(
-      std::make_unique<RigidBody<T>>(name, model_instance, M_BBo_B));
-  return body;
+  const Link<T>& link = this->AddLinkImpl(
+      std::make_unique<Link<T>>(name, model_instance, M_LLo_L));
+  return link;
 }
 
 template <typename T>
-const RigidBody<T>& MultibodyTree<T>::AddRigidBody(
-    const std::string& name, const SpatialInertia<double>& M_BBo_B) {
+const RigidBody<T>& MultibodyTree<T>::AddLink(
+    const std::string& name, const SpatialInertia<double>& M_LLo_L) {
   if (num_model_instances() != 2) {
+    // MbP API is AddRigidBody() rather than AddLink().
     throw std::logic_error(
-        "This model has more model instances than the default.  Please "
+        "This model has more model instances than the default. Please "
         "call AddRigidBody() with an explicit model instance.");
   }
 
-  return AddRigidBody(name, default_model_instance(), M_BBo_B);
+  return AddLink(name, default_model_instance(), M_LLo_L);
 }
 
 template <typename T>
@@ -150,7 +151,7 @@ void MultibodyTree<T>::RemoveJoint(const Joint<T>& joint) {
 
   // Update the ordinals for all joints with higher indices than the
   // one being removed.
-  for (JointIndex index : joints_.indices()) {
+  for (JointIndex index : joints_.valid_indices()) {
     if (index > joint_index) {
       Joint<T>& mutable_joint = joints_.get_mutable_element(index);
       mutable_joint.set_ordinal(mutable_joint.ordinal() - 1);
@@ -194,8 +195,7 @@ bool MultibodyTree<T>::HasUniqueFloatingBaseBodyImpl(
   std::optional<BodyIndex> base_body_index =
       MaybeGetUniqueBaseBodyIndex(model_instance);
   return base_body_index.has_value() &&
-         rigid_bodies_.get_element(base_body_index.value())
-             .is_floating_base_body();
+         links_.get_element(base_body_index.value()).is_floating_base_body();
 }
 
 template <typename T>
@@ -208,8 +208,7 @@ const RigidBody<T>& MultibodyTree<T>::GetUniqueFloatingBaseBodyOrThrowImpl(
         fmt::format("Model {} does not have a unique base body.",
                     model_instances_.get_element(model_instance).name()));
   }
-  const RigidBody<T>& result =
-      rigid_bodies_.get_element(base_body_index.value());
+  const RigidBody<T>& result = links_.get_element(base_body_index.value());
   if (!result.is_floating_base_body()) {
     throw std::logic_error(fmt::format(
         "Model {} has a unique base body, but it is not a floating base body.",
@@ -244,7 +243,7 @@ template <typename T, typename ElementIndex>
 const auto& GetElementByIndex(const MultibodyTree<T>& tree,
                               const ElementIndex index) {
   if constexpr (std::is_same_v<ElementIndex, BodyIndex>) {
-    return tree.get_body(index);
+    return tree.get_link(index);
   }
   if constexpr (std::is_same_v<ElementIndex, FrameIndex>) {
     return tree.get_frame(index);
@@ -421,20 +420,19 @@ const auto& GetElementByName(const MultibodyTree<T>& tree,
 }  // namespace
 
 template <typename T>
-int MultibodyTree<T>::NumBodiesWithName(std::string_view name) const {
-  return static_cast<int>(rigid_bodies_.names_map().count(name));
+int MultibodyTree<T>::NumLinksWithName(std::string_view name) const {
+  return static_cast<int>(links_.names_map().count(name));
 }
 
 template <typename T>
-bool MultibodyTree<T>::HasBodyNamed(std::string_view name) const {
-  return HasElementNamed(*this, name, std::nullopt, rigid_bodies_.names_map());
+bool MultibodyTree<T>::HasLinkNamed(std::string_view name) const {
+  return HasElementNamed(*this, name, std::nullopt, links_.names_map());
 }
 
 template <typename T>
-bool MultibodyTree<T>::HasBodyNamed(std::string_view name,
+bool MultibodyTree<T>::HasLinkNamed(std::string_view name,
                                     ModelInstanceIndex model_instance) const {
-  return HasElementNamed(*this, name, model_instance,
-                         rigid_bodies_.names_map());
+  return HasElementNamed(*this, name, model_instance, links_.names_map());
 }
 
 template <typename T>
@@ -476,13 +474,13 @@ bool MultibodyTree<T>::HasModelInstanceNamed(std::string_view name) const {
 }
 
 template <typename T>
-std::vector<BodyIndex> MultibodyTree<T>::GetBodyIndices(
+std::vector<LinkIndex> MultibodyTree<T>::GetLinkIndices(
     ModelInstanceIndex model_instance) const {
   DRAKE_THROW_UNLESS(model_instances_.has_element(model_instance));
-  std::vector<BodyIndex> indices;
-  for (const Body<T>* body : rigid_bodies_.elements()) {
-    if (body->model_instance() == model_instance) {
-      indices.emplace_back(body->index());
+  std::vector<LinkIndex> indices;
+  for (const Link<T>* link : links_.elements()) {
+    if (link->model_instance() == model_instance) {
+      indices.emplace_back(link->index());
     }
   }
   return indices;
@@ -540,59 +538,56 @@ const Frame<T>& MultibodyTree<T>::GetFrameByName(
 }
 
 template <typename T>
-const RigidBody<T>& MultibodyTree<T>::GetRigidBodyByName(
-    std::string_view name) const {
-  return GetElementByName(*this, name, std::nullopt, rigid_bodies_.names_map());
+const Link<T>& MultibodyTree<T>::GetLinkByName(std::string_view name) const {
+  return GetElementByName(*this, name, std::nullopt, links_.names_map());
 }
 
 template <typename T>
-const RigidBody<T>& MultibodyTree<T>::GetRigidBodyByName(
+const Link<T>& MultibodyTree<T>::GetLinkByName(
     std::string_view name, ModelInstanceIndex model_instance) const {
-  return GetElementByName(*this, name, model_instance,
-                          rigid_bodies_.names_map());
+  return GetElementByName(*this, name, model_instance, links_.names_map());
 }
 
 template <typename T>
-const RigidBody<T>& MultibodyTree<T>::AddRigidBodyImpl(
-    std::unique_ptr<RigidBody<T>> body) {
+const Link<T>& MultibodyTree<T>::AddLinkImpl(std::unique_ptr<Link<T>> link) {
   if (is_finalized()) {
     throw std::logic_error(
         "This MultibodyTree is finalized already. "
         "Therefore adding more bodies is not allowed. "
         "See documentation for Finalize() for details.");
   }
-  if (body == nullptr) {
-    throw std::logic_error("Input body is a nullptr.");
+  if (link == nullptr) {
+    throw std::logic_error("Input link is a nullptr.");
   }
 
-  DRAKE_DEMAND(body->model_instance().is_valid());
+  DRAKE_DEMAND(link->model_instance().is_valid());
 
-  const BodyIndex body_index(num_bodies());
+  const LinkIndex link_index(num_links());
 
-  if (body_index == 0) {
+  if (link_index == 0) {
     // We're adding the first RigidBody -- must be World!
-    DRAKE_DEMAND(body->name() == "world");
-    DRAKE_DEMAND(body->model_instance() == world_model_instance());
+    DRAKE_DEMAND(link->name() == "world");
+    DRAKE_DEMAND(link->model_instance() == world_model_instance());
     // The LinkJointGraph should already contain only World.
     DRAKE_DEMAND(ssize(link_joint_graph_.links()) == 1);
-    DRAKE_DEMAND(link_joint_graph_.link_by_index(body_index).name() == "world");
+    DRAKE_DEMAND(link_joint_graph_.link_by_index(link_index).name() == "world");
   } else {
-    // Make note in the graph of the new rigid body.
-    link_joint_graph_.AddLink(body->name(), body->model_instance());
+    // Make note in the graph of the new rigid link.
+    link_joint_graph_.AddLink(link->name(), link->model_instance());
   }
 
-  body->set_parent_tree(this, body_index);
+  link->set_parent_tree(this, link_index);
   // MultibodyTree can access selected private methods in RigidBody through its
   // RigidBodyAttorney.
-  // - Register body frame.
-  Frame<T>* body_frame =
-      &internal::RigidBodyAttorney<T>::get_mutable_body_frame(body.get());
-  const FrameIndex body_frame_index(num_frames());
-  body_frame->set_parent_tree(this, body_frame_index);
-  DRAKE_DEMAND(body_frame->name() == body->name());
-  frames_.AddBorrowed(body_frame);
-  // - Register body.
-  return rigid_bodies_.Add(std::move(body));
+  // - Register link frame.
+  Frame<T>* link_frame =
+      &internal::RigidBodyAttorney<T>::get_mutable_link_frame(link.get());
+  const FrameIndex link_frame_index(num_frames());
+  link_frame->set_parent_tree(this, link_frame_index);
+  DRAKE_DEMAND(link_frame->name() == link->name());
+  frames_.AddBorrowed(link_frame);
+  // - Register link.
+  return links_.Add(std::move(link));
 }
 
 template <typename T>
@@ -645,18 +640,18 @@ ModelInstanceIndex MultibodyTree<T>::GetModelInstanceByName(
 }
 
 template <typename T>
-std::set<BodyIndex> MultibodyTree<T>::GetBodiesKinematicallyAffectedBy(
+std::set<LinkIndex> MultibodyTree<T>::GetLinksKinematicallyAffectedBy(
     const std::vector<JointIndex>& joint_indexes) const {
-  // For each Joint, find its implementing Mobod and collect the RigidBodies
+  // For each Joint, find its implementing Mobod and collect the links
   // in the subtree rooted by that Mobod. Duplicates are weeded out
-  // and the returned BodyIndexes are sorted.
-  std::set<BodyIndex> links;
+  // and the returned LinkIndexes are sorted.
+  std::set<LinkIndex> links;
   for (const JointIndex& joint_index : joint_indexes) {
     if (get_joint(joint_index).num_velocities() == 0) continue;  // Skip welds.
     const MobodIndex mobod_index =
         graph().joint_by_index(joint_index).mobod_index();
     DRAKE_DEMAND(mobod_index.is_valid());
-    const std::vector<BodyIndex> subtree_links =
+    const std::vector<LinkIndex> subtree_links =
         forest().FindSubtreeLinks(mobod_index);
     links.insert(subtree_links.cbegin(), subtree_links.cend());
   }
@@ -664,17 +659,17 @@ std::set<BodyIndex> MultibodyTree<T>::GetBodiesKinematicallyAffectedBy(
 }
 
 template <typename T>
-std::set<BodyIndex> MultibodyTree<T>::GetBodiesOutboardOfBodies(
-    const std::vector<BodyIndex>& body_indexes) const {
-  // For each given rigid body, find the Mobod it follows and collect the bodies
+std::set<LinkIndex> MultibodyTree<T>::GetLinksOutboardOfLinks(
+    const std::vector<LinkIndex>& link_indexes) const {
+  // For each given link, find the Mobod it follows and collect the links
   // in the subtree rooted by that Mobod. Duplicates are weeded out and the
-  // returned BodyIndexes are sorted.
-  std::set<BodyIndex> bodies;
-  for (const BodyIndex& body_index : body_indexes) {
+  // returned LinkIndexes are sorted.
+  std::set<LinkIndex> bodies;
+  for (const LinkIndex& body_index : link_indexes) {
     const MobodIndex mobod_index =
         graph().link_by_index(body_index).mobod_index();
     DRAKE_DEMAND(mobod_index.is_valid());
-    const std::vector<BodyIndex> subtree_bodies =
+    const std::vector<LinkIndex> subtree_bodies =
         forest().FindSubtreeLinks(mobod_index);
     bodies.insert(subtree_bodies.cbegin(), subtree_bodies.cend());
   }
@@ -745,13 +740,12 @@ void MultibodyTree<T>::SetVelocitiesInArray(
 
 /* Create Joint implementations from the already-built SpanningForest. Joints
 are implemented with a Mobilizer (either forward or reversed), unless they are
-welds between Links that were merged onto a single Mobod. We visit the forest's
-mobilized bodies (Mobods) in depth-first order and create Mobilizers in the same
-order as Mobods. We make a stub 0th Mobilizer for World so that Mobilizers and
-Mobods are numbered identically. (Think of it as a weld of World to the
-universe.) Joints that are interior to optimized WeldedLinksAssemblies
-(composite bodies) won't get modeled at all since they don't appear in the
-forest. */
+welds between Links that were merged onto a composite Mobod. We visit the
+forest's mobilized bodies (Mobods) in depth-first order and create Mobilizers in
+the same order as Mobods. We make a stub 0th Mobilizer for World so that
+Mobilizers and Mobods are numbered identically. (Think of it as a weld of World
+to the universe.) Joints in WeldedLinksAssemblies that are interior to composite
+Mobods won't get modeled at all since they don't appear in the forest. */
 template <typename T>
 void MultibodyTree<T>::CreateJointImplementations() {
   DRAKE_DEMAND(!is_finalized());
@@ -775,8 +769,12 @@ void MultibodyTree<T>::CreateJointImplementations() {
       continue;
     }
 
+    // N.B. If `mobod` is composite, this is the modeled ("active") joint that
+    // connects it to its inboard Mobod. The joint connects a frame on `mobod`s
+    // active link to a frame on _some_ link of the inboard mobod (not
+    // necessarily its active link).
     const JointIndex joint_index =
-        forest().joints(mobod.joint_ordinal()).index();
+        forest().joints(mobod.active_joint_ordinal()).index();
     Joint<T>& joint = joints_.get_mutable_element(joint_index);
 
     // We allow reversed mobilizers only for a subset of joint types.
@@ -827,8 +825,7 @@ const Mobilizer<T>& MultibodyTree<T>::GetFreeBodyMobilizerOrThrow(
 
 template <typename T>
 const Frame<T>& MultibodyTree<T>::AddOrGetJointFrame(
-    const RigidBody<T>& body,
-    const std::optional<math::RigidTransform<double>>& X_BF,
+    const RigidBody<T>& body, const std::optional<RigidTransform<double>>& X_BF,
     ModelInstanceIndex joint_instance, std::string_view joint_name,
     std::string_view frame_suffix) {
   if (X_BF.has_value()) {
@@ -846,11 +843,11 @@ void MultibodyTree<T>::FinalizeInternals() {
 
   // Give different multibody elements the chance to perform any finalize-time
   // setup.
-  for (const auto& body_index : rigid_bodies_.indices()) {
+  for (const auto& body_index : links_.valid_indices()) {
     // This sets the body's is_floating_base_body() flag appropriately.
-    rigid_bodies_.get_mutable_element(body_index).SetTopology();
+    links_.get_mutable_element(body_index).SetTopology();
   }
-  for (const auto& frame_index : frames_.indices()) {
+  for (const auto& frame_index : frames_.valid_indices()) {
     // We (re)set the topology on all frames. The rigid body frames' topologies
     // will already have been set in the body loop immediately above, but it
     // doesn't hurt to set them again. The important thing is that the non-body
@@ -863,7 +860,7 @@ void MultibodyTree<T>::FinalizeInternals() {
   for (const auto& force_element : force_elements_) {
     force_element->SetTopology();
   }
-  for (const auto& actuator_index : actuators_.indices()) {
+  for (const auto& actuator_index : actuators_.valid_indices()) {
     actuators_.get_mutable_element(actuator_index).SetTopology();
   }
 
@@ -902,6 +899,58 @@ void MultibodyTree<T>::FinalizeInternals() {
   }
 
   is_finalized_ = true;
+}
+
+template <typename T>
+void MultibodyTree<T>::SetBaseBodyJointType(
+    BaseBodyJointType joint_type,
+    std::optional<ModelInstanceIndex> model_instance) {
+  DRAKE_THROW_UNLESS(!is_finalized());
+  LinkJointGraph& graph = mutable_graph();
+
+  // Obtain the current option flags to preserve the ones that don't have
+  // to do with base body joints.
+  ForestBuildingOptions options =
+      model_instance.has_value()
+          ? graph.get_forest_building_options_in_use(*model_instance)
+          : graph.get_global_forest_building_options();
+
+  // Clear the existing relevant settings. This leaves us with the default
+  // which is to use quaternion floating joints for base bodies.
+  options = options & ~ForestBuildingOptions::kUseRpyFloatingJoints;
+  options = options & ~ForestBuildingOptions::kUseFixedBase;
+
+  switch (joint_type) {
+    case BaseBodyJointType::kQuaternionFloatingJoint:
+      // Nothing to do here; this is the default.
+      break;
+    case BaseBodyJointType::kRpyFloatingJoint:
+      options = options | ForestBuildingOptions::kUseRpyFloatingJoints;
+      break;
+    case BaseBodyJointType::kWeldJoint:
+      options = options | ForestBuildingOptions::kUseFixedBase;
+      break;
+  }
+
+  if (model_instance.has_value()) {
+    graph.SetForestBuildingOptions(*model_instance, options);
+  } else {
+    graph.SetGlobalForestBuildingOptions(options);
+  }
+}
+
+template <typename T>
+BaseBodyJointType MultibodyTree<T>::GetBaseBodyJointType(
+    std::optional<ModelInstanceIndex> model_instance) const {
+  const ForestBuildingOptions options =
+      model_instance.has_value()
+          ? graph().get_forest_building_options_in_use(*model_instance)
+          : graph().get_global_forest_building_options();
+  if (static_cast<bool>(options & ForestBuildingOptions::kUseRpyFloatingJoints))
+    return BaseBodyJointType::kRpyFloatingJoint;
+  if (static_cast<bool>(options & ForestBuildingOptions::kUseFixedBase))
+    return BaseBodyJointType::kWeldJoint;
+  return BaseBodyJointType::kQuaternionFloatingJoint;
 }
 
 template <typename T>
@@ -962,21 +1011,20 @@ void MultibodyTree<T>::Finalize() {
       if (added_joint.traits_index() ==
           LinkJointGraph::quaternion_floating_joint_traits_index()) {
         return AddEphemeralJoint<QuaternionFloatingJoint>(
-            added_joint.name(), world_body(),
-            get_body(added_joint.child_link_index()));
+            added_joint.name(), world_link(),
+            get_link(added_joint.child_link_index()));
       }
       if (added_joint.traits_index() ==
           LinkJointGraph::rpy_floating_joint_traits_index()) {
         return AddEphemeralJoint<RpyFloatingJoint>(
-            added_joint.name(), world_body(),
-            get_body(added_joint.child_link_index()));
+            added_joint.name(), world_link(),
+            get_link(added_joint.child_link_index()));
       }
       if (added_joint.traits_index() ==
           LinkJointGraph::weld_joint_traits_index()) {
         return AddEphemeralJoint<WeldJoint>(
-            added_joint.name(), world_body(),
-            get_body(added_joint.child_link_index()),
-            math::RigidTransform<double>());
+            added_joint.name(), world_link(),
+            get_link(added_joint.child_link_index()), RigidTransform<double>());
       }
       DRAKE_UNREACHABLE();
     }();
@@ -1001,17 +1049,17 @@ template <typename T>
 void MultibodyTree<T>::CreateBodyNode(MobodIndex mobod_index) {
   const SpanningForest::Mobod& mobod = forest().mobods(mobod_index);
   const LinkJointGraph::Link& active_link =
-      forest().links(mobod.link_ordinal());
+      forest().links(mobod.active_link_ordinal());
   const BodyIndex body_index = active_link.index();
 
-  const RigidBody<T>& body = rigid_bodies_.get_element(body_index);
+  const RigidBody<T>& body = links_.get_element(body_index);
 
   std::unique_ptr<BodyNode<T>> body_node;
   const Mobilizer<T>* const mobilizer = mobilizers_[mobod_index].get();
   if (body_index == world_index()) {
-    body_node = std::make_unique<BodyNodeWorld<T>>(&world_body(), mobilizer);
+    body_node = std::make_unique<BodyNodeWorld<T>>(&world_link(), mobilizer);
   } else {
-    BodyNode<T>* parent_node = body_nodes_[mobod.inboard()].get();
+    BodyNode<T>* parent_node = body_nodes_[mobod.inboard_mobod()].get();
 
     // Only the mobilizer knows how to create a BodyNode with compile-time
     // fixed sizes.
@@ -1277,35 +1325,38 @@ void MultibodyTree<T>::SetFreeBodyRandomAnglesDistributionOrThrow(
   maybe_rpy_mobilizer->set_random_angles_distribution(angles.vector());
 }
 
-// Note that the result is indexed by BodyIndex, not MobodIndex.
+// Note that the result is indexed by LinkIndex (BodyIndex), not MobodIndex.
+// That is, we're returning X_WL for each Link L.
 template <typename T>
-void MultibodyTree<T>::CalcAllBodyPosesInWorld(
+void MultibodyTree<T>::CalcAllLinkPosesInWorld(
     const systems::Context<T>& context,
-    std::vector<RigidTransform<T>>* X_WB) const {
-  DRAKE_THROW_UNLESS(X_WB != nullptr);
-  if (ssize(*X_WB) != num_bodies()) {
-    X_WB->resize(num_bodies(), RigidTransform<T>::Identity());
-  }
+    std::vector<RigidTransform<T>>* X_WL) const {
+  DRAKE_THROW_UNLESS(X_WL != nullptr);
+  const int num_link_indices = links_.num_indices();
+  X_WL->resize(num_link_indices);
+
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  for (BodyIndex body_index(0); body_index < num_bodies(); ++body_index) {
-    const MobodIndex mobod_index = get_body(body_index).mobod_index();
-    X_WB->at(body_index) = pc.get_X_WB(mobod_index);
+  for (LinkIndex link_index(0); link_index < num_link_indices; ++link_index) {
+    (*X_WL)[link_index] = has_link(link_index)
+                              ? pc.get_X_WL(get_link(link_index).ordinal())
+                              : RigidTransform<T>::Identity();  // invalid
   }
 }
 
-// Note that the result is indexed by BodyIndex, not MobodIndex.
+// Note that the result is indexed by LinkIndex (BodyIndex), not MobodIndex.
 template <typename T>
-void MultibodyTree<T>::CalcAllBodySpatialVelocitiesInWorld(
+void MultibodyTree<T>::CalcAllLinkSpatialVelocitiesInWorld(
     const systems::Context<T>& context,
-    std::vector<SpatialVelocity<T>>* V_WB) const {
-  DRAKE_THROW_UNLESS(V_WB != nullptr);
-  if (ssize(*V_WB) != num_bodies()) {
-    V_WB->resize(num_bodies(), SpatialVelocity<T>::Zero());
-  }
+    std::vector<SpatialVelocity<T>>* V_WL) const {
+  DRAKE_THROW_UNLESS(V_WL != nullptr);
+  const int num_link_indices = links_.num_indices();
+  V_WL->resize(num_link_indices);
+
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
-  for (BodyIndex body_index(0); body_index < num_bodies(); ++body_index) {
-    const MobodIndex mobod_index = get_body(body_index).mobod_index();
-    V_WB->at(body_index) = vc.get_V_WB(mobod_index);
+  for (LinkIndex link_index(0); link_index < num_link_indices; ++link_index) {
+    (*V_WL)[link_index] = has_link(link_index)
+                              ? vc.get_V_WL(get_link(link_index).ordinal())
+                              : SpatialVelocity<T>::NaN();  // invalid
   }
 }
 
@@ -1370,7 +1421,7 @@ void MultibodyTree<T>::CalcBlockSystemJacobianCache(
     // Note: Tree mobods never include World.
     for (const SpanningForest::Mobod& mobod : tree) {
       const MobodIndex index_B = mobod.index();
-      const MobodIndex index_P = mobod.inboard();
+      const MobodIndex index_P = mobod.inboard_mobod();
       const SpanningForest::Mobod& parent = forest().mobods(index_P);
       const Vector3<T>& p_PoBo_W = pc.get_p_PoBo_W(index_B);
       const int row_B = 6 * (index_B - base_index);
@@ -1392,7 +1443,7 @@ void MultibodyTree<T>::CalcBlockSystemJacobianCache(
           Jvi_V_WB.template head<3>() = w_WP;
           Jvi_V_WB.template tail<3>() = v_WP + w_WP.cross(p_PoBo_W);
         }
-        ancestor = &forest().mobods(ancestor->inboard());
+        ancestor = &forest().mobods(ancestor->inboard_mobod());
       }
       // Parent contributions are done, just need to fill in the local
       // contribution from H_PB_W.
@@ -1438,7 +1489,7 @@ void MultibodyTree<T>::CalcVelocityKinematicsCache(
   }
 }
 
-// Result is indexed by MobodIndex, not BodyIndex.
+// Result is indexed by MobodIndex, not LinkIndex (or BodyIndex).
 template <typename T>
 void MultibodyTree<T>::CalcSpatialInertiasInWorld(
     const systems::Context<T>& context,
@@ -1453,18 +1504,18 @@ void MultibodyTree<T>::CalcSpatialInertiasInWorld(
   // Skip the world.
   // TODO(joemasterjohn): Consider an optimization to avoid calculating spatial
   //  inertias for locked floating bodies.
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
-    const RigidTransform<T>& X_WB = pc.get_X_WB(body.mobod_index());
+  for (LinkIndex link_index(1); link_index < num_links(); ++link_index) {
+    const Link<T>& link = get_link(link_index);
+    const RigidTransform<T>& X_WB = pc.get_X_WB(link.mobod_index());
 
-    // Orientation of B in W.
+    // Orientation of Mobod B in W.
     const RotationMatrix<T>& R_WB = X_WB.rotation();
 
-    // Spatial inertia of body B about Bo and expressed in the body frame B.
+    // Spatial inertia of Mobod B about Bo and expressed in the body frame B.
     const SpatialInertia<T>& M_BBo_B =
-        frame_body_pose_cache.get_M_BBo_B(body.mobod_index());
+        frame_body_pose_cache.get_M_BBo_B(link.mobod_index());
     // Re-express body B's spatial inertia in the world frame W.
-    SpatialInertia<T>& M_BBo_W = (*M_B_W_all)[body.mobod_index()];
+    SpatialInertia<T>& M_BBo_W = (*M_B_W_all)[link.mobod_index()];
     M_BBo_W = M_BBo_B;               // Wrong frame.
     M_BBo_W.ReExpressInPlace(R_WB);  // Fixed.
   }
@@ -1505,25 +1556,22 @@ void MultibodyTree<T>::CalcFrameBodyPoses(
     FrameBodyPoseCache<T>* frame_body_poses) const {
   DRAKE_DEMAND(frame_body_poses != nullptr);
 
-  // All RigidBodyFrames share this entry which is set once and forever.
-  DRAKE_ASSERT(frame_body_poses->get_X_BF(0).IsExactlyIdentity());
-  DRAKE_ASSERT(frame_body_poses->get_X_FB(0).IsExactlyIdentity());
+  DRAKE_ASSERT(frame_body_poses->get_X_BF(FrameIndex(0)).IsExactlyIdentity());
+  DRAKE_ASSERT(frame_body_poses->get_X_FB(FrameIndex(0)).IsExactlyIdentity());
 
   // The first pass locates each frame with respect to the body frame B
   // of the body to which it is fixed.
   for (const Frame<T>* frame : frames_.elements()) {
-    const int body_pose_index_in_cache = frame->get_body_pose_index_in_cache();
-    if (frame->is_body_frame()) {
-      DRAKE_DEMAND(body_pose_index_in_cache == 0);
-      continue;
-    }
     // TODO(sherm1) Note that we're unnecessarily recalculating the parent
     //  and ancestor poses. Likely OK since we expect short sequences and
     //  the whole computation is done only when parameters change. But if
     //  there is a performance issue, consider doing this in topological
     //  order (or memoizing) so we don't have to recalculate.
-    frame_body_poses->SetX_BF(body_pose_index_in_cache,
-                              frame->CalcPoseInBodyFrame(context));
+    const RigidTransform<T> X_LF = frame->CalcPoseInBodyFrame(context);
+    frame_body_poses->SetX_LF(frame->index(), X_LF);
+
+    // TODO(sherm1) When we support composites, X_BF ≠ X_LF.
+    frame_body_poses->SetX_BF(frame->index(), X_LF);
   }
 
   // For every mobilized body, precalculate its body-frame spatial inertia
@@ -1535,10 +1583,13 @@ void MultibodyTree<T>::CalcFrameBodyPoses(
     const Mobilizer<T>& mobilizer = get_mobilizer(mobod.index());
 
     // Get the parameterized spatial inertia.
-    const RigidBody<T>& body = mobilizer.outboard_body();
-    const SpatialInertia<T> M_BBo_B =
-        body.CalcSpatialInertiaInBodyFrame(context);
-    frame_body_poses->SetM_BBo_B(mobod.index(), M_BBo_B);
+    const Link<T>& link = mobilizer.outboard_body();
+    const SpatialInertia<T> M_LLo_L =
+        link.CalcSpatialInertiaInBodyFrame(context);
+    frame_body_poses->SetM_LLo_L(link.ordinal(), M_LLo_L);
+
+    // TODO(sherm1) When we support composites, M_BBo_B ≠ M_LLo_L.
+    frame_body_poses->SetM_BBo_B(mobod.index(), M_LLo_L);
   }
 }
 
@@ -1640,8 +1691,8 @@ void MultibodyTree<T>::CalcDynamicBiasForces(
   const VelocityKinematicsCache<T>& vc = this->EvalVelocityKinematics(context);
 
   // Skip the world.
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
 
     const SpatialInertia<T>& M_B_W =
         spatial_inertia_in_world_cache[body.mobod_index()];
@@ -1727,8 +1778,8 @@ VectorX<T> MultibodyTree<T>::CalcInverseDynamics(
     const systems::Context<T>& context, const VectorX<T>& known_vdot,
     const MultibodyForces<T>& external_forces) const {
   // Temporary storage used in the computation of inverse dynamics.
-  std::vector<SpatialAcceleration<T>> A_WB(num_bodies());
-  std::vector<SpatialForce<T>> F_BMo_W(num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB(num_links());
+  std::vector<SpatialForce<T>> F_BMo_W(num_links());
   VectorX<T> tau(num_velocities());
   CalcInverseDynamics(context, known_vdot, external_forces.body_forces(),
                       external_forces.generalized_forces(), &A_WB, &F_BMo_W,
@@ -2085,9 +2136,9 @@ RigidTransform<T> MultibodyTree<T>::CalcRelativeTransform(
   // Find each Frame's pose on its own body (F on A, G on B).
   const FrameBodyPoseCache<T>& frame_body_pose_cache =
       EvalFrameBodyPoses(context);
-  const math::RigidTransform<T>& X_AF =
+  const RigidTransform<T>& X_AF =
       frame_F.get_X_BF(frame_body_pose_cache);  // B==A
-  const math::RigidTransform<T>& X_BG =
+  const RigidTransform<T>& X_BG =
       frame_G.get_X_BF(frame_body_pose_cache);  // F==G
 
   // Find each body's pose in World.
@@ -2163,8 +2214,8 @@ void MultibodyTree<T>::CalcPointsVelocities(
 template <typename T>
 T MultibodyTree<T>::CalcTotalMass(const systems::Context<T>& context) const {
   T total_mass = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     const T& body_mass = body.get_mass(context);
     total_mass += body_mass;
   }
@@ -2176,8 +2227,8 @@ T MultibodyTree<T>::CalcTotalMass(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances) const {
   T total_mass = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
       const T& body_mass = body.get_mass(context);
@@ -2190,7 +2241,7 @@ T MultibodyTree<T>::CalcTotalMass(
 template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const systems::Context<T>& context) const {
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2202,8 +2253,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   Vector3<T> sum_mi_pi = Vector3<T>::Zero();
 
   // Sum over all the bodies except the 0th body (which is the world body).
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
 
     // total_mass = ∑ mᵢ.
     const T& body_mass = body.get_mass(context);
@@ -2230,7 +2281,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const std::vector<ModelInstanceIndex>& model_instances) const {
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2250,8 +2301,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
       const T& body_mass = body.get_mass(context);
@@ -2313,14 +2364,14 @@ SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
     if (body_index == 0) continue;  // No contribution from the world body.
 
     // Ensure MultibodyPlant method contains a valid body_index.
-    if (body_index >= num_bodies()) {
+    if (body_index >= num_links()) {
       throw std::logic_error(
           "CalcSpatialInertia(): contains an invalid BodyIndex.");
     }
 
     // Get the current body B's spatial inertia about Bo (body B's origin),
     // expressed in the world frame W.
-    const MobodIndex mobod_index = get_body(body_index).mobod_index();
+    const MobodIndex mobod_index = get_link(body_index).mobod_index();
     const SpatialInertia<T>& M_BBo_W = M_Bi_W[mobod_index];
 
     // Shift M_BBo_W from about-point Bo to about-point Wo and add to the sum.
@@ -2345,7 +2396,7 @@ SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
 template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
     const systems::Context<T>& context) const {
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2357,8 +2408,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   Vector3<T> sum_mi_vi = Vector3<T>::Zero();
 
   // Sum over all the bodies except the 0th body (which is the world body).
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
 
     // total_mass = ∑ mᵢ.
     const T& body_mass = body.get_mass(context);
@@ -2389,7 +2440,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
     const std::vector<ModelInstanceIndex>& model_instances) const {
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2409,8 +2460,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
       const T& body_mass = body.get_mass(context);
@@ -2445,7 +2496,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
 template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
     const systems::Context<T>& context) const {
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2459,8 +2510,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // issue a significantly less helpful exception message.
   // Sum over all the bodies except the 0th body (which is the world body).
   T total_mass = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     const T& body_mass = body.get_mass(context);
     total_mass += body_mass;  // total_mass = ∑ mᵢ.
   }
@@ -2473,8 +2524,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
 
   // Sum over all the bodies except the 0th body (which is the world body).
   Vector3<T> sum_mi_ai = Vector3<T>::Zero();
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     const T& body_mass = body.get_mass(context);
     const Vector3<T> ai_WBcm_W =
         body.CalcCenterOfMassTranslationalAccelerationInWorld(context);
@@ -2492,7 +2543,7 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances) const {
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2509,8 +2560,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // is listed multiple times.
   T total_mass = 0;
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
       const T& body_mass = body.get_mass(context);
@@ -2543,8 +2594,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // The code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   Vector3<T> sum_mi_ai = Vector3<T>::Zero();
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
       const T& body_mass = body.get_mass(context);
@@ -2577,8 +2628,8 @@ SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances,
     const Vector3<T>& p_WoP_W) const {
-  // Assemble a list of BodyIndex.
-  std::vector<BodyIndex> body_indexes;
+  // Assemble a list of LinkIndexes.
+  std::vector<LinkIndex> link_indexes;
   for (auto model_instance : model_instances) {
     // If invalid model_instance, throw an exception with a helpful message.
     if (!model_instances_.has_element(model_instance)) {
@@ -2587,15 +2638,15 @@ SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
           " contains an invalid model_instance.");
     }
 
-    const std::vector<BodyIndex> body_index_in_instance =
-        GetBodyIndices(model_instance);
-    for (BodyIndex body_index : body_index_in_instance)
-      body_indexes.push_back(body_index);
+    const std::vector<LinkIndex> link_index_in_instance =
+        GetLinkIndices(model_instance);
+    for (LinkIndex link_index : link_index_in_instance)
+      link_indexes.push_back(link_index);
   }
 
   // Form spatial momentum about Wo (origin of world frame W), expressed in W.
   const SpatialMomentum<T> L_WS_W =
-      CalcBodiesSpatialMomentumInWorldAboutWo(context, body_indexes);
+      CalcBodiesSpatialMomentumInWorldAboutWo(context, link_indexes);
 
   // Shift the spatial momentum from Wo to point P.
   return L_WS_W.Shift(p_WoP_W);
@@ -2604,7 +2655,7 @@ SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
 template <typename T>
 SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
     const systems::Context<T>& context,
-    const std::vector<BodyIndex>& body_indexes) const {
+    const std::vector<LinkIndex>& link_indexes) const {
   // For efficiency, evaluate all bodies' spatial inertia, velocities, and pose.
   const std::vector<SpatialInertia<T>>& M_Bi_W =
       EvalSpatialInertiaInWorldCache(context);
@@ -2615,15 +2666,15 @@ SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
   // S's spatial momentum in W about Wo (the origin of W), expressed in W.
   SpatialMomentum<T> L_WS_W = SpatialMomentum<T>::Zero();
 
-  // Add contributions from each body Bi.
-  for (BodyIndex body_index : body_indexes) {
-    if (body_index == 0) continue;  // No contribution from the world body.
+  // Add contributions from each link Bi.
+  for (LinkIndex link_index : link_indexes) {
+    if (link_index == 0) continue;  // No contribution from the world link.
 
-    // Ensure MultibodyPlant method contains a valid body_index.
-    DRAKE_DEMAND(body_index < num_bodies());
+    // Ensure MultibodyPlant method contains a valid link_index.
+    DRAKE_DEMAND(link_index < num_links());
 
-    // Form the current body's spatial momentum in W about Bo, expressed in W.
-    const MobodIndex mobod_index = get_body(body_index).mobod_index();
+    // Form the current link's spatial momentum in W about Bo, expressed in W.
+    const MobodIndex mobod_index = get_link(link_index).mobod_index();
     const SpatialInertia<T>& M_BBo_W = M_Bi_W[mobod_index];
     const SpatialVelocity<T>& V_WBo_W = vc.get_V_WB(mobod_index);
     SpatialMomentum<T> L_WBo_W = M_BBo_W * V_WBo_W;
@@ -2641,28 +2692,28 @@ SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
 }
 
 template <typename T>
-const RigidTransform<T>& MultibodyTree<T>::EvalBodyPoseInWorld(
-    const systems::Context<T>& context, const RigidBody<T>& body_B) const {
+const RigidTransform<T>& MultibodyTree<T>::EvalLinkPoseInWorld(
+    const systems::Context<T>& context, const Link<T>& link_L) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
-  body_B.HasThisParentTreeOrThrow(this);
-  return EvalPositionKinematics(context).get_X_WB(body_B.mobod_index());
+  link_L.HasThisParentTreeOrThrow(this);
+  return EvalPositionKinematics(context).get_X_WL(link_L.ordinal());
 }
 
 template <typename T>
-const SpatialVelocity<T>& MultibodyTree<T>::EvalBodySpatialVelocityInWorld(
-    const systems::Context<T>& context, const RigidBody<T>& body_B) const {
+const SpatialVelocity<T>& MultibodyTree<T>::EvalLinkSpatialVelocityInWorld(
+    const systems::Context<T>& context, const Link<T>& link_L) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
-  body_B.HasThisParentTreeOrThrow(this);
-  return EvalVelocityKinematics(context).get_V_WB(body_B.mobod_index());
+  link_L.HasThisParentTreeOrThrow(this);
+  return EvalVelocityKinematics(context).get_V_WL(link_L.ordinal());
 }
 
 template <typename T>
 const SpatialAcceleration<T>&
-MultibodyTree<T>::EvalBodySpatialAccelerationInWorld(
-    const systems::Context<T>& context, const RigidBody<T>& body_B) const {
+MultibodyTree<T>::EvalLinkSpatialAccelerationInWorld(
+    const systems::Context<T>& context, const Link<T>& link_L) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
-  body_B.HasThisParentTreeOrThrow(this);
-  return EvalAccelerationKinematics(context).get_A_WB(body_B.mobod_index());
+  link_L.HasThisParentTreeOrThrow(this);
+  return EvalAccelerationKinematics(context).get_A_WB(link_L.mobod_index());
 }
 
 template <typename T>
@@ -2700,7 +2751,7 @@ void MultibodyTree<T>::CalcAllBodyBiasSpatialAccelerationsInWorld(
 
   // Ensure AsBias_WB_all is a not nullptr and is properly sized.
   DRAKE_THROW_UNLESS(AsBias_WB_all != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(AsBias_WB_all->size()) == num_bodies());
+  DRAKE_THROW_UNLESS(static_cast<int>(AsBias_WB_all->size()) == num_links());
 
   // To calculate a generic body A's spatial acceleration bias in world W,
   // note that body A's spatial velocity in world W is
@@ -2727,7 +2778,7 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcBiasSpatialAcceleration(
 
   // Reserve room to store all the bodies' spatial acceleration bias in world W.
   // TODO(Mitiguy) Inefficient use of heap. Per issue #13560, implement caching.
-  std::vector<SpatialAcceleration<T>> AsBias_WB_all(num_bodies());
+  std::vector<SpatialAcceleration<T>> AsBias_WB_all(num_links());
   CalcAllBodyBiasSpatialAccelerationsInWorld(context, with_respect_to,
                                              &AsBias_WB_all);
 
@@ -3304,7 +3355,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   DRAKE_THROW_UNLESS(Js_v_AScm_E->cols() == num_columns);
 
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -3314,8 +3365,8 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
 
   Js_v_AScm_E->setZero();
   T composite_mass = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     const Vector3<T> pi_BoBcm = body.CalcCenterOfMassInBodyFrame(context);
     MatrixX<T> Jsi_v_ABcm_E(3, num_columns);
     CalcJacobianTranslationalVelocity(
@@ -3348,7 +3399,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   DRAKE_THROW_UNLESS(Js_v_AScm_E->cols() == num_columns);
 
   // Reminder: MultibodyTree always declares a world body.
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -3368,8 +3419,8 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
       const T& body_mass = body.get_mass(context);
@@ -3412,7 +3463,7 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
     const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
     const Frame<T>& frame_A, const Frame<T>& frame_E) const {
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -3422,8 +3473,8 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
 
   T composite_mass = 0;
   Vector3<T> asBias_AScm_E = Vector3<T>::Zero();
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     const Vector3<T> pi_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
     const Frame<T>& frame_B = body.body_frame();
     const SpatialAcceleration<T> AsBiasi_AScm_E = CalcBiasSpatialAcceleration(
@@ -3449,7 +3500,7 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
     JacobianWrtVariable with_respect_to, const Frame<T>& frame_A,
     const Frame<T>& frame_E) const {
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -3468,8 +3519,8 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
       const T& body_mass = body.get_mass(context);
@@ -3528,8 +3579,8 @@ T MultibodyTree<T>::CalcKineticEnergy(
   const VectorX<T>& reflected_inertia = EvalReflectedInertiaCache(context);
   T twice_kinetic_energy_W = 0.0;
   // Add contributions from each body (except World).
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const MobodIndex mobod_index = get_body(body_index).mobod_index();
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const MobodIndex mobod_index = get_link(body_index).mobod_index();
     const SpatialInertia<T>& M_B_W = M_Bi_W[mobod_index];
     const SpatialVelocity<T>& V_WB = vc.get_V_WB(mobod_index);
     const SpatialMomentum<T> L_WB = M_B_W * V_WB;
@@ -3615,12 +3666,14 @@ void MultibodyTree<T>::ThrowDefaultMassInertiaError() const {
     // At this point we're looking at a non-World, terminal WeldedMobods group.
     // Find the matching WeldedLinksAssembly that carries the mass properties.
     const std::optional<WeldedLinksAssemblyIndex> link_assembly_index =
-        graph().links(active_mobod.link_ordinal()).welded_links_assembly();
+        graph()
+            .links(active_mobod.active_link_ordinal())
+            .welded_links_assembly();
     DRAKE_DEMAND(link_assembly_index.has_value());  // Should be an assembly!
     const auto& link_assembly =
         graph().welded_links_assemblies(*link_assembly_index);
     DRAKE_DEMAND(link_assembly.links()[0] ==
-                 graph().links(active_mobod.link_ordinal()).index());
+                 graph().links(active_mobod.active_link_ordinal()).index());
 
     ThrowIfTerminalBodyHasBadDefaultMassProperties(link_assembly.links(),
                                                    active_mobod.index());
@@ -3632,7 +3685,7 @@ void MultibodyTree<T>::ThrowDefaultMassInertiaError() const {
     if (!mobod.is_leaf_mobod()) continue;  // An interior Mobod.
 
     ThrowIfTerminalBodyHasBadDefaultMassProperties(
-        {graph().links(mobod.link_ordinal()).index()}, mobod.index());
+        {graph().links(mobod.active_link_ordinal()).index()}, mobod.index());
   }
 }
 
@@ -3648,7 +3701,7 @@ void MultibodyTree<T>::ThrowIfTerminalBodyHasBadDefaultMassProperties(
   const bool can_rotate = active_mobilizer.can_rotate();
   const bool can_translate = active_mobilizer.can_translate();
 
-  const std::string& active_link_name = get_body(link_assembly[0]).name();
+  const std::string& active_link_name = get_link(link_assembly[0]).name();
   const char* description = is_assembly
                                 ? "the active body for a terminal assembly"
                                 : "a terminal body";
@@ -3681,7 +3734,7 @@ double MultibodyTree<T>::CalcTotalDefaultMass(
     const std::vector<BodyIndex>& body_indexes) const {
   double total_mass = 0;
   for (BodyIndex body_index : body_indexes) {
-    const RigidBody<T>& body_B = get_body(body_index);
+    const RigidBody<T>& body_B = get_link(body_index);
     const double mass_B = body_B.default_mass();
     if (!std::isnan(mass_B)) total_mass += mass_B;
   }
@@ -3692,7 +3745,7 @@ template <typename T>
 bool MultibodyTree<T>::IsAnyDefaultRotationalInertiaNaN(
     const std::vector<BodyIndex>& body_indexes) const {
   for (BodyIndex body_index : body_indexes) {
-    const RigidBody<T>& body_B = get_body(body_index);
+    const RigidBody<T>& body_B = get_link(body_index);
     const RotationalInertia<double> I_BBo_B =
         body_B.default_rotational_inertia();
     if (I_BBo_B.IsNaN()) return true;
@@ -3704,7 +3757,7 @@ template <typename T>
 bool MultibodyTree<T>::AreAllDefaultRotationalInertiaZero(
     const std::vector<BodyIndex>& body_indexes) const {
   for (BodyIndex body_index : body_indexes) {
-    const RigidBody<T>& body_B = get_body(body_index);
+    const RigidBody<T>& body_B = get_link(body_index);
     const RotationalInertia<double> I_BBo_B =
         body_B.default_rotational_inertia();
     if (!I_BBo_B.IsZero()) return false;
@@ -4106,8 +4159,8 @@ std::unique_ptr<MultibodyTree<ToScalar>> MultibodyTree<T>::CloneToScalar()
   tree_clone->frames_.ResizeToMatch(frames_);
 
   // Skipping the world body at body_index = 0.
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const RigidBody<T>& body = get_body(body_index);
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
+    const RigidBody<T>& body = get_link(body_index);
     tree_clone->CloneBodyAndAdd(body);
   }
 
@@ -4208,7 +4261,7 @@ RigidBody<T>* MultibodyTree<T>::CloneBodyAndAdd(
   // MultibodyTree can access selected private methods in RigidBody through its
   // RigidBodyAttorney.
   Frame<T>* body_frame_clone =
-      &internal::RigidBodyAttorney<T>::get_mutable_body_frame(body_clone.get());
+      &internal::RigidBodyAttorney<T>::get_mutable_link_frame(body_clone.get());
   body_frame_clone->set_parent_tree(this, body_frame_index);
   body_frame_clone->set_model_instance(body.model_instance());
 
@@ -4219,7 +4272,7 @@ RigidBody<T>* MultibodyTree<T>::CloneBodyAndAdd(
   // The order in which bodies are added into owned_bodies_ is important to keep
   // the topology invariant. Therefore this method is called from
   // MultibodyTree::CloneToScalar() within a loop by original body_index.
-  return &rigid_bodies_.Add(std::move(body_clone));
+  return &links_.Add(std::move(body_clone));
 }
 
 template <typename T>
@@ -4282,11 +4335,11 @@ std::optional<BodyIndex> MultibodyTree<T>::MaybeGetUniqueBaseBodyIndex(
   // just one of those.
   const SpanningForest::Mobod& world = forest().world_mobod();
   std::optional<BodyIndex> base_body_index{};
-  for (const MobodIndex& base_mobod_index : world.outboards()) {
+  for (const MobodIndex& base_mobod_index : world.outboard_mobods()) {
     const SpanningForest::Mobod& base_mobod = forest().mobods(base_mobod_index);
     DRAKE_DEMAND(base_mobod.level() == 1);
     const LinkJointGraph::Link& active_link =
-        forest().links(base_mobod.link_ordinal());
+        forest().links(base_mobod.active_link_ordinal());
     if (active_link.model_instance() != model_instance) continue;
     if (base_body_index.has_value())  // Not unique if already set.
       return std::nullopt;

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -56,8 +56,8 @@ MultibodyTree<T>::MultibodyTree() {
   // correct.
   DRAKE_DEMAND(world_instance == world_model_instance());
 
-  world_rigid_body_ = &AddRigidBody("world", world_model_instance(),
-                                    SpatialInertia<double>::NaN());
+  world_link_ = &AddRigidBody("world", world_model_instance(),
+                              SpatialInertia<double>::NaN());
 
   // `default_model_instance()` hardcodes the returned index.  Make sure it's
   // correct.
@@ -194,8 +194,7 @@ bool MultibodyTree<T>::HasUniqueFloatingBaseBodyImpl(
   std::optional<BodyIndex> base_body_index =
       MaybeGetUniqueBaseBodyIndex(model_instance);
   return base_body_index.has_value() &&
-         rigid_bodies_.get_element(base_body_index.value())
-             .is_floating_base_body();
+         links_.get_element(base_body_index.value()).is_floating_base_body();
 }
 
 template <typename T>
@@ -208,8 +207,7 @@ const RigidBody<T>& MultibodyTree<T>::GetUniqueFloatingBaseBodyOrThrowImpl(
         fmt::format("Model {} does not have a unique base body.",
                     model_instances_.get_element(model_instance).name()));
   }
-  const RigidBody<T>& result =
-      rigid_bodies_.get_element(base_body_index.value());
+  const RigidBody<T>& result = links_.get_element(base_body_index.value());
   if (!result.is_floating_base_body()) {
     throw std::logic_error(fmt::format(
         "Model {} has a unique base body, but it is not a floating base body.",
@@ -422,19 +420,18 @@ const auto& GetElementByName(const MultibodyTree<T>& tree,
 
 template <typename T>
 int MultibodyTree<T>::NumBodiesWithName(std::string_view name) const {
-  return static_cast<int>(rigid_bodies_.names_map().count(name));
+  return static_cast<int>(links_.names_map().count(name));
 }
 
 template <typename T>
 bool MultibodyTree<T>::HasBodyNamed(std::string_view name) const {
-  return HasElementNamed(*this, name, std::nullopt, rigid_bodies_.names_map());
+  return HasElementNamed(*this, name, std::nullopt, links_.names_map());
 }
 
 template <typename T>
 bool MultibodyTree<T>::HasBodyNamed(std::string_view name,
                                     ModelInstanceIndex model_instance) const {
-  return HasElementNamed(*this, name, model_instance,
-                         rigid_bodies_.names_map());
+  return HasElementNamed(*this, name, model_instance, links_.names_map());
 }
 
 template <typename T>
@@ -480,7 +477,7 @@ std::vector<BodyIndex> MultibodyTree<T>::GetBodyIndices(
     ModelInstanceIndex model_instance) const {
   DRAKE_THROW_UNLESS(model_instances_.has_element(model_instance));
   std::vector<BodyIndex> indices;
-  for (const Body<T>* body : rigid_bodies_.elements()) {
+  for (const Body<T>* body : links_.elements()) {
     if (body->model_instance() == model_instance) {
       indices.emplace_back(body->index());
     }
@@ -542,14 +539,13 @@ const Frame<T>& MultibodyTree<T>::GetFrameByName(
 template <typename T>
 const RigidBody<T>& MultibodyTree<T>::GetRigidBodyByName(
     std::string_view name) const {
-  return GetElementByName(*this, name, std::nullopt, rigid_bodies_.names_map());
+  return GetElementByName(*this, name, std::nullopt, links_.names_map());
 }
 
 template <typename T>
 const RigidBody<T>& MultibodyTree<T>::GetRigidBodyByName(
     std::string_view name, ModelInstanceIndex model_instance) const {
-  return GetElementByName(*this, name, model_instance,
-                          rigid_bodies_.names_map());
+  return GetElementByName(*this, name, model_instance, links_.names_map());
 }
 
 template <typename T>
@@ -567,7 +563,7 @@ const RigidBody<T>& MultibodyTree<T>::AddRigidBodyImpl(
 
   DRAKE_DEMAND(body->model_instance().is_valid());
 
-  const BodyIndex body_index(num_bodies());
+  const BodyIndex body_index(num_links());
 
   if (body_index == 0) {
     // We're adding the first RigidBody -- must be World!
@@ -592,7 +588,7 @@ const RigidBody<T>& MultibodyTree<T>::AddRigidBodyImpl(
   DRAKE_DEMAND(body_frame->name() == body->name());
   frames_.AddBorrowed(body_frame);
   // - Register body.
-  return rigid_bodies_.Add(std::move(body));
+  return links_.Add(std::move(body));
 }
 
 template <typename T>
@@ -745,13 +741,12 @@ void MultibodyTree<T>::SetVelocitiesInArray(
 
 /* Create Joint implementations from the already-built SpanningForest. Joints
 are implemented with a Mobilizer (either forward or reversed), unless they are
-welds between Links that were merged onto a single Mobod. We visit the forest's
-mobilized bodies (Mobods) in depth-first order and create Mobilizers in the same
-order as Mobods. We make a stub 0th Mobilizer for World so that Mobilizers and
-Mobods are numbered identically. (Think of it as a weld of World to the
-universe.) Joints that are interior to optimized WeldedLinksAssemblies
-(composite bodies) won't get modeled at all since they don't appear in the
-forest. */
+welds between Links that were merged onto a composite Mobod. We visit the
+forest's mobilized bodies (Mobods) in depth-first order and create Mobilizers in
+the same order as Mobods. We make a stub 0th Mobilizer for World so that
+Mobilizers and Mobods are numbered identically. (Think of it as a weld of World
+to the universe.) Joints in WeldedLinksAssemblies that are interior to composite
+Mobods won't get modeled at all since they don't appear in the forest. */
 template <typename T>
 void MultibodyTree<T>::CreateJointImplementations() {
   DRAKE_DEMAND(!is_finalized());
@@ -775,8 +770,12 @@ void MultibodyTree<T>::CreateJointImplementations() {
       continue;
     }
 
+    // N.B. If `mobod` is composite, this is the modeled ("active") joint that
+    // connects it to its inboard Mobod. The joint connects a frame on `mobod`s
+    // active link to a frame on _some_ link of the inboard mobod (not
+    // necessarily its active link).
     const JointIndex joint_index =
-        forest().joints(mobod.joint_ordinal()).index();
+        forest().joints(mobod.active_joint_ordinal()).index();
     Joint<T>& joint = joints_.get_mutable_element(joint_index);
 
     // We allow reversed mobilizers only for a subset of joint types.
@@ -827,8 +826,7 @@ const Mobilizer<T>& MultibodyTree<T>::GetFreeBodyMobilizerOrThrow(
 
 template <typename T>
 const Frame<T>& MultibodyTree<T>::AddOrGetJointFrame(
-    const RigidBody<T>& body,
-    const std::optional<math::RigidTransform<double>>& X_BF,
+    const RigidBody<T>& body, const std::optional<RigidTransform<double>>& X_BF,
     ModelInstanceIndex joint_instance, std::string_view joint_name,
     std::string_view frame_suffix) {
   if (X_BF.has_value()) {
@@ -846,9 +844,9 @@ void MultibodyTree<T>::FinalizeInternals() {
 
   // Give different multibody elements the chance to perform any finalize-time
   // setup.
-  for (const auto& body_index : rigid_bodies_.indices()) {
+  for (const auto& body_index : links_.indices()) {
     // This sets the body's is_floating_base_body() flag appropriately.
-    rigid_bodies_.get_mutable_element(body_index).SetTopology();
+    links_.get_mutable_element(body_index).SetTopology();
   }
   for (const auto& frame_index : frames_.indices()) {
     // We (re)set the topology on all frames. The rigid body frames' topologies
@@ -902,6 +900,58 @@ void MultibodyTree<T>::FinalizeInternals() {
   }
 
   is_finalized_ = true;
+}
+
+template <typename T>
+void MultibodyTree<T>::SetBaseBodyJointType(
+    BaseBodyJointType joint_type,
+    std::optional<ModelInstanceIndex> model_instance) {
+  DRAKE_THROW_UNLESS(!is_finalized());
+  LinkJointGraph& graph = mutable_graph();
+
+  // Obtain the current option flags to preserve the ones that don't have
+  // to do with base body joints.
+  ForestBuildingOptions options =
+      model_instance.has_value()
+          ? graph.get_forest_building_options_in_use(*model_instance)
+          : graph.get_global_forest_building_options();
+
+  // Clear the existing relevant settings. This leaves us with the default
+  // which is to use quaternion floating joints for base bodies.
+  options = options & ~ForestBuildingOptions::kUseRpyFloatingJoints;
+  options = options & ~ForestBuildingOptions::kUseFixedBase;
+
+  switch (joint_type) {
+    case BaseBodyJointType::kQuaternionFloatingJoint:
+      // Nothing to do here; this is the default.
+      break;
+    case BaseBodyJointType::kRpyFloatingJoint:
+      options = options | ForestBuildingOptions::kUseRpyFloatingJoints;
+      break;
+    case BaseBodyJointType::kWeldJoint:
+      options = options | ForestBuildingOptions::kUseFixedBase;
+      break;
+  }
+
+  if (model_instance.has_value()) {
+    graph.SetForestBuildingOptions(*model_instance, options);
+  } else {
+    graph.SetGlobalForestBuildingOptions(options);
+  }
+}
+
+template <typename T>
+BaseBodyJointType MultibodyTree<T>::GetBaseBodyJointType(
+    std::optional<ModelInstanceIndex> model_instance) const {
+  const ForestBuildingOptions options =
+      model_instance.has_value()
+          ? graph().get_forest_building_options_in_use(*model_instance)
+          : graph().get_global_forest_building_options();
+  if (static_cast<bool>(options & ForestBuildingOptions::kUseRpyFloatingJoints))
+    return BaseBodyJointType::kRpyFloatingJoint;
+  if (static_cast<bool>(options & ForestBuildingOptions::kUseFixedBase))
+    return BaseBodyJointType::kWeldJoint;
+  return BaseBodyJointType::kQuaternionFloatingJoint;
 }
 
 template <typename T>
@@ -962,21 +1012,20 @@ void MultibodyTree<T>::Finalize() {
       if (added_joint.traits_index() ==
           LinkJointGraph::quaternion_floating_joint_traits_index()) {
         return AddEphemeralJoint<QuaternionFloatingJoint>(
-            added_joint.name(), world_body(),
+            added_joint.name(), world_link(),
             get_body(added_joint.child_link_index()));
       }
       if (added_joint.traits_index() ==
           LinkJointGraph::rpy_floating_joint_traits_index()) {
         return AddEphemeralJoint<RpyFloatingJoint>(
-            added_joint.name(), world_body(),
+            added_joint.name(), world_link(),
             get_body(added_joint.child_link_index()));
       }
       if (added_joint.traits_index() ==
           LinkJointGraph::weld_joint_traits_index()) {
         return AddEphemeralJoint<WeldJoint>(
-            added_joint.name(), world_body(),
-            get_body(added_joint.child_link_index()),
-            math::RigidTransform<double>());
+            added_joint.name(), world_link(),
+            get_body(added_joint.child_link_index()), RigidTransform<double>());
       }
       DRAKE_UNREACHABLE();
     }();
@@ -1001,17 +1050,17 @@ template <typename T>
 void MultibodyTree<T>::CreateBodyNode(MobodIndex mobod_index) {
   const SpanningForest::Mobod& mobod = forest().mobods(mobod_index);
   const LinkJointGraph::Link& active_link =
-      forest().links(mobod.link_ordinal());
+      forest().links(mobod.active_link_ordinal());
   const BodyIndex body_index = active_link.index();
 
-  const RigidBody<T>& body = rigid_bodies_.get_element(body_index);
+  const RigidBody<T>& body = links_.get_element(body_index);
 
   std::unique_ptr<BodyNode<T>> body_node;
   const Mobilizer<T>* const mobilizer = mobilizers_[mobod_index].get();
   if (body_index == world_index()) {
-    body_node = std::make_unique<BodyNodeWorld<T>>(&world_body(), mobilizer);
+    body_node = std::make_unique<BodyNodeWorld<T>>(&world_link(), mobilizer);
   } else {
-    BodyNode<T>* parent_node = body_nodes_[mobod.inboard()].get();
+    BodyNode<T>* parent_node = body_nodes_[mobod.inboard_mobod()].get();
 
     // Only the mobilizer knows how to create a BodyNode with compile-time
     // fixed sizes.
@@ -1277,19 +1326,23 @@ void MultibodyTree<T>::SetFreeBodyRandomAnglesDistributionOrThrow(
   maybe_rpy_mobilizer->set_random_angles_distribution(angles.vector());
 }
 
-// Note that the result is indexed by BodyIndex, not MobodIndex.
+// Note that the result is indexed by BodyIndex (LinkIndex), not MobodIndex.
+// That is, we're returning X_WL for each Link L.
 template <typename T>
 void MultibodyTree<T>::CalcAllBodyPosesInWorld(
     const systems::Context<T>& context,
-    std::vector<RigidTransform<T>>* X_WB) const {
-  DRAKE_THROW_UNLESS(X_WB != nullptr);
-  if (ssize(*X_WB) != num_bodies()) {
-    X_WB->resize(num_bodies(), RigidTransform<T>::Identity());
+    std::vector<RigidTransform<T>>* X_WL) const {
+  DRAKE_THROW_UNLESS(X_WL != nullptr);
+  if (ssize(*X_WL) != num_links()) {
+    X_WL->resize(num_links(), RigidTransform<T>::Identity());
   }
+
+  // TODO(sherm1) We're indexing by LinkOrdinal here but the caller expects
+  //  LinkIndex instead. However, those are identical currently since we don't
+  //  support removing links. Fix this when we do.
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  for (BodyIndex body_index(0); body_index < num_bodies(); ++body_index) {
-    const MobodIndex mobod_index = get_body(body_index).mobod_index();
-    X_WB->at(body_index) = pc.get_X_WB(mobod_index);
+  for (LinkOrdinal ordinal(0); ordinal < num_links(); ++ordinal) {
+    X_WL->at(ordinal) = pc.get_X_WL(ordinal);
   }
 }
 
@@ -1299,11 +1352,11 @@ void MultibodyTree<T>::CalcAllBodySpatialVelocitiesInWorld(
     const systems::Context<T>& context,
     std::vector<SpatialVelocity<T>>* V_WB) const {
   DRAKE_THROW_UNLESS(V_WB != nullptr);
-  if (ssize(*V_WB) != num_bodies()) {
-    V_WB->resize(num_bodies(), SpatialVelocity<T>::Zero());
+  if (ssize(*V_WB) != num_links()) {
+    V_WB->resize(num_links(), SpatialVelocity<T>::Zero());
   }
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
-  for (BodyIndex body_index(0); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(0); body_index < num_links(); ++body_index) {
     const MobodIndex mobod_index = get_body(body_index).mobod_index();
     V_WB->at(body_index) = vc.get_V_WB(mobod_index);
   }
@@ -1370,7 +1423,7 @@ void MultibodyTree<T>::CalcBlockSystemJacobianCache(
     // Note: Tree mobods never include World.
     for (const SpanningForest::Mobod& mobod : tree) {
       const MobodIndex index_B = mobod.index();
-      const MobodIndex index_P = mobod.inboard();
+      const MobodIndex index_P = mobod.inboard_mobod();
       const SpanningForest::Mobod& parent = forest().mobods(index_P);
       const Vector3<T>& p_PoBo_W = pc.get_p_PoBo_W(index_B);
       const int row_B = 6 * (index_B - base_index);
@@ -1392,7 +1445,7 @@ void MultibodyTree<T>::CalcBlockSystemJacobianCache(
           Jvi_V_WB.template head<3>() = w_WP;
           Jvi_V_WB.template tail<3>() = v_WP + w_WP.cross(p_PoBo_W);
         }
-        ancestor = &forest().mobods(ancestor->inboard());
+        ancestor = &forest().mobods(ancestor->inboard_mobod());
       }
       // Parent contributions are done, just need to fill in the local
       // contribution from H_PB_W.
@@ -1453,7 +1506,7 @@ void MultibodyTree<T>::CalcSpatialInertiasInWorld(
   // Skip the world.
   // TODO(joemasterjohn): Consider an optimization to avoid calculating spatial
   //  inertias for locked floating bodies.
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     const RigidTransform<T>& X_WB = pc.get_X_WB(body.mobod_index());
 
@@ -1640,7 +1693,7 @@ void MultibodyTree<T>::CalcDynamicBiasForces(
   const VelocityKinematicsCache<T>& vc = this->EvalVelocityKinematics(context);
 
   // Skip the world.
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
 
     const SpatialInertia<T>& M_B_W =
@@ -1727,8 +1780,8 @@ VectorX<T> MultibodyTree<T>::CalcInverseDynamics(
     const systems::Context<T>& context, const VectorX<T>& known_vdot,
     const MultibodyForces<T>& external_forces) const {
   // Temporary storage used in the computation of inverse dynamics.
-  std::vector<SpatialAcceleration<T>> A_WB(num_bodies());
-  std::vector<SpatialForce<T>> F_BMo_W(num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB(num_links());
+  std::vector<SpatialForce<T>> F_BMo_W(num_links());
   VectorX<T> tau(num_velocities());
   CalcInverseDynamics(context, known_vdot, external_forces.body_forces(),
                       external_forces.generalized_forces(), &A_WB, &F_BMo_W,
@@ -2085,9 +2138,9 @@ RigidTransform<T> MultibodyTree<T>::CalcRelativeTransform(
   // Find each Frame's pose on its own body (F on A, G on B).
   const FrameBodyPoseCache<T>& frame_body_pose_cache =
       EvalFrameBodyPoses(context);
-  const math::RigidTransform<T>& X_AF =
+  const RigidTransform<T>& X_AF =
       frame_F.get_X_BF(frame_body_pose_cache);  // B==A
-  const math::RigidTransform<T>& X_BG =
+  const RigidTransform<T>& X_BG =
       frame_G.get_X_BF(frame_body_pose_cache);  // F==G
 
   // Find each body's pose in World.
@@ -2163,7 +2216,7 @@ void MultibodyTree<T>::CalcPointsVelocities(
 template <typename T>
 T MultibodyTree<T>::CalcTotalMass(const systems::Context<T>& context) const {
   T total_mass = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     const T& body_mass = body.get_mass(context);
     total_mass += body_mass;
@@ -2176,7 +2229,7 @@ T MultibodyTree<T>::CalcTotalMass(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances) const {
   T total_mass = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
@@ -2190,7 +2243,7 @@ T MultibodyTree<T>::CalcTotalMass(
 template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const systems::Context<T>& context) const {
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2202,7 +2255,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   Vector3<T> sum_mi_pi = Vector3<T>::Zero();
 
   // Sum over all the bodies except the 0th body (which is the world body).
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
 
     // total_mass = ∑ mᵢ.
@@ -2230,7 +2283,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const std::vector<ModelInstanceIndex>& model_instances) const {
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2250,7 +2303,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
@@ -2313,7 +2366,7 @@ SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
     if (body_index == 0) continue;  // No contribution from the world body.
 
     // Ensure MultibodyPlant method contains a valid body_index.
-    if (body_index >= num_bodies()) {
+    if (body_index >= num_links()) {
       throw std::logic_error(
           "CalcSpatialInertia(): contains an invalid BodyIndex.");
     }
@@ -2345,7 +2398,7 @@ SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
 template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
     const systems::Context<T>& context) const {
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2357,7 +2410,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   Vector3<T> sum_mi_vi = Vector3<T>::Zero();
 
   // Sum over all the bodies except the 0th body (which is the world body).
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
 
     // total_mass = ∑ mᵢ.
@@ -2389,7 +2442,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
     const std::vector<ModelInstanceIndex>& model_instances) const {
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2409,7 +2462,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
@@ -2445,7 +2498,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
 template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
     const systems::Context<T>& context) const {
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2459,7 +2512,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // issue a significantly less helpful exception message.
   // Sum over all the bodies except the 0th body (which is the world body).
   T total_mass = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     const T& body_mass = body.get_mass(context);
     total_mass += body_mass;  // total_mass = ∑ mᵢ.
@@ -2473,7 +2526,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
 
   // Sum over all the bodies except the 0th body (which is the world body).
   Vector3<T> sum_mi_ai = Vector3<T>::Zero();
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     const T& body_mass = body.get_mass(context);
     const Vector3<T> ai_WBcm_W =
@@ -2492,7 +2545,7 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances) const {
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -2509,7 +2562,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // is listed multiple times.
   T total_mass = 0;
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
@@ -2543,7 +2596,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
   // The code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   Vector3<T> sum_mi_ai = Vector3<T>::Zero();
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
@@ -2620,7 +2673,7 @@ SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
     if (body_index == 0) continue;  // No contribution from the world body.
 
     // Ensure MultibodyPlant method contains a valid body_index.
-    DRAKE_DEMAND(body_index < num_bodies());
+    DRAKE_DEMAND(body_index < num_links());
 
     // Form the current body's spatial momentum in W about Bo, expressed in W.
     const MobodIndex mobod_index = get_body(body_index).mobod_index();
@@ -2645,7 +2698,7 @@ const RigidTransform<T>& MultibodyTree<T>::EvalBodyPoseInWorld(
     const systems::Context<T>& context, const RigidBody<T>& body_B) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   body_B.HasThisParentTreeOrThrow(this);
-  return EvalPositionKinematics(context).get_X_WB(body_B.mobod_index());
+  return EvalPositionKinematics(context).get_X_WL(body_B.ordinal());
 }
 
 template <typename T>
@@ -2653,7 +2706,7 @@ const SpatialVelocity<T>& MultibodyTree<T>::EvalBodySpatialVelocityInWorld(
     const systems::Context<T>& context, const RigidBody<T>& body_B) const {
   DRAKE_MBT_THROW_IF_NOT_FINALIZED();
   body_B.HasThisParentTreeOrThrow(this);
-  return EvalVelocityKinematics(context).get_V_WB(body_B.mobod_index());
+  return EvalVelocityKinematics(context).get_V_WL(body_B.ordinal());
 }
 
 template <typename T>
@@ -2700,7 +2753,7 @@ void MultibodyTree<T>::CalcAllBodyBiasSpatialAccelerationsInWorld(
 
   // Ensure AsBias_WB_all is a not nullptr and is properly sized.
   DRAKE_THROW_UNLESS(AsBias_WB_all != nullptr);
-  DRAKE_THROW_UNLESS(static_cast<int>(AsBias_WB_all->size()) == num_bodies());
+  DRAKE_THROW_UNLESS(static_cast<int>(AsBias_WB_all->size()) == num_links());
 
   // To calculate a generic body A's spatial acceleration bias in world W,
   // note that body A's spatial velocity in world W is
@@ -2727,7 +2780,7 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcBiasSpatialAcceleration(
 
   // Reserve room to store all the bodies' spatial acceleration bias in world W.
   // TODO(Mitiguy) Inefficient use of heap. Per issue #13560, implement caching.
-  std::vector<SpatialAcceleration<T>> AsBias_WB_all(num_bodies());
+  std::vector<SpatialAcceleration<T>> AsBias_WB_all(num_links());
   CalcAllBodyBiasSpatialAccelerationsInWorld(context, with_respect_to,
                                              &AsBias_WB_all);
 
@@ -3304,7 +3357,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   DRAKE_THROW_UNLESS(Js_v_AScm_E->cols() == num_columns);
 
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -3314,7 +3367,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
 
   Js_v_AScm_E->setZero();
   T composite_mass = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     const Vector3<T> pi_BoBcm = body.CalcCenterOfMassInBodyFrame(context);
     MatrixX<T> Jsi_v_ABcm_E(3, num_columns);
@@ -3348,7 +3401,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   DRAKE_THROW_UNLESS(Js_v_AScm_E->cols() == num_columns);
 
   // Reminder: MultibodyTree always declares a world body.
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -3368,7 +3421,7 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
@@ -3412,7 +3465,7 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
     const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
     const Frame<T>& frame_A, const Frame<T>& frame_E) const {
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -3422,7 +3475,7 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
 
   T composite_mass = 0;
   Vector3<T> asBias_AScm_E = Vector3<T>::Zero();
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     const Vector3<T> pi_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
     const Frame<T>& frame_B = body.body_frame();
@@ -3449,7 +3502,7 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
     JacobianWrtVariable with_respect_to, const Frame<T>& frame_A,
     const Frame<T>& frame_E) const {
   // Reminder: MultibodyTree always declares a world body (0ᵗʰ body).
-  if (num_bodies() <= 1) {
+  if (num_links() <= 1) {
     std::string message = fmt::format(
         "{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.",
@@ -3468,7 +3521,7 @@ Vector3<T> MultibodyTree<T>::CalcBiasCenterOfMassTranslationalAcceleration(
   // code below ensures a body's contribution to the sum occurs only once.
   // Duplicate model_instances in std::vector are ignored.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
@@ -3528,7 +3581,7 @@ T MultibodyTree<T>::CalcKineticEnergy(
   const VectorX<T>& reflected_inertia = EvalReflectedInertiaCache(context);
   T twice_kinetic_energy_W = 0.0;
   // Add contributions from each body (except World).
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const MobodIndex mobod_index = get_body(body_index).mobod_index();
     const SpatialInertia<T>& M_B_W = M_Bi_W[mobod_index];
     const SpatialVelocity<T>& V_WB = vc.get_V_WB(mobod_index);
@@ -3615,12 +3668,14 @@ void MultibodyTree<T>::ThrowDefaultMassInertiaError() const {
     // At this point we're looking at a non-World, terminal WeldedMobods group.
     // Find the matching WeldedLinksAssembly that carries the mass properties.
     const std::optional<WeldedLinksAssemblyIndex> link_assembly_index =
-        graph().links(active_mobod.link_ordinal()).welded_links_assembly();
+        graph()
+            .links(active_mobod.active_link_ordinal())
+            .welded_links_assembly();
     DRAKE_DEMAND(link_assembly_index.has_value());  // Should be an assembly!
     const auto& link_assembly =
         graph().welded_links_assemblies(*link_assembly_index);
     DRAKE_DEMAND(link_assembly.links()[0] ==
-                 graph().links(active_mobod.link_ordinal()).index());
+                 graph().links(active_mobod.active_link_ordinal()).index());
 
     ThrowIfTerminalBodyHasBadDefaultMassProperties(link_assembly.links(),
                                                    active_mobod.index());
@@ -3632,7 +3687,7 @@ void MultibodyTree<T>::ThrowDefaultMassInertiaError() const {
     if (!mobod.is_leaf_mobod()) continue;  // An interior Mobod.
 
     ThrowIfTerminalBodyHasBadDefaultMassProperties(
-        {graph().links(mobod.link_ordinal()).index()}, mobod.index());
+        {graph().links(mobod.active_link_ordinal()).index()}, mobod.index());
   }
 }
 
@@ -4106,7 +4161,7 @@ std::unique_ptr<MultibodyTree<ToScalar>> MultibodyTree<T>::CloneToScalar()
   tree_clone->frames_.ResizeToMatch(frames_);
 
   // Skipping the world body at body_index = 0.
-  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links(); ++body_index) {
     const RigidBody<T>& body = get_body(body_index);
     tree_clone->CloneBodyAndAdd(body);
   }
@@ -4219,7 +4274,7 @@ RigidBody<T>* MultibodyTree<T>::CloneBodyAndAdd(
   // The order in which bodies are added into owned_bodies_ is important to keep
   // the topology invariant. Therefore this method is called from
   // MultibodyTree::CloneToScalar() within a loop by original body_index.
-  return &rigid_bodies_.Add(std::move(body_clone));
+  return &links_.Add(std::move(body_clone));
 }
 
 template <typename T>
@@ -4282,11 +4337,11 @@ std::optional<BodyIndex> MultibodyTree<T>::MaybeGetUniqueBaseBodyIndex(
   // just one of those.
   const SpanningForest::Mobod& world = forest().world_mobod();
   std::optional<BodyIndex> base_body_index{};
-  for (const MobodIndex& base_mobod_index : world.outboards()) {
+  for (const MobodIndex& base_mobod_index : world.outboard_mobods()) {
     const SpanningForest::Mobod& base_mobod = forest().mobods(base_mobod_index);
     DRAKE_DEMAND(base_mobod.level() == 1);
     const LinkJointGraph::Link& active_link =
-        forest().links(base_mobod.link_ordinal());
+        forest().links(base_mobod.active_link_ordinal());
     if (active_link.model_instance() != model_instance) continue;
     if (base_body_index.has_value())  // Not unique if already set.
       return std::nullopt;

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -36,9 +36,13 @@ namespace multibody {
 template <typename T>
 class RigidBodyFrame;
 template <typename T>
+using LinkFrame = RigidBodyFrame<T>;
+template <typename T>
 class Frame;
 template <typename T>
 class RigidBody;
+template <typename T>
+using Link = RigidBody<T>;
 template <typename T>
 class Joint;
 template <typename T>
@@ -54,6 +58,16 @@ class UniformGravityFieldElement;
 enum class JacobianWrtVariable {
   kQDot,  ///< J = ∂V/∂q̇
   kV      ///< J = ∂V/∂v
+};
+
+/// The kind of joint to be used to connect base bodies to world at Finalize().
+/// See @ref mbp_working_with_free_bodies "Working with free bodies"
+/// for definitions and discussion.
+/// @see SetBaseBodyJointType() for details.
+enum class BaseBodyJointType {
+  kQuaternionFloatingJoint,  ///< 6 dofs, unrestricted orientation.
+  kRpyFloatingJoint,         ///< 6 dofs using 3 angles; has singularity.
+  kWeldJoint,                ///< 0 dofs, fixed to World.
 };
 
 /// @cond
@@ -81,122 +95,135 @@ class Mobilizer;
 template <typename T>
 class QuaternionFloatingMobilizer;
 
-// %MultibodyTree provides a representation for a physical system consisting of
-// a collection of interconnected rigid and deformable bodies. As such, it owns
-// and manages each of the elements that belong to this physical system.
-// Multibody dynamics elements include bodies, joints, force elements and
-// constraints.
+// MultibodyTree provides a representation for a physical system consisting of a
+// collection of interconnected rigid bodies. As such, it owns and manages
+// each of the elements that belong to this physical system. Multibody
+// dynamics elements include links, joints, force elements and constraints.
 //
-// @tparam_default_scalar
+// @note for unfortunate historical reasons, the user-facing API provided by
+// MultibodyPlant uses RigidBody for the user-specified object that should
+// have been called Link, because multiple links can be welded together to
+// form a single rigid body. MultibodyPlant methods often have "Body" in their
+// name when they are really referring to links, and use BodyIndex to select
+// individual RigidBody objects. Luckily the link/rigid body distinction
+// doesn't matter much in the user-facing API, but it matters a lot internally
+// where the distinction between a Link and a (possibly multi-link) rigid body
+// is critical. We will be strict internally to use Link and LinkIndex for the
+// user-provided objects (those are aliases for RigidBody and BodyIndex,
+// resp.). We call the true rigid bodies "mobilized bodies" or Mobods (indexed
+// by MobodIndex), but sometimes just "bodies" where the context is clear.
+// The internal terminology is consistent with multibody/topology.
+//
+// Since MultibodyTree is the internal implementation class for MultibodyPlant,
+// error messages that are to be delivered to users must be aware of the
+// terminology differences and use terms the user will understand.
 template <typename T>
 class MultibodyTree {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyTree);
 
-  // Creates a MultibodyTree containing only a **world** body and a
+  // Creates a MultibodyTree containing only a World link and a
   // UniformGravityFieldElement.
   MultibodyTree();
 
   ~MultibodyTree();
 
-  // @name Methods to add new MultibodyTree elements.
-  //
-  // To create a %MultibodyTree users will add multibody elements like bodies,
+  // Methods to add new MultibodyTree elements
+
+  // To create a MultibodyTree users will add multibody elements like links,
   // joints, force elements, constraints, etc, using one of these methods.
   // Once a user is done adding multibody elements, the Finalize() method
-  // **must** be called before invoking any %MultibodyTree method.
+  // **must** be called before invoking any MultibodyTree method.
   // See Finalize() for details.
-  // @{
-  // See this Reviewable comment:
-  // https://reviewable.io/reviews/robotlocomotion/drake/5583#-KgGqGisnX9uMuYDkHpx
 
-  // Creates a rigid body with the provided name, model instance, and spatial
-  // inertia.  This method returns a constant reference to the body just added,
-  // which will remain valid for the lifetime of `this` %MultibodyTree.
+  // Creates a Link (a.k.a. RigidBody) with the provided name, model instance,
+  // and spatial inertia. This method returns a constant reference to the
+  // link just added, which will remain valid for the lifetime of `this`
+  // MultibodyTree.
   //
   // Example of usage:
   // @code
   //   MultibodyTree<T> model;
   //   // ... Code to define spatial_inertia, a SpatialInertia<T> object ...
   //   ModelInstanceIndex model_instance = model.AddModelInstance("instance");
-  //   const RigidBody<T>& body =
-  //     model.AddRigidBody("BodyName", model_instance, spatial_inertia);
+  //   const Link<T>& link =
+  //     model.AddLink("LinkName", model_instance, spatial_inertia);
   // @endcode
   //
   // @param[in] name
-  //   A string that identifies the new body to be added to `this` model. A
-  //   std::runtime_error is thrown if a body named `name` already is part of
-  //   @p model_instance. See HasBodyNamed(), RigidBody::name().
+  //   A string that identifies the new link to be added to `this` model. A
+  //   std::runtime_error is thrown if a link named `name` already is part of
+  //   @p model_instance. See HasLinkNamed(), RigidBody::name().
   // @param[in] model_instance
   //   A model instance index which this body is part of.
-  // @param[in] M_BBo_B
-  //   The SpatialInertia of the new rigid body to be added to `this` model,
-  //   computed about the body frame origin `Bo` and expressed in the body
-  //   frame B.
-  // @returns A constant reference to the new RigidBody just added, which will
-  //          remain valid for the lifetime of `this` %MultibodyTree.
-  // @throws std::exception if a body named `name` already exists in this
+  // @param[in] M_LLo_L
+  //   The SpatialInertia of the new link to be added to `this` model,
+  //   computed about the link frame origin Lo and expressed in the link
+  //   frame L.
+  // @returns A constant reference to the new Link just added, which will
+  //          remain valid for the lifetime of `this` MultibodyTree.
+  // @throws std::exception if a link named `name` already exists in this
   //         model instance.
   // @throws std::exception if the model instance does not exist.
-  const RigidBody<T>& AddRigidBody(const std::string& name,
-                                   ModelInstanceIndex model_instance,
-                                   const SpatialInertia<double>& M_BBo_B);
+  const Link<T>& AddLink(const std::string& name,
+                         ModelInstanceIndex model_instance,
+                         const SpatialInertia<double>& M_LLo_L);
 
-  // Creates a rigid body with the provided name, model instance, and spatial
-  // inertia.  The newly created body will be placed in the default model
-  // instance.  This method returns a constant reference to the body just
-  // added, which will remain valid for the lifetime of `this` %MultibodyTree.
+  // Creates a Link with the provided name, and spatial inertia. The newly
+  // created link will be placed in the default model instance. This method
+  // returns a constant reference to the link just added, which will remain
+  // valid for the lifetime of `this` MultibodyTree.
   //
   // Example of usage:
   // @code
   //   MultibodyTree<T> model;
   //   // ... Code to define spatial_inertia, a SpatialInertia<T> object ...
-  //   const RigidBody<T>& body =
-  //     model.AddRigidBody("BodyName", spatial_inertia);
+  //   const Link<T>& link =
+  //     model.AddLink("LinkName", spatial_inertia);
   // @endcode
   //
   // @param[in] name
-  //   A string that identifies the new body to be added to `this` model. A
-  //   std::runtime_error is thrown if a body named `name` already is part of
-  //   the model in the default model instance. See HasBodyNamed(),
+  //   A string that identifies the new link to be added to `this` model. A
+  //   std::runtime_error is thrown if a link named `name` already is part of
+  //   the model in the default model instance. See HasLinkNamed(),
   //   RigidBody::name().
-  // @param[in] M_BBo_B
-  //   The SpatialInertia of the new rigid body to be added to `this` model,
-  //   computed about the body frame origin `Bo` and expressed in the body
-  //   frame B.
-  // @returns A constant reference to the new RigidBody just added, which will
-  //          remain valid for the lifetime of `this` %MultibodyTree.
-  // @throws std::exception if a body named `name` already exists.
+  // @param[in] M_LLo_L
+  //   The SpatialInertia of the new link to be added to `this` model,
+  //   computed about the link frame origin Lo and expressed in the link
+  //   frame L.
+  // @returns A constant reference to the new Link just added, which will
+  //          remain valid for the lifetime of `this` MultibodyTree.
+  // @throws std::exception if a link named `name` already exists.
   // @throws std::exception if additional model instances have been created
   //                        beyond the world and default instances.
-  const RigidBody<T>& AddRigidBody(const std::string& name,
-                                   const SpatialInertia<double>& M_BBo_B);
+  const Link<T>& AddLink(const std::string& name,
+                         const SpatialInertia<double>& M_LLo_L);
 
-  // Takes ownership of `frame` and adds it to `this` %MultibodyTree. Returns
+  // Takes ownership of `frame` and adds it to `this` MultibodyTree. Returns
   // a constant reference to the frame just added, which will remain valid for
-  // the lifetime of `this` %MultibodyTree.
+  // the lifetime of `this` MultibodyTree.
   //
   // Example of usage:
   // @code
   //   MultibodyTree<T> model;
-  //   // ... Define body and X_BF ...
+  //   // ... Define link and X_BF ...
   //   const FixedOffsetFrame<T>& frame =
-  //       model.AddFrame(std::make_unique<FixedOffsetFrame<T>>(body, X_BF));
+  //       model.AddFrame(std::make_unique<FixedOffsetFrame<T>>(link, X_BF));
   // @endcode
   //
   // @throws std::exception if `frame` is a nullptr.
   // @throws std::exception if Finalize() was already called on `this` tree.
   //
   // @param[in] frame A unique pointer to a frame to be added to `this`
-  //                  %MultibodyTree. The frame class must be specialized on
-  //                  the same scalar type T as this %MultibodyTree.
+  //                  MultibodyTree. The frame class must be specialized on
+  //                  the same scalar type T as this MultibodyTree.
   // @returns A constant reference of type `FrameType` to the created frame.
   //          This reference which will remain valid for the lifetime of `this`
-  //          %MultibodyTree.
+  //          MultibodyTree.
   //
   // @tparam FrameType The type of the specific sub-class of Frame to add. The
   //                   template needs to be specialized on the same scalar type
-  //                   T of this %MultibodyTree.
+  //                   T of this MultibodyTree.
   template <template <typename Scalar> class FrameType>
   const FrameType<T>& AddFrame(std::unique_ptr<FrameType<T>> frame);
 
@@ -205,16 +232,16 @@ class MultibodyTree {
   const FrameType<T>& AddEphemeralFrame(std::unique_ptr<FrameType<T>> frame);
 
   // Constructs a new frame with type `FrameType` with the given `args`, and
-  // adds it to `this` %MultibodyTree, which retains ownership. The `FrameType`
-  // will be specialized on the scalar type T of this %MultibodyTree.
+  // adds it to `this` MultibodyTree, which retains ownership. The `FrameType`
+  // will be specialized on the scalar type T of this MultibodyTree.
   //
   // Example of usage:
   // @code
   //   MultibodyTree<T> model;
-  //   // ... Define body and X_BF ...
+  //   // ... Define link and X_BF ...
   //   // Notice FixedOffsetFrame is a template an a scalar type.
   //   const FixedOffsetFrame<T>& frame =
-  //       model.AddFrame<FixedOffsetFrame>(body, X_BF);
+  //       model.AddFrame<FixedOffsetFrame>(link, X_BF);
   // @endcode
   //
   // Note that for dependent names you must use the template keyword (say for
@@ -222,9 +249,9 @@ class MultibodyTree {
   //
   // @code
   //   MultibodyTree<T> model;
-  //   // ... Define body and X_BF ...
+  //   // ... Define link and X_BF ...
   //   const auto& frame =
-  //       model.template AddFrame<FixedOffsetFrame>(body, X_BF);
+  //       model.template AddFrame<FixedOffsetFrame>(link, X_BF);
   // @endcode
   //
   // @throws std::exception if Finalize() was already called on `this` tree.
@@ -234,17 +261,17 @@ class MultibodyTree {
   //                 that takes these arguments.
   // @returns A constant reference of type `FrameType` to the created frame.
   //          This reference which will remain valid for the lifetime of `this`
-  //          %MultibodyTree.
+  //          MultibodyTree.
   //
   // @tparam FrameType A template for the type of Frame to construct. The
   //                   template will be specialized on the scalar type T of
-  //                   this %MultibodyTree.
+  //                   this MultibodyTree.
   template <template <typename Scalar> class FrameType, typename... Args>
   const FrameType<T>& AddFrame(Args&&... args);
 
-  // Takes ownership of `mobilizer` and adds it to `this` %MultibodyTree.
+  // Takes ownership of `mobilizer` and adds it to `this` MultibodyTree.
   // Returns a constant reference to the mobilizer just added, which will
-  // remain valid for the lifetime of `this` %MultibodyTree.
+  // remain valid for the lifetime of `this` MultibodyTree.
   //
   // Example of usage:
   // @code
@@ -268,24 +295,24 @@ class MultibodyTree {
   // than one mobilizer between them.
   //
   // @param[in] mobilizer A unique pointer to a mobilizer to add to `this`
-  //                      %MultibodyTree. The mobilizer class must be
+  //                      MultibodyTree. The mobilizer class must be
   //                      specialized on the same scalar type T as this
-  //                      %MultibodyTree. Notice this is a requirement of this
+  //                      MultibodyTree. Notice this is a requirement of this
   //                      method's signature and therefore an input mobilzer
   //                      specialized on a different scalar type than that of
-  //                      this %MultibodyTree's T will fail to compile.
+  //                      this MultibodyTree's T will fail to compile.
   // @returns A constant reference of type `MobilizerType` to the created
   //          mobilizer. This reference which will remain valid for the
-  //          lifetime of `this` %MultibodyTree.
+  //          lifetime of `this` MultibodyTree.
   //
   // @tparam MobilizerType The type of the specific sub-class of Mobilizer to
   //                       add. The template needs to be specialized on the
-  //                       same scalar type T of this %MultibodyTree.
+  //                       same scalar type T of this MultibodyTree.
   template <template <typename Scalar> class MobilizerType>
   const MobilizerType<T>& AddMobilizer(
       std::unique_ptr<MobilizerType<T>> mobilizer);
 
-  // Creates and adds to `this` %MultibodyTree (which retains ownership) a new
+  // Creates and adds to `this` MultibodyTree (which retains ownership) a new
   // `ForceElement` member with the specific type `ForceElementType`. The
   // arguments to this method `args` are forwarded to `ForceElementType`'s
   // constructor.
@@ -296,7 +323,7 @@ class MultibodyTree {
   // field element.
   //
   // The newly created `ForceElementType` object will be specialized on the
-  // scalar type T of this %MultibodyTree.
+  // scalar type T of this MultibodyTree.
   template <template <typename Scalar> class ForceElementType>
   const ForceElementType<T>& AddForceElement(
       std::unique_ptr<ForceElementType<T>> force_element);
@@ -307,7 +334,7 @@ class MultibodyTree {
   void MaybeSetUniformGravityFieldElement(ForceElement<T>* force_element);
 
   // Adds a new force element model of type `ForceElementType` to `this`
-  // %MultibodyTree.  The arguments to this method `args` are forwarded to
+  // MultibodyTree.  The arguments to this method `args` are forwarded to
   // `ForceElementType`'s constructor.
   // @param[in] args
   //   Zero or more parameters provided to the constructor of the new force
@@ -321,8 +348,8 @@ class MultibodyTree {
   //   field element.
   // @returns A constant reference to the new ForceElement just added, of type
   //   `ForceElementType<T>` specialized on the scalar type T of `this`
-  //   %MultibodyTree. It will remain valid for the lifetime of `this`
-  //   %MultibodyTree.
+  //   MultibodyTree. It will remain valid for the lifetime of `this`
+  //   MultibodyTree.
   // @see The ForceElement class's documentation for further details on how a
   // force element is defined.
   // @throws std::exception if gravity was already added to the model.
@@ -335,46 +362,47 @@ class MultibodyTree {
   const JointType<T>& AddJoint(std::unique_ptr<JointType<T>> joint,
                                bool is_ephemeral_joint = false);
 
-  // This method adds a Joint of type `JointType` between two bodies.
-  // The two bodies connected by this Joint object are referred to as _parent_
-  // and _child_ bodies. The parent/child ordering defines the sign conventions
-  // for the generalized coordinates and the coordinate ordering for multi-DOF
-  // joints.  Our use of the terms _parent_ and _child_ does 𝐧𝐨𝐭 describe the
-  // inboard/outboard relationship between bodies as our usage of inboard/
-  // outboard is more general and is also meaningful for multibody systems
-  // with loops, such as four-bar linkages.  However, when possible the
-  // _parent_ body is made inboard and the _child_ outboard in the tree.
+  // This method adds a Joint of type `JointType` between two links. The two
+  // links connected by this Joint object are referred to as _parent_ and
+  // _child_ links. The parent/child ordering defines the sign conventions
+  // for the generalized coordinates and the coordinate ordering for
+  // multi-DOF joints. Our use of the terms _parent_ and _child_ does 𝐧𝐨𝐭
+  // describe the inboard/outboard relationship between mobilized bodies in
+  // the generated forest as our usage of inboard/outboard is restricted to
+  // a tree topology while parent/child is also meaningful for multibody
+  // systems with loops, such as four-bar linkages. However, when possible
+  // the _parent_ link is made inboard and the _child_ outboard in the tree.
   //
-  // As explained in the Joint class's documentation, in Drake we define a
-  // frame Jp attached to the parent body P with pose `X_PJp` and a frame Jc
-  // attached to the child body C with pose `X_CJc`. This method helps create
-  // a joint between two bodies with fixed poses `X_PJp` and `X_CJc`.
-  // Refer to the Joint class's documentation for more details. (We have
-  // sometimes used F for Jp and M for Jc in documentation; don't confuse
-  // those with the implementing Mobilizer's inboard F frame and outboard M
-  // frame which in general are not the same.)
+  // As explained in the Joint class's documentation, in Drake we define a frame
+  // Jp attached to the parent link P with pose `X_PJp` and a frame Jc
+  // attached to the child link C with pose `X_CJc`. This method helps
+  // create a joint between two links with fixed poses `X_PJp` and `X_CJc`.
+  // Refer to the Joint class's documentation for more details. (Sadly, we
+  // have sometimes used F for Jp and M for Jc in documentation; don't
+  // confuse those with the implementing Mobilizer's inboard F frame and
+  // outboard M frame which in general are not the same.)
   //
   // The arguments to this method `args` are forwarded to `JointType`'s
   // constructor. The newly created `JointType` object will be specialized on
-  // the scalar type T of this %MultibodyTree.
+  // the scalar type T of this MultibodyTree.
   //
   // @param[in] name
   //   The name of the joint.
   // @param[in] parent
-  //   The parent body connected by the new joint.
+  //   The parent link connected by the new joint.
   // @param[in] X_PJp
-  //   The fixed pose of frame Jp attached to the parent body, measured in
-  //   the frame P of that body. X_PJp is an optional parameter; empty curly
-  //   braces {} imply that frame Jp **is** the same body frame P. If instead
+  //   The fixed pose of frame Jp attached to the parent link, measured in
+  //   the frame P of that link. X_PJp is an optional parameter; empty curly
+  //   braces {} imply that frame Jp **is** the same link frame P. If instead
   //   your intention is to make a separate frame Jp that is coincident
   //   (by default at least) with P, provide
   //   X_PJp = RigidTransform<double>::Identity() as your input.
   // @param[in] child
-  //   The child body connected by the new joint.
+  //   The child link connected by the new joint.
   // @param[in] X_CJc
-  //   The fixed pose of frame Jc attached to the child body, measured in
-  //   the frame C of that body. X_CJc is an optional parameter; empty curly
-  //   braces {} imply that frame Jc **is** the same body frame C. If instead
+  //   The fixed pose of frame Jc attached to the child link, measured in
+  //   the frame C of that link. X_CJc is an optional parameter; empty curly
+  //   braces {} imply that frame Jc **is** the same link frame C. If instead
   //   your intention is to make a separate frame Jc that is coincident
   //   (by default at least) with C, provide
   //   X_CJc = RigidTransform<double>::Identity() as your input.
@@ -382,25 +410,25 @@ class MultibodyTree {
   //   The type of the new joint to add, which must be a subclass of Joint<T>.
   // @returns A const reference to the new joint just added, of type
   //   JointType<T> specialized on the scalar type T of `this`
-  //   %MultibodyTree. It will remain valid for the lifetime of `this`
-  //   %MultibodyTree.
+  //   MultibodyTree. It will remain valid for the lifetime of `this`
+  //   MultibodyTree.
   //
   // Example of usage:
   // @code
   //   MultibodyTree<T> model;
-  //   // ... Code to define a parent body P and a child body C.
-  //   const RigidBody<double>& parent_body =
-  //     model.AddRigidBody(parent_name, SpatialInertia<double>(...));
-  //   const RigidBody<double>& child_body =
-  //     model.AddRigidBody(child_name, SpatialInertia<double>(...));
-  //   // Define the pose X_CJc of a frame Jc rigidly attached to child body C.
+  //   // ... Code to define a parent link P and a child link C.
+  //   const Link<double>& parent_link =
+  //     model.AddLink(parent_name, SpatialInertia<double>(...));
+  //   const Link<double>& child_link =
+  //     model.AddLink(child_name, SpatialInertia<double>(...));
+  //   // Define the pose X_CJc of a frame Jc rigidly attached to child link C.
   //   const RevoluteJoint<double>& elbow =
   //     model.AddJoint<RevoluteJoint>(
   //       "Elbow",                /* joint name */
-  //       model.world_body(),     /* parent body */
-  //       {},                     /* frame Jp IS the parent body frame P */
-  //       pendulum,               /* child body, the pendulum */
-  //       X_CJc,                  /* pose of frame Jc in child body frame C */
+  //       model.world_body(),     /* parent link */
+  //       {},                     /* frame Jp IS the parent link frame P */
+  //       pendulum,               /* child link, the pendulum */
+  //       X_CJc,                  /* pose of frame Jc in child link frame C */
   //       Vector3d::UnitZ());     /* revolute axis in this case */
   // @endcode
   //
@@ -412,9 +440,9 @@ class MultibodyTree {
   // is defined.
   template <template <typename> class JointType, typename... Args>
   const JointType<T>& AddJoint(
-      const std::string& name, const RigidBody<T>& parent,
+      const std::string& name, const Link<T>& parent,
       const std::optional<math::RigidTransform<double>>& X_PJp,
-      const RigidBody<T>& child,
+      const Link<T>& child,
       const std::optional<math::RigidTransform<double>>& X_CJc, Args&&... args);
 
   // See MultibodyPlant documentation.
@@ -422,7 +450,7 @@ class MultibodyTree {
 
   // Creates and adds a JointActuator model for an actuator acting on a given
   // `joint`. This method returns a const reference to the actuator just added,
-  // which will remain valid for the lifetime of `this` %MultibodyTree.
+  // which will remain valid for the lifetime of `this` MultibodyTree.
   //
   // @param[in] name
   //   A string that identifies the new actuator to be added to `this`
@@ -435,7 +463,7 @@ class MultibodyTree {
   //   The maximum effort for the actuator. It must be greater than 0. If
   //   the user does not set this value, the default value is +∞.
   // @returns A constant reference to the new JointActuator just added, which
-  // will remain valid for the lifetime of `this` %MultibodyTree.
+  // will remain valid for the lifetime of `this` MultibodyTree.
   // @throws std::exception if `this` model already contains a joint actuator
   // with the given `name`. See HasJointActuatorNamed(),
   // JointActuator::get_name().
@@ -475,17 +503,16 @@ class MultibodyTree {
   void RenameModelInstance(ModelInstanceIndex model_instance,
                            const std::string& name);
 
-  // @}
   // Closes Doxygen section "Methods to add new MultibodyTree elements."
 
   // See MultibodyPlant method.
   int num_frames() const { return frames_.num_elements(); }
 
-  // Returns the number of RigidBodies in the %MultibodyPlant including World.
-  // Therefore the minimum number of bodies is one.
-  int num_bodies() const { return rigid_bodies_.num_elements(); }
+  // Returns the number of Links (aka RigidBodies) in the MultibodyPlant
+  // including World. Therefore the minimum number of links is one.
+  int num_links() const { return links_.num_elements(); }
 
-  // Returns the number of joints added with AddJoint() to the %MultibodyTree.
+  // Returns the number of joints added with AddJoint() to the MultibodyTree.
   int num_joints() const { return joints_.num_elements(); }
 
   // Returns the number of actuators in the model.
@@ -555,7 +582,7 @@ class MultibodyTree {
     return model_instances_.get_element(model_instance).num_actuated_dofs();
   }
 
-  // Returns the height of the Forest data structure of `this` %MultibodyTree.
+  // Returns the height of the Forest data structure of `this` MultibodyTree.
   // That is, the number of bodies in the longest kinematic path between the
   // world and any leaf body. For a model that only contains World, the height
   // of the forest is one.
@@ -564,31 +591,31 @@ class MultibodyTree {
   // could only be considered in the model using constraints.
   int forest_height() const { return forest().height(); }
 
-  // Returns a constant reference to the *world* body.
-  const RigidBody<T>& world_body() const {
-    // world_rigid_body_ is set in the constructor. So this assert is here only
+  // Returns a constant reference to the *world* link.
+  const Link<T>& world_link() const {
+    // world_link_ is set in the constructor. So this assert is here only
     // to verify future constructors do not mess that up.
-    DRAKE_ASSERT(world_rigid_body_ != nullptr);
-    return *world_rigid_body_;
+    DRAKE_ASSERT(world_link_ != nullptr);
+    return *world_link_;
   }
 
   // Returns a constant reference to the *world* frame.
-  const RigidBodyFrame<T>& world_frame() const {
-    return rigid_bodies_.get_element_unchecked(world_index()).body_frame();
+  const LinkFrame<T>& world_frame() const {
+    return links_.get_element_unchecked(world_index()).link_frame();
   }
 
-  // See MultibodyPlant method.
-  bool has_body(BodyIndex body_index) const {
-    return rigid_bodies_.has_element(body_index);
+  // See MultibodyPlant method has_body().
+  bool has_link(LinkIndex link_index) const {
+    return links_.has_element(link_index);
   }
 
-  // See MultibodyPlant method.
-  const RigidBody<T>& get_body(BodyIndex body_index) const {
-    return rigid_bodies_.get_element(body_index);
+  // See MultibodyPlant method get_body().
+  const Link<T>& get_link(LinkIndex link_index) const {
+    return links_.get_element(link_index);
   }
 
-  RigidBody<T>& get_mutable_body(BodyIndex body_index) {
-    return rigid_bodies_.get_mutable_element(body_index);
+  Link<T>& get_mutable_link(LinkIndex link_index) {
+    return links_.get_mutable_element(link_index);
   }
 
   // See MultibodyPlant method.
@@ -700,30 +727,30 @@ class MultibodyTree {
   const RigidBody<T>& GetUniqueFloatingBaseBodyOrThrowImpl(
       ModelInstanceIndex model_instance) const;
 
-  // @name Querying for multibody elements by name
+  // Querying for multibody elements by name
+
   // These methods allow a user to query whether a given multibody element is
   // part of `this` model. These queries can be performed at any time during
-  // the lifetime of a %MultibodyTree model, i.e. there is no restriction on
+  // the lifetime of a MultibodyTree model, i.e. there is no restriction on
   // whether they must be called before or after Finalize(). That is, these
   // queries can be performed while new multibody elements are being added to
   // the model.
-  // @{
 
-  // See MultibodyPlant method.
-  int NumBodiesWithName(std::string_view name) const;
+  // See MultibodyPlant method NumBodiesWithName().
+  int NumLinksWithName(std::string_view name) const;
 
-  // @returns `true` if a body named `name` was added to the model.
-  // @see AddRigidBody().
+  // @returns `true` if a link named `name` was added to the model.
+  // @see AddLink().
   //
-  // @throws std::exception if the body name occurs in multiple model
+  // @throws std::exception if the link name occurs in multiple model
   // instances.
-  bool HasBodyNamed(std::string_view name) const;
+  bool HasLinkNamed(std::string_view name) const;
 
-  // @returns `true` if a body named `name` was added to @p model_instance.
-  // @see AddRigidBody().
+  // @returns `true` if a link named `name` was added to @p model_instance.
+  // @see AddLink().
   //
   // @throws std::exception if @p model_instance is not valid for this model.
-  bool HasBodyNamed(std::string_view name,
+  bool HasLinkNamed(std::string_view name,
                     ModelInstanceIndex model_instance) const;
 
   // See MultibodyPlant method.
@@ -749,15 +776,14 @@ class MultibodyTree {
 
   // See MultibodyMethod.
   bool HasModelInstanceNamed(std::string_view name) const;
-  // @}
 
-  // Returns a list of body indices associated with `model_instance`.
-  std::vector<BodyIndex> GetBodyIndices(
+  // Returns a list of link indices associated with `model_instance`.
+  std::vector<LinkIndex> GetLinkIndices(
       ModelInstanceIndex model_instance) const;
 
   // See MultibodyPlant method.
   const std::vector<JointIndex>& GetJointIndices() const {
-    return joints_.indices();
+    return joints_.valid_indices();
   }
 
   // Returns a list of joint indices associated with `model_instance`.
@@ -766,7 +792,7 @@ class MultibodyTree {
 
   // See MultibodyPlant method.
   const std::vector<JointActuatorIndex>& GetJointActuatorIndices() const {
-    return actuators_.indices();
+    return actuators_.valid_indices();
   }
 
   // See MultibodyPlant method.
@@ -788,12 +814,12 @@ class MultibodyTree {
   const Frame<T>& GetFrameByName(std::string_view name,
                                  ModelInstanceIndex model_instance) const;
 
-  // See MultibodyPlant method.
-  const RigidBody<T>& GetRigidBodyByName(std::string_view name) const;
+  // See MultibodyPlant method GetRigidBodyByName(name).
+  const RigidBody<T>& GetLinkByName(std::string_view name) const;
 
-  // See MultibodyPlant method.
-  const RigidBody<T>& GetRigidBodyByName(
-      std::string_view name, ModelInstanceIndex model_instance) const;
+  // See MultibodyPlant method GetRigidBodyByName(name, model_instance).
+  const RigidBody<T>& GetLinkByName(std::string_view name,
+                                    ModelInstanceIndex model_instance) const;
 
   // See MultibodyPlant method.
   template <template <typename> class JointType = Joint>
@@ -835,25 +861,24 @@ class MultibodyTree {
 
   // See MultibodyPlant method.
   ModelInstanceIndex GetModelInstanceByName(std::string_view name) const;
-  // @}
 
   // Returns `true` if this MultibodyTree was finalized successfully with
   // Finalize() after all multibody elements were added.
   bool is_finalized() const { return is_finalized_; }
 
-  // Returns the set of RigidBodies that are affected kinematically by the given
-  // Joints' degrees of freedom. Weld joints are ignored. Otherwise this is just
-  // the set of Links in the subtrees rooted by these Joints' implementing
+  // Returns the set of Links that are affected kinematically by the given
+  // joints' degrees of freedom. Weld joints are ignored. Otherwise this is just
+  // the set of Links in the subtrees rooted by these joints' implementing
   // Mobods.
-  std::set<BodyIndex> GetBodiesKinematicallyAffectedBy(
+  std::set<LinkIndex> GetLinksKinematicallyAffectedBy(
       const std::vector<JointIndex>& joint_indexes) const;
 
-  // Returns the set of RigidBodies that are on the same Mobod or outboard of
-  // the given bodies. This is just the set of rigid bodies in the subtrees
-  // rooted by these bodies' implementing Mobods. The given bodies are always
+  // Returns the set of Links that are on the same Mobod or outboard of
+  // the given links. This is just the set of links in the subtrees
+  // rooted by these links' implementing Mobods. The given links are always
   // included.
-  std::set<BodyIndex> GetBodiesOutboardOfBodies(
-      const std::vector<BodyIndex>& body_indexes) const;
+  std::set<LinkIndex> GetLinksOutboardOfLinks(
+      const std::vector<LinkIndex>& link_indexes) const;
 
   // Returns the mobilizer model for joint with index `joint_index`. The index
   // is invalid if the joint is not modeled with a mobilizer.
@@ -862,12 +887,12 @@ class MultibodyTree {
     return joint_to_mobilizer_.at(joint_index);
   }
 
-  // @name Model instance accessors
-  // Many functions on %MultibodyTree expect vectors of tree state or
+  // Model instance accessors
+
+  // Many functions on MultibodyTree expect vectors of tree state or
   // joint actuator inputs which encompass the entire tree.  Methods
   // in this section are convenience accessors for the portion of
   // those vectors which apply to a single model instance only.
-  // @{
 
   // See MultibodyPlant method.
   VectorX<T> GetActuationFromArray(ModelInstanceIndex model_instance,
@@ -911,7 +936,6 @@ class MultibodyTree {
                             const Eigen::Ref<const VectorX<T>>& v_instance,
                             EigenPtr<VectorX<T>> v) const;
 
-  // @}
   // End of "Model instance accessors" section.
 
   // MultibodyPlant invokes this to construct a spanning forest/loop constraint
@@ -936,6 +960,15 @@ class MultibodyTree {
     return forest().mobods(index);
   }
 
+  // See MultibodyPlant API.
+  void SetBaseBodyJointType(
+      BaseBodyJointType joint_type,
+      std::optional<ModelInstanceIndex> model_instance = {});
+
+  // See MultibodyPlant API.
+  BaseBodyJointType GetBaseBodyJointType(
+      std::optional<ModelInstanceIndex> model_instance = {}) const;
+
   // Finalize() must be called after all user-defined elements in the plant
   // (joints, bodies, force elements, constraints, etc.) have been added and
   // before any computations are performed. It compiles all the necessary
@@ -954,7 +987,7 @@ class MultibodyTree {
   // @throws std::exception if called post-finalize.
   void Finalize();
 
-  // (Advanced) Allocates a new context for this %MultibodyTree uniquely
+  // (Advanced) Allocates a new context for this MultibodyTree uniquely
   // identifying the state of the multibody system.
   //
   // @throws std::exception if this is not owned by a MultibodyPlant /
@@ -1082,22 +1115,27 @@ class MultibodyTree {
       const RigidBody<T>& body,
       const math::RollPitchYaw<symbolic::Expression>& angles);
 
-  // @name Kinematic computations
+  // Kinematic computations
+
   // Kinematics computations are concerned with the motion of bodies in the
   // model without regard to their mass or the forces and moments that cause
   // the motion. Methods in this category include the computation of poses and
   // spatial velocities.
-  // @{
 
-  // See MultibodyPlant method.
-  void CalcAllBodyPosesInWorld(
+  // Evaluates the position cache if necessary, then extracts all the link
+  // poses and returns them indexed by LinkIndex (BodyIndex). The slots that
+  // correspond to invalid indices will be filled with identity poses.
+  void CalcAllLinkPosesInWorld(
       const systems::Context<T>& context,
-      std::vector<math::RigidTransform<T>>* X_WB) const;
+      std::vector<math::RigidTransform<T>>* X_WL) const;
 
-  // See MultibodyPlant method.
-  void CalcAllBodySpatialVelocitiesInWorld(
+  // Evaluates the velocity cache if necessary, then extracts all the link
+  // spatial velocities and returns them indexed by LinkIndex (BodyIndex). The
+  // slots that correspond to invalid indices will be filled with NaN spatial
+  // velocities.
+  void CalcAllLinkSpatialVelocitiesInWorld(
       const systems::Context<T>& context,
-      std::vector<SpatialVelocity<T>>* V_WB) const;
+      std::vector<SpatialVelocity<T>>* V_WL) const;
 
   // See MultibodyPlant method.
   math::RigidTransform<T> CalcRelativeTransform(
@@ -1172,23 +1210,21 @@ class MultibodyTree {
       const std::vector<ModelInstanceIndex>& model_instances,
       const Vector3<T>& p_WoP_W) const;
 
-  // See MultibodyPlant method.
-  const math::RigidTransform<T>& EvalBodyPoseInWorld(
-      const systems::Context<T>& context, const RigidBody<T>& body_B) const;
+  // See MultibodyPlant method EvalBodyPoseInWorld().
+  const math::RigidTransform<T>& EvalLinkPoseInWorld(
+      const systems::Context<T>& context, const Link<T>& link_L) const;
 
-  // See MultibodyPlantMethod.
-  const SpatialVelocity<T>& EvalBodySpatialVelocityInWorld(
-      const systems::Context<T>& context, const RigidBody<T>& body_B) const;
+  // See MultibodyPlantMethod EvalBodySpatialVelocityInWorld().
+  const SpatialVelocity<T>& EvalLinkSpatialVelocityInWorld(
+      const systems::Context<T>& context, const Link<T>& link_L) const;
 
-  // See MultibodyPlantMethod.
-  const SpatialAcceleration<T>& EvalBodySpatialAccelerationInWorld(
-      const systems::Context<T>& context, const RigidBody<T>& body_B) const;
+  // See MultibodyPlantMethod EvalBodySpatialAccelerationInWorld().
+  const SpatialAcceleration<T>& EvalLinkSpatialAccelerationInWorld(
+      const systems::Context<T>& context, const Link<T>& link_L) const;
 
-  // @}
   // End of "Kinematic computations" section.
 
-  // @name Methods to compute multibody Jacobians.
-  // @{
+  // Methods to compute multibody Jacobians.
 
   // See MultibodyPlant method.
   void CalcJacobianSpatialVelocity(const systems::Context<T>& context,
@@ -1213,9 +1249,9 @@ class MultibodyTree {
   // For each point Bi of (fixed to) a frame B whose translational velocity
   // `v_ABi` in a frame A is characterized by speeds 𝑠, Bi's translational
   // velocity Jacobian in A with respect to 𝑠 is defined as
-  // <pre>
+  //
   //      Js_v_ABi = [ ∂(v_ABi)/∂𝑠₁,  ...  ∂(v_ABi)/∂𝑠ₙ ]    (n is j or k)
-  // </pre>
+  //
   // Point Bi's velocity in A is linear in 𝑠₁, ... 𝑠ₙ and can be written
   // `v_ABi = Js_v_ABi ⋅ 𝑠`  where 𝑠 is [𝑠₁ ... 𝑠ₙ]ᵀ.
   //
@@ -1284,10 +1320,9 @@ class MultibodyTree {
       const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
       const Frame<T>& frame_B, const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
       const Frame<T>& frame_A, const Frame<T>& frame_E) const;
-  // @}
-  // End of multibody Jacobian methods section.
 
-  // @name Computational methods
+  // Computational methods
+
   // These methods expose the computational capabilities of MultibodyTree to
   // compute kinematics, forward and inverse dynamics, and Jacobian matrices,
   // among others.
@@ -1296,7 +1331,6 @@ class MultibodyTree {
   // to the quantity or object of interest to be computed. They all take a
   // `systems::Context` as an input argument storing the state of the multibody
   // system.
-  // @{
 
   // Computes into the position kinematics `pc` all the kinematic quantities
   // that depend on the generalized positions only. These include:
@@ -1340,9 +1374,9 @@ class MultibodyTree {
   // @param[out] M_B_W_all
   //   For each body in the model, entry RigidBody::mobod_index() in M_B_W_all
   //   contains the updated spatial inertia `M_B_W(q)` for that body. On input
-  //   it must be a valid pointer to a vector of size num_bodies().
+  //   it must be a valid pointer to a vector of size num_mobods().
   // @throws std::exception if M_B_W_all is nullptr or if its size is not
-  // num_bodies().
+  // num_mobods().
   void CalcSpatialInertiasInWorld(
       const systems::Context<T>& context,
       std::vector<SpatialInertia<T>>* M_B_W_all) const;
@@ -1389,19 +1423,20 @@ class MultibodyTree {
       const systems::Context<T>& context,
       std::vector<SpatialInertia<T>>* K_BBo_W_all) const;
 
-  // Computes the bias force `Fb_Bo_W(q, v)` for each body in the model.
-  // For a body B, this is the bias term `Fb_Bo_W` in the equation
+  // Computes the bias force `Fb_Bo_W(q, v)` for each mobod in the model.
+  // For a mobod B, this is the bias term `Fb_Bo_W` in the equation
   // `F_BBo_W = M_Bo_W * A_WB + Fb_Bo_W`, where `M_Bo_W` is the spatial inertia
   // about B's origin Bo, `A_WB` is the spatial acceleration of B in W and
   // `F_BBo_W` is the spatial force applied on B about Bo, expressed in W.
   // @param[in] context
   //   The context storing the state of the model.
   // @param[out] Fb_Bo_W_all
-  //   For each body in the model, entry RigidBody::mobod_index() in Fb_Bo_W_all
-  //   contains the updated bias term `Fb_Bo_W(q, v)` for that body. On input
-  //   it must be a valid pointer to a vector of size num_bodies().
+  //   For each mobod in the model, entry RigidBody::mobod_index() in
+  //   Fb_Bo_W_all contains the updated bias term `Fb_Bo_W(q, v)` for that
+  //   mobod. On input it must be a valid pointer to a vector of size
+  //   num_mobods().
   // @throws std::exception if Fb_Bo_W_cache is nullptr or if its size is not
-  // num_bodies().
+  // num_mobods().
   void CalcDynamicBiasForces(const systems::Context<T>& context,
                              std::vector<SpatialForce<T>>* Fb_Bo_W_all) const;
 
@@ -1413,7 +1448,7 @@ class MultibodyTree {
   //   expressed in the world frame W.
   //
   // @param[in] context
-  //   The context containing the state of the %MultibodyTree model.
+  //   The context containing the state of the MultibodyTree model.
   // @param[in] pc
   //   A position kinematics cache object already updated to be in sync with
   //   `context`.
@@ -1421,7 +1456,7 @@ class MultibodyTree {
   //   A velocity kinematics cache object already updated to be in sync with
   //   `context`.
   // @param[in] known_vdot
-  //   A vector with the generalized accelerations for the full %MultibodyTree
+  //   A vector with the generalized accelerations for the full MultibodyTree
   //   model.
   // @param[out] ac
   //   A pointer to a valid, non nullptr, acceleration kinematics cache. This
@@ -1453,10 +1488,10 @@ class MultibodyTree {
   // known vector of generalized accelerations vdot, this method computes the
   // set of generalized forces tau that would need to be applied at each
   // Mobilizer in order to attain the specified generalized accelerations.
-  // Mathematically, this method computes: <pre>
+  // Mathematically, this method computes:
   //   tau = M(q)v̇ + C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W
-  // </pre>
-  // where M(q) is the %MultibodyTree mass matrix, C(q, v)v is the bias
+  //
+  // where M(q) is the MultibodyTree mass matrix, C(q, v)v is the bias
   // term containing Coriolis and gyroscopic effects and tau_app consists
   // of a vector applied generalized forces. The last term is a summation over
   // all bodies in the model where Fapp_Bo_W is an applied spatial force on
@@ -1538,9 +1573,9 @@ class MultibodyTree {
   // known vector of generalized accelerations `vdot`, this method computes the
   // set of generalized forces `tau_id` that would need to be applied at each
   // Mobilizer in order to attain the specified generalized accelerations.
-  // Mathematically, this method computes: <pre>
+  // Mathematically, this method computes:
   //   tau_id = M(q)v̇ + C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W
-  // </pre>
+  //
   // where `M(q)` is the mass matrix, `C(q, v)v` is the bias
   // term containing Coriolis and gyroscopic effects and `tau_app` consists
   // of a vector applied generalized forces.
@@ -1620,28 +1655,28 @@ class MultibodyTree {
   Eigen::SparseMatrix<T> MakeQDotToVelocityMap(
       const systems::Context<T>& context) const;
 
-  /*
-  @anchor internal_forward_dynamics
-  @name Articulated Body Algorithm Forward Dynamics.
+  /* @anchor internal_forward_dynamics
+  Articulated Body Algorithm Forward Dynamics
+
   The Articulated Body Algorithm (ABA) implements a forward dynamics
   computation with O(n) complexity. The algorithm is implemented in terms of
   three main passes:
   1. CalcArticulatedBodyInertiaCache(): which performs a tip-to-base pass to
-     compute the ArticulatedBodyInertia for each body along with other ABA
-     quantities that are configuration dependent only.
+     compute the ArticulatedBodyInertia for each mobilized body along with other
+     ABA quantities that are configuration dependent only.
   2. CalcArticulatedBodyForceCache(): a second tip-to-base pass which
      essentially computes the bias terms in the ABA equations. These are a
      function of the full state x = [q; v] and externally applied actuation and
      forces.
   3. CalcArticulatedBodyAccelerations(): which performs a final base-to-tip
-     recursion to compute the acceleration of each body in the model. These
-     accelerations are a function of the ArticulatedBodyForceCache
+     recursion to compute the acceleration of each mobilized body in the model.
+     These accelerations are a function of the ArticulatedBodyForceCache
      previously computed by CalcArticulatedBodyForces(). That is, accelerations
      are a function of state x and applied forces.
 
-  The Newton-Euler equations governing the motion of a rigid body are: <pre>
+  The Newton-Euler equations governing the motion of a rigid body are:
     Fapp_B = M_B * A_WB + Fb_B
-  </pre>
+
   which describe the effect of the total applied spatial forces Fapp_B on the
   spatial acceleration A_WB of a **rigid body** B with spatial inertia M_B.
   Fb_B is the spatial force bias containing gyroscopic terms.
@@ -1650,9 +1685,9 @@ class MultibodyTree {
   between the spatial acceleration and external forces for a body that belongs
   to a system of rigid bodies or **articulated body**. In particular, if this
   body is the root (or handle) of an articulated body system, the reaction force
-  needed to enforce its the motion with acceleration A_WB is given by: <pre>
+  needed to enforce its the motion with acceleration A_WB is given by:
     F_B = P_B * A_WB + Z_B                                                   (1)
-  </pre>
+
   where F_B is now the spatial force needed to induce the spatial acceleration
   A_WB of this root body B being part of a larger articulated system. Z_B is
   the articulated body spatial forces bias term and P_B the articulated body
@@ -1694,10 +1729,10 @@ class MultibodyTree {
      reference.
 
   Articulated body inertias and force biases can be computed by a recursive tip
-  to base assembly process (Eqs. 7.21-7.24 in [Featherstone, 2008]): <pre>
+  to base assembly process (Eqs. 7.21-7.24 in [Featherstone, 2008]):
     P_B_W = M_B_W + Σᵢ Pplus_BCib_W                                          (2)
     Z_B_W = Fb_B_W - Fapp_B_W + Σᵢ Zplus_Cib_W                               (3)
-  </pre>
+
   where M_B_W is the SpatialInertia of body B, P_B_W its
   ArticulatedBodyInertia, Fapp_B_W are the externally applied forces, and
   Pplus_BCib_W and Zplus_Cib_W are the effective ABI and force bias of an
@@ -1705,30 +1740,30 @@ class MultibodyTree {
   of Ci. Both Pplus_BCib_W and Zplus_Cib_W are shifted to B and expressed in W.
   The role of Pplus_BCib_W and Zplus_Cib_W is clearer when considering the
   equation to compute the reaction force at the mobilizer constraining the
-  motion of body B (Eq. 7.25 in [Featherstone, 2008]): <pre>
+  motion of body B (Eq. 7.25 in [Featherstone, 2008]):
     F_B_W = Pplus_PB_W * Aplus_WB + Zplus_B_W                                (4)
-  </pre>
+
   This equation mirrors Eq. (1) but it is written in terms of the rigidly
   shifted spatial acceleration `Aplus_WB = Φᵀ(p_PB) * A_WP`, or
   Aplus_WB.Shift(p_PB_W) in code.
 
   The articulated body inertia Pplus can be computed once P_B_W is obtained from
-  Eq. (2): <pre>
+  Eq. (2):
      Pplus_PB_W = P_B_W - P_B_W * H_PB_W * D_B⁻¹ * H_PB_Wᵀ * P_B_W
                 = P_B_W - g_B_W * U_B_W                                      (5)
-  </pre>
-  where: <pre>
+
+  where:
     D_B = H_PB_Wᵀ * P_B_W * H_PB_W ∈ ℝᵐˣᵐ                                    (6)
     U_B_W = H_PB_Wᵀ * P_B_W ∈ ℝᵐˣ⁶                                           (7)
     g_B_W = U_B_Wᵀ * D_B⁻¹ ∈ ℝ⁶ˣᵐ                                            (8)
-  </pre>
+
   with m the number of mobilities of body B. U_B_W and g_B_W are useful
   configuration dependent quantities that appear several times in the ABA. The
   force bias Zplus across the mobilizer is computed once the Z_B_W is obtained
-  from Eq. (3): <pre>
+  from Eq. (3):
     Zplus_B_W = Z_B_W + Pplus_PB_W * Ab_WB + g_B_W * e_B                     (9)
     e_B = tau_B - H_PB_Wᵀ * Z_B_W                                           (10)
-  </pre>
+
   where tau_B are the applied generalized forces on body B's mobilizer. Notice
   that, given their definition in Eqs. (3) and (9), the ABA force bias terms
   Z_B_W and Zplus_B_W are not only a function of the velocity dependent
@@ -1756,37 +1791,37 @@ class MultibodyTree {
   Zjplus_B_W, and ej_B the bias terms as defined by Jain. They have different
   numerical values than those introduced by [Featherstone, 2008] (even after
   making the conversion from Plücker to Jain's spatial algebra.)
-  A detailed analysis of the two reveals that: <pre>
+  A detailed analysis of the two reveals that:
     Zjplus_B_W = Zplus_B_W
     Zj_B_W = Z_B_W + P_B_W * Ab_WB
     ej_B = e_B - H_PB_Wᵀ * P_B_W * Ab_WB
-  </pre>
+
   which then translates into the differences we observe with [Jain, 2010,
-  Algorithm 7.2]: <pre>
+  Algorithm 7.2]:
     Zj_B_W = Fb_B_W - Fapp_B_W + Σᵢ Zplus_Cib_W + P_B_W * Ab_WB
     Z_B_W  = Fb_B_W - Fapp_B_W + Σᵢ Zplus_Cib_W,                    from Eq. (3)
-  </pre>
+
   where the term with Ab_WB does not appear in our Eq. (3).
-  <pre>
+
     Zjplus_B_W = Zj_B_W + g_B_W * ej_B
     Zplus_B_W  = Z_B_W  + g_B_W * e_B + Pplus_PB_W * Ab_WB,         from Eq. (9)
-  </pre>
+
   where notice our Eq. (9) has the additional term Pplus_PB_W * Ab_WB. However,
   as mentioned above, the numerical values of Zplus_B_W and Zjplus_B_W are
   exactly the same given the difference cancels out through the additional terms
   present in ej_B, see below. Finally:
-  <pre>
+
     ej_B = tau_B - H_PB_Wᵀ * Zj_B_W
     e_B  = tau_B - H_PB_Wᵀ * Z_B_W,                                from Eq. (10)
-  </pre>
+
   which is deceivingly the same as our Eq. (10), however the result is
   different given it has Zj_B_W in it, which numerically differs from Z_B_W.
   This different definition of the force bias leads to a different expression
   for the computation of reaction forces in terms of the articulated body
-  quantities: <pre>
+  quantities:
     F_B = P_B * A_WB + Z_B,             [Featherstone, 2008, Eq. 7.25]
     F_B = P_B * (A_WB - Ab_WB) + Zj_B,  [Jain, 2010, Eq. 7.34]
-  </pre>
+
   In Drake we prefer Featherstone's definition of the force bias terms given the
   parallelism of the joint reaction forces equation with the Newton-Euler
   equations.
@@ -1796,11 +1831,11 @@ class MultibodyTree {
   Once ABA inertias and force bias terms are computed according to Eqs.
   (2)-(10), the computation of accelerations is remarkably simple. The last base
   to tip pass of the algorithm stems from combining the following three
-  equations: <pre>
+  equations:
     A_WB = Aplus_WB + Ab_WB + H_PB_W * vdot_B                              (11a)
     F_B_W = P_B_W * A_WB + Z_B_W                                           (11b)
     tau_B = H_PB_Wᵀ * F_B_W                                                (11c)
-  </pre>
+
   Equation (11a) is the motion constraint imposed by the body's mobilizer,
   where the spatial acceleration bias Ab_WB = Ac_WB + Ab_PB includes the
   centrifugal and Coriolis terms Ac_WB documented in
@@ -1808,57 +1843,57 @@ class MultibodyTree {
   term across the mobilizer Ab_PB (A_PB = H_PB * vdot_B + Ab_PB.)
   Equation (11b) is the articulated body force balance from Eq. (1) and Eq.
   (11c) projects the reaction force F_B to obtain the generalized forces tau_B.
-  We substitute Eqs. (11a) and (11b) into (11c) to obtain: <pre>
+  We substitute Eqs. (11a) and (11b) into (11c) to obtain:
     H_PB_Wᵀ*[P_B_W * (Aplus_WB + Ab_WB + H_PB_W * vdot_B) + Z_B_W] = tau_B  (12)
-  </pre>
+
   we then factor out terms grouping vdot_B, acceleration biases and forcing:
-  <pre>
+
     (H_PB_Wᵀ*P_B_W*H_PB_W) * vdot_B + (H_PB_Wᵀ*P_B_W) * (Aplus_WB + Ab_WB ) =
       tau_B - H_PB_Wᵀ * Z_B_W                                               (13)
-  </pre>
-  using the definitions in Eqs. (6)-(8), we can rewrite (13) as: <pre>
+
+  using the definitions in Eqs. (6)-(8), we can rewrite (13) as:
     D_B * vdot_B + U_B_W * (Aplus_WB + Ab_WB) = e_B                         (14)
-  </pre>
+
   Therefore the last base-to-tip pass updates generalized accelerations and
-  spatial accelerations according to: <pre>
+  spatial accelerations according to:
     vdot_B = D_B⁻¹ * e_B - g_B_Wᵀ * (Aplus_WB + Ab_WB)                      (15)
     A_WB = Aplus_WB + Ab_WB + H_PB_W * vdot_B                               (16)
-  </pre>
+
   This is implemented in CalcArticulatedBodyAccelerations().
 
   @note Given the different definition of Z and Zplus used by [Featherstone,
-  2008] and [Jain, 2010], the acceleration update used by Jain is: <pre>
+  2008] and [Jain, 2010], the acceleration update used by Jain is:
     vdot_B = D_B⁻¹ * e_B  - g_B_Wᵀ * (Aplus_WB + Ab_WB),           from Eq. (15)
     vdot_B = D_B⁻¹ * ej_B - g_B_Wᵀ * Aplus_WB,            [Jain, 2010. Alg. 7.2]
-  </pre>
+
 
   <h3> Additional Diagonal Inertias </h3>
   @anchor additional_diagonal_inertias
 
   We can model additional diagonal inertias by considering external generalized
-  forces of the form: <pre>
+  forces of the form:
     tau_B <-- -d_B * vdot_B + tau_B                                         (17)
-  </pre>
+
   That is, we update tau_B to include the term -d_B * vdot_B, for the mobilities
   of each body B. Such form of the generalized forces can be used to model fluid
   virtual masses, reflected inertias and/or even effective inertias result of
   discrete time stepping schemes.
 
   When Eq. (17) is used into Eq. (14), the update for vdot_B in Eq. (15) remains
-  exactly the same but with D_B updated to: <pre>
+  exactly the same but with D_B updated to:
     D_B <-- D_B + d_B
-  </pre>
+
   With this modification to D_B, the algorithm remains the same.
 
   We remark that the modeling of this term is equivalent to adding a diagonal
   term D = diag{d_B} (the concantenation of each d_B to form the diagonal matrix
   D) to the mass matrix. This can be seen by considering the Newton-Euler
-  equations of motion: <pre>
+  equations of motion:
     M⋅v̇ + C⋅v = τ − D⋅v̇
-  </pre>
-  which can then rewritten as: <pre>
+
+  which can then rewritten as:
     (M+D)⋅v̇ + C⋅v = τ
-  </pre>
+
   resulting on the same Newton-Euler equations but with the updated mass matrix
   M+D.
 
@@ -1907,12 +1942,11 @@ class MultibodyTree {
                 algorithms. Springer Science & Business Media, pp. 123-130.
   - [Featherstone 2008] Featherstone, R., 2008. Rigid body dynamics algorithms.
                         Springer.
-   @{
   */
 
   // Performs a tip-to-base pass to compute the ArticulatedBodyInertia for each
-  // body as a function of the configuration q stored in `context`. The
-  // computation is stored in `abic` along with other Articulated Body
+  // mobilized body as a function of the configuration q stored in `context`.
+  // The computation is stored in `abic` along with other Articulated Body
   // Algorithm (ABA) quantities.
   void CalcArticulatedBodyInertiaCache(
       const systems::Context<T>& context,
@@ -1936,28 +1970,28 @@ class MultibodyTree {
       const ArticulatedBodyForceCache<T>& aba_force_cache,
       AccelerationKinematicsCache<T>* ac) const;
 
-  // For a body B, computes the spatial acceleration bias term `Ab_WB` as it
-  // appears in the acceleration level motion constraint imposed by body B's
+  // For a mobilized body B, computes the spatial acceleration bias term `Ab_WB`
+  // as it appears in the acceleration level motion constraint imposed by B's
   // mobilizer `A_WB = Aplus_WB + Ab_WB + H_PB_W * vdot_B`, with `Aplus_WB =
   // Φᵀ(p_PB) * A_WP` the rigidly shifted spatial acceleration of the inboard
-  // body P and `H_PB_W` and `vdot_B` its mobilizer's hinge matrix and
+  // mobod P and `H_PB_W` and `vdot_B` its mobilizer's hinge matrix and
   // mobilities, respectively. See @ref abi_computing_accelerations for further
-  // details. On output `Ab_WB_all[mobod_index]`
-  // contains `Ab_WB` for the body with node index `mobod_index`.
+  // details. On output `Ab_WB_all[mobod_index]` contains `Ab_WB` for each mobod
+  // with index `mobod_index`.
   void CalcSpatialAccelerationBias(
       const systems::Context<T>& context,
       std::vector<SpatialAcceleration<T>>* Ab_WB_all) const;
 
   // Computes the articulated body force bias `Zb_Bo_W = Pplus_PB_W * Ab_WB`
-  // for each articulated body B. On output `Zb_Bo_W_all[mobod_index]`
-  // contains `Zb_Bo_W` for the body B with node index `mobod_index`.
+  // for each articulated mobod B. On output `Zb_Bo_W_all[mobod_index]`
+  // contains `Zb_Bo_W` for each mobod B with index `mobod_index`.
   void CalcArticulatedBodyForceBias(
       const systems::Context<T>& context,
       std::vector<SpatialForce<T>>* Zb_Bo_W_all) const;
 
-  /*
-  @anchor forward_dynamics_with_diagonal_terms_apis
-  @name Alternative ABA Signatures to include diagonal inertia terms.
+  /* @anchor forward_dynamics_with_diagonal_terms_apis
+  Alternative ABA Signatures to include diagonal inertia terms
+
   These "advanced" level alternative APIs are provided so that we can
   include the modeling of additional diagonal inertias as discussed in @ref
   additional_diagonal_inertias. The additional inertias affect both articulated
@@ -1986,12 +2020,6 @@ class MultibodyTree {
       const ArticulatedBodyInertiaCache<T>& abic,
       const ArticulatedBodyForceCache<T>& aba_force_cache,
       AccelerationKinematicsCache<T>* ac) const;
-  // @}
-
-  // @} Closes "Articulated Body Algorithm Forward Dynamics" Doxygen section.
-
-  // @}
-  // Closes "Computational methods" Doxygen section.
 
   // See MultibodyPlant method.
   MatrixX<double> MakeStateSelectorMatrix(
@@ -2049,13 +2077,13 @@ class MultibodyTree {
   // See MultibodyPlant method.
   VectorX<double> GetEffortUpperLimits() const;
 
-  // @name Methods to retrieve multibody element variants
-  //
-  // Given two variants of the same %MultibodyTree, these methods map an
+  // Methods to retrieve multibody element variants
+
+  // Given two variants of the same MultibodyTree, these methods map an
   // element in one variant, to its corresponding element in the other variant.
   //
   // A concrete case is the call to ToAutoDiffXd() to obtain a
-  // %MultibodyTree variant templated on AutoDiffXd from a %MultibodyTree
+  // MultibodyTree variant templated on AutoDiffXd from a MultibodyTree
   // templated on `double`. Typically, a user holding a `RigidBody<double>` (or
   // any other multibody element in the original variant templated on `double`)
   // would like to retrieve the corresponding `RigidBody<AutoDiffXd>` variant
@@ -2079,36 +2107,26 @@ class MultibodyTree {
   //
   // MultibodyTree::get_variant() is templated on the multibody element
   // type which is deduced from its only input argument. The returned element
-  // is templated on the scalar type T of the %MultibodyTree on which this
+  // is templated on the scalar type T of the MultibodyTree on which this
   // method is invoked.
-  // @{
 
   // Overload for Frame<T> elements.
   template <typename Scalar>
   const Frame<T>& get_variant(const Frame<Scalar>& element) const {
-    // TODO(amcastro-tri):
-    //   DRAKE_DEMAND the parent tree of the variant is indeed a variant of this
-    //   MultibodyTree. That will require the tree to have some sort of id.
     const FrameIndex frame_index = element.index();
     return frames_.get_element(frame_index);
   }
 
-  // Overload for RigidBody<T> elements.
+  // Overload for Link<T> elements.
   template <typename Scalar>
-  const RigidBody<T>& get_variant(const RigidBody<Scalar>& element) const {
-    // TODO(amcastro-tri):
-    //   DRAKE_DEMAND the parent tree of the variant is indeed a variant of this
-    //   MultibodyTree. That will require the tree to have some sort of id.
-    const BodyIndex body_index = element.index();
-    return rigid_bodies_.get_element(body_index);
+  const Link<T>& get_variant(const Link<Scalar>& element) const {
+    const LinkIndex link_index = element.index();
+    return links_.get_element(link_index);
   }
 
   // Overload for Mobilizer<T> elements.
   template <typename Scalar>
   const Mobilizer<T>& get_variant(const Mobilizer<Scalar>& element) const {
-    // TODO(amcastro-tri):
-    //   DRAKE_DEMAND the parent tree of the variant is indeed a variant of this
-    //   MultibodyTree. That will require the tree to have some sort of id.
     MobodIndex mobilizer_index = element.index();
     DRAKE_DEMAND(mobilizer_index < num_mobilizers());
     const Mobilizer<T>* result = mobilizers_[mobilizer_index].get();
@@ -2117,12 +2135,8 @@ class MultibodyTree {
   }
 
   // Overload for Mobilizer<T> elements (mutable).
-  // TODO(russt): Add mutable accessors for other variants as needed.
   template <typename Scalar>
   Mobilizer<T>& get_mutable_variant(const Mobilizer<Scalar>& element) {
-    // TODO(amcastro-tri):
-    //   DRAKE_DEMAND the parent tree of the variant is indeed a variant of this
-    //   MultibodyTree. That will require the tree to have some sort of id.
     MobodIndex mobilizer_index = element.index();
     DRAKE_DEMAND(mobilizer_index < num_mobilizers());
     Mobilizer<T>* result = mobilizers_[mobilizer_index].get();
@@ -2133,24 +2147,20 @@ class MultibodyTree {
   // Overload for Joint<T> elements.
   template <typename Scalar>
   const Joint<T>& get_variant(const Joint<Scalar>& element) const {
-    // TODO(amcastro-tri):
-    //   DRAKE_DEMAND the parent tree of the variant is indeed a variant of this
-    //   MultibodyTree. That will require the tree to have some sort of id.
     const JointIndex joint_index = element.index();
     return joints_.get_element(joint_index);
   }
-  // @}
 
-  // Creates a deep copy of `this` %MultibodyTree templated on the same
+  // Creates a deep copy of `this` MultibodyTree templated on the same
   // scalar type T as `this` tree.
   std::unique_ptr<MultibodyTree<T>> Clone() const { return CloneToScalar<T>(); }
 
-  // Creates a deep copy of `this` %MultibodyTree templated on AutoDiffXd.
+  // Creates a deep copy of `this` MultibodyTree templated on AutoDiffXd.
   std::unique_ptr<MultibodyTree<AutoDiffXd>> ToAutoDiffXd() const {
     return CloneToScalar<AutoDiffXd>();
   }
 
-  // Creates a deep copy of `this` %MultibodyTree templated on the scalar type
+  // Creates a deep copy of `this` MultibodyTree templated on the scalar type
   // `ToScalar`.
   // The new deep copy is guaranteed to have exactly the same topology
   // as the original tree the method is called on. This method ensures the
@@ -2181,12 +2191,12 @@ class MultibodyTree {
   //
   // MultibodyTree::get_variant() is templated on the multibody element
   // type which is deduced from its only input argument. The returned element
-  // is templated on the scalar type T of the %MultibodyTree on which this
+  // is templated on the scalar type T of the MultibodyTree on which this
   // method is invoked.
   // In the example above, the user could have also invoked the method
   // ToAutoDiffXd().
   //
-  // @pre Finalize() must have already been called on this %MultibodyTree.
+  // @pre Finalize() must have already been called on this MultibodyTree.
   template <typename ToScalar>
   std::unique_ptr<MultibodyTree<ToScalar>> CloneToScalar() const;
 
@@ -2244,10 +2254,10 @@ class MultibodyTree {
     return tree_system_->EvalAcrossNodeJacobianWrtVExpressedInWorld(context);
   }
 
-  // @name                 State access methods
+  // State access methods
+
   // These methods use information in the MultibodyTree to determine how to
   // locate the tree's state variables in a given Context or State.
-  //@{
 
   // Returns true if we are using discrete state for positions and velocities;
   // otherwise we're using continuous state.
@@ -2363,7 +2373,6 @@ class MultibodyTree {
         get_mutable_positions_and_velocities(state);
     return make_mutable_block_segment(&qv, start, length);
   }
-  //@}
 
   // Returns the MultibodyTreeSystem that owns this MultibodyTree.
   // @pre There is an owning MultibodyTreeSystem.
@@ -2524,10 +2533,10 @@ class MultibodyTree {
         block->startRow() + start);
   }
 
-  // Takes ownership of `body` and adds it to this MultibodyTree. Returns a
-  // constant reference to the body just added, which will remain valid for the
-  // lifetime of this MultibodyTree. Public members AddRigidBody() end up here.
-  const RigidBody<T>& AddRigidBodyImpl(std::unique_ptr<RigidBody<T>> body);
+  // Takes ownership of `link` and adds it to this MultibodyTree. Returns a
+  // constant reference to the link just added, which will remain valid for the
+  // lifetime of this MultibodyTree. Public members AddLink() end up here.
+  const Link<T>& AddLinkImpl(std::unique_ptr<Link<T>> link);
 
   const Joint<T>& GetJointByNameImpl(std::string_view,
                                      std::optional<ModelInstanceIndex>) const;
@@ -2601,16 +2610,16 @@ class MultibodyTree {
       const PositionKinematicsCache<T>& pc,
       const VelocityKinematicsCache<T>& vc) const;
 
-  // For all bodies, calculate bias spatial acceleration in the world frame W.
+  // For all mobods, calculate bias spatial acceleration in the world frame W.
   // @param[in] context The state of the multibody system.
   // @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
   // JacobianWrtVariable::kV, indicating whether the spatial acceleration bias
   // is with respect to 𝑠 = q̇ or 𝑠 = v.
-  // @param[out] AsBias_WB_all Each body's spatial acceleration bias in world
+  // @param[out] AsBias_WB_all Each mobod's spatial acceleration bias in world
   // frame W, with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), expressed in frame W.
   // @throws std::exception if with_respect_to is not JacobianWrtVariable::kV
   // @throws std::exception if AsBias_WB_all is nullptr.
-  // @throws std::exception if AsBias_WB_all.size() is not num_bodies().
+  // @throws std::exception if AsBias_WB_all.size() is not num_mobods().
   void CalcAllBodyBiasSpatialAccelerationsInWorld(
       const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
       std::vector<SpatialAcceleration<T>>* AsBias_WB_all) const;
@@ -2621,8 +2630,6 @@ class MultibodyTree {
   // @param[in] body_indexes Array of selected bodies.  This method does not
   //  distinguish between welded bodies, joint-connected bodies,
   //  floating bodies, the world_body(), or repeated bodies.
-  // @throws std::exception if model_instances contains an invalid
-  // ModelInstanceIndex.
   // @throws std::exception if body_indexes contains an invalid BodyIndex.
   SpatialMomentum<T> CalcBodiesSpatialMomentumInWorldAboutWo(
       const systems::Context<T>& context,
@@ -2789,7 +2796,7 @@ class MultibodyTree {
   // Helper method to create a clone of `body` and add it to `this` tree.
   // Because this method is only invoked in a controlled manner from within
   // CloneToScalar(), it is guaranteed that the cloned body in this variant's
-  // `rigid_bodies_` will occupy the same position as its corresponding
+  // `links_` will occupy the same position as its corresponding
   // RigidBody in the source variant `body`.
   template <typename FromScalar>
   RigidBody<T>* CloneBodyAndAdd(const RigidBody<FromScalar>& body);
@@ -2826,10 +2833,10 @@ class MultibodyTree {
       const RigidBody<T>& body) const;
 
   // These objects are defined via MultibodyPlant and are thus user-visible.
-  const RigidBody<T>* world_rigid_body_{nullptr};
+  const Link<T>* world_link_{nullptr};  // aka RigidBody
   // When we need to look up elements by name, we'll use an ElementCollection.
   // Otherwise, we'll just use a plain vector.
-  ElementCollection<T, RigidBody, BodyIndex> rigid_bodies_;
+  ElementCollection<T, Link, LinkIndex> links_;
   ElementCollection<T, Frame, FrameIndex> frames_;
   ElementCollection<T, Joint, JointIndex> joints_;
   std::vector<std::unique_ptr<ForceElement<T>>> force_elements_;

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -40,6 +40,8 @@ class Frame;
 template <typename T>
 class RigidBody;
 template <typename T>
+using Link = RigidBody<T>;
+template <typename T>
 class Joint;
 template <typename T>
 class JointActuator;
@@ -54,6 +56,16 @@ class UniformGravityFieldElement;
 enum class JacobianWrtVariable {
   kQDot,  ///< J = ∂V/∂q̇
   kV      ///< J = ∂V/∂v
+};
+
+/// The kind of joint to be used to connect base bodies to world at Finalize().
+/// See @ref mbp_working_with_free_bodies "Working with free bodies"
+/// for definitions and discussion.
+/// @see SetBaseBodyJointType() for details.
+enum class BaseBodyJointType {
+  kQuaternionFloatingJoint,  ///< 6 dofs, unrestricted orientation.
+  kRpyFloatingJoint,         ///< 6 dofs using 3 angles; has singularity.
+  kWeldJoint,                ///< 0 dofs, fixed to World.
 };
 
 /// @cond
@@ -481,11 +493,11 @@ class MultibodyTree {
   // See MultibodyPlant method.
   int num_frames() const { return frames_.num_elements(); }
 
-  // Returns the number of RigidBodies in the %MultibodyPlant including World.
-  // Therefore the minimum number of bodies is one.
-  int num_bodies() const { return rigid_bodies_.num_elements(); }
+  // Returns the number of Links (aka RigidBodies) in the MultibodyPlant
+  // including World. Therefore the minimum number of links is one.
+  int num_links() const { return links_.num_elements(); }
 
-  // Returns the number of joints added with AddJoint() to the %MultibodyTree.
+  // Returns the number of joints added with AddJoint() to the MultibodyTree.
   int num_joints() const { return joints_.num_elements(); }
 
   // Returns the number of actuators in the model.
@@ -564,31 +576,31 @@ class MultibodyTree {
   // could only be considered in the model using constraints.
   int forest_height() const { return forest().height(); }
 
-  // Returns a constant reference to the *world* body.
-  const RigidBody<T>& world_body() const {
-    // world_rigid_body_ is set in the constructor. So this assert is here only
+  // Returns a constant reference to the *world* link.
+  const Link<T>& world_link() const {
+    // world_link_ is set in the constructor. So this assert is here only
     // to verify future constructors do not mess that up.
-    DRAKE_ASSERT(world_rigid_body_ != nullptr);
-    return *world_rigid_body_;
+    DRAKE_ASSERT(world_link_ != nullptr);
+    return *world_link_;
   }
 
   // Returns a constant reference to the *world* frame.
   const RigidBodyFrame<T>& world_frame() const {
-    return rigid_bodies_.get_element_unchecked(world_index()).body_frame();
+    return links_.get_element_unchecked(world_index()).body_frame();
   }
 
   // See MultibodyPlant method.
   bool has_body(BodyIndex body_index) const {
-    return rigid_bodies_.has_element(body_index);
+    return links_.has_element(body_index);
   }
 
   // See MultibodyPlant method.
   const RigidBody<T>& get_body(BodyIndex body_index) const {
-    return rigid_bodies_.get_element(body_index);
+    return links_.get_element(body_index);
   }
 
   RigidBody<T>& get_mutable_body(BodyIndex body_index) {
-    return rigid_bodies_.get_mutable_element(body_index);
+    return links_.get_mutable_element(body_index);
   }
 
   // See MultibodyPlant method.
@@ -935,6 +947,15 @@ class MultibodyTree {
   [[nodiscard]] const SpanningForest::Mobod& get_mobod(MobodIndex index) const {
     return forest().mobods(index);
   }
+
+  // See MultibodyPlant API.
+  void SetBaseBodyJointType(
+      BaseBodyJointType joint_type,
+      std::optional<ModelInstanceIndex> model_instance = {});
+
+  // See MultibodyPlant API.
+  BaseBodyJointType GetBaseBodyJointType(
+      std::optional<ModelInstanceIndex> model_instance = {}) const;
 
   // Finalize() must be called after all user-defined elements in the plant
   // (joints, bodies, force elements, constraints, etc.) have been added and
@@ -1340,9 +1361,9 @@ class MultibodyTree {
   // @param[out] M_B_W_all
   //   For each body in the model, entry RigidBody::mobod_index() in M_B_W_all
   //   contains the updated spatial inertia `M_B_W(q)` for that body. On input
-  //   it must be a valid pointer to a vector of size num_bodies().
+  //   it must be a valid pointer to a vector of size num_mobods().
   // @throws std::exception if M_B_W_all is nullptr or if its size is not
-  // num_bodies().
+  // num_mobods().
   void CalcSpatialInertiasInWorld(
       const systems::Context<T>& context,
       std::vector<SpatialInertia<T>>* M_B_W_all) const;
@@ -1389,19 +1410,20 @@ class MultibodyTree {
       const systems::Context<T>& context,
       std::vector<SpatialInertia<T>>* K_BBo_W_all) const;
 
-  // Computes the bias force `Fb_Bo_W(q, v)` for each body in the model.
-  // For a body B, this is the bias term `Fb_Bo_W` in the equation
+  // Computes the bias force `Fb_Bo_W(q, v)` for each mobod in the model.
+  // For a mobod B, this is the bias term `Fb_Bo_W` in the equation
   // `F_BBo_W = M_Bo_W * A_WB + Fb_Bo_W`, where `M_Bo_W` is the spatial inertia
   // about B's origin Bo, `A_WB` is the spatial acceleration of B in W and
   // `F_BBo_W` is the spatial force applied on B about Bo, expressed in W.
   // @param[in] context
   //   The context storing the state of the model.
   // @param[out] Fb_Bo_W_all
-  //   For each body in the model, entry RigidBody::mobod_index() in Fb_Bo_W_all
-  //   contains the updated bias term `Fb_Bo_W(q, v)` for that body. On input
-  //   it must be a valid pointer to a vector of size num_bodies().
+  //   For each mobod in the model, entry RigidBody::mobod_index() in
+  //   Fb_Bo_W_all contains the updated bias term `Fb_Bo_W(q, v)` for that
+  //   mobod. On input it must be a valid pointer to a vector of size
+  //   num_mobods().
   // @throws std::exception if Fb_Bo_W_cache is nullptr or if its size is not
-  // num_bodies().
+  // num_mobods().
   void CalcDynamicBiasForces(const systems::Context<T>& context,
                              std::vector<SpatialForce<T>>* Fb_Bo_W_all) const;
 
@@ -2100,7 +2122,7 @@ class MultibodyTree {
     //   DRAKE_DEMAND the parent tree of the variant is indeed a variant of this
     //   MultibodyTree. That will require the tree to have some sort of id.
     const BodyIndex body_index = element.index();
-    return rigid_bodies_.get_element(body_index);
+    return links_.get_element(body_index);
   }
 
   // Overload for Mobilizer<T> elements.
@@ -2601,16 +2623,16 @@ class MultibodyTree {
       const PositionKinematicsCache<T>& pc,
       const VelocityKinematicsCache<T>& vc) const;
 
-  // For all bodies, calculate bias spatial acceleration in the world frame W.
+  // For all mobods, calculate bias spatial acceleration in the world frame W.
   // @param[in] context The state of the multibody system.
   // @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
   // JacobianWrtVariable::kV, indicating whether the spatial acceleration bias
   // is with respect to 𝑠 = q̇ or 𝑠 = v.
-  // @param[out] AsBias_WB_all Each body's spatial acceleration bias in world
+  // @param[out] AsBias_WB_all Each mobod's spatial acceleration bias in world
   // frame W, with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), expressed in frame W.
   // @throws std::exception if with_respect_to is not JacobianWrtVariable::kV
   // @throws std::exception if AsBias_WB_all is nullptr.
-  // @throws std::exception if AsBias_WB_all.size() is not num_bodies().
+  // @throws std::exception if AsBias_WB_all.size() is not num_mobods().
   void CalcAllBodyBiasSpatialAccelerationsInWorld(
       const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
       std::vector<SpatialAcceleration<T>>* AsBias_WB_all) const;
@@ -2621,8 +2643,6 @@ class MultibodyTree {
   // @param[in] body_indexes Array of selected bodies.  This method does not
   //  distinguish between welded bodies, joint-connected bodies,
   //  floating bodies, the world_body(), or repeated bodies.
-  // @throws std::exception if model_instances contains an invalid
-  // ModelInstanceIndex.
   // @throws std::exception if body_indexes contains an invalid BodyIndex.
   SpatialMomentum<T> CalcBodiesSpatialMomentumInWorldAboutWo(
       const systems::Context<T>& context,
@@ -2789,7 +2809,7 @@ class MultibodyTree {
   // Helper method to create a clone of `body` and add it to `this` tree.
   // Because this method is only invoked in a controlled manner from within
   // CloneToScalar(), it is guaranteed that the cloned body in this variant's
-  // `rigid_bodies_` will occupy the same position as its corresponding
+  // `links_` will occupy the same position as its corresponding
   // RigidBody in the source variant `body`.
   template <typename FromScalar>
   RigidBody<T>* CloneBodyAndAdd(const RigidBody<FromScalar>& body);
@@ -2826,10 +2846,10 @@ class MultibodyTree {
       const RigidBody<T>& body) const;
 
   // These objects are defined via MultibodyPlant and are thus user-visible.
-  const RigidBody<T>* world_rigid_body_{nullptr};
+  const Link<T>* world_link_{nullptr};  // aka RigidBody
   // When we need to look up elements by name, we'll use an ElementCollection.
   // Otherwise, we'll just use a plain vector.
-  ElementCollection<T, RigidBody, BodyIndex> rigid_bodies_;
+  ElementCollection<T, Link, LinkIndex> links_;
   ElementCollection<T, Frame, FrameIndex> frames_;
   ElementCollection<T, Joint, JointIndex> joints_;
   std::vector<std::unique_ptr<ForceElement<T>>> force_elements_;

--- a/multibody/tree/multibody_tree_indexes.h
+++ b/multibody/tree/multibody_tree_indexes.h
@@ -6,25 +6,6 @@
 namespace drake {
 namespace multibody {
 
-namespace internal {
-
-// Type used to identify any quantity associated with a "mobilized body"
-// (abbreviated "mobod"), which is a depth-first numbered node of the spanning
-// forest used to model a multibody system. This includes BodyNodes, Mobilizers,
-// and associated computed quantities such as their accelerations.
-using MobodIndex = TypeSafeIndex<class MobodTag>;
-
-// Type used to identify a topological tree within the "forest" of a multibody
-// system.
-using TreeIndex = TypeSafeIndex<class TreeTag>;
-
-// World is always modeled as the 0th mobilized body.
-inline MobodIndex world_mobod_index() {
-  return MobodIndex(0);
-}
-
-}  // namespace internal
-
 // N.B. To simplify checking binding coverage, please ensure these symbols
 // are defined in `tree_py.cc` in the same order.
 
@@ -34,6 +15,12 @@ using FrameIndex = TypeSafeIndex<class FrameTag>;
 /// Type used to identify RigidBodies (a.k.a. Links) by index in a multibody
 /// plant. Interchangeable with LinkIndex.
 using BodyIndex = TypeSafeIndex<class RigidBodyTag>;
+
+/// This is a synonym for BodyIndex.
+using LinkIndex = BodyIndex;
+
+/// Type used to identify links by ordinal within a multibody plant.
+using LinkOrdinal = TypeSafeIndex<class LinkOrdinalTag>;
 
 /// Type used to identify force elements by index within a multibody plant.
 using ForceElementIndex = TypeSafeIndex<class ForceElementTag>;
@@ -95,6 +82,29 @@ inline ModelInstanceIndex world_model_instance() {
 inline ModelInstanceIndex default_model_instance() {
   return ModelInstanceIndex(1);
 }
+
+namespace internal {
+
+// Type used to identify any quantity associated with a "mobilized body"
+// (abbreviated "mobod"), which is a depth-first numbered node of the spanning
+// forest used to model a multibody system. This includes BodyNodes, Mobilizers,
+// and associated computed quantities such as their accelerations.
+using MobodIndex = TypeSafeIndex<class MobodTag>;
+
+// Type used to identify a topological tree within the "forest" of a multibody
+// system.
+using TreeIndex = TypeSafeIndex<class TreeTag>;
+
+// World is always modeled as the 0th mobilized body and link.
+inline MobodIndex world_mobod_index() {
+  return MobodIndex(0);
+}
+
+inline LinkOrdinal world_link_ordinal() {
+  return LinkOrdinal(0);
+}
+
+}  // namespace internal
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -99,10 +99,9 @@ void MultibodyTreeSystem<T>::SetDefaultParameters(
         .get_joint_actuator(joint_actuator_index)
         .SetDefaultParameters(parameters);
   }
-  // Bodies.
-  for (BodyIndex body_index(0); body_index < tree_->num_bodies();
-       ++body_index) {
-    internal_tree().get_body(body_index).SetDefaultParameters(parameters);
+  // Links.
+  for (LinkIndex link_index(0); link_index < tree_->num_links(); ++link_index) {
+    internal_tree().get_link(link_index).SetDefaultParameters(parameters);
   }
   // Frames.
   for (FrameIndex frame_index(0); frame_index < tree_->num_frames();
@@ -136,8 +135,7 @@ MultibodyTree<T>& MultibodyTreeSystem<T>::mutable_tree() {
 }
 
 template <typename T>
-void MultibodyTreeSystem<T>::DeclareMultibodyElementParameters(
-    int* num_frame_body_pose_slots_needed) {
+void MultibodyTreeSystem<T>::DeclareMultibodyElementParameters() {
   // Mobilizers.
   for (MobodIndex mobilizer_index(0); mobilizer_index < tree_->num_mobilizers();
        ++mobilizer_index) {
@@ -156,21 +154,15 @@ void MultibodyTreeSystem<T>::DeclareMultibodyElementParameters(
         .get_mutable_joint_actuator(joint_actuator_index)
         .DeclareParameters(this);
   }
-  // Bodies.
-  for (BodyIndex body_index(0); body_index < tree_->num_bodies();
-       ++body_index) {
-    mutable_tree().get_mutable_body(body_index).DeclareParameters(this);
+  // Links.
+  for (LinkIndex link_index(0); link_index < tree_->num_links(); ++link_index) {
+    mutable_tree().get_mutable_link(link_index).DeclareParameters(this);
   }
   // Frames.
-  *num_frame_body_pose_slots_needed = 1;  // 0th is for an identity transform.
   for (FrameIndex frame_index(0); frame_index < tree_->num_frames();
        ++frame_index) {
     Frame<T>& frame = mutable_tree().get_mutable_frame(frame_index);
     frame.DeclareParameters(this);
-    // This is where the extracted, reformatted, and composed body pose X_BF for
-    // this Frame will be stored in the frame body poses cache entry.
-    frame.set_body_pose_index_in_cache(
-        frame.is_body_frame() ? 0 : (*num_frame_body_pose_slots_needed)++);
   }
   // Force Elements.
   for (ForceElementIndex force_element_index(0);
@@ -192,9 +184,7 @@ void MultibodyTreeSystem<T>::Finalize() {
     tree_->Finalize();
   }
 
-  int num_frame_body_poses_needed{-1};
-  DeclareMultibodyElementParameters(&num_frame_body_poses_needed);
-  DRAKE_DEMAND(num_frame_body_poses_needed > 0);  // Always at least 1.
+  DeclareMultibodyElementParameters();
 
   // Declare state.
   if (is_discrete_) {
@@ -214,23 +204,23 @@ void MultibodyTreeSystem<T>::Finalize() {
 
   cache_indexes_.reflected_inertia =
       this->DeclareCacheEntry(std::string("reflected inertia"),
-                              VectorX<T>(internal_tree().num_velocities()),
+                              VectorX<T>(tree_->num_velocities()),
                               &MultibodyTreeSystem<T>::CalcReflectedInertia,
                               {this->all_parameters_ticket()})
           .cache_index();
 
   cache_indexes_.joint_damping =
       this->DeclareCacheEntry(std::string("joint damping"),
-                              VectorX<T>(internal_tree().num_velocities()),
+                              VectorX<T>(tree_->num_velocities()),
                               &MultibodyTreeSystem<T>::CalcJointDamping,
                               {this->all_parameters_ticket()})
           .cache_index();
 
   cache_indexes_.frame_body_poses =
       this->DeclareCacheEntry(
-              std::string("frame pose in body frame"),
-              FrameBodyPoseCache<T>(internal_tree().num_mobods(),
-                                    num_frame_body_poses_needed),
+              std::string("frame pose in link and body frames"),
+              FrameBodyPoseCache<T>(tree_->num_links(), tree_->num_frames(),
+                                    tree_->num_mobods()),
               &MultibodyTreeSystem<T>::CalcFrameBodyPoses,
               {this->all_parameters_ticket()})
           .cache_index();
@@ -260,11 +250,11 @@ void MultibodyTreeSystem<T>::Finalize() {
               {position_kinematics_cache_entry().ticket()})
           .cache_index();
 
-  // Allocate cache entry to store spatial inertia M_B_W(q) for each body.
+  // Allocate cache entry to store spatial inertia M_B_W(q) for each mobod.
   cache_indexes_.spatial_inertia_in_world =
       this->DeclareCacheEntry(
-              std::string("spatial inertia in world (M_B_W)"),
-              std::vector<SpatialInertia<T>>(internal_tree().num_bodies(),
+              std::string("mobod spatial inertia in world (M_B_W)"),
+              std::vector<SpatialInertia<T>>(internal_tree().num_mobods(),
                                              SpatialInertia<T>::NaN()),
               &MultibodyTreeSystem<T>::CalcSpatialInertiasInWorld,
               {position_kinematics_cache_entry().ticket()})
@@ -273,8 +263,8 @@ void MultibodyTreeSystem<T>::Finalize() {
   // Allocate cache entry for composite-body inertias K_BBo_W(q) for each body.
   cache_indexes_.composite_body_inertia_in_world =
       this->DeclareCacheEntry(
-              std::string("composite body inertia in world (K_BBo_W)"),
-              std::vector<SpatialInertia<T>>(internal_tree().num_bodies(),
+              std::string("composite mobod inertia in world (K_BBo_W)"),
+              std::vector<SpatialInertia<T>>(internal_tree().num_mobods(),
                                              SpatialInertia<T>::NaN()),
               &MultibodyTreeSystem<T>::CalcCompositeBodyInertiasInWorld,
               {position_kinematics_cache_entry().ticket()})
@@ -294,8 +284,8 @@ void MultibodyTreeSystem<T>::Finalize() {
   // Allocate cache entry to store Fb_Bo_W(q, v) for each body.
   cache_indexes_.dynamic_bias =
       this->DeclareCacheEntry(
-              std::string("dynamic bias (Fb_Bo_W)"),
-              std::vector<SpatialForce<T>>(internal_tree().num_bodies()),
+              std::string("mobod dynamic bias (Fb_Bo_W)"),
+              std::vector<SpatialForce<T>>(internal_tree().num_mobods()),
               &MultibodyTreeSystem<T>::CalcDynamicBiasForces,
               // The computation of Fb_Bo_W(q, v) requires updated values of
               // M_Bo_W(q) and V_WB(q, v). We make these prerequisites explicit.
@@ -330,7 +320,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.spatial_acceleration_bias =
       this->DeclareCacheEntry(
               std::string("spatial acceleration bias (Ab_WB)"),
-              std::vector<SpatialAcceleration<T>>(internal_tree().num_bodies()),
+              std::vector<SpatialAcceleration<T>>(internal_tree().num_mobods()),
               &MultibodyTreeSystem<T>::CalcSpatialAccelerationBias,
               {position_ticket, velocity_ticket, this->all_parameters_ticket()})
           .cache_index();
@@ -338,7 +328,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.articulated_body_force_bias =
       this->DeclareCacheEntry(
               std::string("ABI force bias cache (Zb_Bo_W)"),
-              std::vector<SpatialForce<T>>(internal_tree().num_bodies()),
+              std::vector<SpatialForce<T>>(internal_tree().num_mobods()),
               &MultibodyTreeSystem<T>::CalcArticulatedBodyForceBias,
               {position_ticket, velocity_ticket, this->all_parameters_ticket()})
           .cache_index();

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -100,8 +100,7 @@ void MultibodyTreeSystem<T>::SetDefaultParameters(
         .SetDefaultParameters(parameters);
   }
   // Bodies.
-  for (BodyIndex body_index(0); body_index < tree_->num_bodies();
-       ++body_index) {
+  for (BodyIndex body_index(0); body_index < tree_->num_links(); ++body_index) {
     internal_tree().get_body(body_index).SetDefaultParameters(parameters);
   }
   // Frames.
@@ -157,8 +156,7 @@ void MultibodyTreeSystem<T>::DeclareMultibodyElementParameters(
         .DeclareParameters(this);
   }
   // Bodies.
-  for (BodyIndex body_index(0); body_index < tree_->num_bodies();
-       ++body_index) {
+  for (BodyIndex body_index(0); body_index < tree_->num_links(); ++body_index) {
     mutable_tree().get_mutable_body(body_index).DeclareParameters(this);
   }
   // Frames.
@@ -214,14 +212,14 @@ void MultibodyTreeSystem<T>::Finalize() {
 
   cache_indexes_.reflected_inertia =
       this->DeclareCacheEntry(std::string("reflected inertia"),
-                              VectorX<T>(internal_tree().num_velocities()),
+                              VectorX<T>(tree_->num_velocities()),
                               &MultibodyTreeSystem<T>::CalcReflectedInertia,
                               {this->all_parameters_ticket()})
           .cache_index();
 
   cache_indexes_.joint_damping =
       this->DeclareCacheEntry(std::string("joint damping"),
-                              VectorX<T>(internal_tree().num_velocities()),
+                              VectorX<T>(tree_->num_velocities()),
                               &MultibodyTreeSystem<T>::CalcJointDamping,
                               {this->all_parameters_ticket()})
           .cache_index();
@@ -229,7 +227,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.frame_body_poses =
       this->DeclareCacheEntry(
               std::string("frame pose in body frame"),
-              FrameBodyPoseCache<T>(internal_tree().num_mobods(),
+              FrameBodyPoseCache<T>(tree_->num_mobods(),
                                     num_frame_body_poses_needed),
               &MultibodyTreeSystem<T>::CalcFrameBodyPoses,
               {this->all_parameters_ticket()})
@@ -260,11 +258,11 @@ void MultibodyTreeSystem<T>::Finalize() {
               {position_kinematics_cache_entry().ticket()})
           .cache_index();
 
-  // Allocate cache entry to store spatial inertia M_B_W(q) for each body.
+  // Allocate cache entry to store spatial inertia M_B_W(q) for each mobod.
   cache_indexes_.spatial_inertia_in_world =
       this->DeclareCacheEntry(
-              std::string("spatial inertia in world (M_B_W)"),
-              std::vector<SpatialInertia<T>>(internal_tree().num_bodies(),
+              std::string("mobod spatial inertia in world (M_B_W)"),
+              std::vector<SpatialInertia<T>>(internal_tree().num_mobods(),
                                              SpatialInertia<T>::NaN()),
               &MultibodyTreeSystem<T>::CalcSpatialInertiasInWorld,
               {position_kinematics_cache_entry().ticket()})
@@ -273,8 +271,8 @@ void MultibodyTreeSystem<T>::Finalize() {
   // Allocate cache entry for composite-body inertias K_BBo_W(q) for each body.
   cache_indexes_.composite_body_inertia_in_world =
       this->DeclareCacheEntry(
-              std::string("composite body inertia in world (K_BBo_W)"),
-              std::vector<SpatialInertia<T>>(internal_tree().num_bodies(),
+              std::string("composite mobod inertia in world (K_BBo_W)"),
+              std::vector<SpatialInertia<T>>(internal_tree().num_mobods(),
                                              SpatialInertia<T>::NaN()),
               &MultibodyTreeSystem<T>::CalcCompositeBodyInertiasInWorld,
               {position_kinematics_cache_entry().ticket()})
@@ -294,8 +292,8 @@ void MultibodyTreeSystem<T>::Finalize() {
   // Allocate cache entry to store Fb_Bo_W(q, v) for each body.
   cache_indexes_.dynamic_bias =
       this->DeclareCacheEntry(
-              std::string("dynamic bias (Fb_Bo_W)"),
-              std::vector<SpatialForce<T>>(internal_tree().num_bodies()),
+              std::string("mobod dynamic bias (Fb_Bo_W)"),
+              std::vector<SpatialForce<T>>(internal_tree().num_mobods()),
               &MultibodyTreeSystem<T>::CalcDynamicBiasForces,
               // The computation of Fb_Bo_W(q, v) requires updated values of
               // M_Bo_W(q) and V_WB(q, v). We make these prerequisites explicit.
@@ -330,7 +328,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.spatial_acceleration_bias =
       this->DeclareCacheEntry(
               std::string("spatial acceleration bias (Ab_WB)"),
-              std::vector<SpatialAcceleration<T>>(internal_tree().num_bodies()),
+              std::vector<SpatialAcceleration<T>>(internal_tree().num_links()),
               &MultibodyTreeSystem<T>::CalcSpatialAccelerationBias,
               {position_ticket, velocity_ticket, this->all_parameters_ticket()})
           .cache_index();
@@ -338,7 +336,7 @@ void MultibodyTreeSystem<T>::Finalize() {
   cache_indexes_.articulated_body_force_bias =
       this->DeclareCacheEntry(
               std::string("ABI force bias cache (Zb_Bo_W)"),
-              std::vector<SpatialForce<T>>(internal_tree().num_bodies()),
+              std::vector<SpatialForce<T>>(internal_tree().num_links()),
               &MultibodyTreeSystem<T>::CalcArticulatedBodyForceBias,
               {position_ticket, velocity_ticket, this->all_parameters_ticket()})
           .cache_index();

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -3,7 +3,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -3,7 +3,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -539,15 +538,13 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
 
   // This method is called during Finalize(). It tells each MultibodyElement
   // owned by `this` system to declare their system parameters on `this`.
-  // Returns the number of frame body pose slots we need to allocate in the
-  // frame body pose cache entry.
   // TODO(sherm1) This should return information needed for allocating
   //  parameter cache entries, such as which parameters affect which
   //  objects. For now we assume dependence on all parameters.
   //  Alternatively, consider restructuring this so that the parameter
   //  allocation and matching cache resources can be obtained at the
   //  same time by the element that needs them.
-  void DeclareMultibodyElementParameters(int* num_frame_body_pose_slots_needed);
+  void DeclareMultibodyElementParameters();
 
   // Allow different specializations to access each other's private data for
   // scalar conversion.

--- a/multibody/tree/position_kinematics_cache.h
+++ b/multibody/tree/position_kinematics_cache.h
@@ -16,19 +16,45 @@ namespace drake {
 namespace multibody {
 namespace internal {
 
-// This class is one of the cache entries in the Context. It holds the
-// kinematics results of computations that only depend on the generalized
-// positions of the system.
-// Kinematics results include:
-//
-// - Body frame B poses X_WB measured and expressed in the world frame W.
-// - Pose X_FM of a mobilizer's outboard frame M measured and expressed in the
-//   inboard frame F.
-// - Mobilizer's matrices H_FM (with F and M defined above) that map the
-//   mobilizer's generalized velocities v to cross-joint spatial velocities
-//   V_FM = H_FM * v.
-//
-// @tparam_default_scalar
+/* This class is one of the cache entries in the Context. It holds the
+kinematics results of computations that only depend on the generalized
+positions q of the system.
+
+Position kinematics results are mostly per-Mobod. We also need to know the pose
+of every Link (composite mobods carry multiple links). Note that every mobod B
+(composite or not) has a distinguished "active" link L₀, which is the most
+inboard link following that mobod (that is, the link with the joint that
+connects the mobod to its inboard mobod). The body frame B of a mobod is always
+coincident with the frame L₀ of its active link.
+
+Results are indexed by MobodIndex unless otherwise specified:
+ - X_WB: Pose of mobod B measured and expressed in the world frame W.
+         Frame B is the same as frame L₀ of a mobod's active link.
+ - X_WL: Pose of link L in W for every link. Indexed by LinkOrdinal. Same as
+         X_WB if L is the active link of mobod B.
+ - X_PB: Pose of mobod B measured and expressed in its parent (inboard) mobod's
+         frame P.
+ - p_PoBo_W:
+         Position of mobod B's origin Bo measured in its parent (inboard) mobod
+         P, expressed in world frame W.
+ - X_FM: Pose of mobilizer's outboard frame M measured and expressed in
+         its inboard frame F.
+ - H_FM: Mobilizer's hinge matrix, the Jacobian ∂V_FM/∂v that maps the
+         mobilizer's generalized velocities v to cross-mobilizer spatial
+         velocities V_FM = H_FM * v.
+
+@tparam_default_scalar */
+
+// TODO(sherm1) X_WL mostly duplicates X_WB (they are identical if there are no
+//  composite bodies), and always contains all the X_WB transforms (for the
+//  active links). Claude's idea to avoid duplication with no overhead: assign
+//  active link ordinals first, so that
+//  LinkOrdinal(mobod.active_link) == MobodIndex(mobod). Then
+//  X_WL(mobod.index()) == X_WB(mobod.index()) avoiding indirection.
+//  Applies to the velocity_kinematics_cache also.
+
+// TODO(sherm1) Currently we never form composites so each Mobod has only
+//  its active link L₀.
 template <typename T>
 class PositionKinematicsCache {
  public:
@@ -37,10 +63,8 @@ class PositionKinematicsCache {
   template <typename U>
   using RigidTransform = drake::math::RigidTransform<U>;
 
-  // Constructs a position kinematics cache entry for the given
-  // SpanningForest.
   explicit PositionKinematicsCache(const SpanningForest& forest)
-      : num_mobods_(forest.num_mobods()) {
+      : num_mobods_(forest.num_mobods()), num_links_(forest.num_links()) {
     Allocate();
   }
 
@@ -60,6 +84,16 @@ class PositionKinematicsCache {
   RigidTransform<T>& get_mutable_X_WB(MobodIndex mobod_index) {
     DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
     return X_WB_pool_[mobod_index];
+  }
+
+  const RigidTransform<T>& get_X_WL(LinkOrdinal ordinal) const {
+    DRAKE_ASSERT(0 <= ordinal && ordinal < num_links_);
+    return X_WL_pool_[ordinal];
+  }
+
+  void SetX_WL(LinkOrdinal ordinal, const math::RigidTransform<T>& X_WL) {
+    DRAKE_DEMAND(0 <= ordinal && ordinal < num_links_);
+    X_WL_pool_[ordinal] = X_WL;
   }
 
   // Returns a const reference to the rotation matrix `R_WB` that relates the
@@ -122,24 +156,15 @@ class PositionKinematicsCache {
   }
 
  private:
-  // Pool types:
-  // Pools store entries in the same order as the mobilized bodies (BodyNodes)
-  // in the multibody forest, i.e. in DFT (Depth-First Traversal) order.
-  // Therefore clients of this class will access entries by MobodIndex, see
-  // `get_X_WB()` for instance.
-
-  // The type of pools for storing poses.
-  typedef std::vector<RigidTransform<T>> X_PoolType;
-
-  // The type of pools for storing 3D vectors.
-  typedef std::vector<Vector3<T>> Vector3PoolType;
-
   // Allocates resources for this position kinematics cache.
   void Allocate() {
     X_WB_pool_.resize(num_mobods_);
     // Even though RigidTransform defaults to identity, we make it explicit.
     // This pose will never change after this initialization.
     X_WB_pool_[world_mobod_index()] = RigidTransform<T>::Identity();
+
+    X_WL_pool_.resize(num_links_);
+    X_WL_pool_[world_link_ordinal()] = RigidTransform<T>::Identity();
 
     X_PB_pool_.resize(num_mobods_);
     X_PB_pool_[world_mobod_index()] = NaNPose();  // It should never be used.
@@ -165,13 +190,21 @@ class PositionKinematicsCache {
         Vector3<T>::Constant(Eigen::NumTraits<double>::quiet_NaN()));
   }
 
-  // Number of mobilized bodies in the corresponding multibody forest.
+  // Number of Mobods in the multibody forest, including the World mobod.
   int num_mobods_{0};
-  // Pools indexed by MobodIndex.
-  X_PoolType X_WB_pool_;
-  X_PoolType X_PB_pool_;
-  X_PoolType X_FM_pool_;
-  Vector3PoolType p_PoBo_W_pool_;
+
+  // Number of links in the multibody graph includes all user-defined links
+  // (including the World link) and possibly some ephemeral links.
+  int num_links_{0};
+
+  // These are indexed by MobodIndex so are in depth-first order.
+  std::vector<RigidTransform<T>> X_WB_pool_;
+  std::vector<RigidTransform<T>> X_PB_pool_;
+  std::vector<RigidTransform<T>> X_FM_pool_;
+  std::vector<Vector3<T>> p_PoBo_W_pool_;
+
+  // This pool is indexed by LinkOrdinal.
+  std::vector<RigidTransform<T>> X_WL_pool_;
 };
 
 }  // namespace internal

--- a/multibody/tree/rigid_body.cc
+++ b/multibody/tree/rigid_body.cc
@@ -7,7 +7,7 @@
 namespace drake {
 namespace multibody {
 
-// RigidBodyFrame function definitions.
+// RigidBodyFrame (a.k.a. LinkFrame) function definitions.
 
 template <typename T>
 RigidBodyFrame<T>::~RigidBodyFrame() = default;
@@ -17,7 +17,7 @@ template <typename ToScalar>
 std::unique_ptr<Frame<ToScalar>> RigidBodyFrame<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
   const RigidBody<ToScalar>& body_clone =
-      tree_clone.get_body(this->body().index());
+      tree_clone.get_link(this->body().index());
   // RigidBodyFrame's constructor cannot be called from std::make_unique since
   // it is private and therefore we use "new".
   return std::unique_ptr<RigidBodyFrame<ToScalar>>(
@@ -68,7 +68,7 @@ RigidBody<T>::RigidBody(const std::string& body_name,
                         const SpatialInertia<double>& M)
     : MultibodyElement<T>(default_model_instance()),
       name_(internal::DeprecateWhenEmptyName(body_name, "RigidBody")),
-      body_frame_(*this),
+      link_frame_(*this),
       default_spatial_inertia_(M) {}
 
 template <typename T>
@@ -77,7 +77,7 @@ RigidBody<T>::RigidBody(const std::string& body_name,
                         const SpatialInertia<double>& M)
     : MultibodyElement<T>(model_instance),
       name_(internal::DeprecateWhenEmptyName(body_name, "RigidBody")),
-      body_frame_(*this),
+      link_frame_(*this),
       default_spatial_inertia_(M) {}
 
 template <typename T>

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -139,6 +139,10 @@ class RigidBodyFrame final : public Frame<T> {
       const internal::MultibodyTree<ToScalar>& tree_clone) const;
 };
 
+/// LinkFrame is a synonym for RigidBodyFrame and should be preferred.
+template <typename T>
+using LinkFrame = RigidBodyFrame<T>;
+
 /// @cond
 // Internal implementation details. Users should not access implementations
 // in this namespace.
@@ -151,20 +155,20 @@ template <typename T>
 // to the construction and finalize stage of the multibody system.
 class RigidBodyAttorney {
  private:
-  // MultibodyTree keeps a list of mutable pointers to each of the body frames
+  // MultibodyTree keeps a list of mutable pointers to each of the link frames
   // in the system and therefore it needs mutable access.
   // Notice this method is private and therefore users do not have access to it
   // even in the rare event they'd attempt to peek into the "internal::"
   // namespace.
-  static RigidBodyFrame<T>& get_mutable_body_frame(RigidBody<T>* body) {
-    return body->get_mutable_body_frame();
+  static LinkFrame<T>& get_mutable_link_frame(Link<T>* link) {
+    return link->get_mutable_link_frame();
   }
 
   // Used by MultibodyTree _during_ Finalize(), after the call to
-  // SetTopology() has appropriately registered which bodies are floating base
+  // SetTopology() has appropriately registered which links are floating base
   // bodies, but before the MultibodyTree::is_finalized() flag has been set.
-  static bool is_floating_base_body_pre_finalize(const RigidBody<T>& body) {
-    return body.is_floating_base_body_;
+  static bool is_floating_base_body_pre_finalize(const Link<T>& link) {
+    return link.is_floating_base_body_;
   }
 
   friend class internal::MultibodyTree<T>;
@@ -232,7 +236,14 @@ class RigidBody : public MultibodyElement<T> {
   ~RigidBody() override;
 
   /// Returns this element's unique index.
-  BodyIndex index() const { return this->template index_impl<BodyIndex>(); }
+  LinkIndex index() const { return this->template index_impl<LinkIndex>(); }
+
+  /// (Internal use only) Returns this Link's (RigidBody's) unique ordinal.
+  /// Currently identical to the index but will differ when we permit removal of
+  /// Links as we do for Joints.
+  LinkOrdinal ordinal() const {
+    return this->template ordinal_impl<LinkOrdinal>();
+  }
 
   /// Gets the `name` associated with this rigid body. The name will never be
   /// empty.
@@ -244,8 +255,11 @@ class RigidBody : public MultibodyElement<T> {
   ///   MultibodyPlant.
   ScopedName scoped_name() const;
 
-  /// Returns a const reference to the associated BodyFrame.
-  const RigidBodyFrame<T>& body_frame() const { return body_frame_; }
+  /// Returns a const reference to the associated LinkFrame (RigidBodyFrame).
+  const LinkFrame<T>& link_frame() const { return link_frame_; }
+
+  /// (Compatibility) A synonym for link_frame().
+  const LinkFrame<T>& body_frame() const { return link_frame(); }
 
   /// For a floating base %RigidBody, lock its inboard joint. Its generalized
   /// velocities will be 0 until it is unlocked.
@@ -443,7 +457,7 @@ class RigidBody : public MultibodyElement<T> {
       const systems::Context<T>& context) const {
     ThrowIfNotFinalized(__func__);
     DRAKE_ASSERT(this->has_parent_tree());
-    return this->get_parent_tree().EvalBodyPoseInWorld(context, *this);
+    return this->get_parent_tree().EvalLinkPoseInWorld(context, *this);
   }
 
   /// Evaluates V_WB, this body B's SpatialVelocity in the world frame W.
@@ -454,7 +468,7 @@ class RigidBody : public MultibodyElement<T> {
       const systems::Context<T>& context) const {
     ThrowIfNotFinalized(__func__);
     DRAKE_ASSERT(this->has_parent_tree());
-    return this->get_parent_tree().EvalBodySpatialVelocityInWorld(context,
+    return this->get_parent_tree().EvalLinkSpatialVelocityInWorld(context,
                                                                   *this);
   }
 
@@ -469,7 +483,7 @@ class RigidBody : public MultibodyElement<T> {
       const systems::Context<T>& context) const {
     ThrowIfNotFinalized(__func__);
     DRAKE_ASSERT(this->has_parent_tree());
-    return this->get_parent_tree().EvalBodySpatialAccelerationInWorld(context,
+    return this->get_parent_tree().EvalLinkSpatialAccelerationInWorld(context,
                                                                       *this);
   }
 
@@ -763,7 +777,8 @@ class RigidBody : public MultibodyElement<T> {
 
     // Is this RigidBody the active link on its Mobod?
     const bool is_active_link =
-        link.ordinal() == forest.mobods(link.mobod_index()).link_ordinal();
+        link.ordinal() ==
+        forest.mobods(link.mobod_index()).active_link_ordinal();
     is_floating_base_body_ =
         is_active_link && mobilizer_->is_floating_base_mobilizer();
   }
@@ -843,28 +858,27 @@ class RigidBody : public MultibodyElement<T> {
                                                  default_spatial_inertia_);
   }
 
-  // MultibodyTree has access to the mutable RigidBodyFrame through
+  // MultibodyTree has access to the mutable LinkFrame through
   // RigidBodyAttorney.
-  RigidBodyFrame<T>& get_mutable_body_frame() { return body_frame_; }
+  LinkFrame<T>& get_mutable_link_frame() { return link_frame_; }
 
   const internal::Mobilizer<T>& mobilizer() const {
     DRAKE_ASSERT(mobilizer_ != nullptr);
     return *mobilizer_;
   }
 
-  // A string identifying the body in its model.
+  // A string identifying this link in its model.
   // Within a MultibodyPlant model instance this string is guaranteed to be
   // unique by MultibodyPlant's API.
   const std::string name_;
 
-  // Body frame associated with this body.
-  RigidBodyFrame<T> body_frame_;
+  // This link's LinkFrame (a.k.a. RigidBodyFrame).
+  LinkFrame<T> link_frame_;
 
   // Spatial inertia about the body frame origin Bo, expressed in B.
   SpatialInertia<double> default_spatial_inertia_;
 
-  // System parameter index for this bodies SpatialInertia stored in a
-  // context.
+  // System parameter index for this body's SpatialInertia stored in a context.
   systems::NumericParameterIndex spatial_inertia_parameter_index_;
 
   // Below here, members are set at Finalize() via SetTopology().
@@ -872,12 +886,19 @@ class RigidBody : public MultibodyElement<T> {
   // The mobilizer of the Mobod that this body follows.
   const internal::Mobilizer<T>* mobilizer_{};
 
-  // True if the mobilizer is a floating base mobilizer and this body is the
+  // True if the mobilizer is a floating base mobilizer and this link is the
   // active link of the mobilized composite.
   bool is_floating_base_body_{false};
 };
 
-/// (Compatibility) Prefer RigidBody to Body, however this dispreferred alias
+/// Link is a synonym for the mis-named RigidBody class and should be
+/// preferred. When we combine welded-together links there will be multiple
+/// links fixed to a single rigid body (in the physics sense). Saying that
+/// there is more than one RigidBody on a rigid body is too confusing!
+template <typename T>
+using Link = RigidBody<T>;
+
+/// (Compatibility) Prefer Link to Body, however this dispreferred alias
 /// is available to permit older code to continue working.
 template <typename T>
 using Body = RigidBody<T>;

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -234,6 +234,13 @@ class RigidBody : public MultibodyElement<T> {
   /// Returns this element's unique index.
   BodyIndex index() const { return this->template index_impl<BodyIndex>(); }
 
+  /// (Internal use only) Returns this Link's (RigidBody's) unique ordinal.
+  /// Currently identical to the index but will differ when we permit removal of
+  /// Links as we do for Joints.
+  LinkOrdinal ordinal() const {
+    return this->template ordinal_impl<LinkOrdinal>();
+  }
+
   /// Gets the `name` associated with this rigid body. The name will never be
   /// empty.
   const std::string& name() const { return name_; }
@@ -763,7 +770,8 @@ class RigidBody : public MultibodyElement<T> {
 
     // Is this RigidBody the active link on its Mobod?
     const bool is_active_link =
-        link.ordinal() == forest.mobods(link.mobod_index()).link_ordinal();
+        link.ordinal() ==
+        forest.mobods(link.mobod_index()).active_link_ordinal();
     is_floating_base_body_ =
         is_active_link && mobilizer_->is_floating_base_mobilizer();
   }
@@ -881,6 +889,9 @@ class RigidBody : public MultibodyElement<T> {
 /// is available to permit older code to continue working.
 template <typename T>
 using Body = RigidBody<T>;
+
+template <typename T>
+using Link = RigidBody<T>;
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -65,7 +65,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
 
   // Add box body and gimbal (BallRpy) joint.
   const RigidBody<double>& box_link = tree.AddRigidBody("box", M_Bcm);
-  tree.AddJoint<BallRpyJoint>("ball", tree.world_body(), {}, box_link, {});
+  tree.AddJoint<BallRpyJoint>("ball", tree.world_link(), {}, box_link, {});
 
   // Add a massless body that can rotate about x.
   const RigidBody<double>& massless_link =
@@ -173,7 +173,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   // Add box body and gimbal (BallRpy) joint.
   const RigidBody<double>& box_link = tree.AddRigidBody("box", M_Bcm);
   const auto& WB_joint =
-      tree.AddJoint<BallRpyJoint>("ball", tree.world_body(), {}, box_link, {});
+      tree.AddJoint<BallRpyJoint>("ball", tree.world_link(), {}, box_link, {});
 
   // Add a massless body that can rotate about x.
   const RigidBody<double>& massless_link =

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -64,17 +64,17 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
   auto& tree = *tree_owned;
 
   // Add box body and gimbal (BallRpy) joint.
-  const RigidBody<double>& box_link = tree.AddRigidBody("box", M_Bcm);
-  tree.AddJoint<BallRpyJoint>("ball", tree.world_body(), {}, box_link, {});
+  const RigidBody<double>& box_link = tree.AddLink("box", M_Bcm);
+  tree.AddJoint<BallRpyJoint>("ball", tree.world_link(), {}, box_link, {});
 
   // Add a massless body that can rotate about x.
   const RigidBody<double>& massless_link =
-      tree.AddRigidBody("massless", SpatialInertia<double>::Zero());
+      tree.AddLink("massless", SpatialInertia<double>::Zero());
   tree.AddJoint<RevoluteJoint>("revolute", box_link, {}, massless_link, {},
                                Vector3d(1, 0, 0));
 
   // Add cylinder body and let it translate along y.
-  const RigidBody<double>& cylinder_link = tree.AddRigidBody("cylinder", M_Ccm);
+  const RigidBody<double>& cylinder_link = tree.AddLink("cylinder", M_Ccm);
   tree.AddJoint<PrismaticJoint>("prismatic", massless_link, {}, cylinder_link,
                                 {}, Vector3d(0, 1, 0));
 
@@ -171,18 +171,18 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   auto& tree = *tree_owned;
 
   // Add box body and gimbal (BallRpy) joint.
-  const RigidBody<double>& box_link = tree.AddRigidBody("box", M_Bcm);
+  const RigidBody<double>& box_link = tree.AddLink("box", M_Bcm);
   const auto& WB_joint =
-      tree.AddJoint<BallRpyJoint>("ball", tree.world_body(), {}, box_link, {});
+      tree.AddJoint<BallRpyJoint>("ball", tree.world_link(), {}, box_link, {});
 
   // Add a massless body that can rotate about x.
   const RigidBody<double>& massless_link =
-      tree.AddRigidBody("massless", SpatialInertia<double>::Zero());
+      tree.AddLink("massless", SpatialInertia<double>::Zero());
   const auto& BM_joint = tree.AddJoint<RevoluteJoint>(
       "revolute", box_link, {}, massless_link, {}, Vector3d(1, 0, 0));
 
   // Add cylinder body and let it translate along y.
-  const RigidBody<double>& cylinder_link = tree.AddRigidBody("cylinder", M_Ccm);
+  const RigidBody<double>& cylinder_link = tree.AddLink("cylinder", M_Ccm);
   const auto& MC_joint = tree.AddJoint<PrismaticJoint>(
       "prismatic", massless_link, {}, cylinder_link, {}, Vector3d(0, 1, 0));
 

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -44,7 +44,7 @@ class BallRpyJointTest : public ::testing::Test {
     body_ = &model->AddRigidBody("Body", M_B);
 
     // Add a ball rpy joint between the world and body:
-    joint_ = &model->AddJoint<BallRpyJoint>("Joint", model->world_body(),
+    joint_ = &model->AddJoint<BallRpyJoint>("Joint", model->world_link(),
                                             std::nullopt, *body_, std::nullopt,
                                             kDamping);
     mutable_joint_ = dynamic_cast<BallRpyJoint<double>*>(

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -41,10 +41,10 @@ class BallRpyJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add some bodies so we can add joints between them:
-    body_ = &model->AddRigidBody("Body", M_B);
+    body_ = &model->AddLink("Body", M_B);
 
     // Add a ball rpy joint between the world and body:
-    joint_ = &model->AddJoint<BallRpyJoint>("Joint", model->world_body(),
+    joint_ = &model->AddJoint<BallRpyJoint>("Joint", model->world_link(),
                                             std::nullopt, *body_, std::nullopt,
                                             kDamping);
     mutable_joint_ = dynamic_cast<BallRpyJoint<double>*>(

--- a/multibody/tree/test/curvilinear_joint_test.cc
+++ b/multibody/tree/test/curvilinear_joint_test.cc
@@ -56,7 +56,7 @@ class CurvilinearJointTest : public ::testing::Test {
 
     // Add a curvilinear joint between the world and body1.
     joint1_ = &model->AddJoint<CurvilinearJoint>(
-        "Joint1", model->world_body(), std::nullopt, *body1_, std::nullopt,
+        "Joint1", model->world_link(), std::nullopt, *body1_, std::nullopt,
         trajectory_, kDamping);
     Joint<double>& mutable_joint = model->get_mutable_joint(joint1_->index());
     mutable_joint1_ = dynamic_cast<CurvilinearJoint<double>*>(&mutable_joint);

--- a/multibody/tree/test/curvilinear_joint_test.cc
+++ b/multibody/tree/test/curvilinear_joint_test.cc
@@ -52,11 +52,11 @@ class CurvilinearJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add a body so we can add joint to it.
-    body1_ = &model->AddRigidBody("Body", M_B);
+    body1_ = &model->AddLink("Body", M_B);
 
     // Add a curvilinear joint between the world and body1.
     joint1_ = &model->AddJoint<CurvilinearJoint>(
-        "Joint1", model->world_body(), std::nullopt, *body1_, std::nullopt,
+        "Joint1", model->world_link(), std::nullopt, *body1_, std::nullopt,
         trajectory_, kDamping);
     Joint<double>& mutable_joint = model->get_mutable_joint(joint1_->index());
     mutable_joint1_ = dynamic_cast<CurvilinearJoint<double>*>(&mutable_joint);

--- a/multibody/tree/test/curvilinear_mobilizer_test.cc
+++ b/multibody/tree/test/curvilinear_mobilizer_test.cc
@@ -38,7 +38,7 @@ class CurvilinearMobilizerTest : public MobilizerTester {
   void SetUp() override {
     std::unique_ptr<CurvilinearJoint<double>> joint =
         std::make_unique<CurvilinearJoint<double>>(
-            "joint1", tree().world_body().body_frame(), body_->body_frame(),
+            "joint1", tree().world_link().body_frame(), body_->body_frame(),
             trajectory_);
     mobilizer_ = &AddJointAndFinalize<CurvilinearJoint, CurvilinearMobilizer>(
         std::move(joint));

--- a/multibody/tree/test/element_collection_test.cc
+++ b/multibody/tree/test/element_collection_test.cc
@@ -25,8 +25,9 @@ using Collection = ElementCollection<double, ModelInstance, Index>;
 GTEST_TEST(ElementCollectionTest, Empty) {
   const Collection empty;
   EXPECT_EQ(empty.num_elements(), 0);
+  EXPECT_EQ(empty.num_indices(), 0);
   EXPECT_EQ(empty.elements().size(), 0);
-  EXPECT_EQ(empty.indices().size(), 0);
+  EXPECT_EQ(empty.valid_indices().size(), 0);
   EXPECT_EQ(empty.names_map().size(), 0);
   EXPECT_EQ(empty.next_index(), Index{0});
 }
@@ -66,11 +67,13 @@ GTEST_TEST(ElementCollectionTest, AddDense) {
   EXPECT_EQ(dut.names_map().count(std::string{"zero"}), 1);
   EXPECT_EQ(dut.names_map().count(std::string{"one"}), 1);
 
-  EXPECT_THAT(dut.indices(), testing::ElementsAre(Index{0}, Index{1}));
+  EXPECT_THAT(dut.valid_indices(), testing::ElementsAre(Index{0}, Index{1}));
+  EXPECT_EQ(dut.num_indices(), 2);
   EXPECT_EQ(dut.next_index(), Index{2});
 
   dut.Add(std::make_unique<Element<double>>(Index{2}, "two"));
   EXPECT_EQ(dut.num_elements(), 3);
+  EXPECT_EQ(dut.num_indices(), 3);
   EXPECT_EQ(dut.next_index(), Index{3});
 }
 
@@ -129,14 +132,16 @@ GTEST_TEST(ElementCollectionTest, Removals) {
   EXPECT_EQ(dut.names_map().count(std::string{"one"}), 1);
   EXPECT_EQ(dut.names_map().count(std::string{"three"}), 1);
 
-  EXPECT_THAT(dut.indices(),
+  EXPECT_THAT(dut.valid_indices(),
               testing::ElementsAre(Index{0}, Index{1}, Index{3}));
+  EXPECT_EQ(dut.num_indices(), 4);
   EXPECT_EQ(dut.next_index(), Index{4});
 
   // Add 4.
   // Overall we have indices 0,1,3,4 now.
   dut.Add(std::make_unique<Element<double>>(Index{4}, "four"));
   EXPECT_EQ(dut.num_elements(), 4);
+  EXPECT_EQ(dut.num_indices(), 5);
   EXPECT_EQ(dut.next_index(), Index{5});
 
   // Remove 1 then 0. Add 5. Rename 3.
@@ -167,8 +172,9 @@ GTEST_TEST(ElementCollectionTest, Removals) {
   EXPECT_EQ(dut.names_map().count(std::string{"four"}), 1);
   EXPECT_EQ(dut.names_map().count(std::string{"five"}), 1);
 
-  EXPECT_THAT(dut.indices(),
+  EXPECT_THAT(dut.valid_indices(),
               testing::ElementsAre(Index{3}, Index{4}, Index{5}));
+  EXPECT_EQ(dut.num_indices(), 6);
   EXPECT_EQ(dut.next_index(), Index{6});
 }
 
@@ -182,7 +188,7 @@ GTEST_TEST(ElementCollectionTest, RemovalWithDuplicates) {
   EXPECT_EQ(dut.names_map().count(name), 2);
 
   dut.Remove(Index{0});
-  EXPECT_THAT(dut.indices(), testing::ElementsAre(Index{1}));
+  EXPECT_THAT(dut.valid_indices(), testing::ElementsAre(Index{1}));
   ASSERT_EQ(dut.names_map().count(name), 1);
   EXPECT_EQ(dut.names_map().find(name)->second, Index{1});
 }
@@ -202,6 +208,7 @@ GTEST_TEST(ElementCollectionTest, AllocateThenAdd) {
   dut.Add(std::make_unique<Element<double>>(Index{4}, "four"));
   dut.Add(std::make_unique<Element<double>>(Index{2}, "two"));
   dut.Add(std::make_unique<Element<double>>(Index{3}, "three"));
+  EXPECT_EQ(dut.num_indices(), 5);
   EXPECT_EQ(dut.next_index(), Index{5});
 
   const std::vector<std::string> expected_names{
@@ -210,7 +217,7 @@ GTEST_TEST(ElementCollectionTest, AllocateThenAdd) {
   EXPECT_EQ(dut.num_elements(), 5);
   EXPECT_EQ(dut.elements().size(), 5);
   EXPECT_EQ(dut.names_map().size(), 5);
-  EXPECT_EQ(dut.indices().size(), 5);
+  EXPECT_EQ(dut.valid_indices().size(), 5);
   for (Index i{0}; i < 5; ++i) {
     const std::string& name = expected_names.at(i);
     EXPECT_EQ(dut.elements().at(i)->name(), name);
@@ -219,7 +226,7 @@ GTEST_TEST(ElementCollectionTest, AllocateThenAdd) {
     EXPECT_EQ(dut.get_mutable_element(i).name(), name);
     EXPECT_EQ(dut.get_element_unchecked(i).name(), name);
     EXPECT_EQ(dut.names_map().count(name), 1);
-    EXPECT_EQ(dut.indices().at(i), i);
+    EXPECT_EQ(dut.valid_indices().at(i), i);
   }
 }
 

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -55,7 +55,7 @@ class FrameTests : public ::testing::Test {
     frameB_ = &bodyB_->body_frame();
 
     // Joint connecting bodyB to the world.
-    model->AddJoint<RevoluteJoint>("joint0", model->world_body(), {}, *bodyB_,
+    model->AddJoint<RevoluteJoint>("joint0", model->world_link(), {}, *bodyB_,
                                    {}, Vector3d::UnitZ() /*revolute axis*/);
 
     // Some arbitrary pose of frame P in the body frame B.

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -51,11 +51,11 @@ class FrameTests : public ::testing::Test {
     // Create an empty model.
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
-    bodyB_ = &model->AddRigidBody("B", M_Bo_B);
+    bodyB_ = &model->AddLink("B", M_Bo_B);
     frameB_ = &bodyB_->body_frame();
 
     // Joint connecting bodyB to the world.
-    model->AddJoint<RevoluteJoint>("joint0", model->world_body(), {}, *bodyB_,
+    model->AddJoint<RevoluteJoint>("joint0", model->world_link(), {}, *bodyB_,
                                    {}, Vector3d::UnitZ() /*revolute axis*/);
 
     // Some arbitrary pose of frame P in the body frame B.

--- a/multibody/tree/test/free_rotating_body_plant.cc
+++ b/multibody/tree/test/free_rotating_body_plant.cc
@@ -36,7 +36,7 @@ void FreeRotatingBodyPlant<T>::BuildMultibodyTreeModel() {
 
   body_ = &this->mutable_tree().AddRigidBody("B", M_Bcm);
   joint_ = &this->mutable_tree().template AddJoint<BallRpyJoint>(
-      "ball_rpy_joint", tree().world_body(), {}, *body_, {});
+      "ball_rpy_joint", tree().world_link(), {}, *body_, {});
 
   internal::MultibodyTreeSystem<T>::Finalize();
 }

--- a/multibody/tree/test/free_rotating_body_plant.cc
+++ b/multibody/tree/test/free_rotating_body_plant.cc
@@ -34,9 +34,9 @@ void FreeRotatingBodyPlant<T>::BuildMultibodyTreeModel() {
   const double kMass = 1.0;
   SpatialInertia<double> M_Bcm(kMass, Vector3<double>::Zero(), G_Bcm);
 
-  body_ = &this->mutable_tree().AddRigidBody("B", M_Bcm);
+  body_ = &this->mutable_tree().AddLink("B", M_Bcm);
   joint_ = &this->mutable_tree().template AddJoint<BallRpyJoint>(
-      "ball_rpy_joint", tree().world_body(), {}, *body_, {});
+      "ball_rpy_joint", tree().world_link(), {}, *body_, {});
 
   internal::MultibodyTreeSystem<T>::Finalize();
 }

--- a/multibody/tree/test/joint_actuator_test.cc
+++ b/multibody/tree/test/joint_actuator_test.cc
@@ -41,7 +41,7 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
   // Add a prismatic joint between the world and body1:
   const Joint<double>& body1_world =
       tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
-          "prism1", tree.world_body().body_frame(), body1->body_frame(),
+          "prism1", tree.world_link().body_frame(), body1->body_frame(),
           Eigen::Vector3d(0, 0, 1)));
 
   tree.AddJointActuator("act1", body1_world, kPositiveEffortLimit);
@@ -73,7 +73,7 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
   const auto body4 = &tree.AddRigidBody("body4", M_NaN());
   const Joint<double>& body4_world =
       tree.AddJoint(std::make_unique<PlanarJoint<double>>(
-          "planar4", tree.world_body().body_frame(), body4->body_frame(),
+          "planar4", tree.world_link().body_frame(), body4->body_frame(),
           Eigen::Vector3d{0, 0, 0.1}));
 
   const auto& actuator4 =
@@ -105,7 +105,7 @@ JointActuator<double>& AddBodyJointAndActuator(
   const auto& body = tree->AddRigidBody("body1", M_NaN());
   const Joint<double>& joint =
       tree->AddJoint(std::make_unique<PrismaticJoint<double>>(
-          "joint1", tree->world_body().body_frame(), body.body_frame(),
+          "joint1", tree->world_link().body_frame(), body.body_frame(),
           Eigen::Vector3d(0, 0, 1)));
   tree->AddJointActuator("actuator1", joint, kPositiveEffortLimit);
   return tree->get_mutable_joint_actuator(
@@ -174,7 +174,7 @@ GTEST_TEST(JointActuatorTest, RemoveJointActuatorTest) {
   // Add a prismatic joint between the world and body1:
   const Joint<double>& body1_world =
       tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
-          "prism1", tree.world_body().body_frame(), body1->body_frame(),
+          "prism1", tree.world_link().body_frame(), body1->body_frame(),
           Eigen::Vector3d(0, 0, 1)));
   const JointActuator<double>& actuator1 =
       tree.AddJointActuator("act1", body1_world, kPositiveEffortLimit);
@@ -195,7 +195,7 @@ GTEST_TEST(JointActuatorTest, RemoveJointActuatorTest) {
 
   const Joint<double>& body4_world =
       tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
-          "prism4", tree.world_body().body_frame(), body4->body_frame(),
+          "prism4", tree.world_link().body_frame(), body4->body_frame(),
           Eigen::Vector3d(0, 0, 1)));
   const JointActuator<double>& actuator4 =
       tree.AddJointActuator("act4", body4_world, kPositiveEffortLimit);

--- a/multibody/tree/test/joint_actuator_test.cc
+++ b/multibody/tree/test/joint_actuator_test.cc
@@ -34,14 +34,14 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
   internal::MultibodyTree<double>& tree = *tree_pointer;
 
   // Add bodies so we can add joints to them.
-  const auto body1 = &tree.AddRigidBody("body1", M_NaN());
-  const auto body2 = &tree.AddRigidBody("body2", M_NaN());
-  const auto body3 = &tree.AddRigidBody("body3", M_NaN());
+  const auto body1 = &tree.AddLink("body1", M_NaN());
+  const auto body2 = &tree.AddLink("body2", M_NaN());
+  const auto body3 = &tree.AddLink("body3", M_NaN());
 
   // Add a prismatic joint between the world and body1:
   const Joint<double>& body1_world =
       tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
-          "prism1", tree.world_body().body_frame(), body1->body_frame(),
+          "prism1", tree.world_link().body_frame(), body1->body_frame(),
           Eigen::Vector3d(0, 0, 1)));
 
   tree.AddJointActuator("act1", body1_world, kPositiveEffortLimit);
@@ -70,10 +70,10 @@ GTEST_TEST(JointActuatorTest, JointActuatorLimitTest) {
   EXPECT_EQ(actuator1.input_start(), 0);  // First & only actuated dof.
   EXPECT_EQ(actuator1.num_inputs(), 1);   // Prismatic is 1 dof.
 
-  const auto body4 = &tree.AddRigidBody("body4", M_NaN());
+  const auto body4 = &tree.AddLink("body4", M_NaN());
   const Joint<double>& body4_world =
       tree.AddJoint(std::make_unique<PlanarJoint<double>>(
-          "planar4", tree.world_body().body_frame(), body4->body_frame(),
+          "planar4", tree.world_link().body_frame(), body4->body_frame(),
           Eigen::Vector3d{0, 0, 0.1}));
 
   const auto& actuator4 =
@@ -102,10 +102,10 @@ namespace {
 // Adds an actuated 1-dof joint between the world and a body.
 JointActuator<double>& AddBodyJointAndActuator(
     internal::MultibodyTree<double>* tree) {
-  const auto& body = tree->AddRigidBody("body1", M_NaN());
+  const auto& body = tree->AddLink("body1", M_NaN());
   const Joint<double>& joint =
       tree->AddJoint(std::make_unique<PrismaticJoint<double>>(
-          "joint1", tree->world_body().body_frame(), body.body_frame(),
+          "joint1", tree->world_link().body_frame(), body.body_frame(),
           Eigen::Vector3d(0, 0, 1)));
   tree->AddJointActuator("actuator1", joint, kPositiveEffortLimit);
   return tree->get_mutable_joint_actuator(
@@ -166,15 +166,15 @@ GTEST_TEST(JointActuatorTest, RemoveJointActuatorTest) {
   const auto model_instance2 = tree.AddModelInstance("instance2");
 
   // Add bodies so we can add joints to them.
-  const auto body1 = &tree.AddRigidBody("body1", model_instance1, M_NaN());
-  const auto body2 = &tree.AddRigidBody("body2", model_instance1, M_NaN());
-  const auto body3 = &tree.AddRigidBody("body3", model_instance1, M_NaN());
-  const auto body4 = &tree.AddRigidBody("body4", model_instance2, M_NaN());
+  const auto body1 = &tree.AddLink("body1", model_instance1, M_NaN());
+  const auto body2 = &tree.AddLink("body2", model_instance1, M_NaN());
+  const auto body3 = &tree.AddLink("body3", model_instance1, M_NaN());
+  const auto body4 = &tree.AddLink("body4", model_instance2, M_NaN());
 
   // Add a prismatic joint between the world and body1:
   const Joint<double>& body1_world =
       tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
-          "prism1", tree.world_body().body_frame(), body1->body_frame(),
+          "prism1", tree.world_link().body_frame(), body1->body_frame(),
           Eigen::Vector3d(0, 0, 1)));
   const JointActuator<double>& actuator1 =
       tree.AddJointActuator("act1", body1_world, kPositiveEffortLimit);
@@ -195,7 +195,7 @@ GTEST_TEST(JointActuatorTest, RemoveJointActuatorTest) {
 
   const Joint<double>& body4_world =
       tree.AddJoint(std::make_unique<PrismaticJoint<double>>(
-          "prism4", tree.world_body().body_frame(), body4->body_frame(),
+          "prism4", tree.world_link().body_frame(), body4->body_frame(),
           Eigen::Vector3d(0, 0, 1)));
   const JointActuator<double>& actuator4 =
       tree.AddJointActuator("act4", body4_world, kPositiveEffortLimit);

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -76,7 +76,7 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
     // Assign the two bodies (links) that are attached to the bushing.
     // Designate frameA as the frame of bodyA (world) connected to the bushing.
     // Designate frameC as the frame of bodyC (body)  connected to the bushing.
-    bodyA_ = &(model->world_body());
+    bodyA_ = &(model->world_link());
     bodyC_ = &(model->AddRigidBody("BodyC", M_CCo_C));
     const Frame<double>& frameA = bodyA_->body_frame();
     const Frame<double>& frameC = bodyC_->body_frame();

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -76,8 +76,8 @@ class LinearBushingRollPitchYawTester : public ::testing::Test {
     // Assign the two bodies (links) that are attached to the bushing.
     // Designate frameA as the frame of bodyA (world) connected to the bushing.
     // Designate frameC as the frame of bodyC (body)  connected to the bushing.
-    bodyA_ = &(model->world_body());
-    bodyC_ = &(model->AddRigidBody("BodyC", M_CCo_C));
+    bodyA_ = &(model->world_link());
+    bodyC_ = &(model->AddLink("BodyC", M_CCo_C));
     const Frame<double>& frameA = bodyA_->body_frame();
     const Frame<double>& frameC = bodyC_->body_frame();
 

--- a/multibody/tree/test/mobilizer_tester.h
+++ b/multibody/tree/test/mobilizer_tester.h
@@ -34,7 +34,7 @@ class MobilizerTester : public ::testing::Test {
     tree_ = owned_tree_.get();
 
     // Add a body so we can add a mobilizer to it.
-    body_ = &owned_tree_->AddRigidBody("body", M_B);
+    body_ = &owned_tree_->AddLink("body", M_B);
   }
 
   // Adds a Joint, then finalizes to get a model using a Mobilizer and

--- a/multibody/tree/test/model_instance_test.cc
+++ b/multibody/tree/test/model_instance_test.cc
@@ -39,7 +39,7 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
       tree.AddRigidBody("Body3", instance1, SpatialInertia<double>::NaN());
 
   const auto& weld1 = tree.AddJoint<WeldJoint>(
-      "weld1", tree.world_body(), math::RigidTransformd::Identity(), body1,
+      "weld1", tree.world_link(), math::RigidTransformd::Identity(), body1,
       math::RigidTransformd::Identity(), math::RigidTransformd::Identity());
   EXPECT_EQ(weld1.frame_on_parent().model_instance(), instance1);
   EXPECT_EQ(weld1.frame_on_child().model_instance(), instance1);

--- a/multibody/tree/test/model_instance_test.cc
+++ b/multibody/tree/test/model_instance_test.cc
@@ -32,14 +32,14 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
   const ModelInstanceIndex instance1 = tree.AddModelInstance("instance1");
 
   const RigidBody<double>& body1 =
-      tree.AddRigidBody("Body1", instance1, SpatialInertia<double>::NaN());
+      tree.AddLink("Body1", instance1, SpatialInertia<double>::NaN());
   const RigidBody<double>& body2 =
-      tree.AddRigidBody("Body2", instance1, SpatialInertia<double>::NaN());
+      tree.AddLink("Body2", instance1, SpatialInertia<double>::NaN());
   const RigidBody<double>& body3 =
-      tree.AddRigidBody("Body3", instance1, SpatialInertia<double>::NaN());
+      tree.AddLink("Body3", instance1, SpatialInertia<double>::NaN());
 
   const auto& weld1 = tree.AddJoint<WeldJoint>(
-      "weld1", tree.world_body(), math::RigidTransformd::Identity(), body1,
+      "weld1", tree.world_link(), math::RigidTransformd::Identity(), body1,
       math::RigidTransformd::Identity(), math::RigidTransformd::Identity());
   EXPECT_EQ(weld1.frame_on_parent().model_instance(), instance1);
   EXPECT_EQ(weld1.frame_on_child().model_instance(), instance1);
@@ -58,9 +58,9 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
   const ModelInstanceIndex instance2 = tree.AddModelInstance("instance2");
 
   const RigidBody<double>& body4 =
-      tree.AddRigidBody("Body4", instance2, SpatialInertia<double>::NaN());
+      tree.AddLink("Body4", instance2, SpatialInertia<double>::NaN());
   const RigidBody<double>& body5 =
-      tree.AddRigidBody("Body5", instance2, SpatialInertia<double>::NaN());
+      tree.AddLink("Body5", instance2, SpatialInertia<double>::NaN());
 
   const Joint<double>& body4_body5 = tree.AddJoint<PrismaticJoint>(
       "prism3", body4, math::RigidTransformd::Identity(), body5,

--- a/multibody/tree/test/multibody_forces_test.cc
+++ b/multibody/tree/test/multibody_forces_test.cc
@@ -32,7 +32,7 @@ class MultibodyForcesTests : public ::testing::Test {
     const auto M = SpatialInertia<double>::NaN();
     const RigidBody<double>& body1 = model_.AddRigidBody("Body1", M);
     const RigidBody<double>& body2 = model_.AddRigidBody("Body2", M);
-    model_.AddJoint<RevoluteJoint>("Joint1", model_.world_body(), std::nullopt,
+    model_.AddJoint<RevoluteJoint>("Joint1", model_.world_link(), std::nullopt,
                                    body1, std::nullopt, Vector3d::UnitZ());
     model_.AddJoint<RevoluteJoint>("Joint2", body1, std::nullopt, body2,
                                    std::nullopt, Vector3d::UnitZ());
@@ -57,7 +57,7 @@ TEST_F(MultibodyForcesTests, Construction) {
   EXPECT_TRUE(forces->CheckHasRightSizeForModel(model_));
 
   // Test the API to retrieve sizes.
-  EXPECT_EQ(forces->num_bodies(), model_.num_bodies());
+  EXPECT_EQ(forces->num_bodies(), model_.num_links());
   EXPECT_EQ(forces->num_velocities(), model_.num_velocities());
 
   // Assess the constructor did zero the forces.

--- a/multibody/tree/test/multibody_forces_test.cc
+++ b/multibody/tree/test/multibody_forces_test.cc
@@ -30,9 +30,9 @@ class MultibodyForcesTests : public ::testing::Test {
   // MultibodyForces objects for this model.
   void SetUp() override {
     const auto M = SpatialInertia<double>::NaN();
-    const RigidBody<double>& body1 = model_.AddRigidBody("Body1", M);
-    const RigidBody<double>& body2 = model_.AddRigidBody("Body2", M);
-    model_.AddJoint<RevoluteJoint>("Joint1", model_.world_body(), std::nullopt,
+    const RigidBody<double>& body1 = model_.AddLink("Body1", M);
+    const RigidBody<double>& body2 = model_.AddLink("Body2", M);
+    model_.AddJoint<RevoluteJoint>("Joint1", model_.world_link(), std::nullopt,
                                    body1, std::nullopt, Vector3d::UnitZ());
     model_.AddJoint<RevoluteJoint>("Joint2", body1, std::nullopt, body2,
                                    std::nullopt, Vector3d::UnitZ());
@@ -57,7 +57,7 @@ TEST_F(MultibodyForcesTests, Construction) {
   EXPECT_TRUE(forces->CheckHasRightSizeForModel(model_));
 
   // Test the API to retrieve sizes.
-  EXPECT_EQ(forces->num_bodies(), model_.num_bodies());
+  EXPECT_EQ(forces->num_bodies(), model_.num_links());
   EXPECT_EQ(forces->num_velocities(), model_.num_velocities());
 
   // Assess the constructor did zero the forces.

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -64,14 +64,14 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
   auto model = std::make_unique<MultibodyTree<double>>();
 
   // Initially there is only one body, the world.
-  EXPECT_EQ(model->num_bodies(), 1);
+  EXPECT_EQ(model->num_links(), 1);
 
   // Retrieves the world body.
-  const RigidBody<double>& world_body = model->world_body();
+  const RigidBody<double>& world_body = model->world_link();
   EXPECT_EQ(world_body.name(), "world");
 
   // Make sure the (dispreferred) Body alias is working.
-  const Body<double>& also_world_body = model->world_body();
+  const Body<double>& also_world_body = model->world_link();
   EXPECT_EQ(also_world_body.name(), "world");
 
   // Creates a NaN SpatialInertia to instantiate the RigidBody links of the
@@ -82,7 +82,7 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
   const auto M_Bo_B = SpatialInertia<double>::NaN();
 
   // Adds a new body to the world.
-  const RigidBody<double>& pendulum = model->AddRigidBody("pendulum", M_Bo_B);
+  const RigidBody<double>& pendulum = model->AddLink("pendulum", M_Bo_B);
   EXPECT_EQ(pendulum.scoped_name().get_full(),
             "DefaultModelInstance::pendulum");
   EXPECT_EQ(pendulum.body_frame().scoped_name().get_full(),
@@ -109,11 +109,11 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
       "AddJoint.*joint1 would connect body pendulum to itself.*");
 
   // Adds a second pendulum.
-  const RigidBody<double>& pendulum2 = model->AddRigidBody("pendulum2", M_Bo_B);
+  const RigidBody<double>& pendulum2 = model->AddLink("pendulum2", M_Bo_B);
   model->AddJoint<RevoluteJoint>("joint1", world_body, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
-  EXPECT_EQ(model->num_bodies(), 3);
+  EXPECT_EQ(model->num_links(), 3);
   EXPECT_EQ(model->num_joints(), 2);
 
   // Topology is invalid before MultibodyTree::Finalize().
@@ -127,42 +127,42 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
   // Body identifiers are unique and are assigned by MultibodyTree in increasing
   // order starting with index = 0 (world_index()) for the "world" body.
   EXPECT_EQ(world_body.index(), world_index());
-  EXPECT_EQ(pendulum.index(), BodyIndex(1));
-  EXPECT_EQ(pendulum2.index(), BodyIndex(2));
+  EXPECT_EQ(pendulum.index(), LinkIndex(1));
+  EXPECT_EQ(pendulum2.index(), LinkIndex(2));
 
   // Tests API to access bodies.
-  EXPECT_EQ(model->get_body(BodyIndex(1)).index(), pendulum.index());
-  EXPECT_EQ(model->get_body(BodyIndex(2)).index(), pendulum2.index());
+  EXPECT_EQ(model->get_link(LinkIndex(1)).index(), pendulum.index());
+  EXPECT_EQ(model->get_link(LinkIndex(2)).index(), pendulum2.index());
 
   // Verifies that an exception is throw if a call to Finalize() is attempted to
   // an already finalized MultibodyTree.
   EXPECT_THROW(model->Finalize(), std::exception);
 
   // Verifies that after compilation no more bodies can be added.
-  EXPECT_THROW(model->AddRigidBody("B", M_Bo_B), std::exception);
+  EXPECT_THROW(model->AddLink("B", M_Bo_B), std::exception);
 }
 
 // Tests the basic MultibodyTree API to add bodies and joints.
 // Tests we cannot currently create graph loops. See previous test for notes.
 GTEST_TEST(MultibodyTree, TopologicalLoopDisallowed) {
   auto model = std::make_unique<MultibodyTree<double>>();
-  const RigidBody<double>& world_body = model->world_body();
+  const RigidBody<double>& world_body = model->world_link();
   const auto M_Bo_B = SpatialInertia<double>::NaN();
-  const RigidBody<double>& pendulum = model->AddRigidBody("pendulum", M_Bo_B);
+  const RigidBody<double>& pendulum = model->AddLink("pendulum", M_Bo_B);
   model->AddJoint<RevoluteJoint>("joint0", world_body, {}, pendulum, {},
                                  Vector3d::UnitZ());
-  const RigidBody<double>& pendulum2 = model->AddRigidBody("pendulum2", M_Bo_B);
+  const RigidBody<double>& pendulum2 = model->AddLink("pendulum2", M_Bo_B);
   model->AddJoint<RevoluteJoint>("joint1", world_body, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
-  EXPECT_EQ(model->num_bodies(), 3);
+  EXPECT_EQ(model->num_links(), 3);
   EXPECT_EQ(model->num_joints(), 2);
 
   // Attempts to create a loop. Verify we get an exception at Finalize().
   model->AddJoint<RevoluteJoint>("joint2", pendulum, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
-  EXPECT_EQ(model->num_bodies(), 3);
+  EXPECT_EQ(model->num_links(), 3);
   EXPECT_EQ(model->num_joints(), 3);
 
   // Topology is invalid before MultibodyTree::Finalize() or after a
@@ -189,18 +189,18 @@ GTEST_TEST(MultibodyTree, MultibodyElementChecks) {
   // expressed in the body frame B.
   const auto M_Bo_B = SpatialInertia<double>::NaN();
 
-  const RigidBody<double>& body1 = model1->AddRigidBody("body1", M_Bo_B);
-  const RigidBody<double>& body2 = model2->AddRigidBody("body2", M_Bo_B);
+  const RigidBody<double>& body1 = model1->AddLink("body1", M_Bo_B);
+  const RigidBody<double>& body2 = model2->AddLink("body2", M_Bo_B);
 
   // Verify we can add a joint between body1 and the world of model1.
   const RevoluteJoint<double>& pin1 = model1->AddJoint<RevoluteJoint>(
-      "pin1", model1->world_body(), std::nullopt /*inboard frame*/, body1,
+      "pin1", model1->world_link(), std::nullopt /*inboard frame*/, body1,
       std::nullopt /*outboard frame*/, Vector3d::UnitZ() /*axis of rotation*/);
 
   // Verify we can't add a joint between bodies that belong to another plant.
   DRAKE_EXPECT_THROWS_MESSAGE(
       (model1->AddJoint<RevoluteJoint>(
-          "nogood", model1->world_body(), std::nullopt,
+          "nogood", model1->world_link(), std::nullopt,
           body2 /*body2 belongs to model2, not model1!!!*/, std::nullopt,
           Vector3d::UnitZ() /*axis of rotation*/)),
       "AddJoint.*can't add joint nogood.*world.*body2.*different.*Plant.*");
@@ -228,9 +228,9 @@ GTEST_TEST(MultibodyTree, MultibodyElementChecks) {
   const auto& body1_tree = MultibodyElementTester::get_parent_tree(body1);
   const auto& body2_tree = MultibodyElementTester::get_parent_tree(body2);
   EXPECT_NE(&body1_tree, &body2_tree);
-  EXPECT_EQ(&MultibodyElementTester::get_parent_tree(model1->world_body()),
+  EXPECT_EQ(&MultibodyElementTester::get_parent_tree(model1->world_link()),
             &body1_tree);
-  EXPECT_EQ(&MultibodyElementTester::get_parent_tree(model2->world_body()),
+  EXPECT_EQ(&MultibodyElementTester::get_parent_tree(model2->world_link()),
             &body2_tree);
 
   // Verify that bodies have the correct parent tree.
@@ -283,7 +283,7 @@ class TreeTopologyTests : public ::testing::Test {
     model_ = std::make_unique<MultibodyTree<double>>();
 
     const int kNumRigidBodies = 10;
-    bodies_.push_back(&model_->world_body());
+    bodies_.push_back(&model_->world_link());
     for (int i = 1; i < kNumRigidBodies; ++i) AddTestBody(i);
 
     // Adds Joints to connect bodies according to the following diagram:
@@ -303,7 +303,7 @@ class TreeTopologyTests : public ::testing::Test {
     // It is safe here since this tests only focus on topological information.
     const auto M_Bo_B = SpatialInertia<double>::NaN();
     const RigidBody<double>* body =
-        &model_->AddRigidBody(fmt::format("TestBody_{}", i), M_Bo_B);
+        &model_->AddLink(fmt::format("TestBody_{}", i), M_Bo_B);
     bodies_.push_back(body);
     return body;
   }
@@ -345,7 +345,7 @@ class TreeTopologyTests : public ::testing::Test {
     EXPECT_EQ(mobod.index(), mobod_index);
     mobod.HasFollower(link.ordinal());
 
-    const MobodIndex parent_mobod_index = mobod.inboard();
+    const MobodIndex parent_mobod_index = mobod.inboard_mobod();
     EXPECT_TRUE(parent_mobod_index.is_valid() ^ link.is_world());
 
     if (link.is_world()) return;
@@ -353,7 +353,8 @@ class TreeTopologyTests : public ::testing::Test {
     // Verify that the link's mobod is actually a child of its parent mobod.
     const SpanningForest::Mobod& parent_mobod =
         forest.mobods(parent_mobod_index);
-    const std::vector<MobodIndex>& child_mobods = parent_mobod.outboards();
+    const std::vector<MobodIndex>& child_mobods =
+        parent_mobod.outboard_mobods();
     EXPECT_TRUE(std::find(child_mobods.begin(), child_mobods.end(),
                           mobod_index) != child_mobods.end());
   }
@@ -397,7 +398,7 @@ class TreeTopologyTests : public ::testing::Test {
       const LinkOrdinal ordinal = forest.graph().index_to_ordinal(link_index);
       const LinkJointGraph::Link& link = forest.links(ordinal);
       const SpanningForest::Mobod& mobod = forest.mobods(link.mobod_index());
-      EXPECT_EQ(ssize(mobod.outboards()), num_outboards);
+      EXPECT_EQ(ssize(mobod.outboard_mobods()), num_outboards);
     }
 
     // Checks the correctness of each BodyNode associated with a Link.
@@ -419,7 +420,8 @@ class TreeTopologyTests : public ::testing::Test {
     for (const auto& [mobod_index, primary_link_index] :
          expected_mobod_to_link) {
       const SpanningForest::Mobod& mobod = forest.mobods(mobod_index);
-      const LinkJointGraph::Link& link = forest.links(mobod.link_ordinal());
+      const LinkJointGraph::Link& link =
+          forest.links(mobod.active_link_ordinal());
       EXPECT_EQ(link.index(), primary_link_index);
     }
 
@@ -477,7 +479,7 @@ class TreeTopologyTests : public ::testing::Test {
 // This unit tests verifies that the multibody topology is properly compiled.
 TEST_F(TreeTopologyTests, Finalize) {
   model_->Finalize();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
 
   const SpanningForest& forest = model_->forest();
@@ -491,7 +493,7 @@ TEST_F(TreeTopologyTests, Finalize) {
 // velocities as well as the start indexes into the state vector.
 TEST_F(TreeTopologyTests, SizesAndIndexing) {
   FinalizeModel();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
   EXPECT_EQ(model_->num_joints(), 9);
 
@@ -507,7 +509,7 @@ TEST_F(TreeTopologyTests, SizesAndIndexing) {
   int positions_index = 0;
   int velocities_index = 0;
   for (const SpanningForest::Mobod& mobod : forest.mobods()) {
-    const LinkOrdinal active_link_ordinal = mobod.link_ordinal();
+    const LinkOrdinal active_link_ordinal = mobod.active_link_ordinal();
     const LinkJointGraph::Link active_link = forest.links(active_link_ordinal);
 
     EXPECT_EQ(active_link.mobod_index(), mobod.index());
@@ -527,13 +529,13 @@ TEST_F(TreeTopologyTests, SizesAndIndexing) {
 // model.
 TEST_F(TreeTopologyTests, Clone) {
   model_->Finalize();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
   EXPECT_EQ(model_->num_force_elements(), 1);
   const SpanningForest& forest = model_->forest();
 
   auto cloned_model = model_->Clone();
-  EXPECT_EQ(cloned_model->num_bodies(), 10);
+  EXPECT_EQ(cloned_model->num_links(), 10);
   EXPECT_EQ(cloned_model->num_mobilizers(), 10);
   EXPECT_EQ(cloned_model->num_force_elements(), 1);
   const SpanningForest& clone_forest = cloned_model->forest();
@@ -549,11 +551,11 @@ TEST_F(TreeTopologyTests, Clone) {
 // original model.
 TEST_F(TreeTopologyTests, ToAutoDiffXd) {
   model_->Finalize();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
 
   auto autodiff_model = model_->ToAutoDiffXd();
-  EXPECT_EQ(autodiff_model->num_bodies(), 10);
+  EXPECT_EQ(autodiff_model->num_links(), 10);
   EXPECT_EQ(autodiff_model->num_mobilizers(), 10);
   const SpanningForest& autodiff_forest = autodiff_model->forest();
 
@@ -565,11 +567,11 @@ TEST_F(TreeTopologyTests, ToAutoDiffXd) {
 // original model.
 TEST_F(TreeTopologyTests, ToSymbolic) {
   model_->Finalize();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
 
   auto symbolic_model = model_->CloneToScalar<symbolic::Expression>();
-  EXPECT_EQ(symbolic_model->num_bodies(), 10);
+  EXPECT_EQ(symbolic_model->num_links(), 10);
   EXPECT_EQ(symbolic_model->num_mobilizers(), 10);
   const SpanningForest& symbolic_forest = symbolic_model->forest();
 
@@ -612,7 +614,7 @@ TEST_F(TreeTopologyTests, KinematicPathFromWorld) {
     const MobodIndex expected_mobod_index =
         forest.link_by_index(body_index).mobod_index();
     const SpanningForest::Mobod& mobod = forest.mobods(expected_mobod_index);
-    EXPECT_EQ(forest.links(mobod.link_ordinal()).index(), body_index);
+    EXPECT_EQ(forest.links(mobod.active_link_ordinal()).index(), body_index);
     // Both expected and computed Mobods must be at the same level (depth) in
     // the tree.
     const int level = mobod.level();
@@ -632,22 +634,20 @@ TEST_F(TreeTopologyTests, GetTransitiveOutboardBodies) {
   const std::vector<BodyIndex> body4{body4_index};
   std::set<BodyIndex> expected_outboard_bodies{body1_index, body2_index,
                                                body4_index, body6_index};
-  EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body4), expected_outboard_bodies);
+  EXPECT_EQ(model_->GetLinksOutboardOfLinks(body4), expected_outboard_bodies);
 
   const std::vector<BodyIndex> body14{body1_index, body4_index};
-  EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body14),
-            expected_outboard_bodies);
+  EXPECT_EQ(model_->GetLinksOutboardOfLinks(body14), expected_outboard_bodies);
 
   const std::vector<BodyIndex> body94{body9_index, body4_index};
   expected_outboard_bodies.insert(body8_index);
   expected_outboard_bodies.insert(body9_index);
-  EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body94),
-            expected_outboard_bodies);
+  EXPECT_EQ(model_->GetLinksOutboardOfLinks(body94), expected_outboard_bodies);
 
   const std::vector<BodyIndex> body6{body6_index};
   expected_outboard_bodies.clear();
   expected_outboard_bodies.insert(body6_index);
-  EXPECT_EQ(model_->GetBodiesOutboardOfBodies(body6), expected_outboard_bodies);
+  EXPECT_EQ(model_->GetLinksOutboardOfLinks(body6), expected_outboard_bodies);
 }
 
 // Unit test to verify that LinkJointGraph::GetSubgraphsOfWeldedLinks()
@@ -697,9 +697,8 @@ GTEST_TEST(WeldedBodies, CreateSubgraphsOfWeldedLinks) {
 
   // Helper to add a rigid body. For these tests the value of the spatial
   // inertia is not relevant and therefore we leave it un-initialized.
-  auto AddRigidBody =
-      [&model](const std::string& name) -> const RigidBody<double>& {
-    return model.AddRigidBody(name, SpatialInertia<double>::NaN());
+  auto AddLink = [&model](const std::string& name) -> const RigidBody<double>& {
+    return model.AddLink(name, SpatialInertia<double>::NaN());
   };
 
   // Helper to add a joint between two bodies. For this test the actual type of
@@ -720,28 +719,28 @@ GTEST_TEST(WeldedBodies, CreateSubgraphsOfWeldedLinks) {
   };
 
   // Start building the test model.
-  const RigidBody<double>& body_a = AddRigidBody("a");
-  const RigidBody<double>& body_b = AddRigidBody("b");
-  const RigidBody<double>& body_c = AddRigidBody("c");
-  const RigidBody<double>& body_d = AddRigidBody("d");
-  const RigidBody<double>& body_e = AddRigidBody("e");
-  const RigidBody<double>& body_f = AddRigidBody("f");
-  const RigidBody<double>& body_g = AddRigidBody("g");
-  const RigidBody<double>& body_h = AddRigidBody("h");
-  const RigidBody<double>& body_i = AddRigidBody("i");
-  const RigidBody<double>& body_j = AddRigidBody("j");
-  const RigidBody<double>& body_k = AddRigidBody("k");
-  const RigidBody<double>& body_l = AddRigidBody("l");
-  const RigidBody<double>& body_m = AddRigidBody("m");
-  const RigidBody<double>& body_n = AddRigidBody("n");
+  const RigidBody<double>& body_a = AddLink("a");
+  const RigidBody<double>& body_b = AddLink("b");
+  const RigidBody<double>& body_c = AddLink("c");
+  const RigidBody<double>& body_d = AddLink("d");
+  const RigidBody<double>& body_e = AddLink("e");
+  const RigidBody<double>& body_f = AddLink("f");
+  const RigidBody<double>& body_g = AddLink("g");
+  const RigidBody<double>& body_h = AddLink("h");
+  const RigidBody<double>& body_i = AddLink("i");
+  const RigidBody<double>& body_j = AddLink("j");
+  const RigidBody<double>& body_k = AddLink("k");
+  const RigidBody<double>& body_l = AddLink("l");
+  const RigidBody<double>& body_m = AddLink("m");
+  const RigidBody<double>& body_n = AddLink("n");
 
-  AddJoint("wa", model.world_body(), body_a);
+  AddJoint("wa", model.world_link(), body_a);
 
   // Welded body formed by bodies a and b.
   AddWeldJoint("ab", body_a, body_b);
 
   AddJoint("bc", body_b, body_c);
-  AddJoint("wd", model.world_body(), body_d);
+  AddJoint("wd", model.world_link(), body_d);
 
   // Welded body formed by bodies d, e, f and, g.
   AddWeldJoint("de", body_d, body_e);
@@ -749,14 +748,14 @@ GTEST_TEST(WeldedBodies, CreateSubgraphsOfWeldedLinks) {
   AddWeldJoint("dg", body_d, body_g);
 
   AddJoint("gh", body_g, body_h);
-  AddJoint("wi", model.world_body(), body_i);
+  AddJoint("wi", model.world_link(), body_i);
   AddJoint("ij", body_i, body_j);
 
   // Welded body formed by bodies j and k.
   AddWeldJoint("jk", body_j, body_k);
 
   // Welded body formed by bodies w (world), l, m and n.
-  AddWeldJoint("wl", model.world_body(), body_l);
+  AddWeldJoint("wl", model.world_link(), body_l);
   AddWeldJoint("lm", body_l, body_m);
   AddWeldJoint("ln", body_l, body_n);
 
@@ -843,7 +842,7 @@ const RigidBody<double>& AddCubicalLink(
   const UnitInertia<double> G_BBo_B = MakeTestCubeUnitInertia(link_length);
   const SpatialInertia<double> M_BBo_B(mass, p_BoBcm_B, G_BBo_B,
                                        skip_validity_check);
-  return model->AddRigidBody(body_name, M_BBo_B);
+  return model->AddLink(body_name, M_BBo_B);
 }
 
 // Verify RigidBody::default_rotational_inertia() and related MultibodyTree
@@ -939,7 +938,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithZeroMass) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a prismatic joint between the world body and bodyA.
-  AddPrismaticJointX(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddPrismaticJointX(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB.
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -966,7 +965,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithZeroInertia) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a revolute joint between the world body and bodyA.
-  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB.
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -997,7 +996,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithNaNInertia) {
       AddCubicalLink(&model, "bodyB", mass, length, skip_validity_check);
 
   // Add a revolute joint between the world body and bodyA.
-  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB.
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -1025,7 +1024,7 @@ GTEST_TEST(WeldedBodies, NoErrorIfCompositeBodyHasMassDueToWeldedBody) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a prismatic joint between the world body and bodyA (bodyA has mass 0).
-  AddPrismaticJointX(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddPrismaticJointX(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB (bodyB has mass 1).
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -1048,7 +1047,7 @@ GTEST_TEST(WeldedBodies, NoErrorIfCompositeBodyHasInertiaDueToWeldedBody) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a revolute joint between the world body and bodyA.
-  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB (bodyB has non-zero inertia).
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -1073,7 +1072,7 @@ GTEST_TEST(TestDistalBody, NoThrowErrorIfZeroMassBodyIsNotDistal) {
   const RigidBody<double>& body_D = AddCubicalLink(&model, "bodyD", mD, length);
 
   // Add world to bodyA X-prismatic joint (bodyA has zero mass and inertia).
-  AddPrismaticJointX(&model, "WA_prismatic_jointX", model.world_body(), body_A);
+  AddPrismaticJointX(&model, "WA_prismatic_jointX", model.world_link(), body_A);
 
   // Add bodyA to bodyB Y-prismatic joint (bodyB has zero mass and inertia).
   model.AddJoint<PrismaticJoint>("AB_prismatic_jointY", body_A, {}, body_B, {},
@@ -1107,7 +1106,7 @@ GTEST_TEST(TestDistalBody, NoThrowErrorIfZeroInertiaBodyIsNotDistal) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a revolute joint from the world body to bodyA (bodyA has no inertia).
-  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a revolute joint between bodyA and bodyB (bodyB has non-zero inertia).
   AddRevoluteJointZ(&model, "AB_revolute_joint", body_A, body_B);

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -64,14 +64,14 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
   auto model = std::make_unique<MultibodyTree<double>>();
 
   // Initially there is only one body, the world.
-  EXPECT_EQ(model->num_bodies(), 1);
+  EXPECT_EQ(model->num_links(), 1);
 
   // Retrieves the world body.
-  const RigidBody<double>& world_body = model->world_body();
+  const RigidBody<double>& world_body = model->world_link();
   EXPECT_EQ(world_body.name(), "world");
 
   // Make sure the (dispreferred) Body alias is working.
-  const Body<double>& also_world_body = model->world_body();
+  const Body<double>& also_world_body = model->world_link();
   EXPECT_EQ(also_world_body.name(), "world");
 
   // Creates a NaN SpatialInertia to instantiate the RigidBody links of the
@@ -113,7 +113,7 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
   model->AddJoint<RevoluteJoint>("joint1", world_body, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
-  EXPECT_EQ(model->num_bodies(), 3);
+  EXPECT_EQ(model->num_links(), 3);
   EXPECT_EQ(model->num_joints(), 2);
 
   // Topology is invalid before MultibodyTree::Finalize().
@@ -146,7 +146,7 @@ GTEST_TEST(MultibodyTree, BasicAPIToAddBodiesAndJoints) {
 // Tests we cannot currently create graph loops. See previous test for notes.
 GTEST_TEST(MultibodyTree, TopologicalLoopDisallowed) {
   auto model = std::make_unique<MultibodyTree<double>>();
-  const RigidBody<double>& world_body = model->world_body();
+  const RigidBody<double>& world_body = model->world_link();
   const auto M_Bo_B = SpatialInertia<double>::NaN();
   const RigidBody<double>& pendulum = model->AddRigidBody("pendulum", M_Bo_B);
   model->AddJoint<RevoluteJoint>("joint0", world_body, {}, pendulum, {},
@@ -155,14 +155,14 @@ GTEST_TEST(MultibodyTree, TopologicalLoopDisallowed) {
   model->AddJoint<RevoluteJoint>("joint1", world_body, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
-  EXPECT_EQ(model->num_bodies(), 3);
+  EXPECT_EQ(model->num_links(), 3);
   EXPECT_EQ(model->num_joints(), 2);
 
   // Attempts to create a loop. Verify we get an exception at Finalize().
   model->AddJoint<RevoluteJoint>("joint2", pendulum, {}, pendulum2, {},
                                  Vector3d::UnitZ());
 
-  EXPECT_EQ(model->num_bodies(), 3);
+  EXPECT_EQ(model->num_links(), 3);
   EXPECT_EQ(model->num_joints(), 3);
 
   // Topology is invalid before MultibodyTree::Finalize() or after a
@@ -194,13 +194,13 @@ GTEST_TEST(MultibodyTree, MultibodyElementChecks) {
 
   // Verify we can add a joint between body1 and the world of model1.
   const RevoluteJoint<double>& pin1 = model1->AddJoint<RevoluteJoint>(
-      "pin1", model1->world_body(), std::nullopt /*inboard frame*/, body1,
+      "pin1", model1->world_link(), std::nullopt /*inboard frame*/, body1,
       std::nullopt /*outboard frame*/, Vector3d::UnitZ() /*axis of rotation*/);
 
   // Verify we can't add a joint between bodies that belong to another plant.
   DRAKE_EXPECT_THROWS_MESSAGE(
       (model1->AddJoint<RevoluteJoint>(
-          "nogood", model1->world_body(), std::nullopt,
+          "nogood", model1->world_link(), std::nullopt,
           body2 /*body2 belongs to model2, not model1!!!*/, std::nullopt,
           Vector3d::UnitZ() /*axis of rotation*/)),
       "AddJoint.*can't add joint nogood.*world.*body2.*different.*Plant.*");
@@ -228,9 +228,9 @@ GTEST_TEST(MultibodyTree, MultibodyElementChecks) {
   const auto& body1_tree = MultibodyElementTester::get_parent_tree(body1);
   const auto& body2_tree = MultibodyElementTester::get_parent_tree(body2);
   EXPECT_NE(&body1_tree, &body2_tree);
-  EXPECT_EQ(&MultibodyElementTester::get_parent_tree(model1->world_body()),
+  EXPECT_EQ(&MultibodyElementTester::get_parent_tree(model1->world_link()),
             &body1_tree);
-  EXPECT_EQ(&MultibodyElementTester::get_parent_tree(model2->world_body()),
+  EXPECT_EQ(&MultibodyElementTester::get_parent_tree(model2->world_link()),
             &body2_tree);
 
   // Verify that bodies have the correct parent tree.
@@ -283,7 +283,7 @@ class TreeTopologyTests : public ::testing::Test {
     model_ = std::make_unique<MultibodyTree<double>>();
 
     const int kNumRigidBodies = 10;
-    bodies_.push_back(&model_->world_body());
+    bodies_.push_back(&model_->world_link());
     for (int i = 1; i < kNumRigidBodies; ++i) AddTestBody(i);
 
     // Adds Joints to connect bodies according to the following diagram:
@@ -345,7 +345,7 @@ class TreeTopologyTests : public ::testing::Test {
     EXPECT_EQ(mobod.index(), mobod_index);
     mobod.HasFollower(link.ordinal());
 
-    const MobodIndex parent_mobod_index = mobod.inboard();
+    const MobodIndex parent_mobod_index = mobod.inboard_mobod();
     EXPECT_TRUE(parent_mobod_index.is_valid() ^ link.is_world());
 
     if (link.is_world()) return;
@@ -353,7 +353,8 @@ class TreeTopologyTests : public ::testing::Test {
     // Verify that the link's mobod is actually a child of its parent mobod.
     const SpanningForest::Mobod& parent_mobod =
         forest.mobods(parent_mobod_index);
-    const std::vector<MobodIndex>& child_mobods = parent_mobod.outboards();
+    const std::vector<MobodIndex>& child_mobods =
+        parent_mobod.outboard_mobods();
     EXPECT_TRUE(std::find(child_mobods.begin(), child_mobods.end(),
                           mobod_index) != child_mobods.end());
   }
@@ -397,7 +398,7 @@ class TreeTopologyTests : public ::testing::Test {
       const LinkOrdinal ordinal = forest.graph().index_to_ordinal(link_index);
       const LinkJointGraph::Link& link = forest.links(ordinal);
       const SpanningForest::Mobod& mobod = forest.mobods(link.mobod_index());
-      EXPECT_EQ(ssize(mobod.outboards()), num_outboards);
+      EXPECT_EQ(ssize(mobod.outboard_mobods()), num_outboards);
     }
 
     // Checks the correctness of each BodyNode associated with a Link.
@@ -419,7 +420,8 @@ class TreeTopologyTests : public ::testing::Test {
     for (const auto& [mobod_index, primary_link_index] :
          expected_mobod_to_link) {
       const SpanningForest::Mobod& mobod = forest.mobods(mobod_index);
-      const LinkJointGraph::Link& link = forest.links(mobod.link_ordinal());
+      const LinkJointGraph::Link& link =
+          forest.links(mobod.active_link_ordinal());
       EXPECT_EQ(link.index(), primary_link_index);
     }
 
@@ -477,7 +479,7 @@ class TreeTopologyTests : public ::testing::Test {
 // This unit tests verifies that the multibody topology is properly compiled.
 TEST_F(TreeTopologyTests, Finalize) {
   model_->Finalize();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
 
   const SpanningForest& forest = model_->forest();
@@ -491,7 +493,7 @@ TEST_F(TreeTopologyTests, Finalize) {
 // velocities as well as the start indexes into the state vector.
 TEST_F(TreeTopologyTests, SizesAndIndexing) {
   FinalizeModel();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
   EXPECT_EQ(model_->num_joints(), 9);
 
@@ -507,7 +509,7 @@ TEST_F(TreeTopologyTests, SizesAndIndexing) {
   int positions_index = 0;
   int velocities_index = 0;
   for (const SpanningForest::Mobod& mobod : forest.mobods()) {
-    const LinkOrdinal active_link_ordinal = mobod.link_ordinal();
+    const LinkOrdinal active_link_ordinal = mobod.active_link_ordinal();
     const LinkJointGraph::Link active_link = forest.links(active_link_ordinal);
 
     EXPECT_EQ(active_link.mobod_index(), mobod.index());
@@ -527,13 +529,13 @@ TEST_F(TreeTopologyTests, SizesAndIndexing) {
 // model.
 TEST_F(TreeTopologyTests, Clone) {
   model_->Finalize();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
   EXPECT_EQ(model_->num_force_elements(), 1);
   const SpanningForest& forest = model_->forest();
 
   auto cloned_model = model_->Clone();
-  EXPECT_EQ(cloned_model->num_bodies(), 10);
+  EXPECT_EQ(cloned_model->num_links(), 10);
   EXPECT_EQ(cloned_model->num_mobilizers(), 10);
   EXPECT_EQ(cloned_model->num_force_elements(), 1);
   const SpanningForest& clone_forest = cloned_model->forest();
@@ -549,11 +551,11 @@ TEST_F(TreeTopologyTests, Clone) {
 // original model.
 TEST_F(TreeTopologyTests, ToAutoDiffXd) {
   model_->Finalize();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
 
   auto autodiff_model = model_->ToAutoDiffXd();
-  EXPECT_EQ(autodiff_model->num_bodies(), 10);
+  EXPECT_EQ(autodiff_model->num_links(), 10);
   EXPECT_EQ(autodiff_model->num_mobilizers(), 10);
   const SpanningForest& autodiff_forest = autodiff_model->forest();
 
@@ -565,11 +567,11 @@ TEST_F(TreeTopologyTests, ToAutoDiffXd) {
 // original model.
 TEST_F(TreeTopologyTests, ToSymbolic) {
   model_->Finalize();
-  EXPECT_EQ(model_->num_bodies(), 10);
+  EXPECT_EQ(model_->num_links(), 10);
   EXPECT_EQ(model_->num_mobilizers(), 10);
 
   auto symbolic_model = model_->CloneToScalar<symbolic::Expression>();
-  EXPECT_EQ(symbolic_model->num_bodies(), 10);
+  EXPECT_EQ(symbolic_model->num_links(), 10);
   EXPECT_EQ(symbolic_model->num_mobilizers(), 10);
   const SpanningForest& symbolic_forest = symbolic_model->forest();
 
@@ -612,7 +614,7 @@ TEST_F(TreeTopologyTests, KinematicPathFromWorld) {
     const MobodIndex expected_mobod_index =
         forest.link_by_index(body_index).mobod_index();
     const SpanningForest::Mobod& mobod = forest.mobods(expected_mobod_index);
-    EXPECT_EQ(forest.links(mobod.link_ordinal()).index(), body_index);
+    EXPECT_EQ(forest.links(mobod.active_link_ordinal()).index(), body_index);
     // Both expected and computed Mobods must be at the same level (depth) in
     // the tree.
     const int level = mobod.level();
@@ -735,13 +737,13 @@ GTEST_TEST(WeldedBodies, CreateSubgraphsOfWeldedLinks) {
   const RigidBody<double>& body_m = AddRigidBody("m");
   const RigidBody<double>& body_n = AddRigidBody("n");
 
-  AddJoint("wa", model.world_body(), body_a);
+  AddJoint("wa", model.world_link(), body_a);
 
   // Welded body formed by bodies a and b.
   AddWeldJoint("ab", body_a, body_b);
 
   AddJoint("bc", body_b, body_c);
-  AddJoint("wd", model.world_body(), body_d);
+  AddJoint("wd", model.world_link(), body_d);
 
   // Welded body formed by bodies d, e, f and, g.
   AddWeldJoint("de", body_d, body_e);
@@ -749,14 +751,14 @@ GTEST_TEST(WeldedBodies, CreateSubgraphsOfWeldedLinks) {
   AddWeldJoint("dg", body_d, body_g);
 
   AddJoint("gh", body_g, body_h);
-  AddJoint("wi", model.world_body(), body_i);
+  AddJoint("wi", model.world_link(), body_i);
   AddJoint("ij", body_i, body_j);
 
   // Welded body formed by bodies j and k.
   AddWeldJoint("jk", body_j, body_k);
 
   // Welded body formed by bodies w (world), l, m and n.
-  AddWeldJoint("wl", model.world_body(), body_l);
+  AddWeldJoint("wl", model.world_link(), body_l);
   AddWeldJoint("lm", body_l, body_m);
   AddWeldJoint("ln", body_l, body_n);
 
@@ -939,7 +941,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithZeroMass) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a prismatic joint between the world body and bodyA.
-  AddPrismaticJointX(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddPrismaticJointX(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB.
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -966,7 +968,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithZeroInertia) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a revolute joint between the world body and bodyA.
-  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB.
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -997,7 +999,7 @@ GTEST_TEST(WeldedBodies, ThrowErrorForDistalCompositeBodyWithNaNInertia) {
       AddCubicalLink(&model, "bodyB", mass, length, skip_validity_check);
 
   // Add a revolute joint between the world body and bodyA.
-  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB.
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -1025,7 +1027,7 @@ GTEST_TEST(WeldedBodies, NoErrorIfCompositeBodyHasMassDueToWeldedBody) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a prismatic joint between the world body and bodyA (bodyA has mass 0).
-  AddPrismaticJointX(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddPrismaticJointX(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB (bodyB has mass 1).
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -1048,7 +1050,7 @@ GTEST_TEST(WeldedBodies, NoErrorIfCompositeBodyHasInertiaDueToWeldedBody) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a revolute joint between the world body and bodyA.
-  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a weld joint between bodyA and bodyB (bodyB has non-zero inertia).
   AddWeldJoint(&model, "AB_weld_joint", body_A, body_B);
@@ -1073,7 +1075,7 @@ GTEST_TEST(TestDistalBody, NoThrowErrorIfZeroMassBodyIsNotDistal) {
   const RigidBody<double>& body_D = AddCubicalLink(&model, "bodyD", mD, length);
 
   // Add world to bodyA X-prismatic joint (bodyA has zero mass and inertia).
-  AddPrismaticJointX(&model, "WA_prismatic_jointX", model.world_body(), body_A);
+  AddPrismaticJointX(&model, "WA_prismatic_jointX", model.world_link(), body_A);
 
   // Add bodyA to bodyB Y-prismatic joint (bodyB has zero mass and inertia).
   model.AddJoint<PrismaticJoint>("AB_prismatic_jointY", body_A, {}, body_B, {},
@@ -1107,7 +1109,7 @@ GTEST_TEST(TestDistalBody, NoThrowErrorIfZeroInertiaBodyIsNotDistal) {
   const RigidBody<double>& body_B = AddCubicalLink(&model, "bodyB", mB, length);
 
   // Add a revolute joint from the world body to bodyA (bodyA has no inertia).
-  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_body(), body_A);
+  AddRevoluteJointZ(&model, "WA_revolute_joint", model.world_link(), body_A);
 
   // Add a revolute joint between bodyA and bodyB (bodyB has non-zero inertia).
   AddRevoluteJointZ(&model, "AB_revolute_joint", body_A, body_B);

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -70,8 +70,8 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
       "iiwa_actuator_4", "iiwa_actuator_5", "iiwa_actuator_6",
       "iiwa_actuator_7"};
 
-  // Model Size. Counting the world body, there should be eight bodies.
-  EXPECT_EQ(model.num_bodies(), 8);  // It includes the "world" body.
+  // Model Size. Counting the world link, there should be eight links.
+  EXPECT_EQ(model.num_links(), 8);  // It includes the "world" link.
   EXPECT_EQ(model.num_joints(), 7);
   EXPECT_EQ(model.num_actuators(), 7);
   EXPECT_EQ(model.num_actuated_dofs(), 7);
@@ -83,11 +83,11 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
 
   // Query if elements exist in the model.
   for (const std::string& link_name : kLinkNames) {
-    EXPECT_TRUE(model.HasBodyNamed(link_name));
-    EXPECT_EQ(model.NumBodiesWithName(link_name), 1);
+    EXPECT_TRUE(model.HasLinkNamed(link_name));
+    EXPECT_EQ(model.NumLinksWithName(link_name), 1);
   }
-  EXPECT_FALSE(model.HasBodyNamed(kInvalidName));
-  EXPECT_EQ(model.NumBodiesWithName(kInvalidName), 0);
+  EXPECT_FALSE(model.HasLinkNamed(kInvalidName));
+  EXPECT_EQ(model.NumLinksWithName(kInvalidName), 0);
 
   for (const std::string& frame_name : kFrameNames) {
     EXPECT_TRUE(model.HasFrameNamed(frame_name));
@@ -112,24 +112,23 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   // Get links by name.
   for (const std::string& link_name : kLinkNames) {
     drake::test::LimitMalloc guard;
-    const RigidBody<T>& link = model.GetRigidBodyByName(link_name);
+    const RigidBody<T>& link = model.GetLinkByName(link_name);
     EXPECT_EQ(link.name(), link_name);
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model.GetRigidBodyByName(kInvalidName),
+      model.GetLinkByName(kInvalidName),
       ".*There is no RigidBody named .*valid names in model instance "
       "'WorldModelInstance' are: world; valid names in model instance "
       "'DefaultModelInstance' are: iiwa_link_1, iiwa_link_2.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model.GetRigidBodyByName(kLinkNames[0], world_model_instance()),
+      model.GetLinkByName(kLinkNames[0], world_model_instance()),
       ".*There is no RigidBody.*but one does exist in other model instances.*");
 
-  // Test that calling GetRigidBodyByName() with an invalid ModelInstanceIndex
+  // Test that calling GetLinkByName() with an invalid ModelInstanceIndex
   // throws.
   const ModelInstanceIndex kInvalidIndex(1 << 30);
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      model.GetRigidBodyByName(kLinkNames[0], kInvalidIndex),
-      ".*There is no model instance.*in the model.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(model.GetLinkByName(kLinkNames[0], kInvalidIndex),
+                              ".*There is no model instance.*in the model.*");
 
   // Get frames by name.
   for (const std::string& frame_name : kFrameNames) {
@@ -213,26 +212,26 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
   // Attempt to add a body having the same name as a body already part of the
   // model. This is not allowed and an exception should be thrown.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model->AddRigidBody("iiwa_link_5", default_model_instance(),
-                          SpatialInertia<double>::NaN()),
+      model->AddLink("iiwa_link_5", default_model_instance(),
+                     SpatialInertia<double>::NaN()),
       ".* already contains a body named 'iiwa_link_5'. "
       "Body names must be unique within a given model.");
 
   // Attempt to add a frame having the same name as a frame already part of the
   // model. This is not allowed and an exception should be thrown.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model->AddFrame<FixedOffsetFrame>(
-          "iiwa_link_5", model->GetRigidBodyByName("iiwa_link_1"),
-          RigidTransform<double>()),
+      model->AddFrame<FixedOffsetFrame>("iiwa_link_5",
+                                        model->GetLinkByName("iiwa_link_1"),
+                                        RigidTransform<double>()),
       ".* already contains a frame named 'iiwa_link_5'. "
       "Frame names must be unique within a given model.");
 
   // Attempt to add a joint having the same name as a joint already part of the
   // model. This is not allowed and an exception should be thrown.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model->AddJoint<RevoluteJoint>("iiwa_joint_4", model->world_body(),
+      model->AddJoint<RevoluteJoint>("iiwa_joint_4", model->world_link(),
                                      std::nullopt,
-                                     model->GetRigidBodyByName("iiwa_link_5"),
+                                     model->GetLinkByName("iiwa_link_5"),
                                      std::nullopt, Vector3<double>::UnitZ()),
       ".* already contains a joint named 'iiwa_joint_4'. "
       "Joint names must be unique within a given model.");
@@ -263,7 +262,7 @@ GTEST_TEST(MultibodyTree, EmptyGetElementByName) {
   const std::string kInvalidName = "InvalidName";
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model.GetRigidBodyByName(kInvalidName),
+      model.GetLinkByName(kInvalidName),
       ".*There is no RigidBody named .*valid names in model instance "
       "'WorldModelInstance' are.* world.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -292,26 +291,25 @@ GTEST_TEST(MultibodyTree, RetrievingAmbiguousNames) {
   const ModelInstanceIndex other_model_instance =
       model->AddModelInstance("other");
   const std::string link_name = "iiwa_link_5";
-  EXPECT_NO_THROW(model->AddRigidBody(link_name, other_model_instance,
-                                      SpatialInertia<double>::NaN()));
+  EXPECT_NO_THROW(model->AddLink(link_name, other_model_instance,
+                                 SpatialInertia<double>::NaN()));
   EXPECT_NO_THROW(model->Finalize());
 
   // Link name is ambiguous, there are more than one bodies that use the name.
-  EXPECT_GT(model->NumBodiesWithName(link_name), 1);
+  EXPECT_GT(model->NumLinksWithName(link_name), 1);
 
   // Checking if the name exists throws (unfortunately), unless we specify the
   // intended model instance.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model->HasBodyNamed(link_name),
+      model->HasLinkNamed(link_name),
       ".*Body.*appears in multiple model instances.*disambiguate.*");
-  EXPECT_TRUE(model->HasBodyNamed(link_name, default_model_instance()));
+  EXPECT_TRUE(model->HasLinkNamed(link_name, default_model_instance()));
 
   // Accessing by name throws, unless we specify the intended model instance.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model->GetRigidBodyByName(link_name),
+      model->GetLinkByName(link_name),
       ".*RigidBody.*appears in multiple model instances.*disambiguate.*");
-  EXPECT_NO_THROW(
-      model->GetRigidBodyByName(link_name, default_model_instance()));
+  EXPECT_NO_THROW(model->GetLinkByName(link_name, default_model_instance()));
 }
 
 // MBPlant provides most of the testing for MBTreeSystem. Here we just want
@@ -320,7 +318,7 @@ class BadDerivedMBSystem : public MultibodyTreeSystem<double> {
  public:
   explicit BadDerivedMBSystem(bool double_finalize)
       : MultibodyTreeSystem<double>() {
-    mutable_tree().AddRigidBody("body", SpatialInertia<double>::NaN());
+    mutable_tree().AddLink("body", SpatialInertia<double>::NaN());
     Finalize();
     if (double_finalize) {
       Finalize();
@@ -372,7 +370,7 @@ class KukaIiwaModelTests : public ::testing::Test {
           false /* do not finalize model yet */, gravity_);
 
       // Keep pointers to the modeling elements.
-      end_effector_link_ = &tree->GetRigidBodyByName("iiwa_link_7");
+      end_effector_link_ = &tree->GetLinkByName("iiwa_link_7");
       joints_.push_back(&tree->GetJointByName<RevoluteJoint>("iiwa_joint_1"));
       joints_.push_back(&tree->GetJointByName<RevoluteJoint>("iiwa_joint_2"));
       joints_.push_back(&tree->GetJointByName<RevoluteJoint>("iiwa_joint_3"));
@@ -436,7 +434,7 @@ class KukaIiwaModelTests : public ::testing::Test {
   Vector3<T> CalcEndEffectorVelocity(const MultibodyTree<T>& model_on_T,
                                      const Context<T>& context_on_T) const {
     std::vector<SpatialVelocity<T>> V_WB_array;
-    model_on_T.CalcAllBodySpatialVelocitiesInWorld(context_on_T, &V_WB_array);
+    model_on_T.CalcAllLinkSpatialVelocitiesInWorld(context_on_T, &V_WB_array);
     return V_WB_array[end_effector_link_->index()].translational();
   }
 
@@ -447,7 +445,7 @@ class KukaIiwaModelTests : public ::testing::Test {
       const MultibodyTree<T>& model_on_T,
       const Context<T>& context_on_T) const {
     std::vector<SpatialVelocity<T>> V_WB_array;
-    model_on_T.CalcAllBodySpatialVelocitiesInWorld(context_on_T, &V_WB_array);
+    model_on_T.CalcAllLinkSpatialVelocitiesInWorld(context_on_T, &V_WB_array);
     return V_WB_array[end_effector_link_->index()];
   }
 
@@ -460,7 +458,7 @@ class KukaIiwaModelTests : public ::testing::Test {
     Vector3<T> p_WE;
     model_on_T.CalcPointsPositions(context_on_T, linkG_on_T.body_frame(),
                                    Vector3<T>::Zero(),  // position in frame G
-                                   model_on_T.world_body().body_frame(), &p_WE);
+                                   model_on_T.world_link().body_frame(), &p_WE);
     return p_WE;
   }
 
@@ -667,7 +665,7 @@ TEST_F(KukaIiwaModelTests, StateAccess) {
 // In addition, we are testing methods:
 // - MultibodyTree::CalcPointsPositions()
 // - MultibodyTree::CalcPointsVelocities()
-// - MultibodyTree::CalcAllBodySpatialVelocitiesInWorld()
+// - MultibodyTree::CalcAllLinkSpatialVelocitiesInWorld()
 TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityA) {
   // The number of generalized positions in the Kuka iiwa robot arm model.
   const int kNumPositions = tree().num_positions();
@@ -778,7 +776,7 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityA) {
   }
 
   // Verify CalcPointsVelocities() measured-in-frame: v_WEo_E = Jv_WEo_E * v.
-  const RigidBody<double>& link3 = tree().GetRigidBodyByName("iiwa_link_3");
+  const RigidBody<double>& link3 = tree().GetLinkByName("iiwa_link_3");
   const Frame<double>& frame_M = link3.body_frame();  // Measured-in frame.
   Matrix3X<double> v_MEi_M(3, num_position_vectors);  // Quantity to calculate.
   tree().CalcPointsVelocities(*context_, frame_E, p_EoEi_E, frame_M, frame_M,
@@ -829,7 +827,7 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityA) {
 //    respect to v.
 // In addition, this also tests the methods:
 // - MultibodyTree::CalcPointsPositions()
-// - MultibodyTree::CalcAllBodySpatialVelocitiesInWorld()
+// - MultibodyTree::CalcAllLinkSpatialVelocitiesInWorld()
 TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityB) {
   // The number of generalized positions in the Kuka iiwa robot arm model.
   const int kNumPositions = tree().num_positions();
@@ -1027,11 +1025,11 @@ TEST_F(KukaIiwaModelTests, EvalPoseAndSpatialVelocity) {
 
   // Spatial velocity of the end effector in the world frame.
   const SpatialVelocity<double>& V_WE =
-      tree().EvalBodySpatialVelocityInWorld(*context_, *end_effector_link_);
+      tree().EvalLinkSpatialVelocityInWorld(*context_, *end_effector_link_);
 
   // Pose of the end effector in the world frame.
   const RigidTransform<double>& X_WE(
-      tree().EvalBodyPoseInWorld(*context_, *end_effector_link_));
+      tree().EvalLinkPoseInWorld(*context_, *end_effector_link_));
 
   // Independent benchmark solution.
   const SpatialKinematicsPVA<double> MG_kinematics =
@@ -1078,11 +1076,11 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityA) {
 
   // Spatial velocity of the end effector.
   const SpatialVelocity<double>& V_WE =
-      tree().EvalBodySpatialVelocityInWorld(*context_, *end_effector_link_);
+      tree().EvalLinkSpatialVelocityInWorld(*context_, *end_effector_link_);
 
   // Pose of the end effector.
   const math::RigidTransformd& X_WE(
-      tree().EvalBodyPoseInWorld(*context_, *end_effector_link_));
+      tree().EvalLinkPoseInWorld(*context_, *end_effector_link_));
 
   // Position of a frame F measured and expressed in frame E.
   const Vector3d p_EoFo_E = Vector3d(0.2, -0.1, 0.5);
@@ -1180,7 +1178,7 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityB) {
   // Therefore we do not set it.
   const Frame<double>& frame_W = tree().world_frame();
   tree().CalcJacobianSpatialVelocity(*context_, JacobianWrtVariable::kV,
-                                     tree().world_body().body_frame(), p_WoWp_W,
+                                     tree().world_link().body_frame(), p_WoWp_W,
                                      frame_W, frame_W, &Jv_WWp);
 
   // Since in this case we are querying for the world frame, the Jacobian should
@@ -1217,26 +1215,26 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityC) {
   }
 
   // Three arbitrary frames on the robot.
-  const RigidBody<double>& link3 = tree().GetRigidBodyByName("iiwa_link_3");
-  const RigidBody<double>& link5 = tree().GetRigidBodyByName("iiwa_link_5");
-  const RigidBody<double>& link7 = tree().GetRigidBodyByName("iiwa_link_7");
+  const RigidBody<double>& link3 = tree().GetLinkByName("iiwa_link_3");
+  const RigidBody<double>& link5 = tree().GetLinkByName("iiwa_link_5");
+  const RigidBody<double>& link7 = tree().GetLinkByName("iiwa_link_7");
 
   // An arbitrary point Q in the end effector link 7.
   const Vector3d p_L7Q = Vector3d(0.2, -0.1, 0.5);
 
   // Link 3 kinematics.
   const RigidTransform<double>& X_WL3 =
-      tree().EvalBodyPoseInWorld(*context_, link3);
+      tree().EvalLinkPoseInWorld(*context_, link3);
   const RotationMatrix<double>& R_WL3 = X_WL3.rotation();
 
   // link 5 kinematics.
   const RigidTransform<double>& X_WL5 =
-      tree().EvalBodyPoseInWorld(*context_, link5);
+      tree().EvalLinkPoseInWorld(*context_, link5);
   const RotationMatrix<double>& R_WL5 = X_WL5.rotation();
 
   // link 7 kinematics.
   const RigidTransform<double>& X_WL7 =
-      tree().EvalBodyPoseInWorld(*context_, link7);
+      tree().EvalLinkPoseInWorld(*context_, link7);
   const RotationMatrix<double>& R_WL7 = X_WL7.rotation();
 
   // Position of Q in L3, expressed in world.
@@ -1250,11 +1248,11 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityC) {
 
   // Spatial velocity of L3 shifted to Q.
   const SpatialVelocity<double> V_WL3q =
-      tree().EvalBodySpatialVelocityInWorld(*context_, link3).Shift(p_L3Q_W);
+      tree().EvalLinkSpatialVelocityInWorld(*context_, link3).Shift(p_L3Q_W);
 
   // Spatial velocity of L7 shifted to Q.
   const SpatialVelocity<double> V_WL7q =
-      tree().EvalBodySpatialVelocityInWorld(*context_, link7).Shift(p_L7Q_W);
+      tree().EvalLinkSpatialVelocityInWorld(*context_, link7).Shift(p_L7Q_W);
 
   // Relative spatial velocity V_L3L7q_L5 of L7q in L3, expressed in L5.
   const SpatialVelocity<double> V_L3L7q_L5 =
@@ -1328,11 +1326,11 @@ class WeldMobilizerTest : public ::testing::Test {
     // Create an empty model.
     auto model = std::make_unique<MultibodyTree<double>>();
 
-    body1_ = &model->AddRigidBody("body1", M_B);
-    body2_ = &model->AddRigidBody("body2", M_B);
+    body1_ = &model->AddLink("body1", M_B);
+    body2_ = &model->AddLink("body2", M_B);
 
     model->AddJoint(std::make_unique<WeldJoint<double>>(
-        "weld0", model->world_body().body_frame(), body1_->body_frame(),
+        "weld0", model->world_link().body_frame(), body1_->body_frame(),
         X_WB1_));
 
     // Add a weld joint between bodies 1 and 2 by welding together inboard
@@ -1385,11 +1383,11 @@ TEST_F(WeldMobilizerTest, PositionKinematics) {
   // Numerical tolerance used to verify numerical results.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 
-  std::vector<math::RigidTransformd> body_poses;
-  tree().CalcAllBodyPosesInWorld(*context_, &body_poses);
+  std::vector<math::RigidTransformd> link_poses;
+  tree().CalcAllLinkPosesInWorld(*context_, &link_poses);
 
-  EXPECT_TRUE(body_poses[body1_->index()].IsNearlyEqualTo(X_WB1_, kTolerance));
-  EXPECT_TRUE(body_poses[body2_->index()].IsNearlyEqualTo(X_WB2_, kTolerance));
+  EXPECT_TRUE(link_poses[body1_->index()].IsNearlyEqualTo(X_WB1_, kTolerance));
+  EXPECT_TRUE(link_poses[body2_->index()].IsNearlyEqualTo(X_WB2_, kTolerance));
 }
 
 // Verify proper operation of the Joint internal use only method for generating
@@ -1402,8 +1400,8 @@ GTEST_TEST(JointTest, UniqueFrameName) {
   // Create an empty model.
   auto model = std::make_unique<MultibodyTree<double>>();
 
-  const RigidBody<double>& body1 = model->AddRigidBody("body1", M_B);
-  const RigidBody<double>& body2 = model->AddRigidBody("body2", M_B);
+  const RigidBody<double>& body1 = model->AddLink("body1", M_B);
+  const RigidBody<double>& body2 = model->AddLink("body2", M_B);
 
   const auto& frame1 = model->AddFrame<FixedOffsetFrame>(
       "frame1", body1, RigidTransform<double>());

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -70,8 +70,8 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
       "iiwa_actuator_4", "iiwa_actuator_5", "iiwa_actuator_6",
       "iiwa_actuator_7"};
 
-  // Model Size. Counting the world body, there should be eight bodies.
-  EXPECT_EQ(model.num_bodies(), 8);  // It includes the "world" body.
+  // Model Size. Counting the world link, there should be eight links.
+  EXPECT_EQ(model.num_links(), 8);  // It includes the "world" link.
   EXPECT_EQ(model.num_joints(), 7);
   EXPECT_EQ(model.num_actuators(), 7);
   EXPECT_EQ(model.num_actuated_dofs(), 7);
@@ -230,7 +230,7 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
   // Attempt to add a joint having the same name as a joint already part of the
   // model. This is not allowed and an exception should be thrown.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      model->AddJoint<RevoluteJoint>("iiwa_joint_4", model->world_body(),
+      model->AddJoint<RevoluteJoint>("iiwa_joint_4", model->world_link(),
                                      std::nullopt,
                                      model->GetRigidBodyByName("iiwa_link_5"),
                                      std::nullopt, Vector3<double>::UnitZ()),
@@ -460,7 +460,7 @@ class KukaIiwaModelTests : public ::testing::Test {
     Vector3<T> p_WE;
     model_on_T.CalcPointsPositions(context_on_T, linkG_on_T.body_frame(),
                                    Vector3<T>::Zero(),  // position in frame G
-                                   model_on_T.world_body().body_frame(), &p_WE);
+                                   model_on_T.world_link().body_frame(), &p_WE);
     return p_WE;
   }
 
@@ -1180,7 +1180,7 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityB) {
   // Therefore we do not set it.
   const Frame<double>& frame_W = tree().world_frame();
   tree().CalcJacobianSpatialVelocity(*context_, JacobianWrtVariable::kV,
-                                     tree().world_body().body_frame(), p_WoWp_W,
+                                     tree().world_link().body_frame(), p_WoWp_W,
                                      frame_W, frame_W, &Jv_WWp);
 
   // Since in this case we are querying for the world frame, the Jacobian should
@@ -1332,7 +1332,7 @@ class WeldMobilizerTest : public ::testing::Test {
     body2_ = &model->AddRigidBody("body2", M_B);
 
     model->AddJoint(std::make_unique<WeldJoint<double>>(
-        "weld0", model->world_body().body_frame(), body1_->body_frame(),
+        "weld0", model->world_link().body_frame(), body1_->body_frame(),
         X_WB1_));
 
     // Add a weld joint between bodies 1 and 2 by welding together inboard

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -47,7 +47,7 @@ class PlanarJointTest : public ::testing::Test {
     body_ = &model->AddRigidBody("Body", M_B);
 
     // Add a planar joint between the world and body1:
-    joint_ = &model->AddJoint<PlanarJoint>("Joint", model->world_body(),
+    joint_ = &model->AddJoint<PlanarJoint>("Joint", model->world_link(),
                                            std::nullopt, *body_, std::nullopt,
                                            Vector3d::Constant(kDamping));
     mutable_joint_ = dynamic_cast<PlanarJoint<double>*>(

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -44,10 +44,10 @@ class PlanarJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add a body so we can add a joint between it and the world:
-    body_ = &model->AddRigidBody("Body", M_B);
+    body_ = &model->AddLink("Body", M_B);
 
     // Add a planar joint between the world and body1:
-    joint_ = &model->AddJoint<PlanarJoint>("Joint", model->world_body(),
+    joint_ = &model->AddJoint<PlanarJoint>("Joint", model->world_link(),
                                            std::nullopt, *body_, std::nullopt,
                                            Vector3d::Constant(kDamping));
     mutable_joint_ = dynamic_cast<PlanarJoint<double>*>(

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -36,7 +36,7 @@ class PlanarMobilizerTest : public MobilizerTester {
   void SetUp() override {
     mobilizer_ = &AddJointAndFinalize<PlanarJoint, PlanarMobilizer>(
         std::make_unique<PlanarJoint<double>>(
-            "joint0", tree().world_body().body_frame(), body_->body_frame(),
+            "joint0", tree().world_link().body_frame(), body_->body_frame(),
             Vector3d::Zero()));
     mutable_mobilizer_ = const_cast<PlanarMobilizer<double>*>(mobilizer_);
   }

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -55,7 +55,7 @@ class PrismaticJointTest : public ::testing::Test {
 
     // Add a prismatic joint between the world and body1:
     joint1_ = &model->AddJoint<PrismaticJoint>(
-        "Joint1", model->world_body(), std::nullopt, *body1_, std::nullopt,
+        "Joint1", model->world_link(), std::nullopt, *body1_, std::nullopt,
         Vector3d::UnitZ(), kPositionLowerLimit, kPositionUpperLimit, kDamping);
     Joint<double>& mutable_joint = model->get_mutable_joint(joint1_->index());
     mutable_joint1_ = dynamic_cast<PrismaticJoint<double>*>(&mutable_joint);

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -51,11 +51,11 @@ class PrismaticJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add a body so we can add joint to it.
-    body1_ = &model->AddRigidBody("Body", M_B);
+    body1_ = &model->AddLink("Body", M_B);
 
     // Add a prismatic joint between the world and body1:
     joint1_ = &model->AddJoint<PrismaticJoint>(
-        "Joint1", model->world_body(), std::nullopt, *body1_, std::nullopt,
+        "Joint1", model->world_link(), std::nullopt, *body1_, std::nullopt,
         Vector3d::UnitZ(), kPositionLowerLimit, kPositionUpperLimit, kDamping);
     Joint<double>& mutable_joint = model->get_mutable_joint(joint1_->index());
     mutable_joint1_ = dynamic_cast<PrismaticJoint<double>*>(&mutable_joint);

--- a/multibody/tree/test/prismatic_mobilizer_test.cc
+++ b/multibody/tree/test/prismatic_mobilizer_test.cc
@@ -37,7 +37,7 @@ class PrismaticMobilizerTest : public MobilizerTester {
     const PrismaticMobilizer<double>& const_slider =
         AddJointAndFinalize<PrismaticJoint, PrismaticMobilizer>(
             std::make_unique<PrismaticJoint<double>>(
-                "joint0", tree().world_body().body_frame(), body_->body_frame(),
+                "joint0", tree().world_link().body_frame(), body_->body_frame(),
                 axis_Jp_));
     slider_ = const_cast<PrismaticMobilizer<double>*>(&const_slider);
   }

--- a/multibody/tree/test/prismatic_spring_test.cc
+++ b/multibody/tree/test/prismatic_spring_test.cc
@@ -36,7 +36,7 @@ class SpringTester : public ::testing::Test {
     bodyA_ = &model->AddRigidBody("BodyA", SpatialInertia<double>::NaN());
     bodyB_ = &model->AddRigidBody("BodyB", SpatialInertia<double>::NaN());
 
-    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_body(), {},
+    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_link(), {},
                                *bodyA_, {},
                                math::RigidTransform<double>::Identity());
 

--- a/multibody/tree/test/prismatic_spring_test.cc
+++ b/multibody/tree/test/prismatic_spring_test.cc
@@ -33,10 +33,10 @@ class SpringTester : public ::testing::Test {
     // Create an empty model.
     auto model = std::make_unique<MultibodyTree<double>>();
 
-    bodyA_ = &model->AddRigidBody("BodyA", SpatialInertia<double>::NaN());
-    bodyB_ = &model->AddRigidBody("BodyB", SpatialInertia<double>::NaN());
+    bodyA_ = &model->AddLink("BodyA", SpatialInertia<double>::NaN());
+    bodyB_ = &model->AddLink("BodyB", SpatialInertia<double>::NaN());
 
-    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_body(), {},
+    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_link(), {},
                                *bodyA_, {},
                                math::RigidTransform<double>::Identity());
 

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -53,7 +53,7 @@ class QuaternionFloatingJointTest : public ::testing::Test {
 
     // Add a quaternion floating joint between the world and body:
     joint_ = &model->AddJoint<QuaternionFloatingJoint>(
-        "Joint", model->world_body(), std::nullopt, *body_, std::nullopt,
+        "Joint", model->world_link(), std::nullopt, *body_, std::nullopt,
         kAngularDamping, kTranslationalDamping);
     mutable_joint_ = dynamic_cast<QuaternionFloatingJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));

--- a/multibody/tree/test/quaternion_floating_joint_test.cc
+++ b/multibody/tree/test/quaternion_floating_joint_test.cc
@@ -49,11 +49,11 @@ class QuaternionFloatingJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add a body so we can add a joint between world and body:
-    body_ = &model->AddRigidBody("Body", M_B);
+    body_ = &model->AddLink("Body", M_B);
 
     // Add a quaternion floating joint between the world and body:
     joint_ = &model->AddJoint<QuaternionFloatingJoint>(
-        "Joint", model->world_body(), std::nullopt, *body_, std::nullopt,
+        "Joint", model->world_link(), std::nullopt, *body_, std::nullopt,
         kAngularDamping, kTranslationalDamping);
     mutable_joint_ = dynamic_cast<QuaternionFloatingJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));

--- a/multibody/tree/test/quaternion_floating_mobilizer_test.cc
+++ b/multibody/tree/test/quaternion_floating_mobilizer_test.cc
@@ -38,7 +38,7 @@ class QuaternionFloatingMobilizerTest : public MobilizerTester {
     mobilizer_ = &AddJointAndFinalize<QuaternionFloatingJoint,
                                       QuaternionFloatingMobilizer>(
         std::make_unique<QuaternionFloatingJoint<double>>(
-            "joint0", tree().world_body().body_frame(), body_->body_frame()));
+            "joint0", tree().world_link().body_frame(), body_->body_frame()));
     mutable_mobilizer_ =
         const_cast<QuaternionFloatingMobilizer<double>*>(mobilizer_);
   }

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -58,7 +58,7 @@ class RevoluteJointTest : public ::testing::Test {
 
     // Add a revolute joint between the world and body1:
     joint1_ = &model->AddJoint<RevoluteJoint>(
-        "Joint1", model->world_body(), std::nullopt, *body1_, std::nullopt,
+        "Joint1", model->world_link(), std::nullopt, *body1_, std::nullopt,
         Vector3d::UnitZ(), kPositionLowerLimit, kPositionUpperLimit, kDamping);
     mutable_joint1_ = dynamic_cast<RevoluteJoint<double>*>(
         &model->get_mutable_joint(joint1_->index()));

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -54,11 +54,11 @@ class RevoluteJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add some bodies so we can add joints between them:
-    body1_ = &model->AddRigidBody("Body1", M_B);
+    body1_ = &model->AddLink("Body1", M_B);
 
     // Add a revolute joint between the world and body1:
     joint1_ = &model->AddJoint<RevoluteJoint>(
-        "Joint1", model->world_body(), std::nullopt, *body1_, std::nullopt,
+        "Joint1", model->world_link(), std::nullopt, *body1_, std::nullopt,
         Vector3d::UnitZ(), kPositionLowerLimit, kPositionUpperLimit, kDamping);
     mutable_joint1_ = dynamic_cast<RevoluteJoint<double>*>(
         &model->get_mutable_joint(joint1_->index()));

--- a/multibody/tree/test/revolute_mobilizer_test.cc
+++ b/multibody/tree/test/revolute_mobilizer_test.cc
@@ -38,7 +38,7 @@ class RevoluteMobilizerTest : public MobilizerTester {
     const RevoluteMobilizer<double>& const_mobilizer =
         AddJointAndFinalize<RevoluteJoint, RevoluteMobilizer>(
             std::make_unique<RevoluteJoint<double>>(
-                "joint0", tree().world_body().body_frame(), body_->body_frame(),
+                "joint0", tree().world_link().body_frame(), body_->body_frame(),
                 axis_Jp_));
     // Mobilizers are marked ephemeral only if the modeled joint is ephemeral
     // (that is, added automatically).

--- a/multibody/tree/test/revolute_spring_test.cc
+++ b/multibody/tree/test/revolute_spring_test.cc
@@ -38,7 +38,7 @@ class SpringTester : public ::testing::Test {
     bodyB_ = &model->AddRigidBody("BodyB", SpatialInertia<double>::NaN());
     bodyC_ = &model->AddRigidBody("BodyC", SpatialInertia<double>::NaN());
 
-    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_body(), {},
+    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_link(), {},
                                *bodyA_, {},
                                math::RigidTransform<double>::Identity());
 

--- a/multibody/tree/test/revolute_spring_test.cc
+++ b/multibody/tree/test/revolute_spring_test.cc
@@ -34,11 +34,11 @@ class SpringTester : public ::testing::Test {
     // Create an empty model.
     auto model = std::make_unique<MultibodyTree<double>>();
 
-    bodyA_ = &model->AddRigidBody("BodyA", SpatialInertia<double>::NaN());
-    bodyB_ = &model->AddRigidBody("BodyB", SpatialInertia<double>::NaN());
-    bodyC_ = &model->AddRigidBody("BodyC", SpatialInertia<double>::NaN());
+    bodyA_ = &model->AddLink("BodyA", SpatialInertia<double>::NaN());
+    bodyB_ = &model->AddLink("BodyB", SpatialInertia<double>::NaN());
+    bodyC_ = &model->AddLink("BodyC", SpatialInertia<double>::NaN());
 
-    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_body(), {},
+    model->AddJoint<WeldJoint>("WeldBodyAToWorld", model->world_link(), {},
                                *bodyA_, {},
                                math::RigidTransform<double>::Identity());
 

--- a/multibody/tree/test/rigid_body_test.cc
+++ b/multibody/tree/test/rigid_body_test.cc
@@ -73,7 +73,7 @@ class RigidBodyTest : public ::testing::Test {
     // Create an empty model and then add a rigid body.
     auto model = std::make_unique<internal::MultibodyTree<double>>();
     const auto M_BBo_B = SpatialInertia<double>::NaN();
-    rigid_body_ = &model->AddRigidBody("rigidBody_B", M_BBo_B);
+    rigid_body_ = &model->AddLink("rigidBody_B", M_BBo_B);
 
     // Finalize the model and create a default context for this system.
     model->Finalize();

--- a/multibody/tree/test/rpy_ball_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_ball_mobilizer_test.cc
@@ -40,7 +40,7 @@ class RpyBallMobilizerTest : public MobilizerTester {
   void SetUp() override {
     mobilizer_ = &AddJointAndFinalize<BallRpyJoint, RpyBallMobilizer>(
         std::make_unique<BallRpyJoint<double>>(
-            "joint0", tree().world_body().body_frame(), body_->body_frame()));
+            "joint0", tree().world_link().body_frame(), body_->body_frame()));
   }
 
  protected:

--- a/multibody/tree/test/rpy_floating_joint_test.cc
+++ b/multibody/tree/test/rpy_floating_joint_test.cc
@@ -53,7 +53,7 @@ class RpyFloatingJointTest : public ::testing::Test {
 
     // Add a ball rpy joint between the world and body:
     joint_ = &model->AddJoint<RpyFloatingJoint>(
-        "Joint", model->world_body(), std::nullopt, *body_, std::nullopt,
+        "Joint", model->world_link(), std::nullopt, *body_, std::nullopt,
         kAngularDamping, kTranslationalDamping);
     mutable_joint_ = dynamic_cast<RpyFloatingJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));

--- a/multibody/tree/test/rpy_floating_joint_test.cc
+++ b/multibody/tree/test/rpy_floating_joint_test.cc
@@ -49,11 +49,11 @@ class RpyFloatingJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add some bodies so we can add joints between them:
-    body_ = &model->AddRigidBody("Body", M_B);
+    body_ = &model->AddLink("Body", M_B);
 
     // Add a ball rpy joint between the world and body:
     joint_ = &model->AddJoint<RpyFloatingJoint>(
-        "Joint", model->world_body(), std::nullopt, *body_, std::nullopt,
+        "Joint", model->world_link(), std::nullopt, *body_, std::nullopt,
         kAngularDamping, kTranslationalDamping);
     mutable_joint_ = dynamic_cast<RpyFloatingJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));

--- a/multibody/tree/test/rpy_floating_mobilizer_test.cc
+++ b/multibody/tree/test/rpy_floating_mobilizer_test.cc
@@ -36,7 +36,7 @@ class RpyFloatingMobilizerTest : public MobilizerTester {
   void SetUp() override {
     mobilizer_ = &AddJointAndFinalize<RpyFloatingJoint, RpyFloatingMobilizer>(
         std::make_unique<RpyFloatingJoint<double>>(
-            "joint0", tree().world_body().body_frame(), body_->body_frame()));
+            "joint0", tree().world_link().body_frame(), body_->body_frame()));
     mutable_mobilizer_ = const_cast<RpyFloatingMobilizer<double>*>(mobilizer_);
   }
 

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -39,7 +39,7 @@ class ScrewJointTest : public ::testing::Test {
     body_ = &model->AddRigidBody("Body", SpatialInertia<double>::NaN());
 
     // Add a screw joint between the world and body1:
-    joint_ = &model->AddJoint<ScrewJoint>("Joint", model->world_body(),
+    joint_ = &model->AddJoint<ScrewJoint>("Joint", model->world_link(),
                                           std::nullopt, *body_, std::nullopt,
                                           kScrewPitch, kDamping);
     mutable_joint_ = dynamic_cast<ScrewJoint<double>*>(

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -36,10 +36,10 @@ class ScrewJointTest : public ::testing::Test {
   // screw joint.
   void SetUp() override {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
-    body_ = &model->AddRigidBody("Body", SpatialInertia<double>::NaN());
+    body_ = &model->AddLink("Body", SpatialInertia<double>::NaN());
 
     // Add a screw joint between the world and body1:
-    joint_ = &model->AddJoint<ScrewJoint>("Joint", model->world_body(),
+    joint_ = &model->AddJoint<ScrewJoint>("Joint", model->world_link(),
                                           std::nullopt, *body_, std::nullopt,
                                           kScrewPitch, kDamping);
     mutable_joint_ = dynamic_cast<ScrewJoint<double>*>(

--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -37,7 +37,7 @@ class ScrewMobilizerTest : public MobilizerTester {
   void SetUp() override {
     mobilizer_ = &AddJointAndFinalize<ScrewJoint, ScrewMobilizer>(
         std::make_unique<ScrewJoint<double>>(
-            "joint0", tree().world_body().body_frame(), body_->body_frame(),
+            "joint0", tree().world_link().body_frame(), body_->body_frame(),
             kScrewAxis, kScrewPitch, 0.0));
     mutable_mobilizer_ = const_cast<ScrewMobilizer<double>*>(mobilizer_);
   }
@@ -60,7 +60,7 @@ TEST_F(ScrewMobilizerTest, ExceptionRaisingWhenZeroPitch) {
   const double zero_screw_pitch{0};
   const SpanningForest::Mobod dummy_mobod(MobodIndex(0), LinkOrdinal(0));
   ScrewMobilizer<double> zero_pitch_screw_mobilizer(
-      dummy_mobod, tree().world_body().body_frame(), body_->body_frame(),
+      dummy_mobod, tree().world_link().body_frame(), body_->body_frame(),
       Vector3<double>::UnitZ(), zero_screw_pitch);
 
   const double translation_z{1.0};

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -1501,7 +1501,7 @@ GTEST_TEST(SpatialInertia, VerifyMinimumBoundingBoxLengths) {
   // Create a 360 meter massless rod B with 1.0 kg particles at its distal ends.
   // Ensure CalcPrincipalHalfLengthsAndPoseForMinimumBoundingBox() actually
   // produces a minimum bounding box with ½-lengths a = 180 m, b = 0, c = 0.
-  constexpr double kTolerance = 128 * std::numeric_limits<double>::epsilon();
+  constexpr double kTolerance = 64 * std::numeric_limits<double>::epsilon();
   const double mass = 1.0;
   double a = 180, b = 0, c = 0;  // rod's ½-length is 180 meters.
   auto M_BBcm_B = SpatialInertia<double>::NaN();
@@ -1554,7 +1554,8 @@ GTEST_TEST(SpatialInertia, VerifyMinimumBoundingBoxLengths) {
   M_BBcm_B += SpatialInertia<double>::PointMass(mass, Vector3d(-a, -b, -c));
   std::tie(abc, X_BA) =
       M_BBcm_B.CalcPrincipalHalfLengthsAndPoseForMinimumBoundingBox();
-  EXPECT_TRUE(CompareMatrices(Vector3<double>(a, b, c), abc, kTolerance));
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(a, b, c), abc, kTolerance,
+                              MatrixCompareType::relative));
   EXPECT_TRUE(X_BA.rotation().IsExactlyEqualTo(R_identity));
   EXPECT_TRUE(
       CompareMatrices(X_BA.translation(), Vector3<double>::Zero(), kTolerance));

--- a/multibody/tree/test/tree_from_joints_test.cc
+++ b/multibody/tree/test/tree_from_joints_test.cc
@@ -131,7 +131,7 @@ class DoublePendulumModel {
     // Adds the upper and lower links of the pendulum:
     link1_ = &model->AddRigidBody("Link1", M1_L1);
     link2_ = &model->AddRigidBody("Link2", M2_L2);
-    world_body_ = &model->world_body();
+    world_body_ = &model->world_link();
 
     // The shoulder joint connects the world with link 1.
     // Its inboard frame, Si, is the world frame.
@@ -298,7 +298,7 @@ class PendulumTests : public ::testing::Test {
     // External forces:
     MultibodyForces<double> forces(pendulum_.tree());
     // Accelerations of the bodies:
-    std::vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
+    std::vector<SpatialAcceleration<double>> A_WB_array(tree().num_links());
     // Generalized accelerations:
     VectorX<double> vdot = VectorX<double>::Zero(nv);
 
@@ -329,7 +329,7 @@ class PendulumTests : public ::testing::Test {
     pendulum_.elbow().AddInTorque(*context_, tau2, &forces);
 
     // Arrays for output forces:
-    std::vector<SpatialForce<double>> F_BMo_W(tree().num_bodies());
+    std::vector<SpatialForce<double>> F_BMo_W(tree().num_links());
     VectorX<double> tau(tree().num_velocities());
 
     // With vdot = 0, this computes:

--- a/multibody/tree/test/tree_from_joints_test.cc
+++ b/multibody/tree/test/tree_from_joints_test.cc
@@ -129,9 +129,9 @@ class DoublePendulumModel {
     SpatialInertia<double> M2_L2 = M2_L2cm.Shift(-p_L2oL2cm);
 
     // Adds the upper and lower links of the pendulum:
-    link1_ = &model->AddRigidBody("Link1", M1_L1);
-    link2_ = &model->AddRigidBody("Link2", M2_L2);
-    world_body_ = &model->world_body();
+    link1_ = &model->AddLink("Link1", M1_L1);
+    link2_ = &model->AddLink("Link2", M2_L2);
+    world_body_ = &model->world_link();
 
     // The shoulder joint connects the world with link 1.
     // Its inboard frame, Si, is the world frame.
@@ -298,7 +298,7 @@ class PendulumTests : public ::testing::Test {
     // External forces:
     MultibodyForces<double> forces(pendulum_.tree());
     // Accelerations of the bodies:
-    std::vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
+    std::vector<SpatialAcceleration<double>> A_WB_array(tree().num_links());
     // Generalized accelerations:
     VectorX<double> vdot = VectorX<double>::Zero(nv);
 
@@ -329,7 +329,7 @@ class PendulumTests : public ::testing::Test {
     pendulum_.elbow().AddInTorque(*context_, tau2, &forces);
 
     // Arrays for output forces:
-    std::vector<SpatialForce<double>> F_BMo_W(tree().num_bodies());
+    std::vector<SpatialForce<double>> F_BMo_W(tree().num_links());
     VectorX<double> tau(tree().num_velocities());
 
     // With vdot = 0, this computes:

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -134,7 +134,7 @@ class PendulumTests : public ::testing::Test {
   // world body and world body frame.
   void SetUp() override {
     model_ = std::make_unique<MultibodyTree<double>>();
-    world_body_ = &model_->world_body();
+    world_body_ = &model_->world_link();
   }
 
   // Sets up the MultibodyTree model for a double pendulum. See this unit test's
@@ -317,14 +317,14 @@ class PendulumTests : public ::testing::Test {
 
 TEST_F(PendulumTests, CreateModelBasics) {
   // Initially there is only one body, the world.
-  EXPECT_EQ(model_->num_bodies(), 1);
+  EXPECT_EQ(model_->num_links(), 1);
   // And there is only one frame, the world frame.
   EXPECT_EQ(model_->num_frames(), 1);
 
   CreatePendulumModel();
 
   // Verifies the number of multibody elements is correct.
-  EXPECT_EQ(model_->num_bodies(), 3);
+  EXPECT_EQ(model_->num_links(), 3);
   EXPECT_EQ(model_->num_joints(), 2);
   EXPECT_EQ(model_->num_frames(), 5);
   // Joints have no implementations before finalize.
@@ -433,7 +433,7 @@ TEST_F(PendulumTests, Finalize) {
 // bodies in an array of references.
 TEST_F(PendulumTests, StdReferenceWrapperExperiment) {
   // Initially there is only one body, the world.
-  EXPECT_EQ(model_->num_bodies(), 1);
+  EXPECT_EQ(model_->num_links(), 1);
   // And there is only one frame, the world frame.
   EXPECT_EQ(model_->num_frames(), 1);
   CreatePendulumModel();
@@ -462,7 +462,7 @@ TEST_F(PendulumTests, CreateContext) {
   // - world_
   // - upper_link_
   // - lower_link_
-  EXPECT_EQ(model_->num_bodies(), 3);
+  EXPECT_EQ(model_->num_links(), 3);
 
   // Finalize() stage.
   DRAKE_EXPECT_NO_THROW(model_->Finalize());
@@ -655,7 +655,7 @@ class PendulumKinematicTests : public PendulumTests {
 
     // Output vector of spatial forces for each body B at their inboard
     // frame Mo, expressed in the world W.
-    vector<SpatialForce<double>> F_BMo_W_array(tree().num_bodies());
+    vector<SpatialForce<double>> F_BMo_W_array(tree().num_links());
 
     // ======================================================================
     // Compute expected values using the acrobot benchmark.
@@ -669,7 +669,7 @@ class PendulumKinematicTests : public PendulumTests {
     // then to have separate input/output arrays.
 
     const VectorXd vdot = VectorXd::Zero(tree().num_velocities());
-    vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
+    vector<SpatialAcceleration<double>> A_WB_array(tree().num_links());
 
     // Aliases to external forcing arrays:
     std::vector<SpatialForce<double>>& Fapplied_Bo_W_array =
@@ -792,8 +792,8 @@ class PendulumKinematicTests : public PendulumTests {
     // ======================================================================
     // Compute inverse dynamics.
     VectorXd tau(tree().num_velocities());
-    vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
-    vector<SpatialForce<double>> F_BMo_W_array(tree().num_bodies());
+    vector<SpatialAcceleration<double>> A_WB_array(tree().num_links());
+    vector<SpatialForce<double>> F_BMo_W_array(tree().num_links());
     tree().CalcInverseDynamics(*context_, vdot, {}, VectorXd(), &A_WB_array,
                                &F_BMo_W_array, &tau);
 

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -134,7 +134,7 @@ class PendulumTests : public ::testing::Test {
   // world body and world body frame.
   void SetUp() override {
     model_ = std::make_unique<MultibodyTree<double>>();
-    world_body_ = &model_->world_body();
+    world_body_ = &model_->world_link();
   }
 
   // Sets up the MultibodyTree model for a double pendulum. See this unit test's
@@ -161,8 +161,8 @@ class PendulumTests : public ::testing::Test {
     SpatialInertia<double> M_L = M_Lcm.Shift(-p_LoLcm);
 
     // Adds the upper and lower links of the pendulum.
-    upper_link_ = &model_->AddRigidBody("UpperLink", M_U);
-    lower_link_ = &model_->AddRigidBody("LowerLink", M_L);
+    upper_link_ = &model_->AddLink("UpperLink", M_U);
+    lower_link_ = &model_->AddLink("LowerLink", M_L);
 
     // The shoulder is the mobilizer that connects the world to the upper link.
     // Its inboard frame, Si, is the world frame. Its outboard frame, So, a
@@ -317,14 +317,14 @@ class PendulumTests : public ::testing::Test {
 
 TEST_F(PendulumTests, CreateModelBasics) {
   // Initially there is only one body, the world.
-  EXPECT_EQ(model_->num_bodies(), 1);
+  EXPECT_EQ(model_->num_links(), 1);
   // And there is only one frame, the world frame.
   EXPECT_EQ(model_->num_frames(), 1);
 
   CreatePendulumModel();
 
   // Verifies the number of multibody elements is correct.
-  EXPECT_EQ(model_->num_bodies(), 3);
+  EXPECT_EQ(model_->num_links(), 3);
   EXPECT_EQ(model_->num_joints(), 2);
   EXPECT_EQ(model_->num_frames(), 5);
   // Joints have no implementations before finalize.
@@ -417,7 +417,7 @@ TEST_F(PendulumTests, Finalize) {
 
   // Asserts that no more multibody elements can be added after finalize.
   const auto M_Bo_B = SpatialInertia<double>::NaN();
-  EXPECT_THROW(model_->AddRigidBody("B", M_Bo_B), std::logic_error);
+  EXPECT_THROW(model_->AddLink("B", M_Bo_B), std::logic_error);
   EXPECT_THROW(model_->AddFrame<FixedOffsetFrame>("F", *lower_link_, X_LEo_),
                std::logic_error);
   EXPECT_THROW(model_->AddJoint(make_unique<RevoluteJoint<double>>(
@@ -433,7 +433,7 @@ TEST_F(PendulumTests, Finalize) {
 // bodies in an array of references.
 TEST_F(PendulumTests, StdReferenceWrapperExperiment) {
   // Initially there is only one body, the world.
-  EXPECT_EQ(model_->num_bodies(), 1);
+  EXPECT_EQ(model_->num_links(), 1);
   // And there is only one frame, the world frame.
   EXPECT_EQ(model_->num_frames(), 1);
   CreatePendulumModel();
@@ -462,7 +462,7 @@ TEST_F(PendulumTests, CreateContext) {
   // - world_
   // - upper_link_
   // - lower_link_
-  EXPECT_EQ(model_->num_bodies(), 3);
+  EXPECT_EQ(model_->num_links(), 3);
 
   // Finalize() stage.
   DRAKE_EXPECT_NO_THROW(model_->Finalize());
@@ -655,7 +655,7 @@ class PendulumKinematicTests : public PendulumTests {
 
     // Output vector of spatial forces for each body B at their inboard
     // frame Mo, expressed in the world W.
-    vector<SpatialForce<double>> F_BMo_W_array(tree().num_bodies());
+    vector<SpatialForce<double>> F_BMo_W_array(tree().num_links());
 
     // ======================================================================
     // Compute expected values using the acrobot benchmark.
@@ -669,7 +669,7 @@ class PendulumKinematicTests : public PendulumTests {
     // then to have separate input/output arrays.
 
     const VectorXd vdot = VectorXd::Zero(tree().num_velocities());
-    vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
+    vector<SpatialAcceleration<double>> A_WB_array(tree().num_links());
 
     // Aliases to external forcing arrays:
     std::vector<SpatialForce<double>>& Fapplied_Bo_W_array =
@@ -792,8 +792,8 @@ class PendulumKinematicTests : public PendulumTests {
     // ======================================================================
     // Compute inverse dynamics.
     VectorXd tau(tree().num_velocities());
-    vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
-    vector<SpatialForce<double>> F_BMo_W_array(tree().num_bodies());
+    vector<SpatialAcceleration<double>> A_WB_array(tree().num_links());
+    vector<SpatialForce<double>> F_BMo_W_array(tree().num_links());
     tree().CalcInverseDynamics(*context_, vdot, {}, VectorXd(), &A_WB_array,
                                &F_BMo_W_array, &tau);
 

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -45,7 +45,7 @@ class UniversalJointTest : public ::testing::Test {
     body_ = &model->AddRigidBody("Body", M_B);
 
     // Add a universal joint between the world and body1:
-    joint_ = &model->AddJoint<UniversalJoint>("Joint", model->world_body(),
+    joint_ = &model->AddJoint<UniversalJoint>("Joint", model->world_link(),
                                               std::nullopt, *body_,
                                               std::nullopt, kDamping);
     mutable_joint_ = dynamic_cast<UniversalJoint<double>*>(

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -42,10 +42,10 @@ class UniversalJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add some bodies so we can add joints between them:
-    body_ = &model->AddRigidBody("Body", M_B);
+    body_ = &model->AddLink("Body", M_B);
 
     // Add a universal joint between the world and body1:
-    joint_ = &model->AddJoint<UniversalJoint>("Joint", model->world_body(),
+    joint_ = &model->AddJoint<UniversalJoint>("Joint", model->world_link(),
                                               std::nullopt, *body_,
                                               std::nullopt, kDamping);
     mutable_joint_ = dynamic_cast<UniversalJoint<double>*>(

--- a/multibody/tree/test/universal_mobilizer_test.cc
+++ b/multibody/tree/test/universal_mobilizer_test.cc
@@ -38,7 +38,7 @@ class UniversalMobilizerTest : public MobilizerTester {
   void SetUp() override {
     mobilizer_ = &AddJointAndFinalize<UniversalJoint, UniversalMobilizer>(
         std::make_unique<UniversalJoint<double>>(
-            "joint0", tree().world_body().body_frame(), body_->body_frame()));
+            "joint0", tree().world_link().body_frame(), body_->body_frame()));
     mutable_mobilizer_ = const_cast<UniversalMobilizer<double>*>(mobilizer_);
   }
 

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -37,7 +37,7 @@ class WeldJointTest : public ::testing::Test {
     rbody_ = &model->AddRigidBody("rbody", M_B);
     collide_body_ = &model->AddRigidBody("collide_body", M_B);
 
-    joint_ = &model->AddJoint<WeldJoint>("Welder", model->world_body(), X_PJp_,
+    joint_ = &model->AddJoint<WeldJoint>("Welder", model->world_link(), X_PJp_,
                                          *body_, X_CJc_, X_JpJc_);
     // This is reversed since we're using the outboard rbody as the parent.
     rjoint_ = &model->AddJoint<WeldJoint>("RWelder", *rbody_, X_PJp_, *body_,
@@ -55,7 +55,7 @@ class WeldJointTest : public ::testing::Test {
                                       *collide_body_,
                                       RigidTransformd(Vector3d(1.0, 2.0, 3.0)));
     collide_joint_ =
-        &model->AddJoint<WeldJoint>("collide", model->world_body(), X_PJp_,
+        &model->AddJoint<WeldJoint>("collide", model->world_link(), X_PJp_,
                                     *collide_body_, X_CJc_, X_JpJc_);
 
     // We are done adding modeling elements. Transfer tree to system for

--- a/multibody/tree/test/weld_joint_test.cc
+++ b/multibody/tree/test/weld_joint_test.cc
@@ -33,11 +33,11 @@ class WeldJointTest : public ::testing::Test {
     auto model = std::make_unique<internal::MultibodyTree<double>>();
 
     // Add bodies so we can add forward and reverse weld joints.
-    body_ = &model->AddRigidBody("body", M_B);
-    rbody_ = &model->AddRigidBody("rbody", M_B);
-    collide_body_ = &model->AddRigidBody("collide_body", M_B);
+    body_ = &model->AddLink("body", M_B);
+    rbody_ = &model->AddLink("rbody", M_B);
+    collide_body_ = &model->AddLink("collide_body", M_B);
 
-    joint_ = &model->AddJoint<WeldJoint>("Welder", model->world_body(), X_PJp_,
+    joint_ = &model->AddJoint<WeldJoint>("Welder", model->world_link(), X_PJp_,
                                          *body_, X_CJc_, X_JpJc_);
     // This is reversed since we're using the outboard rbody as the parent.
     rjoint_ = &model->AddJoint<WeldJoint>("RWelder", *rbody_, X_PJp_, *body_,
@@ -55,7 +55,7 @@ class WeldJointTest : public ::testing::Test {
                                       *collide_body_,
                                       RigidTransformd(Vector3d(1.0, 2.0, 3.0)));
     collide_joint_ =
-        &model->AddJoint<WeldJoint>("collide", model->world_body(), X_PJp_,
+        &model->AddJoint<WeldJoint>("collide", model->world_link(), X_PJp_,
                                     *collide_body_, X_CJc_, X_JpJc_);
 
     // We are done adding modeling elements. Transfer tree to system for

--- a/multibody/tree/test/weld_mobilizer_test.cc
+++ b/multibody/tree/test/weld_mobilizer_test.cc
@@ -34,7 +34,7 @@ class WeldMobilizerTest : public MobilizerTester {
   void SetUp() override {
     weld_body_to_world_ = &AddJointAndFinalize<WeldJoint, WeldMobilizer>(
         std::make_unique<WeldJoint<double>>("joint0",
-                                            tree().world_body().body_frame(),
+                                            tree().world_link().body_frame(),
                                             body_->body_frame(), X_WB_));
   }
 

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -64,13 +64,13 @@ VectorX<T> UniformGravityFieldElement<T>::CalcGravityGeneralizedForces(
 
   // Temporary output vector of spatial forces for each body B at their inboard
   // frame Mo, expressed in the world W.
-  std::vector<SpatialForce<T>> F_BMo_W_array(model.num_bodies());
+  std::vector<SpatialForce<T>> F_BMo_W_array(model.num_links());
 
   // Zero vector of generalized accelerations.
   const VectorX<T> vdot = VectorX<T>::Zero(model.num_velocities());
 
   // Temporary array for body accelerations.
-  std::vector<SpatialAcceleration<T>> A_WB_array(model.num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB_array(model.num_links());
 
   // Output vector of generalized forces:
   VectorX<T> tau_g(model.num_velocities());
@@ -106,9 +106,9 @@ void UniformGravityFieldElement<T>::DoCalcAndAddForceContribution(
   // Skip the world.
   DRAKE_ASSERT(this->has_parent_tree());
   const internal::MultibodyTree<T>& model = this->get_parent_tree();
-  const int num_bodies = model.num_bodies();
-  // Skip the "world" body.
-  for (BodyIndex body_index(1); body_index < num_bodies; ++body_index) {
+  const int num_links = model.num_links();
+  // Skip the "world" link.
+  for (BodyIndex body_index(1); body_index < num_links; ++body_index) {
     const RigidBody<T>& body = model.get_body(body_index);
 
     // Skip this body if gravity is disabled.
@@ -138,10 +138,10 @@ T UniformGravityFieldElement<T>::CalcPotentialEnergy(
   // Skip the world.
   DRAKE_THROW_UNLESS(this->has_parent_tree());
   const internal::MultibodyTree<T>& model = this->get_parent_tree();
-  const int num_bodies = model.num_bodies();
+  const int num_links = model.num_links();
   T TotalPotentialEnergy = 0.0;
   // Skip the "world" body.
-  for (BodyIndex body_index(1); body_index < num_bodies; ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links; ++body_index) {
     const RigidBody<T>& body = model.get_body(body_index);
 
     // Skip this body if gravity is disabled.
@@ -172,10 +172,10 @@ T UniformGravityFieldElement<T>::CalcConservativePower(
   // Skip the world.
   DRAKE_THROW_UNLESS(this->has_parent_tree());
   const internal::MultibodyTree<T>& model = this->get_parent_tree();
-  const int num_bodies = model.num_bodies();
+  const int num_links = model.num_links();
   T TotalConservativePower = 0.0;
   // Skip the "world" body.
-  for (BodyIndex body_index(1); body_index < num_bodies; ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_links; ++body_index) {
     const RigidBody<T>& body = model.get_body(body_index);
 
     // Skip this body if gravity is disabled.

--- a/multibody/tree/uniform_gravity_field_element.cc
+++ b/multibody/tree/uniform_gravity_field_element.cc
@@ -6,6 +6,9 @@
 #include "drake/multibody/tree/multibody_tree.h"
 #include "drake/multibody/tree/rigid_body.h"
 
+// TODO(sherm1) Everything here needs to be reworked in terms of mobilized
+//  bodies rather than individual links. Also, use the available caches
+//  rather than recalculating them.
 namespace drake {
 namespace multibody {
 
@@ -64,13 +67,13 @@ VectorX<T> UniformGravityFieldElement<T>::CalcGravityGeneralizedForces(
 
   // Temporary output vector of spatial forces for each body B at their inboard
   // frame Mo, expressed in the world W.
-  std::vector<SpatialForce<T>> F_BMo_W_array(model.num_bodies());
+  std::vector<SpatialForce<T>> F_BMo_W_array(model.num_links());
 
   // Zero vector of generalized accelerations.
   const VectorX<T> vdot = VectorX<T>::Zero(model.num_velocities());
 
   // Temporary array for body accelerations.
-  std::vector<SpatialAcceleration<T>> A_WB_array(model.num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB_array(model.num_links());
 
   // Output vector of generalized forces:
   VectorX<T> tau_g(model.num_velocities());
@@ -106,20 +109,20 @@ void UniformGravityFieldElement<T>::DoCalcAndAddForceContribution(
   // Skip the world.
   DRAKE_ASSERT(this->has_parent_tree());
   const internal::MultibodyTree<T>& model = this->get_parent_tree();
-  const int num_bodies = model.num_bodies();
-  // Skip the "world" body.
-  for (BodyIndex body_index(1); body_index < num_bodies; ++body_index) {
-    const RigidBody<T>& body = model.get_body(body_index);
+  const int num_links = model.num_links();
+  // Skip the "world" link.
+  for (LinkIndex link_index(1); link_index < num_links; ++link_index) {
+    const RigidBody<T>& link = model.get_link(link_index);
 
-    // Skip this body if gravity is disabled.
-    if (!is_enabled(body.model_instance())) continue;
+    // Skip this link if gravity is disabled.
+    if (!is_enabled(link.model_instance())) continue;
 
-    internal::MobodIndex mobod_index = body.mobod_index();
+    internal::MobodIndex mobod_index = link.mobod_index();
 
     // TODO(amcastro-tri): Replace this CalcFoo() calls by GetFoo() calls once
-    // caching is in place.
-    const T mass = body.get_mass(context);
-    const Vector3<T> p_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
+    //  caching is in place.
+    const T mass = link.get_mass(context);
+    const Vector3<T> p_BoBcm_B = link.CalcCenterOfMassInBodyFrame(context);
     const math::RotationMatrix<T> R_WB = pc.get_R_WB(mobod_index);
     // TODO(amcastro-tri): Consider caching p_BoBcm_W.
     const Vector3<T> p_BoBcm_W = R_WB * p_BoBcm_B;
@@ -138,20 +141,20 @@ T UniformGravityFieldElement<T>::CalcPotentialEnergy(
   // Skip the world.
   DRAKE_THROW_UNLESS(this->has_parent_tree());
   const internal::MultibodyTree<T>& model = this->get_parent_tree();
-  const int num_bodies = model.num_bodies();
+  const int num_links = model.num_links();
   T TotalPotentialEnergy = 0.0;
-  // Skip the "world" body.
-  for (BodyIndex body_index(1); body_index < num_bodies; ++body_index) {
-    const RigidBody<T>& body = model.get_body(body_index);
+  // Skip the "world" link.
+  for (LinkIndex link_index(1); link_index < num_links; ++link_index) {
+    const RigidBody<T>& link = model.get_link(link_index);
 
-    // Skip this body if gravity is disabled.
-    if (!is_enabled(body.model_instance())) continue;
+    // Skip this link if gravity is disabled.
+    if (!is_enabled(link.model_instance())) continue;
 
     // TODO(amcastro-tri): Replace this CalcFoo() calls by GetFoo() calls once
     // caching is in place.
-    const T mass = body.get_mass(context);
-    const Vector3<T> p_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
-    const math::RigidTransform<T>& X_WB = pc.get_X_WB(body.mobod_index());
+    const T mass = link.get_mass(context);
+    const Vector3<T> p_BoBcm_B = link.CalcCenterOfMassInBodyFrame(context);
+    const math::RigidTransform<T>& X_WB = pc.get_X_WB(link.mobod_index());
     const math::RotationMatrix<T> R_WB = X_WB.rotation();
     const Vector3<T> p_WBo = X_WB.translation();
     // TODO(amcastro-tri): Consider caching p_BoBcm_W and/or p_WBcm.
@@ -172,25 +175,25 @@ T UniformGravityFieldElement<T>::CalcConservativePower(
   // Skip the world.
   DRAKE_THROW_UNLESS(this->has_parent_tree());
   const internal::MultibodyTree<T>& model = this->get_parent_tree();
-  const int num_bodies = model.num_bodies();
+  const int num_links = model.num_links();
   T TotalConservativePower = 0.0;
-  // Skip the "world" body.
-  for (BodyIndex body_index(1); body_index < num_bodies; ++body_index) {
-    const RigidBody<T>& body = model.get_body(body_index);
+  // Skip the "world" link.
+  for (LinkIndex link_index(1); link_index < num_links; ++link_index) {
+    const RigidBody<T>& link = model.get_link(link_index);
 
-    // Skip this body if gravity is disabled.
-    if (!is_enabled(body.model_instance())) continue;
+    // Skip this link if gravity is disabled.
+    if (!is_enabled(link.model_instance())) continue;
 
     // TODO(amcastro-tri): Replace this CalcFoo() calls by GetFoo() calls once
-    // caching is in place.
-    const T mass = body.get_mass(context);
-    const Vector3<T> p_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
-    const math::RigidTransform<T>& X_WB = pc.get_X_WB(body.mobod_index());
+    //  caching is in place.
+    const T mass = link.get_mass(context);
+    const Vector3<T> p_BoBcm_B = link.CalcCenterOfMassInBodyFrame(context);
+    const math::RigidTransform<T>& X_WB = pc.get_X_WB(link.mobod_index());
     const math::RotationMatrix<T> R_WB = X_WB.rotation();
     // TODO(amcastro-tri): Consider caching p_BoBcm_W.
     const Vector3<T> p_BoBcm_W = R_WB * p_BoBcm_B;
 
-    const SpatialVelocity<T>& V_WB = vc.get_V_WB(body.mobod_index());
+    const SpatialVelocity<T>& V_WB = vc.get_V_WB(link.mobod_index());
     const SpatialVelocity<T> V_WBcm = V_WB.Shift(p_BoBcm_W);
     const Vector3<T>& v_WBcm = V_WBcm.translational();
 

--- a/multibody/tree/velocity_kinematics_cache.h
+++ b/multibody/tree/velocity_kinematics_cache.h
@@ -16,20 +16,33 @@ namespace internal {
 
 // TODO(sherm1) Should cache qdot here.
 
-// This class is one of the cache entries in the Context. It holds the
-// kinematics results of computations that depend not only on the generalized
-// positions of the system, but also on its generalized velocities.
-// Velocity kinematics results include:
-//
-// - Spatial velocity `V_WB` for each body B in the model as measured and
-//   expressed in the world frame W.
-// - Spatial velocity `V_PB` for each body B in the model as measured and
-//   expressed in the inboard (or parent) body frame P.
-// - Spatial velocity `V_FMb_W` of frame Mb measured in the inboard frame F and
-//   expressed in W. Mb is an "offset" frame rigidly fixed to M, whose axes are
-//   parallel to M but whose origin is at Bo rather than Mo.
-//
-// @tparam_default_scalar
+/* This class is one of the cache entries in the Context. It holds the
+kinematics results of computations that depend not only on the generalized
+positions of the system, but also on its generalized velocities.
+
+Velocity kinematics results are mostly per-Mobod. We also need to know the
+velocity of every Link (composite mobods carry multiple links). Note that
+every mobod B (composite or not) has a distinguished "active" link L₀, which
+is the most inboard link following that mobod (that is, the link with the
+joint that connects the mobod to its inboard mobod). The body frame B of
+a mobod is always coincident with the frame L₀ of its active link.
+
+- V_WB:   Spatial velocity of mobod B measured and expressed in the world
+          frame W. Frame B is the same as frame L₀ of a mobod's active link.
+- V_WL:   Spatial velocity link L in W for every link. Indexed by
+          LinkOrdinal. Same as V_WB if L is the active link of mobod B.
+- V_PB_W: Spatial velocity of mobod B measured in its parent (inboard)
+          mobod's frame P, expressed in W.
+- V_FM:   For a mobod's mobilizer, the spatial velocity of the mobilizer's
+          outboard frame M (on the mobod) in its inboard frame F (on the mobod's
+          inboard ("parent") mobod), expressed in F.
+
+@tparam_default_scalar */
+
+// TODO(sherm1) V_WL mostly duplicates V_WB (they are identical if there are no
+//  composite bodies), and always contains all the V_WB spatial velocities (for
+//  the active links). See position_kinematics_cache for how to avoid
+//  duplication with no overhead.
 template <typename T>
 class VelocityKinematicsCache {
  public:
@@ -38,15 +51,16 @@ class VelocityKinematicsCache {
   // Constructs a velocity kinematics cache entry for the given
   // SpanningForest.
   // In Release builds specific entries are left uninitialized resulting in a
-  // zero cost operation. However in Debug builds those entries are set to NaN
+  // zero cost operation. However, in Debug builds those entries are set to NaN
   // so that operations using this uninitialized cache entry fail fast, easing
   // bug detection.
   explicit VelocityKinematicsCache(const SpanningForest& forest)
-      : num_mobods_(forest.num_mobods()) {
+      : num_mobods_(forest.num_mobods()), num_links_(forest.num_links()) {
     Allocate();
     DRAKE_ASSERT_VOID(InitializeToNaN());
     // Sets defaults.
     V_WB_pool_[world_mobod_index()].SetZero();   // World's velocity is zero.
+    V_WL_pool_[world_link_ordinal()].SetZero();  //           "
     V_FM_pool_[world_mobod_index()].SetNaN();    // It must never be used.
     V_PB_W_pool_[world_mobod_index()].SetNaN();  // It must never be used.
   }
@@ -58,6 +72,10 @@ class VelocityKinematicsCache {
       V_WB_pool_[mobod_index].SetZero();
       V_FM_pool_[mobod_index].SetZero();
       V_PB_W_pool_[mobod_index].SetZero();
+    }
+    for (LinkOrdinal link_ordinal(0); link_ordinal < num_links_;
+         ++link_ordinal) {
+      V_WL_pool_[link_ordinal].SetZero();
     }
   }
 
@@ -75,6 +93,16 @@ class VelocityKinematicsCache {
   SpatialVelocity<T>& get_mutable_V_WB(MobodIndex mobod_index) {
     DRAKE_ASSERT(0 <= mobod_index && mobod_index < num_mobods_);
     return V_WB_pool_[mobod_index];
+  }
+
+  const SpatialVelocity<T>& get_V_WL(LinkOrdinal ordinal) const {
+    DRAKE_ASSERT(0 <= ordinal && ordinal < num_links_);
+    return V_WL_pool_[ordinal];
+  }
+
+  void SetV_WL(LinkOrdinal ordinal, const SpatialVelocity<T>& V_WL) {
+    DRAKE_DEMAND(0 <= ordinal && ordinal < num_links_);
+    V_WL_pool_[ordinal] = V_WL;
   }
 
   // Returns a const reference to the across-mobilizer (associated with
@@ -106,19 +134,12 @@ class VelocityKinematicsCache {
   }
 
  private:
-  // Pools store entries in the same order as the mobilized bodies (BodyNodes)
-  // in the multibody forest, i.e. in DFT (Depth-First Traversal) order.
-  // Therefore clients of this class will access entries by MobodIndex, see
-  // `get_V_WB()` for instance.
-
-  // The type of the pools for storing spatial velocities.
-  typedef std::vector<SpatialVelocity<T>> SpatialVelocity_PoolType;
-
-  // Allocates resources for this position kinematics cache.
+  // Allocates resources for this velocity kinematics cache.
   void Allocate() {
     V_WB_pool_.resize(num_mobods_);
     V_FM_pool_.resize(num_mobods_);
     V_PB_W_pool_.resize(num_mobods_);
+    V_WL_pool_.resize(num_links_);
   }
 
   // Initializes all pools to have NaN values to ease bug detection when entries
@@ -129,13 +150,26 @@ class VelocityKinematicsCache {
       V_FM_pool_[mobod_index].SetNaN();
       V_PB_W_pool_[mobod_index].SetNaN();
     }
+    for (LinkOrdinal link_ordinal(0); link_ordinal < num_links_;
+         ++link_ordinal) {
+      V_WL_pool_[link_ordinal].SetNaN();
+    }
   }
 
-  // Number of body nodes in the corresponding MultibodyTree.
+  // Number of Mobods in the multibody forest, including the World mobod.
   int num_mobods_{0};
-  SpatialVelocity_PoolType V_WB_pool_;
-  SpatialVelocity_PoolType V_FM_pool_;
-  SpatialVelocity_PoolType V_PB_W_pool_;
+
+  // Number of links in the multibody graph includes all user-defined links
+  // (including the World link) and possibly some ephemeral links.
+  int num_links_{0};
+
+  // These are indexed by MobodIndex so are in depth-first order.
+  std::vector<SpatialVelocity<T>> V_WB_pool_;
+  std::vector<SpatialVelocity<T>> V_FM_pool_;
+  std::vector<SpatialVelocity<T>> V_PB_W_pool_;
+
+  // This pool is indexed by LinkOrdinal.
+  std::vector<SpatialVelocity<T>> V_WL_pool_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
This is a yak shave for the composites code. See #24350 for context.

In this PR there are still no composites being formed so there is exactly one link L on any mobilized body (mobod) B, and that link is the active link L₀ for that mobod. By construction, the L₀ frame and B frame are coincident (and always will be).

### Terminology changes
These are internal terminology changes that help clarify some otherwise-muddy concepts:
- Use "link" for RigidBody, use "mobod" as much as possible for mobilized bodies, with "body B" meaning a mobod while "link L" is a link, more than one of which may follow a mobilized body
- Be careful to distinguish `LinkOrdinal` from `LinkIndex` from `MobodIndex`
- Clarify the "active link" terminology for mobods -- one of the links on a composite is the "active link", which is the link whose joint connects to the inboard mobod.
- Updated comments to describe our terminology troubles and to make them use the improved terminology (see e.g. the class comment for `MultibodyTree`).

### New public symbols
- `Link<t>` is an alias for `RigidBody<T>`
- `LinkIndex` is an alias for `BodyIndex`
- `LinkOrdinal` indexes packed and possibly reordered arrays of Links

Making these public now allows for consistent notation in the many unit tests that mix MbT and MbP APIs. They won't affect user-visible APIs. I don't think there is any need to mention them in the release notes, but we could.

RigidBody and BodyIndex will not be deprecated but the aliases can be used where the Link/Mobod distinction needs to be emphasized, most definitely when working with composites!

### Other changes
Several other minor changes are included here so that the main composites PR can focus on the math:

- Adds a public factory method SpatialVector::NaN() in prep for composite-induced missing items, like reaction forces for weld joints within a composite.
- Introduces distinct link-frame vs. mobod-frame quantities in caches, e.g. X_LF and X_BF for precalculated frame offsets w.r.t. their Link or Mobod, resp., but sets them to the same value in this PR. This allows for consistent link terminology in this PR, and sets the stage for these values to differ in the next one. (Also includes provision for mass properties M_LLo_L vs M_BBo_B, and related position and velocity kinematics quantities.)
- Removed a silly memory optimization from FrameBodyPoseCache in favor of a simpler indexing scheme that generalizes to composites.
- Loosens a few unit tests that were too fussy so that they will continue to work when composites are introduced.
- Clarifies ElementCollection API to distinguish valid indexes from the totality of indexes.
- Moved a few internal implementations from MbP to MbT to make them accessible in tree tests.
- Some opportunistic cleanup for out-of-date and buggy comments as I encountered them.
- Fixed bug in spatial_inertia_test that caused a spurious failure in a Resolute build. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24443)
<!-- Reviewable:end -->
