### PR TITLE
[pydrake] Avoid py::init lambdas when not necessary

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -240,18 +240,12 @@ void DefineGeometrySet(py::module_ m) {
         .def(py::init(), cls_doc.ctor.doc)
         .def(py::init<GeometryId>(), py::arg("geometry_id"), extra_ctor_doc)
         .def(py::init<FrameId>(), py::arg("frame_id"), extra_ctor_doc)
-        .def(py::init([](std::vector<GeometryId> geometry_ids) {
-          return Class(geometry_ids);
-        }),
+        .def(py::init<const std::vector<GeometryId>&>(),
             py::arg("geometry_ids"), extra_ctor_doc)
-        .def(py::init([](std::vector<FrameId> frame_ids) {
-          return Class(frame_ids);
-        }),
-            py::arg("frame_ids"), extra_ctor_doc)
-        .def(py::init([](std::vector<GeometryId> geometry_ids,
-                          std::vector<FrameId> frame_ids) {
-          return Class(geometry_ids, frame_ids);
-        }),
+        .def(py::init<const std::vector<FrameId>&>(), py::arg("frame_ids"),
+            extra_ctor_doc)
+        .def(py::init<const std::vector<GeometryId>&,
+                 const std::vector<FrameId>&>(),
             py::arg("geometry_ids"), py::arg("frame_ids"), extra_ctor_doc)
         .def(
             "Add",

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -196,16 +196,10 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(
         m, "AngleBetweenVectorsConstraint", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          const Frame<double>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& a_A,
-                          const Frame<double>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& b_B,
-                          double angle_lower, double angle_upper,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(plant, frameA, a_A, frameB, b_B,
-              angle_lower, angle_upper, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double, double,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("a_A"),
             py::arg("frameB"), py::arg("b_B"), py::arg("angle_lower"),
             py::arg("angle_upper"), py::arg("plant_context"),
@@ -213,16 +207,12 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 9>(), cls_doc.ctor.doc_double)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          const Frame<AutoDiffXd>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& a_A,
-                          const Frame<AutoDiffXd>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& b_B,
-                          double angle_lower, double angle_upper,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(plant, frameA, a_A, frameB, b_B,
-              angle_lower, angle_upper, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double, double,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("a_A"),
             py::arg("frameB"), py::arg("b_B"), py::arg("angle_lower"),
             py::arg("angle_upper"), py::arg("plant_context"),
@@ -237,15 +227,10 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, solvers::Cost, Ptr>(
         m, "AngleBetweenVectorsCost", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          const Frame<double>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& a_A,
-                          const Frame<double>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& b_B,
-                          double c, systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(
-              plant, frameA, a_A, frameB, b_B, c, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("a_A"),
             py::arg("frameB"), py::arg("b_B"), py::arg("c"),
             py::arg("plant_context"),
@@ -253,16 +238,12 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
-        .def(
-            py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                         const Frame<AutoDiffXd>& frameA,
-                         const Eigen::Ref<const Eigen::Vector3d>& a_A,
-                         const Frame<AutoDiffXd>& frameB,
-                         const Eigen::Ref<const Eigen::Vector3d>& b_B, double c,
-                         systems::Context<AutoDiffXd>* plant_context) {
-              return std::make_unique<Class>(
-                  plant, frameA, a_A, frameB, b_B, c, plant_context);
-            }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("a_A"),
             py::arg("frameB"), py::arg("b_B"), py::arg("c"),
             py::arg("plant_context"),
@@ -277,16 +258,12 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(
         m, "PointToPointDistanceConstraint", cls_doc.doc)
-        .def(py::init([](const multibody::MultibodyPlant<double>* const plant,
-                          const multibody::Frame<double>& frame1,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_B1P1,
-                          const multibody::Frame<double>& frame2,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_B2P2,
-                          double distance_lower, double distance_upper,
-                          systems::Context<double>* plant_context) {
-          return std::make_shared<Class>(plant, frame1, p_B1P1, frame2, p_B2P2,
-              distance_lower, distance_upper, plant_context);
-        }),
+        .def(py::init<const multibody::MultibodyPlant<double>* const,
+                 const multibody::Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const multibody::Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double, double,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frame1"), py::arg("p_B1P1"),
             py::arg("frame2"), py::arg("p_B2P2"), py::arg("distance_lower"),
             py::arg("distance_upper"), py::arg("plant_context"),
@@ -294,17 +271,12 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 9>(), cls_doc.ctor.doc_double)
-        .def(py::init(
-                 [](const multibody::MultibodyPlant<AutoDiffXd>* const plant,
-                     const multibody::Frame<AutoDiffXd>& frame1,
-                     const Eigen::Ref<const Eigen::Vector3d>& p_B1P1,
-                     const multibody::Frame<AutoDiffXd>& frame2,
-                     const Eigen::Ref<const Eigen::Vector3d>& p_B2P2,
-                     double distance_lower, double distance_upper,
-                     systems::Context<AutoDiffXd>* plant_context) {
-                   return std::make_shared<Class>(plant, frame1, p_B1P1, frame2,
-                       p_B2P2, distance_lower, distance_upper, plant_context);
-                 }),
+        .def(py::init<const multibody::MultibodyPlant<AutoDiffXd>* const,
+                 const multibody::Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const multibody::Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double, double,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frame1"), py::arg("p_B1P1"),
             py::arg("frame2"), py::arg("p_B2P2"), py::arg("distance_lower"),
             py::arg("distance_upper"), py::arg("plant_context"),
@@ -319,17 +291,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(
         m, "PointToLineDistanceConstraint", cls_doc.doc)
-        .def(py::init([](const multibody::MultibodyPlant<double>* const plant,
-                          const multibody::Frame<double>& frame_point,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_B1P,
-                          const multibody::Frame<double>& frame_line,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_B2Q,
-                          const Eigen::Ref<const Eigen::Vector3d>& n_B2,
-                          double distance_lower, double distance_upper,
-                          systems::Context<double>* plant_context) {
-          return std::make_shared<Class>(plant, frame_point, p_B1P, frame_line,
-              p_B2Q, n_B2, distance_lower, distance_upper, plant_context);
-        }),
+        .def(py::init<const multibody::MultibodyPlant<double>* const,
+                 const multibody::Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const multibody::Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double, double,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frame_point"), py::arg("p_B1P"),
             py::arg("frame_line"), py::arg("p_B2Q"), py::arg("n_B2"),
             py::arg("distance_lower"), py::arg("distance_upper"),
@@ -338,19 +306,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 10>(), cls_doc.ctor.doc_double)
-        .def(py::init(
-                 [](const multibody::MultibodyPlant<AutoDiffXd>* const plant,
-                     const multibody::Frame<AutoDiffXd>& frame_point,
-                     const Eigen::Ref<const Eigen::Vector3d>& p_B1P,
-                     const multibody::Frame<AutoDiffXd>& frame_line,
-                     const Eigen::Ref<const Eigen::Vector3d>& p_B2Q,
-                     const Eigen::Ref<const Eigen::Vector3d>& n_B2,
-                     double distance_lower, double distance_upper,
-                     systems::Context<AutoDiffXd>* plant_context) {
-                   return std::make_shared<Class>(plant, frame_point, p_B1P,
-                       frame_line, p_B2Q, n_B2, distance_lower, distance_upper,
-                       plant_context);
-                 }),
+        .def(py::init<const multibody::MultibodyPlant<AutoDiffXd>* const,
+                 const multibody::Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const multibody::Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double, double,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frame_point"), py::arg("p_B1P"),
             py::arg("frame_line"), py::arg("p_B2Q"), py::arg("n_B2"),
             py::arg("distance_lower"), py::arg("distance_upper"),
@@ -365,16 +327,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     constexpr auto& cls_doc = doc.PolyhedronConstraint;
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(m, "PolyhedronConstraint", cls_doc.doc)
-        .def(py::init([](const multibody::MultibodyPlant<double>* const plant,
-                          const multibody::Frame<double>& frameF,
-                          const multibody::Frame<double>& frameG,
-                          const Eigen::Ref<const Eigen::Matrix3Xd>& p_GP,
-                          const Eigen::Ref<const Eigen::MatrixXd>& A,
-                          const Eigen::Ref<const Eigen::VectorXd>& b,
-                          systems::Context<double>* plant_context) {
-          return std::make_shared<Class>(
-              plant, frameF, frameG, p_GP, A, b, plant_context);
-        }),
+        .def(py::init<const multibody::MultibodyPlant<double>* const,
+                 const multibody::Frame<double>&,
+                 const multibody::Frame<double>&,
+                 const Eigen::Ref<const Eigen::Matrix3Xd>&,
+                 const Eigen::Ref<const Eigen::MatrixXd>&,
+                 const Eigen::Ref<const Eigen::VectorXd>&,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameF"), py::arg("frameG"),
             py::arg("p_GP"), py::arg("A"), py::arg("b"),
             py::arg("plant_context"),
@@ -382,17 +341,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
-        .def(py::init(
-                 [](const multibody::MultibodyPlant<AutoDiffXd>* const plant,
-                     const multibody::Frame<AutoDiffXd>& frameF,
-                     const multibody::Frame<AutoDiffXd>& frameG,
-                     const Eigen::Ref<const Eigen::Matrix3Xd>& p_GP,
-                     const Eigen::Ref<const Eigen::MatrixXd>& A,
-                     const Eigen::Ref<const Eigen::VectorXd>& b,
-                     systems::Context<AutoDiffXd>* plant_context) {
-                   return std::make_shared<Class>(
-                       plant, frameF, frameG, p_GP, A, b, plant_context);
-                 }),
+        .def(py::init<const multibody::MultibodyPlant<AutoDiffXd>* const,
+                 const multibody::Frame<AutoDiffXd>&,
+                 const multibody::Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Matrix3Xd>&,
+                 const Eigen::Ref<const Eigen::MatrixXd>&,
+                 const Eigen::Ref<const Eigen::VectorXd>&,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameF"), py::arg("frameG"),
             py::arg("p_GP"), py::arg("A"), py::arg("b"),
             py::arg("plant_context"),
@@ -406,13 +361,9 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     constexpr auto& cls_doc = doc.DistanceConstraint;
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(m, "DistanceConstraint", cls_doc.doc)
-        .def(py::init([](const multibody::MultibodyPlant<double>* const plant,
-                          SortedPair<geometry::GeometryId> geometry_pair,
-                          systems::Context<double>* plant_context,
-                          double distance_lower, double distance_upper) {
-          return std::make_unique<Class>(plant, geometry_pair, plant_context,
-              distance_lower, distance_upper);
-        }),
+        .def(py::init<const multibody::MultibodyPlant<double>* const,
+                 SortedPair<geometry::GeometryId>, systems::Context<double>*,
+                 double, double>(),
             py::arg("plant"), py::arg("geometry_pair"),
             py::arg("plant_context"), py::arg("distance_lower"),
             py::arg("distance_upper"),
@@ -420,14 +371,9 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 4>(), cls_doc.ctor.doc_double)
-        .def(py::init(
-                 [](const multibody::MultibodyPlant<AutoDiffXd>* const plant,
-                     SortedPair<geometry::GeometryId> geometry_pair,
-                     systems::Context<AutoDiffXd>* plant_context,
-                     double distance_lower, double distance_upper) {
-                   return std::make_unique<Class>(plant, geometry_pair,
-                       plant_context, distance_lower, distance_upper);
-                 }),
+        .def(py::init<const multibody::MultibodyPlant<AutoDiffXd>* const,
+                 SortedPair<geometry::GeometryId>,
+                 systems::Context<AutoDiffXd>*, double, double>(),
             py::arg("plant"), py::arg("geometry_pair"),
             py::arg("plant_context"), py::arg("distance_lower"),
             py::arg("distance_upper"),
@@ -442,17 +388,11 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     constexpr auto& cls_doc = doc.GazeTargetConstraint;
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(m, "GazeTargetConstraint", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          const Frame<double>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AS,
-                          const Eigen::Ref<const Eigen::Vector3d>& n_A,
-                          const Frame<double>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_BT,
-                          double cone_half_angle,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(plant, frameA, p_AS, n_A, frameB, p_BT,
-              cone_half_angle, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("p_AS"),
             py::arg("n_A"), py::arg("frameB"), py::arg("p_BT"),
             py::arg("cone_half_angle"), py::arg("plant_context"),
@@ -460,17 +400,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 9>(), cls_doc.ctor.doc_double)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          const Frame<AutoDiffXd>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AS,
-                          const Eigen::Ref<const Eigen::Vector3d>& n_A,
-                          const Frame<AutoDiffXd>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_BT,
-                          double cone_half_angle,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(plant, frameA, p_AS, n_A, frameB, p_BT,
-              cone_half_angle, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, double,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("p_AS"),
             py::arg("n_A"), py::arg("frameB"), py::arg("p_BT"),
             py::arg("cone_half_angle"), py::arg("plant_context"),
@@ -657,16 +593,10 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     constexpr auto& cls_doc = doc.PositionConstraint;
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(m, "PositionConstraint", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          const Frame<double>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-                          const Frame<double>& frameB,
-                          std::optional<Eigen::Vector3d> p_BQ,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(plant, frameA, p_AQ_lower, p_AQ_upper,
-              frameB, p_BQ, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
+                 std::optional<Eigen::Vector3d>, systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("p_AQ_lower"),
             py::arg("p_AQ_upper"), py::arg("frameB"), py::arg("p_BQ"),
             py::arg("plant_context"),
@@ -674,17 +604,11 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          const Frame<double>& frameAbar,
-                          const std::optional<math::RigidTransformd>& X_AbarA,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-                          const Frame<double>& frameB,
-                          std::optional<Eigen::Vector3d> p_BQ,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(plant, frameAbar, X_AbarA, p_AQ_lower,
-              p_AQ_upper, frameB, p_BQ, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
+                 const std::optional<math::RigidTransformd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
+                 std::optional<Eigen::Vector3d>, systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameAbar"), py::arg("X_AbarA"),
             py::arg("p_AQ_lower"), py::arg("p_AQ_upper"), py::arg("frameB"),
             py::arg("p_BQ"), py::arg("plant_context"),
@@ -692,16 +616,12 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 9>(), cls_doc.ctor.doc_double_Abar)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          const Frame<AutoDiffXd>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-                          const Frame<AutoDiffXd>& frameB,
-                          std::optional<Eigen::Vector3d> p_BQ,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(plant, frameA, p_AQ_lower, p_AQ_upper,
-              frameB, p_BQ, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Frame<AutoDiffXd>&, std::optional<Eigen::Vector3d>,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("p_AQ_lower"),
             py::arg("p_AQ_upper"), py::arg("frameB"), py::arg("p_BQ"),
             py::arg("plant_context"),
@@ -709,17 +629,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_autodiff)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          const Frame<AutoDiffXd>& frameAbar,
-                          const std::optional<math::RigidTransformd>& X_AbarA,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper,
-                          const Frame<AutoDiffXd>& frameB,
-                          std::optional<Eigen::Vector3d> p_BQ,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(plant, frameAbar, X_AbarA, p_AQ_lower,
-              p_AQ_upper, frameB, p_BQ, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 const Frame<AutoDiffXd>&,
+                 const std::optional<math::RigidTransformd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Frame<AutoDiffXd>&, std::optional<Eigen::Vector3d>,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameAbar"), py::arg("X_AbarA"),
             py::arg("p_AQ_lower"), py::arg("p_AQ_upper"), py::arg("frameB"),
             py::arg("p_BQ"), py::arg("plant_context"),
@@ -740,16 +656,11 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     constexpr auto& cls_doc = doc.PositionCost;
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, solvers::Cost, Ptr>(m, "PositionCost", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          const Frame<double>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AP,
-                          const Frame<double>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
-                          const Eigen::Ref<const Eigen::Matrix3d>& C,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(
-              plant, frameA, p_AP, frameB, p_BQ, C, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Matrix3d>&,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("p_AP"),
             py::arg("frameB"), py::arg("p_BQ"), py::arg("C"),
             py::arg("plant_context"),
@@ -757,16 +668,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          const Frame<AutoDiffXd>& frameA,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_AP,
-                          const Frame<AutoDiffXd>& frameB,
-                          const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
-                          const Eigen::Ref<const Eigen::Matrix3d>& C,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(
-              plant, frameA, p_AP, frameB, p_BQ, C, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::Vector3d>&,
+                 const Eigen::Ref<const Eigen::Matrix3d>&,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameA"), py::arg("p_AP"),
             py::arg("frameB"), py::arg("p_BQ"), py::arg("C"),
             py::arg("plant_context"),
@@ -781,28 +689,18 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     constexpr auto& cls_doc = doc.ComPositionConstraint;
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(m, "ComPositionConstraint", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          const std::optional<std::vector<ModelInstanceIndex>>&
-                              model_instances,
-                          const Frame<double>& expressed_frame,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(
-              plant, model_instances, expressed_frame, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>*,
+                 const std::optional<std::vector<ModelInstanceIndex>>&,
+                 const Frame<double>&, systems::Context<double>*>(),
             py::arg("plant"), py::arg("model_instances"),
             py::arg("expressed_frame"), py::arg("plant_context"),
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 5>(), cls_doc.ctor.doc_double)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          const std::optional<std::vector<ModelInstanceIndex>>&
-                              model_instances,
-                          const Frame<AutoDiffXd>& expressed_frame,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(
-              plant, model_instances, expressed_frame, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 const std::optional<std::vector<ModelInstanceIndex>>&,
+                 const Frame<AutoDiffXd>&, systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("model_instances"),
             py::arg("expressed_frame"), py::arg("plant_context"),
             // Keep alive, reference: `self` keeps `plant` alive.
@@ -817,17 +715,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(
         m, "ComInPolyhedronConstraint", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          std::optional<std::vector<ModelInstanceIndex>>
-                              model_instances,
-                          const Frame<double>& expressed_frame,
-                          const Eigen::Ref<const Eigen::MatrixX3d>& A,
-                          const Eigen::Ref<const Eigen::VectorXd>& lb,
-                          const Eigen::Ref<const Eigen::VectorXd>& ub,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(plant, model_instances,
-              expressed_frame, A, lb, ub, plant_context);
-        }),
+        .def(
+            py::init<const MultibodyPlant<double>*,
+                std::optional<std::vector<ModelInstanceIndex>>,
+                const Frame<double>&, const Eigen::Ref<const Eigen::MatrixX3d>&,
+                const Eigen::Ref<const Eigen::VectorXd>&,
+                const Eigen::Ref<const Eigen::VectorXd>&,
+                systems::Context<double>*>(),
             py::arg("plant"), py::arg("model_instances"),
             py::arg("expressed_frame"), py::arg("A"), py::arg("lb"),
             py::arg("ub"), py::arg("plant_context"),
@@ -835,17 +729,13 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          std::optional<std::vector<ModelInstanceIndex>>
-                              model_instances,
-                          const Frame<AutoDiffXd>& expressed_frame,
-                          const Eigen::Ref<const Eigen::MatrixX3d>& A,
-                          const Eigen::Ref<const Eigen::VectorXd>& lb,
-                          const Eigen::Ref<const Eigen::VectorXd>& ub,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(plant, model_instances,
-              expressed_frame, A, lb, ub, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 std::optional<std::vector<ModelInstanceIndex>>,
+                 const Frame<AutoDiffXd>&,
+                 const Eigen::Ref<const Eigen::MatrixX3d>&,
+                 const Eigen::Ref<const Eigen::VectorXd>&,
+                 const Eigen::Ref<const Eigen::VectorXd>&,
+                 systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("model_instances"),
             py::arg("expressed_frame"), py::arg("A"), py::arg("lb"),
             py::arg("ub"), py::arg("plant_context"),
@@ -860,16 +750,10 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     constexpr auto& cls_doc = doc.OrientationConstraint;
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(m, "OrientationConstraint", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* const plant,
-                          const Frame<double>& frameAbar,
-                          const math::RotationMatrix<double>& R_AbarA,
-                          const Frame<double>& frameBbar,
-                          const math::RotationMatrix<double>& R_BbarB,
-                          double theta_bound,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(plant, frameAbar, R_AbarA, frameBbar,
-              R_BbarB, theta_bound, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>* const, const Frame<double>&,
+                 const math::RotationMatrix<double>&, const Frame<double>&,
+                 const math::RotationMatrix<double>&, double,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameAbar"), py::arg("R_AbarA"),
             py::arg("frameBbar"), py::arg("R_BbarB"), py::arg("theta_bound"),
             py::arg("plant_context"),
@@ -877,16 +761,10 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* const plant,
-                          const Frame<AutoDiffXd>& frameAbar,
-                          const math::RotationMatrix<double>& R_AbarA,
-                          const Frame<AutoDiffXd>& frameBbar,
-                          const math::RotationMatrix<double>& R_BbarB,
-                          double theta_bound,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(plant, frameAbar, R_AbarA, frameBbar,
-              R_BbarB, theta_bound, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>* const,
+                 const Frame<AutoDiffXd>&, const math::RotationMatrix<double>&,
+                 const Frame<AutoDiffXd>&, const math::RotationMatrix<double>&,
+                 double, systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameAbar"), py::arg("R_AbarA"),
             py::arg("frameBbar"), py::arg("R_BbarB"), py::arg("theta_bound"),
             py::arg("plant_context"),
@@ -901,15 +779,10 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     constexpr auto& cls_doc = doc.OrientationCost;
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, solvers::Cost, Ptr>(m, "OrientationCost", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<double>* plant,
-                          const Frame<double>& frameAbar,
-                          const math::RotationMatrix<double>& R_AbarA,
-                          const Frame<double>& frameBbar,
-                          const math::RotationMatrix<double>& R_BbarB, double c,
-                          systems::Context<double>* plant_context) {
-          return std::make_unique<Class>(
-              plant, frameAbar, R_AbarA, frameBbar, R_BbarB, c, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
+                 const math::RotationMatrix<double>&, const Frame<double>&,
+                 const math::RotationMatrix<double>&, double,
+                 systems::Context<double>*>(),
             py::arg("plant"), py::arg("frameAbar"), py::arg("R_AbarA"),
             py::arg("frameBbar"), py::arg("R_BbarB"), py::arg("c"),
             py::arg("plant_context"),
@@ -917,15 +790,10 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
             py::keep_alive<1, 2>(),
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 8>(), cls_doc.ctor.doc_double)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          const Frame<AutoDiffXd>& frameAbar,
-                          const math::RotationMatrix<double>& R_AbarA,
-                          const Frame<AutoDiffXd>& frameBbar,
-                          const math::RotationMatrix<double>& R_BbarB, double c,
-                          systems::Context<AutoDiffXd>* plant_context) {
-          return std::make_unique<Class>(
-              plant, frameAbar, R_AbarA, frameBbar, R_BbarB, c, plant_context);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 const Frame<AutoDiffXd>&, const math::RotationMatrix<double>&,
+                 const Frame<AutoDiffXd>&, const math::RotationMatrix<double>&,
+                 double, systems::Context<AutoDiffXd>*>(),
             py::arg("plant"), py::arg("frameAbar"), py::arg("R_AbarA"),
             py::arg("frameBbar"), py::arg("R_BbarB"), py::arg("c"),
             py::arg("plant_context"),
@@ -941,8 +809,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, Constraint, Ptr>(
         m, "UnitQuaternionConstraint", cls_doc.doc)
-        .def(py::init([]() { return std::make_unique<Class>(); }),
-            cls_doc.ctor.doc);
+        .def(py::init<>(), cls_doc.ctor.doc);
     m.def("AddUnitQuaternionConstraintOnPlant",
         &AddUnitQuaternionConstraintOnPlant<double>, py::arg("plant"),
         py::arg("q_vars"), py::arg("prog"),

--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -65,11 +65,8 @@ void DefineDifferentialIkLegacy(py::module_ m) {
         doc.DifferentialInverseKinematicsParameters.doc);
 
     cls  // BR
-        .def(py::init([](int num_positions, int num_velocities) {
-          return Class{num_positions, num_velocities};
-        }),
-            py::arg("num_positions"), py::arg("num_velocities") = std::nullopt,
-            cls_doc.ctor.doc)
+        .def(py::init<int, int>(), py::arg("num_positions"),
+            py::arg("num_velocities") = std::nullopt, cls_doc.ctor.doc)
         .def("get_time_step", &Class::get_time_step, cls_doc.get_time_step.doc)
         .def("set_time_step", &Class::set_time_step, py::arg("dt"),
             cls_doc.set_time_step.doc)

--- a/bindings/pydrake/multibody/optimization_py.cc
+++ b/bindings/pydrake/multibody/optimization_py.cc
@@ -47,14 +47,9 @@ PYDRAKE_MODULE(optimization, m) {
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, solvers::Constraint, Ptr>(
         m, "CentroidalMomentumConstraint", cls_doc.doc)
-        .def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                          std::optional<std::vector<ModelInstanceIndex>>
-                              model_instances,
-                          systems::Context<AutoDiffXd>* plant_context,
-                          bool angular_only) {
-          return std::make_unique<Class>(
-              plant, model_instances, plant_context, angular_only);
-        }),
+        .def(py::init<const MultibodyPlant<AutoDiffXd>*,
+                 std::optional<std::vector<ModelInstanceIndex>>,
+                 systems::Context<AutoDiffXd>*, bool>(),
             py::arg("plant"), py::arg("model_instances"),
             py::arg("plant_context"), py::arg("angular_only"),
             // Keep alive, reference: `self` keeps `plant` alive.
@@ -115,19 +110,13 @@ PYDRAKE_MODULE(optimization, m) {
     using Ptr = std::shared_ptr<Class>;
     py::class_<Class, solvers::Constraint, Ptr> cls(
         m, "SpatialVelocityConstraint", cls_doc.doc);
-    cls.def(py::init([](const MultibodyPlant<AutoDiffXd>* plant,
-                         const Frame<AutoDiffXd>& frameA,
-                         const Eigen::Ref<const Eigen::Vector3d>& v_AC_lower,
-                         const Eigen::Ref<const Eigen::Vector3d>& v_AC_upper,
-                         const Frame<AutoDiffXd>& frameB,
-                         const Eigen::Ref<const Eigen::Vector3d>& p_BCo,
-                         systems::Context<AutoDiffXd>* plant_context,
-                         const std::optional<
-                             SpatialVelocityConstraint::AngularVelocityBounds>&
-                             w_AC_bounds) {
-      return std::make_unique<Class>(plant, frameA, v_AC_lower, v_AC_upper,
-          frameB, p_BCo, plant_context, w_AC_bounds);
-    }),
+    cls.def(
+        py::init<const MultibodyPlant<AutoDiffXd>*, const Frame<AutoDiffXd>&,
+            const Eigen::Ref<const Eigen::Vector3d>&,
+            const Eigen::Ref<const Eigen::Vector3d>&, const Frame<AutoDiffXd>&,
+            const Eigen::Ref<const Eigen::Vector3d>&,
+            systems::Context<AutoDiffXd>*,
+            const std::optional<Class::AngularVelocityBounds>&>(),
         py::arg("plant"), py::arg("frameA"), py::arg("v_AC_lower"),
         py::arg("v_AC_upper"), py::arg("frameB"), py::arg("p_BCo"),
         py::arg("plant_context"), py::arg("w_AC_bounds") = std::nullopt,

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1167,10 +1167,8 @@ void DefineMultibodyForces(py::module_ m, T) {
     // activated if this module is present, and thus should not create a runtime
     // error.
     cls  // BR
-        .def(py::init([](const MultibodyPlant<T>& plant) {
-          return std::make_unique<Class>(plant);
-        }),
-            py::arg("plant"), cls_doc.ctor.doc_1args_plant)
+        .def(py::init<const MultibodyPlant<T>&>(), py::arg("plant"),
+            cls_doc.ctor.doc_1args_plant)
         .def(py::init<int, int>(), py::arg("nb"), py::arg("nv"),
             cls_doc.ctor.doc_2args_nb_nv)
         .def("SetZero", &Class::SetZero, cls_doc.SetZero.doc)

--- a/bindings/pydrake/multibody/tree_py_inertia.cc
+++ b/bindings/pydrake/multibody/tree_py_inertia.cc
@@ -143,8 +143,8 @@ void DoScalarDependentDefinitions(py::module_ m, T) {
                  const T&>(),
             py::arg("Ixx"), py::arg("Iyy"), py::arg("Izz"), py::arg("Ixy"),
             py::arg("Ixz"), py::arg("Iyz"), cls_doc.ctor.doc_6args)
-        .def(py::init([](const RotationalInertia<T>& I) { return Class(I); }),
-            py::arg("I"), cls_doc.ctor.doc_1args)
+        .def(py::init<const RotationalInertia<T>>(), py::arg("I"),
+            cls_doc.ctor.doc_1args)
         .def("SetFromRotationalInertia", &Class::SetFromRotationalInertia,
             py::arg("I"), py::arg("mass"), py_rvp::reference,
             cls_doc.SetFromRotationalInertia.doc)

--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -239,17 +239,14 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   py::class_<LinearConstraint, Constraint, std::shared_ptr<LinearConstraint>>
       linear_constraint_cls(m, "LinearConstraint", doc.LinearConstraint.doc);
   linear_constraint_cls
-      .def(py::init([](const Eigen::MatrixXd& A, const Eigen::VectorXd& lb,
-                        const Eigen::VectorXd& ub) {
-        return std::make_unique<LinearConstraint>(A, lb, ub);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("A"), py::arg("lb"), py::arg("ub"),
           doc.LinearConstraint.ctor.doc_dense_A)
-      .def(py::init([](const Eigen::SparseMatrix<double>& A,
-                        const Eigen::Ref<const Eigen::VectorXd>& lb,
-                        const Eigen::Ref<const Eigen::VectorXd>& ub) {
-        return std::make_unique<LinearConstraint>(A, lb, ub);
-      }),
+      .def(py::init<const Eigen::SparseMatrix<double>&,
+               const Eigen::Ref<const Eigen::VectorXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("A"), py::arg("lb"), py::arg("ub"),
           doc.LinearConstraint.ctor.doc_sparse_A)
       .def("GetDenseA", &LinearConstraint::GetDenseA,
@@ -311,10 +308,9 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           doc.LorentzConeConstraint.EvalType.kNonconvex.doc);
 
   lorentz_cone_cls
-      .def(py::init([](const Eigen::MatrixXd& A, const Eigen::VectorXd& b,
-                        LorentzConeConstraint::EvalType eval_type) {
-        return std::make_unique<LorentzConeConstraint>(A, b, eval_type);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&,
+               LorentzConeConstraint::EvalType>(),
           py::arg("A"), py::arg("b"),
           py::arg("eval_type") = LorentzConeConstraint::EvalType::kConvexSmooth,
           doc.LorentzConeConstraint.ctor.doc)
@@ -329,9 +325,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   py::class_<RotatedLorentzConeConstraint, Constraint,
       std::shared_ptr<RotatedLorentzConeConstraint>>(
       m, "RotatedLorentzConeConstraint", doc.RotatedLorentzConeConstraint.doc)
-      .def(py::init([](const Eigen::MatrixXd& A, const Eigen::VectorXd& b) {
-        return std::make_unique<RotatedLorentzConeConstraint>(A, b);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("A"), py::arg("b"), doc.RotatedLorentzConeConstraint.ctor.doc)
       .def("A", &RotatedLorentzConeConstraint::A,
           doc.RotatedLorentzConeConstraint.A.doc)
@@ -345,20 +340,15 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   py::class_<LinearEqualityConstraint, LinearConstraint,
       std::shared_ptr<LinearEqualityConstraint>>(
       m, "LinearEqualityConstraint", doc.LinearEqualityConstraint.doc)
-      .def(py::init([](const Eigen::MatrixXd& Aeq, const Eigen::VectorXd& beq) {
-        return std::make_unique<LinearEqualityConstraint>(Aeq, beq);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("Aeq"), py::arg("beq"),
           doc.LinearEqualityConstraint.ctor.doc_dense_Aeq)
-      .def(py::init([](const Eigen::SparseMatrix<double>& Aeq,
-                        const Eigen::VectorXd& beq) {
-        return std::make_unique<LinearEqualityConstraint>(Aeq, beq);
-      }),
+      .def(py::init<const Eigen::SparseMatrix<double>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("Aeq"), py::arg("beq"),
           doc.LinearEqualityConstraint.ctor.doc_sparse_Aeq)
-      .def(py::init([](const Eigen::RowVectorXd& a, double beq) {
-        return std::make_unique<LinearEqualityConstraint>(a, beq);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::RowVectorXd>&, double>(),
           py::arg("a"), py::arg("beq"),
           doc.LinearEqualityConstraint.ctor.doc_row_a)
       .def(
@@ -382,9 +372,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   py::class_<BoundingBoxConstraint, LinearConstraint,
       std::shared_ptr<BoundingBoxConstraint>>(
       m, "BoundingBoxConstraint", doc.BoundingBoxConstraint.doc)
-      .def(py::init([](const Eigen::VectorXd& lb, const Eigen::VectorXd& ub) {
-        return std::make_unique<BoundingBoxConstraint>(lb, ub);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("lb"), py::arg("ub"), doc.BoundingBoxConstraint.ctor.doc);
 
   py::class_<QuadraticConstraint, Constraint,
@@ -406,14 +395,9 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           doc.QuadraticConstraint.HessianType.kZero.doc);
 
   quadratic_constraint_cls
-      .def(py::init([](const Eigen::Ref<const Eigen::MatrixXd>& Q0,
-                        const Eigen::Ref<const Eigen::VectorXd>& b, double lb,
-                        double ub,
-                        std::optional<QuadraticConstraint::HessianType>
-                            hessian_type) {
-        return std::make_unique<QuadraticConstraint>(
-            Q0, b, lb, ub, hessian_type);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&, double, double,
+               std::optional<QuadraticConstraint::HessianType>>(),
           py::arg("Q0"), py::arg("b"), py::arg("lb"), py::arg("ub"),
           py::arg("hessian_type") = std::nullopt,
           doc.QuadraticConstraint.ctor.doc)
@@ -440,10 +424,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   py::class_<PositiveSemidefiniteConstraint, Constraint,
       std::shared_ptr<PositiveSemidefiniteConstraint>>(m,
       "PositiveSemidefiniteConstraint", doc.PositiveSemidefiniteConstraint.doc)
-      .def(py::init([](int rows) {
-        return std::make_unique<PositiveSemidefiniteConstraint>(rows);
-      }),
-          py::arg("rows"), doc.PositiveSemidefiniteConstraint.ctor.doc)
+      .def(py::init<int>(), py::arg("rows"),
+          doc.PositiveSemidefiniteConstraint.ctor.doc)
       .def("matrix_rows", &PositiveSemidefiniteConstraint::matrix_rows,
           doc.PositiveSemidefiniteConstraint.matrix_rows.doc);
 
@@ -451,12 +433,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       std::shared_ptr<LinearMatrixInequalityConstraint>>(m,
       "LinearMatrixInequalityConstraint",
       doc.LinearMatrixInequalityConstraint.doc)
-      .def(py::init(
-               [](std::vector<Eigen::MatrixXd> F, double symmetry_tolerance) {
-                 return std::make_unique<LinearMatrixInequalityConstraint>(
-                     std::move(F), symmetry_tolerance);
-               }),
-          py::arg("F"), py::arg("symmetry_tolerance") = 1E-10,
+      .def(py::init<std::vector<Eigen::MatrixXd>, double>(), py::arg("F"),
+          py::arg("symmetry_tolerance") = 1E-10,
           doc.LinearMatrixInequalityConstraint.ctor.doc)
       .def("F", &LinearMatrixInequalityConstraint::F,
           doc.LinearMatrixInequalityConstraint.F.doc)
@@ -475,10 +453,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   py::class_<ExponentialConeConstraint, Constraint,
       std::shared_ptr<ExponentialConeConstraint>>(
       m, "ExponentialConeConstraint", doc.ExponentialConeConstraint.doc)
-      .def(py::init([](const Eigen::MatrixXd& A, const Eigen::Vector3d& b) {
-        Eigen::SparseMatrix<double> A_sparse = A.sparseView();
-        return std::make_unique<ExponentialConeConstraint>(A_sparse, b);
-      }),
+      .def(py::init<const Eigen::SparseMatrix<double>&,
+               const Eigen::Ref<const Eigen::Vector3d>&>(),
           py::arg("A"), py::arg("b"), doc.ExponentialConeConstraint.ctor.doc)
       .def(
           "A",
@@ -639,9 +615,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
 
   py::class_<LinearCost, Cost, std::shared_ptr<LinearCost>>(
       m, "LinearCost", doc.LinearCost.doc)
-      .def(py::init([](const Eigen::VectorXd& a, double b) {
-        return std::make_unique<LinearCost>(a, b);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&, double>(),
           py::arg("a"), py::arg("b"), doc.LinearCost.ctor.doc)
       .def("a", &LinearCost::a, doc.LinearCost.a.doc)
       .def("b", &LinearCost::b, doc.LinearCost.b.doc)
@@ -660,10 +634,9 @@ void BindEvaluatorsAndBindings(py::module_ m) {
 
   py::class_<QuadraticCost, Cost, std::shared_ptr<QuadraticCost>>(
       m, "QuadraticCost", doc.QuadraticCost.doc)
-      .def(py::init([](const Eigen::MatrixXd& Q, const Eigen::VectorXd& b,
-                        double c, std::optional<bool> is_convex) {
-        return std::make_unique<QuadraticCost>(Q, b, c, is_convex);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&, double,
+               std::optional<bool>>(),
           py::arg("Q"), py::arg("b"), py::arg("c"),
           py::arg("is_convex") = py::none(), doc.QuadraticCost.ctor.doc)
       .def("Q", &QuadraticCost::Q, doc.QuadraticCost.Q.doc)
@@ -693,9 +666,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
 
   py::class_<L1NormCost, Cost, std::shared_ptr<L1NormCost>>(
       m, "L1NormCost", doc.L1NormCost.doc)
-      .def(py::init([](const Eigen::MatrixXd& A, const Eigen::VectorXd& b) {
-        return std::make_unique<L1NormCost>(A, b);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("A"), py::arg("b"), doc.L1NormCost.ctor.doc)
       .def("A", &L1NormCost::A, doc.L1NormCost.A.doc)
       .def("b", &L1NormCost::b, doc.L1NormCost.b.doc)
@@ -716,14 +688,11 @@ void BindEvaluatorsAndBindings(py::module_ m) {
     py::class_<L2NormCost, Cost, std::shared_ptr<L2NormCost>> cls(
         m, "L2NormCost", doc.L2NormCost.doc);
     cls  // BR
-        .def(py::init([](const Eigen::MatrixXd& A, const Eigen::VectorXd& b) {
-          return std::make_unique<L2NormCost>(A, b);
-        }),
+        .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+                 const Eigen::Ref<const Eigen::VectorXd>&>(),
             py::arg("A"), py::arg("b"), doc.L2NormCost.ctor.doc_dense_A)
-        .def(py::init([](const Eigen::SparseMatrix<double>& A,
-                          const Eigen::VectorXd& b) {
-          return std::make_unique<L2NormCost>(A, b);
-        }),
+        .def(py::init<const Eigen::SparseMatrix<double>&,
+                 const Eigen::Ref<const Eigen::VectorXd>&>(),
             py::arg("A"), py::arg("b"), doc.L2NormCost.ctor.doc_sparse_A)
         .def("get_sparse_A", &L2NormCost::get_sparse_A,
             doc.L2NormCost.get_sparse_A.doc)
@@ -749,9 +718,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
 
   py::class_<LInfNormCost, Cost, std::shared_ptr<LInfNormCost>>(
       m, "LInfNormCost", doc.LInfNormCost.doc)
-      .def(py::init([](const Eigen::MatrixXd& A, const Eigen::VectorXd& b) {
-        return std::make_unique<LInfNormCost>(A, b);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("A"), py::arg("b"), doc.LInfNormCost.ctor.doc)
       .def("A", &LInfNormCost::A, doc.LInfNormCost.A.doc)
       .def("b", &LInfNormCost::b, doc.LInfNormCost.b.doc)
@@ -771,9 +739,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   py::class_<PerspectiveQuadraticCost, Cost,
       std::shared_ptr<PerspectiveQuadraticCost>>(
       m, "PerspectiveQuadraticCost", doc.PerspectiveQuadraticCost.doc)
-      .def(py::init([](const Eigen::MatrixXd& A, const Eigen::VectorXd& b) {
-        return std::make_unique<PerspectiveQuadraticCost>(A, b);
-      }),
+      .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
+               const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("A"), py::arg("b"), doc.PerspectiveQuadraticCost.ctor.doc)
       .def(
           "A", &PerspectiveQuadraticCost::A, doc.PerspectiveQuadraticCost.A.doc)

--- a/bindings/pydrake/test/pydrake_pybind_test_util_py.cc
+++ b/bindings/pydrake/test/pydrake_pybind_test_util_py.cc
@@ -87,7 +87,7 @@ PYDRAKE_MODULE(pydrake_pybind_test_util, m) {
     using Class = ExampleDefCopyAndDeepCopy;
     py::class_<Class> cls(m, "ExampleDefCopyAndDeepCopy");
     cls  // BR
-        .def(py::init([](int value) { return Class(value); }))
+        .def(py::init<int>())
         .def(py::self == py::self);
     DefCopyAndDeepCopy(&cls);
   }

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -832,13 +832,8 @@ struct Impl {
       auto cls = DefineTemplateClassWithDefault<Class, PiecewiseTrajectory<T>>(
           m, "ExponentialPlusPiecewisePolynomial", param, cls_doc.doc);
       cls  // BR
-          .def(
-              py::init(
-                  [](const Eigen::MatrixX<T>& K, const Eigen::MatrixX<T>& A,
-                      const Eigen::MatrixX<T>& alpha,
-                      const PiecewisePolynomial<T>& piecewise_polynomial_part) {
-                    return Class(K, A, alpha, piecewise_polynomial_part);
-                  }),
+          .def(py::init<const Eigen::MatrixX<T>&, const Eigen::MatrixX<T>&,
+                   const Eigen::MatrixX<T>&, const PiecewisePolynomial<T>&>(),
               py::arg("K"), py::arg("A"), py::arg("alpha"),
               py::arg("piecewise_polynomial_part"), cls_doc.ctor.doc)
           .def("shiftRight", &Class::shiftRight, py::arg("offset"),


### PR DESCRIPTION
Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24602)
<!-- Reviewable:end -->
