### PR TITLE
[solvers] Allow floats for kPrintToConsole

### DIFF
--- a/solvers/solver_options.cc
+++ b/solvers/solver_options.cc
@@ -62,6 +62,14 @@ void SolverOptions::SetOption(CommonSolverOption key, OptionValue value) {
           return;
         }
       }
+      if (std::holds_alternative<double>(value)) {
+        const double double_value = std::get<double>(value);
+        if (double_value == 0.0 || double_value == 1.0) {
+          const int int_value = static_cast<int>(double_value);
+          options[kCommonKey][fmt::to_string(key)] = OptionValue{int_value};
+          return;
+        }
+      }
       throw std::runtime_error(fmt::format(
           "SolverOptions::SetOption({}) value must be 0 or 1, not {}.", key,
           internal::OptionValueToString(value)));

--- a/solvers/test/solver_options_test.cc
+++ b/solvers/test/solver_options_test.cc
@@ -159,6 +159,9 @@ GTEST_TEST(SolverOptionsTest, SetOptionError) {
       solver_options.SetOption(CommonSolverOption::kPrintToConsole, 2),
       ".*SetOption.*kPrintToConsole.*must be 0 or 1, not 2.");
   DRAKE_EXPECT_THROWS_MESSAGE(
+      solver_options.SetOption(CommonSolverOption::kPrintToConsole, 2.0),
+      ".*SetOption.*kPrintToConsole.*must be 0 or 1, not 2.0.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
       solver_options.SetOption(CommonSolverOption::kMaxThreads, 2.1),
       ".*SetOption.*kMaxThreads.*must be an int > 0, not 2.1.");
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -178,7 +181,8 @@ GTEST_TEST(SolverOptionsTest, Serialization) {
   dut.SetOption(id1, "some_int", 2);
   dut.SetOption(id2, "some_string", "foo");
   dut.SetOption(CommonSolverOption::kPrintFileName, "foo.txt");
-  dut.SetOption(CommonSolverOption::kPrintToConsole, 1);
+  // We'll pass kPrintToConsole as a float to check it's cast back to an int.
+  dut.SetOption(CommonSolverOption::kPrintToConsole, 1.0);
   dut.SetOption(CommonSolverOption::kStandaloneReproductionFileName, "bar.py");
   dut.SetOption(CommonSolverOption::kMaxThreads, 2);
 


### PR DESCRIPTION
The nanobind type caster from bool to OptionValue chooses double instead of int, because double comes first in the variant. Rather than change the caster, it's easier to accept the setting.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24750)
<!-- Reviewable:end -->
