### PR TITLE
[setup] Don't install python-is-python3

### DIFF
--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -50,13 +50,6 @@ readonly workspace_dir="$(cd "$(dirname "${BASH_SOURCE}")/../.." && pwd)"
 packages=$(cat "${BASH_SOURCE%/*}/packages-${VERSION_CODENAME}-build.txt")
 ${maybe_sudo} apt-get install ${maybe_yes} --no-install-recommends ${packages}
 
-# We need a working /usr/bin/python (of any version).
-if [[ ! -e /usr/bin/python ]]; then
-  ${maybe_sudo} apt-get install ${maybe_yes} --no-install-recommends python-is-python3
-else
-  echo "/usr/bin/python is already installed"
-fi
-
 # ============================== Developer prereqs =============================
 
 if [[ "${developer}" -eq 1 ]]; then


### PR DESCRIPTION
We don't need this (#13235) anymore, probably due to some rules_python upgrade years ago. Everything these days uses `#!/usr/bin/env python3` instead of `#!/usr/bin/env python`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24859)
<!-- Reviewable:end -->
