### PR TITLE
[pydrake] Fix example python RenderEngine subclass

### DIFF
--- a/bindings/pydrake/geometry/test/render_engine_subclass_test.py
+++ b/bindings/pydrake/geometry/test/render_engine_subclass_test.py
@@ -33,13 +33,13 @@ class TestRenderEngineSubclass(unittest.TestCase):
                 pass
 
             def DoRegisterVisual(self, id, shape, properties, X_WG):
-                pass
+                return False
 
             def DoUpdateVisualPose(self, id, X_WG):
                 pass
 
             def DoRemoveGeometry(self, id):
-                pass
+                return False
 
             def __deepcopy__(self, memo):
                 return type(self)()
@@ -55,13 +55,13 @@ class TestRenderEngineSubclass(unittest.TestCase):
                 raise RuntimeError("Minimal engine uses the name API")
 
             def DoRegisterNamedVisual(self, id, shape, properties, X_WG, name):
-                pass
+                return False
 
             def DoUpdateVisualPose(self, id, X_WG):
                 pass
 
             def DoRemoveGeometry(self, id):
-                pass
+                return False
 
             def __deepcopy__(self, memo):
                 return type(self)()
@@ -110,9 +110,10 @@ class TestRenderEngineSubclass(unittest.TestCase):
 
         color_only = ColorOnlyEngine()
         color_only.RenderColorImage(color_cam, color_image)
-        with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):
+        pure_virtual_error_regex = ".+pure virtual function.+"
+        with self.assertRaisesRegex(RuntimeError, pure_virtual_error_regex):
             color_only.RenderDepthImage(depth_cam, depth_image)
-        with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):
+        with self.assertRaisesRegex(RuntimeError, pure_virtual_error_regex):
             color_only.RenderLabelImage(color_cam, label_image)
         self.assertIsInstance(color_only.Clone(), ColorOnlyEngine)
         # Passing a name won't tickle the throw in DoRegisterVisual().
@@ -126,17 +127,17 @@ class TestRenderEngineSubclass(unittest.TestCase):
         )
 
         depth_only = DepthOnlyEngine()
-        with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):
+        with self.assertRaisesRegex(RuntimeError, pure_virtual_error_regex):
             depth_only.RenderColorImage(color_cam, color_image)
         depth_only.RenderDepthImage(depth_cam, depth_image)
-        with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):
+        with self.assertRaisesRegex(RuntimeError, pure_virtual_error_regex):
             depth_only.RenderLabelImage(color_cam, label_image)
         self.assertIsInstance(depth_only.Clone(), DepthOnlyEngine)
 
         label_only = LabelOnlyEngine()
-        with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):
+        with self.assertRaisesRegex(RuntimeError, pure_virtual_error_regex):
             label_only.RenderColorImage(color_cam, color_image)
-        with self.assertRaisesRegex(RuntimeError, ".+pure virtual function.+"):
+        with self.assertRaisesRegex(RuntimeError, pure_virtual_error_regex):
             label_only.RenderDepthImage(depth_cam, depth_image)
         label_only.RenderLabelImage(color_cam, label_image)
         self.assertIsInstance(label_only.Clone(), LabelOnlyEngine)


### PR DESCRIPTION
Method overrides that return a bool need to do that, not return None. This mistake will be detected by nanobind in the future

While we're here, also factor out a repeated string literal (which will also change spelling with nanobind).

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24727)
<!-- Reviewable:end -->
