### PR TITLE
[wheel] Trim build dependencies

### DIFF
--- a/tools/wheel/image/packages-almalinux
+++ b/tools/wheel/image/packages-almalinux
@@ -5,7 +5,6 @@ gcc-toolset-14-gcc
 gcc-toolset-14-gcc-c++
 gcc-toolset-14-gcc-gfortran
 lld
-nasm
 
 # Other code tools.
 cmake
@@ -23,6 +22,6 @@ tar
 wget
 which
 
-# Build dependencies (general).
+# Additional build dependencies; see the officially supported Ubuntu spellings
+# under setup/ubuntu/.
 glib2-devel
-libXt-devel


### PR DESCRIPTION
`nasm` is necessary to build libjpeg_turbo (see #20343), but these days we `bazel_dep(nasm)`.

`libXt-dev` appears to have been added circa #16132, when a newer VTK was added to the wheel builder, but appears to have not been necessary since #20964.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24963)
<!-- Reviewable:end -->
