### PR TITLE
[setup,tools] Avoid Python package upgrades newer than one week

### DIFF
--- a/setup/python/mypy/BUILD.bazel
+++ b/setup/python/mypy/BUILD.bazel
@@ -10,6 +10,7 @@ lock(
     args = [
         "--upgrade",
         "--universal",
+        "--exclude-newer=1 week",
         # This is our minimum supported version.
         # When changing this, see drake/tools/workspace/python/README.md.
         "--python-version=3.12",

--- a/tools/workspace/python/venv_upgrade
+++ b/tools/workspace/python/venv_upgrade
@@ -55,7 +55,7 @@ check_working_tree() {
 
 update_requirements() {
     # Use PDM to generate a lock file for itself.
-    "${venv_pdm}/bin/pdm" lock -p "${project_pdm}"
+    "${venv_pdm}/bin/pdm" lock -p "${project_pdm}" --exclude-newer=1w
     sed $'/will be generated/{s/will be/is/\nq\n}' < "$1.in" > "$1"
     "${venv_pdm}/bin/pdm" export -p "${project_pdm}" | grep -vE '^#' >> "$1"
 }
@@ -108,7 +108,8 @@ readonly lockfile="./setup/python/pdm.lock"
 if [ -n "${purge}" ]; then
     rm "$lockfile"
 fi
-lock_args+=( -d -p "${project_drake}" -L "${lockfile}" --append )
+lock_args+=( -d -p "${project_drake}" -L "${lockfile}" )
+lock_args+=( --append --exclude-newer=1w )
 for py in "${python_versions[@]}"; do
     "${venv_pdm}/bin/pdm" lock "${lock_args[@]}" --python ${py}
 done


### PR DESCRIPTION
Try to prevent against incidentally upgrading dependencies to point at malware when upstream packages are compromised.

With the current splitting of responsibilities between uv and pdm, and between pyproject.toml, pdm.lock, and requirements.txt, we have to sprinkle this flag in quite a few places; hopefully in the future this can be consolidated.

Towards #24555.

------

### Testing

This branch is after running `venv_upgrade`, but no dependencies change. If you run this without the changes, it makes various upgrades in `pdm.lock` and `requirements.txt` for releases within the last week: for example, [dep-logic==0.6.0](https://pypi.org/project/dep-logic/), or [click==8.4.0](https://pypi.org/project/click/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24558)
<!-- Reviewable:end -->
