### PR TITLE
[workspace] Preserve existing libjpeg-turbo metadata

### DIFF
--- a/tools/workspace/libjpeg_turbo_internal/repository.bzl
+++ b/tools/workspace/libjpeg_turbo_internal/repository.bzl
@@ -15,8 +15,10 @@ exports_files(["drake_repository_metadata.json"])
 """ + repo_ctx.read(Label(
         "@drake//third_party:com_github_tensorflow_tensorflow/third_party/jpeg/jpeg.BUILD",  # noqa
     )))
-    repository_metadata = {
-        "name": "libjpeg_turbo_internal",
+    repository_metadata = json.decode(
+        repo_ctx.read("drake_repository_metadata.json"),
+    )
+    repository_metadata |= {
         "repository_rule_type": "scripted",
         "upgrade_script": "upgrade.py",
     }


### PR DESCRIPTION
mirror-to-s3 needs the default URLs, SHA, etc., and new_release may want the commit, etc. in the future.

Amends #24603.

I've run `new_release` and confirmed it still prints "may need upgrade", but now `mirror-to-s3 --no-upload` also reports that `libjpeg-turbo` already exists in S3 instead of crashing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24611)
<!-- Reviewable:end -->
