### PR TITLE
[workspace] Cherry-pick googletest patch for new Clang 21 warning

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -219,6 +219,7 @@ bazel_dep(
 single_version_override(
     module_name = "googletest",
     patches = [
+        "//tools/workspace/googletest:patches/upstream/character_conversion_casting.patch",  # noqa
         "//tools/workspace/googletest:patches/upstream/exception_shadowing.patch",  # noqa
         "//tools/workspace/googletest:patches/upstream/param_iterator_interface.patch",  # noqa
         "//tools/workspace/googletest:patches/add_printers.patch",

--- a/tools/workspace/googletest/patches/upstream/character_conversion_casting.patch
+++ b/tools/workspace/googletest/patches/upstream/character_conversion_casting.patch
@@ -1,0 +1,41 @@
+commit fa8438ae6b70c57010177de47a9f13d7041a6328
+Author: Abseil Team <absl-team@google.com>
+Date:   Mon May 19 09:01:54 2025 -0700
+
+    Use static_cast instead of ImplicitCast_ for character conversions
+    
+    Clang has recently added "warnings when mixing different charN_t types" [1].
+    The rationale is that "charN_t represent code units of different UTF encodings.
+    Therefore the values of 2 different charN_t objects do not represent the same
+    characters."
+    
+    Note that the warning here may be legitimate - from https://github.com/google/googletest/issues/4762:
+    "[...] This is incorrect for values that do not represent valid codepoints."
+    
+    For the time being, silence the warning by being more explicit about the
+    conversion being intentional by using static_cast.
+    
+    Link: https://github.com/llvm/llvm-project/pull/138708 [1]
+    PiperOrigin-RevId: 760644157
+    Change-Id: I2e6cc1871975455cecac8731b2f93fd5beeaf0e1
+
+--- googletest/include/gtest/gtest-printers.h
++++ googletest/include/gtest/gtest-printers.h
+@@ -521,11 +521,15 @@ GTEST_API_ void PrintTo(wchar_t wc, ::std::ostream* os);
+ 
+ GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
+ inline void PrintTo(char16_t c, ::std::ostream* os) {
+-  PrintTo(ImplicitCast_<char32_t>(c), os);
++  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
++  // Also see https://github.com/google/googletest/issues/4762.
++  PrintTo(static_cast<char32_t>(c), os);
+ }
+ #ifdef __cpp_lib_char8_t
+ inline void PrintTo(char8_t c, ::std::ostream* os) {
+-  PrintTo(ImplicitCast_<char32_t>(c), os);
++  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
++  // Also see https://github.com/google/googletest/issues/4762.
++  PrintTo(static_cast<char32_t>(c), os);
+ }
+ #endif
+ 


### PR DESCRIPTION
This fixes a CI warning in our resolute-clang builds:

```
...
[7:45:01 AM]  In file included from external/googletest+/googletest/include/gtest/gtest-matchers.h:49:
[7:45:01 AM]  external/googletest+/googletest/include/gtest/gtest-printers.h:534:35: warning: implicit conversion from 'char8_t' to 'char32_t' may change the meaning of the represented code unit [-Wcharacter-conversion]
[7:45:01 AM]    534 |   PrintTo(ImplicitCast_<char32_t>(c), os);
[7:45:01 AM]        |           ~~~~~~~~~~~~~           ^
[7:45:01 AM]  1 warning generated.
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24680)
<!-- Reviewable:end -->
