### PR TITLE
TOPPRA Optionally Relax Constraints to Handle Numerically-Challenging Trajectories

### DIFF
--- a/bindings/generated_docstrings/multibody_optimization.h
+++ b/bindings/generated_docstrings/multibody_optimization.h
@@ -1062,6 +1062,28 @@ Note:
     ensure the reachable set calculated in the backward pass is always
     bounded.)""";
         } ctor;
+        // Symbol: drake::multibody::Toppra::constraint_relaxation
+        struct /* constraint_relaxation */ {
+          // Source: drake/multibody/optimization/toppra.h
+          const char* doc =
+R"""(Returns the problem relaxation tolerance used in the forward pass.)""";
+        } constraint_relaxation;
+        // Symbol: drake::multibody::Toppra::set_constraint_relaxation
+        struct /* set_constraint_relaxation */ {
+          // Source: drake/multibody/optimization/toppra.h
+          const char* doc =
+R"""(Sets the tolerance used to slightly relax the forward pass linear
+constraints. This is a problem tolerance, not a solver tolerance,
+meaning it slightly relaxes the physical problem bounds. This is
+useful for numerically difficult trajectories where the backward pass
+solver finds a solution on the boundary of the feasible set, causing
+the forward pass to fail due to solver precision limits. A typical
+value is ``1e-4`` or ``1e-5``. If 0.0, no relaxation is applied. The
+default is 0.0 (no relaxation).
+
+Raises:
+    RuntimeError if relaxation is negative or not finite.)""";
+        } set_constraint_relaxation;
       } Toppra;
       // Symbol: drake::multibody::ToppraDiscretization
       struct /* ToppraDiscretization */ {

--- a/bindings/pydrake/multibody/optimization_py.cc
+++ b/bindings/pydrake/multibody/optimization_py.cc
@@ -226,7 +226,11 @@ PYDRAKE_MODULE(optimization, m) {
             py::arg("constraint_frame"), py::arg("lower_limit"),
             py::arg("upper_limit"),
             py::arg("discretization") = ToppraDiscretization::kInterpolation,
-            cls_doc.AddFrameAccelerationLimit.doc_trajectory);
+            cls_doc.AddFrameAccelerationLimit.doc_trajectory)
+        .def("set_constraint_relaxation", &Class::set_constraint_relaxation,
+            py::arg("relaxation"), cls_doc.set_constraint_relaxation.doc)
+        .def("constraint_relaxation", &Class::constraint_relaxation,
+            cls_doc.constraint_relaxation.doc);
   }
 }
 }  // namespace

--- a/bindings/pydrake/multibody/test/optimization_test.py
+++ b/bindings/pydrake/multibody/test/optimization_test.py
@@ -397,6 +397,10 @@ class TestToppra(unittest.TestCase):
         gridpoints = Toppra.CalcGridPoints(path, CalcGridPointsOptions())
         toppra = Toppra(path=path, plant=plant, gridpoints=gridpoints)
 
+        # Test basic constraint relaxation API.
+        toppra.set_constraint_relaxation(relaxation=1e-3)
+        self.assertEqual(toppra.constraint_relaxation(), 1e-3)
+
         # Joint constraints
         upper_limit = np.arange(7)
         lower_limit = -upper_limit

--- a/multibody/optimization/test/toppra_test.cc
+++ b/multibody/optimization/test/toppra_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/optimization/toppra.h"
 
+#include <limits>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -814,6 +815,56 @@ TEST_F(PrismaticToppraTest, InfiniteTimeStepError) {
   ASSERT_NO_THROW(toppra->SolvePathParameterization());
   auto result = toppra->SolvePathParameterization(0, 0);
   EXPECT_FALSE(result);
+}
+
+TEST_F(IiwaToppraTest, ConstraintRelaxationTest) {
+  // We construct a trajectory with a tiny velocity but massive acceleration,
+  // causing the linear constraints on path acceleration `u` to have very tight
+  // bounds. This replicates the scenario where the forward pass fails due to
+  // primal feasibility tolerance gaps inherited from the backward pass.
+  std::vector<Eigen::Matrix<Polynomial<double>, Eigen::Dynamic, Eigen::Dynamic>>
+      segments(1);
+  Eigen::Matrix<Polynomial<double>, 7, 1> poly_mat;
+  poly_mat(0, 0) = Polynomial<double>(Eigen::Vector3d(0, -999.99, 500.0));
+  poly_mat(1, 0) = Polynomial<double>(Eigen::Vector3d(0, -1000.01, 500.0));
+  for (int i = 2; i < 7; ++i) {
+    poly_mat(i, 0) = Polynomial<double>(Eigen::Vector3d::Zero());
+  }
+  segments[0] = poly_mat;
+  std::vector<double> breaks = {0.0, 2.0};
+  PiecewisePolynomial<double> path(segments, breaks);
+
+  Eigen::VectorXd gridpoints(3);
+  gridpoints << 0.0, 1.0, 2.0;
+
+  Toppra toppra(path, *iiwa_plant_, gridpoints);
+  toppra.AddJointAccelerationLimit(Eigen::VectorXd::Constant(7, -10),
+                                   Eigen::VectorXd::Constant(7, 10));
+  // Negative relaxation is not allowed.
+  DRAKE_EXPECT_THROWS_MESSAGE(toppra.set_constraint_relaxation(-1e-8),
+                              ".*relaxation >= 0.0.*");
+
+  // Infinite/NaN relaxation is not allowed.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      toppra.set_constraint_relaxation(std::numeric_limits<double>::infinity()),
+      ".*std::isfinite\\(relaxation\\).*");
+  DRAKE_EXPECT_THROWS_MESSAGE(toppra.set_constraint_relaxation(
+                                  std::numeric_limits<double>::quiet_NaN()),
+                              ".*std::isfinite\\(relaxation\\).*");
+
+  // The forward pass LP should fail if the bounds are not relaxed because the
+  // target end velocity (0.101) is at the boundary of controllability, where
+  // numerical integration drift makes it infeasible to reach exactly under the
+  // original joint acceleration limits.
+  toppra.set_constraint_relaxation(0.0);
+  auto result_zero = toppra.SolvePathParameterization(0.0, 0.101);
+  EXPECT_FALSE(result_zero.has_value());
+
+  // But with a sufficiently large positive constraint relaxation, it should
+  // succeed!
+  toppra.set_constraint_relaxation(1e-2);
+  auto result_relaxed = toppra.SolvePathParameterization(0.0, 0.101);
+  EXPECT_TRUE(result_relaxed.has_value());
 }
 
 }  // namespace

--- a/multibody/optimization/toppra.cc
+++ b/multibody/optimization/toppra.cc
@@ -579,18 +579,30 @@ Toppra::ComputeForwardPass(double s_dot_0,
         Vector1d(2 * delta), Vector1d(K(0, knot + 1) - xstar(knot)),
         Vector1d(K(1, knot + 1) - xstar(knot)));
     for (auto& [constraint, coefficients] : forward_lin_constraint_) {
-      constraint.evaluator()->UpdateCoefficients(
-          coefficients.coeffs.col(2 * knot + 1),
-          coefficients.lb.col(knot) -
-              xstar(knot) * coefficients.coeffs.col(2 * knot),
-          coefficients.ub.col(knot) -
-              xstar(knot) * coefficients.coeffs.col(2 * knot));
+      auto lb_val = coefficients.lb.col(knot) -
+                    xstar(knot) * coefficients.coeffs.col(2 * knot);
+      auto ub_val = coefficients.ub.col(knot) -
+                    xstar(knot) * coefficients.coeffs.col(2 * knot);
+      if (constraint_relaxation_ == 0.0) {
+        constraint.evaluator()->UpdateCoefficients(
+            coefficients.coeffs.col(2 * knot + 1), lb_val, ub_val);
+      } else {
+        constraint.evaluator()->UpdateCoefficients(
+            coefficients.coeffs.col(2 * knot + 1),
+            lb_val - Eigen::VectorXd::Constant(lb_val.rows(),
+                                               constraint_relaxation_),
+            ub_val + Eigen::VectorXd::Constant(ub_val.rows(),
+                                               constraint_relaxation_));
+      }
     }
     solvers::MathematicalProgramResult result;
     solver.Solve(*forward_prog_, {}, {}, &result);
     if (!result.is_success()) {
       drake::log()->error(
-          "Toppra failed to find the maximum path acceleration at knot {}/{}.",
+          "Toppra failed to find the maximum path acceleration at knot {}/{}. "
+          "This failure may be caused by a numerically-challenging trajectory. "
+          "Consider slightly relaxing the constraints with "
+          "`Toppra::set_constraint_relaxation()`.",
           knot, N);
       return std::nullopt;
     } else {

--- a/multibody/optimization/toppra.h
+++ b/multibody/optimization/toppra.h
@@ -267,6 +267,27 @@ class Toppra {
                             ToppraDiscretization discretization =
                                 ToppraDiscretization::kInterpolation);
 
+  /**
+   * Sets the tolerance used to slightly relax the forward pass linear
+   * constraints. This is a problem tolerance, not a solver tolerance, meaning
+   * it slightly relaxes the physical problem bounds. This is useful for
+   * numerically difficult trajectories where the backward pass solver finds a
+   * solution on the boundary of the feasible set, causing the forward pass to
+   * fail due to solver precision limits. A typical value is `1e-4` or `1e-5`.
+   * If 0.0, no relaxation is applied. The default is 0.0 (no relaxation).
+   * @throws std::exception if relaxation is negative or not finite.
+   */
+  void set_constraint_relaxation(double relaxation) {
+    DRAKE_THROW_UNLESS(std::isfinite(relaxation));
+    DRAKE_THROW_UNLESS(relaxation >= 0.0);
+    constraint_relaxation_ = relaxation;
+  }
+
+  /**
+   * Returns the problem relaxation tolerance used in the forward pass.
+   */
+  double constraint_relaxation() const { return constraint_relaxation_; }
+
  private:
   /*
    * Performs the backward pass step of TOPPRA, returning the controllable set,
@@ -368,6 +389,9 @@ class Toppra {
   // backward_lin_constraint_.
   std::unordered_map<Binding<LinearConstraint>, ToppraLinearConstraint>
       forward_lin_constraint_;
+
+  // Problem tolerance to relax forward pass linear constraints.
+  double constraint_relaxation_{0.0};
 };
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
There have been long-running issues with TOPPRA being numerically brittle, and it has been causing a lot of problems lately for @sageshoyu and myself. This PR allows the user to relax the constraints if they have one of these brittle trajectories.

Closes #20619. I verified using a relaxation of 1e-5 fixes it.

+assignee:@sageshoyu for feature review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24798)
<!-- Reviewable:end -->
