### PR TITLE
[wheel] Clean up types in wheel builder

### DIFF
--- a/tools/wheel/wheel_builder/common.py
+++ b/tools/wheel/wheel_builder/common.py
@@ -42,6 +42,31 @@ class PythonBinder(Enum):
     PYBIND11 = "pybind11"
 
 
+class PythonTarget:
+    """
+    A representation of a Python target, constructed from the version number
+    tuple.
+
+    Example:
+        PythonTarget(3, 2, 1)
+
+    Members:
+        version_tuple: Target version as a tuple, e.g. (3, 2, 1)
+        version_full: Target full version as a string, e.g. '3.2.1'
+        version: Target major/minor version as a string, e.g. '3.2'
+        tag: Target major/minor version without separators, e.g. '32'
+    """
+
+    def __init__(self, *version_parts: int):
+        assert len(version_parts) in {2, 3}, version_parts
+
+        pv_parts = tuple(map(str, version_parts))
+        self.version_tuple = tuple(version_parts)
+        self.version_full = ".".join(pv_parts)
+        self.version = ".".join(pv_parts[:2])
+        self.tag = "".join(pv_parts[:2])
+
+
 def gripe(message):
     """
     Prints a message to stderr.

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -11,6 +11,7 @@ import tarfile
 
 from .common import (
     PythonBinder,
+    PythonTarget,
     create_snopt_tgz,
     die,
     edit_wheel_version_for_binder,
@@ -50,8 +51,9 @@ targets = {
     #   should be added to the aforementioned installation documentation.
     "x86_64": (
         Target(
-            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             python_binder=PythonBinder.NANOBIND,
+            python=PythonTarget(3, 12, 13),
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble"),
@@ -59,43 +61,43 @@ targets = {
                 # TODO(jwnimmer-tri) We should test this same abi3 wheel on all
                 # newer Python versions (so 3.13, 3.14, etc.).
             ),
-            python_version_tuple=(3, 12, 13),
         ),
         Target(
-            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             python_binder=PythonBinder.PYBIND11,
+            python=PythonTarget(3, 12, 13),
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble"),
                 Platform("ubuntu", "26.04", "resolute", PythonManager.UV),
             ),
-            python_version_tuple=(3, 12, 13),
         ),
         Target(
-            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             python_binder=PythonBinder.PYBIND11,
+            python=PythonTarget(3, 13, 15),
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble", PythonManager.UV),
                 Platform("ubuntu", "26.04", "resolute", PythonManager.UV),
             ),
-            python_version_tuple=(3, 13, 15),
         ),
         Target(
-            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             python_binder=PythonBinder.PYBIND11,
+            python=PythonTarget(3, 14, 7),
+            build_platform=Platform("amd64/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble", PythonManager.UV),
                 Platform("ubuntu", "26.04", "resolute"),
             ),
-            python_version_tuple=(3, 14, 7),
         ),
     ),
     "aarch64": (
         Target(
-            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             python_binder=PythonBinder.NANOBIND,
+            python=PythonTarget(3, 12, 13),
+            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble"),
@@ -103,37 +105,36 @@ targets = {
                 # TODO(jwnimmer-tri) We should test this same abi3 wheel on all
                 # newer Python versions (so 3.13, 3.14, etc.).
             ),
-            python_version_tuple=(3, 12, 13),
         ),
         Target(
-            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             python_binder=PythonBinder.PYBIND11,
+            python=PythonTarget(3, 12, 13),
+            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble"),
                 Platform("ubuntu", "26.04", "resolute", PythonManager.UV),
             ),
-            python_version_tuple=(3, 12, 13),
         ),
         Target(
-            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             python_binder=PythonBinder.PYBIND11,
+            python=PythonTarget(3, 13, 15),
+            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble", PythonManager.UV),
                 Platform("ubuntu", "26.04", "resolute", PythonManager.UV),
             ),
-            python_version_tuple=(3, 13, 15),
         ),
         Target(
-            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             python_binder=PythonBinder.PYBIND11,
+            python=PythonTarget(3, 14, 7),
+            build_platform=Platform("arm64v8/almalinux", "9", "almalinux9"),
             test_platforms=(
                 Platform("amazonlinux", "2023", "AL2023"),
                 Platform("ubuntu", "24.04", "noble", PythonManager.UV),
                 Platform("ubuntu", "26.04", "resolute"),
             ),
-            python_version_tuple=(3, 14, 7),
         ),
     ),
 }[ARCH]
@@ -245,7 +246,7 @@ def _tagname(
     Iff the role is the TEST role, then the test_index must be provided.
     """
     platform = target.platform(role, test_index).alias
-    python_tag = target.python_tag
+    python_tag = target.python.tag
     python_binder = target.python_binder.value
     return f"{tag_base}:{tag_prefix}-{platform}-py{python_tag}-{python_binder}"
 
@@ -280,12 +281,12 @@ def _target_args(target: Target, role: Role, test_index: int | None = None):
 
     if role == BUILD:
         python_args = [
-            "--build-arg", f"PYTHON={target.python_version_full}",
+            "--build-arg", f"PYTHON={target.python.version_full}",
             "--build-arg", f"DRAKE_PYTHON_BINDER={target.python_binder.value}",
         ]  # fmt: skip
     else:
         python_args = [
-            "--build-arg", f"PYTHON={target.python_version}",
+            "--build-arg", f"PYTHON={target.python.version}",
             "--build-arg", f"PYTHON_MANAGER={platform.python_manager.value}",
         ]  # fmt: skip
 
@@ -351,7 +352,7 @@ def _test_wheel(target, identifier, version, options):
     glibc = glibc_versions[target.platform(BUILD).alias]
     wheel = wheel_name(
         python_binder=target.python_binder,
-        python_version=target.python_tag,
+        python_version=target.python.tag,
         wheel_version=version,
         wheel_platform=f"manylinux_{glibc}_{ARCH}",
     )
@@ -419,7 +420,7 @@ def build(options):
     targets_to_build = []
     for t in targets:
         if t.platform(BUILD).name in options.platforms:
-            if t.python_tag in options.python_versions:
+            if t.python.tag in options.python_versions:
                 targets_to_build.append(t)
 
     # Check if there is anything to do.
@@ -488,7 +489,7 @@ def add_selection_arguments(parser):
         "--python",
         dest="python_versions",
         metavar="VERSIONS",
-        default=",".join(sorted({t.python_tag for t in targets})),
+        default=",".join(sorted({t.python.tag for t in targets})),
         help=(
             "python version(s) to build; separate with ','"
             " (default: %(default)s)"

--- a/tools/wheel/wheel_builder/linux_types.py
+++ b/tools/wheel/wheel_builder/linux_types.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from .common import PythonBinder
+from .common import PythonBinder, PythonTarget
 
 
 class PythonManager(Enum):
@@ -29,18 +29,14 @@ class Platform:
 
 @dataclass
 class Target:
-    build_platform: Platform
     python_binder: PythonBinder
+    python: PythonTarget
+    build_platform: Platform
     test_platforms: tuple[Platform]
-    python_version_tuple: tuple[int, int, int]
 
     def __post_init__(self):
+        assert len(self.python.version_tuple) == 3, self.python.version_tuple
         assert isinstance(self.test_platforms, tuple)
-        assert len(self.python_version_tuple) == 3, self.python_version_tuple
-        pv_parts = tuple(map(str, self.python_version_tuple))
-        self.python_version_full = ".".join(pv_parts)
-        self.python_version = ".".join(pv_parts[:2])
-        self.python_tag = "".join(pv_parts[:2])
 
     def platform(self, role: Role, test_index: int | None = None) -> Platform:
         """Returns the Platform for the given `role`. For the test role, the

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -10,6 +10,7 @@ import tempfile
 
 from .common import (
     PythonBinder,
+    PythonTarget,
     build_root,
     create_snopt_tgz,
     die,
@@ -20,14 +21,14 @@ from .common import (
     wheel_name,
     wheelhouse,
 )
-from .macos_types import PythonTarget
+from .macos_types import Target
 
 # This is the complete set of defined targets (i.e. potential wheels). By
 # default, all targets are built, but the user may down-select from this set.
 # On macOS (unlike Linux), this is just the set of Python versions targeted.
 #
 # These should be kept in sync with `setup/mac/Brewfile-developer`.
-PYTHON_TARGETS = (
+TARGETS = (
     # NOTE: adding or removing a python version?  Please also check the
     # following locations for updates:
     # * the artifact tallies in doc/_pages/release_playbook.md (search
@@ -40,21 +41,21 @@ PYTHON_TARGETS = (
     # * the Python versions supported by MOSEK, in tools/wheel/setup.py. If
     #   there is any Python version supported by Drake, but not MOSEK, a note
     #   should be added to the aforementioned installation documentation.
-    PythonTarget(PythonBinder.NANOBIND, 3, 13),
-    PythonTarget(PythonBinder.PYBIND11, 3, 13),
-    PythonTarget(PythonBinder.PYBIND11, 3, 14),
+    Target(PythonBinder.NANOBIND, PythonTarget(3, 13)),
+    Target(PythonBinder.PYBIND11, PythonTarget(3, 13)),
+    Target(PythonBinder.PYBIND11, PythonTarget(3, 14)),
 )
 
 
-def _find_wheel(path, version, python_target):
+def _find_wheel(path, version, target):
     """
     Returns name of built wheel. Uses `glob` to find it, since trying to
     replicate the logic which determines the macOS platform name is not
     accessible and is very non-trivial to replicate.
     """
     pattern = wheel_name(
-        python_binder=python_target.python_binder,
-        python_version=python_target.tag,
+        python_binder=target.python_binder,
+        python_version=target.python.tag,
         wheel_version=version,
         wheel_platform="*",
     )
@@ -79,7 +80,7 @@ def _assert_isdir(path, name):
         die(f"{name} '{path}' is not a valid directory")
 
 
-def _test_wheel(wheel, python_target, env):
+def _test_wheel(wheel, target, env):
     """
     Runs the test script on `wheel`.
     """
@@ -87,12 +88,12 @@ def _test_wheel(wheel, python_target, env):
         resource_root, "macos", "provision-test-python.sh"
     )
     subprocess.check_call(
-        ["bash", setup_script, python_target.version], env=env
+        ["bash", setup_script, target.python.version], env=env
     )
 
     test_python_venv = os.path.join(test_root, "python")
     os.symlink(
-        os.path.join(test_root, f"python{python_target.version}"),
+        os.path.join(test_root, f"python{target.python.version}"),
         test_python_venv,
     )
 
@@ -119,8 +120,8 @@ def build(options):
 
     # Collect set of wheels to be built.
     targets_to_build = []
-    for t in PYTHON_TARGETS:
-        if t.tag in options.python_versions:
+    for t in TARGETS:
+        if t.python.tag in options.python_versions:
             targets_to_build.append(t)
 
     # Check if there is anything to do.
@@ -170,19 +171,19 @@ def build(options):
     create_snopt_tgz(snopt_path=options.snopt_path, output=snopt_tgz)
 
     # Build the wheel(s).
-    for python_target in targets_to_build:
+    for target in targets_to_build:
         version = edit_wheel_version_for_binder(
-            python_target.python_binder, options.version
+            target.python_binder, options.version
         )
-        environment["DRAKE_PYTHON_BINDER"] = python_target.python_binder.value
+        environment["DRAKE_PYTHON_BINDER"] = target.python_binder.value
         environment["DRAKE_IS_ABI3_WHEEL"] = (
-            "1" if python_target.python_binder == PythonBinder.NANOBIND else "0"
+            "1" if target.python_binder == PythonBinder.NANOBIND else "0"
         )
 
         build_script = os.path.join(resource_root, "macos", "build-wheel.sh")
         build_command = ["bash", build_script]
         build_command.append(version)
-        build_command.append(python_target.version)
+        build_command.append(target.python.version)
 
         subprocess.check_call(build_command, env=environment)
 
@@ -190,11 +191,11 @@ def build(options):
         wheel = _find_wheel(
             path=wheelhouse,
             version=version,
-            python_target=python_target,
+            target=target,
         )
 
         if options.test:
-            _test_wheel(wheel, python_target=python_target, env=environment)
+            _test_wheel(wheel, target=target, env=environment)
 
         if options.extract:
             shutil.copy2(wheel, options.output_dir)
@@ -231,7 +232,7 @@ def add_selection_arguments(parser):
         "--python",
         dest="python_versions",
         metavar="VERSIONS",
-        default=",".join(sorted({t.tag for t in PYTHON_TARGETS})),
+        default=",".join(sorted({t.python.tag for t in TARGETS})),
         help=(
             "python version(s) to build; "
             "separate with ',' (default: %(default)s)"

--- a/tools/wheel/wheel_builder/macos_types.py
+++ b/tools/wheel/wheel_builder/macos_types.py
@@ -1,29 +1,27 @@
 # This file contains data types used by the macOS-specific build logic. See
 # //tools/wheel:builder for the user interface.
 
-from .common import PythonBinder
+from dataclasses import dataclass
+
+from .common import PythonBinder, PythonTarget
 
 
-class PythonTarget:
+@dataclass
+class Target:
     """
-    A representation of a Python target, constructed from the binder and Python
-    version number tuple.
+    A representation of a build target, constructed from the binder and Python
+    target.
 
     Example:
-        PythonTarget(PythonBinder.NANOBIND, 3, 2, 1)
+        Target(PythonBinder.NANOBIND, PythonTarget(3, 2, 1))
 
     Members:
         python_binder: Which binder to use.
-        version_tuple: Target version as a tuple, e.g. (3, 2, 1)
-        version_full: Target full version as a string, e.g. '3.2.1'
-        version: Target major/minor version as a string, e.g. '3.2'
-        tag: Target major/minor version without separators, e.g. '32'
+        python: Which version of Python to use.
     """
 
-    def __init__(self, python_binder: PythonBinder, *version_parts: int):
-        self.python_binder = python_binder
-        pv_parts = tuple(map(str, version_parts))
-        self.version_tuple = tuple(version_parts)
-        self.version_full = ".".join(pv_parts)
-        self.version = ".".join(pv_parts[:2])
-        self.tag = "".join(pv_parts[:2])
+    python_binder: PythonBinder
+    python: PythonTarget
+
+    def __post_init__(self):
+        assert len(self.python.version_tuple) == 2, self.python.version_tuple


### PR DESCRIPTION
Move `PythonTarget` from `macos_types.py` to `common.py` and use it also to describe the Python target in `linux_types.py`'s `Target`. The latter had essentially an inline copy of the type; this consolidates them so that there is less duplication. Having it as a separate type for Linux builds will also make it easier to implement testing on multiple Python versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24876)
<!-- Reviewable:end -->
