### PR TITLE
[planning] Fix NVI access level to be protected, not private

### DIFF
--- a/bindings/generated_docstrings/planning_graph_algorithms.h
+++ b/bindings/generated_docstrings/planning_graph_algorithms.h
@@ -35,6 +35,11 @@ R"""(The problem of finding the maximum clique in a graph is known to be
 NP-complete. This base class provides a unified interface for various
 implementations of a solver for this problem which may be solved
 rigorously or via heuristics.)""";
+          // Symbol: drake::planning::graph_algorithms::MaxCliqueSolverBase::DoSolveMaxClique
+          struct /* DoSolveMaxClique */ {
+            // Source: drake/planning/graph_algorithms/max_clique_solver_base.h
+            const char* doc = R"""()""";
+          } DoSolveMaxClique;
           // Symbol: drake::planning::graph_algorithms::MaxCliqueSolverBase::MaxCliqueSolverBase
           struct /* ctor */ {
             // Source: drake/planning/graph_algorithms/max_clique_solver_base.h
@@ -133,6 +138,11 @@ Raises:
         struct /* MinCliqueCoverSolverBase */ {
           // Source: drake/planning/graph_algorithms/min_clique_cover_solver_base.h
           const char* doc = R"""()""";
+          // Symbol: drake::planning::graph_algorithms::MinCliqueCoverSolverBase::DoSolveMinCliqueCover
+          struct /* DoSolveMinCliqueCover */ {
+            // Source: drake/planning/graph_algorithms/min_clique_cover_solver_base.h
+            const char* doc = R"""()""";
+          } DoSolveMinCliqueCover;
           // Symbol: drake::planning::graph_algorithms::MinCliqueCoverSolverBase::MinCliqueCoverSolverBase
           struct /* ctor */ {
             // Source: drake/planning/graph_algorithms/min_clique_cover_solver_base.h

--- a/planning/graph_algorithms/max_clique_solver_base.h
+++ b/planning/graph_algorithms/max_clique_solver_base.h
@@ -45,7 +45,6 @@ class MaxCliqueSolverBase {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MaxCliqueSolverBase);
   MaxCliqueSolverBase() = default;
 
- private:
   virtual VectorX<bool> DoSolveMaxClique(
       const Eigen::SparseMatrix<bool>& adjacency_matrix) const = 0;
 };

--- a/planning/graph_algorithms/min_clique_cover_solver_base.h
+++ b/planning/graph_algorithms/min_clique_cover_solver_base.h
@@ -52,7 +52,6 @@ class MinCliqueCoverSolverBase {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MinCliqueCoverSolverBase);
   MinCliqueCoverSolverBase() = default;
 
- private:
   virtual std::vector<std::set<int>> DoSolveMinCliqueCover(
       const Eigen::SparseMatrix<bool>& adjacency_matrix,
       bool partition = false) = 0;


### PR DESCRIPTION
This is more typical; private ends up fighting with nanobind's return type inference.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24663)
<!-- Reviewable:end -->
