### PR TITLE
[cmake] Guard against lld multi-threading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -775,12 +775,23 @@ add_custom_target(drake_version ALL
     -P "${PROJECT_SOURCE_DIR}/tools/install/libdrake/generate_version.cmake"
 )
 
+# Ask Bazel to calculate any other necessary bazelrc settings by writing out a
+# file at drake/tools/cc_toolchain/cmake.bazelrc. This file will be imported by
+# our cmake/bazelrc.in. Prior to generating it, we'll wipe it away because we
+# don't want a prior stale version of this file to confuse the regeneration.
+add_custom_target(drake_refresh_cmake_bazelrc
+  COMMAND ${CMAKE_COMMAND} -E rm -f "${DRAKE_BAZEL_BUILD_DIR}/bazel-bin/external/drake+/tools/cc_toolchain/cmake.bazelrc"
+  COMMAND "${Bazel_EXECUTABLE}" --quiet build --noannounce_rc --show_result=0
+    @drake//tools/cc_toolchain:cmake.bazelrc
+  WORKING_DIRECTORY "${DRAKE_BAZEL_BUILD_DIR}"
+)
+
 add_custom_target(drake_install ALL
   COMMAND "${Bazel_EXECUTABLE}" build ${BAZEL_INSTALL_TARGET}
   WORKING_DIRECTORY "${DRAKE_BAZEL_BUILD_DIR}"
   USES_TERMINAL
 )
-add_dependencies(drake_install drake_version)
+add_dependencies(drake_install drake_refresh_cmake_bazelrc drake_version)
 
 install(CODE
   "execute_process(

--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -19,10 +19,6 @@ common --@drake//tools/flags:private_runtime_repo_default=internal
 # Flags that tweak repository rules (if any).
 common @BAZEL_REPO_ENV@
 
-# Disable the "convenience symlinks" intended for Bazel users; they only add
-# confusion for the CMake use case.
-build --symlink_prefix=/
-
 # Transcriptions of CMake configs into their equivalent Bazel flags.
 build:Debug --config=debug --fission=no
 build:MinSizeRel --compilation_mode=opt --copt=-Os --host_copt=-Os
@@ -31,6 +27,12 @@ build:RelWithDebInfo --compilation_mode=opt --fission=no --copt=-g --host_copt=-
 
 # Match CMAKE_BUILD_TYPE as well as the WITH_FOO customizations.
 build @BAZEL_CONFIG@
+
+# The drake_refresh_cmake_bazelrc custom target in our CMakeLists.txt runs Bazel
+# to generate this file prior to building the rest of Drake. However, we must
+# use "try-import" instead of "import" because we need to run Bazel to generate
+# this file but Bazel will fail if an "import"ed rcfile is missing.
+try-import bazel-bin/external/drake+/tools/cc_toolchain/cmake.bazelrc
 
 # Respect user.bazelrc (when present).
 try-import @PROJECT_SOURCE_DIR@/user.bazelrc

--- a/tools/cc_toolchain/BUILD.bazel
+++ b/tools/cc_toolchain/BUILD.bazel
@@ -7,6 +7,7 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:sh.bzl", "sh_binary")
+load(":defs.bzl", "generate_cmake_bazelrc")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -136,6 +137,14 @@ bool_flag(
 config_setting(
     name = "with_openmp_true",
     flag_values = {":with_openmp": "True"},
+)
+
+# (Internal use only.) Generates a (possibly-empty) bazelrc fragment that
+# contains recommended flags when building Drake with our CMakeLists.txt
+# wrapper. We could mark this `tags = ["manual"]` but it's convenient to
+# exercise the logic even in Bazel builds to make sure it doesn't bitrot.
+generate_cmake_bazelrc(
+    name = "cmake.bazelrc",
 )
 
 # *****************************************************************************

--- a/tools/cc_toolchain/defs.bzl
+++ b/tools/cc_toolchain/defs.bzl
@@ -1,0 +1,53 @@
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("//tools/skylark:cc.bzl", "CcInfo", "cc_common")
+
+def _generate_cmake_bazelrc_impl(ctx):
+    # Retrieve the link_flags from the current C++ toolchain.
+    cc_toolchain = find_cc_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+    )
+    link_variables = cc_common.create_link_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        is_linking_dynamic_library = True,
+    )
+    link_flags = cc_common.get_memory_inefficient_command_line(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.cpp_link_dynamic_library,
+        variables = link_variables,
+    )
+
+    # If a multi-threaded linker is being used, we need to put it back into
+    # single-threaded mode to avoid overloading the machine.
+    content = ""
+    if "-fuse-ld=lld" in link_flags or "-fuse-ld=mold" in link_flags:
+        content = "build --linkopt=-Wl,--threads=1\n"
+
+    # Write the bazelrc fragment.
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(out, content, is_executable = False)
+    return [
+        DefaultInfo(
+            files = depset([out]),
+            data_runfiles = ctx.runfiles(files = [out]),
+        ),
+    ]
+
+generate_cmake_bazelrc = rule(
+    implementation = _generate_cmake_bazelrc_impl,
+    doc = """
+Generates a (possibly-empty) bazelrc fragment that contains recommended flags
+when building Drake with our CMakeLists.txt wrapper. In particular, checks if
+the linker is multi-threaded and if so sets a thread limit.
+    """,
+    attrs = {
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    fragments = ["cpp"],
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)


### PR DESCRIPTION
If the user ends up linking Drake with `lld`, add `--threads=1` to the linker command to prevent overloading the machine.

Towards #24442.  This is important because if `-fuse-ld=lld` can be passed compiler command line without complaint, then Bazel's local C++ toolchain will always do it without any way to opt-out.  In other words, if `lld` is installed then it will always be used, even without the user flipping any CMake linker switches like `CMAKE_LINKER_TYPE`.

Relates #24439 and #24278.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24457)
<!-- Reviewable:end -->
