### PR TITLE
[multibody] Throw on mixed rigid/deformable body name collisions

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -1100,8 +1100,8 @@ Raises:
     RuntimeError if the model instance does not exist.
 
 Raises:
-    RuntimeError if a deformable body with the same name has already
-    been registered to the model instance.
+    RuntimeError if a deformable body or rigid body with the same name
+    has already been registered to the model instance.
 
 Raises:
     RuntimeError if Finalize() has been called on the multibody plant
@@ -2939,9 +2939,9 @@ Example of usage:
 
 Parameter ``name``:
     A string that identifies the new body to be added to ``this``
-    model. A RuntimeError is thrown if a body named ``name`` already
-    is part of ``model_instance``. See HasBodyNamed(),
-    RigidBody∷name().
+    model. A RuntimeError is thrown if a rigid or deformable body
+    named ``name`` already is part of ``model_instance``. See
+    HasBodyNamed(), RigidBody∷name().
 
 Parameter ``model_instance``:
     A model instance index which this body is part of.
@@ -2983,9 +2983,9 @@ Example of usage:
 
 Parameter ``name``:
     A string that identifies the new body to be added to ``this``
-    model. A RuntimeError is thrown if a body named ``name`` already
-    is part of the model in the default model instance. See
-    HasBodyNamed(), RigidBody∷name().
+    model. A RuntimeError is thrown if a rigid or deformable body
+    named ``name`` already is part of the model in the default model
+    instance. See HasBodyNamed(), RigidBody∷name().
 
 Parameter ``M_BBo_B``:
     The SpatialInertia of the new rigid body to be added to ``this``

--- a/multibody/parsing/detail_collision_filter_group_resolver.cc
+++ b/multibody/parsing/detail_collision_filter_group_resolver.cc
@@ -62,9 +62,7 @@ void CollisionFilterGroupResolver::AddGroup(
     const ScopedName scoped_body_name =
         ScopedName::Parse(FullyQualify(body_name, model_instance));
 
-    // The body name may refer to a rigid body or a deformable body. If the same
-    // scoped name exists as rigid and deformable in the model, then this code
-    // simply selects the rigid body.
+    // The body name may refer to a rigid body or a deformable body.
     const RigidBody<double>* body{};
     const DeformableBody<double>* deformable_body{};
     if (plant_->HasModelInstanceNamed(scoped_body_name.get_namespace())) {
@@ -77,17 +75,13 @@ void CollisionFilterGroupResolver::AddGroup(
         continue;
       }
       body = FindBody(scoped_body_name.get_element(), body_model);
-      deformable_body = FindDeformableBody(
-          std::string(scoped_body_name.get_element()), body_model);
+      if (!body) {
+        deformable_body = FindDeformableBody(
+            std::string(scoped_body_name.get_element()), body_model);
+      }
     }
 
-    if (body && deformable_body) {
-      diagnostic.Error(
-          fmt::format("body name '{}' is ambiguous, refers to both a rigid and "
-                      "deformable body",
-                      scoped_body_name));
-      continue;
-    } else if (!body && !deformable_body) {
+    if (!body && !deformable_body) {
       diagnostic.Error(
           fmt::format("body with name '{}' not found", scoped_body_name));
       continue;

--- a/multibody/parsing/detail_collision_filter_group_resolver.h
+++ b/multibody/parsing/detail_collision_filter_group_resolver.h
@@ -72,8 +72,8 @@ class CollisionFilterGroupResolver {
   }
 
   // Adds a collision filter group. Locates bodies by name immediately, and
-  // emits errors for illegal or ambiguous names, empty groups, missing bodies,
-  // or duplicate group definition attempts.
+  // emits errors for illegal names, empty groups, missing bodies, or duplicate
+  // group definition attempts.
   //
   // @param diagnostic          The error-reporting channel.
   // @param group_name          The name of the group being defined.

--- a/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
+++ b/multibody/parsing/test/detail_collision_filter_group_resolver_test.cc
@@ -1,9 +1,7 @@
 #include "drake/multibody/parsing/detail_collision_filter_group_resolver.h"
 
-#include <memory>
 #include <set>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -21,9 +19,7 @@ namespace {
 using ::testing::MatchesRegex;
 
 using geometry::GeometryId;
-using geometry::GeometryInstance;
 using geometry::SceneGraph;
-using geometry::Sphere;
 using math::RigidTransformd;
 
 class CollisionFilterGroupResolverTest : public test::DiagnosticPolicyTestBase {
@@ -171,28 +167,6 @@ TEST_F(CollisionFilterGroupResolverTest, MissingMemberGroupScoped) {
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::agroup'.*not found"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::sub::agroup'.*not found"));
   EXPECT_THAT(TakeError(), MatchesRegex(".*'r1::zzz::agroup'.*not found"));
-}
-
-TEST_F(CollisionFilterGroupResolverTest, AmbiguousRigidAndDeformableName) {
-  ModelInstanceIndex model = plant_.AddModelInstance("amodel");
-
-  // Add a rigid body to the model.
-  AddBody("abody", model);
-
-  // Add a deformable body to the model with the same name.
-  auto& deformable_model = plant_.mutable_deformable_model();
-  auto sphere = std::make_unique<GeometryInstance>(
-      math::RigidTransformd::Identity(), std::make_unique<Sphere>(1.0),
-      "abody");
-  deformable_model.RegisterDeformableBody(std::move(sphere), model,
-                                          /*config=*/{},
-                                          /*resolution_hint=*/2.0);
-
-  // Ensure that the resolver catches the ambiguous name in the group body
-  // names.
-  resolver_.AddGroup(diagnostic_policy_, "a", {"abody"}, {}, model);
-  EXPECT_THAT(TakeError(),
-              MatchesRegex(".*body.*'amodel::abody'.*is ambiguous.*"));
 }
 
 TEST_F(CollisionFilterGroupResolverTest, GroupGlobalBodies) {

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -63,6 +63,14 @@ DeformableBodyId DeformableModel<T>::RegisterDeformableBody(
           "given model.",
           model_instance_name, name));
     }
+    if (this->plant().HasBodyNamed(name, model_instance)) {
+      const std::string& model_instance_name =
+          this->plant().GetModelInstanceName(model_instance);
+      throw std::logic_error(fmt::format(
+          "RegisterDeformableBody(): Model instance '{}' already contains a "
+          "body named '{}'. Body names must be unique within a given model.",
+          model_instance_name, name));
+    }
     /* Register the geometry with SceneGraph. */
     SceneGraph<T>& scene_graph = this->mutable_scene_graph();
     const ScopedName scoped_name(

--- a/multibody/plant/deformable_model.cc
+++ b/multibody/plant/deformable_model.cc
@@ -68,7 +68,8 @@ DeformableBodyId DeformableModel<T>::RegisterDeformableBody(
           this->plant().GetModelInstanceName(model_instance);
       throw std::logic_error(fmt::format(
           "RegisterDeformableBody(): Model instance '{}' already contains a "
-          "body named '{}'. Body names must be unique within a given model.",
+          "rigid body named '{}'. Body names must be unique within a given "
+          "model.",
           model_instance_name, name));
     }
     /* Register the geometry with SceneGraph. */

--- a/multibody/plant/deformable_model.h
+++ b/multibody/plant/deformable_model.h
@@ -91,8 +91,8 @@ class DeformableModel final : public multibody::PhysicalModel<T> {
    @throws std::exception if `this` %DeformableModel belongs to a continuous
    MultibodyPlant.
    @throws std::exception if the model instance does not exist.
-   @throws std::exception if a deformable body with the same name has already
-   been registered to the model instance.
+   @throws std::exception if a deformable body or rigid body with the same name
+   has already been registered to the model instance.
    @throws std::exception if Finalize() has been called on the multibody plant
    owning this deformable model. */
   DeformableBodyId RegisterDeformableBody(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -14,6 +14,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_export.h"
 #include "drake/common/random.h"
@@ -1429,8 +1431,9 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   ///
   /// @param[in] name
   ///   A string that identifies the new body to be added to `this` model. A
-  ///   std::runtime_error is thrown if a body named `name` already is part of
-  ///   @p model_instance. See HasBodyNamed(), RigidBody::name().
+  ///   std::logic_error is thrown if a rigid or deformable body named `name`
+  ///   already is part of @p model_instance. See HasBodyNamed(),
+  ///   RigidBody::name().
   /// @param[in] model_instance
   ///   A model instance index which this body is part of.
   /// @param[in] M_BBo_B
@@ -1443,6 +1446,14 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
       const std::string& name, ModelInstanceIndex model_instance,
       const SpatialInertia<double>& M_BBo_B = SpatialInertia<double>::Zero()) {
     DRAKE_MBP_THROW_IF_FINALIZED();
+    // Body names must be unique within a model instance across both rigid and
+    // deformable bodies.
+    if (deformable_model().HasBodyNamed(name, model_instance)) {
+      throw std::logic_error(fmt::format(
+          "Model instance '{}' already contains a body named '{}'. Body names "
+          "must be unique within a given model.",
+          GetModelInstanceName(model_instance), name));
+    }
     // Add the actual RigidBody (Link) to the model.
     const RigidBody<T>& body =
         this->mutable_tree().AddLink(name, model_instance, M_BBo_B);
@@ -1475,9 +1486,9 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   ///
   /// @param[in] name
   ///   A string that identifies the new body to be added to `this` model. A
-  ///   std::runtime_error is thrown if a body named `name` already is part of
-  ///   the model in the default model instance. See HasBodyNamed(),
-  ///   RigidBody::name().
+  ///   std::logic_error is thrown if a rigid or deformable body named `name`
+  ///   already is part of the model in the default model instance. See
+  ///   HasBodyNamed(), RigidBody::name().
   /// @param[in] M_BBo_B
   ///   The SpatialInertia of the new rigid body to be added to `this`
   ///   %MultibodyPlant, computed about the body frame origin `Bo` and expressed

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1450,8 +1450,8 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
     // deformable bodies.
     if (deformable_model().HasBodyNamed(name, model_instance)) {
       throw std::logic_error(fmt::format(
-          "Model instance '{}' already contains a body named '{}'. Body names "
-          "must be unique within a given model.",
+          "Model instance '{}' already contains a deformable body named '{}'. "
+          "Body names must be unique within a given model.",
           GetModelInstanceName(model_instance), name));
     }
     // Add the actual RigidBody (Link) to the model.

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -914,6 +914,34 @@ TEST_F(DeformableModelTest, DuplicatedNames) {
   EXPECT_EQ(body1.body_id(), body1_id);
 }
 
+/* Rigid and deformable bodies must not share a name within a model instance. */
+TEST_F(DeformableModelTest, ConflictingRigidAndDeformableNames) {
+  const double kRezHint = 0.5;
+  const ModelInstanceIndex instance0 = plant_->AddModelInstance("instance0");
+  const ModelInstanceIndex instance1 = plant_->AddModelInstance("instance1");
+
+  /* Rigid then deformable with the same name in one model instance throws. */
+  plant_->AddRigidBody("sphere", instance0,
+                       SpatialInertia<double>::MakeUnitary());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      RegisterSphere(deformable_model_ptr_, kRezHint, RigidTransformd{},
+                     instance0),
+      ".*instance0.*already contains a body named 'sphere'.*");
+
+  /* Deformable then rigid with the same name in one model instance throws. */
+  RegisterSphere(deformable_model_ptr_, kRezHint, RigidTransformd{},
+                 instance1);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_->AddRigidBody("sphere", instance1,
+                           SpatialInertia<double>::MakeUnitary()),
+      ".*instance1.*already contains a body named 'sphere'.*");
+
+  /* The same name is allowed across different model instances. */
+  EXPECT_NO_THROW(plant_->AddRigidBody(
+      "sphere", plant_->AddModelInstance("instance2"),
+      SpatialInertia<double>::MakeUnitary()));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/test/deformable_model_test.cc
+++ b/multibody/plant/test/deformable_model_test.cc
@@ -926,20 +926,19 @@ TEST_F(DeformableModelTest, ConflictingRigidAndDeformableNames) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       RegisterSphere(deformable_model_ptr_, kRezHint, RigidTransformd{},
                      instance0),
-      ".*instance0.*already contains a body named 'sphere'.*");
+      ".*instance0.*already contains a rigid body named 'sphere'.*");
 
   /* Deformable then rigid with the same name in one model instance throws. */
-  RegisterSphere(deformable_model_ptr_, kRezHint, RigidTransformd{},
-                 instance1);
+  RegisterSphere(deformable_model_ptr_, kRezHint, RigidTransformd{}, instance1);
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_->AddRigidBody("sphere", instance1,
                            SpatialInertia<double>::MakeUnitary()),
-      ".*instance1.*already contains a body named 'sphere'.*");
+      ".*instance1.*already contains a deformable body named 'sphere'.*");
 
   /* The same name is allowed across different model instances. */
-  EXPECT_NO_THROW(plant_->AddRigidBody(
-      "sphere", plant_->AddModelInstance("instance2"),
-      SpatialInertia<double>::MakeUnitary()));
+  EXPECT_NO_THROW(plant_->AddRigidBody("sphere",
+                                       plant_->AddModelInstance("instance2"),
+                                       SpatialInertia<double>::MakeUnitary()));
 }
 
 }  // namespace


### PR DESCRIPTION
Body names must be unique within a model instance across both rigid and deformable bodies. Previously only same-type duplicates were rejected, leaving collision-filter and name lookup ambiguous for mixed types.

Fixes #23257.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24933)
<!-- Reviewable:end -->
