### PR TITLE
[pydrake] Tweak RemoveFreeVariableMethod int conversion

### DIFF
--- a/bindings/pydrake/solvers/solvers_py_sdpa_free_format.cc
+++ b/bindings/pydrake/solvers/solvers_py_sdpa_free_format.cc
@@ -23,7 +23,7 @@ void DefineSolversSdpaFreeFormat(py::module_ m) {
 #ifdef PYDRAKE_USE_NANOBIND
       // We need to allow passing this enum to SetSolverOption (which only
       // accepts primitive types), even though it's not an IntEnum.
-      .def("__int__",
+      .def("__index__",
           [](RemoveFreeVariableMethod value) {
             return static_cast<int64_t>(value);
           })


### PR DESCRIPTION
Future versions of nanobind will become more restrictive for what implicitly converts to an int. The new required spelling also works for the current nanobind, so we can switch to it now.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24884)
<!-- Reviewable:end -->
