### PR TITLE
[pydrake] Add missing tests for non-pure override trampolines

### DIFF
--- a/bindings/pydrake/geometry/test/render_engine_subclass_test.py
+++ b/bindings/pydrake/geometry/test/render_engine_subclass_test.py
@@ -142,6 +142,12 @@ class TestRenderEngineSubclass(unittest.TestCase):
         label_only.RenderLabelImage(color_cam, label_image)
         self.assertIsInstance(label_only.Clone(), LabelOnlyEngine)
 
+        # Overriding DoGetParameterYaml is not required; when absent, a default
+        # implementation will be used. (The render_test.py already checks that
+        # overriding DoGetParameterYaml works correctly.)
+        for engine in [legacy_engine, color_only, depth_only, label_only]:
+            self.assertIn("Unknown", engine.GetParameterYaml())
+
     def test_legacy_DoClone(self):
         """Sanity checks that DoClone (without __deepcopy__) is sufficient."""
 

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -192,6 +192,14 @@ class CustomDiagram(Diagram):
         return super().DoGetGraphvizFragment(params)
 
 
+class CustomDiagramMinimal(Diagram):
+    def __init__(self):
+        Diagram.__init__(self)
+        builder = DiagramBuilder()
+        builder.AddSystem(Adder(0, 0))
+        builder.BuildInto(self)
+
+
 class TestCustom(unittest.TestCase):
     def _create_adder_system(self):
         system = CustomAdder(2, 3)
@@ -258,6 +266,13 @@ class TestCustom(unittest.TestCase):
         system = CustomDiagram(2, 3)
         graph = system.GetGraphvizString()
         self.assertIn("meaning_of_life=42", graph)
+
+    def test_diagram_graphviz_minimal(self):
+        """GetGraphvizString still works even without overriding
+        DoGetGraphvizFragment."""
+        diagram = CustomDiagramMinimal()
+        graph = diagram.GetGraphvizString()
+        self.assertIn("digraph", graph)
 
     def test_leaf_system_well_known_tickets(self):
         for func in [
@@ -812,6 +827,10 @@ class TestCustom(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "NoneType"):
             simulator.AdvanceTo(0.1)
         self.assertTrue(system.called_witness)
+
+        # Test that GetGraphvizString still works even without overriding
+        # TrivialSystem.DoGetGraphvizFragment.
+        self.assertIn("digraph", system.GetGraphvizString())
 
     def test_event_handler_returns_none(self):
         """Checks that a Python event handler callback function is allowed to


### PR DESCRIPTION
Towards #21572.  When a pydrake override is not pure, we need to test both cases -- where the Python subclass does or does not override the method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24763)
<!-- Reviewable:end -->
