### PR TITLE
[systems] Add PeriodicEventData spaceship operator

### DIFF
--- a/bindings/generated_docstrings/systems_framework.h
+++ b/bindings/generated_docstrings/systems_framework.h
@@ -7582,6 +7582,11 @@ period_sec, where i is a non-negative integer.)""";
           const char* doc =
 R"""(Gets the time after zero when this event should first occur.)""";
         } offset_sec;
+        // Symbol: drake::systems::PeriodicEventData::operator<=>
+        struct /* operator_le_ */ {
+          // Source: drake/systems/framework/event.h
+          const char* doc = R"""()""";
+        } operator_le_;
         // Symbol: drake::systems::PeriodicEventData::period_sec
         struct /* period_sec */ {
           // Source: drake/systems/framework/event.h
@@ -7604,9 +7609,12 @@ R"""(Sets the period with which this event should recur.)""";
       // Symbol: drake::systems::PeriodicEventDataComparator
       struct /* PeriodicEventDataComparator */ {
         // Source: drake/systems/framework/event.h
-        const char* doc =
-R"""(Structure for comparing two PeriodicEventData objects for use in a map
-container, using an arbitrary comparison method.)""";
+        const char* doc_deprecated =
+R"""((Deprecated.)
+
+Deprecated:
+    Use the built-in spaceship operator instead. This will be removed
+    from Drake on or after 2026-09-01.)""";
         // Symbol: drake::systems::PeriodicEventDataComparator::operator()
         struct /* operator_call */ {
           // Source: drake/systems/framework/event.h

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1463,12 +1463,9 @@ Diagram<T>::ConvertScalarType() const {
 }
 
 template <typename T>
-std::map<PeriodicEventData, std::vector<const Event<T>*>,
-         PeriodicEventDataComparator>
+std::map<PeriodicEventData, std::vector<const Event<T>*>>
 Diagram<T>::DoMapPeriodicEventsByTiming(const Context<T>& context) const {
-  std::map<PeriodicEventData, std::vector<const Event<T>*>,
-           PeriodicEventDataComparator>
-      periodic_events_map;
+  std::map<PeriodicEventData, std::vector<const Event<T>*>> periodic_events_map;
 
   for (int i = 0; i < num_subsystems(); ++i) {
     const System<T>& sub_system = *registered_systems_[i];

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -496,8 +496,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   std::unique_ptr<typename Diagram<NewType>::Blueprint> ConvertScalarType()
       const;
 
-  std::map<PeriodicEventData, std::vector<const Event<T>*>,
-           PeriodicEventDataComparator>
+  std::map<PeriodicEventData, std::vector<const Event<T>*>>
   DoMapPeriodicEventsByTiming(const Context<T>& context) const final;
 
   void DoFindUniquePeriodicDiscreteUpdatesOrThrow(

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -7,6 +7,7 @@
 #include <variant>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/continuous_state.h"
@@ -255,10 +256,7 @@ class PeriodicEventData {
   /// Sets the time after zero when this event should first occur.
   void set_offset_sec(double offset_sec) { offset_sec_ = offset_sec; }
 
-  bool operator==(const PeriodicEventData& other) const {
-    return other.period_sec() == period_sec() &&
-           other.offset_sec() == offset_sec();
-  }
+  auto operator<=>(const PeriodicEventData& other) const = default;
 
  private:
   double period_sec_{0.0};
@@ -551,11 +549,9 @@ class Event {
       event_data_;
 };
 
-/**
- * Structure for comparing two PeriodicEventData objects for use in a map
- * container, using an arbitrary comparison method.
- */
-struct PeriodicEventDataComparator {
+struct DRAKE_DEPRECATED("2026-09-01",
+                        "Use the built-in spaceship operator instead.")
+    PeriodicEventDataComparator {
   bool operator()(const PeriodicEventData& a,
                   const PeriodicEventData& b) const {
     if (a.period_sec() == b.period_sec())

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -781,12 +781,9 @@ std::unique_ptr<AbstractValue> LeafSystem<T>::DoAllocateInput(
 }
 
 template <typename T>
-std::map<PeriodicEventData, std::vector<const Event<T>*>,
-         PeriodicEventDataComparator>
+std::map<PeriodicEventData, std::vector<const Event<T>*>>
 LeafSystem<T>::DoMapPeriodicEventsByTiming(const Context<T>&) const {
-  std::map<PeriodicEventData, std::vector<const Event<T>*>,
-           PeriodicEventDataComparator>
-      periodic_events_map;
+  std::map<PeriodicEventData, std::vector<const Event<T>*>> periodic_events_map;
 
   // Build a mapping from (offset,period) to the periodic events sharing
   // that trigger. There are three lists of different types in a

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1781,8 +1781,7 @@ class LeafSystem : public System<T> {
   std::unique_ptr<CompositeEventCollection<T>>
   DoAllocateCompositeEventCollection() const final;
 
-  std::map<PeriodicEventData, std::vector<const Event<T>*>,
-           PeriodicEventDataComparator>
+  std::map<PeriodicEventData, std::vector<const Event<T>*>>
   DoMapPeriodicEventsByTiming(const Context<T>& context) const final;
 
   void DoFindUniquePeriodicDiscreteUpdatesOrThrow(

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -602,8 +602,7 @@ bool System<T>::IsDifferentialEquationSystem() const {
 }
 
 template <typename T>
-std::map<PeriodicEventData, std::vector<const Event<T>*>,
-         PeriodicEventDataComparator>
+std::map<PeriodicEventData, std::vector<const Event<T>*>>
 System<T>::MapPeriodicEventsByTiming(const Context<T>* context) const {
   std::unique_ptr<Context<T>> dummy_context;
   const Context<T>* context_to_use = context;

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -921,8 +921,7 @@ class System : public SystemBase {
 
   @param context Optional Context to pass on to Event selection functions;
       not commonly needed. */
-  std::map<PeriodicEventData, std::vector<const Event<T>*>,
-           PeriodicEventDataComparator>
+  std::map<PeriodicEventData, std::vector<const Event<T>*>>
   MapPeriodicEventsByTiming(const Context<T>* context = nullptr) const;
 
   /** Utility method that computes for _every_ output port i the value y(i) that
@@ -1734,8 +1733,7 @@ class System : public SystemBase {
   by timing.
   @see MapPeriodicEventsByTiming() for a detailed description of the returned
        variable. */
-  virtual std::map<PeriodicEventData, std::vector<const Event<T>*>,
-                   PeriodicEventDataComparator>
+  virtual std::map<PeriodicEventData, std::vector<const Event<T>*>>
   DoMapPeriodicEventsByTiming(const Context<T>& context) const = 0;
 
   // TODO(sherm1) Move these three functions adjacent to the event

--- a/systems/framework/test/event_test.cc
+++ b/systems/framework/test/event_test.cc
@@ -6,6 +6,26 @@ namespace drake {
 namespace systems {
 namespace {
 
+GTEST_TEST(EventsTest, PeriodicEventDataSpaceship) {
+  // Create two periodic event data objects.
+  PeriodicEventData foo, bar;
+  foo.set_period_sec(0);
+  foo.set_offset_sec(0);
+  bar.set_period_sec(0);
+  bar.set_offset_sec(1);
+
+  EXPECT_FALSE(foo == bar);
+  EXPECT_TRUE(foo < bar);
+  EXPECT_FALSE(bar < foo);
+
+  bar = foo;
+  EXPECT_TRUE(foo == bar);
+  EXPECT_FALSE(foo < bar);
+  EXPECT_FALSE(bar < foo);
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // PeriodicEventData has an operator==() member function, and a Comparator
 // struct whose operator() defines a "less than" ordering.
 GTEST_TEST(EventsTest, PeriodicAttributeComparatorTest) {
@@ -38,6 +58,7 @@ GTEST_TEST(EventsTest, PeriodicAttributeComparatorTest) {
   EXPECT_FALSE(comparator(d2, d1));
   EXPECT_TRUE(d1 == d2);
 }
+#pragma GCC diagnostic push
 
 // Check trigger data accessors:
 //   set/get_trigger_type()

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -154,8 +154,7 @@ class TestSystemBase : public System<T> {
     ADD_FAILURE() << "A test called a method that was expected to be unused.";
   }
 
-  std::map<PeriodicEventData, std::vector<const Event<T>*>,
-           PeriodicEventDataComparator>
+  std::map<PeriodicEventData, std::vector<const Event<T>*>>
   DoMapPeriodicEventsByTiming(const Context<T>&) const final {
     ADD_FAILURE() << "A test called a method that was expected to be unused.";
     return {};


### PR DESCRIPTION
The shorter return type helps mitigate the ginormous return type column of the Doxygen method summary table e.g. at https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_adder.html.

The change isn't breaking if the user was using `auto` when capturing the return type, which seems likely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24559)
<!-- Reviewable:end -->
