### PR TITLE
[pydrake] Remove more bindings that always throw at runtime

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -1260,15 +1260,19 @@ void DefineDiscreteValues(py::module_ m) {
             return self->get_value(index);
           },
           return_value_policy_for_scalar_type<T>(), py::arg("index") = 0,
-          doc.DiscreteValues.get_value.doc_1args)
-      .def(
-          "get_mutable_value",
-          [](Class* self, int index) -> Eigen::Ref<VectorX<T>> {
-            return self->get_mutable_value(index);
-          },
-          // N.B. We explicitly want a failure when T != double due to #8116.
-          py_rvp::reference_internal, py::arg("index") = 0,
-          doc.DiscreteValues.get_mutable_value.doc_1args)
+          doc.DiscreteValues.get_value.doc_1args);
+  if constexpr (std::is_same_v<T, double>) {
+    // Mutable Eigen::Ref return value doesn't work with dtype=object.
+    discrete_values  // BR
+        .def(
+            "get_mutable_value",
+            [](Class* self, int index) -> Eigen::Ref<VectorX<T>> {
+              return self->get_mutable_value(index);
+            },
+            py_rvp::reference_internal, py::arg("index") = 0,
+            doc.DiscreteValues.get_mutable_value.doc_1args);
+  }
+  discrete_values  // BR
       .def(
           "SetFrom",
           [](Class* self, const DiscreteValues<double>& other) {

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -101,17 +101,19 @@ void DoScalarDependentDefinitions(py::module_ m) {
           py_rvp::reference_internal, doc.BasicVector.get_value.doc)
       // TODO(eric.cousineau): Remove this once `get_value` is changed, or
       // reference semantics are changed for custom dtypes.
-      .def("_get_value_copy",
-          [](const BasicVector<T>* self) -> VectorX<T> {
-            return self->get_value();
-          })
-      .def(
-          "get_mutable_value",
-          [](BasicVector<T>* self) -> Eigen::Ref<VectorX<T>> {
-            return self->get_mutable_value();
-          },
-          py_rvp::reference_internal, doc.BasicVector.get_mutable_value.doc);
-
+      .def("_get_value_copy", [](const BasicVector<T>* self) -> VectorX<T> {
+        return self->get_value();
+      });
+  if constexpr (std::is_same_v<T, double>) {
+    // Mutable Eigen::Ref return value doesn't work with dtype=object.
+    basic_vector  // BR
+        .def(
+            "get_mutable_value",
+            [](BasicVector<T>* self) -> Eigen::Ref<VectorX<T>> {
+              return self->get_mutable_value();
+            },
+            py_rvp::reference_internal, doc.BasicVector.get_mutable_value.doc);
+  }
   DefineTemplateClassWithDefault<Supervector<T>, VectorBase<T>>(
       m, "Supervector", GetPyParam<T>(), doc.Supervector.doc);
 

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -365,17 +365,22 @@ PYDRAKE_MODULE(primitives, m) {
         .def("GetParameters", &MultilayerPerceptron<T>::GetParameters,
             py::arg("context"),
             py::keep_alive<0, 2>() /* return keeps context alive */,
-            py_rvp::reference, doc.MultilayerPerceptron.GetParameters.doc)
-        .def(
-            "GetMutableParameters",
-            [](const MultilayerPerceptron<T>* self,
-                Context<T>* context) -> Eigen::Ref<VectorX<T>> {
-              return self->GetMutableParameters(context);
-            },
-            py_rvp::reference, py::arg("context"),
-            // Keep alive, ownership: `return` keeps `context` alive.
-            py::keep_alive<0, 2>(),
-            doc.MultilayerPerceptron.GetMutableParameters.doc)
+            py_rvp::reference, doc.MultilayerPerceptron.GetParameters.doc);
+    if constexpr (std::is_same_v<T, double>) {
+      // Mutable Eigen::Ref return value doesn't work with dtype=object.
+      multilayer_perceptron_cls  // BR
+          .def(
+              "GetMutableParameters",
+              [](const MultilayerPerceptron<T>* self,
+                  Context<T>* context) -> Eigen::Ref<VectorX<T>> {
+                return self->GetMutableParameters(context);
+              },
+              py_rvp::reference, py::arg("context"),
+              // Keep alive, ownership: `return` keeps `context` alive.
+              py::keep_alive<0, 2>(),
+              doc.MultilayerPerceptron.GetMutableParameters.doc);
+    }
+    multilayer_perceptron_cls  // BR
         .def("SetParameters", &MultilayerPerceptron<T>::SetParameters,
             py::arg("context"), py::arg("params"),
             doc.MultilayerPerceptron.SetParameters.doc)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -427,7 +427,7 @@ class TestGeneral(unittest.TestCase):
                 discrete_values.get_mutable_value(index=1), x
             )
         else:
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(AttributeError):
                 discrete_values.get_mutable_value(index=1)
 
         discrete_values = DiscreteValues(datum=BasicVector(np.arange(3)))

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -119,6 +119,15 @@ class TestValue(unittest.TestCase):
         value[1] = 6.0
         self.assertEqual(value[1], 6.0)
 
+    @numpy_compare.check_all_types
+    def test_basic_vector_mutable_view(self, T):
+        dut = BasicVector_[T](3)
+        if T is float:
+            self.assertEqual(dut.get_mutable_value().size, 3)
+        else:
+            with self.assertRaises(AttributeError):
+                dut.get_mutable_value()
+
     def assert_basic_vector_equal(self, a, b):
         self.assertIs(type(a), type(b))
         self.assertIsNot(a, b)


### PR DESCRIPTION
Similar to 76a0124c, but for return types. In this case our pybind11 type_caster patch throws and can't be changed to static_assert, so finding the troublesome call sites is a manual hunt.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24741)
<!-- Reviewable:end -->
