### PR TITLE
TOPPRA Gracefully Handles Failure Due to Small Timestep

### DIFF
--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -786,7 +786,8 @@ TEST_F(PrismaticToppraTest, MinTimeStepError) {
       Eigen::Vector3d(0, 0.9, 2), Eigen::RowVector3d(0, 0, 1));
 
   Eigen::VectorXd gridpts(3);
-  gridpts << 0, 1e-12, 2;
+  gridpts << 0, trajectories::PiecewiseTrajectory<double>::kEpsilonTime / 2.0,
+      2;
   auto toppra = MakeToppra(path, gridpts);
 
   // Huge limits (and small gridpoints) lead to tiny time steps.

--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -789,6 +789,7 @@ TEST_F(PrismaticToppraTest, MinTimeStepError) {
   gridpts << 0, 1e-12, 2;
   auto toppra = MakeToppra(path, gridpts);
 
+  // Huge limits (and small gridpoints) lead to tiny time steps.
   auto velocity_constraint =
       toppra->AddJointVelocityLimit(Vector1d(-1e6), Vector1d(1e6));
   auto acceleration_constraint =
@@ -796,6 +797,21 @@ TEST_F(PrismaticToppraTest, MinTimeStepError) {
 
   ASSERT_NO_THROW(toppra->SolvePathParameterization());
   auto result = toppra->SolvePathParameterization();
+  EXPECT_FALSE(result);
+}
+
+TEST_F(PrismaticToppraTest, InfiniteTimeStepError) {
+  auto path = PiecewisePolynomial<double>::FirstOrderHold(
+      Eigen::Vector2d(0, 1), Eigen::RowVector2d(0, 1));
+
+  auto toppra = MakeToppra(path);
+
+  // Tight limits that force zero velocity.
+  toppra->AddJointVelocityLimit(Vector1d(0), Vector1d(0));
+  toppra->AddJointAccelerationLimit(Vector1d(0), Vector1d(0));
+
+  ASSERT_NO_THROW(toppra->SolvePathParameterization());
+  auto result = toppra->SolvePathParameterization(0, 0);
   EXPECT_FALSE(result);
 }
 

--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -714,26 +714,43 @@ GTEST_TEST(ToppraTest, GridpointsTest) {
   EXPECT_EQ(gridpts.size(), 9);
 }
 
-GTEST_TEST(ToppraTest, TimeOptimalTest) {
-  auto plant = std::make_unique<MultibodyPlant<double>>(0);
-  const double mass{1};
-  const Eigen::Vector3d p_AoAcm_A(0, 0, 0);
-  const RotationalInertia<double> I_AAcm_A{0.001, 0.001, 0.001};
-  const SpatialInertia<double> M_AAo_A =
-      SpatialInertia<double>::MakeFromCentralInertia(mass, p_AoAcm_A, I_AAcm_A);
-  auto& body = plant->AddRigidBody("body", M_AAo_A);
-  plant->AddJoint<PrismaticJoint>("joint", plant->world_body(), std::nullopt,
-                                  body, std::nullopt, Eigen::Vector3d::UnitX());
-  plant->Finalize();
+class PrismaticToppraTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    plant_ = std::make_unique<MultibodyPlant<double>>(0);
+    const double mass{1};
+    const Eigen::Vector3d p_AoAcm_A(0, 0, 0);
+    const RotationalInertia<double> I_AAcm_A{0.001, 0.001, 0.001};
+    const SpatialInertia<double> M_AAo_A =
+        SpatialInertia<double>::MakeFromCentralInertia(mass, p_AoAcm_A,
+                                                       I_AAcm_A);
+    auto& body = plant_->AddRigidBody("body", M_AAo_A);
+    plant_->AddJoint<PrismaticJoint>("joint", plant_->world_body(),
+                                     std::nullopt, body, std::nullopt,
+                                     Eigen::Vector3d::UnitX());
+    plant_->Finalize();
+  }
 
+  std::unique_ptr<Toppra> MakeToppra(
+      const PiecewisePolynomial<double>& path,
+      std::optional<Eigen::VectorXd> gridpts = std::nullopt) {
+    if (!gridpts) {
+      auto options = CalcGridPointsOptions();
+      options.max_err = 1e-5;
+      gridpts = Toppra::CalcGridPoints(path, options);
+    }
+    return std::make_unique<Toppra>(path, *plant_, *gridpts);
+  }
+
+  std::unique_ptr<MultibodyPlant<double>> plant_;
+};
+
+TEST_F(PrismaticToppraTest, TimeOptimalTest) {
   auto path = PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
       Eigen::Vector2d(0, 1), Eigen::RowVector2d(0, 1), Vector1d(0),
       Vector1d(0));
 
-  auto options = CalcGridPointsOptions();
-  options.max_err = 1e-5;
-  auto gridpts = Toppra::CalcGridPoints(path, options);
-  auto toppra = std::make_unique<Toppra>(path, *plant, gridpts);
+  auto toppra = MakeToppra(path);
 
   auto acceleration_constraint =
       toppra->AddJointAccelerationLimit(Vector1d(-1), Vector1d(1));
@@ -749,25 +766,11 @@ GTEST_TEST(ToppraTest, TimeOptimalTest) {
   EXPECT_LT(trajectory.end_time(), 2 + tol);
 }
 
-GTEST_TEST(ToppraTest, ZeroVelocityTest) {
-  auto plant = std::make_unique<MultibodyPlant<double>>(0);
-  const double mass{1};
-  const Eigen::Vector3d p_AoAcm_A(0, 0, 0);
-  const RotationalInertia<double> I_AAcm_A{0.001, 0.001, 0.001};
-  const SpatialInertia<double> M_AAo_A =
-      SpatialInertia<double>::MakeFromCentralInertia(mass, p_AoAcm_A, I_AAcm_A);
-  auto& body = plant->AddRigidBody("body", M_AAo_A);
-  plant->AddJoint<PrismaticJoint>("joint", plant->world_body(), std::nullopt,
-                                  body, std::nullopt, Eigen::Vector3d::UnitX());
-  plant->Finalize();
-
+TEST_F(PrismaticToppraTest, ZeroVelocityTest) {
   auto path = PiecewisePolynomial<double>::FirstOrderHold(
       Eigen::Vector3d(0, 0.9, 2), Eigen::RowVector3d(0, 0, 1));
 
-  auto options = CalcGridPointsOptions();
-  options.max_err = 1e-5;
-  auto gridpts = Toppra::CalcGridPoints(path, options);
-  auto toppra = std::make_unique<Toppra>(path, *plant, gridpts);
+  auto toppra = MakeToppra(path);
 
   auto velocity_constraint =
       toppra->AddJointVelocityLimit(Vector1d(-1), Vector1d(1));
@@ -778,28 +781,13 @@ GTEST_TEST(ToppraTest, ZeroVelocityTest) {
   ASSERT_TRUE(result);
 }
 
-TEST_F(IiwaToppraTest, MinTimeStepError) {
-  auto plant = std::make_unique<MultibodyPlant<double>>(0);
-  const double mass{1};
-  const Eigen::Vector3d p_AoAcm_A(0, 0, 0);
-  const RotationalInertia<double> I_AAcm_A{0.001, 0.001, 0.001};
-  const SpatialInertia<double> M_AAo_A =
-      SpatialInertia<double>::MakeFromCentralInertia(mass, p_AoAcm_A, I_AAcm_A);
-  auto& body = plant->AddRigidBody("body", M_AAo_A);
-  plant->AddJoint<PrismaticJoint>("joint", plant->world_body(), std::nullopt,
-                                  body, std::nullopt, Eigen::Vector3d::UnitX());
-  plant->Finalize();
-
+TEST_F(PrismaticToppraTest, MinTimeStepError) {
   auto path = PiecewisePolynomial<double>::FirstOrderHold(
       Eigen::Vector3d(0, 0.9, 2), Eigen::RowVector3d(0, 0, 1));
 
-  // If the retimed trajectory is too fast (and the gridpoints are too close
-  // together), then knot points will be less than kEpsilonTime apart, leading
-  // to an error. This test ensures TOPPRA reports the failure by returning
-  // std::nullopt, rather than throwing an error.
   Eigen::VectorXd gridpts(3);
   gridpts << 0, 1e-12, 2;
-  auto toppra = std::make_unique<Toppra>(path, *plant, gridpts);
+  auto toppra = MakeToppra(path, gridpts);
 
   auto velocity_constraint =
       toppra->AddJointVelocityLimit(Vector1d(-1e6), Vector1d(1e6));

--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -778,6 +778,39 @@ GTEST_TEST(ToppraTest, ZeroVelocityTest) {
   ASSERT_TRUE(result);
 }
 
+TEST_F(IiwaToppraTest, MinTimeStepError) {
+  auto plant = std::make_unique<MultibodyPlant<double>>(0);
+  const double mass{1};
+  const Eigen::Vector3d p_AoAcm_A(0, 0, 0);
+  const RotationalInertia<double> I_AAcm_A{0.001, 0.001, 0.001};
+  const SpatialInertia<double> M_AAo_A =
+      SpatialInertia<double>::MakeFromCentralInertia(mass, p_AoAcm_A, I_AAcm_A);
+  auto& body = plant->AddRigidBody("body", M_AAo_A);
+  plant->AddJoint<PrismaticJoint>("joint", plant->world_body(), std::nullopt,
+                                  body, std::nullopt, Eigen::Vector3d::UnitX());
+  plant->Finalize();
+
+  auto path = PiecewisePolynomial<double>::FirstOrderHold(
+      Eigen::Vector3d(0, 0.9, 2), Eigen::RowVector3d(0, 0, 1));
+
+  // If the retimed trajectory is too fast (and the gridpoints are too close
+  // together), then knot points will be less than kEpsilonTime apart, leading
+  // to an error. This test ensures TOPPRA reports the failure by returning
+  // std::nullopt, rather than throwing an error.
+  Eigen::VectorXd gridpts(3);
+  gridpts << 0, 1e-12, 2;
+  auto toppra = std::make_unique<Toppra>(path, *plant, gridpts);
+
+  auto velocity_constraint =
+      toppra->AddJointVelocityLimit(Vector1d(-1e6), Vector1d(1e6));
+  auto acceleration_constraint =
+      toppra->AddJointAccelerationLimit(Vector1d(-1e6), Vector1d(1e6));
+
+  ASSERT_NO_THROW(toppra->SolvePathParameterization());
+  auto result = toppra->SolvePathParameterization();
+  EXPECT_FALSE(result);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -637,16 +637,15 @@ std::optional<PiecewisePolynomial<double>> Toppra::SolvePathParameterization(
     const double delta = gridpoints_(knot + 1) - gridpoints_(knot);
     const double sd_avg = (sd_knots(knot + 1) + sd_knots(knot)) / 2.;
     const double delta_t = delta / sd_avg;
-    const double next_t = t_knots[knot] + delta_t;
-    if (!std::isfinite(next_t) ||
-        next_t - t_knots[knot] <
-            trajectories::PiecewiseTrajectory<double>::kEpsilonTime) {
+    t_knots[knot + 1] = t_knots[knot] + delta_t;
+
+    if (!std::isfinite(delta_t) ||
+        delta_t < trajectories::PiecewiseTrajectory<double>::kEpsilonTime) {
       drake::log()->error(
           "Toppra hit numerical issues. Found sub-epsilon or non-finite time "
           "step.");
       return std::nullopt;
     }
-    t_knots[knot + 1] = next_t;
 
     const Eigen::Vector3d coeffs(gridpoints_(knot), sd_knots(knot),
                                  0.5 * u_star(knot));

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -638,11 +638,12 @@ std::optional<PiecewisePolynomial<double>> Toppra::SolvePathParameterization(
     const double sd_avg = (sd_knots(knot + 1) + sd_knots(knot)) / 2.;
     const double delta_t = delta / sd_avg;
     const double next_t = t_knots[knot] + delta_t;
-    if (next_t - t_knots[knot] <
-        trajectories::PiecewiseTrajectory<double>::kEpsilonTime) {
+    if (!std::isfinite(next_t) ||
+        next_t - t_knots[knot] <
+            trajectories::PiecewiseTrajectory<double>::kEpsilonTime) {
       drake::log()->error(
-          "Toppra hit numerical issues. Found delta_t less than "
-          "PiecewiseTrajectory<double>::kEpsilonTime.");
+          "Toppra hit numerical issues. Found sub-epsilon or non-finite time "
+          "step.");
       return std::nullopt;
     }
     t_knots[knot + 1] = next_t;

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -637,6 +637,13 @@ std::optional<PiecewisePolynomial<double>> Toppra::SolvePathParameterization(
     const double delta = gridpoints_(knot + 1) - gridpoints_(knot);
     const double sd_avg = (sd_knots(knot + 1) + sd_knots(knot)) / 2.;
     const double delta_t = delta / sd_avg;
+    if (delta_t < trajectories::PiecewiseTrajectory<double>::kEpsilonTime) {
+      drake::log()->error(fmt::format(
+          "Toppra hit numerical issues. Found delta_t {}, which is less than "
+          "PiecewiseTrajectory<double>::kEpsilonTime {}.",
+          delta_t, trajectories::PiecewiseTrajectory<double>::kEpsilonTime));
+      return std::nullopt;
+    }
     t_knots[knot + 1] = t_knots[knot] + delta_t;
 
     const Eigen::Vector3d coeffs(gridpoints_(knot), sd_knots(knot),

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -637,14 +637,15 @@ std::optional<PiecewisePolynomial<double>> Toppra::SolvePathParameterization(
     const double delta = gridpoints_(knot + 1) - gridpoints_(knot);
     const double sd_avg = (sd_knots(knot + 1) + sd_knots(knot)) / 2.;
     const double delta_t = delta / sd_avg;
-    if (delta_t < trajectories::PiecewiseTrajectory<double>::kEpsilonTime) {
-      drake::log()->error(fmt::format(
-          "Toppra hit numerical issues. Found delta_t {}, which is less than "
-          "PiecewiseTrajectory<double>::kEpsilonTime {}.",
-          delta_t, trajectories::PiecewiseTrajectory<double>::kEpsilonTime));
+    const double next_t = t_knots[knot] + delta_t;
+    if (next_t - t_knots[knot] <
+        trajectories::PiecewiseTrajectory<double>::kEpsilonTime) {
+      drake::log()->error(
+          "Toppra hit numerical issues. Found delta_t less than "
+          "PiecewiseTrajectory<double>::kEpsilonTime.");
       return std::nullopt;
     }
-    t_knots[knot + 1] = t_knots[knot] + delta_t;
+    t_knots[knot + 1] = next_t;
 
     const Eigen::Vector3d coeffs(gridpoints_(knot), sd_knots(knot),
                                  0.5 * u_star(knot));


### PR DESCRIPTION
In my experiences retiming numerically difficult trajectories, TOPPRA would occasionally compute gridpoints that were separated by a time step less than `PiecewiseTrajectory<double>::kEpsilonTime`. This would trip a `DRAKE_DEMAND`, hard exiting the program, and preventing any downstream exception handling.

This PR adds a check for this case, instead using TOPPRA's existing method for handling a failure (returning `std::nullopt`). It also cleans up the test cases by adding a test fixture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24532)
<!-- Reviewable:end -->
