### PR TITLE
[examples] Fix acrobot yaml avoid string for controller param

### DIFF
--- a/examples/acrobot/test/acrobot_io_test.py
+++ b/examples/acrobot/test/acrobot_io_test.py
@@ -29,7 +29,7 @@ tape_period: 0.05
         scenario = load_scenario(filename=self.example)
         expected = ", ".join(
             [
-                "{'controller_params': [5, 50, 5, '1e3']",
+                "{'controller_params': [5, 50, 5, 1000.0]",
                 "'initial_state': [1.2, 0, 0, 0]",
                 "'t_final': 30.0",
                 "'tape_period': 0.05}",

--- a/examples/acrobot/test/example_scenario.yaml
+++ b/examples/acrobot/test/example_scenario.yaml
@@ -1,6 +1,6 @@
 # An example scenario for acrobot.
 
-controller_params: [5, 50, 5, 1e3]
+controller_params: [5, 50, 5, !!float 1e3]
 initial_state: [1.2, 0, 0, 0]
 t_final: 30.0
 tape_period: 0.05


### PR DESCRIPTION
Somehow calling [BasicVector::SetFromVector](https://github.com/RobotLocomotion/drake/blob/5361765365c5832bbc387ffc96078560461813c8/examples/acrobot/spong_sim.py#L40-L42) with a list where one element is a string representation of a float succeeded with the pybind11 type caster, but it doesn't work with nanobind. Fix the yaml to using a float (or int) for all controller_params.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24714)
<!-- Reviewable:end -->
