### PR TITLE
[pydrake] Align with nanobind py::foo_error API

### DIFF
--- a/bindings/pydrake/common/wrap_pybind.h
+++ b/bindings/pydrake/common/wrap_pybind.h
@@ -98,7 +98,8 @@ struct type_caster_wrapped {
       // example.
       static constexpr auto original_name = Wrapper::original_name;
       throw py::cast_error(
-          std::string("Can only pass ") + original_name.text + " by value.");
+          fmt::format("Can only pass {} by value.", original_name.text)
+              .c_str());
     }
     return WrappedTypeCaster::cast(
         Wrapper::wrap(std::forward<TType>(src)), policy, parent);

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -96,8 +96,9 @@ class PyRenderEngine : public RenderEngine {
       auto deepcopy = py::module_::import_("copy").attr("deepcopy");
       py::object copied = deepcopy(this);
       if (copied.is_none()) {
-        throw pybind11::type_error(fmt::format(
-            "{}.__deepcopy__ returned None", NiceTypeName::Get(*this)));
+        throw py::type_error(fmt::format(
+            "{}.__deepcopy__ returned None", NiceTypeName::Get(*this))
+                .c_str());
       }
       return copied;
     };

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -174,7 +174,7 @@ void DefineBusValue(py::module_ m) {
           [](py::object self, py::str key) -> py::object {
             py::object result = self.attr("Find")(key);
             if (result.is_none()) {
-              throw py::key_error(py::cast<std::string>(key));
+              throw py::key_error(key.c_str());
             }
             return result;
           },

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -95,7 +95,8 @@ void BindPiecewisePolynomialSerialize(PyClass* cls) {
       return self_py.attr("_polynomials");
     }
     throw py::attribute_error(
-        fmt::format("PiecewisePolynomial has no attribute '{}'", name_cxx));
+        fmt::format("PiecewisePolynomial has no attribute '{}'", name_cxx)
+            .c_str());
   });
   cls->def("__setattr__", [](Class& self, py::str name, py::object value) {
     const std::string_view name_cxx(name.c_str());


### PR DESCRIPTION
Nanobind doesn't offer the `std::string` argument to its exception factory functions (only `const char*`), so respell call sites to use `c_str()` which accepted by both pybind11 and nanobind.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24715)
<!-- Reviewable:end -->
