### PR TITLE
[doc] Correct doxygen groups in geometry

### DIFF
--- a/bindings/generated_docstrings/geometry.h
+++ b/bindings/generated_docstrings/geometry.h
@@ -2229,7 +2229,54 @@ of geometries rigidly affixed to frame f).)""";
         // Symbol: drake::geometry::GeometrySet::Add
         struct /* Add */ {
           // Source: drake/geometry/geometry_set.h
-          const char* doc = R"""()""";
+          const char* doc =
+R"""(@name Methods for adding to the set
+
+The interface for adding geometries to the set is simply an overload
+of the Add() method. For maximum flexibility, the Add method can take:
+
+- a single geometry id
+- a single frame id
+- an iterable object containing geometry ids
+- an iterable object containing frame ids
+- two iterable objects, the first containing geometry ids, the second
+containing frame ids.
+- another GeometrySet instance.
+
+NOTE: the iterable objects don't have to be the same type. The
+"iterable" can also be an initializer list. All of the following
+invocations are valid (this isn't an exhaustive list, but a
+representative set):
+
+
+.. raw:: html
+
+    <details><summary>Click to expand C++ code...</summary>
+
+.. code-block:: c++
+
+    // Assuming that f_* are valid FrameId instances and g_* are valid GeometryId
+    // instances.
+    GeometrySet group;
+    group.Add(f_1);
+    group.Add(g_1);
+    
+    std∷vector<FrameId> frame_ids{f_2, f_3, f_4};
+    group.Add(frame_ids);
+    std∷vector<GeometryId> geometry_ids{g_2, g_3, g_4};
+    group.Add(geometry_ids);
+    
+    // This is valid, but redundant; the ids in those vectors have already been
+    // added.
+    group.Add(geometry_ids, frame_ids);
+    
+    // Mismatched iterable types.
+    std∷set<FrameId> frame_set{f_5, f_6, f_7};
+    group.Add({g_7, g_8}, frame_set);
+
+.. raw:: html
+
+    </details>)""";
         } Add;
         // Symbol: drake::geometry::GeometrySet::GeometrySet
         struct /* ctor */ {

--- a/bindings/generated_docstrings/geometry_proximity.h
+++ b/bindings/generated_docstrings/geometry_proximity.h
@@ -580,6 +580,11 @@ Precondition:
         // Symbol: drake::geometry::MeshFieldLinear::MeshFieldLinear<T, MeshType>
         struct /* ctor */ {
           // Source: drake/geometry/proximity/mesh_field_linear.h
+          const char* doc_move =
+R"""(@name Implements MoveConstructible, MoveAssignable
+
+To copy a MeshFieldLinear, use CloneAndSetMesh().)""";
+          // Source: drake/geometry/proximity/mesh_field_linear.h
           const char* doc_3args_values_mesh_gradient_mode =
 R"""(Constructs a MeshFieldLinear.
 
@@ -1147,7 +1152,13 @@ R"""((Internal use only) Reverses the ordering of all the faces' indices.)""";
         // Symbol: drake::geometry::PolygonSurfaceMesh::ScalarType
         struct /* ScalarType */ {
           // Source: drake/geometry/proximity/polygon_surface_mesh.h
-          const char* doc = R"""()""";
+          const char* doc =
+R"""(@name Mesh type traits
+
+A collection of type traits to enable mesh consumers to be templated
+on mesh type. Each mesh type provides specific definitions of
+*element* and *barycentric coordinates*. For PolygonSurfaceMesh, an
+element is a polygon.)""";
         } ScalarType;
         // Symbol: drake::geometry::PolygonSurfaceMesh::SetAllPositions
         struct /* SetAllPositions */ {
@@ -1556,7 +1567,13 @@ indices -- see SurfaceTriangle∷ReverseWinding().)""";
         // Symbol: drake::geometry::TriangleSurfaceMesh::ScalarType
         struct /* ScalarType */ {
           // Source: drake/geometry/proximity/triangle_surface_mesh.h
-          const char* doc = R"""()""";
+          const char* doc =
+R"""(@name Mesh type traits
+
+A collection of type traits to enable mesh consumers to be templated
+on mesh type. Each mesh type provides specific definitions of
+*vertex*, _element_, and *barycentric coordinates*. For
+TriangleSurfaceMesh, an element is a triangle.)""";
         } ScalarType;
         // Symbol: drake::geometry::TriangleSurfaceMesh::SetAllPositions
         struct /* SetAllPositions */ {
@@ -1874,7 +1891,13 @@ drake∷geometry∷promoted_numerical "promoted_numerical_t" for details.)""";
         // Symbol: drake::geometry::VolumeMesh::ScalarType
         struct /* ScalarType */ {
           // Source: drake/geometry/proximity/volume_mesh.h
-          const char* doc = R"""()""";
+          const char* doc =
+R"""(@name Mesh type traits
+
+A collection of type traits to enable mesh consumers to be templated
+on mesh type. Each mesh type provides specific definitions of
+*vertex*, _element_, and *barycentric coordinates*. For VolumeMesh, an
+element is a tetrahedron.)""";
         } ScalarType;
         // Symbol: drake::geometry::VolumeMesh::SetAllPositions
         struct /* SetAllPositions */ {

--- a/bindings/generated_docstrings/geometry_query_results.h
+++ b/bindings/generated_docstrings/geometry_query_results.h
@@ -208,7 +208,7 @@ R"""(Returns:
         // Symbol: drake::geometry::ContactSurface::area
         struct /* area */ {
           // Source: drake/geometry/query_results/contact_surface.h
-          const char* doc = R"""()""";
+          const char* doc = R"""(Reports the area of indexed face.)""";
         } area;
         // Symbol: drake::geometry::ContactSurface::centroid
         struct /* centroid */ {
@@ -218,7 +218,8 @@ R"""(Returns:
         // Symbol: drake::geometry::ContactSurface::face_normal
         struct /* face_normal */ {
           // Source: drake/geometry/query_results/contact_surface.h
-          const char* doc = R"""()""";
+          const char* doc =
+R"""(Reports the normal for the indexed face.)""";
         } face_normal;
         // Symbol: drake::geometry::ContactSurface::id_M
         struct /* id_M */ {
@@ -244,12 +245,14 @@ and offered as convenient sugar.)""";
         // Symbol: drake::geometry::ContactSurface::num_faces
         struct /* num_faces */ {
           // Source: drake/geometry/query_results/contact_surface.h
-          const char* doc = R"""()""";
+          const char* doc =
+R"""(Reports the number of faces -- triangles or polygons based on surface
+representation.)""";
         } num_faces;
         // Symbol: drake::geometry::ContactSurface::num_vertices
         struct /* num_vertices */ {
           // Source: drake/geometry/query_results/contact_surface.h
-          const char* doc = R"""()""";
+          const char* doc = R"""(Reports the number of vertices.)""";
         } num_vertices;
         // Symbol: drake::geometry::ContactSurface::poly_e_MN
         struct /* poly_e_MN */ {
@@ -281,7 +284,8 @@ exercised are related to this methods return value. See below.)""";
         // Symbol: drake::geometry::ContactSurface::total_area
         struct /* total_area */ {
           // Source: drake/geometry/query_results/contact_surface.h
-          const char* doc = R"""()""";
+          const char* doc =
+R"""(Reports the total area across all faces.)""";
         } total_area;
         // Symbol: drake::geometry::ContactSurface::tri_e_MN
         struct /* tri_e_MN */ {

--- a/bindings/pydrake/geometry/geometry_py_common.cc
+++ b/bindings/pydrake/geometry/geometry_py_common.cc
@@ -237,7 +237,8 @@ void DefineGeometrySet(py::module_ m) {
   {
     using Class = GeometrySet;
     constexpr auto& cls_doc = doc.GeometrySet;
-    constexpr char extra_ctor_doc[] = "See main constructor";
+    constexpr char extra_ctor_doc[] = "See main constructor.";
+    constexpr char extra_add_doc[] = "See first Add() overload for details.";
     // N.B. For containers, we use `std::vector<>` rather than abstract
     // iterators / containers.
     class_<Class>(m, "GeometrySet", cls_doc.doc)
@@ -260,26 +261,26 @@ void DefineGeometrySet(py::module_ m) {
         .def(
             "Add",
             [](Class* self, const FrameId& frame_id) { self->Add(frame_id); },
-            py::arg("frame_id"), cls_doc.Add.doc)
+            py::arg("frame_id"), extra_add_doc)
         .def(
             "Add",
             [](Class* self, std::vector<GeometryId> geometry_ids) {
               self->Add(geometry_ids);
             },
-            py::arg("geometry_ids"), extra_ctor_doc)
+            py::arg("geometry_ids"), extra_add_doc)
         .def(
             "Add",
             [](Class* self, std::vector<FrameId> frame_ids) {
               self->Add(frame_ids);
             },
-            py::arg("frame_ids"), extra_ctor_doc)
+            py::arg("frame_ids"), extra_add_doc)
         .def(
             "Add",
             [](Class* self, std::vector<GeometryId> geometry_ids,
                 std::vector<FrameId> frame_ids) {
               self->Add(geometry_ids, frame_ids);
             },
-            py::arg("geometry_ids"), py::arg("frame_ids"), extra_ctor_doc);
+            py::arg("geometry_ids"), py::arg("frame_ids"), extra_add_doc);
   }
 }
 

--- a/geometry/collision_filter_declaration.h
+++ b/geometry/collision_filter_declaration.h
@@ -81,7 +81,7 @@ class CollisionFilterDeclaration {
    The *declared* pairs can be invalid (e.g., containing GeometryId values that
    aren't part of the SceneGraph data). This will only be detected when applying
    the declaration (see CollisionFilterManager::Apply()).  */
-  //@{
+  ///@{
 
   /** Allows geometry pairs in proximity evaluation by updating the
    candidate pair set `C ← C ⋃ P*`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B, a ≠ b`
@@ -111,7 +111,7 @@ class CollisionFilterDeclaration {
     return *this;
   }
 
-  //@}
+  ///@}
 
   /** @name  Excluding pairs from consideration (adding collision filters)
 
@@ -124,7 +124,7 @@ class CollisionFilterDeclaration {
    The *declared* pairs can be invalid (e.g., containing GeometryId values that
    aren't part of the SceneGraph data). This will only be detected when applying
    the declaration (see CollisionFilterManager::Apply()). */
-  //@{
+  ///@{
 
   /** Excludes geometry pairs from proximity evaluation by updating the
    candidate pair set `C ← C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
@@ -146,7 +146,7 @@ class CollisionFilterDeclaration {
     return *this;
   }
 
-  //@}
+  ///@}
 
  private:
   friend class CollisionFilterDeclTester;

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -193,7 +193,7 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
         self-configured lcm::DrakeLcmInterface object.
      - `params`: The DrakeVisualizer will be configured according to the
         provided parameters. If omitted, it uses default parameters.  */
-  //@{
+  ///@{
 
   /** Connects the newly added DrakeVisualizer to the given SceneGraph's
    QueryObject-valued output port.
@@ -213,7 +213,7 @@ class DrakeVisualizer final : public systems::LeafSystem<T> {
       systems::DiagramBuilder<T>* builder,
       const systems::OutputPort<T>& query_object_port,
       lcm::DrakeLcmInterface* lcm = nullptr, DrakeVisualizerParams params = {});
-  //@}
+  ///@}
 
   // TODO(#7820) When we can easily bind lcmt_* messages, then replace
   //  the DispatchLoadMessage API with something like:

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -217,27 +217,12 @@ enum class RoleAssign {
   kReplace  ///< Replace the existing role properties completely.
 };
 
-/** @name  Geometry role to string conversions
-
- These are simply convenience functions for converting the Role enumeration into
- a human-readable string.  */
-//@{
-
 std::string to_string(const Role& role);
-
-//@}
-
-/** @name  Convenience functions
-
- A collection of functions to help facilitate working with properties.  */
-//@{
 
 /** Constructs an IllustrationProperties instance compatible with a simple
  "phong" material using only the given `diffuse` color.  */
 IllustrationProperties MakePhongIllustrationProperties(
     const Vector4<double>& diffuse);
-
-//@}
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -102,7 +102,7 @@ class GeometrySet {
    // etc.
    ```
    */
-  //@{
+  ///@{
 
   // TODO(SeanCurtis-TRI): The call sites would become even simpler if these
   // constructors were *implicit*. E.g.,:
@@ -158,7 +158,7 @@ class GeometrySet {
     Add(geometry_ids, frame_ids);
   }
 
-  //@}
+  ///@}
 
   /** @name    Methods for adding to the set
 
@@ -198,7 +198,7 @@ class GeometrySet {
    group.Add({g_7, g_8}, frame_set);
    ```
   */
-  //@{
+  ///@{
 
   void Add(GeometryId geometry_id) { geometry_ids_.insert(geometry_id); }
 
@@ -254,7 +254,7 @@ class GeometrySet {
                          other.geometry_ids_.end());
   }
 
-  //@}
+  ///@}
 
  private:
   // Provide access to the two entities that need access to the set's internals.

--- a/geometry/proximity/mesh_field_linear.h
+++ b/geometry/proximity/mesh_field_linear.h
@@ -129,10 +129,10 @@ class MeshFieldLinear {
 
    To copy a %MeshFieldLinear, use CloneAndSetMesh().
   */
-  //@{
+  ///@{
   MeshFieldLinear(MeshFieldLinear&&) = default;
   MeshFieldLinear& operator=(MeshFieldLinear&&) = default;
-  //@}
+  ///@}
 
   /** Constructs a MeshFieldLinear.
    @param values  The field value at each vertex of the mesh.

--- a/geometry/proximity/polygon_surface_mesh.h
+++ b/geometry/proximity/polygon_surface_mesh.h
@@ -86,7 +86,7 @@ class PolygonSurfaceMesh {
    type. Each mesh type provides specific definitions of _element_ and
    _barycentric coordinates_. For %PolygonSurfaceMesh, an element is a
    polygon. */
-  //@{
+  ///@{
 
   using ScalarType = T;
 
@@ -131,7 +131,7 @@ class PolygonSurfaceMesh {
    mesh consumers to be templated on mesh type. */
   int num_elements() const { return num_faces(); }
 
-  //@}
+  ///@}
 
   /** Advanced() Constructs an *empty* mesh. This enables compatibility with STL
    container types and facilitates some unit tests. Otherwise, it shouldn't be

--- a/geometry/proximity/triangle_surface_mesh.h
+++ b/geometry/proximity/triangle_surface_mesh.h
@@ -81,7 +81,7 @@ class TriangleSurfaceMesh {
    and _barycentric coordinates_. For %TriangleSurfaceMesh, an element is a
    triangle.
    */
-  //@{
+  ///@{
 
   using ScalarType = T;
 
@@ -164,7 +164,7 @@ class TriangleSurfaceMesh {
    */
   int num_elements() const { return num_triangles(); }
 
-  //@}
+  ///@}
 
   /**
    Constructs a TriangleSurfaceMesh from triangles and vertices.

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -104,7 +104,7 @@ class VolumeMesh {
    _element_, and _barycentric coordinates_. For %VolumeMesh, an element is a
    tetrahedron.
    */
-  //@{
+  ///@{
 
   using ScalarType = T;
 
@@ -133,7 +133,7 @@ class VolumeMesh {
   template <typename U = T>
   using Barycentric = Vector<U, kVertexPerElement>;
 
-  //@}
+  ///@}
 
   /** Constructor from a vector of vertices and from a vector of elements.
    Each element must be a valid VolumeElement following the vertex ordering

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -187,7 +187,7 @@ class ContactSurface {
          mesh reversed (to maintain the documented invariants). Comparing the
          input parameters with the members of the resulting %ContactSurface will
          reveal if such a swap has occurred. */
-  //@{
+  ///@{
 
   /** Constructs a %ContactSurface with a triangle mesh representation. */
   ContactSurface(GeometryId id_M, GeometryId id_N,
@@ -209,7 +209,7 @@ class ContactSurface {
 
   ~ContactSurface();
 
-  //@}
+  ///@}
 
   /** Returns the geometry id of Geometry M. */
   GeometryId id_M() const { return id_M_; }
@@ -225,28 +225,34 @@ class ContactSurface {
    without worrying about the representation. If necessary, the actual meshes
    and fields can be accessed directly via the representation-dependent APIs
    below. */
-  //@{
+  ///@{
 
+  /** Reports the number of faces -- triangles or polygons based on surface
+   representation. */
   int num_faces() const {
     return is_triangle() ? tri_mesh_W().num_elements()
                          : poly_mesh_W().num_elements();
   }
 
+  /** Reports the number of vertices. */
   int num_vertices() const {
     return is_triangle() ? tri_mesh_W().num_vertices()
                          : poly_mesh_W().num_vertices();
   }
 
+  /** Reports the area of indexed face. */
   const T& area(int face_index) const {
     return is_triangle() ? tri_mesh_W().area(face_index)
                          : poly_mesh_W().area(face_index);
   }
 
+  /** Reports the total area across all faces. */
   const T& total_area() const {
     return is_triangle() ? tri_mesh_W().total_area()
                          : poly_mesh_W().total_area();
   }
 
+  /** Reports the normal for the indexed face. */
   const Vector3<T>& face_normal(int face_index) const {
     return is_triangle() ? tri_mesh_W().face_normal(face_index)
                          : poly_mesh_W().face_normal(face_index);
@@ -264,14 +270,14 @@ class ContactSurface {
     return is_triangle() ? tri_mesh_W().centroid() : poly_mesh_W().centroid();
   }
 
-  //@}
+  ///@}
 
   /** @name Representation-dependent API
 
    These functions provide insight into what representation the %ContactSurface
    instance uses, and provide access to the representation-dependent quantities:
    mesh and field. */
-  //@{
+  ///@{
 
   /** Simply reports if this contact surface's mesh representation is triangle.
    Equivalent to:
@@ -324,7 +330,7 @@ class ContactSurface {
         e_MN_);
   }
 
-  //@}
+  ///@}
 
   /** @name  Evaluation of constituent pressure fields
 
@@ -344,7 +350,7 @@ class ContactSurface {
 
    The values ∇eₘ and ∇eₘ are piecewise constant over the %ContactSurface and
    can only be evaluate on a per-face basis.  */
-  //@{
+  ///@{
 
   /** @returns `true` if `this` contains values for ∇eₘ.  */
   bool HasGradE_M() const { return grad_eM_W_ != nullptr; }
@@ -362,7 +368,7 @@ class ContactSurface {
    @pre `index ∈ [0, mesh().num_faces())`.  */
   const Vector3<T>& EvaluateGradE_N_W(int index) const;
 
-  //@}
+  ///@}
 
   // TODO(#12173): Consider NaN==NaN to be true in equality tests.
   /** Checks to see whether the given ContactSurface object is equal via deep

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -129,7 +129,7 @@ class RenderEngine {
    no such property exists). In that case, attempting to assign
    RenderLabel::kEmpty or RenderLabel::kUnspecified will cause an exception to
    be thrown (as @ref reserved_render_label "documented"). */
-  //@{
+  ///@{
 
   /** Requests registration of the given shape as a rigid geometry with this
    render engine.
@@ -181,7 +181,7 @@ class RenderEngine {
       GeometryId id, const std::vector<internal::RenderMesh>& render_meshes,
       const PerceptionProperties& properties);
 
-  //@}
+  ///@}
 
   /** Removes the geometry indicated by the given `id` from the engine.
    @param id    The id of the geometry to remove.
@@ -252,7 +252,7 @@ class RenderEngine {
    intrinsics and render engine parameters. See the documentation of
    ColorRenderCamera and DepthRenderCamera for the full details.
    */
-  //@{
+  ///@{
 
   /** Renders the registered geometry into the given color (rgb) image based on
    a _fully_ specified camera.
@@ -303,7 +303,7 @@ class RenderEngine {
     DoRenderLabelImage(camera, label_image_out);
   }
 
-  //@}
+  ///@}
 
   /** Reports the render label value this render engine has been configured to
    use.  */
@@ -457,7 +457,7 @@ class RenderEngine {
    classes are not required to encode labels as colors in the same way. They are
    only obliged to return label images with proper label values according to
    the documented semantics.  */
-  //@{
+  ///@{
 
   /** Transforms the given RGB color into its corresponding RenderLabel.  */
   static RenderLabel MakeLabelFromRgb(uint8_t r, uint8_t g, uint8_t /* b */) {
@@ -473,7 +473,7 @@ class RenderEngine {
     return Rgba{r / 255.0, g / 255.0, /* b = */ 0.0};
   }
 
-  //@}
+  ///@}
 
   // TODO(SeanCurtis-TRI): Deprecate this API in favor of our light parameter
   // specification. First enable lights in RenderEngineVtk and confirm pass

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -116,7 +116,7 @@ class RenderLabel {
 
    See class documentation on
    @ref reserved_render_label "reserved labels" for details.  */
-  //@{
+  ///@{
 
   /** See @ref reserved_render_label "Reserved labels"  */
   static const RenderLabel kEmpty;
@@ -133,7 +133,7 @@ class RenderLabel {
   /** The largest value that a %RenderLabel can be instantiated on. */
   static const ValueType kMaxUnreserved;
 
-  //@}
+  ///@}
 
   /** Reports if the label is a reserved label.  */
   bool is_reserved() const { return value_ > kMaxUnreserved; }


### PR DESCRIPTION
The pattern:
```
/** @name Foo
...
*/
//@{

...

//@}
```

is defective. The "private" nature of the group brackets (`//@{` and `//@}`) are not respected by doxygen. The bounds of the group are not recognized leading to a couple of different artifacts:

1. Run-on groups -- members after the closing //@} get included into the most recent `@name` group.
2. Groups aren't properly recognized as groups and not rendered consistently.

By promoting the group domain comments to the same "public" level as the group, the bounds are recognized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24891)
<!-- Reviewable:end -->
