### PR TITLE
[pydrake] Remove bindings that always throw at runtime

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -541,31 +541,45 @@ void DoScalarDependentDefinitions(py::module_ m, T) {
             cls_doc.SetFreeBodySpatialVelocity.doc_3args)
         .def("GetActuationFromArray", &Class::GetActuationFromArray,
             py::arg("model_instance"), py::arg("u"),
-            cls_doc.GetActuationFromArray.doc)
-        .def("SetActuationInArray", &Class::SetActuationInArray,
-            py::arg("model_instance"), py::arg("u_instance"), py::arg("u"),
-            cls_doc.SetActuationInArray.doc)
+            cls_doc.GetActuationFromArray.doc);
+    if constexpr (std::is_same_v<T, double>) {
+      // Mutable EigenPtr doesn't work with dtype=object.
+      cls  // BR
+          .def("SetActuationInArray", &Class::SetActuationInArray,
+              py::arg("model_instance"), py::arg("u_instance"), py::arg("u"),
+              cls_doc.SetActuationInArray.doc);
+    }
+    cls  // BR
         .def("GetPositionsFromArray",
             overload_cast_explicit<VectorX<T>, ModelInstanceIndex,
                 const Eigen::Ref<const VectorX<T>>&>(
                 &Class::GetPositionsFromArray),
             py::arg("model_instance"), py::arg("q"),
-            cls_doc.GetPositionsFromArray.doc_2args)
-        .def("SetPositionsInArray", &Class::SetPositionsInArray,
-            py::arg("model_instance"), py::arg("q_instance"), py::arg("q"),
-            cls_doc.SetPositionsInArray.doc)
+            cls_doc.GetPositionsFromArray.doc_2args);
+    if constexpr (std::is_same_v<T, double>) {
+      // Mutable EigenPtr doesn't work with dtype=object.
+      cls  // BR
+          .def("SetPositionsInArray", &Class::SetPositionsInArray,
+              py::arg("model_instance"), py::arg("q_instance"), py::arg("q"),
+              cls_doc.SetPositionsInArray.doc);
+    }
+    cls  // BR
         .def("GetVelocitiesFromArray",
             overload_cast_explicit<VectorX<T>, ModelInstanceIndex,
                 const Eigen::Ref<const VectorX<T>>&>(
                 &Class::GetVelocitiesFromArray),
             py::arg("model_instance"), py::arg("v"),
-            cls_doc.GetVelocitiesFromArray.doc_2args)
-        .def("SetVelocitiesInArray", &Class::SetVelocitiesInArray,
-            py::arg("model_instance"), py::arg("v_instance"), py::arg("v"),
-            cls_doc.SetVelocitiesInArray.doc)
-        // TODO(eric.cousineau): Ensure all of these return either references,
-        // or copies, consistently. At present, `GetX(context)` returns a
-        // reference, while `GetX(context, model_instance)` returns a copy.
+            cls_doc.GetVelocitiesFromArray.doc_2args);
+    if constexpr (std::is_same_v<T, double>) {
+      // Mutable EigenPtr doesn't work with dtype=object.
+      cls  // BR
+          .def("SetVelocitiesInArray", &Class::SetVelocitiesInArray,
+              py::arg("model_instance"), py::arg("v_instance"), py::arg("v"),
+              cls_doc.SetVelocitiesInArray.doc);
+    }
+    cls  // TODO(eric.cousineau): Ensure all of these return either references,
+         // or copies, consistently. At present, `GetX(context)` returns a
+         // reference, while `GetX(context, model_instance)` returns a copy.
         .def(
             "GetPositions",
             [](const Class* self, const Context<T>& context) {

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -955,10 +955,15 @@ void DoScalarDependentDefinitions(py::module_ m, T) {
             [](const Class& self, const VectorX<T>& u) -> VectorX<T> {
               return self.get_actuation_vector(u);
             },
-            py::arg("u"), cls_doc.get_actuation_vector.doc)
-        .def("set_actuation_vector", &Class::set_actuation_vector,
-            py::arg("u_actuator"), py::arg("u"),
-            cls_doc.set_actuation_vector.doc)
+            py::arg("u"), cls_doc.get_actuation_vector.doc);
+    if constexpr (std::is_same_v<T, double>) {
+      // Mutable EigenPtr doesn't work with dtype=object.
+      cls  // BR
+          .def("set_actuation_vector", &Class::set_actuation_vector,
+              py::arg("u_actuator"), py::arg("u"),
+              cls_doc.set_actuation_vector.doc);
+    }
+    cls  // BR
         .def("input_start", &Class::input_start, cls_doc.input_start.doc)
         .def("num_inputs", &Class::num_inputs, cls_doc.num_inputs.doc)
         .def("effort_limit", &Class::effort_limit, cls_doc.effort_limit.doc)

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -480,11 +480,17 @@ struct Impl {
         // Calculations.
         .def("CalcTimeDerivatives", &System<T>::CalcTimeDerivatives,
             py::arg("context"), py::arg("derivatives"),
-            doc.System.CalcTimeDerivatives.doc)
-        .def("CalcImplicitTimeDerivativesResidual",
-            &System<T>::CalcImplicitTimeDerivativesResidual, py::arg("context"),
-            py::arg("proposed_derivatives"), py::arg("residual"),
-            doc.System.CalcImplicitTimeDerivativesResidual.doc)
+            doc.System.CalcTimeDerivatives.doc);
+    if constexpr (std::is_same_v<T, double>) {
+      // Mutable EigenPtr doesn't work with dtype=object.
+      system_cls  // BR
+          .def("CalcImplicitTimeDerivativesResidual",
+              &System<T>::CalcImplicitTimeDerivativesResidual,
+              py::arg("context"), py::arg("proposed_derivatives"),
+              py::arg("residual"),
+              doc.System.CalcImplicitTimeDerivativesResidual.doc);
+    }
+    system_cls  // BR
         .def(
             "CalcImplicitTimeDerivativesResidual",
             [](const System<T>* self, const Context<T>& context,

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -338,8 +338,11 @@ PYDRAKE_MODULE(primitives, m) {
         .def(py::init<const BasicVector<T>&>(), py::arg("model_vector"),
             doc.Multiplexer.ctor.doc_1args_model_vector);
 
-    DefineTemplateClassWithDefault<MultilayerPerceptron<T>, LeafSystem<T>>(m,
-        "MultilayerPerceptron", GetPyParam<T>(), doc.MultilayerPerceptron.doc)
+    auto multilayer_perceptron_cls =
+        DefineTemplateClassWithDefault<MultilayerPerceptron<T>, LeafSystem<T>>(
+            m, "MultilayerPerceptron", GetPyParam<T>(),
+            doc.MultilayerPerceptron.doc);
+    multilayer_perceptron_cls  // BR
         .def(py::init<const std::vector<int>&, PerceptronActivationType>(),
             py::arg("layers"),
             py::arg("activation_type") = PerceptronActivationType::kTanh,
@@ -413,32 +416,38 @@ PYDRAKE_MODULE(primitives, m) {
                 &MultilayerPerceptron<T>::GetBiases),
             py::arg("params"), py::arg("layer"),
             py::keep_alive<0, 2>() /* return keeps params alive */,
-            py_rvp::reference, doc.MultilayerPerceptron.GetBiases.doc_vector)
-        .def("SetWeights",
-            py::overload_cast<EigenPtr<VectorX<T>>, int,
-                const Eigen::Ref<const MatrixX<T>>&>(
-                &MultilayerPerceptron<T>::SetWeights, py::const_),
-            py::arg("params"), py::arg("layer"), py::arg("W"),
-            doc.MultilayerPerceptron.SetWeights.doc_vector)
-        .def("SetBiases",
-            py::overload_cast<EigenPtr<VectorX<T>>, int,
-                const Eigen::Ref<const VectorX<T>>&>(
-                &MultilayerPerceptron<T>::SetBiases, py::const_),
-            py::arg("params"), py::arg("layer"), py::arg("b"),
-            doc.MultilayerPerceptron.SetBiases.doc_vector)
-        .def("Backpropagation",
-            WrapCallbacks(&MultilayerPerceptron<T>::Backpropagation),
-            py::arg("context"), py::arg("X"), py::arg("loss"),
-            py::arg("dloss_dparams"),
-            doc.MultilayerPerceptron.Backpropagation.doc)
-        .def("BackpropagationMeanSquaredError",
-            &MultilayerPerceptron<T>::BackpropagationMeanSquaredError,
-            py::arg("context"), py::arg("X"), py::arg("Y_desired"),
-            py::arg("dloss_dparams"),
-            doc.MultilayerPerceptron.BackpropagationMeanSquaredError.doc)
-        .def("BatchOutput", &MultilayerPerceptron<T>::BatchOutput,
-            py::arg("context"), py::arg("X"), py::arg("Y"),
-            py::arg("dYdX") = nullptr, doc.MultilayerPerceptron.BatchOutput.doc)
+            py_rvp::reference, doc.MultilayerPerceptron.GetBiases.doc_vector);
+    if constexpr (std::is_same_v<T, double>) {
+      // Mutable EigenPtr doesn't work with dtype=object.
+      multilayer_perceptron_cls  // BR
+          .def("SetWeights",
+              py::overload_cast<EigenPtr<VectorX<T>>, int,
+                  const Eigen::Ref<const MatrixX<T>>&>(
+                  &MultilayerPerceptron<T>::SetWeights, py::const_),
+              py::arg("params"), py::arg("layer"), py::arg("W"),
+              doc.MultilayerPerceptron.SetWeights.doc_vector)
+          .def("SetBiases",
+              py::overload_cast<EigenPtr<VectorX<T>>, int,
+                  const Eigen::Ref<const VectorX<T>>&>(
+                  &MultilayerPerceptron<T>::SetBiases, py::const_),
+              py::arg("params"), py::arg("layer"), py::arg("b"),
+              doc.MultilayerPerceptron.SetBiases.doc_vector)
+          .def("Backpropagation",
+              WrapCallbacks(&MultilayerPerceptron<T>::Backpropagation),
+              py::arg("context"), py::arg("X"), py::arg("loss"),
+              py::arg("dloss_dparams"),
+              doc.MultilayerPerceptron.Backpropagation.doc)
+          .def("BackpropagationMeanSquaredError",
+              &MultilayerPerceptron<T>::BackpropagationMeanSquaredError,
+              py::arg("context"), py::arg("X"), py::arg("Y_desired"),
+              py::arg("dloss_dparams"),
+              doc.MultilayerPerceptron.BackpropagationMeanSquaredError.doc)
+          .def("BatchOutput", &MultilayerPerceptron<T>::BatchOutput,
+              py::arg("context"), py::arg("X"), py::arg("Y"),
+              py::arg("dYdX") = nullptr,
+              doc.MultilayerPerceptron.BatchOutput.doc);
+    }
+    multilayer_perceptron_cls  // BR
         .def(
             "BatchOutput",
             [](const MultilayerPerceptron<T>* self, const Context<T>& context,

--- a/tools/workspace/pybind11/patches/eigen_object_matrices.patch
+++ b/tools/workspace/pybind11/patches/eigen_object_matrices.patch
@@ -325,18 +325,12 @@ Co-Author: Mmanu Chaturvedi <mmanu.chaturvedi@kitware.com>
  
  public:
      bool load(handle src, bool convert) {
-@@ -494,6 +632,17 @@ public:
+@@ -494,6 +632,11 @@ public:
          bool need_copy = !isinstance<Array>(src);
  
          EigenConformable<props::row_major> fits;
 +        constexpr bool is_pyobject = is_pyobject_dtype<Scalar>::value;
-+        // TODO(eric.cousineau): Make this compile-time once Drake does not use this in any code
-+        // for scalar types.
-+        // static_assert(!(is_pyobject && need_writeable), "dtype=object cannot provide writeable
-+        // references");
-+        if (is_pyobject && need_writeable) {
-+            throw cast_error("dtype=object cannot provide writeable references");
-+        }
++        static_assert(!(is_pyobject && need_writeable), "dtype=object cannot provide writeable references");
 +        if (is_pyobject) {
 +            need_copy = true;
 +        }


### PR DESCRIPTION
There was a TODO in our pybind11 dtype=object patch about turning an always-thrown runtime casting exception into a static_assert, so that the impossible bindings won't even compile.

It turns out that with nanobind, the broken bindings already don't compile, so we need to deal with them somehow sooner or later.

It seems most sensible to elevate the pybind11 case to a compile error now and fix all of the call sites immediately.

All of the removed bindings were already unusable -- they threw an error any time you called them.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24738)
<!-- Reviewable:end -->
