### PR TITLE
[multibody] Treat world TreeIndex safely in joint-locking contact filter

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -1128,6 +1128,14 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "joint_locking_world_geometry_test",
+    deps = [
+        ":plant",
+        "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
     name = "spring_mass_system_test",
     timeout = "moderate",
     deps = [

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3226,6 +3226,11 @@ void MultibodyPlant<T>::CalcGeometryContactData(
         const BodyIndex body_index = geometry_id_to_body_index.at(geometry_id);
         const internal::TreeIndex tree_index =
             forest.link_to_tree_index(body_index);
+        // World (and any other non-tree link) has an invalid TreeIndex and no
+        // dofs of its own (#24773).
+        if (!tree_index.is_valid()) {
+          return true;
+        }
         const internal::SpanningForest::Tree& tree = forest.trees(tree_index);
         return !tree.has_dofs() ||
                per_tree_unlocked_indices[tree_index].size() == 0;

--- a/multibody/plant/test/joint_locking_world_geometry_test.cc
+++ b/multibody/plant/test/joint_locking_world_geometry_test.cc
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+
+#include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+// Regression test for #24773: locking a joint must not crash when contact
+// involves collision geometry attached to the World body (invalid TreeIndex).
+GTEST_TEST(JointLockingWorldGeometryTest, WorldContactDoesNotCrash) {
+  systems::DiagramBuilder<double> builder;
+  auto items = AddMultibodyPlantSceneGraph(&builder, /* time_step = */ 0.01);
+  MultibodyPlant<double>& plant = items.plant;
+
+  plant.RegisterCollisionGeometry(
+      plant.world_body(), math::RigidTransformd(), geometry::HalfSpace(),
+      "ground", geometry::ProximityProperties());
+  const RigidBody<double>& box = plant.AddRigidBody(
+      "box", SpatialInertia<double>::SolidBoxWithMass(1.0, 0.1, 0.1, 0.1));
+  plant.RegisterCollisionGeometry(box, math::RigidTransformd(),
+                                  geometry::Box(0.1, 0.1, 0.1), "box",
+                                  geometry::ProximityProperties());
+  plant.Finalize();
+
+  auto diagram = builder.Build();
+  systems::Simulator<double> simulator(*diagram);
+  systems::Context<double>& plant_context =
+      plant.GetMyMutableContextFromRoot(&simulator.get_mutable_context());
+
+  plant.SetFreeBodyPose(&plant_context, box,
+                        math::RigidTransformd(Eigen::Vector3d(0, 0, 0.049)));
+  for (JointIndex i : plant.GetJointIndices()) {
+    const Joint<double>& joint = plant.get_joint(i);
+    if (joint.num_velocities() == 6) {
+      joint.Lock(&plant_context);
+    }
+  }
+
+  EXPECT_NO_THROW(simulator.AdvanceTo(0.01));
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Collision geometry on the World body maps to an invalid TreeIndex. Guard that case in CalcGeometryContactData so locking a joint no longer crashes when contact involves world geometry.

Fixes #24773.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24984)
<!-- Reviewable:end -->
