### PR TITLE
Remove DebugIsTooSlow guard

### DIFF
--- a/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_examples_test.cc
@@ -104,14 +104,6 @@ constexpr std::string_view kStlMesh =  // #19408
     ".*[.][Ss][Tt][Ll].*";
 }  // namespace KnownErrors
 
-constexpr std::string_view DebugIsTooSlow(std::string_view non_debug_result) {
-  if constexpr (kDrakeAssertIsArmed) {
-    return kTooSlow;
-  } else {
-    return non_debug_result;
-  }
-}
-
 class MujocoMenagerieTest : public MujocoParserExamplesTest,
                             public testing::WithParamInterface<
                                 std::pair<const char*, std::string_view>> {};
@@ -159,17 +151,17 @@ const std::pair<const char*, std::string_view> mujoco_menagerie_models[] = {
     {"boston_dynamics_spot/scene_arm", kItWorks},
     {"boston_dynamics_spot/spot", kItWorks},
     {"boston_dynamics_spot/spot_arm", kItWorks},
-    {"flybody/fruitfly", DebugIsTooSlow(KnownErrors::kSizeFromMesh)},
-    {"flybody/scene", DebugIsTooSlow(KnownErrors::kSizeFromMesh)},
+    {"flybody/fruitfly", KnownErrors::kSizeFromMesh},
+    {"flybody/scene", KnownErrors::kSizeFromMesh},
     {"franka_emika_panda/hand", KnownErrors::kStlMesh},
     {"franka_emika_panda/mjx_panda", KnownErrors::kStlMesh},
     {"franka_emika_panda/mjx_scene", KnownErrors::kStlMesh},
     {"franka_emika_panda/mjx_single_cube", KnownErrors::kStlMesh},
-    {"franka_emika_panda/panda", DebugIsTooSlow(KnownErrors::kStlMesh)},
-    {"franka_emika_panda/panda_nohand", DebugIsTooSlow(KnownErrors::kStlMesh)},
-    {"franka_emika_panda/scene", DebugIsTooSlow(KnownErrors::kStlMesh)},
-    {"franka_fr3/fr3", DebugIsTooSlow(KnownErrors::kStlMesh)},
-    {"franka_fr3/scene", DebugIsTooSlow(KnownErrors::kStlMesh)},
+    {"franka_emika_panda/panda", KnownErrors::kStlMesh},
+    {"franka_emika_panda/panda_nohand", KnownErrors::kStlMesh},
+    {"franka_emika_panda/scene", KnownErrors::kStlMesh},
+    {"franka_fr3/fr3", KnownErrors::kStlMesh},
+    {"franka_fr3/scene", KnownErrors::kStlMesh},
     {"google_barkour_v0/barkour_v0", KnownErrors::kStlMesh},
     {"google_barkour_v0/barkour_v0_mjx", KnownErrors::kStlMesh},
     {"google_barkour_v0/scene", KnownErrors::kStlMesh},
@@ -182,10 +174,10 @@ const std::pair<const char*, std::string_view> mujoco_menagerie_models[] = {
     {"google_barkour_vb/scene_mjx", KnownErrors::kStlMesh},
     {"google_robot/robot", KnownErrors::kStlMesh},
     {"google_robot/scene", KnownErrors::kStlMesh},
-    {"hello_robot_stretch/scene", DebugIsTooSlow(KnownErrors::kStlMesh)},
-    {"hello_robot_stretch/stretch", DebugIsTooSlow(KnownErrors::kStlMesh)},
-    {"hello_robot_stretch_3/scene", DebugIsTooSlow(KnownErrors::kStlMesh)},
-    {"hello_robot_stretch_3/stretch", DebugIsTooSlow(KnownErrors::kStlMesh)},
+    {"hello_robot_stretch/scene", KnownErrors::kStlMesh},
+    {"hello_robot_stretch/stretch", KnownErrors::kStlMesh},
+    {"hello_robot_stretch_3/scene", KnownErrors::kStlMesh},
+    {"hello_robot_stretch_3/stretch", KnownErrors::kStlMesh},
     {"kinova_gen3/gen3", KnownErrors::kStlMesh},
     {"kinova_gen3/scene", KnownErrors::kStlMesh},
     {"kuka_iiwa_14/iiwa14", kItWorks},


### PR DESCRIPTION
Computation of MeshDistanceBoundary is no longer part of loading, so parsing tests are no longer affected by it.

Resolves #22412 
Resolves #22311

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24530)
<!-- Reviewable:end -->
