### PR TITLE
[tools] Add test_alt_binder option to drake_py_test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 # This file is named BUILD.bazel instead of the more typical BUILD, so that on
 # OSX it won't conflict with a build artifacts directory named "build".
 
+load("//tools/flags/internal:multi_config.bzl", "python_binder_reset")
 load("//tools/install:install.bzl", "install", "install_test")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:drake_py.bzl", "drake_py_library")
@@ -37,10 +38,13 @@ drake_py_library(
 
 # Expose shared library for (a) installed binaries, (b) Drake Python bindings,
 # and (c) downstream C++ libraries which will also provide Python bindings.
-alias(
+# We use 'python_binder_reset' so that our multi-config test suite (which runs
+# tests using both pybind11 and nanobind) doesn't recompile libdrake for both
+# configs -- it resets the binder flag to its default value for this target.
+python_binder_reset(
     name = "drake_shared_library",
-    actual = "//tools/install/libdrake:drake_shared_library",
     visibility = ["//visibility:public"],
+    exports = "//tools/install/libdrake:drake_shared_library",
 )
 
 # A manually-curated collection of most model files in Drake, so that we can

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -68,11 +68,14 @@ drake_cc_library(
         ],
     }),
     visibility = ["//visibility:public"],
-    deps = [
-        # TODO(#21572) Using pybind11 unconditionally here is wrong, but is
-        # easier for now until all/most binding code has been ported.
-        "@drake//tools/workspace/pybind11",
-    ],
+    deps = select({
+        "//tools/workspace/nanobind:enabled": [
+            "@drake//tools/workspace/nanobind",
+        ],
+        "//conditions:default": [
+            "@drake//tools/workspace/pybind11",
+        ],
+    }),
 )
 
 drake_cc_library(
@@ -380,6 +383,7 @@ drake_py_unittest(
         "//:.clang-format",
     ],
     tags = ["lint"],
+    test_alt_binder = False,
 )
 
 drake_py_unittest(

--- a/bindings/temporary_scaffolding/BUILD.bazel
+++ b/bindings/temporary_scaffolding/BUILD.bazel
@@ -1,26 +1,33 @@
-load("@drake//tools/skylark:cc.bzl", "cc_binary")
-load("@drake//tools/skylark:py.bzl", "py_test")
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_test")
+load("@drake//tools/skylark:pybind.bzl", "pybind_py_library")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-# This is a smoke test on a nanobind binding, as a sanity check of the build.
+# This is a smoke test on a sample binding, as a sanity check of the build
+# and testing of a module that supports both pybind11 and nanobind.
 
-cc_binary(
-    name = "sample_module.so",
-    srcs = ["sample_module.cc"],
-    linkshared = True,
-    linkstatic = True,
-    deps = [
-        "//tools/workspace/nanobind",
-    ],
+pybind_py_library(
+    name = "sample_module",
+    cc_copts = select({
+        "//tools/workspace/nanobind:enabled": [
+            "-DDRAKE_USE_NANOBIND",
+        ],
+        "//conditions:default": [
+            "-DDRAKE_USE_PYBIND11",
+        ],
+    }),
+    cc_srcs = ["sample_module.cc"],
 )
 
-py_test(
+drake_py_test(
     name = "sample_module_test",
     srcs = ["sample_module_test.py"],
-    data = [":sample_module.so"],
     imports = ["."],
     main = "sample_module_test.py",
-    deps = ["//bindings/pydrake/common/test_utilities/scipy_stub"],
+    test_alt_binder = True,
+    deps = [
+        ":sample_module",
+        "//bindings/pydrake/common/test_utilities/scipy_stub",
+    ],
 )
 
 add_lint_tests()

--- a/bindings/temporary_scaffolding/sample_module.cc
+++ b/bindings/temporary_scaffolding/sample_module.cc
@@ -1,11 +1,21 @@
-#include "nanobind/nanobind.h"
-
-#include "drake_nanobind/eigen/dense.h"
-#include "drake_nanobind/eigen/sparse.h"
-
+// clang-format off
+#if defined(DRAKE_USE_PYBIND11)
+# include "pybind11/pybind11.h"
+# include "pybind11/eigen.h"
+namespace py = pybind11;
+#define DEFINE_MODULE PYBIND11_MODULE
+#elif defined(DRAKE_USE_NANOBIND)
+# include "nanobind/nanobind.h"
+# include "drake_nanobind/eigen/dense.h"
+# include "drake_nanobind/eigen/sparse.h"
 namespace py = nanobind;
+#define DEFINE_MODULE NB_MODULE
+#else
+# error
+#endif
+// clang-format on
 
-NB_MODULE(sample_module, m) {
+DEFINE_MODULE(sample_module, m) {
   m  // BR
       .def("dense_to_sparse",
            [](const Eigen::MatrixXd& x) -> Eigen::SparseMatrix<double> {

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -79,11 +79,13 @@ def main():
     main_py = sys.argv[0]
 
     # Parse the test case name out of the runfiles directory name.
-    match = re.search("^(.*bin/(.*?/)?([^/]*_test).runfiles/)", main_py)
+    # TODO(jwnimmer-tri) The (alt_binder...) group is used by test_alt_binder.
+    # Remove it when the test_alt_binder option is removed.
+    match = re.search("^(.*bin/(.*?/)?(alt_binder/[^/]*/)?([^/]*_test).runfiles/)", main_py)
     if not match:
         print(f"error: no test name match in {main_py}")
         sys.exit(1)
-    runfiles, test_package, test_name, = match.groups()
+    runfiles, test_package, _, test_name, = match.groups()
     test_basename = test_name + ".py"
 
     # Find the test's source file.

--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -225,6 +225,7 @@ drake_py_binary(
         "--ensemble_size=3",
         "--num_evaluations=3",
     ],
+    test_rule_test_alt_binder = False,
 )
 
 drake_cc_binary(
@@ -450,6 +451,7 @@ drake_py_test(
         ":test/example_stochastic_scenario.yaml",
     ],
     main = "test/spong_sim_main_test.py",
+    test_alt_binder = False,
     deps = [
         ":acrobot_io",
         "//bindings/pydrake",

--- a/examples/allegro_hand/joint_control/BUILD.bazel
+++ b/examples/allegro_hand/joint_control/BUILD.bazel
@@ -64,6 +64,7 @@ drake_py_unittest(
         ":run_twisting_mug",
     ],
     flaky = True,
+    test_alt_binder = False,
     deps = [
         "@rules_python//python/runfiles",
     ],

--- a/examples/hardware_sim/BUILD.bazel
+++ b/examples/hardware_sim/BUILD.bazel
@@ -105,6 +105,7 @@ drake_py_unittest(
         ":demo_cc",
     ],
     shard_count = 4,
+    test_alt_binder = False,
     deps = [
         ":hardware_sim_test_common",
     ],

--- a/examples/multibody/strandbeest/BUILD.bazel
+++ b/examples/multibody/strandbeest/BUILD.bazel
@@ -46,6 +46,7 @@ drake_py_unittest(
     data = [
         ":run_with_motor",
     ],
+    test_alt_binder = False,
 )
 
 add_lint_tests()

--- a/tools/flags/internal/BUILD.bazel
+++ b/tools/flags/internal/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@with_cfg.bzl", "original_settings")
+
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+# This is an implementation detail of python_binder_reset in :multi_config.bzl.
+original_settings(
+    name = "py_test_with_alt_binder_original_settings",
+)

--- a/tools/flags/internal/multi_config.bzl
+++ b/tools/flags/internal/multi_config.bzl
@@ -1,0 +1,18 @@
+load("@rules_python//python:py_test.bzl", "py_test")
+load("@with_cfg.bzl", "with_cfg")
+
+# The following stanza defines two new rules:
+#
+# py_test_with_alt_binder is equivalent to py_test except that it forces its
+# dependencies to be built with --@drake//tools/flags:python_binder=nanobind.
+# This allows us to run the test under the non-default binder setting as part
+# of the same `bazel test` command as tests with the default binder setting.
+#
+# python_binder_reset is like an alias() rule except that it clears the
+# non-default flag setting. This is useful to mark dependencies that should
+# not be rebuilt under the non-default binder setting (e.g., libdrake).
+
+_builder = with_cfg(py_test)
+_builder.set(Label("//tools/flags:python_binder"), "nanobind")
+_builder.resettable(Label("//tools/flags/internal:py_test_with_alt_binder_original_settings"))
+py_test_with_alt_binder, python_binder_reset = _builder.build()

--- a/tools/lint/buildifier-tables.json
+++ b/tools/lint/buildifier-tables.json
@@ -112,6 +112,7 @@
     "drake_py_binary.test_rule_opt_in_condition": 108,
     "drake_py_binary.test_rule_opt_out_conditions": 108,
     "drake_py_binary.test_rule_rendering": 109,
+    "drake_py_binary.test_rule_test_alt_binder": 110,
 
     "drake_jupyter_py_binary.add_test_rule": 100,
     "drake_jupyter_py_binary.test_rule_args": 101,

--- a/tools/skylark/README.md
+++ b/tools/skylark/README.md
@@ -94,3 +94,19 @@ Can either be True or False (defaults to False).
 When True, marks the test as needing graphics rendering capability, which
 suppresses test configurations (e.g., LSan) that are incompatible with graphics
 drivers' software stack.
+
+**test_alt_binder**
+
+Can be either True, False, or "auto" (defaults to "auto").
+Relevant for Python tests only.
+
+When True, the test is run twice: once with the //tools/flags:python_binder set
+to its default value, and once with the flag set to its alternative value.
+
+When False, the test is run just once, with the //tools/flags:python_binder set
+to its default value.
+
+When "auto", the test's package name is used to choose True vs False.
+TODO(#21572) Eventually "auto" should imply True in //bindings/pydrake/...,
+//tutorials/..., and //examples/... and False everywhere else -- but for now
+it always means False.

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -782,8 +782,11 @@ def drake_cc_binary(
         **kwargs
     )
 
-    if "@googletest//:gtest_main" in deps:
-        fail("Use drake_cc_googletest to declare %s as a test" % name)
+    # Reject misuse of cc_binary for a drake_cc_googletest (but we can only
+    # perform the check if the deps are iterable, i.e., not a `select()`).
+    if type(deps) in (type([]), type(())):
+        if "@googletest//:gtest_main" in deps:
+            fail("Use drake_cc_googletest to declare %s as a test" % name)
 
     if add_test_rule:
         drake_cc_test(

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -1,3 +1,4 @@
+load("//tools/flags/internal:multi_config.bzl", "py_test_with_alt_binder")
 load(
     "//tools/skylark:kwargs.bzl",
     "amend",
@@ -35,6 +36,7 @@ def drake_py_binary(
         test_rule_timeout = None,
         test_rule_flaky = False,
         test_rule_rendering = False,
+        test_rule_test_alt_binder = "auto",
         **kwargs):
     """A wrapper to insert Drake-specific customizations.
     """
@@ -73,6 +75,7 @@ def drake_py_binary(
                 "//tools/kcov:enabled",
             ],
             rendering = test_rule_rendering,
+            test_alt_binder = test_rule_test_alt_binder,
             tags = (test_rule_tags or []) + ["nolint"],
             # The added test rule isn't going to `import unittest`, but test
             # dependencies such as numpy(!!) do so unconditionally.  We should
@@ -126,6 +129,7 @@ def drake_py_test(
         opt_in_condition = None,
         opt_out_conditions = None,
         rendering = False,
+        test_alt_binder = "auto",
         **kwargs):
     """A wrapper to insert Drake-specific customizations.
 
@@ -153,6 +157,9 @@ def drake_py_test(
         See drake/tools/skylark/README.md for details.
 
     @param rendering (optional, default is False)
+        See drake/tools/skylark/README.md for details.
+
+    @param test_alt_binder (optional, default is "auto")
         See drake/tools/skylark/README.md for details.
 
     By default, sets test size to "small" to indicate a unit test. Adds the tag
@@ -194,6 +201,37 @@ def drake_py_test(
         srcs_version = "PY3",
         **kwargs
     )
+    if test_alt_binder not in (True, False, "auto"):
+        fail("test_alt_binder must be set to True, False, or \"auto\"")
+    if test_alt_binder == "auto":
+        # TODO(#21572) Eventually "auto" should enable relevant tests.
+        test_alt_binder = False
+    if test_alt_binder:
+        alt_target_compatible_with, _ = combine_conditions(
+            name = "alt_binder/" + name,
+            opt_in_condition = opt_in_condition,
+            opt_out_conditions = (opt_out_conditions or []) + [
+                # Sanitizers and memcheck use `test_lang_filters` to opt-out of
+                # py_tests, but for some reason that filter doesn't work on the
+                # alt_binder tests, so we need to skip them explicitly.
+                "//tools:using_sanitizer",
+                "//tools/valgrind:enabled",
+                # Python coverage tests are allowed in `test_lang_filters`, but
+                # we actually only want coverage of the primary binder.
+                "//tools/kcov:enabled",
+            ],
+        )
+        py_test_with_alt_binder(
+            name = "alt_binder/" + name,
+            main = kwargs.pop("main", None) or "{}.py".format(name),
+            size = size,
+            srcs = srcs,
+            deps = deps,
+            target_compatible_with = alt_target_compatible_with,
+            python_version = "PY3",
+            srcs_version = "PY3",
+            **kwargs
+        )
 
 def py_linter_test(
         name,

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -69,11 +69,14 @@ def pybind_py_library(
         linkstatic = 1,
         copts = cc_copts + EXTRA_PYBIND_COPTS,
         # Always link to the binding library.
-        # TODO(#21572) Using pybind11 unconditionally here is wrong, but is
-        # easier for now until all/most binding code has been ported.
-        deps = [
-            "@drake//tools/workspace/pybind11",
-        ] + cc_deps,
+        deps = select({
+            "@drake//tools/workspace/nanobind:enabled": [
+                "@drake//tools/workspace/nanobind",
+            ],
+            "//conditions:default": [
+                "@drake//tools/workspace/pybind11",
+            ],
+        }) + cc_deps,
         **kwargs
     )
 

--- a/tutorials/BUILD.bazel
+++ b/tutorials/BUILD.bazel
@@ -241,6 +241,7 @@ drake_py_test(
     args = _NOTEBOOKS,
     data = [":notebooks"],
     tags = ["lint"],
+    test_alt_binder = False,
     deps = [
         "@rules_python//python/runfiles",
     ],


### PR DESCRIPTION
Towards #21572.

Though not strictly required here (since the default of `"auto"` is nerfed), we still mark `test_alt_binder = False` a bunch of tests where `"auto"` resolving to `True` would end up being incorrect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24767)
<!-- Reviewable:end -->
