### PR TITLE
[multibody] AddMultibodyPlantConstraints rejects null plant_context

### DIFF
--- a/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
+++ b/multibody/inverse_kinematics/add_multibody_plant_constraints.cc
@@ -150,7 +150,8 @@ std::vector<Binding<Constraint>> AddMultibodyPlantConstraints(
                         spec.joint0_index, spec.joint1_index));
   }
 
-  if (plant_context != nullptr) {
+  if (plant_ref.num_distance_constraints() > 0) {
+    DRAKE_THROW_UNLESS(plant_context != nullptr);
     for (const auto& [id, params] :
          plant_ref.GetDistanceConstraintParams(*plant_context)) {
       // d(q) == d₀.

--- a/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
+++ b/multibody/inverse_kinematics/test/add_multibody_plant_constraints_test.cc
@@ -82,6 +82,27 @@ class AddMultibodyPlantConstraintsTest : public ::testing::Test {
 
     prog.SetInitialGuessForAllVariables(qn);
     EXPECT_TRUE(prog.CheckSatisfiedAtInitialGuess(constraints, tol));
+
+    // Except for coupler constraints (and unit quaterion constraints),
+    // AddMultibodyPlantConstraints requires a non-null plant_context.
+    // Verify that a null plant_context throws if and only if the plant
+    // has constraints that require a context.
+    const int num_context_required_constraints =
+        plant_->num_constraints() - plant_->num_coupler_constraints();
+    solvers::MathematicalProgram no_context_prog;
+    auto no_context_q =
+        no_context_prog.NewContinuousVariables(plant_->num_positions());
+    auto add_constraints_no_context = [&]() {
+      return AddMultibodyPlantConstraints(plant_, no_context_q,
+                                          &no_context_prog,
+                                          /* plant_context = */ nullptr);
+    };
+    if (num_context_required_constraints > 0) {
+      EXPECT_THROW(add_constraints_no_context(), std::exception);
+    } else {
+      auto no_context_constraints = add_constraints_no_context();
+      EXPECT_EQ(no_context_constraints.size(), expected_num_constraints);
+    }
   }
 
  protected:


### PR DESCRIPTION
When the plant contains distance constraints, the plant_context was documented to be a required parameter, but this was not enforced. Our contract says that we must throw in this case.

Amends #22778.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24756)
<!-- Reviewable:end -->
