### PR TITLE
[tools] Disable kcov on jupyter notebooks

### DIFF
--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -101,9 +101,6 @@ drake_cc_binary(
     ],
     add_test_rule = True,
     test_rule_args = ["--simulation_sec=0.1 --target_realtime_rate=0.0"],
-    # TODO(kyle.edwards@kitware.com): Re-enable this test when it no longer
-    # causes timeouts in kcov.
-    test_rule_opt_out_conditions = ["//tools/kcov:enabled"],
 )
 
 drake_cc_binary(

--- a/planning/trajectory_optimization/BUILD.bazel
+++ b/planning/trajectory_optimization/BUILD.bazel
@@ -175,9 +175,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "gcs_trajectory_optimization_test",
-    # Even with many shards, the SimpleEnv2D suite has a couple of test cases
-    # that routinely time out under coverage tests, all by themselves.
-    opt_out_conditions = ["//tools/kcov:enabled"],
     shard_count = 12,
     deps = [
         ":gcs_trajectory_optimization",

--- a/tools/jupyter/jupyter_py.bzl
+++ b/tools/jupyter/jupyter_py.bzl
@@ -86,6 +86,10 @@ def drake_jupyter_py_binary(
             tags = jupyter_tags + test_rule_tags,
             timeout = test_rule_timeout,
             flaky = test_rule_flaky,
+            opt_out_conditions = [
+                # Smoke tests don't count as coverage.
+                "//tools/kcov:enabled",
+            ],
             # Permit `unittest` given that NumPy uses it.
             allow_import_unittest = True,
         )


### PR DESCRIPTION
It's not especially useful, doesn't work correctly, and our policy on other add_test_rule smoke tests (for drake_cc_binary, drake_py_binary, and drake_cc_googlebench_binary) is that they don't get coverage results. This should speed up our CI coverage times somewhat.

Also remove acute kcov exclusion from two places that were already implicit excluded (due to add_test_rule or shard_count).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24450)
<!-- Reviewable:end -->
