### PR TITLE
Remove artificial restrictions on meshcat visualzer for T = autodiff

### DIFF
--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -157,67 +157,59 @@ systems::EventStatus MeshcatVisualizer<T>::UpdateMeshcat(
 template <typename T>
 void MeshcatVisualizer<T>::RegisterDeformable(
     const QueryObject<T>& query_object, GeometryId deformable_id) const {
-  if constexpr (std::is_same_v<T, double>) {
-    // We should only register after clearing all previously registered
-    // deformables; so we should never redundantly register a deformable.
-    DRAKE_DEMAND(!dynamic_deformable_geometries_.contains(deformable_id));
+  // We should only register after clearing all previously registered
+  // deformables; so we should never redundantly register a deformable.
+  DRAKE_DEMAND(!dynamic_deformable_geometries_.contains(deformable_id));
 
-    const auto& inspector = query_object.inspector();
-    const std::vector<internal::RenderMesh>& render_meshes =
-        inspector.GetDrivenRenderMeshes(deformable_id, params_.role);
-    const int num_render_meshes = ssize(render_meshes);
-    dynamic_deformable_geometries_[deformable_id].reserve(num_render_meshes);
+  const auto& inspector = query_object.inspector();
+  const std::vector<internal::RenderMesh>& render_meshes =
+      inspector.GetDrivenRenderMeshes(deformable_id, params_.role);
+  const int num_render_meshes = ssize(render_meshes);
+  dynamic_deformable_geometries_[deformable_id].reserve(num_render_meshes);
 
-    // GeometryState only supports driven meshes (embedded OBJ with multiple
-    // material groups) for the perception role, not illustration. For
-    // illustration, RegisterDrivenMesh always produces exactly one mesh from
-    // the control-mesh surface. See geometry_state.cc RegisterDrivenMesh and
-    // the TODO therein. Remove this demand when illustration driven-mesh
-    // support is added and update BroadcastDeformables and its tests.
-    DRAKE_DEMAND(num_render_meshes == 1);
+  // GeometryState only supports driven meshes (embedded OBJ with multiple
+  // material groups) for the perception role, not illustration. For
+  // illustration, RegisterDrivenMesh always produces exactly one mesh from
+  // the control-mesh surface. See geometry_state.cc RegisterDrivenMesh and
+  // the TODO therein. Remove this demand when illustration driven-mesh
+  // support is added and update BroadcastDeformables and its tests.
+  DRAKE_DEMAND(num_render_meshes == 1);
+  for (int i = 0; i < num_render_meshes; ++i) {
+    const Rgba& diffuse_color = render_meshes[i].material.has_value()
+                                    ? render_meshes[i].material->diffuse
+                                    : params_.default_color;
 
-    for (int i = 0; i < num_render_meshes; ++i) {
-      const Rgba& diffuse_color = render_meshes[i].material.has_value()
-                                      ? render_meshes[i].material->diffuse
-                                      : params_.default_color;
-
-      dynamic_deformable_geometries_[deformable_id].push_back(
-          {internal::MakeTriangleSurfaceMesh(render_meshes[i]), diffuse_color});
-    }
-  } else {
-    throw std::runtime_error(
-        "Only MeshcatVisualizer<double> supports deformable geometry.");
+    dynamic_deformable_geometries_[deformable_id].push_back(
+        {internal::MakeTriangleSurfaceMesh(render_meshes[i]), diffuse_color});
   }
 }
 
 template <typename T>
 void MeshcatVisualizer<T>::BroadcastDeformables(
     const QueryObject<T>& query_object) const {
-  if constexpr (std::is_same_v<T, double>) {
-    for (auto& [deformable_id, colored_meshes] :
-         dynamic_deformable_geometries_) {
-      const int num_render_meshes = std::size(colored_meshes);
-      const std::string& path = geometries_.at(deformable_id);
+  for (auto& [deformable_id, colored_meshes] : dynamic_deformable_geometries_) {
+    const int num_render_meshes = std::size(colored_meshes);
+    const std::string& path = geometries_.at(deformable_id);
 
-      // We already checked the T is double
-      const std::vector<VectorX<double>> vertex_positions =
-          query_object.GetDrivenMeshConfigurationsInWorld(deformable_id,
-                                                          params_.role);
-      DRAKE_DEMAND(std::ssize(vertex_positions) == num_render_meshes);
+    // The driven mesh configurations are inherently double-valued (any
+    // derivatives carried by T would be empty), so we discard the scalar type
+    // when reporting positions to Meshcat.
+    const std::vector<VectorX<T>> vertex_positions =
+        query_object.GetDrivenMeshConfigurationsInWorld(deformable_id,
+                                                        params_.role);
+    DRAKE_DEMAND(std::ssize(vertex_positions) == num_render_meshes);
 
-      for (int i = 0; i < num_render_meshes; ++i) {
-        colored_meshes[i].mesh.SetAllPositions(vertex_positions[i]);
+    for (int i = 0; i < num_render_meshes; ++i) {
+      colored_meshes[i].mesh.SetAllPositions(
+          internal::convert_to_double(vertex_positions[i]));
 
-        const std::string final_sub_path =
-            num_render_meshes == 1 ? path : fmt::format("{}/{}", path, i);
-        meshcat_->SetObject(final_sub_path, colored_meshes[i].mesh,
-                            colored_meshes[i].diffuse);
-      }
-      meshcat_->SetTransform(path, math::RigidTransformd::Identity());
+      const std::string final_sub_path =
+          num_render_meshes == 1 ? path : fmt::format("{}/{}", path, i);
+      meshcat_->SetObject(final_sub_path, colored_meshes[i].mesh,
+                          colored_meshes[i].diffuse);
     }
+    meshcat_->SetTransform(path, math::RigidTransformd::Identity());
   }
-  // Else do nothing -- we should've already thrown in RegisterDeformable()
-  // for T != double.
 }
 
 template <typename T>

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -199,7 +199,7 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   /* Store a colored surface mesh for each discrete component of a deformable
    geometry's visible geometry. */
   struct ColoredMesh {
-    TriangleSurfaceMesh<T> mesh;
+    TriangleSurfaceMesh<double> mesh;
     Rgba diffuse;
   };
 

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -40,10 +40,13 @@ using multibody::AddMultibodyPlantSceneGraph;
 // Those are covered by the tests for Meshcat.  Here we only aim to demonstrate
 // that we call Meshcat correctly from MeshcatVisualizer.
 //
-// We're intentionally not building MeshcatVisualizer<AutoDiffXd> directly.
-// Parsing with AutoDiffXd is not supported and populating the MBP is more work
-// than it's worth. The scalar-converted instance is tested and that provides
-// sufficient evidence for the validity of the type.
+// The MultibodyPlant-based tests don't build MeshcatVisualizer<AutoDiffXd>
+// directly. Parsing with AutoDiffXd is not supported and populating the MBP is
+// more work than it's worth. The scalar-converted instance is tested and that
+// provides sufficient evidence for the validity of the scalar type.
+//
+// Visualizing deformable geometry is a special case (see
+// DeformableGeometryScalarTypes below).
 
 class MeshcatVisualizerWithIiwaTest : public ::testing::Test {
  protected:
@@ -532,6 +535,13 @@ GTEST_TEST(MeshcatVisualizerTest, DeformableGeometry) {
     // Send the geometry to Meshcat.
     diagram->ForcedPublish(*context);
     EXPECT_TRUE(meshcat->HasPath(expected_path));
+
+    // Note: When this no longer throws, this test should be converted to run
+    // against both scalar types and the test DeformableGeometryScalarTypes can
+    // be removed.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        diagram->ToAutoDiffXd(),
+        ".*because its DeformableModel has 1 registered deformable body.*");
   }
 }
 
@@ -599,6 +609,62 @@ GTEST_TEST(MeshcatVisualizerTest, DeformableGeometrySceneGraphVersionChange) {
   // proves too aggressive in the future, we can be more explicit about the
   // nature of the change.
   EXPECT_NE(meshcat->GetPackedObject(path), packed_initial);
+}
+
+// MeshcatVisualizer supports deformable geometry for both T = double and
+// T = AutoDiffXd. The MultibodyPlant-based test above exercises the double
+// path; the AutoDiffXd deformable pipeline is not yet supported by
+// MultibodyPlant (DeformableModel::CloneToAutoDiffXd produces an empty model),
+// so here we drive a SceneGraph<AutoDiffXd> directly to confirm the visualizer
+// registers and broadcasts deformable geometry.
+template <typename T>
+void TestDeformableScalar() {
+  SCOPED_TRACE(fmt::format("TestDeformableScalar<{}>", NiceTypeName::Get<T>()));
+  auto meshcat = std::make_shared<Meshcat>();
+
+  SceneGraph<T> scene_graph;
+  const SourceId s_id = scene_graph.RegisterSource("test");
+
+  const math::RigidTransformd X_WG(Vector3<double>(0.0, 0.0, 0.0));
+  const Mesh shape(FindResourceOrThrow(
+      "drake/examples/multibody/deformable/models/torus.vtk"));
+  auto instance = std::make_unique<GeometryInstance>(X_WG, shape, "object");
+  instance->set_illustration_properties(IllustrationProperties());
+  constexpr double kRezHint = 0.5;
+  const GeometryId deformable_id = scene_graph.RegisterDeformableGeometry(
+      s_id, scene_graph.world_frame_id(), std::move(instance), kRezHint);
+
+  // The reference mesh determines the number of vertex configuration values.
+  const VolumeMesh<double>* reference_mesh =
+      scene_graph.model_inspector().GetReferenceMesh(deformable_id);
+  ASSERT_NE(reference_mesh, nullptr);
+
+  auto sg_context = scene_graph.CreateDefaultContext();
+  GeometryConfigurationVector<T> configurations;
+  configurations.set_value(
+      deformable_id, VectorX<T>::Zero(reference_mesh->num_vertices() * 3));
+  scene_graph.get_source_configuration_port(s_id).FixValue(sg_context.get(),
+                                                           configurations);
+  const auto& query_object =
+      scene_graph.get_query_output_port().template Eval<QueryObject<T>>(
+          *sg_context);
+
+  const MeshcatVisualizerParams params{.role = Role::kIllustration};
+  MeshcatVisualizer<T> visualizer(meshcat, params);
+  auto vis_context = visualizer.CreateDefaultContext();
+  visualizer.query_object_input_port().FixValue(vis_context.get(),
+                                                query_object);
+
+  const std::string expected_path =
+      "/drake/visualizer/deformable_geometries/object";
+  EXPECT_FALSE(meshcat->HasPath(expected_path));
+  visualizer.ForcedPublish(*vis_context);
+  EXPECT_TRUE(meshcat->HasPath(expected_path));
+}
+
+GTEST_TEST(MeshcatVisualizerTest, DeformableGeometryScalarTypes) {
+  TestDeformableScalar<double>();
+  TestDeformableScalar<AutoDiffXd>();
 }
 
 GTEST_TEST(MeshcatVisualizerTest, MultipleModels) {


### PR DESCRIPTION
The feature to visualize deformable geometry initially included the arbitrary constraint that attempting to visualize such a body with T = autodiff would throw.

There is no reason for MeshcatVisualizer to do so. None of the APIs it depends are preclude T = autodiff. This PR removes this false limitation.

However, there is an upstream limitation -- MbP doesn't support AutoDiff- valued deformable bodies. So, for now, we have a test that will detect when upstream changes its mind so we can update the test to show that it works. We want to make sure MeshcatVisualizer will just work if deformable changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24666)
<!-- Reviewable:end -->
