### PR TITLE
[parsing] Report nested URDF world-weld prefix errors via DiagnosticPolicy

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -163,9 +163,14 @@ std::pair<ModelInstanceIndex, std::string> GetResolvedModelInstanceAndLocalName(
 // scoped name of the nested model. If the relative_to_model_instance is the
 // world_model_instance, the local name of the body is prefixed with the model
 // name.
-std::string GetRelativeBodyName(const RigidBody<double>& body,
-                                ModelInstanceIndex relative_to_model_instance,
-                                const MultibodyPlant<double>& plant) {
+//
+// Returns nullopt (and reports a diagnostic error) when @p body is not a
+// descendant of @p relative_to_model_instance. That can happen for malformed
+// inputs such as a nested URDF that welds a link to the world (see #21413).
+std::optional<std::string> GetRelativeBodyName(
+    const RigidBody<double>& body,
+    ModelInstanceIndex relative_to_model_instance,
+    const MultibodyPlant<double>& plant, const DiagnosticPolicy& diagnostic) {
   const std::string& relative_to_model_absolute_name =
       plant.GetModelInstanceName(relative_to_model_instance);
   // If the relative_to_model instance is the world_model_instance, we need to
@@ -182,10 +187,19 @@ std::string GetRelativeBodyName(const RigidBody<double>& body,
         plant.GetModelInstanceName(body.model_instance());
     // The relative_to_model_absolute_name must be a prefix of the
     // nested_model_absolute_name. Otherwise the nested model is not a
-    // descendent of the model relative to which we are computing the name.
+    // descendant of the model relative to which we are computing the name.
     const std::string required_prefix =
         relative_to_model_absolute_name + std::string(sdf::kScopeDelimiter);
-    DRAKE_DEMAND(nested_model_absolute_name.starts_with(required_prefix));
+    if (!nested_model_absolute_name.starts_with(required_prefix)) {
+      diagnostic.Error(fmt::format(
+          "Body '{}' belonging to model instance '{}' is not a descendant of "
+          "model instance '{}'. This can happen when a nested model (for "
+          "example a URDF included from SDFormat) contains a joint to the "
+          "world.",
+          body.name(), nested_model_absolute_name,
+          relative_to_model_absolute_name));
+      return std::nullopt;
+    }
 
     const std::string nested_model_relative_name =
         nested_model_absolute_name.substr(required_prefix.size());
@@ -688,12 +702,19 @@ bool AddJointFromSpecification(const SDFormatDiagnostic& diagnostic,
       ResolveJointChildLinkName(diagnostic, joint_spec), model_instance,
       *plant);
 
+  const DiagnosticPolicy policy =
+      diagnostic.MakePolicyForNode(*joint_spec.Element());
+
   // Get the pose of frame J in the frame of the child link C, as specified in
   // <joint> <pose> ... </pose></joint>. The default `relative_to` pose of a
   // joint will be the child link.
+  const std::optional<std::string> child_relative_name =
+      GetRelativeBodyName(child_body, model_instance, *plant, policy);
+  if (!child_relative_name.has_value()) {
+    return false;
+  }
   const RigidTransformd X_CJ = ResolveRigidTransform(
-      diagnostic, joint_spec.SemanticPose(),
-      GetRelativeBodyName(child_body, model_instance, *plant));
+      diagnostic, joint_spec.SemanticPose(), *child_relative_name);
 
   // Pose of the frame J in the parent body frame P.
   std::optional<RigidTransformd> X_PJ;
@@ -706,9 +727,13 @@ bool AddJointFromSpecification(const SDFormatDiagnostic& diagnostic,
         diagnostic, joint_spec.SemanticPose(), relative_to);
     X_PJ = X_WM * X_MJ;  // Since P == W.
   } else {
-    X_PJ = ResolveRigidTransform(
-        diagnostic, joint_spec.SemanticPose(),
-        GetRelativeBodyName(parent_body, model_instance, *plant));
+    const std::optional<std::string> parent_relative_name =
+        GetRelativeBodyName(parent_body, model_instance, *plant, policy);
+    if (!parent_relative_name.has_value()) {
+      return false;
+    }
+    X_PJ = ResolveRigidTransform(diagnostic, joint_spec.SemanticPose(),
+                                 *parent_relative_name);
   }
 
   // If P and J are coincident, we won't create a new frame for J, but use frame
@@ -2654,11 +2679,12 @@ void AddBodiesToInterfaceModel(const MultibodyPlant<double>& plant,
   }
 }
 
-void AddFramesToInterfaceModel(const MultibodyPlant<double>& plant,
+bool AddFramesToInterfaceModel(const MultibodyPlant<double>& plant,
                                ModelInstanceIndex model_instance,
                                const sdf::InterfaceModelPtr& interface_model,
                                const std::vector<FrameIndex>& frame_indices,
-                               const std::string& model_frame_name) {
+                               const std::string& model_frame_name,
+                               const DiagnosticPolicy& diagnostic) {
   for (auto index : frame_indices) {
     const auto& frame = plant.get_frame(index);
     if (frame.model_instance() != model_instance) {
@@ -2673,10 +2699,16 @@ void AddFramesToInterfaceModel(const MultibodyPlant<double>& plant,
       // created using the <frame> tag).
       continue;
     }
+    const std::optional<std::string> attached_to =
+        GetRelativeBodyName(frame.body(), model_instance, plant, diagnostic);
+    if (!attached_to.has_value()) {
+      return false;
+    }
     interface_model->AddFrame(
-        {frame.name(), GetRelativeBodyName(frame.body(), model_instance, plant),
+        {frame.name(), *attached_to,
          ToIgnitionPose3d(frame.GetFixedPoseInBodyFrame())});
   }
+  return true;
 }
 
 void AddJointsToInterfaceModel(const MultibodyPlant<double>& plant,
@@ -2719,6 +2751,7 @@ ModelInstanceIndex GetOrCreateModelInstanceByName(
 sdf::InterfaceModelPtr ConvertToInterfaceModel(
     MultibodyPlant<double>* plant, std::string model_name,
     const InterfaceModelHelper& interface_model_helper, sdf::Errors* errors,
+    const DiagnosticPolicy& diagnostic,
     RigidTransformd X_WP = RigidTransformd::Identity()) {
   auto model_instance = interface_model_helper.model_instance();
   sdf::RepostureFunction reposture_model =
@@ -2739,22 +2772,28 @@ sdf::InterfaceModelPtr ConvertToInterfaceModel(
 
   const auto& model_frame = plant->GetFrameByName(
       interface_model_helper.model_frame_name(), model_instance);
-  const std::string canonical_link_name =
-      GetRelativeBodyName(model_frame.body(), model_instance, *plant);
+  const std::optional<std::string> canonical_link_name = GetRelativeBodyName(
+      model_frame.body(), model_instance, *plant, diagnostic);
+  if (!canonical_link_name.has_value()) {
+    return nullptr;
+  }
   const RigidTransformd X_WM = GetDefaultFramePose(*plant, model_frame);
   const RigidTransformd X_PM = X_WP.inverse() * X_WM;
 
   auto interface_model = std::make_shared<sdf::InterfaceModel>(
-      model_name, reposture_model, false, canonical_link_name,
+      model_name, reposture_model, false, *canonical_link_name,
       ToIgnitionPose3d(X_PM));
 
   AddBodiesToInterfaceModel(*plant, interface_model,
                             interface_model_helper.body_indices(),
                             X_WM.inverse());
 
-  AddFramesToInterfaceModel(*plant, model_instance, interface_model,
-                            interface_model_helper.frame_indices(),
-                            interface_model_helper.model_frame_name());
+  if (!AddFramesToInterfaceModel(*plant, model_instance, interface_model,
+                                 interface_model_helper.frame_indices(),
+                                 interface_model_helper.model_frame_name(),
+                                 diagnostic)) {
+    return nullptr;
+  }
 
   AddJointsToInterfaceModel(*plant, interface_model,
                             interface_model_helper.joint_indices());
@@ -2872,7 +2911,10 @@ sdf::InterfaceModelPtr ParseNestedInterfaceModel(
   // This will be populated for the first model instance.
   sdf::InterfaceModelPtr main_interface_model;
   main_interface_model = ConvertToInterfaceModel(
-      plant, model_name, interface_model_helper, errors);
+      plant, model_name, interface_model_helper, errors, subdiagnostic);
+  if (main_interface_model == nullptr) {
+    return nullptr;
+  }
   main_interface_model->SetParserSupportsMergeInclude(true);
 
   return main_interface_model;

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -4087,6 +4087,25 @@ TEST_F(SdfParserTest, ErrorsFromIncludedUrdf) {
   EXPECT_THAT(TakeError(), MatchesRegex(".*bad.urdf.*XML_ERROR.*"));
 }
 
+// Nested URDF that welds to the world must report a DiagnosticPolicy error
+// instead of aborting in GetRelativeBodyName (see #21413).
+TEST_F(SdfParserTest, NestedUrdfWorldWeldDiagnostic) {
+  ParseTestString(R"""(
+<model name="top">
+  <link name="torso"/>
+  <include>
+    <uri>package://drake/multibody/parsing/test/sdf_parser_test/world_weld.urdf</uri>
+    <name>gripper</name>
+  </include>
+</model>)""",
+                  "1.8");
+  EXPECT_THAT(
+      TakeError(),
+      MatchesRegex(
+          ".*Body 'world' belonging to model instance 'WorldModelInstance' is "
+          "not a descendant of model instance '.*gripper'.*"));
+}
+
 // TODO(SeanCurtis-TRI) The logic testing for collision filter group parsing
 // belongs in detail_common_test.cc. Urdf and Sdf parsing just need enough
 // testing to indicate that the method is being invoked correctly.

--- a/multibody/parsing/test/sdf_parser_test/world_weld.urdf
+++ b/multibody/parsing/test/sdf_parser_test/world_weld.urdf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!-- Minimal nested-URDF repro for Drake issue #21413: a fixed joint to world.
+     Non-identity origin is required so MultibodyPlant creates a joint frame
+     attached to world (identity welds elide that frame; see #24687). -->
+<robot name="gripper_with_world_weld">
+  <link name="base_link">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+  </link>
+  <joint name="world_weld" type="fixed">
+    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+    <parent link="world"/>
+    <child link="base_link"/>
+  </joint>
+</robot>


### PR DESCRIPTION
Nested SDFormat models that weld a URDF child to the world currently abort with a `DRAKE_DEMAND` in `GetRelativeBodyName` when the nested absolute name does not start with the expected prefix.

This replaces that abort with a `DiagnosticPolicy` error so bad inputs fail cleanly instead of crashing the process.

Fixes #21413

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24965)
<!-- Reviewable:end -->
