### PR TITLE
[doc] Tweak formatting for doc gen instructions

### DIFF
--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -40,13 +40,13 @@ $ bazel run //doc:build -- --serve
 $ bazel run //doc:pages             -- --serve  # Only the main site.
 $ bazel run //doc/doxygen_cxx:build -- --serve  # Only the C++ API reference.
 $ bazel run //bindings/generated_docstrings:regenerate && \
-#   bazel run //doc/pydrake:build   -- --serve  # Only the Python API reference.
+   bazel run //doc/pydrake:build    -- --serve  # Only the Python API reference.
 $ bazel run //doc/styleguide:build  -- --serve  # Only the Style Guide.
 
 # Further speed up preview generating only some API modules, e.g., math:
 $ bazel run //doc/doxygen_cxx:build -- --serve drake.math            # C++ math API.
 $ bazel run //bindings/generated_docstrings:regenerate && \
-$   bazel run //doc/pydrake:build   -- --serve pydrake.math          # Python math API.
+   bazel run //doc/pydrake:build    -- --serve pydrake.math          # Python math API.
 $ bazel run //doc:build             -- --serve {drake,pydrake}.math  # Both at once.
 
 # Further speed up preview by omitting expensive `dot` graphs (C++ API only):


### PR DESCRIPTION
Multiline commands were being commented out or otherwise misaligned.

-----

Current version on `master` / https://drake.mit.edu/documentation_instructions.html:

<img width="2037" height="1466" alt="image" src="https://github.com/user-attachments/assets/22b0ea87-a8b9-42f5-987b-03529a6b1796" />

PR version:

<img width="1830" height="1330" alt="image" src="https://github.com/user-attachments/assets/b13b8fed-ed10-4736-a099-bbcbd37cab0c" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24560)
<!-- Reviewable:end -->
