### PR TITLE
[pydrake] Move Expression and Formula pickling to C++

### DIFF
--- a/bindings/pydrake/symbolic/_symbolic_extra.py
+++ b/bindings/pydrake/symbolic/_symbolic_extra.py
@@ -27,25 +27,6 @@ def _reduce_mul(*args):
     return functools.reduce(operator.mul, args)
 
 
-def _getstate_via_unapply(self: Expression | Formula) -> tuple:
-    ctor, args = self.Unapply()
-    # We pickle the kind, not the ctor.
-    state = tuple([self.get_kind()] + args)
-    return state
-
-
-def _setstate_via_unapply(self: Expression | Formula, state: tuple) -> None:
-    kind = state[0]
-    ctor = self._MakeUnapplyConstructor(kind)
-    args = state[1:]
-    self._assign(ctor(*args))
-
-
-Expression.__getstate__ = _getstate_via_unapply
-Expression.__setstate__ = _setstate_via_unapply
-Formula.__getstate__ = _getstate_via_unapply
-Formula.__setstate__ = _setstate_via_unapply
-
 # Drake's SymPy support is loaded lazily (on demand), so that Drake does not
 # directly depend on SymPy. The implementation lives in `_symbolic_sympy.py`.
 _symbolic_sympy_defer = None

--- a/bindings/pydrake/symbolic/symbolic_py_monolith.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_monolith.cc
@@ -492,19 +492,19 @@ void DefineSymbolicMonolith(py::module_ m) {
       .def("Differentiate", &Expression::Differentiate, py::arg("x"),
           doc_expression.Differentiate.doc)
       .def("Jacobian", &Expression::Jacobian, py::arg("vars"),
-          doc_expression.Jacobian.doc)
-      // Private for use by pickling.
-      .def("_assign",
-          [](Expression& self, const Expression& other) -> void {
-            self = other;
-          })
-      .def_static("_MakeUnapplyConstructor", [m](ExpressionKind kind) {
-        return internal::MakeUnapplyConstructor(m, kind);
-      });
+          doc_expression.Jacobian.doc);
   // TODO(eric.cousineau): Clean this overload stuff up (#15041).
   pydrake::internal::BindMathOperators<Expression>(&expr_cls);
   pydrake::internal::BindMathOperators<Expression>(&m);
   DefCopyAndDeepCopy(&expr_cls);
+  DefPickle(
+      &expr_cls,
+      [](const Expression& self) -> py::tuple {
+        return internal::PickleExpression(self);
+      },
+      [m](Expression* self, py::tuple state) {
+        new (self) Expression(internal::UnpickleExpression(m, state));
+      });
 
   m.def("if_then_else", &symbolic::if_then_else, py::arg("f_cond"),
       py::arg("e_then"), py::arg("e_else"), doc_expr.if_then_else.doc);
@@ -684,24 +684,24 @@ void DefineSymbolicMonolith(py::module_ m) {
       // `True` and `False` are reserved keywords as of Python3.
       .def_static("True_", &Formula::True, doc_expr.Formula.True.doc)
       .def_static("False_", &Formula::False, doc_expr.Formula.False.doc)
-      .def("__nonzero__",
-          [](const Formula&) {
-            throw std::runtime_error(
-                "You should not call `__bool__` / `__nonzero__` on `Formula`. "
-                "If you are trying to make a map with `Variable`, "
-                "`Expression`, or `Polynomial` as keys (and then access the "
-                "map in Python), please use "
-                "pydrake.common.containers.EqualToDict`.");
-          })
-      // Private for use by pickling.
-      .def("_assign",
-          [](Formula& self, const Formula& other) -> void { self = other; })
-      .def_static("_MakeUnapplyConstructor", [m](FormulaKind kind) {
-        return internal::MakeUnapplyConstructor(m, kind);
+      .def("__nonzero__", [](const Formula&) {
+        throw std::runtime_error(
+            "You should not call `__bool__` / `__nonzero__` on `Formula`. "
+            "If you are trying to make a map with `Variable`, `Expression`, "
+            "or `Polynomial` as keys (and then access the map in Python), "
+            "please use pydrake.common.containers.EqualToDict`.");
       });
   formula_cls.attr("__bool__") = formula_cls.attr("__nonzero__");
   py::implicitly_convertible<bool, Formula>();
   py::implicitly_convertible<Variable, Formula>();
+  DefPickle(
+      &formula_cls,
+      [](const Formula& self) -> py::tuple {
+        return internal::PickleFormula(self);
+      },
+      [m](Formula* self, py::tuple state) {
+        new (self) Formula(internal::UnpickleFormula(m, state));
+      });
 
   // Cannot overload logical operators: http://stackoverflow.com/a/471561
   // Defining custom function for clarity.

--- a/bindings/pydrake/symbolic/symbolic_py_unapply.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_unapply.cc
@@ -5,6 +5,7 @@
 namespace drake {
 namespace pydrake {
 namespace internal {
+namespace {
 
 using drake::symbolic::Expression;
 using drake::symbolic::ExpressionKind;
@@ -71,8 +72,6 @@ py::object MakeUnapplyConstructor(py::module_ m, ExpressionKind kind) {
   }
   DRAKE_UNREACHABLE();
 }
-
-namespace {
 
 // Given the expression "e", returns an extracted list of arguments that would
 // be able to re-construct the same expression, when passed to the result of
@@ -159,8 +158,6 @@ py::list MakeArgs(const Expression& e) {
   return result;
 }
 
-}  // namespace
-
 py::object MakeUnapplyConstructor(py::module_ m, FormulaKind kind) {
   switch (kind) {
     case FormulaKind::False:
@@ -196,8 +193,6 @@ py::object MakeUnapplyConstructor(py::module_ m, FormulaKind kind) {
   }
   DRAKE_UNREACHABLE();
 }
-
-namespace {
 
 // Given the formula "f", returns an extracted list of arguments that would
 // be able to re-construct the same formula, when passed to the result of
@@ -259,6 +254,34 @@ py::object Unapply(py::module_ m, const Expression& e) {
 
 py::object Unapply(py::module_ m, const Formula& f) {
   return py::make_tuple(MakeUnapplyConstructor(m, f.get_kind()), MakeArgs(f));
+}
+
+py::tuple PickleExpression(const Expression& e) {
+  py::list result = MakeArgs(e);
+  result.insert(0, e.get_kind());
+  return py::tuple(result);
+}
+
+Expression UnpickleExpression(py::module_ m, py::tuple state) {
+  py::list args(state);
+  auto kind = py::cast<ExpressionKind>(args.attr("pop")(0));
+  py::object ctor = MakeUnapplyConstructor(m, kind);
+  py::object result = ctor(*args);
+  return cast<Expression>(result);
+}
+
+py::tuple PickleFormula(const Formula& f) {
+  py::list result = MakeArgs(f);
+  result.insert(0, f.get_kind());
+  return py::tuple(result);
+}
+
+Formula UnpickleFormula(py::module_ m, py::tuple state) {
+  py::list args(state);
+  auto kind = py::cast<FormulaKind>(args.attr("pop")(0));
+  py::object ctor = MakeUnapplyConstructor(m, kind);
+  py::object result = ctor(*args);
+  return cast<Formula>(result);
 }
 
 }  // namespace internal

--- a/bindings/pydrake/symbolic/symbolic_py_unapply.h
+++ b/bindings/pydrake/symbolic/symbolic_py_unapply.h
@@ -35,17 +35,15 @@ ctor's identity.
 // @param m The pydrake.symbolic module.
 py::object Unapply(py::module_ m, const symbolic::Formula& f);
 
-// Given the pydrake.symbolic module as "m" and an expression "kind", returns
-// the callable object (i.e., factory function or constructor) that would be
-// able to re-construct the same expression, given appropriate arguments. This
-// is the "ctor" returned by Unapply() for the "e.get_kind()".
-py::object MakeUnapplyConstructor(py::module_ m, symbolic::ExpressionKind kind);
+py::tuple PickleExpression(const symbolic::Expression& e);
 
-// Given the pydrake.symbolic module as "m" and a formula "kind", returns the
-// callable object (i.e., factory function or constructor) that would be able to
-// re-construct the same formula, given appropriate arguments. This is the
-// "ctor" returned by Unapply() for the "f.get_kind()".
-py::object MakeUnapplyConstructor(py::module_ m, symbolic::FormulaKind kind);
+// @param m The pydrake.symbolic module.
+symbolic::Expression UnpickleExpression(py::module_ m, py::tuple state);
+
+py::tuple PickleFormula(const symbolic::Formula& f);
+
+// @param m The pydrake.symbolic module.
+symbolic::Formula UnpickleFormula(py::module_ m, py::tuple state);
 
 }  // namespace internal
 }  // namespace pydrake


### PR DESCRIPTION
For nanobind, the `__setstate__` constructor must be bound in C++, not overridden in Python.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24658)
<!-- Reviewable:end -->
