### PR TITLE
[pydrake] Avoid using default globals in py::eval and py::exec

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -198,8 +198,8 @@ void InitLowLevelModules(py::module_ m) {
     DefCopyAndDeepCopy(&cls);
     // Add the same __fields__ that DefAttributesUsingSerialize would have.
     cls.def_prop_ro_static("__fields__", [](py::object /* cls */) {
-      auto str_ctor = py::eval("str");
-      auto bytes_ctor = py::eval("bytes");
+      auto str_ctor = py::eval("str", py::globals());
+      auto bytes_ctor = py::eval("bytes", py::globals());
       auto make_namespace =
           py::module_::import_("types").attr("SimpleNamespace");
       auto contents = make_namespace();
@@ -228,7 +228,7 @@ void InitLowLevelModules(py::module_ m) {
           name_str == "filename_hint") {
         name = py::str(fmt::format("_{}", name_str));
       }
-      py::eval("object.__setattr__")(self, name, value);
+      py::eval("object.__setattr__", py::globals())(self, name, value);
     });
     // Provide properties for use by yaml_{dump,load}_typed.
     cls.def_prop_rw(
@@ -356,8 +356,9 @@ discussion), use e.g.
   // =========================================================================
 
   // Define `_testing` submodule.
-  py::module_ pydrake_top = py::eval("sys.modules['pydrake']");
-  py::module_ pydrake_common = py::eval("sys.modules['pydrake.common']");
+  py::module_ pydrake_top = py::eval("sys.modules['pydrake']", py::globals());
+  py::module_ pydrake_common =
+      py::eval("sys.modules['pydrake.common']", py::globals());
 
   py::module_ testing = pydrake_common.def_submodule("_testing");
   testing::def_testing(testing);

--- a/bindings/pydrake/common/schema_py.cc
+++ b/bindings/pydrake/common/schema_py.cc
@@ -315,7 +315,7 @@ void DefineModuleSchema(py::module_ m) {
           return self_py.attr("value").attr(name);
         }
       }
-      return py::eval("object.__getattr__")(self, name);
+      return py::eval("object.__getattr__", py::globals())(self, name);
     });
     cls.def("__setattr__", [](Class& self, py::str name, py::object value) {
       if (std::holds_alternative<Rotation::Rpy>(self.value)) {
@@ -334,7 +334,7 @@ void DefineModuleSchema(py::module_ m) {
           return;
         }
       }
-      py::eval("object.__setattr__")(self, name, value);
+      py::eval("object.__setattr__", py::globals())(self, name, value);
     });
   }
 

--- a/bindings/pydrake/common/test/cpp_param_test_util_py.cc
+++ b/bindings/pydrake/common/test/cpp_param_test_util_py.cc
@@ -107,8 +107,9 @@ PYDRAKE_MODULE(cpp_param_test_util, m) {
   m.def("execute_tests", [m]() {
     // Import some definitions from the modules where they are defined into the
     // module where the tests will execute.
-    py::exec("from pydrake.common.cpp_param_test_util import CustomCppType");
-    py::exec("from pydrake.common.cpp_param import List");
+    py::exec("from pydrake.common.cpp_param_test_util import CustomCppType",
+        py::globals());
+    py::exec("from pydrake.common.cpp_param import List", py::globals());
 
     CheckPrimitiveTypes();
     CheckCustomTypes();

--- a/bindings/pydrake/multibody/tree_py_inertia.cc
+++ b/bindings/pydrake/multibody/tree_py_inertia.cc
@@ -295,7 +295,7 @@ void DoScalarDependentDefinitions(py::module_ m, T) {
                   return py::str("SpatialInertia.Zero()");
                 }
               }
-              return py::eval("object.__repr__")(self);
+              return py::eval("object.__repr__", py::globals())(self);
             })
         .def(py::pickle(
             [](const Class& self) {

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -101,7 +101,7 @@ void BindPiecewisePolynomialSerialize(PyClass* cls) {
     } else if (std::string(name) == "polynomials") {
       name = py::str("_polynomials");
     }
-    py::eval("object.__setattr__")(self, name, value);
+    py::eval("object.__setattr__", py::globals())(self, name, value);
   });
   // Define a private property for "_breaks". Setting the breaks resets all of
   // the polynomials; this is fine because deserialization matches __fields__


### PR DESCRIPTION
In nanobind, the [default is empty](https://github.com/wjakob/nanobind/blob/2deac96697d1b304f3c973cef7de5f94cbad5a57/include/nanobind/eval.h#L29) instead of py::globals(), so we'll pass the necessary value even with pybind11 to make porting easier.

Tested by temporarily patching pybind11 to change its defaults.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24569)
<!-- Reviewable:end -->
