### PR TITLE
[pydrake] Suppress nanobind's reference leak warnings

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -120,6 +120,11 @@ void InitLowLevelModules(py::module_ m) {
   PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   constexpr auto& doc = pydrake_doc_common.drake;
 
+#ifdef PYDRAKE_USE_NANOBIND
+  // See https://nanobind.readthedocs.io/en/latest/refleaks.html#reference-leaks
+  nanobind::set_leak_warnings(false);
+#endif
+
   // Morph any DRAKE_ASSERT and DRAKE_DEMAND failures into SystemExit exceptions
   // instead of process aborts.  See RobotLocomotion/drake#5268.
   drake_set_assertion_failure_to_throw_exception();
@@ -349,10 +354,10 @@ deterministic given the C++ random seed (see drake issue #12632 for the
 discussion), use e.g.
 
 .. code-block:: python
-    
+
    generator = pydrake.common.RandomGenerator()
    random_state = numpy.random.RandomState(generator())
-   
+
    my_random_value = random_state.uniform()
    ...
 

--- a/tools/workspace/nanobind/BUILD.bazel
+++ b/tools/workspace/nanobind/BUILD.bazel
@@ -6,7 +6,7 @@ load(
 )
 load("//tools/install:install.bzl", "install", "install_files")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load(":defs.bzl", "LIMITED_API_DEFINES", "cc_library_with_limited_api")
+load(":defs.bzl", "NANOBIND_DEFINES", "cc_library_with_limited_api")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -60,7 +60,7 @@ cc_nolink_library(
 cc_library(
     name = "shared_library",
     srcs = [":libdrake_nanobind.so"],
-    defines = LIMITED_API_DEFINES,
+    defines = NANOBIND_DEFINES,
     deps = [
         ":hdrs",
         "//tools/workspace/nanobind/vendor:nanobind_eigen",

--- a/tools/workspace/nanobind/defs.bzl
+++ b/tools/workspace/nanobind/defs.bzl
@@ -1,15 +1,21 @@
 load("@with_cfg.bzl", "with_cfg")
 load("//tools/skylark:cc.bzl", "cc_library")
 
-# See https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API.
-# This matches our minimum supported Python version of >= 3.12.
-LIMITED_API_DEFINES = ["Py_LIMITED_API=0x030C0000"]
+NANOBIND_DEFINES = [
+    # See https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API.
+    # This matches our minimum supported Python version of >= 3.12.
+    "Py_LIMITED_API=0x030C0000",
+
+    # See https://nanobind.readthedocs.io/en/latest/refleaks.html#reference-leaks
+    # This limits the scope of setting nanobind global flags.
+    "NB_DOMAIN=pydrake",
+]
 
 # cc_library_with_limited_api compiles its dependencies with Py_LIMITED_API set
 # in their copts.
 _builder = with_cfg(cc_library)
 _builder.extend("copt", [
     "-D" + definition
-    for definition in LIMITED_API_DEFINES
+    for definition in NANOBIND_DEFINES
 ])
 cc_library_with_limited_api, _ = _builder.build()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24894)
<!-- Reviewable:end -->

Toward #21572.