### PR TITLE
[multibody] Move joint locking rejection from ICF to CENIC

### DIFF
--- a/multibody/cenic/cenic_integrator.cc
+++ b/multibody/cenic/cenic_integrator.cc
@@ -238,6 +238,8 @@ template <typename T>
 void CenicIntegrator<T>::DoInitialize() {
   using std::isnan;
 
+  ValidatePlantContext();
+
   // Set the initial time step and accuracy.
   if (isnan(this->get_initial_step_size_target())) {
     if (isnan(this->get_maximum_step_size())) {
@@ -515,6 +517,21 @@ void CenicIntegrator<T>::AdvancePlantConfiguration(const T& h,
   const internal::SpanningForest& forest = GetInternalTree(plant()).forest();
   for (int quaternion_start : forest.quaternion_starts()) {
     q->template segment<4>(quaternion_start).normalize();
+  }
+}
+
+template <typename T>
+void CenicIntegrator<T>::ValidatePlantContext() {
+  // Revisit this condition when joint locking support is implemented. See
+  // #23764.
+  const auto& plant_context = plant().GetMyContextFromRoot(this->get_context());
+  for (const JointIndex& j : plant().GetJointIndices()) {
+    if (plant().get_joint(j).is_locked(plant_context)) {
+      throw std::runtime_error(
+          fmt::format("The CENIC integrator does not yet support joint "
+                      "locking, but at least joint {} is locked",
+                      j));
+    }
   }
 }
 

--- a/multibody/cenic/cenic_integrator.h
+++ b/multibody/cenic/cenic_integrator.h
@@ -223,6 +223,9 @@ class CenicIntegrator final : public systems::IntegratorBase<T> {
   void AdvancePlantConfiguration(const T& h, const VectorX<T>& v,
                                  VectorX<T>* q) const;
 
+  /* Throws if the plant context is not compatible with CENIC. */
+  void ValidatePlantContext();
+
   /* Locations of plant and non-plant continuous state. Note that the contained
   `plant` pointer is guaranteed to be non-null by the CenicIntegrator
   constructor .*/

--- a/multibody/cenic/test/cenic_integrator_test.cc
+++ b/multibody/cenic/test/cenic_integrator_test.cc
@@ -71,6 +71,34 @@ constexpr char kBallOnTableMjcf[] = R"""(
   </mujoco>
   )""";
 
+GTEST_TEST(CenicIntegratorTest, JointLockingUnsupported) {
+  DiagramBuilder<double> diagram_builder;
+  auto* plant = diagram_builder.AddSystem<MultibodyPlant<double>>(0.0);
+
+  Parser(plant).AddModelsFromString(kDoublePendulumMjcf, "xml");
+  // Remove a joint to exercise non-contiguous joint indexing.
+  plant->RemoveJoint(plant->get_joint(JointIndex(0)));
+
+  plant->Finalize();
+  auto diagram = diagram_builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  auto& plant_context =
+      plant->GetMyMutableContextFromRoot(diagram_context.get());
+  CenicIntegrator<double> dut(*diagram);
+  dut.set_maximum_step_size(0.1);
+  dut.reset_context(diagram_context.get());
+
+  // Bug regression check: don't accidentally throw by mistakenly iterating
+  // over stale joint indices.
+  EXPECT_NO_THROW(dut.Initialize());
+
+  plant->get_joint(JointIndex(1)).Lock(&plant_context);
+
+  // Actual joint locking check: now something is locked, refuse to give wrong
+  // answers, and explain that joint locking is the problem.
+  DRAKE_EXPECT_THROWS_MESSAGE(dut.Initialize(), ".*joint 1.*locked.*");
+}
+
 // TestParam uses tuple for compatibility with ::testing::Combine.
 // get<0>() is nesting depth for the plant and scene graph.
 // get<1>() is nesting depth for external systems.

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -70,7 +70,6 @@ void IcfBuilder<T>::UpdateModel(
     const IcfLinearFeedbackGains<T>* actuation_feedback,
     const IcfLinearFeedbackGains<T>* external_feedback, IcfModel<T>* model) {
   DRAKE_ASSERT(model != nullptr);
-  ValidateContext(context);
   const SpanningForest& forest = GetInternalTree(plant_).forest();
   const int nv = forest.num_velocities();
 
@@ -296,20 +295,6 @@ void IcfBuilder<T>::ValidatePlant() {
         "constraint(s), {} ball constraint(s), {} tendon constraint(s)",
         plant_.num_distance_constraints(), plant_.num_ball_constraints(),
         plant_.num_tendon_constraints()));
-  }
-}
-
-template <typename T>
-void IcfBuilder<T>::ValidateContext(const systems::Context<T>& context) {
-  // Revisit this condition when joint locking support is implemented. See
-  // #23764.
-  for (const JointIndex& j : plant_.GetJointIndices()) {
-    if (plant_.get_joint(j).is_locked(context)) {
-      throw std::runtime_error(
-          fmt::format("The CENIC integrator does not yet support joint "
-                      "locking, but at least joint {} is locked",
-                      j));
-    }
   }
 }
 

--- a/multibody/contact_solvers/icf/icf_builder.h
+++ b/multibody/contact_solvers/icf/icf_builder.h
@@ -90,9 +90,6 @@ class IcfBuilder {
   /* Throws if the plant provided at construction is not compatible with ICF. */
   void ValidatePlant();
 
-  /* Throws if the context passed to UpdateModel is not compatible with ICF. */
-  void ValidateContext(const systems::Context<T>& context);
-
   /* Computes geometry data and stores it internally for later use. */
   void CalcGeometryContactData(const systems::Context<T>& context);
 

--- a/multibody/contact_solvers/icf/test/icf_builder_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_builder_test.cc
@@ -390,42 +390,6 @@ GTEST_TEST(IcfBuilder, DeformableUnsupported) {
                               ".*deformable.*bodies.* == 0.*fail.*");
 }
 
-GTEST_TEST(IcfBuilder, JointLockingUnsupported) {
-  systems::DiagramBuilder<double> diagram_builder;
-  // TODO(#23764): MultibodyPlant does not yet support joint locking on
-  // continuous plants. Internally, ICF doesn't much care about the plant's
-  // discrete/continuous configuration.
-  multibody::MultibodyPlantConfig plant_config{.time_step = 0.1};
-  MultibodyPlant<double>& plant =
-      multibody::AddMultibodyPlant(plant_config, &diagram_builder);
-
-  Parser(&plant, "Pendulum").AddModelsFromString(kRobotXml, "xml");
-  // Remove a joint to exercise non-contiguous joint indexing.
-  plant.RemoveJoint(plant.get_joint(JointIndex(0)));
-
-  plant.Finalize();
-  IcfBuilder<double> dut(&plant);
-
-  auto diagram = diagram_builder.Build();
-  auto diagram_context = diagram->CreateDefaultContext();
-  auto& plant_context =
-      plant.GetMyMutableContextFromRoot(diagram_context.get());
-
-  IcfModel<double> model;
-  // Bug regression check: don't accidentally throw by mistakenly iterating
-  // over stale joint indices.
-  EXPECT_NO_THROW(
-      dut.UpdateModel(plant_context, 0.01, nullptr, nullptr, &model));
-
-  plant.get_joint(JointIndex(1)).Lock(&plant_context);
-
-  // Actual joint locking check: now something is locked, refuse to give wrong
-  // answers, and explain that joint locking is the problem.
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      dut.UpdateModel(plant_context, 0.01, nullptr, nullptr, &model),
-      ".*joint 1.*locked.*");
-}
-
 }  // namespace
 }  // namespace internal
 }  // namespace icf


### PR DESCRIPTION
This is a tactical move to allow implementation of joint locking support in ICF, while maintaining clear non-support of joint locking at the CENIC level.

The implementation of ICF joint locking support will be a significant patch sequence. Final integration into CENIC will be a single small patch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24575)
<!-- Reviewable:end -->

Toward #23764.