### PR TITLE
[doc] Re-spell aarch64 to arm64 in binary packages

### DIFF
--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -118,12 +118,12 @@ Refer to [Quickstart](/installation.html#quickstart) for next steps.
 
 ## Nightly Releases
 
-Binary packages of Drake for Ubuntu 24.04 (Noble) ⁽¹⁾
-and Ubuntu 26.04 (Resolute)
-and Mac are generated nightly and are available to download at:
+Binary packages of Drake for Ubuntu 24.04 (Noble) ⁽¹⁾,
+Ubuntu 26.04 (Resolute), and macOS are generated nightly and are available to
+download at:
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble.tar.gz)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble-aarch64.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble-aarch64.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble-arm64.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-noble-arm64.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-resolute-amd64v3.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-resolute-amd64v3.tar.gz)
 * https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac-arm64.tar.gz
 
@@ -131,7 +131,7 @@ Older packages for specific dates are available by replacing ``latest``
 with date YYYYMMDD preceded by ``0.0.``. For example,
 
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble.tar.gz)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble-aarch64.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble-aarch64.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble-arm64.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-noble-arm64.tar.gz)
 * [https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-resolute-amd64v3.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-resolute-amd64v3.tar.gz)
 * https://drake-packages.csail.mit.edu/drake/nightly/drake-0.0.20250301-mac-arm64.tar.gz
 
@@ -144,7 +144,7 @@ Nightly archives are retained for 56 days from their date of creation.
 
 The installation instructions are identical to stable releases as shown above.
 
-⁽¹⁾ Drake's support for Ubuntu aarch64 binary packages is currently
+⁽¹⁾ Drake's support for Ubuntu arm64 binary packages is currently
 experimental. Packages are only available on a nightly basis, not for stable
 releases. Additionally, packages are only available for Ubuntu 24.04 (Noble);
 future versions are a work in progress. Follow

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -58,7 +58,7 @@ maybe require extra setup. See the
 
 ⁽³⁾ Drake requires a compiler running in C++23 (or greater) mode.
 
-⁽⁴⁾ On an experimental basis, Drake also supports aarch64 on Ubuntu 24.04
+⁽⁴⁾ On an experimental basis, Drake also supports arm64 on Ubuntu 24.04
 (Noble). Follow [#13514](https://github.com/RobotLocomotion/drake/issues/13514)
 for updates.
 

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -51,9 +51,9 @@ that Conda is involved.
 ⁽³⁾ These end-of-life dates are estimates.
 Refer to [OS Support](/stable.html#os-support) for details.
 
-⁽⁴⁾ Nightly binaries for Ubuntu 24.04 (Noble) on aarch64 are available for all
+⁽⁴⁾ Nightly binaries for Ubuntu 24.04 (Noble) on arm64 are available for all
 [binary installation methods](#choose-an-installation-method). Drake's support
-for Ubuntu on aarch64 is currently experimental, and binaries are not available
+for Ubuntu on arm64 is currently experimental, and binaries are not available
 for stable releases. Follow
 [#13514](https://github.com/RobotLocomotion/drake/issues/13514) for updates.
 If you encounter installation issues with the experimental nightly binaries,


### PR DESCRIPTION
This tracks a change in drake-ci packaging logic ahead of the upcoming stable release of these binaries.

Towards #24512, see also RobotLocomotion/drake-ci#433.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24514)
<!-- Reviewable:end -->
