### PR TITLE
[render] Move label colorize logic into geometry/render

### DIFF
--- a/bindings/generated_docstrings/geometry_render.h
+++ b/bindings/generated_docstrings/geometry_render.h
@@ -12,6 +12,7 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
+// #include "drake/geometry/render/colorize_image.h"
 // #include "drake/geometry/render/light_parameter.h"
 // #include "drake/geometry/render/render_camera.h"
 // #include "drake/geometry/render/render_engine.h"
@@ -133,6 +134,29 @@ Whether or not the image is able to be displayed depends on the
 specific render engine and its configuration.)""";
           } show_window;
         } ColorRenderCamera;
+        // Symbol: drake::geometry::render::ColorizeLabelImage
+        struct /* ColorizeLabelImage */ {
+          // Source: drake/geometry/render/colorize_image.h
+          const char* doc =
+R"""(Colorizes an input label image into an output color image using a
+fixed palette. Non-reserved labels (user-assigned values) are mapped
+to colors from a built-in palette. Reserved labels (empty, don't care,
+etc.) are mapped to ``background_color``.
+
+Parameter ``input``:
+    The input label image.
+
+Parameter ``output``:
+    The image the colorized image will be written to. It will be
+    resized to match ``input`` as necessary and its contents will be
+    completely overwritten.
+
+Parameter ``background_color``:
+    The color to use for all reserved label values.
+
+Precondition:
+    ``output != nullptr``.)""";
+        } ColorizeLabelImage;
         // Symbol: drake::geometry::render::DepthRange
         struct /* DepthRange */ {
           // Source: drake/geometry/render/render_camera.h

--- a/bindings/generated_docstrings/visualization.h
+++ b/bindings/generated_docstrings/visualization.h
@@ -268,7 +268,7 @@ default, black with 0% alpha).)""";
           // Source: drake/visualization/colorize_label_image.h
           const char* doc =
 R"""(Colorizes the ``input`` into ``output``, without using any System port
-conections nor any Context.)""";
+connections nor any Context.)""";
         } Calc;
         // Symbol: drake::visualization::ColorizeLabelImage::ColorizeLabelImage<T>
         struct /* ctor */ {

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -19,12 +19,25 @@ drake_cc_package_library(
     name = "render",
     visibility = ["//visibility:public"],
     deps = [
+        ":colorize_image",
         ":light_parameter",
         ":render_camera",
         ":render_engine",
         ":render_label",
         ":render_material",
         ":render_mesh",
+    ],
+)
+
+drake_cc_library(
+    name = "colorize_image",
+    srcs = ["colorize_image.cc"],
+    hdrs = ["colorize_image.h"],
+    deps = [
+        ":render_label",
+        "//common:essential",
+        "//geometry:rgba",
+        "//systems/sensors:image",
     ],
 )
 
@@ -146,6 +159,14 @@ filegroup(
         "test/meshes/*",
         "test/*.png",
     ]),
+)
+
+drake_cc_googletest(
+    name = "colorize_image_test",
+    deps = [
+        ":colorize_image",
+        "//systems/sensors/test_utilities:image_compare",
+    ],
 )
 
 drake_cc_googletest(

--- a/geometry/render/colorize_image.cc
+++ b/geometry/render/colorize_image.cc
@@ -1,0 +1,65 @@
+#include "drake/geometry/render/colorize_image.h"
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/geometry/render/render_label.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+namespace {
+const std::vector<std::array<uint8_t, 4>>& GetDefaultPalette() {
+  using Color = std::array<uint8_t, 4>;
+  using Result = std::vector<Color>;
+  static const never_destroyed<Result> result{Result{
+      // Based on the TABLEAU_COLORS from matplotlib.
+      Color{0x1f, 0x77, 0xb4, 0xff},  // blue
+      Color{0xff, 0x7f, 0x0e, 0xff},  // orange
+      Color{0x2c, 0xa0, 0x2c, 0xff},  // green
+      Color{0xd6, 0x27, 0x28, 0xff},  // red
+      Color{0x94, 0x67, 0xbd, 0xff},  // purple
+      Color{0x8c, 0x56, 0x4b, 0xff},  // brown
+      Color{0xe3, 0x77, 0xc2, 0xff},  // pink
+      Color{0x7f, 0x7f, 0x7f, 0xff},  // gray
+      Color{0xbc, 0xbd, 0x22, 0xff},  // olive
+      Color{0x17, 0xbe, 0xcf, 0xff},  // cyan
+  }};
+  return result.access();
+}
+}  // namespace
+
+void ColorizeLabelImage(const systems::sensors::ImageLabel16I& input,
+                        systems::sensors::ImageRgba8U* output,
+                        const Rgba& background_color) {
+  DRAKE_THROW_UNLESS(output != nullptr);
+  if (output->width() != input.width() || output->height() != input.height()) {
+    output->resize(input.width(), input.height());
+  }
+  const std::array<uint8_t, 4> background = {
+      static_cast<uint8_t>(background_color.r() * 255),
+      static_cast<uint8_t>(background_color.g() * 255),
+      static_cast<uint8_t>(background_color.b() * 255),
+      static_cast<uint8_t>(background_color.a() * 255),
+  };
+  const std::vector<std::array<uint8_t, 4>>& palette = GetDefaultPalette();
+  for (int v = 0; v < output->height(); ++v) {
+    for (int u = 0; u < output->width(); ++u) {
+      const int16_t label = input.at(u, v)[0];
+      const bool is_reserved = label > RenderLabel::kMaxUnreserved;
+      const std::array<uint8_t, 4>& color =
+          is_reserved ? background : palette[label % palette.size()];
+      for (int ch = 0; ch < 4; ++ch) {
+        output->at(u, v)[ch] = color[ch];
+      }
+    }
+  }
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/colorize_image.h
+++ b/geometry/render/colorize_image.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "drake/geometry/rgba.h"
+#include "drake/systems/sensors/image.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+/** Colorizes an input label image into an output color image using a fixed
+ palette. Non-reserved labels (user-assigned values) are mapped to colors from a
+ built-in palette. Reserved labels (empty, don't care, etc.) are mapped to
+ `background_color`.
+
+ @param input             The input label image.
+ @param[out] output       The image the colorized image will be written to. It
+                          will be resized to match `input` as necessary and its
+                          contents will be completely overwritten.
+ @param background_color  The color to use for all reserved label values.
+ @pre `output != nullptr`. */
+void ColorizeLabelImage(const systems::sensors::ImageLabel16I& input,
+                        systems::sensors::ImageRgba8U* output,
+                        const Rgba& background_color = Rgba{0, 0, 0, 0});
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/test/colorize_image_test.cc
+++ b/geometry/render/test/colorize_image_test.cc
@@ -1,0 +1,63 @@
+#include "drake/geometry/render/colorize_image.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/render/render_label.h"
+#include "drake/systems/sensors/test_utilities/image_compare.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace {
+
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
+
+// Runs all of the code once and spot checks a sample image.
+GTEST_TEST(ColorizeLabelImageTest, Basic) {
+  // A label image with just one non-empty value. Note that kEmpty is NOT a
+  // literal zero.
+  ImageLabel16I label(6, 2, static_cast<int>(RenderLabel::kEmpty));
+  label.at(5, 1)[0] = 0;
+
+  // Expect a color image with a matching value. Label 0 happens to be "tableau
+  // blue" (#1F77B4). The default background color is transparent black.
+  ImageRgba8U expected(6, 2, 0);
+  expected.at(5, 1)[0] = 0x1F;
+  expected.at(5, 1)[1] = 0x77;
+  expected.at(5, 1)[2] = 0xB4;
+  expected.at(5, 1)[3] = 0xFF;
+
+  // Check the colorized image; note that `actual` starts out empty, so this
+  // also confirms that the output gets resized to match the input.
+  ImageRgba8U actual;
+  ColorizeLabelImage(label, &actual);
+  EXPECT_EQ(actual, expected);
+}
+
+// Checks colorization with a non-default background color.
+GTEST_TEST(ColorizeLabelImageTest, Background) {
+  // A label image with just one non-empty value.
+  ImageLabel16I label(6, 2, static_cast<int>(RenderLabel::kEmpty));
+  label.at(5, 1)[0] = 0;
+
+  ImageRgba8U actual;
+  ColorizeLabelImage(label, &actual, Rgba(0.2, 0.2, 0.2, 1.0));
+
+  // Check an arbitrary empty pixel.
+  EXPECT_EQ(actual.at(0, 0)[0], 51);
+  EXPECT_EQ(actual.at(0, 0)[1], 51);
+  EXPECT_EQ(actual.at(0, 0)[2], 51);
+  EXPECT_EQ(actual.at(0, 0)[3], 255);
+
+  // Check the non-empty pixel.
+  EXPECT_EQ(actual.at(5, 1)[0], 0x1F);
+  EXPECT_EQ(actual.at(5, 1)[1], 0x77);
+  EXPECT_EQ(actual.at(5, 1)[2], 0xB4);
+  EXPECT_EQ(actual.at(5, 1)[3], 0xFF);
+}
+
+}  // namespace
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/visualization/BUILD.bazel
+++ b/visualization/BUILD.bazel
@@ -128,6 +128,7 @@ drake_cc_googletest(
     name = "colorize_label_image_test",
     deps = [
         ":colorize_label_image",
+        "//geometry/render:colorize_image",
         "//systems/sensors/test_utilities:image_compare",
     ],
 )

--- a/visualization/colorize_label_image.cc
+++ b/visualization/colorize_label_image.cc
@@ -1,40 +1,13 @@
 #include "drake/visualization/colorize_label_image.h"
 
-#include <array>
-#include <vector>
-
-#include "drake/common/never_destroyed.h"
-#include "drake/geometry/render/render_label.h"
+#include "drake/geometry/render/colorize_image.h"
 
 namespace drake {
 namespace visualization {
 
-using geometry::Rgba;
-using geometry::render::RenderLabel;
 using systems::Context;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
-
-namespace {
-const std::vector<std::array<uint8_t, 4>>& GetDefaultPalette() {
-  using Color = std::array<uint8_t, 4>;
-  using Result = std::vector<Color>;
-  static const never_destroyed<Result> result{Result{
-      // Based on the TABLEAU_COLORS from matplotlib.
-      Color{0x1f, 0x77, 0xb4, 0xff},  // blue
-      Color{0xff, 0x7f, 0x0e, 0xff},  // orange
-      Color{0x2c, 0xa0, 0x2c, 0xff},  // green
-      Color{0xd6, 0x27, 0x28, 0xff},  // red
-      Color{0x94, 0x67, 0xbd, 0xff},  // purple
-      Color{0x8c, 0x56, 0x4b, 0xff},  // brown
-      Color{0xe3, 0x77, 0xc2, 0xff},  // pink
-      Color{0x7f, 0x7f, 0x7f, 0xff},  // gray
-      Color{0xbc, 0xbd, 0x22, 0xff},  // olive
-      Color{0x17, 0xbe, 0xcf, 0xff},  // cyan
-  }};
-  return result.access();
-}
-}  // namespace
 
 template <typename T>
 ColorizeLabelImage<T>::ColorizeLabelImage() {
@@ -49,28 +22,7 @@ ColorizeLabelImage<T>::~ColorizeLabelImage() = default;
 template <typename T>
 void ColorizeLabelImage<T>::Calc(const ImageLabel16I& input,
                                  ImageRgba8U* output) const {
-  DRAKE_THROW_UNLESS(output != nullptr);
-  if (output->width() != input.width() || output->height() != input.height()) {
-    output->resize(input.width(), input.height());
-  }
-  const std::array<uint8_t, 4> background = {
-      static_cast<uint8_t>(background_color_.r() * 255),
-      static_cast<uint8_t>(background_color_.g() * 255),
-      static_cast<uint8_t>(background_color_.b() * 255),
-      static_cast<uint8_t>(background_color_.a() * 255),
-  };
-  const std::vector<std::array<uint8_t, 4>>& palette = GetDefaultPalette();
-  for (int v = 0; v < output->height(); ++v) {
-    for (int u = 0; u < output->width(); ++u) {
-      const int16_t label = input.at(u, v)[0];
-      const bool is_reserved = label > RenderLabel::kMaxUnreserved;
-      const std::array<uint8_t, 4>& color =
-          is_reserved ? background : palette[label % palette.size()];
-      for (int ch = 0; ch < 4; ++ch) {
-        output->at(u, v)[ch] = color[ch];
-      }
-    }
-  }
+  geometry::render::ColorizeLabelImage(input, output, background_color_);
 }
 
 template <typename T>

--- a/visualization/colorize_label_image.h
+++ b/visualization/colorize_label_image.h
@@ -45,7 +45,7 @@ class ColorizeLabelImage final : public systems::LeafSystem<T> {
   }
 
   /** Colorizes the `input` into `output`, without using any System port
-  conections nor any Context. */
+  connections nor any Context. */
   void Calc(const systems::sensors::ImageLabel16I& input,
             systems::sensors::ImageRgba8U* output) const;
 

--- a/visualization/test/colorize_label_image_test.cc
+++ b/visualization/test/colorize_label_image_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/geometry/render/colorize_image.h"
 #include "drake/geometry/render/render_label.h"
 #include "drake/systems/sensors/test_utilities/image_compare.h"
 
@@ -14,58 +15,47 @@ using geometry::render::RenderLabel;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 
-// Runs all of the code once and spot checks a sample image.
-GTEST_TEST(ColorLabelImageTest, Basic) {
-  ColorizeLabelImage<double> dut;
-  auto context = dut.CreateDefaultContext();
+// The colorization itself is tested in geometry/render; here we merely confirm
+// that the System is wired up to that function correctly.
 
-  // Input a label image with just one non-empty value. Note that kEmpty is NOT
-  // a literal zero.
-  ImageLabel16I label(6, 2, static_cast<int>(RenderLabel::kEmpty));
-  label.at(5, 1)[0] = 0;
-  dut.GetInputPort("label_image").FixValue(context.get(), label);
-
-  // Expect a color image with a matching value. Label 0 happens to be "tableau
-  // blue" (#1F77B4).
-  ImageRgba8U expected(6, 2, 0);
-  expected.at(5, 1)[0] = 0x1F;
-  expected.at(5, 1)[1] = 0x77;
-  expected.at(5, 1)[2] = 0xB4;
-  expected.at(5, 1)[3] = 0xFF;
-
-  // Check the colorized image.
-  const auto& actual =
-      dut.GetOutputPort("color_image").template Eval<ImageRgba8U>(*context);
-  EXPECT_EQ(actual, expected);
+GTEST_TEST(ColorizeLabelImageTest, Ports) {
+  const ColorizeLabelImage<double> dut;
+  ASSERT_EQ(dut.num_input_ports(), 1);
+  ASSERT_EQ(dut.num_output_ports(), 1);
+  EXPECT_EQ(dut.GetInputPort("label_image").get_index(), 0);
+  EXPECT_EQ(dut.GetOutputPort("color_image").get_index(), 0);
 }
 
-// Checks the Calc() function when run with a non-default background color.
-GTEST_TEST(ColorLabelImageTest, DirectCalcWithBackground) {
+GTEST_TEST(ColorizeLabelImageTest, BackgroundColorProperty) {
   ColorizeLabelImage<double> dut;
+  EXPECT_EQ(dut.get_background_color(), Rgba(0, 0, 0, 0));
+  dut.set_background_color(Rgba(0.2, 0.2, 0.2, 1.0));
+  EXPECT_EQ(dut.get_background_color(), Rgba(0.2, 0.2, 0.2, 1.0));
+}
 
-  // Make a label image with just one non-empty value.
+// Both the output port and the Calc() shortcut must colorize the input using
+// the background color property.
+GTEST_TEST(ColorizeLabelImageTest, Delegation) {
+  ColorizeLabelImage<double> dut;
+  dut.set_background_color(Rgba(0.2, 0.2, 0.2, 1.0));
+
+  // A label image with just one non-empty value. Note that kEmpty is NOT a
+  // literal zero.
   ImageLabel16I label(6, 2, static_cast<int>(RenderLabel::kEmpty));
   label.at(5, 1)[0] = 0;
 
-  // Choose a non-default background color.
-  dut.set_background_color(Rgba(0.2, 0.2, 0.2, 1.0));
-  EXPECT_EQ(dut.get_background_color(), Rgba(0.2, 0.2, 0.2, 1.0));
+  ImageRgba8U expected;
+  geometry::render::ColorizeLabelImage(label, &expected,
+                                       dut.get_background_color());
 
-  // Colorize.
+  auto context = dut.CreateDefaultContext();
+  dut.GetInputPort("label_image").FixValue(context.get(), label);
+  EXPECT_EQ(dut.GetOutputPort("color_image").Eval<ImageRgba8U>(*context),
+            expected);
+
   ImageRgba8U actual;
   dut.Calc(label, &actual);
-
-  // Check an arbitrary empty pixel.
-  EXPECT_EQ(actual.at(0, 0)[0], 51);
-  EXPECT_EQ(actual.at(0, 0)[1], 51);
-  EXPECT_EQ(actual.at(0, 0)[2], 51);
-  EXPECT_EQ(actual.at(0, 0)[3], 255);
-
-  // Check the non-empty pixel.
-  EXPECT_EQ(actual.at(5, 1)[0], 0x1F);
-  EXPECT_EQ(actual.at(5, 1)[1], 0x77);
-  EXPECT_EQ(actual.at(5, 1)[2], 0xB4);
-  EXPECT_EQ(actual.at(5, 1)[3], 0xFF);
+  EXPECT_EQ(actual, expected);
 }
 
 }  // namespace


### PR DESCRIPTION
Ultimately, this will support multiple, cross-module usage of the colorize logic.

1. drake::visualization::ColorizeLabelImage *system* calls new API.
    - Tests moved away from conversion logic to system-appropriate tests.
2. Color-logic unit tests moved to API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24819)
<!-- Reviewable:end -->
