### PR TITLE
Avoid unnecessary autodiff calculations in KinematicTrajectoryOptimization PathConstraint.

### DIFF
--- a/planning/trajectory_optimization/kinematic_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/kinematic_trajectory_optimization.cc
@@ -64,22 +64,12 @@ class PathConstraint : public Constraint {
 
   void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
               Eigen::VectorXd* y) const override {
-    AutoDiffVecXd y_t;
-    Eval(InitializeAutoDiff(x), &y_t);
-    *y = ExtractValue(y_t);
+    DoEvalGeneric<double>(x, y);
   }
 
   void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
               AutoDiffVecXd* y) const override {
-    AutoDiffVecXd x_sum = basis_function_values_[0] *
-                          x.segment(0, wrapped_constraint_->num_vars());
-    const int num_terms = basis_function_values_.size();
-    for (int i = 1; i < num_terms; ++i) {
-      x_sum += basis_function_values_[i] *
-               x.segment(i * wrapped_constraint_->num_vars(),
-                         wrapped_constraint_->num_vars());
-    }
-    wrapped_constraint_->Eval(x_sum, y);
+    DoEvalGeneric<AutoDiffXd>(x, y);
   }
 
   void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>&,
@@ -89,6 +79,20 @@ class PathConstraint : public Constraint {
   }
 
  private:
+  template <typename T>
+  void DoEvalGeneric(const Eigen::Ref<const Eigen::VectorX<T>>& x,
+                     Eigen::VectorX<T>* y) const {
+    Eigen::VectorX<T> x_sum = basis_function_values_[0] *
+                              x.segment(0, wrapped_constraint_->num_vars());
+    const int num_terms = basis_function_values_.size();
+    for (int i = 1; i < num_terms; ++i) {
+      x_sum += basis_function_values_[i] *
+               x.segment(i * wrapped_constraint_->num_vars(),
+                         wrapped_constraint_->num_vars());
+    }
+    wrapped_constraint_->Eval(x_sum, y);
+  }
+
   std::shared_ptr<Constraint> wrapped_constraint_;
   std::vector<double> basis_function_values_;
 };

--- a/planning/trajectory_optimization/kinematic_trajectory_optimization.cc
+++ b/planning/trajectory_optimization/kinematic_trajectory_optimization.cc
@@ -82,14 +82,16 @@ class PathConstraint : public Constraint {
   template <typename T>
   void DoEvalGeneric(const Eigen::Ref<const Eigen::VectorX<T>>& x,
                      Eigen::VectorX<T>* y) const {
-    Eigen::VectorX<T> x_sum = basis_function_values_[0] *
-                              x.segment(0, wrapped_constraint_->num_vars());
-    const int num_terms = basis_function_values_.size();
-    for (int i = 1; i < num_terms; ++i) {
-      x_sum += basis_function_values_[i] *
-               x.segment(i * wrapped_constraint_->num_vars(),
-                         wrapped_constraint_->num_vars());
-    }
+    const Eigen::Index n = wrapped_constraint_->num_vars();
+    const Eigen::Index num_terms = basis_function_values_.size();
+    // Eigen::Ref of a vector type has a compile-time inner stride of one, so
+    // x's coefficients are contiguous and can be mapped as a matrix whose
+    // columns are the control points that the path point interpolates.
+    const Eigen::Map<const Eigen::MatrixX<T>> X(x.data(), n, num_terms);
+    const Eigen::Map<const Eigen::VectorXd> b(basis_function_values_.data(),
+                                              num_terms);
+    // An explicit cast is needed for MatrixX<AutoDiffXd> * VectorX<double>.
+    const Eigen::VectorX<T> x_sum = X * b.cast<T>();
     wrapped_constraint_->Eval(x_sum, y);
   }
 


### PR DESCRIPTION
Right now, to evaluate the _value_ of a path constraint, the method converts it to an autodiff type, computes the value and gradient, and then extracts the value. If the path constraint is complex, then this can be a significant runtime cost.

As a side note, there's nothing preventing us from enabling symbolic support for this constraint, since it's just batching down into the wrapped constraint anyway. Should we include that support here or in a different PR (or drop it altogether)?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24921)
<!-- Reviewable:end -->
