### PR TITLE
[doc] Update supported CMake on macOS to 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # similar to what governs our minimum Bazel version (see MODULE.bazel).
 # When changing this, tools/install/libdrake/drake-config.cmake.in and its
 # corresponding tests should also be updated.
-cmake_minimum_required(VERSION 3.20...4.3)
+cmake_minimum_required(VERSION 3.20...4.4)
 
 # The build types that Drake's CMake build supports. This is the single source
 # of truth.

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -39,8 +39,8 @@ officially supports when building from source:
 |                                     | arm64 ⁽⁴⁾         | 3.12       | 9.2   | 3.28  | GCC 13                       |
 | Ubuntu 26.04 LTS (Resolute Raccoon) | x86-64-v3         | 3.14       | 9.2   | 4.2   | GCC 15 (default) or Clang 21 |
 |                                     | x86-64, arm64 ⁽⁴⁾ | 3.14       | 9.2   | 4.2   | GCC 15                       |
-| macOS Sequoia (15)                  | arm64             | 3.14       | 9.2   | 4.3   | Apple LLVM 17 (Xcode 26.3)   |
-| macOS Tahoe (26)                    | arm64             | 3.14       | 9.2   | 4.3   | Apple LLVM 21 (Xcode 26.6)   |
+| macOS Sequoia (15)                  | arm64             | 3.14       | 9.2   | 4.4   | Apple LLVM 17 (Xcode 26.3)   |
+| macOS Tahoe (26)                    | arm64             | 3.14       | 9.2   | 4.4   | Apple LLVM 21 (Xcode 26.6)   |
 
 "Official support" means that we have Continuous Integration test coverage to
 notice regressions, so if it doesn't work for you then please file a bug report.

--- a/tools/install/libdrake/drake-config.cmake.in
+++ b/tools/install/libdrake/drake-config.cmake.in
@@ -10,7 +10,7 @@ if(CMAKE_VERSION VERSION_LESS 3.20.0)
   message(FATAL_ERROR "CMake >= 3.20 required")
 endif()
 cmake_policy(PUSH)
-cmake_policy(VERSION 3.20...4.3)
+cmake_policy(VERSION 3.20...4.4)
 set(CMAKE_IMPORT_FILE_VERSION 1)
 
 include(CMakeFindDependencyMacro)

--- a/tools/install/libdrake/test/drake_python_dir_install_test.py
+++ b/tools/install/libdrake/test/drake_python_dir_install_test.py
@@ -19,7 +19,7 @@ class DrakePythonDirInstallTest(unittest.TestCase):
                 venv_pythonpath = item
 
         cmake_content = """
-            cmake_minimum_required(VERSION 3.20...4.3)
+            cmake_minimum_required(VERSION 3.20...4.4)
             project(drake_python_dir_install_test)
             set(CMAKE_PREFIX_PATH {cmake_prefix_path})
             find_package(drake CONFIG REQUIRED)

--- a/tools/install/libdrake/test/find_package_drake_install_test.py
+++ b/tools/install/libdrake/test/find_package_drake_install_test.py
@@ -30,7 +30,7 @@ class FindPackageDrakeInstallTest(unittest.TestCase):
         cmake_prefix_path = install_test_helper.get_install_dir()
 
         cmake_content = f"""
-            cmake_minimum_required(VERSION 3.20...4.3)
+            cmake_minimum_required(VERSION 3.20...4.4)
             project(find_package_drake_install_test)
             set(CMAKE_PREFIX_PATH {cmake_prefix_path})
             find_package(drake CONFIG REQUIRED)


### PR DESCRIPTION
Per the latest CI image provisioning with [Homebrew's](https://formulae.brew.sh/formula/cmake) ingestion of 4.4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24813)
<!-- Reviewable:end -->
