### PR TITLE
Update dependency tinygltf_internal to 3.0.1

### DIFF
--- a/tools/workspace/tinygltf_internal/package.BUILD.bazel
+++ b/tools/workspace/tinygltf_internal/package.BUILD.bazel
@@ -11,11 +11,11 @@ package(
 
 cc_library_vendored(
     name = "tinygltf",
-    srcs = ["tiny_gltf.cc"],
+    srcs = ["attic/tiny_gltf.cc"],
     srcs_vendored = ["drake_vendor/tiny_gltf.cc"],
     hdrs = [
-        "tiny_gltf.h",
-        "tinygltf_json.h",
+        "attic/tiny_gltf.h",
+        "attic/tinygltf_json.h",
     ],
     hdrs_vendored = [
         "drake_vendor/tiny_gltf.h",

--- a/tools/workspace/tinygltf_internal/patches/never_destroyed.patch
+++ b/tools/workspace/tinygltf_internal/patches/never_destroyed.patch
@@ -3,8 +3,8 @@ Remove static destructors (run upon program exit) for local variables
 This patch should be upstreamed, but upstream has disabled pull
 requests, so *shrug*.
 
---- tiny_gltf.h
-+++ tiny_gltf.h
+--- attic/tiny_gltf.h
++++ attic/tiny_gltf.h
 @@ -334,19 +334,15 @@ class Value {
  
    // Lookup value from an array

--- a/tools/workspace/tinygltf_internal/repository.bzl
+++ b/tools/workspace/tinygltf_internal/repository.bzl
@@ -7,8 +7,8 @@ def tinygltf_internal_repository(
         name = name,
         repository = "syoyo/tinygltf",
         upgrade_type = "release",
-        commit = "v3.0.0",
-        sha256 = "806b0f1ba8007837fcd531e23872286f8a8870ee23275e1eb5304cdb48e4cb30",  # noqa
+        commit = "v3.0.1",
+        sha256 = "b7e953f13a30d7b6fd677e484de35febde954143a265da15dacd92ed171c73e6",  # noqa
         build_file = ":package.BUILD.bazel",
         patches = [
             ":patches/never_destroyed.patch",


### PR DESCRIPTION
Upstream force-pushed to the v3.0.0 tag, so we get checksum mismatches on master now.  This "upgrade" fixes it.

Note that we're still using the v2 sources, not the v3 rewrite.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24862)
<!-- Reviewable:end -->
