### PR TITLE
[pydrake] Port Sha256 and MemoryFile to nanobind

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -1,5 +1,6 @@
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "drake/bindings/generated_docstrings/common.h"
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
@@ -172,9 +173,19 @@ void InitLowLevelModules(py::module_ m) {
     class_<Class> cls(m, "Sha256", cls_doc.doc);
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
-        .def_static("Checksum",
-            py::overload_cast<std::string_view>(&Class::Checksum),
-            cls_doc.Checksum.doc_1args_data)
+        .def_static(
+            "Checksum",
+            [](std::variant<py::bytes, std::string_view> data_union) {
+              if (data_union.index() == 0) {
+                const auto& as_bytes = std::get<py::bytes>(data_union);
+                const std::string_view data(as_bytes.c_str(), as_bytes.size());
+                return Class::Checksum(data);
+              } else {
+                const auto& data = std::get<std::string_view>(data_union);
+                return Class::Checksum(data);
+              }
+            },
+            py::arg("data"), cls_doc.Checksum.doc_1args_data)
         .def_static("Parse", &Class::Parse, cls_doc.Parse.doc)
         .def("to_string", &Class::to_string, cls_doc.to_string.doc)
         .def(py::self == py::self)
@@ -194,12 +205,27 @@ void InitLowLevelModules(py::module_ m) {
     using Class = MemoryFile;
     constexpr auto& cls_doc = doc.MemoryFile;
     class_<Class> cls(m, "MemoryFile", cls_doc.doc);
-    py::object ctor = m.attr("MemoryFile");
     cls  // BR
-        .def(py::init<>(), cls_doc.ctor.doc_0args)
-        .def(py::init<std::string, std::string, std::string>(),
-            py::arg("contents"), py::arg("extension"), py::arg("filename_hint"),
-            cls_doc.ctor.doc_3args)
+        .def(
+            // We only bind the three-argument constructor (skipping the default
+            // constructor), but we give it defaulted arguments consistent with
+            // the default constructor. This improves the pydrake documentation.
+            "__init__",
+            [](Class* self, std::variant<py::bytes, std::string> contents_union,
+                std::string extension, std::string filename_hint) {
+              std::string contents;
+              if (contents_union.index() == 0) {
+                const auto& as_bytes = std::get<py::bytes>(contents_union);
+                contents = std::string(as_bytes.c_str(), as_bytes.size());
+              } else {
+                contents = std::move(std::get<std::string>(contents_union));
+              }
+              new (self) Class(std::move(contents), std::move(extension),
+                  std::move(filename_hint));
+            },
+            py::arg("contents") = std::string(),
+            py::arg("extension") = std::string(),
+            py::arg("filename_hint") = std::string(), cls_doc.ctor.doc_3args)
         .def(
             "contents",
             [](const Class& self) {
@@ -223,8 +249,10 @@ void InitLowLevelModules(py::module_ m) {
           result["filename_hint"] = self.filename_hint();
           return result;
         },
-        [ctor](Class* self, const py::dict& kwargs) {
-          new (self) Class(py::cast<Class>(ctor(**kwargs)));
+        [](Class* self, const py::dict& kwargs) {
+          new (self) MemoryFile(py::cast<std::string>(kwargs["contents"]),
+              py::cast<std::string>(kwargs["extension"]),
+              py::cast<std::string>(kwargs["filename_hint"]));
         });
     // Note: __repr__ is defined in _common_extra.py.
     DefCopyAndDeepCopy(&cls);
@@ -260,7 +288,8 @@ void InitLowLevelModules(py::module_ m) {
           name_str == "filename_hint") {
         name = py::str(fmt::format("_{}", name_str).c_str());
       }
-      py::eval("object.__setattr__", py::globals())(self, name, value);
+      py::eval("object.__setattr__", py::globals())(
+          py::cast(self, py_rvp::reference), name, value);
     });
     // Provide properties for use by yaml_{dump,load}_typed.
     cls.def_prop_rw(

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -54,9 +54,6 @@ class TestCommon(unittest.TestCase):
         copy.copy(not_empty)
         copy.deepcopy(not_empty)
 
-    @unittest.skipIf(
-        mut._binder == "nanobind", "TODO(#21572) Fix MemoryFile bindings."
-    )
     def test_memory_file(self):
         content_bytes = b"Some string"
         hint = "hint"
@@ -101,9 +98,6 @@ class TestCommon(unittest.TestCase):
         )
         self.assertEqual(file.extension(), ".urdf")
 
-    @unittest.skipIf(
-        mut._binder == "nanobind", "TODO(#21572) Fix MemoryFile bindings."
-    )
     def test_memory_file_yaml_serialization(self):
         """Confirms that this can be serialized appropriately. The
         serialization work (with all of its nuances) gets tested elsewhere.


### PR DESCRIPTION
(Nanobind does not accept `bytes` for a `std::string` argument by default.)

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24835)
<!-- Reviewable:end -->
