### PR TITLE
[pydrake] RotationMatrix.row(i) and .col(j) return copies

### DIFF
--- a/bindings/pydrake/math/math_py_monolith.cc
+++ b/bindings/pydrake/math/math_py_monolith.cc
@@ -204,8 +204,24 @@ void DefineRotationMatrix(py::module_ m, class_<PyClass<T>>& cls) {
             cls_doc.InvertAndCompose.doc)
         .def("transpose", &Class::transpose, cls_doc.transpose.doc)
         .def("matrix", &Class::matrix, cls_doc.matrix.doc)
-        .def("row", &Class::row, py::arg("index"), cls_doc.row.doc)
-        .def("col", &Class::col, py::arg("index"), cls_doc.col.doc)
+        .def(
+            "row",
+            // The `row` method returns an Eigen::Block, but passing that view
+            // back into Python is too difficult, especially for dtype=object,
+            // so we'll write out a lambda that copies it.
+            [](const Class& self, int index) -> Vector3<T> {
+              return self.row(index);
+            },
+            py::arg("index"), cls_doc.row.doc)
+        .def(
+            "col",
+            // The `col` method returns an Eigen::Block, but passing that view
+            // back into Python is too difficult, especially for dtype=object,
+            // so we'll write out a lambda that copies it.
+            [](const Class& self, int index) -> Vector3<T> {
+              return self.col(index);
+            },
+            py::arg("index"), cls_doc.col.doc)
         .def(
             "multiply",
             [](const Class& self, const Class& other) { return self * other; },

--- a/bindings/pydrake/math/test/math_test.py
+++ b/bindings/pydrake/math/test/math_test.py
@@ -297,12 +297,10 @@ class TestMath(unittest.TestCase):
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
         R = RotationMatrix.MakeZRotation(theta=0)
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
-        # TODO(eric.cousineau): #11575, remove the conditional.
-        if T is float:
-            numpy_compare.assert_float_equal(R.row(index=0), [1.0, 0.0, 0.0])
-            numpy_compare.assert_float_equal(R.col(index=0), [1.0, 0.0, 0.0])
-            R = RotationMatrix.MakeFromOneVector(b_A=[1, 0, 0], axis_index=0)
-            numpy_compare.assert_equal(R.IsValid(), True)
+        numpy_compare.assert_float_equal(R.row(index=0), [1.0, 0.0, 0.0])
+        numpy_compare.assert_float_equal(R.col(index=0), [1.0, 0.0, 0.0])
+        R = RotationMatrix.MakeFromOneVector(b_A=[1, 0, 0], axis_index=0)
+        numpy_compare.assert_equal(R.IsValid(), True)
         R.set(R=np.eye(3))
         numpy_compare.assert_float_equal(R.matrix(), np.eye(3))
         # - Cast.


### PR DESCRIPTION
Teaching nanobind how to return a view is too much work. These methods shouldn't be used in performance-sensitive code, anyway.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24733)
<!-- Reviewable:end -->
