### PR TITLE
[workspace] Deprecate the zlib_repo flag

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -70,7 +70,6 @@ bazel_dep(name = "spdlog", version = "1.17.0", repo_name = "module_spdlog")  # n
 # is used by default.
 
 bazel_dep(name = "glib", version = "2.82.2.bcr.9", repo_name = "module_glib")
-bazel_dep(name = "zlib", version = "1.3.2", repo_name = "module_zlib")
 
 # Add non-replaceable C++ module dependencies that are used by Drake's
 # implementation.
@@ -78,6 +77,7 @@ bazel_dep(name = "zlib", version = "1.3.2", repo_name = "module_zlib")
 bazel_dep(name = "libjpeg_turbo", version = "3.1.3.bcr.6", repo_name = "module_libjpeg")
 bazel_dep(name = "nanobind", version = "2.13.0", repo_name = "module_nanobind")
 bazel_dep(name = "robin-map", version = "1.4.1", repo_name = "module_robin_map")
+bazel_dep(name = "zlib", version = "1.3.2", repo_name = "module_zlib")
 
 # Add additional modules we use at build-time (not runtime dependencies).
 
@@ -167,6 +167,12 @@ use_repo(
     "lapack",
     "opencl",
     #
+    # Aliases for C++ dependencies that are used by our implementation,
+    # but (unlike the prior group) these are not configurable.
+    #
+    "libjpeg",
+    "zlib",
+    #
     # First-party dependencies (i.e., drake-maintained).
     #
     "drake_models",
@@ -190,10 +196,6 @@ use_repo(
     # deprecating it until we have nanobind ready.
     #
     "pybind11",
-    # TODO(jwnimmer-tri) Deprecate these. They are (or should be)
-    # non-configurable, so don't need a module extension.
-    "libjpeg",
-    "zlib",
 )
 
 # Load Java dependencies.

--- a/tools/flags/BUILD.bazel
+++ b/tools/flags/BUILD.bazel
@@ -240,15 +240,16 @@ string_flag(
     ],
 )
 
-# TODO(jwnimmer-tri) Deprecate this flag. We cannot reasonably force Drake's
-# choice of zlib down into all BCR modules that will eventually need it.
-#
-# The :zlib_repo flag configures where Drake obtains @zlib from.
-# The public dependency alias is `@drake//tools/workspace/zlib` or use the
-# drake_dep_repositories() module extension at //tools/workspace:default.bzl.
+# -----------------------------------------------------------------------------
+# Deprecated flags.
+
+# The (deprecated) :zlib_repo flag configures where Drake obtains @zlib from.
 string_flag(
     name = "zlib_repo",
     build_setting_default = "default",
+    deprecation = "DRAKE DEPRECATED: The zlib_repo flag is deprecated for removal; the future default will be 'source'. If you want to build zlib from source as a Bazel module, no action is necessary (that will be the future default). If you want to keep using 'hardcoded', you must either use --override_module on the command line or local_path_override in MODULE.bazel. The deprecated code will be removed from Drake on or after 2026-12-01.",
+    # Avoid deprecation warning during `bazel build //...`.
+    tags = ["manual"],
     values = [
         # The default is based on :private_runtime_repo_default -- "internal"
         # maps to "source" and "external" maps to "hardcoded".
@@ -429,5 +430,25 @@ string_flag(
 )
 
 # -----------------------------------------------------------------------------
+
+# Internal use only. These must appear here to avoid deprecation warnings.
+
+# Remove on 2026-12-01 along with deprecation.
+config_setting(
+    name = "flag_zlib_repo_hardcoded",
+    flag_values = {
+        ":zlib_repo": "hardcoded",
+    },
+    visibility = ["//tools/workspace/zlib:__pkg__"],
+)
+
+# Remove on 2026-12-01 along with deprecation.
+config_setting(
+    name = "flag_zlib_repo_default",
+    flag_values = {
+        ":zlib_repo": "default",
+    },
+    visibility = ["//tools/workspace/zlib:__pkg__"],
+)
 
 add_lint_tests()

--- a/tools/workspace/README.md
+++ b/tools/workspace/README.md
@@ -21,7 +21,7 @@ module extension to incorporate the external. Either way, our `MODULE.bazel`
 file lists every external that we directly use; refer to its comments for more
 details.
 
-Drake also offers configuration flags to govern the externals, e.g., to:
+Drake also offers configuration flags to govern some externals, e.g., to:
 - select where (groups of) externals come from, or
 - opt-in to (or opt-out) of a specific external.
 Refer to the documentation in `tools/flags/BUILD.bazel` for details. Note that
@@ -40,6 +40,9 @@ drake_dep_repositories = use_extension(
 )
 use_repo(drake_dep_repositories, "eigen")
 ```
+
+Drake also offers an alias when the external is a Bazel Central Registry module
+but we customize its build flags using transitions.
 
 ## CMake interface
 
@@ -360,10 +363,11 @@ software's license is acceptable to use within Drake.
 
 When adding a new external, decide whether it will be covered by our
 [Stability Guidelines](https://drake.mit.edu/stable.html). Broadly speaking,
-dependencies that come from the host operating system can be covered as
-stable, but dependencies that we compile from source code should be internal.
-If the new dependency should be in internal, name it like "foo_internal" (not
-just "foo") throughout all of the below.
+dependencies that come from the host operating system or the Bazel Central
+Registry can be covered as stable, but dependencies that we compile from source
+code using our own package.BUILD.bazel files should be internal. If the new
+dependency should be in internal, name it like "foo_internal" (not just "foo")
+throughout all of the below.
 
 When the software is available in the
 [Bazel Central Registry](https://registry.bazel.build/), we generally prefer to

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -163,11 +163,9 @@ def _drake_dep_repositories_impl(module_ctx):
         "fmt",
         "glib",
         "lapack",
+        "libjpeg",
         "opencl",
         "spdlog",
-        # TODO(jwnimmer-tri) Deprecate these. They are (or should be)
-        # non-configurable, so don't need a module extension.
-        "libjpeg",
         "zlib",
     ]
     for name in ALIAS_REPOSITORIES:

--- a/tools/workspace/zlib/BUILD.bazel
+++ b/tools/workspace/zlib/BUILD.bazel
@@ -21,20 +21,6 @@ cc_static_hidden_library(
 )
 
 config_setting(
-    name = "flag_zlib_repo_hardcoded",
-    flag_values = {
-        "//tools/flags:zlib_repo": "hardcoded",
-    },
-)
-
-config_setting(
-    name = "flag_zlib_repo_default",
-    flag_values = {
-        "//tools/flags:zlib_repo": "default",
-    },
-)
-
-config_setting(
     name = "flag_private_runtime_repo_default_external",
     flag_values = {
         "//tools/flags:private_runtime_repo_default": "external",
@@ -44,7 +30,7 @@ config_setting(
 selects.config_setting_group(
     name = "flag_zlib_repo_default_hardcoded",
     match_all = [
-        ":flag_zlib_repo_default",
+        "//tools/flags:flag_zlib_repo_default",
         ":flag_private_runtime_repo_default_external",
     ],
 )
@@ -52,7 +38,7 @@ selects.config_setting_group(
 selects.config_setting_group(
     name = "use_hardcoded",
     match_any = [
-        ":flag_zlib_repo_hardcoded",
+        "//tools/flags:flag_zlib_repo_hardcoded",
         ":flag_zlib_repo_default_hardcoded",
     ],
 )


### PR DESCRIPTION
The zlib_repo flag is deprecated for removal; the future default will be "source". If you want to build zlib from source as a Bazel module, no action is necessary (that will be the future default). If you want to keep using "hardcoded", you must either use --override_module on the command line or local_path_override in MODULE.bazel.

This is a necessary prerequisite to depending on modules from BCR that use zlib. It is impractical to redirect their dependency on zlib to use Drake's selection instead.

Withdraw the TODOs about deprecating the zlib and libjpeg module extensions. For downstream Bazel users, it's important to allow linking against the libraries built with our transitioned build flags so that users don't end up with two copies. Update our docs to reflect this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24814)
<!-- Reviewable:end -->
