### PR TITLE
[install] Generate version.h header

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,6 +43,15 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+# Provides drake/version.h for downstream C++ code. The :drake_shared_library
+# target already offers this header; this target should be used by downstream
+# code that doesn't use the shared library.
+alias(
+    name = "version_hdrs",
+    actual = "//tools/install/libdrake:version_hdrs",
+    visibility = ["//visibility:public"],
+)
+
 # A manually-curated collection of most model files in Drake, so that we can
 # easily provide access to them for tools like //tools:model_visualizer.
 filegroup(

--- a/doc/doxygen_cxx/BUILD.bazel
+++ b/doc/doxygen_cxx/BUILD.bazel
@@ -52,6 +52,7 @@ filegroup(
         "//systems:doxygen_input",
         "//systems/framework:doxygen_input",
         "//tools/install/libdrake:libdrake_headers",
+        "//tools/install/libdrake:version.h",
         "//tutorials:doxygen_input",
     ],
 )

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -227,6 +227,47 @@ install(
     data_dest = "lib/python@PYTHON_VERSION@/site-packages/drake.dist-info",
 )
 
+# Generate drake/version_internal.h (the concrete values consumed by the
+# hand-written drake/version.h) from the version stamp.
+cmake_configure_file(
+    name = "version_internal_header",
+    src = "version_internal.h.in",
+    out = "version_internal.h",
+    atonly = True,
+    cmakelists = [
+        ":stamp_version.cmake",
+    ],
+)
+
+# Expose drake/version.h.
+drake_cc_library(
+    name = "version_hdrs",
+    hdrs = [
+        "version.h",
+        ":version_internal.h",
+    ],
+    strip_include_prefix = "/tools/install/libdrake",
+    # Downstream code should depend on the //:version_hdrs alias, not this
+    # target.
+    visibility = ["//:__pkg__"],
+)
+
+# version.h is a documented public header; expose it to the C++ API doc build.
+exports_files(
+    ["version.h"],
+    visibility = ["//doc/doxygen_cxx:__pkg__"],
+)
+
+# Install both headers to include/drake/.
+install(
+    name = "install_version_header",
+    hdrs = [
+        "version.h",
+        ":version_internal.h",
+    ],
+    hdr_dest = "include/drake",
+)
+
 # Verify that extra include paths are not leaking into our interface deps.
 cc_check_allowed_headers(
     name = "allowed_headers_lint",
@@ -342,6 +383,7 @@ install(
         ":install_cmake_config",
         ":install_libdrake",
         ":install_site_packages_metadata",
+        ":install_version_header",
     ],
 )
 
@@ -379,6 +421,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":drake_headers",
+        ":version_hdrs",
     ],
 )
 
@@ -421,6 +464,11 @@ drake_cc_test(
     # Using `drake_shared_library` can cause timeouts in debug mode.
     timeout = "moderate",
     deps = [":drake_shared_library"],
+)
+
+drake_cc_googletest(
+    name = "version_test",
+    deps = [":version_hdrs"],
 )
 
 drake_cc_googletest(

--- a/tools/install/libdrake/parse_version.py
+++ b/tools/install/libdrake/parse_version.py
@@ -71,11 +71,14 @@ def _parse_stamp(stamp_file):
 # Write version information to CMake cache-style script.
 def _write_version_info(out, version_full, version_parts):
     if version_full is None:
+        # The full version is reported as "unknown", but the numeric components
+        # are reported as 0 so that they remain usable as integers, e.g. in the
+        # DRAKE_VERSION_* preprocessor macros in drake/version.h.
         out.write('set(DRAKE_VERSION "unknown")\n')
-        out.write('set(DRAKE_VERSION_MAJOR "unknown")\n')
-        out.write('set(DRAKE_VERSION_MINOR "unknown")\n')
-        out.write('set(DRAKE_VERSION_PATCH "unknown")\n')
-        out.write('set(DRAKE_VERSION_TWEAK "unknown")\n')
+        out.write('set(DRAKE_VERSION_MAJOR "0")\n')
+        out.write('set(DRAKE_VERSION_MINOR "0")\n')
+        out.write('set(DRAKE_VERSION_PATCH "0")\n')
+        out.write('set(DRAKE_VERSION_TWEAK "0")\n')
     else:
         out.write(f'set(DRAKE_VERSION "{version_full}")\n')
         out.write(f'set(DRAKE_VERSION_MAJOR "{version_parts[0]}")\n')

--- a/tools/install/libdrake/test/find_package_drake_install_test.py
+++ b/tools/install/libdrake/test/find_package_drake_install_test.py
@@ -12,6 +12,10 @@ class FindPackageDrakeInstallTest(unittest.TestCase):
 
         cc_content_drake = """
             #include <drake/common/symbolic/expression.h>
+            #include <drake/version.h>
+            // Confirm the installed drake/version.h is includable and that its
+            // macros are usable in a constant expression.
+            static_assert(DRAKE_VERSION_AT_LEAST(0, 0, 0, 0) || true);
             int main() {
               drake::symbolic::Environment environment;
               return 0;

--- a/tools/install/libdrake/test/version_test.cc
+++ b/tools/install/libdrake/test/version_test.cc
@@ -1,0 +1,20 @@
+#include "drake/version.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace {
+
+// Only packaging builds set a version stamp, and those do not run Bazel tests
+// (nor install tests), so the version is always unstamped here.
+GTEST_TEST(VersionAtLeastTest, BasicUnstamped) {
+  EXPECT_FALSE(DRAKE_VERSION_AT_LEAST(0, 0, 0, 0));
+  EXPECT_FALSE(DRAKE_VERSION_AT_LEAST(1, 51, 1, 20260311));
+}
+
+GTEST_TEST(VersionStringTest, Unstamped) {
+  EXPECT_STREQ(DRAKE_VERSION_STRING, "unknown");
+}
+
+}  // namespace
+}  // namespace drake

--- a/tools/install/libdrake/version.h
+++ b/tools/install/libdrake/version.h
@@ -1,0 +1,59 @@
+#pragma once
+
+// This header provides preprocessor macros for reporting and comparing the
+// Drake version, derived from the same version stamp that populates
+// drake-config.cmake (see drake/tools/install/libdrake). For an unstamped
+// build (e.g., a plain `bazel build`), the version string is "unknown".
+
+#ifndef DRAKE_DOXYGEN_CXX
+#include "drake/version_internal.h"
+#endif
+
+/** @defgroup drake_versioning Drake Version
+@ingroup technical_notes
+@{
+
+Drake exposes its version to downstream C++ as preprocessor macros, so that
+code can adapt to the Drake version at compile time, e.g., to handle API
+changes across releases.
+
+Python users should instead obtain the version at runtime via
+`importlib.metadata.version("%drake")`. */
+
+/** Drake's full version string. For a versioned release this looks like
+"1.51.1"; for a nightly or snapshot build like "0.0.20260721.143022+gitabc";
+for an unstamped build it is "unknown".
+@hideinitializer */
+#define DRAKE_VERSION_STRING DRAKE_INTERNAL_VERSION_STRING
+
+/** Evaluates to true iff this build of Drake is at least as new as the given
+release. It handles stable releases, nightly/snapshot builds, and unstamped
+builds:
+
+- When evaluated against a stable release build, it is true iff the build
+  version is greater than or equal to (major, minor, patch); the yyyymmdd
+  argument is ignored.
+- When evaluated against a nightly or snapshot build, it is true iff the build
+  date is at least yyyymmdd and yyyymmdd is nonzero.
+- When evaluated against an unstamped build, it is always false.
+
+The yyyymmdd argument is the nightly date that corresponds to the stable
+(major, minor, patch) release. Intended for use in preprocessor conditionals:
+
+@code{.cpp}
+#if DRAKE_VERSION_AT_LEAST(1, 51, 1, 20260311)
+// ... use a newer Drake API ...
+#endif
+@endcode
+
+@hideinitializer */
+#define DRAKE_VERSION_AT_LEAST(major, minor, patch, yyyymmdd)               \
+  ((DRAKE_INTERNAL_VERSION_MAJOR == 0 && DRAKE_INTERNAL_VERSION_MINOR == 0) \
+       ? (DRAKE_INTERNAL_VERSION_PATCH >= (yyyymmdd) && (yyyymmdd) > 0)     \
+       : (DRAKE_INTERNAL_VERSION_MAJOR > (major) ||                         \
+          (DRAKE_INTERNAL_VERSION_MAJOR == (major) &&                       \
+           (DRAKE_INTERNAL_VERSION_MINOR > (minor) ||                       \
+            (DRAKE_INTERNAL_VERSION_MINOR == (minor) &&                     \
+             DRAKE_INTERNAL_VERSION_PATCH >= (patch))))))
+
+/** @} */

--- a/tools/install/libdrake/version_internal.h.in
+++ b/tools/install/libdrake/version_internal.h.in
@@ -1,0 +1,13 @@
+#pragma once
+
+// This header is generated from version_internal.h.in; do not edit it by hand.
+//
+// It defines the concrete Drake version values (from the same version stamp
+// that populates drake-config.cmake) that drake/version.h consumes. These
+// macros are for Drake's internal use only; downstream code should instead use
+// the macros in drake/version.h.
+
+#define DRAKE_INTERNAL_VERSION_STRING "@DRAKE_VERSION@"
+#define DRAKE_INTERNAL_VERSION_MAJOR @DRAKE_VERSION_MAJOR@
+#define DRAKE_INTERNAL_VERSION_MINOR @DRAKE_VERSION_MINOR@
+#define DRAKE_INTERNAL_VERSION_PATCH @DRAKE_VERSION_PATCH@


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/24343

Generates a `"drake/version.h"` header that exposes the following macros:

1. `DRAKE_VERSION_STRING`
2. `DRAKE_VERSION_AT_LEAST`

The file is populated from the variables set in `stamp_version.cmake`.

I added `version_test.cc` to verify some of the logic, and an additional line in `find_package_drake_install_test.py` to ensure that the header is present after an install.

I also verified end-to-end behavior by building drake locally (with the `DRAKE_VERSION_OVERRIDE` flag set), installing, and consuming in a small example project via `find_package`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24758)
<!-- Reviewable:end -->
