### PR TITLE
[tools] Disable warning spam on ARM64 builds

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -82,6 +82,8 @@ GCC_FLAGS = CXX_FLAGS + [
     # Eigen uses 16-byte alignment, which these flags don't account for.
     "-Wno-array-bounds",
     "-Wno-stringop-overread",
+    # Disable warning spam on ARM64 builds.
+    "-Wno-psabi",
 ]
 
 # The CC_TEST_FLAGS will be enabled for all cc_test rules in the project.


### PR DESCRIPTION
This suppresses "note: parameter passing for argument of type '...' when C++17 is enabled changed to match C++14 in GCC 10.1".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24545)
<!-- Reviewable:end -->
