### PR TITLE
[workspace] Remove CoinUtils global variables

### DIFF
--- a/tools/install/libdrake/test/exported_symbols_test.py
+++ b/tools/install/libdrake/test/exported_symbols_test.py
@@ -113,14 +113,11 @@ def _is_known_bad_ctor_or_dtor(*, filename, function_name):
     if filename == "Console.cc":
         # TODO(#24446) Patch libsdformat to fix this.
         return True
-    if filename == "CoinParamUtils.cpp":
-        # TODO(#24446) Patch libsdformat to fix this.
-        return True
     if filename == "meshcat.cc":
         # TODO(#24446) Fix this somehow.
         return True
     if filename == "impl.cpp":
-        # TODO(#24446) Find and fix this somehow.
+        # TODO(#24447) Fix VTK to remove globals.
         return True
     return False
 

--- a/tools/workspace/coinutils_internal/package.BUILD.bazel
+++ b/tools/workspace/coinutils_internal/package.BUILD.bazel
@@ -29,6 +29,10 @@ _SRCS = glob(
         "CoinUtils/src/*.cpp",
     ],
     allow_empty = False,
+    exclude = [
+        "CoinUtils/src/CoinParam.cpp",
+        "CoinUtils/src/CoinParamUtils.cpp",
+    ],
 )
 
 _AUTOCONF_DEFINES = [


### PR DESCRIPTION
The fix is simply dropping two unused files from the library.

Also tweak a nearby comment after finding where impl.cpp is coming from.

Towards #24446.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24542)
<!-- Reviewable:end -->
