### PR TITLE
[pydrake] Demote trigger_an_assertion_failure to internal use only

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -418,8 +418,8 @@ discussion), use e.g.
         return result;
       },
       doc.MaybeGetDrakePath.doc);
-  // These are meant to be called internally by pydrake; not by users.
-  m.def("trigger_an_assertion_failure", &trigger_an_assertion_failure,
+  // This is meant to be called internally by pydrake; not by users.
+  m.def("_trigger_an_assertion_failure", &trigger_an_assertion_failure,
       "Trigger a Drake C++ assertion failure");
 
   m.attr("kDrakeAssertIsArmed") = kDrakeAssertIsArmed;

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -20,7 +20,7 @@ class TestCommon(unittest.TestCase):
         # C++ assertion failure from Python and confirm that an exception with
         # an appropriate type and message comes out.
         try:
-            mut.trigger_an_assertion_failure()
+            mut._trigger_an_assertion_failure()
             self.fail("Did not get a SystemExit")
         except SystemExit as e:
             self.assertTrue(e.code is not None)


### PR DESCRIPTION
Closes #9589.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24910)
<!-- Reviewable:end -->
