### PR TITLE
[cmake] Stop pretending to obey CMAKE_CXX_COMPILER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.20...4.3)
 
 project(drake
   DESCRIPTION "Model-based design and verification for robotics"
-  LANGUAGES C CXX
+  LANGUAGES C
 )
 
 # The primary build system for Drake is Bazel (https://bazel.build/). For CMake,
@@ -69,10 +69,7 @@ endif()
 file(REAL_PATH "${CMAKE_C_COMPILER}" C_COMPILER_REALPATH)
 cmake_path(GET C_COMPILER_REALPATH FILENAME C_COMPILER_NAME)
 
-file(REAL_PATH "${CMAKE_CXX_COMPILER}" CXX_COMPILER_REALPATH)
-cmake_path(GET CXX_COMPILER_REALPATH FILENAME CXX_COMPILER_NAME)
-
-if(C_COMPILER_NAME STREQUAL ccache OR CXX_COMPILER_NAME STREQUAL ccache)
+if(C_COMPILER_NAME STREQUAL ccache)
   message(FATAL_ERROR
     "Compilation with ccache is NOT supported due to incompatibility with Bazel"
   )
@@ -109,27 +106,27 @@ else()
   )
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MINIMUM_APPLE_CLANG_VERSION})
+if(CMAKE_C_COMPILER_ID STREQUAL AppleClang)
+  if(CMAKE_C_COMPILER_VERSION VERSION_LESS ${MINIMUM_APPLE_CLANG_VERSION})
     message(WARNING
-      "Compilation with clang++ ${CMAKE_CXX_COMPILER_VERSION} is NOT supported"
+      "Compilation with AppleClang ${CMAKE_C_COMPILER_VERSION} is NOT supported"
     )
   endif()
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MINIMUM_CLANG_VERSION})
+elseif(CMAKE_C_COMPILER_ID STREQUAL Clang)
+  if(CMAKE_C_COMPILER_VERSION VERSION_LESS ${MINIMUM_CLANG_VERSION})
     message(WARNING
-      "Compilation with clang++ ${CMAKE_CXX_COMPILER_VERSION} is NOT supported"
+      "Compilation with Clang ${CMAKE_C_COMPILER_VERSION} is NOT supported"
     )
   endif()
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${MINIMUM_GNU_VERSION})
+elseif(CMAKE_C_COMPILER_ID STREQUAL GNU)
+  if(CMAKE_C_COMPILER_VERSION VERSION_LESS ${MINIMUM_GNU_VERSION})
     message(WARNING
-      "Compilation with g++ ${CMAKE_CXX_COMPILER_VERSION} is NOT supported"
+      "Compilation with GCC ${CMAKE_C_COMPILER_VERSION} is NOT supported"
     )
   endif()
 else()
   message(WARNING
-    "Compilation with ${CMAKE_CXX_COMPILER_ID} is NOT supported. Compilation "
+    "Compilation with ${CMAKE_C_COMPILER_ID} is NOT supported. Compilation "
     "of project drake_install may fail."
   )
 endif()
@@ -167,11 +164,8 @@ if(NOT BUILD_TYPE_LOWER IN_LIST SUPPORTED_BUILD_TYPES_LOWER)
   )
 endif()
 
-# TODO(jwnimmer-tri) We don't currently pass along the user's selected C++
-# standard nor CMAKE_CXX_FLAGS to Bazel, but we should.
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 23)
+# TODO(#24455) We don't currently pass along the user's CMAKE_C_FLAGS and
+# CMAKE_CXX_FLAGS to Bazel, but we should.
 
 # Next we'll find which Python interpreter to use.
 if(PYTHON_EXECUTABLE AND NOT Python_EXECUTABLE)
@@ -217,7 +211,6 @@ if(NOT APPLE)
   # interfere with here.
   string(APPEND BAZEL_REPO_ENV
     " --repo_env=CC=${CMAKE_C_COMPILER}"
-    " --repo_env=CXX=${CMAKE_CXX_COMPILER}"
   )
 endif()
 

--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -43,5 +43,4 @@ try-import @PROJECT_BINARY_DIR@/drake.bazelrc
 build --stamp
 build --workspace_status_command="sed 's/^/STABLE_VERSION /' '@PROJECT_BINARY_DIR@/VERSION.TXT'"
 
-# TODO(jwnimmer-tri) Pass along CMAKE_C_FLAGS and CMAKE_CXX_FLAGS also, and
-# specifically make sure the user's -std=c++NN is respected.
+# TODO(#24455) Pass along CMAKE_C_FLAGS and CMAKE_CXX_FLAGS also.

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -105,8 +105,12 @@ can be specified by the user to be parsed by Drake's CMake and passed to the
 Bazel build.
 
 * [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
-* [`CMAKE_(C|CXX|Fortran)_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html)
+* [`CMAKE_(C|Fortran)_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html)
 * [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)
+
+The `CMAKE_C_COMPILER` is used to compile both C and C++ code, so must be a
+compiler *driver* than can handle both languages, based on the filename. All
+of the supported compilers (GCC, Clang, Xcode) work fine.
 
 Building and installing Drake also requires a working installation of Python.
 When `Python_EXECUTABLE` is specified, it uses the given path to the Python

--- a/setup/ubuntu/install_prereqs_user_environment.sh
+++ b/setup/ubuntu/install_prereqs_user_environment.sh
@@ -37,11 +37,8 @@ clang_major=$(sed -n 's/^clang-\([0-9]\+\)$/\1/p' \
 mkdir -p "$(dirname "${bazelrc}")"
 cat > "${bazelrc}" <<EOF
 common:clang --repo_env=CC=clang-${clang_major}
-common:clang --repo_env=CXX=clang++-${clang_major}
 build:clang --action_env=CC=clang-${clang_major}
-build:clang --action_env=CXX=clang++-${clang_major}
 build:clang --host_action_env=CC=clang-${clang_major}
-build:clang --host_action_env=CXX=clang++-${clang_major}
 EOF
 
 # Prefetch the bazelisk download of bazel.

--- a/tools/cc_toolchain/BUILD.bazel
+++ b/tools/cc_toolchain/BUILD.bazel
@@ -155,7 +155,6 @@ genrule(
     cmd = "cat <<EOF > '$@'\n" +
           "PATH=\"$$PATH\"\n" +
           "CC=\"$${CC:-}\"\n" +
-          "CXX=\"$${CXX:-}\"\n" +
           "EOF",
     visibility = ["//visibility:private"],
 )

--- a/tools/cc_toolchain/print_compiler_config.sh
+++ b/tools/cc_toolchain/print_compiler_config.sh
@@ -6,7 +6,5 @@ capture_compiler_env="$1"
 source "$capture_compiler_env"
 
 [ -n "$CC" ]
-[ -n "$CXX" ]
 
 echo "CC=$(type -P "$CC")"
-echo "CXX=$(type -P "$CXX")"

--- a/tools/wheel/image/build-drake.sh
+++ b/tools/wheel/image/build-drake.sh
@@ -34,8 +34,7 @@ WITH_MOSEK=ON
 # MOSEK is not currently supported for Linux aarch64 wheels.
 [ "$(arch)" == "aarch64" ] && WITH_MOSEK=OFF
 
-# Install Drake using our wheel-build-specific Python interpreter and
-# C/CXX/Fortran compilers.
+# Install Drake using our wheel-build-specific Python interpreter and compilers.
 # N.B. When you change anything here, also fix wheel/macos/build-wheel.sh.
 cmake ../drake-src \
     -DWITH_MOSEK="${WITH_MOSEK}" \
@@ -53,6 +52,5 @@ cmake ../drake-src \
     -DCMAKE_INSTALL_PREFIX=/tmp/drake-wheel-build/drake-dist \
     -DPython_EXECUTABLE=/usr/local/bin/python \
     -DCMAKE_C_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/gcc \
-    -DCMAKE_CXX_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/g++ \
     -DCMAKE_Fortran_COMPILER=/opt/rh/gcc-toolset-14/root/usr/bin/gfortran
 make install


### PR DESCRIPTION
Bazel's auto-detecting C++ toolchain only ever looks at $CC, not $CXX. Remove CMake code that looks for a C++ compiler and passes it along as $CXX to Bazel. Change the "compiler version too old" warnings to use the C compiler instead of C++.

Also remove dead CMAKE_CXX_EXTENSIONS, CMAKE_CXX_STANDARD_REQUIRED, and CMAKE_CXX_STANDARD. Drake doesn't declare any library targets, so changing these defaults doesn't do anything.

Also don't bother to set CXX in --config=clang for developer builds (or echo it back in print_compiler_config), since it has no effect.

Requires:
- [x] https://github.com/RobotLocomotion/drake-ci/pull/429

Towards #24442.  (Earlier I thought the fix to that problem might require further CMake compiler interrogation. It seems like we can get away without it now, but anyway this is still an important cleanup PR.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24456)
<!-- Reviewable:end -->
