### PR TITLE
[geometry] Add deformable geometry visualization to MeshcatVisualizer

### DIFF
--- a/examples/multibody/deformable/BUILD.bazel
+++ b/examples/multibody/deformable/BUILD.bazel
@@ -120,6 +120,7 @@ drake_cc_binary(
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
         "//systems/sensors:camera_config_functions",
+        "//visualization:visualization_config_functions",
         "@gflags",
     ],
     add_test_rule = True,

--- a/examples/multibody/deformable/bubble_gripper.cc
+++ b/examples/multibody/deformable/bubble_gripper.cc
@@ -22,6 +22,8 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/sensors/camera_config.h"
 #include "drake/systems/sensors/camera_config_functions.h"
+#include "drake/visualization/visualization_config.h"
+#include "drake/visualization/visualization_config_functions.h"
 
 DEFINE_double(simulation_time, 15.0, "Desired duration of the simulation [s].");
 DEFINE_double(realtime_rate, 0.0, "Desired real time rate.");
@@ -29,6 +31,12 @@ DEFINE_double(discrete_time_step, 2.5e-2,
               "Discrete time step for the system [s].");
 DEFINE_bool(render_bubble, true,
             "Renders the dot pattern inside the bubble gripper if true.");
+static bool ValidateManipuland(const char*, const std::string& value) {
+  return value == "bear" || value == "ball";
+}
+DEFINE_string(manipuland, "bear",
+              "Deformable manipuland to add. Options are: 'bear' and 'ball'.");
+DEFINE_validator(manipuland, &ValidateManipuland);
 
 using drake::examples::deformable::ParallelGripperController;
 using drake::geometry::AddContactMaterial;
@@ -40,6 +48,7 @@ using drake::geometry::PerceptionProperties;
 using drake::geometry::ProximityProperties;
 using drake::geometry::RenderEngineVtkParams;
 using drake::geometry::Rgba;
+using drake::geometry::Sphere;
 using drake::math::RigidTransformd;
 using drake::math::RollPitchYawd;
 using drake::math::RotationMatrixd;
@@ -58,6 +67,8 @@ using drake::schema::Transform;
 using drake::systems::Context;
 using drake::systems::sensors::ApplyCameraConfig;
 using drake::systems::sensors::CameraConfig;
+using drake::visualization::ApplyVisualizationConfig;
+using drake::visualization::VisualizationConfig;
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 
@@ -158,11 +169,41 @@ int do_main() {
       /* The pose of the box in the right finger's frame. */
       RigidTransformd(Vector3d(0.0, 0.03, -0.1)));
 
-  /* Add in a deformable manipuland. */
-  parser.AddModelsFromUrl(
-      "package://drake/examples/multibody/deformable/models/"
-      "deformable_teddy.sdf");
+  if (FLAGS_manipuland == "bear") {
+    /* Add in a deformable teddy bear. */
+    parser.AddModelsFromUrl(
+        "package://drake/examples/multibody/deformable/models/"
+        "deformable_teddy.sdf");
+  } else {
+    DRAKE_DEMAND(FLAGS_manipuland == "ball");
+    /* Add a deformable sphere in the original teddy bear pickup location. */
+    const double sphere_radius = 0.06;
+    const double sphere_resolution_hint = 0.03;
+    const double work_surface_top_z = -0.005;
+    const Vector3d p_WS(-0.18, 0, work_surface_top_z + sphere_radius + 0.02);
+    auto sphere_instance = std::make_unique<GeometryInstance>(
+        RigidTransformd(p_WS), std::make_unique<Sphere>(sphere_radius),
+        "deformable_sphere");
 
+    ProximityProperties sphere_proximity_props;
+    AddContactMaterial({}, {}, surface_friction, &sphere_proximity_props);
+    sphere_instance->set_proximity_properties(sphere_proximity_props);
+
+    const Rgba sphere_color(0.20, 0.45, 0.95, 1.0);
+    IllustrationProperties sphere_illustration_props;
+    sphere_illustration_props.AddProperty("phong", "diffuse", sphere_color);
+    sphere_instance->set_illustration_properties(sphere_illustration_props);
+    sphere_instance->set_perception_properties(
+        PerceptionProperties(sphere_illustration_props));
+
+    DeformableBodyConfig<double> sphere_config;
+    sphere_config.set_youngs_modulus(5e3);
+    sphere_config.set_poissons_ratio(0.45);
+    sphere_config.set_stiffness_damping_coefficient(0.05);
+    sphere_config.set_mass_density(700.0);
+    deformable_model.RegisterDeformableBody(
+        std::move(sphere_instance), sphere_config, sphere_resolution_hint);
+  }
   /* All rigid and deformable models have been added. Finalize the plant. */
   plant.Finalize();
 
@@ -177,10 +218,9 @@ int do_main() {
                   plant.get_desired_state_input_port(gripper_instance));
 
   /* Add a visualizer that emits LCM messages for visualization. */
-  geometry::DrakeVisualizerParams params;
-  params.role = geometry::Role::kIllustration;
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, nullptr,
-                                           params);
+  VisualizationConfig vis_config;
+  ApplyVisualizationConfig(vis_config, &builder);
+
   /* We want to look in the -Py direction so we line up Bz with -Py.*/
   const Vector3d Bz_P = -Vector3d::UnitY();
   const Vector3d Bx_P = -Vector3d::UnitZ();

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -820,12 +820,14 @@ drake_cc_library(
 drake_cc_googletest(
     name = "meshcat_visualizer_test",
     data = [
+        "//examples/multibody/deformable:torus_tet_mesh",
         "//geometry/render:test_models",
         "//multibody/meshcat:models",
         "@drake_models//:iiwa_description",
     ],
     deps = [
         ":meshcat_visualizer",
+        "//common:find_resource",
         "//common:timer",
         "//common/test_utilities:expect_throws_message",
         "//multibody/parsing",

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -136,11 +136,12 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
   }
   if (!version_.has_value() ||
       !version_->IsSameAs(current_version, params_.role)) {
-    SetObjects(query_object.inspector());
+    SetObjects(query_object);
     SetAlphas(/* initializing = */ true);
     version_ = current_version;
   }
   SetTransforms(context, query_object);
+  BroadcastDeformables(query_object);
   if (params_.enable_alpha_slider) {
     double new_alpha_value = meshcat_->GetSliderValue(alpha_slider_name_);
     if (new_alpha_value != alpha_value_) {
@@ -154,11 +155,79 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
 }
 
 template <typename T>
+void MeshcatVisualizer<T>::RegisterDeformable(
+    const QueryObject<T>& query_object, GeometryId deformable_id) const {
+  if constexpr (std::is_same_v<T, double>) {
+    // We should only register after clearing all previously registered
+    // deformables; so we should never redundantly register a deformable.
+    DRAKE_DEMAND(!dynamic_deformable_geometries_.contains(deformable_id));
+
+    const auto& inspector = query_object.inspector();
+    const std::vector<internal::RenderMesh>& render_meshes =
+        inspector.GetDrivenRenderMeshes(deformable_id, params_.role);
+    const int num_render_meshes = ssize(render_meshes);
+    dynamic_deformable_geometries_[deformable_id].reserve(num_render_meshes);
+
+    // GeometryState only supports driven meshes (embedded OBJ with multiple
+    // material groups) for the perception role, not illustration. For
+    // illustration, RegisterDrivenMesh always produces exactly one mesh from
+    // the control-mesh surface. See geometry_state.cc RegisterDrivenMesh and
+    // the TODO therein. Remove this demand when illustration driven-mesh
+    // support is added and update BroadcastDeformables and its tests.
+    DRAKE_DEMAND(num_render_meshes == 1);
+
+    for (int i = 0; i < num_render_meshes; ++i) {
+      const Rgba& diffuse_color = render_meshes[i].material.has_value()
+                                      ? render_meshes[i].material->diffuse
+                                      : params_.default_color;
+
+      dynamic_deformable_geometries_[deformable_id].push_back(
+          {internal::MakeTriangleSurfaceMesh(render_meshes[i]), diffuse_color});
+    }
+  } else {
+    throw std::runtime_error(
+        "Only MeshcatVisualizer<double> supports deformable geometry.");
+  }
+}
+
+template <typename T>
+void MeshcatVisualizer<T>::BroadcastDeformables(
+    const QueryObject<T>& query_object) const {
+  if constexpr (std::is_same_v<T, double>) {
+    for (auto& [deformable_id, colored_meshes] :
+         dynamic_deformable_geometries_) {
+      const int num_render_meshes = std::size(colored_meshes);
+      const std::string& path = geometries_.at(deformable_id);
+
+      // We already checked the T is double
+      const std::vector<VectorX<double>> vertex_positions =
+          query_object.GetDrivenMeshConfigurationsInWorld(deformable_id,
+                                                          params_.role);
+      DRAKE_DEMAND(std::ssize(vertex_positions) == num_render_meshes);
+
+      for (int i = 0; i < num_render_meshes; ++i) {
+        colored_meshes[i].mesh.SetAllPositions(vertex_positions[i]);
+
+        const std::string final_sub_path =
+            num_render_meshes == 1 ? path : fmt::format("{}/{}", path, i);
+        meshcat_->SetObject(final_sub_path, colored_meshes[i].mesh,
+                            colored_meshes[i].diffuse);
+      }
+      meshcat_->SetTransform(path, math::RigidTransformd::Identity());
+    }
+  }
+  // Else do nothing -- we should've already thrown in RegisterDeformable()
+  // for T != double.
+}
+
+template <typename T>
 void MeshcatVisualizer<T>::SetObjects(
-    const SceneGraphInspector<T>& inspector) const {
+    const QueryObject<T>& query_object) const {
+  const auto& inspector = query_object.inspector();
   // Frames registered previously that are not set again here should be deleted.
   std::map<FrameId, std::string> frames_to_delete{};
   dynamic_frames_.swap(frames_to_delete);
+  dynamic_deformable_geometries_.clear();  // no need to swap
 
   // Geometries registered previously that are not set again here should be
   // deleted.
@@ -197,7 +266,7 @@ void MeshcatVisualizer<T>::SetObjects(
       // We'll turn scoped names into meshcat paths.
       const std::string geometry_name =
           internal::TransformGeometryName(geom_id, inspector);
-      const std::string path = fmt::format("{}/{}", frame_path, geometry_name);
+      std::string path = fmt::format("{}/{}", frame_path, geometry_name);
       const Rgba rgba = properties.GetPropertyOrDefault("phong", "diffuse",
                                                         params_.default_color);
       const std::string diffuse_map = properties.GetPropertyOrDefault(
@@ -208,6 +277,7 @@ void MeshcatVisualizer<T>::SetObjects(
       // available, or, second, the convex hull. Record if we've used one of
       // those proxies.
       bool geometry_already_set = false;
+      bool is_a_deformable_geometry = inspector.IsDeformableGeometry(geom_id);
 
       if constexpr (std::is_same_v<T, double>) {
         if (params_.show_hydroelastic) {
@@ -220,6 +290,7 @@ void MeshcatVisualizer<T>::SetObjects(
                            geometry_already_set = true;
                          },
                          [&](const VolumeMesh<double>* mesh) {
+                           DRAKE_DEMAND(!is_a_deformable_geometry);
                            DRAKE_DEMAND(mesh != nullptr);
                            meshcat_->SetObject(
                                path, ConvertVolumeToSurfaceMesh(*mesh), rgba);
@@ -229,9 +300,10 @@ void MeshcatVisualizer<T>::SetObjects(
         }
       }
 
-      // Proximity role favors convex hulls if available.
+      // For non-deformables, proximity role favors convex hulls if available.
       if (const PolygonSurfaceMesh<double>* hull = nullptr;
           (!geometry_already_set) && (params_.role == Role::kProximity) &&
+          (!is_a_deformable_geometry) &&  // Use convex hull for non-deformables
           (hull = inspector.GetConvexHull(geom_id))) {
         // Convert polygonal surface mesh to triangle surface mesh.
         const TriangleSurfaceMesh<double> tri_hull =
@@ -241,11 +313,25 @@ void MeshcatVisualizer<T>::SetObjects(
       }
 
       if (!geometry_already_set) {
-        meshcat_->SetObject(path, inspector.GetShape(geom_id), rgba,
-                            diffuse_map);
+        // Test if this geometry is a deformable geometry that we want to
+        // visualize. For now, we only accept deformable geometry imported from
+        // a .vtk extension.
+        if (is_a_deformable_geometry) {
+          path = fmt::format("{}/{}/{}", frame_path, "deformable_geometries",
+                             geometry_name);
+
+          RegisterDeformable(query_object, geom_id);
+        } else {
+          // Fall back to the geometry's shape.
+          meshcat_->SetObject(path, inspector.GetShape(geom_id), rgba,
+                              diffuse_map);
+        }
       }
 
-      meshcat_->SetTransform(path, inspector.GetPoseInFrame(geom_id));
+      if (!is_a_deformable_geometry) {
+        meshcat_->SetTransform(path, inspector.GetPoseInFrame(geom_id));
+      }
+
       geometries_[geom_id] = path;
       geometries_to_delete.erase(geom_id);  // Don't delete this one.
       frame_has_any_geometry = true;

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/meshcat.h"
@@ -140,8 +141,18 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    is valid (if not, sends the objects) and then sends the transforms.  */
   systems::EventStatus UpdateMeshcat(const systems::Context<T>& context) const;
 
+  /* Registers a deformable geometry with the visualizer. This doesn't broadcast
+   any messages to Meshcat; that happens in BroadcastDeformables().
+   @pre deformable_id names a deformable geometry.
+   @throws if deformable_id is already registered. */
+  void RegisterDeformable(const QueryObject<T>& query_object,
+                          GeometryId deformable_id) const;
+
+  /* Broadcasts all deformable meshes with current vertex positions. */
+  void BroadcastDeformables(const QueryObject<T>& query_object) const;
+
   /* Makes calls to Meshcat::SetObject to register geometry in SceneGraph. */
-  void SetObjects(const SceneGraphInspector<T>& inspector) const;
+  void SetObjects(const QueryObject<T>& query_object) const;
 
   /* Makes calls to Meshcat::SetTransform to update the poses from SceneGraph.
    */
@@ -184,6 +195,21 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    version_.  This is only for efficiency; it does not represent undeclared
    state. */
   mutable std::map<FrameId, std::string> dynamic_frames_{};
+
+  /* Store a colored surface mesh for each discrete component of a deformable
+   geometry's visible geometry. */
+  struct ColoredMesh {
+    TriangleSurfaceMesh<T> mesh;
+    Rgba diffuse;
+  };
+
+  /* The visual representation of the known deformable geometries. For a single
+   geometry id, we have one or more colored meshes. The contents gets rebuilt
+   when scene graph version changes. We use these cached surface meshes to
+   broadcast the deformed mesh without recomputing/duplicating the surface mesh
+   over and over (instead, we simply update vertex positions). */
+  mutable std::map<GeometryId, std::vector<ColoredMesh>>
+      dynamic_deformable_geometries_{};
 
   /* A store of the geometries sent to Meshcat, so that they can be removed if a
    new geometry version appears that does not contain them. */

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -10,9 +10,11 @@
 #include <gtest/gtest.h>
 #include <msgpack.hpp>
 
+#include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/meshcat_internal.h"
 #include "drake/geometry/meshcat_types_internal.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/simulator.h"
@@ -23,6 +25,8 @@ namespace drake {
 namespace geometry {
 namespace {
 
+using drake::multibody::DeformableModel;
+using drake::multibody::fem::DeformableBodyConfig;
 using internal::TransformGeometryName;
 using multibody::AddMultibodyPlantSceneGraph;
 
@@ -465,6 +469,136 @@ GTEST_TEST(MeshcatVisualizerTest, ConvexHull) {
       fmt::format("/drake/{}/box/box/{}", params.prefix,
                   TransformGeometryName(box_id, inspector)));
   EXPECT_THAT(data, testing::HasSubstr("BufferGeometry"));
+}
+
+// Confirms that paths are added for different geometry types -- in this case
+// a Mesh referencing a VTK file and a Sphere representing all primitives.
+GTEST_TEST(MeshcatVisualizerTest, DeformableGeometry) {
+  auto meshcat = std::make_shared<Meshcat>();
+
+  /* Set up a deformable bodies. Values are just an example here */
+  DeformableBodyConfig<double> deformable_config;
+  deformable_config.set_youngs_modulus(1e4);
+  deformable_config.set_poissons_ratio(0.4);
+  deformable_config.set_mass_density(1e3);
+  deformable_config.set_stiffness_damping_coefficient(0.01);
+
+  ProximityProperties prox_props;
+  IllustrationProperties illus_props;
+
+  const math::RigidTransformd X_WB(Vector3<double>(0.0, 0.0, 0.0));
+  const Mesh mesh(FindResourceOrThrow(
+      "drake/examples/multibody/deformable/models/torus.vtk"));
+  const Sphere sphere(1.0);
+
+  const double kRezHint = 0.5;
+
+  std::vector<const Shape*> testing_shapes{&mesh, &sphere};
+
+  for (const auto& shape : testing_shapes) {
+    SCOPED_TRACE(shape->type_name());
+
+    // Load a scene with mesh collision geometry.
+    systems::DiagramBuilder<double> builder;
+    auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.001);
+
+    DeformableModel<double>& deformable_model =
+        plant.mutable_deformable_model();
+
+    auto instance = std::make_unique<GeometryInstance>(X_WB, *shape, "object");
+    instance->set_proximity_properties(prox_props);
+    instance->set_illustration_properties(illus_props);
+    deformable_model.RegisterDeformableBody(std::move(instance),
+                                            deformable_config, kRezHint);
+
+    plant.Finalize();
+
+    // We set show_hydroelastic to true to make sure the deformable still comes
+    // through for meshes that don't have hydro representations (see above).
+    const MeshcatVisualizerParams params{
+        .role = Role::kIllustration,
+        .prefix = std::string(shape->type_name()),
+        .show_hydroelastic = true};
+    MeshcatVisualizer<double>::AddToBuilder(&builder, scene_graph, meshcat,
+                                            params);
+
+    auto diagram = builder.Build();
+    auto context = diagram->CreateDefaultContext();
+
+    auto expected_path = fmt::format(
+        "/drake/{}/deformable_geometries/DefaultModelInstance/object",
+        params.prefix);
+    EXPECT_FALSE(meshcat->HasPath(expected_path));
+    // Send the geometry to Meshcat.
+    diagram->ForcedPublish(*context);
+    EXPECT_TRUE(meshcat->HasPath(expected_path));
+  }
+}
+
+// Confirms that a SceneGraph geometry version change (here caused by updating
+// illustration properties) triggers re-registration of a deformable geometry
+// in MeshcatVisualizer, including picking up the new color.
+GTEST_TEST(MeshcatVisualizerTest, DeformableGeometrySceneGraphVersionChange) {
+  auto meshcat = std::make_shared<Meshcat>();
+
+  DeformableBodyConfig<double> config;
+  config.set_youngs_modulus(1e4);
+  config.set_poissons_ratio(0.4);
+  config.set_mass_density(1e3);
+  config.set_stiffness_damping_coefficient(0.01);
+
+  systems::DiagramBuilder<double> builder;
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.001);
+  DeformableModel<double>& deformable_model = plant.mutable_deformable_model();
+
+  IllustrationProperties illus_props;
+  const Rgba red(1, 0, 0);
+  const Rgba blue(0, 0, 1);
+  illus_props.AddProperty("phong", "diffuse", red);
+
+  auto instance = std::make_unique<GeometryInstance>(math::RigidTransformd{},
+                                                     Sphere(1.0), "body");
+  instance->set_proximity_properties(ProximityProperties{});
+  instance->set_illustration_properties(illus_props);
+  const auto body_id =
+      deformable_model.RegisterDeformableBody(std::move(instance), config, 0.5);
+
+  plant.Finalize();
+
+  const GeometryId geom_id = deformable_model.GetGeometryId(body_id);
+
+  MeshcatVisualizer<double>::AddToBuilder(
+      &builder, scene_graph, meshcat,
+      MeshcatVisualizerParams{.role = Role::kIllustration});
+
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+
+  // First publish establishes the deformable in Meshcat with the initial color.
+  diagram->ForcedPublish(*context);
+  const std::string path =
+      "/drake/visualizer/deformable_geometries/DefaultModelInstance/body";
+  ASSERT_TRUE(meshcat->HasPath(path));
+  const std::string packed_initial = meshcat->GetPackedObject(path);
+  ASSERT_FALSE(packed_initial.empty());
+
+  // Updating illustration properties bumps the geometry version. On the next
+  // publish, MeshcatVisualizer should detect the change, re-register the
+  // deformable (picking up the new color), and re-send the mesh to Meshcat.
+  IllustrationProperties new_illus_props;
+  new_illus_props.AddProperty("phong", "diffuse", blue);
+  auto& sg_context =
+      diagram->GetMutableSubsystemContext(scene_graph, context.get());
+  scene_graph.AssignRole(&sg_context, *plant.get_source_id(), geom_id,
+                         new_illus_props, RoleAssign::kReplace);
+
+  diagram->ForcedPublish(*context);
+  ASSERT_TRUE(meshcat->HasPath(path));
+  // We use the fact that the packed data doesn't match as evidence that the
+  // geometry changed because of the SceneGraph change. If this assumption
+  // proves too aggressive in the future, we can be more explicit about the
+  // nature of the change.
+  EXPECT_NE(meshcat->GetPackedObject(path), packed_initial);
 }
 
 GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {


### PR DESCRIPTION
Fixes #22943

## Summary

`MeshcatVisualizer` currently skips deformable geometries — they are invisible in Meshcat. This PR adds support for rendering deformable bodies by querying their driven mesh configurations in a similar way as `drake_visualizer` does.

## Motivation

As described in #22943, deformable bodies registered via `DeformableModel` have no visual representation in Meshcat, forcing users to rely on `Meldis` and `DrakeVisualizer` to see deformables. This change allows users to visualize deformable geometries (both primitive shapes and `.vtk` meshes) directly in `MeshcatVisualizer`, updating in real time.

## Approach

1. **`MeshcatVisualizer::SetObjects`** now accepts a `QueryObject` (instead of just the inspector) so it can query deformable mesh configurations. When a geometry is identified as deformable (via `inspector.IsDeformableGeometry()`), it is handled differently:
   - For `.vtk` mesh geometries: vertex positions are queried from `QueryObject::GetDrivenMeshConfigurationsInWorld` and a `TriangleSurfaceMesh` is reconstructed each time the geometry version changes.

2. **`MeshcatVisualizer::SetTransforms`** additionally iterates over tracked deformable geometries and calls `UpdateDeformableGeometry` to refresh their meshes with current vertex positions.

## Performance Note

Deformable meshes are fully reconstructed (new `TriangleSurfaceMesh` + `Meshcat::SetObject`) every publish period. For scenes with large deformable meshes, this may impact visualization throughput.

## Testing

Two new tests in `meshcat_visualizer_test.cc`:
- `VisualizeDeformableGeometry`: Registers a deformable sphere (primitive shape) and verifies it appears in Meshcat under the expected path.
- `VisualizeDeformableVTKGeometry`: Registers a deformable torus from a `.vtk` file via `DeformableModel::RegisterDeformableBody` and verifies it appears under the `deformable_geometries/` subtree.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24608)
<!-- Reviewable:end -->
