### PR TITLE
[pydrake] Don't install pybind11_version in nanobind builds

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -101,9 +101,13 @@ drake_pybind_library(
         "cpp_template.py",
         "deprecation.py",
         "jupyter.py",
-        "pybind11_version.py",
         "yaml.py",
-    ],
+    ] + select({
+        "//tools/workspace/nanobind:enabled": [],
+        "//conditions:default": [
+            "pybind11_version.py",
+        ],
+    }),
     visibility = [
         "//bindings/pydrake:__pkg__",
     ],
@@ -526,6 +530,7 @@ drake_py_unittest(
 
 drake_py_unittest(
     name = "pybind11_version_test",
+    opt_out_conditions = ["//tools/workspace/nanobind:enabled"],
     deps = [
         ":common",
     ],

--- a/bindings/pydrake/common/all.py
+++ b/bindings/pydrake/common/all.py
@@ -13,7 +13,3 @@ from .eigen_geometry import *
 from .schema import *
 from .yaml import *
 from .value import *
-
-# N.B. Since this is generic and relatively scoped, we import the module as a
-# symbol.
-from . import pybind11_version


### PR DESCRIPTION
Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24827)
<!-- Reviewable:end -->
