### PR TITLE
[workspace] Improve context on qhull tag lock

### DIFF
--- a/tools/workspace/qhull_internal/repository.bzl
+++ b/tools/workspace/qhull_internal/repository.bzl
@@ -8,7 +8,7 @@ def qhull_internal_repository(
         repository = "qhull/qhull",
         upgrade_type = "tag",
         commit = "2020.2",
-        tags_pattern = "^(2)",
+        tags_pattern = "^(2)[0-9]{3}\\.",
         sha256 = "59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [


### PR DESCRIPTION
For context, see https://github.com/qhull/qhull/tags. Tested by temporarily reverting to `2020.1`, and additional manual testing with made-up newer versions e.g. `2026.1`.

Follow-up from #24593.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24650)
<!-- Reviewable:end -->
