### PR TITLE
[workspace] Fix coinutils warning

### DIFF
--- a/tools/workspace/coinutils_internal/defs.bzl
+++ b/tools/workspace/coinutils_internal/defs.bzl
@@ -122,8 +122,6 @@ def coin_cc_library(
         linkstatic = True,
         copts = [
             "-w",
-            # On Clang 12, "-w" doesn't suppress this for some reason.
-            "-Wno-register",
             # The Coin family of software uses NDEBUG for gross things, not
             # just controlling <cassert> but actually inserting huge swaths
             # of debugging code, some of which is not thread-safe. Even in


### PR DESCRIPTION
Fix "command-line option '-Wno-register' is valid for C++/ObjC++ but not for C" by removing the flag. As of our current Clang 20, it seems this flag is no longer necessary; perhaps '-w' works correctly now.

(If we ever need to add this back, it should go in `cxxopts` not `copts`.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24556)
<!-- Reviewable:end -->
