### PR TITLE
[pydrake] Add nanobind forward-porting alias for py::borrow

### DIFF
--- a/bindings/pydrake/common/cpp_param_pybind.cc
+++ b/bindings/pydrake/common/cpp_param_pybind.cc
@@ -117,7 +117,7 @@ py::object GetPyParamScalarImpl(const std::type_info& tinfo) {
       throw std::runtime_error("C++ type is not registered in pybind: " + name);
     }
     py::handle h(reinterpret_cast<PyObject*>(info->type));
-    return py::reinterpret_borrow<py::object>(h);
+    return py::borrow<py::object>(h);
   }
 }
 

--- a/bindings/pydrake/common/cpp_param_pybind.h
+++ b/bindings/pydrake/common/cpp_param_pybind.h
@@ -28,8 +28,7 @@ class Object {
   ~Object();
 
   /// Constructs from raw pointer, incrementing the reference count.
-  /// @note This does not implement any of the `py::reinterpret_borrow<>`
-  /// semantics.
+  /// @note This does not implement any of the `py::borrow<>` semantics.
   explicit Object(::PyObject* ptr);
 
   /// Constructs from another Object, incrementing the reference count.
@@ -47,13 +46,13 @@ class Object {
   /// Accesses raw PyObject pointer (no reference counting).
   ::PyObject* ptr() const { return ptr_; }
 
-  /// Converts to a pybind11 Python type, using py::reinterpret_borrow.
+  /// Converts to a pybind11 Python type, using py::borrow.
   template <typename T>
   T to_pyobject() const {
-    return py::reinterpret_borrow<T>(ptr());
+    return py::borrow<T>(ptr());
   }
 
-  /// Converts from a pybind11 Python type, using py::reinterpret_borrow.
+  /// Converts from a pybind11 Python type, using py::borrow.
   template <typename T>
   static Object from_pyobject(const T& h) {
     return Object(h.ptr());

--- a/bindings/pydrake/common/sorted_pair_pybind.h
+++ b/bindings/pydrake/common/sorted_pair_pybind.h
@@ -20,7 +20,7 @@ struct type_caster<drake::SortedPair<T>> {
     if (!convert && !tuple::check_(src)) {
       return false;
     }
-    tuple t = reinterpret_borrow<tuple>(src);
+    tuple t = borrow<tuple>(src);
     if (t.size() != 2) return false;
     InnerCaster first, second;
     if (!first.load(t[0], convert) || !second.load(t[1], convert)) {

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -102,7 +102,8 @@ You may also implicitly convert from `py::object` (and its derived classes) to
 
 If you wish to convert a `py::handle` (or `PyObject*`) to `py::object` or a
 derived class, you should use
-[`py::reinterpret_borrow<>`](http://pybind11.readthedocs.io/en/stable/reference.html#_CPPv218reinterpret_borrow6handle).
+[`py::borrow<>`](https://pybind11.readthedocs.io/en/stable/reference.html#_CPPv4I0E18reinterpret_borrow1T6handle)
+(which is a Drake-specific synonym for `py::reinterpret_borrow<>`).
 
 # Conventions
 

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -184,16 +184,16 @@ inline void ExecuteExtraPythonCode(py::module_ m, bool use_subdir = false) {
 // the module, within the module itself).
 // TODO(eric.cousineau): Unfold cyclic references, and remove the need for this
 // macro (see #11868 for rationale).
-#define PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(variable)                  \
-  {                                                                        \
-    static py::handle variable##_original;                                 \
-    if (variable##_original) {                                             \
-      variable##_original.inc_ref();                                       \
-      variable = py::reinterpret_borrow<py::module_>(variable##_original); \
-      return;                                                              \
-    } else {                                                               \
-      variable##_original = variable;                                      \
-    }                                                                      \
+#define PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(variable)      \
+  {                                                            \
+    static py::handle variable##_original;                     \
+    if (variable##_original) {                                 \
+      variable##_original.inc_ref();                           \
+      variable = py::borrow<py::module_>(variable##_original); \
+      return;                                                  \
+    } else {                                                   \
+      variable##_original = variable;                          \
+    }                                                          \
   }
 
 /// Given a raw pointer, returns a shared_ptr wrapper around it that doesn't own

--- a/tools/workspace/pybind11/patches/nanobind_spellings.patch
+++ b/tools/workspace/pybind11/patches/nanobind_spellings.patch
@@ -93,6 +93,14 @@ See https://github.com/RobotLocomotion/drake/issues/21572.
 
 --- include/pybind11/pytypes.h
 +++ include/pybind11/pytypes.h
+@@ -485,6 +485,7 @@
+ T reinterpret_borrow(handle h) {
+     return {h, object::borrowed_t{}};
+ }
++template <typename T> T borrow(handle h) { return reinterpret_borrow<T>(h); }
+ 
+ /** \rst
+     Like `reinterpret_borrow`, but steals the reference.
 @@ -1630,6 +1630,8 @@
          return std::string(buffer, (size_t) length);
      }


### PR DESCRIPTION
See https://nanobind.readthedocs.io/en/latest/porting.html for background.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24581)
<!-- Reviewable:end -->
