### PR TITLE
[workspace] Remove libsdformat global variables

### DIFF
--- a/tools/install/libdrake/test/exported_symbols_test.py
+++ b/tools/install/libdrake/test/exported_symbols_test.py
@@ -110,9 +110,6 @@ def _is_known_bad_ctor_or_dtor(*, filename, function_name):
     if function_name.startswith("vtktoken::"):
         # TODO(#24447) Fix VTK to remove globals.
         return True
-    if filename == "Console.cc":
-        # TODO(#24446) Patch libsdformat to fix this.
-        return True
     return False
 
 

--- a/tools/workspace/sdformat_internal/patches/console.patch
+++ b/tools/workspace/sdformat_internal/patches/console.patch
@@ -164,11 +164,11 @@ index c0f4c4ed..a2f82f5d 100644
  
  using namespace sdf;
  
++#if 0
  /// Static pointer to the console.
  static std::shared_ptr<Console> myself;
  static std::mutex g_instance_mutex;
  
-+#if 0
  static bool g_quiet = false;
  
  static Console::ConsoleStream g_NullStream(nullptr);
@@ -182,8 +182,19 @@ index c0f4c4ed..a2f82f5d 100644
  {
  #ifndef SDFORMAT_DISABLE_CONSOLE_LOGFILE
    // Set up the file that we'll log to.
-@@ -94,6 +100,7 @@ ConsolePtr Console::Instance()
-   return myself;
+@@ -86,14 +92,11 @@ ConsolePtr Console::Instance()
+ ConsolePtr Console::Instance()
+ {
+-  std::lock_guard<std::mutex> lock(g_instance_mutex);
+-  if (!myself)
+-  {
+-    myself.reset(new Console());
+-  }
+-
+-  return myself;
++  // Purposefully leaked to avoid global destructors (ala never_destroyed).
++  static ConsolePtr* instance = new std::shared_ptr<Console>(new Console());
++  return *instance;
  }
  
 +#if 0


### PR DESCRIPTION
Towards #24446.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24543)
<!-- Reviewable:end -->
