### PR TITLE
[multibody] Add surface velocity to MultibodyPlant

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -1703,6 +1703,7 @@ concepts/notation.
     - <em style="color:gray">model_instance_name[i]</em>_actuation
     - <em style="color:gray">model_instance_name[i]</em>_desired_state
     - <span style="color:green">geometry_query</span>
+    - surface_speeds
     output_ports:
     - state
     - body_poses
@@ -1718,6 +1719,7 @@ concepts/notation.
     - <em style="color:gray">model_instance_name[i]</em>_net_actuation
     - <span style="color:green">geometry_pose</span>
     - <span style="color:green">deformable_body_configuration</span>
+    - surface_displacements
 
 The ports whose names begin with <em style="color:gray">
 model_instance_name[i]</em> represent groups of ports, one for each of
@@ -5777,6 +5779,16 @@ Raises:
     RuntimeError if the plant is not finalized or if the
     ``model_instance`` is invalid.)""";
         } GetStateNames;
+        // Symbol: drake::multibody::MultibodyPlant::GetSurfaceVelocityAxis
+        struct /* GetSurfaceVelocityAxis */ {
+          // Source: drake/multibody/plant/multibody_plant.h
+          const char* doc =
+R"""(Returns the surface-velocity axis for ``body`` expressed in the body
+frame B, or ``std∷nullopt`` if ``body`` has not been registered. Works
+both before and after Finalize(). The returned vector is not
+necessarily the same as was passed to SetSurfaceVelocityAxis(); we
+store the normalized version of that vector.)""";
+        } GetSurfaceVelocityAxis;
         // Symbol: drake::multibody::MultibodyPlant::GetTopologyGraphvizString
         struct /* GetTopologyGraphvizString */ {
           // Source: drake/multibody/plant/multibody_plant.h
@@ -7174,15 +7186,43 @@ MultibodyPlant∷num_positions() or ``q_instance`` is not of size
         struct /* SetRandomState */ {
           // Source: drake/multibody/plant/multibody_plant.h
           const char* doc =
-R"""(Assigns random values to all elements of the state, by drawing samples
-independently for each joint/free body (coming soon: and then solving
-a mathematical program to "project" these samples onto the registered
-system constraints). If a random distribution is not specified for a
-joint/free body, the default state is used.
+R"""(Assigns random values to all elements of the state that support random
+values, by drawing samples independently for each joint/free body
+(coming soon: and then solving a mathematical program to "project"
+these samples onto the registered system constraints). If a random
+distribution is not specified for a joint/free body, the default state
+is used.
 
 See also:
     stochastic_systems)""";
         } SetRandomState;
+        // Symbol: drake::multibody::MultibodyPlant::SetSurfaceVelocityAxis
+        struct /* SetSurfaceVelocityAxis */ {
+          // Source: drake/multibody/plant/multibody_plant.h
+          const char* doc =
+R"""(Sets the surface-velocity axis for ``body`` to ``axis_B``, expressed
+in the body frame B. If ``axis_B`` is ``std∷nullopt``, any existing
+registration for ``body`` is cleared. May be called any number of
+times before Finalize(); a subsequent call overwrites any prior
+registration. A nonzero ``axis_B`` is normalized before storage.
+
+Parameter ``body``:
+    The rigid body (link).
+
+Parameter ``axis_B``:
+    A nonzero vector giving the rotation-axis direction in the body
+    frame B, or ``std∷nullopt`` to clear.
+
+Raises:
+    RuntimeError if called after Finalize().
+
+Raises:
+    RuntimeError if ``axis_B`` has a value and ``body`` is the world
+    body.
+
+Raises:
+    RuntimeError if ``axis_B`` has a value and can't be normalized.)""";
+        } SetSurfaceVelocityAxis;
         // Symbol: drake::multibody::MultibodyPlant::SetUseSampledOutputPorts
         struct /* SetUseSampledOutputPorts */ {
           // Source: drake/multibody/plant/multibody_plant.h
@@ -7943,6 +7983,35 @@ Raises:
 Raises:
     RuntimeError if the model instance does not exist.)""";
         } get_state_output_port;
+        // Symbol: drake::multibody::MultibodyPlant::get_surface_displacements_output_port
+        struct /* get_surface_displacements_output_port */ {
+          // Source: drake/multibody/plant/multibody_plant.h
+          const char* doc =
+R"""(Returns a constant reference to the ``"surface_displacements"`` output
+port, which carries a systems∷BusValue whose signals report the
+cumulative surface displacement (in meters) for each body registered
+via SetSurfaceVelocityAxis(). Each signal's name is the body's scoped
+name (i.e., RigidBody∷scoped_name()). The displacement is initialized
+to zero and integrated from the ``"surface_speeds"`` input port.
+
+Precondition:
+    Finalize() was already called on ``this`` plant.)""";
+        } get_surface_displacements_output_port;
+        // Symbol: drake::multibody::MultibodyPlant::get_surface_speeds_input_port
+        struct /* get_surface_speeds_input_port */ {
+          // Source: drake/multibody/plant/multibody_plant.h
+          const char* doc =
+R"""(Returns a constant reference to the ``"surface_speeds"`` input port,
+which carries a systems∷BusValue whose signals set the surface speed
+for each body registered via SetSurfaceVelocityAxis(). Each signal's
+name is the body's (link's) scoped name (i.e.,
+RigidBody∷scoped_name()) and its value is a finite ``double`` speed in
+m/s. If the port is not connected, or a body's (link's) signal is
+absent, that body's speed is treated as zero.
+
+Precondition:
+    Finalize() was already called on ``this`` plant.)""";
+        } get_surface_speeds_input_port;
         // Symbol: drake::multibody::MultibodyPlant::get_tendon_constraint_specs
         struct /* get_tendon_constraint_specs */ {
           // Source: drake/multibody/plant/multibody_plant.h
@@ -8163,6 +8232,16 @@ R"""(Returns the number of joints in the model.
 See also:
     AddJoint().)""";
         } num_joints;
+        // Symbol: drake::multibody::MultibodyPlant::num_misc_continuous_states
+        struct /* num_misc_continuous_states */ {
+          // Source: drake/multibody/plant/multibody_plant.h
+          const char* doc =
+R"""(Returns the size of the continuous miscellaneous state vector z for
+this model.
+
+Raises:
+    RuntimeError if called pre-finalize.)""";
+        } num_misc_continuous_states;
         // Symbol: drake::multibody::MultibodyPlant::num_model_instances
         struct /* num_model_instances */ {
           // Source: drake/multibody/plant/multibody_plant.h

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -236,6 +236,8 @@ void DoScalarDependentDefinitions(py::module_ m, T) {
             overload_cast_explicit<int, ModelInstanceIndex>(
                 &Class::num_velocities),
             py::arg("model_instance"), cls_doc.num_velocities.doc_1args)
+        .def("num_misc_continuous_states", &Class::num_misc_continuous_states,
+            cls_doc.num_misc_continuous_states.doc)
         .def("num_multibody_states",
             overload_cast_explicit<int>(&Class::num_multibody_states),
             cls_doc.num_multibody_states.doc_0args)
@@ -1193,7 +1195,17 @@ void DoScalarDependentDefinitions(py::module_ m, T) {
                 ModelInstanceIndex>(
                 &Class::get_generalized_contact_forces_output_port),
             py_rvp::reference_internal, py::arg("model_instance"),
-            cls_doc.get_generalized_contact_forces_output_port.doc);
+            cls_doc.get_generalized_contact_forces_output_port.doc)
+        .def("get_surface_speeds_input_port",
+            overload_cast_explicit<const systems::InputPort<T>&>(
+                &Class::get_surface_speeds_input_port),
+            py_rvp::reference_internal,
+            cls_doc.get_surface_speeds_input_port.doc)
+        .def("get_surface_displacements_output_port",
+            overload_cast_explicit<const systems::OutputPort<T>&>(
+                &Class::get_surface_displacements_output_port),
+            py_rvp::reference_internal,
+            cls_doc.get_surface_displacements_output_port.doc);
     // Property accessors.
     cls  // BR
         .def("world_body", &Class::world_body, py_rvp::reference_internal,
@@ -1402,7 +1414,12 @@ void DoScalarDependentDefinitions(py::module_ m, T) {
                 bool>(&Class::GetActuatorNames),
             py::arg("model_instance"),
             py::arg("add_model_instance_prefix") = false,
-            cls_doc.GetActuatorNames.doc_2args);
+            cls_doc.GetActuatorNames.doc_2args)
+        .def("SetSurfaceVelocityAxis", &Class::SetSurfaceVelocityAxis,
+            py::arg("body"), py::arg("axis_B"),
+            cls_doc.SetSurfaceVelocityAxis.doc)
+        .def("GetSurfaceVelocityAxis", &Class::GetSurfaceVelocityAxis,
+            py::arg("body"), cls_doc.GetSurfaceVelocityAxis.doc);
   }
 
   {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -474,6 +474,10 @@ class TestPlant(unittest.TestCase):
             plant.num_actuated_dofs(model_instance=model_instance),
             benchmark.num_actuated_dofs(),
         )
+        self.assertEqual(
+            plant.num_misc_continuous_states(),
+            benchmark.num_misc_continuous_states(),
+        )
         self.assertTrue(plant.is_finalized())
         self.assertTrue(plant.HasBodyNamed(name="Link1"))
         self.assertTrue(
@@ -1849,6 +1853,24 @@ class TestPlant(unittest.TestCase):
             )
         # TODO(eric.cousineau): Merge `check_applied_force_input_ports` into
         # this test.
+
+    @numpy_compare.check_all_types
+    def test_surface_velocity(self, T):
+        plant = MultibodyPlant_[T](0.0)
+        body = plant.AddRigidBody("body")
+
+        # Confirm configuration of surface velocity axis.
+        axis_B = np.array([1.0, 0.0, 0.0])
+        plant.SetSurfaceVelocityAxis(body=body, axis_B=axis_B)
+        numpy_compare.assert_float_equal(
+            plant.GetSurfaceVelocityAxis(body=body), axis_B
+        )
+
+        plant.Finalize()
+
+        # Make sure ports are available.
+        self.assertIsNotNone(plant.get_surface_speeds_input_port())
+        self.assertIsNotNone(plant.get_surface_displacements_output_port())
 
     @numpy_compare.check_all_types
     def test_externally_applied_spatial_force(self, T):

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1389,8 +1389,14 @@ std::optional<LinkInfo> AddRigidLinkFromSpecification(
   std::optional<LinkInfo> link_info;
 
   const std::set<std::string> supported_link_elements{
-      "drake:visual", "collision", "gravity", "inertial",
-      "kinematic",    "pose",      "visual"};
+      "drake:surface_velocity_axis",
+      "drake:visual",
+      "collision",
+      "gravity",
+      "inertial",
+      "kinematic",
+      "pose",
+      "visual"};
 
   sdf::ElementPtr link_element = link.Element();
 
@@ -1493,6 +1499,14 @@ std::optional<LinkInfo> AddRigidLinkFromSpecification(
       }
     }
   }
+
+  // Parse link-level surface velocity axis (if present) and register.
+  if (link_element->HasElement("drake:surface_velocity_axis")) {
+    const Vector3d axis_L = ToVector3(
+        link_element->Get<gz::math::Vector3d>("drake:surface_velocity_axis"));
+    plant->SetSurfaceVelocityAxis(body, axis_L);
+  }
+
   return link_info;
 }
 

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -258,6 +258,29 @@ void UrdfParser::ParseBody(XMLElement* node, MaterialMap* materials) {
           std::move(*geometry_instance->mutable_proximity_properties()));
     }
   }
+
+  // Parse link-level surface velocity axis (if present) and register.
+  const XMLElement* sv_node =
+      node->FirstChildElement("drake:surface_velocity_axis");
+  if (sv_node != nullptr) {
+    if (body_pointer == &w_.plant->world_body()) {
+      Warning(*node,
+              "A URDF file declared the \"world\" link and then"
+              " attempted to assign surface velocity (via the "
+              "<drake:surface_velocity_axis> tag). Only geometries, "
+              "<collision> and <visual>, can be assigned to the world link. "
+              "The <drake:surface_velocity_axis> tag is being ignored.");
+    } else {
+      Eigen::Vector3d axis_B;
+      if (!ParseVectorAttribute(sv_node, "axis", &axis_B)) {
+        Error(*sv_node,
+              "Failed to parse 'axis' attribute of "
+              "<drake:surface_velocity_axis>; ignoring.");
+      } else {
+        w_.plant->SetSurfaceVelocityAxis(*body_pointer, axis_B);
+      }
+    }
+  }
 }
 
 void UrdfParser::ParseCollisionFilterGroup(XMLElement* node) {

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -323,6 +323,7 @@ Here is the full list of custom elements:
 - @ref tag_drake_rotor_inertia
 - @ref tag_drake_screw_thread_pitch
 - @ref tag_drake_stiffness_damping
+- @ref tag_drake_surface_velocity_axis
 - @ref tag_drake_tendon_constraint
 - @ref tag_drake_tendon_constraint_joint
 - @ref tag_drake_tendon_constraint_offset
@@ -1687,6 +1688,17 @@ corresponding to a right-handed thread.
 - SDFormat path: `//model/link/drake:deformable_properties/drake:stiffness_damping`
 - URDF path: n/a
 - Syntax: Non-negative floating point value.
+
+@subsection tag_drake_surface_velocity_axis drake:surface_velocity_axis
+
+- SDFormat path: `//model/link/drake:surface_velocity_axis`
+- URDF path: `//robot/link/drake:surface_velocity_axis`
+- Syntax: Three space-separated floating point values.
+
+@subsubsection tag_drake_surface_velocity_axis_semantics Semantics
+
+If present, this element defines the surface velocity axis for the associated
+link. See @ref mbp_surface_velocity "Surface Velocity" for details.
 
 @subsubsection tag_drake_stiffness_damping_semantics Semantics
 

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -198,6 +198,29 @@ const Frame<double>& GetModelFrameByName(const MultibodyPlant<double>& plant,
   return plant.GetFrameByName("__model__", model_instance);
 }
 
+TEST_F(SdfParserTest, SurfaceVelocityAxis) {
+  AddModelsFromSdfString(R"""(
+    <sdf version='1.12' xmlns:drake='https://drake.mit.edu'>
+      <model name='velocity_test'>
+        <link name='has_velocity'>
+          <drake:surface_velocity_axis>
+            0 2 0
+          </drake:surface_velocity_axis>
+        </link>
+        <link name='no_velocity'/>
+      </model>
+    </sdf>)""");
+
+  const auto& has_velocity = plant_.GetBodyByName("has_velocity");
+  const std::optional<Vector3d> axis_B =
+      plant_.GetSurfaceVelocityAxis(has_velocity);
+  ASSERT_TRUE(axis_B.has_value());
+  EXPECT_TRUE(CompareMatrices(*axis_B, Vector3d(0, 1, 0)));
+
+  const auto& no_velocity = plant_.GetBodyByName("no_velocity");
+  EXPECT_EQ(plant_.GetSurfaceVelocityAxis(no_velocity), std::nullopt);
+}
+
 // Verifies that the SDF loader can leverage a specified package map.
 TEST_F(SdfParserTest, PackageMapSpecified) {
   // We start with the world and default model instances (model_instance.h

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -157,6 +157,34 @@ TEST_F(UrdfParserTest, ModelRenameWithColons) {
   EXPECT_EQ(plant_.GetModelInstanceName(*index), "left::robot");
 }
 
+TEST_F(UrdfParserTest, SurfaceVelocityAxis) {
+  EXPECT_NE(AddModelFromUrdfString(R"""(
+    <robot name='belt_model' xmlns:drake='https://drake.mit.edu'>
+      <link name='world'>
+        <!-- This should dispatch a warning. -->
+        <drake:surface_velocity_axis axis='0 0 3'/>
+      </link>
+      <link name='has_velocity'>
+        <drake:surface_velocity_axis axis='0 0 3'/>
+      </link>
+      <link name='no_velocity'/>
+    </robot>)""",
+                                   ""),
+            std::nullopt);
+  EXPECT_THAT(
+      TakeWarning(),
+      MatchesRegex(".*<drake:surface_velocity_axis> tag is being ignored.*"));
+
+  const auto& has_velocity = plant_.GetBodyByName("has_velocity");
+  const std::optional<Vector3d> axis_B =
+      plant_.GetSurfaceVelocityAxis(has_velocity);
+  ASSERT_TRUE(axis_B.has_value());
+  EXPECT_TRUE(CompareMatrices(*axis_B, Vector3d(0, 0, 1)));
+
+  const auto& no_velocity = plant_.GetBodyByName("no_velocity");
+  EXPECT_EQ(plant_.GetSurfaceVelocityAxis(no_velocity), std::nullopt);
+}
+
 TEST_F(UrdfParserTest, ObsoleteLoopJoint) {
   EXPECT_NE(AddModelFromUrdfString("<robot name='a'><loop_joint/></robot>", ""),
             std::nullopt);

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -166,6 +166,7 @@ drake_cc_library(
         ":contact_properties",
         ":desired_state_input",
         ":hydroelastic_traction_calculator",
+        "@abseil_cpp_internal//absl/base",
     ],
 )
 
@@ -1303,6 +1304,17 @@ drake_cc_googletest(
         ":compliant_contact_manager_tester",
         ":plant",
         "//multibody/parsing",
+    ],
+)
+
+drake_cc_googletest(
+    name = "surface_velocity_test",
+    deps = [
+        ":plant",
+        "//common:value",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/analysis:simulator",
+        "//systems/framework:bus_value",
     ],
 )
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -10,6 +10,7 @@
 #include <typeinfo>
 #include <vector>
 
+#include "absl/base/casts.h"
 #include <fmt/ranges.h>
 
 #include "drake/common/drake_assert.h"
@@ -338,7 +339,9 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
     : internal::MultibodyTreeSystem<T>(
           systems::SystemTypeTag<MultibodyPlant>{},
           other.internal_tree().template CloneToScalar<T>(),
-          other.is_discrete()) {
+          other.is_discrete(),
+          absl::implicit_cast<const internal::MultibodyTreeSystem<U>&>(other)
+              .num_misc_continuous_states()) {
   DRAKE_THROW_UNLESS(other.is_finalized());
 
   // Here we step through every member field one by one, in the exact order
@@ -396,6 +399,8 @@ MultibodyPlant<T>::MultibodyPlant(const MultibodyPlant<U>& other)
     ball_constraints_specs_ = other.ball_constraints_specs_;
     weld_constraints_specs_ = other.weld_constraints_specs_;
     tendon_constraints_specs_ = other.tendon_constraints_specs_;
+
+    surface_velocity_bodies_ = other.surface_velocity_bodies_;
 
     adjacent_bodies_collision_filters_ =
         other.adjacent_bodies_collision_filters_;
@@ -836,6 +841,35 @@ void MultibodyPlant<T>::RemoveConstraint(MultibodyConstraintId id) {
 }
 
 template <typename T>
+void MultibodyPlant<T>::SetSurfaceVelocityAxis(
+    const RigidBody<T>& body, std::optional<Eigen::Vector3d> axis_in_B) {
+  DRAKE_MBP_THROW_IF_FINALIZED();
+  DRAKE_THROW_UNLESS(&body == &get_body(body.index()));
+  if (!axis_in_B.has_value()) {
+    surface_velocity_bodies_.erase(body.index());
+    return;
+  }
+  // Eigen won't necessarily normalize a near-zero vector. So, we'll normalize
+  // first and then test the result.
+  const Eigen::Vector3d axis = axis_in_B->normalized();
+  DRAKE_THROW_UNLESS(body.index() != world_index());
+  DRAKE_THROW_UNLESS(std::abs(1.0 - axis.norm()) < 1e-14);
+  // Defer caching the scoped name until Finalize().
+  surface_velocity_bodies_.insert_or_assign(
+      body.index(), internal::SurfaceVelocityEntry{.axis = axis});
+}
+
+template <typename T>
+std::optional<Eigen::Vector3d> MultibodyPlant<T>::GetSurfaceVelocityAxis(
+    const RigidBody<T>& body) const {
+  auto it = surface_velocity_bodies_.find(body.index());
+  if (it == surface_velocity_bodies_.end()) {
+    return std::nullopt;
+  }
+  return it->second.axis;
+}
+
+template <typename T>
 std::string MultibodyPlant<T>::GetTopologyGraphvizString() const {
   std::string graphviz = "digraph MultibodyPlant {\n";
   graphviz += "label=\"" + this->get_name() + "\";\n";
@@ -866,6 +900,12 @@ std::string MultibodyPlant<T>::GetTopologyGraphvizString() const {
   // TODO(russt): Consider adding actuators, frames, forces, etc.
   graphviz += "}\n";
   return graphviz;
+}
+
+template <typename T>
+int MultibodyPlant<T>::num_misc_continuous_states() const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  return internal::MultibodyTreeSystem<T>::num_misc_continuous_states();
 }
 
 template <typename T>
@@ -1441,7 +1481,23 @@ bool MultibodyPlant<T>::GetFuseWeldedLinks(
 }
 
 template <typename T>
+void MultibodyPlant<T>::DeclareMiscContinuousStates() {
+  DRAKE_DEMAND(!is_discrete());
+
+  this->DeclareMiscContinuousState(ssize(surface_velocity_bodies_));
+
+  // As MultibodyPlant adds other miscellaneous continuous states, they should
+  // be added here. We will also need to start tracking the different semantics
+  // across the various z values. Currently, they're all assumed to be surface
+  // displacements.
+}
+
+template <typename T>
 void MultibodyPlant<T>::Finalize() {
+  if (!is_discrete()) {
+    DeclareMiscContinuousStates();
+  }
+
   // After finalizing the base class, tree is read-only.
   internal::MultibodyTreeSystem<T>::Finalize();
 
@@ -1457,6 +1513,10 @@ void MultibodyPlant<T>::Finalize() {
     if (manager) {
       SetDiscreteUpdateManager(std::move(manager));
     }
+  }
+  // Capture final scoped names for bodies with surface velocity.
+  for (auto& [body_index, entry] : surface_velocity_bodies_) {
+    entry.scoped_name = get_body(body_index).scoped_name().to_string();
   }
 }
 
@@ -2593,6 +2653,39 @@ void MultibodyPlant<T>::CalcHydroelasticContactForcesContinuous(
 }
 
 template <typename T>
+Vector3<T> MultibodyPlant<T>::ComputeSurfaceVelocity(
+    BodyIndex body_index, const systems::Context<T>& context,
+    const Vector3<T>& n_W) const {
+  auto it = surface_velocity_bodies_.find(body_index);
+  if (it == surface_velocity_bodies_.end()) {
+    return Vector3<T>::Zero();
+  }
+
+  const internal::SurfaceVelocityEntry& entry = it->second;
+  // Read speed from the bus port. Default to zero if unconnected or absent.
+  double speed = 0.0;
+  const auto& port = get_surface_speeds_input_port();
+  if (port.HasValue(context)) {
+    const auto& bus = port.template Eval<systems::BusValue>(context);
+    const AbstractValue* v = bus.Find(entry.scoped_name);
+    if (v != nullptr) {
+      speed = v->get_value<double>();
+    }
+  }
+  if (speed == 0.0) return Vector3<T>::Zero();
+
+  // Read axis from the map (body frame B).
+  const Eigen::Vector3d& a_ss_B = entry.axis;
+
+  // Convert contact normal from world frame to body frame B.
+  // Not normalizing the cross product is intentional: parallel vectors
+  // produce zero velocity organically.
+  const RigidTransform<T>& X_WB = get_body(body_index).EvalPoseInWorld(context);
+  const Vector3<T> n_B = X_WB.rotation().inverse() * n_W;
+  return T(speed) * a_ss_B.template cast<T>().cross(n_B);
+}
+
+template <typename T>
 const internal::HydroelasticContactForcesContinuousCacheData<T>&
 MultibodyPlant<T>::EvalHydroelasticContactForcesContinuous(
     const systems::Context<T>& context) const
@@ -3519,6 +3612,56 @@ void MultibodyPlant<T>::DeclareInputPorts() {
                 instance_num_xd)
             .get_index();
   }
+
+  // Input "surface_speeds".
+  input_port_indices_.surface_speeds =
+      this->DeclareAbstractInputPort("surface_speeds",
+                                     Value<systems::BusValue>{})
+          .get_index();
+}
+
+template <typename T>
+void MultibodyPlant<T>::DoCalcMiscDerivatives(
+    const systems::Context<T>& context, systems::VectorBase<T>* zdot) const {
+  const auto& port = get_surface_speeds_input_port();
+  if (!port.HasValue(context)) {
+    zdot->SetZero();
+    return;
+  }
+
+  const auto& bus = port.template Eval<systems::BusValue>(context);
+  // If multibody plant adds more z-values in the future, this won't necessarily
+  // be able to assume that the surface displacements' block starts at 0.
+  int i = 0;
+  for (const auto& [_, entry] : surface_velocity_bodies_) {
+    const AbstractValue* v = bus.Find(entry.scoped_name);
+    const double speed = v != nullptr ? v->get_value<double>() : 0.0;
+    zdot->SetAtIndex(i++, speed);
+  }
+}
+
+template <typename T>
+systems::EventStatus MultibodyPlant<T>::CalcSurfaceDisplacementUpdate(
+    const systems::Context<T>& context, systems::State<T>* state) const {
+  auto& displacements =
+      state->template get_mutable_abstract_state<std::vector<double>>(
+          surface_displacements_abstract_state_index_);
+  // Initialize from the current context (not accumulated from state).
+  displacements = context.template get_abstract_state<std::vector<double>>(
+      surface_displacements_abstract_state_index_);
+
+  const auto& port = get_surface_speeds_input_port();
+  if (!port.HasValue(context)) return systems::EventStatus::DidNothing();
+  const auto& bus = port.template Eval<systems::BusValue>(context);
+  int i = 0;
+  for (const auto& [unused, entry] : surface_velocity_bodies_) {
+    const AbstractValue* v = bus.Find(entry.scoped_name);
+    if (v != nullptr) {
+      displacements[i] += v->get_value<double>() * time_step_;
+    }
+    ++i;
+  }
+  return systems::EventStatus::Succeeded();
 }
 
 template <typename T>
@@ -3539,6 +3682,26 @@ void MultibodyPlant<T>::DeclareStateUpdate() {
           time_step_, 0.0, &MultibodyPlant<T>::CalcStepDiscrete);
       this->DeclareForcedDiscreteUpdateEvent(
           &MultibodyPlant<T>::CalcStepDiscrete);
+    }
+    // Declare surface displacement accumulation state and its update event,
+    // but only when there are surface-velocity bodies.
+    if (!surface_velocity_bodies_.empty()) {
+      // Note: although we're storing a vector of doubles, we're storing this as
+      // abstract state instead of discrete state for the following reasons:
+      // 1. This supports a BusValue-valued output port. We could literally
+      //    store the BusValue, but the vector is a convenient compact
+      //    representation.
+      // 2. Discrete state undergoes scalar conversion, but we only really care
+      //    about double-valued displacements. Abstract state is not
+      //    automatically scalar converted (they can't be), leaving the values
+      //    in our target scalar type.
+      surface_displacements_abstract_state_index_ =
+          this->DeclareAbstractState(Value<std::vector<double>>(
+              std::vector<double>(surface_velocity_bodies_.size(), 0.0)));
+      this->DeclarePeriodicUnrestrictedUpdateEvent(
+          time_step_, 0.0, &MultibodyPlant<T>::CalcSurfaceDisplacementUpdate);
+      this->DeclareForcedUnrestrictedUpdateEvent(
+          &MultibodyPlant<T>::CalcSurfaceDisplacementUpdate);
     }
   }
 }
@@ -3667,6 +3830,30 @@ void MultibodyPlant<T>::DeclareOutputPorts() {
         {state_ticket, this->all_input_ports_ticket(),
          this->all_parameters_ticket()},
         i);
+  }
+
+  // Output "surface_displacements": cumulative surface displacement per body.
+  {
+    systems::BusValue model_bus;
+    for (const auto& [_, entry] : surface_velocity_bodies_) {
+      model_bus.Set(entry.scoped_name, Value<double>(0.0));
+    }
+    DependencyTicket prereq = this->nothing_ticket();
+    if (!surface_velocity_bodies_.empty()) {
+      if (is_discrete()) {
+        // The abstract state is only declared if there are a non-zero number of
+        // bodies with surface velocities.
+        prereq = this->abstract_state_ticket(
+            surface_displacements_abstract_state_index_);
+      } else {
+        prereq = this->z_ticket();
+      }
+    }
+    output_port_indices_.surface_displacements =
+        this->DeclareAbstractOutputPort(
+                "surface_displacements", model_bus,
+                &MultibodyPlant<T>::CalcSurfaceDisplacementOutput, {prereq})
+            .get_index();
   }
 }
 
@@ -3857,6 +4044,32 @@ void MultibodyPlant<T>::DeclareParameters() {
 }
 
 template <typename T>
+void MultibodyPlant<T>::CalcSurfaceDisplacementOutput(
+    const Context<T>& context, systems::BusValue* output) const {
+  output->Clear();
+  if (surface_velocity_bodies_.empty()) return;
+  if (is_discrete()) {
+    const auto& values =
+        context.template get_abstract_state<std::vector<double>>(
+            surface_displacements_abstract_state_index_);
+    int i = 0;
+    for (const auto& [_, entry] : surface_velocity_bodies_) {
+      output->Set(entry.scoped_name, Value<double>(values[i++]));
+    }
+  } else {
+    const auto& z = context.get_continuous_state().get_misc_continuous_state();
+    // If multibody plant adds more z-values in the future, this won't
+    // necessarily be able to assume that the surface displacements' block
+    // starts at 0.
+    int i = 0;
+    for (const auto& [_, entry] : surface_velocity_bodies_) {
+      output->Set(entry.scoped_name,
+                  Value<double>(ExtractDoubleOrThrow(z.GetAtIndex(i++))));
+    }
+  }
+}
+
+template <typename T>
 void MultibodyPlant<T>::CalcStateOutput(const Context<T>& context,
                                         BasicVector<T>* output) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
@@ -3973,6 +4186,13 @@ const systems::InputPort<T>&
 MultibodyPlant<T>::get_applied_spatial_force_input_port() const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   return this->get_input_port(input_port_indices_.applied_spatial_force);
+}
+
+template <typename T>
+const systems::OutputPort<T>&
+MultibodyPlant<T>::get_surface_displacements_output_port() const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  return this->get_output_port(output_port_indices_.surface_displacements);
 }
 
 template <typename T>
@@ -4310,6 +4530,13 @@ template <typename T>
 const systems::InputPort<T>& MultibodyPlant<T>::get_geometry_query_input_port()
     const {
   return this->get_input_port(input_port_indices_.geometry_query);
+}
+
+template <typename T>
+const systems::InputPort<T>& MultibodyPlant<T>::get_surface_speeds_input_port()
+    const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  return this->get_input_port(input_port_indices_.surface_speeds);
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -38,6 +38,7 @@
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/uniform_gravity_field_element.h"
 #include "drake/multibody/tree/weld_joint.h"
+#include "drake/systems/framework/bus_value.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -128,6 +129,11 @@ class MultibodyPlantIcfAttorney;
 // Forward declarations for multibody_plant_model_attorney.h.
 template <typename>
 class MultibodyPlantModelAttorney;
+
+struct SurfaceVelocityEntry {
+  std::string scoped_name;  // Empty until Finalize() is called.
+  Eigen::Vector3d axis;     // unit-length, expressed in link frame L.
+};
 
 }  // namespace internal
 
@@ -269,6 +275,7 @@ input_ports:
 - <em style="color:gray">model_instance_name[i]</em>_actuation
 - <em style="color:gray">model_instance_name[i]</em>_desired_state
 - <span style="color:green">geometry_query</span>
+- surface_speeds
 output_ports:
 - state
 - body_poses
@@ -284,6 +291,7 @@ output_ports:
 - <em style="color:gray">model_instance_name[i]</em>_net_actuation
 - <span style="color:green">geometry_pose</span>
 - <span style="color:green">deformable_body_configuration</span>
+- surface_displacements
 @endsystem
 
 The ports whose names begin with <em style="color:gray">
@@ -1192,6 +1200,24 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   /// documentation for further details on collision geometry registration and
   /// connection with a SceneGraph.
   const systems::InputPort<T>& get_geometry_query_input_port() const;
+
+  /// Returns a constant reference to the `"surface_speeds"` input port, which
+  /// carries a systems::BusValue whose signals set the surface speed for each
+  /// body registered via SetSurfaceVelocityAxis(). Each signal's name is the
+  /// body's (link's) scoped name (i.e., RigidBody::scoped_name()) and its value
+  /// is a finite `double` speed in m/s. If the port is not connected, or a
+  /// body's (link's) signal is absent, that body's speed is treated as zero.
+  /// @pre Finalize() was already called on `this` plant.
+  const systems::InputPort<T>& get_surface_speeds_input_port() const;
+
+  /// Returns a constant reference to the `"surface_displacements"` output port,
+  /// which carries a systems::BusValue whose signals report the cumulative
+  /// surface displacement (in meters) for each body registered via
+  /// SetSurfaceVelocityAxis(). Each signal's name is the body's scoped name
+  /// (i.e., RigidBody::scoped_name()). The displacement is initialized to zero
+  /// and integrated from the `"surface_speeds"` input port.
+  /// @pre Finalize() was already called on `this` plant.
+  const systems::OutputPort<T>& get_surface_displacements_output_port() const;
 
   /// Reports the multibody state x = [q, v] of the model as a @ref
   /// systems::BasicVector<T> "vector-valued" output port of size
@@ -2249,6 +2275,106 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
 
   /// @}
 
+  /// @anchor mbp_surface_velocity
+  /// @name               Surface velocity
+  ///
+  /// @warning Surface velocity is a work in progress. There are no guarantees
+  ///          on its effect until the implementation is complete.
+  ///
+  /// Surface velocity models bodies (links) whose surfaces move relative to
+  /// the body itself — conveyor belts, spinning drums, tank treads, or any
+  /// mechanism where internal motion produces a tangential velocity at contact
+  /// surfaces.
+  ///
+  /// #### Mathematical model
+  ///
+  /// Each registered body defines a velocity field over its contact surface
+  /// (the total surface of *all* proximity geometries affixed to the body).
+  /// At a contact point C, given:
+  ///
+  ///  - â_ss_B — the *rotation axis*, stored in body frame B (see
+  ///    SetSurfaceVelocityAxis()),
+  ///  - `speed` — the *signed* scalar measure of the surface velocity from the
+  ///    `"surface_speeds"` input port (see get_surface_speeds_input_port()),
+  ///  - n̂_C_B — the contact normal at C oriented to point *out* of the body's
+  ///    proximity geometry (likewise expressed in body frame B),
+  ///
+  /// the surface velocity expressed in the body frame B is:
+  ///
+  ///     v_ss_B = speed · (â_ss_B × n̂_C_B)
+  ///
+  /// The formula is the velocity produced at a contact point by a rigid drum
+  /// rotating about axis â_ss_B at peripheral speed `speed`. For example, a
+  /// horizontal conveyor belt whose top face (n̂_C_B ≈ ẑ_B) moves in the
+  /// x̄_B direction: set â_ss_B = ŷ_B, yielding
+  /// v_ss_B = speed · (ŷ × ẑ) = speed · x̂.
+  ///
+  /// Although â_ss_B and n̂_C_B are both unit vectors, their cross product is
+  /// not necessarily unit length. We use that length to further scale the
+  /// resultant `speed`. This gives us the effect of reducing the surface
+  /// velocity as the contact normal aligns with the axis of rotation.
+  ///
+  /// #### Key properties and ramifications
+  ///
+  ///  - **Signed speed.** The input "speed" value can be positive or negative.
+  ///    It still "rotates" around the same axis, but reversing the sign
+  ///    reverses the surface velocity direction.
+  ///  - **Axis follows the body.** â_ss_B is stored in the body frame B, so
+  ///    the velocity field automatically rotates with the body in the world.
+  ///  - **Velocity direction depends on the contact normal.** Two contact
+  ///    points on the same body but at different surface orientations may
+  ///    experience different surface velocity directions.
+  ///  - **Zero velocity along the rotation axis.** When n̂_C_B is parallel to
+  ///    â_ss_B the cross product is zero and the surface velocity vanishes,
+  ///    which is physically correct (no tangential slip along the axis).
+  ///  - **Speed is runtime-controlled.** `speed` is read from the
+  ///    `"surface_speeds"` bus port on every time step. An unconnected port or
+  ///    a missing signal for this body is treated as zero speed. Negative speed
+  ///    reverses the velocity direction.
+  ///  - **Only the direction of â_ss_B matters.** The stored vector is always
+  ///    unit-length; magnitude is discarded upon registration or update.
+  ///  - **No change to the underlying multibody dynamics.** Surface velocity is
+  ///    a *contact* effect that modifies the contact velocity at the point of
+  ///    contact. The only effect it has is in computing contact forces. It
+  ///    plays *no* role in any other MultibodyPlant calculations.
+  ///  - **The body's surface velocity is applied to *all* geometries affixed
+  ///    to the body**, regardless of the geometry's shape or pose on the body.
+  ///    If you need a body composed of multiple parts with different surface
+  ///    velocities, you must model them as separate bodies with separate
+  ///    surface velocity registrations, but they can be connected by weld
+  ///    joints to function as a single rigid body.
+  ///  - **Surface displacement always initializes to zero**. This state is
+  ///    just a visualization affordance; there is no value in setting it to a
+  ///    non-zero value (even in the context of state randomization).
+  /// @{
+
+  /// Sets the surface-velocity axis for `body` to `axis_B`, expressed in the
+  /// body frame B. If `axis_B` is `std::nullopt`, any existing registration
+  /// for `body` is cleared. May be called any number of times before
+  /// Finalize(); a subsequent call overwrites any prior registration. A
+  /// nonzero `axis_B` is normalized before storage.
+  ///
+  /// @param[in] body    The rigid body (link).
+  /// @param[in] axis_B  A nonzero vector giving the rotation-axis direction
+  ///                    in the body frame B, or `std::nullopt` to clear.
+  ///
+  /// @throws std::exception if called after Finalize().
+  /// @throws std::exception if `axis_B` has a value and `body` is the
+  ///         world body.
+  /// @throws std::exception if `axis_B` has a value and can't be normalized.
+  void SetSurfaceVelocityAxis(const RigidBody<T>& body,
+                              std::optional<Eigen::Vector3d> axis_B);
+
+  /// Returns the surface-velocity axis for `body` expressed in the body frame
+  /// B, or `std::nullopt` if `body` has not been registered. Works both
+  /// before and after Finalize(). The returned vector is not necessarily the
+  /// same as was passed to SetSurfaceVelocityAxis(); we store the normalized
+  /// version of that vector.
+  std::optional<Eigen::Vector3d> GetSurfaceVelocityAxis(
+      const RigidBody<T>& body) const;
+
+  /// @}
+
   /// @anchor mbp_geometry
   /// @name                      Geometry
   ///
@@ -3136,15 +3262,15 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     this->ValidateContext(context);
     this->ValidateCreatedForThisSystem(state);
-    internal_tree().SetDefaultState(context, state);
+    internal::MultibodyTreeSystem<T>::SetDefaultState(context, state);
     deformable_model().SetDefaultState(context, state);
   }
 
-  /// Assigns random values to all elements of the state, by drawing samples
-  /// independently for each joint/free body (coming soon: and then
-  /// solving a mathematical program to "project" these samples onto the
-  /// registered system constraints). If a random distribution is not specified
-  /// for a joint/free body, the default state is used.
+  /// Assigns random values to all elements of the state that support random
+  /// values, by drawing samples independently for each joint/free body (coming
+  /// soon: and then solving a mathematical program to "project" these samples
+  /// onto the registered system constraints). If a random distribution is not
+  /// specified for a joint/free body, the default state is used.
   ///
   /// @see @ref stochastic_systems
   void SetRandomState(const systems::Context<T>& context,
@@ -3153,6 +3279,8 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     this->ValidateContext(context);
     this->ValidateCreatedForThisSystem(state);
+    internal::MultibodyTreeSystem<T>::SetRandomState(context, state, generator);
+    // TODO(SeanCurtis-TRI): This should be handled by MultibodyTreeSystem.
     internal_tree().SetRandomState(context, state, generator);
   }
 
@@ -5764,6 +5892,11 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     return internal_tree().num_velocities(model_instance);
   }
 
+  /// Returns the size of the continuous miscellaneous state vector z for this
+  /// model.
+  /// @throws std::exception if called pre-finalize.
+  int num_misc_continuous_states() const;
+
   // N.B. The state in the Context may at some point contain values such as
   // integrated power and other discrete states, hence the specific name.
   /// Returns the size of the multibody system state vector x = [q v]. This
@@ -5957,6 +6090,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     };
     std::vector<Instance> instance;
     systems::InputPortIndex geometry_query;  // Declared in ctor, not Finalize.
+    systems::InputPortIndex surface_speeds;
   };
 
   // This struct stores in one single place the index of all of our outputs.
@@ -5979,6 +6113,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     };
     std::vector<Instance> instance;
     systems::OutputPortIndex geometry_pose;  // Declared in ctor, not Finalize.
+    systems::OutputPortIndex surface_displacements;
     // N.B. The deformable_body_configuration port is owned by DeformableModel,
     // so is not tracked here.
   };
@@ -6248,6 +6383,10 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   void AddInForcesContinuous(const systems::Context<T>& context,
                              MultibodyForces<T>* forces) const override;
 
+  /// Computes the derivatives for the miscelleanous continuous state variables.
+  void DoCalcMiscDerivatives(const systems::Context<T>& context,
+                             systems::VectorBase<T>* zdot) const override;
+
   // Discrete system version of CalcForwardDynamics(). This method does not use
   // O(n) forward dynamics but a discrete solver according to the discrete
   // contact solver specified.
@@ -6409,6 +6548,18 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   // one).
   void RegisterRigidBodyWithSceneGraph(const RigidBody<T>& body);
 
+  // Calc method for the "surface_displacements" output port.
+  void CalcSurfaceDisplacementOutput(const systems::Context<T>& context,
+                                     systems::BusValue* output) const;
+
+  // Declares the MultibodyPlant-owned miscellaneous continuous state variables
+  // and records the offsets for each feature that owns a slice of z.
+  void DeclareMiscContinuousStates();
+
+  // Periodic unrestricted update handler for surface displacement (discrete).
+  systems::EventStatus CalcSurfaceDisplacementUpdate(
+      const systems::Context<T>& context, systems::State<T>* state) const;
+
   // Calc method for the "state" output port.
   void CalcStateOutput(const systems::Context<T>& context,
                        systems::BasicVector<T>* output) const;
@@ -6506,6 +6657,20 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       internal::HydroelasticContactForcesContinuousCacheData<T>* output) const
     requires scalar_predicate<T>::is_bool;
+
+  // Computes the surface velocity at any point on a body B with the given
+  // surface normal.
+  // Returns zero if `body_index` indicates a body with no registered surface
+  // velocity, if the "surface_speeds" port is unconnected, or if the body's
+  // signal is absent.
+  //
+  // @param body_index  Index of the body B owning the surface.
+  // @param context     The plant's context (used to read port and parameter).
+  // @param n_W         Contact normal expressed in the world frame.
+  // @retval v_B_ss     Surface velocity expressed in the body frame B.
+  Vector3<T> ComputeSurfaceVelocity(BodyIndex body_index,
+                                    const systems::Context<T>& context,
+                                    const Vector3<T>& n_W) const;
 
   // Eval version of CalcHydroelasticContactForces().
   const internal::HydroelasticContactForcesContinuousCacheData<T>&
@@ -6751,6 +6916,15 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   // Map of tendon constraint specifications.
   std::map<MultibodyConstraintId, internal::TendonConstraintSpec>
       tendon_constraints_specs_;
+
+  // Per-body surface-velocity data. Keyed by BodyIndex for O(lg N) lookup;
+  // iteration order (ascending BodyIndex) defines displacement state indices.
+  // Frozen at Finalize().
+  std::map<BodyIndex, internal::SurfaceVelocityEntry> surface_velocity_bodies_;
+
+  // Abstract state index for surface displacement accumulation (discrete mode
+  // only). Only valid when surface_velocity_bodies_ is non-empty.
+  systems::AbstractStateIndex surface_displacements_abstract_state_index_{};
 
   // Whether to apply collsion filters to adjacent bodies at Finalize().
   bool adjacent_bodies_collision_filters_{

--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -153,6 +153,44 @@ TYPED_TEST_P(MultibodyPlantDefaultScalarsTest, PortIndexOrdering) {
   CompareMultibodyPlantPortIndices(plant, plant_u);
 }
 
+// This test verifies that scalar conversion preserves the surface displacement
+// state used to integrate surface displacements. As the discrete and continuous
+// implementations are independent, we test both using a mode-agnostic
+// mechanism; if the surface_displacements output port reports a signal, we
+// infer the presence of the supporting state.
+TYPED_TEST_P(MultibodyPlantDefaultScalarsTest,
+             SurfaceVelocityDisplacementState) {
+  using U = TypeParam;
+
+  for (double time_step : {0.0, 0.1}) {
+    SCOPED_TRACE(fmt::format("time_step = {}", time_step));
+    MultibodyPlant<double> plant(time_step);
+    const RigidBody<double>& belt =
+        plant.AddRigidBody("belt", SpatialInertia<double>::MakeUnitary());
+    plant.SetSurfaceVelocityAxis(belt, Vector3<double>::UnitX());
+    plant.Finalize();
+
+    auto context = plant.CreateDefaultContext();
+    const auto& displacements =
+        plant.get_surface_displacements_output_port().Eval<systems::BusValue>(
+            *context);
+    // Presence of the output signal implies presence of the state.
+    EXPECT_NE(displacements.Find(belt.scoped_name().to_string()), nullptr);
+
+    std::unique_ptr<MultibodyPlant<U>> plant_u =
+        System<double>::ToScalarType<U>(plant);
+    const RigidBody<U>& belt_u = plant_u->GetBodyByName("belt");
+    EXPECT_TRUE(plant_u->GetSurfaceVelocityAxis(belt_u).has_value());
+
+    auto context_u = plant_u->CreateDefaultContext();
+    const auto& displacements_u =
+        plant_u->get_surface_displacements_output_port()
+            .template Eval<systems::BusValue>(*context_u);
+    // Presence of the output signal implies presence of the state.
+    EXPECT_NE(displacements_u.Find(belt.scoped_name().to_string()), nullptr);
+  }
+}
+
 // Verifies that we can AddMultibodyPlantSceneGraph, without any conversion.
 TYPED_TEST_P(MultibodyPlantDefaultScalarsTest, DirectlyAdded) {
   using U = TypeParam;
@@ -165,7 +203,7 @@ TYPED_TEST_P(MultibodyPlantDefaultScalarsTest, DirectlyAdded) {
 
 REGISTER_TYPED_TEST_SUITE_P(MultibodyPlantDefaultScalarsTest,
                             RevoluteJointAndSpring, PortIndexOrdering,
-                            DirectlyAdded);
+                            SurfaceVelocityDisplacementState, DirectlyAdded);
 
 using NonDoubleScalarTypes = ::testing::Types<AutoDiffXd, Expression>;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, MultibodyPlantDefaultScalarsTest,

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -190,6 +190,7 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_EQ(plant->num_positions(), 3);
   EXPECT_EQ(plant->num_velocities(), 3);
   EXPECT_EQ(plant->num_multibody_states(), 6);
+  EXPECT_EQ(plant->num_misc_continuous_states(), 0);
 
   // Acrobot is in the default model instance.
   EXPECT_EQ(plant->num_actuators(default_model_instance()), 1);
@@ -2282,6 +2283,8 @@ bool VerifyFeedthroughPorts(const MultibodyPlant<double>& plant) {
       // Green group.
       {"geometry_pose", false},
       {"deformable_body_configuration", false},
+      // Miscellaneous.
+      {"surface_displacements", false},
   };
 
   // Split the manifest into (non-)feedthrough sets, while also substituting and
@@ -3132,6 +3135,7 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
   ASSERT_EQ(link3_num_visuals, 0);
 
   // Scalar convert the plant and verify invariants.
+  ASSERT_TRUE(plant.is_finalized());
   std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant_autodiff =
       systems::System<double>::ToAutoDiffXd(plant);
   EXPECT_TRUE(plant_autodiff->geometry_source_is_registered());

--- a/multibody/plant/test/surface_velocity_test.cc
+++ b/multibody/plant/test/surface_velocity_test.cc
@@ -1,0 +1,440 @@
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/random.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/value.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/bus_value.h"
+
+namespace drake {
+namespace multibody {
+
+// Exposes surface velocity APIs for testing.
+class MultibodyPlantTester {
+ public:
+  MultibodyPlantTester() = delete;
+  static Vector3<double> ComputeSurfaceVelocity(
+      const MultibodyPlant<double>& plant, BodyIndex body_index,
+      const systems::Context<double>& context, const Eigen::Vector3d& n_W) {
+    return plant.ComputeSurfaceVelocity(body_index, context, n_W);
+  }
+
+  // Invokes the (private) periodic displacement-update handler directly.
+  // If `state` is defined, the result is written to that.
+  // If `state` is not provided, the result is ultimately written back to
+  // `context` (akin to a Simulator evaluating an event).
+  // This enables testing the integration math without worrying about framework
+  // triggers.
+  static systems::EventStatus CallSurfaceDisplacementUpdate(
+      const MultibodyPlant<double>& plant, systems::Context<double>* context,
+      systems::State<double>* state = nullptr) {
+    DRAKE_DEMAND(context != nullptr);
+    if (state != nullptr) {
+      return plant.CalcSurfaceDisplacementUpdate(*context, state);
+    }
+    // We have no way to simply allocate a State object, so we'll use a cloned
+    // context to make one.
+    auto cloned_context = context->Clone();
+    systems::EventStatus status = plant.CalcSurfaceDisplacementUpdate(
+        *cloned_context, &cloned_context->get_mutable_state());
+    context->SetStateAndParametersFrom(*cloned_context);
+    return status;
+  }
+
+  // Sets every surface-displacement value to `value`, dispatching on the
+  // plant's continuous/discrete mode (continuous: misc continuous state z;
+  // discrete: the surface-displacement abstract state).
+  static void SetAllSurfaceDisplacements(const MultibodyPlant<double>& plant,
+                                         systems::Context<double>* context,
+                                         double value) {
+    if (plant.is_discrete()) {
+      auto& displacements =
+          context->get_mutable_abstract_state<std::vector<double>>(
+              plant.surface_displacements_abstract_state_index_);
+      displacements.assign(displacements.size(), value);
+    } else {
+      auto& z = context->get_mutable_continuous_state()
+                    .get_mutable_misc_continuous_state();
+      z.SetFromVector(Eigen::VectorXd::Constant(z.size(), value));
+    }
+  }
+};
+
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+
+// Reads a body's cumulative surface displacement via the (mode-agnostic)
+// "surface_displacements" output port.
+double ReadSurfaceDisplacement(const MultibodyPlant<double>& plant,
+                               const systems::Context<double>& context,
+                               const RigidBody<double>& body) {
+  const auto& output =
+      plant.get_surface_displacements_output_port().Eval<systems::BusValue>(
+          context);
+  const AbstractValue* value = output.Find(body.scoped_name().to_string());
+  DRAKE_DEMAND(value != nullptr);
+  return value->get_value<double>();
+}
+
+// Fixes a constant `speed` signal for `body` on the "surface_speeds" input
+// port (leaving any unlisted body's signal absent from the bus).
+void FixSurfaceSpeed(const MultibodyPlant<double>& plant,
+                     systems::Context<double>* context,
+                     const RigidBody<double>& body, double speed) {
+  systems::BusValue bus;
+  bus.Set(body.scoped_name().to_string(), Value<double>(speed));
+  plant.get_surface_speeds_input_port().FixValue(context, bus);
+}
+
+// Initializes a plant with a couple of bodies to test the surface velocity API.
+// The choice of a *continuous* plant is arbitrary and has no bearing on the
+// test.
+class SurfaceVelocityTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    belt_ = &plant_.AddRigidBody("belt", SpatialInertia<double>::MakeUnitary());
+    other_ =
+        &plant_.AddRigidBody("other", SpatialInertia<double>::MakeUnitary());
+  }
+
+  MultibodyPlant<double> plant_{0.0};
+  const RigidBody<double>* belt_{nullptr};
+  const RigidBody<double>* other_{nullptr};
+};
+
+// Tests on the Get/SetSurfaceVelocityAxis() API. We're testing the following:
+//
+// SetSurfaceVelocityAxis()
+//  S1. Can be called pre-finalize.
+//  S2. Unnormalized vectors get normalized.
+//  S3. New axis overwrites old axis.
+//  S4. Setting nullopt clears axis.
+//  S5. Can't be called post-finalize().
+//  S6. Zero vectors can't be normalized (throws).
+//  S7. Can't be called on the world body.
+//
+// GetSurfaceVelocityAxis()
+//  G1. Can be called pre-finalize.
+//  G2. Return nullopt for unregistered body.
+//  G3. Value still present post finalize.
+TEST_F(SurfaceVelocityTest, GetSetSurfaceVelocityAxis) {
+  // (S1) Can set pre-finalize().
+  EXPECT_NO_THROW(plant_.SetSurfaceVelocityAxis(*belt_, Vector3d(0, 2, 0)));
+  // (G1) Can get pre-finalize(), (S2) vector gets normalized.
+  EXPECT_TRUE(CompareMatrices(*plant_.GetSurfaceVelocityAxis(*belt_),
+                              Vector3d(0, 1, 0)));
+  // (G2) Unregistered body returns nullopt.
+  EXPECT_EQ(plant_.GetSurfaceVelocityAxis(*other_), std::nullopt);
+  // (S3) Overwrite with new axis; (S2) tiny vector also normalized.
+  EXPECT_NO_THROW(plant_.SetSurfaceVelocityAxis(*belt_, Vector3d(1e-12, 0, 0)));
+  EXPECT_TRUE(CompareMatrices(*plant_.GetSurfaceVelocityAxis(*belt_),
+                              Vector3d(1, 0, 0)));
+  // (S4) Setting with null clears the registration.
+  EXPECT_NO_THROW(plant_.SetSurfaceVelocityAxis(*belt_, {}));
+  EXPECT_EQ(plant_.GetSurfaceVelocityAxis(*belt_), std::nullopt);
+
+  // (S6) Can't set a zero vector.
+  EXPECT_THROW(plant_.SetSurfaceVelocityAxis(*belt_, Vector3d::Zero()),
+               std::exception);
+
+  // (S7) Can't call on the world body.
+  EXPECT_THROW(
+      plant_.SetSurfaceVelocityAxis(plant_.world_body(), Vector3d{1, 0, 0}),
+      std::exception);
+
+  // Put an axis back onto belt.
+  plant_.SetSurfaceVelocityAxis(*belt_, Vector3d(0, 0, 1));
+  plant_.Finalize();
+
+  // (G3) Value still present after finalize.
+  EXPECT_TRUE(CompareMatrices(*plant_.GetSurfaceVelocityAxis(*belt_),
+                              Vector3d(0, 0, 1)));
+  // (S5) - Can't set post-finalize.
+  EXPECT_THROW(plant_.SetSurfaceVelocityAxis(*belt_, Vector3d(0, 1, 0)),
+               std::exception);
+}
+
+// Confirm port names.
+TEST_F(SurfaceVelocityTest, SurfaceSpeedsPortName) {
+  // Ports don't exist until we finalize.
+  plant_.Finalize();
+  EXPECT_EQ(plant_.get_surface_speeds_input_port().get_name(),
+            "surface_speeds");
+  EXPECT_EQ(plant_.get_surface_displacements_output_port().get_name(),
+            "surface_displacements");
+}
+
+// Tests the ComputeSurfaceVelocity() function.
+//
+// 1. If the port is unconnected, the velocity is zero.
+// 2. A connected bus missing the signal reports zero velocity.
+// 3. Velocity is zero for a body with no axis, even if the bus mistakenly
+//    provides a signal.
+// 4. Finite speeds with various signs work.
+// 5. Axis is truly treated as being in the body frame.
+TEST_F(SurfaceVelocityTest, ComputeSurfaceVelocity) {
+  // Only the belt body has a surface velocity.
+  plant_.SetSurfaceVelocityAxis(*belt_, Vector3d(0, 1, 0));
+
+  plant_.Finalize();
+  std::unique_ptr<systems::Context<double>> context =
+      plant_.CreateDefaultContext();
+
+  // (1) Unconnected port → zero velocity.
+  EXPECT_TRUE(
+      CompareMatrices(MultibodyPlantTester::ComputeSurfaceVelocity(
+                          plant_, belt_->index(), *context, Vector3d(0, 0, 1)),
+                      Vector3d::Zero()));
+
+  // (2) Connected port but missing BusValue signal --> zero velocity.
+  // Setting other, *not* belt.
+  FixSurfaceSpeed(plant_, context.get(), *other_, 1.0);
+  EXPECT_TRUE(
+      CompareMatrices(MultibodyPlantTester::ComputeSurfaceVelocity(
+                          plant_, belt_->index(), *context, Vector3d(0, 0, 1)),
+                      Vector3d::Zero()));
+
+  // (3) Although bus has a signal for "other", no axis --> zero velocity.
+  EXPECT_TRUE(
+      CompareMatrices(MultibodyPlantTester::ComputeSurfaceVelocity(
+                          plant_, other_->index(), *context, Vector3d(0, 0, 1)),
+                      Vector3d::Zero()));
+
+  // (4) Finite speeds all work.
+  for (double speed : {0.25, 0.0, -0.75}) {
+    SCOPED_TRACE(fmt::format("with speed = {}", speed));
+    FixSurfaceSpeed(plant_, context.get(), *belt_, speed);
+    // X_WB = I, so n_W = n_B and axis_B = axis_W. The computed velocity is
+    // v = a X n = (0,1,0) X (0,0,1) = (1,0,0) * speed = (speed, 0, 0).
+    const Vector3d n_W(0, 0, 1);  // Normal in world frame.
+    const Vector3d v_B_expected(speed, 0, 0);
+    EXPECT_TRUE(CompareMatrices(MultibodyPlantTester::ComputeSurfaceVelocity(
+                                    plant_, belt_->index(), *context, n_W),
+                                v_B_expected));
+  }
+
+  // (5) Axis follows the body pose.
+  const RigidTransformd X_WB(RollPitchYawd(0.1, 0.2, 0.3),
+                             Vector3d(0.5, -0.4, 0.3));
+  plant_.SetFloatingBaseBodyPoseInWorldFrame(context.get(), *belt_, X_WB);
+  FixSurfaceSpeed(plant_, context.get(), *belt_, 1.0);
+  const Vector3d n_W = X_WB.rotation().col(2);  // Normal in world frame.
+  const Vector3d v_B_expected(1, 0, 0);
+  EXPECT_TRUE(CompareMatrices(MultibodyPlantTester::ComputeSurfaceVelocity(
+                                  plant_, belt_->index(), *context, n_W),
+                              v_B_expected, 1e-14));
+}
+
+// Fixture for testing the surface displacement state and its accumulation.
+//
+class SurfaceDisplacementTest : public ::testing::Test {
+ protected:
+  void ConfigurePlant(double time_step) {
+    plant_ = std::make_unique<MultibodyPlant<double>>(time_step);
+
+    belt_ =
+        &plant_->AddRigidBody("belt", SpatialInertia<double>::MakeUnitary());
+    plant_->SetSurfaceVelocityAxis(*belt_, Vector3d(1, 0, 0));
+
+    roller_ =
+        &plant_->AddRigidBody("roller", SpatialInertia<double>::MakeUnitary());
+    plant_->SetSurfaceVelocityAxis(*roller_, Vector3d(1, 0, 0));
+
+    plant_->Finalize();
+    context_ = plant_->CreateDefaultContext();
+  }
+
+  double ReadBodySurfaceDisplacement(
+      const RigidBody<double>& body,
+      const systems::Context<double>* context = nullptr) {
+    if (context == nullptr) context = context_.get();
+    return ReadSurfaceDisplacement(*plant_, *context, body);
+  }
+
+  std::unique_ptr<MultibodyPlant<double>> plant_;
+  std::unique_ptr<systems::Context<double>> context_;
+  const RigidBody<double>* belt_{nullptr};
+  const RigidBody<double>* roller_{nullptr};
+};
+
+// Confirms the events that should reset the plant's surface displacement state
+// to zero.
+//
+// This is written to cover both discrete and continuous plants. This is
+// important because where the surface displacement state is stored, depends on
+// the plant's mode; correctness in one mode does *not* imply correctness in
+// the other.
+TEST_F(SurfaceDisplacementTest, StateResets) {
+  for (double time_step : {0.0, 0.01}) {
+    ConfigurePlant(time_step);
+
+    // The allocation of a default context guarantees initial zero values.
+    EXPECT_EQ(ReadBodySurfaceDisplacement(*belt_), 0.0);
+
+    // SetDefaultContext() resets a dirtied displacement.
+    MultibodyPlantTester::SetAllSurfaceDisplacements(*plant_, context_.get(),
+                                                     1.25);
+    ASSERT_EQ(ReadBodySurfaceDisplacement(*belt_), 1.25);
+    plant_->SetDefaultContext(context_.get());
+    EXPECT_EQ(ReadBodySurfaceDisplacement(*belt_), 0.0);
+
+    // SetRandomContext() likewise resets a dirtied displacement. There is no
+    // support for assigning distribution to surface displacement, so, as
+    // documented, it reverts to default values.
+    MultibodyPlantTester::SetAllSurfaceDisplacements(*plant_, context_.get(),
+                                                     2.5);
+    ASSERT_EQ(ReadBodySurfaceDisplacement(*belt_), 2.5);
+    RandomGenerator generator;
+    plant_->SetRandomContext(context_.get(), &generator);
+    EXPECT_EQ(ReadBodySurfaceDisplacement(*belt_), 0.0);
+  }
+}
+
+// In the case where the plant has no connection on the surface_speeds input
+// port, both continuous and discrete plants return a fully-populated output
+// bus. The values in the bus are the unchanged state -- equivalent to
+// connecting input speeds all equal to zero.
+TEST_F(SurfaceDisplacementTest, NoInputConnection) {
+  for (double time_step : {0.0, 0.01}) {
+    SCOPED_TRACE(fmt::format("time_step = {}", time_step));
+    ConfigurePlant(time_step);
+    ASSERT_NE(plant_->GetSurfaceVelocityAxis(*belt_), std::nullopt);
+    ASSERT_NE(plant_->GetSurfaceVelocityAxis(*roller_), std::nullopt);
+
+    // Arbitrary non-zero value to distinguish initial value from unchanging
+    // value.
+    const double baseline = 10.0;
+    MultibodyPlantTester::SetAllSurfaceDisplacements(*plant_, context_.get(),
+                                                     baseline);
+
+    // We'll use a simulator to exercise the continuous/discrete state update
+    // machinery agnostically.
+    systems::Simulator<double> simulator(*plant_, std::move(context_));
+    simulator.AdvanceTo(0.1);
+
+    // Check the output - confirm both signals unchanged from baseline.
+    EXPECT_EQ(ReadBodySurfaceDisplacement(*belt_, &simulator.get_context()),
+              baseline);
+    EXPECT_EQ(ReadBodySurfaceDisplacement(*roller_, &simulator.get_context()),
+              baseline);
+  }
+}
+
+// Update of surface displacement for discrete plants. We're testing:
+//
+//  1. Each invocation accumulates one time_step.
+//  2. The accumulation is on top of the value in the *context* and not in the
+//     mutable state passed in.
+//  3. Bodies with no signal on the surface_speeds bus do not accumulate.
+//  4. Using a simulator to advance time one time step triggers accumulation.
+TEST_F(SurfaceDisplacementTest, DiscreteAccumulation) {
+  constexpr double kTimeStep = 0.01;
+  ConfigurePlant(kTimeStep);  // discrete.
+
+  // With the surface_speeds input port unconnected, attempting to update the
+  // displacement state should report that nothing happened.
+  EXPECT_EQ(MultibodyPlantTester::CallSurfaceDisplacementUpdate(*plant_,
+                                                                context_.get())
+                .severity(),
+            systems::EventStatus::DidNothing().severity());
+
+  const double speed = 2.0;
+  FixSurfaceSpeed(*plant_, context_.get(), *belt_, speed);
+
+  // Prime the context's displacement to a known non-zero baseline.
+  const double baseline = 10.0;
+  MultibodyPlantTester::SetAllSurfaceDisplacements(*plant_, context_.get(),
+                                                   baseline);
+  // The scratch state carries a bogus value; the handler must ignore it.
+  auto scratch = context_->Clone();
+  MultibodyPlantTester::SetAllSurfaceDisplacements(*plant_, scratch.get(),
+                                                   999.0);
+  // context's state is different from scratch's. The reported displacements
+  // will reflect the value in context and not in scratch's state.
+  MultibodyPlantTester::CallSurfaceDisplacementUpdate(
+      *plant_, context_.get(), &scratch->get_mutable_state());
+  EXPECT_NEAR(ReadBodySurfaceDisplacement(*belt_, scratch.get()),
+              baseline + speed * kTimeStep, 1e-14);
+  EXPECT_NEAR(ReadBodySurfaceDisplacement(*roller_), baseline, 1e-14);
+
+  for (int k = 1; k <= 5; ++k) {
+    SCOPED_TRACE(fmt::format("after {} update(s)", k));
+    MultibodyPlantTester::CallSurfaceDisplacementUpdate(*plant_,
+                                                        context_.get());
+    EXPECT_NEAR(ReadBodySurfaceDisplacement(*belt_),
+                baseline + k * speed * kTimeStep, 1e-14);
+    EXPECT_NEAR(ReadBodySurfaceDisplacement(*roller_), baseline, 1e-14);
+  }
+
+  // Reset context.
+  context_->SetTime(0.0);
+  MultibodyPlantTester::SetAllSurfaceDisplacements(*plant_, context_.get(),
+                                                   baseline);
+  systems::Simulator<double> simulator(*plant_, std::move(context_));
+  const double t_final = kTimeStep * 5;
+  simulator.AdvanceTo(t_final);
+
+  // Over [0, t_final] with a period of time_step, the event integrates the
+  // constant speed to speed*t_final.
+  EXPECT_NEAR(ReadBodySurfaceDisplacement(*belt_, &simulator.get_context()),
+              baseline + speed * t_final, 1e-14);
+
+  // As a side effect, simply invoking a forced event increments surface
+  // displacement by speed * time_step per invocation.
+  // Reconfigure a fresh plant/context.
+  ConfigurePlant(kTimeStep);
+  FixSurfaceSpeed(*plant_, context_.get(), *belt_, speed);
+  MultibodyPlantTester::SetAllSurfaceDisplacements(*plant_, context_.get(),
+                                                   baseline);
+  for (int k = 1; k <= 5; ++k) {
+    SCOPED_TRACE(fmt::format("after {} forced event(s)", k));
+    plant_->ExecuteForcedEvents(context_.get());
+    EXPECT_NEAR(ReadBodySurfaceDisplacement(*belt_),
+                baseline + k * speed * kTimeStep, 1e-14);
+    EXPECT_NEAR(ReadBodySurfaceDisplacement(*roller_), baseline, 1e-14);
+  }
+}
+
+// Update of surface displacement for continuous plants. We're testing:
+//
+//  1. Derivatives of surface displacement are exactly the surface speed.
+//  2. Derivative for signal missing from input bus is zero.
+//  3. As continuous state, the integral is simply speed * time.
+TEST_F(SurfaceDisplacementTest, ContinuousIntegration) {
+  ConfigurePlant(/* time_step= */ 0.0);  // continuous.
+
+  const double speed = 2.0;
+  FixSurfaceSpeed(*plant_, context_.get(), *belt_, speed);
+
+  // The time derivative of the displacement is exactly the surface speed.
+  const systems::ContinuousState<double>& derivatives =
+      plant_->EvalTimeDerivatives(*context_);
+  ASSERT_EQ(derivatives.get_misc_continuous_state().size(), 2);
+  EXPECT_EQ(derivatives.get_misc_continuous_state().GetAtIndex(0), speed);
+  EXPECT_EQ(derivatives.get_misc_continuous_state().GetAtIndex(1), 0.0);
+
+  // Integrating over time accumulates speed * t.
+  systems::Simulator<double> simulator(*plant_, std::move(context_));
+  const double t_final = 0.5;
+  simulator.AdvanceTo(t_final);
+  EXPECT_NEAR(ReadBodySurfaceDisplacement(*belt_, &simulator.get_context()),
+              speed * t_final, 1e-9);
+  EXPECT_EQ(ReadBodySurfaceDisplacement(*roller_, &simulator.get_context()),
+            0.0);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -93,6 +93,10 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
 
   bool is_discrete() const { return is_discrete_; }
 
+  /* Returns the size of the continuous miscellaneous state vector z for this
+  model. */
+  int num_misc_continuous_states() const { return num_misc_continuous_states_; }
+
   /* Returns a reference to the up-to-date FrameBodyPoseCache in the
   given Context, recalculating it first if necessary. */
   const FrameBodyPoseCache<T>& EvalFrameBodyPoses(
@@ -392,10 +396,6 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   // a DoLeafSetDefaultState().
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override;
-
-  /* Returns the size of the continuous miscellaneous state vector z for this
-  model. */
-  int num_misc_continuous_states() const { return num_misc_continuous_states_; }
 
  private:
   // This is only meaningful in continuous mode.


### PR DESCRIPTION
This includes:
 - The APIs on MultibodyPlant to declare and introspect surface velocities.
 - The requisite ports.
 - The parsing infrastructure to declare surface velocity in the model files.

It does *not* actually make use of the surface velocity in contact yet.

Relates #19599.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24725)
<!-- Reviewable:end -->
