### PR TITLE
[pydrake] Align with nanobind override API

### DIFF
--- a/bindings/pydrake/geometry/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry/geometry_py_optimization.cc
@@ -1136,8 +1136,8 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
   // python.
   class PyImplicitGraphOfConvexSets : public ImplicitGraphOfConvexSets {
    public:
+    NB_TRAMPOLINE(ImplicitGraphOfConvexSets, 1);
     using Base = ImplicitGraphOfConvexSets;
-    using Base::Base;
     using Base::mutable_gcs;
 
     PyImplicitGraphOfConvexSets() : Base() {}
@@ -1145,7 +1145,7 @@ void DefineGraphOfConvexSetsAndRelated(py::module_ m) {
     // Trampoline virtual methods.
 
     void Expand(GraphOfConvexSets::Vertex* v) override {
-      PYBIND11_OVERLOAD_PURE(void, ImplicitGraphOfConvexSets, Expand, v);
+      PYDRAKE_OVERRIDE_PURE(void, ImplicitGraphOfConvexSets, Expand, v);
     }
   };
 

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -46,33 +46,35 @@ namespace {
 
 class PyRenderEngine : public RenderEngine {
  public:
+  NB_TRAMPOLINE(RenderEngine, 9);
   using Base = RenderEngine;
+
   PyRenderEngine() : Base() {}
 
   void UpdateViewpoint(RigidTransformd const& X_WR) override {
-    PYBIND11_OVERLOAD_PURE(void, Base, UpdateViewpoint, X_WR);
+    PYDRAKE_OVERRIDE_PURE(void, Base, UpdateViewpoint, X_WR);
   }
 
   bool DoRegisterVisual(GeometryId id, Shape const& shape,
       PerceptionProperties const& properties,
       RigidTransformd const& X_WG) override {
-    PYBIND11_OVERLOAD_PURE(
+    PYDRAKE_OVERRIDE_PURE(
         bool, Base, DoRegisterVisual, id, shape, properties, X_WG);
   }
 
   bool DoRegisterNamedVisual(GeometryId id, Shape const& shape,
       PerceptionProperties const& properties, RigidTransformd const& X_WG,
       std::string_view name) override {
-    PYBIND11_OVERLOAD(
+    PYDRAKE_OVERRIDE(
         bool, Base, DoRegisterNamedVisual, id, shape, properties, X_WG, name);
   }
 
   void DoUpdateVisualPose(GeometryId id, RigidTransformd const& X_WG) override {
-    PYBIND11_OVERLOAD_PURE(void, Base, DoUpdateVisualPose, id, X_WG);
+    PYDRAKE_OVERRIDE_PURE(void, Base, DoUpdateVisualPose, id, X_WG);
   }
 
   bool DoRemoveGeometry(GeometryId id) override {
-    PYBIND11_OVERLOAD_PURE(bool, Base, DoRemoveGeometry, id);
+    PYDRAKE_OVERRIDE_PURE(bool, Base, DoRemoveGeometry, id);
   }
 
   std::unique_ptr<RenderEngine> DoClone() const override {
@@ -84,48 +86,48 @@ class PyRenderEngine : public RenderEngine {
 
   std::shared_ptr<RenderEngine> DoCloneShared() const override {
     py::gil_scoped_acquire guard;
+    const RenderEngine* const base = this;
+    py::object self = py::cast(base);
     // RenderEngine subclasses in Python must implement cloning by defining
     // either a __deepcopy__ (preferred) or DoClone (legacy) method. We'll try
     // DoClone first so it has priority, but if it doesn't exist we'll fall back
     // to __deepcopy__ and just let the "no such method deepcopy" error message
-    // propagate if both were missing. Because the PYBIND11_OVERLOAD_INT macro
-    // embeds a conditional `return ...;` statement, we must wrap it in lambda
-    // so that we can post-process the return value in case it does return.
-    auto make_python_deepcopy = [&]() -> py::object {
-      PYBIND11_OVERLOAD_INT(py::object, Base, "DoClone");
+    // propagate if both were missing.
+    py::object result;
+    if (py::hasattr(self, "DoClone")) {
+      result = self.attr("DoClone")();
+    } else {
       auto deepcopy = py::module_::import_("copy").attr("deepcopy");
-      py::object copied = deepcopy(this);
-      if (copied.is_none()) {
-        throw py::type_error(fmt::format(
-            "{}.__deepcopy__ returned None", NiceTypeName::Get(*this))
-                .c_str());
-      }
-      return copied;
-    };
-    py::object result = make_python_deepcopy();
+      result = deepcopy(self);
+    }
+    if (result.is_none()) {
+      throw py::type_error(
+          fmt::format("{}.__deepcopy__ returned None", NiceTypeName::Get(*this))
+              .c_str());
+    }
     return make_shared_ptr_from_py_object<RenderEngine>(result);
   }
 
   void DoRenderColorImage(ColorRenderCamera const& camera,
       ImageRgba8U* color_image_out) const override {
-    PYBIND11_OVERLOAD_PURE(
+    PYDRAKE_OVERRIDE_PURE(
         void, Base, DoRenderColorImage, camera, color_image_out);
   }
 
   void DoRenderDepthImage(DepthRenderCamera const& camera,
       ImageDepth32F* depth_image_out) const override {
-    PYBIND11_OVERLOAD_PURE(
+    PYDRAKE_OVERRIDE_PURE(
         void, Base, DoRenderDepthImage, camera, depth_image_out);
   }
 
   void DoRenderLabelImage(ColorRenderCamera const& camera,
       ImageLabel16I* label_image_out) const override {
-    PYBIND11_OVERLOAD_PURE(
+    PYDRAKE_OVERRIDE_PURE(
         void, Base, DoRenderLabelImage, camera, label_image_out);
   }
 
   std::string DoGetParameterYaml() const override {
-    PYBIND11_OVERLOAD(std::string, Base, DoGetParameterYaml);
+    PYDRAKE_OVERRIDE(std::string, Base, DoGetParameterYaml);
   }
 
   // Expose this protected helper function so that Python implementations can

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -1275,71 +1275,37 @@ class DelegatedForceDensityField final : public ForceDensityFieldPublic<T> {
 template <typename T>
 class PyForceDensityField : public ForceDensityFieldPublic<T> {
  public:
+  NB_TRAMPOLINE(ForceDensityFieldPublic<T>, 3);
+
   explicit PyForceDensityField(ForceDensityType density_type)
       : ForceDensityFieldPublic<T>(density_type) {}
 
   Vector3<T> DoEvaluateAt(const systems::Context<T>& context,
       const Vector3<T>& p_WQ) const override {
-    py::gil_scoped_acquire gil;
-    py::callable override = py::get_override(
-        static_cast<const ForceDensityField<T>*>(this), "DoEvaluateAt");
-    if (!override) {
-      throw std::logic_error(
-          "Python class derived from ForceDensityField<T> must implement "
-          "DoEvaluateAt().");
-    }
-    // Call Python-side DoEvaluateAt.
-    py::object result_obj =
-        override(py::cast(context, py_rvp::reference), py::cast(p_WQ));
-    try {
-      return py::cast<Vector3<T>>(result_obj);
-    } catch (const py::cast_error& e) {
-      throw std::logic_error(
-          "DoEvaluateAt() must return a 3-element list or NumPy array that can "
-          "be converted to Vector3<T>. Got " +
-          py::cast<std::string>(py::str(result_obj)) + ".");
-    }
+    PYDRAKE_OVERRIDE_PURE(Vector3<T>, ForceDensityField<T>, DoEvaluateAt,
+        std::cref(context), p_WQ);
   }
 
   std::unique_ptr<ForceDensityFieldBase<T>> DoClone() const override {
+    // Our required unique_ptr return type cannot be directly fulfilled by a
+    // PYDRAKE_OVERRIDE_PURE; we need to ask the override for a shared_ptr and
+    // then wrap it in a decorator to obtain the necessary C++ signature.
     py::gil_scoped_acquire gil;
-    py::callable override = py::get_override(
-        static_cast<const ForceDensityField<T>*>(this), "DoClone");
-    if (!override) {
-      throw std::logic_error(
-          "Python class derived from ForceDensityField<T> must implement "
-          "DoClone().");
-    }
-    // Call Python-side DoClone.
-    py::object result_obj = override();
-    std::shared_ptr<ForceDensityField<T>> cloned;
-    try {
-      cloned = py::cast<std::shared_ptr<ForceDensityField<T>>>(result_obj);
-    } catch (const py::cast_error& e) {
-      throw std::logic_error(
-          "DoClone() must return a `ForceDensityField<T>`. Got " +
-          py::cast<std::string>(py::str(result_obj.type())) +
-          " Make sure your DoClone() returns a new instance of the same "
-          "Python class, e.g., `return MyForceDensityField(...)`.");
-    }
-    if (cloned.get() == nullptr) {
-      throw std::logic_error(
-          "DoClone() must not return None. Did you forget to return a new "
-          "instance of your class, e.g., `return MyForceDensityField(...)`.");
-    } else if (cloned.get() == this) {
-      throw std::logic_error(
-          "DoClone() must return a clone, not itself. Return a new instance of "
-          "your class, e.g., `return MyForceDensityField(...)`.");
-    }
-    return std::make_unique<DelegatedForceDensityField<T>>(std::move(cloned));
+    const ForceDensityField<T>* const self = this;
+    py::object result_py = py::cast(self).attr("DoClone")();
+    auto result_cxx =
+        py::cast<std::shared_ptr<ForceDensityField<T>>>(result_py);
+    DRAKE_THROW_UNLESS(result_cxx != nullptr);
+    return std::make_unique<DelegatedForceDensityField<T>>(
+        std::move(result_cxx));
   }
 
   void DoDeclareCacheEntries(MultibodyPlant<T>* plant) override {
-    PYBIND11_OVERRIDE(void, ForceDensityField<T>, DoDeclareCacheEntries, plant);
+    PYDRAKE_OVERRIDE(void, ForceDensityField<T>, DoDeclareCacheEntries, plant);
   }
 
   void DoDeclareInputPorts(MultibodyPlant<T>* plant) override {
-    PYBIND11_OVERRIDE(void, ForceDensityField<T>, DoDeclareInputPorts, plant);
+    PYDRAKE_OVERRIDE(void, ForceDensityField<T>, DoDeclareInputPorts, plant);
   }
 };
 

--- a/bindings/pydrake/planning/planning_py_graph_algorithms.cc
+++ b/bindings/pydrake/planning/planning_py_graph_algorithms.cc
@@ -22,12 +22,14 @@ void DefinePlanningGraphAlgorithms(py::module_ m) {
   {
     class PyMaxCliqueSolverBase : public MaxCliqueSolverBase {
      public:
+      NB_TRAMPOLINE(MaxCliqueSolverBase, 1);
+
       // Trampoline virtual methods.
       // The private virtual method of DoSolveMaxClique is made public to enable
       // Python implementations to override it.
       VectorX<bool> DoSolveMaxClique(
           const Eigen::SparseMatrix<bool>& adjacency_matrix) const override {
-        PYBIND11_OVERRIDE_PURE(VectorX<bool>, MaxCliqueSolverBase,
+        PYDRAKE_OVERRIDE_PURE(VectorX<bool>, MaxCliqueSolverBase,
             DoSolveMaxClique, adjacency_matrix);
       }
     };
@@ -65,13 +67,15 @@ void DefinePlanningGraphAlgorithms(py::module_ m) {
   {
     class PyMinCliqueCoverSolverBase : public MinCliqueCoverSolverBase {
      public:
+      NB_TRAMPOLINE(MinCliqueCoverSolverBase, 1);
+
       // Trampoline virtual methods.
       // The private virtual method of DoSolveMinCliqueCover is made public to
       // enable Python implementations to override it.
       std::vector<std::set<int>> DoSolveMinCliqueCover(
           const Eigen::SparseMatrix<bool>& adjacency_matrix,
           bool partition) override {
-        PYBIND11_OVERRIDE_PURE(std::vector<std::set<int>>,
+        PYDRAKE_OVERRIDE_PURE(std::vector<std::set<int>>,
             MinCliqueCoverSolverBase, DoSolveMinCliqueCover, adjacency_matrix,
             partition);
       }

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -238,5 +238,16 @@ std::shared_ptr<T> make_shared_ptr_from_py_object(py::object py_object) {
 #define DRAKE_PYBIND11_NUMPY_OBJECT_DTYPE(Type) \
   PYBIND11_NUMPY_OBJECT_DTYPE(Type)
 
-// This alias helps ease Drake's transition to nanobind.
+// These aliases help ease Drake's transition to nanobind.
 #define PYDRAKE_MODULE PYBIND11_MODULE
+#define PYDRAKE_OVERRIDE PYBIND11_OVERRIDE
+#define PYDRAKE_OVERRIDE_PURE PYBIND11_OVERRIDE_PURE
+
+// This is an implementation of nanobind's NB_TRAMPOLINE macro for pybind11.
+// https://nanobind.readthedocs.io/en/latest/classes.html#overriding-virtual-functions-in-python
+// In particular, `size` should match how many PYDRAKE_OVERRIDE{,_PURE} are used
+// within the class.
+#define NB_TRAMPOLINE(base, size) \
+  static_assert(size >= 0);       \
+  using NBBase = base;            \
+  using NBBase::NBBase

--- a/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
+++ b/bindings/pydrake/solvers/solvers_py_mathematicalprogram.cc
@@ -187,6 +187,7 @@ void SetSolverOptionBySolverType(MathematicalProgram* self,
 // pybind11 trampoline class to permit overriding virtual functions in Python.
 class PySolverInterface : public solvers::SolverInterface {
  public:
+  NB_TRAMPOLINE(solvers::SolverInterface, 6);
   using Base = solvers::SolverInterface;
 
   PySolverInterface() : Base() {}
@@ -198,35 +199,35 @@ class PySolverInterface : public solvers::SolverInterface {
   // interface below.
 
   bool available() const override {
-    PYBIND11_OVERLOAD_PURE(bool, solvers::SolverInterface, available);
+    PYDRAKE_OVERRIDE_PURE(bool, solvers::SolverInterface, available);
   }
 
   bool enabled() const override {
-    PYBIND11_OVERLOAD_PURE(bool, solvers::SolverInterface, enabled);
+    PYDRAKE_OVERRIDE_PURE(bool, solvers::SolverInterface, enabled);
   }
 
   void Solve(const solvers::MathematicalProgram& prog,
       const std::optional<Eigen::VectorXd>& initial_guess,
       const std::optional<solvers::SolverOptions>& solver_options,
       solvers::MathematicalProgramResult* result) const override {
-    PYBIND11_OVERLOAD_PURE(void, solvers::SolverInterface, Solve, prog,
+    PYDRAKE_OVERRIDE_PURE(void, solvers::SolverInterface, Solve, prog,
         initial_guess, solver_options, result);
   }
 
   solvers::SolverId solver_id() const override {
-    PYBIND11_OVERLOAD_PURE(
+    PYDRAKE_OVERRIDE_PURE(
         solvers::SolverId, solvers::SolverInterface, solver_id);
   }
 
   bool AreProgramAttributesSatisfied(
       const solvers::MathematicalProgram& prog) const override {
-    PYBIND11_OVERLOAD_PURE(
+    PYDRAKE_OVERRIDE_PURE(
         bool, solvers::SolverInterface, AreProgramAttributesSatisfied, prog);
   }
 
   std::string ExplainUnsatisfiedProgramAttributes(
       const MathematicalProgram& prog) const override {
-    PYBIND11_OVERLOAD_PURE(std::string, solvers::SolverInterface,
+    PYDRAKE_OVERRIDE_PURE(std::string, solvers::SolverInterface,
         ExplainUnsatisfiedProgramAttributes, prog);
   }
 };

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -239,23 +239,15 @@ struct Impl {
   template <typename LeafSystemBase = LeafSystemPublic>
   class PyLeafSystemBase : public LeafSystemBase {
    public:
+    NB_TRAMPOLINE(LeafSystemBase, 2);
     using Base = LeafSystemBase;
-    using Base::Base;
 
     // Trampoline virtual methods.
 
     void DoCalcTimeDerivatives(const Context<T>& context,
         ContinuousState<T>* derivatives) const override {
-      // Yuck! We have to dig in and use internals :(
-      // We must ensure that pybind only sees pointers, since this method may
-      // be called from C++, and pybind will not have seen these objects yet.
-      // @see https://github.com/pybind/pybind11/issues/1241
-      // TODO(eric.cousineau): Figure out how to supply different behavior,
-      // possibly using function wrapping.
-      PYBIND11_OVERLOAD_INT(
-          void, LeafSystem<T>, "DoCalcTimeDerivatives", &context, derivatives);
-      // If the macro did not return, use default functionality.
-      Base::DoCalcTimeDerivatives(context, derivatives);
+      PYDRAKE_OVERRIDE(void, LeafSystem<T>, DoCalcTimeDerivatives,
+          std::ref(context), derivatives);
     }
 
     // This actually changes the signature of DoGetWitnessFunction,
@@ -265,30 +257,32 @@ struct Impl {
     // trampoline if this is needed outside of LeafSystem.
     void DoGetWitnessFunctions(const Context<T>& context,
         std::vector<const WitnessFunction<T>*>* witnesses) const override {
-      py::gil_scoped_acquire guard;
-      auto wrapped =
-          [&]() -> std::optional<std::vector<const WitnessFunction<T>*>> {
-        PYBIND11_OVERLOAD_INT(
-            std::optional<std::vector<const WitnessFunction<T>*>>,
-            LeafSystem<T>, "DoGetWitnessFunctions", &context);
-        std::vector<const WitnessFunction<T>*> result;
-        // If the macro did not return, use default functionality.
-        Base::DoGetWitnessFunctions(context, &result);
-        return {result};
-      };
-      auto result = wrapped();
-      if (!result.has_value()) {
-        // Give a good error message in case the user forgot to return anything.
-        throw py::type_error(
-            "Overrides of DoGetWitnessFunctions() must return "
-            "List[WitnessFunction], not NoneType.");
+      {
+        py::gil_scoped_acquire guard;
+        const LeafSystem<T>* base = this;
+        py::object self = py::cast(base);
+        if (py::hasattr(self, "DoGetWitnessFunctions")) {
+          auto result =
+              py::cast<std::optional<std::vector<const WitnessFunction<T>*>>>(
+                  (self.attr("DoGetWitnessFunctions"))(&context));
+          if (!result.has_value()) {
+            // Give a good error message in case the user forgot to return
+            // anything.
+            throw py::type_error(
+                "Overrides of DoGetWitnessFunctions() must return "
+                "List[WitnessFunction], not NoneType.");
+          }
+          *witnesses = std::move(*result);
+          return;
+        }
       }
-      *witnesses = std::move(*result);
+      // If not overridden, use default functionality.
+      return Base::DoGetWitnessFunctions(context, witnesses);
     }
 
     SystemBase::GraphvizFragment DoGetGraphvizFragment(
         const SystemBase::GraphvizFragmentParams& params) const override {
-      PYBIND11_OVERRIDE(SystemBase::GraphvizFragment, LeafSystem<T>,
+      PYDRAKE_OVERRIDE(SystemBase::GraphvizFragment, LeafSystem<T>,
           DoGetGraphvizFragment, params);
     }
   };
@@ -308,12 +302,12 @@ struct Impl {
   template <typename DiagramBase = DiagramPublic>
   class PyDiagramBase : public DiagramBase {
    public:
+    NB_TRAMPOLINE(DiagramBase, 1);
     using Base = DiagramBase;
-    using Base::Base;
 
     SystemBase::GraphvizFragment DoGetGraphvizFragment(
         const SystemBase::GraphvizFragmentParams& params) const override {
-      PYBIND11_OVERRIDE(SystemBase::GraphvizFragment, Diagram<T>,
+      PYDRAKE_OVERRIDE(SystemBase::GraphvizFragment, Diagram<T>,
           DoGetGraphvizFragment, params);
     }
   };
@@ -339,24 +333,31 @@ struct Impl {
 
   class PyVectorSystem : public VectorSystemPublic {
    public:
+    NB_TRAMPOLINE(VectorSystemPublic, 0);
     using Base = VectorSystemPublic;
-    using Base::Base;
 
     void DoCalcVectorOutput(const Context<T>& context,
         const Eigen::VectorBlock<const VectorX<T>>& input,
         const Eigen::VectorBlock<const VectorX<T>>& state,
         Eigen::VectorBlock<VectorX<T>>* output) const override {
+      // We can't use PYDRAKE_OVERRIDE here because of the ToEigenRef.
+      //
       // WARNING: Mutating `output` will not work when T is AutoDiffXd,
-      // Expression, etc. See
+      // Expression, etc. For pybind11 background, see
       // https://github.com/pybind/pybind11/pull/1152#issuecomment-340091423
       // TODO(eric.cousineau): This will be resolved once dtype=custom is
       // resolved.
-      PYBIND11_OVERLOAD_INT(void, VectorSystem<T>, "DoCalcVectorOutput",
-          // N.B. Passing `Eigen::Map<>` derived classes by reference rather
-          // than pointer to ensure conceptual clarity. pybind11 `type_caster`
-          // struggles with types of `Map<Derived>*`, but not `Map<Derived>&`.
-          &context, input, state, ToEigenRef(output));
-      // If the macro did not return, use default functionality.
+      {
+        py::gil_scoped_acquire guard;
+        const VectorSystem<T>* const base = this;
+        py::object self = py::cast(base);
+        if (py::hasattr(self, "DoCalcVectorOutput")) {
+          self.attr("DoCalcVectorOutput")(
+              &context, input, state, ToEigenRef(output));
+          return;
+        }
+      }
+      // If not overridden, use default functionality.
       Base::DoCalcVectorOutput(context, input, state, output);
     }
 
@@ -364,12 +365,21 @@ struct Impl {
         const Eigen::VectorBlock<const VectorX<T>>& input,
         const Eigen::VectorBlock<const VectorX<T>>& state,
         Eigen::VectorBlock<VectorX<T>>* derivatives) const override {
+      // We can't use PYDRAKE_OVERRIDE here because of the ToEigenRef.
+      //
       // WARNING: Mutating `derivatives` will not work when T is AutoDiffXd,
       // Expression, etc. See above.
-      PYBIND11_OVERLOAD_INT(void, VectorSystem<T>,
-          "DoCalcVectorTimeDerivatives", &context, input, state,
-          ToEigenRef(derivatives));
-      // If the macro did not return, use default functionality.
+      {
+        py::gil_scoped_acquire guard;
+        const VectorSystem<T>* const base = this;
+        py::object self = py::cast(base);
+        if (py::hasattr(self, "DoCalcVectorTimeDerivatives")) {
+          self.attr("DoCalcVectorTimeDerivatives")(
+              &context, input, state, ToEigenRef(derivatives));
+          return;
+        }
+      }
+      // If not overridden, use default functionality.
       Base::DoCalcVectorOutput(context, input, state, derivatives);
     }
 
@@ -377,12 +387,21 @@ struct Impl {
         const Eigen::VectorBlock<const VectorX<T>>& input,
         const Eigen::VectorBlock<const VectorX<T>>& state,
         Eigen::VectorBlock<VectorX<T>>* next_state) const override {
+      // We can't use PYDRAKE_OVERRIDE here because of the ToEigenRef.
+      //
       // WARNING: Mutating `next_state` will not work when T is AutoDiffXd,
       // Expression, etc. See above.
-      PYBIND11_OVERLOAD_INT(void, VectorSystem<T>,
-          "DoCalcVectorDiscreteVariableUpdates", &context, input, state,
-          ToEigenRef(next_state));
-      // If the macro did not return, use default functionality.
+      {
+        py::gil_scoped_acquire guard;
+        const VectorSystem<T>* const base = this;
+        py::object self = py::cast(base);
+        if (py::hasattr(self, "DoCalcVectorDiscreteVariableUpdates")) {
+          self.attr("DoCalcVectorDiscreteVariableUpdates")(
+              &context, input, state, ToEigenRef(next_state));
+          return;
+        }
+      }
+      // If not overridden, use default functionality.
       Base::DoCalcVectorDiscreteVariableUpdates(
           context, input, state, next_state);
     }
@@ -390,13 +409,17 @@ struct Impl {
 
   class PySystemVisitor : public SystemVisitor<T> {
    public:
+    NB_TRAMPOLINE(SystemVisitor<T>, 2);
+
     // Trampoline virtual methods.
     void VisitSystem(const System<T>& system) override {
-      PYBIND11_OVERLOAD_PURE(void, SystemVisitor<T>, VisitSystem, system);
+      PYDRAKE_OVERRIDE_PURE(
+          void, SystemVisitor<T>, VisitSystem, std::cref(system));
     };
 
     void VisitDiagram(const Diagram<T>& diagram) override {
-      PYBIND11_OVERLOAD_PURE(void, SystemVisitor<T>, VisitDiagram, diagram);
+      PYDRAKE_OVERRIDE_PURE(
+          void, SystemVisitor<T>, VisitDiagram, std::cref(diagram));
     }
   };
 

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -34,6 +34,7 @@ namespace {
 // Python.
 class PySerializerInterface : public SerializerInterface {
  public:
+  NB_TRAMPOLINE(SerializerInterface, 0);
   using Base = SerializerInterface;
 
   PySerializerInterface() : Base() {}
@@ -46,37 +47,35 @@ class PySerializerInterface : public SerializerInterface {
 
   std::unique_ptr<AbstractValue> CreateDefaultValue() const final {
     // Our required unique_ptr return type cannot be directly fulfilled by a
-    // Python override, so we only ask the Python override for a py::object and
-    // then just Clone it to obtain the necessary C++ signature. Because the
-    // PYBIND11_OVERLOAD_PURE macro embeds a `return ...;` statement, we must
-    // wrap it in lambda so that we can post-process the return value.
-    py::object default_value = [this]() -> py::object {
-      PYBIND11_OVERLOAD_PURE(
-          py::object, SerializerInterface, CreateDefaultValue);
-    }();
-    DRAKE_THROW_UNLESS(!default_value.is_none());
-    return py::cast<const AbstractValue*>(default_value)->Clone();
+    // PYDRAKE_OVERRIDE_PURE, so we only ask the override for a py::object and
+    // then Clone it to obtain the necessary C++ signature.
+    py::gil_scoped_acquire guard;
+    const SerializerInterface* const self = this;
+    py::object result_py = py::cast(self).attr("CreateDefaultValue")();
+    const auto* result_cxx = py::cast<const AbstractValue*>(result_py);
+    DRAKE_THROW_UNLESS(result_cxx != nullptr);
+    return result_cxx->Clone();
   }
 
   void Deserialize(const void* message_bytes, int message_length,
       AbstractValue* abstract_value) const override {
+    // Passing {message_bytes, message_length} as a py::buffer means we can't
+    // use PYDRAKE_OVERRIDE_PURE; we'll need to write it out longhand.
     py::gil_scoped_acquire guard;
+    const SerializerInterface* const self = this;
     py::bytes buffer(
         reinterpret_cast<const char*>(message_bytes), message_length);
-    PYBIND11_OVERLOAD_PURE(
-        void, SerializerInterface, Deserialize, buffer, abstract_value);
+    py::cast(self).attr("Deserialize")(buffer, abstract_value);
   }
 
   void Serialize(const AbstractValue& abstract_value,
       std::vector<uint8_t>* message_bytes) const override {
+    // Converting the returned py::buffer to message_bytes means we can't use
+    // PYDRAKE_OVERRIDE_PURE; we'll need to write it out longhand.
     py::gil_scoped_acquire guard;
-    auto wrapped = [&]() -> py::bytes {
-      // N.B. We must pass `abstract_value` as a pointer to prevent `pybind11`
-      // from copying it.
-      PYBIND11_OVERLOAD_PURE(
-          py::bytes, SerializerInterface, Serialize, &abstract_value);
-    };
-    py::bytes result = wrapped();
+    const SerializerInterface* const self = this;
+    // N.B. We must pass `abstract_value` as a pointer to prevent copying.
+    py::bytes result{py::cast(self).attr("Serialize")(&abstract_value)};
     message_bytes->resize(result.size());
     std::copy(
         result.c_str(), result.c_str() + result.size(), message_bytes->data());

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -227,8 +227,8 @@ struct Impl {
 
   class PyTrajectory : public TrajectoryPublic {
    public:
+    NB_TRAMPOLINE(TrajectoryPublic, 7);
     using Base = TrajectoryPublic;
-    using Base::Base;
 
     // Utility function that takes a Python object which is-a Trajectory and
     // wraps it in a unique_ptr that manages object lifetime when returned back
@@ -256,52 +256,51 @@ struct Impl {
 
     std::unique_ptr<Trajectory<T>> DoClone() const final {
       py::gil_scoped_acquire guard;
+      const Trajectory<T>* const self = this;
       // Trajectory subclasses in Python must implement cloning by defining
       // a __deepcopy__ method.
       auto deepcopy = py::module_::import_("copy").attr("deepcopy");
-      return WrapPyTrajectory(deepcopy(this));
+      return WrapPyTrajectory(deepcopy(self));
     }
 
     MatrixX<T> do_value(const T& t) const final {
-      PYBIND11_OVERRIDE_PURE(MatrixX<T>, Trajectory<T>, do_value, t);
+      PYDRAKE_OVERRIDE_PURE(MatrixX<T>, Trajectory<T>, do_value, t);
     }
 
     bool do_has_derivative() const final {
-      PYBIND11_OVERRIDE_PURE(bool, Trajectory<T>, do_has_derivative);
+      PYDRAKE_OVERRIDE_PURE(bool, Trajectory<T>, do_has_derivative);
     }
 
     MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const final {
-      PYBIND11_OVERRIDE_PURE(
+      PYDRAKE_OVERRIDE_PURE(
           MatrixX<T>, Trajectory<T>, DoEvalDerivative, t, derivative_order);
     }
 
     std::unique_ptr<Trajectory<T>> DoMakeDerivative(
         int derivative_order) const final {
       py::gil_scoped_acquire guard;
-      // Because the PYBIND11_OVERRIDE_PURE macro embeds a `return ...;`
-      // statement, we must wrap it in lambda so that we can post-process the
+      const Trajectory<T>* const self = this;
+      // We can't use PYDRAKE_OVERRIDE_PURE because we need to post-process the
       // return value.
-      auto make_python_derivative = [&]() -> py::object {
-        PYBIND11_OVERRIDE_PURE(
-            py::object, Trajectory<T>, DoMakeDerivative, derivative_order);
-      };
-      return WrapPyTrajectory(make_python_derivative());
+      py::object result =
+          py::cast(self).attr("DoMakeDerivative")(derivative_order);
+      return WrapPyTrajectory(result);
     }
 
     T do_start_time() const final {
-      PYBIND11_OVERRIDE_PURE(T, Trajectory<T>, do_start_time);
+      PYDRAKE_OVERRIDE_PURE(T, Trajectory<T>, do_start_time);
     }
 
     T do_end_time() const final {
-      PYBIND11_OVERRIDE_PURE(T, Trajectory<T>, do_end_time);
+      PYDRAKE_OVERRIDE_PURE(T, Trajectory<T>, do_end_time);
     }
 
     Eigen::Index do_rows() const final {
-      PYBIND11_OVERRIDE_PURE(Eigen::Index, Trajectory<T>, do_rows);
+      PYDRAKE_OVERRIDE_PURE(Eigen::Index, Trajectory<T>, do_rows);
     }
 
     Eigen::Index do_cols() const final {
-      PYBIND11_OVERRIDE_PURE(Eigen::Index, Trajectory<T>, do_cols);
+      PYDRAKE_OVERRIDE_PURE(Eigen::Index, Trajectory<T>, do_cols);
     }
   };
 


### PR DESCRIPTION
Towards #21572.

Add `PYDRAKE_OVERRIDE_{,PURE}` macros that currently forward to the pybind11 spelling but in the future will be adapted for nanobind.

Remove uses of `PYBIND11_OVERLOAD_INT` -- it's an implementation detail of pybind11 that we shouldn't be using. The code is arguably easier to maintain without it, anyway.

Add and use `NB_TRAMPOLINE` polyfill with pybind11; for now, its only purpose is to incorporate the constructor 'using' statement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24771)
<!-- Reviewable:end -->
