### PR TITLE
[pydrake] Fix ForceDensityField virtual method overrides

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -4352,7 +4352,7 @@ class TestPlant(unittest.TestCase):
         copy.deepcopy(dut)
 
     @numpy_compare.check_all_types
-    def test_force_density_field(self, T):
+    def test_force_density_field_no_parent(self, T):
         class DummyField(ForceDensityField_[T]):
             def __init__(self, scale):
                 super().__init__()
@@ -4364,7 +4364,7 @@ class TestPlant(unittest.TestCase):
             def DoClone(self):
                 return DummyField(self._scale)
 
-        plant = MultibodyPlant_[T](time_step=0.0)
+        plant = MultibodyPlant_[T](time_step=0.01)
         plant.Finalize()
         context = plant.CreateDefaultContext()
 
@@ -4383,4 +4383,56 @@ class TestPlant(unittest.TestCase):
         )
         numpy_compare.assert_float_equal(
             copy.deepcopy(dut).EvaluateAt(context, p_WQ), value
+        )
+
+    def test_force_density_field_with_parent(self):
+        # Deformables do not support AutoDiffXd currently.
+        T = float
+
+        class MinimalDummyField(ForceDensityField_[T]):
+            def __init__(self):
+                super().__init__()
+
+            def DoClone(self):
+                return MinimalDummyField()
+
+        class InstrumentedDummyField(ForceDensityField_[T]):
+            def __init__(self):
+                super().__init__()
+                self.counters = dict()
+
+            def DoClone(self):
+                result = InstrumentedDummyField()
+                result.counters = self.counters
+                return result
+
+            def DoDeclareCacheEntries(self, plant):
+                key = "DoDeclareCacheEntries"
+                self.counters[key] = self.counters.get(key, 0) + 1
+
+            def DoDeclareInputPorts(self, plant):
+                key = "DoDeclareInputPorts"
+                self.counters[key] = self.counters.get(key, 0) + 1
+
+        dut1 = MinimalDummyField()
+        dut2 = InstrumentedDummyField()
+        counters = dut2.counters
+
+        # Test non-pure virtual method overrides like DoDeclareCacheEntries and
+        # DoDeclareInputPorts, which are triggered when finalizing a plant.
+        # With dut1, we show that they are OK to leave unimplemented.
+        # With dut2, we show that they are called when necessary.
+        builder = DiagramBuilder_[T]()
+        plant, _ = AddMultibodyPlantSceneGraph(builder, 0.01)
+        deformable_model = plant.mutable_deformable_model()
+        deformable_model.AddExternalForce(dut1)
+        deformable_model.AddExternalForce(dut2)
+        self.assertDictEqual(counters, dict())
+        plant.Finalize()
+        self.assertDictEqual(
+            counters,
+            dict(
+                DoDeclareCacheEntries=1,
+                DoDeclareInputPorts=1,
+            ),
         )

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1229,17 +1229,21 @@ class ForceDensityFieldPublic : public ForceDensityField<T> {
         plant, name, model_vector);
   }
 
+  using ForceDensityField<T>::DoDeclareCacheEntries;
+  using ForceDensityField<T>::DoDeclareInputPorts;
+
  protected:
   explicit ForceDensityFieldPublic(ForceDensityType density_type)
       : ForceDensityField<T>(density_type) {}
 };
 
 template <typename T>
-class DelegatedForceDensityField final : public ForceDensityField<T> {
+class DelegatedForceDensityField final : public ForceDensityFieldPublic<T> {
  public:
   explicit DelegatedForceDensityField(
       std::shared_ptr<ForceDensityField<T>> impl)
-      : ForceDensityField<T>(impl->density_type()), impl_(std::move(impl)) {
+      : ForceDensityFieldPublic<T>(impl->density_type()),
+        impl_(std::move(impl)) {
     DRAKE_THROW_UNLESS(impl_ != nullptr);
   }
 
@@ -1251,6 +1255,18 @@ class DelegatedForceDensityField final : public ForceDensityField<T> {
 
   std::unique_ptr<ForceDensityFieldBase<T>> DoClone() const final {
     return impl_->Clone();
+  }
+
+  void DoDeclareCacheEntries(MultibodyPlant<T>* plant) final {
+    // We need a static_cast to get around protected access.
+    auto* impl = static_cast<ForceDensityFieldPublic<T>*>(impl_.get());
+    impl->DoDeclareCacheEntries(plant);
+  }
+
+  void DoDeclareInputPorts(MultibodyPlant<T>* plant) final {
+    // We need a static_cast to get around protected access.
+    auto* impl = static_cast<ForceDensityFieldPublic<T>*>(impl_.get());
+    impl->DoDeclareInputPorts(plant);
   }
 
   std::shared_ptr<ForceDensityField<T>> impl_;


### PR DESCRIPTION
Python subclasses should be able to override DoDeclareCacheEntries and DoDeclareInputPorts, but previously they could not.

Towards #21572, by backfilling test coverage of areas that nanobind is known to cause trouble.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24764)
<!-- Reviewable:end -->
