### PR TITLE
[parsing] Honor MuJoCo mesh asset refpos and refquat

### DIFF
--- a/multibody/parsing/detail_mujoco_parser.cc
+++ b/multibody/parsing/detail_mujoco_parser.cc
@@ -865,6 +865,11 @@ class MujocoParser {
       }
       if (mesh_.contains(mesh)) {
         geom.shape = mesh_.at(mesh)->Clone();
+        // MuJoCo subtracts the asset reference pose from mesh vertices.
+        // Applying the inverse reference pose to the geom frame matches that.
+        if (mesh_ref_pose_.contains(mesh)) {
+          geom.X_BG = geom.X_BG * mesh_ref_pose_.at(mesh).inverse();
+        }
       } else {
         Warning(
             *node,
@@ -1392,8 +1397,6 @@ class MujocoParser {
       WarnUnsupportedAttribute(*mesh_node, "vertex");
       // Note: "normal", "face", and "texcoord" are not supported either, but
       // that lack of support is implied by us not supporting "vertex".
-      WarnUnsupportedAttribute(*mesh_node, "refpos");
-      WarnUnsupportedAttribute(*mesh_node, "refquat");
       WarnUnsupportedElement(*mesh_node, "plugin");
 
       std::string file;
@@ -1407,6 +1410,16 @@ class MujocoParser {
 
         Vector3d scale{1, 1, 1};
         ParseVectorAttribute(mesh_node, "scale", &scale);
+
+        Vector3d refpos{0, 0, 0};
+        ParseVectorAttribute(mesh_node, "refpos", &refpos);
+        // MuJoCo refquat is w, x, y, z.
+        Vector4d refquat{1, 0, 0, 0};
+        ParseVectorAttribute(mesh_node, "refquat", &refquat);
+        const RigidTransformd X_MR(
+            Eigen::Quaternion<double>(refquat[0], refquat[1], refquat[2],
+                                      refquat[3]),
+            refpos);
 
         std::filesystem::path filename(file);
 
@@ -1458,6 +1471,7 @@ class MujocoParser {
           // TODO(russt): Support .vtk files.
           if (extension == ".obj") {
             mesh_[name] = std::make_unique<geometry::Mesh>(filename, scale);
+            mesh_ref_pose_[name] = X_MR;
           } else {
             Error(
                 *node,
@@ -2146,6 +2160,8 @@ class MujocoParser {
   std::optional<std::filesystem::path> meshdir_{};
   std::string eulerseq_{"xyz"};
   std::map<std::string, std::unique_ptr<geometry::Mesh>> mesh_{};
+  // Reference pose of mesh assets from MuJoCo refpos/refquat.
+  std::map<std::string, RigidTransformd> mesh_ref_pose_{};
   // Spatial inertia of mesh assets assuming density = 1.
   std::map<std::string, SpatialInertia<double>> mesh_inertia_{};
   std::map<JointIndex, double> armature_{};

--- a/multibody/parsing/test/detail_mujoco_parser_test.cc
+++ b/multibody/parsing/test/detail_mujoco_parser_test.cc
@@ -759,6 +759,30 @@ TEST_F(BoxMeshTest, MeshFileScale) {
   TestBoxMesh(box_obj_, mesh_asset, "", Vector3d(2, 3, 1.5));
 }
 
+TEST_F(MujocoParserTest, MeshFileReferencePose) {
+  // refpos/refquat shift the mesh asset frame; Drake applies the inverse to
+  // the geom pose so vertices match MuJoCo (#22488).
+  const std::string xml = fmt::format(R"""(
+<mujoco model="test">
+  <asset>
+    <mesh name="box" file="{}" refpos="1 2 3" refquat="0 1 0 0"/>
+  </asset>
+  <worldbody>
+    <geom name="box_geom" type="mesh" mesh="box"/>
+  </worldbody>
+</mujoco>
+)""", box_obj_);
+
+  AddModelFromString(xml, "test");
+  const auto& inspector = scene_graph_->model_inspector();
+  const GeometryId geom_id = inspector.GetGeometryIdByName(
+      inspector.world_frame_id(), Role::kProximity, "box_geom");
+  const RigidTransformd expected(
+      Eigen::Quaternion<double>(0, 1, 0, 0), Vector3d(-1, 2, 3));
+  EXPECT_TRUE(
+      inspector.GetPoseInFrame(geom_id).IsNearlyEqualTo(expected, 1e-14));
+}
+
 TEST_F(BoxMeshTest, MeshFileScaleViaDefault) {
   // Test the scale set via mesh defaults. According to the mjcf docs, this is
   // the only supported mesh default.


### PR DESCRIPTION
Parse refpos and refquat on mesh assets and apply the inverse reference pose to mesh geom frames so vertex placement matches MuJoCo.

Fixes #22488.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24985)
<!-- Reviewable:end -->
