### PR TITLE
For fused-links: Implement "whole-system" SpatialMomentum and failure test for "partial-system" SpatialMomentum

### DIFF
--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -1,6 +1,6 @@
 /* Tests that mass properties are identical whether welded-together links are
 modeled with unfused weld joints or whether links that are welded together
-are fused into a mobilized body (fused Mobod). The test builds two identical
+are fused onto a mobilized body (fused Mobod). The test builds two identical
 models that differ only in whether SetFuseWeldedLinks() is enabled. */
 
 #include <limits>
@@ -158,15 +158,16 @@ void SetState(const TestModel& m, double angle_rad, double angular_vel) {
 }
 
 /* Verify that the spatial inertia for fused mobod Link123 (with links 1, 2, 3)
-matches the sum of spatial inertias for unfused links 1, 2, 3. Next, ensure
-spatial inertia for each of the follower links in a fused mobod are computed
-correctly. Lastly, the 1x1 mass matrix for this 1-DOF model directly depends on
-the spatial inertia of Link123, so we also verify:
-  (a) The mass matrix is identical between the fused and unfused weld models at
-      several configurations.
+matches the sum of spatial inertias for unfused links 1, 2, 3 at several poses.
+Next, ensure spatial inertia for each of the follower links in a fused mobod are
+computed correctly. Lastly, the 1x1 mass matrix for this 1-DOF model directly
+depends on the spatial inertia of Link123, so we also verify:
+  (a) The mass matrix is identical between the fused and unfused weld models.
   (b) The mass matrix matches the analytically computed value.
 
-Analytical derivation
+Similarly, verify spatial momentum calculations.
+
+Analytical derivation for spatial inertia.
 ---------------------
 The model has 4 links, Linki (i=1,2,3,4), each a 1 kg solid cube of side 0.1 m.
 Links 1,2,3 are welded together and are connected to World via a revolute joint
@@ -181,8 +182,7 @@ For a solid cube of mass m and side a, its moment of inertia about any axis
 through its COM is m*a²/6. The parallel axis theorem calculates each cube's
 moment of inertia about the revolute's z-axis via: Iᵢ = m*a²/6 + m*(dᵢ)²,
 where dᵢ (i=1,2,3) is the distance between each cube's COM and the revolute's
-z-axis. Iᵢ is independent of joint angle because the links are welded
-together.
+z-axis. Iᵢ is independent of joint angle because the links are welded together.
 
   Link1: I₁ = 1*(0.1)²/6 + 1*0²    = 1/600 + 0   (d² = 0)
   Link2: I₂ = 1*(0.1)²/6 + 1*1²    = 1/600 + 1   (d² = 1)
@@ -201,15 +201,15 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
       fused_model.link1, fused_model.link2, fused_model.link3,
       fused_model.link4};
 
-  // The mass matrix is configuration-independent for this model (see above),
-  // but we check at several angles to guard against future changes.
+  // Note: The mass matrix is configuration-independent for this model (see
+  // above), but we check at several angles to guard against future changes.
+  // Note: Use a non-zero angular velocity so spatial momentum is non-trivial.
   const std::vector<double> angles = {0.0, M_PI / 6, M_PI / 4, -M_PI / 3};
   for (double angle : angles) {
-    SetState(unfused_model, angle, 0.0);
-    SetState(fused_model, angle, 0.0);
+    SetState(unfused_model, angle, 2.0 /* rad/s */);
+    SetState(fused_model, angle, 2.0 /* rad/s */);
 
-    // Verify Link123's summed spatial inertia does not depend on whether they
-    // are on a fused mobod.
+    // Verify Link123's summed spatial inertia does not depend on fused links.
     SpatialInertia<double> M_UWo_W = unfused_model.plant->CalcSpatialInertia(
         *unfused_model.context, world_frame,
         {unfused_model.link1->index(), unfused_model.link2->index(),
@@ -223,8 +223,29 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
                                 MatrixCompareType::relative))
         << "Link123 spatial inertia mismatch at angle = " << angle;
 
-    // Ensure that individual link spatial inertias are reported correctly
-    // regardless of whether they were fused.
+    // Verify Link123's summed spatial momentum does not depend on fused links.
+    const Vector3<double> p_WoP_W(1.1, -2.3, 4.2);
+    SpatialMomentum<double> L_WUP_W =
+        unfused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
+            *unfused_model.context,
+            {unfused_model.link1->model_instance(),
+             unfused_model.link2->model_instance(),
+             unfused_model.link3->model_instance()},
+            p_WoP_W);
+    SpatialMomentum<double> L_WCP_W =
+        fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
+            *fused_model.context,
+            {fused_model.link1->model_instance(),
+             fused_model.link2->model_instance(),
+             fused_model.link3->model_instance()},
+            p_WoP_W);
+    // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
+    EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WCP_W.get_coeffs(),
+                                 kTolerance, MatrixCompareType::relative))
+        << "Link123 spatial momentum mismatch at angle = " << angle;
+
+    // Ensure that individual link spatial inertias and spatial momentum are
+    // accurately calculated, regardless of whether they were fused.
     for (int i = 0; i < 4; ++i) {
       const RigidBody<double>* unfused_linki = unfused_links[i];
       const RigidBody<double>* fused_linki = fused_links[i];
@@ -238,6 +259,17 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
           << "Spatial inertia mismatch: link" << i + 1
           << " at angle = " << angle;
 
+      // Verify individual link's spatial momentum do not depend on fused links.
+      L_WUP_W = unfused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
+          *unfused_model.context, {unfused_linki->model_instance()}, p_WoP_W);
+      L_WCP_W = fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
+          *fused_model.context, {fused_linki->model_instance()}, p_WoP_W);
+      // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
+      EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WCP_W.get_coeffs(),
+                                   kTolerance, MatrixCompareType::relative))
+          << "Spatial momentum mismatch: link" << i + 1
+          << " at angle = " << angle;
+
       // Since link4 is welded to world, special-case calculations are used. For
       // this special case, also compare link4 results to an analytical value.
       if (i == 3) {
@@ -248,6 +280,13 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
                                     M_CWo_W.CopyToFullMatrix6(), kTolerance,
                                     MatrixCompareType::relative))
             << "Inaccurate link4 spatial inertia at angle = " << angle;
+
+        // Link4's spatial momentum should always be zero (welded to ground).
+        // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
+        EXPECT_FALSE(CompareMatrices(L_WCP_W.get_coeffs(),
+                                     Vector6<double>::Zero(), kTolerance,
+                                     MatrixCompareType::relative))
+            << "Inaccurate link 4 spatial momentum at angle = " << angle;
       }
     }
 
@@ -268,20 +307,20 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
         << "Mass matrix analytical mismatch at angle = " << angle;
 
     // Ensure spatial momentum does not depend on fused welded links.
-    // Use a non-zero angular velocity so that the momentum is non-trivial.
-    SetState(unfused_model, angle, 2.0 /* rad/s */);
-    SetState(fused_model, angle, 2.0 /* rad/s */);
-    const Vector3<double> p_WoWo_W = Vector3<double>::Zero();
+    // Also, use an "about-point" P which is not coincident with Wo.
     const SpatialMomentum<double> L_unfused =
         unfused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
-            *unfused_model.context, p_WoWo_W);
+            *unfused_model.context, p_WoP_W);
+
+    // Test the function for the entire system's spatial momentum in world.
     const SpatialMomentum<double> L_fused =
         fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
-            *fused_model.context, p_WoWo_W);
-    // TODO(Mitiguy) EXPECT_FALSE is wrong, should be EXPECT_TRUE !
+            *fused_model.context, p_WoP_W);
     EXPECT_TRUE(CompareMatrices(L_unfused.get_coeffs(), L_fused.get_coeffs(),
                                 kTolerance, MatrixCompareType::relative))
         << "Spatial momentum mismatch at angle = " << angle;
+
+    // Test the function for a single link's spatial momentum in world.
   }
 }
 

--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -221,8 +221,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
          fused_model.link3->index()});
     EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
                                 M_FWo_W.CopyToFullMatrix6(), kTolerance,
-                                MatrixCompareType::relative))
-        << "Link123 spatial inertia mismatch";
+                                MatrixCompareType::relative));
 
     // Verify Link123's summed spatial momentum does not depend on fused links.
     const Vector3<double> p_WoP_W(1.1, -2.3, 4.2);
@@ -242,8 +241,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
             p_WoP_W);
     // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
     EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WFP_W.get_coeffs(),
-                                 kTolerance, MatrixCompareType::relative))
-        << "Link123 spatial momentum mismatch";
+                                 kTolerance, MatrixCompareType::relative));
 
     // Ensure that individual link spatial inertias and spatial momentum are
     // accurately calculated, regardless of whether they were fused.
@@ -256,8 +254,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
           *fused_model.context, world_frame, {fused_linki->index()});
       EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
                                   M_FWo_W.CopyToFullMatrix6(), kTolerance,
-                                  MatrixCompareType::relative))
-          << "Spatial inertia mismatch: link" << i + 1;
+                                  MatrixCompareType::relative));
 
       // Verify individual links' spatial momentum do not depend on fused links.
       L_WUP_W = unfused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
@@ -266,8 +263,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
           *fused_model.context, {fused_linki->model_instance()}, p_WoP_W);
       // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
       EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WFP_W.get_coeffs(),
-                                   kTolerance, MatrixCompareType::relative))
-          << "Spatial momentum mismatch: link" << i + 1;
+                                   kTolerance, MatrixCompareType::relative));
 
       // Since link4 is welded to world, special-case calculations are used. For
       // this special case, also compare link4 results to an analytical value.
@@ -277,15 +273,13 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
             SpatialInertia<double>::SolidCubeWithMass(m, a).Shift(-p_WoL4o_W);
         EXPECT_TRUE(CompareMatrices(M_L4Wo_W_expected.CopyToFullMatrix6(),
                                     M_FWo_W.CopyToFullMatrix6(), kTolerance,
-                                    MatrixCompareType::relative))
-            << "Inaccurate link4 spatial inertia";
+                                    MatrixCompareType::relative));
 
         // Link4's spatial momentum should always be zero (welded to ground).
         // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
         EXPECT_FALSE(CompareMatrices(L_WFP_W.get_coeffs(),
                                      Vector6<double>::Zero(), kTolerance,
-                                     MatrixCompareType::relative))
-            << "Inaccurate link 4 spatial momentum";
+                                     MatrixCompareType::relative));
       }
     }
 
@@ -294,16 +288,14 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
     unfused_model.plant->CalcMassMatrix(*unfused_model.context, &M_unfused);
     fused_model.plant->CalcMassMatrix(*fused_model.context, &M_fused);
     EXPECT_TRUE(CompareMatrices(M_unfused, M_fused, kTolerance,
-                                MatrixCompareType::relative))
-        << "Mass matrix mismatch";
+                                MatrixCompareType::relative));
 
     // Ensure the mass matrix matches the analytical value.
     const double Izz = m * a * a / 6.0;  // Izz of one cube about its COM.
     const double M_expected = (Izz + m * 0.0) +  // Link1: d² = 0
                               (Izz + m * 1.0) +  // Link2: d² = 1² = 1
                               (Izz + m * 2.0);   // Link3: d² = √2² = 2
-    EXPECT_NEAR(M_fused(0, 0), M_expected, kTolerance)
-        << "Mass matrix analytical mismatch";
+    EXPECT_NEAR(M_fused(0, 0), M_expected, kTolerance);
 
     // Ensure spatial momentum does not depend on fused welded links.
     // Also, use an "about-point" P which is not coincident with Wo.
@@ -316,8 +308,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
         fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
             *fused_model.context, p_WoP_W);
     EXPECT_TRUE(CompareMatrices(L_unfused.get_coeffs(), L_fused.get_coeffs(),
-                                kTolerance, MatrixCompareType::relative))
-        << "Entire system spatial momentum mismatch";
+                                kTolerance, MatrixCompareType::relative));
   }
 }
 
@@ -451,8 +442,7 @@ GTEST_TEST(FusedTest, CalcFrameBodyPosesAllPaths) {
     plant_nf->CalcMassMatrix(*context_nf, &mass_nf);
     plant_f->CalcMassMatrix(*context_f, &mass_f);
     EXPECT_TRUE(CompareMatrices(mass_nf, mass_f, kTolerance,
-                                MatrixCompareType::relative))
-        << "Mass matrix mismatch";
+                                MatrixCompareType::relative));
 
     // Gravity generalized forces should agree (exercises AccumulateGravity
     // which depends on p_BoLcm_B computed in CalcFrameBodyPoses).
@@ -461,8 +451,7 @@ GTEST_TEST(FusedTest, CalcFrameBodyPosesAllPaths) {
     const VectorX<double> tau_g_f =
         plant_f->CalcGravityGeneralizedForces(*context_f);
     EXPECT_TRUE(CompareMatrices(tau_g_nf, tau_g_f, kTolerance,
-                                MatrixCompareType::relative))
-        << "Gravity generalized forces mismatch";
+                                MatrixCompareType::relative));
   }
 }
 

--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -206,6 +206,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
   // Note: Use a non-zero angular velocity so spatial momentum is non-trivial.
   const std::vector<double> angles = {0.0, M_PI / 6, M_PI / 4, -M_PI / 3};
   for (double angle : angles) {
+    SCOPED_TRACE(::testing::Message() << "angle = " << angle);
     SetState(unfused_model, angle, 2.0 /* rad/s */);
     SetState(fused_model, angle, 2.0 /* rad/s */);
 
@@ -221,7 +222,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
     EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
                                 M_FWo_W.CopyToFullMatrix6(), kTolerance,
                                 MatrixCompareType::relative))
-        << "Link123 spatial inertia mismatch at angle = " << angle;
+        << "Link123 spatial inertia mismatch";
 
     // Verify Link123's summed spatial momentum does not depend on fused links.
     const Vector3<double> p_WoP_W(1.1, -2.3, 4.2);
@@ -242,7 +243,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
     // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
     EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WFP_W.get_coeffs(),
                                  kTolerance, MatrixCompareType::relative))
-        << "Link123 spatial momentum mismatch at angle = " << angle;
+        << "Link123 spatial momentum mismatch";
 
     // Ensure that individual link spatial inertias and spatial momentum are
     // accurately calculated, regardless of whether they were fused.
@@ -256,8 +257,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
       EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
                                   M_FWo_W.CopyToFullMatrix6(), kTolerance,
                                   MatrixCompareType::relative))
-          << "Spatial inertia mismatch: link" << i + 1
-          << " at angle = " << angle;
+          << "Spatial inertia mismatch: link" << i + 1;
 
       // Verify individual links' spatial momentum do not depend on fused links.
       L_WUP_W = unfused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
@@ -267,8 +267,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
       // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
       EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WFP_W.get_coeffs(),
                                    kTolerance, MatrixCompareType::relative))
-          << "Spatial momentum mismatch: link" << i + 1
-          << " at angle = " << angle;
+          << "Spatial momentum mismatch: link" << i + 1;
 
       // Since link4 is welded to world, special-case calculations are used. For
       // this special case, also compare link4 results to an analytical value.
@@ -279,14 +278,14 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
         EXPECT_TRUE(CompareMatrices(M_L4Wo_W_expected.CopyToFullMatrix6(),
                                     M_FWo_W.CopyToFullMatrix6(), kTolerance,
                                     MatrixCompareType::relative))
-            << "Inaccurate link4 spatial inertia at angle = " << angle;
+            << "Inaccurate link4 spatial inertia";
 
         // Link4's spatial momentum should always be zero (welded to ground).
         // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
         EXPECT_FALSE(CompareMatrices(L_WFP_W.get_coeffs(),
                                      Vector6<double>::Zero(), kTolerance,
                                      MatrixCompareType::relative))
-            << "Inaccurate link 4 spatial momentum at angle = " << angle;
+            << "Inaccurate link 4 spatial momentum";
       }
     }
 
@@ -296,7 +295,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
     fused_model.plant->CalcMassMatrix(*fused_model.context, &M_fused);
     EXPECT_TRUE(CompareMatrices(M_unfused, M_fused, kTolerance,
                                 MatrixCompareType::relative))
-        << "Mass matrix mismatch at angle = " << angle;
+        << "Mass matrix mismatch";
 
     // Ensure the mass matrix matches the analytical value.
     const double Izz = m * a * a / 6.0;  // Izz of one cube about its COM.
@@ -304,7 +303,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
                               (Izz + m * 1.0) +  // Link2: d² = 1² = 1
                               (Izz + m * 2.0);   // Link3: d² = √2² = 2
     EXPECT_NEAR(M_fused(0, 0), M_expected, kTolerance)
-        << "Mass matrix analytical mismatch at angle = " << angle;
+        << "Mass matrix analytical mismatch";
 
     // Ensure spatial momentum does not depend on fused welded links.
     // Also, use an "about-point" P which is not coincident with Wo.
@@ -318,9 +317,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
             *fused_model.context, p_WoP_W);
     EXPECT_TRUE(CompareMatrices(L_unfused.get_coeffs(), L_fused.get_coeffs(),
                                 kTolerance, MatrixCompareType::relative))
-        << "Spatial momentum mismatch at angle = " << angle;
-
-    // Test the function for a single link's spatial momentum in world.
+        << "Entire system spatial momentum mismatch";
   }
 }
 
@@ -443,6 +440,7 @@ GTEST_TEST(FusedTest, CalcFrameBodyPosesAllPaths) {
   const auto& rev_f = plant_f->GetJointByName<RevoluteJoint>("revolute");
 
   for (const double angle : {M_PI / 5, -M_PI / 3}) {
+    SCOPED_TRACE(::testing::Message() << "angle = " << angle);
     rev_nf.set_angle(context_nf.get(), angle);
     rev_f.set_angle(context_f.get(), angle);
 
@@ -454,7 +452,7 @@ GTEST_TEST(FusedTest, CalcFrameBodyPosesAllPaths) {
     plant_f->CalcMassMatrix(*context_f, &mass_f);
     EXPECT_TRUE(CompareMatrices(mass_nf, mass_f, kTolerance,
                                 MatrixCompareType::relative))
-        << "Mass matrix mismatch at angle = " << angle;
+        << "Mass matrix mismatch";
 
     // Gravity generalized forces should agree (exercises AccumulateGravity
     // which depends on p_BoLcm_B computed in CalcFrameBodyPoses).
@@ -464,7 +462,7 @@ GTEST_TEST(FusedTest, CalcFrameBodyPosesAllPaths) {
         plant_f->CalcGravityGeneralizedForces(*context_f);
     EXPECT_TRUE(CompareMatrices(tau_g_nf, tau_g_f, kTolerance,
                                 MatrixCompareType::relative))
-        << "Gravity generalized forces mismatch at angle = " << angle;
+        << "Gravity generalized forces mismatch";
   }
 }
 

--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -279,8 +279,8 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
         fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
             *fused_model.context, p_WoWo_W);
     // TODO(Mitiguy) EXPECT_FALSE is wrong, should be EXPECT_TRUE !
-    EXPECT_FALSE(CompareMatrices(L_unfused.get_coeffs(), L_fused.get_coeffs(),
-                                 kTolerance, MatrixCompareType::relative))
+    EXPECT_TRUE(CompareMatrices(L_unfused.get_coeffs(), L_fused.get_coeffs(),
+                                kTolerance, MatrixCompareType::relative))
         << "Spatial momentum mismatch at angle = " << angle;
   }
 }

--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -1,5 +1,5 @@
 /* Tests that mass properties are identical whether welded-together links are
-modeled with explicit weld joints or whether links that are welded together
+modeled with unfused weld joints or whether links that are welded together
 are fused into a mobilized body (fused Mobod). The test builds two identical
 models that differ only in whether SetFuseWeldedLinks() is enabled. */
 
@@ -33,7 +33,7 @@ using systems::Context;
 // Tolerance for numerical comparisons.
 constexpr double kTolerance = 32 * std::numeric_limits<double>::epsilon();
 
-// Holds one version of the test model, either a model with explicit welds
+// Holds one version of the test model, either a model with unfused welds
 // or a model with welded links fused onto a mobilized body (fused mobod)
 // along with its context, ready for kinematics queries.
 struct TestModel {
@@ -162,8 +162,8 @@ matches the sum of spatial inertias for unfused links 1, 2, 3. Next, ensure
 spatial inertia for each of the follower links in a fused mobod are computed
 correctly. Lastly, the 1x1 mass matrix for this 1-DOF model directly depends on
 the spatial inertia of Link123, so we also verify:
-  (a) The mass matrix is identical between the explicit-weld and fused
-      models at several configurations.
+  (a) The mass matrix is identical between the fused and unfused weld models at
+      several configurations.
   (b) The mass matrix matches the analytically computed value.
 
 Analytical derivation
@@ -189,14 +189,14 @@ together.
   Link3: I₃ = 1*(0.1)²/6 + 1*√2²   = 1/600 + 2   (d² = 2)
   Total: Iₜ = 3/600 + 3 = 1/200 + 3 = 3.005 kg·m² */
 GTEST_TEST(FusedTest, CompositeSpatialInertia) {
-  const TestModel explicit_model = MakeModel(false /* no combining */);
+  const TestModel unfused_model = MakeModel(false /* no combining */);
   const TestModel fused_model = MakeModel(true /* fuse welds */);
 
   const double m = 1.0, a = 0.1;  // mass m and side-length a of solid cubes.
-  const Frame<double>& world_frame = explicit_model.plant->world_frame();
-  const RigidBody<double>* explicit_links[] = {
-      explicit_model.link1, explicit_model.link2, explicit_model.link3,
-      explicit_model.link4};
+  const Frame<double>& world_frame = unfused_model.plant->world_frame();
+  const RigidBody<double>* unfused_links[] = {
+      unfused_model.link1, unfused_model.link2, unfused_model.link3,
+      unfused_model.link4};
   const RigidBody<double>* fused_links[] = {
       fused_model.link1, fused_model.link2, fused_model.link3,
       fused_model.link4};
@@ -205,20 +205,20 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
   // but we check at several angles to guard against future changes.
   const std::vector<double> angles = {0.0, M_PI / 6, M_PI / 4, -M_PI / 3};
   for (double angle : angles) {
-    SetState(explicit_model, angle, 0.0);
+    SetState(unfused_model, angle, 0.0);
     SetState(fused_model, angle, 0.0);
 
     // Verify Link123's summed spatial inertia does not depend on whether they
     // are on a fused mobod.
-    SpatialInertia<double> M_EWo_W = explicit_model.plant->CalcSpatialInertia(
-        *explicit_model.context, world_frame,
-        {explicit_model.link1->index(), explicit_model.link2->index(),
-         explicit_model.link3->index()});
+    SpatialInertia<double> M_UWo_W = unfused_model.plant->CalcSpatialInertia(
+        *unfused_model.context, world_frame,
+        {unfused_model.link1->index(), unfused_model.link2->index(),
+         unfused_model.link3->index()});
     SpatialInertia<double> M_CWo_W = fused_model.plant->CalcSpatialInertia(
         *fused_model.context, world_frame,
         {fused_model.link1->index(), fused_model.link2->index(),
          fused_model.link3->index()});
-    EXPECT_TRUE(CompareMatrices(M_EWo_W.CopyToFullMatrix6(),
+    EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
                                 M_CWo_W.CopyToFullMatrix6(), kTolerance,
                                 MatrixCompareType::relative))
         << "Link123 spatial inertia mismatch at angle = " << angle;
@@ -226,13 +226,13 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
     // Ensure that individual link spatial inertias are reported correctly
     // regardless of whether they were fused.
     for (int i = 0; i < 4; ++i) {
-      const RigidBody<double>* explicit_linki = explicit_links[i];
+      const RigidBody<double>* unfused_linki = unfused_links[i];
       const RigidBody<double>* fused_linki = fused_links[i];
-      M_EWo_W = explicit_model.plant->CalcSpatialInertia(
-          *explicit_model.context, world_frame, {explicit_linki->index()});
+      M_UWo_W = unfused_model.plant->CalcSpatialInertia(
+          *unfused_model.context, world_frame, {unfused_linki->index()});
       M_CWo_W = fused_model.plant->CalcSpatialInertia(
           *fused_model.context, world_frame, {fused_linki->index()});
-      EXPECT_TRUE(CompareMatrices(M_EWo_W.CopyToFullMatrix6(),
+      EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
                                   M_CWo_W.CopyToFullMatrix6(), kTolerance,
                                   MatrixCompareType::relative))
           << "Spatial inertia mismatch: link" << i + 1
@@ -252,10 +252,10 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
     }
 
     // Ensure the mass matrix does not depend on welded links being combined.
-    MatrixX<double> M_explicit(1, 1), M_fused(1, 1);
-    explicit_model.plant->CalcMassMatrix(*explicit_model.context, &M_explicit);
+    MatrixX<double> M_unfused(1, 1), M_fused(1, 1);
+    unfused_model.plant->CalcMassMatrix(*unfused_model.context, &M_unfused);
     fused_model.plant->CalcMassMatrix(*fused_model.context, &M_fused);
-    EXPECT_TRUE(CompareMatrices(M_explicit, M_fused, kTolerance,
+    EXPECT_TRUE(CompareMatrices(M_unfused, M_fused, kTolerance,
                                 MatrixCompareType::relative))
         << "Mass matrix mismatch at angle = " << angle;
 
@@ -266,6 +266,22 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
                               (Izz + m * 2.0);   // Link3: d² = √2² = 2
     EXPECT_NEAR(M_fused(0, 0), M_expected, kTolerance)
         << "Mass matrix analytical mismatch at angle = " << angle;
+
+    // Ensure spatial momentum does not depend on fused welded links.
+    // Use a non-zero angular velocity so that the momentum is non-trivial.
+    SetState(unfused_model, angle, 2.0 /* rad/s */);
+    SetState(fused_model, angle, 2.0 /* rad/s */);
+    const Vector3<double> p_WoWo_W = Vector3<double>::Zero();
+    const SpatialMomentum<double> L_unfused =
+        unfused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
+            *unfused_model.context, p_WoWo_W);
+    const SpatialMomentum<double> L_fused =
+        fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
+            *fused_model.context, p_WoWo_W);
+    // TODO(Mitiguy) EXPECT_FALSE is wrong, should be EXPECT_TRUE !
+    EXPECT_FALSE(CompareMatrices(L_unfused.get_coeffs(), L_fused.get_coeffs(),
+                                 kTolerance, MatrixCompareType::relative))
+        << "Spatial momentum mismatch at angle = " << angle;
   }
 }
 

--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -206,7 +206,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
   // Note: Use a non-zero angular velocity so spatial momentum is non-trivial.
   const std::vector<double> angles = {0.0, M_PI / 6, M_PI / 4, -M_PI / 3};
   for (double angle : angles) {
-    SCOPED_TRACE(::testing::Message() << "angle = " << angle);
+    SCOPED_TRACE(fmt::format("angle = {}", angle));
     SetState(unfused_model, angle, 2.0 /* rad/s */);
     SetState(fused_model, angle, 2.0 /* rad/s */);
 
@@ -440,7 +440,7 @@ GTEST_TEST(FusedTest, CalcFrameBodyPosesAllPaths) {
   const auto& rev_f = plant_f->GetJointByName<RevoluteJoint>("revolute");
 
   for (const double angle : {M_PI / 5, -M_PI / 3}) {
-    SCOPED_TRACE(::testing::Message() << "angle = " << angle);
+    SCOPED_TRACE(fmt::format("angle = {}", angle));
     rev_nf.set_angle(context_nf.get(), angle);
     rev_f.set_angle(context_f.get(), angle);
 

--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -214,12 +214,12 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
         *unfused_model.context, world_frame,
         {unfused_model.link1->index(), unfused_model.link2->index(),
          unfused_model.link3->index()});
-    SpatialInertia<double> M_CWo_W = fused_model.plant->CalcSpatialInertia(
+    SpatialInertia<double> M_FWo_W = fused_model.plant->CalcSpatialInertia(
         *fused_model.context, world_frame,
         {fused_model.link1->index(), fused_model.link2->index(),
          fused_model.link3->index()});
     EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
-                                M_CWo_W.CopyToFullMatrix6(), kTolerance,
+                                M_FWo_W.CopyToFullMatrix6(), kTolerance,
                                 MatrixCompareType::relative))
         << "Link123 spatial inertia mismatch at angle = " << angle;
 
@@ -232,7 +232,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
              unfused_model.link2->model_instance(),
              unfused_model.link3->model_instance()},
             p_WoP_W);
-    SpatialMomentum<double> L_WCP_W =
+    SpatialMomentum<double> L_WFP_W =
         fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
             *fused_model.context,
             {fused_model.link1->model_instance(),
@@ -240,7 +240,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
              fused_model.link3->model_instance()},
             p_WoP_W);
     // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
-    EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WCP_W.get_coeffs(),
+    EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WFP_W.get_coeffs(),
                                  kTolerance, MatrixCompareType::relative))
         << "Link123 spatial momentum mismatch at angle = " << angle;
 
@@ -251,21 +251,21 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
       const RigidBody<double>* fused_linki = fused_links[i];
       M_UWo_W = unfused_model.plant->CalcSpatialInertia(
           *unfused_model.context, world_frame, {unfused_linki->index()});
-      M_CWo_W = fused_model.plant->CalcSpatialInertia(
+      M_FWo_W = fused_model.plant->CalcSpatialInertia(
           *fused_model.context, world_frame, {fused_linki->index()});
       EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
-                                  M_CWo_W.CopyToFullMatrix6(), kTolerance,
+                                  M_FWo_W.CopyToFullMatrix6(), kTolerance,
                                   MatrixCompareType::relative))
           << "Spatial inertia mismatch: link" << i + 1
           << " at angle = " << angle;
 
-      // Verify individual link's spatial momentum do not depend on fused links.
+      // Verify individual links' spatial momentum do not depend on fused links.
       L_WUP_W = unfused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
           *unfused_model.context, {unfused_linki->model_instance()}, p_WoP_W);
-      L_WCP_W = fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
+      L_WFP_W = fused_model.plant->CalcSpatialMomentumInWorldAboutPoint(
           *fused_model.context, {fused_linki->model_instance()}, p_WoP_W);
       // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
-      EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WCP_W.get_coeffs(),
+      EXPECT_FALSE(CompareMatrices(L_WUP_W.get_coeffs(), L_WFP_W.get_coeffs(),
                                    kTolerance, MatrixCompareType::relative))
           << "Spatial momentum mismatch: link" << i + 1
           << " at angle = " << angle;
@@ -277,13 +277,13 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
         SpatialInertia<double> M_L4Wo_W_expected =
             SpatialInertia<double>::SolidCubeWithMass(m, a).Shift(-p_WoL4o_W);
         EXPECT_TRUE(CompareMatrices(M_L4Wo_W_expected.CopyToFullMatrix6(),
-                                    M_CWo_W.CopyToFullMatrix6(), kTolerance,
+                                    M_FWo_W.CopyToFullMatrix6(), kTolerance,
                                     MatrixCompareType::relative))
             << "Inaccurate link4 spatial inertia at angle = " << angle;
 
         // Link4's spatial momentum should always be zero (welded to ground).
         // TODO(Mitiguy) EXPECT_FALSE is wrong!  Should be EXPECT_TRUE!
-        EXPECT_FALSE(CompareMatrices(L_WCP_W.get_coeffs(),
+        EXPECT_FALSE(CompareMatrices(L_WFP_W.get_coeffs(),
                                      Vector6<double>::Zero(), kTolerance,
                                      MatrixCompareType::relative))
             << "Inaccurate link 4 spatial momentum at angle = " << angle;

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2843,7 +2843,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
 template <typename T>
 SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
     const systems::Context<T>& context, const Vector3<T>& p_WoP_W) const {
-  // Efficienctly evaluate all mobods' spatial inertias, velocities, and poses.
+  // Efficiently evaluate all mobods' spatial inertias, velocities, and poses.
   const std::vector<SpatialInertia<T>>& M_Bi_W =
       EvalSpatialInertiaInWorldCache(context);
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
@@ -2855,19 +2855,15 @@ SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
   for (const SpanningForest::Mobod& mobod : forest().mobods()) {
     if (mobod.is_world()) continue;  // No contribution from the world.
 
-    // Form each mobod B's spatial momentum in W about Bo, expressed in W.
+    // Form each mobod B's spatial momentum in W about Bo, expressed in W, then
+    // shift L_WBBo_W from "about Bo" to "about Wo" and accumulate the sum.
     const MobodIndex mobod_index = mobod.index();
     const SpatialInertia<T>& M_BBo_W = M_Bi_W[mobod_index];
     const SpatialVelocity<T>& V_WBo_W = vc.get_V_WB(mobod_index);
-    SpatialMomentum<T> L_WBBo_W = M_BBo_W * V_WBo_W;
-
-    // Shift L_WBBo_W from "about Bo" to "about Wo" and accumulate the sum.
     const RigidTransform<T>& X_WB = pc.get_X_WB(mobod_index);
     const Vector3<T>& p_WoBo_W = X_WB.translation();
-    // After ShiftInPlace, L_WBBo_W is no longer "about Bo", instead L_WBBo_W
-    // is now L_WBWo_W (B's spatial momentum in W "about Wo", expressed in W).
-    L_WBBo_W.ShiftInPlace(-p_WoBo_W);  // After this, L_WBBo_W is now L_WBWo_W.
-    L_WSWo_W += L_WBBo_W;              // Actually is L_WSWo_W += L_WBWo_W.
+    const SpatialMomentum<T> L_WBWo_W = (M_BBo_W * V_WBo_W).Shift(-p_WoBo_W);
+    L_WSWo_W += L_WBWo_W;
   }
 
   // Shift system S's spatial momentum from "about Wo" to "about point P".
@@ -2914,9 +2910,8 @@ SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
   const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 
-  // Accumulate each body's spatial momentum in the world frame W to this
-  // system S's spatial momentum in W about Wo (the origin of W), expressed in
-  // W.
+  // Accumulate each body's spatial momentum in world W to this system S's
+  // spatial momentum in W about Wo (the origin of W), expressed in W.
   SpatialMomentum<T> L_WS_W = SpatialMomentum<T>::Zero();
 
   // Add contributions from each link Bi.

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2843,16 +2843,35 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
 template <typename T>
 SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
     const systems::Context<T>& context, const Vector3<T>& p_WoP_W) const {
-  // Assemble a list of ModelInstanceIndex.
-  // Skip model_instance_index(0) which always contains the "world" body. The
-  // spatial momentum of the world body measured in the world is always zero.
-  std::vector<ModelInstanceIndex> model_instances;
-  for (ModelInstanceIndex model_instance_index(1);
-       model_instance_index < num_model_instances(); ++model_instance_index)
-    model_instances.push_back(model_instance_index);
+  // Efficienctly evaluate all mobods' spatial inertias, velocities, and poses.
+  const std::vector<SpatialInertia<T>>& M_Bi_W =
+      EvalSpatialInertiaInWorldCache(context);
+  const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
+  const VelocityKinematicsCache<T>& vc = EvalVelocityKinematics(context);
 
-  return CalcSpatialMomentumInWorldAboutPoint(context, model_instances,
-                                              p_WoP_W);
+  // Form L_WSWo_W, the system S's spatial momentum in world W about Wo (world
+  // origin) expressed in W by doing a sum over all mobods in S.
+  SpatialMomentum<T> L_WSWo_W = SpatialMomentum<T>::Zero();
+  for (const SpanningForest::Mobod& mobod : forest().mobods()) {
+    if (mobod.is_world()) continue;  // No contribution from the world.
+
+    // Form each mobod B's spatial momentum in W about Bo, expressed in W.
+    const MobodIndex mobod_index = mobod.index();
+    const SpatialInertia<T>& M_BBo_W = M_Bi_W[mobod_index];
+    const SpatialVelocity<T>& V_WBo_W = vc.get_V_WB(mobod_index);
+    SpatialMomentum<T> L_WBBo_W = M_BBo_W * V_WBo_W;
+
+    // Shift L_WBBo_W from "about Bo" to "about Wo" and accumulate the sum.
+    const RigidTransform<T>& X_WB = pc.get_X_WB(mobod_index);
+    const Vector3<T>& p_WoBo_W = X_WB.translation();
+    // After ShiftInPlace, L_WBBo_W is no longer "about Bo", instead L_WBBo_W
+    // is now L_WBWo_W (B's spatial momentum in W "about Wo", expressed in W).
+    L_WBBo_W.ShiftInPlace(-p_WoBo_W);  // After this, L_WBBo_W is now L_WBWo_W.
+    L_WSWo_W += L_WBBo_W;              // Actually is L_WSWo_W += L_WBWo_W.
+  }
+
+  // Shift system S's spatial momentum from "about Wo" to "about point P".
+  return L_WSWo_W.Shift(p_WoP_W);  // returns L_WSP_W.
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2843,7 +2843,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalAccelerationInWorld(
 template <typename T>
 SpatialMomentum<T> MultibodyTree<T>::CalcSpatialMomentumInWorldAboutPoint(
     const systems::Context<T>& context, const Vector3<T>& p_WoP_W) const {
-  // Efficiently evaluate all mobods' spatial inertias, velocities, and poses.
+  // Efficiently evaluate all mobods' spatial inertias, poses, and velocities.
   const std::vector<SpatialInertia<T>>& M_Bi_W =
       EvalSpatialInertiaInWorldCache(context);
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
@@ -2903,8 +2903,7 @@ template <typename T>
 SpatialMomentum<T> MultibodyTree<T>::CalcBodiesSpatialMomentumInWorldAboutWo(
     const systems::Context<T>& context,
     const std::vector<LinkIndex>& link_indexes) const {
-  // For efficiency, evaluate all bodies' spatial inertia, velocities, and
-  // pose.
+  // Efficiently evaluate all mobods' spatial inertias, poses, and velocities.
   const std::vector<SpatialInertia<T>>& M_Bi_W =
       EvalSpatialInertiaInWorldCache(context);
   const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);


### PR DESCRIPTION
Ensure spatial momentum for a model having fused welds matches a model having unfused melds. Reimplements the "whole system" case so that it is independent of fusing (works on mobilized bodies directly). Adds test cases for the current link-dependent momentum cases which fail when fusing is enabled (that's internal use only currently). These should succeed when we reimplement those cases after fused kinematics is available (see #24746).

There is no end-user value here yet. This is a separately-reviewable piece of the larger fused-body project https://github.com/RobotLocomotion/drake/pull/24350.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24731)
<!-- Reviewable:end -->
