### PR TITLE
Allow not-officially-supported ubuntu derivatives to run setup script.

### DIFF
--- a/setup/install_prereqs.py
+++ b/setup/install_prereqs.py
@@ -78,9 +78,24 @@ def _workspace_dir() -> Path:
 
 @functools.cache
 def _os_distribution() -> str | None:
-    """Returns the distribution ID, e.g., "ubuntu"."""
+    """Returns the distribution ID, e.g., "ubuntu". Derivative distributions
+    that declare "ubuntu" in their ID_LIKE (e.g., TUXEDO OS) are reported as
+    "ubuntu", since they use the same package names and codenames."""
     if platform.system() == "Linux":
-        return platform.freedesktop_os_release()["ID"]
+        os_release = platform.freedesktop_os_release()
+        if (
+            os_release["ID"] != "ubuntu"
+            and "ubuntu" in os_release.get("ID_LIKE", "").split()
+        ):
+            description = os_release.get("PRETTY_NAME", os_release["ID"])
+            _warn(f"""
+                This computer is running {description}, which is an Ubuntu
+                derivative rather than Ubuntu itself. Drake is not officially
+                supported on Ubuntu derivatives, so you may experience
+                compatibility issues.
+            """)
+            return "ubuntu"
+        return os_release["ID"]
     raise NotImplementedError(platform.system())
 
 


### PR DESCRIPTION
Some Linux distributions are Ubuntu under the hood, but report another distribution name (e.g. Tuxedo OS, PopOS, Linux Mint). Drake used to allow users of such distributions to run the setup scripts (issue #18530, PR #18680), but this appears to have regressed at some point (likely PR #24906). This PR restores that functionality via the `ID_LIKE` field in `/etc/os-release`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24926)
<!-- Reviewable:end -->
