### PR TITLE
[pydrake] Align with nanobind py::dict API

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -193,9 +193,11 @@ void InitLowLevelModules(py::module_ m) {
     DefPickle(
         &cls,
         [](const Class& self) {
-          return py::dict(py::arg("contents") = self.contents(),
-              py::arg("extension") = self.extension(),
-              py::arg("filename_hint") = self.filename_hint());
+          py::dict result;
+          result["contents"] = self.contents();
+          result["extension"] = self.extension();
+          result["filename_hint"] = self.filename_hint();
+          return result;
         },
         [ctor](Class* self, const py::dict& kwargs) {
           new (self) Class(py::cast<Class>(ctor(**kwargs)));

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -317,8 +317,10 @@ void DefineInMemoryMesh(py::module_ m) {
     DefPickle(
         &cls,
         [](const Class& self) {
-          return py::dict(py::arg("mesh_file") = self.mesh_file,
-              py::arg("supporting_files") = self.supporting_files);
+          py::dict result;
+          result["mesh_file"] = self.mesh_file;
+          result["supporting_files"] = self.supporting_files;
+          return result;
         },
         [ctor](Class* self, const py::dict& kwargs) {
           new (self) Class(py::cast<Class>(ctor(**kwargs)));
@@ -381,11 +383,14 @@ void DefineMeshSource(py::module_ m) {
     DefPickle(
         &cls,
         [](const Class& self) {
+          py::dict result;
           if (self.is_path()) {
-            return py::dict(py::arg("path") = self.path());
+            result["path"] = self.path();
+          } else {
+            DRAKE_DEMAND(self.is_in_memory());
+            result["mesh"] = self.in_memory();
           }
-          DRAKE_DEMAND(self.is_in_memory());
-          return py::dict(py::arg("mesh") = self.in_memory());
+          return result;
         },
         [ctor](Class* self, const py::dict& kwargs) {
           new (self) Class(py::cast<Class>(ctor(**kwargs)));


### PR DESCRIPTION
Nanobind doesn't offer the `py::arg`-based constructor to `py::dict`, so respell call sites to use one-by-one insertion.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24705)
<!-- Reviewable:end -->
