### PR TITLE
Download all build outputs in debug builds

### DIFF
--- a/tools/bazel-developer.rc
+++ b/tools/bazel-developer.rc
@@ -27,6 +27,13 @@ build:linux --linkopt=-Wl,--threads=2
 # end-user default in drake/CMakeLists.txt.
 build:linux --config=openmp
 
+# Local developer debug builds need separate .dwo debug symbols to enable
+# debugging sessions, but they are not retrieved from the cache by the default
+# --remote_download_outputs=toplevel (which applies to both disk and remote
+# caches).  This flag increases bandwidth usage, so it should not be enabled in
+# CI.
+build:debug --remote_download_outputs=all
+
 ### Lint. ###
 # Run the tests for code style compliance, but not any functional (unit) tests.
 build:lint --build_tests_only


### PR DESCRIPTION
This allows incremental debug builds with remote/disk cache enabled to get separate debug symbols. This is different from the standard workspace cache.

Fixes: #21955.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24728)
<!-- Reviewable:end -->
