### PR TITLE
[parsing] Honor URDF mechanicalReduction as actuator gear ratio

### DIFF
--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -116,7 +116,10 @@ class UrdfParser {
     return internal::ParseScalarAttribute(node, attribute_name, val,
                                           diagnostic_.MakePolicyForNode(node));
   }
-  void ParseMechanicalReduction(const XMLElement& node);
+  // Parses an optional mechanicalReduction child. Returns a gear ratio when
+  // the element contains a single scalar; otherwise returns nullopt (and may
+  // emit a warning for unparseable values).
+  std::optional<double> ParseMechanicalReduction(const XMLElement& node);
 
   void Warning(const XMLNode& location, std::string message) const {
     diagnostic_.Warning(location, std::move(message));
@@ -879,25 +882,27 @@ void UrdfParser::ParseMimicTag(XMLElement* node) {
   plant->AddCouplerConstraint(joint0, joint1, gear_ratio, offset);
 }
 
-void UrdfParser::ParseMechanicalReduction(const XMLElement& node) {
+std::optional<double> UrdfParser::ParseMechanicalReduction(
+    const XMLElement& node) {
   const XMLElement* child = node.FirstChildElement("mechanicalReduction");
   if (!child) {
-    return;
+    return std::nullopt;
   }
   const char* text = child->GetText();
   if (!text) {
-    return;
+    return std::nullopt;
   }
   std::vector<double> values = ConvertToVector<double>(text);
-  if (values.size() == 1 && values[0] == 1) {
-    return;
+  if (values.size() == 1) {
+    return values[0];
   }
   Warning(
       *child,
       fmt::format("A '{}' element contains a mechanicalReduction element with a"
-                  " value '{}' other than the default of 1. MultibodyPlant does"
-                  " not currently support non-default mechanical reductions.",
+                  " value '{}' that cannot be parsed as a single scalar number."
+                  " The mechanicalReduction will be ignored.",
                   node.Name(), text));
+  return std::nullopt;
 }
 
 void UrdfParser::ParseTransmission(const JointEffortLimits& joint_effort_limits,
@@ -909,7 +914,9 @@ void UrdfParser::ParseTransmission(const JointEffortLimits& joint_effort_limits,
   WarnUnsupportedElement(*node, "gap_joint");
   WarnUnsupportedElement(*node, "passive_joint");
   WarnUnsupportedElement(*node, "use_simulated_gripper_joint");
-  ParseMechanicalReduction(*node);
+  // Prefer actuator-level mechanicalReduction over transmission-level.
+  const std::optional<double> transmission_mechanical_reduction =
+      ParseMechanicalReduction(*node);
 
   // Determines the transmission type.
   std::string type;
@@ -941,7 +948,8 @@ void UrdfParser::ParseTransmission(const JointEffortLimits& joint_effort_limits,
     Error(*node, "Transmission is missing an actuator element.");
     return;
   }
-  ParseMechanicalReduction(*actuator_node);
+  const std::optional<double> actuator_mechanical_reduction =
+      ParseMechanicalReduction(*actuator_node);
   // `actuator/hardwareInterface` child tags are silently ignored.
 
   std::string actuator_name;
@@ -1017,6 +1025,18 @@ void UrdfParser::ParseTransmission(const JointEffortLimits& joint_effort_limits,
     }
     plant->get_mutable_joint_actuator(actuator.index())
         .set_default_rotor_inertia(rotor_inertia);
+  }
+
+  // Map standard URDF mechanicalReduction to the actuator gear ratio. An
+  // actuator-level value takes precedence over a transmission-level value.
+  // The custom drake:gear_ratio tag below may still override this.
+  const std::optional<double> mechanical_reduction =
+      actuator_mechanical_reduction.has_value()
+          ? actuator_mechanical_reduction
+          : transmission_mechanical_reduction;
+  if (mechanical_reduction.has_value()) {
+    plant->get_mutable_joint_actuator(actuator.index())
+        .set_default_gear_ratio(*mechanical_reduction);
   }
 
   // Parse and add the optional drake:gear_ratio parameter.

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -234,9 +234,12 @@ one of several treatments:
 - `/robot/transmission/actuator/mechanicalReduction`
 - `/robot/transmission/mechanicalReduction`
 
-Both versions of `mechanicalReduction` will be silently ignored if the supplied
-value is 1; otherwise the they will provoke a warning that the value is being
-ignored.
+Both versions of `mechanicalReduction` are mapped to the JointActuator gear
+ratio (see @ref tag_drake_gear_ratio) when the element contains a single
+scalar value. An actuator-level value takes precedence over a
+transmission-level value. The custom `drake:gear_ratio` tag, if present,
+overrides `mechanicalReduction`. Values that cannot be parsed as a single
+scalar provoke a warning and are ignored.
 
 @section multibody_parsing_drake_extensions Drake Extensions
 
@@ -1163,6 +1166,9 @@ Applies the indicated gear ratio value to the appropriate JointActuator
 object. This value is only used for reflected inertia calculations, and not as
 a torque multiplier. The value is dimensionless for revolute joints, and has
 units of 1/m for prismatic joints.
+
+In URDF, the standard `mechanicalReduction` element is also accepted as a
+synonym for this tag (see @ref urdf_ignored_special).
 
 @see drake::multibody::JointActuator, @ref tag_drake_rotor_inertia,
 @ref reflected_inertia "Reflected Inertia"

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <limits>
 #include <map>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -2843,6 +2844,23 @@ TEST_F(ReflectedInertiaTest, GearRatioManyValues) {
                ".*Expected single value.*value.*");
 }
 
+TEST_F(ReflectedInertiaTest, MechanicalReduction) {
+  // Standard URDF mechanicalReduction maps to the actuator gear ratio.
+  VerifyParameters("", "<mechanicalReduction>113.90625</mechanicalReduction>",
+                   0.0, 113.90625);
+}
+
+TEST_F(ReflectedInertiaTest, MechanicalReductionUnity) {
+  VerifyParameters("", "<mechanicalReduction>1</mechanicalReduction>", 0.0,
+                   1.0);
+}
+
+TEST_F(ReflectedInertiaTest, DrakeGearRatioOverridesMechanicalReduction) {
+  // Custom drake:gear_ratio wins when both are specified.
+  VerifyParameters("<mechanicalReduction>50</mechanicalReduction>",
+                   "<drake:gear_ratio value='300.0' />", 0.0, 300.0);
+}
+
 class ControllerGainsTest : public UrdfParserTest {
  public:
   void VerifyParameters(const std::string& controller_gains_text,
@@ -3198,7 +3216,7 @@ TEST_F(UrdfParserTest, UnsupportedTransmissionJointStuffIgnoredSilent) {
 // documented elsewhere) when it ignores something thought to be a documented
 // URDF element or attribute.
 
-TEST_F(UrdfParserTest, UnsupportedMechanicalReductionIgnoredMaybe) {
+TEST_F(UrdfParserTest, MechanicalReductionGearRatio) {
   // Two substitution slots: actuator, then transmission.
   constexpr const char* robot_template = R"""(
     <robot>
@@ -3216,40 +3234,56 @@ TEST_F(UrdfParserTest, UnsupportedMechanicalReductionIgnoredMaybe) {
         {}
       </transmission>
     </robot>)""";
-  // Match the expected warning.
-  constexpr char pattern[] = ".*mechanicalReduction.*default.*not.*support.*";
+  // Match the expected warning for unparseable values.
+  constexpr char pattern[] =
+      ".*mechanicalReduction.*single scalar.*ignored.*";
 
   struct Case {
     std::string input;
     bool provokes_warning{};
+    // nullopt means the actuator keeps the default gear ratio of 1.
+    std::optional<double> expected_gear_ratio;
   };
   const std::array<Case, 8> cases{{
-      {"<mechanicalReduction>3500.25</mechanicalReduction>", true},
-      {"<mechanicalReduction>22 79 15</mechanicalReduction>", true},
-      {"<mechanicalReduction>QQQ</mechanicalReduction>", true},
-      {"<mechanicalReduction/>", false},
-      {"<mechanicalReduction></mechanicalReduction>", false},
-      {"<mechanicalReduction> </mechanicalReduction>", false},
-      {"<mechanicalReduction>1</mechanicalReduction>", false},
-      {"<mechanicalReduction>1.0</mechanicalReduction>", false},
+      {"<mechanicalReduction>3500.25</mechanicalReduction>", false, 3500.25},
+      {"<mechanicalReduction>22 79 15</mechanicalReduction>", true,
+       std::nullopt},
+      {"<mechanicalReduction>QQQ</mechanicalReduction>", true, std::nullopt},
+      {"<mechanicalReduction/>", false, std::nullopt},
+      {"<mechanicalReduction></mechanicalReduction>", false, std::nullopt},
+      {"<mechanicalReduction> </mechanicalReduction>", false, std::nullopt},
+      {"<mechanicalReduction>1</mechanicalReduction>", false, 1.0},
+      {"<mechanicalReduction>1.0</mechanicalReduction>", false, 1.0},
   }};
 
   for (const Case& acase : cases) {
     // Within actuator.
-    EXPECT_NE(
+    const std::optional<ModelInstanceIndex> actuator_model =
         AddModelFromUrdfString(fmt::format(robot_template, acase.input, ""),
-                               acase.input + "_actuator"),
-        std::nullopt);
+                               acase.input + "_actuator");
+    EXPECT_NE(actuator_model, std::nullopt);
     if (acase.provokes_warning) {
       EXPECT_THAT(TakeWarning(), MatchesRegex(pattern));
     }
+    {
+      const JointActuator<double>& actuator =
+          plant_.GetJointActuatorByName("a", *actuator_model);
+      EXPECT_EQ(actuator.default_gear_ratio(),
+                acase.expected_gear_ratio.value_or(1.0));
+    }
     // Within transmission.
-    EXPECT_NE(
+    const std::optional<ModelInstanceIndex> transmission_model =
         AddModelFromUrdfString(fmt::format(robot_template, "", acase.input),
-                               acase.input + "_transmission"),
-        std::nullopt);
+                               acase.input + "_transmission");
+    EXPECT_NE(transmission_model, std::nullopt);
     if (acase.provokes_warning) {
       EXPECT_THAT(TakeWarning(), MatchesRegex(pattern));
+    }
+    {
+      const JointActuator<double>& actuator =
+          plant_.GetJointActuatorByName("a", *transmission_model);
+      EXPECT_EQ(actuator.default_gear_ratio(),
+                acase.expected_gear_ratio.value_or(1.0));
     }
   }
 }


### PR DESCRIPTION
URDF transmissions with a non-default `mechanicalReduction` currently only warn and leave the actuator gear ratio at 1. MultibodyPlant already supports gear ratios via `drake:gear_ratio`; this wires the official URDF tag through to the same setter.

Fixes #21948

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24966)
<!-- Reviewable:end -->
