### PR TITLE
[tools] Fix hermetic rules_python interpreters with version triples

### DIFF
--- a/tools/install/install.bzl
+++ b/tools/install/install.bzl
@@ -56,7 +56,9 @@ def _python_version(ctx):
     """Returns a string a containing the major.minor version number of the
     current Python toolchain."""
     py_cc_toolchain = ctx.toolchains[_PY_CC_TOOLCHAIN_TYPE].py_cc_toolchain
-    return py_cc_toolchain.python_version
+    version = py_cc_toolchain.python_version
+    major_minor = version.split(".")[:2]
+    return ".".join(major_minor)
 
 #------------------------------------------------------------------------------
 def _output_path(ctx, input_file, strip_prefix = [], ignore_errors = False):

--- a/tools/workspace/python/defs.bzl
+++ b/tools/workspace/python/defs.bzl
@@ -1,17 +1,25 @@
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//tools/skylark:cc.bzl", "CcInfo")
 
-_PY_CC_TOOLCHAIN_TYPE = "@rules_python//python/cc:toolchain_type"
-
 # These rules are intended for use only by our neighboring BUILD.bazel file.
 # The comments in that file explain how and why to use these rules' output.
 
-def _python_version_txt(ctx):
+_PY_CC_TOOLCHAIN_TYPE = "@rules_python//python/cc:toolchain_type"
+
+def _python_version(ctx):
+    """Returns a string a containing the major.minor version number of the
+    current Python toolchain."""
     py_cc_toolchain = ctx.toolchains[_PY_CC_TOOLCHAIN_TYPE].py_cc_toolchain
+    version = py_cc_toolchain.python_version
+    major_minor = version.split(".")[:2]
+    return ".".join(major_minor)
+
+def _python_version_txt_impl(ctx):
+    """Implementation of the python_version_txt() rule, below."""
     output = ctx.actions.declare_file(ctx.label.name)
     ctx.actions.write(
         output = output,
-        content = py_cc_toolchain.python_version,
+        content = _python_version(ctx),
         is_executable = False,
     )
     return [DefaultInfo(
@@ -20,7 +28,7 @@ def _python_version_txt(ctx):
     )]
 
 python_version_txt = rule(
-    implementation = _python_version_txt,
+    implementation = _python_version_txt_impl,
     toolchains = [_PY_CC_TOOLCHAIN_TYPE],
     doc = """Generates a text file containing the major.minor version number of
     the current Python toolchain, without any newlines.""",


### PR DESCRIPTION
Previously we assumed that python_version is always "major.minor", but in the case of hermetic interpreters it might be "major.minor.patch".

Towards #24719.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24720)
<!-- Reviewable:end -->
