### PR TITLE
[pydrake] Simplify binding for SetCustomProjectionFunction

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_projected_gradient_descent.cc
+++ b/bindings/pydrake/solvers/solvers_py_projected_gradient_descent.cc
@@ -53,22 +53,17 @@ void DefineSolversProjectedGradientDescent(py::module_ m) {
 
     pgd_cls.def(
         "SetCustomProjectionFunction",
-        [](Class& self, py::callable python_projection_function) {
-          auto cpp_projection_function = [python_projection_function](
-                                             const Eigen::VectorXd& in,
-                                             Eigen::VectorXd* out) {
-            DRAKE_ASSERT(out != nullptr);
-            py::gil_scoped_acquire gil;
-            auto result = python_projection_function(in);
-            DRAKE_THROW_UNLESS(py::isinstance<py::tuple>(result));
-            py::tuple result_tuple = py::cast<py::tuple>(result);
-            DRAKE_THROW_UNLESS(result_tuple.size() == 2);
-            DRAKE_THROW_UNLESS(py::isinstance<py::bool_>(result_tuple[0]));
-            DRAKE_THROW_UNLESS(py::isinstance<py::array>(result_tuple[1]));
-            *out = py::cast<Eigen::VectorXd>(result_tuple[1]);
-            return py::cast<bool>(result_tuple[0]);
-          };
-          self.SetCustomProjectionFunction(cpp_projection_function);
+        [](Class& self, std::function<std::pair<bool, Eigen::VectorXd>(
+                            const Eigen::VectorXd& in)>
+                            python_projection_function) {
+          self.SetCustomProjectionFunction(
+              [python_projection_function](
+                  const Eigen::VectorXd& in, Eigen::VectorXd* out) {
+                DRAKE_DEMAND(out != nullptr);
+                bool result;
+                std::tie(result, *out) = python_projection_function(in);
+                return result;
+              });
         },
         py::arg("custom_projection_function"),
         R"""(


### PR DESCRIPTION
Declaring a `std::function` signature for the python callback handles argument casting and GIL acquisition for us automatically.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24703)
<!-- Reviewable:end -->
