### PR TITLE
[CENIC] Refactor IcfData::Resize()

### DIFF
--- a/multibody/contact_solvers/icf/icf_data.cc
+++ b/multibody/contact_solvers/icf/icf_data.cc
@@ -9,63 +9,51 @@ namespace icf {
 namespace internal {
 
 template <typename T>
-void IcfData<T>::Scratch::Resize(int num_bodies, int num_velocities,
-                                 int max_clique_size, int num_ball_constraints,
-                                 int num_couplers, int num_distance_constraints,
-                                 int num_welds, std::span<const int> gain_sizes,
-                                 std::span<const int> limit_sizes,
-                                 std::span<const int> patch_sizes) {
-  Av_minus_r.Resize(1, num_velocities, 1);
+void IcfData<T>::Scratch::Resize(const ResizeParams& params) {
+  Av_minus_r.Resize(1, params.num_velocities, 1);
 
-  V_WB_alpha.Resize(num_bodies, 6, 1);
-  U_AbB_W.Resize(ssize(patch_sizes), 6, 1);
-  v_alpha.Resize(1, num_velocities, 1);
+  V_WB_alpha.Resize(params.num_bodies, 6, 1);
+  U_AbB_W.Resize(ssize(params.patch_sizes), 6, 1);
+  v_alpha.Resize(1, params.num_velocities, 1);
 
-  Gw_gain.Resize(1, max_clique_size, 1);
-  Gw_limit.Resize(1, max_clique_size, 1);
+  Gw_gain.Resize(1, params.max_clique_size, 1);
+  Gw_limit.Resize(1, params.max_clique_size, 1);
 
-  ball_constraints_data.Resize(num_ball_constraints);
-  coupler_constraints_data.Resize(num_couplers);
-  distance_constraints_data.Resize(num_distance_constraints);
-  gain_constraints_data.Resize(gain_sizes);
-  limit_constraints_data.Resize(limit_sizes);
-  patch_constraints_data.Resize(patch_sizes);
-  weld_constraints_data.Resize(num_welds);
+  ball_constraints_data.Resize(params.num_ball_constraints);
+  coupler_constraints_data.Resize(params.num_couplers);
+  distance_constraints_data.Resize(params.num_distance_constraints);
+  gain_constraints_data.Resize(params.gain_sizes);
+  limit_constraints_data.Resize(params.limit_sizes);
+  patch_constraints_data.Resize(params.patch_sizes);
+  weld_constraints_data.Resize(params.num_welds);
 
-  H_cc_pool.Resize(1, max_clique_size, max_clique_size);
+  H_cc_pool.Resize(1, params.max_clique_size, params.max_clique_size);
 
-  H_BB_pool.Resize(1, max_clique_size, max_clique_size);
-  H_AA_pool.Resize(1, max_clique_size, max_clique_size);
-  H_AB_pool.Resize(1, max_clique_size, max_clique_size);
-  H_BA_pool.Resize(1, max_clique_size, max_clique_size);
-  GJa_pool.Resize(1, 6, max_clique_size);
-  GJb_pool.Resize(1, 6, max_clique_size);
+  H_BB_pool.Resize(1, params.max_clique_size, params.max_clique_size);
+  H_AA_pool.Resize(1, params.max_clique_size, params.max_clique_size);
+  H_AB_pool.Resize(1, params.max_clique_size, params.max_clique_size);
+  H_BA_pool.Resize(1, params.max_clique_size, params.max_clique_size);
+  GJa_pool.Resize(1, 6, params.max_clique_size);
+  GJb_pool.Resize(1, 6, params.max_clique_size);
 }
 
 template <typename T>
 IcfData<T>::~IcfData() = default;
 
 template <typename T>
-void IcfData<T>::Resize(int num_bodies, int num_velocities, int max_clique_size,
-                        int num_ball_constraints, int num_couplers,
-                        int num_distance_constraints, int num_welds,
-                        std::span<const int> gain_sizes,
-                        std::span<const int> limit_sizes,
-                        std::span<const int> patch_sizes) {
-  v_.resize(num_velocities);
-  V_WB_.Resize(num_bodies, 6, 1);
-  Av_.resize(num_velocities);
-  gradient_.resize(num_velocities);
-  ball_constraints_data_.Resize(num_ball_constraints);
-  coupler_constraints_data_.Resize(num_couplers);
-  distance_constraints_data_.Resize(num_distance_constraints);
-  gain_constraints_data_.Resize(gain_sizes);
-  limit_constraints_data_.Resize(limit_sizes);
-  patch_constraints_data_.Resize(patch_sizes);
-  weld_constraints_data_.Resize(num_welds);
-  scratch_.Resize(num_bodies, num_velocities, max_clique_size,
-                  num_ball_constraints, num_couplers, num_distance_constraints,
-                  num_welds, gain_sizes, limit_sizes, patch_sizes);
+void IcfData<T>::Resize(const ResizeParams& params) {
+  v_.resize(params.num_velocities);
+  V_WB_.Resize(params.num_bodies, 6, 1);
+  Av_.resize(params.num_velocities);
+  gradient_.resize(params.num_velocities);
+  ball_constraints_data_.Resize(params.num_ball_constraints);
+  coupler_constraints_data_.Resize(params.num_couplers);
+  distance_constraints_data_.Resize(params.num_distance_constraints);
+  gain_constraints_data_.Resize(params.gain_sizes);
+  limit_constraints_data_.Resize(params.limit_sizes);
+  patch_constraints_data_.Resize(params.patch_sizes);
+  weld_constraints_data_.Resize(params.num_welds);
+  scratch_.Resize(params);
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/icf_data.h
+++ b/multibody/contact_solvers/icf/icf_data.h
@@ -22,16 +22,20 @@ namespace internal {
 allows call sites to use named fields, avoiding positional-argument confusion as
 the number of constraint types grows. */
 struct ResizeParams {
-  int num_bodies{};
-  int num_velocities{};
-  int max_clique_size{};
-  int num_ball_constraints{};
-  int num_couplers{};
-  int num_distance_constraints{};
-  int num_welds{};
-  std::span<const int> gain_sizes;
-  std::span<const int> limit_sizes;
-  std::span<const int> patch_sizes;
+  int num_bodies{};            // Total number of bodies in the model.
+  int num_velocities{};        // Total number of generalized velocities.
+  int max_clique_size{};       // Maximum number of velocities in any clique.
+  int num_ball_constraints{};  // Number of ball constraints.
+  int num_couplers{};          // Number of coupler constraints.
+  int num_distance_constraints{};  // Number of distance constraints.
+  int num_welds{};                 // Number of weld constraints.
+  std::span<const int>
+      gain_sizes;  // Number of velocities for each gain constraint.
+  std::span<const int>
+      limit_sizes;  // Number of velocities for each limit constraint.
+  std::span<const int>
+      patch_sizes;  // Number of contact pairs for each patch constraint, of
+                    // size equal to the number of patches.
 };
 
 /* Data for the ICF problem minᵥ ℓ(v; q₀, v₀, δt).

--- a/multibody/contact_solvers/icf/icf_data.h
+++ b/multibody/contact_solvers/icf/icf_data.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <span>
+
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
@@ -15,6 +17,22 @@ namespace multibody {
 namespace contact_solvers {
 namespace icf {
 namespace internal {
+
+/* Parameters for IcfData::Resize and IcfData::Scratch::Resize. Using a struct
+allows call sites to use named fields, avoiding positional-argument confusion as
+the number of constraint types grows. */
+struct ResizeParams {
+  int num_bodies{};
+  int num_velocities{};
+  int max_clique_size{};
+  int num_ball_constraints{};
+  int num_couplers{};
+  int num_distance_constraints{};
+  int num_welds{};
+  std::span<const int> gain_sizes;
+  std::span<const int> limit_sizes;
+  std::span<const int> patch_sizes;
+};
 
 /* Data for the ICF problem minᵥ ℓ(v; q₀, v₀, δt).
 
@@ -33,6 +51,7 @@ Note that mutable getters should only be used for setting values, not for
 resizing.
 
 @tparam_nonsymbolic_scalar */
+
 template <typename T>
 class IcfData {
  public:
@@ -47,12 +66,7 @@ class IcfData {
   this class. Calling code must ensure that scratch space is used safely. */
   struct Scratch {
     /* Resizes the scratch space, allocating memory as needed. */
-    void Resize(int num_bodies, int num_velocities, int max_clique_size,
-                int num_ball_constraints, int num_couplers,
-                int num_distance_constraints, int num_welds,
-                std::span<const int> gain_sizes,
-                std::span<const int> limit_sizes,
-                std::span<const int> patch_sizes);
+    void Resize(const ResizeParams& params);
 
     // Scratch space for CalcMomentumTerms. Holds at most one vector of size
     // IcfModel::num_velocities().
@@ -106,27 +120,9 @@ class IcfData {
   ~IcfData();
 
   /* Resizes the data to accommodate the given problem, typically called at the
-  beginning of each solve/time step.
-
-  @param num_bodies Total number of bodies in the model.
-  @param num_velocities Total number of generalized velocities.
-  @param max_clique_size Maximum number of velocities in any clique.
-  @param num_ball_constraints Number of ball constraints.
-  @param num_couplers Number of coupler constraints.
-  @param num_distance_constraints Number of distance constraints.
-  @param num_welds Number of weld constraints.
-  @param gain_sizes Number of velocities for each gain constraint.
-  @param limit_sizes Number of velocities for each limit constraint.
-  @param patch_sizes Number of contact pairs for each patch constraint, of size
-                     equal to the number of patches. */
-  // TODO(sherm1) This argument list will get out of hand as we add more
-  //  constraint types. Consider switching to a parameter struct which would
-  //  let us use named fields at the call sites.
-  void Resize(int num_bodies, int num_velocities, int max_clique_size,
-              int num_ball_constraints, int num_couplers,
-              int num_distance_constraints, int num_welds,
-              std::span<const int> gain_sizes, std::span<const int> limit_sizes,
-              std::span<const int> patch_sizes);
+  beginning of each solve/time step. See ResizeParams for documentation of
+  individual fields. */
+  void Resize(const ResizeParams& params);
 
   /* Returns the number of generalized velocities in the system. */
   int num_velocities() const { return v_.size(); }

--- a/multibody/contact_solvers/icf/icf_model.cc
+++ b/multibody/contact_solvers/icf/icf_model.cc
@@ -98,14 +98,17 @@ Eigen::VectorBlock<VectorX<T>> IcfModel<T>::mutable_clique_segment(
 
 template <typename T>
 void IcfModel<T>::ResizeData(IcfData<T>* data) const {
-  data->Resize(num_bodies_, num_velocities_, max_clique_size_,
-               ball_constraints_pool_.num_constraints(),
-               coupler_constraints_pool_.num_constraints(),
-               distance_constraints_pool_.num_constraints(),
-               weld_constraints_pool_.num_constraints(),
-               gain_constraints_pool_.constraint_sizes(),
-               limit_constraints_pool_.constraint_sizes(),
-               patch_constraints_pool_.patch_sizes());
+  data->Resize(
+      {.num_bodies = num_bodies_,
+       .num_velocities = num_velocities_,
+       .max_clique_size = max_clique_size_,
+       .num_ball_constraints = ball_constraints_pool_.num_constraints(),
+       .num_couplers = coupler_constraints_pool_.num_constraints(),
+       .num_distance_constraints = distance_constraints_pool_.num_constraints(),
+       .num_welds = weld_constraints_pool_.num_constraints(),
+       .gain_sizes = gain_constraints_pool_.constraint_sizes(),
+       .limit_sizes = limit_constraints_pool_.constraint_sizes(),
+       .patch_sizes = patch_constraints_pool_.patch_sizes()});
 }
 
 template <typename T>

--- a/multibody/contact_solvers/icf/test/icf_data_test.cc
+++ b/multibody/contact_solvers/icf/test/icf_data_test.cc
@@ -46,9 +46,16 @@ GTEST_TEST(IcfData, ResizeAndAccessors) {
   const std::vector<int> limit_sizes = {5, 4, 3};
   const std::vector<int> patch_sizes = {8, 6, 4, 2};
 
-  data.Resize(num_bodies, num_velocities, max_clique_size, num_ball_constraints,
-              num_couplers, num_distance_constraints, num_welds, gain_sizes,
-              limit_sizes, patch_sizes);
+  data.Resize({.num_bodies = num_bodies,
+               .num_velocities = num_velocities,
+               .max_clique_size = max_clique_size,
+               .num_ball_constraints = num_ball_constraints,
+               .num_couplers = num_couplers,
+               .num_distance_constraints = num_distance_constraints,
+               .num_welds = num_welds,
+               .gain_sizes = gain_sizes,
+               .limit_sizes = limit_sizes,
+               .patch_sizes = patch_sizes});
 
   // Main data elements
   EXPECT_EQ(data.num_velocities(), num_velocities);
@@ -108,14 +115,22 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
   const std::vector<int> limit_sizes = {4};
   const std::vector<int> patch_sizes = {5};
 
-  data.Resize(num_bodies, num_velocities, max_clique_size, num_ball_constraints,
-              num_couplers, num_distance_constraints, num_welds, gain_sizes,
-              limit_sizes, patch_sizes);
+  data.Resize({.num_bodies = num_bodies,
+               .num_velocities = num_velocities,
+               .max_clique_size = max_clique_size,
+               .num_ball_constraints = num_ball_constraints,
+               .num_couplers = num_couplers,
+               .num_distance_constraints = num_distance_constraints,
+               .num_welds = num_welds,
+               .gain_sizes = gain_sizes,
+               .limit_sizes = limit_sizes,
+               .patch_sizes = patch_sizes});
 
   // Clearing pools changes size but shouldn't change capacity.
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);
-  data.scratch().Resize(0, 0, 0, 0, 0, 0, 0, gain_sizes, limit_sizes,
-                        patch_sizes);
+  data.scratch().Resize({.gain_sizes = gain_sizes,
+                         .limit_sizes = limit_sizes,
+                         .patch_sizes = patch_sizes});
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), 0);
 
   VectorX<double> v = VectorX<double>::LinSpaced(num_velocities, 1.0, 11.0);
@@ -123,9 +138,16 @@ GTEST_TEST(IcfData, LimitMallocOnResize) {
     // Restoring the data to the original size and setting velocities should not
     // cause any new allocations.
     drake::test::LimitMalloc guard;
-    data.Resize(num_bodies, num_velocities, max_clique_size,
-                num_ball_constraints, num_couplers, num_distance_constraints,
-                num_welds, gain_sizes, limit_sizes, patch_sizes);
+    data.Resize({.num_bodies = num_bodies,
+                 .num_velocities = num_velocities,
+                 .max_clique_size = max_clique_size,
+                 .num_ball_constraints = num_ball_constraints,
+                 .num_couplers = num_couplers,
+                 .num_distance_constraints = num_distance_constraints,
+                 .num_welds = num_welds,
+                 .gain_sizes = gain_sizes,
+                 .limit_sizes = limit_sizes,
+                 .patch_sizes = patch_sizes});
     data.set_v(v);
   }
   EXPECT_EQ(data.scratch().V_WB_alpha.size(), num_bodies);


### PR DESCRIPTION
Addresses a TODO in `multibody/contact_solvers/icf/icf_data.h` to refactor `IcfData::Resize()` which had a growing number of arguments each time a new constraint was added.

A new struct, `ResizeParams` is added to consolidate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24822)
<!-- Reviewable:end -->
