### PR TITLE
[workspace] Use host Xcode SDK when building rust code

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,6 +28,9 @@ bazel_dep(name = "with_cfg.bzl", version = "1.0.0")
 # Configure the Rust toolchain.
 
 rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")
+rules_rust.patch(
+    patches = ["//:tools/workspace/rules_rs/patches/no_default_macos_sdkroot.patch"],
+)
 use_repo(rules_rust, "rules_rust")
 
 rust_toolchains = use_extension(

--- a/tools/workspace/rules_rs/patches/no_default_macos_sdkroot.patch
+++ b/tools/workspace/rules_rs/patches/no_default_macos_sdkroot.patch
@@ -1,0 +1,17 @@
+[workspace] Use host Xcode SDK when building rust code
+
+We don't want the hermetic sdkroot. It might differ from the host.
+
+We can drop this patch in lieu of drake#24886 once we can upgrade
+to a newer rules_rs.
+
+--- rust/private/rust.bzl
++++ rust/private/rust.bzl
+@@ -786,7 +786,6 @@ _COMMON_ATTRS = {
+     "macos_sdkroot": attr.label(
+         doc = "Optional macOS SDK root to expose to rustc as SDKROOT when linking macOS targets.",
+         allow_files = True,
+-        default = Label("//rust/private:default_macos_sdkroot"),
+     ),
+     "deps": attr.label_list(
+         doc = dedent("""\


### PR DESCRIPTION
We don't want the hermetic sdkroot. It might differ from the host.

(Also, the hermetic SDK is hosted on crap mirrors, so fails to download frequently.)

This is a work-around until we can land #24886.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24899)
<!-- Reviewable:end -->
