### PR TITLE
[pydrake] Align with nanobind py::object::type API

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -55,7 +55,7 @@ std::string PyNiceTypeNamePtrOverride(const type_erased_ptr& ptr) {
   if (cc_name.find("pydrake::") != std::string::npos) {
     py::handle obj = ResolvePyObject(ptr);
     if (obj) {
-      py::handle cls = obj.get_type();
+      py::handle cls = obj.type();
       const bool use_qualname = true;
       return py::cast<std::string>(
           py::str("{}.{}").format(cls.attr("__module__"),

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -89,8 +89,7 @@ void BindMultibodyElementMixin(PyClass* pcls) {
             return self.GetParentPlant();
           })
       .def("__repr__", [](const Class& self) {
-        py::str cls_name =
-            internal::PrettyClassName(py::cast(&self).get_type());
+        py::str cls_name = internal::PrettyClassName(py::cast(&self).type());
         const int index = self.index();
         const int model_instance = self.model_instance();
         if constexpr (has_name_func<Class>::value) {
@@ -1285,7 +1284,7 @@ class PyForceDensityField : public ForceDensityFieldPublic<T> {
     } catch (const py::cast_error& e) {
       throw std::logic_error(
           "DoClone() must return a `ForceDensityField<T>`. Got " +
-          py::cast<std::string>(py::str(result_obj.get_type())) +
+          py::cast<std::string>(py::str(result_obj.type())) +
           " Make sure your DoClone() returns a new instance of the same "
           "Python class, e.g., `return MyForceDensityField(...)`.");
     }

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -36,7 +36,7 @@ void DoScalarDependentDefinitions(py::module_ m) {
           })
       .def("__repr__",
           [](const VectorBase<T>& self) {
-            py::handle cls = py::cast(&self, py_rvp::reference).get_type();
+            py::handle cls = py::cast(&self, py_rvp::reference).type();
             return py::str("{}({})").format(internal::PrettyClassName(cls),
                 py::cast(self.CopyToVector()).attr("tolist")());
           })

--- a/tools/workspace/pybind11/patches/nanobind_spellings.patch
+++ b/tools/workspace/pybind11/patches/nanobind_spellings.patch
@@ -93,6 +93,14 @@ See https://github.com/RobotLocomotion/drake/issues/21572.
 
 --- include/pybind11/pytypes.h
 +++ include/pybind11/pytypes.h
+@@ -196,6 +196,7 @@
+     // TODO PYBIND11_DEPRECATED(
+     //     "Call py::type::handle_of(h) or py::type::of(h) instead of h.get_type()")
+     handle get_type() const;
++    handle type() const;
+ 
+ private:
+     bool rich_compare(object_api const &other, int value) const;
 @@ -485,6 +485,7 @@
  T reinterpret_borrow(handle h) {
      return {h, object::borrowed_t{}};
@@ -120,3 +128,15 @@ See https://github.com/RobotLocomotion/drake/issues/21572.
  private:
      template <typename T>
      T string_op() const {
+@@ -2549,6 +2549,11 @@
+ }
+ 
+ template <typename D>
++handle object_api<D>::type() const {
++    return type::handle_of(derived());
++}
++
++template <typename D>
+ bool object_api<D>::rich_compare(object_api const &other, int value) const {
+     int rv = PyObject_RichCompareBool(derived().ptr(), other.derived().ptr(), value);
+     if (rv == -1) {


### PR DESCRIPTION
The nanobind method is named `type()` but pybind11 names it `get_type()`. Add a pybind11 alias to compensate and switch everywhere to use it.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24660)
<!-- Reviewable:end -->
