### PR TITLE
[workspace] Using hidden visibility when building zlib from source

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,6 +23,7 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_python", version = "2.0.2")  # Keep this in sync with cmake/MODULE.bazel.in.  # noqa
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "rules_shell", version = "0.8.0")
+bazel_dep(name = "with_cfg.bzl", version = "0.14.6")
 
 # Configure the C++ toolchain.
 

--- a/tools/skylark/cc_hidden.bzl
+++ b/tools/skylark/cc_hidden.bzl
@@ -1,4 +1,16 @@
+load("@with_cfg.bzl", "with_cfg")
 load("//tools/skylark:cc.bzl", "cc_library")
+
+# cc_static_hidden_library is a cc_library rule that recompiles the libraries
+# listed in its `deps` adding `copts = ["-fvisibilty=hidden"]` and using only
+# static linking.
+#
+# This is useful when linking third-party C libraries into libdrake.so when we
+# don't control the BUILD files (so can't directly set copts or linkstatic).
+_builder = with_cfg(cc_library)
+_builder.extend("copt", ["-fvisibility=hidden"])
+_builder.extend("features", ["-supports_dynamic_linker"])
+cc_static_hidden_library, _ = _builder.build()
 
 def cc_wrap_static_archive_hidden(
         name,

--- a/tools/workspace/zlib/BUILD.bazel
+++ b/tools/workspace/zlib/BUILD.bazel
@@ -4,6 +4,7 @@ load("//tools/install:check_is_cc_import.bzl", "check_is_cc_import")
 load("//tools/install:install.bzl", "install", "install_license")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:cc.bzl", "cc_library")
+load("//tools/skylark:cc_hidden.bzl", "cc_static_hidden_library")
 
 # ---- Logic for choosing which zlib to use. ---
 
@@ -12,6 +13,11 @@ cc_library(
     linkopts = ["-lz"],
     tags = ["manual"],
     visibility = ["@zlib//:__subpackages__"],
+)
+
+cc_static_hidden_library(
+    name = "module_zlib_static_hidden",
+    deps = ["@module_zlib//:zlib"],
 )
 
 config_setting(
@@ -55,7 +61,7 @@ alias(
     name = "zlib",
     actual = select({
         ":use_hardcoded": ":hardcoded",
-        "//conditions:default": "@module_zlib//:zlib",
+        "//conditions:default": ":module_zlib_static_hidden",
     }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This hides the zlib symbols in our wheel build.

---

This also sets the stage for #24612 which has the same need to hide C symbols from a BCR module.

Tested manually via `bazel test //tools/install/libdrake/... --@drake//tools/flags:zlib_repo=source` -- fails on master, passes on this branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24675)
<!-- Reviewable:end -->
