### PR TITLE
[pydrake] Avoid py::init<...> vs initializer_list confusion

### DIFF
--- a/bindings/pydrake/planning/planning_py_dof_mask.cc
+++ b/bindings/pydrake/planning/planning_py_dof_mask.cc
@@ -23,8 +23,15 @@ void DefinePlanningDofMask(py::module_ m) {
     constexpr auto& cls_doc = doc.DofMask;
     class_<Class>(m, "DofMask", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc_default)
-        .def(py::init<int, bool>(), py::arg("size"), py::arg("value"),
-            cls_doc.ctor.doc_by_size)
+        .def(
+            "__init__",
+            // N.B. We can't use the simple py::init<int, bool> sugar here,
+            // because nanobind calls the std::initializer_list overload in
+            // that case (converting the `int` to a `bool`).
+            [](Class* self, int size, bool value) {
+              new (self) Class(size, value);
+            },
+            py::arg("size"), py::arg("value"), cls_doc.ctor.doc_by_size)
         .def(py::init<std::vector<bool>>(), py::arg("values"),
             cls_doc.ctor.doc_vector_bool)
         .def_static("MakeFromModel",

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -80,7 +80,13 @@ void DoScalarDependentDefinitions(py::module_ m) {
       .def(py::init<VectorX<T>>(), py::arg("data"),
           doc.BasicVector.ctor.doc_1args_vec)
       .def(
-          py::init<int>(), py::arg("size"), doc.BasicVector.ctor.doc_1args_size)
+          "__init__",
+          [](BasicVector<T>* self, int size) {
+            // N.B. We can't use the simple py::init<int> sugar here, because
+            // nanobind calls the std::initializer_list overload in that case.
+            new (self) BasicVector<T>(size);
+          },
+          py::arg("size"), doc.BasicVector.ctor.doc_1args_size)
       .def(
           "set_value",
           [](BasicVector<T>* self, const Eigen::Ref<const VectorX<T>>& value) {


### PR DESCRIPTION
In nanobind, classes whose C++ constructors are overloaded to accept an initializer_list can have the wrong constructor overload chosen when using py::init<T1, T2, ...> -- binding the initializer_list instead of the specifically-typed constructor. Avoid this by writing out the C++ constructor call by hand instead of using the sugar.

In 64b0f13a we fixed a related problem; there we were able to solve it with template concepts, but in these cases that's not possible.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24743)
<!-- Reviewable:end -->
