### PR TITLE
[pydrake] Fix vector output callback lifetime

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -523,6 +523,13 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
+    name = "output_port_gc_test",
+    deps = [
+        ":framework_py",
+    ],
+)
+
+drake_py_unittest(
     name = "perception_test",
     deps = [
         ":analysis_py",

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -152,6 +152,31 @@ using PyDiscreteUpdateCallback =
 template <typename T>
 using PyUnrestrictedUpdateCallback =
     PyEventCallback<const Context<T>*, State<T>*>;
+#ifdef PYDRAKE_USE_PYBIND11
+template <typename T>
+using PyCalcVectorCallback =
+    py::typing::Callable<void(const Context<T>*, BasicVector<T>*)>;
+#else   // PYDRAKE_USE_NANOBIND
+template <typename T>
+using PyCalcVectorCallback =
+    py::typed<py::callable, void(const Context<T>*, BasicVector<T>*)>;
+#endif  // PYDRAKE_USE_PYBIND11
+
+// Constructs a vector-output calculation callback.
+// @param callback_ptr a callable expecting a context and an output vector.
+// Aliased; its lifetime must be guaranteed elsewhere.
+template <typename T>
+typename LeafOutputPort<T>::CalcVectorCallback MakeCalcVectorCallback(
+    PyObject* callback_ptr) {
+  return [callback_ptr](const Context<T>& context, BasicVector<T>* output) {
+    py::gil_scoped_acquire guard;
+    py::handle py_callback_from_ptr = callback_ptr;
+    auto callback =
+        py::cast<std::function<void(const Context<T>*, BasicVector<T>*)>>(
+            py_callback_from_ptr);
+    callback(&context, output);
+  };
+}
 
 // Constructs a publish event for bound Declare*Event methods.
 // @param trigger_type the trigger type.
@@ -767,7 +792,6 @@ Note: The above is for the C++ documentation. For Python, use
   }
 
   static void DefineLeafSystem(py::module_ m) {
-    using CalcVectorCallback = typename LeafOutputPort<T>::CalcVectorCallback;
     using Class = LeafSystem<T>;
     auto cls =
         DefineTemplateClassWithDefault<LeafSystem<T>, PyLeafSystem, System<T>>(
@@ -845,15 +869,19 @@ Note: The above is for the C++ documentation. For Python, use
             internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
             py::arg("size"), py::arg("random_type") = std::nullopt,
             doc.LeafSystem.DeclareVectorInputPort.doc_3args_size)
-        .def("DeclareVectorOutputPort",
-            WrapCallbacks(
-                [](Class* self, const std::string& name,
-                    const BasicVector<T>& arg1, CalcVectorCallback arg2,
-                    const std::set<DependencyTicket>& arg3)
-                    -> const OutputPort<T>& {
-                  return GetAlias<PyClass>(self)->DeclareVectorOutputPort(
-                      name, arg1, arg2, arg3);
-                }),
+        .def(
+            "DeclareVectorOutputPort",
+            [](Class* self, const std::string& name,
+                const BasicVector<T>& model_value,
+                PyCalcVectorCallback<T> py_calc,
+                const std::set<DependencyTicket>& prerequisites_of_calc)
+                -> const OutputPort<T>& {
+              py::object py_self = py::cast(self, py_rvp::reference);
+              EnsureCallbackLifetime(py_self, py_calc);
+              return GetAlias<PyClass>(self)->DeclareVectorOutputPort(name,
+                  model_value, MakeCalcVectorCallback<T>(py_calc.ptr()),
+                  prerequisites_of_calc);
+            },
             // Use a ref_cycle (rather than the implicit keep-alive of
             // reference_internal) to avoid immortality hazards like #22515.
             internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),
@@ -861,15 +889,18 @@ Note: The above is for the C++ documentation. For Python, use
             py::arg("prerequisites_of_calc") =
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
             doc.LeafSystem.DeclareVectorOutputPort.doc_4args_model_vector)
-        .def("DeclareVectorOutputPort",
-            WrapCallbacks(
-                [](Class* self, const std::string& name, int size,
-                    CalcVectorCallback calc,
-                    const std::set<DependencyTicket>& prerequisites_of_calc)
-                    -> const OutputPort<T>& {
-                  return GetAlias<PyClass>(self)->DeclareVectorOutputPort(
-                      name, size, calc, prerequisites_of_calc);
-                }),
+        .def(
+            "DeclareVectorOutputPort",
+            [](Class* self, const std::string& name, int size,
+                PyCalcVectorCallback<T> py_calc,
+                const std::set<DependencyTicket>& prerequisites_of_calc)
+                -> const OutputPort<T>& {
+              py::object py_self = py::cast(self, py_rvp::reference);
+              EnsureCallbackLifetime(py_self, py_calc);
+              return GetAlias<PyClass>(self)->DeclareVectorOutputPort(name,
+                  size, MakeCalcVectorCallback<T>(py_calc.ptr()),
+                  prerequisites_of_calc);
+            },
             // Use a ref_cycle (rather than the implicit keep-alive of
             // reference_internal) to avoid immortality hazards like #22515.
             internal::ref_cycle<0, 1>(), py_rvp::reference, py::arg("name"),

--- a/bindings/pydrake/systems/test/output_port_gc_test.py
+++ b/bindings/pydrake/systems/test/output_port_gc_test.py
@@ -1,0 +1,50 @@
+"""Tests output-port callbacks against leaks and lifetime problems."""
+
+import gc
+import unittest
+import weakref
+
+from pydrake.systems.framework import BasicVector, LeafSystem
+
+
+class MethodCallbackLeafSystem(LeafSystem):
+    """System with a vector output callback implemented as a bound method."""
+
+    def __init__(self, *, use_model_value):
+        super().__init__()
+        self._count = 0
+        if use_model_value:
+            self.DeclareVectorOutputPort(
+                "output", BasicVector(1), self._calc_output
+            )
+        else:
+            self.DeclareVectorOutputPort("output", 1, self._calc_output)
+
+    def _calc_output(self, context, output):
+        self._count += 1
+        output.SetAtIndex(0, self._count)
+
+    def count(self):
+        return self._count
+
+
+class TestOutputPortGarbageCollection(unittest.TestCase):
+    def test_method_callback_is_callable_and_collectible(self):
+        for use_model_value in (False, True):
+            with self.subTest(use_model_value=use_model_value):
+                system = MethodCallbackLeafSystem(
+                    use_model_value=use_model_value
+                )
+                context = system.CreateDefaultContext()
+
+                value = system.get_output_port().Eval(context)
+                self.assertEqual(value[0], 1)
+                self.assertEqual(system.count(), 1)
+
+                spy = weakref.finalize(system, lambda: None)
+                del value
+                del context
+                del system
+                gc.collect()
+
+                self.assertFalse(spy.alive)


### PR DESCRIPTION
Fixes one callback lifetime cycle identified in #24162.
`DeclareVectorOutputPort` stores its calculation callback in C++. When the callback is a Python bound method, the retained callback keeps the Python `LeafSystem` alive through a cycle that Python GC cannot observe.
This change uses the ownership pattern from #24117:
- Python keeps the system-to-callback lifetime link.
- C++ keeps a non-owning callback alias.
- Callback invocation reacquires the GIL.
The change covers both Python overloads of `DeclareVectorOutputPort`. It does not change the other `WrapCallbacks` sites.
Testing:
- `output_port_gc_test` (default and alternate binders)
- `event_gc_test`
- `custom_test`
- changed-file C++, Python, and BUILD lint
- 200 registrations: 200 callback calls, 0 systems alive after `gc.collect()`
Toward #24162.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24852)
<!-- Reviewable:end -->
