### PR TITLE
[tools] Add python_binder flag

### DIFF
--- a/tools/flags/BUILD.bazel
+++ b/tools/flags/BUILD.bazel
@@ -388,6 +388,19 @@ bool_flag(
 )
 
 # -----------------------------------------------------------------------------
+# Configuration for Drake features.
+
+# When set to 'pybind11', uses pybind11 to provide pydrake bindings.
+# TODO(jwnimmer-tri) Add support for 'nanobind'.
+string_flag(
+    name = "python_binder",
+    build_setting_default = "pybind11",
+    values = [
+        "pybind11",
+    ],
+)
+
+# -----------------------------------------------------------------------------
 # Configuration for Drake's CMake install.
 #
 # The Bazel spelling of these flags should be consisered "internal use only".


### PR DESCRIPTION
Currently only allows "pybind11", but we'll add "nanobind" eventually. Adding the option now allows users to start pinning their preferred binder in their downstream projects.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24724)
<!-- Reviewable:end -->
