### PR TITLE
[cmake] Refactor to make it easier to patch BCR modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(APPLE)
 endif()
 
 # This version number should match bazel_compatibility in MODULE.bazel.
-set(MINIMUM_BAZEL_VERSION 8.4.0)
+set(MINIMUM_BAZEL_VERSION 8.5.0)
 find_package(Bazel ${MINIMUM_BAZEL_VERSION} MODULE)
 if(NOT Bazel_FOUND)
   set(Bazel_EXECUTABLE "${PROJECT_SOURCE_DIR}/third_party/com_github_bazelbuild_bazelisk/bazelisk.py")
@@ -224,14 +224,6 @@ set(DRAKE_BAZEL_BUILD_DIR "${CMAKE_BINARY_DIR}/drake_build_cwd")
 file(MAKE_DIRECTORY "${DRAKE_BAZEL_BUILD_DIR}")
 
 set(BAZEL_REPO_ENV)
-
-# Put this patch where `cmake/MODULE.bazel.in` expects it during its call to
-# `single_version_override`.
-file(CREATE_LINK
-  "${PROJECT_SOURCE_DIR}/tools/workspace/eigen/patches/upstream/cherry-picks.patch"
-  "${DRAKE_BAZEL_BUILD_DIR}/eigen-cherry-picks.patch"
-  SYMBOLIC
-)
 
 if(NOT APPLE)
   # N.B. Bazel does its own compiler-chasing with Xcode, which we shouldn't
@@ -777,6 +769,31 @@ configure_file(cmake/MODULE.bazel.in "${DRAKE_BAZEL_BUILD_DIR}/MODULE.bazel" @ON
 configure_file(cmake/BUILD.bazel.in "${DRAKE_BAZEL_BUILD_DIR}/BUILD.bazel" @ONLY)
 file(CREATE_LINK "${PROJECT_SOURCE_DIR}/.bazeliskrc" "${DRAKE_BAZEL_BUILD_DIR}/.bazeliskrc" SYMBOLIC)
 file(CREATE_LINK "${PROJECT_SOURCE_DIR}/.bazelversion" "${DRAKE_BAZEL_BUILD_DIR}/.bazelversion" SYMBOLIC)
+
+# Bazel only supports module patching in the root module, so we need to forward
+# the drake/patches.MODULE.bazel to be usable by our cmake/MODULE.bazel.in.
+file(CREATE_LINK
+  "${PROJECT_SOURCE_DIR}/patches.MODULE.bazel"
+  "${DRAKE_BAZEL_BUILD_DIR}/patches.MODULE.bazel"
+  SYMBOLIC)
+file(STRINGS
+  "${PROJECT_SOURCE_DIR}/patches.MODULE.bazel"
+  _drake_module_patches)
+foreach(_line IN LISTS _drake_module_patches)
+  # Match lines that look like this:
+  #         "//:path/to/something.patch"
+  # For all matches, symlink the patch from the source dir to the build dir.
+  if(_line MATCHES " *\"//:([^\"]+)\"")
+    set(_patch "${CMAKE_MATCH_1}")
+    cmake_path(GET _patch PARENT_PATH _patch_dir)
+    file(MAKE_DIRECTORY "${DRAKE_BAZEL_BUILD_DIR}/${_patch_dir}")
+    file(CREATE_LINK
+      "${PROJECT_SOURCE_DIR}/${_patch}"
+      "${DRAKE_BAZEL_BUILD_DIR}/${_patch}"
+      SYMBOLIC
+    )
+  endif()
+endforeach()
 
 find_package(Git)
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@
 module(
     name = "drake",
     # This version number should match MINIMUM_BAZEL_VERSION in CMakeLists.txt.
-    bazel_compatibility = [">=8.4.0"],
+    bazel_compatibility = [">=8.5.0"],
 )
 
 # Add starlark rules.
@@ -54,14 +54,6 @@ use_repo(cc_configure, "local_config_cc")
 bazel_dep(name = "eigen", version = "5.0.1.bcr.1", repo_name = "module_eigen")
 bazel_dep(name = "fmt", version = "12.1.0", repo_name = "module_fmt")
 bazel_dep(name = "spdlog", version = "1.17.0", repo_name = "module_spdlog")  # noqa
-
-single_version_override(
-    module_name = "eigen",
-    patch_strip = 1,
-    patches = [
-        "//tools/workspace:eigen/patches/upstream/cherry-picks.patch",
-    ],
-)
 
 # Add C++ module dependencies that are NOT used by Drake's public API, but are
 # used by Drake's implementation. Builds have the option to opt-out of these
@@ -380,6 +372,11 @@ use_repo(
     "crate__paste-1.0.15",
     "crate_licenses",
 )
+
+# Incorporate Drake-specific patches to modules. The list of patches lives in a
+# separate file so that our cmake/MODULE.bazel.in can also include it.
+
+include("//:patches.MODULE.bazel")
 
 # Add CLion support repository used by `tools/clion/bazel_wrapper`.
 

--- a/cmake/MODULE.bazel.in
+++ b/cmake/MODULE.bazel.in
@@ -32,9 +32,6 @@ python_repository(
 
 register_toolchains("@python//:all")
 
-# This patch is only applied when CMake is configured with WITH_USER_EIGEN=OFF.
-single_version_override(
-    module_name = "eigen",
-    patch_strip = 1,
-    patches = ["//:eigen-cherry-picks.patch"],
-)
+# Incorporate Drake-specific patches to modules.
+
+include("//:patches.MODULE.bazel")

--- a/patches.MODULE.bazel
+++ b/patches.MODULE.bazel
@@ -1,0 +1,15 @@
+# -*- bazel -*-
+
+# This file is included by drake/MODULE.bazel and drake/cmake/MODULE.bazel.in.
+#
+# It contains patches to modules that should be applied while building Drake no
+# matter if the user's project uses CMake or Bazel. (Patches to dev_dependency
+# modules should not be listed here.)
+
+single_version_override(
+    module_name = "eigen",
+    patch_strip = 1,
+    patches = [
+        "//:tools/workspace/eigen/patches/upstream/cherry-picks.patch",
+    ],
+)


### PR DESCRIPTION
As we continue to switch more dependencies to come from BCR, it seems likely that some day we'll need to patch more modules than just `eigen`, possibly even as an emergency hotfix. This refactor lays the groundwork to make those future patches easier to add.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24676)
<!-- Reviewable:end -->
