### PR TITLE
[pydrake] Remove erroneous binding of DoCalcTimeDerivatives

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -1053,7 +1053,6 @@ Note: The above is for the C++ documentation. For Python, use
             py::overload_cast<int>(&LeafSystemPublic::DeclareDiscreteState),
             py::arg("num_state_variables"),
             doc.LeafSystem.DeclareDiscreteState.doc_1args_num_state_variables)
-        .def("DoCalcTimeDerivatives", &LeafSystemPublic::DoCalcTimeDerivatives)
         // Abstract state.
         .def("DeclareAbstractState",
             py::overload_cast<const AbstractValue&>(


### PR DESCRIPTION
Python subclasses of LeafSystem may still override this method, but Python code shouldn't be calling NVI DoCalcTimeDerivatives directly. Instead, call CalcTimeDerivatives.

Noticed during nanobind porting for #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24774)
<!-- Reviewable:end -->
