### PR TITLE
Make Mesh/Convex cheap to copy

### DIFF
--- a/bindings/generated_docstrings/geometry.h
+++ b/bindings/generated_docstrings/geometry.h
@@ -3323,6 +3323,13 @@ R"""(Provides a general abstraction to the definition of a mesh. A mesh
 definition can come from disk or memory. APIs that support both can
 take as specification an instance of MeshSource to communicate that
 ability.)""";
+        // Symbol: drake::geometry::MeshSource::Empty
+        struct /* Empty */ {
+          // Source: drake/geometry/mesh_source.h
+          const char* doc =
+R"""(Returns an empty MeshSource -- equivalent to a default-constructed
+MeshSource.)""";
+        } Empty;
         // Symbol: drake::geometry::MeshSource::GetCacheKey
         struct /* GetCacheKey */ {
           // Source: drake/geometry/mesh_source.h
@@ -3346,6 +3353,10 @@ Raises:
         } GetCacheKey;
         // Symbol: drake::geometry::MeshSource::MeshSource
         struct /* ctor */ {
+          // Source: drake/geometry/mesh_source.h
+          const char* doc_0args =
+R"""(The default constructor produces an empty in-memory mesh; the same
+state as a moved-from MeshSource.)""";
           // Source: drake/geometry/mesh_source.h
           const char* doc_1args_path =
 R"""(Constructs from a file path. Note: the path will not be validated in

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -368,6 +368,7 @@ void DefineMeshSource(py::module m) {
     py::class_<Class> cls(m, "MeshSource", cls_doc.doc);
     py::object ctor = m.attr("MeshSource");
     cls  // BR
+        .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<std::filesystem::path>(), py::arg("path"),
             cls_doc.ctor.doc_1args_path)
         .def(py::init<InMemoryMesh>(), py::arg("mesh"),

--- a/bindings/pydrake/geometry/test/common_test.py
+++ b/bindings/pydrake/geometry/test/common_test.py
@@ -381,6 +381,11 @@ class TestGeometryCore(unittest.TestCase):
         self.assertIn("file", obj.supporting_files)
 
     def test_mesh_source(self):
+        # Default constructor produces "empty" in-memory mesh source.
+        source = mut.MeshSource()
+        self.assertTrue(source.is_in_memory())
+        self.assertEqual(source.in_memory().mesh_file.contents(), b"")
+
         source = mut.MeshSource(path="/a/path.obj")
         self.assertTrue(source.is_path())
         self.assertFalse(source.is_in_memory())

--- a/geometry/mesh_source.cc
+++ b/geometry/mesh_source.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/fmt.h"
+#include "drake/common/never_destroyed.h"
 
 namespace drake {
 namespace geometry {
@@ -18,6 +19,8 @@ std::string GetExtensionLower(const std::filesystem::path& file_path) {
 }
 
 }  // namespace
+
+MeshSource::MeshSource() = default;
 
 MeshSource::MeshSource(std::filesystem::path path)
     : source_(std::move(path)), extension_(GetExtensionLower(this->path())) {}
@@ -82,6 +85,11 @@ std::string MeshSource::GetCacheKey(bool is_convex) const {
   // Note: We're using "?" as a separator. It isn't valid for filenames,
   // so using it guarantees we won't collide with potential file names.
   return prefix + (is_convex ? "?convex" : "");
+}
+
+const MeshSource& MeshSource::Empty() {
+  static const never_destroyed<MeshSource> kEmpty;
+  return kEmpty.access();
 }
 
 }  // namespace geometry

--- a/geometry/mesh_source.h
+++ b/geometry/mesh_source.h
@@ -19,6 +19,10 @@ class MeshSource final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MeshSource);
 
+  /** The default constructor produces an empty in-memory mesh; the same state
+   as a moved-from MeshSource. */
+  MeshSource();
+
   /** Constructs from a file path.
    Note: the path will not be validated in any way (existence, availability,
    naming an actual mesh file, etc.). Validation occurs where the %MeshSource's
@@ -84,6 +88,10 @@ class MeshSource final {
   const InMemoryMesh& in_memory() const {
     return std::get<InMemoryMesh>(source_.value());
   }
+
+  /** Returns an empty MeshSource -- equivalent to a default-constructed
+   MeshSource. */
+  static const MeshSource& Empty();
 
  private:
   reset_after_move<std::variant<InMemoryMesh, std::filesystem::path>> source_;

--- a/geometry/shape_specification.cc
+++ b/geometry/shape_specification.cc
@@ -126,7 +126,7 @@ Convex::Convex(MeshSource source, double scale)
     : Convex(std::move(source), Vector3<double>::Constant(scale)) {}
 
 Convex::Convex(MeshSource source, const Vector3<double>& scale3)
-    : source_(std::move(source)), scale_(scale3) {
+    : source_(std::make_shared<MeshSource>(std::move(source))), scale_(scale3) {
   // Note: We don't validate extensions because there's a possibility that a
   // mesh of unsupported type is used, but only processed by client code.
   ThrowForBadScale(scale_, "Convex");
@@ -155,7 +155,7 @@ double Convex::scale() const {
 const PolygonSurfaceMesh<double>& Convex::GetConvexHull() const {
   return hull_.GetOrMake([this]() {
     return std::make_shared<PolygonSurfaceMesh<double>>(
-        internal::MakeConvexHull(source_, scale_));
+        internal::MakeConvexHull(source(), scale_));
   });
 }
 
@@ -240,7 +240,7 @@ Mesh::Mesh(MeshSource source, double scale)
     : Mesh(std::move(source), Vector3<double>::Constant(scale)) {}
 
 Mesh::Mesh(MeshSource source, const Vector3<double>& scale3)
-    : source_(std::move(source)), scale_(scale3) {
+    : source_(std::make_shared<MeshSource>(std::move(source))), scale_(scale3) {
   // Note: We don't validate extensions because there's a possibility that a
   // mesh of unsupported type is used, but only processed by client code.
   ThrowForBadScale(scale_, "Mesh");
@@ -259,7 +259,7 @@ double Mesh::scale() const {
 const PolygonSurfaceMesh<double>& Mesh::GetConvexHull() const {
   return hull_.GetOrMake([this]() {
     return std::make_shared<PolygonSurfaceMesh<double>>(
-        internal::MakeConvexHull(source_, scale_));
+        internal::MakeConvexHull(source(), scale_));
   });
 }
 

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -324,7 +324,9 @@ class Convex final : public Shape {
    %Convex is that the convex hull is always used in place of whatever
    underlying mesh declaration is provided. For all functional geometric
    usage, exclusively use the convex hull returned by GetConvexHull(). */
-  const MeshSource& source() const { return source_; }
+  const MeshSource& source() const {
+    return source_ != nullptr ? *source_ : MeshSource::Empty();
+  }
 
   /** Returns the extension of the underlying input mesh -- all lower case and
    including the dot. If `this` is constructed from a file path, the extension
@@ -334,7 +336,7 @@ class Convex final : public Shape {
 
    If `this` is constructed using in-memory file contents, it is the extension
    of the MemoryFile passed to the constructor. */
-  const std::string& extension() const { return source_.extension(); }
+  const std::string& extension() const { return source().extension(); }
 
   /** Returns a single scale representing the _uniform_ scale factor.
    @throws if the scale is not uniform in all directions. */
@@ -361,7 +363,7 @@ class Convex final : public Shape {
   std::string do_to_string() const final;
   VariantShapeConstPtr get_variant_this() const final;
 
-  MeshSource source_;
+  std::shared_ptr<const MeshSource> source_;
   Vector3<double> scale_;
   internal::LazyShared<PolygonSurfaceMesh<double>> hull_;
 };
@@ -577,7 +579,9 @@ class Mesh final : public Shape {
   ~Mesh() final;
 
   /** Returns the source for this specification's mesh data. */
-  const MeshSource& source() const { return source_; }
+  const MeshSource& source() const {
+    return source_ != nullptr ? *source_ : MeshSource::Empty();
+  }
 
   /** Returns the extension of the mesh type -- all lower case and including
    the dot. If `this` is constructed from a file path, the extension is
@@ -587,7 +591,7 @@ class Mesh final : public Shape {
 
    If `this` is constructed using in-memory file contents, it is the extension
    of the MemoryFile passed to the constructor. */
-  const std::string& extension() const { return source_.extension(); }
+  const std::string& extension() const { return source().extension(); }
 
   /** Returns a single scale representing the _uniform_ scale factor.
    @throws if the scale is not uniform in all directions. */
@@ -615,7 +619,7 @@ class Mesh final : public Shape {
   VariantShapeConstPtr get_variant_this() const final;
 
   // NOTE: Cannot be const to support default copy/move semantics.
-  MeshSource source_;
+  std::shared_ptr<const MeshSource> source_;
   Vector3<double> scale_;
   internal::LazyShared<PolygonSurfaceMesh<double>> hull_;
 };

--- a/geometry/test/mesh_source_test.cc
+++ b/geometry/test/mesh_source_test.cc
@@ -16,6 +16,19 @@ namespace drake {
 namespace geometry {
 namespace {
 
+GTEST_TEST(MeshSourceTest, EmptySource) {
+  const MeshSource s;
+  EXPECT_FALSE(s.is_path());
+  EXPECT_TRUE(s.is_in_memory());
+  EXPECT_TRUE(s.in_memory().mesh_file.contents().empty());
+  EXPECT_EQ(s.extension(), "");
+
+  EXPECT_FALSE(MeshSource::Empty().is_path());
+  EXPECT_TRUE(MeshSource::Empty().is_in_memory());
+  EXPECT_TRUE(MeshSource::Empty().in_memory().mesh_file.contents().empty());
+  EXPECT_EQ(MeshSource::Empty().extension(), "");
+}
+
 GTEST_TEST(MeshSourceTest, PathConstructor) {
   const MeshSource s(std::filesystem::path("path"));
   EXPECT_EQ(s.description(), "path");

--- a/geometry/test/shape_specification_test.cc
+++ b/geometry/test/shape_specification_test.cc
@@ -649,6 +649,23 @@ GTEST_TEST(ShapeTest, MeshConstructor) {
   }
 }
 
+// Mesh and Convex share their sources across copies (making cloning cheap for
+// in-memory meshes).
+GTEST_TEST(ShapeTest, MeshAndConvexSharedSource) {
+  auto validate_shared_source = []<typename MeshType>(MeshType mesh_orig) {
+    SCOPED_TRACE(mesh_orig.type_name());
+    const MeshType mesh_copy(mesh_orig);
+    EXPECT_EQ(&mesh_orig.source(), &mesh_copy.source());
+    const MeshType mesh_move(std::move(mesh_orig));
+    EXPECT_EQ(&mesh_copy.source(), &mesh_move.source());
+    EXPECT_NE(&mesh_orig.source(), &mesh_move.source());
+    // The lint issue was fixed in https://github.com/cpplint/cpplint/pull/288,
+    // but there is no release that includes it.
+  };  // NOLINT(readability/braces) -- templated lambda confuses cpplint.
+  validate_shared_source(Mesh("/fictitious_name.obj", 1.0));
+  validate_shared_source(Convex("/fictitious_name.obj", 1.0));
+}
+
 // Confirms the scale factors are tested in Mesh and Convex constructors.
 GTEST_TEST(ShapeTest, MeshAndConvexValidateScale) {
   const std::string kFilename = "/fictitious_name.obj";


### PR DESCRIPTION
Mesh/Convex no longer store the MemorySource directly, but store a shared_ptr to the MemorySource.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24519)
<!-- Reviewable:end -->
