### PR TITLE
[framework] Vestigialize SingleOutputVectorSource

### DIFF
--- a/bindings/generated_docstrings/systems_framework.h
+++ b/bindings/generated_docstrings/systems_framework.h
@@ -7843,8 +7843,9 @@ protected method
 
 Warning:
     This class is not useful anymore and is to be deprecated. Prefer
-    deriving from LeafSystem directly. Declaring a single vector-valued
-    output port with LeafSystem requires only a few lines of code.)""";
+    deriving from LeafSystem directly. Declaring a single
+    vector-valued output port with LeafSystem requires only a few
+    lines of code.)""";
         // Symbol: drake::systems::SingleOutputVectorSource::DoCalcVectorOutput
         struct /* DoCalcVectorOutput */ {
           // Source: drake/systems/framework/single_output_vector_source.h

--- a/bindings/generated_docstrings/systems_framework.h
+++ b/bindings/generated_docstrings/systems_framework.h
@@ -7828,7 +7828,8 @@ protected method
 
 .. code-block:: c++
 
-    void DoCalcOutput(const Context<T>&, Eigen∷VectorBlock<VectorX<T>>*) const;
+    void DoCalcVectorOutput(const Context<T>& context,
+                            Eigen∷VectorBlock<VectorX<T>>* output) const;
 
 .. raw:: html
 
@@ -7838,7 +7839,12 @@ protected method
 
     name: SingleOutputVectorSource
     output_ports:
-    - y0)""";
+    - y0
+
+Warning:
+    This class is not useful anymore and is to be deprecated. Prefer
+    deriving from LeafSystem directly. Declaring a single vector-valued
+    output port with LeafSystem requires only a few lines of code.)""";
         // Symbol: drake::systems::SingleOutputVectorSource::DoCalcVectorOutput
         struct /* DoCalcVectorOutput */ {
           // Source: drake/systems/framework/single_output_vector_source.h
@@ -12421,7 +12427,12 @@ vector input ports, and only zero or one vector output ports.
 
 By default, this base class does not declare any state; subclasses may
 optionally declare continuous or discrete state, but not both;
-subclasses may not declare abstract state.)""";
+subclasses may not declare abstract state.
+
+Warning:
+    This class is not generally recommended for new code. Prefer
+    deriving from LeafSystem directly, which is straightforward for
+    systems with a small number of ports.)""";
         // Symbol: drake::systems::VectorSystem::CalcVectorOutput
         struct /* CalcVectorOutput */ {
           // Source: drake/systems/framework/vector_system.h

--- a/systems/framework/single_output_vector_source.h
+++ b/systems/framework/single_output_vector_source.h
@@ -29,7 +29,7 @@ namespace systems {
 ///
 /// @warning This class is not useful anymore and is to be deprecated. Prefer
 /// deriving from LeafSystem directly. Declaring a single vector-valued output
-/// port with LeafSystem requires only a few lines of code.
+/// port with %LeafSystem requires only a few lines of code.
 ///
 /// @tparam_default_scalar
 template <typename T>

--- a/systems/framework/single_output_vector_source.h
+++ b/systems/framework/single_output_vector_source.h
@@ -17,7 +17,8 @@ namespace systems {
 /// only a single, vector output port. Subclasses should override the protected
 /// method
 /// @code
-/// void DoCalcOutput(const Context<T>&, Eigen::VectorBlock<VectorX<T>>*) const;
+/// void DoCalcVectorOutput(const Context<T>& context,
+///                         Eigen::VectorBlock<VectorX<T>>* output) const;
 /// @endcode
 ///
 /// @system
@@ -25,6 +26,10 @@ namespace systems {
 /// output_ports:
 /// - y0
 /// @endsystem
+///
+/// @warning This class is not useful anymore and is to be deprecated. Prefer
+/// deriving from LeafSystem directly. Declaring a single vector-valued output
+/// port with LeafSystem requires only a few lines of code.
 ///
 /// @tparam_default_scalar
 template <typename T>

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -34,6 +34,10 @@ namespace systems {
 /// optionally declare continuous or discrete state, but not both; subclasses
 /// may not declare abstract state.
 ///
+/// @warning This class is not generally recommended for new code. Prefer
+/// deriving from LeafSystem directly, which is straightforward for systems with
+/// a small number of ports.
+///
 /// @tparam_default_scalar
 template <typename T>
 class VectorSystem : public LeafSystem<T> {


### PR DESCRIPTION
Document that SingleOutputVectorSource is not useful anymore and is to be deprecated; prefer deriving from LeafSystem instead. Likewise steer new code away from VectorSystem.

Towards #20989.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24937)
<!-- Reviewable:end -->
