### PR TITLE
[workspace] Pin sympy and mpmath together

### DIFF
--- a/tools/workspace/mpmath_py_internal/repository.bzl
+++ b/tools/workspace/mpmath_py_internal/repository.bzl
@@ -5,8 +5,12 @@ def mpmath_py_internal_repository(
         mirrors = None):
     github_archive(
         name = name,
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
         repository = "mpmath/mpmath",
         commit = "1.3.0",
+        commit_pin = 1,
         sha256 = "8f702663fa422fbbf02d15792da4b2566160df35b8a4af55fe64cba2fec2aa00",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -114,6 +114,8 @@ _COHORTS = (
     {"sdformat_internal", "gz_math_internal", "gz_utils_internal"},
     # uwebsockets depends on usockets; be sure to keep them aligned.
     {"uwebsockets_internal", "usockets_internal"},
+    # sympy depends on mpmath; be sure to keep them aligned.
+    {"sympy_py_internal", "mpmath_py_internal"},
 )
 
 

--- a/tools/workspace/sympy_py_internal/repository.bzl
+++ b/tools/workspace/sympy_py_internal/repository.bzl
@@ -6,6 +6,14 @@ def sympy_py_internal_repository(
     github_archive(
         name = name,
         repository = "sympy/sympy",
+        # This dependency is part of a "cohort" defined in
+        # drake/tools/workspace/new_release.py.  When practical, all members
+        # of this cohort should be updated at the same time.
+        upgrade_advice = """
+        When upgrading, check https://github.com/sympy/sympy/issues/29231 (or
+        any release notes related to this issue, etc.) to see if
+        mpmath_py_internal should also be upgraded and its commit_pin removed.
+        """,
         commit = "1.14.0",
         sha256 = "813eecbf60fdf4c692cc1cdb30b940072160f4ab0421fa5d7aaa7a8a8c596615",  # noqa
         build_file = ":package.BUILD.bazel",


### PR DESCRIPTION
See the linked issue for details; sympy cannot currently support the newest mpmath, so we should (a) pin Drake's mpmath to avoid confusion and (b) place them in cohort to ensure they are updated together coherently once a new sympy is released supporting the newer mpmath.

Relates #24588, #24179

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24594)
<!-- Reviewable:end -->
