### PR TITLE
[pydrake] Respell RotationalInertia.__getitem__ binding

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -807,9 +807,13 @@ class TestPlant(unittest.TestCase):
             Exception, r"incompatible function arguments"
         ):
             dut[0]
-        with self.assertRaisesRegex(Exception, r"Unable to cast"):
+        with self.assertRaisesRegex(
+            Exception, r"incompatible function arguments"
+        ):
             dut[0.0, 0.0]
-        with self.assertRaisesRegex(Exception, r"Expected \[i,j\]"):
+        with self.assertRaisesRegex(
+            Exception, r"incompatible function arguments"
+        ):
             dut[0, 0, 0]
         self.assertIsInstance(dut.CopyToFullMatrix3(), np.ndarray)
         dut.IsNearlyEqualTo(other=dut, precision=0.0)

--- a/bindings/pydrake/multibody/tree_py_inertia.cc
+++ b/bindings/pydrake/multibody/tree_py_inertia.cc
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "pybind11/eval.h"
 
 #include "drake/bindings/generated_docstrings/multibody_tree.h"
@@ -71,13 +73,8 @@ void DoScalarDependentDefinitions(py::module_ m, T) {
             cls_doc.CalcMaximumPossibleMomentOfInertia.doc)
         .def(
             "__getitem__",
-            [](const Class& self, py::tuple key) -> T {
-              if (key.size() != 2) {
-                throw std::out_of_range("Expected [i,j] for __getitem__.");
-              }
-              const int i = py::cast<int>(key[0]);
-              const int j = py::cast<int>(key[1]);
-              return self(i, j);
+            [](const Class& self, std::pair<int, int> key) -> T {
+              return self(key.first, key.second);
             },
             cls_doc.operator_call.doc)
         .def("CopyToFullMatrix3", &Class::CopyToFullMatrix3,


### PR DESCRIPTION
Using the built-in caster instead of writing one by hand leads to better error messages that are also consistent across pybind11 and nanobind, which means the same unit test will pass with either binder.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24732)
<!-- Reviewable:end -->
