### PR TITLE
Propagate CMAKE_C_FLAGS and CMAKE_CXX_FLAGS to bazel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ else()
   )
 endif()
 
-# Determine the CMAKE_BUILD_TYPE. We'll store it as BUILD_TYPE_LOWER so that
+# Determine the CMAKE_BUILD_TYPE. We'll store it as BUILD_TYPE_UPPER so that
 # we can treat it as case-insensitive in our string comparisons.
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(IS_MULTI_CONFIG)
@@ -150,22 +150,49 @@ if(NOT CMAKE_BUILD_TYPE)
     FORCE
   )
 endif()
-string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
-string(TOLOWER "${SUPPORTED_BUILD_TYPES}" SUPPORTED_BUILD_TYPES_LOWER)
-if(NOT BUILD_TYPE_LOWER IN_LIST SUPPORTED_BUILD_TYPES_LOWER)
+string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_UPPER)
+string(TOUPPER "${SUPPORTED_BUILD_TYPES}" SUPPORTED_BUILD_TYPES_UPPER)
+if(NOT BUILD_TYPE_UPPER IN_LIST SUPPORTED_BUILD_TYPES_UPPER)
   message(WARNING
     "Configuration CMAKE_BUILD_TYPE='${CMAKE_BUILD_TYPE}' is NOT supported. "
     "Defaulting to Release, options are: ${SUPPORTED_BUILD_TYPES_STRING}"
   )
-  set(BUILD_TYPE_LOWER release)
+  set(BUILD_TYPE_UPPER RELEASE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING
     "Choose the type of build, options are: ${SUPPORTED_BUILD_TYPES_STRING}"
     FORCE
   )
 endif()
 
-# TODO(#24455) We don't currently pass along the user's CMAKE_C_FLAGS and
-# CMAKE_CXX_FLAGS to Bazel, but we should.
+# Forward CMAKE_C_FLAGS, CMAKE_CXX_FLAGS, and any build-type specific variants
+# (like CMAKE_C_FLAGS_RELEASE or CMAKE_CXX_FLAGS_DEBUG) to bazel. See the
+# corresponding comment in bazel.rc.in above the
+# `build @BAZEL_USER_COMPILE_FLAGS@` line for more details.
+set(BAZEL_USER_COMPILE_FLAGS)
+separate_arguments(_user_c_flags UNIX_COMMAND
+  "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BUILD_TYPE_UPPER}}"
+)
+separate_arguments(_user_cxx_flags UNIX_COMMAND
+  "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}}"
+)
+# Entries in the .bazelrc file are tokenized according to the same rules as the
+# Bourne shell. See https://bazel.build/run/bazelrc#bazelrc-syntax-semantics
+# for more info. We must escape backslashes and quotes so that they survive
+# the bazelrc tokenization.
+function(_append_bazel_compile_flag _option _flag)
+  string(REPLACE [[\]] [[\\]] _escaped "${_flag}")
+  string(REPLACE [["]] [[\"]] _escaped "${_escaped}")
+  set(BAZEL_USER_COMPILE_FLAGS
+    "${BAZEL_USER_COMPILE_FLAGS} ${_option}=\"${_escaped}\""
+    PARENT_SCOPE
+  )
+endfunction()
+foreach(_flag IN LISTS _user_c_flags)
+  _append_bazel_compile_flag(--conlyopt "${_flag}")
+endforeach()
+foreach(_flag IN LISTS _user_cxx_flags)
+  _append_bazel_compile_flag(--cxxopt "${_flag}")
+endforeach()
 
 # Next we'll find which Python interpreter to use.
 if(PYTHON_EXECUTABLE AND NOT Python_EXECUTABLE)
@@ -680,13 +707,13 @@ else()
   string(APPEND BAZEL_CONFIG " --@drake//tools/flags:use_eigen_legacy_autodiff=False")
 endif()
 
-if(BUILD_TYPE_LOWER STREQUAL debug)
+if(BUILD_TYPE_UPPER STREQUAL DEBUG)
   string(APPEND BAZEL_CONFIG " --config=Debug")
-elseif(BUILD_TYPE_LOWER STREQUAL minsizerel)
+elseif(BUILD_TYPE_UPPER STREQUAL MINSIZEREL)
   string(APPEND BAZEL_CONFIG " --config=MinSizeRel")
-elseif(BUILD_TYPE_LOWER STREQUAL release)
+elseif(BUILD_TYPE_UPPER STREQUAL RELEASE)
   string(APPEND BAZEL_CONFIG " --config=Release")
-elseif(BUILD_TYPE_LOWER STREQUAL relwithdebinfo)
+elseif(BUILD_TYPE_UPPER STREQUAL RELWITHDEBINFO)
   string(APPEND BAZEL_CONFIG " --config=RelWithDebInfo")
 endif()
 
@@ -727,7 +754,7 @@ endif()
 
 # If CMAKE_BUILD_TYPE is Debug or RelWithDebInfo, do NOT strip symbols during
 # install.
-if(BUILD_TYPE_LOWER MATCHES "^(debug|relwithdebinfo)$")
+if(BUILD_TYPE_UPPER MATCHES "^(DEBUG|RELWITHDEBINFO)$")
   # SNOPT has restrictions for redistribution given that we are statically
   # linking it in.
   if(WITH_SNOPT OR WITH_ROBOTLOCOMOTION_SNOPT)

--- a/cmake/bazel.rc.in
+++ b/cmake/bazel.rc.in
@@ -45,4 +45,11 @@ try-import @PROJECT_BINARY_DIR@/drake.bazelrc
 build --stamp
 build --workspace_status_command="sed 's/^/STABLE_VERSION /' '@PROJECT_BINARY_DIR@/VERSION.TXT'"
 
-# TODO(#24455) Pass along CMAKE_C_FLAGS and CMAKE_CXX_FLAGS also.
+# Forward CMAKE_C_FLAGS and CMAKE_CXX_FLAGS, plus the build-type-specific
+# variants matching CMAKE_BUILD_TYPE (like CMAKE_C_FLAGS_RELEASE or
+# CMAKE_CXX_FLAGS_DEBUG). The C and CXX flags are forwarded as --conlyopt and
+# --cxxopt respectively. These are placed in their own bazelrc line below
+# BAZEL_CONFIG so user-supplied flags appear near the end of the compiler
+# command line. Target-level `copts = [...]` in Drake's BUILD files still
+# appear after these and will win conflicts.
+build @BAZEL_USER_COMPILE_FLAGS@

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -106,11 +106,18 @@ Bazel build.
 
 * [`CMAKE_BUILD_TYPE`](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
 * [`CMAKE_(C|Fortran)_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html)
+* [`CMAKE_(C|CXX)_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html)
 * [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html)
 
 The `CMAKE_C_COMPILER` is used to compile both C and C++ code, so must be a
 compiler *driver* than can handle both languages, based on the filename. All
 of the supported compilers (GCC, Clang, Xcode) work fine.
+
+Any additional compilation flags specified via `CMAKE_C_FLAGS` and
+`CMAKE_CXX_FLAGS` will be forwarded. Build-type specific variants (like
+`CMAKE_C_FLAGS_RELEASE` or `CMAKE_CXX_FLAGS_DEBUG`) may also be provided to
+specify config-specific flags. In some cases, Drake's default flags will have
+priority over the user's flags.
 
 Building and installing Drake also requires a working installation of Python.
 When `Python_EXECUTABLE` is specified, it uses the given path to the Python


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/24455

Manually tested by setting various CXX and C flags and ensuring they propagate to the compiler. Cases tested:

- [x] Manual inspection of `.bazelrc`
- [x] End to end C++ specific flag routing (C++ flags propagate to C++ compilation ONLY). Checked with `#ifdef` in C++ source. 
- [x] End to end C specific flag routing (C flags propagate to C compilation ONLY).
- [x] Defines with spaces (`-DMYDEF="some value"'`)
- [x] Defines with quotes
- [x] Defines with backslashes
- [x] Empty flags (CXX, C, and build type specific flags) still compiles fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24526)
<!-- Reviewable:end -->
