### PR TITLE
[common] Add is_polymorphic detail to NiceTypeName pydrake hook

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -23,6 +23,7 @@
 #include "drake/common/sha256.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/text_logging.h"
+#include "drake/common/unused.h"
 
 namespace drake {
 namespace pydrake {
@@ -41,6 +42,9 @@ void trigger_an_assertion_failure() {
 // Resolves to a Python handle given a type erased pointer. If the instance or
 // lowest-level RTTI type are unregistered, returns an empty handle.
 py::handle ResolvePyObject(const type_erased_ptr& ptr) {
+  // TODO(#21572) Use is_polymorphic for nanobind (or remove it from the struct,
+  // if we change our mind and end up not needing it).
+  unused(ptr.is_polymorphic);
   auto py_type_info = py::detail::get_type_info(ptr.info);
   return py::detail::get_object_handle(ptr.raw, py_type_info);
 }

--- a/common/nice_type_name.cc
+++ b/common/nice_type_name.cc
@@ -120,11 +120,12 @@ string NiceTypeName::RemoveNamespaces(const string& canonical) {
 }
 
 std::string NiceTypeName::GetWithPossibleOverride(const void* ptr,
-                                                  const std::type_info& info) {
+                                                  const std::type_info& info,
+                                                  bool is_polymorphic) {
   internal::NiceTypeNamePtrOverride ptr_override =
       internal::GetNiceTypeNamePtrOverride();
   if (ptr_override) {
-    return ptr_override(internal::type_erased_ptr{ptr, info});
+    return ptr_override(internal::type_erased_ptr{ptr, info, is_polymorphic});
   } else {
     return Get(info);
   }

--- a/common/nice_type_name.h
+++ b/common/nice_type_name.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <typeinfo>
 #include <utility>
 #include <vector>
@@ -70,7 +71,8 @@ class NiceTypeName {
   differ. */
   template <typename T>
   static std::string Get(const T& thing) {
-    return GetWithPossibleOverride(&thing, typeid(thing));
+    constexpr bool is_polymorphic = std::is_polymorphic_v<T>;
+    return GetWithPossibleOverride(&thing, typeid(thing), is_polymorphic);
   }
 
   /** Returns the nicely demangled and canonicalized type name of `info`. This
@@ -109,7 +111,8 @@ class NiceTypeName {
   NiceTypeName() = delete;
 
   static std::string GetWithPossibleOverride(const void* ptr,
-                                             const std::type_info& info);
+                                             const std::type_info& info,
+                                             bool is_polymorphic);
 };
 
 }  // namespace drake

--- a/common/nice_type_name_override.h
+++ b/common/nice_type_name_override.h
@@ -17,6 +17,7 @@ namespace internal {
 struct type_erased_ptr {
   const void* raw{};
   const std::type_info& info;
+  bool is_polymorphic{};
 };
 
 // Callback for overriding an object's nice type name.

--- a/common/test/nice_type_name_test.cc
+++ b/common/test/nice_type_name_test.cc
@@ -33,9 +33,10 @@ class Base {
 };
 class Derived : public Base {};
 
-// Type to have its NiceTypeName be overridden via
+// Types to have their NiceTypeName be overridden via
 // `SetNiceTypeNamePtrOverride`.
 class OverrideName {};
+class OverrideNameDerived : public Base {};
 
 // Test the Identifier pattern.
 using AId = Identifier<class ATag>;
@@ -222,16 +223,29 @@ GTEST_TEST(NiceTypeNameTest, Override) {
       [](const internal::type_erased_ptr& ptr) -> std::string {
         EXPECT_NE(ptr.raw, nullptr);
         if (ptr.info == typeid(OverrideName)) {
+          EXPECT_FALSE(ptr.is_polymorphic);
           return "example_override";
+        } else if (ptr.info == typeid(OverrideNameDerived)) {
+          EXPECT_TRUE(ptr.is_polymorphic);
+          return "example_override_derived";
         } else {
           return NiceTypeName::Get(ptr.info);
         }
       });
 
+  EXPECT_EQ(NiceTypeName::Get<std::string>(), "std::string");
+
   EXPECT_EQ(NiceTypeName::Get<OverrideName>(),
             "drake::(anonymous)::OverrideName");
   const OverrideName obj;
   EXPECT_EQ(NiceTypeName::Get(obj), "example_override");
+
+  const OverrideNameDerived obj_derived;
+  const Base& obj_base = obj_derived;
+  EXPECT_EQ(NiceTypeName::Get<OverrideNameDerived>(),
+            "drake::(anonymous)::OverrideNameDerived");
+  EXPECT_EQ(NiceTypeName::Get(obj_derived), "example_override_derived");
+  EXPECT_EQ(NiceTypeName::Get(obj_base), "example_override_derived");
 }
 
 }  // namespace


### PR DESCRIPTION
Our nanobind port requires this additional information.

_Edited to add: See #24749 for the eventual purpose here. The big picture is that when looking up a type, nanobind has a bifurcated API depending on whether the type is polymorphic or not, so we need to pass along that information down to where its needed._

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24759)
<!-- Reviewable:end -->
