### PR TITLE
[examples] Auto loop breaking four bar example

### DIFF
--- a/examples/multibody/four_bar/BUILD.bazel
+++ b/examples/multibody/four_bar/BUILD.bazel
@@ -18,6 +18,27 @@ filegroup(
 )
 
 drake_cc_binary(
+    name = "four_bar",
+    srcs = ["four_bar.cc"],
+    data = [":models"],
+    deps = [
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//systems/analysis:simulator",
+        "//systems/analysis:simulator_gflags",
+        "//systems/analysis:simulator_print_stats",
+        "//systems/framework:diagram",
+        "//visualization:visualization_config_functions",
+        "@gflags",
+    ],
+    add_test_rule = True,
+    test_rule_args = [
+        "--simulation_time=0.1",
+        "--nointeractive",
+    ],
+)
+
+drake_cc_binary(
     name = "four_bar_with_bushing",
     srcs = ["four_bar_with_bushing.cc"],
     data = [":models"],

--- a/examples/multibody/four_bar/README.md
+++ b/examples/multibody/four_bar/README.md
@@ -1,6 +1,92 @@
-# Four-Bar Linkage Example
+# Four-Bar Linkage Examples
+
+These two examples model the same kind of mechanism -- a planar four-bar
+linkage -- and illustrate two different ways to deal with the closed kinematic
+loop that a four-bar forms:
+
+* `four_bar` loads the loop from an SDFormat model file and lets MultibodyPlant
+  model it automatically, closing it with a constraint that `Finalize()` adds.
+  Note: this uses a Drake feature that is currently experimental and marked
+  "internal use only".
+* `four_bar_with_bushing` leaves one of the four joints out and replaces it
+  with a compliant bushing, so the remaining joints form a tree.
+
+# Automatic loop modeling: `four_bar`
+
+This example loads a four-bar linkage from an SDFormat model file that
+describes it the way you would draw it: as a plain loop of four revolute
+joints, with no attempt to specify a spanning tree and no stand-in for the
+"extra" joint. Beyond opting in with
+`MultibodyPlant::SetEnableLoopTopology()` there is nothing to do about the loop,
+and the rest of the program is just an ordinary simulation.
+
+Under the covers, at `Finalize()` MultibodyPlant breaks the loop by adding a
+"shadow" copy of one link, retargeting one joint onto the shadow, and adding a
+weld constraint that holds the shadow to the link it was split from.
+
+Closing the loop takes a constraint, so this model needs a solver that can
+enforce one. It runs in discrete mode under SAP by default, and continuous
+under CENIC if requested.
+
+The model file, `four_bar.sdf`, describes the linkage in an **assembled**
+configuration, as is required by SDFormat (see the discussion in the model
+file). Thus the parsed model is already assembled at q = 0.
+
+## Running four_bar
+
+To run with default flags:
+
+```
+bazel run //examples/multibody/four_bar:four_bar
+```
+You'll see output like this:
+```
+[console] [info] Meshcat listening for connections at http://localhost:7000
+
+The linkage is shown as the model file defines it.
+Press Enter to simulate . . .
+```
+Open that URL in a browser to see the linkage, then press Enter and watch it
+swing passively under gravity.
+
+To run the same model continuously with the CENIC integrator instead of the
+default discrete SAP solver:
+
+```
+bazel run //examples/multibody/four_bar:four_bar -- \
+    --time_step=0 --simulator_integration_scheme=cenic
+```
+
+To drive the linkage with a constant torque at the `world_driver` joint, which
+is the only actuated one, rather than letting it swing passively, and to run
+start to finish without stopping for Enter:
+
+```
+bazel run //examples/multibody/four_bar:four_bar -- \
+    --applied_torque=5 --nointeractive
+```
+
+`--help` lists all the options, along with the standard Drake simulator flags
+such as `--simulator_target_realtime_rate`:
+
+```
+bazel run //examples/multibody/four_bar:four_bar -- --help
+```
+
+# Closing the loop with a bushing: `four_bar_with_bushing`
+
+A compliant bushing is another way to close a four-bar's kinematic loop: leave
+one of the four revolute joints out of the model, so that the remaining three
+form a tree, and stand a bushing in for the joint that is missing. Unlike the
+loop constraint in `four_bar`, which the solver enforces, a bushing is a force
+element whose stiffness and damping you choose yourself, and the rest of this
+file is largely about how to choose them.
+
+Note that the figure and dimensions below describe *this* example; the
+automatically modeled one above has its own geometry.
+
 This planar four-bar linkage demonstrates how to use a bushing to
-approximate a closed kinematic chain. It loads an SDF model from the
+approximate a closed kinematic chain. It loads an SDFormat model from the
 file "four_bar_with_bushing.sdf" into MultibodyPlant. It handles the closed
 kinematic chain by replacing one of the four-bar's revolute (pin) joints with a
 bushing ([drake::multibody::LinearBushingRollPitchYaw](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_linear_bushing_roll_pitch_yaw.html))
@@ -10,7 +96,7 @@ one of the four-bar's rigid links in half and join those halves with a
 bushing that has both force and torque stiffness/damping. Note: the links
 in this example are constrained to rigid motion in the world X-Z
 plane (bushing X-Y plane) by the 3 revolute joints specified in the
-SDF. Therefore it is not necessary for the bushing to have force
+SDFormat file. Therefore it is not necessary for the bushing to have force
 stiffness/damping along the joint axis.
 
 To run with default flags:
@@ -33,7 +119,7 @@ argument:
 bazel run //examples/multibody/four_bar:four_bar_with_bushing -- --applied_torque=<desired_torque>
 ```
 The torque is applied constantly to the joint actuator with no feedback. Thus,
- if set high enough, you will see the system become unstable. 
+ if set high enough, you will see the system become unstable.
 
 You can change the bushing parameters from the command line to observe their
 effect on
@@ -55,13 +141,13 @@ with the bushing stiffness.
 
 ## Four-bar linkage model
 
-The figure below shows a planar four-bar linkage consisting of 
+The figure below shows a planar four-bar linkage consisting of
 frictionless-pin-connected uniform rigid links *A, B, C* and ground-link *W*.
 - Link *A* connects to *W* and *B* at points *A*ₒ and *B*ₒ
 - Link *B* connects to *A* and *C* at points *B*ₒ and *B*c
 - Link *C* connects to *W* and *B* at points *C*ₒ and *C*ʙ
 
-Right-handed orthogonal unit vectors **Âᵢ B̂ᵢ Ĉᵢ Ŵᵢ** 
+Right-handed orthogonal unit vectors **Âᵢ B̂ᵢ Ĉᵢ Ŵᵢ**
 (*i = x,y,z*) are fixed in *A, B, C, W,* with:
 - **Â**𝐱 directed from *A*ₒ to *B*ₒ
 - **B̂**𝐱 directed from *B*ₒ to *B*c
@@ -93,8 +179,8 @@ With 𝐓ᴀ = 0, the equilibrium values for the angles are:
 
 ## Starting Configuration
 
-The SDF defines all of the links with their x axes parallel to the world x
-axis for convenience of measuring the angles in the state of the system
+The SDFormat file defines all of the links with their x axes parallel to the
+world x axis for convenience of measuring the angles in the state of the system
 with respect to a fixed axis. Below we derive a valid initial configuration
 of the three angles 𝐪ᴀ, 𝐪ʙ, and 𝐪ᴄ.
 
@@ -103,7 +189,7 @@ of the three angles 𝐪ᴀ, 𝐪ʙ, and 𝐪ᴄ.
 | ![FourBarLinkageSchematic](images/FourBarLinkageGeometry.png)    |
 | |
 
-Due to equal link lengths, the initial condition (static equilibrium) 
+Due to equal link lengths, the initial condition (static equilibrium)
 forms an isosceles trapezoid and initial values can be determined from
 trigonometry. 𝐪ᴀ is one angle of a right triangle with its adjacent
 side measuring 1 m and its hypotenuse measuring 4 m.  Hence, initially
@@ -111,7 +197,7 @@ side measuring 1 m and its hypotenuse measuring 4 m.  Hence, initially
 
 Because link *B* is parallel to **Ŵ**𝐱, 𝐪ᴀ and 𝐪ʙ are supplementary,
 hence the initial value is 𝐪ʙ = π - 𝐪ᴀ ≈ 1.823 radians ≈  104.48°.
-Similarly, 𝐪ᴀ and 𝐪ᴄ are supplementary, so initially 𝐪ᴄ = 𝐪ʙ. 
+Similarly, 𝐪ᴀ and 𝐪ᴄ are supplementary, so initially 𝐪ᴄ = 𝐪ʙ.
 
 # Modeling the revolute joint between links B and C with a bushing
 
@@ -176,7 +262,7 @@ For the included example code, a characteristic mass m = 20 kg was chosen
 with tₛ = 0.12 and ζ = 1 (critical damping). Thus
 ωₙ = -ln(0.01) / 0.12 ≈ 38.38 and kₓ = (20)*(38.38)² ≈ 30000.
 
-### Estimate force damping [dx dy dz] from mass and stiffness 
+### Estimate force damping [dx dy dz] from mass and stiffness
 Once m and kₓ have been chosen, damping dₓ can be estimated by picking a
 damping ratio ζ (e.g., ζ ≈ 1, critical damping), then dₓ ≈ 2 ζ √(m kx).
 For our example dₓ ≈ 2·√(20·30000) ≈ 1500.

--- a/examples/multibody/four_bar/four_bar.cc
+++ b/examples/multibody/four_bar/four_bar.cc
@@ -1,0 +1,137 @@
+/* @file
+A four bar linkage demo demonstrating MultibodyPlant's automatic modeling of
+closed kinematic loops, applied to a model parsed from an SDFormat file. It
+shows:
+  - How to describe a four bar linkage in SDFormat as a loop of four joints
+    with no attempt to break the loop (see four_bar.sdf).
+  - How to opt in to automatic loop modeling with
+    `MultibodyPlant::SetEnableLoopTopology()`.
+  - That there is nothing else to do. Internally, Drake will split one of the
+    links and add a constraint as needed to close the loop. The linkage is
+    already assembled as defined, so the mechanism can simply be simulated.
+
+Closing the loop takes a constraint, so we have to use a solver that supports
+constraints. It runs in discrete mode under SAP by default, and continuous under
+CENIC:
+    --time_step=0 --simulator_integration_scheme=cenic
+
+Compare four_bar_with_bushing.cc, which leaves one of the four joints out of
+its model file and closes the loop with a LinearBushingRollPitchYaw force
+element instead of a constraint.
+
+Refer to README.md for more details. */
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <gflags/gflags.h>
+
+#include "drake/multibody/parsing/parser.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/analysis/simulator_gflags.h"
+#include "drake/systems/analysis/simulator_print_stats.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/visualization/visualization_config_functions.h"
+
+namespace drake {
+
+using multibody::AddMultibodyPlantSceneGraph;
+using multibody::Parser;
+using systems::Context;
+using systems::DiagramBuilder;
+using systems::Simulator;
+
+namespace {
+
+DEFINE_double(simulation_time, 10.0, "Duration of the simulation in seconds.");
+
+DEFINE_double(time_step, 1.0e-3,
+              "Discrete time step of the MultibodyPlant in seconds, or 0 for a "
+              "continuous plant. Closing the loop takes a constraint, so this "
+              "needs a solver that supports one: discrete SAP, which is the "
+              "default here, or the continuous CENIC integrator, via "
+              "--time_step=0 --simulator_integration_scheme=cenic.");
+
+DEFINE_double(applied_torque, 0.0,
+              "Constant torque applied to the world_driver joint, in N·m.");
+
+DEFINE_bool(interactive, true,
+            "Show the linkage in the configuration the model file defines, and "
+            "wait for you to press Enter before simulating. Set "
+            "--nointeractive to run start to finish without stopping.");
+
+int do_main() {
+  // Build the MultibodyPlant and SceneGraph.
+  DiagramBuilder<double> builder;
+  auto [four_bar, scene_graph] =
+      AddMultibodyPlantSceneGraph(&builder, FLAGS_time_step);
+
+  // Opt in to automatic modeling of closed topologies. Without this, Finalize()
+  // below would throw because of the loop in the model file.
+  four_bar.SetEnableLoopTopology(true);
+
+  Parser(&builder).AddModelsFromUrl(
+      "package://drake/examples/multibody/four_bar/four_bar.sdf");
+
+  // We are done defining the model.
+  four_bar.Finalize();
+  visualization::AddDefaultVisualization(&builder);
+  auto diagram = builder.Build();
+
+  // Create a context for the diagram and grab the four bar's sub-context.
+  std::unique_ptr<Context<double>> diagram_context =
+      diagram->CreateDefaultContext();
+  Context<double>& four_bar_context =
+      four_bar.GetMyMutableContextFromRoot(diagram_context.get());
+
+  // A constant source for applied torque at the world_driver joint. This is the
+  // only actuated joint in the model (the default is zero torque).
+  four_bar.get_actuation_input_port().FixValue(&four_bar_context,
+                                               FLAGS_applied_torque);
+
+  // Note that we set no initial conditions; we're just at q=0 which is the
+  // assembled configuration the model file defines.
+  std::unique_ptr<Simulator<double>> simulator =
+      MakeSimulatorFromGflags(*diagram, std::move(diagram_context));
+
+  // Show the linkage as the model file defines it, before anything has moved,
+  // and (unless --nointeractive) wait, so that there is time to open the
+  // visualizer in a browser and have a look at it first.
+  simulator->Initialize();
+  diagram->ForcedPublish(simulator->get_context());
+  std::cout << "\nThe linkage is shown as the model file defines it.\n";
+  if (FLAGS_interactive) {
+    std::cout << "Press Enter to simulate . . . " << std::flush;
+    std::string line;
+    std::getline(std::cin, line);  // Just eats the line; EOF is fine too.
+  }
+  // Restart the simulator's real time reference point. Without this it would
+  // count the time we just spent waiting as time it has to make up, and then
+  // run flat out to catch up.
+  simulator->ResetStatistics();
+
+  // Run the simulation.
+  simulator->AdvanceTo(FLAGS_simulation_time);
+
+  // Print some useful statistics.
+  PrintSimulatorStatistics(*simulator);
+
+  return 0;
+}
+
+}  // namespace
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  gflags::SetUsageMessage(
+      "A four bar linkage demo demonstrating MultibodyPlant's automatic "
+      "modeling of closed kinematic loops, from a model file. Open the "
+      "indicated URL to see the Meshcat visualization.");
+  // Changes the default realtime rate to 1X, so the visualization looks
+  // realistic. Otherwise, it finishes too fast. Users can still change it on
+  // command line, e.g., "--simulator_target_realtime_rate=0.5" to slow it down.
+  FLAGS_simulator_target_realtime_rate = 1.0;
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::do_main();
+}

--- a/examples/multibody/four_bar/four_bar.sdf
+++ b/examples/multibody/four_bar/four_bar.sdf
@@ -1,0 +1,301 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="four_bar">
+    <!--
+    A planar four-bar linkage described as a plain loop of four joints.
+    MultibodyPlant is left to work out how to model the loop. See four_bar.cc,
+    which runs this model, and the README for more details.
+
+    There are three moving links (driver, coupler, rocker) plus the ground link
+    and four revolute joints. The mechanism moves in the World x-z plane; the
+    revolute axes all point in the -y direction (towards you), so the linkage
+    swings under Drake's usual -z gravity. "*" marks the connection points,
+    each of which is a frame on a link. The frame names start with a capital
+    letter matching the link to which they are fixed and a lower case letter
+    for the connected link, except that Do and Ro are just monogram names for
+    the driver and rocker link frame origins, which is where those links
+    carry their connection points. Note that each connection point is TWO
+    frames, one on each of the links being connected, and this file's poses put
+    the two of them in the same place -- see below.
+
+                   coupler C, 4.8 m, 1 kg           --*  Cr=Rc
+                                Co      ------------ /
+                         --------*------            /  rocker R
+      Dc=Cd *------------   α                      /  2 m, 2 kg   Wz
+            | driver D                            /               |  Wy
+            | 1 m, 1 kg                        θ /                | /
+      Wd=Do *-----------------------------------* Wr=Ro           +----- Wx
+                   ground: World W, 4 m
+
+    In parent-child order, the joints connect Wd-Do, Wr-Ro, Dc-Cd and Cr-Rc.
+    Link mass centers are at their midpoints; the inertias are those of thin
+    rods (mass * length² / 12 about the mass center). The coupler's link frame
+    Co is at the middle of that link rather than at either connection point.
+
+    THE CONFIGURATION DRAWN ABOVE IS AN ASSEMBLED ONE, and it has to be: an
+    SDFormat file locates each joint from the as-parsed poses of the links it
+    connects, so whatever poses the links are given, the model is always
+    assembled at q = 0. Give the links an inconsistent set of poses and
+    the inconsistency does not show up as a loop that needs closing; it is
+    absorbed into the joint offsets instead, resulting in a different
+    mechanism than the one intended. So the link poses below describe the
+    linkage already assembled, with the driver straight up (its joint angle
+    zero) and the other two links where that leaves them. 
+    
+    To get the assembled pitch angles for the rocker and coupler requires some
+    messy trigonometry we're not going to show here. Hint: if we let θ be the
+    rocker pitch angle as shown above, we know that points Rc of the rocker and
+    Cr of the coupler are both at (2 + 2 sinθ, 0, 2 cosθ) and that the distance
+    from Dc to Cr is 4.8 m. Starting with that, some grinding gives
+
+        rocker pitch θ  =  0.368989 rad
+        coupler pitch α = -0.181280 rad
+
+    The <visual> elements are cosmetic only. Each link is drawn as a skinny box
+    running between its two connection points, stopping just short of them, and
+    each joint is drawn as a single pin in the color of one of the two links it
+    connects. Everything is drawn in the y = 0 plane the mechanism moves in.
+    -->
+
+    <!-- The ground "link" of the linkage, running from Wd to Wr. It is welded
+    to World and carries no mass; what it does carry is the green bar and the
+    two pins that draw the fixed side of the linkage, along with the two frames
+    where the linkage attaches to World. It has to be a body of its own because
+    geometry has to be attached to one, and a model file has no way to put
+    geometry on World itself. (The frames alone would not need it: a joint can
+    name <parent>world</parent> directly. SDFormat can also define frames at
+    <world> scope, but a model cannot reference one of those, just as a frame in
+    a model cannot be attached_to World -- name resolution does not cross
+    between world and model scope in either direction.) -->
+    <link name="ground">
+      <inertial>
+        <mass>0</mass>
+        <inertia>
+          <ixx>0</ixx> <iyy>0</iyy> <izz>0</izz>
+          <ixy>0</ixy> <ixz>0</ixz> <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <visual name="ground_bar">
+        <geometry>
+          <box>
+            <size>3.8 0.1 0.2</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <!-- The revolute axes are along y, while a cylinder's own axis is z, so
+      the pins are rolled a quarter turn about x to match. -->
+      <visual name="world_driver_pin">
+        <pose>-2 0 0 1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.04</radius>
+            <length>0.2</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0 1 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="world_rocker_pin">
+        <pose>2 0 0 1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.04</radius>
+            <length>0.2</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0 1 0 1</diffuse>
+        </material>
+      </visual>
+    </link>
+    <joint name="world_ground_weld" type="fixed">
+      <parent>world</parent>
+      <child>ground</child>
+    </joint>
+
+    <frame name="Wd" attached_to="ground">
+      <pose relative_to="ground">-2 0 0 0 0 0</pose>
+    </frame>
+    <frame name="Wr" attached_to="ground">
+      <pose relative_to="ground">2 0 0 0 0 0</pose>
+    </frame>
+
+    <!-- The driver, a thin rod from its own link frame Do along +z to Dc. Its
+    pose puts Do at Wd, pointing straight up: this is the link whose angle we
+    choose, and the two below are then wherever loop closure puts them. -->
+    <link name="driver">
+      <pose>-2 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0.5 0 0 0</pose>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0.0833333333333333</ixx>
+          <iyy>0.0833333333333333</iyy>
+          <izz>0</izz>
+          <ixy>0</ixy> <ixz>0</ixz> <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <visual name="driver_bar">
+        <pose>0 0 0.5 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.2 0.1 0.8</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>1 0 0 1</diffuse>
+        </material>
+      </visual>
+      <visual name="driver_coupler_pin">
+        <pose>0 0 1 1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.04</radius>
+            <length>0.2</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>1 0 0 1</diffuse>
+        </material>
+      </visual>
+    </link>
+    <frame name="Dc" attached_to="driver">
+      <pose relative_to="driver">0 0 1 0 0 0</pose>
+    </frame>
+
+    <!-- The coupler, a thin rod running along its own x from Cd to Cr, with
+    its link frame Co at the middle. Its pose puts Co midway between Dc and Rc,
+    pitched so that Cd lands on Dc and Cr on Rc. -->
+    <link name="coupler">
+      <pose>0.360673075793211 0 1.432692303172844 0 -0.181279708531571 0</pose>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>0</ixx>
+          <iyy>1.92</iyy>
+          <izz>1.92</izz>
+          <ixy>0</ixy> <ixz>0</ixz> <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <visual name="coupler_bar">
+        <geometry>
+          <box>
+            <size>4.6 0.1 0.2</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>0 0 1 1</diffuse>
+        </material>
+      </visual>
+      <visual name="coupler_rocker_pin">
+        <pose>2.4 0 0 1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.04</radius>
+            <length>0.2</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0 0 1 1</diffuse>
+        </material>
+      </visual>
+    </link>
+    <frame name="Cd" attached_to="coupler">
+      <pose relative_to="coupler">-2.4 0 0 0 0 0</pose>
+    </frame>
+    <frame name="Cr" attached_to="coupler">
+      <pose relative_to="coupler">2.4 0 0 0 0 0</pose>
+    </frame>
+
+    <!-- The rocker, a thin rod from its own link frame Ro along +z to Rc. Its
+    pose puts Ro at Wr, pitched so that Rc is exactly the coupler's length away
+    from Dc. -->
+    <link name="rocker">
+      <pose>2 0 0 0 0.368989441111603 0</pose>
+      <inertial>
+        <pose>0 0 1 0 0 0</pose>
+        <mass>2</mass>
+        <inertia>
+          <ixx>0.6666666666666667</ixx>
+          <iyy>0.6666666666666667</iyy>
+          <izz>0</izz>
+          <ixy>0</ixy> <ixz>0</ixz> <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <visual name="rocker_bar">
+        <pose>0 0 1 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.2 0.1 1.8</size>
+          </box>
+        </geometry>
+        <material>
+          <diffuse>1 1 0 1</diffuse>
+        </material>
+      </visual>
+    </link>
+    <frame name="Rc" attached_to="rocker">
+      <pose relative_to="rocker">0 0 2 0 0 0</pose>
+    </frame>
+
+    <!-- The four revolute joints. Nothing here says anything about a spanning
+    tree; these four joints simply form a loop, and MultibodyPlant decides how
+    to model it. Each one names the two frames the figure above draws it
+    between, and needs no <pose> of its own: an omitted joint pose defaults to
+    the frame named as the joint's <child>, which is where the joint
+    belongs. -->
+
+    <joint name="world_driver" type="revolute">
+      <parent>Wd</parent>
+      <child>driver</child>
+      <axis>
+        <xyz expressed_in="__model__">0 -1 0</xyz>
+        <limit>
+          <!-- No effort limit provided. SDFormat defaults to -1, which we
+               parse as an actuated joint. -->
+        </limit>
+      </axis>
+    </joint>
+
+    <joint name="world_rocker" type="revolute">
+      <parent>Wr</parent>
+      <child>rocker</child>
+      <axis>
+        <xyz expressed_in="__model__">0 -1 0</xyz>
+        <limit>
+          <!-- An effort of 0 is parsed as an unactuated joint. -->
+          <effort>0</effort>
+        </limit>
+      </axis>
+    </joint>
+
+    <joint name="driver_coupler" type="revolute">
+      <parent>Dc</parent>
+      <child>Cd</child>
+      <axis>
+        <xyz expressed_in="__model__">0 -1 0</xyz>
+        <limit>
+          <!-- An effort of 0 is parsed as an unactuated joint. -->
+          <effort>0</effort>
+        </limit>
+      </axis>
+    </joint>
+
+    <joint name="coupler_rocker" type="revolute">
+      <parent>Cr</parent>
+      <child>Rc</child>
+      <axis>
+        <xyz expressed_in="__model__">0 -1 0</xyz>
+        <limit>
+          <!-- An effort of 0 is parsed as an unactuated joint. -->
+          <effort>0</effort>
+        </limit>
+      </axis>
+    </joint>
+
+  </model>
+</sdf>


### PR DESCRIPTION
This is the first of the two new examples from #24976.

This example reads an sdformat file containing an already-assembled linkage and simulates it with no fuss. Can be visualized in Meshcat.

The existing README.md is modified to describe the new test.

Note that enabling automatic loop breaking is still marked "internal use only" and should be considered experimental until that label is removed. See issue https://github.com/RobotLocomotion/drake/issues/24908 for questions that need to be resolved before that happens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24978)
<!-- Reviewable:end -->
