### PR TITLE
[tools] Avoid new_release upgrades newer than one week

### DIFF
--- a/tools/workspace/github.bzl
+++ b/tools/workspace/github.bzl
@@ -14,6 +14,7 @@ def github_archive(
         commit_pin = None,
         tags_pattern = None,
         exclude_tags_pattern = None,
+        upgrade_cooldown_days = None,
         sha256 = "0" * 64,
         build_file = None,
         patches = None,
@@ -50,6 +51,8 @@ def github_archive(
             1.2.1 would be considered.
         exclude_tags_pattern: optional string specifies a regex describing the
             set of tags to ignore when upgrading.
+        upgrade_cooldown_days: optional integer is the required number of days
+            after the latest upstream release/commit before upgrading.
         sha256: required sha256 is the expected SHA-256 checksum of the
             downloaded archive. When unsure, you can omit this argument (or
             comment it out) and then the checksum-mismatch error message will
@@ -121,6 +124,7 @@ def github_archive(
         commit_pin = commit_pin,
         tags_pattern = tags_pattern,
         exclude_tags_pattern = exclude_tags_pattern,
+        upgrade_cooldown_days = upgrade_cooldown_days,
         sha256 = sha256,
         build_file = build_file,
         patches = patches,
@@ -167,6 +171,10 @@ _github_archive_real = repository_rule(
         "commit_pin": attr.bool(),
         "tags_pattern": attr.string(),
         "exclude_tags_pattern": attr.string(),
+        "upgrade_cooldown_days": attr.int(
+            mandatory = False,
+            default = -1,
+        ),
         "sha256": attr.string(
             mandatory = False,
             default = "0" * 64,
@@ -212,6 +220,9 @@ def setup_github_repository(repository_ctx):
     """
 
     # Do the download step first.  (This also writes the metadata.)
+    upgrade_cooldown_days = getattr(repository_ctx.attr, "upgrade_cooldown_days", -1)
+    if upgrade_cooldown_days < 0:
+        upgrade_cooldown_days = None
     github_download_and_extract(
         repository_ctx,
         repository = repository_ctx.attr.repository,
@@ -220,6 +231,7 @@ def setup_github_repository(repository_ctx):
         commit_pin = getattr(repository_ctx.attr, "commit_pin", None),
         tags_pattern = getattr(repository_ctx.attr, "tags_pattern", None),
         exclude_tags_pattern = getattr(repository_ctx.attr, "exclude_tags_pattern", None),
+        upgrade_cooldown_days = upgrade_cooldown_days,
         mirrors = repository_ctx.attr.mirrors,
         sha256 = repository_ctx.attr.sha256,
         extra_strip_prefix = repository_ctx.attr.extra_strip_prefix,
@@ -268,6 +280,7 @@ def github_download_and_extract(
         sha256 = "0" * 64,
         extra_strip_prefix = "",
         upgrade_advice = "",
+        upgrade_cooldown_days = None,
         commit_pin = None):
     """Download an archive of the provided GitHub repository and commit to the
     output path and extract it.
@@ -284,6 +297,9 @@ def github_download_and_extract(
             Used by //tools/workspace:new_release.
         exclude_tags_pattern: regex describing tags to ignore when performing
             upgrades.
+            Used by //tools/workspace:new_release.
+        upgrade_cooldown_days: integer describing the required number of days
+            after the latest upstream release/commit before upgrading.
             Used by //tools/workspace:new_release.
         mirrors: dictionary of mirrors, see mirrors.bzl in this directory for
             an example.
@@ -341,6 +357,7 @@ def github_download_and_extract(
         repository_rule_type = "github",
         repository = repository,
         upgrade_type = upgrade_type,
+        upgrade_cooldown_days = upgrade_cooldown_days,
         commit = commit,
         tags_pattern = tags_pattern,
         exclude_tags_pattern = exclude_tags_pattern,

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -32,6 +32,7 @@ command line.
 
 import argparse
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 import getpass
 import hashlib
@@ -54,9 +55,13 @@ from tools.workspace.metadata import read_repository_metadata
 logger = logging.getLogger("new_release")
 logger.setLevel(logging.INFO)
 
-debug = logging.debug
+debug = logger.debug
 info = logger.info
 warn = logger.warning
+
+# Unless a particular repository specifies otherwise, this is the number of
+# days after the latest upstream release/commit before which we will upgrade.
+_DEFAULT_COOLDOWN_DAYS = 7
 
 # We'll skip these repositories when making suggestions.
 _IGNORED_REPOSITORIES = [
@@ -160,6 +165,38 @@ def _get_default_username() -> str:
     return git_user or http_user
 
 
+def _get_commit_date(
+    gh_repo: github3.repos.repo.Repository,
+    commit: str,
+) -> datetime:
+    """Returns the date of the given commit, or the start of the epoch if the
+    date is not available."""
+    committer_obj = gh_repo.commit(commit).commit.get("committer", {})
+    commit_date = datetime.fromisoformat(
+        committer_obj.get("date", "1970-01-01T00:00:00Z")
+    )
+    return commit_date
+
+
+def _is_commit_too_recent(
+    commit: str,
+    workspace: str,
+    date: datetime,
+    cooldown_days: int | None,
+) -> bool:
+    """Returns true iff the commit is too recent according to given date and
+    `cooldown_days`."""
+    cooldown_days = (
+        _DEFAULT_COOLDOWN_DAYS if cooldown_days is None else cooldown_days
+    )
+    if date > datetime.now(timezone.utc) - timedelta(days=cooldown_days):
+        # This is a bleeding-edge release; ignore it (as potential for
+        # malware), but log it for the user to check.
+        warn(f"Skipping too-recent {commit} for {workspace}")
+        return True
+    return False
+
+
 def _is_ignored_tag(commit: str, exclude_pattern: str | None = None) -> bool:
     """Returns true iff commit matches the `exclude_pattern` or seems to be a
     pre-release.
@@ -182,15 +219,34 @@ def _latest_tag(
     gh_repo: github3.repos.repo.Repository,
     workspace: str,
     exclude_pattern: str | None = None,
-) -> str | None:
-    """Returns the latest tag for the given `workspace` that doesn't match an
-    ignore rule."""
+) -> tuple[str | None, datetime | None]:
+    """Returns (tag name, date) for the latest tag of the given `workspace`
+    that doesn't match an ignore rule."""
     for tag in gh_repo.tags():
         if _is_ignored_tag(tag.name, exclude_pattern):
             continue
-        return tag.name
+        return tag.name, _get_commit_date(gh_repo, tag.name)
     warn(f"Could not find any matching tags for {workspace}")
-    return None
+    return None, None
+
+
+def _latest_release(
+    gh_repo: github3.repos.repo.Repository,
+    workspace: str,
+    exclude_pattern: str | None = None,
+) -> tuple[str | None, datetime | None]:
+    """Returns (tag name, date) for the latest release of the given `workspace`
+    that doesn't match an ignore rule.
+
+    Note that the date is when the official release was published, not the date
+    of the tagged commit associated with the release.
+    """
+    for release in gh_repo.releases():
+        if _is_ignored_tag(release.tag_name, exclude_pattern):
+            continue
+        return release.tag_name, release.published_at
+    warn(f"Could not find any matching releases for {workspace}")
+    return None, None
 
 
 def _handle_github(
@@ -209,7 +265,7 @@ def _handle_github(
 
     if upgrade_type == UpgradeType.COMMIT:
         new_commit = gh_repo.commit("HEAD").sha
-        return old_commit, new_commit
+        commit_date = _get_commit_date(gh_repo, new_commit)
     elif upgrade_type == UpgradeType.TAG:
         # Search for the latest tag by default. If a "tags_pattern" regex was
         # provided, we'll limit to tags matching those. If an
@@ -219,32 +275,41 @@ def _handle_github(
         exclude_tags_pattern = data["exclude_tags_pattern"]
 
         if not tags_pattern:
-            new_commit = _latest_tag(
-                gh_repo, workspace_name, exclude_tags_pattern
+            new_commit, commit_date = _latest_tag(
+                gh_repo,
+                workspace_name,
+                exclude_tags_pattern,
             )
-            return old_commit, new_commit
-
-        match = re.search(tags_pattern, old_commit)
-        assert match, f"No {tags_pattern} in {old_commit}"
-        (old_hit,) = match.groups()
-        for tag in gh_repo.tags():
-            match = re.search(tags_pattern, tag.name)
-            if match:
-                (new_hit,) = match.groups()
-                if old_hit == new_hit:
-                    if _is_ignored_tag(tag.name, exclude_tags_pattern):
-                        continue
-                    new_commit = tag.name
-                    break
-        return old_commit, new_commit
+        else:
+            match = re.search(tags_pattern, old_commit)
+            assert match, f"No {tags_pattern} in {old_commit}"
+            (old_hit,) = match.groups()
+            for tag in gh_repo.tags():
+                match = re.search(tags_pattern, tag.name)
+                if match:
+                    (new_hit,) = match.groups()
+                    if old_hit == new_hit:
+                        if _is_ignored_tag(tag.name, exclude_tags_pattern):
+                            continue
+                        new_commit = tag.name
+                        commit_date = _get_commit_date(gh_repo, new_commit)
+                        break
     else:
         assert upgrade_type == UpgradeType.RELEASE
         exclude_tags_pattern = data["exclude_tags_pattern"]
-        for release in gh_repo.releases():
-            if not _is_ignored_tag(release.tag_name, exclude_tags_pattern):
-                new_commit = release.tag_name
-                break
-        return old_commit, new_commit
+        new_commit, commit_date = _latest_release(
+            gh_repo, workspace_name, exclude_tags_pattern
+        )
+
+    upgrade_cooldown_days = data.get("upgrade_cooldown_days")
+    if _is_commit_too_recent(
+        new_commit,
+        workspace_name,
+        commit_date,
+        upgrade_cooldown_days,
+    ):
+        new_commit = old_commit
+    return old_commit, new_commit
 
 
 def _check_for_upgrades(

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -154,6 +154,10 @@ _vtk_internal_repository_impl = repository_rule(
         # These are the attributes for setup_github_repository.
         "repository": attr.string(),
         "upgrade_type": attr.string(),
+        # VTK's master branch will pretty much never have no commits in any
+        # default cooldown number of days, so we'll skip that rule here and
+        # always take the HEAD.
+        "upgrade_cooldown_days": attr.int(default = 0),
         "commit": attr.string(),
         "sha256": attr.string(),
         "build_file": attr.label(),


### PR DESCRIPTION
Along the lines of #24558, applied to the `new_release` tool when fetching from GitHub and other sources.

Towards #24555.

~~Requires #24593, #24645.~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24570)
<!-- Reviewable:end -->
