### PR TITLE
[tools] Encode dependency upgrade types in metadata

### DIFF
--- a/tools/workspace/README.md
+++ b/tools/workspace/README.md
@@ -249,6 +249,7 @@ argument to the `github_archive` macro call pointing at a local checkout, e.g.:
         name = "foobar",
         local_repository_override = "/path/to/local/foo/bar",
         repository = "foo/bar",
+        type = "commit",
         commit = "0123456789abcdef0123456789abcdef01234567",
         sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",  # noqa
     )
@@ -362,14 +363,17 @@ When indicating licenses in the source, use the identifier from the
 
 For choosing the version or commit to use in `repository.bzl`:
 
-* When upstream provides numbered releases, pin Drake to use the most recent
-stable release. Drake maintainers will automatically upgrade to a more recent
-stable release on a monthly basis.
+* When upstream provides numbered releases, either by official GitHub releases
+  or tagged commits, pin Drake to use the most recent stable release by using
+  either `upgrade_type = "release"` or `upgrade_type = "tag"`, respectively.
+  (Prefer the former if official releases exist and are kept up-to-date.)
+  Drake maintainers will automatically upgrade to a more recent stable release
+  on a monthly basis.
 * Otherwise, pin Drake to use the most recent commit of the upstream mainline
-branch. Drake maintainers will automatically upgrade to a more recent mainline
-commit on a monthly basis.
+  branch by using `upgrade_type = "commit"`. Drake maintainers will
+  automatically upgrade to a more recent mainline commit on a monthly basis.
 * If the pin policy is unsatisfactory for the case of some specific external,
-consult Drake's build system maintainers for advice.
+  consult Drake's build system maintainers for advice.
 
 Mimic an existing example to complete the process, e.g., look at
 `//tools/workspace/tinyobjloader_internal` and mimic the `repository.bzl` and

--- a/tools/workspace/abseil_cpp_internal/repository.bzl
+++ b/tools/workspace/abseil_cpp_internal/repository.bzl
@@ -6,6 +6,7 @@ def abseil_cpp_internal_repository(
     github_archive(
         name = name,
         repository = "abseil/abseil-cpp",
+        upgrade_type = "release",
         commit = "20260526.0",
         sha256 = "6e1aee535473414164bf83e4ebc40240dec71a4701f8a642d906e95bea1aea0c",  # noqa
         patches = [

--- a/tools/workspace/bazelisk_internal/repository.bzl
+++ b/tools/workspace/bazelisk_internal/repository.bzl
@@ -26,6 +26,7 @@ def bazelisk_internal_repository(
         To fully test, a Linux uprovisioned job must be launched from the
         pull request.
         """,  # noqa
+        upgrade_type = "release",
         commit = "v1.29.0",
         sha256 = "7e4c7b8ade016052e63c1553cb4fbe0c4fe921e1e66913d49eef074ed894e933",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/ccd_internal/repository.bzl
+++ b/tools/workspace/ccd_internal/repository.bzl
@@ -6,6 +6,7 @@ def ccd_internal_repository(
     github_archive(
         name = name,
         repository = "danfis/libccd",
+        upgrade_type = "commit",
         commit = "7931e764a19ef6b21b443376c699bbc9c6d4fba8",
         sha256 = "479994a86d32e2effcaad64204142000ee6b6b291fd1859ac6710aee8d00a482",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/clang_cindex_python3_internal/repository.bzl
+++ b/tools/workspace/clang_cindex_python3_internal/repository.bzl
@@ -6,6 +6,7 @@ def clang_cindex_python3_internal_repository(
     github_archive(
         name = name,
         repository = "wjakob/clang-cindex-python3",
+        upgrade_type = "commit",
         commit = "b0b92c9395f3927af6a96ac8915e700259d2f55b",
         sha256 = "a09d12a4303dffe9f53e62149d829e651d79e6848a712fab1d77bed382efc37b",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/clarabel_cpp_internal/repository.bzl
+++ b/tools/workspace/clarabel_cpp_internal/repository.bzl
@@ -9,6 +9,7 @@ def clarabel_cpp_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "oxfordcontrol/Clarabel.cpp",
+        upgrade_type = "release",
         commit = "v0.11.1",
         sha256 = "efa90703958075cc59afe8f54ca164eff057f0fcf9877291bbef11cf960f80c8",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/clp_internal/repository.bzl
+++ b/tools/workspace/clp_internal/repository.bzl
@@ -6,6 +6,7 @@ def clp_internal_repository(
     github_archive(
         name = name,
         repository = "coin-or/Clp",
+        upgrade_type = "release",
         commit = "releases/1.17.11",
         sha256 = "2c078e174dc1a7a308e091b6256fb34b4017897fc140ea707ba207b2913ea46d",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/coinutils_internal/repository.bzl
+++ b/tools/workspace/coinutils_internal/repository.bzl
@@ -6,6 +6,7 @@ def coinutils_internal_repository(
     github_archive(
         name = name,
         repository = "coin-or/CoinUtils",
+        upgrade_type = "release",
         commit = "releases/2.11.13",
         sha256 = "ddfea48e10209215748bc9f90a8c04abbb912b662c1aefaf280018d0a181ef79",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/common_robotics_utilities_internal/repository.bzl
+++ b/tools/workspace/common_robotics_utilities_internal/repository.bzl
@@ -12,6 +12,7 @@ def common_robotics_utilities_internal_repository(
         updated in ToyotaResearchInstitute/common_robotics_utilities/test/ or
         ToyotaResearchInstitute/common_robotics_utilities/CMakeLists.txt.ros2
         """,
+        upgrade_type = "commit",
         commit = "1d8fc9db7c15884c503532d853997cbb05fff25b",
         sha256 = "6dcd5ad139e53f291e275bc22e3a8442e1498ec5e73601d57f593a0820d23783",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/cpplint_internal/repository.bzl
+++ b/tools/workspace/cpplint_internal/repository.bzl
@@ -6,6 +6,7 @@ def cpplint_internal_repository(
     github_archive(
         name = name,
         repository = "cpplint/cpplint",
+        upgrade_type = "release",
         commit = "2.0.2",
         sha256 = "fc6d0cd40f934b58e8e0bb5eb5f1f2b651880b5fbc0e93a54e6fb6503f733b3d",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/csdp_internal/repository.bzl
+++ b/tools/workspace/csdp_internal/repository.bzl
@@ -6,6 +6,7 @@ def csdp_internal_repository(
     github_archive(
         name = name,
         repository = "coin-or/Csdp",
+        upgrade_type = "release",
         commit = "releases/6.2.0",
         sha256 = "3d341974af1f8ed70e1a37cc896e7ae4a513375875e5b46db8e8f38b7680b32f",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/curl_internal/repository.bzl
+++ b/tools/workspace/curl_internal/repository.bzl
@@ -10,6 +10,7 @@ def curl_internal_repository(
         In case of a cmake_configure_file build error when upgrading curl,
         update cmakedefines.bzl to match the new upstream definitions.
         """,
+        upgrade_type = "release",
         commit = "curl-8_20_0",
         sha256 = "738fe8ae973a6f171b4e7cf7146edd19894e19f09cd45a3b673ebdba3549a435",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/dm_control_internal/repository.bzl
+++ b/tools/workspace/dm_control_internal/repository.bzl
@@ -6,6 +6,7 @@ def dm_control_internal_repository(
     github_archive(
         name = name,
         repository = "deepmind/dm_control",
+        upgrade_type = "release",
         commit = "1.0.41",
         sha256 = "c1decdfa8de4628ba1246292a269ff928fe334c7391e5f14a2aeac10cb74dfa9",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/doxygen_internal/repository.bzl
+++ b/tools/workspace/doxygen_internal/repository.bzl
@@ -2,6 +2,7 @@ load("//tools/workspace:metadata.bzl", "generate_repository_metadata")
 
 def _impl(repo_ctx):
     repository = repo_ctx.attr.repository
+    upgrade_type = repo_ctx.attr.upgrade_type
     commit = repo_ctx.attr.commit
     platform = repo_ctx.attr.platform
     sha256 = repo_ctx.attr.sha256
@@ -21,6 +22,9 @@ def _impl(repo_ctx):
         See tools/workspace/doxygen_internal/README.md to upgrade.
         """,
         repository = repository,
+        upgrade_type = upgrade_type,
+        tags_pattern = None,
+        exclude_tags_pattern = None,
         commit = commit,
         # Opt out of mirroring the Doxygen source to S3. mirror_to_s3 globs all
         # repository metadata when looking for sources to mirror, but that
@@ -55,6 +59,9 @@ _doxygen_internal_repository_impl = repository_rule(
         "repository": attr.string(
             mandatory = True,
         ),
+        "upgrade_type": attr.string(
+            mandatory = True,
+        ),
         "commit": attr.string(
             mandatory = True,
         ),
@@ -78,6 +85,7 @@ def doxygen_internal_repository(
     _doxygen_internal_repository_impl(
         name = name,
         repository = "doxygen/doxygen",
+        upgrade_type = "release",
         commit = "Release_1_17_0",
         platform = "noble",
         sha256 = "59d61aa931ac87689e66279e3567ca9114ccabf500d92d449f5ecc834320843e",  # noqa

--- a/tools/workspace/drake_models/repository.bzl
+++ b/tools/workspace/drake_models/repository.bzl
@@ -6,6 +6,7 @@ def drake_models_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/models",
+        upgrade_type = "commit",
         commit = "5c942636d18013870403c17c8209558799122abd",
         sha256 = "ac0d6a943818a9ac07d24224ecfbadd1632946de066954901c1aa4c16319fb38",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/fcl_internal/repository.bzl
+++ b/tools/workspace/fcl_internal/repository.bzl
@@ -6,6 +6,7 @@ def fcl_internal_repository(
     github_archive(
         name = name,
         repository = "flexible-collision-library/fcl",
+        upgrade_type = "commit",
         commit = "e5efcc41b57b2d0da3bf183480f1298a6d531f44",
         sha256 = "37aa84608083170329b6d9f9b07dc20d813b84d85546d1e3f1417cc8c2583c6e",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/github.bzl
+++ b/tools/workspace/github.bzl
@@ -9,8 +9,11 @@ load("//tools/workspace:metadata.bzl", "generate_repository_metadata")
 def github_archive(
         name,
         repository = None,
+        upgrade_type = None,
         commit = None,
         commit_pin = None,
+        tags_pattern = None,
+        exclude_tags_pattern = None,
         sha256 = "0" * 64,
         build_file = None,
         patches = None,
@@ -30,10 +33,23 @@ def github_archive(
             labels when referring to this archive from BUILD files.
         repository: required GitHub repository name in the form
             organization/project.
+        upgrade_type: required whether this dependency should be upgraded by
+            searching for releases ("release"), tags ("tag"), or arbitrary
+            commits to the main branch ("commit").
         commit: required commit is the tag name or git commit sha to download.
         commit_pin: optional boolean, set to True iff the archive should remain
             at the same version indefinitely, eschewing automated upgrades to
             newer versions.
+        tags_pattern: optional string specifies a regex describing the
+            portion of the current tag to lock as invariant (achieved by a
+            parenthetical group). This can be used to pin to a given major or
+            major.minor release series. For example, if version 1.2 of a
+            package is currently in use and
+            `tags_pattern = r"^(\\d+\\.)"` is specified, all newer
+            major versions will be ignored during upgrades, but version 1.3 or
+            1.2.1 would be considered.
+        exclude_tags_pattern: optional string specifies a regex describing the
+            set of tags to ignore when upgrading.
         sha256: required sha256 is the expected SHA-256 checksum of the
             downloaded archive. When unsure, you can omit this argument (or
             comment it out) and then the checksum-mismatch error message will
@@ -100,8 +116,11 @@ def github_archive(
     _github_archive_real(
         name = name,
         repository = repository,
+        upgrade_type = upgrade_type,
         commit = commit,
         commit_pin = commit_pin,
+        tags_pattern = tags_pattern,
+        exclude_tags_pattern = exclude_tags_pattern,
         sha256 = sha256,
         build_file = build_file,
         patches = patches,
@@ -139,10 +158,15 @@ _github_archive_real = repository_rule(
         "repository": attr.string(
             mandatory = True,
         ),
+        "upgrade_type": attr.string(
+            mandatory = True,
+        ),
         "commit": attr.string(
             mandatory = True,
         ),
         "commit_pin": attr.bool(),
+        "tags_pattern": attr.string(),
+        "exclude_tags_pattern": attr.string(),
         "sha256": attr.string(
             mandatory = False,
             default = "0" * 64,
@@ -191,8 +215,11 @@ def setup_github_repository(repository_ctx):
     github_download_and_extract(
         repository_ctx,
         repository = repository_ctx.attr.repository,
+        upgrade_type = repository_ctx.attr.upgrade_type,
         commit = repository_ctx.attr.commit,
         commit_pin = getattr(repository_ctx.attr, "commit_pin", None),
+        tags_pattern = getattr(repository_ctx.attr, "tags_pattern", None),
+        exclude_tags_pattern = getattr(repository_ctx.attr, "exclude_tags_pattern", None),
         mirrors = repository_ctx.attr.mirrors,
         sha256 = repository_ctx.attr.sha256,
         extra_strip_prefix = repository_ctx.attr.extra_strip_prefix,
@@ -232,7 +259,10 @@ def setup_github_repository(repository_ctx):
 def github_download_and_extract(
         repository_ctx,
         repository,
+        upgrade_type,
         commit,
+        tags_pattern,
+        exclude_tags_pattern,
         mirrors,
         output = "",
         sha256 = "0" * 64,
@@ -245,7 +275,16 @@ def github_download_and_extract(
     Args:
         repository_ctx: context of a Bazel repository rule.
         repository: GitHub repository name in the form organization/project.
+        upgrade_type: whether this dependency should be upgraded by searching
+            for releases ("release"), tags ("tag"), or arbitrary commits to the
+            main branch ("commit").
         commit: git revision for which the archive should be downloaded.
+        tags_pattern: regex describing the portion of the current tag
+            to lock when upgrading (achieved by a parenthetical group).
+            Used by //tools/workspace:new_release.
+        exclude_tags_pattern: regex describing tags to ignore when performing
+            upgrades.
+            Used by //tools/workspace:new_release.
         mirrors: dictionary of mirrors, see mirrors.bzl in this directory for
             an example.
         output: path to the directory where the archive will be unpacked,
@@ -282,12 +321,29 @@ def github_download_and_extract(
         [line.strip() for line in upgrade_advice.strip().split("\n")],
     ).replace("\\\n", "\\\n    ")
 
+    upgrade_types = ["commit", "release", "tag"]
+    if upgrade_type not in upgrade_types:
+        fail("got invalid upgrade_type '{}'; must be one of: {}".format(
+            upgrade_type,
+            ", ".join(upgrade_types),
+        ))
+
+    # TODO(tyler-yankee): We should support tags_pattern for releases,
+    # too.
+    if upgrade_type != "tag" and tags_pattern:
+        fail("tags_pattern can only be used for tags")
+    if upgrade_type not in ["release", "tag"] and exclude_tags_pattern:
+        fail("exclude_tags_pattern can only be used for releases or tags")
+
     # Create a summary file for Drake maintainers.
     generate_repository_metadata(
         repository_ctx,
         repository_rule_type = "github",
         repository = repository,
+        upgrade_type = upgrade_type,
         commit = commit,
+        tags_pattern = tags_pattern,
+        exclude_tags_pattern = exclude_tags_pattern,
         version_pin = commit_pin,
         sha256 = sha256,
         urls = urls,
@@ -576,6 +632,7 @@ def setup_github_release_attachments(repository_ctx):
         repository_ctx,
         repository_rule_type = "github_release_attachments",
         repository = repository,
+        upgrade_type = "release",
         commit = commit,
         version_pin = commit_pin,
         attachments = attachments,

--- a/tools/workspace/github3_py_internal/repository.bzl
+++ b/tools/workspace/github3_py_internal/repository.bzl
@@ -6,6 +6,8 @@ def github3_py_internal_repository(
     github_archive(
         name = name,
         repository = "sigmavirus24/github3.py",
+        upgrade_type = "tag",
+        tags_pattern = "^(\\d+\\.)",
         commit = "3.2.0",
         sha256 = "42cf8e721437a0bcfb05e767302c3221cdc96f3e9db3d76ce990fd0526af1d99",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/gklib_internal/repository.bzl
+++ b/tools/workspace/gklib_internal/repository.bzl
@@ -6,6 +6,7 @@ def gklib_internal_repository(
     github_archive(
         name = name,
         repository = "KarypisLab/GKlib",
+        upgrade_type = "commit",
         commit = "3b7d61b9f885063c89901f3901fb4426f9cfb58f",
         sha256 = "ce44d6d64a786df09dc979b0b18f095b0fd95d03682bdaac5276e4d234b41b56",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/gymnasium_py_internal/repository.bzl
+++ b/tools/workspace/gymnasium_py_internal/repository.bzl
@@ -6,6 +6,8 @@ def gymnasium_py_internal_repository(
     github_archive(
         name = name,
         repository = "Farama-Foundation/Gymnasium",
+        upgrade_type = "release",
+        exclude_tags_pattern = "v[0-9.]+a[0-9]+",
         commit = "v1.3.0",
         sha256 = "acdcc261cb0145d6692d0cef69c1b30eb3b78982269c3795b8b3141060fc13fd",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/gz_math_internal/repository.bzl
+++ b/tools/workspace/gz_math_internal/repository.bzl
@@ -9,6 +9,8 @@ def gz_math_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "gazebosim/gz-math",
+        upgrade_type = "tag",
+        tags_pattern = "^(gz)",
         commit = "gz-math9_9.1.0",
         sha256 = "d6d266a2a5094b977a3cfec4646efb2eede5fd36781a53faaa37ba416da5cdaf",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/gz_utils_internal/repository.bzl
+++ b/tools/workspace/gz_utils_internal/repository.bzl
@@ -9,6 +9,8 @@ def gz_utils_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "gazebosim/gz-utils",
+        upgrade_type = "tag",
+        tags_pattern = "^(gz)",
         commit = "gz-utils4_4.0.0",
         sha256 = "b06a179ea4297be8b8d09ea7a5d3d45059a3e4030c1bd256afc62f997cc992ed",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/highway_internal/repository.bzl
+++ b/tools/workspace/highway_internal/repository.bzl
@@ -6,6 +6,7 @@ def highway_internal_repository(
     github_archive(
         name = name,
         repository = "google/highway",
+        upgrade_type = "release",
         commit = "1.4.0",
         sha256 = "e72241ac9524bb653ae52ced768b508045d4438726a303f10181a38f764a453c",  # noqa
         patches = [

--- a/tools/workspace/implib_so_internal/repository.bzl
+++ b/tools/workspace/implib_so_internal/repository.bzl
@@ -6,6 +6,7 @@ def implib_so_internal_repository(
     github_archive(
         name = name,
         repository = "yugr/Implib.so",
+        upgrade_type = "commit",
         commit = "30e547b2e8d608f7cd69bc8ec88d047034a40e35",
         sha256 = "0f5e111ce0648215a288c273639a045bde1f1b40139fbd85d06fd25e03af13a2",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/ipopt_internal/repository.bzl
+++ b/tools/workspace/ipopt_internal/repository.bzl
@@ -6,6 +6,7 @@ def ipopt_internal_repository(
     github_archive(
         name = name,
         repository = "coin-or/Ipopt",
+        upgrade_type = "release",
         commit = "releases/3.14.19",
         sha256 = "b3eb84a23812b53a3325bcd2c599de2b0f5df45a18ed251f9e3c1cd893136287",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/lapack_internal/repository.bzl
+++ b/tools/workspace/lapack_internal/repository.bzl
@@ -10,6 +10,7 @@ def lapack_internal_repository(
         If the upstream list of source files changes, then the linter will fail
         and you'll need to follow its advice to copy the new lock file.
         """,
+        upgrade_type = "release",
         commit = "v3.12.1",
         sha256 = "2ca6407a001a474d4d4d35f3a61550156050c48016d949f0da0529c0aa052422",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/lcm_internal/repository.bzl
+++ b/tools/workspace/lcm_internal/repository.bzl
@@ -10,6 +10,7 @@ def lcm_internal_repository(
         When updating, lcm needs its own pull request separate from the rest of
         the monthly upgrades.
         """,
+        upgrade_type = "release",
         commit = "v1.5.2",
         sha256 = "d443261619080f1c0693237b2019436988e1b2b2ba5fc09a49bf23769e1796de",  # noqa
         patches = [

--- a/tools/workspace/libjpeg_turbo_internal/repository.bzl
+++ b/tools/workspace/libjpeg_turbo_internal/repository.bzl
@@ -31,6 +31,7 @@ libjpeg_turbo_internal_repository = repository_rule(
     attrs = {
         # These are the attributes for setup_github_repository.
         "repository": attr.string(default = "libjpeg-turbo/libjpeg-turbo"),
+        "upgrade_type": attr.string(default = "release"),
         "commit": attr.string(default = "2.1.4"),
         "sha256": attr.string(
             default = "a78b05c0d8427a90eb5b4eb08af25309770c8379592bb0b8a863373128e6143f",  # noqa

--- a/tools/workspace/libpng_internal/repository.bzl
+++ b/tools/workspace/libpng_internal/repository.bzl
@@ -6,6 +6,7 @@ def libpng_internal_repository(
     github_archive(
         name = name,
         repository = "pnggroup/libpng",
+        upgrade_type = "tag",
         commit = "v1.6.58",
         sha256 = "a9d4df463d36a6e5f9c29bd6f4967312d17e996c1854f3511f833924eb1993cf",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/libtiff_internal/repository.bzl
+++ b/tools/workspace/libtiff_internal/repository.bzl
@@ -12,6 +12,7 @@ def libtiff_internal_repository(
         The package.BUILD.bazel file hard-codes the version number and release
         date; be sure to update those to match the new commit.
         """,
+        upgrade_type = "tag",
         commit = "v4.7.1",
         sha256 = "a3faec056a490c62b8749847317521204f8c4d9933cce834e691a74524ec38fe",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/libzip_internal/repository.bzl
+++ b/tools/workspace/libzip_internal/repository.bzl
@@ -6,6 +6,7 @@ def libzip_internal_repository(
     github_archive(
         name = name,
         repository = "nih-at/libzip",
+        upgrade_type = "release",
         commit = "v1.11.4",
         sha256 = "4844595615e2436e3cf1ed46a1b260fbdaf8b8fa8f2b594e8b5d8162c696b8b2",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -10,6 +10,7 @@ def meshcat_repository(
         Updating this commit requires local testing; see
         drake/tools/workspace/meshcat/README.md for details.
         """,
+        upgrade_type = "commit",
         commit = "815addc85f3bca5615ece3e8095bbca009480143",
         sha256 = "0a527248e95f31f8723817e1b678a97827c5293d3fd30b600e383ea09bf6063f",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/metis_internal/repository.bzl
+++ b/tools/workspace/metis_internal/repository.bzl
@@ -6,6 +6,7 @@ def metis_internal_repository(
     github_archive(
         name = name,
         repository = "KarypisLab/METIS",
+        upgrade_type = "tag",
         commit = "v5.2.1",
         sha256 = "1a4665b2cd07edc2f734e30d7460afb19c1217c2547c2ac7bf6e1848d50aff7a",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/mpmath_py_internal/repository.bzl
+++ b/tools/workspace/mpmath_py_internal/repository.bzl
@@ -9,6 +9,7 @@ def mpmath_py_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "mpmath/mpmath",
+        upgrade_type = "release",
         commit = "1.3.0",
         commit_pin = 1,
         sha256 = "8f702663fa422fbbf02d15792da4b2566160df35b8a4af55fe64cba2fec2aa00",  # noqa

--- a/tools/workspace/msgpack_internal/repository.bzl
+++ b/tools/workspace/msgpack_internal/repository.bzl
@@ -6,6 +6,8 @@ def msgpack_internal_repository(
     github_archive(
         name = name,
         repository = "msgpack/msgpack-c",
+        upgrade_type = "release",
+        exclude_tags_pattern = "c-[0-9.]+",
         commit = "cpp-8.0.0",
         sha256 = "f634fb7052da4478096f2a02dfb6d91174e5836b317afb006375249ccb086aa8",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/mujoco_menagerie_internal/repository.bzl
+++ b/tools/workspace/mujoco_menagerie_internal/repository.bzl
@@ -6,6 +6,7 @@ def mujoco_menagerie_internal_repository(
     github_archive(
         name = name,
         repository = "google-deepmind/mujoco_menagerie",
+        upgrade_type = "commit",
         commit = "4c358ef9d9d7f32ca58b40b490884a0c1726a440",
         sha256 = "d57b869703b30890c6b322793ca4ac8b7e4d1e841a1155912262823d3db04f6c",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/nanoflann_internal/repository.bzl
+++ b/tools/workspace/nanoflann_internal/repository.bzl
@@ -6,6 +6,7 @@ def nanoflann_internal_repository(
     github_archive(
         name = name,
         repository = "jlblancoc/nanoflann",
+        upgrade_type = "release",
         commit = "v1.10.0",
         sha256 = "b8ce3d4d4051a62a5ab68e0b1da54fde466f655c3e8d52ead5c470812c45f202",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -22,7 +22,7 @@ and save the plaintext hexadecimal token to that file.
 This program can also automatically prepare upgrades for our GitHub externals
 by passing the name(s) of package(s) to upgrade as additional arguments:
 
-  bazel run //tools/workspace:new_release -- --lint --commit rules_python
+  bazel run //tools/workspace:new_release -- --lint --commit curl_internal
 
 Note that this program runs `bazel` as a subprocess, without any special
 command line flags.  If you do need to use any flags when you run bazel,
@@ -82,30 +82,6 @@ _OTHER_REPOSITORIES = [
     "python",
 ]
 
-# For these repositories, ignore any tags that match the specified regex.
-_IGNORED_TAGS = {
-    "gymnasium_py_internal": r"v[0-9.]+a[0-9]+",
-    "libpng_internal": r"v[0-9.]+(alpha|beta)[0-9]+",
-    "msgpack_internal": r"c-[0-9.]+",
-    "ros_xacro_internal": r"xacro-[0-9.]+",
-    "sdformat_internal": r"sdformat-prerelease_[0-9.]+",
-}
-
-# For these repositories, we only look at tags, not releases.  For the dict
-# value, use a blank value to match the latest tag or a regex to only select
-# tags that share the match with the tag currently in use; the parentheses
-# group in the regex denotes the portion of the tag to lock as invariant.
-# (This can be used to pin to a given major or major.minor release series.)
-_OVERLOOK_RELEASE_REPOSITORIES = {
-    "doxygen_internal": "",
-    "github3_py_internal": r"^(\d+.)",
-    "gz_math_internal": r"^(gz)",
-    "gz_utils_internal": r"^(gz)",
-    "qhull_internal": r"^(2)",
-    "sdformat_internal": "",
-    "xmlrunner_py_internal": "",
-}
-
 # Packages in these cohorts should be upgraded together (in a single commit).
 _COHORTS = (
     # clarabel_cpp uses crate_universe; be sure to keep them aligned.
@@ -143,14 +119,12 @@ def _rewrite_file_contents(path, new_content):
     os.rename(f"{path}.new", path)
 
 
-def _check_output(args):
-    return subprocess.check_output(args).decode("utf8")
-
-
 def _get_default_username():
-    origin_url = _check_output(
-        ["git", "config", "--get", "remote.origin.url"]
-    ).strip()
+    origin_url = (
+        subprocess.check_output(["git", "config", "--get", "remote.origin.url"])
+        .decode("utf8")
+        .strip()
+    )
     # Match one of these two cases:
     #  git@github.com:user/drake.git
     #  https://user@github.com/user/drake.git
@@ -161,36 +135,27 @@ def _get_default_username():
     return git_user or http_user
 
 
-def _smells_like_a_git_commit(revision):
-    """Returns true iff revision seems to be a git commit (as opposed to
-    a version number tag name).  This might produce false positives for
-    very long version numbers, but we've never seen that in practice.
-    """
-    return len(revision) == 40
-
-
-def _is_ignored_tag(commit, workspace):
+def _is_ignored_tag(commit, workspace, exclude_pattern=None):
     """Returns true iff commit matches an ignore rule or seems to be a
     pre-release.
     """
-    ignore_re = _IGNORED_TAGS.get(workspace)
-    if ignore_re and re.match(ignore_re, commit):
+    if exclude_pattern and re.match(exclude_pattern, commit):
         # Matches the regex of tag names to definitely ignore; do so quietly so
         # we don't spam the user.
         return True
 
     development_stages = ["alpha", "beta", "pre", "rc", "unstable"]
-    prerelease = any(stage in commit for stage in development_stages)
-    if prerelease:
-        # Heuristically looks like a pre-release; ignore it, but log it for the
-        # user to check.
-        warn(f"Skipping prerelease {commit} for {workspace}")
-    return prerelease
+    if any(stage in commit for stage in development_stages):
+        # Heuristically looks like a pre-release; ignore it quietly so we
+        # don't spam the user.
+        return True
+
+    return False
 
 
-def _latest_tag(gh_repo, workspace):
+def _latest_tag(gh_repo, workspace, exclude_pattern=None):
     for tag in gh_repo.tags():
-        if _is_ignored_tag(tag.name, workspace):
+        if _is_ignored_tag(tag.name, workspace, exclude_pattern):
             continue
         return tag.name
     warn(f"Could not find any matching tags for {workspace}")
@@ -202,21 +167,26 @@ def _handle_github(workspace_name, gh, data):
     old_commit = data["commit"]
     new_commit = None
     owner, repo_name = data["repository"].split("/")
+    upgrade_type = data["upgrade_type"]
     gh_repo = gh.repository(owner, repo_name)
 
-    # If we're tracking via git commit, then upgrade to the newest commit.
-    if _smells_like_a_git_commit(old_commit):
+    if upgrade_type == "commit":
         new_commit = gh_repo.commit("HEAD").sha
         return old_commit, new_commit
+    elif upgrade_type == "tag":
+        # Search for the latest tag by default. If a "tags_pattern" regex was
+        # provided, we'll limit to tags matching those. If an
+        # "exclude_tags_pattern" regex was provided, we'll (further) ignore
+        # matching those.
+        tags_pattern = data["tags_pattern"]
+        exclude_tags_pattern = data["exclude_tags_pattern"]
 
-    # Sometimes prefer checking only tags, not releases.
-    tags_pattern = _OVERLOOK_RELEASE_REPOSITORIES.get(workspace_name)
-    if tags_pattern == "":
-        new_commit = _latest_tag(gh_repo, workspace_name)
-        return old_commit, new_commit
+        if not tags_pattern:
+            new_commit = _latest_tag(
+                gh_repo, workspace_name, exclude_tags_pattern
+            )
+            return old_commit, new_commit
 
-    # Sometimes limit candidate tags to those matching a regex.
-    if tags_pattern is not None:
         match = re.search(tags_pattern, old_commit)
         assert match, f"No {tags_pattern} in {old_commit}"
         (old_hit,) = match.groups()
@@ -225,21 +195,29 @@ def _handle_github(workspace_name, gh, data):
             if match:
                 (new_hit,) = match.groups()
                 if old_hit == new_hit:
-                    if _is_ignored_tag(tag.name, workspace_name):
+                    if _is_ignored_tag(
+                        tag.name,
+                        workspace_name,
+                        exclude_tags_pattern,
+                    ):
                         continue
                     new_commit = tag.name
                     break
         return old_commit, new_commit
-
-    # By default, use the latest release if there is one.  Otherwise, use the
-    # latest tag.
-    try:
-        new_commit = gh_repo.latest_release().tag_name
-        if _is_ignored_tag(new_commit, workspace_name):
-            new_commit = _latest_tag(gh_repo, workspace_name)
-    except github3.exceptions.NotFoundError:
-        new_commit = _latest_tag(gh_repo, workspace_name)
-    return old_commit, new_commit
+    elif upgrade_type == "release":
+        exclude_tags_pattern = data["exclude_tags_pattern"]
+        for release in gh_repo.releases():
+            if not _is_ignored_tag(
+                release.tag_name, workspace_name, exclude_tags_pattern
+            ):
+                new_commit = release.tag_name
+                break
+        return old_commit, new_commit
+    else:
+        raise ValueError(
+            f"Unknown upgrade type {upgrade_type} for {workspace_name} "
+            "(must be one of: commit, release, tag)."
+        )
 
 
 def _check_for_upgrades(gh, args, metadata):
@@ -255,7 +233,7 @@ def _check_for_upgrades(gh, args, metadata):
             info(f"{workspace_name} may need upgrade")
             continue
         else:
-            raise RuntimeError(f"Bad rule type {rule_type} in {workspace_name}")
+            raise ValueError(f"Bad rule type {rule_type} in {workspace_name}")
         if old_commit == new_commit:
             continue
         elif new_commit is not None:
@@ -355,7 +333,7 @@ def _download(url, local_filename):
 
 
 def _do_upgrade_github_archive(
-    *, temp_dir, old_commit, new_commit, bzl_filename, repository
+    *, temp_dir, upgrade_type, old_commit, new_commit, bzl_filename, repository
 ):
     # Slurp the file we're supposed to modify.
     with open(bzl_filename, "r", encoding="utf-8") as f:
@@ -382,7 +360,7 @@ def _do_upgrade_github_archive(
 
     # Download the new source archive.
     info("Downloading new archive...")
-    if _smells_like_a_git_commit(new_commit):
+    if upgrade_type == "commit":
         new_url = f"https://github.com/{repository}/archive/{new_commit}.tar.gz"
     else:
         new_url = f"https://github.com/{repository}/archive/refs/tags/{new_commit}.tar.gz"  # noqa
@@ -510,6 +488,7 @@ def _do_upgrade(temp_dir, gh, local_drake_checkout, workspace_name, metadata):
         if rule_type == "github":
             _do_upgrade_github_archive(
                 temp_dir=temp_dir,
+                upgrade_type=data["upgrade_type"],
                 old_commit=old_commit,
                 new_commit=new_commit,
                 bzl_filename=bzl_filename,
@@ -543,7 +522,7 @@ def _do_upgrade(temp_dir, gh, local_drake_checkout, workspace_name, metadata):
 
     # Finalize the result.
     if new_commit:
-        if _smells_like_a_git_commit(new_commit):
+        if data["upgrade_type"] == "commit":
             message = f"Update dependency {workspace_name} to latest commit"
         else:
             release = new_commit.lstrip("releases/").lstrip("v")
@@ -578,7 +557,7 @@ def _do_upgrades(temp_dir, gh, local_drake_checkout, workspace_names, metadata):
             info(f"No updates for {workspace_name}")
 
     if not modified_workspace_names:
-        # Nothing was updated
+        # Nothing was updated.
         names = ", ".join(workspace_names)
         info("")
         info("*" * 72)

--- a/tools/workspace/nlohmann_internal/repository.bzl
+++ b/tools/workspace/nlohmann_internal/repository.bzl
@@ -6,6 +6,7 @@ def nlohmann_internal_repository(
     github_archive(
         name = name,
         repository = "nlohmann/json",
+        upgrade_type = "release",
         commit = "v3.12.0",
         sha256 = "4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/nlopt_internal/repository.bzl
+++ b/tools/workspace/nlopt_internal/repository.bzl
@@ -6,6 +6,7 @@ def nlopt_internal_repository(
     github_archive(
         name = name,
         repository = "stevengj/nlopt",
+        upgrade_type = "release",
         commit = "v2.11.0",
         sha256 = "53e552d83e9294d67db37f0f4a23f15933a9ef698485301a18b98b40004cf0de",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/onetbb_internal/repository.bzl
+++ b/tools/workspace/onetbb_internal/repository.bzl
@@ -6,6 +6,7 @@ def onetbb_internal_repository(
     github_archive(
         name = name,
         repository = "oneapi-src/oneTBB",
+        upgrade_type = "release",
         commit = "v2021.8.0",
         # TODO(jwnimmer-tri) We are using the TBB headers from this repository,
         # but the TBB library from MOSEK's binary release. We'll probably need

--- a/tools/workspace/osqp_internal/repository.bzl
+++ b/tools/workspace/osqp_internal/repository.bzl
@@ -10,6 +10,7 @@ def osqp_internal_repository(
         When updating this commit, see
         drake/tools/workspace/qdldl_internal/README.md.
         """,
+        upgrade_type = "release",
         commit = "v1.0.0",
         sha256 = "dd6a1c2e7e921485697d5e7cdeeb043c712526c395b3700601f51d472a7d8e48",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/picosha2_internal/repository.bzl
+++ b/tools/workspace/picosha2_internal/repository.bzl
@@ -6,6 +6,7 @@ def picosha2_internal_repository(
     github_archive(
         name = name,
         repository = "okdshin/PicoSHA2",
+        upgrade_type = "commit",
         commit = "161cb3fc4170fa7a3eca9e582cebd27cc4d1fe29",
         sha256 = "6cf473a00c98298d3ddee0aed853e3c799791f49dbc01c996ea46cb248e85802",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/poisson_disk_sampling_internal/repository.bzl
+++ b/tools/workspace/poisson_disk_sampling_internal/repository.bzl
@@ -6,6 +6,7 @@ def poisson_disk_sampling_internal_repository(
     github_archive(
         name = name,
         repository = "thinks/tph_poisson",
+        upgrade_type = "release",
         commit = "v0.4.0",
         sha256 = "3be4a705ca234ec0dbcc8115e8ac31e9f4dae02423e07e75929d75ed70db0a2d",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -17,6 +17,7 @@ def pybind11_repository(
     github_archive(
         name = name,
         repository = _REPOSITORY,
+        upgrade_type = "release",
         commit = _COMMIT,
         sha256 = _SHA256,
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/qdldl_internal/repository.bzl
+++ b/tools/workspace/qdldl_internal/repository.bzl
@@ -10,6 +10,7 @@ def qdldl_internal_repository(
         When updating this commit, see
         drake/tools/workspace/qdldl_internal/README.md.
         """,
+        upgrade_type = "release",
         commit = "v0.1.8",
         sha256 = "ecf113fd6ad8714f16289eb4d5f4d8b27842b6775b978c39def5913f983f6daa",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/qhull_internal/repository.bzl
+++ b/tools/workspace/qhull_internal/repository.bzl
@@ -6,7 +6,9 @@ def qhull_internal_repository(
     github_archive(
         name = name,
         repository = "qhull/qhull",
+        upgrade_type = "tag",
         commit = "2020.2",
+        tags_pattern = "^(2)",
         sha256 = "59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [

--- a/tools/workspace/ros_xacro_internal/repository.bzl
+++ b/tools/workspace/ros_xacro_internal/repository.bzl
@@ -6,6 +6,8 @@ def ros_xacro_internal_repository(
     github_archive(
         name = name,
         repository = "ros/xacro",
+        upgrade_type = "tag",
+        exclude_tags_pattern = "xacro-[0-9.]+",
         commit = "2.1.1",
         sha256 = "f9d94956574015427e59011d4ee113b206e9c10a27a0c01d4b08ee4268d76741",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/scs_internal/repository.bzl
+++ b/tools/workspace/scs_internal/repository.bzl
@@ -10,6 +10,7 @@ def scs_internal_repository(
         When updating this commit, see
         drake/tools/workspace/qdldl_internal/README.md.
         """,
+        upgrade_type = "release",
         commit = "3.2.11",
         sha256 = "ceb5d9ecf35836ee7e0ce64566190f11a99314ec8143dbb909329809afa3f77f",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/sdformat_internal/repository.bzl
+++ b/tools/workspace/sdformat_internal/repository.bzl
@@ -9,6 +9,7 @@ def sdformat_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "gazebosim/sdformat",
+        upgrade_type = "tag",
         commit = "sdformat16_16.0.1",
         build_file = ":package.BUILD.bazel",
         sha256 = "4fac898700afb2953af5f8ac6b0221e4d9bc1e460aac6d4b7a5c3699c456126c",  # noqa

--- a/tools/workspace/spral_internal/repository.bzl
+++ b/tools/workspace/spral_internal/repository.bzl
@@ -6,6 +6,7 @@ def spral_internal_repository(
     github_archive(
         name = name,
         repository = "ralna/spral",
+        upgrade_type = "release",
         commit = "v2025.09.18",
         sha256 = "1358168ac95297049e4fc810e54a16e0c765796cfbaa156e09979e2620b7dae7",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/stable_baselines3_internal/repository.bzl
+++ b/tools/workspace/stable_baselines3_internal/repository.bzl
@@ -6,6 +6,7 @@ def stable_baselines3_internal_repository(
     github_archive(
         name = name,
         repository = "DLR-RM/stable-baselines3",
+        upgrade_type = "release",
         commit = "v2.8.0",
         sha256 = "9d8cbcf140d725d337ce1af06cd497ddfe2ae91fe175e9d97c2a08edfb4f7a2a",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/stduuid_internal/repository.bzl
+++ b/tools/workspace/stduuid_internal/repository.bzl
@@ -6,6 +6,7 @@ def stduuid_internal_repository(
     github_archive(
         name = name,
         repository = "mariusbancila/stduuid",
+        upgrade_type = "release",
         commit = "v1.2.3",
         sha256 = "b1176597e789531c38481acbbed2a6894ad419aab0979c10410d59eb0ebf40d3",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/styleguide_internal/repository.bzl
+++ b/tools/workspace/styleguide_internal/repository.bzl
@@ -6,6 +6,7 @@ def styleguide_internal_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/styleguide",
+        upgrade_type = "commit",
         commit = "b87173bc4d62e9662a73ceb3f7f34e61c87334a0",
         sha256 = "64ac6a6d71e10a006275ee3b8f557b45bdf174ee9a00282623024451ebc8c4cf",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/suitesparse_internal/repository.bzl
+++ b/tools/workspace/suitesparse_internal/repository.bzl
@@ -6,6 +6,7 @@ def suitesparse_internal_repository(
     github_archive(
         name = name,
         repository = "DrTimothyAldenDavis/SuiteSparse",
+        upgrade_type = "release",
         commit = "v7.12.2",
         sha256 = "679412daa5f69af96d6976595c1ac64f252287a56e98cc4a8155d09cc7fd69e8",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/sympy_py_internal/repository.bzl
+++ b/tools/workspace/sympy_py_internal/repository.bzl
@@ -14,6 +14,7 @@ def sympy_py_internal_repository(
         any release notes related to this issue, etc.) to see if
         mpmath_py_internal should also be upgraded and its commit_pin removed.
         """,
+        upgrade_type = "release",
         commit = "1.14.0",
         sha256 = "813eecbf60fdf4c692cc1cdb30b940072160f4ab0421fa5d7aaa7a8a8c596615",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/tinygltf_internal/repository.bzl
+++ b/tools/workspace/tinygltf_internal/repository.bzl
@@ -6,6 +6,7 @@ def tinygltf_internal_repository(
     github_archive(
         name = name,
         repository = "syoyo/tinygltf",
+        upgrade_type = "release",
         commit = "v3.0.0",
         sha256 = "806b0f1ba8007837fcd531e23872286f8a8870ee23275e1eb5304cdb48e4cb30",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/tinyobjloader_internal/repository.bzl
+++ b/tools/workspace/tinyobjloader_internal/repository.bzl
@@ -6,6 +6,7 @@ def tinyobjloader_internal_repository(
     github_archive(
         name = name,
         repository = "tinyobjloader/tinyobjloader",
+        upgrade_type = "commit",
         commit = "62ff207968f3dc14a64a1e2378dce67b760e7c4a",
         sha256 = "672aa67aae74ebf90edf493015d45010423135720ebbf86d8441abf19bb8f94c",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/tinyxml2_internal/repository.bzl
+++ b/tools/workspace/tinyxml2_internal/repository.bzl
@@ -6,6 +6,7 @@ def tinyxml2_internal_repository(
     github_archive(
         name = name,
         repository = "leethomason/tinyxml2",
+        upgrade_type = "release",
         commit = "11.0.0",
         sha256 = "5556deb5081fb246ee92afae73efd943c889cef0cafea92b0b82422d6a18f289",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/uritemplate_py_internal/repository.bzl
+++ b/tools/workspace/uritemplate_py_internal/repository.bzl
@@ -6,6 +6,7 @@ def uritemplate_py_internal_repository(
     github_archive(
         name = name,
         repository = "python-hyper/uritemplate",
+        upgrade_type = "release",
         commit = "4.2.0",
         sha256 = "b75ed8dcb1446d06f5b885de7629ffd1f88f26b4f3630ace21d108084938b473",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/usockets_internal/repository.bzl
+++ b/tools/workspace/usockets_internal/repository.bzl
@@ -9,6 +9,7 @@ def usockets_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "uNetworking/uSockets",
+        upgrade_type = "release",
         commit = "v0.8.8",
         sha256 = "d14d2efe1df767dbebfb8d6f5b52aa952faf66b30c822fbe464debaa0c5c0b17",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/uwebsockets_internal/repository.bzl
+++ b/tools/workspace/uwebsockets_internal/repository.bzl
@@ -9,6 +9,7 @@ def uwebsockets_internal_repository(
         # drake/tools/workspace/new_release.py.  When practical, all members
         # of this cohort should be updated at the same time.
         repository = "uNetworking/uWebSockets",
+        upgrade_type = "release",
         commit = "v20.78.0",
         sha256 = "8deea90fc34b0987dfe983af9866d52ff762358fb24c8df891a896c0035aa28e",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/voxelized_geometry_tools_internal/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools_internal/repository.bzl
@@ -10,6 +10,7 @@ def voxelized_geometry_tools_internal_repository(
         When updating, ensure that any new unit tests are reflected in
         package.BUILD.bazel and BUILD.bazel in drake.
         """,
+        upgrade_type = "commit",
         commit = "0e7582c72dadb87ae528679e2610c31970cafccb",
         sha256 = "edb20aae2905c5aba5a42474b88bfe862dc9544514b67ffd2a60989588a2a0fa",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/vtk_internal/repository.bzl
+++ b/tools/workspace/vtk_internal/repository.bzl
@@ -153,6 +153,7 @@ _vtk_internal_repository_impl = repository_rule(
     attrs = {
         # These are the attributes for setup_github_repository.
         "repository": attr.string(),
+        "upgrade_type": attr.string(),
         "commit": attr.string(),
         "sha256": attr.string(),
         "build_file": attr.label(),
@@ -183,6 +184,7 @@ def vtk_internal_repository(
         name,
         local_repository_override = None,
         repository = "Kitware/VTK",
+        upgrade_type = "commit",
         commit = "45f8cc6b6a4b14439ee3bab2025fa3ebeb20bfc0",
         sha256 = "a160dea5f99042521364f57a69d5ec85ff6e5ed58528a2925fc080a75b6fa3aa",  # noqa
         build_file = ":package.BUILD.bazel",
@@ -242,6 +244,7 @@ def vtk_internal_repository(
         _vtk_internal_repository_impl(
             name = name,
             repository = repository,
+            upgrade_type = upgrade_type,
             commit = commit,
             sha256 = sha256,
             build_file = build_file,

--- a/tools/workspace/xmlrunner_py_internal/repository.bzl
+++ b/tools/workspace/xmlrunner_py_internal/repository.bzl
@@ -6,6 +6,7 @@ def xmlrunner_py_internal_repository(
     github_archive(
         name = name,
         repository = "xmlrunner/unittest-xml-reporting",
+        upgrade_type = "release",
         commit = "4.0.0",
         sha256 = "5fd1880a41247c4976a73699598225b80e597755791ba76f2c5066142e1cd923",  # noqa
         build_file = ":package.BUILD.bazel",

--- a/tools/workspace/yaml_cpp_internal/repository.bzl
+++ b/tools/workspace/yaml_cpp_internal/repository.bzl
@@ -6,6 +6,7 @@ def yaml_cpp_internal_repository(
     github_archive(
         name = name,
         repository = "jbeder/yaml-cpp",
+        upgrade_type = "release",
         commit = "yaml-cpp-0.9.0",
         sha256 = "25cb043240f828a8c51beb830569634bc7ac603978e0f69d6b63558dadefd49a",  # noqa
         build_file = ":package.BUILD.bazel",


### PR DESCRIPTION
Simplify `new_release`'s search heuristics by hard-coding whether it should be looking to upgrade by commit, tag, or release into repository metadata.

Towards #24570.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24593)
<!-- Reviewable:end -->
