### PR TITLE
Disable distance constraint in IK if stiffness is finite

### DIFF
--- a/bindings/generated_docstrings/multibody_inverse_kinematics.h
+++ b/bindings/generated_docstrings/multibody_inverse_kinematics.h
@@ -58,8 +58,11 @@ constraints for any locked joints (via Joint∷Lock()). Note that you
 must pass a valid ``plant_context`` to use joint locking.
 
 Adds constraints for coupler, distance, ball, and weld constraints.
-The distance constraint is implemented here as a hard kinematic
-constraint (i.e., d(q) == d₀), instead of a soft "spring" force.
+For a distance constraint with infinite stiffness, it is implemented
+here as a hard kinematic constraint (i.e., d(q) == d₀), instead of a
+soft "spring" force; if the distance constraint has a finite
+stiffness, then no kinematic constraint is imposed based on the
+distance constraint.
 
 See also:
     AddUnitQuaternionConstraintOnPlant() for the unit quaternion

--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
@@ -153,6 +153,11 @@ std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
   if (plant_context != nullptr) {
     for (const auto& [id, params] :
          plant_ref.GetDistanceConstraintParams(*plant_context)) {
+      // We only add the distance constraint if the stiffness is infinite (hence
+      // a hard constraint).
+      if (std::isfinite(params.stiffness())) {
+        continue;
+      }
       // d(q) == d₀.
       bindings
           .emplace_back(prog->AddConstraint(

--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.h
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.h
@@ -17,9 +17,11 @@ Adds joint limits constraints, unit quaternion constraints, and constraints for
 any locked joints (via Joint::Lock()). Note that you must pass a valid
 `plant_context` to use joint locking.
 
-Adds constraints for coupler, distance, ball, and weld constraints. The
-distance constraint is implemented here as a hard kinematic constraint (i.e.,
-d(q) == d₀), instead of a soft "spring" force.
+Adds constraints for coupler, distance, ball, and weld constraints. For a
+distance constraint with infinite stiffness, it is implemented here as a hard
+kinematic constraint (i.e., d(q) == d₀), instead of a soft "spring" force; if
+the distance constraint has a finite stiffness, then no kinematic constraint
+is imposed based on the distance constraint.
 
 @see AddUnitQuaternionConstraintOnPlant() for the unit quaternion constraints.
 

--- a/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
+++ b/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/inverse_kinematics/point_to_point_distance_constraint.h"
 #include "drake/multibody/inverse_kinematics/unit_quaternion_constraint.h"
 #include "drake/multibody/tree/prismatic_joint.h"
 #include "drake/multibody/tree/quaternion_floating_joint.h"
@@ -22,6 +23,8 @@ using Eigen::Vector3d;
 using Eigen::VectorXd;
 using math::RigidTransformd;
 using systems::Context;
+
+const double kInf = std::numeric_limits<double>::infinity();
 
 bool SnoptSolverUnavailable() {
   return !(solvers::SnoptSolver::is_available() &&
@@ -105,10 +108,34 @@ TEST_F(AddMultibodyPlantConstraintsTest, CouplerConstraint) {
   EXPECT_NO_THROW(AddMultibodyPlantConstraints(plant_, q, &prog));
 }
 
-TEST_F(AddMultibodyPlantConstraintsTest, DistanceConstraint) {
+TEST_F(AddMultibodyPlantConstraintsTest, DistanceConstraintInfiniteStiffness) {
   plant_->AddDistanceConstraint(*body_A_, Vector3d(0.0, 1.0, 0.0), *body_B_,
                                 Vector3d(0.0, 1.0, 0.0), 1.5);
   CheckConstraints();
+}
+
+TEST_F(AddMultibodyPlantConstraintsTest, DistanceConstraintFiniteStiffness) {
+  const Eigen::Vector3d p_AP(0.0, 1.0, 0.0);
+  const Eigen::Vector3d p_BQ(0.0, 1.0, 0.0);
+  const double distance = 1.5;
+
+  plant_->AddDistanceConstraint(*body_A_, p_AP, *body_B_, p_BQ, distance,
+                                /*stiffness = */ 100);
+  plant_->Finalize();
+  plant_context_ = plant_->CreateDefaultContext();
+  solvers::MathematicalProgram prog;
+  auto q = prog.NewContinuousVariables(plant_->num_positions());
+  auto constraints =
+      AddMultibodyPlantConstraints(plant_, q, &prog, plant_context_.get());
+  // Add a constraint that the distance between A and B is not `distance`. The
+  // IK should be feasible.
+  prog.AddConstraint(
+      std::make_shared<PointToPointDistanceConstraint>(
+          plant_.get(), body_A_->body_frame(), p_AP, body_B_->body_frame(),
+          p_BQ, distance + 0.1, kInf, plant_context_.get()),
+      q);
+  auto result = solvers::Solve(prog);
+  EXPECT_TRUE(result.is_success());
 }
 
 TEST_F(AddMultibodyPlantConstraintsTest, BallConstraint) {


### PR DESCRIPTION
When the stiffness in the distance constraint is infinite, then it means the distance constraint is hard, and we will impose the distance constraint in inverse kinematics; otherwise we ignore the distance constraint in IK.

Resolves #24747

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24752)
<!-- Reviewable:end -->
