### PR TITLE
[pydrake] Align with nanobind factory constructor API (part 2)

### DIFF
--- a/bindings/pydrake/planning/planning_py_iris_common.cc
+++ b/bindings/pydrake/planning/planning_py_iris_common.cc
@@ -133,18 +133,19 @@ is the input dimension.
       m, "IrisParameterizationFunction", cls_doc.doc);
   iris_parameterization_function  // BR
       .def(py::init<>(), cls_doc.ctor.doc_0args)
-      .def(py::init([](const py::callable& parameterization,
-                        int parameterization_dimension) {
-        return IrisParameterizationFunction(
-            py::cast<
-                IrisParameterizationFunction::ParameterizationFunctionDouble>(
-                parameterization),
-            py::cast<
-                IrisParameterizationFunction::ParameterizationFunctionAutodiff>(
-                parameterization),
-            /* parameterization_is_threadsafe = */ false,
-            parameterization_dimension);
-      }),
+      .def(
+          "__init__",
+          [](IrisParameterizationFunction* self,
+              const py::callable& parameterization,
+              int parameterization_dimension) {
+            new (self) IrisParameterizationFunction(
+                py::cast<IrisParameterizationFunction::
+                        ParameterizationFunctionDouble>(parameterization),
+                py::cast<IrisParameterizationFunction::
+                        ParameterizationFunctionAutodiff>(parameterization),
+                /* parameterization_is_threadsafe = */ false,
+                parameterization_dimension);
+          },
           py::arg("parameterization"), py::arg("dimension"),
           parameterization_function_docstring.c_str())
       .def(py::init<const Eigen::VectorX<symbolic::Expression>&,

--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -66,11 +66,13 @@ auto RegisterBinding(py::handle* scope) {
   class_<B> binding_cls(*scope, pyname.c_str());
   AddTemplateClass(*scope, "Binding", binding_cls, GetPyParam<C>());
   binding_cls  // BR
-      .def(py::init([](C* c, const VectorXDecisionVariable& v) {
-        // Maintain python wrapper to avoid hazards like #20131.
-        py::object c_py = py::cast(c);
-        return Binding(make_shared_ptr_from_py_object<C>(c_py), v);
-      }),
+      .def(
+          "__init__",
+          [](B* self, C* c, const VectorXDecisionVariable& v) {
+            // Maintain python wrapper to avoid hazards like #20131.
+            py::object c_py = py::cast(c);
+            new (self) Binding(make_shared_ptr_from_py_object<C>(c_py), v);
+          },
           py::arg("c"), py::arg("v"), cls_doc.ctor.doc)
       .def("evaluator", &B::evaluator, cls_doc.evaluator.doc)
       .def("variables", &B::variables, cls_doc.variables.doc)
@@ -101,14 +103,14 @@ void DefBindingCastConstructor(PyClass* cls) {
   static_assert(std::is_same_v<Binding<C>, typename PyClass::Type>,
       "Bound type must be Binding<C>");
   (*cls)  // BR
-      .def(py::init([](py::object binding) {
+      .def("__init__", [](Binding<C>* self, py::object binding) {
         // Define a type-erased downcast to mirror the implicit
         // "downcast-ability" of Binding<> types.
-        return std::make_unique<Binding<C>>(
+        new (self) Binding<C>(
             // Maintain python wrapper to avoid hazards like #20131.
             make_shared_ptr_from_py_object<C>(binding.attr("evaluator")()),
             py::cast<VectorXDecisionVariable>(binding.attr("variables")()));
-      }));
+      });
 }
 
 class StubEvaluatorBase : public EvaluatorBase {

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -235,7 +235,9 @@ void BindSolverInterface(py::module_ m) {
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
   class_<SolverInterface, PySolverInterface>(
       m, "SolverInterface", doc.SolverInterface.doc)
-      .def(py::init([]() { return std::make_unique<PySolverInterface>(); }),
+      .def(
+          "__init__",
+          [](SolverInterface* self) { new (self) PySolverInterface(); },
           doc.SolverInterface.ctor.doc)
       // The following bindings are present to allow Python to call C++
       // implementations of this interface.

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -263,11 +263,14 @@ void DoScalarIndependentDefinitions(py::module_ m) {
     using Class = ValueProducer;
     constexpr auto& cls_doc = doc.ValueProducer;
     class_<Class>(m, "ValueProducer", cls_doc.doc)
-        .def(py::init([](py::callable allocate,
-                          std::function<void(py::object, py::object)> calc) {
-          return Class(MakeCppCompatibleAllocateCallback(std::move(allocate)),
-              MakeCppCompatibleCalcCallback(std::move(calc)));
-        }),
+        .def(
+            "__init__",
+            [](Class* self, py::callable allocate,
+                std::function<void(py::object, py::object)> calc) {
+              new (self)
+                  Class(MakeCppCompatibleAllocateCallback(std::move(allocate)),
+                      MakeCppCompatibleCalcCallback(std::move(calc)));
+            },
             py::arg("allocate"), py::arg("calc"), cls_doc.ctor.doc_overload_5d)
         .def_static("NoopCalc", &Class::NoopCalc, cls_doc.NoopCalc.doc);
   }
@@ -572,46 +575,53 @@ void DefineEventAndEventSubclasses(py::module_ m) {
     using SystemCallback = std::function<std::optional<EventStatus>(
         const System<T>&, const Context<T>&, const PublishEvent<T>&)>;
     cls  // BR
-        .def(py::init(WrapCallbacks([](const Callback& callback) {
-          return std::make_unique<PublishEvent<T>>(
-              [callback](const System<T>&, const Context<T>& context,
-                  const PublishEvent<T>& event) {
-                return callback(context, event)
-                    .value_or(EventStatus::Succeeded());
-              });
-        })),
+        .def("__init__",
+            WrapCallbacks([](PublishEvent<T>* self, const Callback& callback) {
+              new (self) PublishEvent<T>(
+                  [callback](const System<T>&, const Context<T>& context,
+                      const PublishEvent<T>& event) {
+                    return callback(context, event)
+                        .value_or(EventStatus::Succeeded());
+                  });
+            }),
             py::arg("callback"),
             "Constructs a PublishEvent with the given callback function.")
-        .def(py::init(WrapCallbacks([](const SystemCallback& system_callback) {
-          return std::make_unique<PublishEvent<T>>(
-              [system_callback](const System<T>& system,
-                  const Context<T>& context, const PublishEvent<T>& event) {
-                return system_callback(system, context, event)
-                    .value_or(EventStatus::Succeeded());
-              });
-        })),
+        .def("__init__",
+            WrapCallbacks([](PublishEvent<T>* self,
+                              const SystemCallback& system_callback) {
+              new (self) PublishEvent<T>(
+                  [system_callback](const System<T>& system,
+                      const Context<T>& context, const PublishEvent<T>& event) {
+                    return system_callback(system, context, event)
+                        .value_or(EventStatus::Succeeded());
+                  });
+            }),
             py::arg("system_callback"),
             "Constructs a PublishEvent with the given callback function.")
-        .def(py::init(WrapCallbacks(
-                 [](const TriggerType& trigger_type, const Callback& callback) {
-                   return std::make_unique<PublishEvent<T>>(trigger_type,
-                       [callback](const System<T>&, const Context<T>& context,
-                           const PublishEvent<T>& event) {
-                         return callback(context, event)
-                             .value_or(EventStatus::Succeeded());
-                       });
-                 })),
+        .def("__init__",
+            WrapCallbacks(
+                [](PublishEvent<T>* self, const TriggerType& trigger_type,
+                    const Callback& callback) {
+                  new (self) PublishEvent<T>(trigger_type,
+                      [callback](const System<T>&, const Context<T>& context,
+                          const PublishEvent<T>& event) {
+                        return callback(context, event)
+                            .value_or(EventStatus::Succeeded());
+                      });
+                }),
             py::arg("trigger_type"), py::arg("callback"),
             "Users should not be calling these")
-        .def(py::init(WrapCallbacks([](const TriggerType& trigger_type,
-                                        const SystemCallback& system_callback) {
-          return std::make_unique<PublishEvent<T>>(trigger_type,
-              [system_callback](const System<T>& system,
-                  const Context<T>& context, const PublishEvent<T>& event) {
-                return system_callback(system, context, event)
-                    .value_or(EventStatus::Succeeded());
-              });
-        })),
+        .def("__init__",
+            WrapCallbacks([](PublishEvent<T>* self,
+                              const TriggerType& trigger_type,
+                              const SystemCallback& system_callback) {
+              new (self) PublishEvent<T>(trigger_type,
+                  [system_callback](const System<T>& system,
+                      const Context<T>& context, const PublishEvent<T>& event) {
+                    return system_callback(system, context, event)
+                        .value_or(EventStatus::Succeeded());
+                  });
+            }),
             py::arg("trigger_type"), py::arg("system_callback"),
             "Users should not be calling these");
   }
@@ -635,26 +645,32 @@ void DefineEventAndEventSubclasses(py::module_ m) {
         std::function<std::optional<EventStatus>(const System<T>&,
             const Context<T>&, const UnrestrictedUpdateEvent<T>&, State<T>*)>;
     cls  // BR
-        .def(py::init(WrapCallbacks([](const Callback& callback) {
-          return std::make_unique<UnrestrictedUpdateEvent<T>>(
-              [callback](const System<T>&, const Context<T>& context,
-                  const UnrestrictedUpdateEvent<T>& event, State<T>* state) {
-                return callback(context, event, state)
-                    .value_or(EventStatus::Succeeded());
-              });
-        })),
+        .def("__init__",
+            WrapCallbacks(
+                [](UnrestrictedUpdateEvent<T>* self, const Callback& callback) {
+                  new (self) UnrestrictedUpdateEvent<T>(
+                      [callback](const System<T>&, const Context<T>& context,
+                          const UnrestrictedUpdateEvent<T>& event,
+                          State<T>* state) {
+                        return callback(context, event, state)
+                            .value_or(EventStatus::Succeeded());
+                      });
+                }),
             py::arg("callback"),
             "Constructs an UnrestrictedUpdateEvent with the given callback "
             "function.")
-        .def(py::init(WrapCallbacks([](const SystemCallback& system_callback) {
-          return std::make_unique<UnrestrictedUpdateEvent<T>>(
-              [system_callback](const System<T>& system,
-                  const Context<T>& context,
-                  const UnrestrictedUpdateEvent<T>& event, State<T>* state) {
-                return system_callback(system, context, event, state)
-                    .value_or(EventStatus::Succeeded());
-              });
-        })),
+        .def("__init__",
+            WrapCallbacks([](UnrestrictedUpdateEvent<T>* self,
+                              const SystemCallback& system_callback) {
+              new (self) UnrestrictedUpdateEvent<T>(
+                  [system_callback](const System<T>& system,
+                      const Context<T>& context,
+                      const UnrestrictedUpdateEvent<T>& event,
+                      State<T>* state) {
+                    return system_callback(system, context, event, state)
+                        .value_or(EventStatus::Succeeded());
+                  });
+            }),
             py::arg("system_callback"),
             "Constructs an UnrestrictedUpdateEvent with the given callback "
             "function.");

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -1161,13 +1161,9 @@ Note: The above is for the C++ documentation. For Python, use
           LeafSystem<T>>(
           m, "VectorSystem", GetPyParam<T>(), doc.VectorSystem.doc);
       cls  // BR
-          .def(py::init([](int input_size, int output_size,
-                            std::optional<bool> direct_feedthrough) {
-            return new PyVectorSystem(
-                input_size, output_size, direct_feedthrough);
-          }),
-              py::arg("input_size"), py::arg("output_size"),
-              py::arg("direct_feedthrough"), doc.VectorSystem.ctor.doc_3args);
+          .def(py::init<int, int, std::optional<bool>>(), py::arg("input_size"),
+              py::arg("output_size"), py::arg("direct_feedthrough"),
+              doc.VectorSystem.ctor.doc_3args);
     }
   }
 

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -137,11 +137,9 @@ PYDRAKE_MODULE(lcm, m) {
     constexpr auto& cls_doc = doc.SerializerInterface;
     class_<Class, PySerializerInterface, std::shared_ptr<Class>> cls(
         m, "SerializerInterface");
-    cls  // BR
-         // Adding a constructor permits implementing this interface in Python.
-        .def(py::init(
-                 []() { return std::make_unique<PySerializerInterface>(); }),
-            cls_doc.ctor.doc);
+    cls
+        // Adding a constructor permits implementing this interface in Python.
+        .def(py::init<>(), cls_doc.ctor.doc);
     // The following bindings are present to allow Python to call C++
     // implementations of this interface. Python implementations of the
     // interface will call the trampoline implementation methods above.


### PR DESCRIPTION
Respell the remaining py::init(...) factory-lambda constructors to use placement-new (or the standard py::init<Args...> overload, where possible). This is a follow-up to 576490c5 for some call sites where the right answer was not immediately obvious at the time.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24742)
<!-- Reviewable:end -->
