### PR TITLE
[render_gl] Diffuse color modulates diffuse map

### DIFF
--- a/geometry/geometry_file_formats_doxygen.h
+++ b/geometry/geometry_file_formats_doxygen.h
@@ -320,11 +320,12 @@ namespace geometry {
  mistake a "visual" material from a "dynamics" material. The latter consists of
  parameters such as elasticity, friction, etc. The former models how *light*
  interacts with the object including parameters such as diffuse color,
- specularity, etc. Drakes visual material model is based on the
+ specularity, etc. Drake's visual material model is based on the
  <a href="https://en.wikipedia.org/wiki/Phong_shading">Phong shading
  model</a>, but only makes use of a subset of that model's parameters.
- Currently, only the diffuse color property is parameterized. It can be either a
- single Rgba value, or a texture map.
+ Currently, only the diffuse color property is parameterized. It consists of an
+ Rgba value and an optional texture map; the final diffuse color is their
+ channel-wise product.
 
  Even if a mesh file contains material definitions of its own, for some
  geometry operations, Drake will apply its own heuristic to define a Drake
@@ -336,11 +337,12 @@ namespace geometry {
  steps in sequence, but stops at the first step that provides a viable material
  definition.
 
-  1. If the mesh file specifies materials, then the diffuse color or texture
-     specified in that material will be applied. Note: cases where an .obj
-     references a material name, but the material is not defined in the .mtl
-     file, or the .mtl file is missing, will be treated as if no material is
-     specified and we proceed to step 2.
+  1. If the mesh file specifies materials, then the diffuse color and texture
+     specified in each material will be applied. When both are present, the
+     final diffuse color is their channel-wise product. Note: cases where an
+     .obj references a material name, but the material is not defined in the
+     .mtl file, or the .mtl file is missing, will be treated as if no material
+     is specified and we proceed to step 2.
      - If diffuse properties are *also* defined in the mesh's
        GeometryProperties, a warning will be written to the console.
      - If the material specifies a texture, but the mesh doesn't have texture
@@ -348,9 +350,6 @@ namespace geometry {
        color is used.
      - If the material specifies a texture, but the texture isn't accessible,
        the texture is dismissed and only the material's diffuse color is used.
-     - <b>If the mesh file contains *multiple* materials, then all materials
-       are discarded as if they weren't present and the next step of the
-       algorithm is evaluated.</b>
   2. If the geometry in SceneGraph has had diffuse color or diffuse texture
      defined in its GeometryProperties, then that diffuse specification is
      used. The final diffuse color of the object is always the channel-wise

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -420,6 +420,7 @@ class DefaultTextureColorShader final : public LightingShader {
     glUniform1i(diffuse_map_loc_, 0);  // This texture is GL_TEXTURE0.
     const auto& my_data = data.value().get_value<InstanceData>();
     glBindTexture(GL_TEXTURE_2D, my_data.texture_id);
+    glUniform4fv(diffuse_color_loc_, 1, my_data.diffuse_color.data());
     glUniform2fv(diffuse_scale_loc_, 1, my_data.texture_scale.data());
     glUniform1i(texture_flip_loc_, my_data.flip_y);
   }
@@ -427,6 +428,7 @@ class DefaultTextureColorShader final : public LightingShader {
  private:
   void DoConfigureMoreUniforms() final {
     diffuse_map_loc_ = GetUniformLocation("diffuse_map");
+    diffuse_color_loc_ = GetUniformLocation("diffuse_color");
     diffuse_scale_loc_ = GetUniformLocation("diffuse_map_scale");
     texture_flip_loc_ = GetUniformLocation("texture_flip_y");
   }
@@ -437,6 +439,7 @@ class DefaultTextureColorShader final : public LightingShader {
 
   struct InstanceData {
     GLuint texture_id{};
+    Vector4<float> diffuse_color;
     Vector2<float> texture_scale;
     bool flip_y{};
   };
@@ -454,19 +457,25 @@ class DefaultTextureColorShader final : public LightingShader {
     // In constructing the material with a texture map, the UVs have already
     // been validated.
 
+    const Rgba diffuse =
+        properties.GetPropertyOrDefault("phong", "diffuse", Rgba(1, 1, 1));
     const auto& scale = properties.GetPropertyOrDefault(
         "phong", "diffuse_scale", Vector2d(1, 1));
     const bool flip_y =
         properties.GetPropertyOrDefault("texture", "flip", false);
-    return ShaderProgramData{shader_id(),
-                             AbstractValue::Make(InstanceData{
-                                 *texture_id, scale.cast<float>(), flip_y})};
+    return ShaderProgramData{
+        shader_id(), AbstractValue::Make(
+                         InstanceData{*texture_id, diffuse.rgba().cast<float>(),
+                                      scale.cast<float>(), flip_y})};
   }
 
   std::shared_ptr<TextureLibrary> library_{};
 
   // The location of the "diffuse_map" uniform in the shader.
   GLint diffuse_map_loc_{};
+
+  // The location of the "diffuse_color" uniform in the shader.
+  GLint diffuse_color_loc_{};
 
   // The location of the "diffuse_scale" uniform in the shader.
   GLint diffuse_scale_loc_{};
@@ -486,10 +495,11 @@ void main() {
   tex_coord = tex_coord_in;
 })""";
 
-  // We define the diffuse color by looking up the diffuse_map and then simply
-  // illuminate it.
+  // We define the diffuse color by modulating the diffuse_map with the material
+  // color and then illuminate it.
   static constexpr char kFragmentShader[] = R"""(
 uniform sampler2D diffuse_map;
+uniform vec4 diffuse_color;
 uniform vec2 diffuse_map_scale;
 uniform bool texture_flip_y;
 in vec2 tex_coord;
@@ -501,17 +511,15 @@ void main() {
   //  unsightly visual artifacts when a texture is supposed to exactly align
   //  with a triangle edge, but there are floating point errors in interpolation
   //  which cause the texture to be sampled on the other side.
-  // TODO(20234): To get parity with our other renderings, the diffuse *color*
-  // should modulate the texture for the final diffuse color.
   vec2 uv = fract(tex_coord * diffuse_map_scale);
   if (texture_flip_y) {
     uv.y = 1.0 - uv.y;
   }
-  vec4 map_rgba = texture(diffuse_map, uv);
-  if (map_rgba.a == 0.0) {
+  vec4 rgba = diffuse_color * texture(diffuse_map, uv);
+  if (rgba.a == 0.0) {
     discard;
   }
-  color = GetIlluminatedColor(map_rgba);
+  color = GetIlluminatedColor(rgba);
 })""";
 };
 

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -933,13 +933,23 @@ TEST_F(RenderEngineGlTest, FullyTransparentGeometryDoesNotOccludeColor) {
       GeometryId::get_new_id(), Box(2, 2, 0.1), transparent_material,
       RigidTransformd(Vector3d(0, 0, 1.5)), false /* needs update */);
 
-  // Exercises the "texture" shader.
+  // Exercises the "texture" shader - transparency from texture.
   PerceptionProperties transparent_texture_material;
   transparent_texture_material.AddProperty("label", "id", RenderLabel(1));
   transparent_texture_material.AddProperty(
       "phong", "diffuse_map",
       FindResourceOrThrow(
           "drake/geometry/render/test/meshes/fully_transparent.png"));
+  renderer_->RegisterVisual(
+      GeometryId::get_new_id(), Box(2, 2, 0.1), transparent_texture_material,
+      RigidTransformd(Vector3d(0, 0, 1.5)), false /* needs update */);
+
+  // Exercises the "texture" shader - transparency from phong diffuse.
+  transparent_texture_material.AddProperty("phong", "diffuse",
+                                           Rgba(1, 0, 0, 0));
+  transparent_texture_material.UpdateProperty(
+      "phong", "diffuse_map",
+      FindResourceOrThrow("drake/geometry/render/test/meshes/box.png"));
   renderer_->RegisterVisual(
       GeometryId::get_new_id(), Box(2, 2, 0.1), transparent_texture_material,
       RigidTransformd(Vector3d(0, 0, 1.5)), false /* needs update */);
@@ -1969,18 +1979,33 @@ TEST_F(RenderEngineGlTest, MultiMaterialObj) {
   struct Face {
     // The expected *illuminated* material color. The simple illumination model
     // guarantees that the rendered color should be that of the material --
-    // either the given Kd value *or* the map color at the test location.
-    // TODO(20234): this will change to product of diffuse color and texture.
+    // either the given Kd value or the product of Kd and the map color at the
+    // test location.
     Rgba rendered_color;
     RotationMatrixd rotation;
     std::string name;
   };
   Init(X_WR_, true);
 
-  const std::string filename =
+  const fs::path obj_path =
       FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.obj");
-
-  Mesh mesh(filename);
+  const fs::path mtl_path =
+      FindResourceOrThrow("drake/geometry/render/test/meshes/rainbow_box.mtl");
+  const fs::path png_path = FindResourceOrThrow(
+      "drake/geometry/render/test/meshes/rainbow_stripes.png");
+  std::string mtl_contents = MemoryFile::Make(mtl_path).contents();
+  const std::string original_kd = "Kd 0.800000 0.800000 0.800000";
+  const size_t kd_pos = mtl_contents.find(original_kd);
+  DRAKE_DEMAND(kd_pos != std::string::npos);
+  const Rgba texture_tint(0.8, 0.7, 0.6);
+  mtl_contents.replace(kd_pos, original_kd.size(),
+                       fmt::format("Kd {} {} {}", texture_tint.r(),
+                                   texture_tint.g(), texture_tint.b()));
+  Mesh mesh(InMemoryMesh{
+      MemoryFile::Make(obj_path),
+      {{"rainbow_box.mtl",
+        MemoryFile(std::move(mtl_contents), ".mtl", mtl_path.string())},
+       {"rainbow_stripes.png", MemoryFile::Make(png_path)}}});
   expected_label_ = RenderLabel(3);
   // Note: Passing diffuse color or texture to mesh with materials spawns a
   // warning.
@@ -1990,17 +2015,18 @@ TEST_F(RenderEngineGlTest, MultiMaterialObj) {
   renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
                             true /* needs update */);
 
+  // We already know alpha is included based on the FullyTransparent... test.
   const std::vector<Face> faces{
-      {.rendered_color = Rgba(0.016, 0.945, 0.129),
+      {.rendered_color = texture_tint * Rgba(0.016, 0.945, 0.129),
        .rotation = RotationMatrixd(),
        .name = "green"},
       {.rendered_color = Rgba(0.8, 0.359, 0.023),
        .rotation = RotationMatrixd::MakeXRotation(M_PI / 2),
        .name = "orange"},
-      {.rendered_color = Rgba(0.945, 0.016, 0.016),
+      {.rendered_color = texture_tint * Rgba(0.945, 0.016, 0.016),
        .rotation = RotationMatrixd::MakeXRotation(M_PI),
        .name = "red"},
-      {.rendered_color = Rgba(0.098, 0.016, 0.945),
+      {.rendered_color = texture_tint * Rgba(0.098, 0.016, 0.945),
        .rotation = RotationMatrixd::MakeXRotation(-M_PI / 2),
        .name = "blue"},
       {.rendered_color = Rgba(0.799, 0.8, 0),


### PR DESCRIPTION
Resolves a long-standing todo to have the diffuse color modulate the diffuse map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24870)
<!-- Reviewable:end -->
