### PR TITLE
[pydrake] Align with nanobind py::bytes API

### DIFF
--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -34,10 +34,7 @@ PYDRAKE_MODULE(lcm, m) {
             "Publish",
             [](Class* self, const std::string& channel, py::bytes buffer,
                 std::optional<double> time_sec) {
-              // TODO(eric.cousineau): See if there is a way to extra the raw
-              // bytes from `buffer` without copying.
-              std::string str = buffer;
-              self->Publish(channel, str.data(), str.size(), time_sec);
+              self->Publish(channel, buffer.c_str(), buffer.size(), time_sec);
             },
             py::arg("channel"), py::arg("buffer"),
             py::arg("time_sec") = py::none(), cls_doc.Publish.doc)

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -78,9 +78,10 @@ class PySerializerInterface : public SerializerInterface {
       PYBIND11_OVERLOAD_PURE(
           py::bytes, SerializerInterface, Serialize, &abstract_value);
     };
-    std::string str = wrapped();
-    message_bytes->resize(str.size());
-    std::copy(str.data(), str.data() + str.size(), message_bytes->data());
+    py::bytes result = wrapped();
+    message_bytes->resize(result.size());
+    std::copy(
+        result.c_str(), result.c_str() + result.size(), message_bytes->data());
   }
 };
 
@@ -151,8 +152,8 @@ PYDRAKE_MODULE(lcm, m) {
             "Deserialize",
             [](const Class& self, py::bytes message_bytes,
                 AbstractValue* abstract_value) {
-              std::string str = message_bytes;
-              self.Deserialize(str.data(), str.size(), abstract_value);
+              self.Deserialize(
+                  message_bytes.c_str(), message_bytes.size(), abstract_value);
             },
             py::arg("message_bytes"), py::arg("abstract_value"),
             cls_doc.Deserialize.doc)


### PR DESCRIPTION
Amends #24595. The prior patch claimed to port away from `operator string()` but didn't actually accomplish that.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24668)
<!-- Reviewable:end -->
