### PR TITLE
 [pydrake] Rewrite custom evaluator error-checking

### DIFF
--- a/bindings/pydrake/solvers/_extra.py
+++ b/bindings/pydrake/solvers/_extra.py
@@ -1,39 +1,105 @@
 import numpy as _np
 
 
-def _resolve_array_type(x):
-    # Resolves the scalar type for a given array.
-    assert isinstance(x, _np.ndarray), type(x)
-    assert x.size != 0
-    if x.dtype != object:
-        if x.dtype == float or x.dtype == int:
-            return float
+def _scalar_types_match(actual_type, expected_type):
+    return (actual_type is expected_type) or (
+        (expected_type is float) and (actual_type in (_np.float32, _np.float64))
+    )
+
+
+def _wrap_user_evaluator_func(
+    cls_name: str,
+    user_evaluator_func,
+    num_vars: int,
+    num_outputs: int,
+    output_dim: int,
+    expected_type: type,
+):
+    """The implementation of the C++ helper `WrapUserEvaluatorFunc`."""
+    assert output_dim in {0, 1}
+    if output_dim == 0:
+        assert num_outputs == 1
+
+    def _wrapped(x):
+        # This assertion is guaranteed by the C++ signature that calls us.
+        assert x.ndim == 1
+
+        # Check that the user passed the correct number of variables to the
+        # evaluator. When called from MathematicalProgram this is guaranteed,
+        # but direct calls to the evaluator might still have a mismatch.
+        #
+        # N.B. The C++ Eval code that calls us (via DoEval) in will (in Debug
+        # builds) assertion-check the size, so this Python check is only
+        # reachable in Release builds.
+        if x.size != num_vars:
+            raise ValueError(
+                f"{cls_name} input must have .size = {num_vars}. "
+                f"Got .size = {x.size} instead."
+            )
+
+        # Call the user's evaluator.
+        y = user_evaluator_func(x)
+
+        # For costs, the return value should be a scalar of the expected type.
+        if output_dim == 0:
+            if not _scalar_types_match(type(y), expected_type):
+                raise TypeError(
+                    f"When {cls_name} is called with an array of type "
+                    f"{expected_type.__name__} the return value must be a "
+                    "scalar (not array) of the same type, not a "
+                    f"{type(y).__name__} ({y!r})."
+                )
+            return y
+
+        # For constraints, the return value should be a vector of the expected
+        # type (either an np.ndarray or convertible to it).
+        if y is None:
+            raise TypeError(f"{cls_name} returned None")
+        try:
+            y = _np.asarray(y)
+        except Exception as e:
+            raise TypeError(
+                f"When {cls_name} is called with an array of type "
+                f"{expected_type.__name__} the return value must be an array "
+                f"of the same type (numpy conversion error: {e})."
+            )
+
+        # Validate the shape.
+        valid = (y.size == num_outputs) and (
+            y.ndim == 1 or (y.ndim == 2 and 1 in y.shape)
+        )
+        if not valid:
+            raise ValueError(
+                f"{cls_name} return value must be array of "
+                f".ndim = 1 or 2 (vector) and .size = {num_outputs}. "
+                f"Got .ndim = {y.ndim} and .size = {y.size} instead."
+            )
+        if num_outputs == 0:
+            return y
+
+        # Validate the dtype.
+        if y.dtype != object:
+            if y.dtype is float or y.dtype is int:
+                actual_type = float
+            else:
+                actual_type = y.dtype.type
         else:
-            return x.dtype.type
-    else:
-        # Search array for any non-builtin and non-numpy types.
-        for xi in x.flat:
-            t = type(xi)
-            if t.__module__ not in ("builtins", "numpy"):
-                return t
-        # Unable to infer type.
-        return None
+            # Search array for any non-builtin and non-numpy types.
+            for yi in y.flat:
+                t = type(yi)
+                if t.__module__ not in ("builtins", "numpy"):
+                    actual_type = t
+                    break
+            else:
+                # Unable to infer type.
+                actual_type = type(None)
+        if not _scalar_types_match(actual_type, expected_type):
+            raise TypeError(
+                f"When {cls_name} is called with an array of type "
+                f"{expected_type.__name__} the return value must be the same "
+                f"type, not {actual_type.__name__}."
+            )
 
+        return y
 
-def _check_returned_array_type(cls_name, y, expected_type):
-    # Used by CheckReturnedArrayType in C++.
-    if y.size == 0:
-        return
-    actual_type = _resolve_array_type(y)
-    expected_name = expected_type.__name__
-    if actual_type is None:
-        raise TypeError(
-            f"When {cls_name} is called with an array of type {expected_name} "
-            f"the return value must be the same type."
-        )
-    if actual_type is not expected_type:
-        actual_name = actual_type.__name__
-        raise TypeError(
-            f"When {cls_name} is called with an array of type {expected_name} "
-            f"the return value must be the same type, not {actual_name}."
-        )
+    return _wrapped

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -72,59 +72,15 @@ using symbolic::Variable;
 using symbolic::Variables;
 
 namespace {
-enum class ArrayShapeType { Scalar, Vector };
 
-// Checks array shape, provides user-friendly message if it fails.
-void CheckArrayShape(
-    py::str var_name, py::array x, ArrayShapeType shape, int size) {
-  bool ndim_is_good{};
-  py::str ndim_hint;
-  if (shape == ArrayShapeType::Scalar) {
-    ndim_is_good = (x.ndim() == 0);
-    ndim_hint = py::str("0 (scalar)");
-  } else {
-    ndim_is_good = (x.ndim() == 1 || x.ndim() == 2);
-    ndim_hint = py::str("1 or 2 (vector)");
-  }
-  if (!ndim_is_good || x.size() != size) {
-    throw std::runtime_error(py::cast<std::string>(
-        py::str("{} must be of .ndim = {} and .size = {}. "
-                "Got .ndim = {} and .size = {} instead.")
-            .format(var_name, ndim_hint, size, x.ndim(), x.size())));
-  }
-}
-
-// Checks array type, provides user-friendly message if it fails.
-template <typename T>
-void CheckReturnedArrayType(py::str cls_name, py::array y) {
-  py::module_ m = py::module_::import_("pydrake.solvers._extra");
-  m.attr("_check_returned_array_type")(cls_name, y, GetPyParam<T>()[0]);
-}
-
-// Wraps user function to provide better user-friendliness.
+// Wraps user cost or constraint evaluation function to provide better error
+// messages when the input or output are incorrectly typed or sized.
 template <typename T, typename Func>
-Func WrapUserFunc(py::str cls_name, py::callable func, int num_vars,
-    int num_outputs, ArrayShapeType output_shape) {
-  // TODO(eric.cousineau): It would be nicer to write this in Python.
-  // TODO(eric.cousineau): Consider using `py::detail::make_caster<>`. However,
-  // this may mean the argument is converted twice.
-  py::cpp_function wrapped = [=](py::array x) {
-    // Check input.
-    // WARNING: If the input is badly sized, we will only reach this error in
-    // Release mode. In debug mode, an assertion error will be triggered.
-    CheckArrayShape(py::str("{}: Input").format(cls_name), x,
-        ArrayShapeType::Vector, num_vars);
-    // N.B. We use `py::object` instead of `py::array` for the return type
-    /// because for dtype=object, you cannot implicitly cast `np.array(T())`
-    // (numpy scalar) to `T` (object), at least for AutoDiffXd.
-    py::object y = func(x);
-    // Check output.
-    CheckArrayShape(py::str("{}: Return value").format(cls_name), y,
-        output_shape, num_outputs);
-    CheckReturnedArrayType<T>(cls_name, y);
-    return y;
-  };
-  return py::cast<Func>(wrapped);
+Func WrapUserEvaluatorFunc(py::str cls_name, py::callable func, int num_vars,
+    int num_outputs, int output_dim) {
+  py::module_ m = py::module_::import_("pydrake.solvers._extra");
+  return py::cast<Func>(m.attr("_wrap_user_evaluator_func")(
+      cls_name, func, num_vars, num_outputs, output_dim, GetPyParam<T>()[0]));
 }
 
 // TODO(eric.cousineau): Make a Python virtual base, and implement this in
@@ -164,8 +120,8 @@ class PyFunctionCost : public Cost {
  private:
   template <typename T, typename Func>
   Func Wrap(py::callable func) {
-    return WrapUserFunc<T, Func>(py::str("PyFunctionCost"), func, num_vars(),
-        num_outputs(), ArrayShapeType::Scalar);
+    return WrapUserEvaluatorFunc<T, Func>(py::str("PyFunctionCost"), func,
+        num_vars(), num_outputs(), /* output_dim = */ 0);
   }
 
   const DoubleFunc double_func_;
@@ -213,8 +169,8 @@ class PyFunctionConstraint : public Constraint {
  private:
   template <typename T, typename Func>
   Func Wrap(py::callable func) {
-    return WrapUserFunc<T, Func>(py::str("PyFunctionConstraint"), func,
-        num_vars(), num_outputs(), ArrayShapeType::Vector);
+    return WrapUserEvaluatorFunc<T, Func>(py::str("PyFunctionConstraint"), func,
+        num_vars(), num_outputs(), /* output_dim = */ 1);
   }
 
   const DoubleFunc double_func_;

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1102,27 +1102,27 @@ class TestMathematicalProgram(unittest.TestCase):
             x0_bad = array_T([0.0, 1.0])
             # Bad input (before function is called).
             if kDrakeAssertIsArmed:
-                # See note in `WrapUserFunc`.
+                # See note in `_wrap_user_evaluator_func`.
                 input_error_cls = SystemExit
                 input_error_expected = (
                     "x.rows() == num_vars_ || num_vars_ == Eigen::Dynamic"
                 )
             else:
-                input_error_cls = RuntimeError
+                input_error_cls = ValueError
                 input_error_expected = (
-                    "PyFunctionCost: Input must be of .ndim = 1 or 2 (vector) "
-                    "and .size = 1. Got .ndim = 1 and .size = 2 instead."
+                    "PyFunctionCost input must have .size = 1. "
+                    "Got .size = 2 instead."
                 )
             with self.assertRaises(input_error_cls) as cm:
                 binding_bad_shape.evaluator().Eval(x0_bad)
             self.assertIn(input_error_expected, str(cm.exception))
             # Bad output shape.
-            with self.assertRaises(RuntimeError) as cm:
+            with self.assertRaises(TypeError) as cm:
                 binding_bad_shape.evaluator().Eval(x0)
-            self.assertEqual(
+            self.assertIn(
+                "When PyFunctionCost is called with an array of type "
+                f"{T.__name__} the return value must be a scalar",
                 str(cm.exception),
-                "PyFunctionCost: Return value must be of .ndim = 0 (scalar) "
-                "and .size = 1. Got .ndim = 1 and .size = 1 instead.",
             )
 
             # Bad output dtype.
@@ -1135,11 +1135,10 @@ class TestMathematicalProgram(unittest.TestCase):
             binding_bad_dtype = prog.AddCost(user_cost_bad_dtype, vars=x)
             with self.assertRaises(TypeError) as cm:
                 binding_bad_dtype.evaluator().Eval(x0)
-            self.assertEqual(
-                str(cm.exception),
+            self.assertIn(
                 f"When PyFunctionCost is called with an array of type "
-                f"{T.__name__} the return value must be the same type, not "
-                f"{U.__name__}.",
+                f"{T.__name__} the return value must be a scalar",
+                str(cm.exception),
             )
 
     def test_pyconstraint_wrap_error(self):
@@ -1147,63 +1146,78 @@ class TestMathematicalProgram(unittest.TestCase):
         # TODO(eric.cousineau): It would be nice to not need a
         # MathematicalProgram to test these.
 
-        def user_constraint_bad_shape(x):
-            # WARNING: This should return a vector, not a scalar!
-            return x[0]
+        # The bad constraint returns this value.
+        bad_return = None
+
+        def user_constraint_bad(x):
+            return bad_return
 
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(1, "x")
-        binding_bad_shape = prog.AddConstraint(
-            user_constraint_bad_shape, lb=[0.0], ub=[2.0], vars=x
+        binding_bad = prog.AddConstraint(
+            user_constraint_bad, lb=[0.0], ub=[2.0], vars=x
         )
 
         for T in SCALAR_TYPES:
             array_T = np.vectorize(T)
             x0 = array_T([0.0])
             x0_bad = array_T([0.0, 1.0])
+
             # Bad input (before function is called).
             if kDrakeAssertIsArmed:
-                # See note in `WrapUserFunc`.
+                # See note in `_wrap_user_evaluator_func`.
                 input_error_cls = SystemExit
                 input_error_expected = (
                     "x.rows() == num_vars_ || num_vars_ == Eigen::Dynamic"
                 )
             else:
-                input_error_cls = RuntimeError
+                input_error_cls = ValueError
                 input_error_expected = (
-                    "PyFunctionConstraint: Input must be of .ndim = 1 or 2 "
-                    "(vector) and .size = 1. Got .ndim = 1 and .size = 2 "
-                    "instead."
+                    "PyFunctionConstraint input must have .size = 1. "
+                    "Got .size = 2 instead."
                 )
             with self.assertRaises(input_error_cls) as cm:
-                binding_bad_shape.evaluator().Eval(x0_bad)
+                binding_bad.evaluator().Eval(x0_bad)
             self.assertIn(input_error_expected, str(cm.exception))
-            # Bad output.
-            with self.assertRaises(RuntimeError) as cm:
-                binding_bad_shape.evaluator().Eval(x0)
-            self.assertEqual(
-                str(cm.exception),
-                "PyFunctionConstraint: Return value must be of .ndim = 1 or 2 "
-                "(vector) and .size = 1. Got .ndim = 0 and .size = 1 instead.",
-            )
 
-            # Bad output dtype.
-            U = self.get_different_scalar_type(T)
-
-            def user_constraint_bad_dtype(x):
-                # WARNING: This should return the same dtype as x!
-                return [U(0.0)]
-
-            binding_bad_dtype = prog.AddConstraint(
-                user_constraint_bad_dtype, lb=[0.0], ub=[2.0], vars=x
-            )
+            # Bad result: Want vector, not None!
+            bad_return = None
             with self.assertRaises(TypeError) as cm:
-                binding_bad_dtype.evaluator().Eval(x0)
+                binding_bad.evaluator().Eval(x0)
             self.assertEqual(
                 str(cm.exception),
+                "PyFunctionConstraint returned None",
+            )
+
+            # Bad result: Want vector, not scalar!
+            bad_return = x0[0]
+            with self.assertRaises(ValueError) as cm:
+                binding_bad.evaluator().Eval(x0)
+            self.assertEqual(
+                str(cm.exception),
+                "PyFunctionConstraint return value must be array of "
+                ".ndim = 1 or 2 (vector) and .size = 1. "
+                "Got .ndim = 0 and .size = 1 instead.",
+            )
+
+            # Bad result: Inhomogeneous list sizes (np.asarray raises).
+            bad_return = [[1.0, 2.0], [3.0]]
+            with self.assertRaises(TypeError) as cm:
+                binding_bad.evaluator().Eval(x0)
+            self.assertIn(
+                "numpy conversion error",
+                str(cm.exception),
+            )
+
+            # Bad result: Wrong output dtype!
+            U = self.get_different_scalar_type(T)
+            bad_return = [U(0.0)]
+            with self.assertRaises(TypeError) as cm:
+                binding_bad.evaluator().Eval(x0)
+            self.assertIn(
                 f"When PyFunctionConstraint is called with an array of type "
-                f"{T.__name__} the return value must be the same type, not "
-                f"{U.__name__}.",
+                f"{T.__name__} the return value must be the same type, not ",
+                str(cm.exception),
             )
 
     def test_addcost_symbolic(self):


### PR DESCRIPTION
Implement the TODO to rewrite from C++ to Python. This makes nanobind porting vastly simpler (its ndarray type is totally different).

Towards #21572. ~Requires #24711 to land first.~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24712)
<!-- Reviewable:end -->
