### PR TITLE
[CENIC] Support ball constraints

### DIFF
--- a/bindings/generated_docstrings/multibody_contact_solvers_icf.h
+++ b/bindings/generated_docstrings/multibody_contact_solvers_icf.h
@@ -13,6 +13,8 @@
 #endif
 
 // #include "drake/multibody/contact_solvers/icf/abstract_constraints_pool.h"
+// #include "drake/multibody/contact_solvers/icf/ball_constraints_data_pool.h"
+// #include "drake/multibody/contact_solvers/icf/ball_constraints_pool.h"
 // #include "drake/multibody/contact_solvers/icf/coupler_constraints_data_pool.h"
 // #include "drake/multibody/contact_solvers/icf/coupler_constraints_pool.h"
 // #include "drake/multibody/contact_solvers/icf/eigen_pool.h"

--- a/multibody/contact_solvers/icf/BUILD.bazel
+++ b/multibody/contact_solvers/icf/BUILD.bazel
@@ -13,6 +13,7 @@ drake_cc_package_library(
     name = "icf",
     visibility = ["//visibility:public"],
     deps = [
+        ":ball_constraints_data_pool",
         ":coupler_constraints_data_pool",
         ":eigen_pool",
         ":gain_constraints_data_pool",
@@ -37,6 +38,16 @@ drake_cc_library(
     hdrs = ["eigen_pool.h"],
     deps = [
         "//common:autodiff",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "ball_constraints_data_pool",
+    srcs = ["ball_constraints_data_pool.cc"],
+    hdrs = ["ball_constraints_data_pool.h"],
+    deps = [
+        "//common:default_scalars",
         "//common:essential",
     ],
 )
@@ -109,6 +120,7 @@ drake_cc_library(
     srcs = ["icf_data.cc"],
     hdrs = ["icf_data.h"],
     deps = [
+        ":ball_constraints_data_pool",
         ":coupler_constraints_data_pool",
         ":eigen_pool",
         ":gain_constraints_data_pool",
@@ -180,6 +192,7 @@ drake_cc_library(
 drake_cc_library(
     name = "icf_model",
     srcs = [
+        "ball_constraints_pool.cc",
         "coupler_constraints_pool.cc",
         "gain_constraints_pool.cc",
         "icf_model.cc",
@@ -189,6 +202,7 @@ drake_cc_library(
     ],
     hdrs = [
         "abstract_constraints_pool.h",
+        "ball_constraints_pool.h",
         "coupler_constraints_pool.h",
         "gain_constraints_pool.h",
         "icf_model.h",
@@ -197,6 +211,7 @@ drake_cc_library(
         "weld_constraints_pool.h",
     ],
     deps = [
+        ":ball_constraints_data_pool",
         ":coupler_constraints_data_pool",
         ":eigen_pool",
         ":icf_data",
@@ -220,6 +235,31 @@ drake_cc_library(
     ],
     deps = [
         "//math:partial_permutation",
+    ],
+)
+
+drake_cc_googletest(
+    name = "ball_constraint_init_and_sim_test",
+    deps = [
+        "//multibody/cenic:cenic_integrator",
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//multibody/plant:multibody_plant_config_functions",
+        "//systems/analysis:simulator",
+        "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
+    name = "ball_constraints_pool_test",
+    deps = [
+        ":icf_data",
+        ":icf_model",
+        ":icf_search_direction_data",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:limit_malloc",
+        "//math:gradient",
+        "//multibody/contact_solvers/icf/test_utilities:icf_model_test_helpers",
     ],
 )
 

--- a/multibody/contact_solvers/icf/ball_constraints_data_pool.cc
+++ b/multibody/contact_solvers/icf/ball_constraints_data_pool.cc
@@ -1,0 +1,20 @@
+#include "drake/multibody/contact_solvers/icf/ball_constraints_data_pool.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+template <typename T>
+BallConstraintsDataPool<T>::~BallConstraintsDataPool() = default;
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        BallConstraintsDataPool);

--- a/multibody/contact_solvers/icf/ball_constraints_data_pool.h
+++ b/multibody/contact_solvers/icf/ball_constraints_data_pool.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cmath>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+/* Stores data for ball constraints. This data is updated at each solver
+iteration, as opposed to the BallConstraintsPool, which helps define the
+optimization problem.
+
+Each ball constraint has a 3-dimensional impulse γ ∈ ℝ³, applied at the
+midpoint M between the constraint points P and Q.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class BallConstraintsDataPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BallConstraintsDataPool);
+
+  /* Constructs an empty pool. */
+  BallConstraintsDataPool() = default;
+
+  ~BallConstraintsDataPool();
+
+  /* Resizes the pool, allocating memory only as necessary. */
+  void Resize(int num_balls) { gamma_pool_.resize(num_balls); }
+
+  /* Returns the number of ball constraints this data is for. */
+  int num_constraints() const { return ssize(gamma_pool_); }
+
+  /* Returns the constraint impulse γ ∈ ℝ³ for the k-th constraint in the pool.
+  See BallConstraintsPool for details. */
+  const Vector3<T>& gamma(int k) const { return gamma_pool_[k]; }
+  Vector3<T>& mutable_gamma(int k) { return gamma_pool_[k]; }
+
+  /* Returns the total constraint cost ℓ(v) for all ball constraints in the
+  pool. */
+  const T& cost() const { return cost_; }
+  T& mutable_cost() { return cost_; }
+
+ private:
+  T cost_{NAN};                         // Total cost over all ball constraints.
+  std::vector<Vector3<T>> gamma_pool_;  // Constraint impulses, size 3 each.
+};
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        BallConstraintsDataPool);

--- a/multibody/contact_solvers/icf/ball_constraints_pool.cc
+++ b/multibody/contact_solvers/icf/ball_constraints_pool.cc
@@ -1,0 +1,471 @@
+#include "drake/multibody/contact_solvers/icf/ball_constraints_pool.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "drake/math/cross_product.h"
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+using contact_solvers::internal::BlockSparseSymmetricMatrix;
+using math::VectorToSkewSymmetric;
+
+namespace {
+
+// Given spatial impulse Γ_Bo applied at B and the relative position p_AB of B
+// from A, computes the spatial impulse Γ_Ao shifted to A.
+// Mathematically, Γ_Ao = Φ(p_AB)ᵀ⋅Γ_Bo, where Φ(p) is the shift operator.
+template <typename T>
+Vector6<T> ShiftSpatialImpulse(const Vector6<T>& F, const Vector3<T>& p) {
+  const auto t = F.template head<3>();
+  const auto f = F.template tail<3>();
+  Vector6<T> result;
+  result.template head<3>() = t + p.cross(f);
+  result.template tail<3>() = f;
+  return result;
+}
+
+// Near-rigid parameter β.
+constexpr double kBeta = IcfModel<double>::kBeta;
+
+}  // namespace
+
+template <typename T>
+BallConstraintsPool<T>::BallConstraintsPool(const IcfModel<T>* parent_model)
+    : model_(parent_model) {
+  DRAKE_DEMAND(parent_model != nullptr);
+}
+
+template <typename T>
+BallConstraintsPool<T>::~BallConstraintsPool() = default;
+
+template <typename T>
+void BallConstraintsPool<T>::Resize(const int num_constraints) {
+  body_pairs_.resize(num_constraints);
+  p_AP_W_.Resize(num_constraints, 3, 1);
+  p_BQ_W_.Resize(num_constraints, 3, 1);
+  p_PQ_W_.Resize(num_constraints, 3, 1);
+  R_.Resize(num_constraints, 3, 1);
+}
+
+template <typename T>
+void BallConstraintsPool<T>::Set(int index, int bodyA, int bodyB,
+                                 const Vector3<T>& p_AP_W,
+                                 const Vector3<T>& p_BQ_W,
+                                 const Vector3<T>& p_PQ_W) {
+  DRAKE_ASSERT(0 <= index && index < num_constraints());
+  DRAKE_ASSERT(!model().is_anchored(bodyB));
+
+  body_pairs_[index] = std::make_pair(bodyA, bodyB);
+  p_AP_W_[index] = p_AP_W;
+  p_BQ_W_[index] = p_BQ_W;
+  // Constraint function g₀ = p_PQ_W ∈ ℝ³.
+  p_PQ_W_[index] = p_PQ_W;
+
+  // R_ is time-step-dependent and computed in PrecomputeHessianBlocks().
+}
+
+template <typename T>
+void BallConstraintsPool<T>::CalcSparsityPattern(
+    std::vector<std::vector<int>>* sparsity) const {
+  DRAKE_ASSERT(sparsity != nullptr);
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+    if (!model().is_anchored(bodyA)) {
+      const int c_A = model().body_to_clique(bodyA);
+      const int c_B = model().body_to_clique(bodyB);
+      if (c_A == c_B) continue;  // No off-diagonal block for same-clique.
+      const int c_min = std::min(c_A, c_B);
+      const int c_max = std::max(c_A, c_B);
+      sparsity->at(c_min).push_back(c_max);
+    }
+  }
+}
+
+template <typename T>
+void BallConstraintsPool<T>::CalcData(
+    const EigenPool<Vector6<T>>& V_WB,
+    BallConstraintsDataPool<T>* ball_data) const {
+  DRAKE_ASSERT(ball_data != nullptr);
+
+  const T dt = model().time_step();
+  const T dt_eff = model().effective_time_step();
+  const T taud = kBeta * dt_eff / M_PI;
+  const T dt_plus_taud = dt + taud;
+
+  T& cost = ball_data->mutable_cost();
+  cost = 0;
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+
+    // Compute constraint velocity vc = v_W_AmBm at the midpoint M.
+    // M is at the midpoint of P and Q: p_WM = 0.5(p_WP + p_WQ).
+    // Am is a point on A coincident with M: p_AoAm = p_AP + 0.5*p_PQ.
+    // Bm is a point on B coincident with M: p_BoBm = p_BQ - 0.5*p_PQ.
+    const Vector3<T>& p_PQ_W = p_PQ_W_[k];
+    const Vector3<T> p_AoAm_W = p_AP_W_[k] + 0.5 * p_PQ_W;
+    const Vector3<T> p_BoBm_W = p_BQ_W_[k] - 0.5 * p_PQ_W;
+
+    // v_WBm = v_WBo + w_WB × p_BoBm (shift to Bm).
+    // v_WAm = v_WAo + w_WA × p_AoAm (shift to Am).
+    // vc = v_WBm - v_WAm.
+    const Vector6<T>& V_WB_body = V_WB[bodyB];
+    const Vector3<T>& w_WB = V_WB_body.template head<3>();
+    const Vector3<T>& v_WBo = V_WB_body.template tail<3>();
+    const Vector3<T> v_WBm = v_WBo + w_WB.cross(p_BoBm_W);
+
+    Vector3<T> vc;  // Constraint velocity v_W_AmBm.
+    if (!model().is_anchored(bodyA)) {
+      const Vector6<T>& V_WA_body = V_WB[bodyA];
+      const Vector3<T>& w_WA = V_WA_body.template head<3>();
+      const Vector3<T>& v_WAo = V_WA_body.template tail<3>();
+      const Vector3<T> v_WAm = v_WAo + w_WA.cross(p_AoAm_W);
+      vc = v_WBm - v_WAm;
+    } else {
+      vc = v_WBm;
+    }
+
+    // v̂ = -g₀/(dt + τd) where τd = β·dt_eff/π and g₀ = p_PQ.
+    // This is bounded as dt → 0 (v̂ → -g₀/τd).
+    const Vector3<T> v_hat = -p_PQ_W / dt_plus_taud;
+    const Vector3<T>& R_diag = R_[k];
+
+    // γ = R⁻¹⋅(v̂ - vc), where R is diagonal.
+    const Vector3<T> gamma = (v_hat - vc).cwiseQuotient(R_diag);
+    ball_data->mutable_gamma(k) = gamma;
+
+    // cost = ½(v̂ - vc)ᵀ⋅γ
+    cost += 0.5 * (v_hat - vc).dot(gamma);
+  }
+}
+
+template <typename T>
+void BallConstraintsPool<T>::AccumulateGradient(const IcfData<T>& data,
+                                                VectorX<T>* gradient) const {
+  DRAKE_ASSERT(gradient != nullptr);
+
+  const BallConstraintsDataPool<T>& ball_data = data.ball_constraints_data();
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+    const int c_B = model().body_to_clique(bodyB);
+
+    // The gradient ∂ℓ/∂vc of the ball cost ℓ = ½(v̂ − vc)ᵀR⁻¹(v̂ − vc) is
+    // −R⁻¹⋅(v̂ − vc) (R is diagonal). Define γ ≜ −∂ℓ/∂vc.
+    const Vector3<T>& gamma = ball_data.gamma(k);
+
+    // The constraint Jacobian maps v → vc = v_W_AmBm, so its transpose maps
+    // constraint impulses γ → generalized impulses Jᵀγ so ∇ℓ = −Jᵀ⋅γ.
+    // For body B: the spatial impulse at Bm is (0, γ), shifted
+    // to Bo. Γ_Bo_W = Shift((0, γ), p_BoBm_W)
+    const Vector3<T>& p_PQ_W = p_PQ_W_[k];
+    const Vector3<T> p_BoBm_W = p_BQ_W_[k] - 0.5 * p_PQ_W;
+    const Vector6<T> spatial_gamma_Bm =
+        (Vector6<T>() << Vector3<T>::Zero(), gamma).finished();
+    const Vector6<T> Gamma_Bo_W =
+        ShiftSpatialImpulse(spatial_gamma_Bm, p_BoBm_W);
+
+    Eigen::VectorBlock<VectorX<T>> gradient_b =
+        model().mutable_clique_segment(c_B, gradient);
+    if (model().is_floating(bodyB)) {
+      gradient_b.noalias() -= Gamma_Bo_W;
+    } else {
+      auto J_WB = model().J_WB(bodyB);
+      gradient_b.noalias() -= J_WB.transpose() * Gamma_Bo_W;
+    }
+
+    // For body A: the spatial impulse at Am is (0, −γ), shifted
+    // to Ao. p_AoAm_W = p_AP_W + 0.5*p_PQ_W
+    if (!model().is_anchored(bodyA)) {
+      const int c_A = model().body_to_clique(bodyA);
+      const Vector3<T> p_AoAm_W = p_AP_W_[k] + 0.5 * p_PQ_W;
+      const Vector6<T> minus_spatial_gamma_Am =
+          (Vector6<T>() << Vector3<T>::Zero(), Vector3<T>(-gamma)).finished();
+      const Vector6<T> minus_Gamma_Ao_W =
+          ShiftSpatialImpulse(minus_spatial_gamma_Am, p_AoAm_W);
+
+      Eigen::VectorBlock<VectorX<T>> gradient_a =
+          model().mutable_clique_segment(c_A, gradient);
+      if (model().is_floating(bodyA)) {
+        gradient_a.noalias() -= minus_Gamma_Ao_W;
+      } else {
+        auto J_WA = model().J_WB(bodyA);
+        gradient_a.noalias() -= J_WA.transpose() * minus_Gamma_Ao_W;
+      }
+    }
+  }
+}
+
+template <typename T>
+void BallConstraintsPool<T>::PrecomputeHessianBlocks() {
+  hessian_blocks_.resize(num_constraints());
+
+  using std::max;
+  const T dt = model().time_step();
+  const T dt_eff = model().effective_time_step();
+  const T taud = kBeta * dt_eff / M_PI;
+  // R⁻¹ = K·dt·(dt + τd) where K = 4π²/(β²·dt_eff²·w), so
+  // R_diag = w / (K·dt·(dt + τd)) = β²·dt_eff²·w / (4π²·dt·(dt + τd)).
+  const T r_scale = (kBeta * kBeta * dt_eff * dt_eff) /
+                    (4.0 * M_PI * M_PI * dt * (dt + taud));
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+    const int c_B = model().body_to_clique(bodyB);
+    const int c_A = model().body_to_clique(bodyA);  // negative if anchored.
+
+    typename BallConstraintsPool<T>::HessianBlock& hb = hessian_blocks_[k];
+    hb.c_B = c_B;
+    hb.c_A = c_A;
+    hb.A_is_dynamic = !model().is_anchored(bodyA);
+
+    // Compute the regularization R = ε⋅W, where W ≈ J⋅diag(M)⁻¹⋅Jᵀ.
+    // For a ball constraint between two bodies, the Jacobian maps generalized
+    // velocities to the relative translational velocity v_W_AmBm. For the
+    // diagonal approximation, we need the sum of contributions from both
+    // bodies.
+
+    // Approximate W_B = J_WB⋅diag(M_B)⁻¹⋅J_WBᵀ using body mass.
+    // For a single rigid body, this is approximately 1/mass for translational
+    // DOFs. We use a scalar approximation: w ≈ 1/m_B (+ 1/m_A if not anchored).
+    const T& mass_B = model().body_mass(bodyB);
+    T w = 1.0 / mass_B;
+    if (!model().is_anchored(bodyA)) {
+      w += 1.0 / model().body_mass(bodyA);
+    }
+
+    R_[k].setConstant(r_scale * w);
+
+    const Vector3<T>& R_diag = R_[k];
+
+    const Vector3<T> R_inv = R_diag.cwiseInverse();
+    const Matrix3<T> Gt = R_inv.asDiagonal();
+
+    // TODO(sherm1) Consider precomputing p_BoBm_W and p_AoAm_W.
+    const Vector3<T>& p_PQ_W = p_PQ_W_[k];
+    const Vector3<T> p_BoBm_W = p_BQ_W_[k] - 0.5 * p_PQ_W;
+
+    // Compute G_Bp = Φ(p_BoBm)ᵀ⋅G⋅Φ(p_BoBm) where Φ(p) = [𝕀₃, 0; -pₓ, 𝕀₃] and
+    // G = diag(0, Gt).
+    const Matrix3<T> px_B = VectorToSkewSymmetric(p_BoBm_W);
+    Matrix6<T> G_Bp;
+    G_Bp.template topLeftCorner<3, 3>() = -px_B * Gt * px_B;
+    G_Bp.template topRightCorner<3, 3>() = px_B * Gt;
+    G_Bp.template bottomLeftCorner<3, 3>() = -Gt * px_B;
+    G_Bp.template bottomRightCorner<3, 3>() = Gt;
+
+    // Body B contribution: H_BB = J_WBᵀ⋅G_Bp⋅J_WB
+    DRAKE_ASSERT(!model().is_anchored(bodyB));
+    auto J_WB = model().J_WB(bodyB);
+    if (model().is_floating(bodyB)) {
+      hb.H_BB = G_Bp;
+    } else {
+      const int nv_b = model().clique_size(c_B);
+      Matrix6X<T> GJb(6, nv_b);
+      GJb.noalias() = G_Bp * J_WB;
+      hb.H_BB.resize(nv_b, nv_b);
+      hb.H_BB.noalias() = J_WB.transpose() * GJb;
+    }
+
+    // Body A contribution, only if not anchored.
+    if (hb.A_is_dynamic) {
+      const Vector3<T> p_AoAm_W = p_AP_W_[k] + 0.5 * p_PQ_W;
+      auto J_WA = model().J_WB(bodyA);
+
+      // G_Ap = Φ(p_AoAm)ᵀ⋅G⋅Φ(p_AoAm) where Φ(p) = [𝕀₃, 0; -pₓ, 𝕀₃].
+      const Matrix3<T> px_A = VectorToSkewSymmetric(p_AoAm_W);
+      Matrix6<T> G_Ap;
+      G_Ap.template topLeftCorner<3, 3>() = -px_A * Gt * px_A;
+      G_Ap.template topRightCorner<3, 3>() = px_A * Gt;
+      G_Ap.template bottomLeftCorner<3, 3>() = -Gt * px_A;
+      G_Ap.template bottomRightCorner<3, 3>() = Gt;
+
+      // H_AA = J_WAᵀ⋅G_Ap⋅J_WA
+      if (model().is_floating(bodyA)) {
+        hb.H_AA = G_Ap;
+      } else {
+        const int nv_a = model().clique_size(c_A);
+        Matrix6X<T> GJa(6, nv_a);
+        GJa.noalias() = G_Ap * J_WA;
+        hb.H_AA.resize(nv_a, nv_a);
+        hb.H_AA.noalias() = J_WA.transpose() * GJa;
+      }
+
+      // Let Φ_A = Φ(p_AoAm) and Φ_B = Φ(p_BoBm).
+      // Cross term: H_BA = −J_WBᵀ⋅Φ_Bᵀ⋅G⋅Φ_A⋅J_WA
+
+      // Define G_cross = −Φ_Bᵀ⋅G⋅Φ_A.
+      Matrix6<T> G_cross;
+      G_cross.template topLeftCorner<3, 3>() = px_B * Gt * px_A;
+      G_cross.template topRightCorner<3, 3>() = -px_B * Gt;
+      G_cross.template bottomLeftCorner<3, 3>() = Gt * px_A;
+      G_cross.template bottomRightCorner<3, 3>() = -Gt;
+
+      // Compute H_BA and store the final cross block in the correct
+      // orientation for AddToBlock.
+      const int nv_a = model().clique_size(c_A);
+      const int nv_b = model().clique_size(c_B);
+      MatrixX<T> H_BA(nv_b, nv_a);
+      {
+        Matrix6X<T> GJa(6, nv_a);
+        GJa.noalias() = G_cross * J_WA;
+        if (model().is_floating(bodyB)) {
+          H_BA = GJa;
+        } else {
+          H_BA.noalias() = J_WB.transpose() * GJa;
+        }
+      }
+
+      if (c_B > c_A) {
+        hb.cross_row = c_B;
+        hb.cross_col = c_A;
+        hb.H_cross = H_BA;
+      } else if (c_A > c_B) {
+        hb.cross_row = c_A;
+        hb.cross_col = c_B;
+        hb.H_cross = H_BA.transpose();
+      } else {
+        // c_A == c_B: both bodies in the same clique.
+        hb.cross_row = c_A;
+        hb.cross_col = c_B;
+        hb.H_cross = H_BA + H_BA.transpose();
+      }
+    }
+  }
+}
+
+template <typename T>
+void BallConstraintsPool<T>::AccumulateHessian(
+    const IcfData<T>&, BlockSparseSymmetricMatrix<MatrixX<T>>* hessian) const {
+  DRAKE_ASSERT(hessian != nullptr);
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const typename BallConstraintsPool<T>::HessianBlock& hb =
+        hessian_blocks_[k];
+    hessian->AddToBlock(hb.c_B, hb.c_B, hb.H_BB);
+
+    if (hb.A_is_dynamic) {
+      hessian->AddToBlock(hb.c_A, hb.c_A, hb.H_AA);
+      hessian->AddToBlock(hb.cross_row, hb.cross_col, hb.H_cross);
+    }
+  }
+}
+
+template <typename T>
+void BallConstraintsPool<T>::CalcCostAlongLine(
+    const BallConstraintsDataPool<T>& ball_data,
+    const EigenPool<Vector6<T>>& U_WB, T* dcost, T* d2cost) const {
+  DRAKE_ASSERT(dcost != nullptr);
+  DRAKE_ASSERT(d2cost != nullptr);
+  *dcost = 0.0;
+  *d2cost = 0.0;
+
+  for (int k = 0; k < num_constraints(); ++k) {
+    const int bodyA = body_pairs_[k].first;
+    const int bodyB = body_pairs_[k].second;
+
+    // Compute the constraint "velocity" in the search direction w.
+    // U_AmBm_W = uc (constraint velocity evaluated on w).
+    const Vector3<T>& p_PQ_W = p_PQ_W_[k];
+    const Vector3<T> p_AoAm_W = p_AP_W_[k] + 0.5 * p_PQ_W;
+    const Vector3<T> p_BoBm_W = p_BQ_W_[k] - 0.5 * p_PQ_W;
+
+    const Vector6<T>& U_WB_body = U_WB[bodyB];
+    const Vector3<T>& uw_WB = U_WB_body.template head<3>();
+    const Vector3<T>& uv_WBo = U_WB_body.template tail<3>();
+    const Vector3<T> uv_WBm = uv_WBo + uw_WB.cross(p_BoBm_W);
+
+    Vector3<T> uc;  // Constraint velocity in search direction.
+    if (!model().is_anchored(bodyA)) {
+      const Vector6<T>& U_WA_body = U_WB[bodyA];
+      const Vector3<T>& uw_WA = U_WA_body.template head<3>();
+      const Vector3<T>& uv_WAo = U_WA_body.template tail<3>();
+      const Vector3<T> uv_WAm = uv_WAo + uw_WA.cross(p_AoAm_W);
+      uc = uv_WBm - uv_WAm;
+    } else {
+      uc = uv_WBm;
+    }
+
+    const Vector3<T>& gamma = ball_data.gamma(k);
+    const Vector3<T>& R_diag = R_[k];
+
+    // dℓ̃/dα = −γᵀ⋅uc
+    (*dcost) -= gamma.dot(uc);
+
+    // d²ℓ̃/dα² = ucᵀ⋅R⁻¹⋅uc
+    (*d2cost) += uc.cwiseQuotient(R_diag).dot(uc);
+  }
+}
+
+template <typename T>
+void BallConstraintsPool<T>::ReduceInto(
+    const ReducedMapping& mapping, BallConstraintsPool<T>* reduced_pool) const {
+  // Make sure the pool is (over) allocated.
+  reduced_pool->Resize(num_constraints());
+  // Remove old data.
+  reduced_pool->Resize(0);
+
+  int reduced_size{0};
+  for (int k = 0; k < num_constraints(); ++k) {
+    // In order to include the constraint, at least one body in the pair must
+    // be in a clique participating in the reduced model. If only the first
+    // body's clique participates, we reverse the ordering of the two bodies
+    // for the reduced-model constraint to match the constraint conventions.
+    const int body_a = body_pairs_[k].first;
+    const int body_b = body_pairs_[k].second;
+    const int c_B = model().body_to_clique(body_b);
+    const int c_A = model().body_to_clique(body_a);  // negative if anchored.
+    // Notation: `r_` variables refer to the reduced problem.
+    const bool have_r_c_B = mapping.clique_subsequence.participates(c_B);
+    const bool have_r_c_A =
+        (c_A >= 0 && mapping.clique_subsequence.participates(c_A));
+    const int r_num_cliques = have_r_c_B + have_r_c_A;
+    // If both bodies' cliques have been removed, remove the whole constraint.
+    if (r_num_cliques == 0) {
+      continue;
+    }
+    // At this point, we could have an `r_num_cliques==1` case where body_b has
+    // become anchored (no clique), and body_a is not anchored. This will
+    // require flipping the direction of the ball constraint.
+    bool need_flip = (r_num_cliques == 1 && have_r_c_A);
+
+    // Fill in the reduced constraint.
+    if (need_flip) {
+      reduced_pool->body_pairs_.emplace_back(body_b, body_a);
+      reduced_pool->p_AP_W_.Add(3, 1) = p_BQ_W_[k];
+      reduced_pool->p_BQ_W_.Add(3, 1) = p_AP_W_[k];
+      reduced_pool->p_PQ_W_.Add(3, 1) = -p_PQ_W_[k];
+    } else {
+      reduced_pool->body_pairs_.push_back(body_pairs_[k]);
+      reduced_pool->p_AP_W_.Add(3, 1) = p_AP_W_[k];
+      reduced_pool->p_BQ_W_.Add(3, 1) = p_BQ_W_[k];
+      reduced_pool->p_PQ_W_.Add(3, 1) = p_PQ_W_[k];
+    }
+
+    // Track the reduced pool size.
+    ++reduced_size;
+  }
+  // The values within R_ and HessianBlock will be set by
+  // PrecomputeHessianBlocks(). Set the arrays to the correct size.
+  reduced_pool->R_.Resize(reduced_size, 3, 1);
+  reduced_pool->hessian_blocks_.resize(reduced_size);
+}
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        BallConstraintsPool);

--- a/multibody/contact_solvers/icf/ball_constraints_pool.h
+++ b/multibody/contact_solvers/icf/ball_constraints_pool.h
@@ -1,0 +1,190 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/abstract_constraints_pool.h"
+#include "drake/multibody/contact_solvers/icf/ball_constraints_data_pool.h"
+#include "drake/multibody/contact_solvers/icf/eigen_pool.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+#include "drake/multibody/contact_solvers/icf/reduced_mapping.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+
+// Forward declaration to break circular dependencies.
+template <typename T>
+class IcfModel;
+
+/* A pool of ball constraints between pairs of bodies.
+
+Each ball constraint connects distinct bodies A and B, enforcing coincidence of
+a point P on A and a point Q on B. The constraint function is defined as
+  g = p_PQ = 0 ∈ ℝ³
+where p_PQ is the relative translation between the constraint points P and Q.
+Unlike the weld constraint, the ball constraint leaves the relative orientation
+of the two bodies free (constraining 3 translational DOFs, no rotational DOFs).
+
+Following the SAP weld constraint formulation (see sap_weld_constraint.h), we
+define the constraint velocity as the relative translational velocity of points
+Am (fixed to A) and Bm (fixed to B) coincident at the midpoint M between P and
+Q:
+  vc = v_W_AmBm ∈ ℝ³
+and the convex cost as:
+  ℓ(vc) = ½(v̂ − vc)ᵀR⁻¹(v̂ − vc)
+where R is a 3×3 diagonal "near-rigid" regularization matrix and v̂ is a bias
+velocity computed from g₀, the constraint function evaluated at q₀.
+
+This produces impulse γ ≜ −dℓ(vc)/dvc ∈ ℝ³ which we use to apply equal and
+opposite impulses at Am and Bm (co-located at the midpoint M), ensuring
+conservation of angular momentum and satisfaction of Newton's third law.
+Our sign convention is such that γ is the impulse on B, so the impulse on A
+is −γ.
+
+N.B. Applying the impulse at the midpoint M is a deliberate deviation from the
+SAP ball constraint (see sap_ball_constraint.h), which applies the impulse at
+the points P and Q directly and therefore does NOT conserve angular momentum
+when P and Q are not coincident (it introduces a small moment of order
+O(‖γ‖⋅‖p_PQ‖)). The midpoint formulation used here matches the ICF weld
+constraint and conserves angular momentum. Concretely, the ball constraint is
+the translational (lower) half of the weld constraint.
+
+Like patch and weld constraints, ball constraints involve two bodies and can
+introduce cross-clique coupling (off-diagonal blocks in the Hessian) when the
+two bodies belong to different cliques.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class BallConstraintsPool {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BallConstraintsPool);
+
+  /* Constructs an empty pool. */
+  explicit BallConstraintsPool(const IcfModel<T>* parent_model);
+
+  ~BallConstraintsPool();
+
+  /* @see IsAbstractConstraintsPool. */
+  const IcfModel<T>& model() const { return *model_; }
+  int num_constraints() const { return ssize(body_pairs_); }
+  void AccumulateGradient(const IcfData<T>& data, VectorX<T>* gradient) const;
+  void AccumulateHessian(
+      const IcfData<T>& data,
+      contact_solvers::internal::BlockSparseSymmetricMatrix<MatrixX<T>>*
+          hessian) const;
+  void ReduceInto(const ReducedMapping& mapping,
+                  BallConstraintsPool<T>* reduced_pool) const;
+
+  /* Resizes the constraints pool to store the given number of ball constraints.
+
+  @warning After resizing, constraints may hold invalid data until Set() is
+  called for each constraint index in [0, num_constraints()). */
+  void Resize(int num_constraints);
+
+  /* Sets the k-th ball constraint.
+
+  @param index The index of the constraint within the pool.
+  @param bodyA The index of body A in the IcfModel. May be anchored.
+  @param bodyB The index of body B in the IcfModel. Must not be anchored.
+  @param p_AP_W Position of constraint point P in body A, expressed in world.
+  @param p_BQ_W Position of constraint point Q in body B, expressed in world.
+  @param p_PQ_W Position of Q relative to P, expressed in world.
+
+  Calling this function several times with the same `index` overwrites the
+  previous constraint for that index.
+
+  @pre all indices are in range, bodyA ≠ bodyB, bodyB not anchored. */
+  void Set(int index, int bodyA, int bodyB, const Vector3<T>& p_AP_W,
+           const Vector3<T>& p_BQ_W, const Vector3<T>& p_PQ_W);
+
+  /* Computes the sparsity pattern for the pool. Clique i is connected to
+  clique j > i iff sparsity[i] contains j. */
+  void CalcSparsityPattern(std::vector<std::vector<int>>* sparsity) const;
+
+  /* Precomputes the iteration-invariant Hessian blocks for every ball
+  constraint. Because the ball cost ℓ(vc) = ½(v̂ − vc)ᵀR⁻¹(v̂ − vc) is
+  purely quadratic in the constraint velocity, its Hessian ∂²ℓ/∂v² depends
+  only on the regularization R and the (constant) constraint Jacobians. This
+  method must be called after all Set() calls and before AccumulateHessian()
+  is used. */
+  void PrecomputeHessianBlocks();
+
+  /* Computes problem data as a function of the body spatial velocities V_WB for
+  the full IcfModel. */
+  void CalcData(const EigenPool<Vector6<T>>& V_WB,
+                BallConstraintsDataPool<T>* ball_data) const;
+
+  /* Computes the first and second derivatives of the constraint cost
+  ℓ̃(α) = ℓ(v + α⋅w).
+
+  @param ball_data Constraint data computed at v + α⋅w.
+  @param U_WB Body spatial velocities when generalized velocities equal w.
+         I.e., U_WB = J_WB⋅w.
+  @param[out] dcost the first derivative dℓ̃/dα on output.
+  @param[out] d2cost the second derivative d²ℓ̃/dα² on output. */
+  void CalcCostAlongLine(const BallConstraintsDataPool<T>& ball_data,
+                         const EigenPool<Vector6<T>>& U_WB, T* dcost,
+                         T* d2cost) const;
+
+  /* Testing only access. */
+  const std::vector<std::pair<int, int>>& body_pairs() const {
+    return body_pairs_;
+  }
+  const EigenPool<Vector3<T>>& p_AP_W() const { return p_AP_W_; }
+  const EigenPool<Vector3<T>>& p_BQ_W() const { return p_BQ_W_; }
+  const EigenPool<Vector3<T>>& p_PQ_W() const { return p_PQ_W_; }
+  const EigenPool<Vector3<T>>& g0() const { return p_PQ_W_; }
+  const EigenPool<Vector3<T>>& R() const { return R_; }
+  int hessian_blocks_size() const { return ssize(hessian_blocks_); }
+
+ private:
+  const IcfModel<T>* const model_;  // The parent model.
+
+  // Body pairs involved in each ball constraint, (bodyA, bodyB).
+  // bodyB is always dynamic (not anchored).
+  std::vector<std::pair<int, int>> body_pairs_;
+
+  // Per-constraint data, all indexed by constraint index k.
+  EigenPool<Vector3<T>> p_AP_W_;  // Position of P in A, expressed in W.
+  EigenPool<Vector3<T>> p_BQ_W_;  // Position of Q in B, expressed in W.
+  // Relative translation, expressed in W. For a ball constraint this is also
+  // the constraint function at the start of the step, g₀ = p_PQ_W.
+  EigenPool<Vector3<T>> p_PQ_W_;
+
+  // Near-rigid regularization per constraint.
+  // R depends on the current time step δt and is computed in
+  // PrecomputeHessianBlocks(), which must be called whenever δt changes.
+  // R is a diagonal 3×3 regularization matrix.
+  EigenPool<Vector3<T>> R_;  // The diagonal regularization matrix.
+
+  // Precomputed Hessian blocks for each ball constraint, populated by
+  // PrecomputeHessianBlocks(). These are iteration-invariant because the ball
+  // cost Hessian depends only on R and the constant constraint Jacobians.
+  struct HessianBlock {
+    int c_B{-1};         // Clique index for body B (always valid).
+    int c_A{-1};         // Clique index for body A (-1 if anchored).
+    MatrixX<T> H_BB;     // Diagonal block for body B's clique.
+    MatrixX<T> H_AA;     // Diagonal block for body A's clique (if dynamic).
+    MatrixX<T> H_cross;  // Off-diagonal (or same-clique cross) block.
+    int cross_row{-1};   // Block row index for the cross term.
+    int cross_col{-1};   // Block column index for the cross term.
+    bool A_is_dynamic{false};  // True when body A is not anchored.
+  };
+  std::vector<HessianBlock> hessian_blocks_;
+};
+static_assert(IsAbstractConstraintsPool<BallConstraintsPool>);
+
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::icf::internal::
+        BallConstraintsPool);

--- a/multibody/contact_solvers/icf/icf_builder.cc
+++ b/multibody/contact_solvers/icf/icf_builder.cc
@@ -15,6 +15,7 @@
 #include "drake/multibody/topology/graph.h"
 
 using drake::multibody::CalcContactFrictionFromSurfaceProperties;
+using drake::multibody::internal::BallConstraintSpec;
 using drake::multibody::internal::CouplerConstraintSpec;
 using drake::multibody::internal::GetCombinedHuntCrossleyDissipation;
 using drake::multibody::internal::GetCombinedPointContactStiffness;
@@ -236,6 +237,10 @@ void IcfBuilder<T>::UpdateModel(
   AllocateWeldConstraints(model);
   SetWeldConstraints(context, model);
 
+  // Ball constraints
+  AllocateBallConstraints(model);
+  SetBallConstraints(context, model);
+
   // Limit constraints
   AllocateLimitConstraints(model);
   SetLimitConstraints(context, model);
@@ -300,15 +305,14 @@ void IcfBuilder<T>::ValidatePlant() {
 
   // Revisit this condition as constraints are implemented. See issues #23759,
   // #23760, #23762, #23763.
-  if (plant_.num_constraints() - plant_.num_coupler_constraints() -
-          plant_.num_weld_constraints() >
+  if (plant_.num_constraints() - plant_.num_ball_constraints() -
+          plant_.num_coupler_constraints() - plant_.num_weld_constraints() >
       0) {
     throw std::logic_error(fmt::format(
         "The CENIC integrator does not yet support some constraints, but "
         "they are present in the given MultibodyPlant: {} distance "
-        "constraint(s), {} ball constraint(s), {} tendon constraint(s)",
-        plant_.num_distance_constraints(), plant_.num_ball_constraints(),
-        plant_.num_tendon_constraints()));
+        "constraint(s), {} tendon constraint(s)",
+        plant_.num_distance_constraints(), plant_.num_tendon_constraints()));
   }
 }
 
@@ -504,6 +508,79 @@ void IcfBuilder<T>::SetWeldConstraints(const systems::Context<T>& context,
 
     welds.Set(index, pool_bodyA.index(), pool_bodyB.index(), p_AP_W, p_BQ_W,
               p_PoQo_W, a_PQ_W);
+    ++index;
+  }
+}
+
+template <typename T>
+void IcfBuilder<T>::AllocateBallConstraints(IcfModel<T>* model) const {
+  DRAKE_ASSERT(model != nullptr);
+  const std::map<MultibodyConstraintId, BallConstraintSpec>& specs_map =
+      plant_.get_ball_constraint_specs();
+  BallConstraintsPool<T>& ball_constraints = model->ball_constraints_pool();
+  ball_constraints.Resize(specs_map.size());
+}
+
+template <typename T>
+void IcfBuilder<T>::SetBallConstraints(const systems::Context<T>& context,
+                                       IcfModel<T>* model) const {
+  DRAKE_ASSERT(model != nullptr);
+  using drake::math::RigidTransform;
+
+  const std::map<MultibodyConstraintId, BallConstraintSpec>& specs_map =
+      plant_.get_ball_constraint_specs();
+
+  BallConstraintsPool<T>& ball_constraints = model->ball_constraints_pool();
+
+  int index = 0;
+  for (const auto& [id, spec] : specs_map) {
+    // p_BQ is optional pre-Finalize; on a finalized plant it must be set.
+    DRAKE_DEMAND(spec.p_BQ.has_value());
+
+    const RigidBody<T>& body_A = plant_.get_body(spec.body_A);
+    const RigidBody<T>& body_B = plant_.get_body(spec.body_B);
+
+    // By convention in the ICF ball constraint pool, body B must not be
+    // anchored. If body A is anchored, that's fine.
+    const bool A_anchored = plant_.IsAnchored(body_A);
+    const bool B_anchored = plant_.IsAnchored(body_B);
+
+    // TODO(sherm1): Move this exception up to the plant level so
+    //  that it fails as fast as possible. Currently, the earliest this can
+    //  happen is in MbP::Finalize() after the topology has been finalized.
+    if (A_anchored && B_anchored) {
+      const std::string msg = fmt::format(
+          "Creating a ball constraint between bodies '{}' and '{}' where "
+          "both are welded to the world is not allowed.",
+          body_A.name(), body_B.name());
+      throw std::logic_error(msg);
+    }
+
+    // If B is anchored but A is not, swap roles so that the "B" body in the
+    // pool is always the dynamic one.
+    const RigidBody<T>& pool_bodyA = B_anchored ? body_B : body_A;
+    const RigidBody<T>& pool_bodyB = B_anchored ? body_A : body_B;
+    const Vector3<double>& p_AP_spec =
+        B_anchored ? spec.p_BQ.value() : spec.p_AP;
+    const Vector3<double>& p_BQ_spec =
+        B_anchored ? spec.p_AP : spec.p_BQ.value();
+
+    const RigidTransform<T>& X_WA = pool_bodyA.EvalPoseInWorld(context);
+    const RigidTransform<T>& X_WB = pool_bodyB.EvalPoseInWorld(context);
+
+    // Constraint point positions in world.
+    const Vector3<T> p_WP = X_WA * p_AP_spec.template cast<T>();
+    const Vector3<T> p_WQ = X_WB * p_BQ_spec.template cast<T>();
+
+    // Positions of P in A and Q in B, expressed in world.
+    const Vector3<T> p_AP_W = X_WA.rotation() * p_AP_spec.template cast<T>();
+    const Vector3<T> p_BQ_W = X_WB.rotation() * p_BQ_spec.template cast<T>();
+
+    // Relative translation p_PQ in world.
+    const Vector3<T> p_PQ_W = p_WQ - p_WP;
+
+    ball_constraints.Set(index, pool_bodyA.index(), pool_bodyB.index(), p_AP_W,
+                         p_BQ_W, p_PQ_W);
     ++index;
   }
 }

--- a/multibody/contact_solvers/icf/icf_builder.h
+++ b/multibody/contact_solvers/icf/icf_builder.h
@@ -123,6 +123,14 @@ class IcfBuilder {
   void SetWeldConstraints(const systems::Context<T>& context,
                           IcfModel<T>* model) const;
 
+  /* Resizes the model to accommodate ball constraints. */
+  void AllocateBallConstraints(IcfModel<T>* model) const;
+
+  /* Sets ball constraints in the model.
+  @pre AllocateBallConstraints() has already been called. */
+  void SetBallConstraints(const systems::Context<T>& context,
+                          IcfModel<T>* model) const;
+
   /* Resizes the model to accommodate limit constraints. */
   void AllocateLimitConstraints(IcfModel<T>* model) const;
 

--- a/multibody/contact_solvers/icf/icf_data.cc
+++ b/multibody/contact_solvers/icf/icf_data.cc
@@ -10,8 +10,9 @@ namespace internal {
 
 template <typename T>
 void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
-                                 int max_clique_size, int num_couplers,
-                                 int num_welds, std::span<const int> gain_sizes,
+                                 int max_clique_size, int num_ball_constraints,
+                                 int num_couplers, int num_welds,
+                                 std::span<const int> gain_sizes,
                                  std::span<const int> limit_sizes,
                                  std::span<const int> patch_sizes) {
   Av_minus_r.Resize(1, num_velocities, 1);
@@ -23,6 +24,7 @@ void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
   Gw_gain.Resize(1, max_clique_size, 1);
   Gw_limit.Resize(1, max_clique_size, 1);
 
+  ball_constraints_data.Resize(num_ball_constraints);
   coupler_constraints_data.Resize(num_couplers);
   gain_constraints_data.Resize(gain_sizes);
   limit_constraints_data.Resize(limit_sizes);
@@ -44,21 +46,23 @@ IcfData<T>::~IcfData() = default;
 
 template <typename T>
 void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
-                        int num_couplers, int num_welds,
-                        std::span<const int> gain_sizes,
+                        int num_ball_constraints, int num_couplers,
+                        int num_welds, std::span<const int> gain_sizes,
                         std::span<const int> limit_sizes,
                         std::span<const int> patch_sizes) {
   v_.resize(num_velocities);
   V_WB_.Resize(num_bodies, 6, 1);
   Av_.resize(num_velocities);
   gradient_.resize(num_velocities);
+  ball_constraints_data_.Resize(num_ball_constraints);
   coupler_constraints_data_.Resize(num_couplers);
   gain_constraints_data_.Resize(gain_sizes);
   limit_constraints_data_.Resize(limit_sizes);
   patch_constraints_data_.Resize(patch_sizes);
   weld_constraints_data_.Resize(num_welds);
-  scratch_.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-                  num_welds, gain_sizes, limit_sizes, patch_sizes);
+  scratch_.Resize(num_bodies, num_velocities, max_clique_size,
+                  num_ball_constraints, num_couplers, num_welds, gain_sizes,
+                  limit_sizes, patch_sizes);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_data.h
+++ b/multibody/contact_solvers/icf/icf_data.h
@@ -3,6 +3,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/icf/ball_constraints_data_pool.h"
 #include "drake/multibody/contact_solvers/icf/coupler_constraints_data_pool.h"
 #include "drake/multibody/contact_solvers/icf/eigen_pool.h"
 #include "drake/multibody/contact_solvers/icf/gain_constraints_data_pool.h"
@@ -48,7 +49,7 @@ class IcfData {
   struct Scratch {
     /* Resizes the scratch space, allocating memory as needed. */
     void Resize(int num_bodies, int num_velocities, int max_clique_size,
-                int num_couplers, int num_welds,
+                int num_ball_constraints, int num_couplers, int num_welds,
                 std::span<const int> gain_sizes,
                 std::span<const int> limit_sizes,
                 std::span<const int> patch_sizes);
@@ -76,6 +77,7 @@ class IcfData {
     EigenPool<VectorX<T>> Gw_limit;
 
     // Scratch data pools for CalcCostAlongLine.
+    BallConstraintsDataPool<T> ball_constraints_data;
     CouplerConstraintsDataPool<T> coupler_constraints_data;
     GainConstraintsDataPool<T> gain_constraints_data;
     LimitConstraintsDataPool<T> limit_constraints_data;
@@ -108,6 +110,7 @@ class IcfData {
   @param num_bodies Total number of bodies in the model.
   @param num_velocities Total number of generalized velocities.
   @param max_clique_size Maximum number of velocities in any clique.
+  @param num_ball_constraints Number of ball constraints.
   @param num_couplers Number of coupler constraints.
   @param num_welds Number of weld constraints.
   @param gain_sizes Number of velocities for each gain constraint.
@@ -118,8 +121,8 @@ class IcfData {
   //  constraint types. Consider switching to a parameter struct which would
   //  let us use named fields at the call sites.
   void Resize(int num_bodies, int num_velocities, int max_clique_size,
-              int num_couplers, int num_welds, std::span<const int> gain_sizes,
-              std::span<const int> limit_sizes,
+              int num_ball_constraints, int num_couplers, int num_welds,
+              std::span<const int> gain_sizes, std::span<const int> limit_sizes,
               std::span<const int> patch_sizes);
 
   /* Returns the number of generalized velocities in the system. */
@@ -158,6 +161,14 @@ class IcfData {
   /* Returns the total gradient ∇ℓ(v). Size is num_velocities(). */
   const VectorX<T>& gradient() const { return gradient_; }
   VectorX<T>& mutable_gradient() { return gradient_; }
+
+  /* Returns the data pool for ball constraints. */
+  const BallConstraintsDataPool<T>& ball_constraints_data() const {
+    return ball_constraints_data_;
+  }
+  BallConstraintsDataPool<T>& mutable_ball_constraints_data() {
+    return ball_constraints_data_;
+  }
 
   /* Returns the data pool for coupler constraints. */
   const CouplerConstraintsDataPool<T>& coupler_constraints_data() const {
@@ -212,6 +223,7 @@ class IcfData {
   VectorX<T> gradient_;         // Total cost gradient ∇ℓ(v)
 
   // Type-specific constraint pools.
+  BallConstraintsDataPool<T> ball_constraints_data_;
   CouplerConstraintsDataPool<T> coupler_constraints_data_;
   GainConstraintsDataPool<T> gain_constraints_data_;
   LimitConstraintsDataPool<T> limit_constraints_data_;

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -20,6 +20,7 @@ using multibody::internal::SelectRowsCols;
 template <typename T>
 IcfModel<T>::IcfModel()
     : params_{std::make_unique<IcfParameters<T>>()},
+      ball_constraints_pool_(this),
       coupler_constraints_pool_(this),
       gain_constraints_pool_(this),
       limit_constraints_pool_(this),
@@ -97,6 +98,7 @@ Eigen::VectorBlock<VectorX<T>> IcfModel<T>::mutable_clique_segment(
 template <typename T>
 void IcfModel<T>::ResizeData(IcfData<T>* data) const {
   data->Resize(num_bodies_, num_velocities_, max_clique_size_,
+               ball_constraints_pool_.num_constraints(),
                coupler_constraints_pool_.num_constraints(),
                weld_constraints_pool_.num_constraints(),
                gain_constraints_pool_.constraint_sizes(),
@@ -117,6 +119,7 @@ void IcfModel<T>::CalcData(const VectorX<T>& v, IcfData<T>* data) const {
   CalcBodySpatialVelocities(v, &V_WB);
 
   // Compute constraint data.
+  ball_constraints_pool_.CalcData(V_WB, &data->mutable_ball_constraints_data());
   coupler_constraints_pool_.CalcData(v,
                                      &data->mutable_coupler_constraints_data());
   gain_constraints_pool_.CalcData(v, &data->mutable_gain_constraints_data());
@@ -127,6 +130,7 @@ void IcfModel<T>::CalcData(const VectorX<T>& v, IcfData<T>* data) const {
 
   // Accumulate gradient contributions from constraints.
   VectorX<T>& gradient = data->mutable_gradient();
+  ball_constraints_pool_.AccumulateGradient(*data, &gradient);
   coupler_constraints_pool_.AccumulateGradient(*data, &gradient);
   gain_constraints_pool_.AccumulateGradient(*data, &gradient);
   limit_constraints_pool_.AccumulateGradient(*data, &gradient);
@@ -134,7 +138,7 @@ void IcfModel<T>::CalcData(const VectorX<T>& v, IcfData<T>* data) const {
   weld_constraints_pool_.AccumulateGradient(*data, &gradient);
 
   // Accumulate cost contributions from constraints.
-  data->set_cost(data->momentum_cost() +
+  data->set_cost(data->momentum_cost() + data->ball_constraints_data().cost() +
                  data->coupler_constraints_data().cost() +
                  data->gain_constraints_data().cost() +
                  data->limit_constraints_data().cost() +
@@ -164,6 +168,7 @@ void IcfModel<T>::UpdateHessian(
   }
 
   // Add constraints' contributions.
+  ball_constraints_pool_.AccumulateHessian(data, hessian);
   coupler_constraints_pool_.AccumulateHessian(data, hessian);
   gain_constraints_pool_.AccumulateHessian(data, hessian);
   limit_constraints_pool_.AccumulateHessian(data, hessian);
@@ -277,6 +282,24 @@ T IcfModel<T>::CalcCostAlongLine(
     *d2cost_dalpha2 += constraint_d2cost;
   }
 
+  // Add ball constraints contributions:
+  {
+    T constraint_dcost, constraint_d2cost;
+
+    EigenPool<Vector6<T>>& V_WB_alpha = data.scratch().V_WB_alpha;
+    // N.B. V_WB_alpha was already computed above for patch constraints.
+
+    ball_constraints_pool_.CalcData(V_WB_alpha,
+                                    &data.scratch().ball_constraints_data);
+    ball_constraints_pool_.CalcCostAlongLine(
+        data.scratch().ball_constraints_data, search_direction.U,
+        &constraint_dcost, &constraint_d2cost);
+
+    cost += data.scratch().ball_constraints_data.cost();
+    *dcost_dalpha += constraint_dcost;
+    *d2cost_dalpha2 += constraint_d2cost;
+  }
+
   // Add weld constraints contributions:
   {
     T constraint_dcost, constraint_d2cost;
@@ -318,11 +341,13 @@ void IcfModel<T>::SetSparsityPattern() {
   }
 
   // Build off-diagonal entries in the sparsity pattern.
+  ball_constraints_pool_.CalcSparsityPattern(&sparsity);
   patch_constraints_pool_.CalcSparsityPattern(&sparsity);
   weld_constraints_pool_.CalcSparsityPattern(&sparsity);
 
-  // Precompute the iteration-invariant weld Hessian blocks now that all
-  // constraint data and model parameters are finalized.
+  // Precompute the iteration-invariant ball and weld Hessian blocks now that
+  // all constraint data and model parameters are finalized.
+  ball_constraints_pool_.PrecomputeHessianBlocks();
   weld_constraints_pool_.PrecomputeHessianBlocks();
 
   // TODO(#23912): This line allocates.
@@ -351,9 +376,10 @@ void IcfModel<T>::UpdateTimeStep(const T& time_step) {
 
   params_->time_step = time_step;
 
-  // Weld constraint regularization R depends on the time step.
+  // Ball and weld constraint regularization R depends on the time step.
   // Recompute Hessian blocks whenever dt changes so
   // AccumulateHessian() uses up-to-date values.
+  ball_constraints_pool_.PrecomputeHessianBlocks();
   weld_constraints_pool_.PrecomputeHessianBlocks();
 }
 
@@ -452,6 +478,8 @@ void IcfModel<T>::ReduceInto(IcfModel<T>* reduced_model,
   reduced_model->ResetParameters(std::move(reduced_params));
 
   // Reduce the constraints.
+  ball_constraints_pool().ReduceInto(*mapping,
+                                     &reduced_model->ball_constraints_pool());
   coupler_constraints_pool().ReduceInto(
       *mapping, &reduced_model->coupler_constraints_pool());
   gain_constraints_pool().ReduceInto(*mapping,

--- a/multibody/contact_solvers/icf/icf_model.h
+++ b/multibody/contact_solvers/icf/icf_model.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/block_sparse_lower_triangular_or_symmetric_matrix.h"
+#include "drake/multibody/contact_solvers/icf/ball_constraints_pool.h"
 #include "drake/multibody/contact_solvers/icf/coupler_constraints_pool.h"
 #include "drake/multibody/contact_solvers/icf/eigen_pool.h"
 #include "drake/multibody/contact_solvers/icf/gain_constraints_pool.h"
@@ -162,9 +163,19 @@ class IcfModel {
 
   /* Returns the total number of constraints of any type in the problem. */
   int num_constraints() const {
-    return num_coupler_constraints() + num_gain_constraints() +
-           num_limit_constraints() + num_patch_constraints() +
-           num_weld_constraints();
+    return num_ball_constraints() + num_coupler_constraints() +
+           num_gain_constraints() + num_limit_constraints() +
+           num_patch_constraints() + num_weld_constraints();
+  }
+
+  /* Provides const access to the pool of all ball constraints. */
+  const BallConstraintsPool<T>& ball_constraints_pool() const {
+    return ball_constraints_pool_;
+  }
+
+  /* Provides mutable access to the pool of all ball constraints. */
+  BallConstraintsPool<T>& ball_constraints_pool() {
+    return ball_constraints_pool_;
   }
 
   /* Provides const access to the pool of all coupler constraints. */
@@ -217,6 +228,10 @@ class IcfModel {
   /* Provides mutable access to the pool of all weld constraints. */
   WeldConstraintsPool<T>& weld_constraints_pool() {
     return weld_constraints_pool_;
+  }
+
+  int num_ball_constraints() const {
+    return ball_constraints_pool_.num_constraints();
   }
 
   int num_coupler_constraints() const {
@@ -493,6 +508,7 @@ class IcfModel {
       sparsity_pattern_;
 
   // Fixed set of constraints.
+  BallConstraintsPool<T> ball_constraints_pool_;
   CouplerConstraintsPool<T> coupler_constraints_pool_;
   GainConstraintsPool<T> gain_constraints_pool_;
   LimitConstraintsPool<T> limit_constraints_pool_;

--- a/multibody/contact_solvers/icf/test/ball_constraint_init_and_sim_test.cc
+++ b/multibody/contact_solvers/icf/test/ball_constraint_init_and_sim_test.cc
@@ -1,0 +1,140 @@
+/* Test that CENIC is capable of resolving a ball constraint with a large
+initial error, and then is able to maintain the constraint over time under
+gravity.
+
+Setup:
+  - box1: a cube welded to the world at z=1.0 (no joint in MJCF).
+  - box2: a cube, free body (6 DOF), connected to box1 via AddBallConstraint.
+    The constraint makes a point P on box1 coincident with a point Q on box2.
+    Unlike a weld, the ball constraint leaves box2's orientation free. box2
+    starts severely displaced (a large vertical gap) so the ICF constraint
+    correction required is large, which drives CENIC's internal time step
+    small and exercises the near-rigid small-time-step regime.
+*/
+
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/cenic/cenic_integrator.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/multibody_plant_config_functions.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using multibody::CenicIntegrator;
+using multibody::MultibodyPlant;
+using multibody::MultibodyPlantConfig;
+using multibody::Parser;
+using systems::DiagramBuilder;
+using systems::Simulator;
+
+// MJCF model defining two boxes and a floor.
+//
+// box1: half-extents 0.15m, welded to the world (no joint) at z=1.0.
+// box2: half-extents 0.10m, free floating body (freejoint). The ball
+//       constraint will be added programmatically below.
+// floor: half-extents 1m x 1m x 0.05m, for visual context.
+constexpr char kMjcf[] = R"""(
+  <?xml version="1.0"?>
+  <mujoco model="ball_constraint_demo">
+    <worldbody>
+      <!-- box1: welded to world at z=1.0 (no joint means fixed) -->
+      <body name="box1" pos="0 0 1.0">
+        <inertial mass="2" diaginertia="0.015 0.015 0.015"/>
+        <geom type="box" size="0.15 0.15 0.15" rgba="0.5 0.5 0.5 1"/>
+      </body>
+      <!-- box2: free body, to be ball-constrained to box1 -->
+      <body name="box2" pos="0 0 0.75">
+        <joint name="box2_free" type="free"/>
+        <inertial mass="1" diaginertia="0.0067 0.0067 0.0067"/>
+        <geom type="box" size="0.1 0.1 0.1" rgba="0.9 0.4 0.1 1"/>
+      </body>
+      <!-- floor for visual context -->
+      <geom name="floor" type="box" pos="0 0 -0.05" size="1 1 0.05"
+            rgba="0.2 0.8 0.3 1"/>
+    </worldbody>
+  </mujoco>
+)""";
+
+GTEST_TEST(BallConstraintSimulation, LargeInitialError) {
+  DiagramBuilder<double> builder;
+
+  // Continuous-time plant is required for the CENIC integrator.
+  MultibodyPlantConfig plant_config;
+  plant_config.time_step = 0.0;
+  auto [plant, scene_graph] = AddMultibodyPlant(plant_config, &builder);
+
+  Parser(&plant).AddModelsFromString(kMjcf, "xml");
+
+  const auto& box1 = plant.GetBodyByName("box1");
+  const auto& box2 = plant.GetBodyByName("box2");
+
+  // Ball constraint: point P on box1 at the center of its bottom face (-z),
+  // point Q on box2 at the center of its top face (+z).
+  // When satisfied, Q coincides with P:
+  //   box1 center at z=1.0, bottom face at z=0.85, so P is at world (0,0,0.85).
+  //   Q is 0.10 above box2's center; with box2 upright its center is at
+  //   z = 0.85 - 0.10 = 0.75.
+  const Vector3d p_box1_P(0.0, 0.0, -0.15);
+  const Vector3d p_box2_Q(0.0, 0.0, 0.1);
+  plant.AddBallConstraint(box1, p_box1_P, box2, p_box2_Q);
+
+  plant.Finalize();
+  auto diagram = builder.Build();
+
+  // Set initial conditions: box2's exact constrained center would be at
+  // (0, 0, 0.75). Here we start with box2's center at (0, 0, 0.75 -
+  // initial_gap), so CENIC must overcome the initial gap error to pull box2
+  // up into alignment. An initial_gap of 0.5m is a very large error. This will
+  // cause CENIC to take many small steps to converge, but it should still
+  // succeed. The ball constraint resists gravity to hold point Q against P.
+  // Without the constraint, box2 would fall freely under gravity.
+  auto context = diagram->CreateDefaultContext();
+  auto& plant_context = plant.GetMyMutableContextFromRoot(context.get());
+  const double initial_gap = 0.5;
+  plant.SetFloatingBaseBodyPoseInWorldFrame(
+      &plant_context, box2,
+      RigidTransformd(Vector3d(0.0, 0.0, 0.75 - initial_gap)));
+
+  // Set up the simulator with the CENIC integrator.
+  auto simulator =
+      std::make_unique<Simulator<double>>(*diagram, std::move(context));
+  auto& integrator = simulator->reset_integrator<CenicIntegrator<double>>();
+  integrator.set_maximum_step_size(0.1);
+  integrator.set_fixed_step_mode(false);  // Use error control.
+  integrator.set_target_accuracy(1e-3);
+
+  simulator->Initialize();
+  simulator->AdvanceTo(0.5);
+
+  // Verify the ball constraint held: point Q on box2 should coincide with
+  // point P on box1 in the world, i.e. at (0, 0, 0.85). This is the invariant
+  // the ball constraint enforces, independent of box2's (free) orientation.
+  const auto& final_plant_context =
+      plant.GetMyContextFromRoot(simulator->get_context());
+  const RigidTransformd& X_WB2 =
+      plant.EvalBodyPoseInWorld(final_plant_context, box2);
+  const Vector3d p_WQ = X_WB2 * p_box2_Q;
+  const Vector3d expected_p_WP(0.0, 0.0, 0.85);
+  const double kTolerance = 1e-5;  // 0.01 mm tolerance.
+  const double position_error = (p_WQ - expected_p_WP).norm();
+  EXPECT_LE(position_error, kTolerance);
+}
+
+}  // namespace
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/icf/test/ball_constraints_pool_test.cc
+++ b/multibody/contact_solvers/icf/test/ball_constraints_pool_test.cc
@@ -1,0 +1,677 @@
+#include "drake/multibody/contact_solvers/icf/ball_constraints_pool.h"
+
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/limit_malloc.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/cross_product.h"
+#include "drake/multibody/contact_solvers/icf/icf_data.h"
+#include "drake/multibody/contact_solvers/icf/icf_model.h"
+#include "drake/multibody/contact_solvers/icf/icf_search_direction_data.h"
+#include "drake/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace icf {
+namespace internal {
+namespace {
+
+constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
+
+/* Checks that model.CalcData does not incur any heap allocations on a problem
+with ball constraints. */
+GTEST_TEST(BallConstraintsPool, LimitMallocOnCalcData) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddBallConstraints(&model);
+  model.SetSparsityPattern();
+  EXPECT_EQ(model.num_cliques(), 3);
+  EXPECT_EQ(model.num_velocities(), 18);
+  EXPECT_EQ(model.num_constraints(), 2);
+  EXPECT_EQ(model.num_ball_constraints(), 2);
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  EXPECT_EQ(data.ball_constraints_data().num_constraints(), 2);
+
+  const int nv = model.num_velocities();
+  const VectorXd v = VectorXd::LinSpaced(nv, -10.0, 10.0);
+
+  // Computing data should not cause any new allocations.
+  {
+    drake::test::LimitMalloc guard;
+    model.CalcData(v, &data);
+  }
+}
+
+/* Checks that pool.ReduceInto does not incur any heap allocations on a
+problem with ball constraints. */
+GTEST_TEST(BallConstraintsPool, LimitMallocOnReduceInto) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddBallConstraints(&model);
+
+  IcfModel<double> reduced_model;
+  ReducedMapping mapping;
+
+  // Do a not-smaller reduction to allocate memory in the reduced model.
+  MakeModelReducible(&model, {});
+  model.ReduceInto(&reduced_model, &mapping);
+
+  // Given prior allocation of a big enough model, the constraint pool
+  // reduction does not allocate.
+  {
+    drake::test::LimitMalloc guard;
+    model.ball_constraints_pool().ReduceInto(
+        mapping, &reduced_model.ball_constraints_pool());
+  }
+}
+
+/* Verifies that ball constraints produce correct data. */
+GTEST_TEST(BallConstraintsPool, Data) {
+  IcfModel<AutoDiffXd> model;
+  MakeUnconstrainedModel(&model);
+  model.SetSparsityPattern();
+  EXPECT_EQ(model.num_cliques(), 3);
+  EXPECT_EQ(model.num_velocities(), 18);
+  EXPECT_EQ(model.num_constraints(), 0);
+
+  IcfData<AutoDiffXd> data;
+  model.ResizeData(&data);
+  EXPECT_EQ(data.num_velocities(), model.num_velocities());
+  EXPECT_EQ(data.ball_constraints_data().num_constraints(), 0);
+
+  // At this point there should be no ball constraints.
+  EXPECT_EQ(model.num_ball_constraints(), 0);
+  EXPECT_EQ(model.num_constraints(), 0);
+
+  // Add ball constraints.
+  AddBallConstraints(&model);
+  EXPECT_EQ(model.num_ball_constraints(), 2);
+  EXPECT_EQ(model.num_constraints(), 2);
+
+  // Re-set sparsity since ball constraints introduce cross-clique coupling.
+  model.SetSparsityPattern();
+
+  // Resize data to include ball constraints data.
+  model.ResizeData(&data);
+  EXPECT_EQ(data.ball_constraints_data().num_constraints(), 2);
+
+  const int nv = model.num_velocities();
+  VectorXd v_value = VectorXd::LinSpaced(nv, -10, 10.0);
+  VectorX<AutoDiffXd> v(nv);
+  math::InitializeAutoDiff(v_value, &v);
+  model.CalcData(v, &data);
+
+  const BallConstraintsDataPool<AutoDiffXd>& ball_data =
+      data.ball_constraints_data();
+  EXPECT_EQ(ball_data.num_constraints(), 2);
+
+  // The ball constraints should add positive cost (non-zero constraint error).
+  EXPECT_GT(ball_data.cost().value(), 0.0);
+
+  // Impulses should be finite and non-zero.
+  for (int k = 0; k < 2; ++k) {
+    const Vector3<AutoDiffXd>& gamma = ball_data.gamma(k);
+    EXPECT_TRUE(math::ExtractValue(gamma).allFinite());
+    EXPECT_GT(math::ExtractValue(gamma).norm(), 0.0);
+  }
+
+  // The total cost should include the ball contribution.
+  EXPECT_GT(data.cost().value(), data.momentum_cost().value());
+
+  // Verify accumulated total cost and gradients via AutoDiff.
+  const VectorXd total_cost_derivatives = data.cost().derivatives();
+  const VectorXd total_gradient_value = math::ExtractValue(data.gradient());
+  EXPECT_TRUE(CompareMatrices(total_gradient_value, total_cost_derivatives,
+                              2 * kEpsilon, MatrixCompareType::relative));
+
+  // Verify contributions to Hessian. The autodiff derivatives of the gradient
+  // give the exact Hessian, so the difference from the analytically computed
+  // Hessian is pure floating-point round-off, which scales with the magnitude
+  // of the (large, ~O(10³)) intermediate products rather than with each
+  // individual entry. We therefore use a scale-aware absolute tolerance; a
+  // per-entry relative tolerance would be fragile on the ball's small
+  // rotational-block entries (which lack the weld's large R⁻¹·I diagonal term).
+  auto ball_hessian = model.MakeHessian(data);
+  MatrixXd ball_hessian_value =
+      math::ExtractValue(ball_hessian->MakeDenseMatrix());
+  MatrixXd ball_gradient_derivatives = math::ExtractGradient(data.gradient());
+  const double hessian_scale = ball_hessian_value.cwiseAbs().maxCoeff();
+  EXPECT_TRUE(CompareMatrices(ball_hessian_value, ball_gradient_derivatives,
+                              100 * kEpsilon * hessian_scale,
+                              MatrixCompareType::absolute));
+
+  // The cross-clique ball (body 2, clique 1 to body 3, clique 2) should
+  // produce non-zero off-diagonal blocks in the Hessian.
+  const double off_diag_norm = ball_hessian_value.block<6, 6>(6, 12).norm();
+  EXPECT_GT(off_diag_norm, 0.0);
+
+  // Check CalcCostAlongLine for ball constraints.
+  const VectorX<AutoDiffXd> w = VectorX<AutoDiffXd>::LinSpaced(
+      nv, 0.1, -0.2);  // Arbitrary search direction.
+  IcfSearchDirectionData<AutoDiffXd> search_data;
+
+  // Set data with constant value of v.
+  VectorX<AutoDiffXd> v_constant =
+      VectorX<AutoDiffXd>::LinSpaced(nv, -10, 10.0);
+  model.CalcData(v_constant, &data);
+  model.CalcSearchDirectionData(data, w, &search_data);
+
+  const AutoDiffXd alpha = {
+      0.35 /* arbitrary value */,
+      VectorXd::Ones(1) /* This is the independent variable */};
+  AutoDiffXd dcost, d2cost;
+  const AutoDiffXd cost =
+      model.CalcCostAlongLine(alpha, data, search_data, &dcost, &d2cost);
+
+  const double scale = std::abs(dcost.value());
+  EXPECT_NEAR(dcost.value(), cost.derivatives()[0], scale * kEpsilon);
+  EXPECT_NEAR(d2cost.value(), dcost.derivatives()[0], scale * kEpsilon);
+}
+
+/* Sets up a simple model with 3 bodies in separate cliques, suitable for
+testing ball constraints. Body 0 is the world (anchored), bodies 1-3 are
+dynamic with 6 DOFs each. */
+template <typename T>
+void MakeModelForBall(IcfModel<T>* model, double time_step = 0.01) {
+  const int nv = 18;
+
+  std::unique_ptr<IcfParameters<T>> params = model->ReleaseParameters();
+  ASSERT_TRUE(params != nullptr);
+
+  params->time_step = time_step;
+  params->v0 = VectorX<T>::LinSpaced(nv, -1.0, 1.0);
+
+  // Sparse mass matrix with three cliques of size 6.
+  const Matrix6<T> A1 = 0.3 * Matrix6<T>::Identity();
+  const Matrix6<T> A2 = 2.3 * Matrix6<T>::Identity();
+  const Matrix6<T> A3 = 1.5 * Matrix6<T>::Identity();
+
+  MatrixX<T>& M0 = params->M0;
+  M0 = MatrixX<T>::Identity(nv, nv);
+  M0.template block<6, 6>(0, 0) = A1;
+  M0.template block<6, 6>(6, 6) = A2;
+  M0.template block<6, 6>(12, 12) = A3;
+
+  params->D0 = VectorX<T>::Constant(nv, 0.1);
+  params->k0 = VectorX<T>::LinSpaced(nv, -1.0, 1.0);
+
+  params->clique_sizes = {6, 6, 6};
+
+  // Body 0 = world (anchored), body 1 = floating, body 2 = floating,
+  // body 3 = non-floating (uses non-identity Jacobian).
+  params->body_is_floating = {0, 1, 1, 0};
+  params->body_mass = {1.0e20, 0.3, 2.3, 1.5};
+
+  // Body-to-clique mapping. World is anchored (clique = -1).
+  params->body_to_clique = {-1, 0, 1, 2};
+
+  const Matrix6<T> J_WB3 = VectorX<T>::LinSpaced(36, -1.0, 1.0).reshaped(6, 6);
+
+  params->J_WB.Resize(4, 6, 6);
+  params->J_WB[0] = Matrix6<T>::Identity();  // World (ignored).
+  params->J_WB[1] = Matrix6<T>::Identity();  // Floating body.
+  params->J_WB[2] = Matrix6<T>::Identity();  // Floating body.
+  params->J_WB[3] = J_WB3;
+
+  // No joint locking.
+  auto& reduction = params->reduction;
+  reduction.unlocked_dofs = {0,  1,  2,  3,  4,  5,   // BR
+                             6,  7,  8,  9,  10, 11,  //
+                             12, 13, 14, 15, 16, 17};
+  reduction.per_clique_unlocked_dofs = {
+      {0, 1, 2, 3, 4, 5},
+      {0, 1, 2, 3, 4, 5},
+      {0, 1, 2, 3, 4, 5},
+  };
+
+  model->ResetParameters(std::move(params));
+}
+
+/* Verifies basic construction and accessors. */
+GTEST_TEST(BallConstraintsPool, BasicConstruction) {
+  IcfModel<double> model;
+  MakeModelForBall(&model);
+
+  BallConstraintsPool<double>& balls = model.ball_constraints_pool();
+  EXPECT_EQ(balls.num_constraints(), 0);
+
+  balls.Resize(2);
+  EXPECT_EQ(balls.num_constraints(), 2);
+}
+
+/* Verifies that the ball constraint correctly computes impulses, cost,
+gradient, and Hessian for a simple case: a ball between a floating body
+(body 1) and the world (body 0, anchored). Expected values are computed
+by hand from the ball constraint formulation. */
+GTEST_TEST(BallConstraintsPool, BallToWorld) {
+  IcfModel<double> model;
+  MakeModelForBall(&model);
+
+  BallConstraintsPool<double>& balls = model.ball_constraints_pool();
+  balls.Resize(1);
+
+  // Small constraint error: P and Q are slightly offset.
+  const Vector3<double> p_AP_W(0.1, 0.0, 0.0);
+  const Vector3<double> p_BQ_W(0.0, 0.0, 0.0);
+  const Vector3<double> p_PQ_W(0.05, 0.0, 0.0);  // Small translational err.
+
+  // Body 0 (anchored) = A, body 1 (floating, clique 0) = B.
+  balls.Set(0, /*bodyA=*/0, /*bodyB=*/1, p_AP_W, p_BQ_W, p_PQ_W);
+
+  // Set the sparsity pattern (required for Hessian).
+  model.SetSparsityPattern();
+
+  // Set up data.
+  IcfData<double> data;
+  model.ResizeData(&data);
+
+  // Use v = v0 for simplicity.
+  const VectorXd& v0 = model.v0();
+  const VectorXd v = v0;
+  model.CalcData(v, &data);
+
+  // --- Hand calculation of expected ball constraint values ---
+  //
+  // Body 1 is floating in clique 0, so V_WB[1] = v0[0:6].
+  const double dt = model.time_step();
+  const double mass_B = model.body_mass(1);
+
+  // Body B spatial velocity components (body 1, floating).
+  const Vector3<double> w_WB = v0.head<3>();       // angular
+  const Vector3<double> v_WBo = v0.segment<3>(3);  // linear at Bo
+
+  // Midpoint M is halfway between P and Q.
+  // Bm is on B, coincident with M: p_BoBm = p_BQ - 0.5*p_PQ.
+  const Vector3<double> p_BoBm_W = p_BQ_W - 0.5 * p_PQ_W;
+  // Linear velocity of Bm: v_WBm = v_WBo + w_WB × p_BoBm.
+  const Vector3<double> v_WBm = v_WBo + w_WB.cross(p_BoBm_W);
+
+  // Body A is anchored, so vc = v_WBm (relative to zero). The ball constraint
+  // velocity is purely translational.
+  const Vector3<double> vc = v_WBm;
+
+  // Near-rigid regularization (from ball_constraints_pool.cc constants).
+  constexpr double kBeta = IcfModel<double>::kBeta;
+  const double taud = kBeta * dt / M_PI;
+  const double dt_plus_taud = dt + taud;
+
+  // Constraint function g0 = p_PQ (there is no rotational component).
+  const Vector3<double> g0 = p_PQ_W;
+
+  // Bias velocity: v̂ = -g0 / (dt + τ_d).
+  const Vector3<double> v_hat = -g0 / dt_plus_taud;
+
+  // Regularization R is a uniform diagonal: R = (r_scale/mass_B) * I₃,
+  // (body A is anchored so only B contributes).
+  const double r_scale =
+      (kBeta * kBeta * dt * dt) / (4.0 * M_PI * M_PI * dt * dt_plus_taud);
+  const double R_scalar = r_scale / mass_B;
+
+  // Expected impulse: γ = R⁻¹(v̂ - vc), with R diagonal and uniform.
+  const Vector3<double> expected_gamma = (v_hat - vc) / R_scalar;
+
+  // Expected ball cost: ℓ = ½(v̂ - vc)ᵀ R⁻¹ (v̂ - vc) = ½(v̂ - vc)ᵀ γ.
+  const double expected_ball_cost = 0.5 * (v_hat - vc).dot(expected_gamma);
+
+  // Expected momentum cost for v = v0.
+  // A = M + dt*D (block diagonal), r = A*v0 - dt*k0.
+  // momentum_cost = v0ᵀ(½A v0 - r).
+  MatrixXd A_mat = model.M0();
+  A_mat.diagonal() += dt * model.D0();
+  const VectorXd Av0 = A_mat * v0;
+  const VectorXd r = Av0 - dt * model.k0();
+  const double expected_momentum_cost = v0.dot(0.5 * Av0 - r);
+  const double expected_total_cost =
+      expected_momentum_cost + expected_ball_cost;
+
+  // --- Verify computed values match hand calculation ---
+
+  const Vector3<double>& gamma = data.ball_constraints_data().gamma(0);
+  EXPECT_TRUE(CompareMatrices(gamma, expected_gamma, 4 * kEpsilon,
+                              MatrixCompareType::relative));
+
+  const double ball_cost = data.ball_constraints_data().cost();
+  EXPECT_NEAR(ball_cost, expected_ball_cost,
+              4 * kEpsilon * std::abs(expected_ball_cost));
+
+  EXPECT_NEAR(data.momentum_cost(), expected_momentum_cost,
+              4 * kEpsilon * std::abs(expected_momentum_cost));
+  EXPECT_NEAR(data.cost(), expected_total_cost,
+              4 * kEpsilon * std::abs(expected_total_cost));
+
+  // --- Hand calculation of expected Hessian block for body B (clique 0) ---
+  //
+  // The full Hessian is H = A + ball_contribution, where A = M + dt*D is block
+  // diagonal. For a ball-to-world constraint with floating body B, the ball
+  // contribution to the (c_b, c_b) block is:
+  //   H_BB = G_Bp = Φ(p_BoBm)ᵀ G Φ(p_BoBm)
+  // where G = diag(0, R⁻¹ I₃) (only translational, i.e. the weld's Gr = 0) and
+  // Φ(p) = [I₃, 0; -p×, I₃] is the spatial shift operator. Body B is floating
+  // so J_WB = I₆, giving H_BB = G_Bp directly.
+
+  const double R_inv = 1.0 / R_scalar;
+
+  // p_BoBm_W was already computed above for the velocity calculation.
+
+  // Skew-symmetric matrix [p_BoBm]×.
+  const Eigen::Matrix3d px = math::VectorToSkewSymmetric(p_BoBm_W);
+  const Eigen::Matrix3d I3 = Eigen::Matrix3d::Identity();
+
+  // G_Bp = Φᵀ G Φ with Gr = 0 and Gt = R⁻¹ I₃.
+  // G_Bp = R⁻¹ [ -p×⋅p×  p× ]
+  //            [   -p×   I₃ ]
+  Matrix6<double> expected_H_BB;
+  expected_H_BB.topLeftCorner<3, 3>() = -R_inv * (px * px);
+  expected_H_BB.topRightCorner<3, 3>() = R_inv * px;
+  expected_H_BB.bottomLeftCorner<3, 3>() = -R_inv * px;
+  expected_H_BB.bottomRightCorner<3, 3>() = R_inv * I3;
+
+  // Expected Hessian block: A_clique0 + H_BB.
+  const Matrix6<double> A_clique0 = A_mat.block<6, 6>(0, 0);
+  const Matrix6<double> expected_hessian_block = A_clique0 + expected_H_BB;
+
+  // Build Hessian, verify it is finite, and check the result for bodyB.
+  const MatrixXd hessian = model.MakeHessian(data)->MakeDenseMatrix();
+  EXPECT_TRUE(hessian.allFinite());
+
+  const Matrix6<double> hessian_block_B = hessian.block<6, 6>(0, 0);
+  EXPECT_TRUE(CompareMatrices(hessian_block_B, expected_hessian_block,
+                              4 * kEpsilon, MatrixCompareType::relative));
+}
+
+/* Verifies that the ball constraint applies zero impulse on axes with no
+constraint error and no constraint velocity. We construct a case where the
+constraint is perfectly satisfied (g0 = 0) and the body is at rest, so the
+impulse must be exactly zero. */
+GTEST_TEST(BallConstraintsPool, ZeroImpulseWhenSatisfied) {
+  IcfModel<double> model;
+  MakeModelForBall(&model);
+
+  // Set v0 = 0 so the (only) floating body B is at rest.
+  std::unique_ptr<IcfParameters<double>> params = model.ReleaseParameters();
+  params->v0 = VectorXd::Zero(18);
+  model.ResetParameters(std::move(params));
+
+  BallConstraintsPool<double>& balls = model.ball_constraints_pool();
+  balls.Resize(1);
+
+  // No constraint error: P and Q are coincident (p_PQ = 0).
+  const Vector3<double> p_AP_W(0.1, -0.2, 0.05);
+  const Vector3<double> p_BQ_W(0.1, -0.2, 0.05);
+  const Vector3<double> p_PQ_W(0.0, 0.0, 0.0);
+  balls.Set(0, /*bodyA=*/0, /*bodyB=*/1, p_AP_W, p_BQ_W, p_PQ_W);
+
+  model.SetSparsityPattern();
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  model.CalcData(model.v0(), &data);
+
+  // With zero error and zero velocity, the impulse and cost must be zero.
+  const Vector3<double>& gamma = data.ball_constraints_data().gamma(0);
+  EXPECT_TRUE(CompareMatrices(gamma, Vector3<double>::Zero(), kEpsilon,
+                              MatrixCompareType::absolute));
+  EXPECT_NEAR(data.ball_constraints_data().cost(), 0.0, kEpsilon);
+}
+
+/* Verifies the ball constraint between two dynamic bodies in different
+cliques (cross-clique case). Parameterized to test both clique orderings:
+  - false: bodyA=1 (clique 0), bodyB=2 (clique 1), i.e. c_b > c_a.
+  - true:  bodyA=2 (clique 1), bodyB=1 (clique 0), i.e. c_a > c_b. */
+class CrossCliqueBallTest : public testing::TestWithParam<bool> {};
+
+TEST_P(CrossCliqueBallTest, CrossCliqueBall) {
+  const bool reverse_bodies = GetParam();
+
+  IcfModel<double> model;
+  MakeModelForBall(&model);
+
+  BallConstraintsPool<double>& balls = model.ball_constraints_pool();
+  balls.Resize(1);
+
+  // Ball between body 1 (clique 0) and body 2 (clique 1).
+  const Vector3<double> p_AP_W(0.1, 0.2, 0.3);
+  const Vector3<double> p_BQ_W(0.0, 0.1, 0.0);
+  const Vector3<double> p_PQ_W(0.02, -0.01, 0.03);
+
+  if (reverse_bodies) {
+    // Body 2 = A (clique 1), Body 1 = B (clique 0), i.e. c_a > c_b.
+    balls.Set(0, /*bodyA=*/2, /*bodyB=*/1, p_AP_W, p_BQ_W, p_PQ_W);
+  } else {
+    // Body 1 = A (clique 0), Body 2 = B (clique 1), i.e. c_b > c_a.
+    balls.Set(0, /*bodyA=*/1, /*bodyB=*/2, p_AP_W, p_BQ_W, p_PQ_W);
+  }
+
+  model.SetSparsityPattern();
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  const VectorXd v = model.v0();
+  model.CalcData(v, &data);
+
+  // Verify cost and impulse.
+  EXPECT_GT(data.ball_constraints_data().cost(), 0.0);
+  const Vector3<double>& gamma = data.ball_constraints_data().gamma(0);
+  EXPECT_TRUE(gamma.allFinite());
+  EXPECT_GT(gamma.norm(), 0.0);
+
+  // Build Hessian and verify it has off-diagonal blocks.
+  auto hessian = model.MakeHessian(data);
+  const MatrixXd H_dense = hessian->MakeDenseMatrix();
+  EXPECT_TRUE(H_dense.allFinite());
+
+  // The off-diagonal block between clique 0 and clique 1 should be non-zero.
+  const double off_diag_norm = H_dense.block<6, 6>(0, 6).norm();
+  EXPECT_GT(off_diag_norm, 0.0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BallConstraintsPool, CrossCliqueBallTest, testing::Bool(),
+    [](const testing::TestParamInfo<bool>& test_param_info) {
+      return test_param_info.param ? "CliqueAGreater" : "CliqueBGreater";
+    });
+
+/* Verifies that CalcCostAlongLine produces consistent derivatives using
+AutoDiff. For each sampled α value, we verify the cost, first derivative, and
+second derivative by comparing CalcCostAlongLine outputs against the
+full-precision AutoDiff result obtained by evaluating CalcData at v + α·w. */
+GTEST_TEST(BallConstraintsPool, CalcCostAlongLine) {
+  IcfModel<AutoDiffXd> model;
+  MakeModelForBall(&model);
+
+  BallConstraintsPool<AutoDiffXd>& balls = model.ball_constraints_pool();
+  balls.Resize(1);
+
+  const Vector3<AutoDiffXd> p_AP_W(0.1, 0.0, 0.0);
+  const Vector3<AutoDiffXd> p_BQ_W(0.0, 0.0, 0.0);
+  const Vector3<AutoDiffXd> p_PQ_W(0.05, 0.0, 0.0);
+
+  balls.Set(0, 0, 1, p_AP_W, p_BQ_W, p_PQ_W);
+
+  model.SetSparsityPattern();
+
+  const int nv = model.num_velocities();
+  IcfData<AutoDiffXd> data, scratch;
+  model.ResizeData(&data);
+  model.ResizeData(&scratch);
+
+  // Compute data at the base point v = v0.
+  const VectorX<AutoDiffXd> v = VectorXd::LinSpaced(nv, -1.0, 1.0);
+  model.CalcData(v, &data);
+
+  // Arbitrary search direction.
+  const VectorX<AutoDiffXd> w = VectorX<AutoDiffXd>::LinSpaced(nv, 0.1, 0.5);
+
+  // Precompute search direction data.
+  IcfSearchDirectionData<AutoDiffXd> search_data;
+  model.CalcSearchDirectionData(data, w, &search_data);
+
+  // Verify at several α values.
+  for (double alpha_value : {-0.45, 0.0, 0.15, 0.34, 0.93, 1.32}) {
+    // Make α the independent variable for AutoDiff.
+    const AutoDiffXd alpha = {alpha_value, VectorXd::Ones(1)};
+
+    // Compute the expected cost and its derivative w.r.t. α via AutoDiff.
+    const VectorX<AutoDiffXd> v_alpha = v + alpha * w;
+    model.CalcData(v_alpha, &scratch);
+    const double cost_expected = scratch.cost().value();
+    const double dcost_expected = scratch.cost().derivatives()[0];
+    const VectorXd w_times_H = math::ExtractGradient(scratch.gradient());
+    const double d2cost_expected = w_times_H.dot(math::ExtractValue(w));
+
+    // Compare against CalcCostAlongLine.
+    AutoDiffXd dcost, d2cost;
+    const AutoDiffXd cost =
+        model.CalcCostAlongLine(alpha, data, search_data, &dcost, &d2cost);
+    EXPECT_NEAR(cost.value(), cost_expected,
+                8 * kEpsilon * std::abs(cost_expected));
+    EXPECT_NEAR(dcost.value(), dcost_expected,
+                8 * kEpsilon * std::abs(dcost_expected));
+    EXPECT_NEAR(d2cost.value(), d2cost_expected,
+                8 * kEpsilon * std::abs(d2cost_expected));
+  }
+}
+
+/* Verifies gradient consistency using AutoDiff. */
+GTEST_TEST(BallConstraintsPool, GradientConsistency) {
+  IcfModel<AutoDiffXd> model;
+  MakeModelForBall(&model);
+
+  BallConstraintsPool<AutoDiffXd>& balls = model.ball_constraints_pool();
+  balls.Resize(1);
+
+  const Vector3<AutoDiffXd> p_AP_W(0.1, 0.0, 0.0);
+  const Vector3<AutoDiffXd> p_BQ_W(0.0, 0.0, 0.0);
+  const Vector3<AutoDiffXd> p_PQ_W(0.05, 0.0, 0.0);
+
+  balls.Set(0, 0, 1, p_AP_W, p_BQ_W, p_PQ_W);
+
+  model.SetSparsityPattern();
+
+  const int nv = model.num_velocities();
+  IcfData<AutoDiffXd> data;
+  model.ResizeData(&data);
+
+  const VectorXd v_values = math::ExtractValue(model.v0());
+  VectorX<AutoDiffXd> v(nv);
+  math::InitializeAutoDiff(v_values, &v);
+
+  model.CalcData(v, &data);
+
+  // The AutoDiff derivatives of the cost give the full-precision gradient.
+  const VectorXd cost_derivatives = data.cost().derivatives();
+  const VectorXd gradient_value = math::ExtractValue(data.gradient());
+
+  EXPECT_TRUE(CompareMatrices(gradient_value, cost_derivatives, 100 * kEpsilon,
+                              MatrixCompareType::relative));
+}
+
+/* Verifies that reducing the ball constraint pool produces correct data. */
+GTEST_TEST(BallConstraintsPool, Reduce) {
+  IcfModel<double> model;
+  MakeUnconstrainedModel(&model);
+  AddBallConstraints(&model);
+
+  IcfData<double> data;
+  model.ResizeData(&data);
+  const int nv = model.num_velocities();
+  const VectorXd v = VectorXd::LinSpaced(nv, -10, 10.0);
+  model.CalcData(v, &data);
+
+  auto check_reduced = [&](const std::vector<int>& locked_dofs) {
+    SCOPED_TRACE(fmt::format("locked_dofs [{}]", fmt::join(locked_dofs, ", ")));
+    MakeModelReducible(&model, locked_dofs);
+    IcfModel<double> reduced_model;
+    ReducedMapping mapping;
+    model.ReduceInto(&reduced_model, &mapping);
+
+    // Check the data transmitted by pool.ReduceInto().
+    const auto& full_pool = model.ball_constraints_pool();
+    const auto& reduced_pool = reduced_model.ball_constraints_pool();
+
+    int r_k{0};  // Reduced constraints cursor.
+    for (int k = 0; k < full_pool.num_constraints(); ++k) {
+      SCOPED_TRACE(
+          fmt::format("full constraint {} vs. reduced constraint {}", k, r_k));
+      const auto& [a, b] = full_pool.body_pairs()[k];
+      const int clique_b = model.params().body_to_clique[b];
+      const int clique_a = model.params().body_to_clique[a];
+      const bool have_b = mapping.clique_subsequence.participates(clique_b);
+      const bool have_a =
+          clique_a >= 0 && mapping.clique_subsequence.participates(clique_a);
+      if (!(have_a || have_b)) {
+        continue;
+      }
+      const bool is_flipped = have_a && !have_b;
+      const auto& [r_a, r_b] = reduced_pool.body_pairs()[r_k];
+      SCOPED_TRACE(fmt::format("flipped? {} have a? {} have b? {}", is_flipped,
+                               have_a, have_b));
+      if (is_flipped) {
+        EXPECT_EQ(r_a, b);
+        EXPECT_EQ(r_b, a);
+        EXPECT_EQ(reduced_pool.p_AP_W()[r_k], full_pool.p_BQ_W()[k]);
+        EXPECT_EQ(reduced_pool.p_BQ_W()[r_k], full_pool.p_AP_W()[k]);
+        EXPECT_EQ(reduced_pool.p_PQ_W()[r_k], -full_pool.p_PQ_W()[k]);
+        EXPECT_EQ(reduced_pool.g0()[r_k], -full_pool.g0()[k]);
+      } else {
+        EXPECT_EQ(r_a, a);
+        EXPECT_EQ(r_b, b);
+        EXPECT_EQ(reduced_pool.p_AP_W()[r_k], full_pool.p_AP_W()[k]);
+        EXPECT_EQ(reduced_pool.p_BQ_W()[r_k], full_pool.p_BQ_W()[k]);
+        EXPECT_EQ(reduced_pool.p_PQ_W()[r_k], full_pool.p_PQ_W()[k]);
+        EXPECT_EQ(reduced_pool.g0()[r_k], full_pool.g0()[k]);
+      }
+      ++r_k;
+    }
+    EXPECT_EQ(ssize(reduced_pool.R()), r_k);
+    EXPECT_EQ(reduced_pool.hessian_blocks_size(), r_k);
+    EXPECT_EQ(reduced_pool.num_constraints(), r_k);
+  };
+
+  // Reduce by none; essentially, just copy.
+  const std::vector<int> none_locked;
+  check_reduced(none_locked);
+
+  // Lock some arbitrary dofs.
+  const std::vector<int> arbitrary_locked = {0, 17};
+  check_reduced(arbitrary_locked);
+
+  // Lock clique 0.
+  const std::vector<int> clique0_locked = {0, 1, 2, 3, 4, 5};
+  check_reduced(clique0_locked);
+
+  // Lock clique 1.
+  const std::vector<int> clique1_locked = {6, 7, 8, 9, 10, 11};
+  check_reduced(clique1_locked);
+
+  // Lock clique 2.
+  const std::vector<int> clique2_locked = {12, 13, 14, 15, 16, 17};
+  check_reduced(clique2_locked);
+
+  // Lock everything.
+  std::vector<int> all_locked(model.num_velocities());
+  std::iota(all_locked.begin(), all_locked.end(), 0);
+  check_reduced(all_locked);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace icf
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/icf/test/icf_builder_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_builder_test.cc
@@ -321,21 +321,67 @@ GTEST_TEST(IcfBuilder, RetryStep) {
   }
 }
 
-GTEST_TEST(IcfBuilder, BallConstraintUnsupported) {
+GTEST_TEST(IcfBuilder, BallConstraint) {
   systems::DiagramBuilder<double> diagram_builder;
   multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};
+
   MultibodyPlant<double>& plant =
       multibody::AddMultibodyPlant(plant_config, &diagram_builder);
 
-  Parser(&plant, "Pendulum").AddModelsFromString(kRobotXml, "xml");
-
-  plant.AddBallConstraint(plant.get_body(BodyIndex(0)), Vector3d::Zero(),
-                          plant.get_body(BodyIndex(1)));
-
+  Parser(&plant, "Pendulum1").AddModelsFromString(kRobotXml, "xml");
+  Parser(&plant, "Pendulum2").AddModelsFromString(kRobotXml, "xml");
+  plant.AddBallConstraint(plant.get_body(BodyIndex(1)), Vector3d::Zero(),
+                          plant.get_body(BodyIndex(2)), Vector3d::Zero());
   plant.Finalize();
 
-  DRAKE_EXPECT_THROWS_MESSAGE(IcfBuilder<double>(&plant),
-                              ".*not.*support.*1 ball constraint.*");
+  auto diagram = diagram_builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  const auto& plant_context = plant.GetMyContextFromRoot(*diagram_context);
+
+  const double time_step = 0.01;
+  IcfBuilder<double> builder(&plant);
+  IcfModel<double> model;
+  builder.UpdateModel(plant_context, time_step, nullptr, nullptr, &model);
+  EXPECT_EQ(model.num_cliques(), 2);
+  EXPECT_EQ(model.num_velocities(), plant.num_velocities());
+  ASSERT_EQ(model.num_ball_constraints(), 1);
+
+  // Check the ball constraint produced.
+  const auto& pool = model.ball_constraints_pool();
+  EXPECT_EQ(pool.num_constraints(), 1);
+  EXPECT_EQ(pool.body_pairs()[0].first, 1);
+  EXPECT_EQ(pool.body_pairs()[0].second, 2);
+}
+
+GTEST_TEST(IcfBuilder, NoBallBetweenAnchoredBodies) {
+  systems::DiagramBuilder<double> diagram_builder;
+  multibody::MultibodyPlantConfig plant_config{.time_step = 0.0};
+
+  MultibodyPlant<double>& plant =
+      multibody::AddMultibodyPlant(plant_config, &diagram_builder);
+  const auto M_B = SpatialInertia<double>::MakeUnitary();
+
+  plant.AddRigidBody("free_body", M_B);  // Need something that can move.
+  const RigidBody<double>& body1 = plant.AddRigidBody("body1", M_B);
+  const RigidBody<double>& body2 = plant.AddRigidBody("body2", M_B);
+  plant.AddJoint<WeldJoint>("weld1", plant.world_body(), RigidTransformd(),
+                            body1, RigidTransformd(), RigidTransformd());
+  plant.AddJoint<WeldJoint>("weld2", plant.world_body(), RigidTransformd(),
+                            body2, RigidTransformd(), RigidTransformd());
+  plant.AddBallConstraint(body1, Vector3d::Zero(), body2, Vector3d::Zero());
+  plant.Finalize();
+
+  auto diagram = diagram_builder.Build();
+  auto diagram_context = diagram->CreateDefaultContext();
+  const auto& plant_context = plant.GetMyContextFromRoot(*diagram_context);
+
+  const double time_step = 0.01;
+  IcfBuilder<double> icf_builder(&plant);
+  IcfModel<double> model;
+  DRAKE_EXPECT_THROWS_MESSAGE(icf_builder.UpdateModel(plant_context, time_step,
+                                                      nullptr, nullptr, &model),
+                              ".*ball constraint.*body1.*body2.*both are "
+                              "welded to the world.*not allowed.*");
 }
 
 GTEST_TEST(IcfBuilder, DistanceConstraintUnsupported) {

--- a/multibody/contact_solvers/icf/test/icf_data_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_data_test.cc
@@ -38,14 +38,15 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   const int num_bodies = 5;
   const int num_velocities = 12;
   const int max_clique_size = 6;
+  const int num_ball_constraints = 4;
   const int num_couplers = 2;
   const int num_welds = 3;
   const std::vector<int> gain_sizes = {3, 2};
   const std::vector<int> limit_sizes = {5, 4, 3};
   const std::vector<int> patch_sizes = {8, 6, 4, 2};
 
-  data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-              num_welds, gain_sizes, limit_sizes, patch_sizes);
+  data.Resize(num_bodies, num_velocities, max_clique_size, num_ball_constraints,
+              num_couplers, num_welds, gain_sizes, limit_sizes, patch_sizes);
 
   // Main data elements
   EXPECT_EQ(data.num_velocities(), num_velocities);
@@ -63,6 +64,8 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   EXPECT_EQ(data.scratch().v_alpha[0].size(), num_velocities);
   EXPECT_EQ(data.scratch().Gw_gain[0].size(), max_clique_size);
   EXPECT_EQ(data.scratch().Gw_limit[0].size(), max_clique_size);
+  EXPECT_EQ(data.scratch().ball_constraints_data.num_constraints(),
+            num_ball_constraints);
   EXPECT_EQ(data.scratch().coupler_constraints_data.num_constraints(),
             num_couplers);
   EXPECT_EQ(data.scratch().gain_constraints_data.num_constraints(),
@@ -93,18 +96,19 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
   const int num_bodies = 3;
   const int num_velocities = 11;
   const int max_clique_size = 7;
+  const int num_ball_constraints = 2;
   const int num_couplers = 2;
   const int num_welds = 1;
   const std::vector<int> gain_sizes = {3};
   const std::vector<int> limit_sizes = {4};
   const std::vector<int> patch_sizes = {5};
 
-  data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-              num_welds, gain_sizes, limit_sizes, patch_sizes);
+  data.Resize(num_bodies, num_velocities, max_clique_size, num_ball_constraints,
+              num_couplers, num_welds, gain_sizes, limit_sizes, patch_sizes);
 
   // Clearing pools changes size but shouldn't change capacity.
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
-  data.scratch().Resize(0, 0, 0, 0, 0, gain_sizes, limit_sizes, patch_sizes);
+  data.scratch().Resize(0, 0, 0, 0, 0, 0, gain_sizes, limit_sizes, patch_sizes);
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), 0);
 
   VectorX<double> v = VectorX<double>::LinSpaced(num_velocities, 1.0, 11.0);
@@ -112,8 +116,9 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
     // Restoring the data to the original size and setting velocities should not
     // cause any new allocations.
     drake::test::LimitMalloc guard;
-    data.Resize(num_bodies, num_velocities, max_clique_size, num_couplers,
-                num_welds, gain_sizes, limit_sizes, patch_sizes);
+    data.Resize(num_bodies, num_velocities, max_clique_size,
+                num_ball_constraints, num_couplers, num_welds, gain_sizes,
+                limit_sizes, patch_sizes);
     data.set_v(v);
   }
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);

--- a/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.cc
+++ b/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.cc
@@ -375,8 +375,32 @@ void AddWeldConstraints(IcfModel<T>* model) {
   }
 }
 
+template <typename T>
+void AddBallConstraints(IcfModel<T>* model) {
+  DRAKE_DEMAND(model != nullptr);
+
+  BallConstraintsPool<T>& ball_constraints = model->ball_constraints_pool();
+  ball_constraints.Resize(2);
+
+  // Ball 0: world (body 0, anchored) to body 1.
+  {
+    const Vector3<T> p_AP_W(0.1, 0.0, 0.0);
+    const Vector3<T> p_BQ_W(0.0, 0.0, 0.0);
+    const Vector3<T> p_PoQo_W(0.05, 0.0, 0.0);
+    ball_constraints.Set(0, /*bodyA=*/0, /*bodyB=*/1, p_AP_W, p_BQ_W, p_PoQo_W);
+  }
+
+  // Ball 1: body 2 to body 3 (cross-clique in multi-clique case).
+  {
+    const Vector3<T> p_AP_W(0.1, 0.2, 0.3);
+    const Vector3<T> p_BQ_W(0.0, 0.1, 0.0);
+    const Vector3<T> p_PoQo_W(0.02, -0.01, 0.03);
+    ball_constraints.Set(1, /*bodyA=*/2, /*bodyB=*/3, p_AP_W, p_BQ_W, p_PoQo_W);
+  }
+}
+
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    (&MakeUnconstrainedModel<T>, &MakeModelReducible<T>,
+    (&MakeUnconstrainedModel<T>, &MakeModelReducible<T>, &AddBallConstraints<T>,
      &AddCouplerConstraint<T>, &AddGainConstraints<T>, &AddLimitConstraints<T>,
      &AddPatchConstraints<T>, &AddWeldConstraints<T>));
 

--- a/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.h
+++ b/multibody/contact_solvers/icf/test_utilities/icf_model_test_helpers.h
@@ -63,6 +63,12 @@ one between the world (body 0) and body 1, and one between body 2 and body 3
 template <typename T>
 void AddWeldConstraints(IcfModel<T>* model);
 
+/* Adds ball constraints to the given model. Two ball constraints are added:
+one between the world (body 0) and body 1, and one between body 2 and body 3
+(cross-clique in the multi-clique case). */
+template <typename T>
+void AddBallConstraints(IcfModel<T>* model);
+
 }  // namespace internal
 }  // namespace icf
 }  // namespace contact_solvers


### PR DESCRIPTION
Implements ball constraints in the ICF solver for CENIC support.

Adapted from the SAP ball constraint and given the same treatment as the weld constraints in ICF (#24174).

Following the ICF weld constraint, the impulse is applied at the midpoint M between P and Q, which conserves angular momentum. This is a deliberate deviation from the SAP ball constraint, which applies the impulse at P and Q separately and does not conserve angular momentum when the points are not coincident;

concretely, the ICF ball constraint is the translational half of the ICF weld constraint.

The near-rigid regularization uses the model's effective time step, so it remains well-behaved at very small time steps (per #24403).

New BallConstraintsPool and BallConstraintsDataPool are wired into IcfModel, IcfData, and IcfBuilder, which now accepts plants that carry ball constraints (previously rejected as unsupported).

Testing mirrors that of the weld constraint, plus a CENIC end-to-end simulation test that resolves a large initial constraint error and holds it under gravity.

Closes #23760.

cc: @xuchenhan-lbm

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24730)
<!-- Reviewable:end -->
