### PR TITLE
[multibody] Add joint locking support to icf_model

### DIFF
--- a/bindings/generated_docstrings/multibody_contact_solvers_icf.h
+++ b/bindings/generated_docstrings/multibody_contact_solvers_icf.h
@@ -29,6 +29,7 @@
 // #include "drake/multibody/contact_solvers/icf/limit_constraints_pool.h"
 // #include "drake/multibody/contact_solvers/icf/patch_constraints_data_pool.h"
 // #include "drake/multibody/contact_solvers/icf/patch_constraints_pool.h"
+// #include "drake/multibody/contact_solvers/icf/reduced_mapping.h"
 // #include "drake/multibody/contact_solvers/icf/weld_constraints_data_pool.h"
 // #include "drake/multibody/contact_solvers/icf/weld_constraints_pool.h"
 

--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_package_library(
         ":icf_solver_parameters",
         ":limit_constraints_data_pool",
         ":patch_constraints_data_pool",
+        ":reduced_mapping",
         ":weld_constraints_data_pool",
     ],
 )
@@ -200,6 +201,7 @@ drake_cc_library(
         ":icf_data",
         ":icf_search_direction_data",
         ":limit_constraints_data_pool",
+        ":reduced_mapping",
         ":weld_constraints_data_pool",
         "//common:default_scalars",
         "//common:essential",
@@ -207,6 +209,16 @@ drake_cc_library(
         "//math:vector3_util",
         "//multibody/contact_solvers:block_sparse_lower_triangular_or_symmetric_matrix",  # noqa
         "//multibody/plant:slicing_and_indexing",
+    ],
+)
+
+drake_cc_library(
+    name = "reduced_mapping",
+    hdrs = [
+        "reduced_mapping.h",
+    ],
+    deps = [
+        "//math:partial_permutation",
     ],
 )
 

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -91,7 +91,6 @@ void IcfBuilder<T>::UpdateModel(
     DRAKE_DEMAND(params->body_to_clique.empty());
     DRAKE_DEMAND(params->body_is_floating.empty());
     DRAKE_DEMAND(params->clique_sizes.empty());
-    DRAKE_DEMAND(params->clique_start.empty());
     DRAKE_DEMAND(params->reduction.unlocked_dofs.empty());
     DRAKE_DEMAND(params->reduction.per_clique_unlocked_dofs.empty());
 
@@ -116,10 +115,6 @@ void IcfBuilder<T>::UpdateModel(
 
     // Set the sparsity pattern for the dynamics matrix A = M + δt D.
     params->clique_sizes = plant_facts_.clique_sizes;
-    params->clique_start.resize(plant_facts_.clique_sizes.size() + 1);
-    params->clique_start[0] = 0;
-    std::partial_sum(params->clique_sizes.begin(), params->clique_sizes.end(),
-                     params->clique_start.begin() + 1);
 
     DRAKE_DEMAND(params->v0.size() == nv);
     DRAKE_DEMAND(params->M0.size() == nv * nv);
@@ -131,8 +126,6 @@ void IcfBuilder<T>::UpdateModel(
     DRAKE_DEMAND(ssize(params->body_is_floating) == plant_.num_bodies());
     DRAKE_DEMAND(params->clique_sizes.size() ==
                  plant_facts_.clique_sizes.size());
-    DRAKE_DEMAND(params->clique_start.size() ==
-                 plant_facts_.clique_sizes.size() + 1);
     DRAKE_DEMAND(params->reduction.per_clique_unlocked_dofs.size() ==
                  plant_facts_.clique_sizes.size());
   }

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -14,6 +14,8 @@ using contact_solvers::internal::BlockSparseSymmetricMatrix;
 using contact_solvers::internal::BlockSparsityPattern;
 using Eigen::VectorBlock;
 using multibody::internal::DemandIndicesValid;
+using multibody::internal::SelectRows;
+using multibody::internal::SelectRowsCols;
 
 template <typename T>
 IcfModel<T>::IcfModel()
@@ -35,6 +37,11 @@ void IcfModel<T>::ResetParameters(std::unique_ptr<IcfParameters<T>> params) {
   num_cliques_ = ssize(this->params().clique_sizes);
   max_clique_size_ =
       num_cliques_ > 0 ? std::ranges::max(this->params().clique_sizes) : 0;
+  clique_starts_.resize(num_cliques_ + 1);
+  clique_starts_[0] = 0;
+  std::partial_sum(this->params().clique_sizes.begin(),
+                   this->params().clique_sizes.end(),
+                   clique_starts_.begin() + 1);
 
   // Compute the initial spatial velocity V_WB0 = J_WB⋅v0 for each body.
   V_WB0_.Resize(num_bodies_, 6, 1);
@@ -50,7 +57,7 @@ void IcfModel<T>::ResetParameters(std::unique_ptr<IcfParameters<T>> params) {
   A_.Resize(num_cliques, clique_sizes, clique_sizes);
   clique_diagonal_mass_inverse_.Resize(num_cliques, clique_sizes);
   for (int c = 0; c < num_cliques_; ++c) {
-    const int v_start = this->params().clique_start[c];
+    const int v_start = clique_starts()[c];
     const int nv = clique_sizes[c];
     A_[c] = M0().block(v_start, v_start, nv, nv);
     A_[c].diagonal() += time_step() * D0().segment(v_start, nv);
@@ -74,7 +81,7 @@ template <typename T>
 Eigen::VectorBlock<const VectorX<T>> IcfModel<T>::clique_segment(
     int clique, const VectorX<T>& full_vector) const {
   DRAKE_ASSERT(full_vector.size() == num_velocities_);
-  return full_vector.segment(params().clique_start[clique],
+  return full_vector.segment(clique_starts()[clique],
                              params().clique_sizes[clique]);
 }
 
@@ -83,7 +90,7 @@ Eigen::VectorBlock<VectorX<T>> IcfModel<T>::mutable_clique_segment(
     int clique, VectorX<T>* full_vector) const {
   DRAKE_ASSERT(full_vector != nullptr);
   DRAKE_ASSERT(full_vector->size() == num_velocities_);
-  return full_vector->segment(params().clique_start[clique],
+  return full_vector->segment(clique_starts()[clique],
                               params().clique_sizes[clique]);
 }
 
@@ -291,18 +298,23 @@ T IcfModel<T>::CalcCostAlongLine(
   return cost;
 }
 
+// TODO(#23912): Try removing allocations since this will now be used in the hot
+// path by joint locking.
 template <typename T>
 void IcfModel<T>::SetSparsityPattern() {
   DRAKE_DEMAND(params_ != nullptr);
 
   // N.B. we make a copy here because block_sizes will be moved into the
   // BlockSparsityPattern at the end of this function.
+  // TODO(#23912): This line allocates.
   std::vector<int> block_sizes = params().clique_sizes;
 
   // Build diagonal entries in the sparsity pattern.
+  // TODO(#23912): This line allocates.
   std::vector<std::vector<int>> sparsity(num_cliques_);
-  for (int i = 0; i < num_cliques_; ++i) {
-    sparsity[i].emplace_back(i);
+  for (int c = 0; c < num_cliques_; ++c) {
+    // TODO(#23912): This line allocates.
+    sparsity[c].emplace_back(c);
   }
 
   // Build off-diagonal entries in the sparsity pattern.
@@ -313,6 +325,7 @@ void IcfModel<T>::SetSparsityPattern() {
   // constraint data and model parameters are finalized.
   weld_constraints_pool_.PrecomputeHessianBlocks();
 
+  // TODO(#23912): This line allocates.
   sparsity_pattern_ = std::make_unique<BlockSparsityPattern>(
       std::move(block_sizes), std::move(sparsity));
 }
@@ -324,7 +337,7 @@ void IcfModel<T>::UpdateTimeStep(const T& time_step) {
 
   // Linearized dynamics matrix A = M + δt⋅D
   for (int c = 0; c < num_cliques_; ++c) {
-    const int v_start = params().clique_start[c];
+    const int v_start = clique_starts()[c];
     const int nv = params().clique_sizes[c];
     A_[c] = M0().block(v_start, v_start, nv, nv);
     A_[c].diagonal() += time_step * D0().segment(v_start, nv);
@@ -342,6 +355,107 @@ void IcfModel<T>::UpdateTimeStep(const T& time_step) {
   // Recompute Hessian blocks whenever dt changes so
   // AccumulateHessian() uses up-to-date values.
   weld_constraints_pool_.PrecomputeHessianBlocks();
+}
+
+template <typename T>
+void IcfModel<T>::ReduceInto(IcfModel<T>* reduced_model,
+                             ReducedMapping* mapping) const {
+  DRAKE_DEMAND(reduced_model != nullptr);
+  DRAKE_DEMAND(mapping != nullptr);
+  const auto& full_params = params();
+  const auto& unlocked_dofs = full_params.reduction.unlocked_dofs;
+
+  mapping->velocity_subsequence.ResetToSize(num_velocities());
+  for (const int unlocked : unlocked_dofs) {
+    mapping->velocity_subsequence.push(unlocked);
+  }
+
+  auto reduced_params = reduced_model->ReleaseParameters();
+
+  // Reduce a bunch of easy params.
+  reduced_params->time_step = full_params.time_step;
+  reduced_params->v0 = SelectRows(full_params.v0, unlocked_dofs);
+  reduced_params->M0 = SelectRowsCols(full_params.M0, unlocked_dofs);
+  reduced_params->D0 = SelectRows(full_params.D0, unlocked_dofs);
+  reduced_params->k0 = SelectRows(full_params.k0, unlocked_dofs);
+  reduced_params->body_mass = full_params.body_mass;
+  reduced_params->body_is_floating = full_params.body_is_floating;
+
+  // Map all cliques possibly having unlocked DoFs.
+  mapping->clique_subsequence.ResetToSize(num_cliques());
+  mapping->clique_dof_subsequences.resize(num_cliques());
+  const auto& per_clique_unlocked_dofs =
+      full_params.reduction.per_clique_unlocked_dofs;
+  reduced_params->clique_sizes.clear();
+  DRAKE_DEMAND(num_cliques() == ssize(per_clique_unlocked_dofs));
+  for (int c = 0; c < num_cliques(); ++c) {
+    // Clique participates if at least one of its dofs is not locked.
+    int clique_unlocked_count = ssize(per_clique_unlocked_dofs[c]);
+    if (clique_unlocked_count > 0) {
+      reduced_params->clique_sizes.push_back(clique_unlocked_count);
+      mapping->clique_subsequence.push(c);
+    }
+    mapping->clique_dof_subsequences[c].ResetToSize(
+        full_params.clique_sizes[c]);
+    for (const int& per_clique_unlocked : per_clique_unlocked_dofs[c]) {
+      mapping->clique_dof_subsequences[c].push(per_clique_unlocked);
+    }
+  }
+
+  // Reduce per-body params.
+  reduced_params->body_to_clique.resize(num_bodies());
+  reduced_params->J_WB.Clear();
+  for (int b = 0; b < num_bodies(); ++b) {
+    constexpr int kRows =
+        decltype(full_params.J_WB)::MatrixView::RowsAtCompileTime;
+    const int full_clique = full_params.body_to_clique[b];
+
+    if (is_anchored(b) ||
+        !mapping->clique_subsequence.participates(full_clique)) {
+      // This body will not participate in the reduced problem.
+      reduced_params->body_to_clique[b] = -1;
+      reduced_params->J_WB.Add(kRows, 0);
+    } else {
+      const int reduced_clique =
+          mapping->clique_subsequence.permuted_index(full_clique);
+      reduced_params->body_to_clique[b] = reduced_clique;
+      const int reduced_cols = ssize(per_clique_unlocked_dofs[full_clique]);
+      if (is_floating(b)) {
+        // Floating/free body should be either all locked or all unlocked.
+        DRAKE_DEMAND(reduced_cols == full_params.clique_sizes[full_clique] ||
+                     reduced_cols == 0);
+      }
+      reduced_params->J_WB.Add(kRows, reduced_cols);
+      for (int q = 0; q < reduced_cols; ++q) {
+        reduced_params->J_WB[b].col(q) =
+            full_params.J_WB[b].col(per_clique_unlocked_dofs[full_clique][q]);
+      }
+    }
+  }
+
+  // Initialize the reduction params of the reduced model for no further
+  // reduction.
+  auto set_full_indices = [](int size, std::vector<int>* dofs) {
+    dofs->resize(size);
+    std::iota(dofs->begin(), dofs->end(), 0);
+  };
+  set_full_indices(reduced_params->v0.size(),
+                   &reduced_params->reduction.unlocked_dofs);
+  int nc = ssize(reduced_params->clique_sizes);
+  reduced_params->reduction.per_clique_unlocked_dofs.resize(nc);
+  for (int c = 0; c < nc; ++c) {
+    set_full_indices(reduced_params->clique_sizes[c],
+                     &reduced_params->reduction.per_clique_unlocked_dofs[c]);
+  }
+
+  // Bring the reduced model to basic sanity.
+  reduced_model->ResetParameters(std::move(reduced_params));
+
+  // TODO(#23764): Reduce the constraints.
+  DRAKE_THROW_UNLESS(num_constraints() == 0);
+
+  // Refuse multiple levels of reduction.
+  DRAKE_DEMAND(!reduced_model->is_reducible());
 }
 
 template <typename T>
@@ -370,7 +484,7 @@ void IcfModel<T>::VerifyInvariants() const {
   DRAKE_DEMAND(Av0_.size() == num_velocities_);
   DRAKE_DEMAND(clique_diagonal_mass_inverse_.size() == num_cliques_);
 
-  DRAKE_DEMAND(ssize(params().clique_start) == num_cliques_ + 1);
+  DRAKE_DEMAND(ssize(clique_starts()) == num_cliques_ + 1);
   DRAKE_DEMAND(ssize(params().clique_sizes) == num_cliques_);
   DRAKE_DEMAND(ssize(params().body_to_clique) == num_bodies_);
   DRAKE_DEMAND(ssize(params().body_is_floating) == num_bodies_);

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -16,6 +16,7 @@
 #include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
 #include "drake/multibody/contact_solvers/icf/limit_constraints_pool.h"
 #include "drake/multibody/contact_solvers/icf/patch_constraints_pool.h"
+#include "drake/multibody/contact_solvers/icf/reduced_mapping.h"
 #include "drake/multibody/contact_solvers/icf/weld_constraints_pool.h"
 
 namespace drake {
@@ -61,9 +62,6 @@ struct IcfParameters {
 
   // Number of velocities in each clique, indexed by clique, size nc.
   std::vector<int> clique_sizes;
-
-  // Starting index in the velocity vector for each clique, size nc + 1.
-  std::vector<int> clique_start;
 
   // Parameters that are only for model reduction. These do not affect *this*
   // model, but rather describe how to construct a separate, reduced, model.
@@ -153,6 +151,10 @@ class IcfModel {
   /* Returns the maximum number of velocities in any clique. */
   int max_clique_size() const { return max_clique_size_; }
 
+  /* Returns a vector of starting indices into the velocity vector for each
+  clique, size num_cliques() + 1. The final entry contains num_velocities(). */
+  const std::vector<int>& clique_starts() const { return clique_starts_; }
+
   /* Returns the total number of constraints of any type in the problem. */
   int num_constraints() const {
     return num_coupler_constraints() + num_gain_constraints() +
@@ -160,9 +162,20 @@ class IcfModel {
            num_weld_constraints();
   }
 
+  /* Provides const access to the pool of all coupler constraints. */
+  const CouplerConstraintsPool<T>& coupler_constraints_pool() const {
+    return coupler_constraints_pool_;
+  }
+
   /* Provides mutable access to the pool of all coupler constraints. */
   CouplerConstraintsPool<T>& coupler_constraints_pool() {
     return coupler_constraints_pool_;
+  }
+
+  /* Provides const access to the pool of all gain (e.g., actuation)
+  constraints. */
+  const GainConstraintsPool<T>& gain_constraints_pool() const {
+    return gain_constraints_pool_;
   }
 
   /* Provides mutable access to the pool of all gain (e.g., actuation)
@@ -171,14 +184,29 @@ class IcfModel {
     return gain_constraints_pool_;
   }
 
+  /* Provides const access to the pool of all joint limit constraints. */
+  const LimitConstraintsPool<T>& limit_constraints_pool() const {
+    return limit_constraints_pool_;
+  }
+
   /* Provides mutable access to the pool of all joint limit constraints. */
   LimitConstraintsPool<T>& limit_constraints_pool() {
     return limit_constraints_pool_;
   }
 
+  /* Provides const access to the pool of all patch (contact) constraints. */
+  const PatchConstraintsPool<T>& patch_constraints_pool() const {
+    return patch_constraints_pool_;
+  }
+
   /* Provides mutable access to the pool of all patch (contact) constraints. */
   PatchConstraintsPool<T>& patch_constraints_pool() {
     return patch_constraints_pool_;
+  }
+
+  /* Provides const access to the pool of all weld constraints. */
+  const WeldConstraintsPool<T>& weld_constraints_pool() const {
+    return weld_constraints_pool_;
   }
 
   /* Provides mutable access to the pool of all weld constraints. */
@@ -220,6 +248,11 @@ class IcfModel {
 
   /* Returns the initial coriolis, centrifugal, and gravitational terms, k₀. */
   const VectorX<T>& k0() const { return params().k0; }
+
+  /* Returns true if the model can be made smaller by ReduceInto(). */
+  bool is_reducible() const {
+    return ssize(params().reduction.unlocked_dofs) < ssize(params().v0);
+  }
 
   /* Returns a reference to the spatial velocity Jacobian for the given body. */
   ConstJacobianView J_WB(int body) const {
@@ -381,6 +414,26 @@ class IcfModel {
   ICF solves that share a common initial state (q₀,v₀). */
   void UpdateTimeStep(const T& time_step);
 
+  /* Makes a "reduced" ICF model in `reduced_model`, guided by the reduction
+  parameters at `params().reduction`. The mapping from full problem to reduced
+  problem is summarized in `mapping`.
+
+  It is not required that the problem described by the reduction parameters be
+  smaller than the full problem. Use `is_reducible()` to check that the
+  parameters describe a smaller problem.
+
+  TODO(#23764): constraints are not yet supported here.
+
+  @param[out] reduced_model the reduced model.
+  @param[out] mapping the reduction, as partial permutations.
+
+  @pre reduced_model != nullptr.
+  @pre mapping != nullptr.
+  @throws std::exception if there are any constraints.
+  @post sparsity is uninitialized; call SetSparsity() when needed.
+  */
+  void ReduceInto(IcfModel<T>* reduced_model, ReducedMapping* mapping) const;
+
  private:
   /* Checks that this model's parameters define a valid ICF problem. */
   void VerifyInvariants() const;
@@ -402,6 +455,7 @@ class IcfModel {
   std::unique_ptr<IcfParameters<T>> params_;
 
   // Secondary parameters that are derived from the core parameters.
+  std::vector<int> clique_starts_;
   EigenPool<Vector6<T>> V_WB0_;  // Body spatial velocities at v₀, V = J_WB v₀.
   VectorX<T> scale_factor_;      // Scale diag(M)^{-1/2} for convergence check.
   EigenPool<MatrixX<T>> A_;  // Sparse linearized dynamics matrix A = M₀ + δtD₀.

--- a/multibody/contact_solvers/icf/reduced_mapping.h
+++ b/multibody/contact_solvers/icf/reduced_mapping.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/math/partial_permutation.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+/* Describes the mapping of an ICF problem (IcfModel and constraint pools) to a
+reduced problem. For each of the specific mappings, the
+`PartialPermutation::domain_size()` is the size of the original problem, and
+the `PartialPermutation::permuted_domain_size()` is that of the reduced
+problem.
+
+All permutations used here are *subsequences*; they preserve relative ordering.
+That is, some elements may not participate, but those that do will be sorted in
+ascending order. */
+struct ReducedMapping {
+  /* Maps original velocity indices to reduced velocity indices. */
+  math::internal::PartialPermutation velocity_subsequence;
+  /* Maps original clique indices to reduced clique indices. */
+  math::internal::PartialPermutation clique_subsequence;
+  /* For each clique, maps original dof indices to reduced dof indices. The
+  outer vector is indexed by clique indices of the original problem. */
+  std::vector<math::internal::PartialPermutation> clique_dof_subsequences;
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/icf/test/icf_model_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_model_test.cc
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
@@ -12,6 +14,7 @@
 #include "drake/multibody/contact_solvers/icf/icf_data.h"
 #include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
 #include "drake/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.h"
+#include "drake/multibody/plant/slicing_and_indexing.h"
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
@@ -22,6 +25,11 @@ namespace contact_solvers {
 namespace icf {
 namespace internal {
 namespace {
+
+using contact_solvers::internal::BlockSparseSymmetricMatrix;
+using multibody::internal::ExpandRows;
+using multibody::internal::SelectRows;
+using multibody::internal::SelectRowsCols;
 
 constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
 
@@ -68,6 +76,219 @@ GTEST_TEST(IcfModel, LimitMallocOnModelUpdate) {
     drake::test::LimitMalloc guard;
     MakeUnconstrainedModel(&model);
   }
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+  // Do a non-reducing reduce to allocate storage in the reduced model.
+  MakeModelReducible(&model, {});
+  model.ReduceInto(&reduced_model, &mapping);
+
+  // Reducing into a same size model should cause no new allocations.
+  {
+    // TODO(#23912): measured 10 allocations:
+    // 4 in ReduceInto itself (selects on Eigen params).
+    // 6 in SetSparsityPattern.
+    drake::test::LimitMalloc guard({10});
+    model.ReduceInto(&reduced_model, &mapping);
+  }
+
+  // Reducing into a smaller model should have minimal allocations.
+  MakeModelReducible(&model, {2, 16});
+  {
+    // TODO(#23912): measured 13 allocations:
+    // 4 in ReduceInto itself (selects on Eigen params).
+    // 3 in ResetParameters.
+    // 6 in SetSparsityPattern.
+    drake::test::LimitMalloc guard({13});
+    model.ReduceInto(&reduced_model, &mapping);
+  }
+}
+
+GTEST_TEST(IcfModel, ReducedMapping) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+
+  auto check_permutations_are_sorted = [](const ReducedMapping& m,
+                                          std::string_view message) {
+    SCOPED_TRACE(message);
+    EXPECT_TRUE(
+        std::ranges::is_sorted(m.velocity_subsequence.inverse_permutation()));
+    EXPECT_TRUE(
+        std::ranges::is_sorted(m.clique_subsequence.inverse_permutation()));
+    for (const auto& clique_dofs : m.clique_dof_subsequences) {
+      EXPECT_TRUE(std::ranges::is_sorted(clique_dofs.inverse_permutation()));
+    }
+  };
+
+  // Lock some arbitrary dofs.
+  const std::vector<int> arbitrary_locked = {0, 17};
+  MakeModelReducible(&model, arbitrary_locked);
+  model.ReduceInto(&reduced_model, &mapping);
+  check_permutations_are_sorted(mapping, "arbitrary dofs");
+  EXPECT_EQ(mapping.velocity_subsequence.permuted_domain_size(), 16);
+  for (auto dof : arbitrary_locked) {
+    EXPECT_FALSE(mapping.velocity_subsequence.participates(dof));
+  }
+  EXPECT_EQ(mapping.clique_subsequence.permuted_domain_size(), 3);
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(0).permuted_domain_size(), 5);
+  EXPECT_FALSE(mapping.clique_dof_subsequences.at(0).participates(0));
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(1).permuted_domain_size(), 6);
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(2).permuted_domain_size(), 5);
+  // In clique 2, we've locked overall DOF 17, which is clique-local DOF 5.
+  EXPECT_FALSE(mapping.clique_dof_subsequences.at(2).participates(5));
+
+  // Lock an entire clique.
+  const std::vector<int> clique0_locked = {0, 1, 2, 3, 4, 5};
+  MakeModelReducible(&model, clique0_locked);
+  model.ReduceInto(&reduced_model, &mapping);
+  check_permutations_are_sorted(mapping, "clique0 locked");
+  EXPECT_EQ(mapping.velocity_subsequence.permuted_domain_size(), 12);
+  for (auto dof : clique0_locked) {
+    EXPECT_FALSE(mapping.velocity_subsequence.participates(dof));
+  }
+  EXPECT_EQ(mapping.clique_subsequence.permuted_domain_size(), 2);
+  EXPECT_FALSE(mapping.clique_subsequence.participates(0));
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(0).permuted_domain_size(), 0);
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(1).permuted_domain_size(), 6);
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(2).permuted_domain_size(), 6);
+
+  // Lock everything.
+  std::vector<int> all_locked(model.num_velocities());
+  std::iota(all_locked.begin(), all_locked.end(), 0);
+  MakeModelReducible(&model, all_locked);
+  model.ReduceInto(&reduced_model, &mapping);
+  check_permutations_are_sorted(mapping, "all locked");
+  EXPECT_EQ(mapping.velocity_subsequence.permuted_domain_size(), 0);
+  for (auto dof : all_locked) {
+    EXPECT_FALSE(mapping.velocity_subsequence.participates(dof));
+  }
+  EXPECT_EQ(mapping.clique_subsequence.permuted_domain_size(), 0);
+  EXPECT_FALSE(mapping.clique_subsequence.participates(0));
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(0).permuted_domain_size(), 0);
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(1).permuted_domain_size(), 0);
+  EXPECT_EQ(mapping.clique_dof_subsequences.at(2).permuted_domain_size(), 0);
+}
+
+GTEST_TEST(IcfModel, ReducedDataAndHessian) {
+  IcfModel<double> model;
+  IcfData<double> data;
+  std::unique_ptr<BlockSparseSymmetricMatrix<MatrixXd>> hessian;
+  MakeUnconstrainedModel(&model);
+  model.SetSparsityPattern();
+  model.ResizeData(&data);
+  model.CalcData(VectorX<double>::Zero(model.num_velocities()), &data);
+  hessian = model.MakeHessian(data);
+
+  // The Hessian made by the reduced model should be the same as the
+  // unlocked-dofs slice of the Hessian made by the full model.
+  auto check_reduced_hessian = [&](const std::vector<int>& locked_dofs) {
+    IcfModel<double> reduced_model;
+    ReducedMapping mapping;
+    VectorX<double> reduced_v;
+    IcfData<double> reduced_data;
+    std::unique_ptr<BlockSparseSymmetricMatrix<MatrixXd>> reduced_hessian;
+
+    MakeModelReducible(&model, locked_dofs);
+    model.ReduceInto(&reduced_model, &mapping);
+    reduced_v = VectorX<double>::Zero(reduced_model.num_velocities());
+    reduced_model.ResizeData(&reduced_data);
+    reduced_model.CalcData(reduced_v, &reduced_data);
+    reduced_model.SetSparsityPattern();
+    reduced_hessian = reduced_model.MakeHessian(reduced_data);
+    auto sliced_hessian =
+        SelectRowsCols(hessian->MakeDenseMatrix(),
+                       mapping.velocity_subsequence.inverse_permutation());
+    EXPECT_TRUE(
+        CompareMatrices(sliced_hessian, reduced_hessian->MakeDenseMatrix()));
+  };
+
+  // Reduce by none; essentially, just copy.
+  const std::vector<int> none_locked;
+  check_reduced_hessian(none_locked);
+
+  // Lock some arbitrary dofs.
+  const std::vector<int> arbitrary_locked = {0, 17};
+  check_reduced_hessian(arbitrary_locked);
+
+  // Lock an entire clique.
+  const std::vector<int> clique0_locked = {0, 1, 2, 3, 4, 5};
+  check_reduced_hessian(clique0_locked);
+
+  // Lock an entire clique.
+  const std::vector<int> clique1_locked = {6, 7, 8, 9, 10, 11};
+  check_reduced_hessian(clique1_locked);
+
+  // Lock everything.
+  std::vector<int> all_locked(model.num_velocities());
+  std::iota(all_locked.begin(), all_locked.end(), 0);
+  check_reduced_hessian(all_locked);
+}
+
+GTEST_TEST(IcfModel, ReducedV_WB0) {
+  IcfModel<double> model;
+  IcfData<double> data;
+  MakeUnconstrainedModel(&model);
+
+  // The V_WB0s made by the reduced model are one of:
+  // * 0, if body is anchored or all its dofs are locked,
+  // * equal to the full model, if the body is floating and not locked,
+  // * equal to the full model's Jacobian, multiplied by a velocity with locked
+  // * dofs set to 0.
+  auto check_reduced_V_WB0 = [&](const std::vector<int>& locked_dofs) {
+    SCOPED_TRACE(fmt::format("locked_dofs [{}]", fmt::join(locked_dofs, ", ")));
+    IcfModel<double> reduced_model;
+    ReducedMapping mapping;
+
+    MakeModelReducible(&model, locked_dofs);
+    model.ReduceInto(&reduced_model, &mapping);
+    for (int b = 0; b < model.num_bodies(); ++b) {
+      SCOPED_TRACE(fmt::format("body {}", b));
+      const Vector6<double> V_WB0 = model.V_WB0(b);
+      const Vector6<double> reduced_V_WB0 = reduced_model.V_WB0(b);
+      const int reduced_clique = reduced_model.params().body_to_clique.at(b);
+      if (model.is_anchored(b) || reduced_clique < 0) {
+        EXPECT_TRUE(CompareMatrices(Vector6<double>::Zero(), reduced_V_WB0));
+        // Also check that the corresponding Jacobian is 0 size.
+        EXPECT_EQ(reduced_model.params().J_WB[b].cols(), 0);
+      } else if (model.is_floating(b)) {
+        EXPECT_TRUE(CompareMatrices(V_WB0, reduced_V_WB0));
+      } else {
+        const std::vector<int>& unlocked_dofs =
+            mapping.velocity_subsequence.inverse_permutation();
+        // Make a full velocity with 0 for locked dofs.
+        const VectorXd re_expanded_velocity =
+            ExpandRows(SelectRows(model.v0(), unlocked_dofs),
+                       model.num_velocities(), unlocked_dofs);
+        // Make a clique-local velocity with 0 for locked dofs.
+        const int clique = model.params().body_to_clique.at(b);
+        const VectorXd clique_velocity =
+            model.clique_segment(clique, re_expanded_velocity);
+        const Vector6d expected_V_WB0 =
+            model.params().J_WB[b] * clique_velocity;
+        EXPECT_TRUE(CompareMatrices(expected_V_WB0, reduced_V_WB0));
+      }
+    }
+  };
+
+  // Reduce by none; essentially, just copy.
+  const std::vector<int> none_locked;
+  check_reduced_V_WB0(none_locked);
+
+  // Lock some arbitrary dofs.
+  const std::vector<int> arbitrary_locked = {0, 17};
+  check_reduced_V_WB0(arbitrary_locked);
+
+  // Lock an entire clique.
+  const std::vector<int> clique0_locked = {0, 1, 2, 3, 4, 5};
+  check_reduced_V_WB0(clique0_locked);
+
+  // Lock everything.
+  std::vector<int> all_locked(model.num_velocities());
+  std::iota(all_locked.begin(), all_locked.end(), 0);
+  check_reduced_V_WB0(all_locked);
 }
 
 /* Iterates over each body to check sizes and such. */

--- a/multibody/contact_solvers/icf/test/icf_solver_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_solver_test.cc
@@ -37,7 +37,6 @@ class IcfSolverTest : public ::testing::Test {
     params->D0 = VectorXd::Constant(nv, 0.1);
     params->k0 = VectorXd::LinSpaced(nv, -1.0, 1.0);
     params->clique_sizes = {6, 6};
-    params->clique_start = {0, 6, nv};
     params->body_is_floating = {0, 0};
     params->body_mass = {0.2, 1.8};
     params->J_WB.Resize(2, 6, 6);

--- a/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/weld_constraints_pool_test.cc
@@ -176,7 +176,6 @@ void MakeModelForWeld(IcfModel<T>* model, double time_step = 0.01) {
   params->k0 = VectorX<T>::LinSpaced(nv, -1.0, 1.0);
 
   params->clique_sizes = {6, 6, 6};
-  params->clique_start = {0, 6, 12, nv};
 
   // Body 0 = world (anchored), body 1 = floating, body 2 = floating,
   // body 3 = non-floating (uses non-identity Jacobian).

--- a/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.cc
+++ b/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.cc
@@ -43,13 +43,10 @@ void MakeUnconstrainedModel(IcfModel<T>* model, bool single_clique,
 
   // Define the clique structure for the sparse linearized dynamics matrix A.
   std::vector<int>& clique_sizes = params->clique_sizes;
-  std::vector<int>& clique_start = params->clique_start;
   if (single_clique) {
     clique_sizes = {nv};
-    clique_start = {0, nv};
   } else {
     clique_sizes = {6, 6, 6};
-    clique_start = {0, 6, 12, nv};
   }
 
   // We use non-identity Jacobians to stress-test the algebra.
@@ -101,12 +98,68 @@ void MakeUnconstrainedModel(IcfModel<T>* model, bool single_clique,
                              12, 13, 14, 15, 16, 17};
   if (single_clique) {
     reduction.per_clique_unlocked_dofs.resize(1);
-    reduction.per_clique_unlocked_dofs[0] = reduction.unlocked_dofs;
+    reduction.per_clique_unlocked_dofs.at(0) = reduction.unlocked_dofs;
   } else {
     reduction.per_clique_unlocked_dofs.resize(3);
-    reduction.per_clique_unlocked_dofs[0] = {0, 1, 2, 3, 4, 5};
-    reduction.per_clique_unlocked_dofs[1] = {0, 1, 2, 3, 4, 5};
-    reduction.per_clique_unlocked_dofs[2] = {0, 1, 2, 3, 4, 5};
+    reduction.per_clique_unlocked_dofs.at(0) = {0, 1, 2, 3, 4, 5};
+    reduction.per_clique_unlocked_dofs.at(1) = {0, 1, 2, 3, 4, 5};
+    reduction.per_clique_unlocked_dofs.at(2) = {0, 1, 2, 3, 4, 5};
+  }
+
+  model->ResetParameters(std::move(params));
+}
+
+template <typename T>
+void MakeModelReducible(IcfModel<T>* model,
+                        const std::vector<int>& dofs_to_remove) {
+  DRAKE_DEMAND(model != nullptr);
+  const int nv = model->num_velocities();
+  const int nc = model->num_cliques();
+  DRAKE_DEMAND(ssize(dofs_to_remove) <= nv);
+  DRAKE_DEMAND(std::ranges::is_sorted(dofs_to_remove));
+  DRAKE_DEMAND(std::ranges::adjacent_find(dofs_to_remove) ==
+               dofs_to_remove.end());
+  DRAKE_DEMAND(dofs_to_remove.empty() || std::ranges::max(dofs_to_remove) < nv);
+  DRAKE_DEMAND(dofs_to_remove.empty() || std::ranges::min(dofs_to_remove) >= 0);
+
+  std::vector<int> all_dofs(nv);
+  std::iota(all_dofs.begin(), all_dofs.end(), 0);
+
+  std::unique_ptr<IcfParameters<T>> params = model->ReleaseParameters();
+  typename IcfParameters<T>::ReductionParameters* r = &params->reduction;
+
+  r->unlocked_dofs.clear();
+  std::ranges::set_difference(all_dofs, dofs_to_remove,
+                              std::back_inserter(r->unlocked_dofs));
+
+  r->per_clique_unlocked_dofs.resize(nc);
+  for (int c = 0; c < nc; ++c) {
+    r->per_clique_unlocked_dofs.at(c).clear();
+  }
+  int remove_cursor{0};
+  int clique_cursor{0};
+  for (int v = 0; v < nv; ++v) {
+    if (v >= model->clique_starts().at(clique_cursor + 1)) {
+      ++clique_cursor;
+    }
+    const int clique_v = v - model->clique_starts().at(clique_cursor);
+    if ((remove_cursor >= ssize(dofs_to_remove)) ||
+        (v < dofs_to_remove.at(remove_cursor))) {
+      r->per_clique_unlocked_dofs.at(clique_cursor).push_back(clique_v);
+    } else if (v == dofs_to_remove.at(remove_cursor)) {
+      ++remove_cursor;
+    } else {
+      DRAKE_UNREACHABLE();
+    }
+  }
+
+  // Check for partially-locked free/floating bodies; that is not supported.
+  for (int b = 0; b < model->num_bodies(); ++b) {
+    if (params->body_is_floating.at(b)) {
+      const int clique = params->body_to_clique.at(b);
+      const int clique_size = ssize(r->per_clique_unlocked_dofs.at(clique));
+      DRAKE_DEMAND(clique_size == 6 || clique_size == 0);
+    }
   }
 
   model->ResetParameters(std::move(params));
@@ -323,9 +376,9 @@ void AddWeldConstraints(IcfModel<T>* model) {
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    (&MakeUnconstrainedModel<T>, &AddCouplerConstraint<T>,
-     &AddGainConstraints<T>, &AddLimitConstraints<T>, &AddPatchConstraints<T>,
-     &AddWeldConstraints<T>));
+    (&MakeUnconstrainedModel<T>, &MakeModelReducible<T>,
+     &AddCouplerConstraint<T>, &AddGainConstraints<T>, &AddLimitConstraints<T>,
+     &AddPatchConstraints<T>, &AddWeldConstraints<T>));
 
 }  // namespace internal
 }  // namespace icf

--- a/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.h
+++ b/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.h
@@ -17,6 +17,25 @@ template <typename T>
 void MakeUnconstrainedModel(IcfModel<T>* model, bool single_clique = false,
                             double time_step = 0.01);
 
+/* Makes a model reducible by setting the ReductionParameters such that
+`dofs_to_remove` would be removed in the reduced model.
+
+For test purposes, it is valid to pass an empty `dofs_to_remove`. The resulting
+model's reduction parameters are valid, so `model.ReduceInto()` can be used to
+effectively copy the model. However, the described problem is not smaller than
+the original, so `model.is_reducible()` would return false.
+
+@pre `model` != nullptr.
+@pre `dofs_to_remove` is a subsequence of the velocity indices:
+  * all non-negative,
+  * all < `model.num_velocities()`,
+  * sequence is sorted,
+  * elements are unique.
+*/
+template <typename T>
+void MakeModelReducible(IcfModel<T>* model,
+                        const std::vector<int>& dofs_to_remove);
+
 /* Adds a coupler constraint to the given model. */
 template <typename T>
 void AddCouplerConstraint(IcfModel<T>* model);


### PR DESCRIPTION
This patch adds the core support for joint locking in ICF, but without any consideration of constraints. Constraint reductions will be added in subsequent patches.

Towards #23764.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24587)
<!-- Reviewable:end -->
