### PR TITLE
[doc] Publish tutorials as website html

### DIFF
--- a/bindings/pydrake/systems/drawing.py
+++ b/bindings/pydrake/systems/drawing.py
@@ -2,6 +2,7 @@
 Provides general visualization utilities. This is NOT related to `rendering`.
 """
 
+import os
 from tempfile import NamedTemporaryFile
 
 from pydrake.common import temp_directory
@@ -16,7 +17,7 @@ try:
     # IPython module may not be available; in which case, we're definitely
     # *not* running as a notebook.
     from IPython import get_ipython
-    from IPython.display import SVG, display
+    from IPython.display import SVG, Image, display
 
     running_as_notebook = get_ipython() and hasattr(get_ipython(), "kernel")
 except ModuleNotFoundError:
@@ -71,7 +72,9 @@ def plot_graphviz(dot_text):
         # Handle this case for now.
         assert len(g) == 1
         g = g[0]
-    if running_as_notebook:
+    if "DRAKE_IS_BUILDING_DOCUMENTATION" in os.environ:
+        return display(Image(g.create_png()))
+    elif running_as_notebook:
         return display(SVG(g.create_svg()))
     else:
         f = NamedTemporaryFile(suffix=".png", dir=temp_directory())

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -132,6 +132,7 @@ drake_py_binary(
         "//doc/doxygen_cxx:build",
         "//doc/pydrake:build",
         "//doc/styleguide:build",
+        "//doc/tutorials:build",
     ],
     deps = [
         ":defs",
@@ -147,6 +148,7 @@ drake_py_binary(
         "pydrake.math",
         "sitemap",
         "styleguide",
+        "tutorials.solver_parameters",
     ],
     test_rule_tags = DEFAULT_TEST_TAGS,
 )
@@ -162,6 +164,7 @@ test_suite(
         "//doc/doxygen_cxx:build_test",
         "//doc/pydrake:build_test",
         "//doc/styleguide:build_test",
+        "//doc/tutorials:build_test",
     ],
 )
 

--- a/doc/build.py
+++ b/doc/build.py
@@ -28,22 +28,32 @@ def _build(*, out_dir, temp_dir, quick, modules):
     pages_build = manifest.Rlocation("drake/doc/pages")
     styleguide_build = manifest.Rlocation("drake/doc/styleguide/build")
     pydrake_build = manifest.Rlocation("drake/doc/pydrake/build")
+    tutorials_build = manifest.Rlocation("drake/doc/tutorials/build")
     doxygen_build = manifest.Rlocation("drake/doc/doxygen_cxx/build")
-    for item in [pages_build, styleguide_build, pydrake_build, doxygen_build]:
+    for item in [
+        pages_build,
+        styleguide_build,
+        pydrake_build,
+        tutorials_build,
+        doxygen_build,
+    ]:
         assert item and os.path.exists(item), item
 
     # Figure out which modules to ask for from each helper tool.
     do_pages = True
     do_styleguide = True
     do_pydrake = True
+    do_tutorials = True
     do_doxygen = True
     do_sitemap = True
     pydrake_modules = []
     doxygen_modules = []
+    tutorials_modules = []
     if modules:
         do_pages = False
         do_styleguide = False
         do_pydrake = False
+        do_tutorials = False
         do_doxygen = False
         do_sitemap = False
     for module in modules:
@@ -60,6 +70,9 @@ def _build(*, out_dir, temp_dir, quick, modules):
         elif module.startswith("pydrake."):
             do_pydrake = True
             pydrake_modules.append(module)
+        elif module.startswith("tutorials."):
+            do_tutorials = True
+            tutorials_modules.append(module)
         elif module.startswith("drake."):
             do_doxygen = True
             doxygen_modules.append(module)
@@ -75,6 +88,11 @@ def _build(*, out_dir, temp_dir, quick, modules):
     if do_pydrake:
         check_call(
             [pydrake_build, f"--out_dir={out_dir}/pydrake"] + pydrake_modules
+        )
+    if do_tutorials:
+        check_call(
+            [tutorials_build, f"--out_dir={out_dir}/tutorials"]
+            + tutorials_modules
         )
     if do_doxygen:
         maybe_quick = ["--quick"] if quick else []
@@ -92,6 +110,7 @@ def _build(*, out_dir, temp_dir, quick, modules):
     result.append("styleguide/cppguide.html") if do_styleguide else None
     result.append("styleguide/pyguide.html") if do_styleguide else None
     result.append("pydrake/") if do_pydrake else None
+    result.append("tutorials/") if do_tutorials else None
     result.append("doxygen_cxx/") if do_doxygen else None
     return result
 

--- a/doc/tutorials/BUILD.bazel
+++ b/doc/tutorials/BUILD.bazel
@@ -1,0 +1,52 @@
+load(
+    "//doc:defs.bzl",
+    "DEFAULT_TEST_TAGS",
+    "enumerate_filegroup",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load(
+    "//tools/skylark:drake_py.bzl",
+    "drake_py_binary",
+)
+
+package(default_visibility = ["//visibility:private"])
+
+alias(
+    name = "notebooks",
+    actual = "//tutorials:notebooks",
+)
+
+enumerate_filegroup(
+    name = "notebooks.txt",
+    data = [":notebooks"],
+)
+
+filegroup(
+    name = "templates",
+    data = glob(["templates/**"]),
+)
+
+drake_py_binary(
+    name = "build",
+    srcs = ["build.py"],
+    data = [
+        ":notebooks",
+        ":notebooks.txt",
+        ":templates",
+        "@drake_models",
+    ],
+    visibility = ["//doc:__pkg__"],
+    deps = [
+        "//bindings/pydrake",
+        "//doc:defs",
+    ],
+    add_test_rule = True,
+    test_rule_args = [
+        "--out_dir=<test>",
+        # Only generate one tutorial, so that the test provides quick feedback.
+        "tutorials.solver_parameters",
+    ],
+    test_rule_tags = DEFAULT_TEST_TAGS,
+)
+
+add_lint_tests()

--- a/doc/tutorials/build.py
+++ b/doc/tutorials/build.py
@@ -1,0 +1,117 @@
+"""Command-line tool to generate Drake's rendered tutorials.
+
+For instructions, see https://drake.mit.edu/documentation_instructions.html.
+"""
+
+import os
+from pathlib import Path
+import sys
+
+from python import runfiles
+
+from doc.defs import (
+    check_call,
+    main,
+    perl_cleanup_html_output,
+    symlink_input,
+)
+
+# These versions match what's shipped in Ubuntu 24.04 Noble, which is what our
+# CI documentation build uses when running jupyter-nbconvert.
+_MATHJAX_URL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_HTMLorMML"  # noqa
+_REQUIREJS_URL = (
+    "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"
+)
+
+# These tutorials cannot be executed during the documentation build.
+_NO_EXECUTE = (
+    # Requires deepnote.
+    "licensed_solvers_deepnote",
+)
+
+
+def _build(*, out_dir, temp_dir, modules):
+    """Generates into out_dir; writes scratch files into temp_dir.
+    As a precondition, both directories must already exist and be empty.
+    If modules are provided, only generate those modules and their children.
+    """
+    assert len(os.listdir(temp_dir)) == 0
+    assert len(os.listdir(out_dir)) == 0
+
+    nbconvert = "/usr/bin/jupyter-nbconvert"
+    if not os.path.isfile(nbconvert):
+        print(
+            "Please re-run 'setup/install_prereqs' with the '--developer' flag"
+        )
+        sys.exit(1)
+
+    # Find Drake's nbconvert templates.
+    manifest = runfiles.Create()
+    templates_dir = Path(
+        manifest.Rlocation(
+            "drake/doc/tutorials/templates/drake_style/conf.json"
+        )
+    ).parent.parent
+
+    # Create a hermetic copy of our input.  This helps ensure that only files
+    # listed in BUILD.bazel will render onto the website.
+    symlink_input(
+        "drake/doc/tutorials/notebooks.txt",
+        temp_dir,
+        strip_prefix=["drake/doc/"],
+    )
+    input_dir = Path(temp_dir) / "drake/tutorials"
+    all_tutorials = sorted(["tutorials." + x.stem for x in input_dir.iterdir()])
+
+    # Process the command-line request for which tutorials to document.
+    if not modules:
+        modules_to_document = set(all_tutorials)
+    else:
+        modules_to_document = set()
+        for x in modules:
+            if x in all_tutorials:
+                modules_to_document.add(x)
+            else:
+                print(f"error: Unknown tutorial '{x}'")
+                sys.exit(1)
+
+    # Run the documentation generator.
+    for module in modules_to_document:
+        assert module.startswith("tutorials.")
+        name = module[len("tutorials.") :]
+        check_call(
+            [
+                nbconvert,
+                str(input_dir / f"{name}.ipynb"),
+                "--to=html",
+                f"--TemplateExporter.extra_template_basedirs={templates_dir}",
+                "--template=drake_style",
+                f"--HTMLExporter.mathjax_url={_MATHJAX_URL}",
+                f"--HTMLExporter.require_js_url={_REQUIREJS_URL}",
+                f"--output={out_dir}/{name}.html",
+            ]
+            + (["--execute"] if name not in _NO_EXECUTE else [])
+        )
+
+    # Tidy up.
+    perl_cleanup_html_output(
+        out_dir=out_dir,
+        extra_perl_statements=[
+            # Replace links to ipynb files with links to html, instead.
+            r's#(href="\./[^.]*?\.)ipynb#$1html#g;',
+        ],
+    )
+
+    # The filename to suggest as the starting point for preview; in this case,
+    # it's an empty filename (i.e., the index page).
+    return [""]
+
+
+if __name__ == "__main__":
+    os.environ["PYTHONPATH"] = ":".join(sys.path)
+    main(
+        build=_build,
+        subdir="tutorials",
+        description=__doc__.strip(),
+        supports_modules=True,
+    )

--- a/doc/tutorials/templates/drake_style/conf.json
+++ b/doc/tutorials/templates/drake_style/conf.json
@@ -1,0 +1,3 @@
+{
+    "base_template": "lab"
+}

--- a/doc/tutorials/templates/drake_style/index.html.j2
+++ b/doc/tutorials/templates/drake_style/index.html.j2
@@ -1,0 +1,79 @@
+{% extends 'lab/index.html.j2' %}
+{% block notebook_css %}
+{{ super() }}
+{{ resources.include_css("static/theme-drake.css") }}
+{% endblock notebook_css %}
+{% block body_header %}
+{{ super() }}
+<header class="site-header">
+  <div class="site-header-inner contain">
+    <a class="drake-logo" href="/"><img src="/images/drake-logo-white.svg"></a>
+    <div class="menu-mobile-toggle">
+      <span></span>
+    </div>
+    <nav class="site-menu">
+      <ul>
+        <li class="site-menu-item site-menu-item-main">
+          <a class="site-menu-item" href="/">Home</a>
+        </li>
+        <li class="site-menu-item site-menu-item-main">
+          <a class="site-menu-item" href="/installation.html">Installation</a>
+        </li>
+        <li class="site-menu-item site-menu-item-main">
+          <a class="site-menu-item" href="/gallery.html">Gallery</a>
+        </li>
+        <li class="site-menu-item site-menu-item-main">API Documentation
+          <div class="sub">
+            <a class="site-menu-item" href="/doxygen_cxx/index.html">C++</a> <a class="site-menu-item" href="/pydrake/index.html">Python</a>
+          </div>
+        </li>
+        <li class="site-menu-item site-menu-item-main">Resources
+          <div class="sub">
+            <a class="site-menu-item" href="/getting_help.html">Getting Help</a> <a class="site-menu-item" href="https://deepnote.com/workspace/Drake-0b3b2c53-a7ad-441b-80f8-bf8350752305/project/Tutorials-2b4fc509-aef2-417d-a40d-6071dfed9199/notebook/index-753e3c9d261247ba9f0eb1d7868c18c8">Tutorials</a> <a class="site-menu-item" href="/python_bindings.html">Python Bindings</a> <a class="site-menu-item" href="/developers.html">For Developers</a> <a class="site-menu-item" href="/credits.html">Credits</a>
+          </div>
+        </li>
+        <li class="github-link">
+          <a class="site-menu-item" href="https://github.com/RobotLocomotion/drake">GitHub <img src="/third_party/images/GitHub-Mark-Light-64px.png"></a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+{% endblock body_header %}
+{% block body_footer %}
+<script>
+  /* Enables clicking for the mobile "hamburger" (three-line) menu item. */
+  const siteHeader = document.querySelector('.site-header')
+  const mobileButton = document.querySelector('.menu-mobile-toggle')
+  const body = document.querySelector('body')
+
+  mobileButton.addEventListener('click', function(event) {
+    siteHeader.classList.toggle('open');
+    body.classList.toggle('overflow-hidden');
+  })
+</script>
+<footer class="site-footer padding">
+  <div class="contain">
+    <a href="/" class="drake-logo">
+      <img src="/images/drake-logo.svg">
+    </a>
+    <div class="footer-menu">
+      <ul>
+        <li>
+          <a href="https://accessibility.mit.edu/" class="site-menu-item">Accessibility</a>
+        </li>
+        <li>
+          <a href="/doxygen_cxx/index.html" class="site-menu-item">C++</a>
+        </li>
+        <li>
+          <a href="/pydrake/index.html" class="site-menu-item">Python</a>
+        </li>
+        <li class="github-link">
+          <a href="https://github.com/RobotLocomotion/drake" class="site-menu-item">GitHub <img src="/third_party/images/GitHub-Mark-64px.png"></a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</footer>
+{{ super() }}
+{% endblock body_footer %}

--- a/doc/tutorials/templates/drake_style/static/theme-drake.css
+++ b/doc/tutorials/templates/drake_style/static/theme-drake.css
@@ -1,0 +1,1369 @@
+@import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;400;600;700;800&display=swap');
+
+@charset "UTF-8";
+
+:root {
+  --toyota-red: #EB0A1E;
+  --primary: #EB0A1E;
+  --breakpoint-xs: 0;
+  --breakpoint-sm: 576px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 992px;
+  --breakpoint-xl: 1200px;
+  --font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --jp-content-font-size1: 1em;
+  --jp-content-heading-font-weight: bold;
+  --jp-content-link-color: var(--toyota-red);
+  --jp-notebook-padding: 0;
+}
+
+/* TODO(jwnimmer-tri) This style sheet was forked from our pydrake API style
+sheet. It's likely that some of the content here is deadwood that could be
+trimmed out. */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+tt, code, kbd, samp {
+  font-family: 'DejaVu Sans Mono', monospace;
+}
+
+pre, xmp, plaintext, listing {
+  font-family: 'DejaVu Sans Mono', monospace;
+}
+
+pre, code, .rst-content tt, .rst-content code, kbd, samp {
+  font-family: 'DejaVu Sans Mono', monospace;
+}
+
+.btn {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+input[type="button"], input[type="reset"], input[type="submit"] {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+input[type="text"], input[type="password"], input[type="email"], input[type="url"], input[type="date"], input[type="month"], input[type="time"], input[type="datetime"], input[type="datetime-local"], input[type="week"], input[type="number"], input[type="search"], input[type="tel"], input[type="color"] {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+textarea {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+.wy-table caption, .rst-content table.docutils caption, .rst-content table.field-list caption {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+body {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+h1, h2, .rst-content .toctree-wrapper p.caption, h3, h4, h5, h6, legend {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+code, .rst-content tt, .rst-content code {
+  font-family: 'DejaVu Sans Mono', monospace;
+}
+
+.linenodiv pre {
+  font-family: 'DejaVu Sans Mono', monospace;
+}
+
+div[class^='highlight'] pre {
+  font-family: 'DejaVu Sans Mono', monospace;
+}
+
+footer span.commit code, footer span.commit .rst-content tt, .rst-content footer span.commit tt {
+  font-family: 'DejaVu Sans Mono', monospace;
+}
+
+.rst-versions {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+.rst-content .sidebar .sidebar-title {
+  font-family: 'DejaVu Sans', sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -ms-overflow-style: scrollbar;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+@-ms-viewport {
+  width: device-width;
+}
+article, aside, dialog, figcaption, figure, footer, header, hgroup, main, nav, section {
+  display: block;
+}
+
+body {
+  margin: 0;
+  font-family: 'Work Sans', 'DejaVu Sans', 'DejaVu Sans Mono', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  overflow-x: unset;
+  color: #212529;
+  text-align: left;
+  background-color: #fff;
+}
+
+[tabindex="-1"]:focus {
+  outline: 0 !important;
+}
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+abbr[title],
+abbr[data-original-title] {
+  text-decoration: underline;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+  cursor: help;
+  border-bottom: 0;
+}
+
+address {
+  margin-bottom: 1rem;
+  font-style: normal;
+  line-height: inherit;
+}
+
+ol,
+ul,
+dl {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+  margin-bottom: 0;
+}
+
+dt {
+  font-weight: 700;
+}
+
+dd {
+  margin-bottom: .5rem;
+  margin-left: 0;
+}
+
+blockquote {
+  margin: 0 0 1rem;
+}
+
+dfn {
+  font-style: italic;
+}
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+small {
+  font-size: 80%;
+}
+
+sub,
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -.25em;
+}
+
+sup {
+  top: -.5em;
+}
+
+a {
+  color: var(--toyota-red);
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-text-decoration-skip: objects;
+}
+a:hover {
+  color: #80000c;
+  text-decoration: underline;
+}
+
+a:visited {
+  color: var(--toyota-red);
+}
+
+a:not([href]):not([tabindex]) {
+  color: inherit;
+  text-decoration: none;
+}
+a:not([href]):not([tabindex]):hover, a:not([href]):not([tabindex]):focus {
+  color: inherit;
+  text-decoration: none;
+}
+a:not([href]):not([tabindex]):focus {
+  outline: 0;
+}
+
+pre,
+code,
+kbd,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+pre {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  overflow: auto;
+  -ms-overflow-style: scrollbar;
+}
+
+figure {
+  margin: 0 0 1rem;
+}
+
+img {
+  vertical-align: middle;
+  border-style: none;
+}
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+caption {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  color: #6c757d;
+  text-align: left;
+  caption-side: bottom;
+}
+
+th {
+  text-align: inherit;
+}
+
+label {
+  display: inline-block;
+  margin-bottom: .5rem;
+}
+
+button {
+  border-radius: 0;
+}
+
+button:focus {
+  outline: 1px dotted;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+input,
+button,
+select,
+optgroup,
+textarea {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  font-family: 'Work Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+button,
+input {
+  overflow: visible;
+}
+
+button,
+select {
+  text-transform: none;
+}
+
+button,
+html [type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+
+input[type="radio"],
+input[type="checkbox"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+input[type="date"],
+input[type="time"],
+input[type="datetime-local"],
+input[type="month"] {
+  -webkit-appearance: listbox;
+}
+
+textarea {
+  overflow: auto;
+  resize: vertical;
+}
+
+fieldset {
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+legend {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
+  margin-bottom: .5rem;
+  font-size: 1.5rem;
+  line-height: inherit;
+  color: inherit;
+  white-space: normal;
+}
+
+progress {
+  vertical-align: baseline;
+}
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+[type="search"] {
+  outline-offset: -2px;
+  -webkit-appearance: none;
+}
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+  font: inherit;
+  -webkit-appearance: button;
+}
+
+output {
+  display: inline-block;
+}
+
+summary {
+  display: list-item;
+  cursor: pointer;
+}
+
+template {
+  display: none;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+input[type="text"], input[type="password"], input[type="email"], input[type="url"], input[type="date"], input[type="month"], input[type="time"], input[type="datetime"], input[type="datetime-local"], input[type="week"], input[type="number"], input[type="search"], input[type="tel"], input[type="color"] {
+  font-family: 'Work Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+}
+
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  line-height: 1.2;
+  color: inherit;
+}
+
+h1, .h1 {
+  font-weight: bold;
+  margin-bottom: 1.5rem;
+  font-size: 2.5rem;
+}
+
+h2, .h2 {
+  font-size: 2rem;
+}
+
+h3, .h3 {
+  font-size: 1.75rem;
+}
+
+h4, .h4 {
+  font-size: 1.5rem;
+}
+
+h5, .h5 {
+  font-size: 1.25rem;
+}
+
+h6, .h6 {
+  font-size: 1rem;
+}
+
+.lead {
+  font-size: 1.25rem;
+  font-weight: 300;
+}
+
+.display-1 {
+  font-size: 6rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
+.display-2 {
+  font-size: 5.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
+.display-3 {
+  font-size: 4.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
+.display-4 {
+  font-size: 3.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
+hr {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  border: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+small,
+.small {
+  font-size: 80%;
+  font-weight: 400;
+}
+
+mark,
+.mark {
+  padding: 0.2em;
+  background-color: #fcf8e3;
+}
+
+.list-unstyled {
+  padding-left: 0;
+  list-style: none;
+}
+
+.list-inline {
+  padding-left: 0;
+  list-style: none;
+}
+
+.list-inline-item {
+  display: inline-block;
+}
+.list-inline-item:not(:last-child) {
+  margin-right: 0.5rem;
+}
+
+.initialism {
+  font-size: 90%;
+  text-transform: uppercase;
+}
+
+.blockquote {
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+
+.blockquote-footer {
+  display: block;
+  font-size: 80%;
+  color: #6c757d;
+}
+.blockquote-footer::before {
+  content: "\2014 \00A0";
+}
+
+.img-fluid {
+  max-width: 100%;
+  height: auto;
+}
+
+.img-thumbnail {
+  padding: 0.25rem;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  max-width: 100%;
+  height: auto;
+}
+
+.figure {
+  display: inline-block;
+}
+
+.figure-img {
+  margin-bottom: 0.5rem;
+  line-height: 1;
+}
+
+.figure-caption {
+  font-size: 90%;
+  color: #6c757d;
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+code {
+  font-size: 87.5%;
+  color: #e83e8c;
+  word-break: break-word;
+}
+a > code {
+  color: inherit;
+}
+
+.jp-RenderedHTMLCommon code {
+  font-size: 87.5%;
+}
+
+kbd {
+  padding: 0.2rem 0.4rem;
+  font-size: 87.5%;
+  color: #fff;
+  background-color: #212529;
+  border-radius: 0.2rem;
+}
+kbd kbd {
+  padding: 0;
+  font-size: 100%;
+  font-weight: 700;
+}
+
+pre {
+  display: block;
+  /* font-size: 87.5%; */
+  color: #212529;
+}
+pre code {
+  font-size: inherit;
+  color: inherit;
+  word-break: normal;
+}
+
+.pre-scrollable {
+  max-height: 340px;
+  overflow-y: scroll;
+}
+
+.container {
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
+}
+@media (min-width: 576px) {
+  .container {
+    max-width: 540px;
+  }
+}
+@media (min-width: 768px) {
+  .container {
+    max-width: 720px;
+  }
+}
+@media (min-width: 992px) {
+  .container {
+    max-width: 960px;
+  }
+}
+@media (min-width: 1200px) {
+  .container {
+    max-width: 1140px;
+  }
+}
+
+
+/* Custom  */
+
+/* LEFT NAVIGATION */
+.wy-body-for-nav {
+  background: none;
+  background-image: none;
+}
+
+.wy-nav-side {
+  background-color: #F5F5F5;
+  color: #262626;
+  overflow-y: unset;
+}
+
+.wy-nav-side .icon.icon-home {
+  display: none;
+}
+
+.wy-side-nav-search {
+  background-color: #F5F5F5;
+}
+
+.wy-menu-vertical a {
+  display: inline-block;
+  line-height: 24px;
+  padding: .35em 1.618em;
+  display: block;
+  position: relative;
+  font-size: 13px;
+  font-weight: normal;
+  color: #5f5f5f;
+}
+
+.wy-side-nav-search {
+  padding: 1.618em 1.618em .4045em;
+}
+
+.wy-side-nav-search input[type=text] {
+  border-radius: 0;
+  margin: 0 0 10px;
+}
+
+.wy-side-nav-search input[type=text] {
+  outline: 0;
+  border-radius: 0;
+  padding: 0.6rem 0.75rem;
+  border-color: #ffffff;
+  border: 0;
+  color: #262626;
+  box-shadow: none;
+  border-style: solid;
+  font-size: 13px;
+  width: 100%;
+  background-color: #f3f4f7;
+  background-image: url(../images/search.svg);
+  background-repeat: no-repeat;
+  background-size: 18px 18px;
+  background-position: 12px 10px;
+  padding-left: 40px;
+  background-color: #ffffff;
+}
+
+.wy-menu-vertical a {
+  transition: all 225ms ease;
+  -webkit-transition: all 225ms ease;
+  border-left: 4px solid transparent;
+}
+
+.wy-menu-vertical a:hover {
+  background-color: transparent;
+  color: var(--toyota-red);
+  cursor: pointer;
+}
+
+.wy-menu-vertical li.current {
+  background: transparent;
+}
+
+.wy-menu-vertical li.on a, .wy-menu-vertical li.current>a {
+  color: #404040;
+  padding: .4045em 1.618em;
+  font-weight: bold;
+  position: relative;
+  background: transparent;
+  border: none;
+  border-left: 4px solid var(--toyota-red);
+  border-bottom: none !important;
+  border-top: none !important;
+}
+
+.wy-menu-vertical li.toctree-l2.current>a {
+  background-color: #dddddd;
+}
+
+.wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current>a span.toctree-expand, .wy-menu-vertical li span.toctree-expand {
+  display: block;
+  font-size: 1em;
+  line-height: 2em;
+  color: #333;
+}
+
+.wy-menu-vertical li.current a {
+  color: #575656;
+  border-right: none;
+}
+
+/* MAIN CONTENT */
+
+.wy-breadcrumbs li {
+  font-size: 12px;
+  display: inline-block;
+}
+
+.wy-nav-content-wrap {
+  height: 100%;
+}
+
+.wy-nav-content {
+  max-width: 100%;
+}
+
+.rst-content {
+  max-width: 850px;
+}
+
+.wy-plain-list-disc li, .rst-content .section ul li, .rst-content .toctree-wrapper ul li, article ul li {
+  margin-bottom: 10px;
+}
+
+.rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) > dt {
+  display: inline-block;
+  margin: 6px 0;
+  font-size: 90%;
+  line-height: normal;
+  background: #ffebec;
+  color: #cc0e1e;
+  border-top: solid 3px var(--toyota-red);
+  padding: 6px;
+  position: relative;
+}
+
+.wy-alert.wy-alert-info, .rst-content .note, .rst-content .wy-alert-info.attention, .rst-content .wy-alert-info.caution, .rst-content .wy-alert-info.danger, .rst-content .wy-alert-info.error, .rst-content .wy-alert-info.hint, .rst-content .wy-alert-info.important, .rst-content .wy-alert-info.tip, .rst-content .wy-alert-info.warning, .rst-content .seealso, .rst-content .wy-alert-info.admonition-todo {
+  background: #f2f2f2;
+}
+
+.wy-alert.wy-alert-info .wy-alert-title, .rst-content .note .wy-alert-title, .rst-content .wy-alert-info.attention .wy-alert-title, .rst-content .wy-alert-info.caution .wy-alert-title, .rst-content .wy-alert-info.danger .wy-alert-title, .rst-content .wy-alert-info.error .wy-alert-title, .rst-content .wy-alert-info.hint .wy-alert-title, .rst-content .wy-alert-info.important .wy-alert-title, .rst-content .wy-alert-info.tip .wy-alert-title, .rst-content .wy-alert-info.warning .wy-alert-title, .rst-content .seealso .wy-alert-title, .rst-content .wy-alert-info.admonition-todo .wy-alert-title, .wy-alert.wy-alert-info .rst-content .admonition-title, .rst-content .wy-alert.wy-alert-info .admonition-title, .rst-content .note .admonition-title, .rst-content .wy-alert-info.attention .admonition-title, .rst-content .wy-alert-info.caution .admonition-title, .rst-content .wy-alert-info.danger .admonition-title, .rst-content .wy-alert-info.error .admonition-title, .rst-content .wy-alert-info.hint .admonition-title, .rst-content .wy-alert-info.important .admonition-title, .rst-content .wy-alert-info.tip .admonition-title, .rst-content .wy-alert-info.warning .admonition-title, .rst-content .seealso .admonition-title, .rst-content .wy-alert-info.admonition-todo .admonition-title {
+  background: var(--toyota-red);
+}
+
+.wy-alert.wy-alert-warning .wy-alert-title, .rst-content .wy-alert-warning.note .wy-alert-title, .rst-content .attention .wy-alert-title, .rst-content .caution .wy-alert-title, .rst-content .wy-alert-warning.danger .wy-alert-title, .rst-content .wy-alert-warning.error .wy-alert-title, .rst-content .wy-alert-warning.hint .wy-alert-title, .rst-content .wy-alert-warning.important .wy-alert-title, .rst-content .wy-alert-warning.tip .wy-alert-title, .rst-content .warning .wy-alert-title, .rst-content .wy-alert-warning.seealso .wy-alert-title, .rst-content .admonition-todo .wy-alert-title, .wy-alert.wy-alert-warning .rst-content .admonition-title, .rst-content .wy-alert.wy-alert-warning .admonition-title, .rst-content .wy-alert-warning.note .admonition-title, .rst-content .attention .admonition-title, .rst-content .caution .admonition-title, .rst-content .wy-alert-warning.danger .admonition-title, .rst-content .wy-alert-warning.error .admonition-title, .rst-content .wy-alert-warning.hint .admonition-title, .rst-content .wy-alert-warning.important .admonition-title, .rst-content .wy-alert-warning.tip .admonition-title, .rst-content .warning .admonition-title, .rst-content .wy-alert-warning.seealso .admonition-title, .rst-content .admonition-todo .admonition-title {
+  background: #3f3f3f;
+}
+
+.btn {
+  display: inline-block;
+  border-radius: 30px;
+  line-height: normal;
+  white-space: nowrap;
+  text-align: center;
+  cursor: pointer;
+  font-size: 100%;
+  padding: 15px 30px;
+  color: white;
+  border: none;
+  background-color: var(--toyota-red);
+  text-decoration: none;
+  font-weight: normal;
+  font-family: "Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;
+  box-shadow: none;
+  outline-none: false;
+  vertical-align: middle;
+  *display: inline;
+  zoom: 1;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.1s linear;
+  -moz-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.btn-neutral {
+  background-color: #e7e7e7 !important;
+}
+
+.btn-neutral:hover {
+  background-color: var(--toyota-red) !important;
+  color: white !important;
+  text-decoration: none;
+}
+
+.wy-grid-for-nav {
+  position: relative;
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  width: 100%;
+  height: 100%;
+  min-height: 100vh;
+}
+
+.wy-nav-side {
+  position: relative;
+  float: none;
+  padding-bottom: 2em;
+  width: auto;
+  overflow-x: unset;
+  z-index: 200;
+}
+
+.wy-nav-content-wrap {
+  margin-left: 0;
+}
+
+.wy-side-scroll {
+  width: 100%;
+  position: sticky;
+  position: -webkit-sticky;
+  top:0;
+  overflow-x: unset;
+  overflow-y: unset;
+  height: unset;
+}
+
+@media screen and (max-width: 768px) {
+  .wy-grid-for-nav {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr;
+    width: 100%;
+    height: 100%;
+    min-height: 100vh;
+    padding-top: 61px;
+  }
+
+  .wy-nav-content-wrap.shift {
+    position: unset;
+    min-width: 100%;
+    left: 0;
+    top: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .wy-nav-side {
+    position: relative;
+    float: none;
+    display: none;
+    padding-bottom: 2em;
+    left: 0;
+    width: 100vw;
+    overflow-x: unset;
+    overflow-y: hidden;
+    min-height: auto;
+    /* height: 0; */
+    z-index: 200;
+    /* padding-top: 0px; */
+    transition: all 2s ease;
+    -webkit-transition: all 2s ease;
+  }
+
+  .wy-nav-side.shift {
+    width: 100%;
+    left: 0;
+    display: block;
+    height: auto;
+  }
+
+  .wy-nav-top {
+    position: absolute;
+    top: 0;
+    z-index: 99999;
+    width: 100vw;
+    background: #e0e1e5;
+  }
+
+  .wy-nav-top a {
+    display: none;
+  }
+
+  .wy-nav-top i {
+    color: white;
+    font-size: 20px;
+    padding: 14px 8px;
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .wy-nav-top i:before {
+    content: "Table of Contents";
+    font-size: 14px;
+    font-weight: normal;
+    font-family: "Toyota Type", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    color: #3c3b3b;
+    position: relative;
+  }
+
+  .wy-nav-top i:after {
+    content: "";
+    color: #3c3b3b;
+    font-family: "FontAwesome";
+    display: inline-block;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1;
+    text-decoration: inherit;
+  }
+}
+
+
+/* ////////
+
+HEADER 
+
+////// */
+
+/* Header */
+
+.site-header {
+  position: relative;
+  background: #111111;
+  width: 100vw;
+  z-index: 9999999;
+}
+
+.site-header.open {
+  position: fixed;
+}
+
+.site-header-inner {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  grid-gap: 3.236em;
+  flex-wrap: wrap;
+  padding: 40px 0;
+  margin: 0;
+}
+
+.drake-logo {
+  margin: 0 0 5px;
+  padding: 0 2.4em;
+}
+
+@media screen and (max-width:980px) {
+  .drake-logo {
+    padding: 0;
+  }
+}
+
+.drake-logo img {
+  width: 200px;
+}
+
+.site-menu ul {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-menu li {
+  position: relative;
+  font-size: 14px;
+  margin: 0 15px;
+  color: white;
+
+  cursor: pointer;
+
+  transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+  -webkit-transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+}
+
+.site-menu li:first-child {
+  margin-left: 0;
+}
+
+.site-menu li a {
+  position: relative;
+  color: white;
+
+  text-decoration: none;
+  transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+  -webkit-transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+}
+
+.site-menu li:not([class^="github-link"]) a:after {
+  content: "";
+  position: absolute;
+  top: calc(100% + 3px);
+  left: 0;
+  width: 100%;
+  background: white;
+  height: 1px;
+  
+  transform-origin: left;
+  transform: scaleX(0);
+  -webkit-transform: scaleX(0);
+  
+  transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+  -webkit-transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+}
+
+.site-menu li:not([class^="github-link"]) a:hover:after {
+  transform: scaleX(1);
+  -webkit-transform: scaleX(1);
+}
+
+.sub {
+  position: absolute;
+  width: auto;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  text-align: left;
+
+  margin-top: 0px;
+  margin-left: -10px;
+  padding: 10px;
+  border-top: 3px solid var(--primary);
+
+  background-color: #1C1818DD;
+
+  transition: all 0.6s cubic-bezier(0.2, 0.3, 0, 1);
+  -webkit-transition: all 0.6s cubic-bezier(0.2, 0.3, 0, 1);
+}
+
+.sub a {
+  display: block;
+  padding: 0 10px 0 0;
+  margin: 0 0 5px;
+
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.site-menu li:hover>div.sub {
+  opacity: 1;
+  visibility: visible;
+
+  transition: all 0.6s cubic-bezier(0.2, 0.3, 0, 1);
+  -webkit-transition: all 0.6s cubic-bezier(0.2, 0.3, 0, 1);
+}
+
+.site-menu .github-link {
+  margin-left: auto;
+  margin-right:2.4em;
+}
+
+.github-link a {
+  display: flex;
+  align-items: center;
+}
+
+.github-link a img {
+  width: 25px;
+  margin-left: 12px;
+}
+
+@media screen and (max-width: 980px) {
+  .site-header-inner {
+    display: flex;
+     justify-content: space-between;
+     flex-wrap: wrap;
+     padding: 40px 45px;
+     width: 100%;
+     max-width: none;
+  }
+  
+  .drake-logo {
+    position: relative;
+    z-index: 2;
+  }
+
+  .drake-logo img {
+    width: 175px;
+    max-width: 40vw;
+  }
+
+  .site-menu {
+    opacity: 0;
+    visibility: hidden;
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    width: calc(100vw - 40px);
+    height: calc(100vh - 40px);
+    overflow-y: scroll;
+    background: #1C1818;
+    overflow-y: scroll;
+    transition: all 0.225s ease;
+    -webkit-transition: all 0.225s ease;
+  }
+
+  .site-header.open .site-menu {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .site-menu ul {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    list-style: none;
+    margin: 0;
+    padding: 80px 25px 25px;
+  }
+
+  .site-menu li {
+    position: relative;
+    font-size: 20px;
+    margin: 0 0 5px;
+    text-align: left;
+    color: white;
+    cursor: pointer;
+    transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+    -webkit-transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+  }
+
+  .site-menu li:first-child {
+    margin-left: 0;
+  }
+
+  .site-menu .github-link {
+    margin-left: 0;
+    margin-top: 20px;
+  }
+
+  .sub {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    width: 100%;
+    white-space: nowrap;
+    opacity: 1;
+    text-align: center;
+    visibility: unset;
+    text-align: left;
+    padding-top: 5px;
+    margin: 0;
+    border: 0;
+    transition: all 0.6s cubic-bezier(0.2, 0.3, 0, 1);
+    -webkit-transition: all 0.6s cubic-bezier(0.2, 0.3, 0, 1);
+  }
+
+  .site-menu li a {
+    text-align: left;
+    color: white;
+    text-decoration: none;
+  }
+
+  .sub a {
+    display: inline-block;
+    margin: 0 0 2px;
+    padding: 0;
+    font-size: 16px;
+    line-height: 1.5;
+    font-weight: 500;
+    border-bottom: 1px solid var(--primary);
+  }
+}
+
+/* Mobile Menu Icon */
+
+.menu-mobile-toggle {
+  display: none;
+}
+
+.menu-mobile-toggle {
+  width: 30px;
+  height: 30px;
+  position: relative;
+  z-index: 9;
+
+  cursor: pointer;
+}
+
+.menu-mobile-toggle span {
+  display: block;
+  width: 100%;
+  height: 2px;
+  position: absolute;
+  top: 50%;
+  background-color: white;
+  transform: translate(0, -50%);
+  transition: opacity 0.3s 0.3s, background-color 0.225s;
+}
+
+.menu-mobile-toggle:before,
+.menu-mobile-toggle:after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 2px;
+  position: absolute;
+  background-color: white;
+  transition: transform 0.3s, top 0.3s 0.3s, bottom 0.3s 0.3s, background-color 0.225s;
+}
+
+.menu-mobile-toggle:hover span,
+.menu-mobile-toggle:hover:before,
+.menu-mobile-toggle:hover:after {
+  background-color: var(--primary);
+}
+
+.menu-mobile-toggle:before {
+  top: 6px;
+}
+
+.menu-mobile-toggle:after {
+  bottom: 6px;
+}
+
+.open .menu-mobile-toggle span {
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.open .menu-mobile-toggle::before,
+.open .menu-mobile-toggle::after {
+  background-color: var(--primary);
+  transition: top 0.3s, bottom 0.3s, transform 0.3s 0.3s;
+}
+
+.open .menu-mobile-toggle::before {
+  top: calc(50% - 1px);
+  transform: rotate(45deg);
+}
+
+.open .menu-mobile-toggle::after {
+  bottom: calc(50% - 1px);
+  transform: rotate(-45deg);
+}
+
+@media screen and (max-width: 980px) {
+  .menu-mobile-toggle {
+    display: block;
+  }
+}
+
+/* Footer */
+
+footer.site-footer {
+  padding: 50px 2.4em 75px 0;
+}
+
+footer.site-footer>div.contain {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.footer-menu ul {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.footer-menu li {
+  position: relative;
+  margin: 0 15px;
+  color: black;
+
+  cursor: pointer;
+
+  transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+  -webkit-transition: all 0.225s cubic-bezier(0.2, 0.3, 0, 1);
+}
+
+.footer-menu li:last-child {
+  margin: 0 0 0 15px;
+}
+
+.footer-menu li a {
+  color: black;
+
+  text-decoration: none;
+}
+
+.copyright {
+  padding: 25px 0 0;
+  text-align: center;
+  width: 100%;
+}
+
+.copyright span {
+  font-size: 14px;
+  color: #676767;
+}
+
+
+@media screen and (max-width: 980px) {
+  footer.site-footer>div.contain {
+    display: block;
+  }
+
+  .footer-menu ul {
+    display: block;
+    margin: 35px 0;
+  }
+
+  .footer-menu li {
+    position: relative;
+    margin: 0px;
+  }
+
+  .copyright {
+    padding: 50px 0 0;
+    text-align: left;
+  }
+}
+
+.is-hidden {
+  display: none;
+}

--- a/setup/ubuntu/packages-noble-developer.txt
+++ b/setup/ubuntu/packages-noble-developer.txt
@@ -8,6 +8,7 @@ fonts-dejavu-extra
 gnupg
 graphviz
 jekyll
+jupyter-nbconvert
 libclang-20-dev
 libclang-rt-20-dev
 libomp-20-dev

--- a/setup/ubuntu/packages-resolute-developer.txt
+++ b/setup/ubuntu/packages-resolute-developer.txt
@@ -6,6 +6,7 @@ fonts-dejavu-core
 fonts-dejavu-extra
 graphviz
 jekyll
+jupyter-nbconvert
 libclang-20-dev
 libclang-rt-21-dev
 libomp-21-dev

--- a/tutorials/BUILD.bazel
+++ b/tutorials/BUILD.bazel
@@ -230,10 +230,16 @@ _NOTEBOOKS = glob(
     allow_empty = False,
 )
 
+filegroup(
+    name = "notebooks",
+    srcs = _NOTEBOOKS,
+    visibility = ["//doc/tutorials:__pkg__"],
+)
+
 drake_py_test(
     name = "notebook_lint_test",
     args = _NOTEBOOKS,
-    data = _NOTEBOOKS,
+    data = [":notebooks"],
     tags = ["lint"],
     deps = [
         "@rules_python//python/runfiles",
@@ -243,7 +249,7 @@ drake_py_test(
 install_files(
     name = "install_notebooks",
     dest = "share/drake/tutorials",
-    files = _NOTEBOOKS,
+    files = [":notebooks"],
 )
 
 install(

--- a/tutorials/authoring_multibody_simulation.ipynb
+++ b/tutorials/authoring_multibody_simulation.ipynb
@@ -104,7 +104,7 @@
     "# When this notebook is run in test mode it needs to stop execution without\n",
     "# user interaction. For interactive model visualization you won't normally\n",
     "# need the 'loop_once' flag.\n",
-    "test_mode = True if \"TEST_SRCDIR\" in os.environ else False\n",
+    "test_mode = \"TEST_SRCDIR\" in os.environ or \"DRAKE_IS_BUILDING_DOCUMENTATION\" in os.environ\n",
     "\n",
     "# Start the interactive visualizer.\n",
     "# Click the \"Stop Running\" button in MeshCat when you're finished.\n",
@@ -475,7 +475,7 @@
    "source": [
     "## Get a quick preview of hydroelastic contact\n",
     "\n",
-    "With a small change to configuration, we can run the same simulation with hydroelastic contact for all bodies, without editing the model files. This method applies reasonable defaults everywhere, but it may not be optimal for a given scene. To get finer control, editing model files will then be necessary. See the [basic hydroelastic contact](http://localhost:8888/notebooks/hydroelastic_contact_basics.ipynb) tutorial for more information."
+    "With a small change to configuration, we can run the same simulation with hydroelastic contact for all bodies, without editing the model files. This method applies reasonable defaults everywhere, but it may not be optimal for a given scene. To get finer control, editing model files will then be necessary. See the [basic hydroelastic contact](./hydroelastic_contact_basics.ipynb) tutorial for more information."
    ]
   },
   {


### PR DESCRIPTION
Keeping Deepnote working is a **lot** of trouble every month.  It might be easier to publish our tutorials directly on our website (non-interactive), and then tell people to `pip install drake` if they want to run them interactively.  As a first step in that experiment, this turns on publishing to our website, but doesn't advertise the new home.  This will allow us to assess CI stability, and how well they work/look online on the real site, before making any switch-over.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24548)
<!-- Reviewable:end -->
