### PR TITLE
[pydrake] Keep nested Iris options alive for inline MathematicalProgram

### DIFF
--- a/bindings/pydrake/planning/planning_py_iris_np2.cc
+++ b/bindings/pydrake/planning/planning_py_iris_np2.cc
@@ -1,6 +1,7 @@
 #include <utility>
 
 #include "drake/bindings/generated_docstrings/planning_iris.h"
+#include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -43,7 +44,8 @@ void DefinePlanningIrisNp2(py::module_ m) {
 
   // IrisNp2Options
   const auto& cls_doc = doc.IrisNp2Options;
-  class_<IrisNp2Options> iris_np2_options(m, "IrisNp2Options", cls_doc.doc);
+  class_<IrisNp2Options> iris_np2_options(
+      m, "IrisNp2Options", py::dynamic_attr(), cls_doc.doc);
   iris_np2_options  // BR
       .def(py::init<>())
       .def_prop_rw("solver_options",
@@ -63,7 +65,27 @@ void DefinePlanningIrisNp2(py::module_ m) {
           py::for_getter(py_rvp::reference_internal),
 #endif  // PYDRAKE_USE_PYBIND11
           cls_doc.solver_options.doc)
-      .def_rw("sampled_iris_options", &IrisNp2Options::sampled_iris_options,
+      .def_prop_rw("sampled_iris_options",
+#ifdef PYDRAKE_USE_PYBIND11
+          py::cpp_function(
+              [](IrisNp2Options& self) -> CommonSampledIrisOptions& {
+                return self.sampled_iris_options;
+              },
+              py_rvp::reference_internal, internal::ref_cycle<0, 1>()),
+          py::cpp_function(
+              [](IrisNp2Options& self, const CommonSampledIrisOptions& value) {
+                self.sampled_iris_options = value;
+              }),
+#else   // PYDRAKE_USE_NANOBIND
+          [](IrisNp2Options& self) -> CommonSampledIrisOptions& {
+            return self.sampled_iris_options;
+          },
+          [](IrisNp2Options& self, const CommonSampledIrisOptions& value) {
+            self.sampled_iris_options = value;
+          },
+          py::for_getter(py_rvp::reference_internal),
+          py::for_getter(internal::ref_cycle<0, 1>()),
+#endif  // PYDRAKE_USE_PYBIND11
           cls_doc.sampled_iris_options.doc)
       .def_rw("parameterization", &IrisNp2Options::parameterization,
           cls_doc.parameterization.doc)

--- a/bindings/pydrake/planning/planning_py_iris_zo.cc
+++ b/bindings/pydrake/planning/planning_py_iris_zo.cc
@@ -1,4 +1,5 @@
 #include "drake/bindings/generated_docstrings/planning_iris.h"
+#include "drake/bindings/pydrake/common/ref_cycle_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/planning/planning_py.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -16,10 +17,31 @@ void DefinePlanningIrisZo(py::module_ m) {
 
   // IrisZoOptions
   const auto& cls_doc = doc.IrisZoOptions;
-  class_<IrisZoOptions> iris_zo_options(m, "IrisZoOptions", cls_doc.doc);
+  class_<IrisZoOptions> iris_zo_options(
+      m, "IrisZoOptions", py::dynamic_attr(), cls_doc.doc);
   iris_zo_options  // BR
       .def(py::init<>())
-      .def_rw("sampled_iris_options", &IrisZoOptions::sampled_iris_options,
+      .def_prop_rw("sampled_iris_options",
+#ifdef PYDRAKE_USE_PYBIND11
+          py::cpp_function(
+              [](IrisZoOptions& self) -> CommonSampledIrisOptions& {
+                return self.sampled_iris_options;
+              },
+              py_rvp::reference_internal, internal::ref_cycle<0, 1>()),
+          py::cpp_function(
+              [](IrisZoOptions& self, const CommonSampledIrisOptions& value) {
+                self.sampled_iris_options = value;
+              }),
+#else   // PYDRAKE_USE_NANOBIND
+          [](IrisZoOptions& self) -> CommonSampledIrisOptions& {
+            return self.sampled_iris_options;
+          },
+          [](IrisZoOptions& self, const CommonSampledIrisOptions& value) {
+            self.sampled_iris_options = value;
+          },
+          py::for_getter(py_rvp::reference_internal),
+          py::for_getter(internal::ref_cycle<0, 1>()),
+#endif  // PYDRAKE_USE_PYBIND11
           cls_doc.sampled_iris_options.doc)
       .def_rw("bisection_steps", &IrisZoOptions::bisection_steps,
           cls_doc.bisection_steps.doc)

--- a/bindings/pydrake/planning/test/iris_test.py
+++ b/bindings/pydrake/planning/test/iris_test.py
@@ -14,7 +14,7 @@ from pydrake.planning import (
     RobotDiagramBuilder,
     SceneGraphCollisionChecker,
 )
-from pydrake.solvers import IpoptSolver, SolverOptions
+from pydrake.solvers import IpoptSolver, MathematicalProgram, SolverOptions
 from pydrake.symbolic import Variable
 
 # Taken from iris_from_clique_cover_test.py
@@ -316,3 +316,26 @@ class TestOptionsPrinting(unittest.TestCase):
         self.check_fields(options.ray_sampler_options, fields, printed)
 
         self.check_sampled_iris_options(options.sampled_iris_options, printed)
+
+
+class TestInlineProgKeepAlive(unittest.TestCase):
+    """Regression test for #23590."""
+
+    def test_iris_np2_inline_prog(self):
+        options = mut.IrisNp2Options()
+        options.sampled_iris_options.prog_with_additional_constraints = (
+            MathematicalProgram()
+        )
+        self.assertIsNotNone(
+            options.sampled_iris_options.prog_with_additional_constraints
+        )
+
+    def test_iris_zo_inline_prog(self):
+        options = mut.IrisZoOptions()
+        options.sampled_iris_options.prog_with_additional_constraints = (
+            MathematicalProgram()
+        )
+        self.assertIsNotNone(
+            options.sampled_iris_options.prog_with_additional_constraints
+        )
+


### PR DESCRIPTION
Accessing sampled_iris_options on IrisNp2Options or IrisZoOptions returned a temporary Python view, so keep_alive for prog_with_additional_constraints could not retain an inline MathematicalProgram(). Use dynamic_attr and a ref_cycle on the nested options getter so the program stays alive.

Fixes #23590.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake/24986)
<!-- Reviewable:end -->
