### PR TITLE
[wheel] Remove pythonX.Y symlink indirection on macOS

### DIFF
--- a/tools/wheel/macos/provision-test-python.sh
+++ b/tools/wheel/macos/provision-test-python.sh
@@ -21,4 +21,4 @@ fi
 
 # NOTE: Xcode ships python3, make sure to use the one from brew.
 $(brew --prefix python@$1)/bin/python$1 \
-    -m venv /tmp/drake-wheel-test/python$1
+    -m venv /tmp/drake-wheel-test/python

--- a/tools/wheel/wheel_builder/macos.py
+++ b/tools/wheel/wheel_builder/macos.py
@@ -84,17 +84,12 @@ def _test_wheel(wheel, target, env):
     """
     Runs the test script on `wheel`.
     """
+    # Set up the environment.
     setup_script = os.path.join(
         resource_root, "macos", "provision-test-python.sh"
     )
     subprocess.check_call(
         ["bash", setup_script, target.python.version], env=env
-    )
-
-    test_python_venv = os.path.join(test_root, "python")
-    os.symlink(
-        os.path.join(test_root, f"python{target.python.version}"),
-        test_python_venv,
     )
 
     # Install the wheel.
@@ -107,8 +102,6 @@ def _test_wheel(wheel, target, env):
         print(f"-- Executing test {test}")
         subprocess.check_call(["bash", test_script, test, wheel], env=env)
         print(f"-- Executing test {test} - PASSED")
-
-    os.unlink(test_python_venv)
 
 
 def build(options):


### PR DESCRIPTION
The `python` spelling is needed for `install-wheel.sh` and `test-wheel.sh` to be reusable across the Linux and macOS builders, but it being a symlink pointing to `pythonX.Y` (the directory where the venv lives) is unnecessary. `provision-build.sh` already creates a unique test root each time a wheel is tested (via
`macos/provision-test-python.sh`).

The broader motivation for the change is to remove confusion around the uniqueness of the test root and Python virtual environment ahead of a future commit to support testing a single wheel with multiple Python versions.

Towards #24903.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24919)
<!-- Reviewable:end -->
