### PR TITLE
[multibody] ICF handles 0-size problems

### DIFF
--- a/multibody/cenic/test/cenic_integrator_generic_integrator_test.cc
+++ b/multibody/cenic/test/cenic_integrator_generic_integrator_test.cc
@@ -38,6 +38,11 @@ struct IntegratorTestFactory<CenicIntegrator<double>> {
       return std::unexpected(
           "TODO(#23921, #24304): CENIC cannot yet pass this test.");
     }
+    if (test_info->name() == std::string("TrivialFixedStepJointsLocked") ||
+        test_info->name() ==
+            std::string("TrivialErrorControlledStepJointsLocked")) {
+      return std::unexpected("TODO(#23764): CENIC cannot yet pass this test.");
+    }
 
     IntegratorTestArticles<SpecificSystem> result;
     DiagramBuilder<double> builder;
@@ -55,14 +60,6 @@ struct IntegratorTestFactory<CenicIntegrator<double>> {
     if (!system_is_continuous_plant()) {
       auto plant =
           builder.template AddNamedSystem<MultibodyPlant<double>>("plant", 0.0);
-      // Add a single free body to the world. This prevents CENIC complaining
-      // about having no cliques.
-      const double radius = 0.05;  // m
-      const double mass = 0.1;     // kg
-      multibody::SpatialInertia<double> M_BBcm =
-          multibody::SpatialInertia<double>::SolidSphereWithMass(mass, radius);
-
-      plant->AddRigidBody("Ball", M_BBcm);
       plant->Finalize();
     }
 

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -76,8 +76,12 @@ void IcfBuilder<T>::UpdateModel(
 
   std::unique_ptr<IcfParameters<T>> params = model->ReleaseParameters();
   DRAKE_DEMAND(params != nullptr);
-  // Detect if this is the first time we are setting up params.
-  if (params->v0.size() == 0) {
+  // Detect if this is the first time we are setting up params. Use a
+  // body-indexed parameter, since any valid initialized state will have at
+  // least one body.
+  if (params->body_mass.empty()) {
+    // These checks will trip if the block was partially allocated.
+    DRAKE_DEMAND(params->v0.size() == 0);
     DRAKE_DEMAND(params->M0.size() == 0);
     DRAKE_DEMAND(params->D0.size() == 0);
     DRAKE_DEMAND(params->k0.size() == 0);

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -30,9 +30,8 @@ void IcfModel<T>::ResetParameters(std::unique_ptr<IcfParameters<T>> params) {
   num_velocities_ = v0().size();
   num_bodies_ = ssize(this->params().body_to_clique);
   num_cliques_ = ssize(this->params().clique_sizes);
-  DRAKE_DEMAND(num_cliques_ > 0);
-  max_clique_size_ = *std::max_element(this->params().clique_sizes.begin(),
-                                       this->params().clique_sizes.end());
+  max_clique_size_ =
+      num_cliques_ > 0 ? std::ranges::max(this->params().clique_sizes) : 0;
 
   // Compute the initial spatial velocity V_WB0 = J_WB⋅v0 for each body.
   V_WB0_.Resize(num_bodies_, 6, 1);
@@ -348,9 +347,9 @@ void IcfModel<T>::VerifyInvariants() const {
   DRAKE_DEMAND(time_step() > 0);
 
   DRAKE_DEMAND(num_bodies_ > 0);
-  DRAKE_DEMAND(num_velocities_ > 0);
-  DRAKE_DEMAND(num_cliques_ > 0);
-  DRAKE_DEMAND(max_clique_size_ > 0);
+  DRAKE_DEMAND(num_velocities_ >= 0);
+  DRAKE_DEMAND(num_cliques_ >= 0);
+  DRAKE_DEMAND(max_clique_size_ >= 0);
 
   DRAKE_DEMAND(v0().size() == num_velocities_);
   DRAKE_DEMAND(M0().rows() == num_velocities_);

--- a/multibody/contact_solvers/icf/icf_solver.cc
+++ b/multibody/contact_solvers/icf/icf_solver.cc
@@ -44,7 +44,7 @@ bool IcfSolver::SolveWithGuess(const IcfModel<double>& model,
   using std::clamp;
   DRAKE_ASSERT(data != nullptr);
   DRAKE_ASSERT(tolerance > 0);
-  DRAKE_ASSERT(model.num_velocities() > 0);
+  DRAKE_ASSERT(model.num_velocities() >= 0);
   DRAKE_ASSERT(model.num_velocities() == data->num_velocities());
 
   // Retrieve scratch space for decision variables vₖ and search direction wₖ.

--- a/multibody/contact_solvers/icf/icf_solver.h
+++ b/multibody/contact_solvers/icf/icf_solver.h
@@ -121,8 +121,7 @@ class IcfSolver {
                        To begin, stores the initial guess for velocities v.
 
   @return true if and only if the optimizer converged to tolerance ε.
-  @pre The model and data must compatible, e.g., via model.ResizeData(&data).
-  @pre The model must be non-empty, e.g., model.num_velocities() > 0. */
+  @pre The model and data must compatible, e.g., via model.ResizeData(&data). */
   bool SolveWithGuess(const IcfModel<double>& model, const double tolerance,
                       IcfData<double>* data);
 

--- a/systems/analysis/test_utilities/generic_integrator_test.h
+++ b/systems/analysis/test_utilities/generic_integrator_test.h
@@ -12,21 +12,21 @@ namespace drake {
 namespace systems {
 namespace analysis_test {
 
+// GenericIntegratorBaseTest contains much of the formal setup for generic
+// integrator tests, but it does not put any model elements into the
+// MultibodyPlant. It does provide virtual methods for derived fixtures to put
+// interesting model elements into the plant.
+//
 // T is the integrator test factory type (e.g.,
 // IntegratorTestFactory<RungeKutta3Integrator<double>>).
 template <class T>
-class GenericIntegratorTest : public ::testing::Test {
+class GenericIntegratorBaseTest : public ::testing::Test {
  protected:
   void SetUp() {
     auto plant = std::make_unique<multibody::MultibodyPlant<double>>(0.0);
 
-    // Add a single free body to the world.
-    const double radius = 0.05;  // m
-    const double mass = 0.1;     // kg
-    multibody::SpatialInertia<double> M_BBcm =
-        multibody::SpatialInertia<double>::SolidSphereWithMass(mass, radius);
+    SetupPlant(plant.get());
 
-    plant->AddRigidBody("Ball", M_BBcm);
     plant->Finalize();
 
     auto maybe_dut = T::MakeIntegratorTestArticles(std::move(plant));
@@ -43,21 +43,41 @@ class GenericIntegratorTest : public ::testing::Test {
     SetPlantContext();
   }
 
-  void SetPlantContext() const {
-    // Set body linear and angular velocity.
-    Vector3<double> v0(1., 2., 3.);    // Linear velocity in body's frame.
-    Vector3<double> w0(-4., 5., -6.);  // Angular velocity in body's frame.
-    VectorX<double> generalized_velocities(6);
-    generalized_velocities << w0, v0;
-    plant_->SetVelocities(plant_context_, generalized_velocities);
+  // Derived fixtures can modify the plant model and context.
+  virtual void SetupPlant(multibody::MultibodyPlant<double>*) {}
+  virtual void SetPlantContext() {}
 
-    // Set body position and orientation.
-    Vector3<double> p0(1., 2., 3.);  // Body's frame position in the world.
-    // Set body's frame orientation to 90 degree rotation about y-axis.
-    Vector4<double> q0(std::sqrt(2.) / 2., 0., std::sqrt(2.) / 2., 0.);
-    VectorX<double> generalized_positions(7);
-    generalized_positions << q0, p0;
-    plant_->SetPositions(plant_context_, generalized_positions);
+  // Check a fixed step of integration, with the expectation that no continuous
+  // state is expected to change. The caller is expected to provide a
+  // no-changes scenario.
+  void CheckTrivialFixedStep() {
+    integrator_->set_maximum_step_size(0.1);
+    integrator_->set_target_accuracy(1e-5);
+    integrator_->Initialize();
+    integrator_->set_fixed_step_mode(true);
+    VectorX<double> state_before =
+        context_->get_continuous_state().CopyToVector();
+    EXPECT_TRUE(integrator_->IntegrateWithSingleFixedStepToTime(0.1));
+    EXPECT_EQ(context_->get_time(), 0.1);
+    VectorX<double> state_after =
+        context_->get_continuous_state().CopyToVector();
+    EXPECT_TRUE(CompareMatrices(state_before, state_after));
+  }
+
+  // Check an error-controlled step of integration, with the expectation that
+  // no continuous state is expected to change. The caller is expected to
+  // provide a no-changes scenario.
+  void CheckTrivialErrorControlledStep() {
+    integrator_->set_maximum_step_size(0.1);
+    integrator_->set_target_accuracy(1e-5);
+    integrator_->Initialize();
+    VectorX<double> state_before =
+        context_->get_continuous_state().CopyToVector();
+    integrator_->IntegrateWithMultipleStepsToTime(0.5);
+    EXPECT_EQ(context_->get_time(), 0.5);
+    VectorX<double> state_after =
+        context_->get_continuous_state().CopyToVector();
+    EXPECT_TRUE(CompareMatrices(state_before, state_after));
   }
 
   // `articles_` holds the objects received from the factory and retains
@@ -68,6 +88,59 @@ class GenericIntegratorTest : public ::testing::Test {
   Context<double>* plant_context_{};
   IntegratorBase<double>* integrator_{};
   Context<double>* context_{};
+};
+
+TYPED_TEST_SUITE_P(GenericIntegratorBaseTest);
+
+// Confirms that integration supports fixed steps on systems with no continuous
+// state. Uses an empty plant.
+TYPED_TEST_P(GenericIntegratorBaseTest, TrivialFixedStepEmptyPlant) {
+  ASSERT_EQ(this->context_->get_continuous_state().size(), 0);
+  this->CheckTrivialFixedStep();
+}
+
+// Confirms that integration supports error controlled steps on systems with no
+// continuous state. Uses an empty plant.
+TYPED_TEST_P(GenericIntegratorBaseTest, TrivialErrorControlledStepEmptyPlant) {
+  ASSERT_EQ(this->context_->get_continuous_state().size(), 0);
+  this->CheckTrivialErrorControlledStep();
+}
+
+// GenericIntegratorTest extends GenericIntegratorBaseTest by adding a single
+// free body into the MultibodyPlant. It adds a sphere with mass, and sets some
+// non-trivial initial state.
+//
+// T is the integrator test factory type (e.g.,
+// IntegratorTestFactory<RungeKutta3Integrator<double>>).
+template <class T>
+class GenericIntegratorTest : public GenericIntegratorBaseTest<T> {
+ protected:
+  void SetupPlant(multibody::MultibodyPlant<double>* plant) override {
+    // Add a single free body to the world.
+    const double radius = 0.05;  // m
+    const double mass = 0.1;     // kg
+    multibody::SpatialInertia<double> M_BBcm =
+        multibody::SpatialInertia<double>::SolidSphereWithMass(mass, radius);
+
+    plant->AddRigidBody("Ball", M_BBcm);
+  }
+
+  void SetPlantContext() override {
+    // Set body linear and angular velocity.
+    Vector3<double> v0(1., 2., 3.);    // Linear velocity in body's frame.
+    Vector3<double> w0(-4., 5., -6.);  // Angular velocity in body's frame.
+    VectorX<double> generalized_velocities(6);
+    generalized_velocities << w0, v0;
+    this->plant_->SetVelocities(this->plant_context_, generalized_velocities);
+
+    // Set body position and orientation.
+    Vector3<double> p0(1., 2., 3.);  // Body's frame position in the world.
+    // Set body's frame orientation to 90 degree rotation about y-axis.
+    Vector4<double> q0(std::sqrt(2.) / 2., 0., std::sqrt(2.) / 2., 0.);
+    VectorX<double> generalized_positions(7);
+    generalized_positions << q0, p0;
+    this->plant_->SetPositions(this->plant_context_, generalized_positions);
+  }
 };
 
 TYPED_TEST_SUITE_P(GenericIntegratorTest);
@@ -124,7 +197,29 @@ TYPED_TEST_P(GenericIntegratorTest, NegativeTime) {
   EXPECT_EQ(this->context_->get_time(), -0.5);
 }
 
-REGISTER_TYPED_TEST_SUITE_P(GenericIntegratorTest, DenseOutput, NegativeTime);
+// Confirms that integration supports fixed steps on systems with no active
+// dofs. Uses joint locking to lock all dofs.
+TYPED_TEST_P(GenericIntegratorTest, TrivialFixedStepJointsLocked) {
+  for (const multibody::JointIndex& j : this->plant_->GetJointIndices()) {
+    this->plant_->get_joint(j).Lock(this->plant_context_);
+  }
+  ASSERT_NE(this->context_->get_continuous_state().size(), 0);
+  this->CheckTrivialFixedStep();
+}
+
+// Confirms that integration supports error controlled steps on systems with no
+// active dofs. Uses joint locking to lock all dofs.
+TYPED_TEST_P(GenericIntegratorTest, TrivialErrorControlledStepJointsLocked) {
+  for (const multibody::JointIndex& j : this->plant_->GetJointIndices()) {
+    this->plant_->get_joint(j).Lock(this->plant_context_);
+  }
+  ASSERT_NE(this->context_->get_continuous_state().size(), 0);
+  this->CheckTrivialErrorControlledStep();
+}
+
+REGISTER_TYPED_TEST_SUITE_P(GenericIntegratorTest, DenseOutput, NegativeTime,
+                            TrivialFixedStepJointsLocked,
+                            TrivialErrorControlledStepJointsLocked);
 
 }  // namespace analysis_test
 }  // namespace systems


### PR DESCRIPTION
Extends the generic integrator test suite to present 0-dof problems to all integrators. There are four cases {fixed-step, error-controlled} * {trivial system, joint-locked plant}.

These tests flush out a few bugs and bad assumptions in ICF, and thus help clear the way for joint locking. A few tests are skipped for CENIC/ICF for now, but will pass in the eventual implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24524)
<!-- Reviewable:end -->
