### PR TITLE
[pydrake] Respell ContactModel enum synonyms

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1691,17 +1691,15 @@ PYDRAKE_MODULE(plant, m) {
   {
     using Class = ContactModel;
     constexpr auto& cls_doc = doc.ContactModel;
-    py::enum_<Class>(m, "ContactModel", cls_doc.doc)
+    py::enum_<Class> cls(m, "ContactModel", cls_doc.doc);
+    cls  // BR
         .value("kHydroelastic", Class::kHydroelastic, cls_doc.kHydroelastic.doc)
         .value("kPoint", Class::kPoint, cls_doc.kPoint.doc)
         .value("kHydroelasticWithFallback", Class::kHydroelasticWithFallback,
-            cls_doc.kHydroelasticWithFallback.doc)
-        // Legacy alias. TODO(jwnimmer-tri) Deprecate this constant.
-        .value("kHydroelasticsOnly", Class::kHydroelasticsOnly,
-            cls_doc.kHydroelasticsOnly.doc)
-        // Legacy alias. TODO(jwnimmer-tri) Deprecate this constant.
-        .value("kPointContactOnly", Class::kPointContactOnly,
-            cls_doc.kPointContactOnly.doc);
+            cls_doc.kHydroelasticWithFallback.doc);
+    // Legacy aliases. TODO(jwnimmer-tri) Deprecate these constants.
+    cls.attr("kHydroelasticsOnly") = cls.attr("kHydroelastic");
+    cls.attr("kPointContactOnly") = cls.attr("kPoint");
   }
 
   {


### PR DESCRIPTION
For enums with duplicate names for the same values, we must declare them using attr assignment instead of redundant `value()` calls, because in nanobind the redundant calls result in distinct enum values that do not compare as `__eq__`.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24757)
<!-- Reviewable:end -->
