### PR TITLE
[pydrake] Align with nanobind py::callable API

### DIFF
--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1247,7 +1247,7 @@ class PyForceDensityField : public ForceDensityFieldPublic<T> {
   Vector3<T> DoEvaluateAt(const systems::Context<T>& context,
       const Vector3<T>& p_WQ) const override {
     py::gil_scoped_acquire gil;
-    py::function override = py::get_override(
+    py::callable override = py::get_override(
         static_cast<const ForceDensityField<T>*>(this), "DoEvaluateAt");
     if (!override) {
       throw std::logic_error(
@@ -1269,7 +1269,7 @@ class PyForceDensityField : public ForceDensityFieldPublic<T> {
 
   std::unique_ptr<ForceDensityFieldBase<T>> DoClone() const override {
     py::gil_scoped_acquire gil;
-    py::function override = py::get_override(
+    py::callable override = py::get_override(
         static_cast<const ForceDensityField<T>*>(this), "DoClone");
     if (!override) {
       throw std::logic_error(

--- a/bindings/pydrake/planning/planning_py_iris_common.cc
+++ b/bindings/pydrake/planning/planning_py_iris_common.cc
@@ -141,7 +141,7 @@ void CheckReturnedArrayType(py::str cls_name, py::array y) {
 // Wraps user function to provide better user-friendliness.
 template <typename T, typename Func>
 Func WrapParameterizationFunc(
-    py::str cls_name, py::function func, int num_vars) {
+    py::str cls_name, py::callable func, int num_vars) {
   py::cpp_function wrapped = [=](py::array x) {
     // Check input.
     // WARNING: If the input is badly sized, we will only reach this error in
@@ -184,7 +184,7 @@ is the input dimension.
       m, "IrisParameterizationFunction", cls_doc.doc);
   iris_parameterization_function  // BR
       .def(py::init<>(), cls_doc.ctor.doc_0args)
-      .def(py::init([](const py::function& parameterization,
+      .def(py::init([](const py::callable& parameterization,
                         int parameterization_dimension) {
         return IrisParameterizationFunction(
             WrapParameterizationFunc<double,

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -103,7 +103,7 @@ void CheckReturnedArrayType(py::str cls_name, py::array y) {
 
 // Wraps user function to provide better user-friendliness.
 template <typename T, typename Func>
-Func WrapUserFunc(py::str cls_name, py::function func, int num_vars,
+Func WrapUserFunc(py::str cls_name, py::callable func, int num_vars,
     int num_outputs, ArrayShapeType output_shape) {
   // TODO(eric.cousineau): It would be nicer to write this in Python.
   // TODO(eric.cousineau): Consider using `py::detail::make_caster<>`. However,
@@ -137,7 +137,7 @@ class PyFunctionCost : public Cost {
   // Note that we do not allow Python implementations of Cost to be declared as
   // thread safe.
   PyFunctionCost(
-      int num_vars, const py::function& func, const std::string& description)
+      int num_vars, const py::callable& func, const std::string& description)
       : Cost(num_vars, description),
         double_func_(Wrap<double, DoubleFunc>(func)),
         autodiff_func_(Wrap<AutoDiffXd, AutoDiffFunc>(func)) {}
@@ -163,7 +163,7 @@ class PyFunctionCost : public Cost {
 
  private:
   template <typename T, typename Func>
-  Func Wrap(py::function func) {
+  Func Wrap(py::callable func) {
     return WrapUserFunc<T, Func>(py::str("PyFunctionCost"), func, num_vars(),
         num_outputs(), ArrayShapeType::Scalar);
   }
@@ -182,7 +182,7 @@ class PyFunctionConstraint : public Constraint {
 
   // Note that we do not allow Python implementations of Constraint to be
   // declared as thread safe.
-  PyFunctionConstraint(int num_vars, const py::function& func,
+  PyFunctionConstraint(int num_vars, const py::callable& func,
       const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
       const std::string& description)
       : Constraint(lb.size(), num_vars, lb, ub, description),
@@ -212,7 +212,7 @@ class PyFunctionConstraint : public Constraint {
 
  private:
   template <typename T, typename Func>
-  Func Wrap(py::function func) {
+  Func Wrap(py::callable func) {
     return WrapUserFunc<T, Func>(py::str("PyFunctionConstraint"), func,
         num_vars(), num_outputs(), ArrayShapeType::Vector);
   }
@@ -625,7 +625,7 @@ void BindMathematicalProgram(py::module_ m) {
           doc.MathematicalProgram.AddVisualizationCallback.doc)
       .def(
           "AddCost",
-          [](MathematicalProgram* self, py::function func,
+          [](MathematicalProgram* self, py::callable func,
               const Eigen::Ref<const VectorXDecisionVariable>& vars,
               std::string& description) {
             return self->AddCost(std::make_shared<PyFunctionCost>(
@@ -776,7 +776,7 @@ void BindMathematicalProgram(py::module_ m) {
           doc.MathematicalProgram.AddMaximizeGeometricMeanCost.doc_2args)
       .def(
           "AddConstraint",
-          [](MathematicalProgram* self, py::function func,
+          [](MathematicalProgram* self, py::callable func,
               const Eigen::VectorXd& lb, const Eigen::VectorXd& ub,
               const Eigen::Ref<const VectorXDecisionVariable>& vars,
               std::string& description) {
@@ -1578,7 +1578,7 @@ void BindSolutionResult(py::module_ m) {
 void BindPyFunctionCost(py::module_ m) {
   class_<PyFunctionCost, Cost, std::shared_ptr<PyFunctionCost>>(
       m, "PyFunctionCost", "Cost with its evaluator as a Python function")
-      .def(py::init<int, const py::function&, const std::string&>(),
+      .def(py::init<int, const py::callable&, const std::string&>(),
           py::arg("num_vars"), py::arg("func"), py::arg("description") = "",
           "Constructs a cost for a python function `func`, applied to "
           "`num_vars` variables.");
@@ -1588,7 +1588,7 @@ void BindPyFunctionConstraint(py::module_ m) {
   class_<PyFunctionConstraint, Constraint,
       std::shared_ptr<PyFunctionConstraint>>(m, "PyFunctionConstraint",
       "Constraint with its evaluator as a Python function")
-      .def(py::init<int, const py::function&, const Eigen::VectorXd&,
+      .def(py::init<int, const py::callable&, const Eigen::VectorXd&,
                const Eigen::VectorXd&, const std::string&>(),
           py::arg("num_vars"), py::arg("func"), py::arg("lb"), py::arg("ub"),
           py::arg("description") = "",

--- a/bindings/pydrake/solvers/solvers_py_projected_gradient_descent.cc
+++ b/bindings/pydrake/solvers/solvers_py_projected_gradient_descent.cc
@@ -53,7 +53,7 @@ void DefineSolversProjectedGradientDescent(py::module_ m) {
 
     pgd_cls.def(
         "SetCustomProjectionFunction",
-        [](Class& self, py::function python_projection_function) {
+        [](Class& self, py::callable python_projection_function) {
           auto cpp_projection_function = [python_projection_function](
                                              const Eigen::VectorXd& in,
                                              Eigen::VectorXd* out) {

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -263,7 +263,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
     using Class = ValueProducer;
     constexpr auto& cls_doc = doc.ValueProducer;
     class_<Class>(m, "ValueProducer", cls_doc.doc)
-        .def(py::init([](py::function allocate,
+        .def(py::init([](py::callable allocate,
                           std::function<void(py::object, py::object)> calc) {
           return Class(MakeCppCompatibleAllocateCallback(std::move(allocate)),
               MakeCppCompatibleCalcCallback(std::move(calc)));

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -729,7 +729,7 @@ Note: The above is for the C++ documentation. For Python, use
             py::arg("model_vector"), doc.LeafSystem.DeclareNumericParameter.doc)
         .def(
             "DeclareAbstractOutputPort",
-            [](PyLeafSystem* self, const std::string& name, py::function alloc,
+            [](PyLeafSystem* self, const std::string& name, py::callable alloc,
                 std::function<void(py::object, py::object)> calc,
                 const std::set<DependencyTicket>& prerequisites_of_calc)
                 -> const OutputPort<T>& {
@@ -1367,7 +1367,7 @@ void DefineSystemScalarConverter(PyClass* cls) {
       AddTemplateMethod(
           converter, "_AddConstructor",
           [](SystemScalarConverter* self,
-              py::function python_converter_function) {
+              py::callable python_converter_function) {
             AddPydrakeConverterFunction(self,
                 ConverterFunction{
                     [python_converter_function](const System<U>& system_u_cpp) {

--- a/bindings/pydrake/systems/value_producer_pybind.cc
+++ b/bindings/pydrake/systems/value_producer_pybind.cc
@@ -7,7 +7,7 @@ namespace drake {
 namespace pydrake {
 
 std::function<std::unique_ptr<AbstractValue>()>
-MakeCppCompatibleAllocateCallback(py::function allocate) {
+MakeCppCompatibleAllocateCallback(py::callable allocate) {
   return [allocate = std::move(allocate)]() -> std::unique_ptr<AbstractValue> {
     py::gil_scoped_acquire guard;
 

--- a/bindings/pydrake/systems/value_producer_pybind.h
+++ b/bindings/pydrake/systems/value_producer_pybind.h
@@ -15,7 +15,7 @@ namespace pydrake {
 // cannot return unique_ptr, so we need to wrap the call to match signatures.
 // The argument is the Python callback; the return value is the C++ callback.
 std::function<std::unique_ptr<AbstractValue>()>
-MakeCppCompatibleAllocateCallback(py::function allocate);
+MakeCppCompatibleAllocateCallback(py::callable allocate);
 
 // For parity with `allocate`, we also provide a wrapper for `calc`. It doesn't
 // do any special tricks (our nominal WrapCallbacks() technique could've handled

--- a/tools/workspace/pybind11/patches/nanobind_spellings.patch
+++ b/tools/workspace/pybind11/patches/nanobind_spellings.patch
@@ -128,6 +128,13 @@ See https://github.com/RobotLocomotion/drake/issues/21572.
  private:
      template <typename T>
      T string_op() const {
+@@ -2272,4 +2272,6 @@
+ };
+ 
++using callable = function;
++
+ class staticmethod : public object {
+ public:
 @@ -2549,6 +2549,11 @@
  }
  


### PR DESCRIPTION
Add a `pybind11::callable` alias and switch everywhere to use it.

Towards https://github.com/RobotLocomotion/drake/issues/21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24696)
<!-- Reviewable:end -->
