### PR TITLE
Report release tag in VERSION.TXT on rebuilds from source

### DIFF
--- a/tools/install/libdrake/generate_version.cmake
+++ b/tools/install/libdrake/generate_version.cmake
@@ -23,9 +23,26 @@ endif()
 if(DEFINED DRAKE_VERSION_OVERRIDE)
   set(DRAKE_VERSION "${DRAKE_VERSION_OVERRIDE}")
 else()
-  string(TIMESTAMP BUILD_TIMESTAMP "%Y%m%d.%H%M%S")
-  string(REGEX REPLACE "[.]0+([0-9])" ".\\1"
-    DRAKE_VERSION "0.0.${BUILD_TIMESTAMP}+${BUILD_IDENTIFIER}")
+  if(GIT_EXECUTABLE AND EXISTS "${GIT_DIR}")
+    # Check if we are building an existing release.
+    execute_process(COMMAND
+      "${GIT_EXECUTABLE}" "--git-dir=${GIT_DIR}" describe --tags --exact-match HEAD
+      RESULT_VARIABLE GIT_TAG_RESULT_VARIABLE
+      ERROR_VARIABLE GIT_TAG_ERROR_VARIABLE
+      OUTPUT_VARIABLE GIT_TAG_OUTPUT_VARIABLE
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(GIT_TAG_RESULT_VARIABLE EQUAL 0)
+      set(DRAKE_VERSION "${GIT_TAG_OUTPUT_VARIABLE}")
+    endif()
+  endif()
+
+  if(NOT DEFINED DRAKE_VERSION)
+    # Fall back to a combination of timestamp and git SHA.
+    string(TIMESTAMP BUILD_TIMESTAMP "%Y%m%d.%H%M%S")
+    string(REGEX REPLACE "[.]0+([0-9])" ".\\1"
+      DRAKE_VERSION "0.0.${BUILD_TIMESTAMP}+${BUILD_IDENTIFIER}")
+  endif()
 endif()
 
 configure_file(${INPUT_FILE} ${OUTPUT_FILE} @ONLY)


### PR DESCRIPTION
With regard to stable releases, the current VERSION.TXT machinery in drake and drake-ci is only designed to handle the creation of release *candidates*, i.e., where the git tag doesn't yet exist but we should be producing artifacts with the soon-upcoming release number baked in.

Extend this to check whether an already-tagged release is currently being built, in which case VERSION.TXT should record that release.

Towards #24343.

## Testing

I've tested this with (1) `git checkout v1.52.0` and (2) `git checkout master`:

```
# (1)
v1.52.0 d64fcfd7c7aacd3aaced5e2f8556c18ace780b97

# (2)
0.0.20260424.143818+git3154ae1b 3154ae1b3df332dc88aa74adc4f013e927efd4f0
```

Since the added logic only fires in the non-`DRAKE_VERSION_OVERRIDE` branch, drake-ci won't ever see it during staging (as intended).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24460)
<!-- Reviewable:end -->
