### PR TITLE
[doc] Update policy for private runtime dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -165,9 +165,7 @@ use_repo(
     "blas",
     "glib",
     "lapack",
-    "libjpeg",
     "opencl",
-    "zlib",
     #
     # First-party dependencies (i.e., drake-maintained).
     #
@@ -192,6 +190,10 @@ use_repo(
     # deprecating it until we have nanobind ready.
     #
     "pybind11",
+    # TODO(jwnimmer-tri) Deprecate these. They are (or should be)
+    # non-configurable, so don't need a module extension.
+    "libjpeg",
+    "zlib",
 )
 
 # Load Java dependencies.

--- a/doc/_pages/stable.md
+++ b/doc/_pages/stable.md
@@ -126,9 +126,8 @@ dependency.
 
 We may add new dependencies without prior notice. All of our dependencies will
 either be installed via the host system via our `install_prereqs` scripts,
-and/or downloaded at build-time via our `add_default_...` macros (when not
-using `bzlmod`) or our `MODULE.bazel` file (when using bzlmod), and/or
-specified via packaging metadata in the case of `apt` or `pip`.
+and/or downloaded at build-time via our `MODULE.bazel` file, and/or
+specified via packaging metadata in the case of our `apt` or `pip` binaries.
 
 ## LCM messages
 

--- a/tools/flags/BUILD.bazel
+++ b/tools/flags/BUILD.bazel
@@ -146,9 +146,16 @@ string_flag(
 
 # The :private_runtime_repo_default configures what happens when a specific
 # :foobar_repo flag is set to "default". When "external" is selected, the
-# dependency is provided outisde of Bazel (e.g., via pkg-config or other OS-
+# dependency is provided outside of Bazel (e.g., via pkg-config or other OS-
 # specific logic). When "internal" is selected, the dependency is provided with
 # Bazel mechanisms (e.g., "bazel_dep", module extension, etc.).
+#
+# Note that only a limited number of private runtime dependencies have :foo_repo
+# flags that are responsive to this default. Most private dependencies will be
+# unconditionally built from source. Only libraries that are closely associated
+# with the operating system or hardware environment offer these flags, e.g.,
+# BLAS / LAPACK / OpenCL. (We also offer a flag for glib because its copyleft
+# license sometimes requires special handling.)
 string_flag(
     name = "private_runtime_repo_default",
     build_setting_default = "internal",
@@ -196,19 +203,6 @@ string_flag(
     ],
 )
 
-# The :libjpeg_repo flag configures where Drake obtains @libjpeg from.
-# The public dependency alias is `@drake//tools/workspace/libjpeg` or use the
-# drake_dep_repositories() module extension at //tools/workspace:default.bzl.
-string_flag(
-    name = "libjpeg_repo",
-    build_setting_default = "source",
-    values = [
-        # For now, the only supported value is "source", to compile jpeg from
-        # source.
-        "source",
-    ],
-)
-
 # The :lapack_repo flag configures where Drake obtains @lapack from.
 # The public dependency alias is `@drake//tools/workspace/lapack` or use the
 # drake_dep_repositories() module extension at //tools/workspace:default.bzl.
@@ -246,9 +240,9 @@ string_flag(
     ],
 )
 
-# TODO(jwnimmer-tri) There is an "libx11" module in BCR, but I haven't been able
-# to get it to work yet, so for the moment we don't offer it as a module option.
-
+# TODO(jwnimmer-tri) Deprecate this flag. We cannot reasonably force Drake's
+# choice of zlib down into all BCR modules that will eventually need it.
+#
 # The :zlib_repo flag configures where Drake obtains @zlib from.
 # The public dependency alias is `@drake//tools/workspace/zlib` or use the
 # drake_dep_repositories() module extension at //tools/workspace:default.bzl.

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -163,9 +163,11 @@ def _drake_dep_repositories_impl(module_ctx):
         "fmt",
         "glib",
         "lapack",
-        "libjpeg",
         "opencl",
         "spdlog",
+        # TODO(jwnimmer-tri) Deprecate these. They are (or should be)
+        # non-configurable, so don't need a module extension.
+        "libjpeg",
         "zlib",
     ]
     for name in ALIAS_REPOSITORIES:

--- a/tools/workspace/libjpeg/BUILD.bazel
+++ b/tools/workspace/libjpeg/BUILD.bazel
@@ -4,23 +4,11 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:private"])
 
-# ---- Logic for choosing which libjpeg to use. ---
-
-# For now, the only supported value is --@drake//tools/flags:libjpeg_repo=source
-# to compile libjpeg from source.
-
-alias(
-    name = "libjpeg",
-    actual = ":module_libjpeg_static_hidden",
-    visibility = ["//visibility:public"],
-)
-
 cc_static_hidden_library(
-    name = "module_libjpeg_static_hidden",
+    name = "libjpeg",
+    visibility = ["//visibility:public"],
     deps = ["@module_libjpeg//:jpeg"],
 )
-
-# ---- Logic for installing jpeg-related files. ---
 
 install_files(
     name = "install_license",


### PR DESCRIPTION
Update our documentation surrounding private_runtime_repo_default. We no longer aspire to make most private dependencies configurable with Bazel flags. If users want to override modules, they should use Bazel module overrides, not Drake-custom flags.

Remove config flag for libjpeg_repo. Per the new policy, we will never have other options for this flag. It was only recently added, so is not part of Stable API yet, so can be yanked without deprecation.

Add a few TODOs for things we'll want to deprecate soon.

Remove outdated pre-bzlmod text from our stable API docs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24791)
<!-- Reviewable:end -->
