### PR TITLE
[render_gl] Remove light limit (and streamline shaders)

### DIFF
--- a/bindings/generated_docstrings/geometry_render_gl.h
+++ b/bindings/generated_docstrings/geometry_render_gl.h
@@ -89,9 +89,11 @@ specified in the (phong, diffuse) property.)""";
         struct /* lights */ {
           // Source: drake/geometry/render_gl/render_engine_gl_params.h
           const char* doc =
-R"""(Lights in the scene. More than five lights is an error. If no lights
-are defined, a single directional light, fixed to the camera frame, is
-used.)""";
+R"""(Lights in the scene. If no lights are defined, a single directional
+light, fixed to the camera frame, is used.
+
+Note: RenderEngineGl does not have a hard-coded limit on the number of
+lights, but more lights increases rendering cost.)""";
         } lights;
         auto Serialize__fields() const {
           return std::array{

--- a/bindings/generated_docstrings/geometry_render_vtk.h
+++ b/bindings/generated_docstrings/geometry_render_vtk.h
@@ -400,7 +400,7 @@ R"""(Lights in the scene. If no lights are defined, a single directional
 light, fixed to the camera frame, is used.
 
 Note: RenderEngineVtk does not have a hard-coded limit on the number
-of lights; but more lights increases rendering cost. Note: the
+of lights, but more lights increases rendering cost. Note: the
 attenuation values have no effect on VTK *directional* lights.)""";
         } lights;
         // Symbol: drake::geometry::RenderEngineVtkParams::shadow_map_size

--- a/geometry/render_gl/internal_render_engine_gl.cc
+++ b/geometry/render_gl/internal_render_engine_gl.cc
@@ -73,24 +73,42 @@ namespace fs = std::filesystem;
 class LightingShader : public ShaderProgram {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LightingShader);
-  LightingShader() : ShaderProgram() {}
+  explicit LightingShader(const std::vector<LightParameter>& lights)
+      : light_count_(ssize(lights)) {
+    DRAKE_DEMAND(!lights.empty());
+  }
 
+  /* Sets all light uniforms in an already-compiled-and-linked shader program.
+   It should be called in two cases:
+
+    1. A final, derived class should invoke it in its constructor body after
+       calling LoadFromSources().
+    2. A cloned shader program should invoke it.
+
+   @pre An OpenGL context is active.
+   @pre `lights` is the same size as the light configuration provided to the
+        LightingShader constructor. */
   void SetAllLights(const std::vector<LightParameter>& lights) const {
-    DRAKE_DEMAND(lights.size() <= kMaxNumLights);
+    DRAKE_DEMAND(ssize(lights) == light_count_);
+    Use();
     for (int i = 0; i < ssize(lights); ++i) {
       SetLightParameters(i, lights[i]);
     }
-    // Set the remaining lights off (invalid light type 0).
-    for (int i = ssize(lights); i < kMaxNumLights; ++i) {
-      glUniform1i(GetLightFieldLocation(i, "type"), 0);
-    }
+    Unuse();
   }
-
-  static constexpr int kMaxNumLights{5};
 
  protected:
   // Derived classes have the chance to configure additional uniforms.
   virtual void DoConfigureMoreUniforms() {}
+
+  std::string VertexShaderSource() const {
+    return fmt::format("#version 330\n{}", kVertexShader);
+  }
+
+  std::string FragmentShaderSource() const {
+    return fmt::format("#version 330\n#define LIGHT_COUNT {}\n{}", light_count_,
+                       kFragmentShader);
+  }
 
   // This provides GLSL code necessary for performing lighting calculations:
   //   - Transforms the vertex into device *and* world coordinates.
@@ -101,11 +119,11 @@ class LightingShader : public ShaderProgram {
   // whatever work is unique to the shader and invoke PrepareLighting() so that
   // the transformed vertex is evaluated.
   static constexpr char kVertexShader[] = R"""(
-#version 330
 layout(location = 0) in vec3 p_MV;
 layout(location = 1) in vec3 n_M;
-uniform mat4 T_CM;  // The "model view matrix" (in OpenGl terms).
-uniform mat4 T_DC;  // The "projection matrix" (in OpenGl terms).
+uniform mat4 T_DM;  // Transform from model to device coordinates. This is the
+                    // product of the so-called projection matrix and model-view
+                    // matrix.
 uniform mat4 T_WM;  // The pose of the geometry (model) in the world.
 uniform mat3 T_WM_normals;  // Rotation * inverse_scale to transform normals.
 // TODO(SeanCurtis-TRI): Rather than propagating normal and position vertex in
@@ -118,7 +136,7 @@ out vec3 p_WV; // Vertex position in world space.
 
 void PrepareLighting() {
   // gl_Position is p_DV; the vertex position in device coordinates.
-  gl_Position = T_DC * T_CM * vec4(p_MV, 1);
+  gl_Position = T_DM * vec4(p_MV, 1);
 
   n_W = normalize(T_WM_normals * n_M);
   p_WV = (T_WM * vec4(p_MV, 1)).xyz;
@@ -131,17 +149,9 @@ void PrepareLighting() {
   // main function should compute the diffuse value at the fragment and call
   // GetIlluminatedColor() to get the illuminated result.
   static constexpr char kFragmentShader[] = R"""(
-#version 330
 uniform mat4 X_WC;  // Transform light position from camera to world.
 in vec3 n_W;
 in vec3 p_WV;
-
-// TODO(SeanCurtis-TRI): Rather than hard-code this in this compile-time string,
-// set this to the actual number of lights reported. We can still have the
-// render engine subject to a hard light limit, but we can make sure the shader
-// only has defined lights. This should roll into changes in how derived
-// classes access these GLSL functions.
-const int MAX_LIGHT_NUM = 5;
 
 // TODO(SeanCurtis-TRI): We should packing these uniforms more tightly. vec3s
 //   are stored as vec4 anyways, so we might as well reduce the uniform calls
@@ -151,7 +161,6 @@ const int MAX_LIGHT_NUM = 5;
 //   intensity is the fourth field of atten_coeff.
 //   cos_half_angle is the fourth field of direction.
 struct Light {
-    // 0 for no light
     // 1 for Point Light
     // 2 for Spot Light
     // 3 for Directional Light
@@ -173,7 +182,7 @@ struct Light {
     vec3 dir;
 };
 
-uniform Light lights[MAX_LIGHT_NUM];
+uniform Light lights[LIGHT_COUNT];
 
 vec3 GetLightPositionInWorld(Light light) {
   vec3 v_W = light.position.xyz;  // Interpreting v as v_W.
@@ -225,18 +234,21 @@ vec3 GetLightIllumination(Light light, vec3 nhat_W) {
   }
 
   // "Exposure" is the fraction of the light's full luminance that shines on
-  // the given fragment.
-  float exposure;
+  // the given fragment. A *good* value would lie in [0, 1]. As long as
+  // light.type is one of {1, 2, 3}, we'll compute a valid exposure value. On
+  // the off chance that an unexpected light.type is provided, we'll return
+  // an absurdly large exposure value to make it obvious that something is wrong
+  // (extreme over exposure); a zero value would merely cause the erroneous
+  // light to have no effect.
+  float exposure = 10;
   if (light.type == 1) {
     exposure = GetPointExposure(light, dir_FL_W, nhat_W);
   } else if (light.type == 2) {
     exposure = GetSpotExposure(light, dir_FL_W, nhat_W);
-  } else if (light.type == 3) {
+  } else {  // light.type == 3
     exposure = GetDirectionalExposure(light, nhat_W);
-  } else {
-      // Invalid light; no exposure.
-      return vec3(0.0, 0.0, 0.0);
   }
+  if (exposure <= 0.0) return vec3(0.0, 0.0, 0.0);
 
   // Attenuation.
   float inv_attenuation = light.atten_coeff[0] +
@@ -254,7 +266,7 @@ vec4 GetIlluminatedColor(vec4 diffuse) {
   vec3 nhat_W = normalize(n_W);
 
   vec3 illum = vec3(0.0, 0.0, 0.0);
-  for (int i = 0; i < MAX_LIGHT_NUM; i++) {
+  for (int i = 0; i < LIGHT_COUNT; ++i) {
     illum += GetLightIllumination(lights[i], nhat_W);
   }
   return vec4(illum * diffuse.rgb, diffuse.a);
@@ -264,7 +276,7 @@ vec4 GetIlluminatedColor(vec4 diffuse) {
 
  private:
   GLint GetLightFieldLocation(int index, std::string field_name) const {
-    DRAKE_ASSERT(index >= 0 && index < kMaxNumLights);
+    DRAKE_ASSERT(index >= 0 && index < light_count_);
     return GetUniformLocation(fmt::format("lights[{}].{}", index, field_name));
   }
 
@@ -326,6 +338,8 @@ vec4 GetIlluminatedColor(vec4 diffuse) {
   // The transform between world and camera frame (used for transforming light
   // positions defined in the camera frame).
   GLint X_WC_loc_{};
+
+  int light_count_{};
 };
 
 /* The built-in shader for Rgba diffuse colored objects. This shader supports
@@ -334,13 +348,13 @@ class DefaultRgbaColorShader final : public LightingShader {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DefaultRgbaColorShader);
 
-  explicit DefaultRgbaColorShader(const Rgba& default_diffuse)
-      : LightingShader(), default_diffuse_(default_diffuse) {
-    // TODO(SeanCurtis-TRI): See if I can't come up with a more elegant way for
-    // derived classes to exercise LightShader's GLSL functionality.
+  DefaultRgbaColorShader(const Rgba& default_diffuse,
+                         const std::vector<LightParameter>& lights)
+      : LightingShader(lights), default_diffuse_(default_diffuse) {
     LoadFromSources(
-        fmt::format("{}{}", LightingShader::kVertexShader, kVertexShader),
-        fmt::format("{}{}", LightingShader::kFragmentShader, kFragmentShader));
+        fmt::format("{}{}", VertexShaderSource(), kVertexShader),
+        fmt::format("{}{}", FragmentShaderSource(), kFragmentShader));
+    SetAllLights(lights);
   }
 
   void SetInstanceParameters(const ShaderProgramData& data) const final {
@@ -407,12 +421,14 @@ class DefaultTextureColorShader final : public LightingShader {
    is alright, because the owning RenderEngineGl instances share that library
    as well -- so the shader program instances are consistent with the render
    engine instances. */
-  explicit DefaultTextureColorShader(shared_ptr<TextureLibrary> library)
-      : LightingShader(), library_(std::move(library)) {
+  DefaultTextureColorShader(shared_ptr<TextureLibrary> library,
+                            const std::vector<LightParameter>& lights)
+      : LightingShader(lights), library_(std::move(library)) {
     DRAKE_DEMAND(library_ != nullptr);
     LoadFromSources(
-        fmt::format("{}{}", LightingShader::kVertexShader, kVertexShader),
-        fmt::format("{}{}", LightingShader::kFragmentShader, kFragmentShader));
+        fmt::format("{}{}", VertexShaderSource(), kVertexShader),
+        fmt::format("{}{}", FragmentShaderSource(), kFragmentShader));
+    SetAllLights(lights);
   }
 
   void SetInstanceParameters(const ShaderProgramData& data) const final {
@@ -566,13 +582,13 @@ class DefaultDepthShader final : public ShaderProgram {
 
 layout(location = 0) in vec3 p_MV;
 out float depth;
-uniform mat4 T_CM;  // The "model view matrix" (in OpenGl terms).
-uniform mat4 T_DC;  // The "projection matrix" (in OpenGl terms).
+uniform mat4 T_DM;
 
 void main() {
-  vec4 p_CV = T_CM * vec4(p_MV, 1);
-  depth = -p_CV.z;
-  gl_Position = T_DC * p_CV;
+  vec4 p_DV = T_DM * vec4(p_MV, 1);
+  // For Drake's perspective projection, w_D equals physical camera depth.
+  depth = p_DV.w;
+  gl_Position = p_DV;
 })""";
 
   // The fragment shader "clamps" the depth of the fragment to the specified
@@ -652,19 +668,13 @@ class DefaultLabelShader final : public ShaderProgram {
 
   GLint encoded_label_loc_{};
 
-  // The vertex shader simply transforms the vertices. Strictly speaking, we
-  // could combine modelview and projection matrices into a single transform,
-  // but there's no real value in doing so. Leaving it as is maintains
-  // compatibility with the depth shader.
+  // The vertex shader simply transforms the vertices.
   static constexpr char kVertexShader[] = R"""(
 #version 330
 layout(location = 0) in vec3 p_MV;
-uniform mat4 T_CM;  // The "model view matrix" (in OpenGl terms).
-uniform mat4 T_DC;  // The "projection matrix" (in OpenGl terms).
+uniform mat4 T_DM;
 void main() {
-  // X_CM = T_CM (although X may not be a *rigid* transform).
-  vec4 p_CV = T_CM * vec4(p_MV, 1);
-  gl_Position = T_DC * p_CV;
+  gl_Position = T_DM * vec4(p_MV, 1);
 })""";
 
   // For each fragment from a geometry, it simply writes the provided label.
@@ -682,11 +692,6 @@ void main() {
 // values because those values which *might* be considered "bad" can be used
 // by users for debugging.
 RenderEngineGlParams CleanupLights(RenderEngineGlParams params) {
-  if (ssize(params.lights) > LightingShader::kMaxNumLights) {
-    throw std::runtime_error(
-        fmt::format("RenderEngineGl supports up to five lights; {} specified.",
-                    ssize(params.lights)));
-  }
   for (auto& light : params.lights) {
     if (light.type != "point") {
       const double dir_magnitude = light.direction.norm();
@@ -718,11 +723,12 @@ RenderEngineGl::RenderEngineGl(RenderEngineGlParams params)
   // Color shaders. See documentation on GetShaderProgram. We want color from
   // texture to be "more preferred" than color from rgba, so we add the
   // texture color shader *after* the rgba color shader.
-  AddShader(make_unique<DefaultRgbaColorShader>(params.default_diffuse),
+  const auto& lights = active_lights();
+  AddShader(
+      make_unique<DefaultRgbaColorShader>(parameters_.default_diffuse, lights),
+      RenderType::kColor);
+  AddShader(make_unique<DefaultTextureColorShader>(texture_library_, lights),
             RenderType::kColor);
-  AddShader(make_unique<DefaultTextureColorShader>(texture_library_),
-            RenderType::kColor);
-  ConfigureLights();
 
   // Depth shaders -- a single shader that accepts all geometry.
   AddShader(make_unique<DefaultDepthShader>(), RenderType::kDepth);
@@ -1048,8 +1054,8 @@ unique_ptr<RenderEngine> RenderEngineGl::DoClone() const {
     }
   }
 
-  // Update the shader OpenGL state to properly configure the lighting.
-  clone->ConfigureLights();
+  // Restore the lighting uniforms in the clone's newly linked programs.
+  clone->RestoreLightingUniforms();
 
   return clone;
 }
@@ -2467,17 +2473,13 @@ ShaderProgramData RenderEngineGl::GetShaderProgram(
   return *data;
 }
 
-void RenderEngineGl::ConfigureLights() {
-  // Set the lights *once* for all color shaders. Currently, lighting can only
-  // be figured upon construction.
+void RenderEngineGl::RestoreLightingUniforms() {
   for (const auto& [_, shader_ptr] : shader_programs_[RenderType::kColor]) {
     const auto* lighting_program =
         dynamic_pointer_cast_or_throw<const LightingShader>(shader_ptr.get());
     // All color image shaders should inherit form LightingShader.
     DRAKE_DEMAND(lighting_program != nullptr);
-    lighting_program->Use();
     lighting_program->SetAllLights(active_lights());
-    lighting_program->Unuse();
   }
 }
 

--- a/geometry/render_gl/internal_render_engine_gl.h
+++ b/geometry/render_gl/internal_render_engine_gl.h
@@ -328,10 +328,8 @@ class RenderEngineGl final : public render::RenderEngine, private ShapeReifier {
     return *active_lights_;
   }
 
-  // Configures all uniforms related to lighting. This should be called once
-  // upon construction, after the shaders have been instantiated. This includes
-  // during cloning.
-  void ConfigureLights();
+  // Restores the lighting uniforms after the cloned shaders have been relinked.
+  void RestoreLightingUniforms();
 
   // The cached value transformation between camera and world frames.
   math::RigidTransformd X_CW_;

--- a/geometry/render_gl/internal_shader_program.cc
+++ b/geometry/render_gl/internal_shader_program.cc
@@ -9,6 +9,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"
 
 namespace drake {
@@ -107,25 +108,25 @@ void ShaderProgram::LoadFromFiles(const std::string& vertex_shader_file,
   LoadFromSources(LoadFile(vertex_shader_file), LoadFile(fragment_shader_file));
 }
 
-void ShaderProgram::SetProjectionMatrix(const Eigen::Matrix4f& T_DC) const {
-  glUniformMatrix4fv(projection_matrix_loc_, 1, GL_FALSE, T_DC.data());
-}
-
-void ShaderProgram::SetModelViewMatrix(const Eigen::Matrix4f& X_CW,
-                                       const Eigen::Matrix4f& T_WM,
-                                       const Eigen::Matrix3f& N_WM) const {
-  const Eigen::Matrix4f T_CM = X_CW * T_WM;
-  // Our camera frame C wrt the OpenGL's camera frame Cgl.
+void ShaderProgram::SetProjectionMatrix(const Eigen::Matrix4f& T_DCgl) const {
+  // Drake's physical camera frame Cphysical wrt OpenGL's camera frame Cgl.
   // clang-format off
-  static const Eigen::Matrix4f kT_CglC =
+  static const Eigen::Matrix4f kT_CglCphysical =
       (Eigen::Matrix4f() << 1,  0,  0, 0,
                             0, -1,  0, 0,
                             0,  0, -1, 0,
                             0,  0,  0, 1)
           .finished();
   // clang-format on
-  const Eigen::Matrix4f T_CglM = kT_CglC * T_CM;
-  glUniformMatrix4fv(model_view_loc_, 1, GL_FALSE, T_CglM.data());
+  T_DCphysical_ = T_DCgl * kT_CglCphysical;
+}
+
+void ShaderProgram::SetModelViewMatrix(const Eigen::Matrix4f& X_CW,
+                                       const Eigen::Matrix4f& T_WM,
+                                       const Eigen::Matrix3f& N_WM) const {
+  const Eigen::Matrix4f T_CphysicalM = X_CW * T_WM;
+  const Eigen::Matrix4f T_DM = T_DCphysical_ * T_CphysicalM;
+  glUniformMatrix4fv(model_to_device_matrix_loc_, 1, GL_FALSE, T_DM.data());
   DoSetModelViewMatrix(X_CW, T_WM, N_WM);
 }
 
@@ -162,8 +163,7 @@ void ShaderProgram::Free() {
 }
 
 void ShaderProgram::ConfigureUniforms() {
-  projection_matrix_loc_ = GetUniformLocation("T_DC");
-  model_view_loc_ = GetUniformLocation("T_CM");
+  model_to_device_matrix_loc_ = GetUniformLocation("T_DM");
   DoConfigureUniforms();
 }
 

--- a/geometry/render_gl/internal_shader_program.h
+++ b/geometry/render_gl/internal_shader_program.h
@@ -49,16 +49,27 @@ namespace internal {
 
  Explicit functionality is given in derived classes. They specify the actual
  shader code and any idiosyncratic details. To be compatible with *this*
- shader abstraction, a shader must meet some minimum requirements:
+ shader abstraction, a shader must specify a uniform mat4 called "T_DM" for the
+ model-to-device matrix. This is a projective transform taking a model-frame
+ point in ℜ³ to homogeneous OpenGL clip coordinates. We define this matrix
+ as:
 
-   - It must specify a uniform mat4 called "T_CM" - this transforms
-     vertices from the geometry's canonical frame M to the OpenGl camera frame
-     C. This transform may include scale factors (meaning it is not necessarily
-     a RigidTransform).
-   - It must specify a uniform mat4 called "T_DC" - this transforms
-     vertices from the camera's frame C to the OpenGl normalized device frame
-     D. This is a projective transform, taking points in ℜ³ and mapping them
-     to ℜ².
+   `T_DM = T_DCgl * T_CglCPhysical * X_CphysicalW * T_WM`
+
+ where,
+
+   - `T_DCgl`: the OpenGL projection matrix. This is passed to
+      SetProjectionMatrix() as T_DCgl.
+   - `T_CglCPhysical`: the fixed transform between Drake's physical camera frame
+     and OpenGL's camera frame. The two cameras have different conventions. This
+     is hard-coded in the shader program's architecture.
+   - `X_CphysicalW`: the rigid relationship between the physical camera frame
+     and the world frame. This is passed to SetModelViewMatrix() as X_CW.
+   - `T_WM`:  the model-to-world transform (see documentation on frames for
+      OpenGlGeometry).
+   - We define `T_DCphysical = T_DCgl * T_CglCPhysical`. This is a constant for
+     the camera's intrinsics and is what is *internally* stored as a result of
+     calling SetProjectionMatrix().
 
  The %ShaderProgram stores the identifier for an OpenGl program. These programs
  are included in the objects that are shared across OpenGl contexts. However,
@@ -132,14 +143,15 @@ class ShaderProgram {
   virtual void SetDepthCameraParameters(
       const render::DepthRenderCamera& /* camera */) const {}
 
-  /* Sets the OpenGl projection matrix state. The projection matrix transforms a
-   vertex from the camera frame C to the OpenGl 2D device frame D -- it
-   projects a point in 3D to a point on the image.  */
-  void SetProjectionMatrix(const Eigen::Matrix4f& T_DC) const;
+  /* Stores T_DCphysical by multiplying the given `T_DCgl` with the internal
+   `T_CglCPhysical` transform. Only needs to be called once per unique set of
+   camera intrinsics (doesn't depend on rendered geometry poses or even camera
+   pose). */
+  void SetProjectionMatrix(const Eigen::Matrix4f& T_DCgl) const;
 
-  /* Sets the OpenGl model view matrix (and allows the shader to do any other
-   (instance, camera)-dependent configuration). The model view matrix T_CM
-   transforms a vertex from the model frame M to the camera frame C.
+  /* Writes the resulting `T_DM`, the OpenGL model-to-device matrix, to the
+   current OpenGl context. Allows derived shader programs to do any other
+   instance- and camera-dependent configuration.
 
    This method invokes DoSetModelViewMatrix() with many of the component
    matrices.
@@ -151,11 +163,14 @@ class ShaderProgram {
    matrix S_MG (such that it is zero off the diagonal and has the x-, y-, and
    z-scale values along the diagonal).
 
-   @param X_CW   The transform relating the world frame and the camera frame.
+   @param X_CW   The transform relating the world frame and the camera's
+                 physical frame. Noted above as X_CphysicalW.
    @param T_WM   The transform to map the model's vertex positions into the
                  world frame. Not necessarily a rigid transform.
    @param N_WM   The transform to map the model's vertex normals into the
-                 world frame.  */
+                 world frame.
+   @pre SetProjectionMatrix() has been called with the current camera's
+        projection matrix (unchecked). */
   void SetModelViewMatrix(const Eigen::Matrix4f& X_CW,
                           const Eigen::Matrix4f& T_WM,
                           const Eigen::Matrix3f& N_WM) const;
@@ -263,10 +278,13 @@ class ShaderProgram {
   GLuint vertex_id_{0};
   GLuint fragment_id_{0};
 
-  // Locations of the projection matrix and the model view matrix in the
-  // *supported* shader.
-  GLint projection_matrix_loc_{};
-  GLint model_view_loc_{};
+  // The physical-camera-to-device matrix is common to all instances rendered
+  // by this shader. It is cached and combined with each instance's model-view
+  // matrix.
+  mutable Eigen::Matrix4f T_DCphysical_{Eigen::Matrix4f::Identity()};
+
+  // Location of the model-to-device matrix in the supported shader.
+  GLint model_to_device_matrix_loc_{};
 };
 
 }  // namespace internal

--- a/geometry/render_gl/render_engine_gl_params.h
+++ b/geometry/render_gl/render_engine_gl_params.h
@@ -28,8 +28,11 @@ struct RenderEngineGlParams {
   /** The default background color for color images.  */
   Rgba default_clear_color{204 / 255., 229 / 255., 255 / 255., 1.0};
 
-  /** Lights in the scene. More than five lights is an error. If no lights are
-   defined, a single directional light, fixed to the camera frame, is used. */
+  /** Lights in the scene. If no lights are defined, a single directional
+   light, fixed to the camera frame, is used.
+
+   Note: RenderEngineGl does not have a hard-coded limit on the number of
+         lights, but more lights increases rendering cost. */
   std::vector<render::LightParameter> lights;
 };
 

--- a/geometry/render_gl/test/internal_render_engine_gl_test.cc
+++ b/geometry/render_gl/test/internal_render_engine_gl_test.cc
@@ -2878,53 +2878,42 @@ TEST_F(RenderEngineGlTest, SingleLight) {
   }
 }
 
-// Quick test to make sure that lights combine. Also, confirm that too many
-// lights throw.
+// Quick test to make sure that lights combine. We'll stress test an arbitrary
+// number of lights (the only limit is what the GPU can support in practice).
 TEST_F(RenderEngineGlTest, MultiLights) {
-  // Too many lights throw.
-  {
-    const RenderEngineGlParams params{.lights = {
-                                          {.position = {0, 0, 0}},
-                                          {.position = {1, 0, 0}},
-                                          {.position = {2, 0, 0}},
-                                          {.position = {3, 0, 0}},
-                                          {.position = {4, 0, 0}},
-                                          {.position = {5, 0, 0}},
-                                      }};
-    auto make_renderer = [](const RenderEngineGlParams& p) {
-      return RenderEngineGl(p);
-    };
-    EXPECT_THROW(make_renderer(params), std::exception);
-  }
+  const ColorRenderCamera camera(depth_camera_.core(), FLAGS_show_window);
+  const RigidTransformd X_WR(RotationMatrixd::MakeXRotation(M_PI),
+                             Vector3d(0, 0, 3));
+  ImageRgba8U image(camera.core().intrinsics().width(),
+                    camera.core().intrinsics().height());
+  const int cx = image.width() / 2;
+  const int cy = image.height() / 2;
 
-  // Lights combine.
-  {
-    const ColorRenderCamera camera(depth_camera_.core(), FLAGS_show_window);
-    const RigidTransformd X_WR(RotationMatrixd::MakeXRotation(M_PI),
-                               Vector3d(0, 0, 3));
-    ImageRgba8U image(camera.core().intrinsics().width(),
-                      camera.core().intrinsics().height());
-    const int cx = image.width() / 2;
-    const int cy = image.height() / 2;
+  // We have three conceptual lights. The *conceptual* lights are pointing
+  // directly at the image center, but their total intensity is 0.75. So, we
+  // should get 75% of the diffuse color. Six is an arbitrary number of lights
+  // related to the historical behavior of a five-light limit. It *hints* at the
+  // idea that there is no conceptual limit on the light count (only GPU
+  // limits).
+  const RenderEngineGlParams params{
+      .lights = {{.type = "point", .intensity = 0.25 * 0.5},
+                 {.type = "point", .intensity = 0.25 * 0.5},
+                 {.type = "spot", .intensity = 0.25 * 0.5, .cone_angle = 45},
+                 {.type = "spot", .intensity = 0.25 * 0.5, .cone_angle = 45},
+                 {.type = "directional", .intensity = 0.25 * 0.5},
+                 {.type = "directional", .intensity = 0.25 * 0.5}},
+  };
+  RenderEngineGl renderer(params);
 
-    // The lights are pointing directly at the image center, but their total
-    // intensity is 0.75. So, we should get 75% of the diffuse color.
-    const RenderEngineGlParams params{
-        .lights = {{.type = "point", .intensity = 0.25},
-                   {.type = "spot", .intensity = 0.25, .cone_angle = 45},
-                   {.type = "directional", .intensity = 0.25}}};
-    RenderEngineGl renderer(params);
+  InitializeRenderer(X_WR, true /* add terrain */, &renderer);
 
-    InitializeRenderer(X_WR, true /* add terrain */, &renderer);
+  EXPECT_NO_THROW(renderer.RenderColorImage(camera, &image));
 
-    EXPECT_NO_THROW(renderer.RenderColorImage(camera, &image));
-
-    const RgbaColor test_color(image.at(cx, cy));
-    const RgbaColor expected_color = kTerrainColor.scale_rgb(0.75);
-    EXPECT_TRUE(IsColorNear(test_color, expected_color))
-        << "  test color: " << test_color << "\n"
-        << "  expected color: " << expected_color;
-  }
+  const RgbaColor test_color(image.at(cx, cy));
+  const RgbaColor expected_color = kTerrainColor.scale_rgb(0.75);
+  EXPECT_TRUE(IsColorNear(test_color, expected_color))
+      << "  test color: " << test_color << "\n"
+      << "  expected color: " << expected_color;
 }
 
 namespace {

--- a/geometry/render_gl/test/internal_shader_program_test.cc
+++ b/geometry/render_gl/test/internal_shader_program_test.cc
@@ -41,7 +41,9 @@ class TestShader final : public ShaderProgram {
 
   // Collection of flags which report if certain virtual methods have been
   // invoked.
-  bool DoSetModelViewMatrixCalled() const { return do_mv_matrix_called_; }
+  bool DoSetModelViewMatrixCalled() const {
+    return do_model_view_matrix_called_;
+  }
 
   bool CalledDoConfigureUniforms() const {
     return do_configure_uniforms_called_;
@@ -100,14 +102,14 @@ class TestShader final : public ShaderProgram {
   void DoSetModelViewMatrix(const Eigen::Matrix4f& X_CW,
                             const Eigen::Matrix4f& T_WM,
                             const Eigen::Matrix3f& N_WM) const override {
-    do_mv_matrix_called_ = true;
+    do_model_view_matrix_called_ = true;
     EXPECT_TRUE(CompareMatrices(X_CW, X_CW_expected_));
     EXPECT_TRUE(CompareMatrices(T_WM, T_WM_expected_));
     EXPECT_TRUE(CompareMatrices(N_WM, N_WM_expected_));
   }
 
   bool do_configure_uniforms_called_{false};
-  mutable bool do_mv_matrix_called_{false};
+  mutable bool do_model_view_matrix_called_{false};
   mutable bool set_instance_params_called_{false};
   mutable bool set_depth_camera_called_{false};
 
@@ -119,21 +121,20 @@ class TestShader final : public ShaderProgram {
 
 constexpr char kVertexSource[] = R"""(
   #version 330
-  uniform mat4 T_CM;
-  uniform mat4 T_DC;
-  out vec4 p_CV;
+  uniform mat4 T_DM;
+  out vec4 p_DV;
   void main() {
-    gl_Position = T_DC * vec4(0.0, 0.0, 0.0, 1.0);
-    p_CV = T_CM * vec4(0.0, 0.0, 0.0, 1.0);
+    p_DV = T_DM * vec4(0.0, 0.0, 0.0, 1.0);
+    gl_Position = p_DV;
   }
 )""";
 
 constexpr char kFragmentSource[] = R"""(
   #version 330
   uniform float test_uniform;
-  in vec4 p_CV;
+  in vec4 p_DV;
   void main() {
-    gl_FragColor = vec4(0.18, 0.54, 0.34, test_uniform) + p_CV;
+    gl_FragColor = vec4(0.18, 0.54, 0.34, test_uniform) + p_DV;
   }
 )""";
 
@@ -157,34 +158,32 @@ class ShaderProgramTest : public ::testing::Test {
   // Reports the program id of the given program.
   static GLuint gl_id(const ShaderProgram& program) { return program.gl_id_; }
 
-  static GLint proj_mat_loc(const ShaderProgram& program) {
-    return program.projection_matrix_loc_;
+  static GLint model_to_device_loc(const ShaderProgram& program) {
+    return program.model_to_device_matrix_loc_;
   }
 
-  static GLint model_view_loc(const ShaderProgram& program) {
-    return program.model_view_loc_;
+  static const Matrix4f& T_DCphysical(const ShaderProgram& program) {
+    return program.T_DCphysical_;
   }
 
   static ::testing::AssertionResult Equals(const TestShader& p1,
                                            const TestShader& p2) {
     if (p1.id_ != p2.id_ || p1.gl_id_ != p2.gl_id_ ||
-        p1.projection_matrix_loc_ != p2.projection_matrix_loc_ ||
-        p1.model_view_loc_ != p2.model_view_loc_ ||
+        p1.model_to_device_matrix_loc_ != p2.model_to_device_matrix_loc_ ||
+        !CompareMatrices(p1.T_DCphysical_, p2.T_DCphysical_) ||
         p1.magic_number_ != p2.magic_number_) {
       return ::testing::AssertionFailure()
              << "Shader programs didn't match"
              << "\n  p1:"
              << "\n    shader id: " << fmt::to_string(p1.id_)
              << "\n    OpenGl id: " << p1.gl_id_
-             << "\n    projection matrix location: "
-             << p1.projection_matrix_loc_
-             << "\n    model view matrix location: " << p1.model_view_loc_
+             << "\n    model-to-device matrix location: "
+             << p1.model_to_device_matrix_loc_
              << "\n    magic number: " << p1.magic_number_ << "\n  p2:"
              << "\n    shader id: " << fmt::to_string(p2.id_)
              << "\n    OpenGl id: " << p2.gl_id_
-             << "\n    projection matrix location: "
-             << p2.projection_matrix_loc_
-             << "\n    model view matrix location: " << p2.model_view_loc_
+             << "\n    model-to-device matrix location: "
+             << p2.model_to_device_matrix_loc_
              << "\n    magic number: " << p1.magic_number_;
     }
     return ::testing::AssertionSuccess();
@@ -277,37 +276,19 @@ TEST_F(ShaderProgramTest, LoadShadersError) {
   }
 
   {
-    // Case: Missing projection matrix uniform. In this case, one is *listed*
-    // in the shader, but because it isn't used, it gets compiled out.
+    // Case: Missing model-to-device matrix uniform. It is listed in the shader,
+    // but gets compiled out because it isn't used.
     DRAKE_EXPECT_THROWS_MESSAGE(program.LoadFromSources(R"""(
   #version 330
-  uniform mat4 T_CM;
-  uniform mat4 T_DC;
-  out vec4 p_CV;
+  uniform mat4 T_DM;
+  out vec4 p_DV;
   void main() {
     gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
-    p_CV = T_CM * vec4(0.0, 0.0, 0.0, 1.0);
+    p_DV = vec4(0.0, 0.0, 0.0, 1.0);
   }
 )""",
                                                         kFragmentSource),
-                                "Cannot get shader uniform 'T_DC'");
-  }
-
-  {
-    // Case: Missing modelview matrix uniform. In this case, one is *listed*
-    // in the shader, but because it isn't used, it gets compiled out.
-    DRAKE_EXPECT_THROWS_MESSAGE(program.LoadFromSources(R"""(
-  #version 330
-  uniform mat4 T_CM;
-  uniform mat4 T_DC;
-  out vec4 p_CV;
-  void main() {
-    gl_Position = T_DC * vec4(0.0, 0.0, 0.0, 1.0);
-    p_CV = vec4(0.0, 0.0, 0.0, 1.0);
-  }
-)""",
-                                                        kFragmentSource),
-                                "Cannot get shader uniform 'T_CM'");
+                                "Cannot get shader uniform 'T_DM'");
   }
 }
 
@@ -409,32 +390,30 @@ TEST_F(ShaderProgramTest, SetDepthCameraParameters) {
   ASSERT_TRUE(shader.CalledSetDepthCameraParameters());
 }
 
-// Confirms that given matrix propagates into the OpenGl state.
+// Confirms that the projection matrix is cached for later composition.
 TEST_F(ShaderProgramTest, SetProjectionMatrix) {
   TestShader shader;
   shader.LoadFromSources(kVertexSource, kFragmentSource);
 
-  // Note: this is a weird, invalid projection matrix that we shouldn't expect
-  // should ever happen by accident.
-  const Matrix4f proj_mat = -Matrix4f::Ones();
-  shader.Use();
-  shader.SetProjectionMatrix(proj_mat);
-  shader.Unuse();
-  float proj_mat_data[16];
-  glGetUniformfv(gl_id(shader), proj_mat_loc(shader), &proj_mat_data[0]);
-  const Matrix4f gl_proj_mat(proj_mat_data);
-  EXPECT_TRUE(CompareMatrices(proj_mat, gl_proj_mat));
+  const Matrix4f T_DCgl = -Matrix4f::Ones();
+  shader.SetProjectionMatrix(T_DCgl);
+  const Matrix4f X_CglCphysical =
+      (Matrix4f() << 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1)
+          .finished();
+  EXPECT_TRUE(CompareMatrices(T_DCgl * X_CglCphysical, T_DCphysical(shader)));
 }
 
-// Confirms that given matrix propagates into the OpenGl state and that the
-// virtual API gets exercised.
+// Confirms that the composed model-to-device matrix propagates into the OpenGL
+// state and that the virtual API gets exercised.
 TEST_F(ShaderProgramTest, SetModelViewMatrix) {
   TestShader test_shader;
   test_shader.LoadFromSources(kVertexSource, kFragmentSource);
   const ShaderProgram& shader = test_shader;
 
   // Note: the matrix values for T_CW and X_WG are arbitrary collections of
-  // values without real meaning. We just need distinct values.
+  // values without real meaning. We just need distinct values. For compactness,
+  // C is Cphysical, Drake's physical camera frame (as opposed to Cgl, OpenGl's
+  // conventional camera frame).
   Matrix4f X_CW = Matrix4f::Identity();
   X_CW.col(3) << 10, 20, 30, 1;
   const RigidTransformd X_WG(Vector3d(1, 2, 3));  // Simple transformation.
@@ -443,25 +422,26 @@ TEST_F(ShaderProgramTest, SetModelViewMatrix) {
   for (int i = 0; i < 3; ++i) T_WM.col(i) *= scale(i);
   Matrix3f N_WM = X_WG.rotation().matrix().cast<float>();
   for (int i = 0; i < 3; ++i) N_WM.col(i) /= scale(i);
+  const Matrix4f T_DCgl = 2 * Matrix4f::Identity();
   ASSERT_FALSE(test_shader.DoSetModelViewMatrixCalled());
   test_shader.SetExpectedModelViewComponents(X_CW, T_WM, N_WM);
   shader.Use();
+  shader.SetProjectionMatrix(T_DCgl);
   shader.SetModelViewMatrix(X_CW, T_WM, N_WM);
   shader.Unuse();
   ASSERT_TRUE(test_shader.DoSetModelViewMatrixCalled());
 
-  float mv_mat_data[16];
-  glGetUniformfv(gl_id(shader), model_view_loc(shader), &mv_mat_data[0]);
-  const Matrix4f gl_mv_mat(mv_mat_data);
+  float model_to_device_data[16];
+  glGetUniformfv(gl_id(shader), model_to_device_loc(shader),
+                 model_to_device_data);
+  const Matrix4f gl_T_DM(model_to_device_data);
 
-  // Construct the OpenGl model view matrix by hand.
+  // Construct the OpenGL model-to-device matrix by hand.
   const Matrix4f X_CglC =
       (Matrix4f() << 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1)
           .finished();
-  const Eigen::DiagonalMatrix<float, 4, 4> scale_mat(
-      Vector4<float>(scale(0), scale(1), scale(2), 1.0));
-  const Matrix4f expected_mv_mat = X_CglC * X_CW * T_WM;
-  EXPECT_TRUE(CompareMatrices(expected_mv_mat, gl_mv_mat));
+  const Matrix4f expected_T_DM = T_DCgl * X_CglC * X_CW * T_WM;
+  EXPECT_TRUE(CompareMatrices(expected_T_DM, gl_T_DM));
 }
 
 // Confirms that the clone contains the same data (including any derived data).

--- a/geometry/render_vtk/render_engine_vtk_params.h
+++ b/geometry/render_vtk/render_engine_vtk_params.h
@@ -219,7 +219,7 @@ struct RenderEngineVtkParams {
    fixed to the camera frame, is used.
 
    Note: RenderEngineVtk does not have a hard-coded limit on the number of
-         lights; but more lights increases rendering cost.
+         lights, but more lights increases rendering cost.
    Note: the attenuation values have no effect on VTK *directional* lights. */
   std::vector<render::LightParameter> lights;
 

--- a/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
+++ b/geometry/render_vtk/test/internal_render_engine_vtk_test.cc
@@ -2064,9 +2064,8 @@ TEST_F(RenderEngineVtkTest, SingleLight) {
   }
 }
 
-// Quick test to make sure that lights combine. We'll intentionally use more
-// lights than RenderEngineGl allows for to confirm that RenderEngineVtk doesn't
-// share the limit.
+// Quick test to make sure that lights combine. We'll stress test an arbitrary
+// number of lights (the only limit is what the GPU can support in practice).
 TEST_F(RenderEngineVtkTest, MultiLights) {
   const ColorRenderCamera camera(depth_camera_.core(), FLAGS_show_window);
   const RigidTransformd X_WR(RotationMatrixd::MakeXRotation(M_PI),
@@ -2078,8 +2077,10 @@ TEST_F(RenderEngineVtkTest, MultiLights) {
 
   // We have three conceptual lights. The *conceptual* lights are pointing
   // directly at the image center, but their total intensity is 0.75. So, we
-  // should get 75% of the diffuse color. To test the non-limits on the number
-  // of lights, we'll duplicate each light with half the intensity.
+  // should get 75% of the diffuse color. Six is an arbitrary number of lights
+  // related to the historical behavior of a five-light limit. It *hints* at the
+  // idea that there is no conceptual limit on the light count (only GPU
+  // limits).
   const RenderEngineVtkParams params{
       .lights = {{.type = "point", .intensity = 0.25 * 0.5},
                  {.type = "point", .intensity = 0.25 * 0.5},

--- a/tools/install/libdrake/test/exported_symbols_test.py
+++ b/tools/install/libdrake/test/exported_symbols_test.py
@@ -449,7 +449,6 @@ class ExportedSymbolsTest(unittest.TestCase):
             failures.append(function_name)
 
             if "encode_one_block" in name:
-                manifest = runfiles.Create()
                 subprocess.run(
                     [
                         "objdump",
@@ -458,6 +457,7 @@ class ExportedSymbolsTest(unittest.TestCase):
                         f"--disassemble={name}",
                     ],
                     text=True,
+                    check=False,
                 )
 
         return failures

--- a/tools/install/libdrake/test/exported_symbols_test.py
+++ b/tools/install/libdrake/test/exported_symbols_test.py
@@ -440,24 +440,10 @@ class ExportedSymbolsTest(unittest.TestCase):
                 # so we'll skip it here to avoid duplicate reports.
                 continue
             function_name = ExportedSymbolsTest._demangle(name).strip()
-            if _is_known_bad_ctor_or_dtor(
+            if not _is_known_bad_ctor_or_dtor(
                 filename="",
                 function_name=function_name,
             ):
-                continue
-
-            failures.append(function_name)
-
-            if "encode_one_block" in name:
-                subprocess.run(
-                    [
-                        "objdump",
-                        LIBDRAKE,
-                        "-Mintel",
-                        f"--disassemble={name}",
-                    ],
-                    text=True,
-                    check=False,
-                )
+                failures.append(function_name)
 
         return failures

--- a/tools/install/libdrake/test/exported_symbols_test.py
+++ b/tools/install/libdrake/test/exported_symbols_test.py
@@ -440,10 +440,24 @@ class ExportedSymbolsTest(unittest.TestCase):
                 # so we'll skip it here to avoid duplicate reports.
                 continue
             function_name = ExportedSymbolsTest._demangle(name).strip()
-            if not _is_known_bad_ctor_or_dtor(
+            if _is_known_bad_ctor_or_dtor(
                 filename="",
                 function_name=function_name,
             ):
-                failures.append(function_name)
+                continue
+
+            failures.append(function_name)
+
+            if "encode_one_block" in name:
+                manifest = runfiles.Create()
+                subprocess.run(
+                    [
+                        "objdump",
+                        LIBDRAKE,
+                        "-Mintel",
+                        f"--disassemble={name}",
+                    ],
+                    text=True,
+                )
 
         return failures


### PR DESCRIPTION
The primary benefit is the removal of the hard-coded light limit. Attendant with that, we streamlined the shaders.

  - We no longer encode an "empty light" slot. The shader knows exactly how many lights it has.
  - The transformation of geometry vertices from the "model" frame to the device clip space used to use two matrices (provided as uniforms). The decomposition wasn't really helpful as we multipled the matrix for every vertex in the geometry. Instead, we now pre-compute on the CPU and pass it once per object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24953)
<!-- Reviewable:end -->
