### PR TITLE
Meshcat supports textures on primitives

### DIFF
--- a/bindings/generated_docstrings/geometry.h
+++ b/bindings/generated_docstrings/geometry.h
@@ -4227,6 +4227,11 @@ R"""(Sets the 3D object at a given ``path`` in the scene tree. Note that
 "/foo/<object>". See meshcat_path. Any objects previously set at this
 `path`` will be replaced.
 
+The ``rgba`` and ``diffuse_map`` values work together. The color
+modulates the textures appearance (by doing a channel-wise
+multiplication). For example, specifying a red color will "tint" the
+texture red.
+
 Parameter ``path``:
     a "/"-delimited string indicating the path in the scene tree. See
     meshcat_path "Meshcat paths" for the semantics.
@@ -4236,6 +4241,17 @@ Parameter ``shape``:
 
 Parameter ``rgba``:
     an Rgba that specifies the (solid) color of the object.
+
+Parameter ``diffuse_map``:
+    an optional path to an image file to use as a diffuse texture map.
+    The image must be in a format supported by the browser's three.js
+    renderer (e.g., PNG, JPEG, WebP). It will *not* be applied to
+    Convex shapes (as convex hulls don't have texture coordinates). It
+    is not *currently* applied to Mesh shapes because Mesh shapes
+    reference file formats that can define their own materials. In the
+    future, the map may be applied if the referenced file doesn't
+    actually specify any materials; this will not be considered a
+    "breaking" change.
 
 Note:
     If ``shape`` is a mesh, the file referred to can be either an .obj

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -268,10 +268,12 @@ void DefineMeshcat(py::module_ m) {
             // sleeps; for both reasons, we must release the GIL.
             py::call_guard<py::gil_scoped_release>(), cls_doc.Flush.doc)
         .def("SetObject",
-            py::overload_cast<std::string_view, const Shape&, const Rgba&>(
-                &Class::SetObject),
+            py::overload_cast<std::string_view, const Shape&, const Rgba&,
+                std::string_view>(&Class::SetObject),
             py::arg("path"), py::arg("shape"),
-            py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_shape)
+            py::arg("rgba") = Rgba(.9, .9, .9, 1.),
+            py::arg("diffuse_map") = std::string_view(),
+            cls_doc.SetObject.doc_shape)
         .def("SetObject",
             py::overload_cast<std::string_view, const perception::PointCloud&,
                 double, const Rgba&>(&Class::SetObject),

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -209,6 +209,7 @@ class TestGeometryVisualizers(unittest.TestCase):
             path="/test/box",
             shape=mut.Box(1, 1, 1),
             rgba=mut.Rgba(0.5, 0.5, 0.5),
+            diffuse_map="",
         )
         meshcat.SetTransform(
             path="/test/box",

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -14,6 +14,7 @@
 #include "drake/common/extract_double.h"
 #include "drake/common/overloaded.h"
 #include "drake/common/scope_exit.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/value.h"
 #include "drake/geometry/proximity/polygon_to_triangle_mesh.h"
 #include "drake/geometry/proximity/sorted_triplet.h"
@@ -643,6 +644,17 @@ void DrakeVisualizer<T>::SendLoadNonDeformableMessage(
         return MakeHydroMesh(g_id, inspector, inspector.GetPoseInFrame(g_id),
                              color);
       }
+    }
+    if (params.role == Role::kIllustration &&
+        props->HasProperty("phong", "diffuse_map")) {
+      static logging::Warn log_once(
+          "DrakeVisualizer does not currently support the ('phong', "
+          "'diffuse_map') property (see issue #19077). This warning is only "
+          "shown on the first encounter, which occurred with the geometry "
+          "named '{}' on frame '{}'; further encounters will be silently "
+          "ignored.",
+          inspector.GetName(g_id),
+          inspector.GetName(inspector.GetFrameId(g_id)));
     }
     return ShapeToLcm().Convert(shape, inspector.GetPoseInFrame(g_id), params,
                                 color);

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -1418,17 +1418,6 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
   InternalGeometry& geometry =
       ValidateRoleAssign(source_id, geometry_id, Role::kIllustration, assign);
 
-  // We don't warn until after all the error checking has already happened.
-  if (properties.HasProperty("phong", "diffuse_map")) {
-    static logging::Warn log_once(
-        "Explicitly defined values for the ('phong', 'diffuse_map') property "
-        "are not currently used in illustration roles -- only perception "
-        "roles. This warning is only shown during SceneGraph's first encounter "
-        "with an ignored 'diffuse_map', which occurred with the geometry named "
-        "'{}' on a geometry frame named '{}'; "
-        "further encounters will be silently ignored.",
-        GetName(geometry_id), GetName(GetFrameId(geometry_id)));
-  }
   // TODO(SeanCurtis-TRI): We want to remove this warning. For that to happen,
   // we need systems dependent on illustration properties to recognize if there
   // has been a change since last they processed the state. The simplest way to

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -265,6 +265,59 @@ int ToMeshcatColor(const Rgba& rgba) {
          static_cast<int>(255 * rgba.b());
 }
 
+// Creates the common material data for all cases. Assigns it into object and
+// returns a raw pointer to the material for further, local modification. The
+// material is actually owned by `object` upon return.
+internal::MaterialData* CreateCommonMaterialData(
+    const Rgba& rgba, std::string_view diffuse_map,
+    internal::UuidGenerator* uuid_generator, internal::LumpedObjectData* object,
+    FileStorage* file_storage = nullptr,
+    std::vector<std::shared_ptr<const MemoryFile>>* assets = nullptr) {
+  DRAKE_DEMAND(uuid_generator != nullptr);
+  DRAKE_DEMAND(object != nullptr);
+  DRAKE_DEMAND(diffuse_map.empty() || file_storage != nullptr);
+  DRAKE_DEMAND(diffuse_map.empty() || assets != nullptr);
+
+  auto material = std::make_unique<internal::MaterialData>();
+  material->uuid = uuid_generator->GenerateRandom();
+  material->type = "MeshPhongMaterial";
+  material->color = ToMeshcatColor(rgba);
+  // From meshcat-python: Three.js allows a material to have an opacity which is
+  // != 1, but to still be *non-transparent*, in which case the opacity only
+  // serves to desaturate the material's color. That's a pretty odd combination
+  // of things to want, so by default we just use the opacity value to decide
+  // whether to set transparent to True or False.
+  material->transparent = (rgba.a() != 1.0);
+  material->opacity = rgba.a();
+
+  if (!diffuse_map.empty()) {
+    std::optional<std::string> content = ReadFile(fs::path(diffuse_map));
+    if (content.has_value()) {
+      auto asset =
+          file_storage->Insert(std::move(*content), std::string(diffuse_map));
+      auto image = std::make_unique<internal::ImageData>();
+      image->uuid = uuid_generator->GenerateRandom();
+      image->url = FileStorage::GetCasUrl(*asset);
+      auto texture = std::make_unique<internal::TextureData>();
+      texture->uuid = uuid_generator->GenerateRandom();
+      texture->image = image->uuid;
+      texture->wrap = {internal::TextureData::RepeatWrapping,
+                       internal::TextureData::RepeatWrapping};
+      material->map = texture->uuid;
+      object->image = std::move(image);
+      object->texture = std::move(texture);
+      assets->push_back(std::move(asset));
+    } else {
+      drake::log()->warn(
+          "Meshcat: Failed to load diffuse_map texture \"{}\"; the "
+          "texture will be ignored.",
+          diffuse_map);
+    }
+  }
+  object->material = std::move(material);
+  return object->material.get();
+}
+
 // Sets the lumped object's geometry, material, and object type based on the
 // mesh data and its material properties.
 void SetLumpedObjectFromTriangleMesh(
@@ -282,18 +335,14 @@ void SetLumpedObjectFromTriangleMesh(
   geometry->faces = faces.cast<uint32_t>();
   object->geometry = std::move(geometry);
 
-  auto material = std::make_unique<internal::MaterialData>();
-  material->uuid = uuid_generator->GenerateRandom();
-  material->type = "MeshPhongMaterial";
-  material->color = ToMeshcatColor(rgba);
-  material->transparent = (rgba.a() != 1.0);
-  material->opacity = rgba.a();
+  // We don't currently assign any textures to meshes.
+  internal::MaterialData* material = CreateCommonMaterialData(
+      rgba, /* diffuse_map= */ "", uuid_generator, object);
   material->wireframe = wireframe;
   material->wireframeLineWidth = wireframe_line_width;
   material->vertexColors = false;
   material->side = side;
   material->flatShading = true;
-  object->material = std::move(material);
 
   internal::MeshData mesh;
   mesh.uuid = uuid_generator->GenerateRandom();
@@ -308,10 +357,12 @@ class MeshcatShapeReifier : public ShapeReifier {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MeshcatShapeReifier);
 
   MeshcatShapeReifier(internal::UuidGenerator* uuid_generator,
-                      FileStorage* file_storage, Rgba rgba)
+                      FileStorage* file_storage, Rgba rgba,
+                      std::string_view diffuse_map)
       : uuid_generator_(*uuid_generator),
         file_storage_(*file_storage),
-        rgba_(rgba) {
+        rgba_(rgba),
+        diffuse_map_(diffuse_map) {
     DRAKE_DEMAND(uuid_generator != nullptr);
     DRAKE_DEMAND(file_storage != nullptr);
   }
@@ -333,6 +384,14 @@ class MeshcatShapeReifier : public ShapeReifier {
     DRAKE_DEMAND(data != nullptr);
     auto& output = *static_cast<Output*>(data);
     auto& lumped = output.lumped;
+
+    if (!diffuse_map_.empty()) {
+      static logging::Warn one_time(
+          "Meshcat: diffuse_map is not currently supported for assignment on "
+          "Mesh shapes: '{}'",
+          diffuse_map_);
+      diffuse_map_ = "";
+    }
     // TODO(russt): Use file contents to generate the uuid, and avoid resending
     // meshes unless necessary.  Using the filename is tempting, but that leads
     // to problems when the file contents change on disk.
@@ -602,6 +661,13 @@ class MeshcatShapeReifier : public ShapeReifier {
   void ImplementGeometry(const Convex& mesh, void* data) override {
     DRAKE_DEMAND(data != nullptr);
     auto& output = *static_cast<Output*>(data);
+    if (!diffuse_map_.empty()) {
+      static logging::Warn one_time(
+          "Meshcat: diffuse_map cannot be assigned to Convex; convex hulls "
+          "have no texture coordinates. diffuse_map will be ignored: '{}'.",
+          diffuse_map_);
+      diffuse_map_ = "";
+    }
 
     const PolygonSurfaceMesh<double>& hull = mesh.GetConvexHull();
     const TriangleSurfaceMesh<double> tri_hull =
@@ -706,6 +772,7 @@ class MeshcatShapeReifier : public ShapeReifier {
   internal::UuidGenerator& uuid_generator_;
   FileStorage& file_storage_;
   Rgba rgba_;
+  std::string_view diffuse_map_;
 };
 
 // Meshcat inherits three.js's y-up world and it is applied to camera and
@@ -1003,7 +1070,8 @@ class Meshcat::Impl {
   }
 
   // This function is public via the PIMPL.
-  void SetObject(std::string_view path, const Shape& shape, const Rgba& rgba) {
+  void SetObject(std::string_view path, const Shape& shape, const Rgba& rgba,
+                 std::string_view diffuse_map = "") {
     DRAKE_DEMAND(IsThread(main_thread_id_));
 
     internal::SetObjectData data;
@@ -1014,7 +1082,8 @@ class Meshcat::Impl {
     // them again for efficiency. We don't want to send meshes over the network
     // (which could be from the cloud to a local browser) more than necessary.
 
-    MeshcatShapeReifier reifier(&uuid_generator_, &file_storage_, rgba);
+    MeshcatShapeReifier reifier(&uuid_generator_, &file_storage_, rgba,
+                                diffuse_map);
     std::vector<std::shared_ptr<const MemoryFile>> assets;
     MeshcatShapeReifier::Output reifier_output{.lumped = data.object,
                                                .assets = assets};
@@ -1032,28 +1101,18 @@ class Meshcat::Impl {
 
       // Add a material if not already defined.
       if (data.object.material == nullptr) {
-        auto material = std::make_unique<internal::MaterialData>();
-        material->uuid = uuid_generator_.GenerateRandom();
-        material->type = "MeshPhongMaterial";
-        material->color = ToMeshcatColor(rgba);
+        internal::MaterialData* material =
+            CreateCommonMaterialData(rgba, diffuse_map, &uuid_generator_,
+                                     &data.object, &file_storage_, &assets);
         // TODO(russt): Most values are taken verbatim from meshcat-python.
         material->reflectivity = 0.5;
         material->side = SideOfFaceToRender::kDoubleSide;
-        // From meshcat-python: Three.js allows a material to have an opacity
-        // which is != 1, but to still be non - transparent, in which case the
-        // opacity only serves to desaturate the material's color. That's a
-        // pretty odd combination of things to want, so by default we just use
-        // the opacity value to decide whether to set transparent to True or
-        // False.
-        material->transparent = (rgba.a() != 1.0);
-        material->opacity = rgba.a();
         material->linewidth = 1.0;
         material->wireframe = false;
         material->wireframeLineWidth = 1.0;
 
         meshfile_object.uuid = uuid_generator_.GenerateRandom();
         meshfile_object.material = material->uuid;
-        data.object.material = std::move(material);
       }
     }
 
@@ -2642,8 +2701,8 @@ void Meshcat::Flush() const {
 }
 
 void Meshcat::SetObject(std::string_view path, const Shape& shape,
-                        const Rgba& rgba) {
-  impl().SetObject(path, shape, rgba);
+                        const Rgba& rgba, std::string_view diffuse_map) {
+  impl().SetObject(path, shape, rgba, diffuse_map);
 }
 
 void Meshcat::SetObject(std::string_view path,

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -176,21 +176,33 @@ class Meshcat {
 
   /** Sets the 3D object at a given `path` in the scene tree.  Note that
   `path`="/foo" will always set an object in the tree at "/foo/<object>".  See
-  @ref meshcat_path.  Any objects previously set at this `path` will be
-  replaced.
+  @ref meshcat_path. Any objects previously set at this `path` will be replaced.
+
+  The `rgba` and `diffuse_map` values work together. The color modulates the
+  textures appearance (by doing a channel-wise multiplication). For example,
+  specifying a red color will "tint" the texture red.
+
   @param path a "/"-delimited string indicating the path in the scene tree.
               See @ref meshcat_path "Meshcat paths" for the semantics.
   @param shape a Shape that specifies the geometry of the object.
   @param rgba an Rgba that specifies the (solid) color of the object.
+  @param diffuse_map an optional path to an image file to use as a diffuse
+              texture map. The image must be in a format supported by the
+              browser's three.js renderer (e.g., PNG, JPEG, WebP). It will _not_
+              be applied to Convex shapes (as convex hulls don't have texture
+              coordinates). It is not _currently_ applied to Mesh shapes because
+              Mesh shapes reference file formats that can define their own
+              materials. In the future, the map may be applied if the referenced
+              file doesn't actually specify any materials; this will not be
+              considered a "breaking" change.
   @note If `shape` is a mesh, the file referred to can be either an .obj file
   or an _embedded_ .gltf file (it has all geometry data and texture data
   contained within the single .gltf file).
   @pydrake_mkdoc_identifier{shape}
   */
   void SetObject(std::string_view path, const Shape& shape,
-                 const Rgba& rgba = Rgba(.9, .9, .9, 1.));
-
-  // TODO(russt): SetObject with texture map.
+                 const Rgba& rgba = Rgba(.9, .9, .9, 1.),
+                 std::string_view diffuse_map = "");
 
   /** Sets the "object" at a given `path` in the scene tree to be
   `point_cloud`.  Note that `path`="/foo" will always set an object in the tree

--- a/geometry/meshcat_types_internal.h
+++ b/geometry/meshcat_types_internal.h
@@ -108,6 +108,11 @@ struct MaterialData {
   // other materials.
   std::optional<bool> flatShading;
 
+  // UUID of the TextureData to use as a diffuse color map. Note: the name
+  // matches the three.js name for diffuse or albedo (depending on the shader).
+  // For simple serialization, we're stuck with the same name here.
+  std::optional<std::string> map;
+
   template <typename Packer>
   // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
   void msgpack_pack(Packer& o) const {
@@ -121,6 +126,7 @@ struct MaterialData {
     if (wireframe) ++n;
     if (wireframeLineWidth) ++n;
     if (flatShading) ++n;
+    if (map) ++n;
     o.pack_map(n);
     PACK_MAP_VAR(o, uuid);
     PACK_MAP_VAR(o, type);
@@ -161,6 +167,10 @@ struct MaterialData {
     if (flatShading) {
       o.pack("flatShading");
       o.pack(*flatShading);
+    }
+    if (map) {
+      o.pack("map");
+      o.pack(*map);
     }
   }
 
@@ -347,11 +357,69 @@ struct MeshfileObjectData {
   MSGPACK_DEFINE_MAP(uuid, type, format, data, mtl_library, resources, matrix);
 };
 
+// There is no actual three.js Image class, but this is known to be a sufficient
+// subset of the three.js json object to trigger an image load from the `url`.
+struct ImageData {
+  std::string uuid;
+  std::string url;
+
+  template <typename Packer>
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  void msgpack_pack(Packer& o) const {
+    o.pack_map(2);
+    PACK_MAP_VAR(o, uuid);
+    PACK_MAP_VAR(o, url);
+  }
+  void msgpack_unpack(msgpack::object const&) {
+    throw std::runtime_error("unpack is not implemented for ImageData.");
+  }
+};
+
+// Corresponds to the three.js Texture class, but only includes the fields that
+// we actually use.
+// https://threejs.org/docs/?q=Texture#Texture
+struct TextureData {
+  std::string uuid;
+  std::string image;  // uuid of the associated ImageData
+  std::optional<std::array<int, 2>> wrap;
+
+  // The collection of enumerated values we need to send to three js to
+  // configure the texture correctly. Three.js puts them all in a single name
+  // space. We'll parallel that by putting them all in this single enum.
+  enum ThreeJsEnum {
+    // Wrapping modes for use with `wrap`.
+    RepeatWrapping = 1000,
+    ClampToEdgeWrapping = 1001,
+    MirroredRepeatWrapping = 1002
+  };
+
+  template <typename Packer>
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  void msgpack_pack(Packer& o) const {
+    int n = 2;
+    if (wrap) ++n;
+    o.pack_map(n);
+    PACK_MAP_VAR(o, uuid);
+    PACK_MAP_VAR(o, image);
+    if (wrap) {
+      o.pack("wrap");
+      o.pack_array(2);
+      o.pack((*wrap)[0]);
+      o.pack((*wrap)[1]);
+    }
+  }
+  void msgpack_unpack(msgpack::object const&) {
+    throw std::runtime_error("unpack is not implemented for TextureData.");
+  }
+};
+
 struct LumpedObjectData {
   ObjectData metadata{};
-  // We deviate from the msgpack names (geometries, materials) here since we
-  // currently only support zero or one geometry/material.
+  // We deviate from the msgpack names (geometries, images, textures, materials)
+  // here since we currently only support zero or one of each.
   std::unique_ptr<GeometryData> geometry;
+  std::unique_ptr<ImageData> image;
+  std::unique_ptr<TextureData> texture;
   std::unique_ptr<MaterialData> material;
   std::variant<std::monostate, MeshData, MeshfileObjectData> object;
 
@@ -360,6 +428,8 @@ struct LumpedObjectData {
   void msgpack_pack(Packer& o) const {
     int size = 2;
     if (geometry) ++size;
+    if (image) ++size;
+    if (texture) ++size;
     if (material) ++size;
     o.pack_map(size);
     PACK_MAP_VAR(o, metadata);
@@ -367,6 +437,16 @@ struct LumpedObjectData {
       o.pack("geometries");
       o.pack_array(1);
       o.pack(*geometry);
+    }
+    if (image) {
+      o.pack("images");
+      o.pack_array(1);
+      o.pack(*image);
+    }
+    if (texture) {
+      o.pack("textures");
+      o.pack_array(1);
+      o.pack(*texture);
     }
     if (material) {
       o.pack("materials");
@@ -576,7 +656,7 @@ namespace adaptor {
 template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime,
           int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime>
 struct pack<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
-                          MaxRowsAtCompileTime, MaxColsAtCompileTime> > {
+                          MaxRowsAtCompileTime, MaxColsAtCompileTime>> {
   template <typename Stream>
   packer<Stream>& operator()(
       // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack.

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -200,6 +200,8 @@ void MeshcatVisualizer<T>::SetObjects(
       const std::string path = fmt::format("{}/{}", frame_path, geometry_name);
       const Rgba rgba = properties.GetPropertyOrDefault("phong", "diffuse",
                                                         params_.default_color);
+      const std::string diffuse_map = properties.GetPropertyOrDefault(
+          "phong", "diffuse_map", std::string{});
 
       // The "object" will typically be the geometry's shape. But, for the
       // proximity role, we prefer, first, the hydroelastic surface if
@@ -239,7 +241,8 @@ void MeshcatVisualizer<T>::SetObjects(
       }
 
       if (!geometry_already_set) {
-        meshcat_->SetObject(path, inspector.GetShape(geom_id), rgba);
+        meshcat_->SetObject(path, inspector.GetShape(geom_id), rgba,
+                            diffuse_map);
       }
 
       meshcat_->SetTransform(path, inspector.GetPoseInFrame(geom_id));

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -13,6 +13,7 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/find_runfiles.h"
+#include "drake/common/overloaded.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/maybe_pause_for_user.h"
 #include "drake/geometry/meshcat.h"
@@ -101,6 +102,21 @@ Mesh GetPyramidInMemory(double scale = 1.0) {
       scale);
 }
 
+struct Property {
+  std::string name;
+  std::variant<double, bool> value{};
+};
+
+void ApplyProperties(Meshcat* meshcat, const std::string& path,
+                     const std::vector<Property>& properties) {
+  for (const auto& [name, value] : properties) {
+    std::visit(overloaded{[meshcat, &path, &name](auto&& arg) {
+                 meshcat->SetProperty(path, name, arg);
+               }},
+               value);
+  }
+}
+
 int do_main() {
   auto meshcat = std::make_shared<Meshcat>();
 
@@ -110,62 +126,97 @@ int do_main() {
   const double start_x = -8.5;
   double x = start_x;
 
-  Vector3d sphere_home{++x, 0, 0};
-  // The weird name for the sphere is to confirm that meshcat collapses
-  // redundant slashes. We'll subsequently refer to it without the slash to
-  // make sure they're equivalent.
-  meshcat->SetObject("sphere//scoped_name", Sphere(0.25), Rgba(1.0, 0, 0, 1));
-  meshcat->SetTransform("sphere/scoped_name", RigidTransformd(sphere_home));
-  // Note: this isn't the preferred means for setting opacity, but it is the
-  // simplest way to exercise chained property names.
-  meshcat->SetProperty("sphere/scoped_name/<object>", "material.opacity", 0.5);
-  meshcat->SetProperty("sphere/scoped_name/<object>", "material.transparent",
-                       true);
+  const std::string checker_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/checker.png");
+  // Creates an instance of the given shape and another instance of the same
+  // shape with a texture map applied to it.
+  auto make_shape_and_textured =
+      [&meshcat, &x, &checker_path](
+          const std::string& path, const Shape& shape, const Rgba& rgba,
+          const std::vector<Property>& properties = {}) {
+        const Vector3d shape_home{++x, 0, 0};
+        meshcat->SetObject(path, shape, rgba);
+        meshcat->SetTransform(path, RigidTransformd(shape_home));
+        ApplyProperties(meshcat.get(), path + "/<object>", properties);
 
-  // The weird name for the cylinder is to confirm that meshcat elides terminal
-  // slashes. We'll subsequently refer to it without the slash to make sure
-  // they're equivalent.
-  meshcat->SetObject("cylinder/", Cylinder(0.25, 0.5), Rgba(0.0, 1.0, 0, 1));
-  meshcat->SetTransform("cylinder", RigidTransformd(Vector3d{++x, 0, 0}));
+        // One test includes a terminal slash -- for the textured version, we'll
+        // strip it out.
+        const std::string textured_path =
+            path.ends_with('/') ? path.substr(0, path.size() - 1) + "_textured"
+                                : path + "_textured";
+        meshcat->SetObject(textured_path, shape, rgba, checker_path);
+        meshcat->SetTransform(textured_path,
+                              RigidTransformd(shape_home + Vector3d{0, 1, 0}));
+        ApplyProperties(meshcat.get(), textured_path + "/<object>", properties);
+
+        return shape_home;
+      };
+
+  // The sphere is going to serve triple-duty as a test of:
+  // - the sphere shape generally (and its texture coordinates),
+  // - setting an object with a path that has redundant slashes (we'll
+  //   subsequently refer to it as simply "sphere/scoped_name"),
+  // - setting properties with chained names (e.g., "material.opacity").
+  const Vector3d sphere_home = make_shape_and_textured(
+      "sphere//scoped_name", Sphere(0.25), Rgba(1.0, 0, 0, 1),
+      {{"material.opacity", 0.5}, {"material.transparent", true}});
+
+  // The cylinder is going to serve double-duty as a test of:
+  // - the cylinder shape generally (and its texture coordinates),
+  // - elision of path with trailing slashes (we'll subsequently refer to it as
+  //   simply "cylinder").
+  make_shape_and_textured("cylinder/", Cylinder(0.25, 0.5),
+                          Rgba(0.0, 1.0, 0, 1));
 
   // For animation, we'll aim the camera between the cylinder and ellipsoid.
   const Vector3d animation_target{x + 0.5, 0, 0};
 
-  meshcat->SetObject("ellipsoid", Ellipsoid(0.25, 0.25, 0.5),
-                     Rgba(1.0, 0, 1, 0.5));
-  meshcat->SetTransform("ellipsoid", RigidTransformd(Vector3d{++x, 0, 0}));
+  make_shape_and_textured("ellipsoid", Ellipsoid(0.25, 0.25, 0.5),
+                          Rgba(1.0, 0, 1, 0.5));
 
-  Vector3d box_home{++x, 0, 0};
-  meshcat->SetObject("box", Box(0.25, 0.25, 0.5), Rgba(0, 0, 1, 1));
-  meshcat->SetTransform("box", RigidTransformd(box_home));
+  const Vector3d box_home =
+      make_shape_and_textured("box", Box(0.25, 0.25, 0.5), Rgba(0, 0, 1, 1));
 
+  // Note: We're explicitly passing a diffuse_map to SetObject() to show that
+  // the diffuse_map is *not* used for Mesh or Convex.
   const std::string polytope_with_hole = FindResourceOrThrow(
       "drake/examples/scene_graph/cuboctahedron_with_hole.obj");
   meshcat->SetObject("obj_as_convex", Convex(polytope_with_hole, 0.25),
-                     Rgba(0.8, 0.4, 0.1, 1.0));
+                     Rgba(0.8, 0.4, 0.1, 1.0), checker_path);
   meshcat->SetTransform("obj_as_convex", RigidTransformd(Vector3d{++x, 0, 0}));
 
+  // We're using this mostly transparent yellow color in contexts where we
+  // expect the Rgba value to be ignored. If we see things tinted yellow and
+  // made mostly translucent, we'll know that there's a bug.
+  const Rgba ignored_yellow(1.0, 1.0, 0.0, 0.25);
+
+  // Passing yellow color and checker texture, but they'll be ignored and we'll
+  // see the multi-color splotches defined by the polytope's material
+  // (see cuboctahedron_with_hole.mtl).
   meshcat->SetObject("obj_as_mesh", Mesh(polytope_with_hole, 0.25),
-                     Rgba(0.8, 0.4, 0.1, 1.0));
+                     ignored_yellow, checker_path);
   meshcat->SetTransform("obj_as_mesh", RigidTransformd(Vector3d{x, 1, 0}));
 
-  meshcat->SetObject("capsule", Capsule(0.25, 0.5), Rgba(0, 1, 1, 1));
-  meshcat->SetTransform("capsule", RigidTransformd(Vector3d{++x, 0, 0}));
+  make_shape_and_textured("capsule", Capsule(0.25, 0.5), Rgba(0, 1, 1, 1));
 
   // Note that height (in z) is the first argument.
-  meshcat->SetObject("cone", MeshcatCone(0.5, 0.25, 0.5), Rgba(1, 0, 0, 1));
-  meshcat->SetTransform("cone", RigidTransformd(Vector3d{++x, 0, 0}));
+  make_shape_and_textured("cone", MeshcatCone(0.5, 0.25, 0.5),
+                          Rgba(1, 0, 0, 1));
 
-  // The color and shininess properties come from PBR materials.
+  // Both glTFs are passed a color and texture that will be ignored; instead,
+  // we'll get the blue-and-silver colors with arrows, etc. as defined by
+  // the glTF's internal material definitions.
   meshcat->SetObject(
       "gltf",
       Mesh(FindResourceOrThrow(
                "drake/geometry/render/test/meshes/fully_textured_pyramid.gltf"),
-           0.5));
+           0.5),
+      ignored_yellow, checker_path);
   const Vector3d gltf_pose{++x, 0, 0};
   meshcat->SetTransform("gltf", RigidTransformd(gltf_pose));
 
-  meshcat->SetObject("gltf_in_memory", GetPyramidInMemory(0.5));
+  meshcat->SetObject("gltf_in_memory", GetPyramidInMemory(0.5), ignored_yellow,
+                     checker_path);
   meshcat->SetTransform("gltf_in_memory",
                         RigidTransformd(gltf_pose + Vector3d(0, 1.5, 0)));
 
@@ -316,15 +367,19 @@ Ignore those for now; we'll need to circle back and fix them later.
   std::cout << ltrim(R"""(
 - The background should be grey.
 - From left to right along the x axis, you should see:
-  - a slightly transparent red sphere
-  - a green cylinder (with the long axis in z)
-  - a pink semi-transparent ellipsoid (long axis in z)
-  - a blue box (long axis in z)
+  - a slightly transparent red sphere (with a checker-textured version behind
+    it).
+  - a green cylinder (with the long axis in z) (with a checker-textured version
+    behind it).
+  - a pink semi-transparent ellipsoid (long axis in z) (with a checker-textured
+    version behind it).
+  - a blue box (long axis in z)  (with a checker-textured version behind it).
   - an orange polytope (with a similary shaped textured polytope behind it).
     The textured shape has a hole through. The orange polytope is its convex
     hull.
-  - a teal capsule (long axis in z)
-  - a red cone (expanding in +z, twice as wide in y than in x)
+  - a teal capsule (long axis in z) (with a checker-textured version behind it).
+  - a red cone (expanding in +z, twice as wide in y than in x) (with a checker-
+    textured version behind it).
   - two shiny, textured pyramids (created with PBR materials); one read from
     disk, the other loaded from memory.
   - a yellow mustard bottle w/ label
@@ -593,6 +648,7 @@ Ignore those for now; we'll need to circle back and fix them later.
                "  - reposition the camera\n"
                "  - add an in-memory glTF file (textured pyramid)\n"
                "  - add an in-memory obj file (textured cuboctahedron)\n"
+               "  - textured primitive\n"
                "\n";
 
   meshcat->SetEnvironmentMap(
@@ -606,6 +662,9 @@ Ignore those for now; we'll need to circle back and fix them later.
   meshcat->SetObject("obj_in_memory", GetCuboctahedronInMemory(0.1));
   meshcat->SetTransform("obj_in_memory",
                         RigidTransformd(Vector3d(-0.25, 0.3, 0.1)));
+  meshcat->SetObject("box", Box(0.1, 0.1, 0.1), Rgba(0.4, 0.4, 1, 1),
+                     checker_path);
+  meshcat->SetTransform("box", RigidTransformd(Vector3d(0.25, -0.3, 0.05)));
 
   std::cout
       << "Now we'll check the standalone HTML file capturing this scene.\n"

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -491,6 +491,31 @@ GTEST_TEST(MeshcatTest, SetObjectWithShape) {
   EXPECT_TRUE(meshcat.GetPackedObject("bad").empty());
 }
 
+GTEST_TEST(MeshcatTest, SetObjectWithDiffuseMap) {
+  const std::string texture_path = FindResourceOrThrow(
+      "drake/geometry/render/test/meshes/rainbow_stripes.png");
+  Meshcat meshcat;
+  meshcat.SetObject("box", Box(0.5, 0.5, 0.5), Rgba(0.9, 0.9, 0.9),
+                    texture_path);
+  const std::string packed = meshcat.GetPackedObject("box");
+  ASSERT_FALSE(packed.empty());
+  // Image should be served from CAS, not inlined as a data URI.
+  EXPECT_THAT(packed, HasSubstr("cas-v1/"));
+  // Material should reference the texture and carry a wrap mode.
+  EXPECT_THAT(packed, HasSubstr("map"));
+  EXPECT_THAT(packed, HasSubstr("wrap"));
+}
+
+GTEST_TEST(MeshcatTest, SetObjectWithDiffuseMap_MissingFile) {
+  Meshcat meshcat;
+  meshcat.SetObject("box", Box(0.5, 0.5, 0.5), Rgba(0.9, 0.9, 0.9),
+                    "/no/such/texture.png");
+  // Object is still created; the bad texture is skipped after warning.
+  const std::string packed = meshcat.GetPackedObject("box");
+  ASSERT_FALSE(packed.empty());
+  EXPECT_EQ(packed.find("cas-v1/"), std::string::npos);
+}
+
 // Confirms that an OBJ with a missing material becomes a MeshData instead of a
 // MeshfileObjectData.
 GTEST_TEST(MeshcatTest, ObjWithMissingMtl) {

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -702,6 +703,59 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Graphviz) {
   SetUpDiagram();
   EXPECT_THAT(visualizer_->GetGraphvizString(),
               testing::HasSubstr("-> meshcat_in"));
+}
+
+GTEST_TEST(MeshcatVisualizerTest, DiffuseMapIllustrationProperty) {
+  auto meshcat = std::make_shared<Meshcat>();
+  systems::DiagramBuilder<double> builder;
+  auto [plant, scene_graph] =
+      multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
+  const std::string sdf_content = R"""(
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="box">
+    <link name="box">
+      <visual name="visual">
+        <geometry>
+          <box><size>0.2 0.2 0.02</size></box>
+        </geometry>
+        <material>
+          <drake:diffuse_map>package://drake/geometry/render/test/meshes/rainbow_stripes.png</drake:diffuse_map>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>
+)""";
+  multibody::Parser(&plant).AddModelsFromString(sdf_content, "sdf");
+  plant.Finalize();
+
+  // Confirm there's a single geometry with illustration properties and it has
+  // the expected diffuse map.
+  const auto& inspector = scene_graph.model_inspector();
+  std::vector<GeometryId> g_ids =
+      inspector.GetAllGeometryIds(Role::kIllustration);
+  ASSERT_EQ(g_ids.size(), 1);
+  const GeometryId geom_id = g_ids.front();
+  const IllustrationProperties* props =
+      inspector.GetIllustrationProperties(geom_id);
+  ASSERT_NE(props, nullptr);
+  ASSERT_TRUE(props->HasProperty("phong", "diffuse_map"));
+
+  MeshcatVisualizer<double>::AddToBuilder(&builder, scene_graph, meshcat);
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+  diagram->ForcedPublish(*context);
+
+  const std::string geom_path = fmt::format(
+      "visualizer/box/box/{}", TransformGeometryName(geom_id, inspector));
+  ASSERT_TRUE(meshcat->HasPath(geom_path));
+  // A mere indicator that the texture information was provided to Meshcat. See
+  // the SetObjectWithDiffuseMap test in meshcat_test.cc or
+  // meshcat_manual_test for the more definitive tests. This merely serves as
+  // regression protection.
+  EXPECT_THAT(meshcat->GetPackedObject(geom_path),
+              testing::HasSubstr("cas-v1/"));
 }
 
 }  // namespace

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -10,8 +10,8 @@ def meshcat_repository(
         Updating this commit requires local testing; see
         drake/tools/workspace/meshcat/README.md for details.
         """,
-        commit = "f7b8588f73aa14bffe52f662fb0ba04f4f1d4f22",
-        sha256 = "79dfc209d1c7330fcf6bf323074a8d01cb5627c97d989ccb34b7e8aba165f36e",  # noqa
+        commit = "815addc85f3bca5615ece3e8095bbca009480143",
+        sha256 = "0a527248e95f31f8723817e1b678a97827c5293d3fd30b600e383ea09bf6063f",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
We could assign the ('phong', 'diffuse_map') property to geometries with illustration roles, but it would dispatch a one-time warning and otherwise have no effect.

Meshcat now supports it. A warning will still be dispatched because the illustration property is not generally supported in Drake (meldis, for example). But Meshcat *will* apply the texture.

Resolves #19076.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24564)
<!-- Reviewable:end -->
