### PR TITLE
[parsing] Parse SDFormat 1.11 joint axis mimic tags

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -888,12 +888,90 @@ bool AddJointFromSpecification(const SDFormatDiagnostic& diagnostic,
   return true;
 }
 
-// Helper method to parse a custom drake:mimic tag.
+// Helper method to add a coupler constraint from a mimic specification.
+// Reports diagnostics against `mimic_node` using `mimic_tag` in messages
+// (e.g. "mimic" or "drake:mimic"). The coupler models
+// q_follower = gear_ratio * q_leader + offset.
+bool AddMimicCouplerConstraint(
+    const SDFormatDiagnostic& diagnostic, sdf::ElementPtr mimic_node,
+    const std::string& mimic_tag, const sdf::Joint& joint_spec,
+    const std::string& joint_to_mimic, double gear_ratio, double offset,
+    ModelInstanceIndex model_instance, MultibodyPlant<double>* plant) {
+  if (!plant->HasJointNamed(joint_to_mimic, model_instance)) {
+    diagnostic.Error(
+        mimic_node,
+        fmt::format("Joint '{}' {} element specifies joint '{}' which"
+                    " does not exist.",
+                    joint_spec.Name(), mimic_tag, joint_to_mimic));
+    return false;
+  }
+
+  if (joint_to_mimic == joint_spec.Name()) {
+    diagnostic.Error(mimic_node,
+                     fmt::format("Joint '{}' {} element specifies "
+                                 "joint '{}'. Joints cannot mimic themselves.",
+                                 joint_spec.Name(), mimic_tag, joint_to_mimic));
+    return false;
+  }
+
+  const Joint<double>& joint0 =
+      plant->GetJointByName(joint_spec.Name(), model_instance);
+  const Joint<double>& joint1 =
+      plant->GetJointByName(joint_to_mimic, model_instance);
+
+  if (joint0.num_velocities() != 1 || joint1.num_velocities() != 1) {
+    // The URDF documentation is ambiguous as to whether multi-dof joints
+    // are supported by the mimic tag. So we only raise a warning, not an
+    // error. The same policy applies to SDFormat //joint/axis/mimic.
+    diagnostic.Warning(
+        mimic_node,
+        fmt::format("Drake only supports the {} element for "
+                    "single-dof joints. The joint '{}' (with {} "
+                    "dofs) is attempting to mimic joint '{}' (with "
+                    "{} dofs). The {} element will be ignored.",
+                    mimic_tag, joint0.name(), joint0.num_velocities(),
+                    joint_to_mimic, joint1.num_velocities(), mimic_tag));
+  } else {
+    plant->AddCouplerConstraint(joint0, joint1, gear_ratio, offset);
+  }
+
+  return true;
+}
+
+// Returns the SDFormat element to use for diagnostics for an official mimic
+// tag. The sole call site only invokes this when axis->Mimic() is present, so
+// the mimic child element is expected to exist.
+sdf::ElementPtr GetOfficialMimicDiagnosticNode(const sdf::JointAxis& axis) {
+  DRAKE_DEMAND(axis.Element() != nullptr);
+  DRAKE_DEMAND(axis.Element()->HasElement("mimic"));
+  return axis.Element()->GetElement("mimic");
+}
+
+// Helper method to parse SDFormat //joint/axis/mimic, //joint/axis2/mimic,
+// and the custom //joint/drake:mimic tag into coupler constraints.
 bool ParseMimicTag(const SDFormatDiagnostic& diagnostic,
                    const sdf::Joint& joint_spec,
                    ModelInstanceIndex model_instance,
                    MultibodyPlant<double>* plant) {
-  if (!joint_spec.Element()->HasElement("drake:mimic")) return true;
+  const bool has_drake_mimic = joint_spec.Element()->HasElement("drake:mimic");
+
+  // Collect official SDFormat 1.11+ mimic constraints from axis and axis2.
+  struct OfficialMimic {
+    sdf::ElementPtr node;
+    sdf::MimicConstraint constraint;
+  };
+  std::vector<OfficialMimic> official_mimics;
+  for (unsigned int axis_index = 0; axis_index < 2; ++axis_index) {
+    const sdf::JointAxis* axis = joint_spec.Axis(axis_index);
+    if (axis == nullptr) continue;
+    const std::optional<sdf::MimicConstraint> mimic = axis->Mimic();
+    if (!mimic.has_value()) continue;
+    official_mimics.push_back({GetOfficialMimicDiagnosticNode(*axis), *mimic});
+  }
+
+  if (!has_drake_mimic && official_mimics.empty()) {
+    return true;
+  }
 
   // Only warn for non-SAP discrete solvers; continuous plants have different
   // error reporting.
@@ -901,12 +979,36 @@ bool ParseMimicTag(const SDFormatDiagnostic& diagnostic,
       plant->get_discrete_contact_solver() != DiscreteContactSolver::kSap) {
     diagnostic.Warning(
         joint_spec.Element(),
-        fmt::format("Joint '{}' specifies a drake:mimic element that will be "
+        fmt::format("Joint '{}' specifies a mimic element that will be "
                     "ignored. Mimic elements are currently only supported by "
                     "MultibodyPlant with a discrete time step and using "
                     "DiscreteContactSolver::kSap, or by continuous time plants "
                     "using the CENIC integrator.",
                     joint_spec.Name()));
+    return true;
+  }
+
+  // Official SDFormat mimic:
+  //   follower = multiplier * (leader - reference) + offset
+  // which matches Drake's coupler
+  //   q0 = gear_ratio * q1 + Δq
+  // when gear_ratio = multiplier and Δq = offset - multiplier * reference.
+  for (const OfficialMimic& item : official_mimics) {
+    // Drake's coupler constraint addresses whole single-dof joints, so the
+    // leader @axis attribute is only meaningful when it names the (sole) axis
+    // of a 1-dof joint. Non-"axis" values imply a multi-dof leader axis which
+    // is rejected by AddMimicCouplerConstraint's dof check.
+    const double multiplier = item.constraint.Multiplier();
+    const double offset =
+        item.constraint.Offset() - multiplier * item.constraint.Reference();
+    if (!AddMimicCouplerConstraint(diagnostic, item.node, "mimic", joint_spec,
+                                   item.constraint.Joint(), multiplier, offset,
+                                   model_instance, plant)) {
+      return false;
+    }
+  }
+
+  if (!has_drake_mimic) {
     return true;
   }
 
@@ -921,23 +1023,6 @@ bool ParseMimicTag(const SDFormatDiagnostic& diagnostic,
   }
 
   const std::string joint_to_mimic = mimic_node->Get<std::string>("joint");
-
-  if (!plant->HasJointNamed(joint_to_mimic, model_instance)) {
-    diagnostic.Error(
-        mimic_node,
-        fmt::format("Joint '{}' drake:mimic element specifies joint '{}' which"
-                    " does not exist.",
-                    joint_spec.Name(), joint_to_mimic));
-    return false;
-  }
-
-  if (joint_to_mimic == joint_spec.Name()) {
-    diagnostic.Error(mimic_node,
-                     fmt::format("Joint '{}' drake:mimic element specifies "
-                                 "joint '{}'. Joints cannot mimic themselves.",
-                                 joint_spec.Name(), joint_to_mimic));
-    return false;
-  }
 
   if (!mimic_node->HasAttribute("multiplier")) {
     diagnostic.Error(
@@ -957,29 +1042,9 @@ bool ParseMimicTag(const SDFormatDiagnostic& diagnostic,
 
   const double gear_ratio = mimic_node->Get<double>("multiplier");
   const double offset = mimic_node->Get<double>("offset");
-
-  const Joint<double>& joint0 =
-      plant->GetJointByName(joint_spec.Name(), model_instance);
-  const Joint<double>& joint1 =
-      plant->GetJointByName(joint_to_mimic, model_instance);
-
-  if (joint0.num_velocities() != 1 || joint1.num_velocities() != 1) {
-    // The URDF documentation is ambiguous as to whether multi-dof joints
-    // are supported by the mimic tag (which the drake:mimic tag is analogous
-    // to). So we only raise a warning, not an error.
-    diagnostic.Warning(
-        mimic_node,
-        fmt::format("Drake only supports the drake:mimic element for "
-                    "single-dof joints. The joint '{}' (with {} "
-                    "dofs) is attempting to mimic joint '{}' (with "
-                    "{} dofs). The drake:mimic element will be ignored.",
-                    joint0.name(), joint0.num_velocities(), joint_to_mimic,
-                    joint1.num_velocities()));
-  } else {
-    plant->AddCouplerConstraint(joint0, joint1, gear_ratio, offset);
-  }
-
-  return true;
+  return AddMimicCouplerConstraint(diagnostic, mimic_node, "drake:mimic",
+                                   joint_spec, joint_to_mimic, gear_ratio,
+                                   offset, model_instance, plant);
 }
 
 // Helper method to load an SDF file and read the contents into an sdf::Root
@@ -2499,7 +2564,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSpecification(
     }
   }
 
-  // Parse drake:mimic elements only after all joints have been added.
+  // Parse mimic elements only after all joints have been added.
   for (uint64_t joint_index = 0; joint_index < model.JointCount();
        ++joint_index) {
     // Get a pointer to the SDF joint, and the joint axis information.
@@ -3210,7 +3275,7 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
       }
     }
 
-    // Parse drake:mimic elements only after all joints have been added.
+    // Parse mimic elements only after all joints have been added.
     for (uint64_t joint_index = 0; joint_index < world.JointCount();
          ++joint_index) {
       // Get a pointer to the SDF joint, and the joint axis information.

--- a/multibody/parsing/parsing_doxygen.h
+++ b/multibody/parsing/parsing_doxygen.h
@@ -1480,6 +1480,13 @@ the relation: `q0 = multiplier * q1 + offset`. The units of `multiplier` and
 `offset` depend on the type of joints specified. This tag only supports single
 degree of freedom joints that exist in the same model instance.
 
+Drake also parses the official SDFormat 1.11+ `//joint/axis/mimic` and
+`//joint/axis2/mimic` elements (see
+http://sdformat.org/spec?ver=1.11&elem=joint#axis_mimic). Those use child
+elements for `multiplier`, `offset`, and `reference`, with
+`follower = multiplier * (leader - reference) + offset`. When `reference` is
+zero, the mapping matches this custom tag and URDF.
+
 @subsection tag_drake_mu_dynamic drake:mu_dynamic
 
 - SDFormat path: `//model/link/collision/drake:proximity_properties/drake:mu_dynamic`

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1129,6 +1129,177 @@ TEST_F(SdfParserTest, MimicSuccessfulParsingForwardReference) {
   EXPECT_EQ(spec.offset, 0.5);
 }
 
+// SDFormat 1.11 official //joint/axis/mimic, with multiplier/offset/reference
+// values from libsdformat's DOMJointAxis.ParseMimic test. Drake's coupler is
+//   q_follower = gear_ratio * q_leader + offset
+// and SDFormat defines
+//   follower = multiplier * (leader - reference) + offset
+// so gear_ratio = multiplier and Drake offset = offset - multiplier *
+// reference.
+TEST_F(SdfParserTest, OfficialMimicSuccessfulParsing) {
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  ParseTestString(R"""(
+    <model name='test'>
+      <link name='link1'/>
+      <link name='link2'/>
+      <link name='link3'/>
+      <joint name='source_joint' type='revolute'>
+        <parent>link1</parent>
+        <child>link2</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <joint name='follow_joint' type='revolute'>
+        <parent>link1</parent>
+        <child>link3</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <mimic joint='source_joint'>
+            <multiplier>4</multiplier>
+            <offset>2</offset>
+            <reference>3</reference>
+          </mimic>
+        </axis>
+      </joint>
+    </model>)""",
+                  "1.11");
+  DRAKE_EXPECT_NO_THROW(plant_.GetJointByName("follow_joint"));
+  DRAKE_EXPECT_NO_THROW(plant_.GetJointByName("source_joint"));
+  const Joint<double>& joint_with_mimic = plant_.GetJointByName("follow_joint");
+  const Joint<double>& joint_to_mimic = plant_.GetJointByName("source_joint");
+
+  EXPECT_EQ(plant_.num_constraints(), 1);
+  EXPECT_EQ(plant_.num_coupler_constraints(), 1);
+  const internal::CouplerConstraintSpec& spec =
+      plant_.get_coupler_constraint_specs().begin()->second;
+  EXPECT_EQ(spec.joint0_index, joint_with_mimic.index());
+  EXPECT_EQ(spec.joint1_index, joint_to_mimic.index());
+  EXPECT_EQ(spec.gear_ratio, 4);
+  EXPECT_EQ(spec.offset, 2 - 4 * 3);
+}
+
+TEST_F(SdfParserTest, OfficialMimicZeroReferenceMatchesUrdf) {
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  ParseTestString(R"""(
+    <model name='a'>
+      <link name='A'/>
+      <link name='B'/>
+      <link name='C'/>
+      <joint name='joint_AB' type='revolute'>
+        <parent>A</parent>
+        <child>B</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <joint name='joint_AC' type='revolute'>
+        <parent>A</parent>
+        <child>C</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <mimic joint='joint_AB'>
+            <multiplier>1</multiplier>
+            <offset>0.5</offset>
+            <reference>0</reference>
+          </mimic>
+        </axis>
+      </joint>
+    </model>)""",
+                  "1.11");
+  const Joint<double>& joint_with_mimic = plant_.GetJointByName("joint_AC");
+  const Joint<double>& joint_to_mimic = plant_.GetJointByName("joint_AB");
+  EXPECT_EQ(plant_.num_coupler_constraints(), 1);
+  const internal::CouplerConstraintSpec& spec =
+      plant_.get_coupler_constraint_specs().begin()->second;
+  EXPECT_EQ(spec.joint0_index, joint_with_mimic.index());
+  EXPECT_EQ(spec.joint1_index, joint_to_mimic.index());
+  EXPECT_EQ(spec.gear_ratio, 1);
+  EXPECT_EQ(spec.offset, 0.5);
+}
+
+TEST_F(SdfParserTest, OfficialMimicForwardReference) {
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  ParseTestString(R"""(
+    <model name='a'>
+      <link name='A'/>
+      <link name='B'/>
+      <link name='C'/>
+      <joint name='joint_AB' type='revolute'>
+        <parent>A</parent>
+        <child>B</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <mimic joint='joint_AC'>
+            <multiplier>2</multiplier>
+            <offset>0.25</offset>
+            <reference>1</reference>
+          </mimic>
+        </axis>
+      </joint>
+      <joint name='joint_AC' type='revolute'>
+        <parent>A</parent>
+        <child>C</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+    </model>)""",
+                  "1.11");
+  const Joint<double>& joint_with_mimic = plant_.GetJointByName("joint_AB");
+  const Joint<double>& joint_to_mimic = plant_.GetJointByName("joint_AC");
+  EXPECT_EQ(plant_.num_coupler_constraints(), 1);
+  const internal::CouplerConstraintSpec& spec =
+      plant_.get_coupler_constraint_specs().begin()->second;
+  EXPECT_EQ(spec.joint0_index, joint_with_mimic.index());
+  EXPECT_EQ(spec.joint1_index, joint_to_mimic.index());
+  EXPECT_EQ(spec.gear_ratio, 2);
+  EXPECT_EQ(spec.offset, 0.25 - 2 * 1);
+}
+
+TEST_F(SdfParserTest, OfficialMimicAxis2OnUniversalWarns) {
+  plant_.set_discrete_contact_approximation(DiscreteContactApproximation::kSap);
+  ParseTestString(R"""(
+    <model name='a'>
+      <link name='A'/>
+      <link name='B'/>
+      <link name='C'/>
+      <joint name='joint_AB' type='revolute'>
+        <parent>A</parent>
+        <child>B</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+      <joint name='joint_AC' type='universal'>
+        <parent>A</parent>
+        <child>C</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <effort>0</effort>
+          </limit>
+        </axis>
+        <axis2>
+          <xyz>1 0 0</xyz>
+          <limit>
+            <effort>0</effort>
+          </limit>
+          <mimic joint='joint_AB'>
+            <multiplier>1</multiplier>
+            <offset>0</offset>
+            <reference>0</reference>
+          </mimic>
+        </axis2>
+      </joint>
+    </model>)""",
+                  "1.11");
+  EXPECT_THAT(TakeWarning(),
+              MatchesRegex(".*Drake only supports the mimic element for "
+                           "single-dof joints.*"));
+  EXPECT_EQ(plant_.num_coupler_constraints(), 0);
+}
+
 static constexpr char kMimicModel[] = R"""(
     <model name='a'>
       <link name='A'/>


### PR DESCRIPTION
SDFormat 1.11 defines official `//joint/axis/mimic` and `//joint/axis2/mimic` elements. Drake already creates coupler constraints from custom `drake:mimic` tags; this adds parsing for the official tags alongside the existing custom ones.

Fixes #20704

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24967)
<!-- Reviewable:end -->
