### PR TITLE
[pydrake] Add regression tests for nullptr arguments

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -358,20 +358,20 @@ void DoScalarIndependentDefinitions(py::module_ m) {
             static_cast<void (*)(CameraInfo const&,
                 Image<PixelType::kRgba8U> const*, char const*)>(
                 &PyRenderEngine::ThrowIfInvalid<Image<PixelType::kRgba8U>>),
-            py::arg("intrinsics"), py::arg("image"), py::arg("image_type"),
-            cls_doc.ThrowIfInvalid.doc)
+            py::arg("intrinsics"), py::arg("image").none(),
+            py::arg("image_type"), cls_doc.ThrowIfInvalid.doc)
         .def_static("ThrowIfInvalid",
             static_cast<void (*)(CameraInfo const&,
                 Image<PixelType::kDepth32F> const*, char const*)>(
                 &PyRenderEngine::ThrowIfInvalid<Image<PixelType::kDepth32F>>),
-            py::arg("intrinsics"), py::arg("image"), py::arg("image_type"),
-            cls_doc.ThrowIfInvalid.doc)
+            py::arg("intrinsics"), py::arg("image").none(),
+            py::arg("image_type"), cls_doc.ThrowIfInvalid.doc)
         .def_static("ThrowIfInvalid",
             static_cast<void (*)(CameraInfo const&,
                 Image<PixelType::kLabel16I> const*, char const*)>(
                 &PyRenderEngine::ThrowIfInvalid<Image<PixelType::kLabel16I>>),
-            py::arg("intrinsics"), py::arg("image"), py::arg("image_type"),
-            cls_doc.ThrowIfInvalid.doc);
+            py::arg("intrinsics"), py::arg("image").none(),
+            py::arg("image_type"), cls_doc.ThrowIfInvalid.doc);
     // Note that we do not bind MakeRgbFromLabel nor MakeLabelFromRgb, because
     // crossing the C++ <=> Python boundary one pixel at a time would be
     // extraordinarily inefficient.

--- a/bindings/pydrake/geometry/test/optimization_test.py
+++ b/bindings/pydrake/geometry/test/optimization_test.py
@@ -985,6 +985,14 @@ class TestGeometryOptimization(unittest.TestCase):
             ),
             MathematicalProgramResult,
         )
+        self.assertIsInstance(
+            spp.SolveConvexRestriction(
+                active_edges=[edge0, edge1],
+                options=options,
+                initial_guess=None,
+            ),
+            MathematicalProgramResult,
+        )
         self.assertEqual(
             len(
                 spp.GetSolutionPath(

--- a/bindings/pydrake/geometry/test/visualizers_test.py
+++ b/bindings/pydrake/geometry/test/visualizers_test.py
@@ -160,6 +160,28 @@ class TestGeometryVisualizers(unittest.TestCase):
         load_subscriber.clear()
         draw_subscriber.clear()
 
+    @numpy_compare.check_nonsymbolic_types
+    def test_drake_visualizer_internal_lcm(self, T):
+        """Use lcm=None during construction."""
+        builder = DiagramBuilder_[T]()
+        scene_graph = builder.AddSystem(mut.SceneGraph_[T]())
+
+        # Add the visualizer by hand.
+        by_hand = builder.AddSystem(mut.DrakeVisualizer_[T](lcm=None))
+        builder.Connect(
+            scene_graph.get_query_output_port(),
+            by_hand.query_object_input_port(),
+        )
+
+        # Add the visualizer with the AddToBuilder sugar.
+        mut.DrakeVisualizer_[T].AddToBuilder(
+            builder=builder,
+            scene_graph=scene_graph,
+            lcm=None,
+        )
+
+        builder.Build()
+
     def test_meshcat_params(self):
         prop_a = mut.MeshcatParams.PropertyTuple(
             path="a",

--- a/bindings/pydrake/multibody/test/cenic_test.py
+++ b/bindings/pydrake/multibody/test/cenic_test.py
@@ -12,8 +12,11 @@ class TestCenic(unittest.TestCase):
         builder = RobotDiagramBuilder_[T](time_step=0.0)
         diagram = builder.Build()
 
-        # Create the device under test.
+        # The context argument is not required.
         CenicIntegrator = mut.CenicIntegrator_[T]
+        CenicIntegrator(system=diagram)
+
+        # Create the device under test.
         dut = CenicIntegrator(system=diagram, context=None)
 
         # Confirm parameter operations.

--- a/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_differential_test.py
@@ -173,39 +173,39 @@ class TestPlanner(unittest.TestCase):
         Parser(plant).AddModels(file_name)
         plant.Finalize()
 
-        robot_context = plant.CreateDefaultContext()
         frame = plant.GetFrameByName("Link2")
         time_step = 0.1
         parameters = mut.DifferentialInverseKinematicsParameters(2, 2)
 
-        integrator = mut.DifferentialInverseKinematicsIntegrator(
-            robot=plant,
-            frame_A=plant.world_frame(),
-            frame_E=frame,
-            time_step=time_step,
-            parameters=parameters,
-            robot_context=robot_context,
-            log_only_when_result_state_changes=True,
-        )
+        for robot_context in [plant.CreateDefaultContext(), None]:
+            integrator = mut.DifferentialInverseKinematicsIntegrator(
+                robot=plant,
+                frame_A=plant.world_frame(),
+                frame_E=frame,
+                time_step=time_step,
+                parameters=parameters,
+                robot_context=robot_context,
+                log_only_when_result_state_changes=True,
+            )
 
-        context = integrator.CreateDefaultContext()
-        X_AE = integrator.ForwardKinematics(context=context)
+            context = integrator.CreateDefaultContext()
+            X_AE = integrator.ForwardKinematics(context=context)
 
-        integrator.get_mutable_parameters().set_time_step(0.2)
-        self.assertEqual(integrator.get_parameters().get_time_step(), 0.2)
+            integrator.get_mutable_parameters().set_time_step(0.2)
+            self.assertEqual(integrator.get_parameters().get_time_step(), 0.2)
 
-        integrator2 = mut.DifferentialInverseKinematicsIntegrator(
-            robot=plant,
-            frame_E=frame,
-            time_step=time_step,
-            parameters=parameters,
-            robot_context=robot_context,
-            log_only_when_result_state_changes=True,
-        )
+            integrator2 = mut.DifferentialInverseKinematicsIntegrator(
+                robot=plant,
+                frame_E=frame,
+                time_step=time_step,
+                parameters=parameters,
+                robot_context=robot_context,
+                log_only_when_result_state_changes=True,
+            )
 
-        context2 = integrator2.CreateDefaultContext()
-        X_WE = integrator2.ForwardKinematics(context2)
-        self.assertTrue(X_AE.IsExactlyEqualTo(X_WE))
+            context2 = integrator2.CreateDefaultContext()
+            X_WE = integrator2.ForwardKinematics(context2)
+            self.assertTrue(X_AE.IsExactlyEqualTo(X_WE))
 
 
 class TestDiffIkSystems(unittest.TestCase):

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -258,6 +258,20 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(parser.plant(), plant)
         self.assertEqual(parser.scene_graph(), scene_graph)
 
+        # Again, but leaving out the plant and scene_graph from the Parser
+        # constructor; they should be retrieved from inside the builder.
+        builder = DiagramBuilder()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=0.0)
+        parser = Parser(
+            builder=builder,
+            plant=None,
+            scene_graph=None,
+            model_name_prefix="prefix",
+        )
+        self.assertEqual(parser.builder(), builder)
+        self.assertEqual(parser.plant(), plant)
+        self.assertEqual(parser.scene_graph(), scene_graph)
+
     def test_model_instance_info(self):
         """Checks that ModelInstanceInfo bindings exist."""
         ModelInstanceInfo.model_name

--- a/bindings/pydrake/solvers/test/projected_gradient_descent_solver_test.py
+++ b/bindings/pydrake/solvers/test/projected_gradient_descent_solver_test.py
@@ -33,6 +33,7 @@ class TestProjectedGradientDescentSolver(unittest.TestCase):
 
         # Test that we can specify a projection solver interface.
         projection_solver = ClarabelSolver()
+        solver.SetProjectionSolverInterface(None)
         solver.SetProjectionSolverInterface(
             projection_solver_interface=projection_solver
         )

--- a/bindings/pydrake/symbolic/test/symbolic_test.py
+++ b/bindings/pydrake/symbolic/test/symbolic_test.py
@@ -912,6 +912,9 @@ class TestSymbolicExpression(unittest.TestCase):
         (x + y + uni + gau + exp).Evaluate(env, g)
         (x + y + uni + gau + exp).Evaluate(env=env, generator=g)
 
+        # Checks passing nullptr as the generator (and no environment).
+        sym.Expression().Evaluate(None)
+
     def test_evaluate_partial(self):
         env = {x: 3.0, y: 4.0}
         partial_evaluated = (x + y + z).EvaluatePartial(env)
@@ -1733,8 +1736,12 @@ class TestSymbolicPolynomial(unittest.TestCase):
         m = np.array([[3, 4]])
         evaluated1 = sym.Evaluate(m)
         evaluated2 = sym.Evaluate(m=m)
+        evaluated3 = sym.Evaluate(m=m, env={})
+        evaluated4 = sym.Evaluate(m=m, generator=None)
         self.assertTrue(np.array_equal(evaluated1, m))
         self.assertTrue(np.array_equal(evaluated2, m))
+        self.assertTrue(np.array_equal(evaluated3, m))
+        self.assertTrue(np.array_equal(evaluated4, m))
 
     def test_matrix_evaluate_with_env(self):
         m = np.array([[x + y, x * y]])
@@ -1742,8 +1749,10 @@ class TestSymbolicPolynomial(unittest.TestCase):
         expected = np.array([[m[0, 0].Evaluate(env), m[0, 1].Evaluate(env)]])
         evaluated1 = sym.Evaluate(m, env)
         evaluated2 = sym.Evaluate(m=m, env=env)
+        evaluated3 = sym.Evaluate(m=m, env=env, generator=None)
         self.assertTrue(np.array_equal(evaluated1, expected))
         self.assertTrue(np.array_equal(evaluated2, expected))
+        self.assertTrue(np.array_equal(evaluated3, expected))
 
     def test_matrix_evaluate_with_random_generator(self):
         u = sym.Variable("uni", sym.Variable.Type.RANDOM_UNIFORM)

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -222,7 +222,7 @@ PYDRAKE_MODULE(analysis, m) {
               py::keep_alive<0, 1>(), cls_doc.get_mutable_context.doc)
           .def("reset_context",
               py::overload_cast<Context<T>*>(&Class::reset_context),
-              py::arg("context"),
+              py::arg("context") = nullptr,
               // Keep alive, reference: `context` keeps `self` alive.
               py::keep_alive<2, 1>(), cls_doc.reset_context.doc);
     }
@@ -537,7 +537,7 @@ Parameter ``interruptible``:
               num_samples, generator, /* parallelism = */ Parallelism::None());
         },
         py::arg("make_simulator"), py::arg("output"), py::arg("final_time"),
-        py::arg("num_samples"), py::arg("generator"),
+        py::arg("num_samples"), py::arg("generator") = nullptr,
         doc.analysis.MonteCarloSimulation.doc);
   }
 

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -249,6 +249,9 @@ class TestAnalysis(unittest.TestCase):
 
         integrator.Reset()
 
+        # Clearing the context is allowed.
+        integrator.reset_context(context=None)
+
     def test_symbolic_integrators(self):
         x = Variable("x")
         sys = SymbolicVectorSystem_[Expression](state=[x], dynamics=[-x + x**3])
@@ -350,6 +353,9 @@ class TestAnalysis(unittest.TestCase):
         self.assertEqual(simulator.get_num_unrestricted_updates(), 0)
 
         self.assertIs(simulator.get_system(), system)
+
+        # Clearing the context is allowed.
+        simulator.reset_context(context=None)
 
     def test_simulator_default_context_no_cpp_leak(self):
         """Regression test for #23924"""

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -205,12 +205,16 @@ class TestSystemsLcm(unittest.TestCase):
             lcm.Publish("TEST_LOOP", message.encode())
             for attempt in range(10):
                 new_count = sub.WaitForMessage(
-                    old_message_count, value, timeout=0.02
+                    old_message_count=old_message_count,
+                    message=value,
+                    timeout=0.02,
                 )
                 if new_count > old_message_count:
                     break
                 lcm.HandleSubscriptions(0)
             self.assertEqual(value.get_value().utime, old_message_count + 1)
+        # Omitting the message= output argument shouldn't crash.
+        sub.WaitForMessage(old_message_count=3, timeout=1e-6)
 
     def _fix_and_publish(self, dut, value):
         context = dut.CreateDefaultContext()
@@ -261,6 +265,17 @@ class TestSystemsLcm(unittest.TestCase):
             publish_offset=0.01,
             publish_triggers={TriggerType.kPeriodic},
         )
+        # Passing None for the SerializerInterface / LcmInterfaceSystem doesn't
+        # crash. (We can't read back the message, though.)
+        dut = mut.LcmPublisherSystem.Make(
+            channel="TEST_CHANNEL",
+            lcm_type=lcmt_quaternion,
+            lcm=None,
+            publish_period=0.1,
+            publish_offset=0.01,
+        )
+        self._fix_and_publish(dut, Value(model_message))
+        lcm.HandleSubscriptions(0)
 
     def test_publisher_cpp(self):
         lcm = DrakeLcm()

--- a/bindings/pydrake/systems/test/monte_carlo_test.py
+++ b/bindings/pydrake/systems/test/monte_carlo_test.py
@@ -49,3 +49,12 @@ class TestMonteCarlo(unittest.TestCase):
             self.assertIsNot(
                 result[0].generator_snapshot, result[i].generator_snapshot
             )
+
+        # The generator is allowed to be None.
+        MonteCarloSimulation(
+            make_simulator=make_simulator,
+            output=calc_output,
+            final_time=1.0,
+            num_samples=1,
+            generator=None,
+        )

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -983,6 +983,9 @@ class TestGeneral(unittest.TestCase):
         del dut
         self.assertListEqual(readback, [1, 2, 3])
 
+        # Allow None without crashing.
+        SharedPointerSystem(value_to_hold=None)
+
     def test_shared_pointer_system_builder(self):
         builder = DiagramBuilder()
         self.assertListEqual(
@@ -997,6 +1000,12 @@ class TestGeneral(unittest.TestCase):
         self.assertListEqual(readback, [1, 2, 3])
         del diagram
         self.assertListEqual(readback, [1, 2, 3])
+
+        # Allow None without crashing.
+        SharedPointerSystem.AddToBuilder(
+            builder=DiagramBuilder(),
+            value_to_hold=None,
+        )
 
     def test_sine(self):
         # Test scalar output.

--- a/bindings/pydrake/visualization/test/config_test.py
+++ b/bindings/pydrake/visualization/test/config_test.py
@@ -48,6 +48,14 @@ class TestConfig(unittest.TestCase):
             builder=builder,
         )
 
+    def test_apply_visualization_config_plain(self):
+        """Exercises ApplyVisualizationConfig with minimal arguments."""
+        builder = DiagramBuilder()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        plant.Finalize()
+        config = mut.VisualizationConfig()
+        mut.ApplyVisualizationConfig(config=config, builder=builder)
+
     def test_add_default_visualization(self):
         """Exercises AddDefaultVisualization."""
         builder = DiagramBuilder()
@@ -55,3 +63,10 @@ class TestConfig(unittest.TestCase):
         plant.Finalize()
         meshcat = Meshcat()
         mut.AddDefaultVisualization(builder=builder, meshcat=meshcat)
+
+    def test_add_default_visualization_plain(self):
+        """Exercises AddDefaultVisualization with an implicit meshcat."""
+        builder = DiagramBuilder()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        plant.Finalize()
+        mut.AddDefaultVisualization(builder=builder)


### PR DESCRIPTION
Towards #21572.  Nanobind switches the default for pointer arguments: in pybind11, pointers are allowed to be None by default; in nanobind they are not. To ensure that our bindings correctly annotate nullness for nanobind, we need to have regression tests that cover passing None to everywhere that is supposed to allow it.

The approach I used was modifying the docstring generator to print out all signatures that took raw pointers, unique_ptr, or shared_ptr, and then stepping through those one by one to assess whether (1) it was bound and (2) the function was designed to allow nulls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24718)
<!-- Reviewable:end -->
