### PR TITLE
[pydrake] Add pydrake::class_ forward-porting alias

### DIFF
--- a/bindings/pydrake/autodiffutils/autodiffutils_py_everything.cc
+++ b/bindings/pydrake/autodiffutils/autodiffutils_py_everything.cc
@@ -23,7 +23,7 @@ void DefineAutodiffutils(py::module_ m) {
   constexpr auto& doc = pydrake_doc_math.drake.math;
 
   // TODO(m-chaturvedi) Add Pybind11 documentation.
-  py::class_<AutoDiffXd> autodiff(m, "AutoDiffXd");
+  class_<AutoDiffXd> autodiff(m, "AutoDiffXd");
   autodiff  // BR
       .def(py::init<double>(), py::arg("value"),
           "Constructs a value with empty derivatives.")

--- a/bindings/pydrake/common/cpp_template_pybind.h
+++ b/bindings/pydrake/common/cpp_template_pybind.h
@@ -62,7 +62,7 @@ std::string TemporaryClassName(const std::string& name = "TemporaryName") {
 /// @param py_class Class instantiation to be added.
 /// @note The class name should be *unique*. If you would like automatic unique
 /// names, consider constructing the class binding as
-/// `py::class_<Class, ...>(m, TemporaryClassName<Class>().c_str())`.
+/// `class_<Class, ...>(m, TemporaryClassName<Class>().c_str())`.
 /// @param param Parameters for the instantiation.
 inline py::object AddTemplateClass(  // BR
     py::handle scope, const std::string& template_name, py::handle py_class,
@@ -81,7 +81,7 @@ inline py::object AddTemplateClass(  // BR
 /// The caller may opt-in to py::dynamic_attr() as the last argument.
 /// @return pybind11 class
 template <typename Class, typename... Options>
-py::class_<Class, Options...> DefineTemplateClassWithDefault(  // BR
+class_<Class, Options...> DefineTemplateClassWithDefault(  // BR
     py::handle scope, const std::string& default_name, py::tuple param,
     const char* doc_string = "",
     const std::optional<std::string>& template_suffix = {},
@@ -105,12 +105,11 @@ py::class_<Class, Options...> DefineTemplateClassWithDefault(  // BR
   } else {
     doc = doc_string;
   }
-  py::class_<Class, Options...> py_class =
+  class_<Class, Options...> py_class =
       dynamic_attr.has_value()
-          ? py::class_<Class, Options...>(
+          ? class_<Class, Options...>(
                 scope, class_name.c_str(), doc.c_str(), *dynamic_attr)
-          : py::class_<Class, Options...>(
-                scope, class_name.c_str(), doc.c_str());
+          : class_<Class, Options...>(scope, class_name.c_str(), doc.c_str());
   // Register it as a template instantiation.
   const bool skip_rename = is_default;
   AddTemplateClass(scope, template_name, py_class, param, skip_rename);

--- a/bindings/pydrake/common/identifier_pybind.h
+++ b/bindings/pydrake/common/identifier_pybind.h
@@ -15,7 +15,7 @@ void BindIdentifier(
     ModuleOrClass m, const std::string& name, const char* id_doc) {
   constexpr auto& cls_doc = pydrake_doc_common.drake.Identifier;
 
-  py::class_<Class>(m, name.c_str(), id_doc)
+  class_<Class>(m, name.c_str(), id_doc)
       .def("get_value", &Class::get_value, cls_doc.get_value.doc)
       .def("is_valid", &Class::is_valid, cls_doc.is_valid.doc)
       .def(py::self == py::self)

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -77,7 +77,7 @@ class UnregisteredType {};
 class UnregisteredDerivedType : public RegisteredType {};
 
 void def_testing(py::module_ m) {
-  py::class_<RegisteredType>(m, "RegisteredType").def(py::init());
+  class_<RegisteredType>(m, "RegisteredType").def(py::init());
   // See comments in `module_test.py`.
   m.def("get_nice_type_name_cc_registered_instance",
       [](const RegisteredType& obj) { return NiceTypeName::Get(obj); });
@@ -123,7 +123,7 @@ void InitLowLevelModules(py::module_ m) {
   {
     using Class = Parallelism;
     constexpr auto& cls_doc = doc.Parallelism;
-    py::class_<Class> cls(m, "Parallelism", cls_doc.doc);
+    class_<Class> cls(m, "Parallelism", cls_doc.doc);
     py::implicitly_convertible<bool, Class>();
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
@@ -145,7 +145,7 @@ void InitLowLevelModules(py::module_ m) {
   {
     using Class = Sha256;
     constexpr auto& cls_doc = doc.Sha256;
-    py::class_<Class> cls(m, "Sha256", cls_doc.doc);
+    class_<Class> cls(m, "Sha256", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def_static("Checksum",
@@ -169,7 +169,7 @@ void InitLowLevelModules(py::module_ m) {
   {
     using Class = MemoryFile;
     constexpr auto& cls_doc = doc.MemoryFile;
-    py::class_<Class> cls(m, "MemoryFile", cls_doc.doc);
+    class_<Class> cls(m, "MemoryFile", cls_doc.doc);
     py::object ctor = m.attr("MemoryFile");
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
@@ -282,7 +282,7 @@ void InitLowLevelModules(py::module_ m) {
   // N.B. The AutoDiffXd overload is bound later on in this function.
 
   // Adds a binding for drake::RandomGenerator.
-  py::class_<RandomGenerator> random_generator_cls(m, "RandomGenerator",
+  class_<RandomGenerator> random_generator_cls(m, "RandomGenerator",
       (std::string(doc.RandomGenerator.doc) + R"""(
 
 Note: For many workflows in drake, we aim to have computations that are fully

--- a/bindings/pydrake/common/schema_py.cc
+++ b/bindings/pydrake/common/schema_py.cc
@@ -28,7 +28,7 @@ void DefineModuleSchema(py::module_ m) {
   {
     using Class = Distribution;
     constexpr auto& cls_doc = doc.Distribution;
-    py::class_<Class>(m, "Distribution", cls_doc.doc)
+    class_<Class>(m, "Distribution", cls_doc.doc)
         .def("Sample", &Class::Sample, py::arg("generator"), cls_doc.Sample.doc)
         .def("Mean", &Class::Mean, cls_doc.Mean.doc)
         .def("ToSymbolic", &Class::ToSymbolic, cls_doc.ToSymbolic.doc);
@@ -37,7 +37,7 @@ void DefineModuleSchema(py::module_ m) {
   {
     using Class = Deterministic;
     constexpr auto& cls_doc = doc.Deterministic;
-    py::class_<Class, Distribution> cls(m, "Deterministic", cls_doc.doc);
+    class_<Class, Distribution> cls(m, "Deterministic", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
@@ -49,7 +49,7 @@ void DefineModuleSchema(py::module_ m) {
   {
     using Class = Gaussian;
     constexpr auto& cls_doc = doc.Gaussian;
-    py::class_<Class, Distribution> cls(m, "Gaussian", cls_doc.doc);
+    class_<Class, Distribution> cls(m, "Gaussian", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
@@ -62,7 +62,7 @@ void DefineModuleSchema(py::module_ m) {
   {
     using Class = Uniform;
     constexpr auto& cls_doc = doc.Uniform;
-    py::class_<Class, Distribution> cls(m, "Uniform", cls_doc.doc);
+    class_<Class, Distribution> cls(m, "Uniform", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
@@ -75,7 +75,7 @@ void DefineModuleSchema(py::module_ m) {
   {
     using Class = UniformDiscrete;
     constexpr auto& cls_doc = doc.UniformDiscrete;
-    py::class_<Class, Distribution> cls(m, "UniformDiscrete", cls_doc.doc);
+    class_<Class, Distribution> cls(m, "UniformDiscrete", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))
@@ -117,18 +117,18 @@ void DefineModuleSchema(py::module_ m) {
   {
     // We need to bind these to placate some runtime type checks, but we should
     // not expose them to users.
-    py::class_<schema::internal::InvalidVariantSelection<Deterministic>>(
+    class_<schema::internal::InvalidVariantSelection<Deterministic>>(
         m, "_InvalidVariantSelectionDeterministic");
-    py::class_<schema::internal::InvalidVariantSelection<Gaussian>>(
+    class_<schema::internal::InvalidVariantSelection<Gaussian>>(
         m, "_InvalidVariantSelectionGaussian");
-    py::class_<schema::internal::InvalidVariantSelection<Uniform>>(
+    class_<schema::internal::InvalidVariantSelection<Uniform>>(
         m, "_InvalidVariantSelectionUniform");
   }
 
   {
     using Class = DistributionVector;
     constexpr auto& cls_doc = doc.DistributionVector;
-    py::class_<Class>(m, "DistributionVector", cls_doc.doc)
+    class_<Class>(m, "DistributionVector", cls_doc.doc)
         .def("Sample", &Class::Sample, py::arg("generator"), cls_doc.Sample.doc)
         .def("Mean", &Class::Mean, cls_doc.Mean.doc)
         .def("ToSymbolic", &Class::ToSymbolic, cls_doc.ToSymbolic.doc);
@@ -149,7 +149,7 @@ void DefineModuleSchema(py::module_ m) {
     {
       using Class = DeterministicVector<Size>;
       constexpr auto& cls_doc = doc.DeterministicVector;
-      py::class_<Class, DistributionVector> cls(
+      class_<Class, DistributionVector> cls(
           m, TemporaryClassName<Class>().c_str(), cls_doc.doc);
       AddTemplateClass(m, "DeterministicVector", cls, py_param);
       if constexpr (Size == Eigen::Dynamic) {
@@ -167,7 +167,7 @@ void DefineModuleSchema(py::module_ m) {
     {
       using Class = GaussianVector<Size>;
       constexpr auto& cls_doc = doc.GaussianVector;
-      py::class_<Class, DistributionVector> cls(
+      class_<Class, DistributionVector> cls(
           m, TemporaryClassName<Class>().c_str(), cls_doc.doc);
       AddTemplateClass(m, "GaussianVector", cls, py_param);
       if constexpr (Size == Eigen::Dynamic) {
@@ -186,7 +186,7 @@ void DefineModuleSchema(py::module_ m) {
     {
       using Class = UniformVector<Size>;
       constexpr auto& cls_doc = doc.UniformVector;
-      py::class_<Class, DistributionVector> cls(
+      class_<Class, DistributionVector> cls(
           m, TemporaryClassName<Class>().c_str(), cls_doc.doc);
       AddTemplateClass(m, "UniformVector", cls, py_param);
       if constexpr (Size == Eigen::Dynamic) {
@@ -238,12 +238,12 @@ void DefineModuleSchema(py::module_ m) {
     // struct first, then bind its inner structs, then bind the outer struct.
     using Class = Rotation;
     constexpr auto& cls_doc = doc.Rotation;
-    py::class_<Class> cls(m, "Rotation", cls_doc.doc);
+    class_<Class> cls(m, "Rotation", cls_doc.doc);
 
     // Inner structs.
     {
       using Inner = Class::Identity;
-      py::class_<Inner> inner(cls, "Identity", cls_doc.Identity.doc);
+      class_<Inner> inner(cls, "Identity", cls_doc.Identity.doc);
       inner.def(py::init<const Inner&>(), py::arg("other"));
       inner.def(ParamInit<Inner>());
       DefAttributesUsingSerialize(&inner, cls_doc.Identity);
@@ -252,7 +252,7 @@ void DefineModuleSchema(py::module_ m) {
     }
     {
       using Inner = Class::Rpy;
-      py::class_<Inner> inner(cls, "Rpy", cls_doc.Rpy.doc);
+      class_<Inner> inner(cls, "Rpy", cls_doc.Rpy.doc);
       inner.def(py::init<const Inner&>(), py::arg("other"));
       inner.def(ParamInit<Inner>());
       DefAttributesUsingSerialize(&inner, cls_doc.Rpy);
@@ -261,7 +261,7 @@ void DefineModuleSchema(py::module_ m) {
     }
     {
       using Inner = Class::AngleAxis;
-      py::class_<Inner> inner(cls, "AngleAxis", cls_doc.AngleAxis.doc);
+      class_<Inner> inner(cls, "AngleAxis", cls_doc.AngleAxis.doc);
       inner.def(py::init<const Inner&>(), py::arg("other"));
       inner.def(ParamInit<Inner>());
       DefAttributesUsingSerialize(&inner, cls_doc.AngleAxis);
@@ -270,7 +270,7 @@ void DefineModuleSchema(py::module_ m) {
     }
     {
       using Inner = Class::Uniform;
-      py::class_<Inner> inner(cls, "Uniform", cls_doc.Uniform.doc);
+      class_<Inner> inner(cls, "Uniform", cls_doc.Uniform.doc);
       inner.def(py::init<const Inner&>(), py::arg("other"));
       inner.def(ParamInit<Inner>());
       DefAttributesUsingSerialize(&inner, cls_doc.Uniform);
@@ -343,7 +343,7 @@ void DefineModuleSchema(py::module_ m) {
   {
     using Class = Transform;
     constexpr auto& cls_doc = doc.Transform;
-    py::class_<Class> cls(m, "Transform", cls_doc.doc);
+    class_<Class> cls(m, "Transform", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Class&>(), py::arg("other"))

--- a/bindings/pydrake/common/serialize_pybind.h
+++ b/bindings/pydrake/common/serialize_pybind.h
@@ -31,7 +31,7 @@ class DefAttributesArchive {
 
   using CxxClass = typename PyClass::Type;
 
-  // @param ppy_class A pointer to the `py::class_` to add the properties to.
+  // @param ppy_class A pointer to the `class_` to add the properties to.
   // @param prototype A pointer to the instance that will be visited.
   // @param docs A pointer to the mkdoc struct for this ppy_class; can be null
   //   iff `Docs` is `void`, in which case docstrings will not be added.

--- a/bindings/pydrake/common/test/cpp_param_test_util_py.cc
+++ b/bindings/pydrake/common/test/cpp_param_test_util_py.cc
@@ -102,7 +102,7 @@ void CheckTyping() {
 
 PYDRAKE_MODULE(cpp_param_test_util, m) {
   // Define custom class only once here.
-  py::class_<CustomCppType>(m, "CustomCppType");
+  class_<CustomCppType>(m, "CustomCppType");
 
   m.def("execute_tests", [m]() {
     // Import some definitions from the modules where they are defined into the

--- a/bindings/pydrake/common/test/cpp_template_test_util_py.cc
+++ b/bindings/pydrake/common/test/cpp_template_test_util_py.cc
@@ -27,7 +27,7 @@ struct SimpleTemplate {
 template <typename... Ts>
 auto BindSimpleTemplate(py::module_ m) {
   using Class = SimpleTemplate<Ts...>;
-  py::class_<Class> py_class(m, TemporaryClassName<Class>().c_str());
+  class_<Class> py_class(m, TemporaryClassName<Class>().c_str());
   py_class  // BR
       .def(py::init<>())
       .def("GetNames", &Class::GetNames);
@@ -102,7 +102,7 @@ PYDRAKE_MODULE(cpp_template_test_util, m) {
   AddTemplateFunction(
       m, "Callee", py::overload_cast<double>(&Callee), GetPyParam<double>());
 
-  py::class_<SimpleType> py_class(m, "SimpleType");
+  class_<SimpleType> py_class(m, "SimpleType");
   py_class  // BR
       .def(py::init<>());
   AddTemplateMethod(py_class, "SimpleMethod", &SimpleType::SimpleMethod<int>,

--- a/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
+++ b/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
@@ -33,7 +33,7 @@ PYDRAKE_MODULE(cc_module, m) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     using Class = ExampleCppStruct;
     constexpr auto& cls_doc = doc.ExampleCppStruct;
-    py::class_<Class> cls(m, "ExampleCppStruct", cls_doc.doc_deprecated);
+    class_<Class> cls(m, "ExampleCppStruct", cls_doc.doc_deprecated);
     cls  // BR
         .def(DeprecatedParamInit<Class>(cls_doc.doc_deprecated))
         .def_rw("i", &Class::i)
@@ -44,7 +44,7 @@ PYDRAKE_MODULE(cc_module, m) {
   {
     using Class = ExampleCppClass;
     constexpr auto& cls_doc = doc.ExampleCppClass;
-    py::class_<Class> cls(m, "ExampleCppClass", cls_doc.doc);
+    class_<Class> cls(m, "ExampleCppClass", cls_doc.doc);
     cls  // BR
         .def(py::init(), cls_doc.ctor.doc_0args)
         .def_rw("prop", &Class::prop, cls_doc.prop.doc);

--- a/bindings/pydrake/common/test/ref_cycle_test_util_py.cc
+++ b/bindings/pydrake/common/test/ref_cycle_test_util_py.cc
@@ -35,8 +35,8 @@ class TestDummyBase {
 
 PYDRAKE_MODULE(ref_cycle_test_util, m) {
   // The classes refer to each other so we must declare both before defining.
-  py::class_<IsDynamic> cls_is_dynamic(m, "IsDynamic", py::dynamic_attr());
-  py::class_<NotDynamic> cls_not_dynamic(m, "NotDynamic");
+  class_<IsDynamic> cls_is_dynamic(m, "IsDynamic", py::dynamic_attr());
+  class_<NotDynamic> cls_not_dynamic(m, "NotDynamic");
 
   using internal::ref_cycle;
   {

--- a/bindings/pydrake/common/test/serialize_test_bar_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_bar_py.cc
@@ -22,7 +22,7 @@ PYDRAKE_MODULE(serialize_test_bar, m) {
   // bug into this binding by omitting it. The regression test will confirm
   // that `import bar` raises an exception.
 
-  py::class_<Bar> cls(m, "Bar");
+  class_<Bar> cls(m, "Bar");
   DefAttributesUsingSerialize(&cls);
 }
 

--- a/bindings/pydrake/common/test/serialize_test_foo_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_foo_py.cc
@@ -7,7 +7,7 @@ namespace pydrake {
 namespace test {
 
 PYDRAKE_MODULE(serialize_test_foo, m) {
-  py::class_<Foo> cls(m, "Foo");
+  class_<Foo> cls(m, "Foo");
   DefAttributesUsingSerialize(&cls);
 }
 

--- a/bindings/pydrake/common/test/serialize_test_util_py.cc
+++ b/bindings/pydrake/common/test/serialize_test_util_py.cc
@@ -84,7 +84,7 @@ struct MyData3 {
 
 PYDRAKE_MODULE(serialize_test_util, m) {
   // Bind MyData1 with no documentation.
-  py::class_<MyData1> cls1(m, "MyData1");
+  class_<MyData1> cls1(m, "MyData1");
   cls1  // BR
       .def(py::init())
       .def(ParamInit<MyData1>());
@@ -94,7 +94,7 @@ PYDRAKE_MODULE(serialize_test_util, m) {
 
   // Bind MyData2 along with its documentation.
   constexpr MyData2Docs cls2_doc;
-  py::class_<MyData2> cls2(m, "MyData2", cls2_doc.doc);
+  class_<MyData2> cls2(m, "MyData2", cls2_doc.doc);
   cls2  // BR
       .def(py::init())
       .def(ParamInit<MyData2>());
@@ -105,7 +105,7 @@ PYDRAKE_MODULE(serialize_test_util, m) {
   // Bind MyData3 with two instantiations.
   {
     using Class = MyData3<double>;
-    py::class_<Class> cls(m, TemporaryClassName<Class>().c_str());
+    class_<Class> cls(m, TemporaryClassName<Class>().c_str());
     AddTemplateClass(m, "MyData3", cls, GetPyParam<double>());
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls);
@@ -114,7 +114,7 @@ PYDRAKE_MODULE(serialize_test_util, m) {
   }
   {
     using Class = MyData3<int>;
-    py::class_<Class> cls(m, TemporaryClassName<Class>().c_str());
+    class_<Class> cls(m, TemporaryClassName<Class>().c_str());
     AddTemplateClass(m, "MyData3", cls, GetPyParam<int>());
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls);

--- a/bindings/pydrake/common/test/text_logging_test_helpers_py.cc
+++ b/bindings/pydrake/common/test/text_logging_test_helpers_py.cc
@@ -77,7 +77,7 @@ PYDRAKE_MODULE(text_logging_test_helpers, m) {
 
   {
     using Class = Worker;
-    py::class_<Class>(m, "Worker")
+    class_<Class>(m, "Worker")
         .def(py::init<>())
         .def("Start", &Class::Start)
         .def("Stop", &Class::Stop);

--- a/bindings/pydrake/common/test/value_test_util_py.cc
+++ b/bindings/pydrake/common/test/value_test_util_py.cc
@@ -39,14 +39,14 @@ struct UnregisteredType {
 PYDRAKE_MODULE(value_test_util, m) {
   py::module_::import_("pydrake.common");
 
-  py::class_<MoveOnlyType>(m, "MoveOnlyType")
+  class_<MoveOnlyType>(m, "MoveOnlyType")
       .def(py::init<int>())
       .def("x", &MoveOnlyType::x)
       .def("set_x", &MoveOnlyType::set_x);
   // Define `Value[MoveOnlyType]` instantiation.
   AddValueInstantiation<MoveOnlyType>(m);
 
-  py::class_<CustomType>(m, "CustomType")
+  class_<CustomType>(m, "CustomType")  // BR
       .def(py::init())
       .def(py::self == py::self);
   // Define `Value[List[CustomType]]` instantiation.

--- a/bindings/pydrake/common/test/wrap_test_util_py.cc
+++ b/bindings/pydrake/common/test/wrap_test_util_py.cc
@@ -92,17 +92,17 @@ struct type_caster<drake::pydrake::TypeConversionExample>
 namespace drake {
 namespace pydrake {
 PYDRAKE_MODULE(wrap_test_util, m) {
-  py::class_<MyValue>(m, "MyValue")
+  class_<MyValue>(m, "MyValue")
       .def(py::init<double>(), py::arg("value"))
       .def_rw("value", &MyValue::value, py_rvp::reference_internal);
 
-  py::class_<MyContainerRawPtr> my_container(m, "MyContainerRawPtr");
+  class_<MyContainerRawPtr> my_container(m, "MyContainerRawPtr");
   my_container  // BR
       .def(py::init());
   DefReadWriteKeepAlive(&my_container, "member", &MyContainerRawPtr::member,
       "MyContainerRawPtr doc");
 
-  py::class_<MyContainerUniquePtr> my_unique(m, "MyContainerUniquePtr");
+  class_<MyContainerUniquePtr> my_unique(m, "MyContainerUniquePtr");
   my_unique.def(py::init<MyValue, MyValue>(), py::arg("member"),
       py::arg("copyable_member"));
   DefReadUniquePtr(&my_unique, "member", &MyContainerUniquePtr::member,
@@ -116,7 +116,7 @@ PYDRAKE_MODULE(wrap_test_util, m) {
   m.def("CheckTypeConversionExample", &CheckTypeConversionExample,
       py::arg("obj"));
 
-  py::class_<NotCopyable>(m, "NotCopyable")  // BR
+  class_<NotCopyable>(m, "NotCopyable")  // BR
       .def(py::init());
 
   // Using WrapCallbacks() -> Good.

--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -16,7 +16,7 @@ template <typename Class>
 auto BindTypeSafeIndex(
     py::module_ m, const std::string& name, const std::string& class_doc = "") {
   constexpr auto& cls_doc = pydrake_doc_common.drake.TypeSafeIndex;
-  py::class_<Class> cls(m, name.c_str(), class_doc.c_str());
+  class_<Class> cls(m, name.c_str(), class_doc.c_str());
   cls  // BR
       .def(py::init<>(), cls_doc.ctor.doc_0args)
       .def(py::init<int>(), cls_doc.ctor.doc_1args_index)

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -67,7 +67,7 @@ void DefineModuleValue(py::module_ m) {
     };
   };
 
-  py::class_<AbstractValue> abstract_value(m, "AbstractValue");
+  class_<AbstractValue> abstract_value(m, "AbstractValue");
   DefClone(&abstract_value);
   abstract_value  // BR
       .def("SetFrom", &AbstractValue::SetFrom, doc.AbstractValue.SetFrom.doc)

--- a/bindings/pydrake/common/value_pybind.h
+++ b/bindings/pydrake/common/value_pybind.h
@@ -25,11 +25,10 @@ namespace pydrake {
 /// @tparam Class Class to be bound. By default, `Value<T>` is used.
 /// @returns Reference to the registered Python type.
 template <typename T, typename Class = drake::Value<T>>
-py::class_<Class, drake::AbstractValue> AddValueInstantiation(
-    py::module_ scope) {
+class_<Class, drake::AbstractValue> AddValueInstantiation(py::module_ scope) {
   static_assert(!py::detail::is_pyobject<T>::value, "See docs for GetPyParam");
   py::module_ py_common = py::module_::import_("pydrake.common.value");
-  py::class_<Class, drake::AbstractValue> py_class(
+  class_<Class, drake::AbstractValue> py_class(
       scope, TemporaryClassName<Class>().c_str());
   // Register instantiation.
   py::tuple param = GetPyParam<T>();
@@ -55,7 +54,7 @@ py::class_<Class, drake::AbstractValue> AddValueInstantiation(
     const T& v = caster;  // Use implicit conversion from `type_caster<>`.
     return new Class(v);
   }));
-  // If the type is registered via `py::class_`, or is of type `Object`
+  // If the type is registered via `class_`, or is of type `Object`
   // (`py::object`), then we can obtain a mutable view into the value.
   constexpr bool has_get_mutable_value =
       internal::is_generic_pybind_v<T> || std::is_same_v<T, Object>;

--- a/bindings/pydrake/common/wrap_pybind.h
+++ b/bindings/pydrake/common/wrap_pybind.h
@@ -20,7 +20,7 @@ namespace pydrake {
 namespace internal {
 
 // Determines if a type will go through pybind11's generic caster. This
-// implies that the type has been declared using `py::class_`, and can have
+// implies that the type has been declared using `class_`, and can have
 // a reference passed through. Otherwise, the type uses type-conversion:
 // https://pybind11.readthedocs.io/en/stable/advanced/cast/index.html
 template <typename T>

--- a/bindings/pydrake/examples/examples_py_acrobot.cc
+++ b/bindings/pydrake/examples/examples_py_acrobot.cc
@@ -29,13 +29,13 @@ void DefineExamplesAcrobot(py::module_ m) {
   // conversion. Issue #7660.
   using T = double;
 
-  py::class_<AcrobotInput<T>, BasicVector<T>>(
+  class_<AcrobotInput<T>, BasicVector<T>>(
       m, "AcrobotInput", doc.AcrobotInput.doc)
       .def(py::init<>(), doc.AcrobotInput.ctor.doc)
       .def("tau", &AcrobotInput<T>::tau, doc.AcrobotInput.tau.doc)
       .def("set_tau", &AcrobotInput<T>::set_tau, doc.AcrobotInput.set_tau.doc);
 
-  py::class_<AcrobotParams<T>, BasicVector<T>>(
+  class_<AcrobotParams<T>, BasicVector<T>>(
       m, "AcrobotParams", doc.AcrobotParams.doc)
       .def(py::init<>(), doc.AcrobotParams.ctor.doc)
       .def("m1", &AcrobotParams<T>::m1, doc.AcrobotParams.m1.doc)
@@ -60,7 +60,7 @@ void DefineExamplesAcrobot(py::module_ m) {
       .def("set_gravity", &AcrobotParams<T>::set_gravity,
           doc.AcrobotParams.set_gravity.doc);
 
-  py::class_<AcrobotState<T>, BasicVector<T>>(
+  class_<AcrobotState<T>, BasicVector<T>>(
       m, "AcrobotState", doc.AcrobotState.doc)
       .def(py::init<>(), doc.AcrobotState.ctor.doc)
       .def("theta1", &AcrobotState<T>::theta1, doc.AcrobotState.theta1.doc)
@@ -78,7 +78,7 @@ void DefineExamplesAcrobot(py::module_ m) {
       .def("set_theta2dot", &AcrobotState<T>::set_theta2dot,
           doc.AcrobotState.set_theta2dot.doc);
 
-  py::class_<SpongControllerParams<T>, BasicVector<T>>(
+  class_<SpongControllerParams<T>, BasicVector<T>>(
       m, "SpongControllerParams", doc.AcrobotParams.doc)
       .def(py::init<>(), doc.SpongControllerParams.ctor.doc)
       .def("k_e", &SpongControllerParams<T>::k_e,
@@ -100,7 +100,7 @@ void DefineExamplesAcrobot(py::module_ m) {
           &SpongControllerParams<T>::set_balancing_threshold,
           doc.SpongControllerParams.set_balancing_threshold.doc);
 
-  py::class_<AcrobotPlant<T>, LeafSystem<T>>(
+  class_<AcrobotPlant<T>, LeafSystem<T>>(
       m, "AcrobotPlant", doc.AcrobotPlant.doc)
       .def(py::init<>(), doc.AcrobotPlant.ctor.doc)
       .def("DynamicsBiasTerm", &AcrobotPlant<T>::DynamicsBiasTerm,
@@ -126,7 +126,7 @@ void DefineExamplesAcrobot(py::module_ m) {
           py_rvp::reference_internal, py::arg("context"),
           doc.AcrobotPlant.get_mutable_parameters.doc);
 
-  py::class_<AcrobotWEncoder<T>, Diagram<T>>(
+  class_<AcrobotWEncoder<T>, Diagram<T>>(
       m, "AcrobotWEncoder", doc.AcrobotWEncoder.doc)
       .def(py::init<bool>(), py::arg("acrobot_state_as_second_output") = false,
           doc.AcrobotWEncoder.ctor.doc)
@@ -139,7 +139,7 @@ void DefineExamplesAcrobot(py::module_ m) {
           py::keep_alive<0, 1>(),
           doc.AcrobotWEncoder.get_mutable_acrobot_state.doc);
 
-  py::class_<AcrobotSpongController<T>, LeafSystem<T>>(
+  class_<AcrobotSpongController<T>, LeafSystem<T>>(
       m, "AcrobotSpongController", doc.AcrobotSpongController.doc)
       .def(py::init<>(), doc.AcrobotSpongController.ctor.doc)
       .def("get_parameters", &AcrobotSpongController<T>::get_parameters,
@@ -153,7 +153,7 @@ void DefineExamplesAcrobot(py::module_ m) {
           py::keep_alive<0, 2>(),
           doc.AcrobotSpongController.get_mutable_parameters.doc);
 
-  py::class_<AcrobotGeometry, LeafSystem<double>>(
+  class_<AcrobotGeometry, LeafSystem<double>>(
       m, "AcrobotGeometry", doc.AcrobotGeometry.doc)
       .def_static("AddToBuilder",
           py::overload_cast<systems::DiagramBuilder<double>*,

--- a/bindings/pydrake/examples/examples_py_compass_gait.cc
+++ b/bindings/pydrake/examples/examples_py_compass_gait.cc
@@ -23,8 +23,7 @@ void DefineExamplesCompassGait(py::module_ m) {
   // conversion.
   using T = double;
 
-  py::class_<CompassGait<T>, LeafSystem<T>>(
-      m, "CompassGait", doc.CompassGait.doc)
+  class_<CompassGait<T>, LeafSystem<T>>(m, "CompassGait", doc.CompassGait.doc)
       .def(py::init<>(), doc.CompassGait.ctor.doc)
       .def("get_minimal_state_output_port",
           &CompassGait<T>::get_minimal_state_output_port,
@@ -35,7 +34,7 @@ void DefineExamplesCompassGait(py::module_ m) {
           py_rvp::reference_internal,
           doc.CompassGait.get_floating_base_state_output_port.doc);
 
-  py::class_<CompassGaitParams<T>, BasicVector<T>>(
+  class_<CompassGaitParams<T>, BasicVector<T>>(
       m, "CompassGaitParams", doc.CompassGaitParams.doc)
       .def(py::init<>(), doc.CompassGaitParams.ctor.doc)
       .def("mass_hip", &CompassGaitParams<T>::mass_hip,
@@ -64,7 +63,7 @@ void DefineExamplesCompassGait(py::module_ m) {
       .def("set_slope", &CompassGaitParams<T>::set_slope,
           doc.CompassGaitParams.set_slope.doc);
 
-  py::class_<CompassGaitContinuousState<T>, BasicVector<T>>(
+  class_<CompassGaitContinuousState<T>, BasicVector<T>>(
       m, "CompassGaitContinuousState", doc.CompassGaitContinuousState.doc)
       .def(py::init<>(), doc.CompassGaitContinuousState.ctor.doc)
       .def("stance", &CompassGaitContinuousState<T>::stance,
@@ -84,7 +83,7 @@ void DefineExamplesCompassGait(py::module_ m) {
       .def("set_swingdot", &CompassGaitContinuousState<T>::set_swingdot,
           doc.CompassGaitContinuousState.set_swingdot.doc);
 
-  py::class_<CompassGaitGeometry, LeafSystem<double>>(
+  class_<CompassGaitGeometry, LeafSystem<double>>(
       m, "CompassGaitGeometry", doc.CompassGaitGeometry.doc)
       .def_static("AddToBuilder",
           py::overload_cast<systems::DiagramBuilder<double>*,

--- a/bindings/pydrake/examples/examples_py_pendulum.cc
+++ b/bindings/pydrake/examples/examples_py_pendulum.cc
@@ -27,7 +27,7 @@ void DefineExamplesPendulum(py::module_ m) {
   // conversion.
   using T = double;
 
-  py::class_<PendulumInput<T>, BasicVector<T>>(
+  class_<PendulumInput<T>, BasicVector<T>>(
       m, "PendulumInput", doc.PendulumInput.doc)
       .def(py::init<>(), doc.PendulumInput.ctor.doc)
       .def("tau", &PendulumInput<T>::tau, doc.PendulumInput.tau.doc)
@@ -36,7 +36,7 @@ void DefineExamplesPendulum(py::module_ m) {
       .def("with_tau", &PendulumInput<T>::with_tau, py::arg("tau"),
           doc.PendulumInput.with_tau.doc);
 
-  py::class_<PendulumParams<T>, BasicVector<T>>(
+  class_<PendulumParams<T>, BasicVector<T>>(
       m, "PendulumParams", doc.PendulumParams.doc)
       .def(py::init<>(), doc.PendulumParams.ctor.doc)
       .def("mass", &PendulumParams<T>::mass, doc.PendulumParams.mass.doc)
@@ -62,7 +62,7 @@ void DefineExamplesPendulum(py::module_ m) {
       .def("with_gravity", &PendulumParams<T>::with_gravity, py::arg("gravity"),
           doc.PendulumParams.with_gravity.doc);
 
-  py::class_<PendulumState<T>, BasicVector<T>>(
+  class_<PendulumState<T>, BasicVector<T>>(
       m, "PendulumState", doc.PendulumState.doc)
       .def(py::init<>(), doc.PendulumState.ctor.doc)
       .def("theta", &PendulumState<T>::theta, doc.PendulumState.theta.doc)
@@ -77,7 +77,7 @@ void DefineExamplesPendulum(py::module_ m) {
       .def("with_thetadot", &PendulumState<T>::with_thetadot,
           py::arg("thetadot"), doc.PendulumState.with_thetadot.doc);
 
-  py::class_<PendulumPlant<T>, LeafSystem<T>>(
+  class_<PendulumPlant<T>, LeafSystem<T>>(
       m, "PendulumPlant", doc.PendulumPlant.doc)
       .def(py::init<>(), doc.PendulumPlant.ctor.doc)
       .def("get_state_output_port", &PendulumPlant<T>::get_state_output_port,
@@ -100,7 +100,7 @@ void DefineExamplesPendulum(py::module_ m) {
           py_rvp::reference_internal, py::arg("context"),
           doc.PendulumPlant.get_mutable_parameters.doc);
 
-  py::class_<PendulumGeometry, LeafSystem<double>>(
+  class_<PendulumGeometry, LeafSystem<double>>(
       m, "PendulumGeometry", doc.PendulumGeometry.doc)
       .def_static("AddToBuilder", &PendulumGeometry::AddToBuilder,
           py::arg("builder"), py::arg("pendulum_state_port"),

--- a/bindings/pydrake/examples/examples_py_quadrotor.cc
+++ b/bindings/pydrake/examples/examples_py_quadrotor.cc
@@ -21,7 +21,7 @@ void DefineExamplesQuadrotor(py::module_ m) {
   // conversion. Issue #7660.
   using T = double;
 
-  py::class_<QuadrotorPlant<T>, LeafSystem<T>>(
+  class_<QuadrotorPlant<T>, LeafSystem<T>>(
       m, "QuadrotorPlant", doc.QuadrotorPlant.doc)
       .def(py::init<>(), doc.QuadrotorPlant.ctor.doc)
       .def(py::init<double, double, const Eigen::Matrix3d&, double, double>(),
@@ -37,7 +37,7 @@ void DefineExamplesQuadrotor(py::module_ m) {
       .def("inertia", &QuadrotorPlant<T>::inertia, py_rvp::reference_internal,
           doc.QuadrotorPlant.inertia.doc);
 
-  py::class_<QuadrotorGeometry, LeafSystem<double>>(
+  class_<QuadrotorGeometry, LeafSystem<double>>(
       m, "QuadrotorGeometry", doc.QuadrotorGeometry.doc)
       .def("get_frame_id", &QuadrotorGeometry::get_frame_id,
           doc.QuadrotorGeometry.get_frame_id.doc)

--- a/bindings/pydrake/examples/examples_py_rimless_wheel.cc
+++ b/bindings/pydrake/examples/examples_py_rimless_wheel.cc
@@ -23,7 +23,7 @@ void DefineExamplesRimlessWheel(py::module_ m) {
   // conversion.
   using T = double;
 
-  py::class_<RimlessWheelParams<T>, BasicVector<T>>(
+  class_<RimlessWheelParams<T>, BasicVector<T>>(
       m, "RimlessWheelParams", doc.RimlessWheelParams.doc)
       .def(py::init<>(), doc.RimlessWheelParams.ctor.doc)
       .def(
@@ -47,7 +47,7 @@ void DefineExamplesRimlessWheel(py::module_ m) {
       .def("set_slope", &RimlessWheelParams<T>::set_slope,
           doc.RimlessWheelParams.set_slope.doc);
 
-  py::class_<RimlessWheelContinuousState<T>, BasicVector<T>>(
+  class_<RimlessWheelContinuousState<T>, BasicVector<T>>(
       m, "RimlessWheelContinuousState", doc.RimlessWheelContinuousState.doc)
       .def(py::init<>(), doc.RimlessWheelContinuousState.ctor.doc)
       .def("theta", &RimlessWheelContinuousState<T>::theta,
@@ -59,7 +59,7 @@ void DefineExamplesRimlessWheel(py::module_ m) {
       .def("set_thetadot", &RimlessWheelContinuousState<T>::set_thetadot,
           doc.RimlessWheelContinuousState.set_thetadot.doc);
 
-  py::class_<RimlessWheel<T>, LeafSystem<T>>(
+  class_<RimlessWheel<T>, LeafSystem<T>>(
       m, "RimlessWheel", doc.RimlessWheel.doc)
       .def(py::init<>(), doc.RimlessWheel.ctor.doc)
       .def("get_minimal_state_output_port",
@@ -73,7 +73,7 @@ void DefineExamplesRimlessWheel(py::module_ m) {
       .def_static("calc_alpha", &RimlessWheel<T>::calc_alpha, py::arg("params"),
           doc.RimlessWheel.calc_alpha.doc);
 
-  py::class_<RimlessWheelGeometry, LeafSystem<double>>(
+  class_<RimlessWheelGeometry, LeafSystem<double>>(
       m, "RimlessWheelGeometry", doc.RimlessWheelGeometry.doc)
       .def_static("AddToBuilder",
           py::overload_cast<systems::DiagramBuilder<double>*,

--- a/bindings/pydrake/examples/examples_py_van_der_pol.cc
+++ b/bindings/pydrake/examples/examples_py_van_der_pol.cc
@@ -20,7 +20,7 @@ void DefineExamplesVanDerPol(py::module_ m) {
   // conversion.
   using T = double;
 
-  py::class_<VanDerPolOscillator<T>, LeafSystem<T>>(
+  class_<VanDerPolOscillator<T>, LeafSystem<T>>(
       m, "VanDerPolOscillator", doc.VanDerPolOscillator.doc)
       .def(py::init<>(), doc.VanDerPolOscillator.ctor.doc)
       .def("get_position_output_port",

--- a/bindings/pydrake/geometry/geometry_py_bounding_box.cc
+++ b/bindings/pydrake/geometry/geometry_py_bounding_box.cc
@@ -20,7 +20,7 @@ void DefineGeometryBoundingBox(py::module_ m) {
   constexpr auto& doc = pydrake_doc_geometry_proximity.drake.geometry;
 
   // Define Aabb class first.
-  py::class_<Aabb> aabb_cls(m, "Aabb", doc.Aabb.doc);
+  class_<Aabb> aabb_cls(m, "Aabb", doc.Aabb.doc);
   aabb_cls  // BR
       .def(py::init<const Vector3<double>&, const Vector3<double>&>(),
           py::arg("p_HoBo"), py::arg("half_width"), doc.Aabb.ctor.doc)
@@ -44,7 +44,7 @@ void DefineGeometryBoundingBox(py::module_ m) {
   DefCopyAndDeepCopy(&aabb_cls);
 
   // Define Obb class.
-  py::class_<Obb> obb_cls(m, "Obb", doc.Obb.doc);
+  class_<Obb> obb_cls(m, "Obb", doc.Obb.doc);
   obb_cls  // BR
       .def(py::init<const math::RigidTransformd&, const Vector3<double>&>(),
           py::arg("X_HB"), py::arg("half_width"), doc.Obb.ctor.doc)

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -60,7 +60,7 @@ void DefineCollisionFilterDeclaration(py::module_ m) {
     using Class = CollisionFilterDeclaration;
     constexpr auto& cls_doc = doc.CollisionFilterDeclaration;
 
-    py::class_<Class>(m, "CollisionFilterDeclaration", cls_doc.doc)
+    class_<Class>(m, "CollisionFilterDeclaration", cls_doc.doc)
         .def(py::init(), cls_doc.ctor.doc)
         .def(py::init<CollisionFilterScope>(), py::arg("scope"),
             cls_doc.ctor.doc)
@@ -79,7 +79,7 @@ void DefineCollisionFilterManager(py::module_ m) {
   {
     using Class = CollisionFilterManager;
     constexpr auto& cls_doc = doc.CollisionFilterManager;
-    py::class_<Class>(m, "CollisionFilterManager", cls_doc.doc)
+    class_<Class>(m, "CollisionFilterManager", cls_doc.doc)
         .def("Apply", &Class::Apply, py::arg("declaration"), cls_doc.Apply.doc)
         .def("ApplyTransient", &Class::ApplyTransient, py::arg("declaration"),
             cls_doc.ApplyTransient.doc)
@@ -96,7 +96,7 @@ void DefineGeometryFrame(py::module_ m) {
   {
     using Class = GeometryFrame;
     constexpr auto& cls_doc = doc.GeometryFrame;
-    py::class_<Class> cls(m, "GeometryFrame", cls_doc.doc);
+    class_<Class> cls(m, "GeometryFrame", cls_doc.doc);
     cls  // BR
         .def(py::init<const std::string&, int>(), py::arg("frame_name"),
             py::arg("frame_group_id") = 0, cls_doc.ctor.doc)
@@ -111,7 +111,7 @@ void DefineGeometryInstance(py::module_ m) {
   {
     using Class = GeometryInstance;
     constexpr auto& cls_doc = doc.GeometryInstance;
-    py::class_<Class> cls(m, "GeometryInstance", cls_doc.doc);
+    class_<Class> cls(m, "GeometryInstance", cls_doc.doc);
     cls  // BR
         .def(py::init<const math::RigidTransform<double>&, const Shape&,
                  const std::string&>(),
@@ -156,7 +156,7 @@ void DefineGeometryProperties(py::module_ m) {
     constexpr auto& cls_doc = doc.GeometryProperties;
     py::handle abstract_value_cls =
         py::module_::import_("pydrake.common.value").attr("AbstractValue");
-    py::class_<Class>(m, "GeometryProperties", cls_doc.doc)
+    class_<Class>(m, "GeometryProperties", cls_doc.doc)
         .def("HasGroup", &Class::HasGroup, py::arg("group_name"),
             cls_doc.HasGroup.doc)
         .def("num_groups", &Class::num_groups, cls_doc.num_groups.doc)
@@ -236,7 +236,7 @@ void DefineGeometrySet(py::module_ m) {
     constexpr char extra_ctor_doc[] = "See main constructor";
     // N.B. For containers, we use `std::vector<>` rather than abstract
     // iterators / containers.
-    py::class_<Class>(m, "GeometrySet", cls_doc.doc)
+    class_<Class>(m, "GeometrySet", cls_doc.doc)
         .def(py::init(), cls_doc.ctor.doc)
         .def(py::init<GeometryId>(), py::arg("geometry_id"), extra_ctor_doc)
         .def(py::init<FrameId>(), py::arg("frame_id"), extra_ctor_doc)
@@ -283,7 +283,7 @@ void DefineGeometryVersion(py::module_ m) {
   {
     using Class = GeometryVersion;
     constexpr auto& cls_doc = doc.GeometryVersion;
-    py::class_<Class> cls(m, "GeometryVersion", cls_doc.doc);
+    class_<Class> cls(m, "GeometryVersion", cls_doc.doc);
     cls  // BR
         .def(py::init(), cls_doc.ctor.doc)
         .def(py::init<const GeometryVersion&>(), py::arg("other"),
@@ -307,7 +307,7 @@ void DefineInMemoryMesh(py::module_ m) {
   {
     using Class = InMemoryMesh;
     constexpr auto& cls_doc = doc.InMemoryMesh;
-    py::class_<Class> cls(m, "InMemoryMesh", cls_doc.doc);
+    class_<Class> cls(m, "InMemoryMesh", cls_doc.doc);
     py::object ctor = m.attr("InMemoryMesh");
     cls  // BR
         .def(ParamInit<Class>())
@@ -330,7 +330,7 @@ void DefineInMemoryMesh(py::module_ m) {
 
 void DefineGeometryPropertiesSubclasses(py::module_ m) {
   {
-    py::class_<IllustrationProperties, GeometryProperties> cls(
+    class_<IllustrationProperties, GeometryProperties> cls(
         m, "IllustrationProperties", doc.IllustrationProperties.doc);
     cls  // BR
         .def(py::init(), doc.IllustrationProperties.ctor.doc)
@@ -339,7 +339,7 @@ void DefineGeometryPropertiesSubclasses(py::module_ m) {
     DefCopyAndDeepCopy(&cls);
   }
   {
-    py::class_<PerceptionProperties, GeometryProperties> cls(
+    class_<PerceptionProperties, GeometryProperties> cls(
         m, "PerceptionProperties", doc.PerceptionProperties.doc);
     cls  // BR
         .def(py::init(), doc.PerceptionProperties.ctor.doc)
@@ -348,7 +348,7 @@ void DefineGeometryPropertiesSubclasses(py::module_ m) {
     DefCopyAndDeepCopy(&cls);
   }
   {
-    py::class_<ProximityProperties, GeometryProperties> cls(
+    class_<ProximityProperties, GeometryProperties> cls(
         m, "ProximityProperties", doc.ProximityProperties.doc);
     cls  // BR
         .def(py::init(), doc.ProximityProperties.ctor.doc)
@@ -362,7 +362,7 @@ void DefineMeshSource(py::module_ m) {
   {
     using Class = MeshSource;
     constexpr auto& cls_doc = doc.MeshSource;
-    py::class_<Class> cls(m, "MeshSource", cls_doc.doc);
+    class_<Class> cls(m, "MeshSource", cls_doc.doc);
     py::object ctor = m.attr("MeshSource");
     cls  // BR
         .def(py::init(), cls_doc.ctor.doc_0args)
@@ -402,7 +402,7 @@ void DefineRgba(py::module_ m) {
   {
     using Class = Rgba;
     constexpr auto& cls_doc = doc.Rgba;
-    py::class_<Class> cls(m, "Rgba", cls_doc.doc);
+    class_<Class> cls(m, "Rgba", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<double, double, double, double>(), py::arg("r"),
@@ -469,13 +469,13 @@ void DefineRoleAssign(py::module_ m) {
 void DefineShapes(py::module_ m) {
   // Shape constructors.
   {
-    py::class_<Shape> cls(m, "Shape", doc.Shape.doc);
+    class_<Shape> cls(m, "Shape", doc.Shape.doc);
     cls  // BR
         .def("__repr__", [](const Shape& self) { return self.to_string(); });
     DefClone(&cls);
   }
   {
-    py::class_<Box, Shape> cls(m, "Box", doc.Box.doc);
+    class_<Box, Shape> cls(m, "Box", doc.Box.doc);
     cls  // BR
         .def(py::init<double, double, double>(), py::arg("width"),
             py::arg("depth"), py::arg("height"), doc.Box.ctor.doc_3args)
@@ -496,7 +496,7 @@ void DefineShapes(py::module_ m) {
         });
   }
   {
-    py::class_<Capsule, Shape> cls(m, "Capsule", doc.Capsule.doc);
+    class_<Capsule, Shape> cls(m, "Capsule", doc.Capsule.doc);
     cls  // BR
         .def(py::init<double, double>(), py::arg("radius"), py::arg("length"),
             doc.Capsule.ctor.doc_2args)
@@ -514,7 +514,7 @@ void DefineShapes(py::module_ m) {
         });
   }
   {
-    py::class_<Convex, Shape> cls(m, "Convex", doc.Convex.doc);
+    class_<Convex, Shape> cls(m, "Convex", doc.Convex.doc);
     cls  // BR
         .def(py::init<std::filesystem::path, double>(), py::arg("filename"),
             py::arg("scale") = 1.0, doc.Convex.ctor.doc_2args_filename_scale)
@@ -565,7 +565,7 @@ void DefineShapes(py::module_ m) {
     // Shape::to_string() does not properly condition strings for python.
   }
   {
-    py::class_<Cylinder, Shape> cls(m, "Cylinder", doc.Cylinder.doc);
+    class_<Cylinder, Shape> cls(m, "Cylinder", doc.Cylinder.doc);
     cls  // BR
         .def(py::init<double, double>(), py::arg("radius"), py::arg("length"),
             doc.Cylinder.ctor.doc_2args)
@@ -583,7 +583,7 @@ void DefineShapes(py::module_ m) {
         });
   }
   {
-    py::class_<Ellipsoid, Shape> cls(m, "Ellipsoid", doc.Ellipsoid.doc);
+    class_<Ellipsoid, Shape> cls(m, "Ellipsoid", doc.Ellipsoid.doc);
     cls  // BR
         .def(py::init<double, double, double>(), py::arg("a"), py::arg("b"),
             py::arg("c"), doc.Ellipsoid.ctor.doc_3args)
@@ -603,13 +603,13 @@ void DefineShapes(py::module_ m) {
         });
   }
   {
-    py::class_<HalfSpace, Shape>(m, "HalfSpace", doc.HalfSpace.doc)
+    class_<HalfSpace, Shape>(m, "HalfSpace", doc.HalfSpace.doc)
         .def(py::init<>(), doc.HalfSpace.ctor.doc)
         .def_static("MakePose", &HalfSpace::MakePose, py::arg("Hz_dir_F"),
             py::arg("p_FB"), doc.HalfSpace.MakePose.doc);
   }
   {
-    py::class_<Mesh, Shape> cls(m, "Mesh", doc.Mesh.doc);
+    class_<Mesh, Shape> cls(m, "Mesh", doc.Mesh.doc);
     cls  // BR
         .def(py::init<std::filesystem::path, double>(), py::arg("filename"),
             py::arg("scale") = 1.0, doc.Mesh.ctor.doc_2args_filename_scale)
@@ -650,7 +650,7 @@ void DefineShapes(py::module_ m) {
     // Shape::to_string() does not properly condition strings for python.
   }
   {
-    py::class_<Sphere, Shape> cls(m, "Sphere", doc.Sphere.doc);
+    class_<Sphere, Shape> cls(m, "Sphere", doc.Sphere.doc);
     cls  // BR
         .def(py::init<double>(), py::arg("radius"), doc.Sphere.ctor.doc)
         .def("radius", &Sphere::radius, doc.Sphere.radius.doc);
@@ -659,7 +659,7 @@ void DefineShapes(py::module_ m) {
         [](Sphere* self, const double radius) { new (self) Sphere(radius); });
   }
   {
-    py::class_<MeshcatCone, Shape> cls(m, "MeshcatCone", doc.MeshcatCone.doc);
+    class_<MeshcatCone, Shape> cls(m, "MeshcatCone", doc.MeshcatCone.doc);
     cls  // BR
         .def(py::init<double, double, double>(), py::arg("height"),
             py::arg("a") = 1.0, py::arg("b") = 1.0,

--- a/bindings/pydrake/geometry/geometry_py_meshes.cc
+++ b/bindings/pydrake/geometry/geometry_py_meshes.cc
@@ -152,7 +152,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = SurfacePolygon;
     constexpr auto& cls_doc = doc.SurfacePolygon;
-    py::class_<Class> cls(m, "SurfacePolygon", cls_doc.doc);
+    class_<Class> cls(m, "SurfacePolygon", cls_doc.doc);
     cls  // BR
         .def("num_vertices", &Class::num_vertices, cls_doc.num_vertices.doc)
         .def("vertex", &Class::vertex, py::arg("i"), cls_doc.vertex.doc);
@@ -162,7 +162,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = SurfaceTriangle;
     constexpr auto& cls_doc = doc.SurfaceTriangle;
-    py::class_<Class> cls(m, "SurfaceTriangle", cls_doc.doc);
+    class_<Class> cls(m, "SurfaceTriangle", cls_doc.doc);
     cls  // BR
         .def(py::init<int, int, int>(), py::arg("v0"), py::arg("v1"),
             py::arg("v2"), cls_doc.ctor.doc_3args)
@@ -176,7 +176,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = VolumeElement;
     constexpr auto& cls_doc = doc.VolumeElement;
-    py::class_<Class> cls(m, "VolumeElement", cls_doc.doc);
+    class_<Class> cls(m, "VolumeElement", cls_doc.doc);
     cls  // BR
         .def(py::init<int, int, int, int>(), py::arg("v0"), py::arg("v1"),
             py::arg("v2"), py::arg("v3"), cls_doc.ctor.doc_4args)

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -98,7 +98,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   // SampledVolume. This struct must be declared before ConvexSet as methods in
   // ConvexSet depend on this struct.
   {
-    py::class_<SampledVolume>(m, "SampledVolume", doc.SampledVolume.doc)
+    class_<SampledVolume>(m, "SampledVolume", doc.SampledVolume.doc)
         .def_rw("volume", &SampledVolume::volume, doc.SampledVolume.volume.doc)
         .def_rw("rel_accuracy", &SampledVolume::rel_accuracy,
             doc.SampledVolume.rel_accuracy.doc)
@@ -108,7 +108,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   // ConvexSet
   {
     const auto& cls_doc = doc.ConvexSet;
-    py::class_<ConvexSet>(m, "ConvexSet", cls_doc.doc)
+    class_<ConvexSet>(m, "ConvexSet", cls_doc.doc)
         .def("Clone", &ConvexSet::Clone, cls_doc.Clone.doc)
         .def("ambient_dimension", &ConvexSet::ambient_dimension,
             cls_doc.ambient_dimension.doc)
@@ -161,18 +161,17 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
 
   // There is a dependency cycle between Hyperellipsoid <=> AffineBall, so we
   // need to "forward declare" the Hyperellipsoid class here.
-  py::class_<Hyperellipsoid, ConvexSet> hyperellipsoid_cls(
+  class_<Hyperellipsoid, ConvexSet> hyperellipsoid_cls(
       m, "Hyperellipsoid", doc.Hyperellipsoid.doc);
 
   // There is a dependency cycle between VPolytope <=> HPolyhedron, so we
   // need to "forward declare" the VPolytope class here.
-  py::class_<VPolytope, ConvexSet> vpolytope_cls(
-      m, "VPolytope", doc.VPolytope.doc);
+  class_<VPolytope, ConvexSet> vpolytope_cls(m, "VPolytope", doc.VPolytope.doc);
 
   // AffineBall
   {
     const auto& cls_doc = doc.AffineBall;
-    py::class_<AffineBall, ConvexSet> cls(m, "AffineBall", cls_doc.doc);
+    class_<AffineBall, ConvexSet> cls(m, "AffineBall", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -203,7 +202,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   // AffineSubspace
   {
     const auto& cls_doc = doc.AffineSubspace;
-    py::class_<AffineSubspace, ConvexSet> cls(m, "AffineSubspace", cls_doc.doc);
+    class_<AffineSubspace, ConvexSet> cls(m, "AffineSubspace", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -236,7 +235,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   {
     using Class = CartesianProduct;
     const auto& cls_doc = doc.CartesianProduct;
-    py::class_<Class, ConvexSet>(m, "CartesianProduct", cls_doc.doc)
+    class_<Class, ConvexSet>(m, "CartesianProduct", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(
             "__init__",
@@ -271,7 +270,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   {
     using Class = ConvexHull;
     const auto& cls_doc = doc.ConvexHull;
-    py::class_<Class, ConvexSet>(m, "ConvexHull", cls_doc.doc)
+    class_<Class, ConvexSet>(m, "ConvexHull", cls_doc.doc)
         .def(
             "__init__",
             [](Class* self, const std::vector<ConvexSet*>& sets,
@@ -313,7 +312,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   {
     using Class = HPolyhedron;
     const auto& cls_doc = doc.HPolyhedron;
-    py::class_<Class, ConvexSet> cls(m, "HPolyhedron", cls_doc.doc);
+    class_<Class, ConvexSet> cls(m, "HPolyhedron", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -439,7 +438,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   {
     using Class = Hyperrectangle;
     const auto& cls_doc = doc.Hyperrectangle;
-    py::class_<Class, ConvexSet> cls(m, "Hyperrectangle", cls_doc.doc);
+    class_<Class, ConvexSet> cls(m, "Hyperrectangle", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&,
@@ -470,7 +469,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   {
     using Class = Intersection;
     const auto& cls_doc = doc.Intersection;
-    py::class_<Class, ConvexSet>(m, "Intersection", cls_doc.doc)
+    class_<Class, ConvexSet>(m, "Intersection", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(
             "__init__",
@@ -489,7 +488,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   {
     using Class = MinkowskiSum;
     const auto& cls_doc = doc.MinkowskiSum;
-    py::class_<Class, ConvexSet>(m, "MinkowskiSum", cls_doc.doc)
+    class_<Class, ConvexSet>(m, "MinkowskiSum", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(
             "__init__",
@@ -512,7 +511,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   {
     using Class = Point;
     const auto& cls_doc = doc.Point;
-    py::class_<Class, ConvexSet> cls(m, "Point", cls_doc.doc);
+    class_<Class, ConvexSet> cls(m, "Point", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&>(), py::arg("x"),
@@ -532,7 +531,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
   // Spectrahedron
   {
     const auto& cls_doc = doc.Spectrahedron;
-    py::class_<Spectrahedron, ConvexSet>(m, "Spectrahedron", cls_doc.doc)
+    class_<Spectrahedron, ConvexSet>(m, "Spectrahedron", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<const solvers::MathematicalProgram&>(), py::arg("prog"),
             cls_doc.ctor.doc_1args);
@@ -574,7 +573,7 @@ void DefineConvexSetBaseClassAndSubclasses(py::module_ m) {
 void DefineIris(py::module_ m) {
   {
     const auto& cls_doc = doc.IrisOptions;
-    py::class_<IrisOptions> iris_options(m, "IrisOptions", cls_doc.doc);
+    class_<IrisOptions> iris_options(m, "IrisOptions", cls_doc.doc);
     iris_options  // BR
         .def(ParamInit<IrisOptions>())
         .def_rw("require_sample_point_is_contained",
@@ -714,7 +713,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
   // GraphOfConvexSetsOptions
   {
     const auto& cls_doc = doc.GraphOfConvexSetsOptions;
-    py::class_<GraphOfConvexSetsOptions> gcs_options(
+    class_<GraphOfConvexSetsOptions> gcs_options(
         m, "GraphOfConvexSetsOptions", cls_doc.doc);
     gcs_options  // BR
         .def(py::init<>())
@@ -804,7 +803,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
   {
     using Class = GcsGraphvizOptions;
     constexpr auto& cls_doc = doc.GcsGraphvizOptions;
-    py::class_<Class> cls(m, "GcsGraphvizOptions", cls_doc.doc);
+    class_<Class> cls(m, "GcsGraphvizOptions", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -819,7 +818,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
             GraphOfConvexSets::Transcription::kRestriction};
 
     const auto& cls_doc = doc.GraphOfConvexSets;
-    py::class_<GraphOfConvexSets> graph_of_convex_sets(
+    class_<GraphOfConvexSets> graph_of_convex_sets(
         m, "GraphOfConvexSets", cls_doc.doc);
 
     BindIdentifier<GraphOfConvexSets::VertexId>(
@@ -841,7 +840,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
 
     // Vertex
     const auto& vertex_doc = doc.GraphOfConvexSets.Vertex;
-    py::class_<GraphOfConvexSets::Vertex>(
+    class_<GraphOfConvexSets::Vertex>(
         graph_of_convex_sets, "Vertex", vertex_doc.doc)
         .def("id", &GraphOfConvexSets::Vertex::id, vertex_doc.id.doc)
         .def("ambient_dimension", &GraphOfConvexSets::Vertex::ambient_dimension,
@@ -912,8 +911,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
 
     // Edge
     const auto& edge_doc = doc.GraphOfConvexSets.Edge;
-    py::class_<GraphOfConvexSets::Edge>(
-        graph_of_convex_sets, "Edge", edge_doc.doc)
+    class_<GraphOfConvexSets::Edge>(graph_of_convex_sets, "Edge", edge_doc.doc)
         .def("id", &GraphOfConvexSets::Edge::id, edge_doc.id.doc)
         .def("name", &GraphOfConvexSets::Edge::name, edge_doc.name.doc)
         .def("u",
@@ -1151,7 +1149,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
     }
   };
 
-  py::class_<ImplicitGraphOfConvexSets, PyImplicitGraphOfConvexSets>
+  class_<ImplicitGraphOfConvexSets, PyImplicitGraphOfConvexSets>
       implicit_gcs_cls(
           m, "ImplicitGraphOfConvexSets", doc.ImplicitGraphOfConvexSets.doc);
   implicit_gcs_cls  // BR
@@ -1172,8 +1170,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
   // ImplicitGraphOfConvexSetsFromExplicit
   {
     const auto& cls_doc = doc.ImplicitGraphOfConvexSetsFromExplicit;
-    py::class_<ImplicitGraphOfConvexSetsFromExplicit,
-        ImplicitGraphOfConvexSets>(
+    class_<ImplicitGraphOfConvexSetsFromExplicit, ImplicitGraphOfConvexSets>(
         m, "ImplicitGraphOfConvexSetsFromExplicit", cls_doc.doc)
         .def(py::init<const GraphOfConvexSets&>(), py::arg("gcs"),
             // Keep alive, reference: `self` keeps `gcs` alive.
@@ -1204,7 +1201,7 @@ void DefineCIrisCollisionGeometry(py::module_ m) {
         .value("kCapsule", CIrisGeometryType::kCapsule,
             doc.CIrisGeometryType.kCapsule.doc);
 
-    py::class_<CIrisCollisionGeometry>(
+    class_<CIrisCollisionGeometry>(
         m, "CIrisCollisionGeometry", doc.CIrisCollisionGeometry.doc)
         .def("type", &CIrisCollisionGeometry::type,
             doc.CIrisCollisionGeometry.type.doc)
@@ -1225,7 +1222,7 @@ void DefineCIrisCollisionGeometry(py::module_ m) {
 void DefineCspaceFreeStructs(py::module_ m) {
   {
     constexpr auto& prog_doc = doc.SeparationCertificateProgramBase;
-    auto prog_cls = py::class_<SeparationCertificateProgramBase>(
+    auto prog_cls = class_<SeparationCertificateProgramBase>(
         m, "SeparationCertificateProgramBase", prog_doc.doc)
                         .def(
                             "prog",
@@ -1238,7 +1235,7 @@ void DefineCspaceFreeStructs(py::module_ m) {
 
     constexpr auto& result_doc = doc.SeparationCertificateResultBase;
     auto result_cls =
-        py::class_<SeparationCertificateResultBase>(
+        class_<SeparationCertificateResultBase>(
             m, "SeparationCertificateResultBase", result_doc.doc)
             .def_ro("a", &SeparationCertificateResultBase::a)
             .def_ro("b", &SeparationCertificateResultBase::b)
@@ -1248,7 +1245,7 @@ void DefineCspaceFreeStructs(py::module_ m) {
 
     constexpr auto& find_options_doc = doc.FindSeparationCertificateOptions;
     auto find_options_cls =
-        py::class_<FindSeparationCertificateOptions>(
+        class_<FindSeparationCertificateOptions>(
             m, "FindSeparationCertificateOptions", find_options_doc.doc)
             .def(py::init<>())
             .def_rw(
@@ -1266,7 +1263,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
   {
     using BaseClass = CspaceFreePolytopeBase;
     const auto& base_cls_doc = doc.CspaceFreePolytopeBase;
-    py::class_<BaseClass> cspace_free_polytope_base_cls(
+    class_<BaseClass> cspace_free_polytope_base_cls(
         m, "CspaceFreePolytopeBase", base_cls_doc.doc);
     cspace_free_polytope_base_cls
         // TODO(Alexandre.Amice): Bind rational_forward_kinematics to resolve
@@ -1280,7 +1277,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
 
     {
       const auto& options_cls_doc = base_cls_doc.Options;
-      py::class_<BaseClass::Options> options_cls(
+      class_<BaseClass::Options> options_cls(
           cspace_free_polytope_base_cls, "Options", options_cls_doc.doc);
       options_cls  // BR
           .def(py::init<>(), options_cls_doc.ctor.doc)
@@ -1291,10 +1288,10 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
 
     using Class = CspaceFreePolytope;
     const auto& cls_doc = doc.CspaceFreePolytope;
-    py::class_<Class, BaseClass> cspace_free_polytope_cls(
+    class_<Class, BaseClass> cspace_free_polytope_cls(
         m, "CspaceFreePolytope", cls_doc.doc);
 
-    py::class_<Class::SeparatingPlaneLagrangians>(cspace_free_polytope_cls,
+    class_<Class::SeparatingPlaneLagrangians>(cspace_free_polytope_cls,
         "SeparatingPlaneLagrangians", cls_doc.SeparatingPlaneLagrangians.doc)
         .def(py::init<int, int>(), py::arg("C_rows"), py::arg("s_size"),
             cls_doc.SeparatingPlaneLagrangians.ctor.doc)
@@ -1309,7 +1306,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
         .def("s_upper", &Class::SeparatingPlaneLagrangians::mutable_s_upper);
 
     using SepCertClass = Class::SeparationCertificateResult;
-    py::class_<SepCertClass>(cspace_free_polytope_cls,
+    class_<SepCertClass>(cspace_free_polytope_cls,
         "SeparationCertificateResult", cls_doc.SeparationCertificateResult.doc)
         .def_ro("plane_index", &SepCertClass::plane_index)
         .def_ro("positive_side_rational_lagrangians",
@@ -1334,7 +1331,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
         .def_ro("plane_decision_var_vals",
             &SepCertClass::plane_decision_var_vals, py_rvp::copy);
 
-    py::class_<Class::SeparationCertificate>(cspace_free_polytope_cls,
+    class_<Class::SeparationCertificate>(cspace_free_polytope_cls,
         "SeparationCertificate", cls_doc.SeparationCertificate.doc)
         .def("GetSolution", &Class::SeparationCertificate::GetSolution,
             py::arg("plane_index"), py::arg("a"), py::arg("b"),
@@ -1345,7 +1342,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
         .def_rw("negative_side_rational_lagrangians",
             &Class::SeparationCertificate::negative_side_rational_lagrangians);
 
-    py::class_<Class::SeparationCertificateProgram,
+    class_<Class::SeparationCertificateProgram,
         SeparationCertificateProgramBase>(cspace_free_polytope_cls,
         "SeparationCertificateProgram",
         cls_doc.SeparationCertificateProgram.doc)
@@ -1355,7 +1352,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
         .def_ro(
             "certificate", &Class::SeparationCertificateProgram::certificate);
 
-    py::class_<Class::FindSeparationCertificateGivenPolytopeOptions,
+    class_<Class::FindSeparationCertificateGivenPolytopeOptions,
         FindSeparationCertificateOptions>(cspace_free_polytope_cls,
         "FindSeparationCertificateGivenPolytopeOptions",
         cls_doc.FindSeparationCertificateGivenPolytopeOptions.doc)
@@ -1369,8 +1366,8 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
         .value("kSum", Class::EllipsoidMarginCost::kSum)
         .value("kGeometricMean", Class::EllipsoidMarginCost::kGeometricMean);
 
-    py::class_<Class::FindPolytopeGivenLagrangianOptions>(
-        cspace_free_polytope_cls, "FindPolytopeGivenLagrangianOptions",
+    class_<Class::FindPolytopeGivenLagrangianOptions>(cspace_free_polytope_cls,
+        "FindPolytopeGivenLagrangianOptions",
         cls_doc.FindPolytopeGivenLagrangianOptions.doc)
         .def(py::init<>())
         .def_rw("backoff_scale",
@@ -1390,7 +1387,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
         .def_rw("ellipsoid_margin_cost",
             &Class::FindPolytopeGivenLagrangianOptions::ellipsoid_margin_cost);
 
-    py::class_<Class::SearchResult>(
+    class_<Class::SearchResult>(
         cspace_free_polytope_cls, "SearchResult", cls_doc.SearchResult.doc)
         .def(py::init<>())
         .def("C", &Class::SearchResult::C)
@@ -1402,7 +1399,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
         .def("num_iter", &Class::SearchResult::num_iter)
         .def("certified_polytope", &Class::SearchResult::certified_polytope);
 
-    py::class_<Class::BilinearAlternationOptions>(cspace_free_polytope_cls,
+    class_<Class::BilinearAlternationOptions>(cspace_free_polytope_cls,
         "BilinearAlternationOptions", cls_doc.BilinearAlternationOptions.doc)
         .def(py::init<>())
         .def_rw("max_iter", &Class::BilinearAlternationOptions::max_iter,
@@ -1420,7 +1417,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
             &Class::BilinearAlternationOptions::ellipsoid_scaling,
             cls_doc.BilinearAlternationOptions.ellipsoid_scaling.doc);
 
-    py::class_<Class::BinarySearchOptions>(cspace_free_polytope_cls,
+    class_<Class::BinarySearchOptions>(cspace_free_polytope_cls,
         "BinarySearchOptions", cls_doc.BinarySearchOptions.doc)
         .def(py::init<>())
         .def_rw("scale_max", &Class::BinarySearchOptions::scale_max)

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -160,7 +160,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = ClippingRange;
     const auto& cls_doc = doc.ClippingRange;
-    py::class_<Class>(m, "ClippingRange", cls_doc.doc)
+    class_<Class>(m, "ClippingRange", cls_doc.doc)
         .def(py::init<Class const&>(), py::arg("other"), "Copy constructor")
         .def(py::init<double, double>(), py::arg("near"), py::arg("far"),
             cls_doc.ctor.doc)
@@ -172,7 +172,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = RenderCameraCore;
     const auto& cls_doc = doc.RenderCameraCore;
-    py::class_<Class> cls(m, "RenderCameraCore");
+    class_<Class> cls(m, "RenderCameraCore");
     cls  // BR
         .def(py::init<Class const&>(), py::arg("other"), "Copy constructor")
         .def(
@@ -200,7 +200,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = ColorRenderCamera;
     const auto& cls_doc = doc.ColorRenderCamera;
-    py::class_<Class> cls(m, "ColorRenderCamera", cls_doc.doc);
+    class_<Class> cls(m, "ColorRenderCamera", cls_doc.doc);
     cls  // BR
         .def(py::init<Class const&>(), py::arg("other"), "Copy constructor")
         .def(py::init<RenderCameraCore, bool>(), py::arg("core"),
@@ -217,7 +217,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = DepthRange;
     const auto& cls_doc = doc.DepthRange;
-    py::class_<Class> cls(m, "DepthRange");
+    class_<Class> cls(m, "DepthRange");
     cls  // BR
         .def(py::init<Class const&>(), py::arg("other"), "Copy constructor")
         .def(py::init<double, double>(), py::arg("min_in"), py::arg("min_out"),
@@ -233,7 +233,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = DepthRenderCamera;
     const auto& cls_doc = doc.DepthRenderCamera;
-    py::class_<Class> cls(m, "DepthRenderCamera");
+    class_<Class> cls(m, "DepthRenderCamera");
     cls  // BR
         .def(py::init<Class const&>(), py::arg("other"), "Copy constructor")
         .def(py::init<RenderCameraCore, DepthRange>(), py::arg("core"),
@@ -250,7 +250,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   }
 
   {
-    py::class_<RenderLabel> render_label(m, "RenderLabel", doc.RenderLabel.doc);
+    class_<RenderLabel> render_label(m, "RenderLabel", doc.RenderLabel.doc);
     render_label
         .def(py::init<int>(), py::arg("value"), doc.RenderLabel.ctor.doc_1args)
         .def("is_reserved", &RenderLabel::is_reserved)
@@ -292,7 +292,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = RenderEngine;
     const auto& cls_doc = doc.RenderEngine;
-    py::class_<Class, PyRenderEngine, std::shared_ptr<Class>> cls(
+    class_<Class, PyRenderEngine, std::shared_ptr<Class>> cls(
         m, "RenderEngine");
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
@@ -379,7 +379,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = geometry::NullTexture;
     constexpr auto& cls_doc = doc_vtk.NullTexture;
-    py::class_<Class> cls(m, "NullTexture", cls_doc.doc);
+    class_<Class> cls(m, "NullTexture", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls);
@@ -390,7 +390,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = geometry::EquirectangularMap;
     constexpr auto& cls_doc = doc_vtk.EquirectangularMap;
-    py::class_<Class> cls(m, "EquirectangularMap", cls_doc.doc);
+    class_<Class> cls(m, "EquirectangularMap", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls);
@@ -401,7 +401,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = geometry::EnvironmentMap;
     constexpr auto& cls_doc = doc_vtk.EnvironmentMap;
-    py::class_<Class> cls(m, "EnvironmentMap", cls_doc.doc);
+    class_<Class> cls(m, "EnvironmentMap", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls);
@@ -412,7 +412,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = geometry::GltfExtension;
     constexpr auto& cls_doc = doc_vtk.GltfExtension;
-    py::class_<Class> cls(m, "GltfExtension", cls_doc.doc);
+    class_<Class> cls(m, "GltfExtension", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls);
@@ -423,7 +423,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = geometry::render::LightParameter;
     constexpr auto& cls_doc = doc.LightParameter;
-    py::class_<Class> cls(m, "LightParameter", cls_doc.doc);
+    class_<Class> cls(m, "LightParameter", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls);
@@ -434,7 +434,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = geometry::SsaoParameter;
     constexpr auto& cls_doc = doc_vtk.SsaoParameter;
-    py::class_<Class> cls(m, "SsaoParameter", cls_doc.doc);
+    class_<Class> cls(m, "SsaoParameter", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls);
@@ -445,7 +445,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = RenderEngineVtkParams;
     constexpr auto& cls_doc = doc_vtk.RenderEngineVtkParams;
-    py::class_<Class> cls(m, "RenderEngineVtkParams", cls_doc.doc);
+    class_<Class> cls(m, "RenderEngineVtkParams", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -475,7 +475,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = RenderEngineGlParams;
     constexpr auto& cls_doc = doc_gl.RenderEngineGlParams;
-    py::class_<Class> cls(m, "RenderEngineGlParams", cls_doc.doc);
+    class_<Class> cls(m, "RenderEngineGlParams", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -505,7 +505,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = RenderEngineGltfClientParams;
     constexpr auto& cls_doc = doc_gltf_client.RenderEngineGltfClientParams;
-    py::class_<Class> cls(m, "RenderEngineGltfClientParams", cls_doc.doc);
+    class_<Class> cls(m, "RenderEngineGltfClientParams", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);

--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -51,7 +51,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = geometry::DefaultProximityProperties;
     constexpr auto& cls_doc = doc.DefaultProximityProperties;
-    py::class_<Class> cls(m, "DefaultProximityProperties", cls_doc.doc);
+    class_<Class> cls(m, "DefaultProximityProperties", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -62,7 +62,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = geometry::SceneGraphConfig;
     constexpr auto& cls_doc = doc.SceneGraphConfig;
-    py::class_<Class> cls(m, "SceneGraphConfig", cls_doc.doc);
+    class_<Class> cls(m, "SceneGraphConfig", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -173,7 +173,7 @@ void DefineDrakeVisualizerParams(py::module_ m) {
   {
     using Class = DrakeVisualizerParams;
     constexpr auto& cls_doc = doc.DrakeVisualizerParams;
-    py::class_<Class> cls(
+    class_<Class> cls(
         m, "DrakeVisualizerParams", py::dynamic_attr(), cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
@@ -187,13 +187,13 @@ void DefineMeshcatParams(py::module_ m) {
   {
     using Class = MeshcatParams;
     constexpr auto& cls_doc = doc.MeshcatParams;
-    py::class_<Class, std::shared_ptr<Class>> cls(
+    class_<Class, std::shared_ptr<Class>> cls(
         m, "MeshcatParams", py::dynamic_attr(), cls_doc.doc);
     // MeshcatParams::PropertyTuple
     {
       using Nested = MeshcatParams::PropertyTuple;
       constexpr auto& nested_doc = doc.MeshcatParams.PropertyTuple;
-      py::class_<Nested> nested(cls, "PropertyTuple", nested_doc.doc);
+      class_<Nested> nested(cls, "PropertyTuple", nested_doc.doc);
       nested.def(ParamInit<Nested>());
       DefAttributesUsingSerialize(&nested, nested_doc);
       DefReprUsingSerialize(&nested);
@@ -210,8 +210,7 @@ void DefineMeshcat(py::module_ m) {
   {
     using Class = Meshcat;
     constexpr auto& cls_doc = doc.Meshcat;
-    py::class_<Class, std::shared_ptr<Class>> meshcat(
-        m, "Meshcat", cls_doc.doc);
+    class_<Class, std::shared_ptr<Class>> meshcat(m, "Meshcat", cls_doc.doc);
 
     // Meshcat::SideOfFaceToRender enumeration
     constexpr auto& side_doc = doc.Meshcat.SideOfFaceToRender;
@@ -225,7 +224,7 @@ void DefineMeshcat(py::module_ m) {
             side_doc.kDoubleSide.doc);
 
     const auto& perspective_camera_doc = doc.Meshcat.PerspectiveCamera;
-    py::class_<Meshcat::PerspectiveCamera> perspective_camera_cls(
+    class_<Meshcat::PerspectiveCamera> perspective_camera_cls(
         meshcat, "PerspectiveCamera", perspective_camera_doc.doc);
     perspective_camera_cls  // BR
         .def(ParamInit<Meshcat::PerspectiveCamera>());
@@ -235,7 +234,7 @@ void DefineMeshcat(py::module_ m) {
     DefCopyAndDeepCopy(&perspective_camera_cls);
 
     const auto& orthographic_camera_doc = doc.Meshcat.OrthographicCamera;
-    py::class_<Meshcat::OrthographicCamera> orthographic_camera_cls(
+    class_<Meshcat::OrthographicCamera> orthographic_camera_cls(
         meshcat, "OrthographicCamera", orthographic_camera_doc.doc);
     orthographic_camera_cls  // BR
         .def(ParamInit<Meshcat::OrthographicCamera>());
@@ -245,8 +244,7 @@ void DefineMeshcat(py::module_ m) {
     DefCopyAndDeepCopy(&orthographic_camera_cls);
 
     const auto& gamepad_doc = doc.Meshcat.Gamepad;
-    py::class_<Meshcat::Gamepad> gamepad_cls(
-        meshcat, "Gamepad", gamepad_doc.doc);
+    class_<Meshcat::Gamepad> gamepad_cls(meshcat, "Gamepad", gamepad_doc.doc);
     gamepad_cls  // BR
         .def(ParamInit<Meshcat::Gamepad>());
     DefAttributesUsingSerialize(&gamepad_cls, gamepad_doc);
@@ -473,7 +471,7 @@ void DefineMeshcatAnimation(py::module_ m) {
   {
     using Class = MeshcatAnimation;
     constexpr auto& cls_doc = doc.MeshcatAnimation;
-    py::class_<Class> cls(m, "MeshcatAnimation", cls_doc.doc);
+    class_<Class> cls(m, "MeshcatAnimation", cls_doc.doc);
 
     // MeshcatAnimation::LoopMode enumeration
     constexpr auto& loop_doc = doc.MeshcatAnimation.LoopMode;
@@ -535,7 +533,7 @@ void DefineMeshcatVisualizerParams(py::module_ m) {
   {
     using Class = MeshcatVisualizerParams;
     constexpr auto& cls_doc = doc.MeshcatVisualizerParams;
-    py::class_<Class> cls(
+    class_<Class> cls(
         m, "MeshcatVisualizerParams", py::dynamic_attr(), cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -27,7 +27,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = DrakeLcmInterface;
     constexpr auto& cls_doc = doc.DrakeLcmInterface;
-    py::class_<Class>(m, "DrakeLcmInterface", cls_doc.doc)
+    class_<Class>(m, "DrakeLcmInterface", cls_doc.doc)
         .def("get_lcm_url", &DrakeLcmInterface::get_lcm_url,
             cls_doc.get_lcm_url.doc)
         .def(
@@ -91,7 +91,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = DrakeLcmParams;
     constexpr auto& cls_doc = doc.DrakeLcmParams;
-    py::class_<Class> cls(m, "DrakeLcmParams", cls_doc.doc);
+    class_<Class> cls(m, "DrakeLcmParams", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -102,7 +102,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = DrakeLcm;
     constexpr auto& cls_doc = doc.DrakeLcm;
-    py::class_<Class, DrakeLcmInterface> cls(m, "DrakeLcm", cls_doc.doc);
+    class_<Class, DrakeLcmInterface> cls(m, "DrakeLcm", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<std::string>(), py::arg("lcm_url"),

--- a/bindings/pydrake/manipulation/manipulation_py_franka_panda.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_franka_panda.cc
@@ -40,8 +40,7 @@ void DefineManipulationFrankaPanda(py::module_ m) {
   {
     using Class = PandaCommandReceiver;
     constexpr auto& cls_doc = doc.PandaCommandReceiver;
-    py::class_<Class, LeafSystem<double>>(
-        m, "PandaCommandReceiver", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "PandaCommandReceiver", cls_doc.doc)
         .def(py::init<int, PandaControlMode>(), py::arg("num_joints"),
             py::arg("control_mode"), cls_doc.ctor.doc)
         .def("LatchInitialPosition",
@@ -71,7 +70,7 @@ void DefineManipulationFrankaPanda(py::module_ m) {
   {
     using Class = PandaCommandSender;
     constexpr auto& cls_doc = doc.PandaCommandSender;
-    py::class_<Class, LeafSystem<double>>(m, "PandaCommandSender", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "PandaCommandSender", cls_doc.doc)
         .def(py::init<int, PandaControlMode>(), py::arg("num_joints"),
             py::arg("control_mode"), cls_doc.ctor.doc)
         .def("get_position_input_port", &Class::get_position_input_port,
@@ -85,7 +84,7 @@ void DefineManipulationFrankaPanda(py::module_ m) {
   {
     using Class = PandaStatusReceiver;
     constexpr auto& cls_doc = doc.PandaStatusReceiver;
-    py::class_<Class, LeafSystem<double>>(m, "PandaStatusReceiver", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "PandaStatusReceiver", cls_doc.doc)
         .def(py::init<int>(), py::arg("num_joints") = kPandaArmNumJoints,
             cls_doc.ctor.doc)
         .def("get_position_commanded_output_port",
@@ -123,7 +122,7 @@ void DefineManipulationFrankaPanda(py::module_ m) {
   {
     using Class = PandaStatusSender;
     constexpr auto& cls_doc = doc.PandaStatusSender;
-    py::class_<Class, LeafSystem<double>>(m, "PandaStatusSender", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "PandaStatusSender", cls_doc.doc)
         .def(py::init<int>(), py::arg("num_joints") = kPandaArmNumJoints,
             cls_doc.ctor.doc)
         .def("get_position_commanded_input_port",

--- a/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
@@ -53,7 +53,7 @@ void DefineManipulationKukaIiwa(py::module_ m) {
   {
     using Class = IiwaCommandReceiver;
     constexpr auto& cls_doc = doc.IiwaCommandReceiver;
-    py::class_<Class, LeafSystem<double>>(m, "IiwaCommandReceiver", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "IiwaCommandReceiver", cls_doc.doc)
         .def(py::init<int, IiwaControlMode>(),
             py::arg("num_joints") = kIiwaArmNumJoints,
             py::arg("control_mode") = IiwaControlMode::kPositionAndTorque,
@@ -79,7 +79,7 @@ void DefineManipulationKukaIiwa(py::module_ m) {
   {
     using Class = IiwaCommandSender;
     constexpr auto& cls_doc = doc.IiwaCommandSender;
-    py::class_<Class, LeafSystem<double>>(m, "IiwaCommandSender", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "IiwaCommandSender", cls_doc.doc)
         .def(py::init<int, IiwaControlMode>(),
             py::arg("num_joints") = kIiwaArmNumJoints,
             py::arg("control_mode") = IiwaControlMode::kPositionAndTorque,
@@ -95,7 +95,7 @@ void DefineManipulationKukaIiwa(py::module_ m) {
   {
     using Class = IiwaStatusReceiver;
     constexpr auto& cls_doc = doc.IiwaStatusReceiver;
-    py::class_<Class, LeafSystem<double>>(m, "IiwaStatusReceiver", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "IiwaStatusReceiver", cls_doc.doc)
         .def(py::init<int>(), py::arg("num_joints") = kIiwaArmNumJoints,
             cls_doc.ctor.doc)
         .def("get_time_measured_output_port",
@@ -128,7 +128,7 @@ void DefineManipulationKukaIiwa(py::module_ m) {
   {
     using Class = IiwaStatusSender;
     constexpr auto& cls_doc = doc.IiwaStatusSender;
-    py::class_<Class, LeafSystem<double>>(m, "IiwaStatusSender", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "IiwaStatusSender", cls_doc.doc)
         .def(py::init<int>(), py::arg("num_joints") = kIiwaArmNumJoints,
             cls_doc.ctor.doc)
         .def("get_time_measured_input_port",
@@ -160,7 +160,7 @@ void DefineManipulationKukaIiwa(py::module_ m) {
   {
     using Class = IiwaDriver;
     constexpr auto& cls_doc = doc.IiwaDriver;
-    py::class_<Class> cls(m, "IiwaDriver", cls_doc.doc);
+    class_<Class> cls(m, "IiwaDriver", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -171,7 +171,7 @@ void DefineManipulationKukaIiwa(py::module_ m) {
   {
     using Class = SimIiwaDriver<double>;
     constexpr auto& cls_doc = doc.SimIiwaDriver;
-    py::class_<Class, Diagram<double>>(m, "SimIiwaDriver", cls_doc.doc)
+    class_<Class, Diagram<double>>(m, "SimIiwaDriver", cls_doc.doc)
         .def(py::init<const IiwaDriver&,
                  const multibody::MultibodyPlant<double>*>(),
             py::arg("driver_config"), py::arg("controller_plant"),

--- a/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_schunk_wsg.cc
@@ -25,7 +25,7 @@ void DefineManipulationSchunkWsg(py::module_ m) {
   {
     using Class = manipulation::schunk_wsg::SchunkWsgPositionController;
     constexpr auto& cls_doc = doc.SchunkWsgPositionController;
-    py::class_<Class, Diagram<double>>(
+    class_<Class, Diagram<double>>(
         m, "SchunkWsgPositionController", cls_doc.doc)
         .def(py::init<double, double, double, double, double, double>(),
             py::arg("time_step") = 0.05, py::arg("kp_command") = 200.,
@@ -50,7 +50,7 @@ void DefineManipulationSchunkWsg(py::module_ m) {
   {
     using Class = manipulation::schunk_wsg::SchunkWsgController;
     constexpr auto& cls_doc = doc.SchunkWsgController;
-    py::class_<Class, Diagram<double>>(m, "SchunkWsgController", cls_doc.doc)
+    class_<Class, Diagram<double>>(m, "SchunkWsgController", cls_doc.doc)
         .def(py::init<double, double, double>(), py::arg("kp") = 2000.,
             py::arg("ki") = 0., py::arg("kd") = 5., cls_doc.ctor.doc);
   }
@@ -58,7 +58,7 @@ void DefineManipulationSchunkWsg(py::module_ m) {
   {
     using Class = manipulation::schunk_wsg::SchunkWsgCommandReceiver;
     constexpr auto& cls_doc = doc.SchunkWsgCommandReceiver;
-    py::class_<Class, LeafSystem<double>>(
+    class_<Class, LeafSystem<double>>(
         m, "SchunkWsgCommandReceiver", cls_doc.doc)
         .def(py::init<double, double>(), py::arg("initial_position") = 0.02,
             py::arg("initial_force") = 40., cls_doc.ctor.doc)
@@ -72,8 +72,7 @@ void DefineManipulationSchunkWsg(py::module_ m) {
   {
     using Class = manipulation::schunk_wsg::SchunkWsgCommandSender;
     constexpr auto& cls_doc = doc.SchunkWsgCommandSender;
-    py::class_<Class, LeafSystem<double>>(
-        m, "SchunkWsgCommandSender", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "SchunkWsgCommandSender", cls_doc.doc)
         .def(py::init<double>(), py::arg("default_force_limit") = 40.0,
             cls_doc.ctor.doc)
         .def("get_position_input_port", &Class::get_position_input_port,
@@ -87,8 +86,7 @@ void DefineManipulationSchunkWsg(py::module_ m) {
   {
     using Class = manipulation::schunk_wsg::SchunkWsgStatusReceiver;
     constexpr auto& cls_doc = doc.SchunkWsgStatusReceiver;
-    py::class_<Class, LeafSystem<double>>(
-        m, "SchunkWsgStatusReceiver", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "SchunkWsgStatusReceiver", cls_doc.doc)
         .def(py::init(), cls_doc.ctor.doc)
         .def("get_status_input_port", &Class::get_status_input_port,
             py_rvp::reference_internal, cls_doc.get_status_input_port.doc)
@@ -101,8 +99,7 @@ void DefineManipulationSchunkWsg(py::module_ m) {
   {
     using Class = manipulation::schunk_wsg::SchunkWsgStatusSender;
     constexpr auto& cls_doc = doc.SchunkWsgStatusSender;
-    py::class_<Class, LeafSystem<double>>(
-        m, "SchunkWsgStatusSender", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "SchunkWsgStatusSender", cls_doc.doc)
         .def(py::init(), cls_doc.ctor.doc)
         .def("get_state_input_port", &Class::get_state_input_port,
             py_rvp::reference_internal, cls_doc.get_state_input_port.doc)
@@ -113,7 +110,7 @@ void DefineManipulationSchunkWsg(py::module_ m) {
   {
     using Class = manipulation::schunk_wsg::SchunkWsgTrajectoryGenerator;
     constexpr auto& cls_doc = doc.SchunkWsgTrajectoryGenerator;
-    py::class_<Class, LeafSystem<double>>(
+    class_<Class, LeafSystem<double>>(
         m, "SchunkWsgTrajectoryGenerator", cls_doc.doc)
         .def(py::init<int, int, bool>(), py::arg("input_size"),
             py::arg("position_index"), py::arg("use_force_limit") = true,
@@ -134,7 +131,7 @@ void DefineManipulationSchunkWsg(py::module_ m) {
   {
     using Class = manipulation::schunk_wsg::SchunkWsgDriver;
     constexpr auto& cls_doc = doc.SchunkWsgDriver;
-    py::class_<Class> cls(m, "SchunkWsgDriver", cls_doc.doc);
+    class_<Class> cls(m, "SchunkWsgDriver", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);

--- a/bindings/pydrake/manipulation/manipulation_py_util.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_util.cc
@@ -18,7 +18,7 @@ void DefineManipulationUtil(py::module_ m) {
   {
     using Class = ZeroForceDriver;
     constexpr auto& cls_doc = doc.ZeroForceDriver;
-    py::class_<Class> cls(m, "ZeroForceDriver", cls_doc.doc);
+    class_<Class> cls(m, "ZeroForceDriver", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);

--- a/bindings/pydrake/math/math_py_monolith.cc
+++ b/bindings/pydrake/math/math_py_monolith.cc
@@ -44,7 +44,7 @@ using symbolic::Variable;
 namespace {
 template <template <typename> typename PyClass, typename T>
 // NOLINTNEXTLINE(runtime/references)
-void DefineRigidTransform(py::module_ m, py::class_<PyClass<T>>& cls) {
+void DefineRigidTransform(py::module_ m, class_<PyClass<T>>& cls) {
   py::tuple param = GetPyParam<T>();
 
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -165,7 +165,7 @@ void DefineRigidTransform(py::module_ m, py::class_<PyClass<T>>& cls) {
 
 template <template <typename> typename PyClass, typename T>
 // NOLINTNEXTLINE(runtime/references)
-void DefineRotationMatrix(py::module_ m, py::class_<PyClass<T>>& cls) {
+void DefineRotationMatrix(py::module_ m, class_<PyClass<T>>& cls) {
   py::tuple param = GetPyParam<T>();
 
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -264,7 +264,7 @@ void DefineRotationMatrix(py::module_ m, py::class_<PyClass<T>>& cls) {
 
 template <template <typename> typename PyClass, typename T>
 // NOLINTNEXTLINE(runtime/references)
-void DefineRollPitchYaw(py::class_<PyClass<T>>& cls) {
+void DefineRollPitchYaw(class_<PyClass<T>>& cls) {
   py::tuple param = GetPyParam<T>();
 
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -507,7 +507,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   // TODO(eric.cousineau): Bind remaining classes for all available scalar
   // types.
   using T = double;
-  py::class_<BarycentricMesh<T>>(m, "BarycentricMesh", doc.BarycentricMesh.doc)
+  class_<BarycentricMesh<T>>(m, "BarycentricMesh", doc.BarycentricMesh.doc)
       .def(py::init<BarycentricMesh<T>::MeshGrid>(),
           doc.BarycentricMesh.ctor.doc)
       .def("get_input_grid", &BarycentricMesh<T>::get_input_grid,
@@ -654,7 +654,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = NumericalGradientOption;
     constexpr auto& cls_doc = doc.NumericalGradientOption;
-    py::class_<Class>(m, "NumericalGradientOption", cls_doc.doc)
+    class_<Class>(m, "NumericalGradientOption", cls_doc.doc)
         .def(py::init<NumericalGradientMethod, double>(), py::arg("method"),
             py::arg("function_accuracy") = 1E-15, cls_doc.ctor.doc)
         .def("NumericalGradientMethod", &Class::method, cls_doc.method.doc)

--- a/bindings/pydrake/multibody/benchmarks_py.cc
+++ b/bindings/pydrake/multibody/benchmarks_py.cc
@@ -26,8 +26,7 @@ void init_acrobot(py::module_ m) {
   py::module_::import_("pydrake.geometry");
   py::module_::import_("pydrake.multibody.plant");
 
-  py::class_<AcrobotParameters>(
-      m, "AcrobotParameters", doc.AcrobotParameters.doc)
+  class_<AcrobotParameters>(m, "AcrobotParameters", doc.AcrobotParameters.doc)
       .def(py::init(), doc.AcrobotParameters.doc);
 
   m.def("MakeAcrobotPlant",
@@ -54,7 +53,7 @@ PYDRAKE_MODULE(benchmarks, m) {
     constexpr auto& cls_doc =
         pydrake_doc_multibody_benchmarks_mass_damper_spring.drake.multibody
             .benchmarks.MassDamperSpringAnalyticalSolution;
-    py::class_<Class>(m, "MassDamperSpringAnalyticalSolution", cls_doc.doc)
+    class_<Class>(m, "MassDamperSpringAnalyticalSolution", cls_doc.doc)
         .def(py::init<const T&, const T&, const T&>(), py::arg("mass"),
             py::arg("b"), py::arg("k"), cls_doc.ctor.doc)
         .def("SetInitialValue", &Class::SetInitialValue, py::arg("x0"),

--- a/bindings/pydrake/multibody/contact_solvers_py.cc
+++ b/bindings/pydrake/multibody/contact_solvers_py.cc
@@ -17,7 +17,7 @@ void DefineIcf(py::module_ m) {
   {
     using Class = IcfSolverParameters;
     constexpr auto& cls_doc = doc.IcfSolverParameters;
-    py::class_<Class> cls(
+    class_<Class> cls(
         m, "IcfSolverParameters", py::dynamic_attr(), cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -73,8 +73,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
   {
     using Class = InverseKinematics;
     constexpr auto& cls_doc = doc.InverseKinematics;
-    py::class_<Class> cls(
-        m, "InverseKinematics", py::dynamic_attr(), cls_doc.doc);
+    class_<Class> cls(m, "InverseKinematics", py::dynamic_attr(), cls_doc.doc);
     cls  // BR
         .def(py::init<const MultibodyPlant<double>&, bool>(), py::arg("plant"),
             py::arg("with_joint_limits") = true,
@@ -193,7 +192,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = AngleBetweenVectorsConstraint;
     constexpr auto& cls_doc = doc.AngleBetweenVectorsConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(
+    class_<Class, Constraint, Ptr>(
         m, "AngleBetweenVectorsConstraint", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
                  const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
@@ -224,8 +223,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = AngleBetweenVectorsCost;
     constexpr auto& cls_doc = doc.AngleBetweenVectorsCost;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, solvers::Cost, Ptr>(
-        m, "AngleBetweenVectorsCost", cls_doc.doc)
+    class_<Class, solvers::Cost, Ptr>(m, "AngleBetweenVectorsCost", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
                  const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
                  const Eigen::Ref<const Eigen::Vector3d>&, double,
@@ -255,7 +253,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = PointToPointDistanceConstraint;
     constexpr auto& cls_doc = doc.PointToPointDistanceConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(
+    class_<Class, Constraint, Ptr>(
         m, "PointToPointDistanceConstraint", cls_doc.doc)
         .def(py::init<const multibody::MultibodyPlant<double>* const,
                  const multibody::Frame<double>&,
@@ -288,7 +286,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = PointToLineDistanceConstraint;
     constexpr auto& cls_doc = doc.PointToLineDistanceConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(
+    class_<Class, Constraint, Ptr>(
         m, "PointToLineDistanceConstraint", cls_doc.doc)
         .def(py::init<const multibody::MultibodyPlant<double>* const,
                  const multibody::Frame<double>&,
@@ -325,7 +323,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = PolyhedronConstraint;
     constexpr auto& cls_doc = doc.PolyhedronConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(m, "PolyhedronConstraint", cls_doc.doc)
+    class_<Class, Constraint, Ptr>(m, "PolyhedronConstraint", cls_doc.doc)
         .def(py::init<const multibody::MultibodyPlant<double>* const,
                  const multibody::Frame<double>&,
                  const multibody::Frame<double>&,
@@ -359,7 +357,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = DistanceConstraint;
     constexpr auto& cls_doc = doc.DistanceConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(m, "DistanceConstraint", cls_doc.doc)
+    class_<Class, Constraint, Ptr>(m, "DistanceConstraint", cls_doc.doc)
         .def(py::init<const multibody::MultibodyPlant<double>* const,
                  SortedPair<geometry::GeometryId>, systems::Context<double>*,
                  double, double>(),
@@ -386,7 +384,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = GazeTargetConstraint;
     constexpr auto& cls_doc = doc.GazeTargetConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(m, "GazeTargetConstraint", cls_doc.doc)
+    class_<Class, Constraint, Ptr>(m, "GazeTargetConstraint", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
                  const Eigen::Ref<const Eigen::Vector3d>&,
                  const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
@@ -419,7 +417,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = MinimumDistanceLowerBoundConstraint;
     constexpr auto& cls_doc = doc.MinimumDistanceLowerBoundConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr> minimum_distance_lower_bound_constraint(
+    class_<Class, Constraint, Ptr> minimum_distance_lower_bound_constraint(
         m, "MinimumDistanceLowerBoundConstraint", cls_doc.doc);
 
     std::string py_penalty_doc =
@@ -509,7 +507,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = MinimumDistanceUpperBoundConstraint;
     constexpr auto& cls_doc = doc.MinimumDistanceUpperBoundConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr> minimum_distance_upper_bound_constraint(
+    class_<Class, Constraint, Ptr> minimum_distance_upper_bound_constraint(
         m, "MinimumDistanceUpperBoundConstraint", cls_doc.doc);
 
     std::string py_penalty_doc =
@@ -597,7 +595,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = PositionConstraint;
     constexpr auto& cls_doc = doc.PositionConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(m, "PositionConstraint", cls_doc.doc)
+    class_<Class, Constraint, Ptr>(m, "PositionConstraint", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
                  const Eigen::Ref<const Eigen::Vector3d>&,
                  const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
@@ -660,7 +658,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = PositionCost;
     constexpr auto& cls_doc = doc.PositionCost;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, solvers::Cost, Ptr>(m, "PositionCost", cls_doc.doc)
+    class_<Class, solvers::Cost, Ptr>(m, "PositionCost", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
                  const Eigen::Ref<const Eigen::Vector3d>&, const Frame<double>&,
                  const Eigen::Ref<const Eigen::Vector3d>&,
@@ -693,7 +691,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = ComPositionConstraint;
     constexpr auto& cls_doc = doc.ComPositionConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(m, "ComPositionConstraint", cls_doc.doc)
+    class_<Class, Constraint, Ptr>(m, "ComPositionConstraint", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>*,
                  const std::optional<std::vector<ModelInstanceIndex>>&,
                  const Frame<double>&, systems::Context<double>*>(),
@@ -718,8 +716,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = ComInPolyhedronConstraint;
     constexpr auto& cls_doc = doc.ComInPolyhedronConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(
-        m, "ComInPolyhedronConstraint", cls_doc.doc)
+    class_<Class, Constraint, Ptr>(m, "ComInPolyhedronConstraint", cls_doc.doc)
         .def(
             py::init<const MultibodyPlant<double>*,
                 std::optional<std::vector<ModelInstanceIndex>>,
@@ -754,7 +751,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = OrientationConstraint;
     constexpr auto& cls_doc = doc.OrientationConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(m, "OrientationConstraint", cls_doc.doc)
+    class_<Class, Constraint, Ptr>(m, "OrientationConstraint", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>* const, const Frame<double>&,
                  const math::RotationMatrix<double>&, const Frame<double>&,
                  const math::RotationMatrix<double>&, double,
@@ -783,7 +780,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = OrientationCost;
     constexpr auto& cls_doc = doc.OrientationCost;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, solvers::Cost, Ptr>(m, "OrientationCost", cls_doc.doc)
+    class_<Class, solvers::Cost, Ptr>(m, "OrientationCost", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>*, const Frame<double>&,
                  const math::RotationMatrix<double>&, const Frame<double>&,
                  const math::RotationMatrix<double>&, double,
@@ -812,8 +809,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
     using Class = UnitQuaternionConstraint;
     constexpr auto& cls_doc = doc.UnitQuaternionConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, Constraint, Ptr>(
-        m, "UnitQuaternionConstraint", cls_doc.doc)
+    class_<Class, Constraint, Ptr>(m, "UnitQuaternionConstraint", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc);
     m.def("AddUnitQuaternionConstraintOnPlant",
         &AddUnitQuaternionConstraintOnPlant<double>, py::arg("plant"),
@@ -827,9 +823,9 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
   {
     using Class = GlobalInverseKinematics;
     constexpr auto& cls_doc = doc.GlobalInverseKinematics;
-    py::class_<Class> global_ik(m, "GlobalInverseKinematics", cls_doc.doc);
+    class_<Class> global_ik(m, "GlobalInverseKinematics", cls_doc.doc);
 
-    py::class_<GlobalInverseKinematics::Options>(
+    class_<GlobalInverseKinematics::Options>(
         global_ik, "Options", cls_doc.Options.doc)
         .def(py::init<>(), cls_doc.Options.ctor.doc)
         .def_rw("num_intervals_per_half_axis",
@@ -854,7 +850,7 @@ PYDRAKE_MODULE(inverse_kinematics, m) {
                   self.interval_binning, self.linear_constraint_only);
         });
 
-    py::class_<GlobalInverseKinematics::Polytope3D>(
+    class_<GlobalInverseKinematics::Polytope3D>(
         global_ik, "Polytope3D", cls_doc.Polytope3D.doc)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixX3d>&,
                  const Eigen::Ref<const Eigen::VectorXd>&>(),

--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -47,7 +47,7 @@ void DefineDifferentialIkLegacy(py::module_ m) {
   {
     using Class = DifferentialInverseKinematicsResult;
     constexpr auto& cls_doc = doc.DifferentialInverseKinematicsResult;
-    py::class_<Class> cls(m, "DifferentialInverseKinematicsResult",
+    class_<Class> cls(m, "DifferentialInverseKinematicsResult",
         doc.DifferentialInverseKinematicsResult.doc);
 
     // TODO(m-chaturvedi) Add Pybind11 documentation.
@@ -61,7 +61,7 @@ void DefineDifferentialIkLegacy(py::module_ m) {
     using Class = DifferentialInverseKinematicsParameters;
     constexpr auto& cls_doc = doc.DifferentialInverseKinematicsParameters;
 
-    py::class_<Class> cls(m, "DifferentialInverseKinematicsParameters",
+    class_<Class> cls(m, "DifferentialInverseKinematicsParameters",
         doc.DifferentialInverseKinematicsParameters.doc);
 
     cls  // BR
@@ -214,7 +214,7 @@ void DefineDifferentialIkLegacy(py::module_ m) {
   {
     using Class = DifferentialInverseKinematicsIntegrator;
     constexpr auto& cls_doc = doc.DifferentialInverseKinematicsIntegrator;
-    py::class_<Class, LeafSystem<double>>(
+    class_<Class, LeafSystem<double>>(
         m, "DifferentialInverseKinematicsIntegrator", cls_doc.doc)
         .def(py::init<const multibody::MultibodyPlant<double>&,
                  const multibody::Frame<double>&,
@@ -250,11 +250,11 @@ void DefineDifferentialIkLegacy(py::module_ m) {
 
 // The pybind class for the DifferentialInverseKinematicsSystem.
 using PyClassDifferentialInverseKinematicsSystem =
-    py::class_<DifferentialInverseKinematicsSystem, LeafSystem<double>>;
+    class_<DifferentialInverseKinematicsSystem, LeafSystem<double>>;
 
 // The pybind class for DifferentialInverseKinematicsSystem's ingredients.
 template <typename Derived>
-using PyClassIngredient = py::class_<Derived, Ingredient>;
+using PyClassIngredient = class_<Derived, Ingredient>;
 
 // Bind the common Ingredient API for both Ingredient and its Config struct.
 // The bound class gets returned so non-common APIs can be subsequently bound.
@@ -271,7 +271,7 @@ PyClassIngredient<Derived> BindIngredient(const char* class_name,
 
   PyClassIngredient<Derived> cls(*diff_ik_cls, class_name, cls_doc.doc);
 
-  py::class_<Config> config_cls(cls, "Config", cls_doc.Config.doc);
+  class_<Config> config_cls(cls, "Config", cls_doc.Config.doc);
   config_cls.def(ParamInit<Config>());
   DefAttributesUsingSerialize(&config_cls, cls_doc.Config);
   DefReprUsingSerialize(&config_cls);
@@ -303,7 +303,7 @@ void DefineDifferentialIkSystem(py::module_ m) {
 
   {
     constexpr auto nested_cls_doc = cls_doc.Ingredient;
-    py::class_<Ingredient>(cls, "Ingredient", nested_cls_doc.doc);
+    class_<Ingredient>(cls, "Ingredient", nested_cls_doc.doc);
     // We're explicitly not binding `AddToProgram` because we expect only the
     // C++ DifferentialInverseKinematicsSystem would call it.
   }
@@ -311,7 +311,7 @@ void DefineDifferentialIkSystem(py::module_ m) {
   {
     using NestedClass = Recipe;
     constexpr auto nested_cls_doc = cls_doc.Recipe;
-    py::class_<NestedClass>(cls, "Recipe", nested_cls_doc.doc)
+    class_<NestedClass>(cls, "Recipe", nested_cls_doc.doc)
         .def(py::init<>(), nested_cls_doc.ctor.doc)
         .def(
             "AddIngredient",
@@ -430,7 +430,7 @@ void DefineDifferentialIkController(py::module_ m) {
 
   using Class = DifferentialInverseKinematicsController;
   constexpr auto& cls_doc = doc.DifferentialInverseKinematicsController;
-  py::class_<Class, systems::Diagram<double>>(
+  class_<Class, systems::Diagram<double>>(
       m, "DifferentialInverseKinematicsController")
       .def(
           "__init__",

--- a/bindings/pydrake/multibody/meshcat_py.cc
+++ b/bindings/pydrake/multibody/meshcat_py.cc
@@ -30,7 +30,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = ContactVisualizerParams;
     constexpr auto& cls_doc = doc.ContactVisualizerParams;
-    py::class_<Class> cls(
+    class_<Class> cls(
         m, "ContactVisualizerParams", py::dynamic_attr(), cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
@@ -43,7 +43,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = multibody::meshcat::internal::PointContactVisualizerItem;
     constexpr char doc_internal[] = "(internal use only)";
-    py::class_<Class>(
+    class_<Class>(
         m, "_PointContactVisualizerItem", py::dynamic_attr(), doc_internal)
         .def(py::init<std::string, std::string, Eigen::Vector3d,
                  Eigen::Vector3d>(),
@@ -59,7 +59,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = multibody::meshcat::internal::PointContactVisualizer;
     constexpr char doc_internal[] = "(internal use only)";
-    py::class_<Class>(m, "_PointContactVisualizer", doc_internal)
+    class_<Class>(m, "_PointContactVisualizer", doc_internal)
         .def(py::init<std::shared_ptr<geometry::Meshcat>,
                  ContactVisualizerParams>(),
             py::arg("meshcat"), py::arg("params"), doc_internal)
@@ -71,8 +71,8 @@ void DoScalarIndependentDefinitions(py::module_ m) {
     using Class =
         multibody::meshcat::internal::HydroelasticContactVisualizerItem;
     constexpr char doc_internal[] = "(internal use only)";
-    py::class_<Class>(m, "_HydroelasticContactVisualizerItem",
-        py::dynamic_attr(), doc_internal)
+    class_<Class>(m, "_HydroelasticContactVisualizerItem", py::dynamic_attr(),
+        doc_internal)
         .def(py::init<std::string, std::string, Eigen::Vector3d,
                  Eigen::Vector3d, Eigen::Vector3d, Eigen::Matrix3Xd,
                  Eigen::Matrix3Xi, Eigen::VectorXd>(),
@@ -93,7 +93,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = multibody::meshcat::internal::HydroelasticContactVisualizer;
     constexpr char doc_internal[] = "(internal use only)";
-    py::class_<Class>(m, "_HydroelasticContactVisualizer", doc_internal)
+    class_<Class>(m, "_HydroelasticContactVisualizer", doc_internal)
         .def(py::init<std::shared_ptr<geometry::Meshcat>,
                  ContactVisualizerParams>(),
             py::arg("meshcat"), py::arg("params"), doc_internal)

--- a/bindings/pydrake/multibody/optimization_py.cc
+++ b/bindings/pydrake/multibody/optimization_py.cc
@@ -33,7 +33,7 @@ PYDRAKE_MODULE(optimization, m) {
   {
     using Class = CalcGridPointsOptions;
     constexpr auto& cls_doc = doc.CalcGridPointsOptions;
-    py::class_<Class> cls(m, "CalcGridPointsOptions", cls_doc.doc);
+    class_<Class> cls(m, "CalcGridPointsOptions", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -45,7 +45,7 @@ PYDRAKE_MODULE(optimization, m) {
     using Class = CentroidalMomentumConstraint;
     constexpr auto& cls_doc = doc.CentroidalMomentumConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, solvers::Constraint, Ptr>(
+    class_<Class, solvers::Constraint, Ptr>(
         m, "CentroidalMomentumConstraint", cls_doc.doc)
         .def(py::init<const MultibodyPlant<AutoDiffXd>*,
                  std::optional<std::vector<ModelInstanceIndex>>,
@@ -62,7 +62,7 @@ PYDRAKE_MODULE(optimization, m) {
     using Class = ContactWrenchFromForceInWorldFrameEvaluator;
     constexpr auto& cls_doc = doc.ContactWrenchFromForceInWorldFrameEvaluator;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, solvers::EvaluatorBase, Ptr>(
+    class_<Class, solvers::EvaluatorBase, Ptr>(
         m, "ContactWrenchFromForceInWorldFrameEvaluator", cls_doc.doc)
         .def(py::init<const MultibodyPlant<AutoDiffXd>*,
                  systems::Context<AutoDiffXd>*,
@@ -72,7 +72,7 @@ PYDRAKE_MODULE(optimization, m) {
   }
 
   {
-    py::class_<ContactWrench>(m, "ContactWrench", doc.ContactWrench.doc)
+    class_<ContactWrench>(m, "ContactWrench", doc.ContactWrench.doc)
         .def_ro("bodyA_index", &ContactWrench::bodyA_index,
             doc.ContactWrench.bodyA_index.doc)
         .def_ro("bodyB_index", &ContactWrench::bodyB_index,
@@ -87,7 +87,7 @@ PYDRAKE_MODULE(optimization, m) {
     using Class = QuaternionEulerIntegrationConstraint;
     constexpr auto& cls_doc = doc.QuaternionEulerIntegrationConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, solvers::Constraint, Ptr>(
+    class_<Class, solvers::Constraint, Ptr>(
         m, "QuaternionEulerIntegrationConstraint", cls_doc.doc)
         .def(py::init<bool>(), py::arg("allow_quaternion_negation"),
             cls_doc.ctor.doc)
@@ -108,7 +108,7 @@ PYDRAKE_MODULE(optimization, m) {
     using Class = SpatialVelocityConstraint;
     constexpr auto& cls_doc = doc.SpatialVelocityConstraint;
     using Ptr = std::shared_ptr<Class>;
-    py::class_<Class, solvers::Constraint, Ptr> cls(
+    class_<Class, solvers::Constraint, Ptr> cls(
         m, "SpatialVelocityConstraint", cls_doc.doc);
     cls.def(
         py::init<const MultibodyPlant<AutoDiffXd>*, const Frame<AutoDiffXd>&,
@@ -128,7 +128,7 @@ PYDRAKE_MODULE(optimization, m) {
     using Avb = SpatialVelocityConstraint::AngularVelocityBounds;
     constexpr auto& avb_doc =
         doc.SpatialVelocityConstraint.AngularVelocityBounds;
-    py::class_<SpatialVelocityConstraint::AngularVelocityBounds>(
+    class_<SpatialVelocityConstraint::AngularVelocityBounds>(
         cls, "AngularVelocityBounds", avb_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc)
         .def_rw("magnitude_lower", &Avb::magnitude_lower,
@@ -143,7 +143,7 @@ PYDRAKE_MODULE(optimization, m) {
   {
     using Class = StaticEquilibriumProblem;
     constexpr auto& cls_doc = doc.StaticEquilibriumProblem;
-    py::class_<Class>(m, "StaticEquilibriumProblem", cls_doc.doc)
+    class_<Class>(m, "StaticEquilibriumProblem", cls_doc.doc)
         .def(py::init<const MultibodyPlant<AutoDiffXd>*,
                  systems::Context<AutoDiffXd>*,
                  const std::set<
@@ -176,7 +176,7 @@ PYDRAKE_MODULE(optimization, m) {
   {
     using Class = Toppra;
     constexpr auto& cls_doc = doc.Toppra;
-    py::class_<Class>(m, "Toppra", cls_doc.doc)
+    class_<Class>(m, "Toppra", cls_doc.doc)
         .def(py::init<const Trajectory<double>&, const MultibodyPlant<double>&,
                  const Eigen::Ref<const Eigen::VectorXd>&>(),
             py::arg("path"), py::arg("plant"), py::arg("gridpoints"),

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -35,7 +35,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = CollisionFilterGroups;
     constexpr auto& cls_doc = doc.CollisionFilterGroups;
-    auto cls = py::class_<Class>(m, "CollisionFilterGroups", cls_doc.doc);
+    auto cls = class_<Class>(m, "CollisionFilterGroups", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def("AddGroup", &Class::AddGroup, py::arg("name"), py::arg("members"),
@@ -53,11 +53,11 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = PackageMap;
     constexpr auto& cls_doc = doc.PackageMap;
-    py::class_<Class> cls(m, "PackageMap", cls_doc.doc);
+    class_<Class> cls(m, "PackageMap", cls_doc.doc);
     {
       using Nested = PackageMap::RemoteParams;
       constexpr auto& nested_doc = cls_doc.RemoteParams;
-      py::class_<Nested> nested(cls, "RemoteParams", nested_doc.doc);
+      class_<Nested> nested(cls, "RemoteParams", nested_doc.doc);
       nested.def(ParamInit<Nested>());
       nested.def("ToJson", &Nested::ToJson, nested_doc.ToJson.doc);
       DefAttributesUsingSerialize(&nested, nested_doc);
@@ -112,7 +112,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = Parser;
     constexpr auto& cls_doc = doc.Parser;
-    auto cls = py::class_<Class>(m, "Parser", cls_doc.doc);
+    auto cls = class_<Class>(m, "Parser", cls_doc.doc);
     cls  // BR
         .def(py::init<MultibodyPlant<double>*, SceneGraph<double>*,
                  std::string_view>(),
@@ -161,7 +161,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::AddWeld;
     constexpr auto& cls_doc = doc.parsing.AddWeld;
-    py::class_<Class> cls(m, "AddWeld", cls_doc.doc);
+    class_<Class> cls(m, "AddWeld", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -171,7 +171,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::AddModel;
     constexpr auto& cls_doc = doc.parsing.AddModel;
-    py::class_<Class> cls(m, "AddModel", cls_doc.doc);
+    class_<Class> cls(m, "AddModel", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -181,7 +181,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::AddModelInstance;
     constexpr auto& cls_doc = doc.parsing.AddModelInstance;
-    py::class_<Class> cls(m, "AddModelInstance", cls_doc.doc);
+    class_<Class> cls(m, "AddModelInstance", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -191,7 +191,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::AddFrame;
     constexpr auto& cls_doc = doc.parsing.AddFrame;
-    py::class_<Class> cls(m, "AddFrame", cls_doc.doc);
+    class_<Class> cls(m, "AddFrame", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -201,7 +201,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::AddCollisionFilterGroup;
     constexpr auto& cls_doc = doc.parsing.AddCollisionFilterGroup;
-    py::class_<Class> cls(m, "AddCollisionFilterGroup", cls_doc.doc);
+    class_<Class> cls(m, "AddCollisionFilterGroup", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -211,7 +211,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::AddDirectives;
     constexpr auto& cls_doc = doc.parsing.AddDirectives;
-    py::class_<Class> cls(m, "AddDirectives", cls_doc.doc);
+    class_<Class> cls(m, "AddDirectives", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -221,7 +221,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::ModelDirective;
     constexpr auto& cls_doc = doc.parsing.ModelDirective;
-    py::class_<Class> cls(m, "ModelDirective", cls_doc.doc);
+    class_<Class> cls(m, "ModelDirective", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -231,7 +231,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::ModelDirectives;
     constexpr auto& cls_doc = doc.parsing.ModelDirectives;
-    py::class_<Class> cls(m, "ModelDirectives", cls_doc.doc);
+    class_<Class> cls(m, "ModelDirectives", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);
@@ -249,7 +249,7 @@ PYDRAKE_MODULE(parsing, m) {
   {
     using Class = parsing::ModelInstanceInfo;
     constexpr auto& cls_doc = doc.parsing.ModelInstanceInfo;
-    py::class_<Class>(m, "ModelInstanceInfo", cls_doc.doc)
+    class_<Class>(m, "ModelInstanceInfo", cls_doc.doc)
         .def_ro("model_name", &Class::model_name, cls_doc.model_name.doc)
         .def_ro("model_path", &Class::model_path, cls_doc.model_path.doc)
         .def_ro("parent_frame_name", &Class::parent_frame_name,

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1602,7 +1602,7 @@ PYDRAKE_MODULE(plant, m) {
   {
     using Class = ContactResultsToLcmSystem<T>;
     constexpr auto& cls_doc = doc.ContactResultsToLcmSystem;
-    py::class_<Class, systems::LeafSystem<T>>(
+    class_<Class, systems::LeafSystem<T>>(
         m, "ContactResultsToLcmSystem", cls_doc.doc)
         .def(py::init<const MultibodyPlant<T>&>(), py::arg("plant"),
             cls_doc.ctor.doc)
@@ -1639,7 +1639,7 @@ PYDRAKE_MODULE(plant, m) {
   {
     using Class = PropellerInfo;
     constexpr auto& cls_doc = doc.PropellerInfo;
-    py::class_<Class> cls(m, "PropellerInfo", cls_doc.doc);
+    class_<Class> cls(m, "PropellerInfo", cls_doc.doc);
     cls  // BR
         .def(py::init<const BodyIndex&, const math::RigidTransform<double>&,
                  double, double>(),
@@ -1656,7 +1656,7 @@ PYDRAKE_MODULE(plant, m) {
   {
     using Class = DistanceConstraintParams;
     constexpr auto& cls_doc = doc.DistanceConstraintParams;
-    py::class_<Class> cls(m, "DistanceConstraintParams", cls_doc.doc);
+    class_<Class> cls(m, "DistanceConstraintParams", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<BodyIndex, Vector3<double>&, BodyIndex, Vector3<double>&,
@@ -1743,7 +1743,7 @@ PYDRAKE_MODULE(plant, m) {
   {
     using Class = MultibodyPlantConfig;
     constexpr auto& cls_doc = doc.MultibodyPlantConfig;
-    py::class_<Class> cls(m, "MultibodyPlantConfig", cls_doc.doc);
+    class_<Class> cls(m, "MultibodyPlantConfig", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -1755,14 +1755,14 @@ PYDRAKE_MODULE(plant, m) {
   {
     using Class = PhysicalModel<T>;
     constexpr auto& cls_doc = doc.PhysicalModel;
-    auto cls = py::class_<Class>(m, "PhysicalModel", cls_doc.doc);
+    auto cls = class_<Class>(m, "PhysicalModel", cls_doc.doc);
   }
 
   // DeformableModel
   {
     using Class = DeformableModel<double>;
     constexpr auto& cls_doc = doc.DeformableModel;
-    py::class_<Class, PhysicalModel<T>> cls(m, "DeformableModel", cls_doc.doc);
+    class_<Class, PhysicalModel<T>> cls(m, "DeformableModel", cls_doc.doc);
     cls  // BR
         .def("num_bodies", &Class::num_bodies, cls_doc.num_bodies.doc)
         .def(

--- a/bindings/pydrake/multibody/rational_py.cc
+++ b/bindings/pydrake/multibody/rational_py.cc
@@ -35,7 +35,7 @@ PYDRAKE_MODULE(rational, m) {
   {
     using Class = drake::multibody::RationalForwardKinematics;
     constexpr auto& cls_doc = doc.RationalForwardKinematics;
-    py::class_<Class>(m, "RationalForwardKinematics")
+    class_<Class>(m, "RationalForwardKinematics")
         .def(py::init<const MultibodyPlant<double>*>(), py::arg("plant"),
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>()  // BR

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -130,7 +130,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = DoorHingeConfig;
     constexpr auto& cls_doc = doc.DoorHingeConfig;
-    py::class_<Class> cls(m, "DoorHingeConfig", cls_doc.doc);
+    class_<Class> cls(m, "DoorHingeConfig", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>(), cls_doc.ctor.doc);
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -150,7 +150,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = ScopedName;
     constexpr auto& cls_doc = doc.ScopedName;
-    py::class_<Class> cls(m, "ScopedName", cls_doc.doc);
+    class_<Class> cls(m, "ScopedName", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(py::init<std::string_view, std::string_view>(),
@@ -185,7 +185,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = PdControllerGains;
     constexpr auto& cls_doc = doc.PdControllerGains;
-    py::class_<Class> cls(m, "PdControllerGains", cls_doc.doc);
+    class_<Class> cls(m, "PdControllerGains", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     cls  // BR
@@ -1356,7 +1356,7 @@ void DefineForceDensityField(py::module_ m, T) {
 void DefineDeformableBody(py::module_ m) {
   using Class = DeformableBody<double>;
   constexpr auto& cls_doc = doc.DeformableBody;
-  py::class_<Class> cls(m, "DeformableBody", cls_doc.doc);
+  class_<Class> cls(m, "DeformableBody", cls_doc.doc);
   BindMultibodyElementMixin<double>(&cls);
   cls  // BR
       .def("body_id", &Class::body_id, cls_doc.body_id.doc)

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -34,7 +34,7 @@ void init_pc_flags(py::module_ m) {
   {
     using Class = Fields;
     constexpr auto& cls_doc = doc.Fields;
-    py::class_<Class>(m, "Fields", cls_doc.doc)
+    class_<Class>(m, "Fields", cls_doc.doc)
         .def(py::init<BaseFieldT>(), py::arg("base_fields"), cls_doc.ctor.doc)
         .def("base_fields", &Class::base_fields, cls_doc.base_fields.doc)
         .def("has_base_fields", &Class::has_base_fields,
@@ -64,7 +64,7 @@ void init_perception(py::module_ m) {
   {
     using Class = PointCloud;
     constexpr auto& cls_doc = doc.PointCloud;
-    py::class_<Class> cls(m, "PointCloud", cls_doc.doc);
+    class_<Class> cls(m, "PointCloud", cls_doc.doc);
     cls.attr("T") = GetPyParam<Class::T>()[0];
     cls.attr("C") = GetPyParam<Class::C>()[0];
     cls.attr("D") = GetPyParam<Class::D>()[0];
@@ -142,8 +142,7 @@ void init_perception(py::module_ m) {
   {
     using Class = DepthImageToPointCloud;
     constexpr auto& cls_doc = doc.DepthImageToPointCloud;
-    py::class_<Class, LeafSystem<double>>(
-        m, "DepthImageToPointCloud", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "DepthImageToPointCloud", cls_doc.doc)
         .def(py::init<const CameraInfo&, PixelType, float,
                  pc_flags::BaseFieldT>(),
             py::arg("camera_info"),
@@ -163,7 +162,7 @@ void init_perception(py::module_ m) {
   {
     using Class = PointCloudToLcm;
     constexpr auto& cls_doc = doc.PointCloudToLcm;
-    py::class_<Class, LeafSystem<double>>(m, "PointCloudToLcm", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "PointCloudToLcm", cls_doc.doc)
         .def(py::init<std::string>(), py::arg("frame_name") = std::string(),
             cls_doc.ctor.doc);
   }

--- a/bindings/pydrake/planning/planning_py_collision_checker.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker.cc
@@ -29,7 +29,7 @@ void DefinePlanningCollisionChecker(py::module_ m) {
   {
     using Class = CollisionChecker;
     constexpr auto& cls_doc = doc.CollisionChecker;
-    py::class_<Class> cls(m, "CollisionChecker", cls_doc.doc);
+    class_<Class> cls(m, "CollisionChecker", cls_doc.doc);
     cls  // BR
         .def("model", &Class::model, py_rvp::reference_internal,
             cls_doc.model.doc)
@@ -288,7 +288,7 @@ void DefinePlanningCollisionChecker(py::module_ m) {
   {
     using Class = SceneGraphCollisionChecker;
     constexpr auto& cls_doc = doc.SceneGraphCollisionChecker;
-    py::class_<Class, CollisionChecker> cls(
+    class_<Class, CollisionChecker> cls(
         m, "SceneGraphCollisionChecker", cls_doc.doc);
     py::object params_ctor = m.attr("CollisionCheckerParams");
     cls  // BR
@@ -321,7 +321,7 @@ void DefinePlanningCollisionChecker(py::module_ m) {
   {
     using Class = UnimplementedCollisionChecker;
     constexpr auto& cls_doc = doc.UnimplementedCollisionChecker;
-    py::class_<Class, CollisionChecker> cls(
+    class_<Class, CollisionChecker> cls(
         m, "UnimplementedCollisionChecker", cls_doc.doc);
     py::object params_ctor = m.attr("CollisionCheckerParams");
     cls  // BR

--- a/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
@@ -26,7 +26,7 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module_ m) {
   {
     using Class = BodyShapeDescription;
     constexpr auto& cls_doc = doc.BodyShapeDescription;
-    py::class_<Class> cls(m, "BodyShapeDescription", cls_doc.doc);
+    class_<Class> cls(m, "BodyShapeDescription", cls_doc.doc);
     cls  // BR
         .def(py::init<const geometry::Shape&, const math::RigidTransformd&,
                  std::string, std::string>(),
@@ -49,7 +49,7 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module_ m) {
   {
     using Class = CollisionCheckerContext;
     constexpr auto& cls_doc = doc.CollisionCheckerContext;
-    py::class_<Class, std::shared_ptr<Class>> cls(
+    class_<Class, std::shared_ptr<Class>> cls(
         m, "CollisionCheckerContext", cls_doc.doc);
     cls  // BR
         .def(py::init<const RobotDiagram<double>*>(), py::arg("model"),
@@ -69,7 +69,7 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module_ m) {
   {
     using Class = DistanceAndInterpolationProvider;
     constexpr auto& cls_doc = doc.DistanceAndInterpolationProvider;
-    py::class_<Class, std::shared_ptr<Class>> cls(
+    class_<Class, std::shared_ptr<Class>> cls(
         m, "DistanceAndInterpolationProvider", cls_doc.doc);
     cls  // BR
         .def("ComputeConfigurationDistance",
@@ -83,7 +83,7 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module_ m) {
   {
     using Class = LinearDistanceAndInterpolationProvider;
     constexpr auto& cls_doc = doc.LinearDistanceAndInterpolationProvider;
-    py::class_<Class, DistanceAndInterpolationProvider,
+    class_<Class, DistanceAndInterpolationProvider,
         std::shared_ptr<LinearDistanceAndInterpolationProvider>>
         cls(m, "LinearDistanceAndInterpolationProvider", cls_doc.doc);
     cls  // BR
@@ -108,7 +108,7 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module_ m) {
   {
     using Class = CollisionCheckerParams;
     constexpr auto& cls_doc = doc.CollisionCheckerParams;
-    py::class_<Class> cls(m, "CollisionCheckerParams", cls_doc.doc);
+    class_<Class> cls(m, "CollisionCheckerParams", cls_doc.doc);
     cls  // BR
         .def(py::init<>())
         .def(ParamInit<Class>())
@@ -150,7 +150,7 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module_ m) {
   {
     using Class = EdgeMeasure;
     constexpr auto& cls_doc = doc.EdgeMeasure;
-    py::class_<Class> cls(m, "EdgeMeasure", cls_doc.doc);
+    class_<Class> cls(m, "EdgeMeasure", cls_doc.doc);
     cls  // BR
         .def(py::init<double, double>(), py::arg("distance"), py::arg("alpha"),
             cls_doc.ctor.doc)
@@ -209,7 +209,7 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module_ m) {
   {
     using Class = RobotClearance;
     constexpr auto& cls_doc = doc.RobotClearance;
-    py::class_<Class> cls(m, "RobotClearance", cls_doc.doc);
+    class_<Class> cls(m, "RobotClearance", cls_doc.doc);
     cls  // BR
         .def(py::init<int>(), py::arg("num_positions"), cls_doc.ctor.doc)
         .def(py::init<const Class&>(), py::arg("other"))

--- a/bindings/pydrake/planning/planning_py_dof_mask.cc
+++ b/bindings/pydrake/planning/planning_py_dof_mask.cc
@@ -21,7 +21,7 @@ void DefinePlanningDofMask(py::module_ m) {
   {
     using Class = DofMask;
     constexpr auto& cls_doc = doc.DofMask;
-    py::class_<Class>(m, "DofMask", cls_doc.doc)
+    class_<Class>(m, "DofMask", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc_default)
         .def(py::init<int, bool>(), py::arg("size"), py::arg("value"),
             cls_doc.ctor.doc_by_size)

--- a/bindings/pydrake/planning/planning_py_experimental_placeholder.cc
+++ b/bindings/pydrake/planning/planning_py_experimental_placeholder.cc
@@ -16,7 +16,7 @@ void DefinePlanningPlaceholder(py::module_ m) {
   {
     using Class = Placeholder;
     constexpr auto& cls_doc = doc.Placeholder;
-    py::class_<Class>(m, "Placeholder", cls_doc.doc)
+    class_<Class>(m, "Placeholder", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc);
   }
 }

--- a/bindings/pydrake/planning/planning_py_graph_algorithms.cc
+++ b/bindings/pydrake/planning/planning_py_graph_algorithms.cc
@@ -32,7 +32,7 @@ void DefinePlanningGraphAlgorithms(py::module_ m) {
       }
     };
     const auto& cls_doc = doc.MaxCliqueSolverBase;
-    py::class_<MaxCliqueSolverBase, PyMaxCliqueSolverBase>(
+    class_<MaxCliqueSolverBase, PyMaxCliqueSolverBase>(
         m, "MaxCliqueSolverBase", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc)
         .def("SolveMaxClique", &MaxCliqueSolverBase::SolveMaxClique,
@@ -40,7 +40,7 @@ void DefinePlanningGraphAlgorithms(py::module_ m) {
   }
   {
     const auto& cls_doc = doc.MaxCliqueSolverViaMip;
-    py::class_<MaxCliqueSolverViaMip, MaxCliqueSolverBase>(
+    class_<MaxCliqueSolverViaMip, MaxCliqueSolverBase>(
         m, "MaxCliqueSolverViaMip", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(py::init<const std::optional<Eigen::VectorXd>&,
@@ -58,7 +58,7 @@ void DefinePlanningGraphAlgorithms(py::module_ m) {
   }
   {
     const auto& cls_doc = doc.MaxCliqueSolverViaGreedy;
-    py::class_<MaxCliqueSolverViaGreedy, MaxCliqueSolverBase>(
+    class_<MaxCliqueSolverViaGreedy, MaxCliqueSolverBase>(
         m, "MaxCliqueSolverViaGreedy", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc);
   }
@@ -77,7 +77,7 @@ void DefinePlanningGraphAlgorithms(py::module_ m) {
       }
     };
     const auto& cls_doc = doc.MinCliqueCoverSolverBase;
-    py::class_<MinCliqueCoverSolverBase, PyMinCliqueCoverSolverBase>(
+    class_<MinCliqueCoverSolverBase, PyMinCliqueCoverSolverBase>(
         m, "MinCliqueCoverSolverBase", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc)
         .def("SolveMinCliqueCover",
@@ -88,7 +88,7 @@ void DefinePlanningGraphAlgorithms(py::module_ m) {
   {
     using Class = MinCliqueCoverSolverViaGreedy;
     const auto& cls_doc = doc.MinCliqueCoverSolverViaGreedy;
-    py::class_<Class, MinCliqueCoverSolverBase>(
+    class_<Class, MinCliqueCoverSolverBase>(
         m, "MinCliqueCoverSolverViaGreedy", cls_doc.doc)
         .def(
             "__init__",

--- a/bindings/pydrake/planning/planning_py_iris_common.cc
+++ b/bindings/pydrake/planning/planning_py_iris_common.cc
@@ -20,7 +20,7 @@ void DefinePlanningCommonSampledIrisOptions(py::module_ m) {
 
   // CommonSampledIrisOptions
   const auto& cls_doc = doc.CommonSampledIrisOptions;
-  py::class_<CommonSampledIrisOptions> common_sampled_iris_options(
+  class_<CommonSampledIrisOptions> common_sampled_iris_options(
       m, "CommonSampledIrisOptions", cls_doc.doc);
   common_sampled_iris_options  // BR
       .def(py::init<>())
@@ -180,7 +180,7 @@ is the input dimension.
    automatically sets threadsafe to false.
 )";
 
-  py::class_<IrisParameterizationFunction> iris_parameterization_function(
+  class_<IrisParameterizationFunction> iris_parameterization_function(
       m, "IrisParameterizationFunction", cls_doc.doc);
   iris_parameterization_function  // BR
       .def(py::init<>(), cls_doc.ctor.doc_0args)

--- a/bindings/pydrake/planning/planning_py_iris_from_clique_cover.cc
+++ b/bindings/pydrake/planning/planning_py_iris_from_clique_cover.cc
@@ -15,7 +15,7 @@ void DefinePlanningIrisFromCliqueCover(py::module_ m) {
   using namespace drake::planning;
   constexpr auto& doc = pydrake_doc_planning_iris.drake.planning;
   auto cls_doc = doc.IrisFromCliqueCoverOptions;
-  py::class_<IrisFromCliqueCoverOptions>(
+  class_<IrisFromCliqueCoverOptions>(
       m, "IrisFromCliqueCoverOptions", cls_doc.doc)
       .def(py::init<>())
       .def_rw("iris_options", &IrisFromCliqueCoverOptions::iris_options,

--- a/bindings/pydrake/planning/planning_py_iris_np2.cc
+++ b/bindings/pydrake/planning/planning_py_iris_np2.cc
@@ -18,7 +18,7 @@ void DefinePlanningIrisNp2(py::module_ m) {
 
   // RaySamplerOptions
   const auto& ray_sampler_options_doc = doc.RaySamplerOptions;
-  py::class_<RaySamplerOptions> ray_sampler_options(
+  class_<RaySamplerOptions> ray_sampler_options(
       m, "RaySamplerOptions", ray_sampler_options_doc.doc);
   ray_sampler_options  // BR
       .def(py::init<>())
@@ -43,7 +43,7 @@ void DefinePlanningIrisNp2(py::module_ m) {
 
   // IrisNp2Options
   const auto& cls_doc = doc.IrisNp2Options;
-  py::class_<IrisNp2Options> iris_np2_options(m, "IrisNp2Options", cls_doc.doc);
+  class_<IrisNp2Options> iris_np2_options(m, "IrisNp2Options", cls_doc.doc);
   iris_np2_options  // BR
       .def(py::init<>())
       .def_prop_rw("solver_options",

--- a/bindings/pydrake/planning/planning_py_iris_zo.cc
+++ b/bindings/pydrake/planning/planning_py_iris_zo.cc
@@ -16,7 +16,7 @@ void DefinePlanningIrisZo(py::module_ m) {
 
   // IrisZoOptions
   const auto& cls_doc = doc.IrisZoOptions;
-  py::class_<IrisZoOptions> iris_zo_options(m, "IrisZoOptions", cls_doc.doc);
+  class_<IrisZoOptions> iris_zo_options(m, "IrisZoOptions", cls_doc.doc);
   iris_zo_options  // BR
       .def(py::init<>())
       .def_rw("sampled_iris_options", &IrisZoOptions::sampled_iris_options,

--- a/bindings/pydrake/planning/planning_py_joint_limits.cc
+++ b/bindings/pydrake/planning/planning_py_joint_limits.cc
@@ -14,7 +14,7 @@ void DefinePlanningJointLimits(py::module_ m) {
 
   using Class = JointLimits;
   constexpr auto& cls_doc = doc.JointLimits;
-  py::class_<Class>(m, "JointLimits")
+  class_<Class>(m, "JointLimits")
       .def(py::init<>(), cls_doc.ctor.doc)
       .def(py::init<const multibody::MultibodyPlant<double>&, bool, bool,
                bool>(),

--- a/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
+++ b/bindings/pydrake/planning/planning_py_trajectory_optimization.cc
@@ -21,7 +21,7 @@ namespace internal {
 
 template <typename C>
 void RegisterAddConstraintToAllKnotPoints(
-    py::class_<planning::trajectory_optimization::MultipleShooting>* cls) {
+    class_<planning::trajectory_optimization::MultipleShooting>* cls) {
   using drake::planning::trajectory_optimization::MultipleShooting;
   constexpr auto& doc = pydrake_doc_planning_trajectory_optimization.drake
                             .planning.trajectory_optimization;
@@ -52,7 +52,7 @@ void DefinePlanningTrajectoryOptimization(py::module_ m) {
   {
     using Class = MultipleShooting;
     constexpr auto& cls_doc = doc.MultipleShooting;
-    py::class_<Class> cls(m, "MultipleShooting", cls_doc.doc);
+    class_<Class> cls(m, "MultipleShooting", cls_doc.doc);
     cls  // BR
         .def("time", &Class::time, cls_doc.time.doc)
         .def("prog", overload_cast_explicit<MathematicalProgram&>(&Class::prog),
@@ -210,7 +210,7 @@ void DefinePlanningTrajectoryOptimization(py::module_ m) {
   {
     using Class = DirectCollocation;
     constexpr auto& cls_doc = doc.DirectCollocation;
-    py::class_<Class, MultipleShooting>(m, "DirectCollocation", cls_doc.doc)
+    class_<Class, MultipleShooting>(m, "DirectCollocation", cls_doc.doc)
         .def(py::init<const systems::System<double>*,
                  const systems::Context<double>&, int, double, double,
                  std::variant<systems::InputPortSelection,
@@ -227,7 +227,7 @@ void DefinePlanningTrajectoryOptimization(py::module_ m) {
   {
     using Class = DirectCollocationConstraint;
     constexpr auto& cls_doc = doc.DirectCollocationConstraint;
-    py::class_<Class, solvers::Constraint, std::shared_ptr<Class>>(
+    class_<Class, solvers::Constraint, std::shared_ptr<Class>>(
         m, "DirectCollocationConstraint", cls_doc.doc)
         .def(py::init<const systems::System<double>&,
                  const systems::Context<double>&,
@@ -249,13 +249,13 @@ void DefinePlanningTrajectoryOptimization(py::module_ m) {
   {
     using Class = DirectTranscription;
     constexpr auto& cls_doc = doc.DirectTranscription;
-    py::class_<Class, MultipleShooting> cls(
+    class_<Class, MultipleShooting> cls(
         m, "DirectTranscription", doc.DirectTranscription.doc);
 
     // Inject the nested TimeStep so it's already bound when we bind the
     // constructor that depends on it. In C++ it's *not* nested. Nesting makes
     // things a bit more pythonic -- better would be kwonly named arg.
-    py::class_<TimeStep>(cls, "TimeStep", doc.TimeStep.doc)
+    class_<TimeStep>(cls, "TimeStep", doc.TimeStep.doc)
         .def(py::init<double>(), py::arg("value"))
         .def_rw("value", &TimeStep::value, doc.TimeStep.value.doc);
 
@@ -282,7 +282,7 @@ void DefinePlanningTrajectoryOptimization(py::module_ m) {
   {
     using Class = KinematicTrajectoryOptimization;
     constexpr auto& cls_doc = doc.KinematicTrajectoryOptimization;
-    py::class_<Class>(m, "KinematicTrajectoryOptimization", cls_doc.doc)
+    class_<Class>(m, "KinematicTrajectoryOptimization", cls_doc.doc)
         .def(py::init<int, int, int, double>(), py::arg("num_positions"),
             py::arg("num_control_points"), py::arg("spline_order") = 4,
             py::arg("duration") = 1.0, cls_doc.ctor.doc_4args)
@@ -388,7 +388,7 @@ void DefinePlanningTrajectoryOptimization(py::module_ m) {
   {
     using Class = GcsTrajectoryOptimization;
     constexpr auto& cls_doc = doc.GcsTrajectoryOptimization;
-    py::class_<Class> gcs_traj_opt(m, "GcsTrajectoryOptimization", cls_doc.doc);
+    class_<Class> gcs_traj_opt(m, "GcsTrajectoryOptimization", cls_doc.doc);
 
     const std::unordered_set<
         geometry::optimization::GraphOfConvexSets::Transcription>
@@ -401,7 +401,7 @@ void DefinePlanningTrajectoryOptimization(py::module_ m) {
 
     // Subgraph
     const auto& subgraph_doc = doc.GcsTrajectoryOptimization.Subgraph;
-    py::class_<Class::Subgraph>(gcs_traj_opt, "Subgraph", subgraph_doc.doc)
+    class_<Class::Subgraph>(gcs_traj_opt, "Subgraph", subgraph_doc.doc)
         .def("name", &Class::Subgraph::name, subgraph_doc.name.doc)
         .def("order", &Class::Subgraph::order, subgraph_doc.order.doc)
         .def("size", &Class::Subgraph::size, subgraph_doc.size.doc)
@@ -552,7 +552,7 @@ void DefinePlanningTrajectoryOptimization(py::module_ m) {
     // EdgesBetweenSubgraphs
     const auto& subgraph_edges_doc =
         doc.GcsTrajectoryOptimization.EdgesBetweenSubgraphs;
-    py::class_<Class::EdgesBetweenSubgraphs>(
+    class_<Class::EdgesBetweenSubgraphs>(
         gcs_traj_opt, "EdgesBetweenSubgraphs", subgraph_edges_doc.doc)
         .def("AddVelocityBounds",
             &Class::EdgesBetweenSubgraphs::AddVelocityBounds, py::arg("lb"),

--- a/bindings/pydrake/planning/planning_py_zmp_planner.cc
+++ b/bindings/pydrake/planning/planning_py_zmp_planner.cc
@@ -15,7 +15,7 @@ void DefinePlanningZmpPlanner(py::module_ m) {
   {
     using Class = ZmpPlanner;
     constexpr auto& cls_doc = doc.ZmpPlanner;
-    auto cls = py::class_<Class>(m, "ZmpPlanner", cls_doc.doc)
+    auto cls = class_<Class>(m, "ZmpPlanner", cls_doc.doc)
                    .def(py::init<>(), cls_doc.ctor.doc);
     cls  // BR
         .def("Plan", &Class::Plan, py::arg("zmp_d"), py::arg("x0"),

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -51,7 +51,7 @@ elaborate, the binding of `Parser` is found in
 
 ```{.cc}
 using Class = Parser;
-py::class_<Class>(m, "Parser", ...)
+class_<Class>(m, "Parser", ...)
 ```
 
 and binding of `MultibodyPlant` template instantiations are in
@@ -267,7 +267,7 @@ An example of incorporating docstrings:
       using namespace drake::math;
       constexpr auto& doc = pydrake_doc_math.drake.math;
       using T = double;
-      py::class_<RigidTransform<T>>(m, "RigidTransform", doc.RigidTransform.doc)
+      class_<RigidTransform<T>>(m, "RigidTransform", doc.RigidTransform.doc)
           .def(py::init(), doc.RigidTransform.ctor.doc_0args)
           ...
           .def(py::init<const RotationMatrix<T>&>(), py::arg("R"),
@@ -303,7 +303,7 @@ and the docstring structures. Borrowing from above:
     {
       using Class = RigidTransform<T>;
       constexpr auto& cls_doc = doc.RigidTransform;
-      py::class_<Class>(m, "RigidTransform", cls_doc.doc)
+      class_<Class>(m, "RigidTransform", cls_doc.doc)
           .def(py::init(), cls_doc.ctor.doc_0args)
           ...
     }

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -43,6 +43,9 @@ namespace py = pybind11;
 /// the @ref PydrakeReturnValuePolicy "Return Value Policy" section.
 using py_rvp = py::rv_policy;
 
+// This alias helps ease Drake's transition to nanobind.
+using py::class_;
+
 // Implementation for `overload_cast_explicit`. We must use this structure so
 // that we can constrain what is inferred. Otherwise, the ambiguity confuses
 // the compiler.
@@ -110,7 +113,7 @@ void DefClone(PyClass* ppy_class) {
 }
 
 /// Binds `__getstate__` and `__setstate__` for pickling on the given
-/// `ppy_class` (which must point to a `py::class_`).
+/// `ppy_class` (which must point to a `class_`).
 ///
 /// The get_state functor should take `(const Class& self)` and return a
 /// newly-pickled class `-> Pickled` by value.
@@ -149,7 +152,7 @@ void DefPickle(PyClass* ppy_class, GetState&& get_state, SetState&& set_state) {
 /// useful when the C++ class only has a default constructor. Example:
 /// @code
 /// using Class = ExampleClass;
-/// py::class_<Class>(m, "ExampleClass")  // BR
+/// class_<Class>(m, "ExampleClass")  // BR
 ///     .def(ParamInit<Class>());
 /// @endcode
 ///

--- a/bindings/pydrake/solvers/solvers_py_augmented_lagrangian.cc
+++ b/bindings/pydrake/solvers/solvers_py_augmented_lagrangian.cc
@@ -16,7 +16,7 @@ void DefineSolversAugmentedLagrangian(py::module_ m) {
   {
     using Class = AugmentedLagrangianNonsmooth;
     constexpr auto& cls_doc = doc.AugmentedLagrangianNonsmooth;
-    py::class_<AugmentedLagrangianNonsmooth>(
+    class_<AugmentedLagrangianNonsmooth>(
         m, "AugmentedLagrangianNonsmooth", cls_doc.doc)
         .def(py::init<const MathematicalProgram*, bool>(), py::arg("prog"),
             py::arg("include_x_bounds"), cls_doc.ctor.doc)
@@ -59,7 +59,7 @@ void DefineSolversAugmentedLagrangian(py::module_ m) {
   {
     using Class = AugmentedLagrangianSmooth;
     constexpr auto& cls_doc = doc.AugmentedLagrangianSmooth;
-    py::class_<Class>(m, "AugmentedLagrangianSmooth", cls_doc.doc)
+    class_<Class>(m, "AugmentedLagrangianSmooth", cls_doc.doc)
         .def(py::init<const MathematicalProgram*, bool>(), py::arg("prog"),
             py::arg("include_x_bounds"), cls_doc.ctor.doc)
         .def(

--- a/bindings/pydrake/solvers/solvers_py_branch_and_bound.cc
+++ b/bindings/pydrake/solvers/solvers_py_branch_and_bound.cc
@@ -17,12 +17,12 @@ void DefineSolversBranchAndBound(py::module_ m) {
   {
     using Class = MixedIntegerBranchAndBound;
     constexpr auto& cls_doc = doc.MixedIntegerBranchAndBound;
-    py::class_<Class> bnb_cls(m, "MixedIntegerBranchAndBound", cls_doc.doc);
+    class_<Class> bnb_cls(m, "MixedIntegerBranchAndBound", cls_doc.doc);
 
     {
       using Nested = MixedIntegerBranchAndBound::Options;
       constexpr auto& options_doc = cls_doc.Options;
-      py::class_<Nested> options_cls(bnb_cls, "Options", options_doc.doc);
+      class_<Nested> options_cls(bnb_cls, "Options", options_doc.doc);
       options_cls.def(ParamInit<Nested>());
       DefAttributesUsingSerialize(&options_cls, options_doc);
       DefReprUsingSerialize(&options_cls);

--- a/bindings/pydrake/solvers/solvers_py_clarabel.cc
+++ b/bindings/pydrake/solvers/solvers_py_clarabel.cc
@@ -13,12 +13,12 @@ void DefineSolversClarabel(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<ClarabelSolver, SolverInterface>(
+  class_<ClarabelSolver, SolverInterface>(
       m, "ClarabelSolver", doc.ClarabelSolver.doc)
       .def(py::init<>(), doc.ClarabelSolver.ctor.doc)
       .def_static("id", &ClarabelSolver::id, doc.ClarabelSolver.id.doc);
 
-  py::class_<ClarabelSolverDetails>(
+  class_<ClarabelSolverDetails>(
       m, "ClarabelSolverDetails", doc.ClarabelSolverDetails.doc)
       .def_ro("solve_time", &ClarabelSolverDetails::solve_time,
           doc.ClarabelSolverDetails.solve_time.doc)

--- a/bindings/pydrake/solvers/solvers_py_clp.cc
+++ b/bindings/pydrake/solvers/solvers_py_clp.cc
@@ -13,11 +13,11 @@ void DefineSolversClp(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<ClpSolver, SolverInterface>(m, "ClpSolver", doc.ClpSolver.doc)
+  class_<ClpSolver, SolverInterface>(m, "ClpSolver", doc.ClpSolver.doc)
       .def(py::init<>(), doc.ClpSolver.ctor.doc)
       .def_static("id", &ClpSolver::id, doc.ClpSolver.id.doc);
 
-  py::class_<ClpSolverDetails>(m, "ClpSolverDetails", doc.ClpSolverDetails.doc)
+  class_<ClpSolverDetails>(m, "ClpSolverDetails", doc.ClpSolverDetails.doc)
       .def_ro(
           "status", &ClpSolverDetails::status, doc.ClpSolverDetails.status.doc);
   AddValueInstantiation<ClpSolverDetails>(m);

--- a/bindings/pydrake/solvers/solvers_py_csdp.cc
+++ b/bindings/pydrake/solvers/solvers_py_csdp.cc
@@ -14,14 +14,13 @@ void DefineSolversCsdp(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<CsdpSolver, SolverInterface> csdp_cls(
+  class_<CsdpSolver, SolverInterface> csdp_cls(
       m, "CsdpSolver", doc.CsdpSolver.doc);
   csdp_cls  // BR
       .def(py::init<>(), doc.CsdpSolver.ctor.doc)
       .def_static("id", &CsdpSolver::id, doc.CsdpSolver.id.doc);
 
-  py::class_<CsdpSolverDetails>(
-      m, "CsdpSolverDetails", doc.CsdpSolverDetails.doc)
+  class_<CsdpSolverDetails>(m, "CsdpSolverDetails", doc.CsdpSolverDetails.doc)
       .def_ro("return_code", &CsdpSolverDetails::return_code,
           doc.CsdpSolverDetails.return_code.doc)
       .def_ro("primal_objective", &CsdpSolverDetails::primal_objective,

--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -63,7 +63,7 @@ auto RegisterBinding(py::handle* scope) {
   constexpr auto& cls_doc = pydrake_doc_solvers.drake.solvers.Binding;
   typedef Binding<C> B;
   const string pyname = TemporaryClassName<B>();
-  py::class_<B> binding_cls(*scope, pyname.c_str());
+  class_<B> binding_cls(*scope, pyname.c_str());
   AddTemplateClass(*scope, "Binding", binding_cls, GetPyParam<C>());
   binding_cls  // BR
       .def(py::init([](C* c, const VectorXDecisionVariable& v) {
@@ -133,8 +133,8 @@ class StubEvaluatorBase : public EvaluatorBase {
 
 void DefTesting(py::module_ m) {
   // Test helpers for binding casting.
-  py::class_<StubEvaluatorBase, EvaluatorBase,
-      std::shared_ptr<StubEvaluatorBase>>(m, "StubEvaluatorBase");
+  class_<StubEvaluatorBase, EvaluatorBase, std::shared_ptr<StubEvaluatorBase>>(
+      m, "StubEvaluatorBase");
   RegisterBinding<StubEvaluatorBase>(&m)  // BR
       .def_static(
           "Make", [](const Eigen::Ref<const VectorXDecisionVariable>& v) {
@@ -158,7 +158,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   {
     using Class = EvaluatorBase;
     constexpr auto& cls_doc = doc.EvaluatorBase;
-    py::class_<Class, std::shared_ptr<EvaluatorBase>> cls(m, "EvaluatorBase");
+    class_<Class, std::shared_ptr<EvaluatorBase>> cls(m, "EvaluatorBase");
     cls  // BR
         .def("num_outputs", &Class::num_outputs, cls_doc.num_outputs.doc)
         .def("num_vars", &Class::num_vars, cls_doc.num_vars.doc)
@@ -195,7 +195,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   auto evaluator_binding = RegisterBinding<EvaluatorBase>(&m);
   DefBindingCastConstructor<EvaluatorBase>(&evaluator_binding);
 
-  py::class_<Constraint, EvaluatorBase, std::shared_ptr<Constraint>>(
+  class_<Constraint, EvaluatorBase, std::shared_ptr<Constraint>>(
       m, "Constraint", doc.Constraint.doc)
       .def("num_constraints", &Constraint::num_constraints,
           doc.Constraint.num_constraints.doc)
@@ -236,7 +236,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           },
           py::arg("x"), doc.Constraint.CheckSatisfied.doc);
 
-  py::class_<LinearConstraint, Constraint, std::shared_ptr<LinearConstraint>>
+  class_<LinearConstraint, Constraint, std::shared_ptr<LinearConstraint>>
       linear_constraint_cls(m, "LinearConstraint", doc.LinearConstraint.doc);
   linear_constraint_cls
       .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -293,7 +293,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           },
           py::arg("new_lb"), py::arg("new_ub"), doc.Constraint.set_bounds.doc);
 
-  py::class_<LorentzConeConstraint, Constraint,
+  class_<LorentzConeConstraint, Constraint,
       std::shared_ptr<LorentzConeConstraint>>
       lorentz_cone_cls(
           m, "LorentzConeConstraint", doc.LorentzConeConstraint.doc);
@@ -322,7 +322,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           py::arg("new_A"), py::arg("new_b"),
           doc.LorentzConeConstraint.UpdateCoefficients.doc);
 
-  py::class_<RotatedLorentzConeConstraint, Constraint,
+  class_<RotatedLorentzConeConstraint, Constraint,
       std::shared_ptr<RotatedLorentzConeConstraint>>(
       m, "RotatedLorentzConeConstraint", doc.RotatedLorentzConeConstraint.doc)
       .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -337,7 +337,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           py::arg("new_b"),
           doc.RotatedLorentzConeConstraint.UpdateCoefficients.doc);
 
-  py::class_<LinearEqualityConstraint, LinearConstraint,
+  class_<LinearEqualityConstraint, LinearConstraint,
       std::shared_ptr<LinearEqualityConstraint>>(
       m, "LinearEqualityConstraint", doc.LinearEqualityConstraint.doc)
       .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -369,15 +369,14 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           py::arg("Aeq"), py::arg("beq"),
           doc.LinearEqualityConstraint.UpdateCoefficients.doc);
 
-  py::class_<BoundingBoxConstraint, LinearConstraint,
+  class_<BoundingBoxConstraint, LinearConstraint,
       std::shared_ptr<BoundingBoxConstraint>>(
       m, "BoundingBoxConstraint", doc.BoundingBoxConstraint.doc)
       .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&,
                const Eigen::Ref<const Eigen::VectorXd>&>(),
           py::arg("lb"), py::arg("ub"), doc.BoundingBoxConstraint.ctor.doc);
 
-  py::class_<QuadraticConstraint, Constraint,
-      std::shared_ptr<QuadraticConstraint>>
+  class_<QuadraticConstraint, Constraint, std::shared_ptr<QuadraticConstraint>>
       quadratic_constraint_cls(
           m, "QuadraticConstraint", doc.QuadraticConstraint.doc);
 
@@ -421,7 +420,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       .def("hessian_type", &QuadraticConstraint::hessian_type,
           doc.QuadraticConstraint.hessian_type.doc);
 
-  py::class_<PositiveSemidefiniteConstraint, Constraint,
+  class_<PositiveSemidefiniteConstraint, Constraint,
       std::shared_ptr<PositiveSemidefiniteConstraint>>(m,
       "PositiveSemidefiniteConstraint", doc.PositiveSemidefiniteConstraint.doc)
       .def(py::init<int>(), py::arg("rows"),
@@ -429,7 +428,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       .def("matrix_rows", &PositiveSemidefiniteConstraint::matrix_rows,
           doc.PositiveSemidefiniteConstraint.matrix_rows.doc);
 
-  py::class_<LinearMatrixInequalityConstraint, Constraint,
+  class_<LinearMatrixInequalityConstraint, Constraint,
       std::shared_ptr<LinearMatrixInequalityConstraint>>(m,
       "LinearMatrixInequalityConstraint",
       doc.LinearMatrixInequalityConstraint.doc)
@@ -441,7 +440,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       .def("matrix_rows", &LinearMatrixInequalityConstraint::matrix_rows,
           doc.LinearMatrixInequalityConstraint.matrix_rows.doc);
 
-  py::class_<LinearComplementarityConstraint, Constraint,
+  class_<LinearComplementarityConstraint, Constraint,
       std::shared_ptr<LinearComplementarityConstraint>>(m,
       "LinearComplementarityConstraint",
       doc.LinearComplementarityConstraint.doc)
@@ -450,7 +449,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       .def("q", &LinearComplementarityConstraint::q,
           doc.LinearComplementarityConstraint.q.doc);
 
-  py::class_<ExponentialConeConstraint, Constraint,
+  class_<ExponentialConeConstraint, Constraint,
       std::shared_ptr<ExponentialConeConstraint>>(
       m, "ExponentialConeConstraint", doc.ExponentialConeConstraint.doc)
       .def(py::init<const Eigen::SparseMatrix<double>&,
@@ -465,7 +464,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       .def("b", &ExponentialConeConstraint::b,
           doc.ExponentialConeConstraint.b.doc);
 
-  py::class_<ExpressionConstraint, Constraint,
+  class_<ExpressionConstraint, Constraint,
       std::shared_ptr<ExpressionConstraint>>(
       m, "ExpressionConstraint", doc.ExpressionConstraint.doc)
       .def(py::init<const Eigen::Ref<const VectorX<symbolic::Expression>>&,
@@ -483,7 +482,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   {
     using Class = MinimumValueLowerBoundConstraint;
     constexpr auto& cls_doc = doc.MinimumValueLowerBoundConstraint;
-    py::class_<Class, Constraint, std::shared_ptr<Class>>(
+    class_<Class, Constraint, std::shared_ptr<Class>>(
         m, "MinimumValueLowerBoundConstraint", cls_doc.doc)
         .def(
             "__init__",
@@ -539,7 +538,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   {
     using Class = MinimumValueUpperBoundConstraint;
     constexpr auto& cls_doc = doc.MinimumValueUpperBoundConstraint;
-    py::class_<Class, Constraint, std::shared_ptr<Class>>(
+    class_<Class, Constraint, std::shared_ptr<Class>>(
         m, "MinimumValueUpperBoundConstraint", cls_doc.doc)
         .def(
             "__init__",
@@ -613,10 +612,10 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   RegisterBinding<ExpressionConstraint>(&m);
 
   // Mirror procedure for costs
-  py::class_<Cost, EvaluatorBase, std::shared_ptr<Cost>> cost(
+  class_<Cost, EvaluatorBase, std::shared_ptr<Cost>> cost(
       m, "Cost", doc.Cost.doc);
 
-  py::class_<LinearCost, Cost, std::shared_ptr<LinearCost>>(
+  class_<LinearCost, Cost, std::shared_ptr<LinearCost>>(
       m, "LinearCost", doc.LinearCost.doc)
       .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&, double>(),
           py::arg("a"), py::arg("b"), doc.LinearCost.ctor.doc)
@@ -635,7 +634,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       .def("update_constant_term", &LinearCost::update_constant_term,
           py::arg("new_b"), doc.LinearCost.update_constant_term.doc);
 
-  py::class_<QuadraticCost, Cost, std::shared_ptr<QuadraticCost>>(
+  class_<QuadraticCost, Cost, std::shared_ptr<QuadraticCost>>(
       m, "QuadraticCost", doc.QuadraticCost.doc)
       .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
                const Eigen::Ref<const Eigen::VectorXd>&, double,
@@ -667,7 +666,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       .def("update_constant_term", &QuadraticCost::update_constant_term,
           py::arg("new_c"), doc.QuadraticCost.update_constant_term.doc);
 
-  py::class_<L1NormCost, Cost, std::shared_ptr<L1NormCost>>(
+  class_<L1NormCost, Cost, std::shared_ptr<L1NormCost>>(
       m, "L1NormCost", doc.L1NormCost.doc)
       .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
                const Eigen::Ref<const Eigen::VectorXd>&>(),
@@ -688,7 +687,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           py::arg("val"), doc.L1NormCost.update_b_entry.doc);
 
   {
-    py::class_<L2NormCost, Cost, std::shared_ptr<L2NormCost>> cls(
+    class_<L2NormCost, Cost, std::shared_ptr<L2NormCost>> cls(
         m, "L2NormCost", doc.L2NormCost.doc);
     cls  // BR
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -719,7 +718,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
             doc.L2NormCost.UpdateCoefficients.doc_sparse_A);
   }
 
-  py::class_<LInfNormCost, Cost, std::shared_ptr<LInfNormCost>>(
+  class_<LInfNormCost, Cost, std::shared_ptr<LInfNormCost>>(
       m, "LInfNormCost", doc.LInfNormCost.doc)
       .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
                const Eigen::Ref<const Eigen::VectorXd>&>(),
@@ -739,7 +738,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       .def("update_b_entry", &LInfNormCost::update_b_entry, py::arg("i"),
           py::arg("val"), doc.LInfNormCost.update_b_entry.doc);
 
-  py::class_<PerspectiveQuadraticCost, Cost,
+  class_<PerspectiveQuadraticCost, Cost,
       std::shared_ptr<PerspectiveQuadraticCost>>(
       m, "PerspectiveQuadraticCost", doc.PerspectiveQuadraticCost.doc)
       .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
@@ -764,7 +763,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
           py::arg("i"), py::arg("val"),
           doc.PerspectiveQuadraticCost.update_b_entry.doc);
 
-  py::class_<ExpressionCost, Cost, std::shared_ptr<ExpressionCost>>(
+  class_<ExpressionCost, Cost, std::shared_ptr<ExpressionCost>>(
       m, "ExpressionCost", doc.ExpressionCost.doc)
       .def(py::init<const symbolic::Expression&>(), py::arg("e"),
           doc.ExpressionCost.ctor.doc)
@@ -787,7 +786,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
   // implementation as is, or convert it to symbolic::Polynomial first.
   RegisterBinding<ExpressionCost>(&m);
 
-  py::class_<VisualizationCallback, EvaluatorBase,
+  class_<VisualizationCallback, EvaluatorBase,
       std::shared_ptr<VisualizationCallback>>(
       m, "VisualizationCallback", doc.VisualizationCallback.doc);
 

--- a/bindings/pydrake/solvers/solvers_py_gurobi.cc
+++ b/bindings/pydrake/solvers/solvers_py_gurobi.cc
@@ -15,14 +15,14 @@ void DefineSolversGurobi(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<GurobiSolver, SolverInterface> cls(
+  class_<GurobiSolver, SolverInterface> cls(
       m, "GurobiSolver", doc.GurobiSolver.doc);
   cls  // BR
       .def(py::init<>(), doc.GurobiSolver.ctor.doc)
       .def_static("id", &GurobiSolver::id, doc.GurobiSolver.id.doc);
   pysolvers::BindAcquireLicense(&cls, doc.GurobiSolver);
 
-  py::class_<GurobiSolverDetails>(
+  class_<GurobiSolverDetails>(
       m, "GurobiSolverDetails", doc.GurobiSolverDetails.doc)
       .def_ro("optimizer_time", &GurobiSolverDetails::optimizer_time,
           doc.GurobiSolverDetails.optimizer_time.doc)
@@ -34,7 +34,7 @@ void DefineSolversGurobi(py::module_ m) {
           doc.GurobiSolverDetails.objective_bound.doc);
   AddValueInstantiation<GurobiSolverDetails>(m);
 
-  py::class_<GurobiSolver::SolveStatusInfo>(
+  class_<GurobiSolver::SolveStatusInfo>(
       cls, "SolveStatusInfo", doc.GurobiSolver.SolveStatusInfo.doc)
       .def_ro("reported_runtime",
           &GurobiSolver::SolveStatusInfo::reported_runtime,

--- a/bindings/pydrake/solvers/solvers_py_ids.cc
+++ b/bindings/pydrake/solvers/solvers_py_ids.cc
@@ -14,7 +14,7 @@ using solvers::SolverType;
 
 void DefineSolversIds(py::module_ m) {
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
-  py::class_<SolverId>(m, "SolverId", doc.SolverId.doc)
+  class_<SolverId>(m, "SolverId", doc.SolverId.doc)
       .def(py::init<std::string>(), py::arg("name"), doc.SolverId.ctor.doc)
       .def("name", &SolverId::name, doc.SolverId.name.doc)
       .def("__hash__",

--- a/bindings/pydrake/solvers/solvers_py_ipopt.cc
+++ b/bindings/pydrake/solvers/solvers_py_ipopt.cc
@@ -13,12 +13,11 @@ void DefineSolversIpopt(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<IpoptSolver, SolverInterface>(
-      m, "IpoptSolver", doc.IpoptSolver.doc)
+  class_<IpoptSolver, SolverInterface>(m, "IpoptSolver", doc.IpoptSolver.doc)
       .def(py::init<>(), doc.IpoptSolver.ctor.doc)
       .def_static("id", &IpoptSolver::id, doc.IpoptSolver.id.doc);
 
-  py::class_<IpoptSolverDetails>(
+  class_<IpoptSolverDetails>(
       m, "IpoptSolverDetails", doc.IpoptSolverDetails.doc)
       .def_ro("status", &IpoptSolverDetails::status,
           doc.IpoptSolverDetails.status.doc)

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -277,7 +277,7 @@ class PySolverInterface : public solvers::SolverInterface {
 
 void BindSolverInterface(py::module_ m) {
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
-  py::class_<SolverInterface, PySolverInterface>(
+  class_<SolverInterface, PySolverInterface>(
       m, "SolverInterface", doc.SolverInterface.doc)
       .def(py::init([]() { return std::make_unique<PySolverInterface>(); }),
           doc.SolverInterface.ctor.doc)
@@ -340,7 +340,7 @@ void BindSolverInterface(py::module_ m) {
 
 void BindMathematicalProgramResult(py::module_ m) {
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
-  py::class_<MathematicalProgramResult>(
+  class_<MathematicalProgramResult>(
       m, "MathematicalProgramResult", doc.MathematicalProgramResult.doc)
       .def(py::init<>(), doc.MathematicalProgramResult.ctor.doc)
       .def("is_success", &MathematicalProgramResult::is_success,
@@ -472,7 +472,7 @@ void BindMathematicalProgramResult(py::module_ m) {
 
 void BindMathematicalProgram(py::module_ m) {
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
-  py::class_<MathematicalProgram> prog_cls(m, "MathematicalProgram",
+  class_<MathematicalProgram> prog_cls(m, "MathematicalProgram",
       py::dynamic_attr(), doc.MathematicalProgram.doc);
   prog_cls.def(py::init<>(), doc.MathematicalProgram.ctor.doc);
   DefClone(&prog_cls);
@@ -1576,7 +1576,7 @@ void BindSolutionResult(py::module_ m) {
 }
 
 void BindPyFunctionCost(py::module_ m) {
-  py::class_<PyFunctionCost, Cost, std::shared_ptr<PyFunctionCost>>(
+  class_<PyFunctionCost, Cost, std::shared_ptr<PyFunctionCost>>(
       m, "PyFunctionCost", "Cost with its evaluator as a Python function")
       .def(py::init<int, const py::function&, const std::string&>(),
           py::arg("num_vars"), py::arg("func"), py::arg("description") = "",
@@ -1585,7 +1585,7 @@ void BindPyFunctionCost(py::module_ m) {
 }
 
 void BindPyFunctionConstraint(py::module_ m) {
-  py::class_<PyFunctionConstraint, Constraint,
+  class_<PyFunctionConstraint, Constraint,
       std::shared_ptr<PyFunctionConstraint>>(m, "PyFunctionConstraint",
       "Constraint with its evaluator as a Python function")
       .def(py::init<int, const py::function&, const Eigen::VectorXd&,

--- a/bindings/pydrake/solvers/solvers_py_mixed_integer_rotation_constraint.cc
+++ b/bindings/pydrake/solvers/solvers_py_mixed_integer_rotation_constraint.cc
@@ -17,7 +17,7 @@ void DefineSolversMixedIntegerRotationConstraint(py::module_ m) {
   {
     using Class = MixedIntegerRotationConstraintGenerator;
     constexpr auto& cls_doc = doc.MixedIntegerRotationConstraintGenerator;
-    py::class_<Class> cls(
+    class_<Class> cls(
         m, "MixedIntegerRotationConstraintGenerator", cls_doc.doc);
     cls  // BR
         .def("phi", &Class::phi, cls_doc.phi.doc)
@@ -39,7 +39,7 @@ void DefineSolversMixedIntegerRotationConstraint(py::module_ m) {
 
     using Struct = Class::ReturnType;
     constexpr auto& struct_doc = cls_doc.ReturnType;
-    py::class_<Struct>(cls, "ReturnType", struct_doc.doc)
+    class_<Struct>(cls, "ReturnType", struct_doc.doc)
         // Massage these return types to return copies, not references (#8116).
         .def_ro("B_", &Struct::B_, py_rvp::copy, struct_doc.B_.doc)
         .def_ro(

--- a/bindings/pydrake/solvers/solvers_py_mobylcp.cc
+++ b/bindings/pydrake/solvers/solvers_py_mobylcp.cc
@@ -11,7 +11,7 @@ void DefineSolversMobyLCP(py::module_ m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
-  py::class_<MobyLcpSolver, SolverInterface>(
+  class_<MobyLcpSolver, SolverInterface>(
       m, "MobyLcpSolver", doc.MobyLcpSolver.doc)
       .def(py::init<>(), doc.MobyLcpSolver.ctor.doc)
       .def_static("id", &MobyLcpSolver::id, doc.MobyLcpSolver.id.doc);

--- a/bindings/pydrake/solvers/solvers_py_mosek.cc
+++ b/bindings/pydrake/solvers/solvers_py_mosek.cc
@@ -14,14 +14,14 @@ void DefineSolversMosek(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<MosekSolver, SolverInterface> cls(
+  class_<MosekSolver, SolverInterface> cls(
       m, "MosekSolver", doc.MosekSolver.doc);
   cls  // BR
       .def(py::init<>(), doc.MosekSolver.ctor.doc)
       .def_static("id", &MosekSolver::id, doc.MosekSolver.id.doc);
   pysolvers::BindAcquireLicense(&cls, doc.MosekSolver);
 
-  py::class_<MosekSolverDetails>(
+  class_<MosekSolverDetails>(
       m, "MosekSolverDetails", doc.MosekSolverDetails.doc)
       .def_ro("optimizer_time", &MosekSolverDetails::optimizer_time,
           doc.MosekSolverDetails.optimizer_time.doc)

--- a/bindings/pydrake/solvers/solvers_py_nlopt.cc
+++ b/bindings/pydrake/solvers/solvers_py_nlopt.cc
@@ -13,8 +13,7 @@ void DefineSolversNlopt(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<NloptSolver, SolverInterface>(
-      m, "NloptSolver", doc.NloptSolver.doc)
+  class_<NloptSolver, SolverInterface>(m, "NloptSolver", doc.NloptSolver.doc)
       .def(py::init<>(), doc.NloptSolver.ctor.doc)
       .def_static("id", &NloptSolver::id, doc.NloptSolver.id.doc)
       .def_static("ConstraintToleranceName",
@@ -33,7 +32,7 @@ void DefineSolversNlopt(py::module_ m) {
       .def_static("MaxTimeName", &NloptSolver::MaxTimeName,
           doc.NloptSolver.MaxTimeName.doc);
 
-  py::class_<NloptSolverDetails>(
+  class_<NloptSolverDetails>(
       m, "NloptSolverDetails", doc.NloptSolverDetails.doc)
       .def_ro("status", &NloptSolverDetails::status,
           doc.NloptSolverDetails.status.doc);

--- a/bindings/pydrake/solvers/solvers_py_options.cc
+++ b/bindings/pydrake/solvers/solvers_py_options.cc
@@ -36,7 +36,7 @@ void DefineSolversOptions(py::module_ m) {
     using Class = SolverOptions;
     using NestedOptionsDict = decltype(Class{}.options);
     using OptionValue = SolverOptions::OptionValue;
-    py::class_<Class> cls(m, "SolverOptions", doc.SolverOptions.doc);
+    class_<Class> cls(m, "SolverOptions", doc.SolverOptions.doc);
     cls  // BR
         .def(
             "__init__",

--- a/bindings/pydrake/solvers/solvers_py_osqp.cc
+++ b/bindings/pydrake/solvers/solvers_py_osqp.cc
@@ -13,12 +13,11 @@ void DefineSolversOsqp(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<OsqpSolver, SolverInterface>(m, "OsqpSolver", doc.OsqpSolver.doc)
+  class_<OsqpSolver, SolverInterface>(m, "OsqpSolver", doc.OsqpSolver.doc)
       .def(py::init<>(), doc.OsqpSolver.ctor.doc)
       .def_static("id", &OsqpSolver::id, doc.OsqpSolver.id.doc);
 
-  py::class_<OsqpSolverDetails>(
-      m, "OsqpSolverDetails", doc.OsqpSolverDetails.doc)
+  class_<OsqpSolverDetails>(m, "OsqpSolverDetails", doc.OsqpSolverDetails.doc)
       .def_ro("iter", &OsqpSolverDetails::iter, doc.OsqpSolverDetails.iter.doc)
       .def_ro("status_val", &OsqpSolverDetails::status_val,
           doc.OsqpSolverDetails.status_val.doc)

--- a/bindings/pydrake/solvers/solvers_py_projected_gradient_descent.cc
+++ b/bindings/pydrake/solvers/solvers_py_projected_gradient_descent.cc
@@ -16,7 +16,7 @@ void DefineSolversProjectedGradientDescent(py::module_ m) {
   {
     using Class = ProjectedGradientDescentSolver;
     constexpr auto& cls_doc = doc.ProjectedGradientDescentSolver;
-    py::class_<Class, SolverInterface> pgd_cls(
+    class_<Class, SolverInterface> pgd_cls(
         m, "ProjectedGradientDescentSolver", cls_doc.doc);
 
     pgd_cls  // BR

--- a/bindings/pydrake/solvers/solvers_py_scs.cc
+++ b/bindings/pydrake/solvers/solvers_py_scs.cc
@@ -13,11 +13,11 @@ void DefineSolversScs(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<ScsSolver, SolverInterface>(m, "ScsSolver", doc.ScsSolver.doc)
+  class_<ScsSolver, SolverInterface>(m, "ScsSolver", doc.ScsSolver.doc)
       .def(py::init<>(), doc.ScsSolver.ctor.doc)
       .def_static("id", &ScsSolver::id, doc.ScsSolver.id.doc);
 
-  py::class_<ScsSolverDetails>(m, "ScsSolverDetails", doc.ScsSolverDetails.doc)
+  class_<ScsSolverDetails>(m, "ScsSolverDetails", doc.ScsSolverDetails.doc)
       .def_ro("scs_status", &ScsSolverDetails::scs_status,
           doc.ScsSolverDetails.scs_status.doc)
       .def_ro("iter", &ScsSolverDetails::iter, doc.ScsSolverDetails.iter.doc)

--- a/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
+++ b/bindings/pydrake/solvers/solvers_py_semidefinite_relaxation.cc
@@ -16,7 +16,7 @@ void DefineSolversSemidefiniteRelaxation(py::module_ m) {
 
   {
     const auto& cls_doc = doc.SemidefiniteRelaxationOptions;
-    py::class_<SemidefiniteRelaxationOptions> options(
+    class_<SemidefiniteRelaxationOptions> options(
         m, "SemidefiniteRelaxationOptions", cls_doc.doc);
     options  // BR
         .def(ParamInit<SemidefiniteRelaxationOptions>())

--- a/bindings/pydrake/solvers/solvers_py_snopt.cc
+++ b/bindings/pydrake/solvers/solvers_py_snopt.cc
@@ -13,12 +13,11 @@ void DefineSolversSnopt(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::class_<SnoptSolver, SolverInterface>(
-      m, "SnoptSolver", doc.SnoptSolver.doc)
+  class_<SnoptSolver, SolverInterface>(m, "SnoptSolver", doc.SnoptSolver.doc)
       .def(py::init<>(), doc.SnoptSolver.ctor.doc)
       .def_static("id", &SnoptSolver::id, doc.SnoptSolver.id.doc);
 
-  py::class_<SnoptSolverDetails>(
+  class_<SnoptSolverDetails>(
       m, "SnoptSolverDetails", doc.SnoptSolverDetails.doc)
       .def_ro(
           "info", &SnoptSolverDetails::info, doc.SnoptSolverDetails.info.doc)

--- a/bindings/pydrake/solvers/solvers_py_unrevised_lemke.cc
+++ b/bindings/pydrake/solvers/solvers_py_unrevised_lemke.cc
@@ -11,7 +11,7 @@ void DefineSolversUnrevisedLemke(py::module_ m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
-  py::class_<UnrevisedLemkeSolver<double>, SolverInterface>(
+  class_<UnrevisedLemkeSolver<double>, SolverInterface>(
       m, "UnrevisedLemkeSolver", doc.UnrevisedLemkeSolver.doc)
       .def(py::init<>(), doc.UnrevisedLemkeSolver.ctor.doc)
       .def_static("id", &UnrevisedLemkeSolver<double>::id,

--- a/bindings/pydrake/solvers/solvers_pybind.h
+++ b/bindings/pydrake/solvers/solvers_pybind.h
@@ -37,7 +37,7 @@ void BindAcquireLicense(PyClass* pcls, Doc&& cls_doc) {
   const std::string license_doc =
       fmt::format("Context-manageable license from ``{}.AcquireLicense()``.",
           py::str(cls.attr("__name__")).c_str());
-  py::class_<PyLicense>(cls, "License", license_doc.c_str())
+  class_<PyLicense>(cls, "License", license_doc.c_str())
       .def("__enter__", &PyLicense::enter)
       .def("__exit__", &PyLicense::exit)
       .def("is_valid", &PyLicense::is_valid,

--- a/bindings/pydrake/symbolic/symbolic_py_monolith.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_monolith.cc
@@ -49,14 +49,14 @@ void DefineSymbolicMonolith(py::module_ m) {
       pydrake_doc_common_symbolic_expression.drake.symbolic;
 
   // These declarations must be first, because low-level operators return them.
-  py::class_<Expression> expr_cls(m, "Expression", doc_expr.Expression.doc);
-  py::class_<Formula> formula_cls(m, "Formula", doc_expr.Formula.doc);
-  py::class_<Polynomial> polynomial_cls(m, "Polynomial", doc.Polynomial.doc);
-  py::class_<RationalFunction> rat_fun_cls(
+  class_<Expression> expr_cls(m, "Expression", doc_expr.Expression.doc);
+  class_<Formula> formula_cls(m, "Formula", doc_expr.Formula.doc);
+  class_<Polynomial> polynomial_cls(m, "Polynomial", doc.Polynomial.doc);
+  class_<RationalFunction> rat_fun_cls(
       m, "RationalFunction", doc.RationalFunction.doc);
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
-  py::class_<Variable> var_cls(m, "Variable", doc_expr.Variable.doc);
+  class_<Variable> var_cls(m, "Variable", doc_expr.Variable.doc);
   constexpr auto& var_doc = doc_expr.Variable;
   py::enum_<Variable::Type>(var_cls, "Type")
       .value(
@@ -241,7 +241,7 @@ void DefineSymbolicMonolith(py::module_ m) {
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads,
   // etc.
   constexpr auto& doc_variables = doc_expr.Variables;
-  py::class_<Variables> cls_variables(m, "Variables", doc_variables.doc);
+  class_<Variables> cls_variables(m, "Variables", doc_variables.doc);
   cls_variables  // BR
       .def(py::init<>(), doc_variables.ctor.doc_0args)
       .def(py::init<const Eigen::Ref<const VectorX<Variable>>&>(),
@@ -571,7 +571,7 @@ void DefineSymbolicMonolith(py::module_ m) {
             enum_doc.kHalfAnglePreferCos.doc);
   }
 
-  py::class_<SinCos>(m, "SinCos", doc.SinCos.doc)
+  class_<SinCos>(m, "SinCos", doc.SinCos.doc)
       .def(py::init<Variable, Variable, SinCosSubstitutionType>(), py::arg("s"),
           py::arg("c"), py::arg("type") = SinCosSubstitutionType::kAngle,
           doc.SinCos.ctor.doc)
@@ -728,7 +728,7 @@ void DefineSymbolicMonolith(py::module_ m) {
       py::arg("m"), doc_expr.positive_semidefinite.doc_1args_m);
 
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
-  py::class_<Monomial>(m, "Monomial", doc.Monomial.doc)
+  class_<Monomial>(m, "Monomial", doc.Monomial.doc)
       .def(py::init<>(), doc.Monomial.ctor.doc_0args)
       .def(py::init<const Variable&>(), py::arg("var"),
           doc.Monomial.ctor.doc_1args_var)
@@ -832,7 +832,7 @@ void DefineSymbolicMonolith(py::module_ m) {
           py::arg("sort_monomial") = false,
           doc.CalcMonomialBasisOrderUpToOne.doc);
 
-  py::class_<Polynomial::SubstituteAndExpandCacheData>(m,
+  class_<Polynomial::SubstituteAndExpandCacheData>(m,
       "SubstituteAndExpandCacheData",
       doc.Polynomial.SubstituteAndExpandCacheData.doc)
       .def(py::init<>())

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -57,7 +57,7 @@ PYDRAKE_MODULE(analysis, m) {
   {
     using Class = SimulatorConfig;
     constexpr auto& cls_doc = doc.SimulatorConfig;
-    py::class_<Class> cls(m, "SimulatorConfig", cls_doc.doc);
+    class_<Class> cls(m, "SimulatorConfig", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -68,7 +68,7 @@ PYDRAKE_MODULE(analysis, m) {
   {
     using Class = SimulatorStatus;
     constexpr auto& cls_doc = doc.SimulatorStatus;
-    py::class_<Class> cls(m, "SimulatorStatus", cls_doc.doc);
+    class_<Class> cls(m, "SimulatorStatus", cls_doc.doc);
 
     using Enum = Class::ReturnReason;
     constexpr auto& enum_doc = cls_doc.ReturnReason;
@@ -97,7 +97,7 @@ PYDRAKE_MODULE(analysis, m) {
   {
     constexpr auto& cls_doc = doc.InitializeParams;
     using Class = InitializeParams;
-    py::class_<Class> cls(m, "InitializeParams", cls_doc.doc);
+    class_<Class> cls(m, "InitializeParams", cls_doc.doc);
     cls  // BR
         .def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
@@ -513,7 +513,7 @@ Parameter ``interruptible``:
         py::arg("make_simulator"), py::arg("output"), py::arg("final_time"),
         py::arg("generator"), doc.analysis.RandomSimulation.doc);
 
-    py::class_<RandomSimulationResult>(
+    class_<RandomSimulationResult>(
         m, "RandomSimulationResult", doc.analysis.RandomSimulationResult.doc)
         .def_rw("output", &RandomSimulationResult::output,
             doc.analysis.RandomSimulationResult.output.doc)
@@ -544,7 +544,7 @@ Parameter ``interruptible``:
   {
     using Class = RegionOfAttractionOptions;
     constexpr auto& cls_doc = doc.analysis.RegionOfAttractionOptions;
-    py::class_<Class, std::shared_ptr<Class>> cls(
+    class_<Class, std::shared_ptr<Class>> cls(
         m, "RegionOfAttractionOptions", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -40,13 +40,12 @@ PYDRAKE_MODULE(controllers, m) {
   {
     using Class = DynamicProgrammingOptions;
     constexpr auto& cls_doc = doc.DynamicProgrammingOptions;
-    py::class_<DynamicProgrammingOptions> cls(
+    class_<DynamicProgrammingOptions> cls(
         m, "DynamicProgrammingOptions", cls_doc.doc);
     {
       using Nested = Class::PeriodicBoundaryCondition;
       constexpr auto& nested_doc = cls_doc.PeriodicBoundaryCondition;
-      py::class_<Nested> nested(
-          cls, "PeriodicBoundaryCondition", nested_doc.doc);
+      class_<Nested> nested(cls, "PeriodicBoundaryCondition", nested_doc.doc);
       nested  // BR
           .def(py::init<int, double, double>(), py::arg("state_index"),
               py::arg("low"), py::arg("high"), nested_doc.ctor.doc)
@@ -80,8 +79,7 @@ PYDRAKE_MODULE(controllers, m) {
   {
     using Class = InverseDynamics<double>;
     constexpr auto& cls_doc = doc.InverseDynamics;
-    py::class_<Class, LeafSystem<double>> cls(
-        m, "InverseDynamics", cls_doc.doc);
+    class_<Class, LeafSystem<double>> cls(m, "InverseDynamics", cls_doc.doc);
     {
       using Nested = Class::InverseDynamicsMode;
       constexpr auto& nested_doc = cls_doc.InverseDynamicsMode;
@@ -117,8 +115,7 @@ PYDRAKE_MODULE(controllers, m) {
   {
     using Class = InverseDynamicsController<double>;
     constexpr auto& cls_doc = doc.InverseDynamicsController;
-    py::class_<Class, Diagram<double>>(
-        m, "InverseDynamicsController", cls_doc.doc)
+    class_<Class, Diagram<double>>(m, "InverseDynamicsController", cls_doc.doc)
         .def(py::init<const MultibodyPlant<double>&, const VectorX<double>&,
                  const VectorX<double>&, const VectorX<double>&, bool,
                  const systems::Context<double>*>(),
@@ -154,7 +151,7 @@ PYDRAKE_MODULE(controllers, m) {
   {
     using Class = JointStiffnessController<double>;
     constexpr auto& cls_doc = doc.JointStiffnessController;
-    py::class_<Class, LeafSystem<double>> cls(
+    class_<Class, LeafSystem<double>> cls(
         m, "JointStiffnessController", cls_doc.doc);
     cls  // BR
         .def(py::init<const MultibodyPlant<double>&,
@@ -179,7 +176,7 @@ PYDRAKE_MODULE(controllers, m) {
     using T = double;
     using Class = PidControlledSystem<T>;
     constexpr auto& cls_doc = doc.PidControlledSystem;
-    py::class_<Class, Diagram<T>>(m, "PidControlledSystem", cls_doc.doc)
+    class_<Class, Diagram<T>>(m, "PidControlledSystem", cls_doc.doc)
         .def(
             "__init__",
             [](Class* self, System<T>& plant, double Kp, double Ki, double Kd,
@@ -258,7 +255,7 @@ PYDRAKE_MODULE(controllers, m) {
   {
     using Class = PidController<double>;
     constexpr auto& cls_doc = doc.PidController;
-    py::class_<Class, LeafSystem<double>>(m, "PidController", cls_doc.doc)
+    class_<Class, LeafSystem<double>>(m, "PidController", cls_doc.doc)
         .def(py::init<const VectorX<double>&, const VectorX<double>&,
                  const VectorX<double>&>(),
             py::arg("kp"), py::arg("ki"), py::arg("kd"), cls_doc.ctor.doc_3args)
@@ -345,7 +342,7 @@ PYDRAKE_MODULE(controllers, m) {
   {
     using Class = FiniteHorizonLinearQuadraticRegulatorOptions;
     constexpr auto& cls_doc = doc.FiniteHorizonLinearQuadraticRegulatorOptions;
-    py::class_<Class> cls(
+    class_<Class> cls(
         m, "FiniteHorizonLinearQuadraticRegulatorOptions", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
@@ -377,7 +374,7 @@ PYDRAKE_MODULE(controllers, m) {
   {
     using Class = FiniteHorizonLinearQuadraticRegulatorResult;
     constexpr auto& cls_doc = doc.FiniteHorizonLinearQuadraticRegulatorResult;
-    py::class_<Class> cls(
+    class_<Class> cls(
         m, "FiniteHorizonLinearQuadraticRegulatorResult", cls_doc.doc);
     DefReadUniquePtr(&cls, "x0", &Class::x0, cls_doc.x0.doc);
     DefReadUniquePtr(&cls, "u0", &Class::u0, cls_doc.u0.doc);

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -76,7 +76,7 @@ py::object DoEval(const SomeObject* self, const systems::Context<T>& context) {
 void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = UseDefaultName;
-    py::class_<Class>(m, "UseDefaultName", doc.UseDefaultName.doc)
+    class_<Class>(m, "UseDefaultName", doc.UseDefaultName.doc)
         .def("__repr__", [](const Class&) { return "kUseDefaultName"; });
   }
   m.attr("kUseDefaultName") = kUseDefaultName;
@@ -106,7 +106,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   BindTypeSafeIndex<AbstractParameterIndex>(m, "AbstractParameterIndex");
   BindTypeSafeIndex<SystemConstraintIndex>(m, "SystemConstraintIndex");
 
-  py::class_<FixedInputPortValue>(
+  class_<FixedInputPortValue>(
       m, "FixedInputPortValue", doc.FixedInputPortValue.doc)
       .def("GetMutableData", &FixedInputPortValue::GetMutableData,
           py_rvp::reference_internal,
@@ -115,7 +115,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   // N.B. `AbstractValues` provides the ability to reference non-owned values,
   // without copying them. For consistency with other model-value Python
   // bindings, only the ownership variant is exposed.
-  py::class_<AbstractValues> abstract_values(
+  class_<AbstractValues> abstract_values(
       m, "AbstractValues", doc.AbstractValues.doc);
   DefClone(&abstract_values);
   abstract_values  // BR
@@ -163,7 +163,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
           doc.WitnessFunctionDirection.kCrossesZero.doc);
 
   {
-    py::class_<PeriodicEventData> cls(
+    class_<PeriodicEventData> cls(
         m, "PeriodicEventData", doc.PeriodicEventData.doc);
     DefCopyAndDeepCopy(&cls);
     cls  // BR
@@ -176,7 +176,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = EventStatus;
     constexpr auto& cls_doc = doc.EventStatus;
-    py::class_<Class> cls(m, "EventStatus", cls_doc.doc);
+    class_<Class> cls(m, "EventStatus", cls_doc.doc);
 
     using Enum = Class::Severity;
     constexpr auto& enum_doc = cls_doc.Severity;
@@ -239,7 +239,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
     DefCopyAndDeepCopy(&cls);
   }
 
-  py::class_<ContextBase>(m, "ContextBase", doc.ContextBase.doc)
+  class_<ContextBase>(m, "ContextBase", doc.ContextBase.doc)
       .def("num_input_ports", &ContextBase::num_input_ports,
           doc.ContextBase.num_input_ports.doc)
       .def("num_output_ports", &ContextBase::num_output_ports,
@@ -262,7 +262,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = ValueProducer;
     constexpr auto& cls_doc = doc.ValueProducer;
-    py::class_<Class>(m, "ValueProducer", cls_doc.doc)
+    class_<Class>(m, "ValueProducer", cls_doc.doc)
         .def(py::init([](py::function allocate,
                           std::function<void(py::object, py::object)> calc) {
           return Class(MakeCppCompatibleAllocateCallback(std::move(allocate)),
@@ -275,7 +275,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = CacheEntryValue;
     constexpr auto& cls_doc = doc.CacheEntryValue;
-    py::class_<Class>(m, "CacheEntryValue", cls_doc.doc)
+    class_<Class>(m, "CacheEntryValue", cls_doc.doc)
         .def(
             "GetValueOrThrow",
             [](const Class& self) {
@@ -297,7 +297,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = CacheEntry;
     constexpr auto& cls_doc = doc.CacheEntry;
-    py::class_<Class>(m, "CacheEntry", cls_doc.doc)
+    class_<Class>(m, "CacheEntry", cls_doc.doc)
         .def("prerequisites", &Class::prerequisites, cls_doc.prerequisites.doc)
         .def("EvalAbstract", &Class::EvalAbstract, py::arg("context"),
             py_rvp::reference_internal, cls_doc.EvalAbstract.doc)
@@ -348,13 +348,13 @@ void DoScalarIndependentDefinitions(py::module_ m) {
     // useful without the full bindings.
     using Class = ExternalSystemConstraint;
     constexpr auto& cls_doc = doc.ExternalSystemConstraint;
-    py::class_<Class>(m, "_ExternalSystemConstraint", cls_doc.doc)
+    class_<Class>(m, "_ExternalSystemConstraint", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc_0args);
   }
 }
 
 template <typename T>
-py::class_<Context<T>, ContextBase> DefineContext(py::module_ m) {
+class_<Context<T>, ContextBase> DefineContext(py::module_ m) {
   auto context_cls = DefineTemplateClassWithDefault<Context<T>, ContextBase>(
       m, "Context", GetPyParam<T>(), doc.Context.doc);
   context_cls

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -231,7 +231,7 @@ struct Impl {
     // to override this method in `PyLeafSystem`, expose the method here for
     // direct(-ish) access. (Otherwise, we get an error about inaccessible
     // downcasting when trying to bind `PyLeafSystem::DoCalcTimeDerivatives` to
-    // `py::class_<LeafSystem<T>, ...>`.
+    // `class_<LeafSystem<T>, ...>`.
     using Base::DoCalcTimeDerivatives;
   };
 
@@ -402,8 +402,7 @@ struct Impl {
     }
   };
 
-  static py::class_<System<T>, SystemBase, PySystem> DefineSystem(
-      py::module_ m) {
+  static class_<System<T>, SystemBase, PySystem> DefineSystem(py::module_ m) {
     // TODO(eric.cousineau): Show constructor, but somehow make sure `pybind11`
     // knows this is abstract?
     auto system_cls =
@@ -1208,11 +1207,11 @@ void DoScalarIndependentDefinitions(py::module_ m) {
     using Class = SystemBase;
     constexpr auto& cls_doc = doc.SystemBase;
     // TODO(eric.cousineau): Bind remaining methods.
-    py::class_<Class> cls(m, "SystemBase", cls_doc.doc);
+    class_<Class> cls(m, "SystemBase", cls_doc.doc);
     {
       using Nested = SystemBase::GraphvizFragment;
       constexpr auto& nested_doc = doc.SystemBase.GraphvizFragment;
-      py::class_<Nested>(cls, "GraphvizFragment", nested_doc.doc)
+      class_<Nested>(cls, "GraphvizFragment", nested_doc.doc)
           .def_rw(
               "input_ports", &Nested::input_ports, nested_doc.input_ports.doc)
           .def_rw("output_ports", &Nested::output_ports,
@@ -1223,7 +1222,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
       // GraphvizFragmentParams
       using Nested = SystemBasePublic::GraphvizFragmentParams;
       constexpr auto& nested_doc = doc.SystemBase.GraphvizFragmentParams;
-      py::class_<Nested>(cls, "GraphvizFragmentParams", nested_doc.doc)
+      class_<Nested>(cls, "GraphvizFragmentParams", nested_doc.doc)
           .def_rw("max_depth", &Nested::max_depth, nested_doc.max_depth.doc)
           .def_rw("options", &Nested::options, nested_doc.options.doc)
           .def_rw("node_id", &Nested::node_id, nested_doc.node_id.doc)
@@ -1420,7 +1419,7 @@ void DefineFrameworkPySystems(py::module_ m) {
   DoScalarIndependentDefinitions(m);
 
   // Declare (but don't define) to resolve a dependency cycle.
-  py::class_<SystemScalarConverter> cls_system_scalar_converter(
+  class_<SystemScalarConverter> cls_system_scalar_converter(
       m, "SystemScalarConverter");
   auto cls_system_double = Impl<double>::DefineSystem(m);
   auto cls_system_autodiff = Impl<AutoDiffXd>::DefineSystem(m);
@@ -1429,7 +1428,7 @@ void DefineFrameworkPySystems(py::module_ m) {
   // Do templated instantiations of system types.
   auto bind_common_scalar_types = [&](auto dummy) {
     using T = decltype(dummy);
-    py::class_<System<T>, SystemBase, typename Impl<T>::PySystem>* cls_system{};
+    class_<System<T>, SystemBase, typename Impl<T>::PySystem>* cls_system{};
     if constexpr (std::is_same_v<T, double>) {
       cls_system = &cls_system_double;
     } else if constexpr (std::is_same_v<T, AutoDiffXd>) {

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -138,7 +138,7 @@ void DefineBusValue(py::module_ m) {
   using Class = systems::BusValue;
   constexpr auto& cls_doc =
       pydrake_doc_systems_framework.drake.systems.BusValue;
-  py::class_<Class> cls(m, "BusValue", cls_doc.doc);
+  class_<Class> cls(m, "BusValue", cls_doc.doc);
   cls  // BR
       .def(py::init<>(), cls_doc.ctor.doc)
       .def(

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -115,7 +115,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = LcmInterfaceSystem;
     constexpr auto& cls_doc = doc.LcmInterfaceSystem;
-    py::class_<Class, LeafSystem<double>>(m, "LcmInterfaceSystem",
+    class_<Class, LeafSystem<double>>(m, "LcmInterfaceSystem",
         (std::string(cls_doc.doc) + kLcmInterfaceSystemClassWarning).c_str())
         .def(py::init<DrakeLcmInterface*>(),
             // Keep alive, reference: `self` keeps `lcm` alive.
@@ -135,7 +135,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = SerializerInterface;
     constexpr auto& cls_doc = doc.SerializerInterface;
-    py::class_<Class, PySerializerInterface, std::shared_ptr<Class>> cls(
+    class_<Class, PySerializerInterface, std::shared_ptr<Class>> cls(
         m, "SerializerInterface");
     cls  // BR
          // Adding a constructor permits implementing this interface in Python.
@@ -172,7 +172,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = LcmBuses;
     constexpr auto& cls_doc = doc.LcmBuses;
-    py::class_<Class> cls(m, "LcmBuses");
+    class_<Class> cls(m, "LcmBuses");
     cls  // BR
         .def_ro_static("kLcmUrlMemqNull", &Class::kLcmUrlMemqNull
             // TODO(jwnimmer-tri) The `cls_doc.kLcmUrlMemqNull.doc` docstring
@@ -200,7 +200,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = LcmPublisherSystem;
     constexpr auto& cls_doc = doc.LcmPublisherSystem;
-    py::class_<Class, LeafSystem<double>> cls(m, "LcmPublisherSystem");
+    class_<Class, LeafSystem<double>> cls(m, "LcmPublisherSystem");
     cls  // BR
         .def(py::init<const std::string&,
                  std::shared_ptr<const SerializerInterface>,
@@ -238,7 +238,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = LcmSubscriberSystem;
     constexpr auto& cls_doc = doc.LcmSubscriberSystem;
-    py::class_<Class, LeafSystem<double>>(m, "LcmSubscriberSystem")
+    class_<Class, LeafSystem<double>>(m, "LcmSubscriberSystem")
         .def(py::init<const std::string&,
                  std::shared_ptr<const SerializerInterface>,
                  LcmInterfaceSystem*, double>(),
@@ -261,7 +261,7 @@ PYDRAKE_MODULE(lcm, m) {
   {
     using Class = LcmScopeSystem;
     constexpr auto& cls_doc = doc.LcmScopeSystem;
-    py::class_<Class, LeafSystem<double>>(m, "LcmScopeSystem")
+    class_<Class, LeafSystem<double>>(m, "LcmScopeSystem")
         .def(py::init<int>(), py::arg("size"), cls_doc.ctor.doc)
         .def_static(
             "AddToBuilder",

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -75,10 +75,10 @@ PYDRAKE_MODULE(primitives, m) {
 
   {
     using Class = SelectorParams;
-    py::class_<Class> cls(m, "SelectorParams", doc.SelectorParams.doc);
+    class_<Class> cls(m, "SelectorParams", doc.SelectorParams.doc);
     {
       using Nested = Class::InputPortParams;
-      py::class_<Nested> nested(
+      class_<Nested> nested(
           cls, "InputPortParams", doc.SelectorParams.InputPortParams.doc);
       nested.def(ParamInit<Nested>());
       DefAttributesUsingSerialize(&nested, doc.SelectorParams.InputPortParams);
@@ -87,7 +87,7 @@ PYDRAKE_MODULE(primitives, m) {
     }
     {
       using Nested = Class::OutputSelection;
-      py::class_<Nested> nested(
+      class_<Nested> nested(
           cls, "OutputSelection", doc.SelectorParams.OutputSelection.doc);
       nested.def(ParamInit<Nested>());
       DefAttributesUsingSerialize(&nested, doc.SelectorParams.OutputSelection);
@@ -96,7 +96,7 @@ PYDRAKE_MODULE(primitives, m) {
     }
     {
       using Nested = Class::OutputPortParams;
-      py::class_<Nested> nested(
+      class_<Nested> nested(
           cls, "OutputPortParams", doc.SelectorParams.OutputPortParams.doc);
       nested.def(ParamInit<Nested>());
       DefAttributesUsingSerialize(&nested, doc.SelectorParams.OutputPortParams);
@@ -834,7 +834,7 @@ PYDRAKE_MODULE(primitives, m) {
   };
   type_visit(bind_non_symbolic_scalar_types, NonSymbolicScalarPack{});
 
-  py::class_<BarycentricMeshSystem<double>, LeafSystem<double>>(
+  class_<BarycentricMeshSystem<double>, LeafSystem<double>>(
       m, "BarycentricMeshSystem", doc.BarycentricMeshSystem.doc)
       .def(py::init<math::BarycentricMesh<double>,
                const Eigen::Ref<const MatrixX<double>>&>(),
@@ -846,7 +846,7 @@ PYDRAKE_MODULE(primitives, m) {
           doc.BarycentricMeshSystem.get_output_values.doc);
 
   // TODO(jwnimmer-tri) Add more scalar types bindings for this class.
-  py::class_<RandomSource<double>, LeafSystem<double>>(
+  class_<RandomSource<double>, LeafSystem<double>>(
       m, "RandomSource", doc.RandomSource.doc)
       .def(py::init<RandomDistribution, int, double>(), py::arg("distribution"),
           py::arg("num_outputs"), py::arg("sampling_interval_sec"),

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -25,7 +25,7 @@ PYDRAKE_MODULE(rendering, m) {
 
   // See the todo in multibody_position_to_geometry_pose.h. This should
   // ultimately move into a different module.
-  py::class_<MultibodyPositionToGeometryPose<T>, LeafSystem<T>>(m,
+  class_<MultibodyPositionToGeometryPose<T>, LeafSystem<T>>(m,
       "MultibodyPositionToGeometryPose",
       doc.MultibodyPositionToGeometryPose.doc)
       .def(py::init<const multibody::MultibodyPlant<T>&, bool>(),

--- a/bindings/pydrake/systems/sensors_py_camera_config.cc
+++ b/bindings/pydrake/systems/sensors_py_camera_config.cc
@@ -20,11 +20,11 @@ void DefineSensorsCameraConfig(py::module_ m) {
     // To bind nested serializable structs without errors, we declare the outer
     // struct first, then bind its inner structs, then bind the outer struct.
     constexpr auto& config_cls_doc = doc.CameraConfig;
-    py::class_<CameraConfig> config_cls(m, "CameraConfig", config_cls_doc.doc);
+    class_<CameraConfig> config_cls(m, "CameraConfig", config_cls_doc.doc);
 
     // Inner struct.
     constexpr auto& fov_degrees_doc = doc.CameraConfig.FovDegrees;
-    py::class_<CameraConfig::FovDegrees> fov_class(
+    class_<CameraConfig::FovDegrees> fov_class(
         config_cls, "FovDegrees", fov_degrees_doc.doc);
     fov_class  // BR
         .def(ParamInit<CameraConfig::FovDegrees>())
@@ -38,7 +38,7 @@ void DefineSensorsCameraConfig(py::module_ m) {
 
     // Inner struct.
     constexpr auto& focal_doc = doc.CameraConfig.FocalLength;
-    py::class_<CameraConfig::FocalLength> focal_class(
+    class_<CameraConfig::FocalLength> focal_class(
         config_cls, "FocalLength", focal_doc.doc);
     focal_class  // BR
         .def(ParamInit<CameraConfig::FocalLength>())

--- a/bindings/pydrake/systems/sensors_py_image.cc
+++ b/bindings/pydrake/systems/sensors_py_image.cc
@@ -59,7 +59,7 @@ void DefineSensorsImage(py::module_ m) {
 
       // Add traits. Note that we choose not to bind kPixelScalar because the
       // ChannelType already makes the same information easily available.
-      py::class_<ImageTraitsT> traits(
+      class_<ImageTraitsT> traits(
           m, TemporaryClassName<ImageTraitsT>().c_str());
       traits.attr("ChannelType") = GetPyParam<T>()[0];
       traits.attr("kNumChannels") = int{ImageTraitsT::kNumChannels};
@@ -92,7 +92,7 @@ void DefineSensorsImage(py::module_ m) {
         return array;
       };
 
-      py::class_<ImageT> image(m, TemporaryClassName<ImageT>().c_str());
+      class_<ImageT> image(m, TemporaryClassName<ImageT>().c_str());
       AddTemplateClass(m, "Image", image, py_param);
       image  // BR
           .def(py::init<>(), doc.Image.ctor.doc_0args)

--- a/bindings/pydrake/systems/sensors_py_image_io.cc
+++ b/bindings/pydrake/systems/sensors_py_image_io.cc
@@ -31,10 +31,10 @@ void DefineSensorsImageIo(py::module_ m) {
   {
     using Class = ImageIo;
     constexpr auto& cls_doc = doc.ImageIo;
-    py::class_<Class> cls(m, "ImageIo", cls_doc.doc);
+    class_<Class> cls(m, "ImageIo", cls_doc.doc);
 
     {
-      py::class_<Class::Metadata> metadata_cls(
+      class_<Class::Metadata> metadata_cls(
           cls, "Metadata", cls_doc.Metadata.doc);
       metadata_cls.def(ParamInit<Class::Metadata>());
       DefAttributesUsingSerialize(&metadata_cls, cls_doc.Metadata);
@@ -101,7 +101,7 @@ void DefineSensorsImageIo(py::module_ m) {
   {
     using Class = ImageWriter;
     constexpr auto& cls_doc = doc.ImageWriter;
-    py::class_<Class, LeafSystem<double>> cls(m, "ImageWriter", cls_doc.doc);
+    class_<Class, LeafSystem<double>> cls(m, "ImageWriter", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def(

--- a/bindings/pydrake/systems/sensors_py_lcm.cc
+++ b/bindings/pydrake/systems/sensors_py_lcm.cc
@@ -20,7 +20,7 @@ void DefineSensorsLcm(py::module_ m) {
   {
     using Class = LcmImageArrayToImages;
     constexpr auto& cls_doc = doc.LcmImageArrayToImages;
-    py::class_<Class, LeafSystem<double>> cls(
+    class_<Class, LeafSystem<double>> cls(
         m, "LcmImageArrayToImages", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
@@ -37,7 +37,7 @@ void DefineSensorsLcm(py::module_ m) {
   {
     using Class = ImageToLcmImageArrayT;
     constexpr auto& cls_doc = doc.ImageToLcmImageArrayT;
-    py::class_<Class, LeafSystem<double>> cls(
+    class_<Class, LeafSystem<double>> cls(
         m, "ImageToLcmImageArrayT", cls_doc.doc);
     cls  // BR
         .def(py::init<const std::string&, const std::string&,

--- a/bindings/pydrake/systems/sensors_py_rgbd.cc
+++ b/bindings/pydrake/systems/sensors_py_rgbd.cc
@@ -48,7 +48,7 @@ void DefineSensorsRgbd(py::module_ m) {
   {
     using Class = CameraInfo;
     constexpr auto& cls_doc = doc.CameraInfo;
-    py::class_<Class> cls(m, "CameraInfo", cls_doc.doc);
+    class_<Class> cls(m, "CameraInfo", cls_doc.doc);
     cls  // BR
         .def(py::init<int, int, double>(), py::arg("width"), py::arg("height"),
             py::arg("fov_y"), cls_doc.ctor.doc_3args_width_height_fov_y)
@@ -84,7 +84,7 @@ void DefineSensorsRgbd(py::module_ m) {
         });
   }
 
-  py::class_<RgbdSensor, LeafSystem<double>> rgbd_sensor(
+  class_<RgbdSensor, LeafSystem<double>> rgbd_sensor(
       m, "RgbdSensor", doc.RgbdSensor.doc);
 
   rgbd_sensor
@@ -145,8 +145,7 @@ void DefineSensorsRgbd(py::module_ m) {
   {
     using Class = RgbdSensorDiscrete;
     constexpr auto& cls_doc = doc.RgbdSensorDiscrete;
-    py::class_<Class, Diagram<double>> cls(
-        m, "RgbdSensorDiscrete", cls_doc.doc);
+    class_<Class, Diagram<double>> cls(m, "RgbdSensorDiscrete", cls_doc.doc);
     cls  // BR
         .def(
             "__init__",
@@ -176,7 +175,7 @@ void DefineSensorsRgbd(py::module_ m) {
   {
     using Class = RgbdSensorAsync;
     constexpr auto& cls_doc = doc.RgbdSensorAsync;
-    py::class_<Class, LeafSystem<double>> rgbd_sensor_async(
+    class_<Class, LeafSystem<double>> rgbd_sensor_async(
         m, "RgbdSensorAsync", cls_doc.doc);
     rgbd_sensor_async
         .def(py::init<const geometry::SceneGraph<double>*, geometry::FrameId,

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -49,7 +49,7 @@ class Arbitrary {
 void DeclareBuilderLifeSupportTestHelpers(py::module_ m) {
   // the Arbitrary type exists to test annotations pointing to a wrong-typed
   // argument.
-  py::class_<Arbitrary>(m, "Arbitrary").def(py::init<>());
+  class_<Arbitrary>(m, "Arbitrary").def(py::init<>());
 
   type_visit(
       [&m](auto dummy) {
@@ -220,13 +220,13 @@ PYDRAKE_MODULE(test_util, m) {
   py::module_::import_("pydrake.systems.framework");
   py::module_::import_("pydrake.systems.primitives");
 
-  py::class_<DeleteListenerSystem, LeafSystem<T>>(m, "DeleteListenerSystem")
+  class_<DeleteListenerSystem, LeafSystem<T>>(m, "DeleteListenerSystem")
       .def(py::init<std::function<void()>>());
-  py::class_<DeleteListenerVector, BasicVector<T>>(m, "DeleteListenerVector")
+  class_<DeleteListenerVector, BasicVector<T>>(m, "DeleteListenerVector")
       .def(py::init<std::function<void()>>());
 
   // A 2-dimensional subclass of BasicVector.
-  py::class_<MyVector2<T>, BasicVector<T>>(m, "MyVector2")
+  class_<MyVector2<T>, BasicVector<T>>(m, "MyVector2")
       .def(py::init<const Eigen::Vector2d&>(), py::arg("data"));
 
   // Call overrides to ensure a custom Python class can override these methods.
@@ -300,10 +300,10 @@ PYDRAKE_MODULE(test_util, m) {
   DeclareBuilderLifeSupportTestHelpers(m);
 
   // We only bind the interface class (DummySystemA) and the factory function.
-  py::class_<DummySystemA, LeafSystem<double>>(m, "DummySystemA");
+  class_<DummySystemA, LeafSystem<double>>(m, "DummySystemA");
   m.def("MakeDummySystem", &MakeDummySystem);
 
-  py::class_<CountingContextSystem, LeafSystem<T>>(m, "CountingContextSystem")
+  class_<CountingContextSystem, LeafSystem<T>>(m, "CountingContextSystem")
       .def(py::init<>())
       .def_static("GetNumberOfLiveContexts",
           &CountingContextSystem::GetNumberOfLiveContexts);

--- a/bindings/pydrake/test/pydrake_pybind_test_util_py.cc
+++ b/bindings/pydrake/test/pydrake_pybind_test_util_py.cc
@@ -73,11 +73,11 @@ struct ExampleParamInit {
 PYDRAKE_MODULE(pydrake_pybind_test_util, m) {
   {
     using Class = Item;
-    py::class_<Class>(m, "Item").def_ro("value", &Class::value);
+    class_<Class>(m, "Item").def_ro("value", &Class::value);
   }
   {
     using Class = ExamplePyKeepAlive;
-    py::class_<Class>(m, "ExamplePyKeepAlive")
+    class_<Class>(m, "ExamplePyKeepAlive")
         .def(py::init())
         .def("a", &Class::a, py_rvp::reference_internal)
         .def("a_list", &Class::a_list, py_rvp::reference_internal);
@@ -85,7 +85,7 @@ PYDRAKE_MODULE(pydrake_pybind_test_util, m) {
 
   {
     using Class = ExampleDefCopyAndDeepCopy;
-    py::class_<Class> cls(m, "ExampleDefCopyAndDeepCopy");
+    class_<Class> cls(m, "ExampleDefCopyAndDeepCopy");
     cls  // BR
         .def(py::init<int>())
         .def(py::self == py::self);
@@ -94,7 +94,7 @@ PYDRAKE_MODULE(pydrake_pybind_test_util, m) {
 
   {
     using Class = ExampleDefClone;
-    py::class_<Class> cls(m, "ExampleDefClone");
+    class_<Class> cls(m, "ExampleDefClone");
     cls  // BR
         .def(py::init<double>())
         .def(py::self == py::self);
@@ -103,7 +103,7 @@ PYDRAKE_MODULE(pydrake_pybind_test_util, m) {
 
   {
     using Class = ExampleParamInit;
-    py::class_<Class>(m, "ExampleParamInit")
+    class_<Class>(m, "ExampleParamInit")
         .def(ParamInit<Class>())
         .def_rw("a", &Class::a)
         .def_rw("b", &Class::b)

--- a/bindings/pydrake/visualization/visualization_py_config.cc
+++ b/bindings/pydrake/visualization/visualization_py_config.cc
@@ -17,7 +17,7 @@ void DefineVisualizationConfig(py::module_ m) {
   {
     using Class = VisualizationConfig;
     constexpr auto& cls_doc = doc.VisualizationConfig;
-    py::class_<Class> cls(m, "VisualizationConfig", cls_doc.doc);
+    class_<Class> cls(m, "VisualizationConfig", cls_doc.doc);
     cls.def(ParamInit<Class>());
     DefAttributesUsingSerialize(&cls, cls_doc);
     DefReprUsingSerialize(&cls);

--- a/bindings/pydrake/visualization/visualization_py_image_systems.cc
+++ b/bindings/pydrake/visualization/visualization_py_image_systems.cc
@@ -17,7 +17,7 @@ void DefineVisualizationImageSystems(py::module_ m) {
   {
     using Class = ColorizeDepthImage<double>;
     constexpr auto& cls_doc = doc.ColorizeDepthImage;
-    py::class_<Class, systems::LeafSystem<double>>(
+    class_<Class, systems::LeafSystem<double>>(
         m, "ColorizeDepthImage", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc)
         .def_prop_rw("invalid_color", &Class::get_invalid_color,
@@ -36,7 +36,7 @@ void DefineVisualizationImageSystems(py::module_ m) {
   {
     using Class = ColorizeLabelImage<double>;
     constexpr auto& cls_doc = doc.ColorizeLabelImage;
-    py::class_<Class, systems::LeafSystem<double>>(
+    class_<Class, systems::LeafSystem<double>>(
         m, "ColorizeLabelImage", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc)
         .def_prop_rw("background_color", &Class::get_background_color,
@@ -48,7 +48,7 @@ void DefineVisualizationImageSystems(py::module_ m) {
   {
     using Class = ConcatenateImages<double>;
     constexpr auto& cls_doc = doc.ConcatenateImages;
-    py::class_<Class, systems::LeafSystem<double>>(
+    class_<Class, systems::LeafSystem<double>>(
         m, "ConcatenateImages", cls_doc.doc)
         .def(py::init<int, int>(), py::kw_only(), py::arg("rows") = 1,
             py::arg("cols") = 1, cls_doc.ctor.doc)


### PR DESCRIPTION
With nanobind, we'll need to customize the class_ defaults; using an alias gives us the seam to do that.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24669)
<!-- Reviewable:end -->
