### PR TITLE
[pydrake] Move pybind11/eval.h to common include

### DIFF
--- a/bindings/pydrake/common/cpp_param_pybind.cc
+++ b/bindings/pydrake/common/cpp_param_pybind.cc
@@ -1,7 +1,5 @@
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 
-#include "pybind11/eval.h"
-
 namespace drake {
 namespace pydrake {
 

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -1,8 +1,6 @@
 #include <memory>
 #include <string>
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/common.h"
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/autodiffutils/autodiffutils_py.h"

--- a/bindings/pydrake/common/schema_py.cc
+++ b/bindings/pydrake/common/schema_py.cc
@@ -2,8 +2,6 @@
 #include <string>
 #include <vector>
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/common_schema.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/serialize_pybind.h"

--- a/bindings/pydrake/common/test/cpp_param_test_util_py.cc
+++ b/bindings/pydrake/common/test/cpp_param_test_util_py.cc
@@ -6,8 +6,6 @@
 
 #include <string>
 
-#include "pybind11/eval.h"
-
 #include "drake/common/drake_assert.h"
 
 using std::string;

--- a/bindings/pydrake/common/test/cpp_template_test_util_py.cc
+++ b/bindings/pydrake/common/test/cpp_template_test_util_py.cc
@@ -8,8 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "pybind11/eval.h"
-
 #include "drake/common/nice_type_name.h"
 
 using std::string;

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -1,8 +1,6 @@
 #include <memory>
 #include <string>
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/common.h"
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/submodules_py.h"

--- a/bindings/pydrake/geometry/geometry_py.cc
+++ b/bindings/pydrake/geometry/geometry_py.cc
@@ -1,7 +1,5 @@
 #include "drake/bindings/pydrake/geometry/geometry_py.h"
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 
 namespace drake {

--- a/bindings/pydrake/multibody/benchmarks_py.cc
+++ b/bindings/pydrake/multibody/benchmarks_py.cc
@@ -1,5 +1,3 @@
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/multibody_benchmarks_acrobot.h"
 #include "drake/bindings/generated_docstrings/multibody_benchmarks_mass_damper_spring.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -6,8 +6,6 @@
 #include <string>
 #include <utility>
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/multibody_tree.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"

--- a/bindings/pydrake/multibody/tree_py_inertia.cc
+++ b/bindings/pydrake/multibody/tree_py_inertia.cc
@@ -1,7 +1,5 @@
 #include <utility>
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/multibody_tree.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -8,9 +8,9 @@
 // for specialization. Any pybind11 headers with `type_caster<>` specializations
 // must be included here (e.g., eigen.h, functional.h, numpy.h, stl.h) as well
 // as ADL headers (e.g., operators.h). Headers that are unused by pydrake
-// (e.g., complex.h) are omitted, as are headers that do not specialize anything
-// (e.g., eval.h).
+// (e.g., complex.h) are omitted.
 #include "pybind11/eigen.h"
+#include "pybind11/eval.h"
 #include "pybind11/functional.h"
 #include "pybind11/numpy.h"
 #include "pybind11/operators.h"

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -7,8 +7,6 @@
 #include <utility>
 #include <vector>
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/systems_framework.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -5,8 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/lcm.h"
 #include "drake/bindings/generated_docstrings/systems_lcm.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -5,8 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include "pybind11/eval.h"
-
 #include "drake/bindings/generated_docstrings/common_trajectories.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"


### PR DESCRIPTION
In nanobind, we need to guard this include with warning suppressions, so it's convenient to have it in one place.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24753)
<!-- Reviewable:end -->
