### PR TITLE
[tools] Suppress kcov on sharded drake_py_unittest

### DIFF
--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -270,7 +270,7 @@ def drake_py_test(
         srcs = ["test/%s.py" % name]
     if kwargs.get("shard_count") != None:
         fail("Only drake_py_unittest can use sharding")
-    shard_count = kwargs.pop("_drake_py_unittest_shard_count", None)
+    kwargs["shard_count"] = kwargs.pop("_drake_py_unittest_shard_count", None)
 
     kwargs = incorporate_allow_network(kwargs, allow_network = allow_network)
     kwargs = incorporate_display(kwargs, display = display)
@@ -293,7 +293,6 @@ def drake_py_test(
         py_target = py_test,
         isolate = isolate,
         size = size,
-        shard_count = shard_count,
         srcs = srcs,
         deps = deps,
         target_compatible_with = target_compatible_with,

--- a/tools/skylark/kwargs.bzl
+++ b/tools/skylark/kwargs.bzl
@@ -121,9 +121,20 @@ def incorporate_allow_network(kwargs, *, allow_network):
     return kwargs
 
 def incorporate_test_weight_heuristics(kwargs):
-    # kcov is only appropriate for small-sized unit tests. If a test needs a
-    # shard_count or a special timeout, we assume it is not small.
-    if "shard_count" in kwargs or "timeout" in kwargs:
+    # If a test needs a shard_count or a special timeout, we assume it is not
+    # small -- kcov is only appropriate for small-sized unit tests.
+    required = {
+        "shard_count": 1,
+        "size": "small",
+        "timeout": "short",
+    }
+    big = False
+    for arg_name, required_value in required.items():
+        value = kwargs.get(arg_name, None) or required_value
+        if value != required_value:
+            big = True
+            break
+    if big:
         kwargs = amend(kwargs, "opt_out_conditions", append = [
             "//tools/kcov:enabled",
         ])


### PR DESCRIPTION
This had been true since 8ae45299 but got broken in 69e064f8.

Amends #24413.  Closes #24444.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24445)
<!-- Reviewable:end -->
