### PR TITLE
[workspace] Update gymnasium_py_internal checksum

### DIFF
--- a/tools/workspace/gymnasium_py_internal/repository.bzl
+++ b/tools/workspace/gymnasium_py_internal/repository.bzl
@@ -9,7 +9,7 @@ def gymnasium_py_internal_repository(
         upgrade_type = "release",
         exclude_tags_pattern = "v[0-9.]+a[0-9]+",
         commit = "v1.3.0",
-        sha256 = "acdcc261cb0145d6692d0cef69c1b30eb3b78982269c3795b8b3141060fc13fd",  # noqa
+        sha256 = "600df166dd6aca13281130a80eff1a23f4f867a5c919ed614743806e7e5efeaa",  # noqa
         build_file = ":package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
GitHub's source archive is not guaranteed to be stable.

Build warns:
```
WARNING: Download from https://github.com/Farama-Foundation/Gymnasium/archive/refs/tags/v1.3.0.tar.gz failed:
class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException
Checksum was 600df166dd6aca13281130a80eff1a23f4f867a5c919ed614743806e7e5efeaa but wanted acdcc261cb0145d6692d0cef69c1b30eb3b78982269c3795b8b3141060fc13fd
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24768)
<!-- Reviewable:end -->
