### PR TITLE
[render] Correct RenderEngineGL "upside down" images

### DIFF
--- a/bindings/generated_docstrings/geometry_render_gl.h
+++ b/bindings/generated_docstrings/geometry_render_gl.h
@@ -32,14 +32,10 @@ will throw.
 Note:
     RenderEngineGl behaves a bit differently from other RenderEngine
     implementations (e.g., RenderEngineVtk) with respect to displayed
-    images. First, RenderEngineGl can only display a *single* image
-    type at a time. So, if a shown window has been requested for both
-    label and color images, the images will alternate in the same
-    window. Second, the window display draws all images *flipped
-    vertically*. The image produced will be compatible with the Drake
-    ecosystem, only the visualization will be upside down. This has
-    been documented in
-    https://github.com/RobotLocomotion/drake/issues/14254.
+    images. RenderEngineGl can only display a *single* image type at a
+    time. So, if ``show_window`` has been requested for both label and
+    color images, the images will alternate quickly (flickering) in
+    the shared window.
 
 ** Using RenderEngineGl in multiple threads **
 

--- a/bindings/generated_docstrings/systems_sensors.h
+++ b/bindings/generated_docstrings/systems_sensors.h
@@ -1214,8 +1214,8 @@ displayed depends on the specific render engine and its configuration
 Note: This flag is intended for quick debug use during development
 instead of serving as an image viewer. Currently, there are known
 issues, e.g., flickering windows when multiple cameras share the same
-renderer or upside-down images if RenderEngineGl is set. See issue
-#18862 for the proposal to visualize images via Meldis.)""";
+renderer. See issue #18862 for the proposal to visualize images via
+Meldis.)""";
           } show_rgb;
           // Symbol: drake::systems::sensors::CameraConfig::width
           struct /* width */ {

--- a/bindings/pydrake/visualization/_model_visualizer.py
+++ b/bindings/pydrake/visualization/_model_visualizer.py
@@ -15,9 +15,11 @@ from pydrake.geometry import (
     EquirectangularMap,
     LightParameter,
     MeshcatCone,
+    RenderEngineGlParams,
     RenderEngineVtkParams,
     Rgba,
     StartMeshcat,
+    kHasRenderEngineGl,
 )
 from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.meshcat import JointSliders
@@ -67,6 +69,10 @@ class ModelVisualizer:
 
     # Note: this class uses C++ method names to ease future porting.
 
+    _SUPPORTED_RGBD_RENDERERS = (
+        ("vtk", "gl") if kHasRenderEngineGl else ("vtk",)
+    )
+
     def __init__(
         self,
         *,
@@ -75,7 +81,7 @@ class ModelVisualizer:
         triad_radius=0.005,
         triad_opacity=0.9,
         publish_contacts=True,
-        show_rgbd_sensor=False,
+        show_rgbd_sensor: bool | str = False,
         browser_new=False,
         pyplot=False,
         meshcat=None,
@@ -92,10 +98,11 @@ class ModelVisualizer:
           triad_radius: the radius of visualization triads.
           triad_opacity: the opacity of visualization triads.
           publish_contacts: a flag for VisualizationConfig.
-          show_rgbd_sensor: when True, adds an RgbdSensor to the scene and pops
-             up a local preview window of the rgb image. At the moment, the
-             image display uses a native window so will not work in a remote or
-             cloud runtime environment.
+          show_rgbd_sensor: when ``True``, ``"vtk"``, or ``"gl"``, adds an
+             RgbdSensor to the scene and pops up a local preview window of the
+             rgb image. ``True`` selects ``"vtk"``; ``False`` disables
+             the sensor. At the moment, the image display uses a native window
+             so will not work in a remote or cloud runtime environment.
           environment_map: Meshcat environment map filename.
           no_lights: optionally disable the lights in the render engine and
              meshcat. This is useful when using an environment map to assess
@@ -122,6 +129,21 @@ class ModelVisualizer:
         self._triad_radius = triad_radius
         self._triad_opacity = triad_opacity
         self._publish_contacts = publish_contacts
+        if show_rgbd_sensor is True:
+            show_rgbd_sensor = "vtk"
+        if (
+            show_rgbd_sensor is not False
+            and show_rgbd_sensor not in self._SUPPORTED_RGBD_RENDERERS
+        ):
+            if show_rgbd_sensor == "gl":
+                raise ValueError(
+                    "show_rgbd_sensor='gl' requires "
+                    "pydrake.geometry.kHasRenderEngineGl to be True"
+                )
+            choices = ", ".join(repr(x) for x in self._SUPPORTED_RGBD_RENDERERS)
+            raise ValueError(
+                f"show_rgbd_sensor must be bool or one of: {choices}"
+            )
         self._show_rgbd_sensor = show_rgbd_sensor
         self._browser_new = browser_new
         self._pyplot = pyplot
@@ -224,6 +246,54 @@ class ModelVisualizer:
         # It's safe to let the user change the package map. We'll make a copy
         # of it during Finalize().
         return self._builder.parser().package_map()
+
+    def _make_rgbd_sensor_config(self):
+        """Returns the configuration for the preview camera, assuming we want
+        to display an interactive window."""
+        assert self._show_rgbd_sensor in self._SUPPORTED_RGBD_RENDERERS
+        camera_config = CameraConfig(width=1440, height=1080)
+        camera_config.name = "preview"
+        camera_config.X_PB.base_frame = "$rgbd_sensor_body"
+        camera_config.z_far = 3  # Show 3m of frustum.
+        camera_config.fps = 1.0  # Ignored -- we're not simulating.
+        # The meshcat default field of view is 75 degrees. We want the two
+        # images to match.
+        camera_config.focal = CameraConfig.FovDegrees(y=75)
+        # Don't pop up a native window during unit tests.
+        is_unit_test = "TEST_SRCDIR" in os.environ
+        camera_config.show_rgb = not is_unit_test
+
+        # An empty list causes the render engine to revert to default lighting.
+        lights = []
+        if self._no_lights:
+            # We can only disable *all* lights by creating a light with zero
+            # intensity.
+            lights = [LightParameter(intensity=0)]
+
+        if self._show_rgbd_sensor == "gl":
+            # Note: RenderEngineGL doesn't have full feature parity with
+            # RenderEngineVtk. So, RenderEngineGl does not do the
+            # initialization necessary for RenderEngineVtk.
+            camera_config.renderer_class = RenderEngineGlParams(lights=lights)
+            return camera_config
+
+        vtk_params = RenderEngineVtkParams(
+            exposure=1,
+            lights=lights,
+        )
+        if self._environment_map.is_file():
+            vtk_params.environment_map = EnvironmentMap(
+                skybox=True,
+                texture=EquirectangularMap(path=str(self._environment_map)),
+            )
+        if camera_config.show_rgb and sys.platform != "darwin":
+            # Note: GLX requires an X display (even if we're not showing the
+            # window). We don't always have an X display (e.g., unit tests), so
+            # we'll simply stay away from GLX unless we're showing the render
+            # window.
+            vtk_params.backend = "GLX"
+        camera_config.renderer_class = vtk_params
+        return camera_config
 
     def parser(self):
         """
@@ -417,37 +487,7 @@ class ModelVisualizer:
         # sensor is affixed to the world frame and we'll modify that pose
         # below.
         if self._show_rgbd_sensor:
-            camera_config = CameraConfig(width=1440, height=1080)
-            camera_config.name = "preview"
-            camera_config.X_PB.base_frame = "$rgbd_sensor_body"
-            camera_config.z_far = 3  # Show 3m of frustum.
-            camera_config.fps = 1.0  # Ignored -- we're not simulating.
-            # The meshcat default field of view is 75 degrees. We want the two
-            # images to match.
-            camera_config.focal = CameraConfig.FovDegrees(y=75)
-            is_unit_test = "TEST_SRCDIR" in os.environ
-            if not is_unit_test:
-                # Pop up a local window.
-                camera_config.show_rgb = True
-                camera_config.renderer_class = RenderEngineVtkParams()
-                camera_config.renderer_class.exposure = 1
-                if self._environment_map.is_file():
-                    camera_config.renderer_class.environment_map = (
-                        EnvironmentMap(
-                            skybox=True,
-                            texture=EquirectangularMap(
-                                path=str(self._environment_map)
-                            ),
-                        )
-                    )
-                if self._no_lights:
-                    # We can only disable *all* lights by creating a light with
-                    # zero intensity.
-                    camera_config.renderer_class.lights = [
-                        LightParameter(intensity=0)
-                    ]
-                if "darwin" not in sys.platform:
-                    camera_config.renderer_class.backend = "GLX"
+            camera_config = self._make_rgbd_sensor_config()
             ApplyCameraConfig(
                 config=camera_config, builder=self._builder.builder()
             )

--- a/bindings/pydrake/visualization/model_visualizer.py
+++ b/bindings/pydrake/visualization/model_visualizer.py
@@ -96,12 +96,22 @@ def _main():
         help="Visualize the frames as triads for all links.",
     )
     assert defaults["show_rgbd_sensor"] is False
+    rgbd_renderers = _ModelVisualizer._SUPPORTED_RGBD_RENDERERS
+    show_rgbd_renderer_help = (
+        "Add and show an RgbdSensor using the indicated render engine "
+        "type. At the moment, the image display uses a native window so will "
+        "not work in a remote or cloud runtime environment."
+    )
+    if "gl" not in rgbd_renderers:
+        show_rgbd_renderer_help += (
+            " The 'gl' option is not available because "
+            "pydrake.geometry.kHasRenderEngineGl is False."
+        )
     args_parser.add_argument(
         "--show_rgbd_sensor",
-        action="store_true",
-        help="Add and show an RgbdSensor. At the moment, the image display "
-        "uses a native window so will not work in a remote or cloud "
-        "runtime environment.",
+        choices=rgbd_renderers,
+        default=False,
+        help=show_rgbd_renderer_help,
     )
     assert defaults["environment_map"] == Path()
     args_parser.add_argument(

--- a/bindings/pydrake/visualization/test/model_visualizer_camera_test.py
+++ b/bindings/pydrake/visualization/test/model_visualizer_camera_test.py
@@ -1,12 +1,18 @@
 import pydrake.visualization as mut  # ruff: isort: skip
 
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import umsgpack
 
 import pydrake.common.test_utilities.numpy_compare as numpy_compare
-from pydrake.geometry import Meshcat
+from pydrake.geometry import (
+    Meshcat,
+    RenderEngineGlParams,
+    RenderEngineVtkParams,
+    kHasRenderEngineGl,
+)
 from pydrake.math import (
     RigidTransform,
     RollPitchYaw,
@@ -78,4 +84,40 @@ class TestModelVisualizerCamera(unittest.TestCase):
 
         numpy_compare.assert_allclose(
             X_WB.GetAsMatrix34(), X_WB_expected.GetAsMatrix34(), atol=1e-15
+        )
+
+    def test_rgbd_renderer_configuration(self):
+        """Checks that the preview camera gets the selected renderer."""
+
+        vtk_config = mut.ModelVisualizer(
+            show_rgbd_sensor=True
+        )._make_rgbd_sensor_config()
+        self.assertIsInstance(vtk_config.renderer_class, RenderEngineVtkParams)
+
+        vtk_config = mut.ModelVisualizer(
+            show_rgbd_sensor="vtk"
+        )._make_rgbd_sensor_config()
+        self.assertIsInstance(vtk_config.renderer_class, RenderEngineVtkParams)
+
+        # Note: we're not instantiating the render engine, just configuring
+        # one. So, we can safely "lie" about the availability.
+        with patch.object(
+            mut.ModelVisualizer,
+            "_SUPPORTED_RGBD_RENDERERS",
+            ("vtk", "gl"),
+        ):
+            gl_config = mut.ModelVisualizer(
+                show_rgbd_sensor="gl"
+            )._make_rgbd_sensor_config()
+        self.assertIsInstance(gl_config.renderer_class, RenderEngineGlParams)
+
+        with self.assertRaisesRegex(ValueError, "show_rgbd_sensor"):
+            mut.ModelVisualizer(show_rgbd_sensor="bad")
+
+    def test_show_rgbd_sensor_availability_messaging(self):
+        """Checks that RenderEngineGl is offered only when available. This test
+        runs in CI contexts where kHasRenderEngineGl is False and True."""
+        self.assertEqual(
+            "gl" in mut.ModelVisualizer._SUPPORTED_RGBD_RENDERERS,
+            kHasRenderEngineGl,
         )

--- a/geometry/render_gl/factory.h
+++ b/geometry/render_gl/factory.h
@@ -17,12 +17,9 @@ extern const bool kHasRenderEngineGl;
 
  @note %RenderEngineGl behaves a bit differently from other RenderEngine
  implementations (e.g., RenderEngineVtk) with respect to displayed images.
- First, %RenderEngineGl can only display a *single* image type at a time. So,
- if a shown window has been requested for both label and color images, the
- images will alternate in the same window. Second, the window display draws all
- images *flipped vertically*. The image produced will be compatible with the
- Drake ecosystem, only the visualization will be upside down. This has been
- documented in https://github.com/RobotLocomotion/drake/issues/14254.
+ %RenderEngineGl can only display a *single* image type at a time. So, if
+ `show_window` has been requested for both label and color images, the images
+ will alternate quickly (flickering) in the shared window.
 
  <b> Using RenderEngineGl in multiple threads </b>
 

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -2419,8 +2419,10 @@ void RenderEngineGl::SetWindowVisibility(const RenderCameraCore& camera,
     glBlitNamedFramebuffer(target.frame_buffer, 0,
                            // Src bounds.
                            0, 0, intrinsics.width(), intrinsics.height(),
-                           // Dest bounds.
-                           0, 0, intrinsics.width(), intrinsics.height(),
+                           // Dest bounds. The render target uses upper-left
+                           // image coordinates, while the native window's
+                           // default framebuffer is presented bottom-up.
+                           0, intrinsics.height(), intrinsics.width(), 0,
                            GL_COLOR_BUFFER_BIT, GL_NEAREST);
     opengl_context_->UpdateWindow();
   } else {

--- a/geometry/render_gl/test/multithread_safety_test.cc
+++ b/geometry/render_gl/test/multithread_safety_test.cc
@@ -219,11 +219,6 @@ Vector4<int> RgbaVector(const ImageRgba8U::T* data) {
       │                       │
       └───────────────────────┘
 
- N.B. If you set `show_window` to true in the camera settings, the camera will
- be flipped vertically (the cylinder and capsule will change positions). This
- is a documented property of how `show_window` works with RenderEngineGl (see
- render_gl/factory.h).
-
  To test the correctness of the rendered image, we'll sample the color on
  each shape. The rendered images are saved to the test outputs.
 

--- a/systems/sensors/camera_config.h
+++ b/systems/sensors/camera_config.h
@@ -486,9 +486,8 @@ struct CameraConfig {
 
    Note: This flag is intended for quick debug use during development instead of
    serving as an image viewer. Currently, there are known issues, e.g.,
-   flickering windows when multiple cameras share the same renderer or
-   upside-down images if RenderEngineGl is set. See issue #18862 for the
-   proposal to visualize images via Meldis. */
+   flickering windows when multiple cameras share the same renderer. See issue
+   #18862 for the proposal to visualize images via Meldis. */
   bool show_rgb{false};
 
   /** Controls whether the images are broadcast in a compressed format. */


### PR DESCRIPTION
If a camera using RenderEngineGl sets its `show_window` to true, the image would be displayed upside down. This changes the "blitting" of the rendered image to cause the interactive window to display the right side up.

As the beginning of a number of changes to RenderEngineGl, this also makes the engine available to easy introspection via model_visualizer. The render engine can be selected as a command-line parameter.

Resolves #14254

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24823)
<!-- Reviewable:end -->
