### PR TITLE
[workspace] Unpin mpmath_py_internal

### DIFF
--- a/tools/workspace/mpmath_py_internal/repository.bzl
+++ b/tools/workspace/mpmath_py_internal/repository.bzl
@@ -10,8 +10,12 @@ def mpmath_py_internal_repository(
         # of this cohort should be updated at the same time.
         repository = "mpmath/mpmath",
         upgrade_type = "release",
+        upgrade_advice = """
+        When upgrading, check https://github.com/sympy/sympy/issues/29231 (or
+        any release notes related to this issue, etc.) for a compatible upgrade
+        with sympy_internal.
+        """,
         commit = "1.3.0",
-        commit_pin = 1,
         sha256 = "8f702663fa422fbbf02d15792da4b2566160df35b8a4af55fe64cba2fec2aa00",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,

--- a/tools/workspace/sympy_py_internal/repository.bzl
+++ b/tools/workspace/sympy_py_internal/repository.bzl
@@ -11,8 +11,8 @@ def sympy_py_internal_repository(
         # of this cohort should be updated at the same time.
         upgrade_advice = """
         When upgrading, check https://github.com/sympy/sympy/issues/29231 (or
-        any release notes related to this issue, etc.) to see if
-        mpmath_py_internal should also be upgraded and its commit_pin removed.
+        any release notes related to this issue, etc.) for a compatible upgrade
+        with mpmath_py_internal.
         """,
         upgrade_type = "release",
         commit = "1.14.0",


### PR DESCRIPTION
This was previously pinned to avoid confusion from `new_release` reporting possible upgrades, when in reality an upgrade is currently not possible due to sympy's dependency on mpmath, and its incompatibility with the latest version.

However, OSQP and QDLDL have a similar relationship, and as recently determined, some slight confusion around reporting possible upgrades is the lesser of two evils compared to pinning. With the latter, we may fail to ever report upgrades again even when a future release resolves any compatibility issues.

So, instead, shape up mpmath's upgrade advice to match sympy for now.

See discussion on #24691.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24707)
<!-- Reviewable:end -->
