### PR TITLE
Fix dropped derivatives in Eigen Cholesky solves of AutoDiff matrices

### DIFF
--- a/common/ad/BUILD.bazel
+++ b/common/ad/BUILD.bazel
@@ -57,6 +57,7 @@ drake_cc_googletest(
     deps = [
         ":auto_diff",
         "//common/test_utilities:eigen_matrix_compare",
+        "//math:gradient",
     ],
 )
 

--- a/common/ad/BUILD.bazel
+++ b/common/ad/BUILD.bazel
@@ -53,6 +53,14 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "eigen_cholesky_test",
+    deps = [
+        ":auto_diff",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "matrix_test",
     deps = [
         ":auto_diff",

--- a/common/ad/internal/eigen_specializations.h
+++ b/common/ad/internal/eigen_specializations.h
@@ -58,6 +58,30 @@ struct ScalarBinaryOpTraits<double, drake::ad::AutoDiff, BinOp> {
   using ReturnType = drake::ad::AutoDiff;
 };
 
+// Eigen's triangular solvers (the back end of LLT, LDLT, and LU solves with a
+// vector right-hand side) skip the divide-and-propagate step for any component
+// where is_identically_zero() returns true. The default implementation of that
+// check uses operator==, which for AutoDiff compares only the value and
+// ignores the derivatives. A component whose value happens to be exactly zero
+// but whose derivatives are nonzero (e.g., velocities when linearizing about a
+// fixed point) would therefore have its derivatives silently dropped; see
+// drake#17037. This specialization makes the check derivative-aware, mirroring
+// the specialization Eigen ships for its own AutoDiffScalar. Note that Eigen
+// 3.4.x does not provide this customization point, so builds against a system
+// Eigen 3.4.x remain subject to drake#17037 and should use
+// drake::math::LinearSolver instead of calling Eigen's factorizations directly
+// on AutoDiff matrices.
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
+namespace internal {
+template <>
+struct is_identically_zero_impl<drake::ad::AutoDiff> {
+  static bool run(const drake::ad::AutoDiff& s) {
+    return s.value() == 0.0 && (s.derivatives().array() == 0.0).all();
+  }
+};
+}  // namespace internal
+#endif
+
 }  // namespace Eigen
 
 #endif  // DRAKE_DOXYGEN_CXX

--- a/common/ad/internal/eigen_specializations.h
+++ b/common/ad/internal/eigen_specializations.h
@@ -58,21 +58,9 @@ struct ScalarBinaryOpTraits<double, drake::ad::AutoDiff, BinOp> {
   using ReturnType = drake::ad::AutoDiff;
 };
 
-// Eigen's triangular solvers (the back end of LLT, LDLT, and LU solves with a
-// vector right-hand side) skip the divide-and-propagate step for any component
-// where is_identically_zero() returns true. The default implementation of that
-// check uses operator==, which for AutoDiff compares only the value and
-// ignores the derivatives. A component whose value happens to be exactly zero
-// but whose derivatives are nonzero (e.g., velocities when linearizing about a
-// fixed point) would therefore have its derivatives silently dropped; see
-// drake#17037. This specialization makes the check derivative-aware, mirroring
-// the specialization Eigen ships for its own AutoDiffScalar. Note that Eigen
-// 3.4.x does not provide this customization point, so builds against a system
-// Eigen 3.4.x remain subject to drake#17037 and should use
-// drake::math::LinearSolver instead of calling Eigen's factorizations directly
-// on AutoDiff matrices.
 #if EIGEN_VERSION_AT_LEAST(5, 0, 0)
 namespace internal {
+// Identically zero means that both value and derivatives are zero/empty.
 template <>
 struct is_identically_zero_impl<drake::ad::AutoDiff> {
   static bool run(const drake::ad::AutoDiff& s) {

--- a/common/ad/test/eigen_cholesky_test.cc
+++ b/common/ad/test/eigen_cholesky_test.cc
@@ -2,6 +2,8 @@
 
 #include "drake/common/ad/auto_diff.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff.h"
+#include "drake/math/autodiff_gradient.h"
 
 // Regression tests for drake#17037: Eigen's triangular solvers skip the
 // divide-and-propagate step for any right-hand-side component that compares
@@ -16,40 +18,25 @@ namespace drake {
 namespace ad {
 namespace {
 
+using drake::math::ExtractGradient;
+using drake::math::InitializeAutoDiff;
 using Eigen::Matrix2d;
 using Eigen::MatrixXd;
 using Eigen::Vector2d;
 
-constexpr double kTolerance = 1e-14;
+constexpr bool kOldEigen = !EIGEN_VERSION_AT_LEAST(5, 0, 0);
 
-// Returns the gradient of v with respect to the two independent variables.
-MatrixXd ExtractGradient(const VectorX<AutoDiff>& v) {
-  MatrixXd result = MatrixXd::Zero(v.size(), 2);
-  for (int i = 0; i < v.size(); ++i) {
-    const auto& derivs = v[i].derivatives();
-    for (int j = 0; j < derivs.size(); ++j) {
-      result(i, j) = derivs[j];
-    }
-  }
-  return result;
-}
+constexpr double kTolerance = 1e-14;
 
 // Returns b = [b0, b1] with ∂b/∂b = I₂, so that ∂x/∂b = M⁻¹ exactly.
 VectorX<AutoDiff> MakeIndependentRhs(double b0, double b1) {
-  VectorX<AutoDiff> b(2);
-  b[0] = AutoDiff{b0, Vector2d::Unit(0)};
-  b[1] = AutoDiff{b1, Vector2d::Unit(1)};
-  return b;
+  return InitializeAutoDiff(Vector2d{b0, b1});
 }
 
 // Solving with llt() exercises the non-unit-diagonal triangular solve, where
 // the zero-skip would omit the division of the derivatives by the Cholesky
 // diagonal. x[0] has value zero with nonzero derivatives.
 GTEST_TEST(EigenCholeskyTest, LltDynamicSolve) {
-#if !EIGEN_VERSION_AT_LEAST(5, 0, 0)
-  GTEST_SKIP() << "Eigen 3.4.x lacks the is_identically_zero customization "
-                  "point; see drake#17037.";
-#endif
   MatrixX<AutoDiff> M = MatrixX<AutoDiff>::Zero(2, 2);
   M(0, 0) = 4.0;
   M(1, 1) = 9.0;
@@ -57,8 +44,13 @@ GTEST_TEST(EigenCholeskyTest, LltDynamicSolve) {
   const VectorX<AutoDiff> x = M.llt().solve(b);
 
   const Vector2d value_expected(0.0, 5.0 / 9.0);
-  const MatrixXd gradient_expected =
+  MatrixXd gradient_expected =
       (Matrix2d() << 0.25, 0.0, 0.0, 1.0 / 9.0).finished();
+  if (kOldEigen) {
+    // Eigen 3.4.x lacks the is_identically_zero customization point, so expect
+    // a *wrong* answer in that case. See drake#17037.
+    gradient_expected(0, 0) = 1.0;
+  }
   EXPECT_TRUE(
       CompareMatrices(ExtractGradient(x), gradient_expected, kTolerance));
   EXPECT_NEAR(x[0].value(), value_expected[0], kTolerance);
@@ -69,10 +61,6 @@ GTEST_TEST(EigenCholeskyTest, LltDynamicSolve) {
 // zero-skip would omit propagating the derivatives of the intermediate
 // component y[0] = b[0] (value zero, nonzero derivatives) into y[1].
 GTEST_TEST(EigenCholeskyTest, LdltDynamicSolve) {
-#if !EIGEN_VERSION_AT_LEAST(5, 0, 0)
-  GTEST_SKIP() << "Eigen 3.4.x lacks the is_identically_zero customization "
-                  "point; see drake#17037.";
-#endif
   MatrixX<AutoDiff> M(2, 2);
   M(0, 0) = 4.0;
   M(0, 1) = 2.0;
@@ -82,8 +70,14 @@ GTEST_TEST(EigenCholeskyTest, LdltDynamicSolve) {
   const VectorX<AutoDiff> x = M.ldlt().solve(b);
 
   // M⁻¹ = (1/8) [3 -2; -2 4].
-  const MatrixXd gradient_expected =
+  MatrixXd gradient_expected =
       (Matrix2d() << 3.0 / 8.0, -2.0 / 8.0, -2.0 / 8.0, 4.0 / 8.0).finished();
+  if (kOldEigen) {
+    // Eigen 3.4.x lacks the is_identically_zero customization point, so expect
+    // a *wrong* answer in that case. See drake#17037.
+    gradient_expected(0, 0) = 0.25;
+    gradient_expected(1, 0) = 0;
+  }
   EXPECT_TRUE(
       CompareMatrices(ExtractGradient(x), gradient_expected, kTolerance));
   EXPECT_NEAR(x[0].value(), -0.25, kTolerance);
@@ -94,14 +88,14 @@ GTEST_TEST(EigenCholeskyTest, LdltDynamicSolve) {
 // zero-skip; this control case documents that boundary (and must keep passing
 // on all supported Eigen versions).
 GTEST_TEST(EigenCholeskyTest, LltFixedSizeSolve) {
-  Eigen::Matrix<AutoDiff, 2, 2> M;
+  Matrix2<AutoDiff> M;
   M.setZero();
   M(0, 0) = 4.0;
   M(1, 1) = 9.0;
-  Eigen::Matrix<AutoDiff, 2, 1> b;
+  Vector2<AutoDiff> b;
   b[0] = AutoDiff{0.0, Vector2d::Unit(0)};
   b[1] = AutoDiff{5.0, Vector2d::Unit(1)};
-  const Eigen::Matrix<AutoDiff, 2, 1> x = M.llt().solve(b);
+  const Vector2<AutoDiff> x = M.llt().solve(b);
 
   VectorX<AutoDiff> x_dynamic(2);
   x_dynamic << x[0], x[1];

--- a/common/ad/test/eigen_cholesky_test.cc
+++ b/common/ad/test/eigen_cholesky_test.cc
@@ -1,0 +1,116 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/ad/auto_diff.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+// Regression tests for drake#17037: Eigen's triangular solvers skip the
+// divide-and-propagate step for any right-hand-side component that compares
+// equal to zero. Without a derivative-aware is_identically_zero specialization
+// (see eigen_specializations.h), a component whose value is exactly zero but
+// whose derivatives are nonzero has its derivatives silently dropped by
+// dynamic-size llt() and ldlt() solves. The systems below are constructed to
+// hit exactly that case, and the expected gradients are the analytic inverse
+// of the (constant) matrix: x = M⁻¹b implies ∂x/∂b = M⁻¹.
+
+namespace drake {
+namespace ad {
+namespace {
+
+using Eigen::Matrix2d;
+using Eigen::MatrixXd;
+using Eigen::Vector2d;
+
+constexpr double kTolerance = 1e-14;
+
+// Returns the gradient of v with respect to the two independent variables.
+MatrixXd ExtractGradient(const VectorX<AutoDiff>& v) {
+  MatrixXd result = MatrixXd::Zero(v.size(), 2);
+  for (int i = 0; i < v.size(); ++i) {
+    const auto& derivs = v[i].derivatives();
+    for (int j = 0; j < derivs.size(); ++j) {
+      result(i, j) = derivs[j];
+    }
+  }
+  return result;
+}
+
+// Returns b = [b0, b1] with ∂b/∂b = I₂, so that ∂x/∂b = M⁻¹ exactly.
+VectorX<AutoDiff> MakeIndependentRhs(double b0, double b1) {
+  VectorX<AutoDiff> b(2);
+  b[0] = AutoDiff{b0, Vector2d::Unit(0)};
+  b[1] = AutoDiff{b1, Vector2d::Unit(1)};
+  return b;
+}
+
+// Solving with llt() exercises the non-unit-diagonal triangular solve, where
+// the zero-skip would omit the division of the derivatives by the Cholesky
+// diagonal. x[0] has value zero with nonzero derivatives.
+GTEST_TEST(EigenCholeskyTest, LltDynamicSolve) {
+#if !EIGEN_VERSION_AT_LEAST(5, 0, 0)
+  GTEST_SKIP() << "Eigen 3.4.x lacks the is_identically_zero customization "
+                  "point; see drake#17037.";
+#endif
+  MatrixX<AutoDiff> M = MatrixX<AutoDiff>::Zero(2, 2);
+  M(0, 0) = 4.0;
+  M(1, 1) = 9.0;
+  const VectorX<AutoDiff> b = MakeIndependentRhs(0.0, 5.0);
+  const VectorX<AutoDiff> x = M.llt().solve(b);
+
+  const Vector2d value_expected(0.0, 5.0 / 9.0);
+  const MatrixXd gradient_expected =
+      (Matrix2d() << 0.25, 0.0, 0.0, 1.0 / 9.0).finished();
+  EXPECT_TRUE(
+      CompareMatrices(ExtractGradient(x), gradient_expected, kTolerance));
+  EXPECT_NEAR(x[0].value(), value_expected[0], kTolerance);
+  EXPECT_NEAR(x[1].value(), value_expected[1], kTolerance);
+}
+
+// Solving with ldlt() exercises the unit-diagonal triangular solve, where the
+// zero-skip would omit propagating the derivatives of the intermediate
+// component y[0] = b[0] (value zero, nonzero derivatives) into y[1].
+GTEST_TEST(EigenCholeskyTest, LdltDynamicSolve) {
+#if !EIGEN_VERSION_AT_LEAST(5, 0, 0)
+  GTEST_SKIP() << "Eigen 3.4.x lacks the is_identically_zero customization "
+                  "point; see drake#17037.";
+#endif
+  MatrixX<AutoDiff> M(2, 2);
+  M(0, 0) = 4.0;
+  M(0, 1) = 2.0;
+  M(1, 0) = 2.0;
+  M(1, 1) = 3.0;
+  const VectorX<AutoDiff> b = MakeIndependentRhs(0.0, 1.0);
+  const VectorX<AutoDiff> x = M.ldlt().solve(b);
+
+  // M⁻¹ = (1/8) [3 -2; -2 4].
+  const MatrixXd gradient_expected =
+      (Matrix2d() << 3.0 / 8.0, -2.0 / 8.0, -2.0 / 8.0, 4.0 / 8.0).finished();
+  EXPECT_TRUE(
+      CompareMatrices(ExtractGradient(x), gradient_expected, kTolerance));
+  EXPECT_NEAR(x[0].value(), -0.25, kTolerance);
+  EXPECT_NEAR(x[1].value(), 0.5, kTolerance);
+}
+
+// Fixed-size solves use Eigen's unrolled triangular solver, which has no
+// zero-skip; this control case documents that boundary (and must keep passing
+// on all supported Eigen versions).
+GTEST_TEST(EigenCholeskyTest, LltFixedSizeSolve) {
+  Eigen::Matrix<AutoDiff, 2, 2> M;
+  M.setZero();
+  M(0, 0) = 4.0;
+  M(1, 1) = 9.0;
+  Eigen::Matrix<AutoDiff, 2, 1> b;
+  b[0] = AutoDiff{0.0, Vector2d::Unit(0)};
+  b[1] = AutoDiff{5.0, Vector2d::Unit(1)};
+  const Eigen::Matrix<AutoDiff, 2, 1> x = M.llt().solve(b);
+
+  VectorX<AutoDiff> x_dynamic(2);
+  x_dynamic << x[0], x[1];
+  const MatrixXd gradient_expected =
+      (Matrix2d() << 0.25, 0.0, 0.0, 1.0 / 9.0).finished();
+  EXPECT_TRUE(CompareMatrices(ExtractGradient(x_dynamic), gradient_expected,
+                              kTolerance));
+}
+
+}  // namespace
+}  // namespace ad
+}  // namespace drake


### PR DESCRIPTION
Towards #17037.

## The problem

#17037 tracked wrong derivatives from dynamic-size `llt()` / `ldlt()` solves of AutoDiff matrices: Eigen's triangular solvers skip the divide-and-propagate step for any right-hand-side component that compares equal to zero, and for autodiff types `== 0` sees only the value. A component whose value is exactly zero but whose derivatives are nonzero (e.g., velocities when linearizing about a fixed point) therefore has its derivatives silently dropped.

Two things have changed since that discussion, and their combination reintroduces the bug on current master:

1. Eigen's fix ([libeigen/eigen!976](https://gitlab.com/libeigen/eigen/-/merge_requests/976)) shipped in Eigen 5.0.0+, but was **not** backported to the 3.4 branch (3.4.1 still reproduces the original problem). The fix works through a scalar customization point, `Eigen::internal::is_identically_zero`, which Eigen specializes only for its own `AutoDiffScalar`.
2. Drake has since replaced `Eigen::AutoDiffScalar` with `drake::ad::AutoDiff`, which does not specialize that customization point — so the value-only fallback applies and derivatives are dropped again, even with the Eigen 5.0.1 that Drake now pins.

Minimal repro on current master (Eigen 5.0.1): solving `diag(4, 9) x = b` with `b0 = 0 (∂b0/∂b0 = 1)`, `b1 = 5 (∂b1/∂b1 = 1)` via dynamic-size `llt().solve(b)` yields `∂x0/∂b0 == 1` instead of `0.25` — the derivative is never divided by the Cholesky diagonal.

All current in-tree call sites happen to be unaffected (they use `math::LinearSolver`, double matrices, or fixed-size solves, which take Eigen's unrolled triangular path that has no zero-skip). Dynamic-size solves in downstream user code are exposed.

## The fix

Specialize `Eigen::internal::is_identically_zero` for `AutoDiff` so the check is derivative-aware (true only when the value **and** all partials are zero), mirroring the specialization Eigen ships for its own `AutoDiffScalar`.

The specialization is guarded by `EIGEN_VERSION_AT_LEAST(5, 0, 0)`: Eigen 3.4.x has no such customization point, so builds against a system Eigen 3.4.x remain subject to #17037. The new regression test skips on 3.4.x with a pointer to the issue, and the long-standing guidance to prefer `drake::math::LinearSolver` over raw Eigen factorizations for AutoDiff still applies there.

Performance: for components with nonzero values the check costs a single value comparison, as before. The derivative scan only runs when a component's value is exactly zero — the case that previously computed wrong results.

## Testing

New regression test `common/ad/test/eigen_cholesky_test.cc`:

- dynamic `llt()` solve — exercises the non-unit-diagonal division skip;
- dynamic `ldlt()` solve — exercises the unit-diagonal propagation skip;
- fixed-size `llt()` solve — control case documenting the unaffected boundary.

Both dynamic cases fail without the specialization and pass with it. Expected gradients are the analytic `M⁻¹` (constant matrix, so `∂x/∂b = M⁻¹` exactly).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24796)
<!-- Reviewable:end -->
