### PR TITLE
Fix CollisionFilter's silent bug for bad geometry ids

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -1192,6 +1192,7 @@ drake_cc_googletest(
     name = "collision_filter_test",
     deps = [
         ":collision_filter",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/proximity/collision_filter.cc
+++ b/geometry/proximity/collision_filter.cc
@@ -1,6 +1,9 @@
 #include "drake/geometry/proximity/collision_filter.h"
 
 #include <algorithm>
+#include <stdexcept>
+
+#include <fmt/format.h>
 
 #include "drake/common/drake_assert.h"
 
@@ -18,44 +21,26 @@ void CollisionFilter::Apply(const CollisionFilterDeclaration& declaration,
         "You cannot attempt to modify the persistent collision filter "
         "configuration when there are active, transient filter declarations");
   }
-  ApplyDeclarationToState(declaration, extract_ids, is_invariant,
-                          &persistent_base_);
+  /* Resolve and validate all IDs once, before touching any state. */
+  const std::vector<ResolvedStatement> resolved =
+      ResolveStatementsOrThrow(declaration, extract_ids, is_invariant);
+  const StateDelta delta{resolved, FilterId{}};
+
+  ApplyStatements(delta, &persistent_base_);
   /* Keep the cached composite and the persistent base in sync. We *could*
    simply copy the persistent base to the filter state, but we assume that the
    application of a declaration is a generally cheaper operation than a
    wholesale copy. */
-  ApplyDeclarationToState(declaration, extract_ids, is_invariant,
-                          &filter_state_);
+  ApplyStatements(delta, &filter_state_);
 }
 
 FilterId CollisionFilter::ApplyTransient(
     const CollisionFilterDeclaration& declaration,
     const CollisionFilter::ExtractIds& extract_ids) {
-  /* Transient declarations are never invariant. */
-  using Statement = CollisionFilterDeclaration::Statement;
-  using Op = CollisionFilterDeclaration::StatementOp;
-  const CollisionFilterScope scope = declaration.scope();
-
-  /* Resolve every statement's GeometrySet to explicit GeometryId vectors now,
-   while we have the extract_ids callback. The resolved statements are stored
-   compactly in the StateDelta and replayed cheaply in RebuildComposite()
-   without needing the callback again. */
-  std::vector<ResolvedStatement> resolved;
-  resolved.reserve(declaration.statements().size());
-  for (const Statement& statement : declaration.statements()) {
-    ResolvedStatement rs;
-    rs.operation = statement.operation;
-    const std::unordered_set<GeometryId> ids_A =
-        extract_ids(statement.set_A, scope);
-    rs.set_A.assign(ids_A.begin(), ids_A.end());
-    if (statement.operation == Op::kExcludeBetween ||
-        statement.operation == Op::kAllowBetween) {
-      const std::unordered_set<GeometryId> ids_B =
-          extract_ids(statement.set_B, scope);
-      rs.set_B.assign(ids_B.begin(), ids_B.end());
-    }
-    resolved.push_back(std::move(rs));
-  }
+  /* Transient declarations are never invariant. Resolve and validate all IDs
+   before touching state, so the callback is not re-invoked at replay time. */
+  std::vector<ResolvedStatement> resolved = ResolveStatementsOrThrow(
+      declaration, extract_ids, /*is_invariant=*/false);
 
   const FilterId new_id = FilterId::get_new_id();
   StateDelta delta{std::move(resolved), new_id};
@@ -250,17 +235,19 @@ void CollisionFilter::ApplyStatement(const ResolvedStatement& statement,
   using Op = CollisionFilterDeclaration::StatementOp;
   switch (statement.operation) {
     case Op::kExcludeBetween:
-      AddPairsBetween(statement.set_A, statement.set_B, /*is_invariant=*/false,
+      AddPairsBetween(statement.set_A, statement.set_B, statement.is_invariant,
                       state);
       break;
     case Op::kExcludeWithin:
-      AddPairsBetween(statement.set_A, statement.set_A, /*is_invariant=*/false,
+      AddPairsBetween(statement.set_A, statement.set_A, statement.is_invariant,
                       state);
       break;
     case Op::kAllowBetween:
+      DRAKE_DEMAND(!statement.is_invariant);
       RemovePairsBetween(statement.set_A, statement.set_B, state);
       break;
     case Op::kAllowWithin:
+      DRAKE_DEMAND(!statement.is_invariant);
       RemovePairsBetween(statement.set_A, statement.set_A, state);
       break;
   }
@@ -273,41 +260,50 @@ void CollisionFilter::ApplyStatements(const StateDelta& delta,
   }
 }
 
-void CollisionFilter::ApplyDeclarationToState(
+std::vector<CollisionFilter::ResolvedStatement>
+CollisionFilter::ResolveStatementsOrThrow(
     const CollisionFilterDeclaration& declaration,
-    const CollisionFilter::ExtractIds& extract_ids, bool is_invariant,
-    FilterState* state) {
+    const CollisionFilter::ExtractIds& extract_ids, bool is_invariant) const {
   using Statement = CollisionFilterDeclaration::Statement;
   using Op = CollisionFilterDeclaration::StatementOp;
   const CollisionFilterScope scope = declaration.scope();
-  for (const Statement& statement : declaration.statements()) {
-    const std::unordered_set<GeometryId> ids_A_set =
-        extract_ids(statement.set_A, scope);
-    const std::vector<GeometryId> ids_A(ids_A_set.begin(), ids_A_set.end());
 
-    switch (statement.operation) {
-      case Op::kExcludeBetween: {
-        const std::unordered_set<GeometryId> ids_B_set =
-            extract_ids(statement.set_B, scope);
-        const std::vector<GeometryId> ids_B(ids_B_set.begin(), ids_B_set.end());
-        AddPairsBetween(ids_A, ids_B, is_invariant, state);
-        break;
-      }
-      case Op::kExcludeWithin:
-        AddPairsBetween(ids_A, ids_A, is_invariant, state);
-        break;
-      case Op::kAllowBetween: {
-        DRAKE_DEMAND(!is_invariant);
-        const std::unordered_set<GeometryId> ids_B_set =
-            extract_ids(statement.set_B, scope);
-        const std::vector<GeometryId> ids_B(ids_B_set.begin(), ids_B_set.end());
-        RemovePairsBetween(ids_A, ids_B, state);
-        break;
-      }
-      case Op::kAllowWithin:
-        DRAKE_DEMAND(!is_invariant);
-        RemovePairsBetween(ids_A, ids_A, state);
-        break;
+  std::vector<ResolvedStatement> resolved;
+  resolved.reserve(declaration.statements().size());
+  for (const Statement& statement : declaration.statements()) {
+    ResolvedStatement rs;
+    rs.operation = statement.operation;
+    rs.is_invariant = is_invariant;
+
+    const std::unordered_set<GeometryId> ids_A =
+        extract_ids(statement.set_A, scope);
+    ThrowIfAnyUnregistered(ids_A);
+    // Note: here and on rs.set_B below, we convert unordered_set to vector.
+    // This is simply because we may iterate through the set multiple times
+    // (particularly if it's part of a transient declaration) and prefer
+    // memory-contiguous representation to keep that running smoothly.
+    rs.set_A.assign(ids_A.begin(), ids_A.end());
+
+    if (statement.operation == Op::kExcludeBetween ||
+        statement.operation == Op::kAllowBetween) {
+      const std::unordered_set<GeometryId> ids_B =
+          extract_ids(statement.set_B, scope);
+      ThrowIfAnyUnregistered(ids_B);
+      rs.set_B.assign(ids_B.begin(), ids_B.end());
+    }
+    resolved.push_back(std::move(rs));
+  }
+  return resolved;
+}
+
+void CollisionFilter::ThrowIfAnyUnregistered(
+    const std::unordered_set<GeometryId>& ids) const {
+  for (GeometryId id : ids) {
+    if (!geometries_.contains(id)) {
+      throw std::runtime_error(fmt::format(
+          "Collision filter declaration references geometry id {} which has "
+          "not been registered with this filter system.",
+          id));
     }
   }
 }

--- a/geometry/proximity/collision_filter.h
+++ b/geometry/proximity/collision_filter.h
@@ -197,7 +197,8 @@ class CollisionFilter {
   /* A resolved statement: the GeometrySets of the original declaration have
    been expanded to explicit vectors of GeometryIds at the time the transient
    was applied. Storing resolved IDs means the extract_ids callback is not
-   needed at replay time.
+   needed at replay time. It also stores whether the statement was declared
+   as invariant or not (see Apply()).
 
    For Within operations, set_B is empty and the cross product is set_A × set_A.
    For Between operations, the cross product is set_A × set_B.
@@ -210,6 +211,7 @@ class CollisionFilter {
     Operation operation{};
     std::vector<GeometryId> set_A;
     std::vector<GeometryId> set_B;
+    bool is_invariant{false};
   };
 
   /* A transient declaration stored as its resolved statements. */
@@ -248,11 +250,19 @@ class CollisionFilter {
    when a geometry is unregistered. */
   static void RemovePairsFor(GeometryId id, FilterState* state);
 
-  /* Applies the given declaration (using the extract_ids callback) to `state`.
-   Used by the public Apply(). */
-  static void ApplyDeclarationToState(
+  /* Resolves all statements in `declaration` by calling `extract_ids` on each
+   GeometrySet, validates that every resulting GeometryId is registered with
+   this filter system, and returns the resolved statements. `is_invariant` is
+   forwarded into each ResolvedStatement so that ApplyStatement() can enforce
+   the invariant flag without re-consulting the original declaration.
+   @throws std::exception if any GeometryId produced by `extract_ids` has not
+                          been added to `this` filter system. */
+  std::vector<ResolvedStatement> ResolveStatementsOrThrow(
       const CollisionFilterDeclaration& declaration,
-      const ExtractIds& extract_ids, bool is_invariant, FilterState* state);
+      const ExtractIds& extract_ids, bool is_invariant) const;
+
+  /* Throws std::runtime_error if any id in `ids` is not in geometries_. */
+  void ThrowIfAnyUnregistered(const std::unordered_set<GeometryId>& ids) const;
 
   /* Rebuilds filter_state_ from persistent_base_ plus all entries in
    transient_history_ replayed in order. Called after RemoveDeclaration() or

--- a/geometry/proximity/test/collision_filter_test.cc
+++ b/geometry/proximity/test/collision_filter_test.cc
@@ -9,6 +9,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/expect_throws_message.h"
+
 namespace drake {
 namespace geometry {
 
@@ -650,6 +652,33 @@ TEST_F(CollisionFilterTest, EquivalencyWithInactive) {
   /* Matching inactive sets (and matching pairwise states) are equivalent. */
   SetActiveStatus(&filters3, GeometrySet(id_A), /* active= */ false, extract);
   EXPECT_TRUE(filters1.IsEquivalent(filters3));
+}
+
+/* Confirms that Apply() and ApplyTransient() throw when a declaration
+ references a GeometryId that has not been registered with the filter system.
+ Testing methodology:
+   - All declarations get resolved by a call to the same method:
+     ResolveStatements(). So, a single declaration type is sufficient.
+   - We do make sure that an unknown in set A or set B is detected. */
+TEST_F(CollisionFilterTest, ApplyWithUnknownGeometryIdThrows) {
+  CollisionFilter filters;
+  auto [id_A, id_B, id_C] = this->InitIds(&filters);
+  const auto& extract = this->get_extract_ids_functor();
+
+  const GeometryId unknown_id = GeometryId::get_new_id();
+  ASSERT_FALSE(filters.HasGeometry(unknown_id));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      filters.Apply(CollisionFilterDeclaration().ExcludeBetween(
+                        GeometrySet(unknown_id), GeometrySet(id_A)),
+                    extract, false),
+      ".*not been registered.*");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      filters.ApplyTransient(CollisionFilterDeclaration().ExcludeBetween(
+                                 GeometrySet(id_A), GeometrySet(unknown_id)),
+                             extract),
+      ".*not been registered.*");
 }
 
 }  // namespace internal


### PR DESCRIPTION
CollisionFilter documented that bad geometry ids should throw. In a recent change to CollisionFilter this was (apparently) lost. This restores the throwing and adds a test to catch it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24892)
<!-- Reviewable:end -->
