### PR TITLE
[multibody] Throw if CalcSpatialInertia frame is not in the plant

### DIFF
--- a/bindings/generated_docstrings/multibody_plant.h
+++ b/bindings/generated_docstrings/multibody_plant.h
@@ -4529,6 +4529,9 @@ Parameter ``body_indexes``:
     welded bodies, joint-connected bodies, etc.
 
 Raises:
+    RuntimeError if ``frame_F`` does not belong to ``this`` plant.
+
+Raises:
     RuntimeError if body_indexes contains an invalid BodyIndex or if
     there is a repeated BodyIndex.
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4165,6 +4165,7 @@ class MultibodyPlant final : public internal::MultibodyTreeSystem<T> {
   ///  the expressed-in frame for the returned spatial inertia.
   /// @param[in] body_indexes Array of selected bodies.  This method does not
   ///  distinguish between welded bodies, joint-connected bodies, etc.
+  /// @throws std::exception if `frame_F` does not belong to `this` plant.
   /// @throws std::exception if body_indexes contains an invalid BodyIndex or
   ///  if there is a repeated BodyIndex.
   /// @note The mass and inertia of the world_body() does not contribute to the

--- a/multibody/plant/test/fused_welds_test.cc
+++ b/multibody/plant/test/fused_welds_test.cc
@@ -373,7 +373,9 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
   const TestModel fused_model = MakeModel(true);
 
   const double m = 1.0, a = 0.1;  // mass m and side-length a of solid cubes.
+  // Each plant must be queried with a frame it owns (see #22636).
   const Frame<double>& world_frame = unfused_model.plant->world_frame();
+  const Frame<double>& fused_world_frame = fused_model.plant->world_frame();
   const RigidBody<double>* unfused_links[] = {
       unfused_model.link1, unfused_model.link2, unfused_model.link3,
       unfused_model.link4};
@@ -396,7 +398,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
         {unfused_model.link1->index(), unfused_model.link2->index(),
          unfused_model.link3->index()});
     SpatialInertia<double> M_FWo_W = fused_model.plant->CalcSpatialInertia(
-        *fused_model.context, world_frame,
+        *fused_model.context, fused_world_frame,
         {fused_model.link1->index(), fused_model.link2->index(),
          fused_model.link3->index()});
     EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
@@ -438,7 +440,7 @@ GTEST_TEST(FusedTest, CompositeSpatialInertia) {
       M_UWo_W = unfused_model.plant->CalcSpatialInertia(
           *unfused_model.context, world_frame, {unfused_linki->index()});
       M_FWo_W = fused_model.plant->CalcSpatialInertia(
-          *fused_model.context, world_frame, {fused_linki->index()});
+          *fused_model.context, fused_world_frame, {fused_linki->index()});
       EXPECT_TRUE(CompareMatrices(M_UWo_W.CopyToFullMatrix6(),
                                   M_FWo_W.CopyToFullMatrix6(), kTolerance,
                                   MatrixCompareType::relative));

--- a/multibody/plant/test/multibody_plant_momentum_energy_test.cc
+++ b/multibody/plant/test/multibody_plant_momentum_energy_test.cc
@@ -7,6 +7,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/fixed_offset_frame.h"
 #include "drake/multibody/tree/multibody_tree_indexes.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/rigid_body.h"
@@ -335,6 +336,14 @@ TEST_F(TwoDofPlanarPendulumTest, CalcSpatialInertia) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcSpatialInertia(*context_, frame_A, body_indexes),
       "CalcSpatialInertia\\(\\): contains a repeated BodyIndex.*");
+
+  // Verify an exception is thrown if frame_F was never added to the plant
+  // (regression test for #22636).
+  const FixedOffsetFrame<double> orphan_frame("orphan_frame", frame_A,
+                                              math::RigidTransformd());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcSpatialInertia(*context_, orphan_frame, {body_A.index()}),
+      ".*does not belong to the supplied MultibodyTree.*");
 }
 
 }  // namespace

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2634,6 +2634,9 @@ template <typename T>
 SpatialInertia<T> MultibodyTree<T>::CalcSpatialInertia(
     const systems::Context<T>& context, const Frame<T>& frame_F,
     const std::vector<LinkIndex>& link_indexes) const {
+  // Ensure frame_F belongs to this tree; otherwise pose queries can segfault.
+  frame_F.HasThisParentTreeOrThrow(this);
+
   // Check if there are repeated LinkIndex in link_indexes by converting the
   // vector to a set (to eliminate duplicates) and see if their sizes differ.
   const std::set<LinkIndex> without_duplicate_bodies(link_indexes.begin(),


### PR DESCRIPTION
Validate that frame_F belongs to this MultibodyTree before computing spatial inertia, so an unowned FixedOffsetFrame throws instead of segfaulting.

Fixes #22636.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24934)
<!-- Reviewable:end -->
