### PR TITLE
[common] Add atomic_shared_ptr polyfill

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -12,6 +12,7 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
+// #include "drake/common/atomic_shared_ptr.h"
 // #include "drake/common/autodiff.h"
 // #include "drake/common/autodiff_config.h"
 // #include "drake/common/cond.h"

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -28,6 +28,7 @@ drake_cc_package_library(
     name = "common",
     visibility = ["//visibility:public"],
     deps = [
+        ":atomic_shared_ptr",
         ":autodiff",
         ":cond",
         ":copyable_unique_ptr",
@@ -147,6 +148,14 @@ drake_cc_library(
             "text_logging_spdlog.h",
         ],
     }),
+    deps = [
+        ":essential",
+    ],
+)
+
+drake_cc_library(
+    name = "atomic_shared_ptr",
+    hdrs = ["atomic_shared_ptr.h"],
     deps = [
         ":essential",
     ],
@@ -700,6 +709,13 @@ install(
 )
 
 # === test/ ===
+
+drake_cc_googletest(
+    name = "atomic_shared_ptr_test",
+    deps = [
+        ":atomic_shared_ptr",
+    ],
+)
 
 # A config file that forces legacy mode (for legacy-specific tests).
 # TODO(jwnimmer-tri) On 2026-07-01 remove all of the deprecated legacy stuff.

--- a/common/atomic_shared_ptr.h
+++ b/common/atomic_shared_ptr.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace internal {
+
+// LLVM libc++ doesn't support std::atomic<std::shared_ptr<T>>, so will need a
+// different implementation; https://github.com/llvm/llvm-project/issues/99980.
+#ifdef __cpp_lib_atomic_shared_ptr
+
+// This is the implementation targeted at libstdc++ (GCC).
+
+template <typename T>
+using atomic_shared_ptr = std::atomic<std::shared_ptr<T>>;
+
+#else  // __cpp_lib_atomic_shared_ptr
+
+// This is the implementation targeted at libc++ (LLVM).
+
+/* Polyfill implementation of std::atomic<std::shared_ptr<T>>> based on the
+deprecated free-function API. Note that this implementation will not perform
+as well as the newer std::atomic<std::shared_ptr<T>> because the deprecated
+free-function API typically uses a fixed-size global hash table of mutexes.
+
+See https://en.cppreference.com/cpp/memory/shared_ptr/atomic2 and
+https://en.cppreference.com/cpp/memory/shared_ptr/atomic. */
+template <typename T>
+class atomic_shared_ptr {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(atomic_shared_ptr);
+
+  using value_type = std::shared_ptr<T>;
+
+  constexpr atomic_shared_ptr() noexcept = default;
+
+  // NOLINTNEXTLINE(runtime/explicit) To match standard API.
+  constexpr atomic_shared_ptr(std::nullptr_t) noexcept : atomic_shared_ptr() {}
+
+  // NOLINTNEXTLINE(runtime/explicit) To match standard API.
+  atomic_shared_ptr(std::shared_ptr<T> desired) noexcept
+      : ptr_(std::move(desired)) {}
+
+  void operator=(std::shared_ptr<T> desired) noexcept {
+    this->store(std::move(desired));
+  }
+
+  bool is_lock_free() const noexcept { return std::atomic_is_lock_free(&ptr_); }
+
+  void store(std::shared_ptr<T> desired,
+             std::memory_order order = std::memory_order_seq_cst) noexcept {
+    std::atomic_store_explicit(&ptr_, std::move(desired), order);
+  }
+
+  std::shared_ptr<T> load(
+      std::memory_order order = std::memory_order_seq_cst) const noexcept {
+    return std::atomic_load_explicit(&ptr_, order);
+  }
+
+  operator std::shared_ptr<T>() const noexcept { return load(); }
+
+  std::shared_ptr<T> exchange(
+      std::shared_ptr<T> desired,
+      std::memory_order order = std::memory_order_seq_cst) noexcept {
+    return std::atomic_exchange_explicit(&ptr_, std::move(desired), order);
+  }
+
+  bool compare_exchange_strong(std::shared_ptr<T>& expected,
+                               std::shared_ptr<T> desired,
+                               std::memory_order success,
+                               std::memory_order failure) noexcept {
+    return std::atomic_compare_exchange_strong_explicit(
+        &ptr_, &expected, std::move(desired), success, failure);
+  }
+
+  bool compare_exchange_weak(std::shared_ptr<T>& expected,
+                             std::shared_ptr<T> desired,
+                             std::memory_order success,
+                             std::memory_order failure) noexcept {
+    return std::atomic_compare_exchange_weak_explicit(
+        &ptr_, &expected, std::move(desired), success, failure);
+  }
+
+  bool compare_exchange_strong(
+      std::shared_ptr<T>& expected, std::shared_ptr<T> desired,
+      std::memory_order order = std::memory_order_seq_cst) noexcept {
+    const std::memory_order fail_order =
+        (order == std::memory_order_acq_rel)   ? std::memory_order_acquire
+        : (order == std::memory_order_release) ? std::memory_order_relaxed
+                                               : order;
+    return this->compare_exchange_strong(expected, std::move(desired), order,
+                                         fail_order);
+  }
+
+  bool compare_exchange_weak(
+      std::shared_ptr<T>& expected, std::shared_ptr<T> desired,
+      std::memory_order order = std::memory_order_seq_cst) noexcept {
+    const std::memory_order fail_order =
+        (order == std::memory_order_acq_rel)   ? std::memory_order_acquire
+        : (order == std::memory_order_release) ? std::memory_order_relaxed
+                                               : order;
+    return this->compare_exchange_weak(expected, std::move(desired), order,
+                                       fail_order);
+  }
+
+  // We are unable to implement this easily, but we don't need it.
+  void wait(std::shared_ptr<T> old,
+            std::memory_order order =
+                std::memory_order_seq_cst) const noexcept = delete;
+
+  // We are unable to implement this easily, but we don't need it.
+  void notify_one() noexcept = delete;
+
+  // We are unable to implement this easily, but we don't need it.
+  void notify_all() noexcept = delete;
+
+  static constexpr bool is_always_lock_free = false;
+
+ private:
+  std::shared_ptr<T> ptr_;
+};
+
+#endif  // __cpp_lib_atomic_shared_ptr
+
+}  // namespace internal
+}  // namespace drake

--- a/common/test/atomic_shared_ptr_test.cc
+++ b/common/test/atomic_shared_ptr_test.cc
@@ -1,0 +1,55 @@
+#include "drake/common/atomic_shared_ptr.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace internal {
+namespace {
+
+// The typedef implementation (`using atomic_shared_ptr = ...`) doesn't need a
+// unit test. For the polyfill implementation, our primary tool for finding bugs
+// is code inspection during review, not unit tests. The leverage of a unit test
+// to be able to find a memory ordering bug or race condition is very low. We'll
+// merely check that the supported API compiles, to find any easy-to-miss typos
+// in the signatures.
+
+GTEST_TEST(AtomicSharedPtrTest, CompileCheck) {
+  using DUT = atomic_shared_ptr<int>;
+
+  // Compile check the required typedef.
+  // The value_type is the unwrapped shared_ptr<T> (without atomics).
+  typename DUT::value_type non_atomic;
+
+  // Compile check the required constant.
+  [[maybe_unused]] constexpr bool ignore = DUT::is_always_lock_free;
+
+  // Compile check the required constructors and assignment.
+  DUT empty;
+  DUT explicitly_empty(nullptr);
+  DUT dut(non_atomic);
+  const DUT& const_dut = dut;
+  dut = non_atomic;
+  non_atomic = const_dut;
+
+  // Compile check all methods (except for the three unimplemented ones).
+  const auto seq_cst = std::memory_order_seq_cst;
+  const_dut.is_lock_free();
+  dut.store(non_atomic, seq_cst);
+  const_dut.load(seq_cst);
+  dut.exchange(non_atomic, seq_cst);
+  dut.compare_exchange_strong(non_atomic, non_atomic, seq_cst, seq_cst);
+  dut.compare_exchange_weak(non_atomic, non_atomic, seq_cst, seq_cst);
+  dut.compare_exchange_strong(non_atomic, non_atomic, seq_cst);
+  dut.compare_exchange_weak(non_atomic, non_atomic, seq_cst);
+
+  // Compile check default arguments.
+  dut.store(non_atomic);
+  const_dut.load();
+  dut.exchange(non_atomic);
+  dut.compare_exchange_strong(non_atomic, non_atomic);
+  dut.compare_exchange_weak(non_atomic, non_atomic);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace drake

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -306,6 +306,7 @@ drake_cc_library(
     name = "lazy_shared",
     hdrs = ["lazy_shared.h"],
     deps = [
+        "//common:atomic_shared_ptr",
         "//common:essential",
     ],
 )

--- a/geometry/lazy_shared.h
+++ b/geometry/lazy_shared.h
@@ -4,17 +4,12 @@
 #include <type_traits>
 #include <utility>
 
+#include "drake/common/atomic_shared_ptr.h"
 #include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
-
-// LLVM libc++ doesn't support std::atomic<std::shared_ptr<T>>, so will need a
-// different implementation; https://github.com/llvm/llvm-project/issues/99980.
-#ifdef __cpp_lib_atomic_shared_ptr
-
-// This is the implementation targeted at libstdc++ (GCC).
 
 /* Wrapper that stores a T, with the ability to initalize it on first use ("lazy
 evaluation") in a thread-safe way.
@@ -92,57 +87,8 @@ class LazyShared {
   }
 
  private:
-  mutable std::atomic<std::shared_ptr<const T>> data_;
+  mutable drake::internal::atomic_shared_ptr<const T> data_;
 };
-
-#else  // __cpp_lib_atomic_shared_ptr
-
-// This is the implementation targeted at libc++ (LLVM). It is exactly the same
-// logic as the other implementation above, but uses the deprecated atomic
-// operation functions, instead of the std::atomic template class. Refer to the
-// other implementation above for comments and explanation.
-
-template <typename T>
-class LazyShared {
- public:
-  LazyShared() = default;
-  LazyShared(const LazyShared& other) : data_(std::atomic_load(&other.data_)) {}
-  LazyShared(LazyShared&& other) noexcept
-      : data_(std::atomic_exchange(&other.data_, std::shared_ptr<const T>())) {}
-  LazyShared& operator=(const LazyShared& other) {
-    if (this != &other) {
-      std::atomic_store(&data_, std::atomic_load(&other.data_));
-    }
-    return *this;
-  }
-  LazyShared& operator=(LazyShared&& other) noexcept {
-    if (this != &other) {
-      std::atomic_store(&data_, std::atomic_exchange(
-                                    &other.data_, std::shared_ptr<const T>()));
-    }
-    return *this;
-  }
-  ~LazyShared() = default;
-  template <typename Factory>
-  const T& GetOrMake(Factory&& factory) const
-    requires(std::is_invocable_r_v<std::shared_ptr<const T>, Factory>)
-  {
-    std::shared_ptr<const T> result = std::atomic_load(&data_);
-    if (result == nullptr) {
-      std::shared_ptr<const T> candidate = factory();
-      DRAKE_DEMAND(candidate != nullptr);
-      if (std::atomic_compare_exchange_strong(&data_, &result, candidate)) {
-        result = std::move(candidate);
-      }
-    }
-    return *result;
-  }
-
- private:
-  mutable std::shared_ptr<const T> data_;
-};
-
-#endif  // __cpp_lib_atomic_shared_ptr
 
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
This came up related to #24454 (CC @SeanCurtis-TRI).  I think this is probably a worthwhile cleanup to land on master (better separation of concerns, paves the way to additional uses of atomic shared_ptr) but I'm not sure if it solves the problem for #24454, because the lock contention of the fallback implementation might be too severe.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24493)
<!-- Reviewable:end -->
