### PR TITLE
Deprecate pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,6 +734,9 @@ if(WITH_ROBOTLOCOMOTION_SNOPT OR WITH_SNOPT)
   endif()
 endif()
 
+# Drake's default will change to "nanobind" around 2026-12-01. Using "pybind11"
+# is deprecated and will be removed from Drake on or after 2027-03-01. For help,
+# see https://github.com/RobotLocomotion/drake/issues/21572#porting-guide.
 set(DRAKE_PYTHON_BINDER "pybind11" CACHE STRING "Binding library to use for pydrake." )
 set_property(CACHE DRAKE_PYTHON_BINDER PROPERTY STRINGS "pybind11" "nanobind")
 string(APPEND BAZEL_CONFIG " --@drake//tools/flags:python_binder=${DRAKE_PYTHON_BINDER}")

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -212,7 +212,10 @@ Adjusting open-source dependencies:
 * `DRAKE_PYTHON_BINDER` (default `pybind11`). Can be set to either `pybind11`
   or `nanobind` to choose which binding library to use when compiling `pydrake`
   bindings.
-  (Support for `nanobind` is currently experimental / unstable.)
+  * Drake's default will change to `nanobind` around 2026-12-01.
+  * Using `pybind11` is deprecated and will be removed from Drake on or after
+    2027-03-01. For help, see our
+    [porting guide](https://github.com/RobotLocomotion/drake/issues/21572#porting-guide).
 
 Adjusting closed-source (commercial) software dependencies:
 

--- a/tools/flags/BUILD.bazel
+++ b/tools/flags/BUILD.bazel
@@ -385,9 +385,12 @@ bool_flag(
 # -----------------------------------------------------------------------------
 # Configuration for Drake features.
 
-# When set to 'pybind11', uses pybind11 to provide pydrake bindings.
-# When set to 'nanobind', uses nanobind to provide pydrake bindings.
-# (Support for 'nanobind' is currently experimental / unstable.)
+# When set to 'nanobind', uses nanobind to provide pydrake bindings. This will
+# become Drake's default around 2026-12-01.
+#
+# When set to 'pybind11', uses pybind11 to provide pydrake bindings. This is
+# deprecated and will be removed from Drake on or after 2027-03-01. For help,
+# see https://github.com/RobotLocomotion/drake/issues/21572#porting-guide.
 string_flag(
     name = "python_binder",
     build_setting_default = "pybind11",


### PR DESCRIPTION
Using pybind11 is deprecated and will be removed from Drake on or after 2027-03-01.

Drake's default will change to nanobind around 2026-12-01.

Towards #21572.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24897)
<!-- Reviewable:end -->
