### PR TITLE
[multibody] Add SapJointFrictionConstraint for joint dry friction

### DIFF
--- a/multibody/contact_solvers/sap/BUILD.bazel
+++ b/multibody/contact_solvers/sap/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_package_library(
         ":sap_friction_cone_constraint",
         ":sap_holonomic_constraint",
         ":sap_hunt_crossley_constraint",
+        ":sap_joint_friction_constraint",
         ":sap_limit_constraint",
         ":sap_model",
         ":sap_pd_controller_constraint",
@@ -215,6 +216,19 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
         "//multibody/contact_solvers:contact_configuration",
+    ],
+)
+
+drake_cc_library(
+    name = "sap_joint_friction_constraint",
+    srcs = ["sap_joint_friction_constraint.cc"],
+    hdrs = ["sap_joint_friction_constraint.h"],
+    deps = [
+        ":sap_constraint",
+        ":sap_constraint_jacobian",
+        "//common:default_scalars",
+        "//common:essential",
+        "//common:extract_double",
     ],
 )
 
@@ -444,6 +458,17 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//math:gradient",
         "//solvers:constraint",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sap_joint_friction_constraint_test",
+    deps = [
+        ":expect_equal",
+        ":sap_joint_friction_constraint",
+        ":validate_constraint_gradients",
+        "//common:pointer_cast",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/contact_solvers/sap/sap_joint_friction_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_joint_friction_constraint.cc
@@ -1,0 +1,137 @@
+#include "drake/multibody/contact_solvers/sap/sap_joint_friction_constraint.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/extract_double.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+template <typename T>
+SapJointFrictionConstraint<T>::SapJointFrictionConstraint(int clique,
+                                                          int clique_dof,
+                                                          int clique_nv,
+                                                          Parameters parameters)
+    : SapConstraint<T>(CalcConstraintJacobian(clique, clique_dof, clique_nv),
+                       {}),
+      parameters_(std::move(parameters)),
+      clique_dof_(clique_dof) {
+  DRAKE_DEMAND(parameters_.friction > 0.0);
+  DRAKE_DEMAND(parameters_.sigma > 0.0);
+}
+
+template <typename T>
+SapConstraintJacobian<T> SapJointFrictionConstraint<T>::CalcConstraintJacobian(
+    int clique, int clique_dof, int clique_nv) {
+  DRAKE_DEMAND(clique >= 0);
+  DRAKE_DEMAND(0 <= clique_dof && clique_dof < clique_nv);
+  MatrixX<T> J = MatrixX<T>::Zero(1, clique_nv);
+  J(0, clique_dof) = 1.0;
+  return SapConstraintJacobian<T>(clique, std::move(J));
+}
+
+template <typename T>
+std::unique_ptr<AbstractValue> SapJointFrictionConstraint<T>::DoMakeData(
+    const T& time_step,
+    const Eigen::Ref<const VectorX<T>>& delassus_estimation) const {
+  // Regularization R = σ⋅w, with w the diagonal approximation of the Delassus
+  // operator for this constraint, which estimates the inverse effective inertia
+  // of the constrained DOF. See class documentation.
+  const T R = parameters_.sigma * delassus_estimation(0);
+  // The Delassus estimation w = 1/Aᵢᵢ is positive and finite for any DOF with
+  // a positive diagonal entry in the (positive definite) dynamics matrix A.
+  // Both are needed for R⁻¹ and the cost to be well defined.
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  DRAKE_DEMAND(R > 0.0 && R < kInf);
+  const T gamma_max = time_step * parameters_.friction;
+  SapJointFrictionConstraintData<T> data(R, gamma_max);
+  return SapConstraint<T>::MoveAndMakeAbstractValue(std::move(data));
+}
+
+template <typename T>
+void SapJointFrictionConstraint<T>::DoCalcData(
+    const Eigen::Ref<const VectorX<T>>& vc,
+    AbstractValue* abstract_data) const {
+  using std::max;
+  using std::min;
+  auto& data =
+      abstract_data->get_mutable_value<SapJointFrictionConstraintData<T>>();
+  const T& gamma_max = data.gamma_max();
+  data.mutable_vc() = vc(0);
+  data.mutable_y() = -vc(0) * data.R_inv();
+  data.mutable_gamma() = max(-gamma_max, min(gamma_max, data.y()));
+}
+
+template <typename T>
+T SapJointFrictionConstraint<T>::DoCalcCost(
+    const AbstractValue& abstract_data) const {
+  using std::abs;
+  const auto& data =
+      abstract_data.get_value<SapJointFrictionConstraintData<T>>();
+  const T& R = data.R();
+  const T& gamma_max = data.gamma_max();
+  const T& vc = data.vc();
+  const T& y = data.y();
+  // The stiction condition |vc| ≤ R⋅γₘₐₓ is equivalent to |y| ≤ γₘₐₓ.
+  if (abs(y) <= gamma_max) {
+    return 0.5 * R * y * y;  // Equals vc²/(2R).
+  }
+  return gamma_max * abs(vc) - 0.5 * R * gamma_max * gamma_max;
+}
+
+template <typename T>
+void SapJointFrictionConstraint<T>::DoCalcImpulse(
+    const AbstractValue& abstract_data, EigenPtr<VectorX<T>> gamma) const {
+  const auto& data =
+      abstract_data.get_value<SapJointFrictionConstraintData<T>>();
+  (*gamma)(0) = data.gamma();
+}
+
+template <typename T>
+void SapJointFrictionConstraint<T>::DoCalcCostHessian(
+    const AbstractValue& abstract_data, MatrixX<T>* G) const {
+  using std::abs;
+  const auto& data =
+      abstract_data.get_value<SapJointFrictionConstraintData<T>>();
+  // The Hessian is R⁻¹ in stiction and zero in sliding. At the transition we
+  // pick the stiction value, consistently with the branch used in DoCalcCost().
+  (*G)(0, 0) = abs(data.y()) <= data.gamma_max() ? data.R_inv() : T(0.0);
+}
+
+template <typename T>
+void SapJointFrictionConstraint<T>::DoAccumulateGeneralizedImpulses(
+    int, const Eigen::Ref<const VectorX<T>>& gamma,
+    EigenPtr<VectorX<T>> tau) const {
+  // N.B. The NVI guarantees the clique index is correct, and since there is
+  // only one, we don't need to use it.
+  // For this constraint the generalized impulses are τ = Jᵀ⋅γ = eᵢ⋅γ.
+  (*tau)(clique_dof_) += gamma(0);
+}
+
+template <typename T>
+std::unique_ptr<SapConstraint<double>>
+SapJointFrictionConstraint<T>::DoToDouble() const {
+  SapJointFrictionConstraint<double>::Parameters p_to_double{
+      ExtractDoubleOrThrow(parameters_.friction), parameters_.sigma};
+  // N.B. Joint friction constraints always act on a single clique.
+  const int clique = this->first_clique();
+  const int clique_nv = this->num_velocities(0);
+  return std::make_unique<SapJointFrictionConstraint<double>>(
+      clique, clique_dof(), clique_nv, std::move(p_to_double));
+}
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::contact_solvers::internal::
+        SapJointFrictionConstraint);

--- a/multibody/contact_solvers/sap/sap_joint_friction_constraint.cc
+++ b/multibody/contact_solvers/sap/sap_joint_friction_constraint.cc
@@ -23,7 +23,7 @@ SapJointFrictionConstraint<T>::SapJointFrictionConstraint(int clique,
                        {}),
       parameters_(std::move(parameters)),
       clique_dof_(clique_dof) {
-  DRAKE_DEMAND(parameters_.friction > 0.0);
+  DRAKE_DEMAND(parameters_.tau_c > 0.0);
   DRAKE_DEMAND(parameters_.sigma > 0.0);
 }
 
@@ -50,7 +50,7 @@ std::unique_ptr<AbstractValue> SapJointFrictionConstraint<T>::DoMakeData(
   // Both are needed for R⁻¹ and the cost to be well defined.
   constexpr double kInf = std::numeric_limits<double>::infinity();
   DRAKE_DEMAND(R > 0.0 && R < kInf);
-  const T gamma_max = time_step * parameters_.friction;
+  const T gamma_max = time_step * parameters_.tau_c;
   SapJointFrictionConstraintData<T> data(R, gamma_max);
   return SapConstraint<T>::MoveAndMakeAbstractValue(std::move(data));
 }
@@ -119,7 +119,7 @@ template <typename T>
 std::unique_ptr<SapConstraint<double>>
 SapJointFrictionConstraint<T>::DoToDouble() const {
   SapJointFrictionConstraint<double>::Parameters p_to_double{
-      ExtractDoubleOrThrow(parameters_.friction), parameters_.sigma};
+      ExtractDoubleOrThrow(parameters_.tau_c), parameters_.sigma};
   // N.B. Joint friction constraints always act on a single clique.
   const int clique = this->first_clique();
   const int clique_nv = this->num_velocities(0);

--- a/multibody/contact_solvers/sap/sap_joint_friction_constraint.h
+++ b/multibody/contact_solvers/sap/sap_joint_friction_constraint.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/sap/sap_constraint.h"
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+
+/* Structure to store data needed for SapJointFrictionConstraint computations.
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class SapJointFrictionConstraintData {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SapJointFrictionConstraintData);
+
+  /* Constructs data for a SapJointFrictionConstraint.
+   Refer to SapJointFrictionConstraint's documentation for further details.
+   @param R Regularization parameter. It must be strictly positive.
+   @param gamma_max Friction impulse bound γₘₐₓ = δt⋅τ_c. */
+  SapJointFrictionConstraintData(const T& R, const T& gamma_max)
+      : parameters_{R, 1.0 / R, gamma_max} {}
+
+  /* Regularization R. */
+  const T& R() const { return parameters_.R; }
+
+  /* Inverse of the regularization, R⁻¹. */
+  const T& R_inv() const { return parameters_.R_inv; }
+
+  /* Friction impulse bound γₘₐₓ. */
+  const T& gamma_max() const { return parameters_.gamma_max; }
+
+  /* Const access. */
+  const T& vc() const { return vc_; }
+  const T& y() const { return y_; }
+  const T& gamma() const { return gamma_; }
+
+  /* Mutable access. */
+  T& mutable_vc() { return vc_; }
+  T& mutable_y() { return y_; }
+  T& mutable_gamma() { return gamma_; }
+
+ private:
+  // Values stored in this struct remain const after construction.
+  struct ConstParameters {
+    T R;          // Regularization R.
+    T R_inv;      // Inverse of the regularization R⁻¹.
+    T gamma_max;  // Friction impulse bound γₘₐₓ = δt⋅τ_c.
+  };
+  ConstParameters parameters_;
+
+  T vc_{};     // Constraint velocity, i.e. the velocity of the constrained DOF.
+  T y_{};      // Un-projected impulse y = −vc/R.
+  T gamma_{};  // Projected impulse γ = clamp(y, −γₘₐₓ, γₘₐₓ).
+};
+
+/* Implements a dry (Coulomb) friction constraint on the i-th degree of freedom
+ (DOF) of a given clique in a SapContactProblem, for the SAP solver [Castro et
+ al., 2021]. This constraint models load-independent friction within a joint,
+ such as gearbox friction, in the same spirit as MuJoCo's `frictionloss`
+ attribute. The friction generalized force τ opposes the joint velocity and its
+ magnitude is bounded by a constant τ_c ≥ 0 with units of generalized force
+ (N⋅m for a revolute DOF or N for a prismatic DOF). In stiction the friction
+ force takes whatever value in [−τ_c, τ_c] is needed to hold the DOF at rest,
+ and during sliding it saturates at τ = −τ_c⋅sign(v).
+
+ Constraint kinematics:
+  We consider the i-th DOF of a clique with m DOFs. The constraint velocity is
+  simply the generalized velocity of that DOF:
+    vc = vᵢ = eᵢᵀ⋅v
+  where eᵢ is the i-th element of the standard basis of ℝᵐ. Therefore the
+  constraint Jacobian is J = eᵢᵀ and this constraint has a single equation.
+
+ Regularized friction:
+  With δt the time step of the SapContactProblem, the friction impulse is
+  bounded by γₘₐₓ = δt⋅τ_c. The ideal maximum dissipation cost γₘₐₓ⋅|vc| is not
+  differentiable at vc = 0 and therefore cannot be used directly by SAP. As for
+  the friction in contact constraints (see SapFrictionConeConstraint), we
+  regularize it. We use the convex cost:
+    ℓ(vc) = vc²/(2R)                if |vc| ≤ R⋅γₘₐₓ  (stiction)
+            γₘₐₓ⋅|vc| − R⋅γₘₐₓ²/2   otherwise          (sliding)
+  which has a continuous first derivative, so that the impulse
+    γ(vc) = −∂ℓ/∂vc = clamp(−vc/R, −γₘₐₓ, γₘₐₓ)
+  is continuous, and a piecewise constant second derivative, the Hessian
+    G(vc) = ∂²ℓ/∂vc² = R⁻¹  in stiction and zero in sliding.
+  Notice that:
+    1. The friction impulse always opposes the constraint velocity, satisfying
+       the principle of maximum dissipation.
+    2. It obeys |γ| ≤ γₘₐₓ, i.e. the friction force γ/δt is bounded by τ_c.
+
+  The regularization R is parameterized in a scale independent manner as
+    R = σ⋅w
+  where w is the diagonal approximation of the Delassus operator for this
+  constraint (an estimate of the inverse effective inertia of the constrained
+  DOF) and σ is a dimensionless parameter, see Parameters::sigma. During
+  stiction the DOF creeps with a residual velocity bounded by
+    vₛ = R⋅γₘₐₓ = σ⋅w⋅δt⋅τ_c,
+  that is, σ times the change in velocity that the friction force alone would
+  produce on the DOF in a single time step. Under a sustained load τₐ with
+  |τₐ| < τ_c the DOF settles to a steady creep velocity v∞ = σ⋅w⋅δt⋅τₐ, which
+  is below vₛ.
+
+ [Castro et al., 2021] Castro A., Permenter F. and Han X., 2021. An
+   Unconstrained Convex Formulation of Compliant Contact. Available at
+   https://arxiv.org/abs/2110.10107
+
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class SapJointFrictionConstraint final : public SapConstraint<T> {
+ public:
+  /* We do not allow copy, move, or assignment generally to avoid slicing.
+    Protected copy construction is enabled for sub-classes to use in their
+    implementation of DoClone(). */
+  //@{
+  SapJointFrictionConstraint& operator=(const SapJointFrictionConstraint&) =
+      delete;
+  SapJointFrictionConstraint(SapJointFrictionConstraint&&) = delete;
+  SapJointFrictionConstraint& operator=(SapJointFrictionConstraint&&) = delete;
+  //@}
+
+  /* Numerical parameters that define the constraint. Refer to this class's
+   documentation for details. */
+  struct Parameters {
+    bool operator==(const Parameters&) const = default;
+
+    /* Dry friction bound τ_c on the generalized force of the constrained DOF.
+     It has units of generalized force, i.e. N⋅m for a revolute DOF and N for a
+     prismatic DOF. It must be strictly positive. */
+    T friction{0.0};
+    /* Dimensionless parameterization of the regularization of friction, R =
+     σ⋅w. Refer to this class's documentation for details. It must be strictly
+     positive. */
+    double sigma{1.0e-3};
+  };
+
+  /* Constructs a dry friction constraint for the DOF with index `clique_dof`
+   within the clique with index `clique` in a given SapContactProblem.
+   @param[in] clique The clique involved in the constraint. Must be
+   non-negative.
+   @param[in] clique_dof DOF in `clique` to be constrained. It must be in [0,
+   clique_nv).
+   @param[in] clique_nv Number of generalized velocities for `clique`.
+   @param[in] parameters Parameters of the constraint.
+   @pre parameters.friction > 0.
+   @pre parameters.sigma > 0. */
+  SapJointFrictionConstraint(int clique, int clique_dof, int clique_nv,
+                             Parameters parameters);
+
+  const Parameters& parameters() const { return parameters_; }
+
+  /* Returns the degree of freedom, DOF, that this constraint acts on. Provided
+   at construction. */
+  int clique_dof() const { return clique_dof_; }
+
+ private:
+  /* Private copy construction is enabled to use in the implementation of
+    DoClone(). */
+  SapJointFrictionConstraint(const SapJointFrictionConstraint&) = default;
+
+  /* Computes the constraint Jacobian J = eᵢᵀ, with i = clique_dof. */
+  static SapConstraintJacobian<T> CalcConstraintJacobian(int clique,
+                                                         int clique_dof,
+                                                         int clique_nv);
+
+  /* Implementations of SapConstraint NVI functions. */
+  std::unique_ptr<AbstractValue> DoMakeData(
+      const T& time_step,
+      const Eigen::Ref<const VectorX<T>>& delassus_estimation) const override;
+  void DoCalcData(const Eigen::Ref<const VectorX<T>>& vc,
+                  AbstractValue* abstract_data) const override;
+  T DoCalcCost(const AbstractValue& abstract_data) const override;
+  void DoCalcImpulse(const AbstractValue& abstract_data,
+                     EigenPtr<VectorX<T>> gamma) const override;
+  void DoCalcCostHessian(const AbstractValue& abstract_data,
+                         MatrixX<T>* G) const override;
+  std::unique_ptr<SapConstraint<T>> DoClone() const final {
+    return std::unique_ptr<SapJointFrictionConstraint<T>>(
+        new SapJointFrictionConstraint<T>(*this));
+  }
+  std::unique_ptr<SapConstraint<double>> DoToDouble() const final;
+  void DoAccumulateGeneralizedImpulses(
+      int c, const Eigen::Ref<const VectorX<T>>& gamma,
+      EigenPtr<VectorX<T>> tau) const final;
+  // no-op for this constraint.
+  void DoAccumulateSpatialImpulses(int, const Eigen::Ref<const VectorX<T>>&,
+                                   SpatialForce<T>*) const final {};
+
+  Parameters parameters_;
+  int clique_dof_{-1};  // Initialized to an invalid value.
+};
+
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/sap_joint_friction_constraint.h
+++ b/multibody/contact_solvers/sap/sap_joint_friction_constraint.h
@@ -64,10 +64,12 @@ class SapJointFrictionConstraintData {
  al., 2021]. This constraint models load-independent friction within a joint,
  such as gearbox friction, in the same spirit as MuJoCo's `frictionloss`
  attribute. The friction generalized force τ opposes the joint velocity and its
- magnitude is bounded by a constant τ_c ≥ 0 with units of generalized force
- (N⋅m for a revolute DOF or N for a prismatic DOF). In stiction the friction
+ magnitude is bounded by a constant τ_c > 0 with units of generalized force
+ (N⋅m for a revolute DOF or N for a prismatic DOF). In stiction, the friction
  force takes whatever value in [−τ_c, τ_c] is needed to hold the DOF at rest,
- and during sliding it saturates at τ = −τ_c⋅sign(v).
+ and during sliding it saturates at τ = −τ_c⋅sign(v). A DOF with τ_c = 0 has no
+ dry friction at all. The caller should skip building the constraint in that
+ case, instead of building one with a zero bound.
 
  Constraint kinematics:
   We consider the i-th DOF of a clique with m DOFs. The constraint velocity is
@@ -79,7 +81,7 @@ class SapJointFrictionConstraintData {
  Regularized friction:
   With δt the time step of the SapContactProblem, the friction impulse is
   bounded by γₘₐₓ = δt⋅τ_c. The ideal maximum dissipation cost γₘₐₓ⋅|vc| is not
-  differentiable at vc = 0 and therefore cannot be used directly by SAP. As for
+  differentiable at vc = 0 and therefore cannot be used directly by SAP. As with
   the friction in contact constraints (see SapFrictionConeConstraint), we
   regularize it. We use the convex cost:
     ℓ(vc) = vc²/(2R)                if |vc| ≤ R⋅γₘₐₓ  (stiction)
@@ -108,6 +110,9 @@ class SapJointFrictionConstraintData {
  [Castro et al., 2021] Castro A., Permenter F. and Han X., 2021. An
    Unconstrained Convex Formulation of Compliant Contact. Available at
    https://arxiv.org/abs/2110.10107
+ [Castro et al., 2023] Castro A., Han X., and Masterjohn J., 2023. A Theory of
+   Irrotational Contact Fields. Available online at
+   https://arxiv.org/abs/2312.03908
 
  @tparam_nonsymbolic_scalar */
 template <typename T>
@@ -130,8 +135,9 @@ class SapJointFrictionConstraint final : public SapConstraint<T> {
 
     /* Dry friction bound τ_c on the generalized force of the constrained DOF.
      It has units of generalized force, i.e. N⋅m for a revolute DOF and N for a
-     prismatic DOF. It must be strictly positive. */
-    T friction{0.0};
+     prismatic DOF. It must be strictly positive. The default value of zero is
+     an invalid sentinel that callers are required to overwrite. */
+    T tau_c{0.0};
     /* Dimensionless parameterization of the regularization of friction, R =
      σ⋅w. Refer to this class's documentation for details. It must be strictly
      positive. */
@@ -146,7 +152,7 @@ class SapJointFrictionConstraint final : public SapConstraint<T> {
    clique_nv).
    @param[in] clique_nv Number of generalized velocities for `clique`.
    @param[in] parameters Parameters of the constraint.
-   @pre parameters.friction > 0.
+   @pre parameters.tau_c > 0.
    @pre parameters.sigma > 0. */
   SapJointFrictionConstraint(int clique, int clique_dof, int clique_nv,
                              Parameters parameters);

--- a/multibody/contact_solvers/sap/test/sap_joint_friction_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_joint_friction_constraint_test.cc
@@ -1,0 +1,239 @@
+#include "drake/multibody/contact_solvers/sap/sap_joint_friction_constraint.h"
+
+#include <cmath>
+#include <limits>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/pointer_cast.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/contact_solvers/sap/expect_equal.h"
+#include "drake/multibody/contact_solvers/sap/validate_constraint_gradients.h"
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+namespace drake {
+namespace multibody {
+namespace contact_solvers {
+namespace internal {
+namespace {
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+void ExpectEqual(const SapJointFrictionConstraint<double>& c1,
+                 const SapJointFrictionConstraint<double>& c2) {
+  ExpectBaseIsEqual(c1, c2);
+  EXPECT_EQ(c1.clique_dof(), c2.clique_dof());
+  EXPECT_EQ(c1.parameters(), c2.parameters());
+}
+
+class SapJointFrictionConstraintTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    dut_ = std::make_unique<SapJointFrictionConstraint<double>>(
+        clique_, clique_dof_, clique_nv_, parameters_);
+    SapJointFrictionConstraint<AutoDiffXd>::Parameters p_ad{
+        parameters_.friction, parameters_.sigma};
+    dut_ad_ = std::make_unique<SapJointFrictionConstraint<AutoDiffXd>>(
+        clique_, clique_dof_, clique_nv_, p_ad);
+  }
+
+  // Expected values from the class documentation.
+  double R() const { return parameters_.sigma * delassus_estimation_; }
+  double gamma_max() const { return time_step_ * parameters_.friction; }
+  // Stiction velocity: constraint velocities of magnitude below this value are
+  // in stiction, above it are in sliding.
+  double vs() const { return R() * gamma_max(); }
+
+  // Makes data with the fixture's time step and Delassus estimation and
+  // computes cost, impulse and Hessian at vc.
+  struct Evaluation {
+    double cost;
+    double gamma;
+    double G;
+  };
+  Evaluation Evaluate(double vc) const {
+    std::unique_ptr<AbstractValue> data =
+        dut_->MakeData(time_step_, Vector1d(delassus_estimation_));
+    dut_->CalcData(Vector1d(vc), data.get());
+    Evaluation e;
+    e.cost = dut_->CalcCost(*data);
+    VectorXd gamma(1);
+    dut_->CalcImpulse(*data, &gamma);
+    e.gamma = gamma(0);
+    MatrixXd G(1, 1);
+    dut_->CalcCostHessian(*data, &G);
+    e.G = G(0, 0);
+    return e;
+  }
+
+ protected:
+  // Arbitrary set of indexes and parameters.
+  const int clique_{12};
+  const int clique_dof_{3};
+  const int clique_nv_{7};
+  const double time_step_{2.0e-3};
+  const double delassus_estimation_{1.5};
+  const SapJointFrictionConstraint<double>::Parameters parameters_{
+      .friction = 2.5, .sigma = 1.0e-2};
+  std::unique_ptr<SapJointFrictionConstraint<double>> dut_;
+  std::unique_ptr<SapJointFrictionConstraint<AutoDiffXd>> dut_ad_;
+};
+
+// Bare minimum sanity checks on a newly constructed constraint.
+TEST_F(SapJointFrictionConstraintTest, Construction) {
+  EXPECT_EQ(dut_->num_constraint_equations(), 1);
+  EXPECT_EQ(dut_->num_cliques(), 1);
+  EXPECT_EQ(dut_->first_clique(), clique_);
+  EXPECT_THROW(dut_->second_clique(), std::exception);
+  EXPECT_EQ(dut_->num_objects(), 0);
+  EXPECT_EQ(dut_->clique_dof(), clique_dof_);
+  EXPECT_EQ(dut_->parameters(), parameters_);
+  const MatrixXd J_expected =
+      VectorXd::Unit(clique_nv_, clique_dof_).transpose();
+  EXPECT_EQ(dut_->first_clique_jacobian().MakeDenseMatrix(), J_expected);
+  EXPECT_THROW(dut_->second_clique_jacobian(), std::exception);
+}
+
+// Verifies the regularization and impulse bound computed by MakeData().
+TEST_F(SapJointFrictionConstraintTest, MakeData) {
+  std::unique_ptr<AbstractValue> abstract_data =
+      dut_->MakeData(time_step_, Vector1d(delassus_estimation_));
+  const auto& data =
+      abstract_data->get_value<SapJointFrictionConstraintData<double>>();
+  EXPECT_NEAR(data.R(), R(), kEps);
+  EXPECT_NEAR(data.R_inv(), 1.0 / R(), kEps);
+  EXPECT_NEAR(data.gamma_max(), gamma_max(), kEps);
+}
+
+// Verifies cost, impulse and Hessian against the analytical expressions in the
+// class documentation, in both the stiction and the sliding regimes.
+TEST_F(SapJointFrictionConstraintTest, StictionRegime) {
+  for (const double vc : {-0.7 * vs(), 0.0, 0.3 * vs()}) {
+    const Evaluation e = Evaluate(vc);
+    EXPECT_NEAR(e.cost, vc * vc / (2.0 * R()), kEps);
+    // The impulse is computed as -vc⋅R⁻¹, which incurs a few roundoff errors
+    // relative to -vc/R.
+    EXPECT_NEAR(e.gamma, -vc / R(), 4 * kEps * gamma_max());
+    EXPECT_NEAR(e.G, 1.0 / R(), kEps / R());
+    // In stiction the impulse is strictly within its bounds.
+    EXPECT_LT(std::abs(e.gamma), gamma_max());
+  }
+}
+
+TEST_F(SapJointFrictionConstraintTest, SlidingRegime) {
+  for (const double vc : {-3.5 * vs(), 1.2 * vs()}) {
+    const Evaluation e = Evaluate(vc);
+    const double sign = vc > 0 ? 1.0 : -1.0;
+    EXPECT_NEAR(
+        e.cost,
+        gamma_max() * std::abs(vc) - 0.5 * R() * gamma_max() * gamma_max(),
+        kEps);
+    // The impulse saturates at the bound and opposes motion.
+    EXPECT_NEAR(e.gamma, -sign * gamma_max(), kEps * gamma_max());
+    EXPECT_EQ(e.G, 0.0);
+  }
+}
+
+// The cost and impulse must be continuous at the transition between stiction
+// and sliding, |vc| = vs. The Hessian jumps from 1/R to zero.
+TEST_F(SapJointFrictionConstraintTest, ContinuityAtTransition) {
+  for (const double sign : {-1.0, 1.0}) {
+    const double delta = 1.0e-10 * vs();
+    const Evaluation below = Evaluate(sign * (vs() - delta));
+    const Evaluation above = Evaluate(sign * (vs() + delta));
+    // The cost has a continuous first derivative of magnitude γₘₐₓ at the
+    // transition, so across the width 2⋅delta it changes by 2⋅γₘₐₓ⋅delta up
+    // to second order terms (delta²/(2R), far below roundoff here).
+    EXPECT_NEAR(above.cost - below.cost, 2.0 * gamma_max() * delta,
+                16 * kEps * above.cost);
+    // The impulse is Lipschitz with constant 1/R.
+    EXPECT_NEAR(below.gamma, above.gamma, 2.0 * delta / R());
+    EXPECT_NEAR(below.G, 1.0 / R(), kEps / R());
+    EXPECT_EQ(above.G, 0.0);
+  }
+}
+
+// Verifies the principle of maximum dissipation: the impulse always opposes
+// the constraint velocity and is bounded by gamma_max.
+TEST_F(SapJointFrictionConstraintTest, MaximumDissipation) {
+  for (const double vc : VectorXd::LinSpaced(21, -5.0 * vs(), 5.0 * vs())) {
+    const Evaluation e = Evaluate(vc);
+    EXPECT_LE(e.gamma * vc, 0.0);
+    EXPECT_LE(std::abs(e.gamma), gamma_max() * (1.0 + kEps));
+  }
+}
+
+// This test validates the implementation of analytical constraint gradient and
+// Hessian against numerical results obtained with automatic differentiation.
+TEST_F(SapJointFrictionConstraintTest, ValidateConstraintGradients) {
+  std::unique_ptr<AbstractValue> abstract_data =
+      dut_ad_->MakeData(time_step_, Vector1<AutoDiffXd>(delassus_estimation_));
+
+  // Helper to validate gradients at the constraint velocity vc.
+  // It returns the impulse at vc.
+  auto validate_gradients = [&](double vc) {
+    VectorX<AutoDiffXd> gamma_ad(1);
+    VectorX<AutoDiffXd> vc_ad = math::InitializeAutoDiff(Vector1d(vc));
+    dut_ad_->CalcData(vc_ad, abstract_data.get());
+    dut_ad_->CalcImpulse(*abstract_data, &gamma_ad);
+    ValidateConstraintGradients(*dut_ad_, *abstract_data);
+    return math::ExtractValue(gamma_ad)(0);
+  };
+
+  // Stiction.
+  {
+    const double gamma = validate_gradients(0.4 * vs());
+    EXPECT_LT(std::abs(gamma), gamma_max());
+    EXPECT_LT(gamma, 0.0);
+  }
+  // Sliding in the positive direction.
+  {
+    const double gamma = validate_gradients(2.0 * vs());
+    EXPECT_NEAR(gamma, -gamma_max(), kEps * gamma_max());
+  }
+  // Sliding in the negative direction.
+  {
+    const double gamma = validate_gradients(-2.0 * vs());
+    EXPECT_NEAR(gamma, gamma_max(), kEps * gamma_max());
+  }
+}
+
+TEST_F(SapJointFrictionConstraintTest, Clone) {
+  // N.B. Here we dynamic cast to the derived type so that we can test that the
+  // clone is a deep-copy of the original constraint.
+  auto clone =
+      dynamic_pointer_cast<SapJointFrictionConstraint<double>>(dut_->Clone());
+  ASSERT_NE(clone, nullptr);
+  ExpectEqual(*dut_, *clone);
+
+  // Test ToDouble.
+  auto clone_from_ad = dynamic_pointer_cast<SapJointFrictionConstraint<double>>(
+      dut_ad_->ToDouble());
+  ASSERT_NE(clone_from_ad, nullptr);
+  ExpectEqual(*dut_, *clone_from_ad);
+}
+
+TEST_F(SapJointFrictionConstraintTest, AccumulateGeneralizedImpulses) {
+  const MatrixXd J = dut_->first_clique_jacobian().MakeDenseMatrix();
+  const int nv = dut_->num_velocities(0);
+  // Arbitrary impulse.
+  const Vector1d gamma(1.7);
+  // Arbitrary initial value.
+  const VectorXd tau0 = VectorXd::LinSpaced(nv, -5.0, 3.7);
+  const VectorXd tau_expected = tau0 + J.transpose() * gamma;
+  VectorXd tau = tau0;
+  dut_->AccumulateGeneralizedImpulses(0 /* Only one clique */, gamma, &tau);
+  EXPECT_TRUE(
+      CompareMatrices(tau, tau_expected, kEps, MatrixCompareType::relative));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace contact_solvers
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/contact_solvers/sap/test/sap_joint_friction_constraint_test.cc
+++ b/multibody/contact_solvers/sap/test/sap_joint_friction_constraint_test.cc
@@ -36,15 +36,15 @@ class SapJointFrictionConstraintTest : public ::testing::Test {
   void SetUp() override {
     dut_ = std::make_unique<SapJointFrictionConstraint<double>>(
         clique_, clique_dof_, clique_nv_, parameters_);
-    SapJointFrictionConstraint<AutoDiffXd>::Parameters p_ad{
-        parameters_.friction, parameters_.sigma};
+    SapJointFrictionConstraint<AutoDiffXd>::Parameters p_ad{parameters_.tau_c,
+                                                            parameters_.sigma};
     dut_ad_ = std::make_unique<SapJointFrictionConstraint<AutoDiffXd>>(
         clique_, clique_dof_, clique_nv_, p_ad);
   }
 
   // Expected values from the class documentation.
   double R() const { return parameters_.sigma * delassus_estimation_; }
-  double gamma_max() const { return time_step_ * parameters_.friction; }
+  double gamma_max() const { return time_step_ * parameters_.tau_c; }
   // Stiction velocity: constraint velocities of magnitude below this value are
   // in stiction, above it are in sliding.
   double vs() const { return R() * gamma_max(); }
@@ -79,7 +79,7 @@ class SapJointFrictionConstraintTest : public ::testing::Test {
   const double time_step_{2.0e-3};
   const double delassus_estimation_{1.5};
   const SapJointFrictionConstraint<double>::Parameters parameters_{
-      .friction = 2.5, .sigma = 1.0e-2};
+      .tau_c = 2.5, .sigma = 1.0e-2};
   std::unique_ptr<SapJointFrictionConstraint<double>> dut_;
   std::unique_ptr<SapJointFrictionConstraint<AutoDiffXd>> dut_ad_;
 };


### PR DESCRIPTION
Towards #18932.

This PR adds `SapJointFrictionConstraint`, a single equation SAP constraint that models load independent dry (Coulomb) friction on one degree of freedom joints. Future PRs will wire it up.

## Model

The constraint velocity is the joint velocity, `vc = eᵢᵀ v`, and the friction impulse is bounded by `γₘₐₓ = δt τ_c`. The ideal maximum dissipation cost `γₘₐₓ |vc|` is not differentiable at `vc = 0`, so, as for friction in `SapFrictionConeConstraint`, it is regularized. The cost is the Huber function

```
ℓ(vc) = vc²/(2R)                if |vc| ≤ R γₘₐₓ   (stiction)
        γₘₐₓ |vc| − R γₘₐₓ²/2   otherwise           (sliding)
```

so the impulse `γ = −∂ℓ/∂vc = clamp(−vc/R, −γₘₐₓ, γₘₐₓ)` is continuous and the Hessian is `1/R` in stiction and zero in sliding. Friction always opposes the constraint velocity and `|γ| ≤ γₘₐₓ`, so the force `γ/δt` is bounded by `τ_c`.

The regularization is `R = σ w`, with `w` the diagonal Delassus approximation for the constraint (an estimate of the inverse effective inertia of the DOF) and `σ` the same dimensionless parameter used for contact friction. During stiction the DOF creeps with a residual velocity bounded by `R γₘₐₓ = σ w δt τ_c`, i.e. `σ` times the velocity change friction alone could produce on the DOF in one step, and under a sustained load `τₐ` below the bound it settles at `σ w δt τₐ`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24920)
<!-- Reviewable:end -->
