### PR TITLE
[multibody] Changed to "fused" terminology in topology code

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -5011,7 +5011,7 @@ be used by Finalize(); post-finalize it returns the joint type that
 *was* used if there were any base bodies in need of a joint.
 
 See also:
-    SetBaseBodyJointType(), GetCombineWeldedBodies(), Finalize())""";
+    SetBaseBodyJointType(), GetFuseWeldedLinks(), Finalize())""";
         } GetBaseBodyJointType;
         // Symbol: drake::multibody::MultibodyPlant::GetBodiesKinematicallyAffectedBy
         struct /* GetBodiesKinematicallyAffectedBy */ {
@@ -5168,25 +5168,6 @@ Note:
 See also:
     RegisterCollisionGeometry(), Finalize())""";
         } GetCollisionGeometriesForBody;
-        // Symbol: drake::multibody::MultibodyPlant::GetCombineWeldedBodies
-        struct /* GetCombineWeldedBodies */ {
-          // Source: drake/multibody/plant/multibody_plant.h
-          const char* doc =
-R"""((Internal use only for now) Returns the global or a model_instance
-setting for whether or not to combine welded RigidBody (Link)
-elements.
-
-Note:
-    This function can be called pre-Finalize() or post-Finalize().
-
-Parameter ``model_instance``:
-    (optional). If this argument is missing or not recognized, returns
-    the global setting. Otherwise returns the setting for this
-    specific model_instance.
-
-See also:
-    SetCombineWeldedBodies(), GetBaseBodyJointType(), Finalize())""";
-        } GetCombineWeldedBodies;
         // Symbol: drake::multibody::MultibodyPlant::GetConstraintActiveStatus
         struct /* GetConstraintActiveStatus */ {
           // Source: drake/multibody/plant/multibody_plant.h
@@ -5412,6 +5393,24 @@ Raises:
 Raises:
     RuntimeError if ``body`` is not a free body.)""";
         } GetFreeBodyPose;
+        // Symbol: drake::multibody::MultibodyPlant::GetFuseWeldedLinks
+        struct /* GetFuseWeldedLinks */ {
+          // Source: drake/multibody/plant/multibody_plant.h
+          const char* doc =
+R"""((Internal use only for now) Returns the global or a model_instance
+setting for whether or not to fuse welded Link (RigidBody) elements.
+
+Note:
+    This function can be called pre-Finalize() or post-Finalize().
+
+Parameter ``model_instance``:
+    (optional). If this argument is missing or not recognized, returns
+    the global setting. Otherwise returns the setting for this
+    specific model_instance.
+
+See also:
+    SetFuseWeldedLinks(), GetBaseBodyJointType(), Finalize())""";
+        } GetFuseWeldedLinks;
         // Symbol: drake::multibody::MultibodyPlant::GetJointActuatorByName
         struct /* GetJointActuatorByName */ {
           // Source: drake/multibody/plant/multibody_plant.h
@@ -6660,45 +6659,8 @@ Raises:
     RuntimeError if called after Finalize().
 
 See also:
-    GetBaseBodyJointType(), SetCombineWeldedBodies(), Finalize())""";
+    GetBaseBodyJointType(), SetFuseWeldedLinks(), Finalize())""";
         } SetBaseBodyJointType;
-        // Symbol: drake::multibody::MultibodyPlant::SetCombineWeldedBodies
-        struct /* SetCombineWeldedBodies */ {
-          // Source: drake/multibody/plant/multibody_plant.h
-          const char* doc =
-R"""((Internal use only for now) Controls whether welded-together RigidBody
-(Link) elements are to be combined into a single composite mobilized
-body in the generated model. If so, those Weld joints will not be
-modeled (i.e. will have no corresponding mobilizer) in the
-post-Finalize() model and there will be fewer mobilized bodies and
-modeled joints in the generated model than in the user's specification
-of links and joints. Results for the original RigidBody (Link)
-elements can still be obtained by name or BodyIndex, but no results
-(in particular, no reaction forces) are available for the unmodeled
-Weld joints.
-
-You can set this flag globally or on a per-model instance basis. If
-there is a setting for a joint's model instance then that setting is
-used; otherwise, the global setting is used.
-
-The default global setting for Drake is *not* to combine welded
-RigidBody elements.
-
-Parameter ``combine``:
-    Whether to combine welded-together bodies. This only affects a
-    particular model instance if the ``model_instance`` argument is
-    also provided, otherwise it sets the global value.
-
-Parameter ``model_instance``:
-    (optional) if present, specifies a particular model instance to
-    which the ``combine`` argument applies.
-
-Raises:
-    RuntimeError if called after Finalize().
-
-See also:
-    GetCombineWeldedBodies(), SetBaseBodyJointType(), Finalize())""";
-        } SetCombineWeldedBodies;
         // Symbol: drake::multibody::MultibodyPlant::SetConstraintActiveStatus
         struct /* SetConstraintActiveStatus */ {
           // Source: drake/multibody/plant/multibody_plant.h
@@ -7089,6 +7051,48 @@ given ``state`` rather than directly to the Context.
 Precondition:
     ``state`` comes from this MultibodyPlant.)""";
         } SetFreeBodySpatialVelocity;
+        // Symbol: drake::multibody::MultibodyPlant::SetFuseWeldedLinks
+        struct /* SetFuseWeldedLinks */ {
+          // Source: drake/multibody/plant/multibody_plant.h
+          const char* doc =
+R"""((Internal use only for now) Controls whether Link (RigidBody) elements
+that are welded to each other are to be fused onto a single mobilized
+body (a "fused mobod") in the generated model. If so, those weld
+joints will not be modeled (i.e. will have no corresponding mobilizer)
+in the post-Finalize() model; there will be fewer mobilized bodies and
+modeled joints in the generated model than in the user's specification
+of links and joints. Regardless of whether ``fuse`` is true or false,
+results for calculations (e.g., positions & velocities) involving
+individual links can still be obtained by name or LinkIndex
+(BodyIndex). However, no results (e.g., no reaction forces) are
+available for fused weld joints on a mobod.
+
+The ``fuse`` flag can be set globally or on a per-model instance
+basis. If SetFuseWeldedLinks() is called with a model instance then
+that setting is used for elements in that model instance; otherwise,
+the global setting is used.
+
+You will be able to override this setting for individual weld joints,
+for example to model a force/torque sensor (not available yet).
+
+The default global setting for Drake is *not* to combine welded
+RigidBody elements.
+
+Parameter ``fuse``:
+    Whether to fuse welded-together bodies. This only affects a
+    particular model instance if the ``model_instance`` argument is
+    also provided, otherwise it sets the global value.
+
+Parameter ``model_instance``:
+    (optional) if present, specifies a particular model instance to
+    which the ``fuse`` argument applies.
+
+Raises:
+    RuntimeError if called after Finalize().
+
+See also:
+    GetFuseWeldedLinks(), SetBaseBodyJointType(), Finalize())""";
+        } SetFuseWeldedLinks;
         // Symbol: drake::multibody::MultibodyPlant::SetPositions
         struct /* SetPositions */ {
           // Source: drake/multibody/plant/multibody_plant.h

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -459,7 +459,7 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "composite_test",
+    name = "fused_welds_test",
     deps = [
         ":plant",
         "//common/test_utilities:eigen_matrix_compare",

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1423,9 +1423,9 @@ void MultibodyPlant<T>::SetBaseBodyJointType(
 }
 
 template <typename T>
-void MultibodyPlant<T>::SetCombineWeldedBodies(
-    bool combine, std::optional<ModelInstanceIndex> model_instance) {
-  mutable_tree().SetCombineWeldedBodies(combine, model_instance);
+void MultibodyPlant<T>::SetFuseWeldedLinks(
+    bool fuse, std::optional<ModelInstanceIndex> model_instance) {
+  mutable_tree().SetFuseWeldedLinks(fuse, model_instance);
 }
 
 template <typename T>
@@ -1435,9 +1435,9 @@ BaseBodyJointType MultibodyPlant<T>::GetBaseBodyJointType(
 }
 
 template <typename T>
-bool MultibodyPlant<T>::GetCombineWeldedBodies(
+bool MultibodyPlant<T>::GetFuseWeldedLinks(
     std::optional<ModelInstanceIndex> model_instance) const {
-  return internal_tree().GetCombineWeldedBodies(model_instance);
+  return internal_tree().GetFuseWeldedLinks(model_instance);
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1759,38 +1759,43 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// @param[in] model_instance (optional) the index of the model instance to
   ///   which `joint_type` is to be applied.
   /// @throws std::exception if called after Finalize().
-  /// @see GetBaseBodyJointType(), SetCombineWeldedBodies(), Finalize()
+  /// @see GetBaseBodyJointType(), SetFuseWeldedLinks(), Finalize()
   void SetBaseBodyJointType(
       BaseBodyJointType joint_type,
       std::optional<ModelInstanceIndex> model_instance = {});
 
-  /// (Internal use only for now) Controls whether welded-together RigidBody
-  /// (Link) elements are to be combined into a single composite mobilized
-  /// body in the generated model. If so, those Weld joints will not be modeled
-  /// (i.e. will have no corresponding mobilizer) in the post-Finalize()
-  /// model and there will be fewer mobilized bodies and modeled joints in the
-  /// generated model than in the user's specification of links and joints.
-  /// Results for the original RigidBody (Link) elements can still be obtained
-  /// by name or BodyIndex, but no results (in particular, no reaction forces)
-  /// are available for the unmodeled Weld joints.
+  /// (Internal use only for now) Controls whether Link (RigidBody) elements
+  /// that are welded to each other are to be fused onto a single mobilized body
+  /// (a "fused mobod") in the generated model. If so, those weld joints will
+  /// not be modeled (i.e. will have no corresponding mobilizer) in the
+  /// post-Finalize() model; there will be fewer mobilized bodies and modeled
+  /// joints in the generated model than in the user's specification of links
+  /// and joints. Regardless of whether `fuse` is true or false, results for
+  /// calculations (e.g., positions & velocities) involving individual links can
+  /// still be obtained by name or LinkIndex (BodyIndex). However, no results
+  /// (e.g., no reaction forces) are available for fused weld joints on a mobod.
   ///
-  /// You can set this flag globally or on a per-model instance basis. If
-  /// there is a setting for a joint's model instance then that setting is
-  /// used; otherwise, the global setting is used.
+  /// The `fuse` flag can be set globally or on a per-model instance basis.
+  /// If SetFuseWeldedLinks() is called with a model instance then that
+  /// setting is used for elements in that model instance; otherwise, the
+  /// global setting is used.
+  ///
+  /// You will be able to override this setting for individual weld joints,
+  /// for example to model a force/torque sensor (not available yet).
   ///
   /// The default global setting for Drake is _not_ to combine welded RigidBody
   /// elements.
   ///
-  /// @param[in] combine Whether to combine welded-together bodies. This only
+  /// @param[in] fuse Whether to fuse welded-together bodies. This only
   ///   affects a particular model instance if the `model_instance` argument is
   ///   also provided, otherwise it sets the global value.
   /// @param[in] model_instance (optional) if present, specifies a particular
-  ///   model instance to which the `combine` argument applies.
+  ///   model instance to which the `fuse` argument applies.
   ///
   /// @throws std::exception if called after Finalize().
-  /// @see GetCombineWeldedBodies(), SetBaseBodyJointType(), Finalize()
-  void SetCombineWeldedBodies(
-      bool combine, std::optional<ModelInstanceIndex> model_instance = {});
+  /// @see GetFuseWeldedLinks(), SetBaseBodyJointType(), Finalize()
+  void SetFuseWeldedLinks(
+      bool fuse, std::optional<ModelInstanceIndex> model_instance = {});
 
   /// Returns the currently-set choice for base body joint type, either for
   /// the global setting or for a specific model instance if provided.
@@ -1800,20 +1805,20 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// This can be called any time -- pre-finalize it returns the joint type
   /// that will be used by Finalize(); post-finalize it returns the joint type
   /// that _was_ used if there were any base bodies in need of a joint.
-  /// @see SetBaseBodyJointType(), GetCombineWeldedBodies(), Finalize()
+  /// @see SetBaseBodyJointType(), GetFuseWeldedLinks(), Finalize()
   BaseBodyJointType GetBaseBodyJointType(
       std::optional<ModelInstanceIndex> model_instance = {}) const;
 
   /// (Internal use only for now) Returns the global or a model_instance setting
-  /// for whether or not to combine welded RigidBody (Link) elements.
+  /// for whether or not to fuse welded Link (RigidBody) elements.
   ///
   /// @note This function can be called pre-Finalize() or post-Finalize().
   ///
   /// @param[in] model_instance (optional). If this argument is missing or
   ///   not recognized, returns the global setting. Otherwise returns the
   ///   setting for this specific model_instance.
-  /// @see SetCombineWeldedBodies(), GetBaseBodyJointType(), Finalize()
-  bool GetCombineWeldedBodies(
+  /// @see SetFuseWeldedLinks(), GetBaseBodyJointType(), Finalize()
+  bool GetFuseWeldedLinks(
       std::optional<ModelInstanceIndex> model_instance = {}) const;
 
   /// This method must be called after all elements in the model (joints,

--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -1,7 +1,7 @@
 /* Tests that mass properties are identical whether welded-together links are
-modeled with explicit weld joints or combined into a single composite
-mobilized body. The test builds two identical models that differ only in whether
-SetCombineWeldedBodies() is enabled. */
+modeled with explicit weld joints or whether links that are welded together
+are fused into a mobilized body (fused Mobod). The test builds two identical
+models that differ only in whether SetFuseWeldedLinks() is enabled. */
 
 #include <limits>
 #include <memory>
@@ -33,7 +33,8 @@ using systems::Context;
 // Tolerance for numerical comparisons.
 constexpr double kTolerance = 32 * std::numeric_limits<double>::epsilon();
 
-// Holds one version of the test model (either explicit welds or composites)
+// Holds one version of the test model, either a model with explicit welds
+// or a model with welded links fused onto a mobilized body (fused mobod)
 // along with its context, ready for kinematics queries.
 struct TestModel {
   std::unique_ptr<MultibodyPlant<double>> plant;
@@ -68,14 +69,14 @@ The positions of the link origins from World origin Wo, expressed in World are:
   Link3: (cos θ − sin θ, sin θ + cos θ, 0)
   Link4: (4, 0, 0)
 
-With combine_welded_bodies = false, five mobilized bodies are created,
+With fuse_welded_bodies = false, five mobilized bodies are created,
 (World, Link1 via revolute, Link2 via weld, Link3 via weld, Link 4 via weld).
-With combine_welded_bodies = true two mobilized bodies are created,
-(World with link4 and one composite mobilized body with Link1, Link2, Link3). */
-TestModel MakeModel(bool combine_welded_bodies) {
+With fuse_welded_bodies = true two mobilized bodies are created,
+(World with link4 and one fused mobilized body with Link1, Link2, Link3). */
+TestModel MakeModel(bool fuse_welded_bodies) {
   TestModel m;
   m.plant = std::make_unique<MultibodyPlant<double>>(0.0 /* continuous */);
-  m.plant->SetCombineWeldedBodies(combine_welded_bodies);
+  m.plant->SetFuseWeldedLinks(fuse_welded_bodies);
 
   // To facilitate an analytical solution, each link has a trivial inertia,
   // namely a 1 kg solid cube, 0.1 m per side.
@@ -118,13 +119,13 @@ TestModel MakeModel(bool combine_welded_bodies) {
   EXPECT_EQ(m.plant->num_positions(), 1);   // 1 revolute angle.
   EXPECT_EQ(m.plant->num_velocities(), 1);  // 1 revolute angular rate.
   const internal::MultibodyTree<double>& tree = GetInternalTree(*m.plant);
-  EXPECT_EQ(tree.num_mobods(), combine_welded_bodies ? 2 : 5);
-  EXPECT_EQ(tree.num_mobilizers(), combine_welded_bodies ? 2 : 5);
+  EXPECT_EQ(tree.num_mobods(), fuse_welded_bodies ? 2 : 5);
+  EXPECT_EQ(tree.num_mobilizers(), fuse_welded_bodies ? 2 : 5);
   // Note: num_mobilizers() == num_mobods() because the World body gets a dummy
   // weld mobilizer at index 0 to keep mobilizer/body-node indexing identical.
 
   // Sanity check: Some information in the SpanningForest should be the same,
-  // whether or not the welded links are combined.
+  // whether or not the welded links are fused.
   const internal::SpanningForest& forest = tree.forest();
   const internal::SpanningForest::Mobod& mobod_0 =
       forest.mobods(internal::MobodIndex(0));
@@ -137,8 +138,8 @@ TestModel MakeModel(bool combine_welded_bodies) {
 
   // Ensure Mobods (mobilized bodies) have the proper follower link ordinals.
   // Each Mobod should have an active link ordinal. If welded links have
-  // been combined, then there are additional follower link ordinals.
-  if (combine_welded_bodies) {
+  // been fused, then there are additional follower link ordinals.
+  if (fuse_welded_bodies) {
     EXPECT_EQ(mobod_0.follower_link_ordinals(),
               (std::vector{LinkOrdinal(0), LinkOrdinal(4)}));
     EXPECT_EQ(mobod_1.follower_link_ordinals(),
@@ -156,10 +157,12 @@ void SetState(const TestModel& m, double angle_rad, double angular_vel) {
   m.revolute->set_angular_rate(m.context.get(), angular_vel);
 }
 
-/* Ensure the composite mobilized body's combined spatial inertia for Link123
-(links 1, 2, 3) is computed correctly. The 1x1 mass matrix for this 1-DOF
-model directly depends on the spatial inertia of Link123, so we also verify:
-  (a) The mass matrix is identical between the explicit-weld and composite
+/* Verify that the spatial inertia for fused mobod Link123 (with links 1, 2, 3)
+matches the sum of spatial inertias for unfused links 1, 2, 3. Next, ensure
+spatial inertia for each of the follower links in a fused mobod are computed
+correctly. Lastly, the 1x1 mass matrix for this 1-DOF model directly depends on
+the spatial inertia of Link123, so we also verify:
+  (a) The mass matrix is identical between the explicit-weld and fused
       models at several configurations.
   (b) The mass matrix matches the analytically computed value.
 
@@ -178,43 +181,43 @@ For a solid cube of mass m and side a, its moment of inertia about any axis
 through its COM is m*a²/6. The parallel axis theorem calculates each cube's
 moment of inertia about the revolute's z-axis via: Iᵢ = m*a²/6 + m*(dᵢ)²,
 where dᵢ (i=1,2,3) is the distance between each cube's COM and the revolute's
-z-axis. Iᵢ is independent of joint angle because the composite is welded
+z-axis. Iᵢ is independent of joint angle because the links are welded
 together.
 
   Link1: I₁ = 1*(0.1)²/6 + 1*0²    = 1/600 + 0   (d² = 0)
   Link2: I₂ = 1*(0.1)²/6 + 1*1²    = 1/600 + 1   (d² = 1)
   Link3: I₃ = 1*(0.1)²/6 + 1*√2²   = 1/600 + 2   (d² = 2)
   Total: Iₜ = 3/600 + 3 = 1/200 + 3 = 3.005 kg·m² */
-GTEST_TEST(CompositeTest, CompositeSpatialInertia) {
+GTEST_TEST(FusedTest, CompositeSpatialInertia) {
   const TestModel explicit_model = MakeModel(false /* no combining */);
-  const TestModel composite_model = MakeModel(true /* combine welds */);
+  const TestModel fused_model = MakeModel(true /* fuse welds */);
 
   const double m = 1.0, a = 0.1;  // mass m and side-length a of solid cubes.
   const Frame<double>& world_frame = explicit_model.plant->world_frame();
   const RigidBody<double>* explicit_links[] = {
       explicit_model.link1, explicit_model.link2, explicit_model.link3,
       explicit_model.link4};
-  const RigidBody<double>* composite_links[] = {
-      composite_model.link1, composite_model.link2, composite_model.link3,
-      composite_model.link4};
+  const RigidBody<double>* fused_links[] = {
+      fused_model.link1, fused_model.link2, fused_model.link3,
+      fused_model.link4};
 
   // The mass matrix is configuration-independent for this model (see above),
   // but we check at several angles to guard against future changes.
   const std::vector<double> angles = {0.0, M_PI / 6, M_PI / 4, -M_PI / 3};
   for (double angle : angles) {
     SetState(explicit_model, angle, 0.0);
-    SetState(composite_model, angle, 0.0);
+    SetState(fused_model, angle, 0.0);
 
     // Verify Link123's summed spatial inertia does not depend on whether they
-    // are a composite body.
+    // are on a fused mobod.
     SpatialInertia<double> M_EWo_W = explicit_model.plant->CalcSpatialInertia(
         *explicit_model.context, world_frame,
         {explicit_model.link1->index(), explicit_model.link2->index(),
          explicit_model.link3->index()});
-    SpatialInertia<double> M_CWo_W = composite_model.plant->CalcSpatialInertia(
-        *composite_model.context, world_frame,
-        {composite_model.link1->index(), composite_model.link2->index(),
-         composite_model.link3->index()});
+    SpatialInertia<double> M_CWo_W = fused_model.plant->CalcSpatialInertia(
+        *fused_model.context, world_frame,
+        {fused_model.link1->index(), fused_model.link2->index(),
+         fused_model.link3->index()});
     EXPECT_TRUE(CompareMatrices(M_EWo_W.CopyToFullMatrix6(),
                                 M_CWo_W.CopyToFullMatrix6(), kTolerance,
                                 MatrixCompareType::relative))
@@ -224,11 +227,11 @@ GTEST_TEST(CompositeTest, CompositeSpatialInertia) {
     // regardless of whether they were fused.
     for (int i = 0; i < 4; ++i) {
       const RigidBody<double>* explicit_linki = explicit_links[i];
-      const RigidBody<double>* composite_linki = composite_links[i];
+      const RigidBody<double>* fused_linki = fused_links[i];
       M_EWo_W = explicit_model.plant->CalcSpatialInertia(
           *explicit_model.context, world_frame, {explicit_linki->index()});
-      M_CWo_W = composite_model.plant->CalcSpatialInertia(
-          *composite_model.context, world_frame, {composite_linki->index()});
+      M_CWo_W = fused_model.plant->CalcSpatialInertia(
+          *fused_model.context, world_frame, {fused_linki->index()});
       EXPECT_TRUE(CompareMatrices(M_EWo_W.CopyToFullMatrix6(),
                                   M_CWo_W.CopyToFullMatrix6(), kTolerance,
                                   MatrixCompareType::relative))
@@ -249,11 +252,10 @@ GTEST_TEST(CompositeTest, CompositeSpatialInertia) {
     }
 
     // Ensure the mass matrix does not depend on welded links being combined.
-    MatrixX<double> M_explicit(1, 1), M_composite(1, 1);
+    MatrixX<double> M_explicit(1, 1), M_fused(1, 1);
     explicit_model.plant->CalcMassMatrix(*explicit_model.context, &M_explicit);
-    composite_model.plant->CalcMassMatrix(*composite_model.context,
-                                          &M_composite);
-    EXPECT_TRUE(CompareMatrices(M_explicit, M_composite, kTolerance,
+    fused_model.plant->CalcMassMatrix(*fused_model.context, &M_fused);
+    EXPECT_TRUE(CompareMatrices(M_explicit, M_fused, kTolerance,
                                 MatrixCompareType::relative))
         << "Mass matrix mismatch at angle = " << angle;
 
@@ -262,7 +264,7 @@ GTEST_TEST(CompositeTest, CompositeSpatialInertia) {
     const double M_expected = (Izz + m * 0.0) +  // Link1: d² = 0
                               (Izz + m * 1.0) +  // Link2: d² = 1² = 1
                               (Izz + m * 2.0);   // Link3: d² = √2² = 2
-    EXPECT_NEAR(M_composite(0, 0), M_expected, kTolerance)
+    EXPECT_NEAR(M_fused(0, 0), M_expected, kTolerance)
         << "Mass matrix analytical mismatch at angle = " << angle;
   }
 }
@@ -270,20 +272,20 @@ GTEST_TEST(CompositeTest, CompositeSpatialInertia) {
 /* Tests that CalcFrameBodyPoses() computes the correct composite mass
 properties by exercising every code path (including reverse welds):
 - Pass 1: non-identity frame poses X_LF, where link frame L and frame F are
-  both rigidly attached to the same body (so X_LF is constant). When a
+  both rigidly attached to the same mobod (so X_LF is constant). When a
   weld joint is NOT reversed, F is the inboard frame on the parent body, whereas
   for a reversed weld, F is the inboard frame on the child body.
 - Pass 2: poses X_BL, where mobod (mobilized body) frame B and link frame L
-  are both rigidly attached to the same body (so X_BL is constant). If L is the
-  composite body's "active" link, frame B is frame L and X_BL is identity. In
-  general, X_BL is non-identity for each "follower" link L welded into the
-  composite body B.
+  are both rigidly attached to the same mobod (so X_BL is constant). If L is the
+  fused mobod's "active" link, frame B is frame L and X_BL is identity. In
+  general, X_BL is non-identity for each "follower" link L welded onto the
+  fused mobod B.
 - Pass 3: mass property accumulation with both shifting and re-expressing.
 
 The strategy is to build two versions of the same physical system -- one with
-composites enabled and one without -- then verify that the mass matrix and
-gravity generalized forces agree. The mass matrix depends on M_BBo_B (the
-composite spatial inertia computed in Pass 3), while gravity forces also
+fusing enabled and one without -- then verify that the mass matrix and gravity
+generalized forces agree. The mass matrix depends on M_BBo_B (the spatial
+inertia computed in Pass 3 of CalcFrameBodyPoses()), while gravity forces also
 depend on p_BoLcm_B (each follower link's center of mass offset from Bo).
 
 Topology:
@@ -297,7 +299,7 @@ Topology:
      /
    World
 */
-GTEST_TEST(CompositeTest, CalcFrameBodyPosesAllPaths) {
+GTEST_TEST(FusedTest, CalcFrameBodyPosesAllPaths) {
   // Normal (not reversed) weld between parent=LinkA → child=LinkB.
   // Weld joint parent frame Jp is offset from LinkA's frame A by
   //      (+0.5, 0, +0.3) with a 30-degree rotation about x.
@@ -334,9 +336,9 @@ GTEST_TEST(CompositeTest, CalcFrameBodyPosesAllPaths) {
           RotationalInertia<double>(0.08, 0.04, 0.07, 0.002, 0.001, -0.003));
 
   // --- Helper lambda to build a model. ---
-  auto make_model = [&](bool combine) {
+  auto make_model = [&](bool fuse) {
     auto plant = std::make_unique<MultibodyPlant<double>>(0.0);
-    plant->SetCombineWeldedBodies(combine);
+    plant->SetFuseWeldedLinks(fuse);
 
     const auto& linkA = plant->AddRigidBody("LinkA", M_AAo_A);
     const auto& linkB = plant->AddRigidBody("LinkB", M_BBo_B);
@@ -364,49 +366,48 @@ GTEST_TEST(CompositeTest, CalcFrameBodyPosesAllPaths) {
   };
 
   // --- Build both models. ---
-  auto [plant_nc, context_nc] = make_model(false);  // no composites
-  auto [plant_c, context_c] = make_model(true);     // composites
+  auto [plant_nf, context_nf] = make_model(false);  // no fusing
+  auto [plant_f, context_f] = make_model(true);     // fusing
 
-  const auto& tree_nc = GetInternalTree(*plant_nc);
-  const auto& tree_c = GetInternalTree(*plant_c);
+  const auto& tree_nf = GetInternalTree(*plant_nf);
+  const auto& tree_f = GetInternalTree(*plant_f);
 
   // Sanity check: Both models should have the same number of bodies (World +
   // 3 links), number of joints (1 revolute + 2 welds), and number of states
   // (1 revolute angle and 1 revolute angular rate), but they should differ in
   // the number of mobilized bodies.
-  EXPECT_EQ(plant_nc->num_bodies(), plant_c->num_bodies());
-  EXPECT_EQ(plant_nc->num_joints(), plant_c->num_joints());
-  EXPECT_EQ(plant_nc->num_positions(), plant_c->num_positions());
-  EXPECT_EQ(plant_nc->num_velocities(), plant_c->num_velocities());
-  ASSERT_EQ(tree_nc.num_mobods(), 4);  // World + LinkA + LinkB + LinkC.
-  ASSERT_EQ(tree_c.num_mobods(),
-            2);  // World + composite body (links A, B, C).
+  EXPECT_EQ(plant_nf->num_bodies(), plant_f->num_bodies());
+  EXPECT_EQ(plant_nf->num_joints(), plant_f->num_joints());
+  EXPECT_EQ(plant_nf->num_positions(), plant_f->num_positions());
+  EXPECT_EQ(plant_nf->num_velocities(), plant_f->num_velocities());
+  ASSERT_EQ(tree_nf.num_mobods(), 4);  // World + LinkA + LinkB + LinkC.
+  ASSERT_EQ(tree_f.num_mobods(),
+            2);  // World + fused mobod (links A, B, C).
 
-  const auto& rev_nc = plant_nc->GetJointByName<RevoluteJoint>("revolute");
-  const auto& rev_c = plant_c->GetJointByName<RevoluteJoint>("revolute");
+  const auto& rev_nf = plant_nf->GetJointByName<RevoluteJoint>("revolute");
+  const auto& rev_f = plant_f->GetJointByName<RevoluteJoint>("revolute");
 
   for (const double angle : {M_PI / 5, -M_PI / 3}) {
-    rev_nc.set_angle(context_nc.get(), angle);
-    rev_c.set_angle(context_c.get(), angle);
+    rev_nf.set_angle(context_nf.get(), angle);
+    rev_f.set_angle(context_f.get(), angle);
 
-    // The mass matrix (1×1) should agree between the two models. This
-    // directly validates that CalcFrameBodyPoses produced the correct
-    // composite body inertia (M_BBo_B), since the mass matrix is computed
-    // from it.
-    MatrixX<double> mass_nc(1, 1), mass_c(1, 1);
-    plant_nc->CalcMassMatrix(*context_nc, &mass_nc);
-    plant_c->CalcMassMatrix(*context_c, &mass_c);
-    EXPECT_TRUE(CompareMatrices(mass_nc, mass_c, kTolerance,
+    // The mass matrix (1×1) should agree between the two models. This directly
+    // validates that CalcFrameBodyPoses() produced the correct mobod inertia
+    // (M_BBo_B), since the mass matrix is computed from it.
+    MatrixX<double> mass_nf(1, 1), mass_f(1, 1);
+    plant_nf->CalcMassMatrix(*context_nf, &mass_nf);
+    plant_f->CalcMassMatrix(*context_f, &mass_f);
+    EXPECT_TRUE(CompareMatrices(mass_nf, mass_f, kTolerance,
                                 MatrixCompareType::relative))
         << "Mass matrix mismatch at angle = " << angle;
 
     // Gravity generalized forces should agree (exercises AccumulateGravity
     // which depends on p_BoLcm_B computed in CalcFrameBodyPoses).
-    const VectorX<double> tau_g_nc =
-        plant_nc->CalcGravityGeneralizedForces(*context_nc);
-    const VectorX<double> tau_g_c =
-        plant_c->CalcGravityGeneralizedForces(*context_c);
-    EXPECT_TRUE(CompareMatrices(tau_g_nc, tau_g_c, kTolerance,
+    const VectorX<double> tau_g_nf =
+        plant_nf->CalcGravityGeneralizedForces(*context_nf);
+    const VectorX<double> tau_g_f =
+        plant_f->CalcGravityGeneralizedForces(*context_f);
+    EXPECT_TRUE(CompareMatrices(tau_g_nf, tau_g_f, kTolerance,
                                 MatrixCompareType::relative))
         << "Gravity generalized forces mismatch at angle = " << angle;
   }

--- a/multibody/topology/link_joint_graph.cc
+++ b/multibody/topology/link_joint_graph.cc
@@ -741,7 +741,7 @@ std::vector<LinkIndex> LinkJointGraph::FindPathFromWorld(
   std::vector<LinkIndex> path(mobod->level() + 1);
   while (mobod->inboard_mobod().is_valid()) {
     const Link& link = links(mobod->active_link_ordinal());
-    path[mobod->level()] = link.index();  // Active Link if optimized assembly.
+    path[mobod->level()] = link.index();  // Active Link if fused assembly.
     mobod = &forest().mobods(mobod->inboard_mobod());
   }
   DRAKE_DEMAND(mobod->is_world());

--- a/multibody/topology/link_joint_graph.h
+++ b/multibody/topology/link_joint_graph.h
@@ -35,12 +35,12 @@ Terminology notes:
  - The LinkIndex we use here is just an alias for MultibodyPlant's BodyIndex;
    they may be used interchangeably.
  - The spanning forest we generate uses "mobilized bodies" (Mobods). A single
-   Mobod may model a single Link or a composite formed of multiple Links that
-   are welded together. Conversely, a single Link may be split to create
-   multiple Mobods (to break cycles in the graph). As there is not necessarily
-   a one-to-one mapping, we're careful in this topology code not to use the term
-   "body" when we mean "link". If we say "body" at all it is in the context of
-   "mobilized body" or Mobod.
+   Mobod may model a single Link or a fused set of multiple Links that are
+   interconnected by weld joints. Conversely, a single Link may be split to
+   create multiple Mobods (to break cycles in the graph). As there is not
+   necessarily a one-to-one mapping, we're careful in this topology code not
+   to use the term "body" when we mean "link". If we say "body" at all it is
+   in the context of "mobilized body" or Mobod.
  - Because Links and Joints may be removed from an existing graph, there may be
    gaps in the sequence of LinkIndex and JointIndex values. However, any
    remaining Links and Joints are stored consecutively, indexed by LinkOrdinal
@@ -89,10 +89,10 @@ correspondence between elements of the graph and the forest:
     which will be included in the forest and added as an ephemeral element to
     the graph.
   - An assembly (links welded together) may be represented using fewer Mobods
-    than links so many Links may follow one Mobod.
+    than links so many Links may follow one "fused" Mobod.
   - Building the forest may require additional Joints to mobilize free bodies or
     immobilize static bodies. Each Joint maps to at most one Mobod; a weld joint
-    whose parent and child Links follow the same composite Mobod will not be
+    whose parent and child Links follow the same fused Mobod will not be
     modeled.
   - We never delete any of the user's Links or Joints; we may add new ones
     during forest building (the ephemeral elements mentioned above) but those
@@ -110,13 +110,15 @@ class LinkJointGraph {
     std::string name;
     int nq{-1};
     int nv{-1};
-    bool has_quaternion{false};  // If so, the first 4 qs are wxyz.
+    bool has_quaternion{false};  // If so, the first 4 qs are w[xyz].
   };
 
   /* A WeldedLinksAssembly is a set of Links and Weld Joints where the links
   are interconnected by paths comprised of one or more of those welds. Thus
   the whole assembly will move as a single rigid object. An assembly is
-  massless only if _all_ its constituent links are massless. */
+  massless only if _all_ its constituent links are massless. Note that these
+  links will not necessarily be fused (modeled together with a single mobod);
+  that's an option. */
   class WeldedLinksAssembly {
    public:
     const std::vector<LinkIndex>& links() const { return links_; }
@@ -386,7 +388,8 @@ class LinkJointGraph {
 
   /* Returns a reference to the vector of Link objects, contiguous and ordered
   by ordinal (not by LinkIndex). World is always the first entry and is always
-  present. `ssize(links())` is the number of Links currently in this graph. */
+  present. `ssize(links())` is the number of Links currently in this graph,
+  including both user and ephemeral links. */
   [[nodiscard]] const std::vector<Link>& links() const { return data_.links; }
 
   /* Returns the number of Links currently in this graph, including World and
@@ -410,7 +413,7 @@ class LinkJointGraph {
 
   /* Returns a reference to the vector of Joint objects, contiguous and ordered
   by ordinal (not by JointIndex). `ssize(joints())` is the number of Joints
-  currently in this graph. */
+  currently in this graph, including both user and ephemeral joints. */
   [[nodiscard]] const std::vector<Joint>& joints() const {
     return data_.joints;
   }
@@ -433,7 +436,7 @@ class LinkJointGraph {
       JointIndex joint_index) const;
 
   /* Returns a reference to the vector of LoopConstraint objects. These are
-  always "ephemeral" (added during forest-building) so this will return empty
+  always ephemeral (added during forest-building) so this will return empty
   if there is no valid forest. See the class comment for more information. */
   [[nodiscard]] const std::vector<LoopConstraint>& loop_constraints() const {
     return data_.loop_constraints;
@@ -444,20 +447,20 @@ class LinkJointGraph {
   [[nodiscard]] inline const LoopConstraint& loop_constraints(
       LoopConstraintIndex constraint_index) const;
 
-  /* Links with this ordinal or higher are "ephemeral" (added during
+  /* Links with this ordinal or higher are ephemeral (added during
   forest-building). See the class comment for more information. */
   [[nodiscard]] int num_user_links() const { return data_.num_user_links; }
 
-  /* Joints with this ordinal or higher are "ephemeral" (added during
+  /* Joints with this ordinal or higher are ephemeral (added during
   forest-building). See the class comment for more information. */
   [[nodiscard]] int num_user_joints() const { return data_.num_user_joints; }
 
   /* After the SpanningForest has been built, returns the index of the mobilized
-  body (Mobod) followed by this Link. If the Link is part of an optimized
-  WeldedLinksAssembly, the Mobod may be a composite body modeling other links
-  in addition to the given one. If the given Link was split into a primary and
-  shadows, this is the mobilized body followed by the primary. If there is no
-  valid forest, the returned index will be invalid. */
+  body (Mobod) followed by this Link. If the Link is part of a fused
+  WeldedLinksAssembly, the Mobod may be a fused (composite) body modeling other
+  links in addition to the given one. If the given Link was split into a
+  primary and shadows, this is the mobilized body followed by the primary. If
+  there is no valid forest, the returned index will be invalid. */
   [[nodiscard]] MobodIndex link_to_mobod(LinkIndex index) const;
 
   /* After the SpanningForest has been built, returns the graph's maximal
@@ -467,37 +470,37 @@ class LinkJointGraph {
   and will move as a single rigid body.
 
   The list of links in a WeldedLinksAssembly is ordered to facilitate
-  post-processing computations for links that follow composite Mobods. The first
-  Link entry is always the _active link_, whose non-weld inboard Joint moves the
-  whole assembly. (By convention, we consider World to be the active link for
-  the welded-to-World WeldedLinksAssembly.) The remaining links are ordered such
-  that kinematics of all links within a composite can be determined by
-  processing the links in the listed order, starting with the known kinematics
-  of the active link (in general, the most-inboard link of any composite Mobod).
-  See the note below for more detail.
+  post-processing computations for links that follow fused Mobods.
+  The first Link entry is always the _active link_, whose non-weld inboard
+  Joint moves the whole assembly. (By convention, we consider World to be the
+  active link for the welded-to-World WeldedLinksAssembly.) The remaining
+  links are ordered such that kinematics of all links within a fused mobod can
+  be determined by processing the links in the listed order, starting with
+  the known kinematics of the active link (in general, the most-inboard link
+  of any fused Mobod). See the note below for more detail.
 
   Modeling options affect how an assembly is modeled in the SpanningForest:
-  (1) If assembly optimization is disabled, then each link is modeled by
-      its own single-link Mobod with a Weld mobilizer, in the same manner as
-      is done for non-assembly links. Loops are cut by splitting links as
-      necessary. Reaction forces will be calculated for all the joints.
-  (2) If assembly optimization is enabled and no weld joint is marked for
+  (1) If fusing is disabled, then each link is modeled by its own single-link
+      Mobod with a Weld mobilizer, in the same manner as is done for
+      non-assembly links. Loops are cut by splitting links as necessary.
+      Reaction forces will be calculated for all the joints.
+  (2) If fusing is enabled and no weld joint is marked for
       special treatment, then the entire assembly is modeled with one
-      composite Mobod and its weld joints are not modeled at all. No loop
+      fused Mobod and its weld joints are not modeled at all. No loop
       splitting occurs; weld joints that close a loop are simply added to
       the assembly and left unmodeled. No reaction forces are calculated.
   (3) If any link's weld joint has been marked "must be modeled" then that link
       begins a new Mobod with a Weld mobilizer modeling the joint. In this case
       the assembly is modeled by several Mobods, which can be a mix of
-      single-link and composite Mobods. Loop splitting occurs when a _modeled_
+      single-link and fused-link Mobods. Loop splitting occurs when a _modeled_
       weld closes a loop, but not when an _unmodeled_ one does. Reaction
       forces are calculated for the modeled joints only.
 
   Most multibody algorithms have complexity proportional to the number of
-  Mobods, so optimized assemblies can result in considerable speedups. The
+  Mobods, so fused assemblies can result in considerable speedups. The
   tradeoff is that joints that are not modeled will not have reaction forces
   calculated. By marking some welds "must be modeled" you can get those
-  reactions and still obtain most of the advantage of optimized assemblies.
+  reactions and still obtain most of the advantage of fused assemblies.
 
   The 0th WeldedLinksAssembly is always present (if there is a valid
   SpanningForest) and its first entry is World (Link 0), even if nothing else is
@@ -514,22 +517,22 @@ class LinkJointGraph {
 
   @note (Advanced) To be precise about the order in which the links appear,
   consider a typical weld joint jᵢ interior to a WeldedLinksAssembly with active
-  link A that has been modeled with a single composite Mobod. Joint jᵢ connects
+  link A that has been modeled with just one fused Mobod. Joint jᵢ connects
   parent link pᵢ to child link cᵢ. Whichever of those links is topologically
   closer to A (typically, but not necessarily, pᵢ) will appear in the list
   before, but not necessarily adjacent to, the more-distal link. In case of a
   tie (only possible if the welds form a topological loop interior to the
-  assembly) the ordering of the two links is arbitrary. That ordering
-  permits intra-assembly kinematics (i.e., X_ALᵢ for the iᵗʰ link following a
-  composite Mobod) to be efficiently calculated by traversing the links in
-  order. (Precalculating those transforms allows for efficient post-processing
-  to get link kinematics from the calculated composite Mobod kinematics.)
-  Although we don't expect to report reaction forces for unmodeled joints for
-  a composite Mobod, this ordering can also facilitate computing those forces
-  for testing or other internal purposes: When there are no loops, it is
-  possible to post-process in reverse order to calculate reaction forces for
-  unmodeled joints interior to a composite body. Processed that way, each link
-  will have only one unknown reaction force at the time it is encountered. */
+  assembly) the ordering of the two links is arbitrary. That ordering permits
+  intra-assembly kinematics (i.e., X_ALᵢ for the iᵗʰ link following a fused
+  Mobod) to be efficiently calculated by traversing the links in order.
+  (Precalculating those transforms allows for efficient post-processing to get
+  link kinematics from the calculated fused Mobod kinematics.) Although we don't
+  report reaction forces for fused weld joints (i.e. weld joints internal to a
+  fused Mobod), this ordering can also facilitate computing those forces for
+  testing or other internal purposes: When there are no loops, it is possible to
+  post-process in reverse order to calculate reaction forces for unmodeled
+  joints interior to a fused mobod. Processed that way, each link will have only
+  one unknown reaction force at the time it is encountered. */
   [[nodiscard]] const std::vector<WeldedLinksAssembly>&
   welded_links_assemblies() const {
     return data_.welded_links_assemblies;
@@ -590,22 +593,22 @@ class LinkJointGraph {
   /* After the SpanningForest is built, returns the sequence of links from World
   to the given Link L in the forest. This is done by finding the path of Mobods
   leading to L's Mobod and reporting the sequence of links following those
-  Mobods. However, if any of those are composite Mobods (because of optimized
-  welded link assemblies) we report only the most-inboard link of each Mobod so
-  that there is only one link returned for each level in Link L's tree. World is
-  always the most-inboard link for its assembly so will always be the first
-  entry in the result. However, if L follows a composite Mobod, the final entry
-  will be L's Mobod's most-inboard link, which might not be L. Cost is O(ℓ)
-  where ℓ is Link L's level in the SpanningForest.
+  Mobods. However, if any of those are fused Mobods (because the option to
+  fuse welded link assemblies was chosen) we report only the active (most
+  inboard) link of each Mobod so that there is only one link returned for
+  each level in Link L's tree. World is always the active link for its assembly
+  so will always be the first entry in the result. However, if L follows a fused
+  Mobod, the final entry will be L's Mobod's active link, which might not be
+  L. Cost is O(ℓ) where ℓ is Link L's level in the SpanningForest.
   @throws std::exception if the SpanningForest hasn't been built yet.
   @see welded_link_assemblies(), SpanningForest::FindPathFromWorld() */
   std::vector<LinkIndex> FindPathFromWorld(LinkIndex link_index) const;
 
   /* After the SpanningForest is built, finds the first Link common to the paths
   towards World from each of two links in the forest. In case the ancestor is
-  on a composite Mobod (due to the ancestor being part of a WeldedLinksAssembly
-  that was optimized), the returned link will be that Mobod's most-inboard link,
-  not necessarily the link that would be the common ancestor if every link had
+  on a fused Mobod (due to the ancestor being part of a WeldedLinksAssembly
+  that was fused), the returned link will be that Mobod's active link, not
+  necessarily the link that would be the common ancestor if every link had
   its own Mobod.
 
   Returns World immediately if the links are on different trees of the forest.
@@ -631,10 +634,11 @@ class LinkJointGraph {
   /* After the SpanningForest is built, this method can be called to return a
   partitioning of the LinkJointGraph into subgraphs such that (a) every link is
   in one and only one subgraph, and (b) two links are in the same subgraph iff
-  there is a path between them which consists only of Weld joints. Each subgraph
-  of welded links is represented as a set of link indexes (using LinkIndex). By
-  definition, these subgraphs will be disconnected by any non-Weld joint between
-  two Links. A few notes:
+  there is a path between them which consists only of Weld joints (that is,
+  they are in the same assembly). Each subgraph of welded links is
+  represented as a set of link indexes (using LinkIndex). By definition,
+  these subgraphs will be disconnected by any non-Weld joint between two
+  Links. A few notes:
     - The maximum number of returned subgraphs equals the number of links in
       the graph. This corresponds to a graph with no Weld joints.
     - The World link is included in a set of welded links, and this set is
@@ -864,7 +868,7 @@ class LinkJointGraph {
   }
 
   // Notes that we didn't model this Joint in the forest because it is just a
-  // weld within an existing composite Mobod. We expect that the joint has
+  // weld within an existing fused Mobod. We expect that the joint has
   // already been added to the assembly; we just need to note that we decided
   // not to model it.
   void NoteUnmodeledJointInWeldedLinksAssembly(
@@ -900,7 +904,7 @@ class LinkJointGraph {
 
     std::vector<JointTraits> joint_traits;
 
-    // The first entry in links is the World Link with LinkIndex(0) and name
+    // The first entry in links is the World Link with LinkOrdinal(0) and name
     // world_link().name(). Ephemeral "as-built" links and joints are placed
     // at the end of these lists, following the user-supplied ones.
     // Access these lists by _ordinal_ rather than _index_.
@@ -950,7 +954,7 @@ class LinkJointGraph {
     // The 0th assembly always exists and contains World (listed first) and any
     // links welded (recursively) to World. Other assemblies are only
     // present if there are at least two Links welded together. The first Link
-    // in an assembly is the active Link.
+    // in a fused assembly is the active Link.
     std::vector<WeldedLinksAssembly> welded_links_assemblies;
 
     bool forest_is_valid{false};  // set false whenever changes are made

--- a/multibody/topology/link_joint_graph_defs.h
+++ b/multibody/topology/link_joint_graph_defs.h
@@ -50,8 +50,7 @@ enum class ForestBuildingOptions : uint32_t {
   kStatic = 1 << 0,                ///< Weld all links to World.
   kUseFixedBase = 1 << 1,          ///< Use welds rather than floating joints.
   kUseRpyFloatingJoints = 1 << 2,  ///< For floating, use RPY not quaternion.
-  kOptimizeWeldedLinksAssemblies =
-      1 << 3  ///< Make a single Mobod for welded Links.
+  kFuseWeldedLinksAssemblies = 1 << 3  ///< Use just one Mobod for welded Links.
 };
 
 // These overloads make the above enums behave like bitmasks for the operations

--- a/multibody/topology/link_joint_graph_joint.h
+++ b/multibody/topology/link_joint_graph_joint.h
@@ -185,7 +185,7 @@ class LinkJointGraph::Joint {
   // - monostate: not yet processed
   // - MobodIndex: modeled directly by a mobilizer
   // - WeldedLinksAssemblyIndex: not modeled because this is a weld interior to
-  //     the indicated assembly and we are optimizing so that one Mobod serves
+  //     the indicated assembly and we are fusing so that one Mobod serves
   //     the whole assembly.
   std::variant<std::monostate, MobodIndex, WeldedLinksAssemblyIndex>
       how_modeled_;

--- a/multibody/topology/link_joint_graph_link.h
+++ b/multibody/topology/link_joint_graph_link.h
@@ -18,7 +18,7 @@ namespace internal {
 user input and also those added during forest building as Shadow links created
 when we cut a user link in order to break a kinematic loop. Links may be
 modeled individually (each with its own Mobod) or can be combined with other
-mutually-welded links in a WeldedLinksAssembly onto a composite Mobod. */
+mutually-welded links in a WeldedLinksAssembly onto a fused Mobod. */
 class LinkJointGraph::Link {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Link);
@@ -108,12 +108,12 @@ class LinkJointGraph::Link {
   const std::vector<LinkIndex>& shadow_links() const { return shadow_links_; }
 
   /* Returns the index of the mobilized body (Mobod) that mobilizes this %Link.
-  If this %Link is part of a WeldedLinksAssembly, the returned Mobod may be
-  a composite of some or all of the links in the assembly (including this one
-  of course). If you ask this Mobod what Joint it represents, it will report the
-  Joint that was used to mobilize that composite; that won't necessarily be a
-  Joint connected to this %Link. See inboard_joint_index() to find the Joint
-  that connected this %Link to its WeldedLinksAssembly. */
+  If this %Link is part of a WeldedLinksAssembly, the returned Mobod may be a
+  fused mobod (containing some or all of the links in the assembly -- including
+  this one of course). If you ask this Mobod what Joint it represents, it will
+  report the Joint that was used to mobilize that fused mobod; that won't
+  necessarily be a Joint connected to this %Link. See inboard_joint_index() to
+  find the Joint that connected this %Link to its WeldedLinksAssembly. */
   MobodIndex mobod_index() const { return mobod_; }
 
   /* Returns the Joint that was used to associate this %Link with its

--- a/multibody/topology/spanning_forest.cc
+++ b/multibody/topology/spanning_forest.cc
@@ -67,7 +67,7 @@ The algorithm has three phases:
     numerics, but we can't allow massless terminal bodies unless they are welded
     to a massful body. Welded-together Links form a WeldedLinksAssembly object
     which will be modeled by one or more Mobods which may be a mix of
-    single-link and composite Mobods.
+    single-link and fused-link Mobods.
   2 Reorder the forest nodes (mobilized bodies) depth first for optimal
     computation. Each tree will consist only of consecutively-numbered nodes.
   3 Assign joint coordinates q and velocities v sequentially according
@@ -82,7 +82,7 @@ The algorithm has three phases:
 
 ForestBuildingOptions (global or per-model instance) determine
   - whether we produce a Mobod for _each_ Link in a WeldedLinksAssembly or
-    should produce a minimal number of Mobods by creating composite Mobods (as
+    should produce a minimal number of Mobods by creating fused Mobods (as
     permitted by options on individual weld joints), and
   - what kind of Joint we use to mobilize unconnected root Links: 0 dof fixed,
     6 dof roll-pitch-yaw floating, or 6 dof quaternion floating.
@@ -120,7 +120,7 @@ numbering here for clarification.
       E.1 Extend each tree one level at a time.
       E.2 Process all level 1 (base) Links directly jointed to World.
       E.3 Then process all level 2 Links jointed to level 1 Links, etc.
-      E.4 WeldedLinksAssemblies are (optionally) modeled using composite Mobods
+      E.4 WeldedLinksAssemblies are (optionally) modeled using fused Mobods
           where permitted (one level per Mobod).
       E.5 If we encounter a Link that has already been processed there is a
           loop. Split the Link into primary and shadow Links, and allocate
@@ -160,8 +160,8 @@ bool SpanningForest::BuildForest() {
   data_.forest_height = 1;  // Just World so far.
 
   /* Decide on forward/reverse mobilizers; optionally optimize
-  WeldedLinksAssemblies so that all the Links in a WeldedLinksAssembly follow a
-  single Mobod; choose links to serve as base (root) bodies and add 6dof
+  WeldedLinksAssemblies by fusing all the Links in a WeldedLinksAssembly
+  onto a single Mobod; choose links to serve as base (root) bodies and add 6dof
   mobilizers for them; split loops; add shadow bodies and weld constraints.
   (1.2-1.5) */
   ChooseForestTopology();
@@ -376,7 +376,7 @@ void SpanningForest::AssignCoordinates() {
 
 /* Phase 1 steps 1.4 and 1.5. */
 void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
-  // TODO(sherm1) Consider whether an optimized WeldedLinksAssembly (i.e.,
+  // TODO(sherm1) Consider whether a fused WeldedLinksAssembly (i.e.,
   //  follows just one Mobod) should be allowed to be a base body or
   //  should wait along with the other unjointed Links.
 
@@ -435,7 +435,7 @@ void SpanningForest::ChooseBaseBodiesAndAddTrees(int* num_unprocessed_links) {
                                                  unjointed_link);
     const JointOrdinal next_joint_ordinal =
         graph().index_to_ordinal(next_joint_index);
-    if (should_merge_parent_and_child(joints(next_joint_ordinal))) {
+    if (should_fuse_parent_and_child(joints(next_joint_ordinal))) {
       JoinExistingMobod(&data_.mobods[0], unjointed_link, next_joint_ordinal);
     } else {
       AddNewMobod(unjointed_link, next_joint_ordinal, world_mobod().index(),
@@ -463,7 +463,7 @@ void SpanningForest::ExtendTrees(const std::vector<JointIndex>& joints_to_model,
      Links onto a single Mobod), keep growing a WeldedLinkAssembly as far
      as possible to build the complete assembly and model it with a single
      Mobod.
-   2 If we encounter a massless Link (or massless optimized WeldedLinkAssembly),
+   2 If we encounter a massless Link (or massless fused WeldedLinkAssembly),
      we don't want its Mobod to be a terminal body of a branch. In that case we
      keep growing that branch until we can end with something massful. If we
      fail, we have to mark this forest as unsuited for dynamics since its mass
@@ -479,14 +479,14 @@ system mass matrix singular.
 
 Definitions used below
 ----------------------
-- Given a link L, we denote the _optimized_ WeldedLinksAssembly it belongs to
-    as L+. If we're not optimizing WeldedLinksAssemblies, then L+ == L.
+- Given a link L, we denote the _fused_ WeldedLinksAssembly it belongs to
+    as L+. If we're not fusing WeldedLinksAssemblies, then L+ == L.
 - A joint connects two links, parent and child. Every joint of interest here
     has at least one of its links already in the forest; that is its "inboard"
     link I. The other link is the "outboard" link O and is usually not yet in
     the forest.
 - A "merged joint" is a weld joint that connects two links that should be part
-    of the same optimized WeldedLinksAssembly. Merged joints do not have a
+    of the same fused WeldedLinksAssembly. Merged joints do not have a
     corresponding mobilizer in the forest; they are unmodeled.
 - Define Jₒₚₑₙ(L+) as the set of all not-yet-processed joints connected to any
     link in L+. These are "open" in the sense that only inboard link I of the
@@ -563,7 +563,7 @@ void SpanningForest::ExtendTreesOneLevel(const std::vector<JointIndex>& J_in,
       const JointOrdinal j_level_ordinal =
           graph().index_to_ordinal(j_level_index);
       const Joint& j_level = joints(j_level_ordinal);
-      DRAKE_DEMAND(!should_merge_parent_and_child(j_level));
+      DRAKE_DEMAND(!should_fuse_parent_and_child(j_level));
 
       /* The inboard link returned here is guaranteed to be in the forest
       already; in particular it follows the indicated inboard_mobod. The
@@ -582,7 +582,7 @@ void SpanningForest::ExtendTreesOneLevel(const std::vector<JointIndex>& J_in,
       }
 
       /* There isn't a loop and the outboard link isn't part of the same
-      optimized WeldedLinksAssembly as the inboard link. That means we are going
+      fused WeldedLinksAssembly as the inboard link. That means we are going
       to need a new Mobod. Note: a reference to this Mobod could be invalidated
       below; refer to it by its stable index instead. (A.3)*/
       const MobodIndex new_mobod_index =
@@ -592,7 +592,7 @@ void SpanningForest::ExtendTreesOneLevel(const std::vector<JointIndex>& J_in,
       --(*num_unprocessed_links);
 
       /* We just put link O on the new Mobod. O might just be the active link of
-      an optimized WeldedLinksAssembly O+. If so we need to build O+ now and
+      a fused WeldedLinksAssembly O+. If so we need to build O+ now and
       find all its open joints. (A.4) */
       J_open.clear();
       const Link& j_level_outboard_link = links(j_level_outboard_link_ordinal);
@@ -690,13 +690,13 @@ void SpanningForest::FindNextLevelJoints(MobodIndex inboard_mobod_index,
     const Joint& j_in = joint_by_index(j_in_index);
     if (j_in.has_been_processed()) continue;
 
-    if (!should_merge_parent_and_child(j_in)) {
+    if (!should_fuse_parent_and_child(j_in)) {
       J_level->push_back(j_in.index());
       continue;
     }
 
     /* This has to be a merged (unmodeled) joint with parent & child links part
-    of the same optimized WeldedLinksAssembly. We must grow the assembly in the
+    of the same fused WeldedLinksAssembly. We must grow the assembly in the
     outboard direction of the joint, which is the end that is _not_ already
     following the inboard Mobod. */
     const LinkIndex outboard_link_index =
@@ -962,8 +962,8 @@ const SpanningForest::Mobod& SpanningForest::JoinExistingMobod(
   if (!follower_link.is_massless())
     inboard_mobod->has_massful_follower_link_ = true;
 
-  /* We're not going to model this weld Joint since it is interior to an
-  optimized WeldedLinksAssembly. We need to note the assembly it is part of. */
+  /* We're not going to model this weld Joint since it is interior to a
+  fused WeldedLinksAssembly. We need to note the assembly it is part of. */
   mutable_graph().NoteUnmodeledJointInWeldedLinksAssembly(weld_joint_ordinal,
                                                           assembly_index);
   return *inboard_mobod;
@@ -1004,7 +1004,7 @@ void SpanningForest::GrowAssemblyMobod(
     would have already been in the forest. Hence all its non-merge joints
     are open (unprocessed). */
     DRAKE_DEMAND(!joint.has_been_processed());
-    if (!should_merge_parent_and_child(joint)) {
+    if (!should_fuse_parent_and_child(joint)) {
       open_joint_indexes->push_back(joint_index);
       continue;  // On to the next Joint.
     }

--- a/multibody/topology/spanning_forest.h
+++ b/multibody/topology/spanning_forest.h
@@ -33,8 +33,8 @@ study the original LinkJointGraph and update it to reflect:
   - which Links are welded together into WeldedLinksAssemblies.
 
 Welded-together Links have no relative motion so should be excluded from mutual
-collision computations and can (optionally) be optimized by modeling with one
-or more composite Mobods.
+collision computations and can (optionally) be optimized by modeling them with
+one or more _fused_ Mobods.
 
 Problem statement
 
@@ -74,7 +74,7 @@ And these additional properties are highly desirable:
   - The maximum branch length is minimized when breaking cycles.
   - Input parent->child edge directions are preserved as inboard->outboard
     directions when possible without increasing the maximum branch length.
-  - Welded-together links are combined onto one composite Mobod (optionally).
+  - Welded-together links are combined onto one fused Mobod (optionally).
 
 Discussion
 
@@ -87,7 +87,7 @@ even though inboard->outboard ordering may differ from parent->child, even if
 there are no loops. We distinguish "moving" (or "articulated") Joints from
 "weld" (0 dof) Joints; every moving Joint is modeled by a mobilizer, but welds
 may be eliminated by creating WeldedLinksAssemblies that can be modeled with
-composite Mobods.
+fused Mobods.
 
 Every Link is associated with a single Mobod in the SpanningForest. Multiple
 Links (contained in a WeldedLinksAssembly) may be represented by a single Mobod.
@@ -125,7 +125,7 @@ Things we get for free (O(1)) here as a side effect of building the forest:
   - find out which Mobod(s) represents a given Link
   - find out which Mobod (if any) represents a given Joint (welds internal
       to WeldedLinksAssemblies may be unmodeled)
-  - find all the Links that follow a particular Mobod (can be composite
+  - find all the Links that follow a particular Mobod (can be fused
       Mobods for Links in WeldedLinksAssemblies)
   - find out what (ephemeral) Links, Joints, and LoopConstraints appear in
       the forest but not the source Graph.
@@ -310,14 +310,14 @@ class SpanningForest {
 
   /* Returns precalculated groups of mobilized bodies that are mutually
   interconnected by Weld mobilizers so have no relative degrees of freedom. Note
-  that if you have chosen the modeling option to optimize welded-together Links
-  into single composite bodies, then each WeldedLinksAssembly gets only a single
+  that if you have chosen the modeling option to fuse welded-together Links onto
+  fused mobods, then each WeldedLinksAssembly gets only a single
   Mobod and hence there won't be any WeldedMobods groups here (except for World,
   see below). On the other hand, if some of the joints in a WeldedLinksAssembly
   have been designated "must be modeled", the assembly will be split over
   several Mobods connected by a weld mobilizer; in that case there will be a
-  corresponding WeldedMobods group. Use mobod_to_links() to find all the Links
-  following a single Mobod.
+  corresponding WeldedMobods group. Use mobod_to_link_ordinals() to find
+  all the Links following a single Mobod.
 
   The always-present World WeldedMobods group comes first and contains World,
   mobilized bodies representing Links marked "Static", and bodies (if any)
@@ -329,7 +329,7 @@ class SpanningForest {
   are in no particular order.
 
   Except for World, Mobods not welded to any other Mobods do not appear here.
-  @see mobod_to_links() */
+  @see mobod_to_link_ordinals() */
   const std::vector<std::vector<MobodIndex>>& welded_mobods() const {
     return data_.welded_mobods;
   }
@@ -355,15 +355,15 @@ class SpanningForest {
   }
 
   /* Returns the Link that is represented by the given Mobod, or the active
-  link if given a composite mobod. This could be one of the Links from the
+  link if given a fused mobod. This could be one of the Links from the
   original graph or an added shadow Link. An active link is the one whose
   mobilizer is used to move the whole mobod. Cost is O(1) and very fast.
   @pre mobod_index is in range */
   inline LinkOrdinal mobod_to_active_link_ordinal(MobodIndex mobod_index) const;
 
   /* Returns all the Links mobilized by this Mobod. The active link returned
-  by mobod_to_active_link() comes first, then any other links in the same
-  composite mobod. O(1), very fast.
+  by mobod_to_active_link_ordinal() comes first, then any other links in the
+  same fused mobod. O(1), very fast.
   @pre mobod_index is in range  */
   inline const std::vector<LinkOrdinal>& mobod_to_link_ordinals(
       MobodIndex mobod_index) const;
@@ -525,7 +525,7 @@ class SpanningForest {
   // "open" joints, each of which has one end already following the given
   // inboard Mobod. Returns a list of joints that represent the "next level" in
   // the forest outboard of the given Mobod. For any joint that isn't going to
-  // be an unmodeled internal joint in an optimized WeldedLinksAssembly, that
+  // be an unmodeled internal joint in a fused WeldedLinksAssembly, that
   // joint goes directly on the "next level" list. Otherwise, we have to extend
   // the assembly and find all the open joints where one end is part of the
   // assembly; those are the "next level".
@@ -576,7 +576,8 @@ class SpanningForest {
   // forward or reversed Mobilizer of the Joint's type. Then we add a Weld
   // Constraint to attach the shadow to its primary. Some details:
   //  - if one link is massless, split the other one
-  //  - if both are massless we have an invalid forest
+  //  - if both are massless we have an invalid forest (can't be used for
+  //    dynamics)
   //  - either or both Links may be part of a WeldedLinksAssembly; it is the
   //    mass properties of the whole assembly that determines masslessness.
   void HandleLoopClosure(JointOrdinal loop_joint_ordinal);
@@ -624,16 +625,16 @@ class SpanningForest {
     return *data_.graph;
   }
 
-  // Returns true if this model instance requests optimization (link merging) of
+  // Returns true if this model instance requests fusing (link merging) of
   // WeldedLinksAssemblies, either explicitly or via inheritance from the global
   // settings.
-  bool should_merge_welded_links_assemblies(ModelInstanceIndex index) const {
-    return static_cast<bool>(
-        options(index) & ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+  bool should_fuse_welded_links_assemblies(ModelInstanceIndex index) const {
+    return static_cast<bool>(options(index) &
+                             ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   }
 
-  // This implements our policy for when to optimize WeldedLinksAssemblies by
-  // merging their constituent Links onto a single Mobod. We're given a Joint
+  // This implements our policy for when to fuse WeldedLinksAssemblies by
+  // merging their constituent Links onto one fused Mobod. We're given a Joint
   // connecting parent and child Links and need to decide whether the parent and
   // child will follow a single Mobod or two different Mobods. If we decide to
   // merge them, the Joint won't be modeled at all since it will be interior to
@@ -641,27 +642,27 @@ class SpanningForest {
   //
   // To return true (merge), the following must all be true:
   //   - The joint must be a weld, and
-  //   - the joint's model instance must request optimizing assemblies, and
+  //   - the joint's model instance must request fusing assemblies, and
   //   - the joint has _not_ demanded that it be separately modeled.
-  bool should_merge_parent_and_child(const Joint& joint) const {
+  bool should_fuse_parent_and_child(const Joint& joint) const {
     return joint.is_weld() && !joint.must_be_modeled() &&
-           should_merge_welded_links_assemblies(joint.model_instance());
+           should_fuse_welded_links_assemblies(joint.model_instance());
   }
 
   // Adds the follower Link to the WeldedLinksAssembly that inboard_mobod is
-  // mobilizing and notes that the Joint is internal to that WeldedLinksAssembly
+  // mobilizing and notes that the Joint is internal to that fused assembly
   // so is not modeled. Will create the WeldedLinksAssembly if there was only
   // one Link mobilized before.
   const Mobod& JoinExistingMobod(Mobod* inboard_mobod,
                                  LinkOrdinal follower_link_ordinal,
                                  JointOrdinal weld_joint_ordinal);
 
-  // We're given an existing Mobod and a to-be-merged weld joint where that
+  // We're given an existing Mobod and a to-be-fused weld joint where that
   // joint's inboard link is already following the Mobod. Greedily extend this
-  // Mobod recursively to merge all links that are merge-welded to the inboard
-  // link. As we encounter non-merge joints attached to this assembly we append
-  // them to `open_joint_indexes` for processing next. Those constitute the
-  // "next level" outboard of this optimized WeldedLinksAssembly.
+  // Mobod recursively to fuse all links that are fuse-welded to the inboard
+  // link. As we encounter non-fusable joints attached to this assembly we
+  // append them to `open_joint_indexes` for processing next. Those constitute
+  // the "next level" outboard of this fused WeldedLinksAssembly.
   void GrowAssemblyMobod(Mobod* inboard_mobod, LinkIndex outboard_link_index,
                          JointOrdinal weld_joint_ordinal,
                          std::vector<JointIndex>* open_joint_indexes,
@@ -696,7 +697,7 @@ class SpanningForest {
 
     // Welded Mobod groups. These are disjoint sets of Mobods that have no
     // relative motion due to _separately modeled_ weld Joints (and _not_ due to
-    // weld constraints). (If we are optimizing WeldedLinksAssemblies, there
+    // weld constraints). (If we are fusing WeldedLinksAssemblies, there
     // won't be any Mobods welded together because we'll make all
     // welded-together Links follow a single Mobod.) The World Mobod group is
     // always present and comes first even if nothing is welded to it. Other

--- a/multibody/topology/spanning_forest_mobod.h
+++ b/multibody/topology/spanning_forest_mobod.h
@@ -19,7 +19,7 @@ namespace internal {
 A %Mobod models one or more Links and a single Joint. Those Links are said to
 "follow" this mobod. If there is more than one follower it is because the links
 are welded together (by unmodeled weld joints); in that case this is a
-"composite mobod". The modeled joint is the one that connects this mobod to its
+"fused mobod". The modeled joint is the one that connects this mobod to its
 inboard mobod. We call that joint the mobod's "active joint", and that joint's
 link that follows this mobod the "active link". (The active link may be either
 the parent or child link of the active joint, depending on how the forest was
@@ -88,9 +88,9 @@ class SpanningForest::Mobod {
   }
 
   /* Returns the ordinal of the Link mobilized by this %Mobod. If this is a
-  composite %Mobod (representing a collection of welded-together links), this is
-  the most-inboard ("active") link of that composite, the one with the modeled
-  Joint whose mobilizer connects the composite %Mobod to its inboard %Mobod.
+  fused %Mobod (representing a collection of welded-together links), this is
+  the most-inboard ("active") link of that mobod, the one with the modeled
+  Joint whose mobilizer connects the fused %Mobod to its inboard %Mobod.
   @see follower_link_ordinals(), joint() */
   LinkOrdinal active_link_ordinal() const {
     return follower_link_ordinals()[0];
@@ -101,7 +101,7 @@ class SpanningForest::Mobod {
   bool has_massful_follower_link() const { return has_massful_follower_link_; }
 
   /* Returns all the Links that are mobilized by this %Mobod. If this is a
-  composite %Mobod, the first link returned is the most-inboard ("active") link
+  fused %Mobod, the first link returned is the most-inboard ("active") link
   as returned by active_link_ordinal(). There is always at least one link.
   @see active_link_ordinal() */
   const std::vector<LinkOrdinal>& follower_link_ordinals() const {
@@ -110,7 +110,7 @@ class SpanningForest::Mobod {
   }
 
   /* Returns true if there is more than one link following this Mobod. */
-  bool is_composite() const { return ssize(follower_link_ordinals_) > 1; }
+  bool is_fused() const { return ssize(follower_link_ordinals_) > 1; }
 
   /* Returns true if the given Link is one of the followers of this %Mobod. */
   bool HasFollower(LinkOrdinal link_ordinal) const {
@@ -121,8 +121,8 @@ class SpanningForest::Mobod {
   }
 
   /* Returns the ordinal of the Joint represented by this %Mobod. If this
-  is a composite %Mobod (with internal, unmodeled weld joints), the joint
-  returned here is the modeled joint whose mobilizer connects the composite
+  is a fused %Mobod (with internal, unmodeled weld joints), the joint
+  returned here is the modeled joint whose mobilizer connects the fused
   %Mobod to its inboard %Mobod in the forest. The returned ordinal is invalid
   only if this is the World %Mobod. */
   JointOrdinal active_joint_ordinal() const { return joint_ordinal_; }
@@ -226,8 +226,8 @@ class SpanningForest::Mobod {
   // Set to true if _any_ follower link has mass.
   bool has_massful_follower_link_{false};
 
-  // The Joint modeled by this mobod's mobilizer. If this is a composite mobod,
-  // this is the active joint that connects the composite mobod to its inboard
+  // The Joint modeled by this mobod's mobilizer. If this is a fused mobod,
+  // this is the active joint that connects the fused mobod to its inboard
   // mobod.
   JointOrdinal joint_ordinal_;
 

--- a/multibody/topology/test/link_joint_graph_test.cc
+++ b/multibody/topology/test/link_joint_graph_test.cc
@@ -98,15 +98,14 @@ GTEST_TEST(LinkJointGraph, FlagsAndOptions) {
 
   // Repeat for Modeling Options.
   const auto use_fixed_base = ForestBuildingOptions::kUseFixedBase;
-  const auto combine_links =
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies;
+  const auto combine_links = ForestBuildingOptions::kFuseWeldedLinksAssemblies;
   auto forest_building_options = use_fixed_base | combine_links;
   static_assert(
       std::is_same_v<decltype(forest_building_options), ForestBuildingOptions>);
   EXPECT_EQ(forest_building_options & use_fixed_base,
             ForestBuildingOptions::kUseFixedBase);
   EXPECT_EQ(forest_building_options & combine_links,
-            ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+            ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   EXPECT_FALSE(static_cast<bool>(forest_building_options &
                                  ForestBuildingOptions::kUseRpyFloatingJoints));
   EXPECT_EQ(
@@ -130,7 +129,7 @@ GTEST_TEST(LinkJointGraph, SpecifyForestBuildingOptions) {
 
   const ForestBuildingOptions default_options = ForestBuildingOptions::kDefault;
   const ForestBuildingOptions two_options =
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies |
+      ForestBuildingOptions::kFuseWeldedLinksAssemblies |
       ForestBuildingOptions::kUseRpyFloatingJoints;
 
   // If we haven't said anything, global and all ModelInstance options are

--- a/multibody/topology/test/spanning_forest_test.cc
+++ b/multibody/topology/test/spanning_forest_test.cc
@@ -607,12 +607,12 @@ unless there is already an explicit weld; we'll check that.
 
 WeldedLinksAssemblies are always computed and consist of subgraphs of links that
 are mutually welded together (directly or indirectly). Depending on forest
-building options, we may use a single Mobod for a WeldedLinksAssembly (an
-"optimized assembly"), or we may use a Mobod for each of those welded-together
-links (an "unoptimized assembly"). In the latter case we also
+building options, we may use a single Mobod for a WeldedLinksAssembly (a
+"fused assembly"), or we may use a Mobod for each of those welded-together
+links (an "unfused assembly"). In the latter case we also
 compute "welded Mobod" groups consisting of Mobods that are mutually
 interconnected by weld mobilizers (directly or indirectly). When we're
-optimizing (modeling each WeldedLinksAssembly with just one Mobod), there won't
+fusing (modeling each WeldedLinksAssembly with just one Mobod), there won't
 be any welded-together Mobods. By convention, there will still be one welded
 Mobod group, consisting just of the World Mobod.
 
@@ -635,7 +635,7 @@ The LinkJointGraph
     * link10 would be the preferred base link but link 11 "base11" is marked
       "must be base link" so we have to use a reversed mobilizer there
 
-SerialChain 1 (don't optimize WeldedLinkAssemblies)
+SerialChain 1 (don't fuse WeldedLinkAssemblies)
 ---------------------------------------------------
   ≡> added weld joint       [mobods]
   6> added floating joint   {links}
@@ -846,7 +846,7 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   EXPECT_FALSE(forest.mobods(MobodIndex(3)).is_base_body());  // Generic case
   EXPECT_EQ(find_outv(3), pair(3, 2));
 
-  /* SerialChain 2 (optimize WeldedLinksAssemblies)
+  /* SerialChain 2 (fuse WeldedLinksAssemblies)
   -------------------------------------------------
   If instead we ask to merge welded Links we should get a much smaller
   forest:
@@ -863,11 +863,10 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
 
   graph.ResetForestBuildingOptions();  // Restore default options.
   graph.SetGlobalForestBuildingOptions(
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   graph.SetForestBuildingOptions(
-      static_model_instance,
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies |
-          ForestBuildingOptions::kStatic);
+      static_model_instance, ForestBuildingOptions::kFuseWeldedLinksAssemblies |
+                                 ForestBuildingOptions::kStatic);
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_NO_THROW(forest.SanityCheckForest());
 
@@ -896,7 +895,7 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
                    LinkIndex(1), LinkIndex(2), LinkIndex(3), LinkIndex(4),
                    LinkIndex(5), LinkIndex(11), LinkIndex(10), LinkIndex(9)}));
 
-  /* SerialChain 3 (optimize WeldedLinksAssemblies except for 10 & 11)
+  /* SerialChain 3 (fuse WeldedLinksAssemblies except for 10 & 11)
   --------------------------------------------------------------------
   We can optionally insist that a weld joint within an assembly that would
   otherwise be ignored is actually modeled with a weld mobilizer (useful if
@@ -937,7 +936,7 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   const std::vector<MobodIndex> now_expected{MobodIndex(6), MobodIndex(7)};
   EXPECT_EQ(forest.welded_mobods(WeldedMobodsIndex(1)), now_expected);
 
-  /* SerialChain 4 (optimize WeldedLinksAssemblies and use a fixed base)
+  /* SerialChain 4 (fuse WeldedLinksAssemblies and use a fixed base)
   ----------------------------------------------------------------------
   Finally, we'll restore joint 10-11 to its default setting and build again but
   this time with the kUseFixedBase option for model_instance.
@@ -955,16 +954,15 @@ GTEST_TEST(SpanningForest, SerialChainAndMore) {
   graph.ChangeJointFlags(joint_10_11_index, JointFlags::kDefault);
   graph.ResetForestBuildingOptions();  // Back to defaults.
   graph.SetGlobalForestBuildingOptions(
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   // Caution: we must specify all the forest building options we want for
   // a model instance; it won't inherit any of the global ones if set.
   graph.SetForestBuildingOptions(
-      model_instance, ForestBuildingOptions::kOptimizeWeldedLinksAssemblies |
+      model_instance, ForestBuildingOptions::kFuseWeldedLinksAssemblies |
                           ForestBuildingOptions::kUseFixedBase);
   graph.SetForestBuildingOptions(
-      static_model_instance,
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies |
-          ForestBuildingOptions::kStatic);
+      static_model_instance, ForestBuildingOptions::kFuseWeldedLinksAssemblies |
+                                 ForestBuildingOptions::kStatic);
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_NO_THROW(forest.SanityCheckForest());
 
@@ -1018,7 +1016,7 @@ a base body; it gets floating joint 15.
 
 There are three loops in this graph: {7-2-11}, {13-1-4}, and {10-6-8}. The
 forest-building algorithm will encounter them in that order. The last two loops
-are formed entirely of welds. When modeling in the unoptimized mode where every
+are formed entirely of welds. When modeling in the unfused mode where every
 Joint gets a Mobod all of these must be broken by adding shadow links. In each
 case the loop joint will be between two bodies at the same level in their tree,
 so the choice of which one to split should be made so that the parent->child
@@ -1028,7 +1026,7 @@ levels in the forest diagram below.) As a result, Link {11} will be split with
 shadow link {14*} on Joint 8, Link {1} gets shadow {15*} on weld Joint 1, and
 Link {8} gets shadow {16*} on weld Joint 6.
 
-Therefore we expect the following unoptimized WeldedLinksAssemblies, with the
+Therefore we expect the following unfused WeldedLinksAssemblies, with the
 World Assembly first:
   links            joints
   {0, 5, 7, 12}    12 11 13
@@ -1084,7 +1082,7 @@ like this:
 
 In this case we don't need to split the all-Weld loops since they are now
 just assemblies. Note that processing by level proceeds until we reach a new
-Mobod, so all the joints in an optimized assembly are processed together. Thus
+Mobod, so all the joints in a fused assembly are processed together. Thus
 the joint ordering is different than the previous case.
   links       joints
   {0 5 7 12}  12 11 13
@@ -1331,9 +1329,9 @@ GTEST_TEST(SpanningForest, WeldedSubgraphs) {
       EXPECT_EQ(forest.welded_mobods(w)[mobod], expected_mobods[w][mobod]);
   }
 
-  // Now optimize WeldedLinkAssemblies so they get a single Mobod.
+  // Now fuse WeldedLinkAssemblies so they get a single Mobod.
   graph.SetGlobalForestBuildingOptions(
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_NO_THROW(forest.SanityCheckForest());
 
@@ -1842,7 +1840,7 @@ GTEST_TEST(SpanningForest, WorldAssemblyComesFirst) {
 
   // Remodel making single Mobods for WeldedLinksAssemblies (optimizing).
   graph.SetGlobalForestBuildingOptions(
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_NO_THROW(forest.SanityCheckForest());
   EXPECT_EQ(ssize(forest.mobods()), 3);  // Because we're merging.
@@ -2128,7 +2126,7 @@ GTEST_TEST(SpanningForest, LoopWithAssemblies) {
   EXPECT_TRUE(graph.BuildForest());
 
   graph.SetGlobalForestBuildingOptions(
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   EXPECT_TRUE(graph.BuildForest());
   const SpanningForest& forest = graph.forest();
   EXPECT_NO_THROW(forest.SanityCheckForest());
@@ -2211,7 +2209,7 @@ GTEST_TEST(SpanningForest, LoopWithAssemblies) {
   EXPECT_NO_THROW(graph_copy.forest().SanityCheckForest());  // Empty but OK.
 }
 
-/* Make sure massless, optimized assemblies are working correctly. They are
+/* Make sure massless, fused assemblies are working correctly. They are
 supposed to behave the same way as individual massless bodies:
   - They should use only a single Mobod, and be treated as a single level
     along a branch for branch-length minimization purposes.
@@ -2221,11 +2219,11 @@ supposed to behave the same way as individual massless bodies:
   - We should not break a loop in a way that leaves a branch with a
     terminal massless assembly. (Test 3 below)
 */
-GTEST_TEST(SpanningForest, MasslessOptimizedAssemblies) {
+GTEST_TEST(SpanningForest, MasslessFusedAssemblies) {
   LinkJointGraph graph;
   const SpanningForest& forest = graph.forest();
   graph.SetGlobalForestBuildingOptions(
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   graph.RegisterJointType("revolute", 1, 1);
   const ModelInstanceIndex model_instance(19);
 
@@ -2368,10 +2366,10 @@ GTEST_TEST(SpanningForest, MasslessOptimizedAssemblies) {
 
 /* A joint connects a parent link to a child link. In general, the joint,
 parent, and child can each be in different model instances. Each of those
-model instances can specify whether we should optimize link assemblies to use
+model instances can specify whether we should fuse link assemblies to use
 a single Mobod or whether parent and child must each have their own Mobod.
 Our policy is that when a joint is a weld, we look only at that joint's
-model instance to determine whether that joint will optimize parent and child
+model instance to determine whether that joint will fuse parent and child
 onto a single Mobod.
 
 A few nuances:
@@ -2418,30 +2416,25 @@ GTEST_TEST(SpanningForest, CheckMergingPolicy) {
   // Only I5 should determine whether we merge {1} and {2}. Set the merge
   // flag on everything else and verify it makes no difference.
   graph.SetForestBuildingOptions(
-      ModelInstanceIndex(1),
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ModelInstanceIndex(1), ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   graph.SetForestBuildingOptions(
-      ModelInstanceIndex(2),
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ModelInstanceIndex(2), ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   graph.SetForestBuildingOptions(
-      ModelInstanceIndex(4),
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ModelInstanceIndex(4), ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_EQ(ssize(forest.mobods()), 4);
 
   // If I5 says merge, we should have one fewer Mobod.
   graph.SetForestBuildingOptions(
-      ModelInstanceIndex(5),
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+      ModelInstanceIndex(5), ForestBuildingOptions::kFuseWeldedLinksAssemblies);
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_EQ(ssize(forest.mobods()), 3);
 
   // We're still getting a Mobod for the static link {3}. Let's merge that
   // with World now.
   graph.SetForestBuildingOptions(
-      ModelInstanceIndex(3),
-      ForestBuildingOptions::kOptimizeWeldedLinksAssemblies |
-          ForestBuildingOptions::kStatic);
+      ModelInstanceIndex(3), ForestBuildingOptions::kFuseWeldedLinksAssemblies |
+                                 ForestBuildingOptions::kStatic);
   EXPECT_TRUE(graph.BuildForest());
   EXPECT_EQ(ssize(forest.mobods()), 2);
 

--- a/multibody/tree/body_node_impl.cc
+++ b/multibody/tree/body_node_impl.cc
@@ -118,11 +118,11 @@ void BodyNodeImpl<T, ConcreteMobilizer>::CalcPositionKinematicsCache_BaseToTip(
   const SpanningForest::Mobod& mobod = mobilizer_->mobod();
   pc->SetX_WL(mobod.active_link_ordinal(), X_WB);
 
-  // For composite mobods, also set X_WL for each follower (non-active) link Lₒ.
-  // Because Lₒ is rigidly offset from B by X_BLₒ (pre-computed in
+  // For fused mobods, also set X_WL for each follower (non-active)
+  // link Lₒ. Because Lₒ is rigidly offset from B by X_BLₒ (pre-computed in
   // frame_body_pose_cache during CalcFrameBodyPoses), its world pose is simply:
   //   X_WLₒ = X_WB * X_BLₒ
-  if (mobod.is_composite()) {
+  if (mobod.is_fused()) {
     const auto& followers = mobod.follower_link_ordinals();
     // followers[0] is the active link (already handled above); start at 1.
     for (int i = 1; i < ssize(followers); ++i) {

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -940,8 +940,8 @@ void MultibodyTree<T>::SetBaseBodyJointType(
 }
 
 template <typename T>
-void MultibodyTree<T>::SetCombineWeldedBodies(
-    bool combine, std::optional<ModelInstanceIndex> model_instance) {
+void MultibodyTree<T>::SetFuseWeldedLinks(
+    bool fuse, std::optional<ModelInstanceIndex> model_instance) {
   DRAKE_THROW_UNLESS(!is_finalized());
   LinkJointGraph& graph = mutable_graph();
 
@@ -953,11 +953,11 @@ void MultibodyTree<T>::SetCombineWeldedBodies(
           : graph.get_global_forest_building_options();
 
   // Clear the existing setting. This leaves us with the default which is _not_
-  // to combine welded bodies.
-  options = options & ~ForestBuildingOptions::kOptimizeWeldedLinksAssemblies;
+  // to fuse welded bodies.
+  options = options & ~ForestBuildingOptions::kFuseWeldedLinksAssemblies;
 
-  if (combine) {
-    options = options | ForestBuildingOptions::kOptimizeWeldedLinksAssemblies;
+  if (fuse) {
+    options = options | ForestBuildingOptions::kFuseWeldedLinksAssemblies;
   }
 
   if (model_instance.has_value()) {
@@ -982,15 +982,15 @@ BaseBodyJointType MultibodyTree<T>::GetBaseBodyJointType(
 }
 
 template <typename T>
-bool MultibodyTree<T>::GetCombineWeldedBodies(
+bool MultibodyTree<T>::GetFuseWeldedLinks(
     std::optional<ModelInstanceIndex> model_instance) const {
   const ForestBuildingOptions options =
       model_instance.has_value()
           ? graph().get_forest_building_options_in_use(*model_instance)
           : graph().get_global_forest_building_options();
 
-  return static_cast<bool>(
-      options & ForestBuildingOptions::kOptimizeWeldedLinksAssemblies);
+  return static_cast<bool>(options &
+                           ForestBuildingOptions::kFuseWeldedLinksAssemblies);
 }
 
 template <typename T>
@@ -1631,7 +1631,7 @@ void MultibodyTree<T>::CalcFrameBodyPoses(
   }
 
   // Pass 2 (over all mobods): find the pose X_BL of each Link frame L on its
-  // Mobod B. This is normally identity except if B is a composite mobod and
+  // Mobod B. This is normally identity except if B is a fused mobod and
   // Link L is not its "active" (most inboard) link.
   std::vector<uint8_t> got_X_BL(num_links(), false);
   for (const SpanningForest::Mobod& mobod : forest().mobods()) {
@@ -1640,7 +1640,7 @@ void MultibodyTree<T>::CalcFrameBodyPoses(
     frame_body_poses->SetX_BL(active_link_ordinal,
                               RigidTransform<T>::Identity());
     got_X_BL[active_link_ordinal] = true;
-    if (!mobod.is_composite()) continue;
+    if (!mobod.is_fused()) continue;
 
     // Continue with the "follower" links in mobod B, which should be in
     // inboard ⇒ outboard order (starting after the "active" link that we just
@@ -2582,9 +2582,9 @@ SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
 
     // Get the current body B's spatial inertia about Bo (body B's origin),
     // expressed in the world frame W. Start the calculation with a cached value
-    // for M_BBo_W if B is not a composite body (i.e., it is a one-link Mobod).
+    // for M_BBo_W if B is not a fused body (i.e., it is a one-link Mobod).
     const MobodIndex mobod_index = get_link(body_index).mobod_index();
-    if (!get_mobod(mobod_index).is_composite()) {
+    if (!get_mobod(mobod_index).is_fused()) {
       const SpatialInertia<T>& M_BBo_W = M_Bi_W[mobod_index];
 
       // Shift M_BBo_W from about-point Bo to about-point Wo and add to the sum.

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -966,15 +966,15 @@ class MultibodyTree {
       std::optional<ModelInstanceIndex> model_instance = {});
 
   // See MultibodyPlant API.
-  void SetCombineWeldedBodies(
-      bool combine, std::optional<ModelInstanceIndex> model_instance = {});
+  void SetFuseWeldedLinks(
+      bool fuse, std::optional<ModelInstanceIndex> model_instance = {});
 
   // See MultibodyPlant API.
   BaseBodyJointType GetBaseBodyJointType(
       std::optional<ModelInstanceIndex> model_instance = {}) const;
 
   // See MultibodyPlant API.
-  bool GetCombineWeldedBodies(
+  bool GetFuseWeldedLinks(
       std::optional<ModelInstanceIndex> model_instance = {}) const;
 
   // Finalize() must be called after all user-defined elements in the plant


### PR DESCRIPTION
Changes terminology in multibody/topology from "composite" and "optimized" to "fused" (thanks, Ganesh!) when we combine welded-together links onto a single mobilized body for efficiency. Also modifies places in MultibodyPlant & Tree that interface with topology. 

Renames composite_test to fused_welds_test and fixes its internal terminology to match.
Renames mobod.is_composite() to mobod.is_fused().
Renames Set/GetFuseWeldedBodies() to Set/GetFuseWeldedLinks() to better match documentation.

No user-visible changes here except to code in namespace `internal::` or already denoted "Internal use only".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24710)
<!-- Reviewable:end -->
