### PR TITLE
[tools] Change how the macOS and wheel venv is activated

### DIFF
--- a/bindings/pydrake/test/all_install_test.py
+++ b/bindings/pydrake/test/all_install_test.py
@@ -3,6 +3,7 @@ Ensures we can import `pydrake.all` from install.
 """
 
 import os
+import sys
 import unittest
 
 import install_test_helper
@@ -10,14 +11,17 @@ import install_test_helper
 
 class TestAllInstall(unittest.TestCase):
     def test_install(self):
-        # Get install directory.
         install_dir = install_test_helper.get_install_dir()
-        # Override PYTHONPATH to only use the installed `pydrake` module.
-        env_python_path = "PYTHONPATH"
+
+        # Override PYTHONPATH to only use the installed `pydrake` module, plus
+        # the drake.venv if it exists.
+        paths = [install_test_helper.get_python_site_packages_dir(install_dir)]
+        for item in sys.path:
+            if "/venv.drake/" in item:
+                paths.append(item)
         tool_env = dict(os.environ)
-        tool_env[env_python_path] = (
-            install_test_helper.get_python_site_packages_dir(install_dir)
-        )
+        tool_env["PYTHONPATH"] = ":".join(paths)
+
         # Ensure we can import all user-visible modules.
         script = "import pydrake.all"
         install_test_helper.check_call(

--- a/bindings/pydrake/test/common_install_test.py
+++ b/bindings/pydrake/test/common_install_test.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 
 import install_test_helper
@@ -6,14 +7,17 @@ import install_test_helper
 
 class TestCommonInstall(unittest.TestCase):
     def testDrakeFindResourceOrThrowInInstall(self):
-        # Override PYTHONPATH to only use the installed `pydrake` module.
         install_dir = install_test_helper.get_install_dir()
-        env_python_path = "PYTHONPATH"
+
+        # Override PYTHONPATH to only use the installed `pydrake` module, plus
+        # the drake.venv if it exists.
+        paths = [install_test_helper.get_python_site_packages_dir(install_dir)]
+        for item in sys.path:
+            if "/venv.drake/" in item:
+                paths.append(item)
         tool_env = dict(os.environ)
-        tool_env[env_python_path] = (
-            install_test_helper.get_python_site_packages_dir(install_dir)
-        )
-        data_folder = os.path.join(install_dir, "share", "drake")
+        tool_env["PYTHONPATH"] = ":".join(paths)
+
         # Calling `pydrake.getDrakePath()` twice verifies that there
         # is no memory allocation issue in the C code.
         output_path = install_test_helper.check_output(
@@ -25,6 +29,7 @@ class TestCommonInstall(unittest.TestCase):
             ],
             env=tool_env,
         ).strip()
+        data_folder = os.path.join(install_dir, "share", "drake")
         self.assertIn(data_folder, output_path)
 
 

--- a/tools/install/libdrake/test/drake_python_dir_install_test.py
+++ b/tools/install/libdrake/test/drake_python_dir_install_test.py
@@ -13,6 +13,11 @@ class DrakePythonDirInstallTest(unittest.TestCase):
 
         cmake_prefix_path = install_test_helper.get_install_dir()
 
+        venv_pythonpath = ""
+        for item in sys.path:
+            if "/venv.drake/" in item:
+                venv_pythonpath = item
+
         cmake_content = """
             cmake_minimum_required(VERSION 3.20...4.3)
             project(drake_python_dir_install_test)
@@ -30,7 +35,7 @@ class DrakePythonDirInstallTest(unittest.TestCase):
 
             # PYTHON_DIR Sanity check
             execute_process(
-              COMMAND ${{CMAKE_COMMAND}} -E env PYTHONPATH=""
+              COMMAND ${{CMAKE_COMMAND}} -E env PYTHONPATH="{venv_pythonpath}"
                 {python_exe} -c "import pydrake.all"
               ERROR_QUIET
               RESULT_VARIABLE _IMPORT_RESULT)
@@ -41,7 +46,7 @@ class DrakePythonDirInstallTest(unittest.TestCase):
             # PYTHON_DIR Actual test
             execute_process(
               COMMAND ${{CMAKE_COMMAND}} -E env
-                PYTHONPATH=${{drake_PYTHON_DIR}}
+                PYTHONPATH={venv_pythonpath}:${{drake_PYTHON_DIR}}
                 {python_exe} -c "import pydrake.all"
               RESULT_VARIABLE _IMPORT_RESULT)
             if(NOT 0 EQUAL _IMPORT_RESULT)
@@ -52,6 +57,7 @@ class DrakePythonDirInstallTest(unittest.TestCase):
         """.format(
             cmake_prefix_path=cmake_prefix_path,
             python_exe=sys.executable,
+            venv_pythonpath=venv_pythonpath,
             py_major=sys.version_info.major,
             py_minor=sys.version_info.minor,
         )

--- a/tools/jupyter/BUILD.bazel
+++ b/tools/jupyter/BUILD.bazel
@@ -32,6 +32,7 @@ drake_jupyter_py_binary(
 
 drake_py_unittest(
     name = "jupyter_prereqs_test",
+    opt_in_condition = "//tools/skylark:linux",
 )
 
 # Add example failing notebook.

--- a/tools/workspace/python/venv_sync
+++ b/tools/workspace/python/venv_sync
@@ -57,6 +57,7 @@ if [[ -z "${repository}" ]]; then
     echo "error: --repository is required"
     exit 1
 fi
+readonly major_minor=$(${python} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 
 # Place the venv(s) in a sibling directory to the output base. That should be a
 # suitable disk location for build artifacts, but without polluting the actual
@@ -101,6 +102,14 @@ readonly install_args=( $(cat "${repository}/@pdm-install-args") )
     --clean-unselected \
     "${install_args[@]}"
 
+# Create a trampoline that sets PYTHONPATH before running.
+cat > "${venv_drake}/bin/run-python3" <<EOF
+#!/bin/sh
+export PYTHONPATH="${venv_drake}/lib/python${major_minor}/site-packages"
+exec "${python}" "\$@"
+EOF
+chmod +x "${venv_drake}/bin/run-python3"
+
 # Compute the checksum of our requirements file.
 readonly checksum=$(cd "${project}" && "${python}" <<EOF
 import hashlib
@@ -121,7 +130,7 @@ fi
 ln -nsf "${venv_drake}" "${repository}/${checksum}"
 
 # Tell repository.bzl which path to use.
-echo -n "${checksum}/bin/python3" > "${repository}/venv_python3.txt"
+echo -n "${checksum}/bin/run-python3" > "${repository}/venv_python3.txt"
 
 # Symlink our venv path for wheel builds to use (if requested; see
 # documentation of --symlink, above).


### PR DESCRIPTION
Previously we set the rules_python interpreter to point to the venv's python3, so that the venv site-packages were automatically importable by all targets (even non-Drake targets).

With the forthcoming rules_python 2.0.0, py_binary and py_test executables each have their own venv in their runfiles, and the pyvenv.cfg there ends up masking our venv's site-packages, which leads to import failures.

To solve this, we set the rules_python interpreter to a small bash trampoline that adds the venv site-packages to PYTHONPATH and then execs the (non-venv) python interpreter.

This is a somewhat ugly work-around, but hopefully it will become moot soon when we replace our homegrown pdm venv with a venv managed by rules_python directly.

Disable a jupyter prereqs regression test that's too difficult to get working on macOS.

See #24474 for the `rules_python@2.0.0` upgrade to show this works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24473)
<!-- Reviewable:end -->
