### PR TITLE
[workspace] Update dependency github3_py_internal to 4.0.1

### DIFF
--- a/tools/workspace/github3_py_internal/repository.bzl
+++ b/tools/workspace/github3_py_internal/repository.bzl
@@ -7,9 +7,18 @@ def github3_py_internal_repository(
         name = name,
         repository = "sigmavirus24/github3.py",
         upgrade_type = "tag",
-        tags_pattern = "^(\\d+\\.)",
-        commit = "3.2.0",
-        sha256 = "42cf8e721437a0bcfb05e767302c3221cdc96f3e9db3d76ce990fd0526af1d99",  # noqa
+        upgrade_advice = """
+        This upgrade requires manual testing. Check the following for reliance
+        on any changed APIs:
+          * //tools/release_engineering:mirror_to_s3
+          * //tools/release_engineering:relnotes
+          * //tools/workspace:new_release
+        If unsure on how to test these changes locally or in CI, contact
+        @BetsyMcPhail.
+        """,
+        tags_pattern = "^\\d+(\\.)",
+        commit = "4.0.1",
+        sha256 = "7a1c3f157aa3b9e0973e957ac0b402c09a83d405247d278c10eb4c390977f132",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
See the [release notes](https://github3.readthedocs.io/en/latest/release-notes/4.0.0.html). 

Note that `//tools/release_engineering:relnotes` does use `commits()`, but not the API that changed: we use [`repos.repo.Repository.commits`](https://github3.readthedocs.io/en/latest/api-reference/repos.html#github3.repos.repo.Repository.commits), not [`repos.comparison.Comparison.commits`](https://github3.readthedocs.io/en/latest/api-reference/repos.html#github3.repos.comparison.Comparison.commits).

Running `//tools/workspace:new_release` and `//tools/release_engineering:mirror_to_s3 -- --dry-run` locally both seemed fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24651)
<!-- Reviewable:end -->
