### PR TITLE
Migrate from toolchains_llvm to llvm

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -262,6 +262,10 @@ bazel_dep(
     version = "0.8.16",
     dev_dependency = True,
 )
+# N.B. We must NOT register llvm's toolchain here. We want to use the
+# auto-detecting toolchain, above ("local_config_cc"). We only use llvm
+# for linting (clang-format) and testing (llvm-objdump).
+
 bazel_dep(
     name = "ruff_prebuilt",
     version = "0.16.0.1",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -259,7 +259,7 @@ single_version_override(
 
 bazel_dep(
     name = "llvm",
-    version = "0.8.9",
+    version = "0.8.16",
     dev_dependency = True,
 )
 bazel_dep(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -258,19 +258,10 @@ single_version_override(
 )
 
 bazel_dep(
-    name = "toolchains_llvm",
-    version = "1.8.0",
-    dev_dependency = True,
-)
-
-llvm = use_repo_rule("@toolchains_llvm//toolchain:rules.bzl", "llvm")
-
-llvm(
     name = "llvm",
+    version = "0.8.9",
     dev_dependency = True,
-    llvm_versions = {"": "22.1.7"},
 )
-
 bazel_dep(
     name = "ruff_prebuilt",
     version = "0.16.0.1",

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -494,8 +494,11 @@ drake_py_unittest(
     timeout = "moderate",
     data = [
         ":libdrake.so",
-        "@llvm//:bin/llvm-objdump",
+        "@llvm//tools:llvm-objdump",
     ],
+    env = {
+        "LLVM_OBJDUMP_RLOCATIONPATH": "$(rlocationpath @llvm//tools:llvm-objdump)",
+    },
     deps = [
         "@rules_python//python/runfiles",
         lief_requirement("lief"),

--- a/tools/install/libdrake/test/exported_symbols_test.py
+++ b/tools/install/libdrake/test/exported_symbols_test.py
@@ -1,4 +1,5 @@
 import bisect
+import os
 import struct
 import subprocess
 import unittest
@@ -249,7 +250,7 @@ class ExportedSymbolsTest(unittest.TestCase):
         manifest = runfiles.Create()
         objdump_all = subprocess.check_output(
             [
-                manifest.Rlocation("llvm/bin/llvm-objdump"),
+                manifest.Rlocation(os.environ["LLVM_OBJDUMP_RLOCATIONPATH"]),
                 LIBDRAKE,
                 "-Mintel",
                 "--no-addresses",

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -47,7 +47,7 @@ drake_py_library(
     srcs = ["clang_format.py"],
     data = [
         "//:.clang-format",
-        "@llvm//:bin/clang-format",
+        "@llvm//tools:clang-format",
     ],
     deps = [
         ":module_py",

--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -1,7 +1,6 @@
 """Drake's wrapper for the clang-format binary."""
 
 import os
-from pathlib import Path
 import sys
 
 from python import runfiles
@@ -9,8 +8,8 @@ from python import runfiles
 
 def get_clang_format_path():
     manifest = runfiles.Create()
-    path = Path(manifest.Rlocation("llvm/bin/clang-format"))
-    if not path.is_file():
+    path = next(manifest.root().glob("llvm*/bin/clang-format"), None)
+    if path is None or not path.is_file():
         raise RuntimeError(f"Could not find required clang-format at {path}")
     return path
 

--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -7,11 +7,13 @@ from python import runfiles
 
 
 def get_clang_format_path():
+    # In our runfiles, there should be exactly one path that looks like
+    # "llvm+{module_extension_...}-{version}-{os}-{arch}/bin/clang-format".
+    # Find and return it (or raise an error).
     manifest = runfiles.Create()
-    path = next(manifest.root().glob("llvm*/bin/clang-format"), None)
-    if path is None or not path.is_file():
-        raise RuntimeError(f"Could not find required clang-format at {path}")
-    return path
+    matches = list(manifest.root().glob("llvm+*/bin/clang-format"))
+    assert len(matches) == 1, repr(matches)
+    return matches[0]
 
 
 def _main():


### PR DESCRIPTION
Extracted from #24810.

Closes #24151.

This no longer lets us independently choose the `clang-format` version from the `bazel_dep` module version, but that should be fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24832)
<!-- Reviewable:end -->
