### PR TITLE
[ad] Speed up matrix multiplies

### DIFF
--- a/bindings/generated_docstrings/geometry.h
+++ b/bindings/generated_docstrings/geometry.h
@@ -5814,7 +5814,7 @@ throwsᵈ | throwsᵈ | ░░░░░ | ░░░░░░░ | ░░░░�
 throwsᵈ | throwsᵈ | throwsᵈ | ░░░░░░ | ░░░░░ | ░░░░░ | | HalfSpace |
 throwsᵈ | throwsᵈ | throwsᵈ | throwsᵈ | throwsᵈ | throwsᵃ | ░░░░░ |
 ░░░░░ | | Mesh | ᵇ | ᵇ | ᵇ | ᵇ | ᵇ | ᵇ | ᵇ | ░░░░░ | | Sphere | 2e-15
-| 3e-15 | throwsᵈ | 2e-15 | throwsᵈ | 2e-15 | ᵇ | 5e-15 | ***Table
+| 5e-15 | throwsᵈ | 2e-15 | throwsᵈ | 2e-15 | ᵇ | 5e-15 | ***Table
 2***: Worst observed error (in m) for 2mm penetration between
 geometries approximately 20cm in size for ``T`` = drake∷AutoDiffXd
 "AutoDiffXd".
@@ -6141,7 +6141,7 @@ as a zero-radius sphere.
 Mesh | Sphere | | :--------: | :-----: | :------: | :-----: |
 :-------: | :--------: | :--------: | :-----: | :-----: | | double |
 2e-15 | 4e-15 | 6e-15 | 3e-15 | 3e-5ᵇ | 5e-15 | 6e-15ᶜ | 4e-15 | |
-AutoDiffXd | 1e-15 | 7e-15 | ᵃ | ᵃ | ᵃ | 5e-15 | ᵃ | 3e-15 | |
+AutoDiffXd | 1e-15 | 7e-15 | ᵃ | ᵃ | ᵃ | 5e-15 | ᵃ | 4e-15 | |
 Expression | ᵃ | ᵃ | ᵃ | ᵃ | ᵃ | ᵃ | ᵃ | ᵃ | ***Table 8***: Worst
 observed error (in m) for 2mm penetration/separation between geometry
 approximately 20cm in size and a point.

--- a/common/ad/BUILD.bazel
+++ b/common/ad/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_library(
     name = "auto_diff",
     srcs = [
         "internal/derivatives_xpr.cc",
+        "internal/eigen_specializations.cc",
         "internal/partials.cc",
         "internal/standard_operations.cc",
     ],
@@ -56,6 +57,14 @@ drake_cc_googletest(
     deps = [
         ":auto_diff",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "matrix_heap_test",
+    deps = [
+        ":auto_diff",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/common/ad/internal/eigen_specializations.cc
+++ b/common/ad/internal/eigen_specializations.cc
@@ -1,0 +1,53 @@
+#include "drake/common/ad/auto_diff.h"
+
+namespace drake {
+namespace ad {
+namespace internal {
+namespace {
+
+AutoDiff GenericGevv(const Eigen::Ref<const VectorX<AutoDiff>, 0, StrideX>& a,
+                     const Eigen::Ref<const VectorX<AutoDiff>, 0, StrideX>& b) {
+  DRAKE_ASSERT(a.size() == b.size());
+  DRAKE_ASSERT(a.size() > 0);
+  AutoDiff result = a.coeffRef(0) * b.coeffRef(0);
+  for (int i = 1; i < a.size(); ++i) {
+    const AutoDiff& a_i = a.coeffRef(i);
+    const AutoDiff& b_i = b.coeffRef(i);
+    // Spell out `result += a_i * b_i` with a combined multiply-accumulate.
+    // ∂/∂x result + (a * b) = result' + (a * b)' = result' + ba' + ab'
+    result.partials().AddScaled(b_i.value(), a_i.partials());
+    result.partials().AddScaled(a_i.value(), b_i.partials());
+    result.value() += a_i.value() * b_i.value();
+  }
+  return result;
+}
+
+}  // namespace
+
+void Gemm(const Eigen::Ref<const MatrixX<AutoDiff>, 0, StrideX>& left,
+          const Eigen::Ref<const MatrixX<AutoDiff>, 0, StrideX>& right,
+          EigenPtr<MatrixX<AutoDiff>> result) {
+  // These checks are guaranteed by our header file functions that call us.
+  DRAKE_ASSERT(result != nullptr);
+  DRAKE_ASSERT(result->rows() == left.rows());
+  DRAKE_ASSERT(result->cols() == right.cols());
+  DRAKE_ASSERT(left.cols() == right.rows());
+
+  // Multiplying Mx0 matrix * 0xN matrix produces a MxN zero matrix without any
+  // partials.
+  if (left.cols() == 0) {
+    result->setZero();
+    return;
+  }
+
+  // Delegate to Gevv.
+  for (int i = 0; i < result->rows(); ++i) {
+    for (int j = 0; j < result->cols(); ++j) {
+      (*result)(i, j) = GenericGevv(left.row(i), right.col(j));
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/internal/eigen_specializations.h
+++ b/common/ad/internal/eigen_specializations.h
@@ -4,8 +4,13 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/drake_assert.h"
+
 /* This file contains Eigen-related specializations for Drake's AutoDiff
 scalar type (plus the intimately related std::numeric_limits specialization).
+
+The specializations both add basic capability (e.g., NumTraits) as well as
+improve performance (e.g., fewer copies than Eigen would naively use).
 
 NOTE: This file should never be included directly, rather only from
 auto_diff.h in a very specific order. */
@@ -56,3 +61,67 @@ struct ScalarBinaryOpTraits<double, drake::ad::AutoDiff, BinOp> {
 }  // namespace Eigen
 
 #endif  // DRAKE_DOXYGEN_CXX
+
+namespace drake {
+namespace ad {
+namespace internal {
+
+/* A specialized implementation of BLAS GEMM for AutoDiff that is faster than
+Eigen's generic implementation. With our current mechanism for hooking this into
+Eigen, we only need to support the simplified form C ⇐ A@B rather than the more
+general C ⇐ αA@B+βC of typical GEMM; if we figure out how to hook into Eigen's
+expression templates, we could expand to the more general form.
+
+The dynamic StrideX allows for passing numpy.ndarray without copies. This
+function isn't yet bound / used in pydrake, but might be in the future.
+
+Sets result = left * right. */
+void Gemm(const Eigen::Ref<const MatrixX<AutoDiff>, 0, StrideX>& left,
+          const Eigen::Ref<const MatrixX<AutoDiff>, 0, StrideX>& right,
+          EigenPtr<MatrixX<AutoDiff>> result);
+
+/* Eigen promises "automatic conversion of the inner product to a scalar", so
+when we calculate an inner product we need to return this magic type that acts
+like both a Matrix1<AutoDiff> and a scalar AutoDiff. There does not appear to be
+any practical way to mimic what Eigen does, other than multiple inheritance. */
+class DegenerateAutoDiffInnerProduct
+    : public AutoDiff,
+      public Eigen::Map<Eigen::Matrix<AutoDiff, 1, 1>> {
+ public:
+  DegenerateAutoDiffInnerProduct()
+      // Because Map here expects an AutoDiff* the `this` pointer to the just-
+      // constructed object converts to point to the AutoDiff base class object
+      // so that both the Map matrix and the AutoDiff scalar use the same
+      // memory.
+      : Map(this) {}
+};
+
+/* Helper to look up the return type we'll use for an AutoDiff matmul. */
+template <typename MatrixL, typename MatrixR>
+using AutoDiffMatMulResult =
+    std::conditional_t<MatrixL::RowsAtCompileTime == 1 &&
+                           MatrixR::ColsAtCompileTime == 1,
+                       DegenerateAutoDiffInnerProduct,
+                       Eigen::Matrix<AutoDiff, MatrixL::RowsAtCompileTime,
+                                     MatrixR::ColsAtCompileTime>>;
+
+}  // namespace internal
+
+// Matrix<AutoDiff> * Matrix<AutoDiff> => Matrix<AutoDiff>
+template <typename MatrixL, typename MatrixR>
+internal::AutoDiffMatMulResult<MatrixL, MatrixR> operator*(const MatrixL& lhs,
+                                                           const MatrixR& rhs)
+  requires std::is_base_of_v<Eigen::MatrixBase<MatrixL>, MatrixL> &&
+           std::is_base_of_v<Eigen::MatrixBase<MatrixR>, MatrixR> &&
+           std::is_same_v<typename MatrixL::Scalar, AutoDiff> &&
+           std::is_same_v<typename MatrixR::Scalar, AutoDiff>
+{
+  internal::AutoDiffMatMulResult<MatrixL, MatrixR> result;
+  DRAKE_THROW_UNLESS(lhs.cols() == rhs.rows());
+  result.resize(lhs.rows(), rhs.cols());
+  internal::Gemm(lhs, rhs, &result);
+  return result;
+}
+
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/test/matrix_heap_test.cc
+++ b/common/ad/test/matrix_heap_test.cc
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/ad/auto_diff.h"
+#include "drake/common/test_utilities/limit_malloc.h"
+
+namespace drake {
+namespace ad {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+using test::LimitMalloc;
+
+class MatrixHeapTest : public ::testing::Test {
+ protected:
+  const AutoDiff a00_{0.1, Vector3d::LinSpaced(1.0, 2.0)};
+  const AutoDiff a01_{0.2, Vector3d::LinSpaced(2.0, 3.0)};
+  const AutoDiff a02_{0.3, Vector3d::LinSpaced(3.0, 4.0)};
+  const AutoDiff a10_{0.4, Vector3d::LinSpaced(4.0, 5.0)};
+  const AutoDiff a11_{0.5, Vector3d::LinSpaced(5.0, 6.0)};
+  const AutoDiff a12_{0.6, Vector3d::LinSpaced(6.0, 7.0)};
+
+  const AutoDiff b00_{0.7, Vector3d::LinSpaced(7.0, 8.0)};
+  const AutoDiff b10_{0.8, Vector3d::LinSpaced(8.0, 9.0)};
+  const AutoDiff b20_{0.9, Vector3d::LinSpaced(9.0, 10.0)};
+
+  // clang-format off
+  const MatrixX<AutoDiff> A_ad_ =
+      (MatrixX<AutoDiff>(2, 3)
+       << a00_, a01_, a02_,
+          a10_, a11_, a12_).finished();
+  const MatrixX<AutoDiff> B_ad_ =
+      (MatrixX<AutoDiff>(3, 1)
+       << b00_,
+          b10_,
+          b20_).finished();
+  // clang-format on
+};
+
+TEST_F(MatrixHeapTest, MatrixProduct) {
+  // The expected allocations are:
+  // - X's matrix storage (2 x 1)
+  // - X(0, 0)'s partials
+  // - X(1, 0)'s partials
+  // Note in particular that none of the intermediate results need their own
+  // allocations -- their storage is moved/reused all the way into the final
+  // result.
+  int size = -1;
+  {
+    LimitMalloc guard({3});
+    MatrixX<AutoDiff> X = A_ad_ * B_ad_;
+    size = X.size();
+  }
+  EXPECT_EQ(size, 2);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace ad
+}  // namespace drake

--- a/common/ad/test/matrix_test.cc
+++ b/common/ad/test/matrix_test.cc
@@ -47,6 +47,33 @@ GTEST_TEST(MatrixTest, MatrixProduct) {
   EXPECT_TRUE(CompareMatrices(C(1, 0).derivatives(), 8 * xy_grad, tol));
 }
 
+GTEST_TEST(MatrixTest, OneDimensional) {
+  const AutoDiff x{0.4, Vector3d::LinSpaced(0.0, 2.0)};
+  const AutoDiff y{0.3, Vector3d::LinSpaced(-1.0, 1.0)};
+
+  Eigen::Matrix<AutoDiff, 1, 2> A;
+  A << x, y;
+  Eigen::Matrix<AutoDiff, 2, 1> B;
+  B << y, x;
+
+  // When the result of matrix multiplication is a 1x1 matrix at compile time,
+  // Eigen allows us to assign it to either a matrix or a scalar.
+  const Eigen::Matrix<AutoDiff, 1, 1> C1 = A * B;
+  const AutoDiff C2 = A * B;
+  EXPECT_EQ(C1[0].value(), C2.value());
+  EXPECT_EQ(C1[0].derivatives(), C2.derivatives());
+}
+
+GTEST_TEST(MatrixTest, ZeroDimensional) {
+  Eigen::Matrix<AutoDiff, 2, 0> A;
+  Eigen::Matrix<AutoDiff, 0, 1> B;
+  const Eigen::Matrix<AutoDiff, 2, 1> C = A * B;
+  for (int row = 0; row < 2; ++row) {
+    EXPECT_EQ(C[row].value(), 0.0);
+    EXPECT_EQ(C[row].derivatives().size(), 0);
+  }
+}
+
 }  // namespace
 }  // namespace ad
 }  // namespace drake

--- a/common/symbolic/expression/expression.h
+++ b/common/symbolic/expression/expression.h
@@ -1424,8 +1424,12 @@ class ExpressionInnerProduct
     : public Expression,
       public Eigen::Map<Eigen::Matrix<Expression, 1, 1>> {
  public:
-  ExpressionInnerProduct() : Map(this) {}
-  void resize(int rows, int cols) { DRAKE_ASSERT(rows == 1 && cols == 1); }
+  ExpressionInnerProduct()
+      // Because Map here expects an Expression* the `this` pointer to the just-
+      // constructed object converts to point to the Expression base class
+      // object so that both the Map matrix and the Expression scalar use the
+      // same memory.
+      : Map(this) {}
 };
 
 /* Helper to look up the return type we'll use for an Expression matmul. */

--- a/geometry/proximity/test/distance_to_point_characterize_test.cc
+++ b/geometry/proximity/test/distance_to_point_characterize_test.cc
@@ -154,7 +154,7 @@ INSTANTIATE_TEST_SUITE_P(
         QueryInstance(kPoint, kCylinder, kIgnores),
         QueryInstance(kPoint, kEllipsoid, kIgnores),
         QueryInstance(kPoint, kHalfSpace, 5e-15),
-        QueryInstance(kPoint, kSphere, 3e-15)),
+        QueryInstance(kPoint, kSphere, 4e-15)),
     QueryInstanceName);
 // clang-format on
 

--- a/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
@@ -133,7 +133,7 @@ INSTANTIATE_TEST_SUITE_P(
         QueryInstance(kCapsule, kCylinder, kThrows),
         QueryInstance(kCapsule, kEllipsoid, kThrows),
         QueryInstance(kCapsule, kHalfSpace, kThrows),
-        QueryInstance(kCapsule, kSphere, 3e-15),
+        QueryInstance(kCapsule, kSphere, 5e-15),
 
         QueryInstance(kConvex, kConvex, kThrows),
         QueryInstance(kConvex, kCylinder, kThrows),

--- a/geometry/proximity/test/triangle_surface_mesh_test.cc
+++ b/geometry/proximity/test/triangle_surface_mesh_test.cc
@@ -126,8 +126,7 @@ std::unique_ptr<TriangleSurfaceMesh<double>> GenerateZeroAreaMesh() {
 // The optional parameter X_WM will change the vertex positions to W's frame.
 template <typename T>
 std::unique_ptr<TriangleSurfaceMesh<T>> TestSurfaceMesh(
-    const math::RigidTransform<T> X_WM = math::RigidTransform<T>::Identity(),
-    const Vector3<T>& scale = Vector3<T>::Ones()) {
+    const math::RigidTransform<T>& X_WM = math::RigidTransform<T>::Identity()) {
   // A simple surface mesh comprises of two co-planar triangles with vertices on
   // the coordinate axes and the origin like this:
   //   y
@@ -154,8 +153,7 @@ std::unique_ptr<TriangleSurfaceMesh<T>> TestSurfaceMesh(
   const Vector3<T> vertex_data_M[4] = {
       {0., 0., 0.}, {15., 0., 0.}, {15., 15., 0.}, {0., 15., 0.}};
   std::vector<Vector3<T>> vertices_W;
-  for (int v = 0; v < 4; ++v)
-    vertices_W.emplace_back(X_WM * vertex_data_M[v].cwiseProduct(scale));
+  for (int v = 0; v < 4; ++v) vertices_W.emplace_back(X_WM * vertex_data_M[v]);
   auto surface_mesh_W = std::make_unique<TriangleSurfaceMesh<T>>(
       std::move(faces), std::move(vertices_W));
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -281,7 +281,7 @@ class QueryObject {
    | Ellipsoid | throwsᵈ | throwsᵈ  | throwsᵈ |  throwsᵈ  |   throwsᵈ  |   ░░░░░░   |  ░░░░░  |  ░░░░░  |
    | HalfSpace | throwsᵈ | throwsᵈ  | throwsᵈ |  throwsᵈ  |   throwsᵈ  |   throwsᵃ  |  ░░░░░  |  ░░░░░  |
    | Mesh      |    ᵇ    |    ᵇ     |    ᵇ    |     ᵇ     |      ᵇ     |     ᵇ      |    ᵇ    |  ░░░░░  |
-   | Sphere    |  2e-15  |  3e-15   | throwsᵈ |   2e-15   |   throwsᵈ  |   2e-15    |    ᵇ    |  5e-15  |
+   | Sphere    |  2e-15  |  5e-15   | throwsᵈ |   2e-15   |   throwsᵈ  |   2e-15    |    ᵇ    |  5e-15  |
    __*Table 2*__: Worst observed error (in m) for 2mm penetration between
    geometries approximately 20cm in size for `T` = @ref drake::AutoDiffXd
    "AutoDiffXd".
@@ -766,7 +766,7 @@ class QueryObject {
    |   Scalar   |   %Box  | %Capsule | %Convex | %Cylinder | %Ellipsoid | %HalfSpace |  %Mesh  | %Sphere |
    | :--------: | :-----: | :------: | :-----: | :-------: | :--------: | :--------: | :-----: | :-----: |
    |   double   |  2e-15  |   4e-15  |  6e-15  |   3e-15   |    3e-5ᵇ   |    5e-15   | 6e-15ᶜ  |  4e-15  |
-   | AutoDiffXd |  1e-15  |   7e-15  |    ᵃ    |     ᵃ     |      ᵃ     |    5e-15   |    ᵃ    |  3e-15  |
+   | AutoDiffXd |  1e-15  |   7e-15  |    ᵃ    |     ᵃ     |      ᵃ     |    5e-15   |    ᵃ    |  4e-15  |
    | Expression |   ᵃ     |    ᵃ     |    ᵃ    |     ᵃ     |      ᵃ     |      ᵃ     |    ᵃ    |    ᵃ    |
    __*Table 8*__: Worst observed error (in m) for 2mm penetration/separation
    between geometry approximately 20cm in size and a point.

--- a/multibody/contact_solvers/sap/test/sap_model_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_model_test.cc
@@ -870,7 +870,7 @@ TEST_F(DummyModelTest, CostGradients) {
                               MatrixCompareType::relative));
 
   // Validate gradient and its gradient (Hessian of the cost).
-  EXPECT_TRUE(CompareMatrices(cost_gradient, gradient_ad_value, kEpsilon,
+  EXPECT_TRUE(CompareMatrices(cost_gradient, gradient_ad_value, 2 * kEpsilon,
                               MatrixCompareType::relative));
 
   // Unit test the validity of the constraints Hessian G by directly forming the


### PR DESCRIPTION
Towards #17492.

This mimics the approach from #19304 for `symbolic::Expression` over to `ad::AutoDiff`.  All of Eigen's expression templates are written assuming that a `Scalar` basically fits in a register (i.e., cheap to copy).  With fat scalars that don't fit, the cost of all the copying/moving through deeply nested functors really adds up.  For common operations (in this case, starting with just matmul) we need to replace Eigen's logic with our own.

---

This PR compared to master:

| Case | master | pull | change |
|:---|:---|:---|:---|
| ArrayArrayMac/0/-1/100 | 1.63 us | 1.52 us | -6.5% ✅ |
| ArrayArrayMac/0/-1/3 | 0.0468 us | 0.0429 us | -8.2% ✅ |
| ArrayArrayMac/0/0/100 | 1.87 us | 1.72 us | -8.2% ✅ |
| ArrayArrayMac/0/0/3 | 0.0674 us | 0.049 us | -27.2% ✅ |
| ArrayArrayMac/2/-1/100 | 8.65 us | 8.81 us | +1.8% ⚪ |
| ArrayArrayMac/2/-1/3 | 0.194 us | 0.193 us | -0.8% ⚪ |
| ArrayArrayMac/2/0/100 | 9.04 us | 9.0 us | -0.4% ⚪ |
| ArrayArrayMac/2/0/3 | 0.208 us | 0.205 us | -1.6% ⚪ |
| ArrayArrayMac/2/2/100 | 14.5 us | 13.2 us | -9.0% ✅ |
| ArrayArrayMac/2/2/3 | 0.231 us | 0.229 us | -1.0% ⚪ |
| ArrayScalarMac/0/-1/100 | 1.43 us | 1.45 us | +1.2% ⚪ |
| ArrayScalarMac/0/-1/3 | 0.043 us | 0.0425 us | -1.3% ⚪ |
| ArrayScalarMac/0/0/100 | 2.76 us | 2.48 us | -10.3% ✅ |
| ArrayScalarMac/0/0/3 | 0.121 us | 0.101 us | -16.5% ✅ |
| ArrayScalarMac/2/-1/100 | 8.68 us | 8.97 us | +3.3% ❌ |
| ArrayScalarMac/2/-1/3 | 0.209 us | 0.192 us | -7.7% ✅ |
| ArrayScalarMac/2/0/100 | 9.67 us | 9.43 us | -2.5% ⚪ |
| ArrayScalarMac/2/0/3 | 0.27 us | 0.257 us | -5.0% ✅ |
| ArrayScalarMac/2/2/100 | 19.2 us | 17.4 us | -9.3% ✅ |
| ArrayScalarMac/2/2/3 | 0.542 us | 0.532 us | -1.9% ⚪ |
| MatrixMultiply/0/0/100 | 27.7 millis | 3.2 millis | -88.5% ✅ |
| MatrixMultiply/0/0/3 | 0.695 us | 0.2 us | -71.3% ✅ |
| MatrixMultiply/2/0/100 | 107.0 millis | 27.5 millis | -74.2% ✅ |
| MatrixMultiply/2/0/3 | 2.1 us | 0.575 us | -72.6% ✅ |
| MatrixMultiply/2/2/100 | 160.0 millis | 59.5 millis | -62.8% ✅ |
| MatrixMultiply/2/2/3 | 2.76 us | 0.671 us | -75.7% ✅ |
| VectorDotProduct/0/-1/100 | 1.42 us | 1.27 us | -10.6% ✅ |
| VectorDotProduct/0/-1/3 | 0.0367 us | 0.0311 us | -15.1% ✅ |
| VectorDotProduct/0/0/100 | 1.62 us | 1.37 us | -15.5% ✅ |
| VectorDotProduct/0/0/3 | 0.0445 us | 0.0342 us | -23.3% ✅ |
| VectorDotProduct/2/-1/100 | 8.19 us | 7.43 us | -9.3% ✅ |
| VectorDotProduct/2/-1/3 | 0.123 us | 0.12 us | -1.8% ⚪ |
| VectorDotProduct/2/0/100 | 10.5 us | 6.9 us | -34.0% ✅ |
| VectorDotProduct/2/0/3 | 0.13 us | 0.123 us | -5.4% ✅ |
| VectorDotProduct/2/2/100 | 10.9 us | 8.82 us | -19.3% ✅ |
| VectorDotProduct/2/2/3 | 0.138 us | 0.133 us | -3.7% ✅ |

| Case | master | pull | change |
|:---|:---|:---|:---|
| CassieAutoDiff/ForwardDynamics/0 | 432.0 us | 311.0 us | -27.9% ✅ |
| CassieAutoDiff/ForwardDynamics/1 | 1.69 millis | 1.25 millis | -26.1% ✅ |
| CassieAutoDiff/ForwardDynamics/10 | 713.0 us | 557.0 us | -22.0% ✅ |
| CassieAutoDiff/ForwardDynamics/11 | 2.08 millis | 1.61 millis | -22.6% ✅ |
| CassieAutoDiff/ForwardDynamics/2 | 709.0 us | 544.0 us | -23.2% ✅ |
| CassieAutoDiff/ForwardDynamics/3 | 1.98 millis | 1.53 millis | -22.9% ✅ |
| CassieAutoDiff/ForwardDynamics/8 | 503.0 us | 362.0 us | -28.0% ✅ |
| CassieAutoDiff/ForwardDynamics/9 | 1.84 millis | 1.4 millis | -23.9% ✅ |
| CassieAutoDiff/InverseDynamics/0 | 226.0 us | 141.0 us | -37.8% ✅ |
| CassieAutoDiff/InverseDynamics/1 | 874.0 us | 549.0 us | -37.2% ✅ |
| CassieAutoDiff/InverseDynamics/2 | 485.0 us | 370.0 us | -23.8% ✅ |
| CassieAutoDiff/InverseDynamics/3 | 995.0 us | 623.0 us | -37.4% ✅ |
| CassieAutoDiff/InverseDynamics/4 | 370.0 us | 253.0 us | -31.6% ✅ |
| CassieAutoDiff/InverseDynamics/5 | 990.0 us | 617.0 us | -37.7% ✅ |
| CassieAutoDiff/InverseDynamics/6 | 533.0 us | 409.0 us | -23.3% ✅ |
| CassieAutoDiff/InverseDynamics/7 | 1.15 millis | 707.0 us | -38.5% ✅ |
| CassieAutoDiff/MassMatrix/0 | 180.0 us | 120.0 us | -33.3% ✅ |
| CassieAutoDiff/MassMatrix/1 | 676.0 us | 451.0 us | -33.4% ✅ |
| CassieAutoDiff/MassMatrix/2 | 180.0 us | 120.0 us | -33.2% ✅ |
| CassieAutoDiff/MassMatrix/3 | 740.0 us | 492.0 us | -33.4% ✅ |
| CassieAutoDiff/PosAndVelKinematics/0 | 75.4 us | 39.0 us | -48.3% ✅ |
| CassieAutoDiff/PosAndVelKinematics/1 | 255.0 us | 122.0 us | -52.1% ✅ |
| CassieAutoDiff/PosAndVelKinematics/2 | 101.0 us | 60.7 us | -40.1% ✅ |
| CassieAutoDiff/PosAndVelKinematics/3 | 292.0 us | 143.0 us | -51.0% ✅ |
| CassieAutoDiff/PositionKinematics/0 | 38.5 us | 19.3 us | -49.9% ✅ |
| CassieAutoDiff/PositionKinematics/1 | 142.0 us | 67.3 us | -52.8% ✅ |

---

This PR compared to master with master using legacy AutoDiff:

| Case | master | pull | change |
|:---|:---|:---|:---|
| CassieAutoDiff/ForwardDynamics/0 | 410.0 us | 311.0 us | -24.0% ✅ |
| CassieAutoDiff/ForwardDynamics/1 | 1.21 millis | 1.25 millis | +3.2% ❌ |
| CassieAutoDiff/ForwardDynamics/10 | 625.0 us | 557.0 us | -10.9% ✅ |
| CassieAutoDiff/ForwardDynamics/11 | 1.64 millis | 1.61 millis | -2.4% ⚪ |
| CassieAutoDiff/ForwardDynamics/2 | 609.0 us | 544.0 us | -10.6% ✅ |
| CassieAutoDiff/ForwardDynamics/3 | 1.54 millis | 1.53 millis | -0.7% ⚪ |
| CassieAutoDiff/ForwardDynamics/8 | 454.0 us | 362.0 us | -20.2% ✅ |
| CassieAutoDiff/ForwardDynamics/9 | 1.41 millis | 1.4 millis | -0.4% ⚪ |
| CassieAutoDiff/InverseDynamics/0 | 197.0 us | 141.0 us | -28.6% ✅ |
| CassieAutoDiff/InverseDynamics/1 | 633.0 us | 549.0 us | -13.4% ✅ |
| CassieAutoDiff/InverseDynamics/2 | 390.0 us | 370.0 us | -5.2% ✅ |
| CassieAutoDiff/InverseDynamics/3 | 789.0 us | 623.0 us | -21.0% ✅ |
| CassieAutoDiff/InverseDynamics/4 | 300.0 us | 253.0 us | -15.7% ✅ |
| CassieAutoDiff/InverseDynamics/5 | 782.0 us | 617.0 us | -21.2% ✅ |
| CassieAutoDiff/InverseDynamics/6 | 456.0 us | 409.0 us | -10.4% ✅ |
| CassieAutoDiff/InverseDynamics/7 | 974.0 us | 707.0 us | -27.4% ✅ |
| CassieAutoDiff/MassMatrix/0 | 159.0 us | 120.0 us | -24.5% ✅ |
| CassieAutoDiff/MassMatrix/1 | 472.0 us | 451.0 us | -4.5% ✅ |
| CassieAutoDiff/MassMatrix/2 | 159.0 us | 120.0 us | -24.7% ✅ |
| CassieAutoDiff/MassMatrix/3 | 584.0 us | 492.0 us | -15.7% ✅ |
| CassieAutoDiff/PosAndVelKinematics/0 | 65.7 us | 39.0 us | -40.7% ✅ |
| CassieAutoDiff/PosAndVelKinematics/1 | 175.0 us | 122.0 us | -30.4% ✅ |
| CassieAutoDiff/PosAndVelKinematics/2 | 83.2 us | 60.7 us | -27.0% ✅ |
| CassieAutoDiff/PosAndVelKinematics/3 | 224.0 us | 143.0 us | -35.9% ✅ |
| CassieAutoDiff/PositionKinematics/0 | 33.2 us | 19.3 us | -42.0% ✅ |
| CassieAutoDiff/PositionKinematics/1 | 100.0 us | 67.3 us | -32.9% ✅ |


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24459)
<!-- Reviewable:end -->
