### PR TITLE
[wheel] Split up test image provisioning

### DIFF
--- a/tools/wheel/test/Dockerfile
+++ b/tools/wheel/test/Dockerfile
@@ -1,10 +1,24 @@
 ARG PLATFORM=ubuntu:24.04
 
-FROM ${PLATFORM}
+# -----------------------------------------------------------------------------
+# Create a base provisioned image.
+# -----------------------------------------------------------------------------
+
+FROM ${PLATFORM} AS base
+
+ADD provision-base.sh /image/
+
+RUN /image/provision-base.sh
+
+# -----------------------------------------------------------------------------
+# Provision the requested Python version.
+# -----------------------------------------------------------------------------
+
+FROM base AS python
 
 ARG PYTHON=3
 ARG PYTHON_MANAGER=pip
 
-ADD provision.sh /image/
+ADD provision-python.sh /image/
 
-RUN /image/provision.sh ${PYTHON} ${PYTHON_MANAGER}
+RUN /image/provision-python.sh ${PYTHON} ${PYTHON_MANAGER}

--- a/tools/wheel/test/provision-base.sh
+++ b/tools/wheel/test/provision-base.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Internal script to prepare a bare Docker image to be provisioned for testing
+# a Drake wheel.
+
+set -eu -o pipefail
+
+. /etc/os-release
+
+case "${ID}" in
+  ubuntu)
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get -y update
+    # Install system prerequisites required by Drake's wheel, only on Ubuntu.
+    apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
+
+    # Install uv and its prerequisites (even under test configurations in which
+    # it's not strictly needed, for image caching).
+    apt-get -y install --no-install-recommends \
+      ca-certificates gzip tar wget
+    wget -qO- https://astral.sh/uv/install.sh | sh
+    ;;
+  amzn)
+    dnf update -y
+    # N.B. AL2023 provides all the Python versions we need via dnf, so we
+    # don't need, nor support, uv here, and we install a specific version of
+    # Python in provision-python.sh.
+    ;;
+  *)
+    echo "Unsupported distro '${ID}'" >&2
+    exit 1
+    ;;
+esac

--- a/tools/wheel/test/provision-python.sh
+++ b/tools/wheel/test/provision-python.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# Internal script to provision a bare Docker image for testing a Drake wheel.
+# Internal script to provision a Python virtual environment inside an
+# otherwise already-provisioned Docker image.
 
 set -eu -o pipefail
 
@@ -15,22 +16,13 @@ readonly VENV="/tmp/drake-wheel-test/python"
 case "${ID}" in
   ubuntu)
     export DEBIAN_FRONTEND=noninteractive
-    apt-get -y update
-    # Install system prerequisites required by Drake's wheel, only on Ubuntu.
-    apt-get -y install --no-install-recommends libx11-6 libsm6 libglib2.0-0t64
-
-    # Install Python and set up the virtual environment.
     case "${PYTHON_MANAGER}" in
       pip)
         apt-get -y install --no-install-recommends \
-          lib${PYTHON}-dev ${PYTHON}-venv \
-          python3-venv
+          lib${PYTHON}-dev ${PYTHON}-venv
         ${PYTHON} -m venv ${VENV}
         ;;
       uv)
-        apt-get -y install --no-install-recommends \
-          ca-certificates gzip tar wget
-        wget -qO- https://astral.sh/uv/install.sh | sh
         ${HOME}/.local/bin/uv venv ${VENV} --python ${PYTHON_VERSION}
         ;;
       *)
@@ -40,9 +32,6 @@ case "${ID}" in
     esac
     ;;
   amzn)
-    dnf update -y
-
-    # Install Python and set up the virtual environment.
     case "${PYTHON_MANAGER}" in
       pip)
         dnf install -y ${PYTHON}

--- a/tools/wheel/wheel_builder/linux.py
+++ b/tools/wheel/wheel_builder/linux.py
@@ -248,24 +248,21 @@ def _test_tagname(test_case: TestCase, tag_prefix: str) -> str:
     Generates a Docker tag name for a test-role TestCase and tag prefix.
     """
     platform = test_case.platform.alias
-    manager = test_case.python_manager.value
+    python_manager = test_case.python_manager.value
     python_tag = test_case.python.tag
-    return f"{TAG_BASE}:{tag_prefix}-{platform}-py{python_tag}-{manager}"
+    return f"{TAG_BASE}:{tag_prefix}-{platform}-py{python_tag}-{python_manager}"
 
 
 def _build_stage(target, args, tag_prefix, stage=None):
     """
-    Runs a Docker build and return the build tag.
+    Runs a Docker build and returns the build tag.
     """
 
     # Generate canonical tag from target.
     tag = _build_tagname(target, tag_prefix)
 
     # Generate extra arguments to specify what stage to build.
-    if stage is not None:
-        extra = ["--target", stage]
-    else:
-        extra = []
+    extra = [] if stage is None else ["--target", stage]
 
     # Run the build.
     print("[-] Build", tag, extra + args)
@@ -319,6 +316,7 @@ def _build_image(target, identifier, version, options):
     if options.tag_stages:
         # Inspect Dockerfile, find stages, and build them.
         dockerfile = os.path.join(resource_root, "Dockerfile")
+        tag = None
         with open(dockerfile, encoding="utf-8") as f:
             for line in f:
                 if line.startswith("FROM"):
@@ -326,6 +324,7 @@ def _build_image(target, identifier, version, options):
                     tag = _build_stage(
                         target, args, tag_prefix=stage, stage=stage
                     )
+        assert tag is not None, f"No named stages found in {dockerfile}"
     else:
         tag = _build_stage(target, args, tag_prefix=identifier)
         _images_to_remove.add(tag)


### PR DESCRIPTION
Split the provisioning of a test image into two stages, where we save everything not strictly Python-related until the latter stage. Under `--tag-stages` we track the tags used during the build; otherwise, we rely on Docker's caching of each stage.

Closes #24854.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24925)
<!-- Reviewable:end -->
