### PR TITLE
[pydrake] Align with nanobind list and tuple API

### DIFF
--- a/bindings/pydrake/common/cpp_param_pybind.cc
+++ b/bindings/pydrake/common/cpp_param_pybind.cc
@@ -61,8 +61,8 @@ void RegisterType(
   // Create an object that is a unique hash.
   py::object canonical =
       py::eval(py::str(canonical_str.c_str()), m.attr("__dict__"));
-  py::list aliases(1);
-  aliases[0] = GetPyHash(typeid(T));
+  py::list aliases;
+  aliases.append(GetPyHash(typeid(T)));
   param_aliases.attr("register")(canonical, aliases);
 }
 

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -42,9 +42,8 @@ using PyPenaltyFunction = std::function<py::tuple(double, bool)>;
 CppPenaltyFunction UnwrapPyPenaltyFunction(PyPenaltyFunction penalty_function) {
   if (penalty_function) {
     return [penalty_function](double x, double* penalty, double* dpenalty) {
-      py::tuple penalty_tuple(2);
       const bool compute_grad = dpenalty != nullptr;
-      penalty_tuple = penalty_function(x, compute_grad);
+      py::tuple penalty_tuple = penalty_function(x, compute_grad);
       *penalty = py::cast<double>(penalty_tuple[0]);
       if (compute_grad) {
         *dpenalty = py::cast<double>(penalty_tuple[1]);

--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -517,8 +517,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
                 std::function<py::tuple(double, bool)> new_penalty_function) {
               auto penalty_fun = [new_penalty_function](double x,
                                      double* penalty, double* dpenalty) {
-                py::tuple penalty_tuple(2);
-                penalty_tuple = new_penalty_function(x, dpenalty != nullptr);
+                py::tuple penalty_tuple =
+                    new_penalty_function(x, dpenalty != nullptr);
                 *penalty = py::cast<double>(penalty_tuple[0]);
                 if (dpenalty) {
                   *dpenalty = py::cast<double>(penalty_tuple[1]);
@@ -574,8 +574,8 @@ void BindEvaluatorsAndBindings(py::module_ m) {
                 std::function<py::tuple(double, bool)> new_penalty_function) {
               auto penalty_fun = [new_penalty_function](double x,
                                      double* penalty, double* dpenalty) {
-                py::tuple penalty_tuple(2);
-                penalty_tuple = new_penalty_function(x, dpenalty != nullptr);
+                py::tuple penalty_tuple =
+                    new_penalty_function(x, dpenalty != nullptr);
                 *penalty = py::cast<double>(penalty_tuple[0]);
                 if (dpenalty) {
                   *dpenalty = py::cast<double>(penalty_tuple[1]);

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -730,18 +730,16 @@ void DoDefineFrameworkDiagramBuilder(py::module_ m) {
                   input_locator.first, py_rvp::reference_internal, self_py);
               py::object input_port_index_py = py::cast(input_locator.second);
 
-              py::tuple input_locator_py(2);
-              input_locator_py[0] = input_system_py;
-              input_locator_py[1] = input_port_index_py;
+              py::tuple input_locator_py =
+                  py::make_tuple(input_system_py, input_port_index_py);
 
               // Keep alive, ownership: `output_system_py` keeps `self` alive.
               py::object output_system_py = py::cast(
                   output_locator.first, py_rvp::reference_internal, self_py);
               py::object output_port_index_py = py::cast(output_locator.second);
 
-              py::tuple output_locator_py(2);
-              output_locator_py[0] = output_system_py;
-              output_locator_py[1] = output_port_index_py;
+              py::tuple output_locator_py =
+                  py::make_tuple(output_system_py, output_port_index_py);
 
               out[input_locator_py] = output_locator_py;
             }

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -73,10 +73,7 @@ constexpr auto& doc = pydrake_doc_systems_framework.drake.systems;
 // common/ref_cycle_pybind bookkeeping scheme.
 py::object UniquelyWrapCallback(py::object callback) {
   static std::atomic<uint64_t> uniquifier{0};
-  py::tuple wrapped(2);
-  wrapped[0] = callback;
-  wrapped[1] = uniquifier.fetch_add(1);
-  return wrapped;
+  return py::make_tuple(callback, uniquifier.fetch_add(1));
 }
 
 // This helper function causes the lifetime of `callback` to be at least as
@@ -1081,9 +1078,8 @@ Note: The above is for the C++ documentation. For Python, use
                     input_locator.first, py_rvp::reference_internal, self_py);
                 py::object input_port_index_py = py::cast(input_locator.second);
 
-                py::tuple input_locator_py(2);
-                input_locator_py[0] = input_system_py;
-                input_locator_py[1] = input_port_index_py;
+                py::tuple input_locator_py =
+                    py::make_tuple(input_system_py, input_port_index_py);
 
                 // Keep alive, ownership: `output_system_py` keeps `self` alive.
                 py::object output_system_py = py::cast(
@@ -1091,9 +1087,8 @@ Note: The above is for the C++ documentation. For Python, use
                 py::object output_port_index_py =
                     py::cast(output_locator.second);
 
-                py::tuple output_locator_py(2);
-                output_locator_py[0] = output_system_py;
-                output_locator_py[1] = output_port_index_py;
+                py::tuple output_locator_py =
+                    py::make_tuple(output_system_py, output_port_index_py);
 
                 out[input_locator_py] = output_locator_py;
               }
@@ -1111,9 +1106,7 @@ Note: The above is for the C++ documentation. For Python, use
                     locator.first, py_rvp::reference_internal, self_py);
                 py::object port_index_py = py::cast(locator.second);
 
-                py::tuple locator_py(2);
-                locator_py[0] = system_py;
-                locator_py[1] = port_index_py;
+                py::tuple locator_py = py::make_tuple(system_py, port_index_py);
                 out.append(locator_py);
               }
               return out;
@@ -1129,9 +1122,7 @@ Note: The above is for the C++ documentation. For Python, use
                   py::cast(locator.first, py_rvp::reference_internal, self_py);
               py::object port_index_py = py::cast(locator.second);
 
-              py::tuple locator_py(2);
-              locator_py[0] = system_py;
-              locator_py[1] = port_index_py;
+              py::tuple locator_py = py::make_tuple(system_py, port_index_py);
               return locator_py;
             },
             py::arg("port_index"), doc.Diagram.get_output_port_locator.doc)


### PR DESCRIPTION
Nanobind doesn't offer a sized constructor for py::list or py::tuple.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24653)
<!-- Reviewable:end -->
