### PR TITLE
[pydrake] Add none() annotation to nullable args

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_projected_gradient_descent.cc
+++ b/bindings/pydrake/solvers/solvers_py_projected_gradient_descent.cc
@@ -26,7 +26,7 @@ void DefineSolversProjectedGradientDescent(py::module_ m) {
             cls_doc.SetCustomGradientFunction.doc)
         .def("SetProjectionSolverInterface",
             &Class::SetProjectionSolverInterface,
-            py::arg("projection_solver_interface"),
+            py::arg("projection_solver_interface").none(),
             cls_doc.SetProjectionSolverInterface.doc)
         .def_static("ConvergenceTolOptionName",
             &Class::ConvergenceTolOptionName,

--- a/bindings/pydrake/symbolic/symbolic_py_monolith.cc
+++ b/bindings/pydrake/symbolic/symbolic_py_monolith.cc
@@ -389,7 +389,7 @@ void DefineSymbolicMonolith(py::module_ m) {
           [](const Expression& self, RandomGenerator* generator) {
             return self.Evaluate(generator);
           },
-          py::arg("generator"), doc_expression.Evaluate.doc_1args)
+          py::arg("generator").none(), doc_expression.Evaluate.doc_1args)
       .def(
           "EvaluatePartial",
           [](const Expression& self, const Environment::map& env) {

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -400,7 +400,7 @@ Parameter ``interruptible``:
               self->reset_context_from_shared(
                   make_shared_ptr_from_py_object<Context<T>>(py_context));
             },
-            py::arg("context"), doc.Simulator.reset_context.doc)
+            py::arg("context").none(), doc.Simulator.reset_context.doc)
         .def("set_target_realtime_rate",
             &Simulator<T>::set_target_realtime_rate, py::arg("realtime_rate"),
             doc.Simulator.set_target_realtime_rate.doc)

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -201,7 +201,7 @@ PYDRAKE_MODULE(lcm, m) {
         .def(py::init<const std::string&,
                  std::shared_ptr<const SerializerInterface>,
                  LcmInterfaceSystem*, double, double>(),
-            py::arg("channel"), py::arg("serializer"), py::arg("lcm"),
+            py::arg("channel"), py::arg("serializer"), py::arg("lcm").none(),
             py::arg("publish_period") = 0.0, py::arg("publish_offset") = 0.0,
             // Keep alive, reference: `self` keeps `lcm` alive.
             py::keep_alive<1, 4>(), cls_doc.ctor.doc_5args)

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -550,7 +550,7 @@ PYDRAKE_MODULE(primitives, m) {
                   std::make_unique<py::object>(std::move(value_to_hold));
               new (self) SharedPointerSystem<T>(std::move(wrapped));
             },
-            py::arg("value_to_hold"), doc.SharedPointerSystem.ctor.doc)
+            py::arg("value_to_hold").none(), doc.SharedPointerSystem.ctor.doc)
         .def_static(
             "AddToBuilder",
             [](DiagramBuilder<T>* builder, py::object value_to_hold) {
@@ -559,7 +559,7 @@ PYDRAKE_MODULE(primitives, m) {
               return SharedPointerSystem<T>::AddToBuilder(
                   builder, std::move(wrapped));
             },
-            py::arg("builder"), py::arg("value_to_hold"),
+            py::arg("builder"), py::arg("value_to_hold").none(),
             doc.SharedPointerSystem.AddToBuilder.doc)
         .def(
             "get",


### PR DESCRIPTION
Towards #21572.

This is a no-op for pybind11 (which defaults to allowing nullptr), but is important for nanobind (which defaults to rejecting nullptr).

We don't yet have CI test coverage for the nanobind case, so this has been manually tested on the nanobind branch (#24749) that removing any one of these annotations causes test failures.  Many of the tests of `None` were added by #24718.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24765)
<!-- Reviewable:end -->
