### PR TITLE
[common] Add {:r} repr formatter for TypeSafeIndex and Identifier

### DIFF
--- a/bindings/generated_docstrings/common.h
+++ b/bindings/generated_docstrings/common.h
@@ -800,6 +800,14 @@ decouples details of implementation from the idea of the object.
 Combined with its immutability, it would serve well as a element of a
 public API.
 
+**Formatting**
+
+Identifiers may be formatted with ``fmt`` (e.g., ``fmt∷format``,
+`fmt∷to_string`). The default format (``{}``) prints the underlying
+integer. The ``{:r:}`` (repr) format prints a typed representation
+that includes the identifier type name, e.g., ``FooId(1)``. Further
+specs after ``r:`` are applied to that string (e.g., ``{:r:>10}``).
+
 See also:
     TypeSafeIndex
 
@@ -2344,6 +2352,14 @@ conversion:
     </details>
 
 TODO(#15354) We hope to fix this irregularity in the future.
+
+**Formatting**
+
+Indices may be formatted with ``fmt`` (e.g., ``fmt∷format``,
+`fmt∷to_string`). The default format (``{}``) prints the underlying
+integer. The ``{:r:}`` (repr) format prints a typed representation
+that includes the index type name, e.g., ``FooIndex(0)``. Further
+specs after ``r:`` are applied to that string (e.g., ``{:r:>10}``).
 
 See also:
     drake∷geometry∷Identifier

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -299,6 +299,7 @@ drake_cc_library(
     deps = [
         ":essential",
         ":hash",
+        ":nice_type_name",
     ],
 )
 
@@ -1110,6 +1111,7 @@ drake_cc_googletest(
         ":identifier",
         ":nice_type_name",
         ":nice_type_name_override_header",
+        ":type_safe_index",
     ],
 )
 

--- a/common/identifier.h
+++ b/common/identifier.h
@@ -2,12 +2,14 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/fmt.h"
 #include "drake/common/hash.h"
+#include "drake/common/nice_type_name.h"
 
 namespace drake {
 
@@ -132,6 +134,14 @@ int64_t get_new_identifier();
  of the object. Combined with its immutability, it would serve well as a element
  of a public API.
 
+ __Formatting__
+
+ Identifiers may be formatted with `fmt` (e.g., `fmt::format`,
+ `fmt::to_string`). The default format (`{}`) prints the underlying integer.
+ The `{:r:}` (repr) format prints a typed representation that includes the
+ identifier type name, e.g., `FooId(1)`. Further specs after `r:` are
+ applied to that string (e.g., `{:r:>10}`).
+
  @sa TypeSafeIndex
 
  @tparam Tag              The name of the tag that uniquely segregates one
@@ -247,4 +257,50 @@ struct hash<drake::Identifier<Tag>> : public drake::DefaultHash {};
 
 }  // namespace std
 
-DRAKE_FORMATTER_AS(typename Tag, drake, Identifier<Tag>, x, drake::to_string(x))
+// Provide fmt support where "{}" is the underlying integer and "{:r:}" is a
+// typed representation such as "FooId(1)". After the "r:" prefix, any remaining
+// format spec is applied to that representation string (e.g., "{:r:>10}").
+namespace fmt {
+template <typename Tag>
+struct formatter<drake::Identifier<Tag>> {
+  template <typename FormatParseContext>
+  constexpr auto parse(FormatParseContext& ctx) {
+    auto it = ctx.begin();
+    if (it != ctx.end() && *it != '}') {
+      if (*it == 'r') {
+        ++it;
+        if (it == ctx.end() || *it != ':') {
+          throw format_error(
+              "Invalid format specifier for Identifier; use {} or {:r:}.");
+        }
+        ++it;
+        repr = true;
+        ctx.advance_to(it);
+        return repr_formatter.parse(ctx);
+      }
+      throw format_error(
+          "Invalid format specifier for Identifier; use {} or {:r:}.");
+    }
+    return it;
+  }
+
+  template <typename FormatContext>
+  auto format(const drake::Identifier<Tag>& id,
+              // NOLINTNEXTLINE(runtime/references) To match fmt API.
+              FormatContext& ctx) const {
+    if (repr) {
+      const auto text =
+          fmt::format("{}({})",
+                      drake::NiceTypeName::RemoveNamespaces(
+                          drake::NiceTypeName::Get<drake::Identifier<Tag>>()),
+                      id.get_value());
+      return repr_formatter.format(text, ctx);
+    }
+    return fmt::format_to(ctx.out(), "{}", id.get_value());
+  }
+
+ private:
+  bool repr{false};
+  formatter<std::string_view> repr_formatter;
+};
+}  // namespace fmt

--- a/common/nice_type_name.cc
+++ b/common/nice_type_name.cc
@@ -96,6 +96,11 @@ string NiceTypeName::Canonicalize(const string& demangled) {
       // Change e.g., "drake::Identifier<drake::package::FooTag>" to
       // "drake::package::FooId".
       SPair(std::regex("\\bdrake::Identifier<([^>]*)Tag>"), "$1Id"),
+
+      // Recognize TypeSafeIndex ...
+      // Change e.g., "drake::TypeSafeIndex<drake::package::FooTag>" to
+      // "drake::package::FooIndex".
+      SPair(std::regex("\\bdrake::TypeSafeIndex<([^>]*)Tag>"), "$1Index"),
   }};
 
   string canonical(demangled);

--- a/common/test/identifier_test.cc
+++ b/common/test/identifier_test.cc
@@ -184,6 +184,20 @@ TEST_F(IdentifierTests, PutInSet) {
 
 TEST_F(IdentifierTests, FmtFormatterProducesExpectedString) {
   EXPECT_EQ(fmt::to_string(a2_), "2");
+  EXPECT_EQ(fmt::format("{}", a2_), "2");
+}
+
+TEST_F(IdentifierTests, FmtFormatterRepr) {
+  EXPECT_EQ(fmt::format("{:r:}", a2_), "AId(2)");
+  EXPECT_EQ(fmt::format("The given {:r:} is out of bounds", a2_),
+            "The given AId(2) is out of bounds");
+  EXPECT_EQ(fmt::format("{:r:>8}", a2_), "  AId(2)");
+
+  if (kDrakeAssertIsArmed) {
+    AId invalid;
+    DRAKE_EXPECT_THROWS_MESSAGE(fmt::format("{:r:}", invalid),
+                                ".*is_valid.*failed.*");
+  }
 }
 
 // Tests the ability to convert the id to string via std::to_string.

--- a/common/test/nice_type_name_test.cc
+++ b/common/test/nice_type_name_test.cc
@@ -12,6 +12,7 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/identifier.h"
 #include "drake/common/nice_type_name_override.h"
+#include "drake/common/type_safe_index.h"
 
 using std::string;
 
@@ -35,6 +36,9 @@ class Derived : public Base {};
 
 // Test the Identifier pattern.
 using AId = Identifier<class ATag>;
+
+// Test the TypeSafeIndex pattern.
+using AIndex = TypeSafeIndex<class ATag>;
 
 // Can't test much of NiceTypeName::Demangle because its behavior is compiler-
 // and platform-specific. Everyone should agree on simple types though.
@@ -150,6 +154,10 @@ GTEST_TEST(NiceTypeNameTest, Enum) {
 
 GTEST_TEST(NiceTypeNameTest, IdentifierTemplate) {
   EXPECT_EQ(NiceTypeName::Get<AId>(), "drake::(anonymous)::AId");
+}
+
+GTEST_TEST(NiceTypeNameTest, TypeSafeIndexTemplate) {
+  EXPECT_EQ(NiceTypeName::Get<AIndex>(), "drake::(anonymous)::AIndex");
 }
 
 // Test the type_info form of NiceTypeName::Get().

--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -341,9 +341,23 @@ GTEST_TEST(TypeSafeIndex, ToString) {
 GTEST_TEST(TypeSafeIndex, ToStringFmtFormatter) {
   AIndex index(87);
   EXPECT_EQ(fmt::to_string(index), "87");
+  EXPECT_EQ(fmt::format("{}", index), "87");
 
   AIndex invalid;
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(fmt::to_string(invalid),
+                                       "Converting to an int.+");
+}
+
+GTEST_TEST(TypeSafeIndex, ToStringFmtFormatterRepr) {
+  // Prefer the Tag naming convention so NiceTypeName can render FooIndex.
+  using FooIndex = TypeSafeIndex<class FooTag>;
+  const FooIndex index(87);
+  EXPECT_EQ(fmt::format("{:r:}", index), "FooIndex(87)");
+  EXPECT_EQ(fmt::format("The given {:r:} is out of bounds", index),
+            "The given FooIndex(87) is out of bounds");
+  EXPECT_EQ(fmt::format("{:r:>13}", index), " FooIndex(87)");
+
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(fmt::format("{:r:}", FooIndex{}),
                                        "Converting to an int.+");
 }
 

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -2,11 +2,13 @@
 
 #include <limits>
 #include <string>
+#include <string_view>
 #include <typeinfo>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/fmt.h"
 #include "drake/common/hash.h"
+#include "drake/common/nice_type_name.h"
 
 namespace drake {
 
@@ -142,6 +144,14 @@ namespace internal {
 ///    some_vector(int{foo_index}) = 0.0;  // Compiles OK.
 /// @endcode
 /// TODO(#15354) We hope to fix this irregularity in the future.
+///
+/// __Formatting__
+///
+/// Indices may be formatted with `fmt` (e.g., `fmt::format`,
+/// `fmt::to_string`). The default format (`{}`) prints the underlying
+/// integer. The `{:r:}` (repr) format prints a typed representation that
+/// includes the index type name, e.g., `FooIndex(0)`. Further specs after
+/// `r:` are applied to that string (e.g., `{:r:>10}`).
 ///
 /// @sa drake::geometry::Identifier
 ///
@@ -578,5 +588,51 @@ template <typename Tag>
 struct hash<drake::TypeSafeIndex<Tag>> : public drake::DefaultHash {};
 }  // namespace std
 
-DRAKE_FORMATTER_AS(typename Tag, drake, TypeSafeIndex<Tag>, x,
-                   std::to_string(int{x}))
+// Provide fmt support where "{}" is the underlying integer and "{:r:}" is a
+// typed representation such as "FooIndex(0)". After the "r:" prefix, any
+// remaining format spec is applied to that representation string (e.g.,
+// "{:r:>10}").
+namespace fmt {
+template <typename Tag>
+struct formatter<drake::TypeSafeIndex<Tag>> {
+  template <typename FormatParseContext>
+  constexpr auto parse(FormatParseContext& ctx) {
+    auto it = ctx.begin();
+    if (it != ctx.end() && *it != '}') {
+      if (*it == 'r') {
+        ++it;
+        if (it == ctx.end() || *it != ':') {
+          throw format_error(
+              "Invalid format specifier for TypeSafeIndex; use {} or {:r:}.");
+        }
+        ++it;
+        repr = true;
+        ctx.advance_to(it);
+        return repr_formatter.parse(ctx);
+      }
+      throw format_error(
+          "Invalid format specifier for TypeSafeIndex; use {} or {:r:}.");
+    }
+    return it;
+  }
+
+  template <typename FormatContext>
+  auto format(const drake::TypeSafeIndex<Tag>& index,
+              // NOLINTNEXTLINE(runtime/references) To match fmt API.
+              FormatContext& ctx) const {
+    if (repr) {
+      const auto text = fmt::format(
+          "{}({})",
+          drake::NiceTypeName::RemoveNamespaces(
+              drake::NiceTypeName::Get<drake::TypeSafeIndex<Tag>>()),
+          int{index});
+      return repr_formatter.format(text, ctx);
+    }
+    return fmt::format_to(ctx.out(), "{}", int{index});
+  }
+
+ private:
+  bool repr{false};
+  formatter<std::string_view> repr_formatter;
+};
+}  // namespace fmt

--- a/multibody/tree/element_collection.cc
+++ b/multibody/tree/element_collection.cc
@@ -7,7 +7,6 @@
 #include <fmt/format.h>
 
 #include "drake/common/nice_type_name.h"
-#include "drake/common/unused.h"
 #include "drake/multibody/tree/deformable_body.h"
 #include "drake/multibody/tree/joint.h"
 #include "drake/multibody/tree/joint_actuator.h"
@@ -127,33 +126,25 @@ void ElementCollection<T, Element, Index>::AppendNull() {
   elements_by_index_.push_back(nullptr);
 }
 
-namespace {
-std::string RemoveTemplates(std::string type_name) {
-  const auto offset = type_name.find('<');
-  DRAKE_DEMAND(offset != std::string::npos);
-  type_name.erase(offset);
-  return type_name;
-}
-}  // namespace
-
 template <typename T, template <typename> class Element, typename Index>
 void ElementCollection<T, Element, Index>::ThrowInvalidIndexException(
     Index index) const {
-  const std::string nice_type = RemoveTemplates(
-      NiceTypeName::RemoveNamespaces(NiceTypeName::Get<Element<T>>()));
   if (!index.is_valid()) {
+    // Invalid indices cannot be formatted with {:r:} (value conversion
+    // asserts), so render the type name alone.
+    const std::string index_type =
+        NiceTypeName::RemoveNamespaces(NiceTypeName::Get<Index>());
     throw std::logic_error(fmt::format(
-        "The given default-constructed {}Index() cannot be used. You must "
+        "The given default-constructed {}() cannot be used. You must "
         "pass a valid integer as the index.",
-        nice_type));
+        index_type));
   }
   if (index >= next_index()) {
-    throw std::logic_error(fmt::format(
-        "The given {}Index({}) is out of bounds (must be less than {})",
-        nice_type, index, next_index()));
+    throw std::logic_error(
+        fmt::format("The given {:r:} is out of bounds (must be less than {})",
+                    index, next_index()));
   }
-  throw std::logic_error(
-      fmt::format("The {}Index({}) has been removed", nice_type, index));
+  throw std::logic_error(fmt::format("The {:r:} has been removed", index));
 }
 
 using symbolic::Expression;


### PR DESCRIPTION
Default fmt output remains the bare integer. The new {:r} specifier prints a typed representation (e.g. FooIndex(0), FooId(1)) using NiceTypeName. Also teach NiceTypeName to canonicalize TypeSafeIndex the same way it already does for Identifier.

Fixes #24262.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24936)
<!-- Reviewable:end -->
