### PR TITLE
[planning] Remove obsolete CollectRegisteredGeometries call in SceneGraphCollisionChecker

### DIFF
--- a/planning/scene_graph_collision_checker.cc
+++ b/planning/scene_graph_collision_checker.cc
@@ -63,9 +63,6 @@ std::optional<GeometryId> SceneGraphCollisionChecker::DoAddCollisionShapeToBody(
     const std::string& group_name, const RigidBody<double>& bodyA,
     const Shape& shape, const RigidTransform<double>& X_AG) {
   const FrameId body_frame_id = plant().GetBodyFrameIdOrThrow(bodyA.index());
-
-  const GeometrySet bodyA_geometries =
-      plant().CollectRegisteredGeometries(plant().GetBodiesWeldedTo(bodyA));
   log()->debug("Adding shape (group: [{}]) to {} (FrameID {}) at X_AG =\n{}",
                group_name, bodyA.scoped_name(), body_frame_id,
                fmt_eigen(X_AG.GetAsMatrix4()));


### PR DESCRIPTION
Cleans up a vestigial call missed in #19387.

+@jwnimmer-tri for review as this is a very simple change, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24610)
<!-- Reviewable:end -->
