### PR TITLE
[pydrake] Mark all enums arithmetic by default

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -264,13 +264,13 @@ void InitLowLevelModules(py::module_ m) {
 
   ExecuteExtraPythonCode(m, true);
 
-  py::enum_<drake::ToleranceType>(m, "ToleranceType", doc.ToleranceType.doc)
+  enum_<drake::ToleranceType>(m, "ToleranceType", doc.ToleranceType.doc)
       .value("kAbsolute", drake::ToleranceType::kAbsolute,
           doc.ToleranceType.kAbsolute.doc)
       .value("kRelative", drake::ToleranceType::kRelative,
           doc.ToleranceType.kRelative.doc);
 
-  py::enum_<drake::RandomDistribution>(
+  enum_<drake::RandomDistribution>(
       m, "RandomDistribution", doc.RandomDistribution.doc)
       .value("kUniform", drake::RandomDistribution::kUniform,
           doc.RandomDistribution.kUniform.doc)

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -48,7 +48,7 @@ void DefineCollisionFilterScope(py::module_ m) {
   {
     using Class = CollisionFilterScope;
     constexpr auto& cls_doc = doc.CollisionFilterScope;
-    py::enum_<Class>(m, "CollisionFilterScope", cls_doc.doc)
+    enum_<Class>(m, "CollisionFilterScope", cls_doc.doc)
         .value("kAll", Class::kAll, cls_doc.kAll.doc)
         .value("kOmitDeformable", Class::kOmitDeformable,
             cls_doc.kOmitDeformable.doc);
@@ -457,7 +457,7 @@ void DefineRgba(py::module_ m) {
 void DefineRole(py::module_ m) {
   {
     constexpr auto& cls_doc = doc.Role;
-    py::enum_<Role>(m, "Role", py::is_arithmetic(), cls_doc.doc)
+    enum_<Role>(m, "Role", cls_doc.doc)
         .value("kUnassigned", Role::kUnassigned, cls_doc.kUnassigned.doc)
         .value("kProximity", Role::kProximity, cls_doc.kProximity.doc)
         .value("kIllustration", Role::kIllustration, cls_doc.kIllustration.doc)
@@ -469,7 +469,7 @@ void DefineRoleAssign(py::module_ m) {
   {
     constexpr auto& cls_doc = doc.RoleAssign;
     using Class = RoleAssign;
-    py::enum_<Class>(m, "RoleAssign", cls_doc.doc)
+    enum_<Class>(m, "RoleAssign", cls_doc.doc)
         .value("kNew", Class::kNew, cls_doc.kNew.doc)
         .value("kReplace", Class::kReplace, cls_doc.kReplace.doc);
   }

--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -57,7 +57,7 @@ constexpr auto& doc =
 
 // Definitions for cspace_separating_plane.h.
 void DefineCspaceSeparatingPlane(py::module_ m) {
-  py::enum_<SeparatingPlaneOrder>(
+  enum_<SeparatingPlaneOrder>(
       m, "SeparatingPlaneOrder", doc.SeparatingPlaneOrder.doc)
       .value("kAffine", SeparatingPlaneOrder::kAffine,
           doc.SeparatingPlaneOrder.kAffine.doc);
@@ -828,7 +828,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
 
     // Transcription
     constexpr auto& enum_doc = doc.GraphOfConvexSets.Transcription;
-    py::enum_<GraphOfConvexSets::Transcription> enum_py(
+    enum_<GraphOfConvexSets::Transcription> enum_py(
         graph_of_convex_sets, "Transcription", enum_doc.doc);
     enum_py  // BR
         .value(
@@ -1186,12 +1186,11 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
 // Definitions for c_iris_collision_geometry.h.
 void DefineCIrisCollisionGeometry(py::module_ m) {
   {
-    py::enum_<PlaneSide>(m, "PlaneSide", doc.PlaneSide.doc)
+    enum_<PlaneSide>(m, "PlaneSide", doc.PlaneSide.doc)
         .value("kPositive", PlaneSide::kPositive)
         .value("kNegative", PlaneSide::kNegative);
 
-    py::enum_<CIrisGeometryType>(
-        m, "CIrisGeometryType", doc.CIrisGeometryType.doc)
+    enum_<CIrisGeometryType>(m, "CIrisGeometryType", doc.CIrisGeometryType.doc)
         .value("kPolytope", CIrisGeometryType::kPolytope,
             doc.CIrisGeometryType.kPolytope.doc)
         .value("kSphere", CIrisGeometryType::kSphere,
@@ -1361,7 +1360,7 @@ void DefineCspaceFreePolytopeAndRelated(py::module_ m) {
             &Class::FindSeparationCertificateGivenPolytopeOptions::
                 ignore_redundant_C);
 
-    py::enum_<Class::EllipsoidMarginCost>(cspace_free_polytope_cls,
+    enum_<Class::EllipsoidMarginCost>(cspace_free_polytope_cls,
         "EllipsoidMarginCost", cls_doc.EllipsoidMarginCost.doc)
         .value("kSum", Class::EllipsoidMarginCost::kSum)
         .value("kGeometricMean", Class::EllipsoidMarginCost::kGeometricMean);

--- a/bindings/pydrake/geometry/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry/geometry_py_scene_graph.cc
@@ -43,7 +43,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
     using Class = HydroelasticContactRepresentation;
     constexpr auto& cls_doc =
         doc_query_results.HydroelasticContactRepresentation;
-    py::enum_<Class>(m, "HydroelasticContactRepresentation", cls_doc.doc)
+    enum_<Class>(m, "HydroelasticContactRepresentation", cls_doc.doc)
         .value("kTriangle", Class::kTriangle, cls_doc.kTriangle.doc)
         .value("kPolygon", Class::kPolygon, cls_doc.kPolygon.doc);
   }

--- a/bindings/pydrake/geometry/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry/geometry_py_visualizers.cc
@@ -214,7 +214,7 @@ void DefineMeshcat(py::module_ m) {
 
     // Meshcat::SideOfFaceToRender enumeration
     constexpr auto& side_doc = doc.Meshcat.SideOfFaceToRender;
-    py::enum_<Meshcat::SideOfFaceToRender>(
+    enum_<Meshcat::SideOfFaceToRender>(
         meshcat, "SideOfFaceToRender", side_doc.doc)
         .value("kFrontSide", Meshcat::SideOfFaceToRender::kFrontSide,
             side_doc.kFrontSide.doc)
@@ -475,7 +475,7 @@ void DefineMeshcatAnimation(py::module_ m) {
 
     // MeshcatAnimation::LoopMode enumeration
     constexpr auto& loop_doc = doc.MeshcatAnimation.LoopMode;
-    py::enum_<MeshcatAnimation::LoopMode>(cls, "LoopMode", loop_doc.doc)
+    enum_<MeshcatAnimation::LoopMode>(cls, "LoopMode", loop_doc.doc)
         .value("kLoopOnce", MeshcatAnimation::LoopMode::kLoopOnce,
             loop_doc.kLoopOnce.doc)
         .value("kLoopRepeat", MeshcatAnimation::LoopMode::kLoopRepeat,

--- a/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
+++ b/bindings/pydrake/manipulation/manipulation_py_kuka_iiwa.cc
@@ -36,7 +36,7 @@ void DefineManipulationKukaIiwa(py::module_ m) {
   {
     using Class = IiwaControlMode;
     constexpr auto& cls_doc = doc.IiwaControlMode;
-    py::enum_<Class>(m, "IiwaControlMode", cls_doc.doc)
+    enum_<Class>(m, "IiwaControlMode", cls_doc.doc)
         .value("kPositionOnly", Class::kPositionOnly, cls_doc.kPositionOnly.doc)
         .value("kTorqueOnly", Class::kTorqueOnly, cls_doc.kTorqueOnly.doc)
         .value("kPositionAndTorque", Class::kPositionAndTorque,

--- a/bindings/pydrake/math/math_py_monolith.cc
+++ b/bindings/pydrake/math/math_py_monolith.cc
@@ -562,7 +562,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = KnotVectorType;
     constexpr auto& cls_doc = doc.KnotVectorType;
-    py::enum_<Class>(m, "KnotVectorType", py::is_arithmetic(), cls_doc.doc)
+    enum_<Class>(m, "KnotVectorType", cls_doc.doc)
         .value("kUniform", Class::kUniform, cls_doc.kUniform.doc)
         .value("kClampedUniform", Class::kClampedUniform,
             cls_doc.kClampedUniform.doc);
@@ -661,7 +661,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = NumericalGradientMethod;
     constexpr auto& cls_doc = doc.NumericalGradientMethod;
-    py::enum_<Class>(m, "NumericalGradientMethod", cls_doc.doc)
+    enum_<Class>(m, "NumericalGradientMethod", cls_doc.doc)
         .value("kForward", Class::kForward, cls_doc.kForward.doc)
         .value("kBackward", Class::kBackward, cls_doc.kBackward.doc)
         .value("kCentral", Class::kCentral, cls_doc.kCentral.doc);

--- a/bindings/pydrake/multibody/fem_py.cc
+++ b/bindings/pydrake/multibody/fem_py.cc
@@ -22,7 +22,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = MaterialModel;
     constexpr auto& cls_doc = doc.MaterialModel;
-    py::enum_<Class>(m, "MaterialModel", cls_doc.doc)
+    enum_<Class>(m, "MaterialModel", cls_doc.doc)
         .value("kLinearCorotated", Class::kLinearCorotated,
             cls_doc.kLinearCorotated.doc)
         .value("kCorotated", Class::kCorotated, cls_doc.kCorotated.doc)
@@ -33,7 +33,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = drake::multibody::ForceDensityType;
     constexpr auto& cls_doc = doc_multibody.ForceDensityType;
-    py::enum_<Class>(m, "ForceDensityType", cls_doc.doc)
+    enum_<Class>(m, "ForceDensityType", cls_doc.doc)
         .value("kPerCurrentVolume", Class::kPerCurrentVolume,
             cls_doc.kPerCurrentVolume.doc)
         .value("kPerReferenceVolume", Class::kPerReferenceVolume,

--- a/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py_differential.cc
@@ -32,7 +32,7 @@ void DefineDifferentialIkLegacy(py::module_ m) {
 
   py::module_::import_("pydrake.systems.framework");
 
-  py::enum_<DifferentialInverseKinematicsStatus>(m,
+  enum_<DifferentialInverseKinematicsStatus>(m,
       "DifferentialInverseKinematicsStatus",
       doc.DifferentialInverseKinematicsStatus.doc)
       .value("kSolutionFound",

--- a/bindings/pydrake/multibody/optimization_py.cc
+++ b/bindings/pydrake/multibody/optimization_py.cc
@@ -167,7 +167,7 @@ PYDRAKE_MODULE(optimization, m) {
   {
     using Class = ToppraDiscretization;
     constexpr auto& cls_doc = doc.ToppraDiscretization;
-    py::enum_<Class>(m, "ToppraDiscretization", cls_doc.doc)
+    enum_<Class>(m, "ToppraDiscretization", cls_doc.doc)
         .value("kCollocation", Class::kCollocation, cls_doc.kCollocation.doc)
         .value("kInterpolation", Class::kInterpolation,
             cls_doc.kInterpolation.doc);

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1691,7 +1691,7 @@ PYDRAKE_MODULE(plant, m) {
   {
     using Class = ContactModel;
     constexpr auto& cls_doc = doc.ContactModel;
-    py::enum_<Class>(m, "ContactModel", cls_doc.doc)
+    enum_<Class>(m, "ContactModel", cls_doc.doc)
         .value("kHydroelastic", Class::kHydroelastic, cls_doc.kHydroelastic.doc)
         .value("kPoint", Class::kPoint, cls_doc.kPoint.doc)
         .value("kHydroelasticWithFallback", Class::kHydroelasticWithFallback,
@@ -1711,7 +1711,7 @@ PYDRAKE_MODULE(plant, m) {
     // uses below slightly confusing on first glance.
     using Class = DiscreteContactSolver;
     constexpr auto& cls_doc = doc.DiscreteContactSolver;
-    py::enum_<Class> cls(m, "DiscreteContactSolver", cls_doc.doc_deprecated);
+    enum_<Class> cls(m, "DiscreteContactSolver", cls_doc.doc_deprecated);
     // Remove on 2026-09-01 per TAMSI deprecation.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -1727,8 +1727,7 @@ PYDRAKE_MODULE(plant, m) {
     // uses below slightly confusing on first glance.
     using Class = DiscreteContactApproximation;
     constexpr auto& cls_doc = doc.DiscreteContactApproximation;
-    py::enum_<Class> cls(
-        m, "DiscreteContactApproximation", cls_doc.doc_deprecated);
+    enum_<Class> cls(m, "DiscreteContactApproximation", cls_doc.doc_deprecated);
     // Remove on 2026-09-01 per TAMSI deprecation.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -1746,7 +1745,7 @@ PYDRAKE_MODULE(plant, m) {
     using Class = BaseBodyJointType;
     constexpr auto& tree_doc = pydrake_doc_multibody_tree.drake.multibody;
     constexpr auto& cls_doc = tree_doc.BaseBodyJointType;
-    py::enum_<Class> cls(m, "BaseBodyJointType", cls_doc.doc);
+    enum_<Class> cls(m, "BaseBodyJointType", cls_doc.doc);
     cls.value("kQuaternionFloatingJoint", Class::kQuaternionFloatingJoint,
            cls_doc.kQuaternionFloatingJoint.doc)
         .value("kRpyFloatingJoint", Class::kRpyFloatingJoint,

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -141,7 +141,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Enum = JacobianWrtVariable;
     constexpr auto& enum_doc = doc.JacobianWrtVariable;
-    py::enum_<Enum> enum_py(m, "JacobianWrtVariable", enum_doc.doc);
+    enum_<Enum> enum_py(m, "JacobianWrtVariable", enum_doc.doc);
     enum_py  // BR
         .value("kQDot", Enum::kQDot, enum_doc.kQDot.doc)
         .value("kV", Enum::kV, enum_doc.kV.doc);

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -24,7 +24,7 @@ void init_pc_flags(py::module_ m) {
   {
     using Class = BaseField;
     constexpr auto& cls_doc = doc.BaseField;
-    py::enum_<Class>(m, "BaseField", py::is_arithmetic(), cls_doc.doc)
+    enum_<Class>(m, "BaseField", cls_doc.doc)
         .value("kNone", Class::kNone, cls_doc.kNone.doc)
         .value("kXYZs", Class::kXYZs, cls_doc.kXYZs.doc)
         .value("kNormals", Class::kNormals, cls_doc.kNormals.doc)

--- a/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
+++ b/bindings/pydrake/planning/planning_py_collision_checker_interface_types.cc
@@ -169,7 +169,7 @@ void DefinePlanningCollisionCheckerInterfaceTypes(py::module_ m) {
   {
     using Class = RobotCollisionType;
     constexpr auto& cls_doc = doc.RobotCollisionType;
-    py::enum_<Class> cls(m, "RobotCollisionType", cls_doc.doc);
+    enum_<Class> cls(m, "RobotCollisionType", cls_doc.doc);
     cls  // BR
         .value("kNoCollision", Class::kNoCollision, cls_doc.kNoCollision.doc)
         .value("kEnvironmentCollision", Class::kEnvironmentCollision,

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -46,6 +46,17 @@ using py_rvp = py::rv_policy;
 // This alias helps ease Drake's transition to nanobind.
 using py::class_;
 
+/// A drake-specific wrapper for py::enum_ that adds is_arithmetic by default.
+/// This matches normal C++ semantics of being able to use the enum as an int.
+template <typename T>
+class __attribute__((visibility("hidden"))) enum_ : public py::enum_<T> {
+ public:
+  template <typename... Extra>
+  enum_(py::handle scope, const char* name, const Extra&... extra)
+      : py::enum_<T>(scope, name, py::is_arithmetic(),
+            std::forward<decltype(extra)>(extra)...) {}
+};
+
 // Implementation for `overload_cast_explicit`. We must use this structure so
 // that we can constrain what is inferred. Otherwise, the ambiguity confuses
 // the compiler.

--- a/bindings/pydrake/solvers/solvers_py_evaluators.cc
+++ b/bindings/pydrake/solvers/solvers_py_evaluators.cc
@@ -300,7 +300,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       lorentz_cone_cls(
           m, "LorentzConeConstraint", doc.LorentzConeConstraint.doc);
 
-  py::enum_<LorentzConeConstraint::EvalType>(
+  enum_<LorentzConeConstraint::EvalType>(
       lorentz_cone_cls, "EvalType", doc.LorentzConeConstraint.EvalType.doc)
       .value("kConvex", LorentzConeConstraint::EvalType::kConvex,
           doc.LorentzConeConstraint.EvalType.kConvex.doc)
@@ -382,7 +382,7 @@ void BindEvaluatorsAndBindings(py::module_ m) {
       quadratic_constraint_cls(
           m, "QuadraticConstraint", doc.QuadraticConstraint.doc);
 
-  py::enum_<QuadraticConstraint::HessianType>(quadratic_constraint_cls,
+  enum_<QuadraticConstraint::HessianType>(quadratic_constraint_cls,
       "HessianType", doc.QuadraticConstraint.HessianType.doc)
       .value("kPositiveSemidefinite",
           QuadraticConstraint::HessianType::kPositiveSemidefinite,

--- a/bindings/pydrake/solvers/solvers_py_ids.cc
+++ b/bindings/pydrake/solvers/solvers_py_ids.cc
@@ -32,7 +32,7 @@ void DefineSolversIds(py::module_ m) {
           },
           py::is_operator());
 
-  py::enum_<SolverType> solver_type(m, "SolverType", doc.SolverType.doc);
+  enum_<SolverType> solver_type(m, "SolverType", doc.SolverType.doc);
   solver_type  // BR
       .value("kClp", SolverType::kClp, doc.SolverType.kClp.doc)
       .value("kCsdp", SolverType::kCsdp, doc.SolverType.kCsdp.doc)

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -435,7 +435,7 @@ void BindMathematicalProgram(py::module_ m) {
   prog_cls.def(py::init<>(), doc.MathematicalProgram.ctor.doc);
   DefClone(&prog_cls);
 
-  py::enum_<MathematicalProgram::NonnegativePolynomial>(prog_cls,
+  enum_<MathematicalProgram::NonnegativePolynomial>(prog_cls,
       "NonnegativePolynomial",
       doc.MathematicalProgram.NonnegativePolynomial.doc)
       .value("kSos", MathematicalProgram::NonnegativePolynomial::kSos,
@@ -1510,7 +1510,7 @@ for every column of ``prog_var_vals``. )""")
 
 void BindSolutionResult(py::module_ m) {
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
-  py::enum_<SolutionResult> solution_result_enum(
+  enum_<SolutionResult> solution_result_enum(
       m, "SolutionResult", doc.SolutionResult.doc);
   solution_result_enum
       .value("kSolutionFound", SolutionResult::kSolutionFound,

--- a/bindings/pydrake/solvers/solvers_py_mixed_integer_optimization_util.cc
+++ b/bindings/pydrake/solvers/solvers_py_mixed_integer_optimization_util.cc
@@ -39,7 +39,7 @@ void DefineSolversMixedIntegerOptimizationUtil(py::module_ m) {
       doc.AddLogarithmicSos1Constraint.doc_2args);
 
   {
-    py::enum_<IntervalBinning>(m, "IntervalBinning", doc.IntervalBinning.doc)
+    enum_<IntervalBinning>(m, "IntervalBinning", doc.IntervalBinning.doc)
         .value("kLogarithmic", IntervalBinning::kLogarithmic)
         .value("kLinear", IntervalBinning::kLinear);
   }

--- a/bindings/pydrake/solvers/solvers_py_mixed_integer_rotation_constraint.cc
+++ b/bindings/pydrake/solvers/solvers_py_mixed_integer_rotation_constraint.cc
@@ -30,7 +30,7 @@ void DefineSolversMixedIntegerRotationConstraint(py::module_ m) {
 
     using Enum = Class::Approach;
     constexpr auto& enum_doc = cls_doc.Approach;
-    py::enum_<Class::Approach>(cls, "Approach", enum_doc.doc)
+    enum_<Class::Approach>(cls, "Approach", enum_doc.doc)
         .value("kBoxSphereIntersection", Enum::kBoxSphereIntersection,
             enum_doc.kBoxSphereIntersection.doc)
         .value("kBilinearMcCormick", Enum::kBilinearMcCormick,

--- a/bindings/pydrake/solvers/solvers_py_options.cc
+++ b/bindings/pydrake/solvers/solvers_py_options.cc
@@ -19,7 +19,7 @@ void DefineSolversOptions(py::module_ m) {
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
   {
-    py::enum_<CommonSolverOption>(
+    enum_<CommonSolverOption>(
         m, "CommonSolverOption", doc.CommonSolverOption.doc)
         .value("kPrintFileName", CommonSolverOption::kPrintFileName,
             doc.CommonSolverOption.kPrintFileName.doc)

--- a/bindings/pydrake/solvers/solvers_py_program_attribute.cc
+++ b/bindings/pydrake/solvers/solvers_py_program_attribute.cc
@@ -11,7 +11,7 @@ void DefineProgramAttribute(py::module_ m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
-  py::enum_<ProgramAttribute>(m, "ProgramAttribute", doc.ProgramAttribute.doc)
+  enum_<ProgramAttribute>(m, "ProgramAttribute", doc.ProgramAttribute.doc)
       .value("kGenericCost", ProgramAttribute::kGenericCost,
           doc.ProgramAttribute.kGenericCost.doc)
       .value("kGenericConstraint", ProgramAttribute::kGenericConstraint,
@@ -48,7 +48,7 @@ void DefineProgramAttribute(py::module_ m) {
       .value("kCallback", ProgramAttribute::kCallback,
           doc.ProgramAttribute.kCallback.doc);
 
-  py::enum_<ProgramType>(m, "ProgramType", doc.ProgramType.doc)
+  enum_<ProgramType>(m, "ProgramType", doc.ProgramType.doc)
       .value("kLP", ProgramType::kLP, doc.ProgramType.kLP.doc)
       .value("kQP", ProgramType::kQP, doc.ProgramType.kQP.doc)
       .value("kSOCP", ProgramType::kSOCP, doc.ProgramType.kSOCP.doc)

--- a/bindings/pydrake/solvers/solvers_py_sdpa_free_format.cc
+++ b/bindings/pydrake/solvers/solvers_py_sdpa_free_format.cc
@@ -12,7 +12,7 @@ void DefineSolversSdpaFreeFormat(py::module_ m) {
   using namespace drake::solvers;
   constexpr auto& doc = pydrake_doc_solvers.drake.solvers;
 
-  py::enum_<RemoveFreeVariableMethod>(
+  enum_<RemoveFreeVariableMethod>(
       m, "RemoveFreeVariableMethod", doc.RemoveFreeVariableMethod.doc)
       .value("kNullspace", RemoveFreeVariableMethod::kNullspace,
           doc.RemoveFreeVariableMethod.kNullspace.doc)

--- a/bindings/pydrake/symbolic/symbolic_py_monolith.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_monolith.cc
@@ -58,7 +58,7 @@ void DefineSymbolicMonolith(py::module_ m) {
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   class_<Variable> var_cls(m, "Variable", doc_expr.Variable.doc);
   constexpr auto& var_doc = doc_expr.Variable;
-  py::enum_<Variable::Type>(var_cls, "Type")
+  enum_<Variable::Type>(var_cls, "Type")
       .value(
           "CONTINUOUS", Variable::Type::CONTINUOUS, var_doc.Type.CONTINUOUS.doc)
       .value("INTEGER", Variable::Type::INTEGER, var_doc.Type.INTEGER.doc)
@@ -321,7 +321,7 @@ void DefineSymbolicMonolith(py::module_ m) {
 
   {
     constexpr auto& cls_doc = doc_expr.ExpressionKind;
-    py::enum_<ExpressionKind>(m, "ExpressionKind", cls_doc.doc)
+    enum_<ExpressionKind>(m, "ExpressionKind", cls_doc.doc)
         .value("Constant", ExpressionKind::Constant, cls_doc.Constant.doc)
         .value("Var", ExpressionKind::Var, cls_doc.Var.doc)
         .value("Add", ExpressionKind::Add, cls_doc.Add.doc)
@@ -562,7 +562,7 @@ void DefineSymbolicMonolith(py::module_ m) {
   {
     using Enum = SinCosSubstitutionType;
     constexpr auto& enum_doc = doc.SinCosSubstitutionType;
-    py::enum_<Enum> enum_py(m, "SinCosSubstitutionType", enum_doc.doc);
+    enum_<Enum> enum_py(m, "SinCosSubstitutionType", enum_doc.doc);
     enum_py  // BR
         .value("kAngle", Enum::kAngle, enum_doc.kAngle.doc)
         .value("kHalfAnglePreferSin", Enum::kHalfAnglePreferSin,
@@ -604,7 +604,7 @@ void DefineSymbolicMonolith(py::module_ m) {
 
   {
     constexpr auto& cls_doc = doc_expr.FormulaKind;
-    py::enum_<FormulaKind>(m, "FormulaKind", cls_doc.doc)
+    enum_<FormulaKind>(m, "FormulaKind", cls_doc.doc)
         // `True` and `False` are reserved keywords as of Python3.
         .value("False_", FormulaKind::False, cls_doc.False.doc)
         .value("True_", FormulaKind::True, cls_doc.True.doc)

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -72,7 +72,7 @@ PYDRAKE_MODULE(analysis, m) {
 
     using Enum = Class::ReturnReason;
     constexpr auto& enum_doc = cls_doc.ReturnReason;
-    py::enum_<Class::ReturnReason>(cls, "ReturnReason", enum_doc.doc)
+    enum_<Class::ReturnReason>(cls, "ReturnReason", enum_doc.doc)
         .value("kReachedBoundaryTime", Enum::kReachedBoundaryTime,
             enum_doc.kReachedBoundaryTime.doc)
         .value("kReachedTerminationCondition",

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -83,7 +83,7 @@ PYDRAKE_MODULE(controllers, m) {
     {
       using Nested = Class::InverseDynamicsMode;
       constexpr auto& nested_doc = cls_doc.InverseDynamicsMode;
-      py::enum_<Nested>(cls, "InverseDynamicsMode")
+      enum_<Nested>(cls, "InverseDynamicsMode")
           .value("kInverseDynamics", Nested::kInverseDynamics, nested_doc.doc)
           .value("kGravityCompensation", Nested::kGravityCompensation,
               nested_doc.kGravityCompensation.doc)

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -81,15 +81,15 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   }
   m.attr("kUseDefaultName") = kUseDefaultName;
 
-  py::enum_<PortDataType>(m, "PortDataType")
+  enum_<PortDataType>(m, "PortDataType")
       .value("kVectorValued", kVectorValued)
       .value("kAbstractValued", kAbstractValued);
 
-  py::enum_<InputPortSelection>(m, "InputPortSelection")
+  enum_<InputPortSelection>(m, "InputPortSelection")
       .value("kNoInput", InputPortSelection::kNoInput)
       .value("kUseFirstInputIfItExists",
           InputPortSelection::kUseFirstInputIfItExists);
-  py::enum_<OutputPortSelection>(m, "OutputPortSelection")
+  enum_<OutputPortSelection>(m, "OutputPortSelection")
       .value("kNoOutput", OutputPortSelection::kNoOutput)
       .value("kUseFirstOutputIfItExists",
           OutputPortSelection::kUseFirstOutputIfItExists);
@@ -138,7 +138,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
   {
     using Class = TriggerType;
     constexpr auto& cls_doc = doc.TriggerType;
-    py::enum_<TriggerType>(m, "TriggerType", cls_doc.doc)
+    enum_<TriggerType>(m, "TriggerType", cls_doc.doc)
         .value("kUnknown", Class::kUnknown, cls_doc.kUnknown.doc)
         .value("kInitialization", Class::kInitialization,
             cls_doc.kInitialization.doc)
@@ -149,7 +149,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
         .value("kWitness", Class::kWitness, cls_doc.kWitness.doc);
   }
 
-  py::enum_<WitnessFunctionDirection>(
+  enum_<WitnessFunctionDirection>(
       m, "WitnessFunctionDirection", doc.WitnessFunctionDirection.doc)
       .value("kNone", WitnessFunctionDirection::kNone,
           doc.WitnessFunctionDirection.kNone.doc)
@@ -180,7 +180,7 @@ void DoScalarIndependentDefinitions(py::module_ m) {
 
     using Enum = Class::Severity;
     constexpr auto& enum_doc = cls_doc.Severity;
-    py::enum_<Enum>(cls, "Severity", enum_doc.doc)
+    enum_<Enum>(cls, "Severity", enum_doc.doc)
         .value("kDidNothing", Enum::kDidNothing, enum_doc.kDidNothing.doc)
         .value("kSucceeded", Enum::kSucceeded, enum_doc.kSucceeded.doc)
         .value("kReachedTermination", Enum::kReachedTermination,

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -64,7 +64,7 @@ PYDRAKE_MODULE(primitives, m) {
   py::module_::import_("pydrake.systems.framework");
   py::module_::import_("pydrake.trajectories");
 
-  py::enum_<PerceptronActivationType>(
+  enum_<PerceptronActivationType>(
       m, "PerceptronActivationType", doc.PerceptronActivationType.doc)
       .value("kIdentity", PerceptronActivationType::kIdentity,
           doc.PerceptronActivationType.kIdentity.doc)

--- a/bindings/pydrake/systems/sensors_py_image.cc
+++ b/bindings/pydrake/systems/sensors_py_image.cc
@@ -23,7 +23,7 @@ void DefineSensorsImage(py::module_ m) {
   // functions as `__str__` in Python. The `enum.Enum` class already provides a
   // `__str__` that looks more Pythonic than our C++ `to_string`.
 
-  py::enum_<PixelFormat>(m, "PixelFormat")
+  enum_<PixelFormat>(m, "PixelFormat")
       .value("kRgb", PixelFormat::kRgb)
       .value("kBgr", PixelFormat::kBgr)
       .value("kRgba", PixelFormat::kRgba)
@@ -32,7 +32,7 @@ void DefineSensorsImage(py::module_ m) {
       .value("kDepth", PixelFormat::kDepth)
       .value("kLabel", PixelFormat::kLabel);
 
-  py::enum_<PixelScalar>(m, "PixelScalar")
+  enum_<PixelScalar>(m, "PixelScalar")
       .value("k8U", PixelScalar::k8U)
       .value("k16I", PixelScalar::k16I)
       .value("k16U", PixelScalar::k16U)
@@ -40,7 +40,7 @@ void DefineSensorsImage(py::module_ m) {
 
   {
     // Expose image types and their traits.
-    py::enum_<PixelType> pixel_type(m, "PixelType");
+    enum_<PixelType> pixel_type(m, "PixelType");
 
     // This uses the `type_visit` pattern for looping. See `type_pack_test.cc`
     // for more information on the pattern.

--- a/bindings/pydrake/systems/sensors_py_image_io.cc
+++ b/bindings/pydrake/systems/sensors_py_image_io.cc
@@ -22,7 +22,7 @@ void DefineSensorsImageIo(py::module_ m) {
   constexpr auto& doc = pydrake_doc_systems_sensors.drake.systems.sensors;
 
   {
-    py::enum_<ImageFileFormat>(m, "ImageFileFormat")
+    enum_<ImageFileFormat>(m, "ImageFileFormat")
         .value("kJpeg", ImageFileFormat::kJpeg)
         .value("kPng", ImageFileFormat::kPng)
         .value("kTiff", ImageFileFormat::kTiff);


### PR DESCRIPTION
In pybind11, enum conversion to an integer (`__int__`) is always enabled, but in nanobind it's gated by the `py::is_arithmetic` annotation. We'll enable `py::is_arithmetic` globally so that we don't lose integer conversion during the transition. In the past we'd only applied this annotation selectively to avoid providing possibly misleading operators, but given that C++ enums are always numeric, continuing the same idea in Python seems fine.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24754)
<!-- Reviewable:end -->
