### PR TITLE
Fix bug in scalar converting MultibodyPlant vis a vis DeformableModel

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -1007,6 +1007,14 @@ Raises:
     RuntimeError if no deformable body with the given ``id`` has been
     registered in this model.)""";
         } GetReferencePositions;
+        // Symbol: drake::multibody::DeformableModel::GetScalarConversionFailureReason
+        struct /* GetScalarConversionFailureReason */ {
+          // Source: drake/multibody/plant/deformable_model.h
+          const char* doc =
+R"""(DeformableModel can't convert to non-double scalar types, so it
+implements the ScalarConvertibleComponent interface for describing the
+failure reasons.)""";
+        } GetScalarConversionFailureReason;
         // Symbol: drake::multibody::DeformableModel::GetVelocities
         struct /* GetVelocities */ {
           // Source: drake/multibody/plant/deformable_model.h

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -330,6 +330,24 @@ DeformableBodyId DeformableModel<T>::GetBodyId(
 }
 
 template <typename T>
+std::string DeformableModel<T>::GetScalarConversionFailureReason(
+    const std::type_info& scalar) const {
+  // NOLINTNEXTLINE(readability/casting) False positive.
+  if (scalar == typeid(double) || is_empty()) return {};
+  std::vector<std::string> parts;
+  if (num_bodies() > 0) {
+    parts.push_back(fmt::format("{} registered deformable {}", num_bodies(),
+                                num_bodies() == 1 ? "body" : "bodies"));
+  }
+  if (!force_densities_.empty()) {
+    parts.push_back(fmt::format(
+        "{} registered external force density {}", force_densities_.size(),
+        force_densities_.size() == 1 ? "field" : "fields"));
+  }
+  return fmt::format("its DeformableModel has {}", fmt::join(parts, " and "));
+}
+
+template <typename T>
 void DeformableModel<T>::SetParallelism(Parallelism parallelism) {
   parallelism_ = parallelism;
   const std::vector<DeformableBodyIndex>& body_indices =
@@ -397,6 +415,7 @@ std::unique_ptr<PhysicalModel<double>> DeformableModel<T>::CloneToDouble(
 template <typename T>
 std::unique_ptr<PhysicalModel<AutoDiffXd>>
 DeformableModel<T>::CloneToAutoDiffXd(MultibodyPlant<AutoDiffXd>* plant) const {
+  ThrowForUnsupportedScalarType<AutoDiffXd>();
   return std::make_unique<DeformableModel<AutoDiffXd>>(plant);
 }
 
@@ -404,6 +423,7 @@ template <typename T>
 std::unique_ptr<PhysicalModel<symbolic::Expression>>
 DeformableModel<T>::CloneToSymbolic(
     MultibodyPlant<symbolic::Expression>* plant) const {
+  ThrowForUnsupportedScalarType<symbolic::Expression>();
   return std::make_unique<DeformableModel<symbolic::Expression>>(plant);
 }
 

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -4,11 +4,16 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <typeinfo>
 #include <unordered_map>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include "drake/common/eigen_types.h"
 #include "drake/common/identifier.h"
+#include "drake/common/nice_type_name.h"
 #include "drake/common/parallelism.h"
 #include "drake/multibody/fem/deformable_body_config.h"
 #include "drake/multibody/fem/discrete_time_integrator.h"
@@ -505,6 +510,12 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
   /** Returns true if and only if this %DeformableModel is empty. */
   bool is_cloneable_to_symbolic() const final { return is_empty(); }
 
+  /** DeformableModel can't convert to non-double scalar types, so it implements
+   the ScalarConvertibleComponent interface for describing the failure reasons.
+   */
+  std::string GetScalarConversionFailureReason(
+      const std::type_info& scalar) const final;
+
   // TODO(xuchenhan-tri): Restrict the entry point to parallelism configuration
   // so that's more difficult to misuse. We want to avoid, for example, a user
   // calling SetParallelism(Parallelism::Max()) on a model that has already been
@@ -545,6 +556,16 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
    empty, the clone simply returns an empty model. */
   std::unique_ptr<PhysicalModel<symbolic::Expression>> CloneToSymbolic(
       MultibodyPlant<symbolic::Expression>* plant) const final;
+
+  template <typename U>
+  void ThrowForUnsupportedScalarType() const {
+    if (!is_empty()) {
+      throw std::logic_error(fmt::format(
+          "DeformableModel does not support scalar conversion to type "
+          "drake::{} because {}.",
+          NiceTypeName::Get<U>(), GetScalarConversionFailureReason(typeid(U))));
+    }
+  }
 
   void DoDeclareSystemResources() final;
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -6,6 +6,8 @@
 #include <memory>
 #include <set>
 #include <stdexcept>
+#include <string>
+#include <typeinfo>
 #include <vector>
 
 #include <fmt/ranges.h>
@@ -388,7 +390,6 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
     // called because `FinalizePlantOnly()` has to allocate system resources
     // requested by physical models.
     physical_models_ = other.physical_models_->template CloneToScalar<T>(this);
-    this->RemoveUnsupportedScalars(*physical_models_);
 
     coupler_constraints_specs_ = other.coupler_constraints_specs_;
     distance_constraints_params_ = other.distance_constraints_params_;
@@ -1552,6 +1553,14 @@ void MultibodyPlant<T>::FinalizeConstraints() {
 
 template <typename T>
 void MultibodyPlant<T>::FinalizePlantOnly() {
+  // Physical models (e.g. DeformableModel) may not support every scalar type.
+  // We must disable the unsupported conversions here, at finalization of the
+  // owning plant, so that an attempt to scalar-convert (e.g. ToAutoDiffXd()) a
+  // plant that contains such a model fails immediately with a clear "does not
+  // support" message, rather than silently producing a degenerate plant that
+  // fails downstream with an inscrutable error.
+  RemoveUnsupportedScalars(*physical_models_);
+
   DeclareInputPorts();
   DeclareParameters();
   DeclareCacheEntries();
@@ -4338,6 +4347,29 @@ void MultibodyPlant<T>::RemoveUnsupportedScalars(
 }
 
 template <typename T>
+std::string MultibodyPlant<T>::GetUnsupportedScalarConversionMessage(
+    const std::type_info& source_type,
+    const std::type_info& destination_type) const {
+  std::string result =
+      systems::SystemBase::GetUnsupportedScalarConversionMessage(
+          source_type, destination_type);
+  std::vector<std::string> causes;
+  auto collect = [&](const internal::ScalarConvertibleComponent<T>& component) {
+    std::string reason =
+        component.GetScalarConversionFailureReason(destination_type);
+    if (!reason.empty()) {
+      causes.push_back(std::move(reason));
+    }
+  };
+  if (physical_models_ != nullptr) collect(*physical_models_);
+  if (discrete_update_manager_ != nullptr) collect(*discrete_update_manager_);
+  if (!causes.empty()) {
+    result += fmt::format(" (because {})", fmt::join(causes, " and "));
+  }
+  return result;
+}
+
+template <typename T>
 std::vector<std::set<BodyIndex>>
 MultibodyPlant<T>::FindSubgraphsOfWeldedBodies() const {
   return internal_tree().graph().GetSubgraphsOfWeldedLinks();
@@ -4466,3 +4498,21 @@ DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::multibody::MultibodyPlant);
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct drake::multibody::AddMultibodyPlantSceneGraphResult);
+
+// The scalar-converting copy constructor is a member function template
+// (template <typename U>), so it is NOT covered by the class-level explicit
+// instantiations above.  Without these explicit definitions, optimized builds
+// inline the constructor into the SystemScalarConverter lambda and leave no
+// standalone symbol — breaking direct call sites.
+template drake::multibody::MultibodyPlant<double>::MultibodyPlant(
+    const drake::multibody::MultibodyPlant<drake::AutoDiffXd>&);
+template drake::multibody::MultibodyPlant<double>::MultibodyPlant(
+    const drake::multibody::MultibodyPlant<drake::symbolic::Expression>&);
+template drake::multibody::MultibodyPlant<drake::AutoDiffXd>::MultibodyPlant(
+    const drake::multibody::MultibodyPlant<double>&);
+template drake::multibody::MultibodyPlant<drake::AutoDiffXd>::MultibodyPlant(
+    const drake::multibody::MultibodyPlant<drake::symbolic::Expression>&);
+template drake::multibody::MultibodyPlant<drake::symbolic::Expression>::
+    MultibodyPlant(const drake::multibody::MultibodyPlant<double>&);
+template drake::multibody::MultibodyPlant<drake::symbolic::Expression>::
+    MultibodyPlant(const drake::multibody::MultibodyPlant<drake::AutoDiffXd>&);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -6511,6 +6511,15 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   void RemoveUnsupportedScalars(
       const internal::ScalarConvertibleComponent<T>& component);
 
+  // Augments the generic SystemBase message with the specific reason(s) `this`
+  // plant's components disallow conversion to `destination_type` (e.g. a
+  // non-empty DeformableModel), so a failed ToAutoDiffXd()/ToSymbolic()
+  // explains why. See RemoveUnsupportedScalars(), which decides what is
+  // convertible.
+  std::string GetUnsupportedScalarConversionMessage(
+      const std::type_info& source_type,
+      const std::type_info& destination_type) const final;
+
   // Adds a DeformableModel to this plant. The added DeformableModel is owned
   // by `this` MultibodyPlant and calls its `DeclareSystemResources()` method
   // when `this` MultibodyPlant is finalized to declare the system resources it

--- a/multibody/plant/physical_model_collection.cc
+++ b/multibody/plant/physical_model_collection.cc
@@ -1,5 +1,13 @@
 #include "drake/multibody/plant/physical_model_collection.h"
 
+#include <string>
+#include <typeinfo>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 namespace drake {
 namespace multibody {
 namespace internal {
@@ -56,6 +64,19 @@ bool PhysicalModelCollection<T>::is_cloneable_to_symbolic() const {
     }
   }
   return true;
+}
+
+template <typename T>
+std::string PhysicalModelCollection<T>::GetScalarConversionFailureReason(
+    const std::type_info& scalar) const {
+  std::vector<std::string> reasons;
+  for (const auto& model : owned_models_) {
+    std::string reason = model->GetScalarConversionFailureReason(scalar);
+    if (!reason.empty()) {
+      reasons.push_back(std::move(reason));
+    }
+  }
+  return fmt::format("{}", fmt::join(reasons, " and "));
 }
 
 template <typename T>

--- a/multibody/plant/physical_model_collection.h
+++ b/multibody/plant/physical_model_collection.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <typeinfo>
 #include <utility>
 #include <vector>
 
@@ -76,6 +78,11 @@ class PhysicalModelCollection : public ScalarConvertibleComponent<T> {
   bool is_cloneable_to_autodiff() const override;
 
   bool is_cloneable_to_symbolic() const override;
+
+  /* Implements the API provided by ScalarConvertibleComponent to report the
+   *reasons* why scalar conversion is not possible. */
+  std::string GetScalarConversionFailureReason(
+      const std::type_info& scalar) const override;
 
   /* Declare system resources on all owned models and nulls the back pointer to
    the owning plant. For each PhysicalModelCollection object, this function

--- a/multibody/plant/scalar_convertible_component.h
+++ b/multibody/plant/scalar_convertible_component.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <typeinfo>
+
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 
@@ -29,6 +32,19 @@ class ScalarConvertibleComponent {
   /* Returns true if `this` component can be scalar converted to
    symbolic::Expression. */
   virtual bool is_cloneable_to_symbolic() const = 0;
+
+  /* (Optional, display-only) If this component blocks scalar conversion to the
+   destination scalar identified by `scalar`, returns a short human-readable
+   phrase explaining why (e.g. "its DeformableModel has 1 registered deformable
+   body"), for MultibodyPlant to embed in its "(because ...)" diagnostic.
+   Returns "" when this component does not block conversion to `scalar`. A
+   non-empty phrase MUST be consistent with the matching is_cloneable_to_*()
+   bool (non-empty implies that bool returns false); the reason is never used to
+   decide convertibility. */
+  virtual std::string GetScalarConversionFailureReason(
+      const std::type_info&) const {
+    return {};
+  }
 };
 
 }  // namespace internal

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -562,6 +562,48 @@ TEST_F(DeformableModelTest, NonEmptyClone) {
             deformable_model_ptr_->HasConstraint(body_id));
 }
 
+/* A plant that owns a non-empty DeformableModel must not be scalar-convertible
+ to AutoDiffXd or symbolic::Expression. Finalize() disables those conversions on
+ the plant's SystemScalarConverter so that the attempt fails immediately with a
+ clear message, rather than silently producing a plant with an empty deformable
+ model that fails downstream (e.g. when SceneGraph tries to read the missing
+ deformable configurations). */
+TEST_F(DeformableModelTest, PlantWithDeformableIsNotScalarConvertible) {
+  RegisterSphere(0.5);
+  EXPECT_FALSE(deformable_model_ptr_->is_empty());
+  plant_->Finalize();
+
+  /* The failure message explains *why* the plant is not convertible. */
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_->ToAutoDiffXd(),
+      ".*does not support scalar conversion to type drake::AutoDiffXd"
+      ".*because its DeformableModel has 1 registered deformable body.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_->ToSymbolic(),
+      ".*drake::symbolic::Expression.*because its DeformableModel has 1 "
+      "registered deformable body.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MultibodyPlant<AutoDiffXd>(*plant_),
+      ".*DeformableModel.*registered deformable body.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MultibodyPlant<symbolic::Expression>(*plant_),
+      ".*DeformableModel.*registered deformable body.*");
+
+  /* The reason also surfaces when the plant is nested in a Diagram (the path
+   that propagates through Diagram::GetUnsupportedScalarConversionMessage). */
+  auto diagram = builder_.Build();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      diagram->ToAutoDiffXd(),
+      ".*because its DeformableModel has 1 registered deformable body.*");
+
+  /* An empty DeformableModel does not impede scalar conversion. */
+  systems::DiagramBuilder<double> empty_builder;
+  auto added = AddMultibodyPlant(MultibodyPlantConfig{.time_step = 0.01},
+                                 &empty_builder);
+  added.plant.Finalize();
+  EXPECT_NO_THROW(added.plant.ToAutoDiffXd());
+}
+
 // Remove on 2026-09-01 per TAMSI deprecation.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
DeformableModel reports that it is only cloneable to AutoDiffXd or Symbolic if it is _empty_. However, attempting to clone the plant would nevertheless "succeed". The cloned result would have the registered deformable models stripped out of the DeformableModel.

Rather than silently creating a lossy clone, this changes the behavior to throw. It provides mechanisms to enforce that and provides details on why the plant can't be scalar converted.

Specifically, MultibodyPlant needed its invocation of RemoveUnsupportedScalars() removed from the scalar-converting constructor to FinalizePlantOnly() to close a gap in conversion logic.

 - The scalar copy constructor can only be called on finalized plants (a documented requirement).
 - However, the finalized plant hadn't necessarily recognized which conversions were valid yet.
 - So, the conversion would happena and the converted *copy* would know if it was convertible; but the source may have been wrong. This subverted the system conversion mechanism. By making sure a finalized plant knows what target scalar types are valid, the conversion constructor automatically benefits.

This is *in theory* a breaking change because it changes observable behavior. If a user was cloning a plant with deformable bodies into an unsupported scalar type, but ignored the fact that the deformable bodies were gone, this constitutes a new exception

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24640)
<!-- Reviewable:end -->
