### PR TITLE
Remove destructors on function-local statics

### DIFF
--- a/common/symbolic/expression/formula.cc
+++ b/common/symbolic/expression/formula.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
 #define DRAKE_COMMON_SYMBOLIC_EXPRESSION_DETAIL_HEADER
 #include "drake/common/symbolic/expression/formula_cell.h"
 #undef DRAKE_COMMON_SYMBOLIC_EXPRESSION_DETAIL_HEADER
@@ -114,12 +115,12 @@ string Formula::to_string() const {
 }
 
 Formula Formula::True() {
-  static Formula tt{make_shared<const FormulaTrue>()};
-  return tt;
+  static never_destroyed<Formula> tt{make_shared<const FormulaTrue>()};
+  return tt.access();
 }
 Formula Formula::False() {
-  static Formula ff{make_shared<const FormulaFalse>()};
-  return ff;
+  static never_destroyed<Formula> ff{make_shared<const FormulaFalse>()};
+  return ff.access();
 }
 
 Formula forall(const Variables& vars, const Formula& f) {

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -12,6 +12,7 @@
 #include <fmt/ranges.h>
 
 #include "drake/common/hash.h"
+#include "drake/common/never_destroyed.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
@@ -635,11 +636,11 @@ void SystemBase::WarnPortDeprecation(bool is_input, int port_index) const {
   hash_append(hash, is_input);
   hash_append(hash, port->get_name());
   const size_t key = size_t{hash};
-  static std::mutex g_mutex;
-  static std::unordered_set<size_t> g_warned_hash;
+  static never_destroyed<std::mutex> g_mutex;
+  static never_destroyed<std::unordered_set<size_t>> g_warned_hash;
   {
-    std::lock_guard lock(g_mutex);
-    const bool inserted = g_warned_hash.insert(key).second;
+    std::lock_guard lock(g_mutex.access());
+    const bool inserted = g_warned_hash.access().insert(key).second;
     if (!inserted) {
       // The key was already in the map, which means that we've already
       // warned about this port name on this particular system subclass.

--- a/tools/workspace/sdformat_internal/patches/upstream/never_destroyed.patch
+++ b/tools/workspace/sdformat_internal/patches/upstream/never_destroyed.patch
@@ -1,0 +1,41 @@
+Remove static destructors (run upon program exit) for local variables.
+
+https://github.com/gazebosim/sdformat/pull/1690
+
+--- src/parser.cc
++++ src/parser.cc
+@@ -1750,14 +1750,12 @@
+           // NOTE: sdf::init is an expensive call. For performance reason,
+           // a new sdf pointer is created here by cloning a fresh sdf template
+           // pointer instead of calling init every iteration.
+-          // SDFPtr includeSDF(new SDF);
+-          // init(includeSDF, _config);
+-          static SDFPtr includeSDFTemplate;
+-          if (!includeSDFTemplate)
+-          {
+-            includeSDFTemplate.reset(new SDF);
+-            init(includeSDFTemplate, _config);
+-          }
++          // This template is purposefully never deleted ala gz::utils::NeverDestroyed.
++          static SDF* includeSDFTemplate = [&_config]() {
++            SDFPtr temp(new SDF, [](SDF*) { /* The deleter is a no-op. */ });
++            init(temp, _config);
++            return temp.get();
++          }();
+           SDFPtr includeSDF(new SDF);
+           includeSDF->SetRoot(includeSDFTemplate->Root()->Clone());
+ 
+
+--- src/SDF.cc
++++ src/SDF.cc
+@@ -583,8 +583,8 @@
+   }
+ 
+   // An empty SDF string is returned if a query into the embeddedSdf map fails.
+-  static const std::string emptySdfString;
+-  return emptySdfString;
++  static const gz::utils::NeverDestroyed<std::string> emptySdfString;
++  return emptySdfString.Access();
+ }
+ }
+ }

--- a/tools/workspace/sdformat_internal/repository.bzl
+++ b/tools/workspace/sdformat_internal/repository.bzl
@@ -14,6 +14,7 @@ def sdformat_internal_repository(
         build_file = ":package.BUILD.bazel",
         sha256 = "4fac898700afb2953af5f8ac6b0221e4d9bc1e460aac6d4b7a5c3699c456126c",  # noqa
         patches = [
+            ":patches/upstream/never_destroyed.patch",
             ":patches/upstream/no_density_not_a_problem.patch",
             ":patches/upstream/support_drake_visual.patch",
             ":patches/console.patch",

--- a/tools/workspace/tinygltf_internal/patches/never_destroyed.patch
+++ b/tools/workspace/tinygltf_internal/patches/never_destroyed.patch
@@ -1,0 +1,44 @@
+Remove static destructors (run upon program exit) for local variables
+
+This patch should be upstreamed, but upstream has disabled pull
+requests, so *shrug*.
+
+--- tiny_gltf.h
++++ tiny_gltf.h
+@@ -334,19 +334,15 @@ class Value {
+ 
+   // Lookup value from an array
+   const Value &Get(size_t idx) const {
+-    static Value null_value;
+     assert(IsArray());
+-    return (idx < array_value_.size())
+-               ? array_value_[idx]
+-               : null_value;
++    return (idx < array_value_.size()) ? array_value_[idx] : Null();
+   }
+ 
+   // Lookup value from a key-value pair
+   const Value &Get(const std::string &key) const {
+-    static Value null_value;
+     assert(IsObject());
+     Object::const_iterator it = object_value_.find(key);
+-    return (it != object_value_.end()) ? it->second : null_value;
++    return (it != object_value_.end()) ? it->second : Null();
+   }
+ 
+   size_t ArrayLen() const {
+@@ -379,6 +375,14 @@ class Value {
+   bool operator==(const tinygltf::Value &other) const;
+ 
+  protected:
++  static const Value &Null() {
++    // We use placement-new (with no delete) so that the destructor does not run
++    // at program exit, avoiding the Static Destruction Order Fiasco.
++    alignas(Value) static char storage[sizeof(Value)];
++    static const Value *null_singleton = new (storage) Value();
++    return *null_singleton;
++  }
++
+   int type_ = NULL_TYPE;
+ 
+   int int_value_ = 0;

--- a/tools/workspace/tinygltf_internal/repository.bzl
+++ b/tools/workspace/tinygltf_internal/repository.bzl
@@ -10,5 +10,8 @@ def tinygltf_internal_repository(
         commit = "v3.0.0",
         sha256 = "806b0f1ba8007837fcd531e23872286f8a8870ee23275e1eb5304cdb48e4cb30",  # noqa
         build_file = ":package.BUILD.bazel",
+        patches = [
+            ":patches/never_destroyed.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
These are forbidden by our style guide: https://drake.mit.edu/styleguide/cppguide.html#Static_and_Global_Variables.

I have a regression test underway for this at #24785, but hopefully these are obviously good by inspection.

Towards #24446.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24784)
<!-- Reviewable:end -->
