### PR TITLE
[pydrake] Use nanobind's stubgen for nanobind bindings

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -408,6 +408,7 @@ drake_py_binary(
         ":all_py",
         "@stable_baselines3_internal//:stable_baselines3",
         mypy_requirement("mypy"),
+        "@module_nanobind//:stubgen_lib",
     ],
 )
 

--- a/bindings/pydrake/geometry/_geometry_extra.py
+++ b/bindings/pydrake/geometry/_geometry_extra.py
@@ -108,8 +108,14 @@ def _add_extraneous_repr_functions():
         # Convert array to list to ease converting repr to mesh type.
         return f"{type_name}({data_param}, scale3={mesh.scale3().tolist()!r})"
 
-    Mesh.__repr__ = lambda x: mesh_or_convex_repr(x, "Mesh")
-    Convex.__repr__ = lambda x: mesh_or_convex_repr(x, "Convex")
+    def mesh_repr(mesh):
+        return mesh_or_convex_repr(mesh, "Mesh")
+
+    def convex_repr(convex):
+        return mesh_or_convex_repr(convex, "Convex")
+
+    Mesh.__repr__ = mesh_repr
+    Convex.__repr__ = convex_repr
 
 
 _add_extraneous_repr_functions()

--- a/bindings/pydrake/geometry/geometry_py_render.cc
+++ b/bindings/pydrake/geometry/geometry_py_render.cc
@@ -252,6 +252,8 @@ void DoScalarIndependentDefinitions(py::module_ m) {
         .def(py::init<int>(), py::arg("value"), doc.RenderLabel.ctor.doc_1args)
         .def("is_reserved", &RenderLabel::is_reserved)
         .def("__int__", [](const RenderLabel& self) -> int { return self; })
+        .def_prop_ro(
+            "_value_", [](const RenderLabel& self) -> int { return self; })
         .def("__repr__",
             [](const RenderLabel& self) -> std::string {
               if (self == RenderLabel::kEmpty) {

--- a/bindings/pydrake/numpy_object_pybind.h
+++ b/bindings/pydrake/numpy_object_pybind.h
@@ -30,7 +30,7 @@ struct pydrake_numpy_dtype_object_type_caster {
 
   NB_TYPE_CASTER(
       T, const_name("numpy.ndarray[") +
-             concat_maybe(const_name("dtype=") + PlainScalarCaster::Name,
+             concat_maybe(const_name("dtype=object"),
                  const_name<kCompileTime1D>(shape<kCompileTime1DShape>::name,
                      shape<T::RowsAtCompileTime, T::ColsAtCompileTime>::name),
                  dtype_const_name<Scalar>::name) +

--- a/bindings/pydrake/stubgen.py
+++ b/bindings/pydrake/stubgen.py
@@ -8,8 +8,6 @@ import subprocess
 import sys
 import tempfile
 
-from mypy import stubgen
-
 
 def _pydrake_modules():
     """Returns the list[str] of all pydrake module names."""
@@ -98,17 +96,52 @@ def _actual_main():
         if source.endswith(".py"):
             native_modules.remove(name)
 
-    # Run stubgen. It writes junk in the current directory, so we need to run
-    # it from a safe place.
-    with tempfile.TemporaryDirectory(prefix="drake_stubgen_") as temp:
-        os.chdir(temp)
-        args = ["--output=."] + [f"--module={name}" for name in native_modules]
-        returncode = stubgen.main(args=args) or 0
-        assert returncode == 0, returncode
+    binder = sys.modules["pydrake.common"]._binder
+    if binder == "pybind11":
+        from mypy import stubgen
 
-        # The generation was successful. Copy the *.pyi files to output.
-        pyi_generated = _pyi_generated(Path(temp))
-        _copy_pyi(pyi_generated, output_root, pyi_outputs)
+        # Run MyPy stubgen. It writes junk in the current directory, so we need
+        # to run it from a safe place.
+        with tempfile.TemporaryDirectory(prefix="drake_stubgen_") as temp:
+            os.chdir(temp)
+            args = ["--output=."] + [
+                f"--module={name}" for name in native_modules
+            ]
+            returncode = stubgen.main(args=args) or 0
+            assert returncode == 0, returncode
+
+            # The generation was successful. Copy the *.pyi files to output.
+            pyi_generated = _pyi_generated(Path(temp))
+            _copy_pyi(pyi_generated, output_root, pyi_outputs)
+    else:
+        from nanobind.stubgen import StubGen
+
+        # Run Nanobind stubgen. For consistency with _copy_pyi, it's easiest
+        # to use a temp directory. After we drop pybind11 we can simplify this.
+        with tempfile.TemporaryDirectory(prefix="drake_stubgen_") as temp:
+            for name in native_modules:
+                module = sys.modules[name]
+                stubgen = StubGen(module=module)
+                stubgen.put(module)
+                content = stubgen.get()
+                if name in {
+                    "pydrake.common",
+                    "pydrake.geometry",
+                    "pydrake.multibody.benchmarks",
+                    "pydrake.planning",
+                }:
+                    relative_path = name.replace(".", "/") + "/__init__.pyi"
+                else:
+                    relative_path = name.replace(".", "/") + ".pyi"
+                print(f"Creating at {relative_path}")
+                output_path = Path(temp) / relative_path
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(content, encoding="utf-8")
+
+            # The generation was successful. Copy the *.pyi files to output.
+            os.chdir(temp)
+            pyi_generated = _pyi_generated(Path(temp))
+            _copy_pyi(pyi_generated, output_root, pyi_outputs)
 
 
 def _wrapper_main():


### PR DESCRIPTION
Tweak a few bindings to be compatible with the new stubgen, most importantly the dtype=object for AutoDiffXd and Expression.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24883)
<!-- Reviewable:end -->
