### PR TITLE
[multibody] Add joint locking support to icf_builder

### DIFF
--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -206,6 +206,7 @@ drake_cc_library(
         "//math:geometric_transform",
         "//math:vector3_util",
         "//multibody/contact_solvers:block_sparse_lower_triangular_or_symmetric_matrix",  # noqa
+        "//multibody/plant:slicing_and_indexing",
     ],
 )
 

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -21,7 +21,9 @@ using drake::multibody::internal::GetCombinedPointContactStiffness;
 using drake::multibody::internal::GetCoulombFriction;
 using drake::multibody::internal::GetHuntCrossleyDissipation;
 using drake::multibody::internal::GetPointContactStiffness;
+using drake::multibody::internal::JointLockingCacheData;
 using drake::multibody::internal::LinkJointGraph;
+using drake::multibody::internal::MultibodyPlantIcfAttorney;
 using drake::multibody::internal::SpanningForest;
 using drake::multibody::internal::TreeIndex;
 using drake::multibody::internal::WeldConstraintSpec;
@@ -90,6 +92,8 @@ void IcfBuilder<T>::UpdateModel(
     DRAKE_DEMAND(params->body_is_floating.empty());
     DRAKE_DEMAND(params->clique_sizes.empty());
     DRAKE_DEMAND(params->clique_start.empty());
+    DRAKE_DEMAND(params->reduction.unlocked_dofs.empty());
+    DRAKE_DEMAND(params->reduction.per_clique_unlocked_dofs.empty());
 
     // Yes, Virginia, this is the first time we are setting the params.
 
@@ -101,6 +105,8 @@ void IcfBuilder<T>::UpdateModel(
     params->body_mass.resize(plant_.num_bodies());
     params->J_WB.Resize(plant_.num_bodies(), 6,
                         plant_facts_.body_jacobian_cols);
+    params->reduction.per_clique_unlocked_dofs.resize(
+        plant_facts_.clique_sizes.size());
 
     // Clique membership, and body floating status are defined at builder
     // construction time, since they depend only on the plant and not on the
@@ -127,6 +133,8 @@ void IcfBuilder<T>::UpdateModel(
                  plant_facts_.clique_sizes.size());
     DRAKE_DEMAND(params->clique_start.size() ==
                  plant_facts_.clique_sizes.size() + 1);
+    DRAKE_DEMAND(params->reduction.per_clique_unlocked_dofs.size() ==
+                 plant_facts_.clique_sizes.size());
   }
 
   // Set the time step δt and initial velocities v₀
@@ -139,6 +147,20 @@ void IcfBuilder<T>::UpdateModel(
 
   // Set joint damping D₀.
   params->D0 = plant_.EvalJointDampingCache(context);
+
+  // Set joint locking params.
+  const JointLockingCacheData<T>& locking =
+      MultibodyPlantIcfAttorney<T>::EvalJointLocking(plant_, context);
+  params->reduction.unlocked_dofs = locking.unlocked_velocity_indices;
+  for (int t = 0; t < forest.num_trees(); ++t) {
+    const int clique = tree_to_clique(t);
+    if (clique < 0) {
+      // Skip the data for trees with no velocities; see tree_to_clique().
+      continue;
+    }
+    params->reduction.per_clique_unlocked_dofs[clique] =
+        locking.unlocked_velocity_indices_per_tree[t];
+  }
 
   // Compute nonlinear bias terms k₀.
   MultibodyForces<T>& forces = scratch_.forces;
@@ -827,8 +849,7 @@ void IcfBuilder<T>::RefreshGeometryDetails(
 
   // Retrieve constant model parameters.
   const multibody::internal::ContactByPenaltyMethodParameters& contact_params =
-      multibody::internal::MultibodyPlantIcfAttorney<
-          T>::GetContactByPenaltyMethodParameters(plant_);
+      MultibodyPlantIcfAttorney<T>::GetContactByPenaltyMethodParameters(plant_);
   const double default_dissipation = contact_params.dissipation;
   const double default_stiffness = contact_params.geometry_stiffness;
 

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -2,6 +2,8 @@
 
 #include <utility>
 
+#include "drake/multibody/plant/slicing_and_indexing.h"
+
 namespace drake {
 namespace multibody {
 namespace contact_solvers {
@@ -11,6 +13,7 @@ namespace internal {
 using contact_solvers::internal::BlockSparseSymmetricMatrix;
 using contact_solvers::internal::BlockSparsityPattern;
 using Eigen::VectorBlock;
+using multibody::internal::DemandIndicesValid;
 
 template <typename T>
 IcfModel<T>::IcfModel()
@@ -388,6 +391,17 @@ void IcfModel<T>::VerifyInvariants() const {
     nv += clique_nv;
   }
   DRAKE_DEMAND(nv == num_velocities_);
+
+  const auto& reduction = params().reduction;
+  DemandIndicesValid(reduction.unlocked_dofs, num_velocities_);
+  DRAKE_DEMAND(ssize(reduction.per_clique_unlocked_dofs) == num_cliques_);
+  nv = 0;
+  for (int c = 0; c < num_cliques_; ++c) {
+    const auto& unlocked = reduction.per_clique_unlocked_dofs[c];
+    DemandIndicesValid(unlocked, clique_size(c));
+    nv += ssize(unlocked);
+  }
+  DRAKE_DEMAND(nv == ssize(reduction.unlocked_dofs));
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -64,6 +64,18 @@ struct IcfParameters {
 
   // Starting index in the velocity vector for each clique, size nc + 1.
   std::vector<int> clique_start;
+
+  // Parameters that are only for model reduction. These do not affect *this*
+  // model, but rather describe how to construct a separate, reduced, model.
+  struct ReductionParameters {
+    // Specifies DOFs that cannot be eliminated, as an ordered sequence of
+    // velocity indices.
+    std::vector<int> unlocked_dofs;
+    // Specifies DOFs that cannot be eliminated, per clique. Each is an ordered
+    // sequence of clique-local velocity indices.
+    std::vector<std::vector<int>> per_clique_unlocked_dofs;
+  };
+  ReductionParameters reduction;
 };
 
 /* This class defines a convex ICF problem,

--- a/multibody/contact_solvers/icf/test/icf_builder_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_builder_test.cc
@@ -323,7 +323,7 @@ GTEST_TEST(IcfBuilder, RetryStep) {
 
 GTEST_TEST(IcfBuilder, BallConstraintUnsupported) {
   systems::DiagramBuilder<double> diagram_builder;
-  multibody::MultibodyPlantConfig plant_config{.time_step = 0.1};
+  multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};
   MultibodyPlant<double>& plant =
       multibody::AddMultibodyPlant(plant_config, &diagram_builder);
 
@@ -388,6 +388,56 @@ GTEST_TEST(IcfBuilder, DeformableUnsupported) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(IcfBuilder<double>(&plant),
                               ".*deformable.*bodies.* == 0.*fail.*");
+}
+
+GTEST_TEST(IcfBuilder, JointLockingSupport) {
+  systems::DiagramBuilder<double> diagram_builder;
+  multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};
+  MultibodyPlant<double>& plant =
+      multibody::AddMultibodyPlant(plant_config, &diagram_builder);
+
+  Parser(&plant, "Pendulum").AddModelsFromString(kRobotXml, "xml");
+
+  plant.Finalize();
+  IcfBuilder<double> dut(&plant);
+
+  auto diagram = diagram_builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  auto& plant_context =
+      plant.GetMyMutableContextFromRoot(diagram_context.get());
+
+  IcfModel<double> model;
+
+  const double time_step = 0.01;  // For UpdateModel().
+  {
+    // Update a model and check for *no* joint locking effects. The only
+    // results of interest are the ReductionParameters at params().reduction.
+    dut.UpdateModel(plant_context, time_step, nullptr, nullptr, &model);
+    const auto& r = model.params().reduction;
+    const std::vector<int> expected_unlocked_dofs = {0, 1};
+    EXPECT_EQ(r.unlocked_dofs, expected_unlocked_dofs);
+
+    EXPECT_EQ(ssize(r.per_clique_unlocked_dofs), model.num_cliques());
+
+    ASSERT_EQ(model.num_cliques(), 1);
+    EXPECT_EQ(r.per_clique_unlocked_dofs[0], expected_unlocked_dofs);
+  }
+
+  plant.get_joint(JointIndex(1)).Lock(&plant_context);
+
+  {
+    // Update a model and check for joint locking effects. The only results of
+    // interest are the ReductionParameters at params().reduction.
+    dut.UpdateModel(plant_context, time_step, nullptr, nullptr, &model);
+    const auto& r = model.params().reduction;
+    const std::vector<int> expected_unlocked_dofs = {0};
+    EXPECT_EQ(r.unlocked_dofs, expected_unlocked_dofs);
+
+    EXPECT_EQ(ssize(r.per_clique_unlocked_dofs), model.num_cliques());
+
+    ASSERT_EQ(model.num_cliques(), 1);
+    EXPECT_EQ(r.per_clique_unlocked_dofs[0], expected_unlocked_dofs);
+  }
 }
 
 }  // namespace

--- a/multibody/contact_solvers/icf/test/icf_solver_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_solver_test.cc
@@ -44,6 +44,13 @@ class IcfSolverTest : public ::testing::Test {
     params->J_WB[0] = VectorXd::LinSpaced(36, -1.0, 1.0).reshaped(6, 6);
     params->J_WB[1] = 3.4 * Matrix6<double>::Identity();
     params->body_to_clique = {0, 1};
+    auto& reduction = params->reduction;
+    reduction.unlocked_dofs = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    reduction.per_clique_unlocked_dofs =
+        {
+            {0, 1, 2, 3, 4, 5},
+            {0, 1, 2, 3, 4, 5},
+        },
     model_.ResetParameters(std::move(params));
 
     // Add a basic contact (patch) constraint with one pair and one patch.

--- a/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
@@ -194,6 +194,17 @@ void MakeModelForWeld(IcfModel<T>* model, double time_step = 0.01) {
   params->J_WB[2] = Matrix6<T>::Identity();  // Floating body.
   params->J_WB[3] = J_WB3;
 
+  // No joint locking.
+  auto& reduction = params->reduction;
+  reduction.unlocked_dofs = {0,  1,  2,  3,  4,  5,   // BR
+                             6,  7,  8,  9,  10, 11,  //
+                             12, 13, 14, 15, 16, 17};
+  reduction.per_clique_unlocked_dofs = {
+      {0, 1, 2, 3, 4, 5},
+      {0, 1, 2, 3, 4, 5},
+      {0, 1, 2, 3, 4, 5},
+  };
+
   model->ResetParameters(std::move(params));
 }
 

--- a/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.cc
+++ b/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.cc
@@ -94,6 +94,21 @@ void MakeUnconstrainedModel(IcfModel<T>* model, bool single_clique,
     params->body_to_clique = {-1, 0, 1, 2};
   }
 
+  // No joint locking.
+  auto& reduction = params->reduction;
+  reduction.unlocked_dofs = {0,  1,  2,  3,  4,  5,   // BR
+                             6,  7,  8,  9,  10, 11,  //
+                             12, 13, 14, 15, 16, 17};
+  if (single_clique) {
+    reduction.per_clique_unlocked_dofs.resize(1);
+    reduction.per_clique_unlocked_dofs[0] = reduction.unlocked_dofs;
+  } else {
+    reduction.per_clique_unlocked_dofs.resize(3);
+    reduction.per_clique_unlocked_dofs[0] = {0, 1, 2, 3, 4, 5};
+    reduction.per_clique_unlocked_dofs[1] = {0, 1, 2, 3, 4, 5};
+    reduction.per_clique_unlocked_dofs[2] = {0, 1, 2, 3, 4, 5};
+  }
+
   model->ResetParameters(std::move(params));
 }
 

--- a/multibody/plant/multibody_plant_icf_attorney.h
+++ b/multibody/plant/multibody_plant_icf_attorney.h
@@ -58,6 +58,11 @@ class MultibodyPlantIcfAttorney {
   GetContactByPenaltyMethodParameters(const MultibodyPlant<T>& plant) {
     return plant.penalty_method_contact_parameters_;
   }
+
+  static const internal::JointLockingCacheData<T>& EvalJointLocking(
+      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
+    return plant.EvalJointLocking(context);
+  }
 };
 
 }  // namespace internal


### PR DESCRIPTION
This patch implements and tests the joint locking functionality of icf_builder, namely, to store relevant joint locking data from the plant to where the rest of ICF can use them.

It also introduces the empty skeleton of the central function of joint locking: IcfModel::ReduceInto(). Its full implementation and tests will come in a later patch.


Toward #23764.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24579)
<!-- Reviewable:end -->
