### PR TITLE
[math] Expose PartialPermutation's inverse permutation

### DIFF
--- a/math/partial_permutation.h
+++ b/math/partial_permutation.h
@@ -16,6 +16,7 @@ namespace internal {
 // corresponds to a distinct element of S. The mapping is defined by the
 // permutation of indexes in S into indexes in S' as ip = P(i), with i ∈ [0,n)
 // and ip ∈ [0,m).
+//
 // In general we say that we have a "partial permutation" when m < n and
 // otherwise we say we have a "full permutation" when m = n.
 // We refer to S as the "domain", and to the number of elements contained in S
@@ -24,6 +25,10 @@ namespace internal {
 // We define the "inverse permutation" as the mapping from elements s'ᵢₚ in S'
 // to elements sᵢ in S whenever there exist i ∈ [0,n) such that ip = P(i).
 // Elements sᵢ for which no ip is defined are left unchanged.
+//
+// Note: The inverse permutation can be used as the "array of indices" accepted
+// by Eigen slicing operators. The same is true for forward permutations *only*
+// when the permutation is full, not partial.
 class PartialPermutation {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PartialPermutation);
@@ -152,6 +157,11 @@ class PartialPermutation {
 
   // Returns permutation as a std::vector, see constructor for details.
   const std::vector<int>& permutation() const { return permutation_; }
+
+  // Returns inverse permutation as a std::vector, see constructor for details.
+  const std::vector<int>& inverse_permutation() const {
+    return inverse_permutation_;
+  }
 
   // Extends this partial permutation to a full permutation. No-op if this
   // partial permutation is already a full permutation. This is equivalent to

--- a/math/test/partial_permutation_test.cc
+++ b/math/test/partial_permutation_test.cc
@@ -105,6 +105,11 @@ GTEST_TEST(PartialPermutation, PermuteEigenVectorAndBack) {
   p.ApplyInverse(xp, &x_back);
   const VectorXd x_back_expected = (VectorXd(4) << 0., -1., 2., 3.).finished();
   EXPECT_EQ(x_back, x_back_expected);
+
+  // The inverse permutation is the same form accepted by Eigen slicing
+  // operators.
+  VectorXd slice = x(p.inverse_permutation());
+  EXPECT_EQ(slice, xp_expected);
 }
 
 // Perform the permutation of a std::vector<int>.
@@ -153,6 +158,15 @@ GTEST_TEST(PartialPermutation, ExtendToFullPermutation) {
   EXPECT_EQ(p.domain_size(), 4);
   EXPECT_EQ(p.permuted_domain_size(), 4);
   EXPECT_EQ(p.permutation(), (PartialPermutation({0, 3, 2, 1})).permutation());
+}
+
+// Verifies the inverse permutation exposed as a vector.
+GTEST_TEST(PartialPermutation, InversePermutation) {
+  const std::vector<int> permutation = {0, -1, 2, 1};
+  PartialPermutation p(permutation);
+  std::vector<int> indices(p.inverse_permutation());
+  const std::vector<int> expected_indices = {0, 3, 2};
+  EXPECT_EQ(indices, expected_indices);
 }
 
 GTEST_TEST(VertexPartialPermutation, Constructor) {


### PR DESCRIPTION
This is especially useful with modern Eigen slicing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24461)
<!-- Reviewable:end -->

Toward #23764.