### PR TITLE
[wheel] Simplify setup.py

### DIFF
--- a/tools/wheel/image/build-wheel.sh
+++ b/tools/wheel/image/build-wheel.sh
@@ -127,13 +127,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
         pydrake/*/*.so
 fi
 
-if [[ "$(uname)" == "Linux" ]]; then
-    # We compile a (trivial) extension specified from setup.py, so we must
-    # ensure our C compiler is available.
-    CC=/opt/rh/gcc-toolset-14/root/usr/bin/gcc python -m build --wheel
-else
-    python -m build --wheel
-fi
+python -m build --wheel
 
 if [[ "$(uname)" == "Darwin" ]]; then
     delocate-wheel -w wheelhouse -v dist/drake*.whl

--- a/tools/wheel/image/packages-almalinux
+++ b/tools/wheel/image/packages-almalinux
@@ -1,6 +1,6 @@
 # Core compilers and linkers.
-# N.B. When you change anything here, also fix wheel/image/build-drake.sh,
-# wheel/image/build-wheel.sh, and wheel/licenses/gcc/copyright.
+# N.B. When you change anything here, also fix wheel/image/build-drake.sh
+# and wheel/licenses/gcc/copyright.
 gcc-toolset-14-gcc
 gcc-toolset-14-gcc-c++
 gcc-toolset-14-gcc-gfortran

--- a/tools/wheel/image/setup.py
+++ b/tools/wheel/image/setup.py
@@ -1,9 +1,15 @@
+import glob
 import os
 
-# Note: use setuptools.glob rather than the built-in glob; see
-# https://bugs.python.org/issue37578.
-import setuptools
-from setuptools import find_packages, glob, setup
+from setuptools import Distribution, find_packages, setup
+
+
+class BinaryDistribution(Distribution):
+    """Force the wheel builder to output a platform-specific wheel tag."""
+
+    def has_ext_modules(self) -> bool:
+        return True
+
 
 DRAKE_VERSION = os.environ.get("DRAKE_VERSION", "0.0.0")
 
@@ -29,15 +35,19 @@ python_required = [
 ]
 
 
-def find_data_files(*patterns):
+def _find_data_files(*patterns: str) -> list[str]:
     result = []
     for pattern in patterns:
-        result += [f"../{f}" for f in glob.iglob(pattern, recursive=True)]
+        result += [
+            f"../{f}"
+            for f in glob.iglob(pattern, recursive=True, include_hidden=True)
+        ]
     return result
 
 
-def _actually_find_packages():
-    """Work around broken(?!) setuptools."""
+def _actually_find_packages() -> list[str]:
+    """Find additional `pydrake` modules intended to be packaged in the wheel
+    which aren't found by `setuptools` due to a missing `__init__.py` file."""
     result = find_packages()
     result.extend(
         [
@@ -54,13 +64,6 @@ def _actually_find_packages():
     )
     print(f"Using packages={result}")
     return result
-
-
-# Generate a source file we can use to produce an extension library (which we
-# do to force the wheel to not be platform-agnostic). We need this because
-# trying to build an extension module with no sources is not reliable.
-with open("dummy.c", "wt", encoding="utf-8") as f:
-    f.write("void not_used() {}")
 
 
 setup(
@@ -101,7 +104,7 @@ See https://drake.mit.edu/pip.html for installation instructions and caveats.
     # Add in any packaged data.
     include_package_data=True,
     package_data={
-        "": find_data_files(
+        "": _find_data_files(
             "pydrake/py.typed",
             "pydrake/**/*.pyi",
             "pydrake/**/*.so",
@@ -121,9 +124,6 @@ See https://drake.mit.edu/pip.html for installation instructions and caveats.
         else {}
     ),
     install_requires=python_required,
-    # Ensure the wheel is not platform-agnostic.
-    ext_modules=[
-        setuptools.Extension(name="drake", sources=["dummy.c"]),
-    ],
+    distclass=BinaryDistribution,
     zip_safe=False,
 )


### PR DESCRIPTION
Override extension metadata so that we no longer need a C compiler to build the wheel.

Update usage of `glob` with a fix from Python 3.11 (see: https://github.com/python/cpython/issues/81759, https://github.com/python/cpython/pull/30153).

Clarify usage of `setuptools.find_packages`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24914)
<!-- Reviewable:end -->
