### PR TITLE
[workspace] Wire up libjpeg_turbo_internal as a scripted upgrade

### DIFF
--- a/third_party/com_github_tensorflow_tensorflow/third_party/jpeg/jpeg.BUILD
+++ b/third_party/com_github_tensorflow_tensorflow/third_party/jpeg/jpeg.BUILD
@@ -1,8 +1,8 @@
 # Description:
 #   libjpeg-turbo is a drop in replacement for jpeglib optimized with SIMD.
 
-load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 
 licenses(["notice"])  # custom notice-style license, see LICENSE.md
 

--- a/tools/workspace/libjpeg_turbo_internal/repository.bzl
+++ b/tools/workspace/libjpeg_turbo_internal/repository.bzl
@@ -15,17 +15,21 @@ exports_files(["drake_repository_metadata.json"])
 """ + repo_ctx.read(Label(
         "@drake//third_party:com_github_tensorflow_tensorflow/third_party/jpeg/jpeg.BUILD",  # noqa
     )))
+    repository_metadata = {
+        "name": "libjpeg_turbo_internal",
+        "repository_rule_type": "scripted",
+        "upgrade_script": "upgrade.py",
+    }
+    repo_ctx.file(
+        "drake_repository_metadata.json",
+        json.encode(repository_metadata),
+    )
 
 libjpeg_turbo_internal_repository = repository_rule(
     attrs = {
         # These are the attributes for setup_github_repository.
         "repository": attr.string(default = "libjpeg-turbo/libjpeg-turbo"),
         "commit": attr.string(default = "2.1.4"),
-        "commit_pin": attr.int(
-            # We need to match our version of libjpeg-turbo to the BUILD file
-            # we've adopted from tensorflow. Run `upgrade.py` to upgrade.
-            default = 1,
-        ),
         "sha256": attr.string(
             default = "a78b05c0d8427a90eb5b4eb08af25309770c8379592bb0b8a863373128e6143f",  # noqa
         ),


### PR DESCRIPTION
The `upgrade.py` script is already sufficient to check Drake's version of libjpeg-turbo against upstream tensorflow, but with the current `new_release` machinery, we can give maintainers a heads-up to check for upgrades instead of pinning.

(No actual upgrade is necessary at this time.)

With the change, `bazel run //tools/workspace:new_release` now shows:

```
libjpeg_turbo_internal may need upgrade
```

just like we currently have for `crate_universe` (which uses an `upgrade.sh`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24603)
<!-- Reviewable:end -->
